### PR TITLE
Fix threadpool load induced delayed responses to plugin requests

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/Plugins/InboundRequestContext.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/InboundRequestContext.cs
@@ -17,7 +17,7 @@ namespace NuGet.Protocol.Plugins
         private readonly IConnection _connection;
         private bool _isDisposed;
         private readonly IPluginLogger _logger;
-
+        private readonly InboundRequestProcessingHandler _inboundRequestProcessingHandler;
         /// <summary>
         /// Gets the request ID.
         /// </summary>
@@ -37,7 +37,7 @@ namespace NuGet.Protocol.Plugins
             IConnection connection,
             string requestId,
             CancellationToken cancellationToken)
-            : this(connection, requestId, cancellationToken, PluginLogger.DefaultInstance)
+            : this(connection, requestId, cancellationToken, new InboundRequestProcessingHandler(), PluginLogger.DefaultInstance)
         {
         }
 
@@ -52,12 +52,15 @@ namespace NuGet.Protocol.Plugins
         /// is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown if <paramref name="requestId" />
         /// is either <c>null</c> or an empty string.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" />
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="inboundRequestProcessingHandler" />
+        /// is <c>null</c>.</exception>
+        /// /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" />
         /// is <c>null</c>.</exception>
         internal InboundRequestContext(
             IConnection connection,
             string requestId,
             CancellationToken cancellationToken,
+            InboundRequestProcessingHandler inboundRequestProcessingHandler,
             IPluginLogger logger)
         {
             if (connection == null)
@@ -75,6 +78,11 @@ namespace NuGet.Protocol.Plugins
                 throw new ArgumentNullException(nameof(logger));
             }
 
+            if (inboundRequestProcessingHandler == null)
+            {
+                throw new ArgumentNullException(nameof(inboundRequestProcessingHandler));
+            }
+
             _connection = connection;
             RequestId = requestId;
 
@@ -85,6 +93,43 @@ namespace NuGet.Protocol.Plugins
             _cancellationToken = _cancellationTokenSource.Token;
 
             _logger = logger;
+
+            _inboundRequestProcessingHandler = inboundRequestProcessingHandler;
+        }
+
+        private async Task ProcessResponse(IRequestHandler requestHandler, Message request, IResponseHandler responseHandler)
+        {
+            // Top-level exception handler for a worker pool thread.
+            try
+            {
+                if (_logger.IsEnabled)
+                {
+                    _logger.Write(new TaskLogMessage(_logger.Now, request.RequestId, request.Method, request.Type, TaskState.Executing));
+                }
+
+                await requestHandler.HandleResponseAsync(
+                    _connection,
+                    request,
+                    responseHandler,
+                    _cancellationToken);
+            }
+            catch (OperationCanceledException) when (_cancellationToken.IsCancellationRequested)
+            {
+                var response = MessageUtilities.Create(request.RequestId, MessageType.Cancel, request.Method);
+
+                await _connection.SendAsync(response, CancellationToken.None);
+            }
+            catch (Exception ex)
+            {
+                BeginFaultAsync(request, ex);
+            }
+            finally
+            {
+                if (_logger.IsEnabled)
+                {
+                    _logger.Write(new TaskLogMessage(_logger.Now, request.RequestId, request.Method, request.Type, TaskState.Completed));
+                }
+            }
         }
 
         /// <summary>
@@ -108,8 +153,7 @@ namespace NuGet.Protocol.Plugins
             {
             }
 
-            // Do not dispose of _connection or _logger.  This context does not own them.
-
+            // Do not dispose of the _connection, _logger or _requestProcessingContext.  This context does not own them.
             GC.SuppressFinalize(this);
 
             _isDisposed = true;
@@ -210,42 +254,9 @@ namespace NuGet.Protocol.Plugins
             {
                 _logger.Write(new TaskLogMessage(_logger.Now, request.RequestId, request.Method, request.Type, TaskState.Queued));
             }
+            Func<Task> task = async () => await ProcessResponse(requestHandler, request, responseHandler);
 
-            Task.Run(async () =>
-                {
-                    // Top-level exception handler for a worker pool thread.
-                    try
-                    {
-                        if (_logger.IsEnabled)
-                        {
-                            _logger.Write(new TaskLogMessage(_logger.Now, request.RequestId, request.Method, request.Type, TaskState.Executing));
-                        }
-
-                        await requestHandler.HandleResponseAsync(
-                            _connection,
-                            request,
-                            responseHandler,
-                            _cancellationToken);
-                    }
-                    catch (OperationCanceledException) when (_cancellationToken.IsCancellationRequested)
-                    {
-                        var response = MessageUtilities.Create(request.RequestId, MessageType.Cancel, request.Method);
-
-                        await _connection.SendAsync(response, CancellationToken.None);
-                    }
-                    catch (Exception ex)
-                    {
-                        BeginFaultAsync(request, ex);
-                    }
-                    finally
-                    {
-                        if (_logger.IsEnabled)
-                        {
-                            _logger.Write(new TaskLogMessage(_logger.Now, request.RequestId, request.Method, request.Type, TaskState.Completed));
-                        }
-                    }
-                },
-                _cancellationToken);
+            _inboundRequestProcessingHandler.Handle(request.Method, task, _cancellationToken);
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/InboundRequestContext.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/InboundRequestContext.cs
@@ -55,7 +55,7 @@ namespace NuGet.Protocol.Plugins
         /// is either <c>null</c> or an empty string.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="inboundRequestProcessingHandler" />
         /// is <c>null</c>.</exception>
-        /// /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" />
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" />
         /// is <c>null</c>.</exception>
         internal InboundRequestContext(
             IConnection connection,
@@ -254,7 +254,7 @@ namespace NuGet.Protocol.Plugins
             {
                 _logger.Write(new TaskLogMessage(_logger.Now, request.RequestId, request.Method, request.Type, TaskState.Queued));
             }
-            Func<Task> task = async () => await ProcessResponseAsync(requestHandler, request, responseHandler);
+            Func<Task> task = () => ProcessResponseAsync(requestHandler, request, responseHandler);
 
             _inboundRequestProcessingHandler.Handle(request.Method, task, _cancellationToken);
         }

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/InboundRequestContext.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/InboundRequestContext.cs
@@ -18,6 +18,7 @@ namespace NuGet.Protocol.Plugins
         private bool _isDisposed;
         private readonly IPluginLogger _logger;
         private readonly InboundRequestProcessingHandler _inboundRequestProcessingHandler;
+
         /// <summary>
         /// Gets the request ID.
         /// </summary>
@@ -97,9 +98,8 @@ namespace NuGet.Protocol.Plugins
             _inboundRequestProcessingHandler = inboundRequestProcessingHandler;
         }
 
