### PR TITLE
Improve VC++ Project support

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectSystems/CpsProjectSystem.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectSystems/CpsProjectSystem.cs
@@ -34,8 +34,23 @@ namespace NuGet.PackageManagement.VisualStudio
                 {
                     await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
-                    var root = VsProjectAdapter.ProjectDirectory;
-                    var relativeTargetPath = PathUtility.GetRelativePath(PathUtility.EnsureTrailingSlash(root), targetFullPath);
+                    string relativeTargetPath = "";
+
+                    var root = Environment.GetEnvironmentVariable("NuGetRepositoryBasePath");
+
+                    if(root.Length !=0)
+                    {
+                        relativeTargetPath = PathUtility.GetRelativePath(PathUtility.EnsureTrailingSlash(root), targetFullPath);
+
+                        relativeTargetPath = "$(NuGetRepositoryBasePath)\\" + relativeTargetPath;
+                    }
+                    else
+                    {
+                        //default
+                        root = VsProjectAdapter.ProjectDirectory;
+                        relativeTargetPath = PathUtility.GetRelativePath(PathUtility.EnsureTrailingSlash(root), targetFullPath);
+                    }
+
                     await AddImportStatementAsync(location, relativeTargetPath);
                 });
         }
@@ -69,6 +84,19 @@ namespace NuGet.PackageManagement.VisualStudio
                     // For VS 2012 or above, the operation has to be done inside the Writer lock
                     var relativeTargetPath = PathUtility.GetRelativePath(PathUtility.EnsureTrailingSlash(root), targetFullPath);
                     await RemoveImportStatementAsync(relativeTargetPath);
+
+
+                    //try remove $(NuGetRepositoryBasePath)
+                    root = Environment.GetEnvironmentVariable("NuGetRepositoryBasePath");
+
+                    if (root.Length != 0)
+                    {
+                        relativeTargetPath = PathUtility.GetRelativePath(PathUtility.EnsureTrailingSlash(root), targetFullPath);
+
+                        relativeTargetPath = "$(NuGetRepositoryBasePath)\\" + relativeTargetPath;
+
+                        await RemoveImportStatementAsync(relativeTargetPath);
+                    }
                 });
         }
 

--- a/src/NuGet.Core/NuGet.PackageManagement/Projects/IMSBuildProjectSystem.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Projects/IMSBuildProjectSystem.cs
@@ -80,6 +80,9 @@ namespace NuGet.ProjectManagement
     public enum ImportLocation
     {
         Top,
-        Bottom
+        Bottom,
+        ExtensionSettings, //VC++ Projrct <ImportGroup Label="ExtensionSettings">
+        Shared,            //VC++ Projrct <ImportGroup Label="Shared">
+        ExtensionTargets,  //VC++ Projrct <ImportGroup Label="ExtensionTargets">
     }
 }

--- a/src/NuGet.Core/NuGet.PackageManagement/Projects/MSBuildNuGetProject.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Projects/MSBuildNuGetProject.cs
@@ -358,8 +358,33 @@ namespace NuGet.ProjectManagement
                 foreach (var buildImportFile in compatibleBuildFilesGroup.Items)
                 {
                     var fullImportFilePath = Path.Combine(packageInstallPath, buildImportFile);
-                    ProjectSystem.AddImport(fullImportFilePath,
-                        fullImportFilePath.EndsWith(".props", StringComparison.OrdinalIgnoreCase) ? ImportLocation.Top : ImportLocation.Bottom);
+
+                    var importFileName = Path.GetFileName(fullImportFilePath);
+
+                    ImportLocation Location = ImportLocation.Bottom;
+
+                    if (importFileName.Equals(packageIdentity.Id + ".props", StringComparison.OrdinalIgnoreCase))
+                    {
+                        Location = ImportLocation.Top;
+                    }
+                    else if (importFileName.Equals(packageIdentity.Id + ".targets", StringComparison.OrdinalIgnoreCase))
+                    {
+                        Location = ImportLocation.Bottom;
+                    }
+                    else if (importFileName.Equals(packageIdentity.Id + ".vcxitems", StringComparison.OrdinalIgnoreCase))
+                    {
+                        Location = ImportLocation.Shared;
+                    }
+                    else if (importFileName.Equals(packageIdentity.Id + ".Extension.props", StringComparison.OrdinalIgnoreCase))
+                    {
+                        Location = ImportLocation.ExtensionSettings;
+                    }
+                    else if (importFileName.Equals(packageIdentity.Id + ".Extension.targets", StringComparison.OrdinalIgnoreCase))
+                    {
+                        Location = ImportLocation.ExtensionTargets;
+                    }
+
+                    ProjectSystem.AddImport(fullImportFilePath, Location);
                 }
             }
 

--- a/src/NuGet.Core/NuGet.Packaging/ContentModel/ManagedCodeConventions.cs
+++ b/src/NuGet.Core/NuGet.Packaging/ContentModel/ManagedCodeConventions.cs
@@ -28,7 +28,7 @@ namespace NuGet.Client
             fileExtensions: new[] { ".dll", ".winmd", ".exe" });
         private static readonly ContentPropertyDefinition MSBuildProperty = new ContentPropertyDefinition(PropertyNames.MSBuild,
             parser: AllowEmptyFolderParser,
-            fileExtensions: new[] { ".targets", ".props" });
+            fileExtensions: new[] { ".targets", ".props", ".vcxitems" });
         private static readonly ContentPropertyDefinition SatelliteAssemblyProperty = new ContentPropertyDefinition(PropertyNames.SatelliteAssembly,
             parser: AllowEmptyFolderParser,
             fileExtensions: new[] { ".resources.dll" });

--- a/src/NuGet.Core/NuGet.Packaging/PackageReaderBase.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageReaderBase.cs
@@ -486,7 +486,10 @@ namespace NuGet.Packaging
             var file = Path.GetFileName(path);
 
             return StringComparer.OrdinalIgnoreCase.Equals(file, string.Format(CultureInfo.InvariantCulture, "{0}.targets", packageId))
-                   || StringComparer.OrdinalIgnoreCase.Equals(file, string.Format(CultureInfo.InvariantCulture, "{0}.props", packageId));
+                   || StringComparer.OrdinalIgnoreCase.Equals(file, string.Format(CultureInfo.InvariantCulture, "{0}.props", packageId))
+                   || StringComparer.OrdinalIgnoreCase.Equals(file, string.Format(CultureInfo.InvariantCulture, "{0}.vcxitems", packageId))
+                   || StringComparer.OrdinalIgnoreCase.Equals(file, string.Format(CultureInfo.InvariantCulture, "{0}.Extension.targets", packageId))
+                   || StringComparer.OrdinalIgnoreCase.Equals(file, string.Format(CultureInfo.InvariantCulture, "{0}.Extension.props", packageId));
         }
 
         /// <summary>


### PR DESCRIPTION
## Future 1

add NuGetRepositoryBasePath Variable support, Facilitate team members to configure their own base paths.

When working in a team, different people have different code paths, and each sln saves a package, which takes up too much space, so the NuGetRepositoryBasePath environment variable has been added to manually specify the package root directory.


## Future 2
add VC++ Project Shared ImportGroup, ExtensionSettings ImportGroup and ExtensionTargets ImportGroup support.

C ++ projects are often complicated, so we want to add our imports in more places in some cases.

Thanks