-        private async Task ProcessResponse(IRequestHandler requestHandler, Message request, IResponseHandler responseHandler)
+        private async Task ProcessResponseAsync(IRequestHandler requestHandler, Message request, IResponseHandler responseHandler)
         {
-            // Top-level exception handler for a worker pool thread.
             try
             {
                 if (_logger.IsEnabled)
@@ -254,7 +254,7 @@ namespace NuGet.Protocol.Plugins
             {
                 _logger.Write(new TaskLogMessage(_logger.Now, request.RequestId, request.Method, request.Type, TaskState.Queued));
             }
-            Func<Task> task = async () => await ProcessResponse(requestHandler, request, responseHandler);
+            Func<Task> task = async () => await ProcessResponseAsync(requestHandler, request, responseHandler);
 
             _inboundRequestProcessingHandler.Handle(request.Method, task, _cancellationToken);
         }

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/InboundRequestProcessingHandler.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/InboundRequestProcessingHandler.cs
@@ -19,6 +19,10 @@ namespace NuGet.Protocol.Plugins
         {
         }
 
+        /// <summary>
+        /// Requests from the processing methods provided in this set are handled on a dedicated thread.
+        /// </summary>
+        /// <param name="fastProcessingMethods"></param>
         public InboundRequestProcessingHandler(ISet<MessageMethod> fastProcessingMethods) 
         {
             _fastProccessingMethods = fastProcessingMethods ?? throw new ArgumentNullException(nameof(fastProcessingMethods));
@@ -32,6 +36,12 @@ namespace NuGet.Protocol.Plugins
 
         }
 
+        /// <summary>
+        /// Methods that are in the fast processing method list will be handled on a separate thread. Everything else will be queued on the threadpool.
+        /// </summary>
+        /// <param name="messageMethod"></param>
+        /// <param name="task"></param>
+        /// <param name="cancellationToken"></param>
         internal void Handle(MessageMethod messageMethod, Func<Task> task, CancellationToken cancellationToken)
         {
             ThrowIfDisposed();

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/InboundRequestProcessingHandler.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/InboundRequestProcessingHandler.cs
@@ -47,7 +47,7 @@ namespace NuGet.Protocol.Plugins
             ThrowIfDisposed();
             if (_fastProccessingMethods.Contains(messageMethod))
             {
-                _processingThread.Value.Push(task);
+                _processingThread.Value.Enqueue(task);
             }
             else
             {

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/InboundRequestProcessingHandler.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/InboundRequestProcessingHandler.cs
@@ -1,0 +1,71 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NuGet.Protocol.Plugins
+{
+    internal class InboundRequestProcessingHandler : IDisposable
+    {
+        private readonly ISet<MessageMethod> _fastProccessingMethods;
+        private readonly Lazy<DedicatedAsynchronousProcessingThread> _processingThread;
+        private bool _isDisposed;
+
+        public InboundRequestProcessingHandler() :
+            this(new HashSet<MessageMethod>())
+        {
+        }
+
+        public InboundRequestProcessingHandler(ISet<MessageMethod> fastProcessingMethods) 
+        {
+            _fastProccessingMethods = fastProcessingMethods ?? throw new ArgumentNullException(nameof(fastProcessingMethods));
+            // Lazily initialize the processing thread. It is not needed if there are no time critical methods.
+            _processingThread = new Lazy<DedicatedAsynchronousProcessingThread>(() =>
+            {
+                var thread = new DedicatedAsynchronousProcessingThread();
+                thread.Start();
+                return thread;
+            });
+
+        }
+
+        internal void Handle(MessageMethod messageMethod, Func<Task> task, CancellationToken cancellationToken)
+        {
+            ThrowIfDisposed();
+            if (_fastProccessingMethods.Contains(messageMethod))
+            {
+                _processingThread.Value.Push(task);
+            }
+            else
+            {
+                Task.Run(async () =>
+                {
+                    await task();
+                }, cancellationToken);
+            }
+        }
+
+        public void Dispose()
+        {
+            if (_isDisposed)
+            {
+                return;
+            }
+            _processingThread.Value.Dispose();
+            GC.SuppressFinalize(this);
+
+            _isDisposed = true;
+        }
+
+        private void ThrowIfDisposed()
+        {
+            if (_isDisposed)
+            {
+                throw new ObjectDisposedException(GetType().Name);
+            }
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Logging/AssemblyLogMessage.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Logging/AssemblyLogMessage.cs
@@ -12,15 +12,18 @@ namespace NuGet.Protocol.Plugins
         private readonly string _fileVersion;
         private readonly string _fullName;
         private readonly string _informationalVersion;
+        private readonly string _entryAssemblyFullName;
 
         internal AssemblyLogMessage(DateTimeOffset now)
             : base(now)
         {
             var assembly = typeof(PluginFactory).Assembly;
+            var entryAssembly = Assembly.GetEntryAssembly();
             var informationalVersionAttribute = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>();
             var fileVersionAttribute = assembly.GetCustomAttribute<AssemblyFileVersionAttribute>();
 
             _fullName = assembly.FullName;
+            _entryAssemblyFullName = entryAssembly.FullName;
 
             if (fileVersionAttribute != null)
             {
@@ -35,7 +38,9 @@ namespace NuGet.Protocol.Plugins
 
         public override string ToString()
         {
-            var message = new JObject(new JProperty("assembly full name", _fullName));
+            var message = new JObject(
+                new JProperty("assembly full name", _fullName),
+                new JProperty("entry assembly full name", _entryAssemblyFullName));
 
             if (!string.IsNullOrEmpty(_fileVersion))
             {

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Logging/AssemblyLogMessage.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Logging/AssemblyLogMessage.cs
@@ -23,7 +23,7 @@ namespace NuGet.Protocol.Plugins
             var fileVersionAttribute = assembly.GetCustomAttribute<AssemblyFileVersionAttribute>();
 
             _fullName = assembly.FullName;
-            _entryAssemblyFullName = entryAssembly.FullName;
+            _entryAssemblyFullName = entryAssembly?.FullName;
 
             if (fileVersionAttribute != null)
             {

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Logging/ProcessLogMessage.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Logging/ProcessLogMessage.cs
@@ -11,6 +11,7 @@ namespace NuGet.Protocol.Plugins
     {
         private readonly int _processId;
         private readonly string _processName;
+        private readonly DateTime _processStartTime;
 
         internal ProcessLogMessage(DateTimeOffset now)
             : base(now)
@@ -19,6 +20,7 @@ namespace NuGet.Protocol.Plugins
             {
                 _processId = process.Id;
                 _processName = process.ProcessName;
+                _processStartTime = process.StartTime.ToUniversalTime();
             }
         }
 
@@ -26,7 +28,8 @@ namespace NuGet.Protocol.Plugins
         {
             var message = new JObject(
                 new JProperty("process ID", _processId),
-                new JProperty("process name", _processName));
+                new JProperty("process name", _processName),
+                new JProperty("process start time", _processStartTime.ToString("O")));
 
             return ToString("process", message);
         }

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/MessageDispatcher.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/MessageDispatcher.cs
@@ -52,9 +52,11 @@ namespace NuGet.Protocol.Plugins
         /// is <c>null</c>.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="idGenerator" />
         /// is <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" />
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="inboundRequestProcessingHandler" />
         /// is <c>null</c>.</exception>
-        internal MessageDispatcher(IRequestHandlers requestHandlers, IIdGenerator idGenerator, InboundRequestProcessingHandler inboundRequestProcessingContext, IPluginLogger logger)
+        /// /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" />
+        /// is <c>null</c>.</exception>
+        internal MessageDispatcher(IRequestHandlers requestHandlers, IIdGenerator idGenerator, InboundRequestProcessingHandler inboundRequestProcessingHandler, IPluginLogger logger)
         {
             if (requestHandlers == null)
             {
@@ -66,9 +68,9 @@ namespace NuGet.Protocol.Plugins
                 throw new ArgumentNullException(nameof(idGenerator));
             }
 
-            if(inboundRequestProcessingContext == null)
+            if(inboundRequestProcessingHandler == null)
             {
-                throw new ArgumentNullException(nameof(inboundRequestProcessingContext));
+                throw new ArgumentNullException(nameof(inboundRequestProcessingHandler));
             }
             if (logger == null)
             {
@@ -81,7 +83,7 @@ namespace NuGet.Protocol.Plugins
 
             _inboundRequestContexts = new ConcurrentDictionary<string, InboundRequestContext>();
             _outboundRequestContexts = new ConcurrentDictionary<string, OutboundRequestContext>();
-            _inboundRequestProcessingContext = inboundRequestProcessingContext;
+            _inboundRequestProcessingContext = inboundRequestProcessingHandler;
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginFactory.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginFactory.cs
@@ -210,8 +210,8 @@ namespace NuGet.Protocol.Plugins
 
                 var sender = new Sender(pluginProcess.StandardInput);
                 var receiver = new StandardOutputReceiver(pluginProcess);
-                var processingContext = new InboundRequestProcessingHandler(new HashSet<MessageMethod> { MessageMethod.Handshake, MessageMethod.Log});
-                var messageDispatcher = new MessageDispatcher(requestHandlers, new RequestIdGenerator(), processingContext, _logger);
+                var processingHandler = new InboundRequestProcessingHandler(new HashSet<MessageMethod> { MessageMethod.Handshake, MessageMethod.Log});
+                var messageDispatcher = new MessageDispatcher(requestHandlers, new RequestIdGenerator(), processingHandler, _logger);
                 connection = new Connection(messageDispatcher, sender, receiver, options, _logger);
 
                 var plugin = new Plugin(

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginFactory.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginFactory.cs
@@ -210,7 +210,8 @@ namespace NuGet.Protocol.Plugins
 
                 var sender = new Sender(pluginProcess.StandardInput);
                 var receiver = new StandardOutputReceiver(pluginProcess);
-                var messageDispatcher = new MessageDispatcher(requestHandlers, new RequestIdGenerator(), _logger);
+                var processingContext = new InboundRequestProcessingHandler(new HashSet<MessageMethod> { MessageMethod.Handshake, MessageMethod.Log});
+                var messageDispatcher = new MessageDispatcher(requestHandlers, new RequestIdGenerator(), processingContext, _logger);
                 connection = new Connection(messageDispatcher, sender, receiver, options, _logger);
 
                 var plugin = new Plugin(
@@ -317,7 +318,7 @@ namespace NuGet.Protocol.Plugins
                 WriteCommonLogMessages(logger);
             }
 
-            var messageDispatcher = new MessageDispatcher(requestHandlers, new RequestIdGenerator(), logger);
+            var messageDispatcher = new MessageDispatcher(requestHandlers, new RequestIdGenerator(), new InboundRequestProcessingHandler(), logger);
             var connection = new Connection(messageDispatcher, sender, receiver, options, logger);
             var pluginProcess = new PluginProcess();
 

--- a/src/NuGet.Core/NuGet.Protocol/Utility/DedicatedAsynchronousProcessingThread.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Utility/DedicatedAsynchronousProcessingThread.cs
@@ -22,6 +22,10 @@ namespace NuGet.Protocol
         private readonly int _pollingDelayInMilliseconds;
         private readonly ConcurrentQueue<Func<Task>> _taskQueue = new ConcurrentQueue<Func<Task>>();
 
+        /// <summary>
+        /// DedicatedAsync processing thread.
+        /// </summary>
+        /// <param name="pollingDelayInMilliseconds">The await delay when there are no tasks in the queue.</param>
         public DedicatedAsynchronousProcessingThread(int pollingDelayInMilliseconds = 50)
         {
             _pollingDelayInMilliseconds = pollingDelayInMilliseconds;
@@ -39,6 +43,10 @@ namespace NuGet.Protocol
                 TaskScheduler.Default);
         }
 
+        /// <summary>
+        /// Queueus a task for execution.
+        /// </summary>
+        /// <param name="task">Task to be executed.</param>
         internal void Push(Func<Task> task)
         {
             ThrowIfDisposed();

--- a/src/NuGet.Core/NuGet.Protocol/Utility/DedicatedAsynchronousProcessingThread.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Utility/DedicatedAsynchronousProcessingThread.cs
@@ -10,7 +10,7 @@ namespace NuGet.Protocol
 {
     /// <summary>
     /// This class represents a dedicated asynchronous task processing thread.
-    /// Uses a queue to execute all the tasks added through the invocation of <see cref="Push(Func{Task})"/>.
+    /// Uses a queue to execute all the tasks added through the invocation of <see cref="Enqueue(Func{Task})"/>.
     /// The tasks queued here cannot be awaited (think Task.Run, rather than Task.WhenAny/WhenAll).
     /// This implementation is internal on purpose as this is specifically tailed to the plugin V2 use-case.
     /// </summary>
@@ -47,7 +47,7 @@ namespace NuGet.Protocol
         /// Queueus a task for execution.
         /// </summary>
         /// <param name="task">Task to be executed.</param>
-        internal void Push(Func<Task> task)
+        internal void Enqueue(Func<Task> task)
         {
             ThrowIfDisposed();
             ThrowIfNotAlreadyStarted();

--- a/src/NuGet.Core/NuGet.Protocol/Utility/DedicatedAsynchronousProcessingThread.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Utility/DedicatedAsynchronousProcessingThread.cs
@@ -14,21 +14,21 @@ namespace NuGet.Protocol
     /// The tasks queued here cannot be awaited (think Task.Run, rather than Task.WhenAny/WhenAll).
     /// This implementation is internal on purpose as this is specifically tailed to the plugin V2 use-case.
     /// </summary>
-    internal class DedicatedAsynchronousProcessingThread : IDisposable
+    internal sealed class DedicatedAsynchronousProcessingThread : IDisposable
     {
         private Task _processingThread;
         private bool _isDisposed;
         private bool _isClosed;
-        private readonly int _pollingDelayInMilliseconds;
+        private TimeSpan _pollingDelay;
         private readonly ConcurrentQueue<Func<Task>> _taskQueue = new ConcurrentQueue<Func<Task>>();
 
         /// <summary>
         /// DedicatedAsync processing thread.
         /// </summary>
-        /// <param name="pollingDelayInMilliseconds">The await delay when there are no tasks in the queue.</param>
-        public DedicatedAsynchronousProcessingThread(int pollingDelayInMilliseconds = 50)
+        /// <param name="pollingDelay">The await delay when there are no tasks in the queue.</param>
+        public DedicatedAsynchronousProcessingThread(TimeSpan pollingDelay)
         {
-            _pollingDelayInMilliseconds = pollingDelayInMilliseconds;
+            _pollingDelay = pollingDelay;
         }
 
         internal void Start()
@@ -66,7 +66,7 @@ namespace NuGet.Protocol
                     }
                     else
                     {
-                        await Task.Delay(_pollingDelayInMilliseconds);
+                        await Task.Delay(_pollingDelay.Milliseconds);
                     }
                 }
                 catch

--- a/src/NuGet.Core/NuGet.Protocol/Utility/DedicatedAsynchronousProcessingThread.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Utility/DedicatedAsynchronousProcessingThread.cs
@@ -1,0 +1,107 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NuGet.Protocol
+{
+    /// <summary>
+    /// This class represents a dedicated asynchronous task processing thread.
+    /// Uses a queue to execute all the tasks added through the invocation of <see cref="Push(Func{Task})"/>.
+    /// The tasks queued here cannot be awaited (think Task.Run, rather than Task.WhenAny/WhenAll).
+    /// This implementation is internal on purpose as this is specifically tailed to the plugin V2 use-case.
+    /// </summary>
+    internal class DedicatedAsynchronousProcessingThread : IDisposable
+    {
+        private Task _processingThread;
+        private bool _isDisposed;
+        private bool _isClosed;
+        private readonly int _pollingDelayInMilliseconds;
+        private readonly ConcurrentQueue<Func<Task>> _taskQueue = new ConcurrentQueue<Func<Task>>();
+
+        public DedicatedAsynchronousProcessingThread(int pollingDelayInMilliseconds = 50)
+        {
+            _pollingDelayInMilliseconds = pollingDelayInMilliseconds;
+        }
+
+        internal void Start()
+        {
+            ThrowIfDisposed();
+            ThrowIfAlreadyStarted();
+
+            _processingThread = Task.Factory.StartNew(
+                ProcessAsync,
+                CancellationToken.None,
+                TaskCreationOptions.LongRunning | TaskCreationOptions.DenyChildAttach,
+                TaskScheduler.Default);
+        }
+
+        internal void Push(Func<Task> task)
+        {
+            ThrowIfDisposed();
+            ThrowIfNotAlreadyStarted();
+            _taskQueue.Enqueue(task);
+        }
+
+        private async Task ProcessAsync()
+        {
+            while (!_isClosed)
+            {
+                try
+                {
+                    if (_taskQueue.TryDequeue(out var result))
+                    {
+                        await result();
+                    }
+                    else
+                    {
+                        await Task.Delay(_pollingDelayInMilliseconds);
+                    }
+                }
+                catch
+                {
+                }
+            }
+        }
+
+        public void Dispose()
+        {
+            if (_isDisposed)
+            {
+                return;
+            }
+
+            _isClosed = true;
+
+            GC.SuppressFinalize(this);
+
+            _isDisposed = true;
+        }
+
+        private void ThrowIfAlreadyStarted()
+        {
+            if (_processingThread != null)
+            {
+                throw new InvalidOperationException("The processing thread is already started.");
+            }
+        }
+
+        private void ThrowIfNotAlreadyStarted()
+        {
+            if (_processingThread == null)
+            {
+                throw new InvalidOperationException("The processing thread is not started yet.");
+            }
+        }
+        private void ThrowIfDisposed()
+        {
+            if (_isDisposed)
+            {
+                throw new ObjectDisposedException(GetType().Name);
+            }
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/DedicatedAsynchronousProcessingThreadTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/DedicatedAsynchronousProcessingThreadTests.cs
@@ -1,0 +1,123 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Xunit;
+
+namespace NuGet.Protocol.Tests
+{
+    public class DedicatedAsynchronousProcessingThreadTests
+    {
+        [Fact]
+        public void Dispose_IsIdempotent()
+        {
+            using (var thread = new DedicatedAsynchronousProcessingThread())
+            {
+                thread.Dispose();
+                thread.Dispose();
+            }
+        }
+
+        [Fact]
+        public void Start_ThrowsForDisposesObject()
+        {
+            var thread = new DedicatedAsynchronousProcessingThread();
+            thread.Dispose();
+            Assert.Throws<ObjectDisposedException>(() => thread.Start());
+        }
+
+        [Fact]
+        public void Push_ThrowsForDisposesObject()
+        {
+            var thread = new DedicatedAsynchronousProcessingThread();
+            thread.Start();
+            thread.Dispose();
+
+            Assert.Throws<ObjectDisposedException>(() => thread.Push(() => Task.CompletedTask));
+        }
+
+        [Fact]
+        public void Start_ThrowsForAlreadyStartedObject()
+        {
+            using (var thread = new DedicatedAsynchronousProcessingThread())
+            {
+                thread.Start();
+                var exception = Assert.Throws<InvalidOperationException>(() => thread.Start());
+                exception.Message.Should().Be("The processing thread is already started.");
+            }
+        }
+
+        [Fact]
+        public void Push_ThrowsForNotStartedObject()
+        {
+            using (var thread = new DedicatedAsynchronousProcessingThread())
+            {
+                var exception = Assert.Throws<InvalidOperationException>(() => thread.Push(() => Task.CompletedTask));
+                exception.Message.Should().Be("The processing thread is not started yet.");
+            }
+        }
+
+        [Fact]
+        public void Push_ExecutesTaskAsynchronously()
+        {
+            using (var thread = new DedicatedAsynchronousProcessingThread())
+            using (var handledEvent = new ManualResetEventSlim(initialState: false))
+            {
+                thread.Start();
+                var executed = false;
+                Func<Task> task = () => { executed = true; handledEvent.Set(); return Task.CompletedTask; };
+                thread.Push(task);
+                handledEvent.Wait();
+                Assert.True(executed);
+            }
+        }
+
+        [Fact]
+        public void Push_ExecutesTaskAsynchronouslyInSameOrderAsPush()
+        {
+            using (var countdownEvent = new CountdownEvent(3))
+            using (var thread = new DedicatedAsynchronousProcessingThread())
+            {
+                thread.Start();
+                var queue = new Queue<int>();
+
+                Func<Task> task1 = () => { queue.Enqueue(1); countdownEvent.Signal(); return Task.CompletedTask; };
+                Func<Task> task2 = () => { queue.Enqueue(2); countdownEvent.Signal(); return Task.CompletedTask; };
+                Func<Task> task3 = () => { queue.Enqueue(3); countdownEvent.Signal(); return Task.CompletedTask; };
+
+                thread.Push(task1);
+                thread.Push(task2);
+                thread.Push(task3);
+
+                countdownEvent.Wait();
+                Assert.Equal(1, queue.Dequeue());
+                Assert.Equal(2, queue.Dequeue());
+                Assert.Equal(3, queue.Dequeue());
+                Assert.Empty(queue);
+            }
+        }
+
+        [Fact]
+        public void Push_ExecutesNoLaterThanDelay()
+        {
+            var delay = 100;
+            var tolerance = 5;
+            using (var handledEvent = new ManualResetEventSlim(initialState: false))
+            using (var thread = new DedicatedAsynchronousProcessingThread(delay))
+            {
+                thread.Start();
+                var stopwatch = new Stopwatch();
+                Func<Task> task1 = () => { stopwatch.Stop(); handledEvent.Set(); return Task.CompletedTask; };
+                stopwatch.Start();
+                thread.Push(task1);
+                handledEvent.Wait();
+                Assert.True(delay + tolerance > stopwatch.ElapsedMilliseconds);
+            }
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/ConnectionTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/ConnectionTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -503,13 +504,13 @@ namespace NuGet.Protocol.Plugins.Tests
                 _simulatedIpc = SimulatedIpc.Create(_combinedCancellationTokenSource.Token);
                 _remoteSender = new Sender(_simulatedIpc.RemoteStandardOutputForRemote);
                 _remoteReceiver = new StandardInputReceiver(_simulatedIpc.RemoteStandardInputForRemote);
-                _remoteDispatcher = new MessageDispatcher(new RequestHandlers(), new RequestIdGenerator(), new InboundRequestProcessingHandler(), localLogger);
+                _remoteDispatcher = new MessageDispatcher(new RequestHandlers(), new RequestIdGenerator(), new InboundRequestProcessingHandler(Enumerable.Empty<MessageMethod>()), localLogger);
                 LocalToRemoteConnection = new Connection(_remoteDispatcher, _remoteSender, _remoteReceiver, localToRemoteOptions, localLogger);
 
                 var remoteLogger = Logger.CreateLogger("B");
                 _localSender = new Sender(_simulatedIpc.RemoteStandardInputForLocal);
                 _localReceiver = new StandardInputReceiver(_simulatedIpc.RemoteStandardOutputForLocal);
-                _localDispatcher = new MessageDispatcher(new RequestHandlers(), new RequestIdGenerator(), new InboundRequestProcessingHandler(), remoteLogger);
+                _localDispatcher = new MessageDispatcher(new RequestHandlers(), new RequestIdGenerator(), new InboundRequestProcessingHandler(Enumerable.Empty<MessageMethod>()), remoteLogger);
                 RemoteToLocalConnection = new Connection(_localDispatcher, _localSender, _localReceiver, remoteToLocalOptions, remoteLogger);
                 CancellationToken = _combinedCancellationTokenSource.Token;
             }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/ConnectionTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/ConnectionTests.cs
@@ -503,13 +503,13 @@ namespace NuGet.Protocol.Plugins.Tests
                 _simulatedIpc = SimulatedIpc.Create(_combinedCancellationTokenSource.Token);
                 _remoteSender = new Sender(_simulatedIpc.RemoteStandardOutputForRemote);
                 _remoteReceiver = new StandardInputReceiver(_simulatedIpc.RemoteStandardInputForRemote);
-                _remoteDispatcher = new MessageDispatcher(new RequestHandlers(), new RequestIdGenerator(), localLogger);
+                _remoteDispatcher = new MessageDispatcher(new RequestHandlers(), new RequestIdGenerator(), new InboundRequestProcessingHandler(), localLogger);
                 LocalToRemoteConnection = new Connection(_remoteDispatcher, _remoteSender, _remoteReceiver, localToRemoteOptions, localLogger);
 
                 var remoteLogger = Logger.CreateLogger("B");
                 _localSender = new Sender(_simulatedIpc.RemoteStandardInputForLocal);
                 _localReceiver = new StandardInputReceiver(_simulatedIpc.RemoteStandardOutputForLocal);
-                _localDispatcher = new MessageDispatcher(new RequestHandlers(), new RequestIdGenerator(), remoteLogger);
+                _localDispatcher = new MessageDispatcher(new RequestHandlers(), new RequestIdGenerator(), new InboundRequestProcessingHandler(), remoteLogger);
                 RemoteToLocalConnection = new Connection(_localDispatcher, _localSender, _localReceiver, remoteToLocalOptions, remoteLogger);
                 CancellationToken = _combinedCancellationTokenSource.Token;
             }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/InboundRequestContextTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/InboundRequestContextTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Moq;
@@ -59,7 +60,7 @@ namespace NuGet.Protocol.Plugins.Tests
                     Mock.Of<IConnection>(),
                     requestId: "a",
                     cancellationToken: CancellationToken.None,
-                    inboundRequestProcessingHandler: new InboundRequestProcessingHandler(),
+                    inboundRequestProcessingHandler: new InboundRequestProcessingHandler(Enumerable.Empty<MessageMethod>()),
                     logger: null));
 
             Assert.Equal("logger", exception.ParamName);

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/InboundRequestProcessingHandlerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/InboundRequestProcessingHandlerTests.cs
@@ -1,0 +1,86 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.Protocol.Plugins;
+using Xunit;
+
+namespace NuGet.Protocol.Tests.Plugins
+{
+    public class InboundRequestProcessingHandlerTests
+    {
+        [Fact]
+        public void Constructor_ThrowsForNullSet()
+        {
+            var exception = Assert.Throws<ArgumentNullException>(
+                () => new InboundRequestProcessingHandler(fastProcessingMethods: null));
+
+            Assert.Equal("fastProcessingMethods", exception.ParamName);
+        }
+
+        [Fact]
+        public void Dispose_IsIdempotent()
+        {
+            using (var handler = new InboundRequestProcessingHandler())
+            {
+                handler.Dispose();
+                handler.Dispose();
+            }
+        }
+
+
+        [Fact]
+        public void Handle_NoFastProcessingMethods_ExecuteTask()
+        {
+            using (var handledEvent = new ManualResetEventSlim(initialState: false))
+            using (var handler = new InboundRequestProcessingHandler())
+            {
+                var executed = false;
+                Func<Task> task = () => { executed = true; handledEvent.Set(); return Task.CompletedTask; };
+
+                handler.Handle(MessageMethod.Handshake, task, CancellationToken.None);
+                handledEvent.Wait();
+                Assert.True(executed);
+            }
+        }
+
+        [Fact]
+        public void Handle_ForFastProcessingMethods_ExecuteTask()
+        {
+            var method = MessageMethod.Handshake;
+            using (var handledEvent = new ManualResetEventSlim(initialState: false))
+            using (var handler = new InboundRequestProcessingHandler(new HashSet<MessageMethod>() { method }))
+            {
+                var executed = false;
+                Func<Task> task = () => { executed = true; handledEvent.Set(); return Task.CompletedTask; };
+
+                handler.Handle(method, task, CancellationToken.None);
+                handledEvent.Wait();
+                Assert.True(executed);
+            }
+        }
+
+        [Fact]
+        public void Handle_ThrowsForDisposedObject()
+        {
+            using (var handledEvent = new ManualResetEventSlim(initialState: false))
+            {
+                var handler = new InboundRequestProcessingHandler();
+
+                var executed = false;
+                Func<Task> task = () => { executed = true; handledEvent.Set(); return Task.CompletedTask; };
+
+                handler.Handle(MessageMethod.Handshake, task, CancellationToken.None);
+                handledEvent.Wait();
+                Assert.True(executed);
+                handler.Dispose();
+
+                // Act & Assert
+                Assert.Throws<ObjectDisposedException>(() => handler.Handle(MessageMethod.Handshake, task, CancellationToken.None));
+            }
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/InboundRequestProcessingHandlerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/InboundRequestProcessingHandlerTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Protocol.Plugins;
@@ -24,7 +25,7 @@ namespace NuGet.Protocol.Tests.Plugins
         [Fact]
         public void Dispose_IsIdempotent()
         {
-            using (var handler = new InboundRequestProcessingHandler())
+            using (var handler = new InboundRequestProcessingHandler(Enumerable.Empty<MessageMethod>()))
             {
                 handler.Dispose();
                 handler.Dispose();
@@ -36,7 +37,7 @@ namespace NuGet.Protocol.Tests.Plugins
         public void Handle_NoFastProcessingMethods_ExecuteTask()
         {
             using (var handledEvent = new ManualResetEventSlim(initialState: false))
-            using (var handler = new InboundRequestProcessingHandler())
+            using (var handler = new InboundRequestProcessingHandler(Enumerable.Empty<MessageMethod>()))
             {
                 var executed = false;
                 Func<Task> task = () => { executed = true; handledEvent.Set(); return Task.CompletedTask; };
@@ -68,7 +69,7 @@ namespace NuGet.Protocol.Tests.Plugins
         {
             using (var handledEvent = new ManualResetEventSlim(initialState: false))
             {
-                var handler = new InboundRequestProcessingHandler();
+                var handler = new InboundRequestProcessingHandler(Enumerable.Empty<MessageMethod>());
 
                 var executed = false;
                 Func<Task> task = () => { executed = true; handledEvent.Set(); return Task.CompletedTask; };

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Logging/AssemblyLogMessageTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Logging/AssemblyLogMessageTests.cs
@@ -17,26 +17,31 @@ namespace NuGet.Protocol.Plugins.Tests
 
             var message = VerifyOuterMessageAndReturnInnerMessage(logMessage, now, "assembly");
 
-            Assert.Equal(3, message.Count);
+            Assert.Equal(4, message.Count);
 
             var actualAssemblyFullName = message.Value<string>("assembly full name");
             var actualFileVersion = message.Value<string>("file version");
             var actualInformationalVersion = message.Value<string>("informational version");
+            var actualEntryAssemblyFullName = message.Value<string>("entry assembly full name");
 
             GetExpectedValues(
                 out var expectedAssemblyFullName,
                 out var expectedFileVersion,
-                out var expectedActualInformationalVersion);
+                out var expectedActualInformationalVersion,
+                out var expectedEntryAssemblyFullName);
 
             Assert.Equal(expectedAssemblyFullName, actualAssemblyFullName);
             Assert.Equal(expectedFileVersion, actualFileVersion);
             Assert.Equal(expectedActualInformationalVersion, actualInformationalVersion);
+            Assert.Equal(expectedEntryAssemblyFullName, actualEntryAssemblyFullName);
+
         }
 
         private static void GetExpectedValues(
             out object expectedAssemblyFullName,
             out object expectedFileVersion,
-            out object expectedActualInformationalVersion)
+            out object expectedActualInformationalVersion,
+            out object expectedEntryAssemblyFullName)
         {
             var assembly = typeof(PluginFactory).Assembly;
             var informationalVersionAttribute = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>();
@@ -45,6 +50,7 @@ namespace NuGet.Protocol.Plugins.Tests
             expectedAssemblyFullName = assembly.FullName;
             expectedFileVersion = fileVersionAttribute.Version;
             expectedActualInformationalVersion = informationalVersionAttribute.InformationalVersion;
+            expectedEntryAssemblyFullName = Assembly.GetEntryAssembly()?.FullName;
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Logging/ProcessLogMessageTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Logging/ProcessLogMessageTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Diagnostics;
 using FluentAssertions;
+using NuGet.Common;
 using Xunit;
 
 namespace NuGet.Protocol.Plugins.Tests
@@ -38,7 +39,10 @@ namespace NuGet.Protocol.Plugins.Tests
 
             actualProcessId.Should().Be(expectedProcessId);
             actualProcessName.Should().Be(expectedProcessName);
-            actualProcessStartTime.Should().Be(expectedProcessStartTime);
+            if (!RuntimeEnvironmentHelper.IsMono)
+            {
+                actualProcessStartTime.Should().Be(expectedProcessStartTime);
+            }
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Logging/ProcessLogMessageTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Logging/ProcessLogMessageTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics;
+using FluentAssertions;
 using Xunit;
 
 namespace NuGet.Protocol.Plugins.Tests
@@ -35,9 +36,9 @@ namespace NuGet.Protocol.Plugins.Tests
             var actualProcessName = message.Value<string>("process name");
             var actualProcessStartTime = message.Value<string>("process start time");
 
-            Assert.Equal(expectedProcessId, actualProcessId);
-            Assert.Equal(expectedProcessName, actualProcessName);
-            Assert.Equal(expectedProcessStartTime, actualProcessStartTime);
+            actualProcessId.Should().Be(expectedProcessId);
+            actualProcessName.Should().Be(expectedProcessName);
+            actualProcessStartTime.Should().Be(expectedProcessStartTime);
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Logging/ProcessLogMessageTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Logging/ProcessLogMessageTests.cs
@@ -18,22 +18,26 @@ namespace NuGet.Protocol.Plugins.Tests
 
             var message = VerifyOuterMessageAndReturnInnerMessage(logMessage, now, "process");
 
-            Assert.Equal(2, message.Count);
+            Assert.Equal(3, message.Count);
 
             int expectedProcessId;
             string expectedProcessName;
+            string expectedProcessStartTime;
 
             using (var process = Process.GetCurrentProcess())
             {
                 expectedProcessId = process.Id;
                 expectedProcessName = process.ProcessName;
+                expectedProcessStartTime = process.StartTime.ToUniversalTime().ToString("O");
             }
 
             var actualProcessId = message.Value<int>("process ID");
             var actualProcessName = message.Value<string>("process name");
+            var actualProcessStartTime = message.Value<string>("process start time");
 
             Assert.Equal(expectedProcessId, actualProcessId);
             Assert.Equal(expectedProcessName, actualProcessName);
+            Assert.Equal(expectedProcessStartTime, actualProcessStartTime);
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Logging/ProcessLogMessageTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Logging/ProcessLogMessageTests.cs
@@ -24,13 +24,11 @@ namespace NuGet.Protocol.Plugins.Tests
 
             int expectedProcessId;
             string expectedProcessName;
-            string expectedProcessStartTime;
 
             using (var process = Process.GetCurrentProcess())
             {
                 expectedProcessId = process.Id;
                 expectedProcessName = process.ProcessName;
-                expectedProcessStartTime = process.StartTime.ToUniversalTime().ToString("O");
             }
 
             var actualProcessId = message.Value<int>("process ID");
@@ -39,10 +37,7 @@ namespace NuGet.Protocol.Plugins.Tests
 
             actualProcessId.Should().Be(expectedProcessId);
             actualProcessName.Should().Be(expectedProcessName);
-            if (!RuntimeEnvironmentHelper.IsMono)
-            {
-                actualProcessStartTime.Should().Be(expectedProcessStartTime);
-            }
+            actualProcessStartTime.Should().NotBeNull(); // do not assert due to accuracy problems on Mac.
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/MessageDispatcherTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/MessageDispatcherTests.cs
@@ -48,7 +48,7 @@ namespace NuGet.Protocol.Plugins.Tests
         }
 
         [Fact]
-        public void Constructor_ThrowsForNullInboundRequestProcessingContext()
+        public void Constructor_ThrowsForNullInboundRequestProcessinHandler()
         {
             var exception = Assert.Throws<ArgumentNullException>(
                 () => new MessageDispatcher(new RequestHandlers(), new ConstantIdGenerator(), inboundRequestProcessingHandler: null, logger: PluginLogger.DefaultInstance));
@@ -146,8 +146,8 @@ namespace NuGet.Protocol.Plugins.Tests
         [Fact]
         public void Close_WithDedicatedProcessingContext_DisposesAllActiveInboundRequests()
         {
-            using (var processingContext = new InboundRequestProcessingHandler(new HashSet<MessageMethod>() { MessageMethod.Handshake }))
-            using (var dispatcher = new MessageDispatcher(new RequestHandlers(), _idGenerator, processingContext, PluginLogger.DefaultInstance))
+            using (var processingHandler = new InboundRequestProcessingHandler(new HashSet<MessageMethod>() { MessageMethod.Handshake }))
+            using (var dispatcher = new MessageDispatcher(new RequestHandlers(), _idGenerator, processingHandler, PluginLogger.DefaultInstance))
             using (var handlingEvent = new ManualResetEventSlim(initialState: false))
             using (var blockingEvent = new ManualResetEventSlim(initialState: false))
             {
@@ -258,14 +258,14 @@ namespace NuGet.Protocol.Plugins.Tests
         }
 
         [Fact]
-        public void Dispose_DisposesInboundRequestProcessingContext()
+        public void Dispose_DisposesInboundRequestProcessingHandler()
         {
-            var context = new InboundRequestProcessingHandler();
+            var processingHandler = new InboundRequestProcessingHandler(new HashSet<MessageMethod>());
 
-            using (var dispatcher = new MessageDispatcher(new RequestHandlers(), _idGenerator, context, PluginLogger.DefaultInstance))
+            using (var dispatcher = new MessageDispatcher(new RequestHandlers(), _idGenerator, processingHandler, PluginLogger.DefaultInstance))
             {
                 dispatcher.Dispose();
-                Assert.Throws<ObjectDisposedException>( () => context.Handle(MessageMethod.Handshake, null, CancellationToken.None));
+                Assert.Throws<ObjectDisposedException>(() => processingHandler.Handle(MessageMethod.Handshake, task: null, CancellationToken.None));
             }
         }
 
@@ -862,10 +862,10 @@ namespace NuGet.Protocol.Plugins.Tests
         }
 
         [Fact]
-        public async Task OnMessageReceived_WithDedicatedProcessingContext_DoesNotThrowForResponseAfterWaitForResponseIsCancelled()
+        public async Task OnMessageReceived_WithDedicatedProcessingHandler_DoesNotThrowForResponseAfterWaitForResponseIsCancelled()
         {
-            using (var context = new InboundRequestProcessingHandler(new HashSet<MessageMethod> { MessageMethod.PrefetchPackage }))
-            using (var dispatcher = new MessageDispatcher(new RequestHandlers(), _idGenerator, context, PluginLogger.DefaultInstance))
+            using (var processingHandler = new InboundRequestProcessingHandler(new HashSet<MessageMethod> { MessageMethod.PrefetchPackage }))
+            using (var dispatcher = new MessageDispatcher(new RequestHandlers(), _idGenerator, processingHandler, PluginLogger.DefaultInstance))
             using (var cancellationTokenSource = new CancellationTokenSource())
             using (var sentEvent = new ManualResetEventSlim(initialState: false))
             {
@@ -1055,8 +1055,8 @@ namespace NuGet.Protocol.Plugins.Tests
         [Fact]
         public void OnMessageReceived_WithDedicatedProcessingContext_CallsBackIntoHandler()
         {
-            using (var processingContext = new InboundRequestProcessingHandler(new HashSet<MessageMethod>() { MessageMethod.Handshake }))
-            using (var dispatcher = new MessageDispatcher(new RequestHandlers(), _idGenerator, processingContext, PluginLogger.DefaultInstance))
+            using (var processingHandler = new InboundRequestProcessingHandler(new HashSet<MessageMethod>() { MessageMethod.Handshake }))
+            using (var dispatcher = new MessageDispatcher(new RequestHandlers(), _idGenerator, processingHandler, PluginLogger.DefaultInstance))
             using (var blockingEvent = new ManualResetEventSlim(initialState: false))
             {
                 var requestHandler = new RequestHandler();

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/MessageDispatcherTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/MessageDispatcherTests.cs
@@ -51,9 +51,9 @@ namespace NuGet.Protocol.Plugins.Tests
         public void Constructor_ThrowsForNullInboundRequestProcessingContext()
         {
             var exception = Assert.Throws<ArgumentNullException>(
-                () => new MessageDispatcher(new RequestHandlers(), new ConstantIdGenerator(), inboundRequestProcessingContext: null, logger: PluginLogger.DefaultInstance));
+                () => new MessageDispatcher(new RequestHandlers(), new ConstantIdGenerator(), inboundRequestProcessingHandler: null, logger: PluginLogger.DefaultInstance));
 
-            Assert.Equal("inboundRequestProcessingContext", exception.ParamName);
+            Assert.Equal("inboundRequestProcessingHandler", exception.ParamName);
         }
 
         [Fact]

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/MessageDispatcherTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/MessageDispatcherTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Moq;
@@ -41,9 +42,18 @@ namespace NuGet.Protocol.Plugins.Tests
         public void Constructor_ThrowsForNullLogger()
         {
             var exception = Assert.Throws<ArgumentNullException>(
-                () => new MessageDispatcher(new RequestHandlers(), new ConstantIdGenerator(), logger: null));
+                () => new MessageDispatcher(new RequestHandlers(), new ConstantIdGenerator(), new InboundRequestProcessingHandler(), logger: null));
 
             Assert.Equal("logger", exception.ParamName);
+        }
+
+        [Fact]
+        public void Constructor_ThrowsForNullInboundRequestProcessingContext()
+        {
+            var exception = Assert.Throws<ArgumentNullException>(
+                () => new MessageDispatcher(new RequestHandlers(), new ConstantIdGenerator(), inboundRequestProcessingContext: null, logger: PluginLogger.DefaultInstance));
+
+            Assert.Equal("inboundRequestProcessingContext", exception.ParamName);
         }
 
         [Fact]
@@ -134,6 +144,49 @@ namespace NuGet.Protocol.Plugins.Tests
         }
 
         [Fact]
+        public void Close_WithDedicatedProcessingContext_DisposesAllActiveInboundRequests()
+        {
+            using (var processingContext = new InboundRequestProcessingHandler(new HashSet<MessageMethod>() { MessageMethod.Handshake }))
+            using (var dispatcher = new MessageDispatcher(new RequestHandlers(), _idGenerator, processingContext, PluginLogger.DefaultInstance))
+            using (var handlingEvent = new ManualResetEventSlim(initialState: false))
+            using (var blockingEvent = new ManualResetEventSlim(initialState: false))
+            {
+                var requestHandler = new RequestHandler();
+
+                Assert.True(dispatcher.RequestHandlers.TryAdd(MessageMethod.Handshake, requestHandler));
+
+                var connection = new Mock<IConnection>(MockBehavior.Strict);
+                var payload = new HandshakeRequest(ProtocolConstants.CurrentVersion, ProtocolConstants.CurrentVersion);
+                var request = dispatcher.CreateMessage(MessageType.Request, MessageMethod.Handshake, payload);
+
+                dispatcher.SetConnection(connection.Object);
+
+                var actualCancellationToken = default(CancellationToken);
+
+                requestHandler.HandleResponseAsyncFunc = (conn, message, responseHandler, cancellationToken) =>
+                {
+                    handlingEvent.Set();
+
+                    actualCancellationToken = cancellationToken;
+
+                    blockingEvent.Set();
+
+                    return Task.FromResult(0);
+                };
+
+                connection.Raise(x => x.MessageReceived += null, new MessageEventArgs(request));
+
+                handlingEvent.Wait();
+
+                dispatcher.Close();
+
+                blockingEvent.Wait();
+
+                Assert.True(actualCancellationToken.IsCancellationRequested);
+            }
+        }
+
+        [Fact]
         public void Close_IsIdempotent()
         {
             using (var dispatcher = new MessageDispatcher(new RequestHandlers(), _idGenerator))
@@ -196,11 +249,23 @@ namespace NuGet.Protocol.Plugins.Tests
         {
             var logger = new Mock<IPluginLogger>(MockBehavior.Strict);
 
-            using (var dispatcher = new MessageDispatcher(new RequestHandlers(), _idGenerator, logger.Object))
+            using (var dispatcher = new MessageDispatcher(new RequestHandlers(), _idGenerator, new InboundRequestProcessingHandler(), logger.Object))
             {
                 dispatcher.Dispose();
 
                 logger.Verify();
+            }
+        }
+
+        [Fact]
+        public void Dispose_DisposesInboundRequestProcessingContext()
+        {
+            var context = new InboundRequestProcessingHandler();
+
+            using (var dispatcher = new MessageDispatcher(new RequestHandlers(), _idGenerator, context, PluginLogger.DefaultInstance))
+            {
+                dispatcher.Dispose();
+                Assert.Throws<ObjectDisposedException>( () => context.Handle(MessageMethod.Handshake, null, CancellationToken.None));
             }
         }
 
@@ -797,6 +862,53 @@ namespace NuGet.Protocol.Plugins.Tests
         }
 
         [Fact]
+        public async Task OnMessageReceived_WithDedicatedProcessingContext_DoesNotThrowForResponseAfterWaitForResponseIsCancelled()
+        {
+            using (var context = new InboundRequestProcessingHandler(new HashSet<MessageMethod> { MessageMethod.PrefetchPackage }))
+            using (var dispatcher = new MessageDispatcher(new RequestHandlers(), _idGenerator, context, PluginLogger.DefaultInstance))
+            using (var cancellationTokenSource = new CancellationTokenSource())
+            using (var sentEvent = new ManualResetEventSlim(initialState: false))
+            {
+                var connection = new Mock<IConnection>(MockBehavior.Strict);
+
+                connection.SetupGet(x => x.Options)
+                    .Returns(ConnectionOptions.CreateDefault());
+
+                connection.Setup(x => x.SendAsync(It.IsNotNull<Message>(), It.IsAny<CancellationToken>()))
+                    .Callback<Message, CancellationToken>(
+                        (message, cancellationToken) =>
+                        {
+                            sentEvent.Set();
+                        })
+                    .Returns(Task.FromResult(0));
+
+                dispatcher.SetConnection(connection.Object);
+
+                var outboundRequestTask = Task.Run(() => dispatcher.DispatchRequestAsync<PrefetchPackageRequest, PrefetchPackageResponse>(
+                    MessageMethod.PrefetchPackage,
+                    new PrefetchPackageRequest(
+                        packageSourceRepository: "a",
+                        packageId: "b",
+                        packageVersion: "c"),
+                    cancellationTokenSource.Token));
+
+                sentEvent.Wait();
+
+                cancellationTokenSource.Cancel();
+
+                await Assert.ThrowsAsync<TaskCanceledException>(() => outboundRequestTask);
+
+                var response = MessageUtilities.Create(
+                    _idGenerator.Id,
+                    MessageType.Response,
+                    MessageMethod.PrefetchPackage,
+                    new PrefetchPackageResponse(MessageResponseCode.Success));
+
+                connection.Raise(x => x.MessageReceived += null, new MessageEventArgs(response));
+            }
+        }
+
+        [Fact]
         public async Task OnMessageReceived_DoesNotThrowForCancelResponseAfterWaitForResponseIsCancelled()
         {
             using (var dispatcher = new MessageDispatcher(new RequestHandlers(), _idGenerator))
@@ -937,6 +1049,40 @@ namespace NuGet.Protocol.Plugins.Tests
                 sentEvent.Wait();
 
                 connection.Verify();
+            }
+        }
+
+        [Fact]
+        public void OnMessageReceived_WithDedicatedProcessingContext_CallsBackIntoHandler()
+        {
+            using (var processingContext = new InboundRequestProcessingHandler(new HashSet<MessageMethod>() { MessageMethod.Handshake }))
+            using (var dispatcher = new MessageDispatcher(new RequestHandlers(), _idGenerator, processingContext, PluginLogger.DefaultInstance))
+            using (var blockingEvent = new ManualResetEventSlim(initialState: false))
+            {
+                var requestHandler = new RequestHandler();
+
+                Assert.True(dispatcher.RequestHandlers.TryAdd(MessageMethod.Handshake, requestHandler));
+
+                var connection = new Mock<IConnection>(MockBehavior.Strict);
+                var payload = new HandshakeRequest(ProtocolConstants.CurrentVersion, ProtocolConstants.CurrentVersion);
+                var request = dispatcher.CreateMessage(MessageType.Request, MessageMethod.Handshake, payload);
+
+                dispatcher.SetConnection(connection.Object);
+
+                var responseReceived = false;
+
+                requestHandler.HandleResponseAsyncFunc = (conn, message, responseHandler, cancellationToken) =>
+                {
+                    responseReceived = true;
+                    blockingEvent.Set();
+                    return Task.FromResult(0);
+                };
+
+                connection.Raise(x => x.MessageReceived += null, new MessageEventArgs(request));
+
+                blockingEvent.Wait();
+
+                Assert.True(responseReceived);
             }
         }
 

--- a/test/TestUtilities/Test.Utility/ReadTimeoutHonoringSlowStream.cs
+++ b/test/TestUtilities/Test.Utility/ReadTimeoutHonoringSlowStream.cs
@@ -12,10 +12,6 @@ namespace Test.Utility
     {
         private readonly Stream _innerStream;
         private readonly CancellationToken _cancellationToken;
-<<<<<<< HEAD
-=======
-        private int _readTimeout = int.MaxValue;
->>>>>>> Fix threadpool load induced delayed responses to plugin requests
 
         public ReadTimeoutHonoringSlowStream(Stream innerStream)
             : this(innerStream, CancellationToken.None)
@@ -37,23 +33,14 @@ namespace Test.Utility
             try
             {
                 var expectedDelayInMs = DelayPerByte.TotalMilliseconds * read;
-<<<<<<< HEAD
                 if (ReadTimeout > expectedDelayInMs)
-=======
-                if (_readTimeout > expectedDelayInMs)
->>>>>>> Fix threadpool load induced delayed responses to plugin requests
                 {
                     Task.Delay(new TimeSpan(DelayPerByte.Ticks * read)).Wait(_cancellationToken);
                 }
                 else
                 {
-<<<<<<< HEAD
                     Task.Delay(ReadTimeout).Wait(_cancellationToken);
                     throw new IOException($"..timed out because no data was received for {ReadTimeout}ms.", new TimeoutException());
-=======
-                    Task.Delay(_readTimeout).Wait(_cancellationToken);
-                    throw new IOException($"..timed out because no data was received for {_readTimeout}ms.", new TimeoutException());
->>>>>>> Fix threadpool load induced delayed responses to plugin requests
                 }
             }
             catch (OperationCanceledException)
@@ -63,11 +50,7 @@ namespace Test.Utility
             return read;
         }
 
-<<<<<<< HEAD
         public override int ReadTimeout { get; set; } = Timeout.Infinite;
-=======
-        public override int ReadTimeout { get => _readTimeout; set => _readTimeout = value; }
->>>>>>> Fix threadpool load induced delayed responses to plugin requests
         public override bool CanTimeout => true;
     }
 }

--- a/test/TestUtilities/Test.Utility/ReadTimeoutHonoringSlowStream.cs
+++ b/test/TestUtilities/Test.Utility/ReadTimeoutHonoringSlowStream.cs
@@ -12,6 +12,10 @@ namespace Test.Utility
     {
         private readonly Stream _innerStream;
         private readonly CancellationToken _cancellationToken;
+<<<<<<< HEAD
+=======
+        private int _readTimeout = int.MaxValue;
+>>>>>>> Fix threadpool load induced delayed responses to plugin requests
 
         public ReadTimeoutHonoringSlowStream(Stream innerStream)
             : this(innerStream, CancellationToken.None)
@@ -33,14 +37,23 @@ namespace Test.Utility
             try
             {
                 var expectedDelayInMs = DelayPerByte.TotalMilliseconds * read;
+<<<<<<< HEAD
                 if (ReadTimeout > expectedDelayInMs)
+=======
+                if (_readTimeout > expectedDelayInMs)
+>>>>>>> Fix threadpool load induced delayed responses to plugin requests
                 {
                     Task.Delay(new TimeSpan(DelayPerByte.Ticks * read)).Wait(_cancellationToken);
                 }
                 else
                 {
+<<<<<<< HEAD
                     Task.Delay(ReadTimeout).Wait(_cancellationToken);
                     throw new IOException($"..timed out because no data was received for {ReadTimeout}ms.", new TimeoutException());
+=======
+                    Task.Delay(_readTimeout).Wait(_cancellationToken);
+                    throw new IOException($"..timed out because no data was received for {_readTimeout}ms.", new TimeoutException());
+>>>>>>> Fix threadpool load induced delayed responses to plugin requests
                 }
             }
             catch (OperationCanceledException)
@@ -50,7 +63,11 @@ namespace Test.Utility
             return read;
         }
 
+<<<<<<< HEAD
         public override int ReadTimeout { get; set; } = Timeout.Infinite;
+=======
+        public override int ReadTimeout { get => _readTimeout; set => _readTimeout = value; }
+>>>>>>> Fix threadpool load induced delayed responses to plugin requests
         public override bool CanTimeout => true;
     }
 }


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/8528
Regression: No  
* Last working version:   
* How are we preventing it in future: 

## Fix

Details: The NuGet plugin communication happens through STDOUT/STDIN. 
When NuGet receives something on standard output it is handled on a dedicated thread. 
Once that happens we figure out what kind of message we have and delegate based on the type. 
When we get a request to NuGet we put it on the threadpool https://github.com/NuGet/NuGet.Client/blob/50fe55b45854fddc529507a61d2175a764794bcf/src/NuGet.Core/NuGet.Protocol/Plugins/InboundRequestContext.cs#L214. 
Because this comes from a dedicated thread and we flood the threadpool with requests, it's possible that it takes longer than 5 seconds to get to this request. 
To mitigate, we will add a dedicated thread per NuGet side plugin that handles these requests. 
The plugin side implementation will remain unchanged. 

Resources for reading: 
https://docs.microsoft.com/en-us/dotnet/api/system.threading.tasks.taskscheduler?view=netframework-4.8#the-default-task-scheduler-and-the-thread-pool

Note that this doesn't fix our issues with threadpool starvation (sometiems it's starvation, other times it's working as expected as far as the threadpool is concerned). 
That's a separate task, but when plugins are involved, the starvation is more apparent. 

Impl Details:

The InboundRequestProcessingHandler is the one responsible for ensuring the response task executes. It makes a decision whether to queue it on the threadpool or on the dedicated thread. 
The dedicated thread implementation is a generic task executing implementation. 
Note that only the NuGet side codepaths of the plugin code are affected. 

## Testing/Validation

Tests Added: Yes  
Reason for not adding tests:  
Validation:  Manual, https://dev.azure.com/dnceng/internal/_build/results?buildId=441955 now has a 100% success rate as far as restore goes :) 
