### PR TITLE
Add packages.config support to msbuild /restore

### DIFF
--- a/NuGet.sln
+++ b/NuGet.sln
@@ -1,4 +1,3 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.28404.58
@@ -235,6 +234,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NuGet.Packaging.Core", "src\NuGet.Core\NuGet.Packaging.Core\NuGet.Packaging.Core.csproj", "{02B7C422-C592-4BA6-89A7-ACBD7923B34D}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NuGet.Tools.Test", "test\NuGet.Clients.Tests\NuGet.Tools.Test\NuGet.Tools.Test.csproj", "{437C6B7E-B625-4AE5-A4CE-F2B3747FE1CE}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Msbuild.Integration.Test", "test\NuGet.Core.FuncTests\Msbuild.Integration.Test\Msbuild.Integration.Test.csproj", "{92EF44DB-4F40-4610-A1AD-3A554A0CA8B9}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -566,6 +567,10 @@ Global
 		{437C6B7E-B625-4AE5-A4CE-F2B3747FE1CE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{437C6B7E-B625-4AE5-A4CE-F2B3747FE1CE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{437C6B7E-B625-4AE5-A4CE-F2B3747FE1CE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{92EF44DB-4F40-4610-A1AD-3A554A0CA8B9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{92EF44DB-4F40-4610-A1AD-3A554A0CA8B9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{92EF44DB-4F40-4610-A1AD-3A554A0CA8B9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{92EF44DB-4F40-4610-A1AD-3A554A0CA8B9}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -662,6 +667,7 @@ Global
 		{98A04824-9BCE-48BD-8544-916F3F0007D0} = {23CEFC88-9365-4464-A517-700224ECA033}
 		{02B7C422-C592-4BA6-89A7-ACBD7923B34D} = {506AF844-92E0-4404-BBFC-0AB073890A72}
 		{437C6B7E-B625-4AE5-A4CE-F2B3747FE1CE} = {01BC4531-1E25-48D7-A8FD-A47D6FEC47FB}
+		{92EF44DB-4F40-4610-A1AD-3A554A0CA8B9} = {BB63CACA-866F-454F-BA4C-78B788D032BB}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {3747A66A-00D1-41B8-A9C5-ED0D7BEA9D25}

--- a/build/common.project.props
+++ b/build/common.project.props
@@ -246,7 +246,8 @@
                                    $(RepositoryRootDirectory)test\NuGet.Core.Tests\*.Utility\*.csproj;
                                    $(RepositoryRootDirectory)test\NuGet.Core.Tests\NuGet.Credentials.Test\*.csproj;
                                    $(RepositoryRootDirectory)test\NuGet.Core.Tests\NuGet.Indexing.Test\*.csproj" />
-    <CoreFuncTestProjects Include="$(RepositoryRootDirectory)test\NuGet.Core.FuncTests\*\*.csproj" />
+    <CoreFuncTestProjects Include="$(RepositoryRootDirectory)test\NuGet.Core.FuncTests\*\*.csproj"
+                          Exclude="$(RepositoryRootDirectory)test\NuGet.Core.FuncTests\Msbuild.Integration.Test\*.csproj" />
   </ItemGroup>
 
   <!-- All projects in the repository -->

--- a/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreSettingsTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreSettingsTask.cs
@@ -26,6 +26,8 @@ namespace NuGet.Build.Tasks
 
         public string RestorePackagesPath { get; set; }
 
+        public string RestoreRepositoryPath { get; set; }
+
         public string[] RestoreFallbackFolders { get; set; }
 
         public string RestoreConfigFile { get; set; }
@@ -46,6 +48,8 @@ namespace NuGet.Build.Tasks
         /// Command line value of RestorePackagesPath
         /// </summary>
         public string RestorePackagesPathOverride { get; set; }
+
+        public string RestoreRepositoryPathOverride { get; set; }
 
         /// <summary>
         /// Command line value of RestoreSources
@@ -73,6 +77,9 @@ namespace NuGet.Build.Tasks
         public string OutputPackagesPath { get; set; }
 
         [Output]
+        public string OutputRepositoryPath { get; set; }
+
+        [Output]
         public string[] OutputFallbackFolders { get; set; }
 
         [Output]
@@ -88,6 +95,7 @@ namespace NuGet.Build.Tasks
             BuildTasksUtility.LogInputParam(log, nameof(ProjectUniqueName), ProjectUniqueName);
             BuildTasksUtility.LogInputParam(log, nameof(RestoreSources), RestoreSources);
             BuildTasksUtility.LogInputParam(log, nameof(RestorePackagesPath), RestorePackagesPath);
+            BuildTasksUtility.LogInputParam(log, nameof(RestoreRepositoryPath), RestoreRepositoryPath);
             BuildTasksUtility.LogInputParam(log, nameof(RestoreFallbackFolders), RestoreFallbackFolders);
             BuildTasksUtility.LogInputParam(log, nameof(RestoreConfigFile), RestoreConfigFile);
             BuildTasksUtility.LogInputParam(log, nameof(RestoreSolutionDirectory), RestoreSolutionDirectory);
@@ -127,6 +135,11 @@ namespace NuGet.Build.Tasks
                     () => GetGlobalAbsolutePath(RestorePackagesPathOverride),
                     () => string.IsNullOrEmpty(RestorePackagesPath) ? null : UriUtility.GetAbsolutePathFromFile(ProjectUniqueName, RestorePackagesPath),
                     () => SettingsUtility.GetGlobalPackagesFolder(settings));
+
+                OutputRepositoryPath = RestoreSettingsUtils.GetValue(
+                    () => GetGlobalAbsolutePath(RestoreRepositoryPathOverride),
+                    () => string.IsNullOrEmpty(RestoreRepositoryPath) ? null : UriUtility.GetAbsolutePathFromFile(ProjectUniqueName, RestoreRepositoryPath),
+                    () => SettingsUtility.GetRepositoryPath(settings));
 
                 // Sources
                 var currentSources = RestoreSettingsUtils.GetValue(
@@ -169,6 +182,7 @@ namespace NuGet.Build.Tasks
 
             // Log Outputs
             BuildTasksUtility.LogOutputParam(log, nameof(OutputPackagesPath), OutputPackagesPath);
+            BuildTasksUtility.LogOutputParam(log, nameof(OutputRepositoryPath), OutputRepositoryPath);
             BuildTasksUtility.LogOutputParam(log, nameof(OutputSources), OutputSources);
             BuildTasksUtility.LogOutputParam(log, nameof(OutputFallbackFolders), OutputFallbackFolders);
             BuildTasksUtility.LogOutputParam(log, nameof(OutputConfigFilePaths), OutputConfigFilePaths);

--- a/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreSettingsTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreSettingsTask.cs
@@ -135,7 +135,7 @@ namespace NuGet.Build.Tasks
                 var absoluteConfigFilePath = GetGlobalAbsolutePath(RestoreConfigFile);
                 string restoreDir;
                 // To match non-msbuild behavior, we only default the restoreDir for non-PackagesConfig scenarios.
-                if (string.IsNullOrEmpty(RestoreRootConfigDirectory) && RestoreProjectStyle != "PackagesConfig")
+                if (string.IsNullOrEmpty(RestoreRootConfigDirectory))
                 {
                     restoreDir = Path.GetDirectoryName(ProjectUniqueName);
                 }

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.Build.Tasks.csproj
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.Build.Tasks.csproj
@@ -30,6 +30,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == '$(NETFXTargetFramework)' ">
+    <ProjectReference Include="..\NuGet.PackageManagement\NuGet.PackageManagement.csproj" />
     <Reference Include="Microsoft.Build.Utilities.v4.0" />
     <Reference Include="Microsoft.Build.Framework" />
   </ItemGroup>

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.Build.Tasks.csproj
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.Build.Tasks.csproj
@@ -26,11 +26,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\NuGet.Commands\NuGet.Commands.csproj" />
+    <ProjectReference Include="$(NuGetCoreSrcDirectory)NuGet.Commands\NuGet.Commands.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == '$(NETFXTargetFramework)' ">
-    <ProjectReference Include="..\NuGet.PackageManagement\NuGet.PackageManagement.csproj" />
+    <ProjectReference Include="$(NuGetCoreSrcDirectory)NuGet.PackageManagement\NuGet.PackageManagement.csproj" />
     <Reference Include="Microsoft.Build.Utilities.v4.0" />
     <Reference Include="Microsoft.Build.Framework" />
   </ItemGroup>

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -524,21 +524,23 @@ Copyright (c) .NET Foundation. All rights reserved.
     ============================================================
   -->
   <Target Name="_GetRestoreSettings"
-          Condition=" '$(RestoreProjectStyle)' == 'PackageReference' OR '$(RestoreProjectStyle)' == 'ProjectJson' OR '$(RestoreProjectStyle)' == 'DotnetToolReference' "
+          Condition=" '$(RestoreProjectStyle)' == 'PackageReference' OR '$(RestoreProjectStyle)' == 'ProjectJson' OR '$(RestoreProjectStyle)' == 'DotnetToolReference' OR '$(RestoreProjectStyle)' == 'PackagesConfig'"
           DependsOnTargets="_GetRestoreSettingsOverrides;_GetRestoreSettingsCurrentProject;_GetRestoreSettingsAllFrameworks"
-          Returns="$(_OutputSources);$(_OutputPackagesPath);$(_OutputFallbackFolders);$(_OutputConfigFilePaths)">
+          Returns="$(_OutputSources);$(_OutputPackagesPath);$(_OutputRepositoryPath);$(_OutputFallbackFolders);$(_OutputConfigFilePaths)">
 
     <!-- For transitive project styles, we rely on evaluating all the settings and including them in the dg spec to faciliate no-op restore-->
     <GetRestoreSettingsTask
      ProjectUniqueName="$(MSBuildProjectFullPath)"
      RestoreSources="$(RestoreSources)"
      RestorePackagesPath="$(RestorePackagesPath)"
+     RestoreRepositoryPath="$(RestoreRepositoryPath)"
      RestoreFallbackFolders="$(RestoreFallbackFolders)"
      RestoreConfigFile="$(RestoreConfigFile)"
      RestoreRootConfigDirectory="$(RestoreRootConfigDirectory)"
      RestoreSolutionDirectory="$(RestoreSolutionDirectory)"
      RestoreSettingsPerFramework="@(_RestoreSettingsPerFramework)"
      RestorePackagesPathOverride="$(_RestorePackagesPathOverride)"
+     RestoreRepositoryPathOverride="$(RestoreRepositoryPathOverride)"
      RestoreSourcesOverride="$(_RestoreSourcesOverride)"
      RestoreFallbackFoldersOverride="$(_RestoreFallbackFoldersOverride)"
      MSBuildStartupDirectory="$(MSBuildStartupDirectory)">
@@ -548,6 +550,9 @@ Copyright (c) .NET Foundation. All rights reserved.
       <Output
         TaskParameter="OutputPackagesPath"
         PropertyName="_OutputPackagesPath" />
+      <Output
+        TaskParameter="OutputRepositoryPath"
+        PropertyName="_OutputRepositoryPath" />
       <Output
         TaskParameter="OutputFallbackFolders"
         PropertyName="_OutputFallbackFolders" />
@@ -728,6 +733,22 @@ Copyright (c) .NET Foundation. All rights reserved.
         <RestorePackagesWithLockFile>$(RestorePackagesWithLockFile)</RestorePackagesWithLockFile>
         <NuGetLockFilePath>$(NuGetLockFilePath)</NuGetLockFilePath>
         <RestoreLockedMode>$(RestoreLockedMode)</RestoreLockedMode>
+      </_RestoreGraphEntry>
+    </ItemGroup>
+
+    <!-- Non-NuGet type -->
+    <ItemGroup Condition=" '$(RestoreProjectStyle)' == 'PackagesConfig' ">
+      <_RestoreGraphEntry Include="$([System.Guid]::NewGuid())">
+        <Type>ProjectSpec</Type>
+        <ProjectUniqueName>$(MSBuildProjectFullPath)</ProjectUniqueName>
+        <ProjectPath>$(MSBuildProjectFullPath)</ProjectPath>
+        <ProjectName>$(_RestoreProjectName)</ProjectName>
+        <Sources>$(_OutputSources)</Sources>
+        <ProjectStyle>$(RestoreProjectStyle)</ProjectStyle>
+        <RepositoryPath>$(_OutputRepositoryPath)</RepositoryPath>
+        <TargetFrameworks>@(_RestoreTargetFrameworksOutputFiltered)</TargetFrameworks>
+        <ConfigFilePaths>$(_OutputConfigFilePaths)</ConfigFilePaths>
+        <PackagesPath>$(_OutputPackagesPath)</PackagesPath>
       </_RestoreGraphEntry>
     </ItemGroup>
 
@@ -1131,7 +1152,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     ============================================================
   -->
   <Target Name="_GetRestoreSettingsOverrides"
-          Returns="$(_RestorePackagesPathOverride);$(_RestoreSourcesOverride);$(_RestoreFallbackFoldersOverride)">
+          Returns="$(_RestorePackagesPathOverride);$(_RestoreRepositoryPathOverride);$(_RestoreSourcesOverride);$(_RestoreFallbackFoldersOverride)">
 
     <!-- RestorePackagesPathOverride -->
     <MsBuild
@@ -1143,6 +1164,18 @@ Copyright (c) .NET Foundation. All rights reserved.
       <Output
           TaskParameter="TargetOutputs"
           PropertyName="_RestorePackagesPathOverride" />
+    </MsBuild>
+
+    <!-- RestoreRepositoryPathOverride -->
+    <MsBuild
+      BuildInParallel="$(RestoreBuildInParallel)"
+      Condition=" '$(RestoreRepositoryPathOverride)' != '' "
+      Projects="$(MSBuildThisFileFullPath)"
+      Targets="_GetRestoreRepositoryPathOverride">
+
+      <Output
+        TaskParameter="TargetOutputs"
+        PropertyName="_RestoreRepositoryPathOverride" />
     </MsBuild>
 
     <!-- RestoreSourcesOverride -->
@@ -1179,6 +1212,18 @@ Copyright (c) .NET Foundation. All rights reserved.
           Returns="$(_RestorePackagesPathOverride)">
     <PropertyGroup>
       <_RestorePackagesPathOverride>$(RestorePackagesPath)</_RestorePackagesPathOverride>
+    </PropertyGroup>
+  </Target>
+
+  <!--
+    ============================================================
+    _GetRestoreRepositoryPathOverride
+    ============================================================
+  -->
+  <Target Name="_GetRestoreRepositoryPathOverride"
+          Returns="$(_RestoreRepositoryPathOverride)">
+    <PropertyGroup>
+      <_RestorePackagesPathOverride>$(RestoreRepositoryPath)</_RestorePackagesPathOverride>
     </PropertyGroup>
   </Target>
 

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -529,6 +529,9 @@ Copyright (c) .NET Foundation. All rights reserved.
           DependsOnTargets="_GetRestoreSettingsOverrides;_GetRestoreSettingsCurrentProject;_GetRestoreSettingsAllFrameworks"
           Returns="$(_OutputSources);$(_OutputPackagesPath);$(_OutputRepositoryPath);$(_OutputFallbackFolders);$(_OutputConfigFilePaths)">
 
+    <PropertyGroup Condition=" '$(RestoreSolutionDirectory)' == '' AND '$(RestoreProjectStyle)' == 'PackagesConfig' AND '$(SolutionDir)' != '*Undefined*'">
+      <RestoreSolutionDirectory>$(SolutionDir)</RestoreSolutionDirectory>
+    </PropertyGroup>
     <!-- For transitive project styles, we rely on evaluating all the settings and including them in the dg spec to faciliate no-op restore-->
     <GetRestoreSettingsTask
      ProjectUniqueName="$(MSBuildProjectFullPath)"

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -130,7 +130,8 @@ Copyright (c) .NET Foundation. All rights reserved.
       RestoreForce="$(RestoreForce)"
       HideWarningsAndErrors="$(HideWarningsAndErrors)"
       Interactive="$(NuGetInteractive)"
-      RestoreForceEvaluate="$(RestoreForceEvaluate)"/>
+      RestoreForceEvaluate="$(RestoreForceEvaluate)"
+      RestorePackagesConfig="$(RestorePackagesConfig)"/>
   </Target>
 
   <!--
@@ -540,9 +541,10 @@ Copyright (c) .NET Foundation. All rights reserved.
      RestoreSolutionDirectory="$(RestoreSolutionDirectory)"
      RestoreSettingsPerFramework="@(_RestoreSettingsPerFramework)"
      RestorePackagesPathOverride="$(_RestorePackagesPathOverride)"
-     RestoreRepositoryPathOverride="$(RestoreRepositoryPathOverride)"
+     RestoreRepositoryPathOverride="$(_RestoreRepositoryPathOverride)"
      RestoreSourcesOverride="$(_RestoreSourcesOverride)"
      RestoreFallbackFoldersOverride="$(_RestoreFallbackFoldersOverride)"
+     RestoreProjectStyle="$(RestoreProjectStyle)"
      MSBuildStartupDirectory="$(MSBuildStartupDirectory)">
       <Output
         TaskParameter="OutputSources"
@@ -733,20 +735,9 @@ Copyright (c) .NET Foundation. All rights reserved.
         <RestorePackagesWithLockFile>$(RestorePackagesWithLockFile)</RestorePackagesWithLockFile>
         <NuGetLockFilePath>$(NuGetLockFilePath)</NuGetLockFilePath>
         <RestoreLockedMode>$(RestoreLockedMode)</RestoreLockedMode>
-      </_RestoreGraphEntry>
-    </ItemGroup>
-
-    <!-- Non-NuGet type -->
-    <ItemGroup Condition=" '$(RestoreProjectStyle)' == 'PackagesConfig' ">
-      <_RestoreGraphEntry Include="$([System.Guid]::NewGuid())">
-        <Type>ProjectSpec</Type>
-        <ProjectUniqueName>$(MSBuildProjectFullPath)</ProjectUniqueName>
-        <ProjectPath>$(MSBuildProjectFullPath)</ProjectPath>
-        <ProjectName>$(_RestoreProjectName)</ProjectName>
         <Sources>$(_OutputSources)</Sources>
-        <ProjectStyle>$(RestoreProjectStyle)</ProjectStyle>
+        <SolutionDir>$(SolutionDir)</SolutionDir>
         <RepositoryPath>$(_OutputRepositoryPath)</RepositoryPath>
-        <TargetFrameworks>@(_RestoreTargetFrameworksOutputFiltered)</TargetFrameworks>
         <ConfigFilePaths>$(_OutputConfigFilePaths)</ConfigFilePaths>
         <PackagesPath>$(_OutputPackagesPath)</PackagesPath>
       </_RestoreGraphEntry>

--- a/src/NuGet.Core/NuGet.Build.Tasks/RestoreTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/RestoreTask.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Build.Framework;
-using Newtonsoft.Json;
 using NuGet.Commands;
 using NuGet.Common;
 
@@ -123,6 +122,7 @@ namespace NuGet.Build.Tasks
                 log.LogWarning(Strings.NoProjectsProvidedToTask);
                 return true;
             }
+            var restoreSummaries = new List<RestoreSummary>();
 
             // Convert to the internal wrapper
             var wrappedItems = RestoreGraphItems.Select(MSBuildUtility.WrapMSBuildItem);
@@ -152,5 +152,7 @@ namespace NuGet.Build.Tasks
         {
             _cts.Dispose();
         }
+
     }
+
 }

--- a/src/NuGet.Core/NuGet.Build.Tasks/RestoreTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/RestoreTask.cs
@@ -66,6 +66,12 @@ namespace NuGet.Build.Tasks
         /// </summary>
         public bool RestoreForceEvaluate { get; set; }
 
+        /// <summary>
+        /// Restore projects using packages.config for dependencies.
+        /// </summary>
+        /// <returns></returns>
+        public bool RestorePackagesConfig { get; set; }
+
         public override bool Execute()
         {
 #if DEBUG
@@ -82,7 +88,7 @@ namespace NuGet.Build.Tasks
                 }
                 Debugger.Break();
 #else
-            Debugger.Launch();
+                Debugger.Launch();
 #endif
             }
 #endif
@@ -97,6 +103,7 @@ namespace NuGet.Build.Tasks
             log.LogDebug($"(in) RestoreForce '{RestoreForce}'");
             log.LogDebug($"(in) HideWarningsAndErrors '{HideWarningsAndErrors}'");
             log.LogDebug($"(in) RestoreForceEvaluate '{RestoreForceEvaluate}'");
+            log.LogDebug($"(in) RestorePackagesConfig '{RestorePackagesConfig}'");
 
             try
             {
@@ -114,7 +121,7 @@ namespace NuGet.Build.Tasks
                 return false;
             }
         }
- 
+
         private async Task<bool> ExecuteAsync(Common.ILogger log)
         {
             if (RestoreGraphItems.Length < 1 && !HideWarningsAndErrors)
@@ -122,7 +129,6 @@ namespace NuGet.Build.Tasks
                 log.LogWarning(Strings.NoProjectsProvidedToTask);
                 return true;
             }
-            var restoreSummaries = new List<RestoreSummary>();
 
             // Convert to the internal wrapper
             var wrappedItems = RestoreGraphItems.Select(MSBuildUtility.WrapMSBuildItem);
@@ -139,6 +145,7 @@ namespace NuGet.Build.Tasks
                 force: RestoreForce,
                 forceEvaluate: RestoreForceEvaluate,
                 hideWarningsAndErrors: HideWarningsAndErrors,
+                restorePC: RestorePackagesConfig,
                 log: log,
                 cancellationToken: _cts.Token);
         }

--- a/src/NuGet.Core/NuGet.Build.Tasks/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/Strings.Designer.cs
@@ -8,10 +8,14 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace NuGet.Build.Tasks {
+namespace NuGet.Build.Tasks
+{
     using System;
-    
-    
+
+
+    using System.Reflection;
+
+
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -22,113 +26,181 @@ namespace NuGet.Build.Tasks {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    internal class Strings {
-        
+    internal class Strings
+    {
+
         private static global::System.Resources.ResourceManager resourceMan;
-        
+
         private static global::System.Globalization.CultureInfo resourceCulture;
-        
+
         [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
-        internal Strings() {
+        internal Strings()
+        {
         }
-        
+
         /// <summary>
         ///   Returns the cached ResourceManager instance used by this class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Resources.ResourceManager ResourceManager {
-            get {
-                if (object.ReferenceEquals(resourceMan, null)) {
+        internal static global::System.Resources.ResourceManager ResourceManager
+        {
+            get
+            {
+                if (object.ReferenceEquals(resourceMan, null))
+                {
                     global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("NuGet.Build.Tasks.Strings", typeof(Strings).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
             }
         }
-        
+
         /// <summary>
         ///   Overrides the current thread's CurrentUICulture property for all
         ///   resource lookups using this strongly typed resource class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Globalization.CultureInfo Culture {
-            get {
+        internal static global::System.Globalization.CultureInfo Culture
+        {
+            get
+            {
                 return resourceCulture;
             }
-            set {
+            set
+            {
                 resourceCulture = value;
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Argument cannot be null or empty.
         /// </summary>
-        internal static string Argument_Cannot_Be_Null_Or_Empty {
-            get {
+        internal static string Argument_Cannot_Be_Null_Or_Empty
+        {
+            get
+            {
                 return ResourceManager.GetString("Argument_Cannot_Be_Null_Or_Empty", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to ProjectReference &apos;{0}&apos; was resolved using &apos;{1}&apos; instead of the project target framework &apos;{2}&apos;. This project may not be fully compatible with your project..
         /// </summary>
-        internal static string ImportsFallbackWarning {
-            get {
+        internal static string ImportsFallbackWarning
+        {
+            get
+            {
                 return ResourceManager.GetString("ImportsFallbackWarning", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Project &apos;{0}&apos; targets &apos;{2}&apos;. It cannot be referenced by a project that targets &apos;{1}&apos;..
         /// </summary>
-        internal static string NoCompatibleTargetFramework {
-            get {
+        internal static string NoCompatibleTargetFramework
+        {
+            get
+            {
                 return ResourceManager.GetString("NoCompatibleTargetFramework", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Unable to find a project to restore!.
         /// </summary>
-        internal static string NoProjectsProvidedToTask {
-            get {
+        internal static string NoProjectsProvidedToTask
+        {
+            get
+            {
                 return ResourceManager.GetString("NoProjectsProvidedToTask", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Nothing to do. None of the projects specified contain packages to restore..
         /// </summary>
-        internal static string NoProjectsToRestore {
-            get {
+        internal static string NoProjectsToRestore
+        {
+            get
+            {
                 return ResourceManager.GetString("NoProjectsToRestore", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Restore canceled!.
         /// </summary>
-        internal static string RestoreCanceled {
-            get {
+        internal static string RestoreCanceled
+        {
+            get
+            {
                 return ResourceManager.GetString("RestoreCanceled", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The project fallback framework &apos;{0}&apos; is not a supported target framework..
         /// </summary>
-        internal static string UnsupportedFallbackFramework {
-            get {
+        internal static string UnsupportedFallbackFramework
+        {
+            get
+            {
                 return ResourceManager.GetString("UnsupportedFallbackFramework", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The project target framework &apos;{0}&apos; is not a supported target framework..
         /// </summary>
-        internal static string UnsupportedTargetFramework {
-            get {
+        internal static string UnsupportedTargetFramework
+        {
+            get
+            {
                 return ResourceManager.GetString("UnsupportedTargetFramework", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///  Looks up a localized string similar to No solution found. Restore against a solution or pass in /p:SolutionDir
+        /// </summary>
+        internal static string RestoreNoSolutionFound
+        {
+            get
+            {
+                return ResourceManager.GetString("RestoreNoSolutionFound", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///  Looks up a localized string similar to All packages listed in {0} are already installed.
+        /// </summary>
+        internal static string InstallCommandNothingToInstall
+        {
+            get
+            {
+                return ResourceManager.GetString("InstallCommandNothingToInstall", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///  Looks up a localized string similar to Invalid PackageSaveMode value '{0}'
+        /// </summary>
+        internal static string Warning_InvalidPackageSaveMode
+        {
+            get
+            {
+                return ResourceManager.GetString("Warning_InvalidPackageSaveMode", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///  Looks up a localized string similar to Error parsing packages.config file at {0}: {1}
+        /// </summary>
+        internal static string Error_PackagesConfigParseError
+        {
+            get
+            {
+                return ResourceManager.GetString("Error_PackagesConfigParseError", resourceCulture);
             }
         }
     }

--- a/src/NuGet.Core/NuGet.Build.Tasks/Strings.resx
+++ b/src/NuGet.Core/NuGet.Build.Tasks/Strings.resx
@@ -144,4 +144,16 @@
   <data name="Argument_Cannot_Be_Null_Or_Empty" xml:space="preserve">
     <value>Argument cannot be null or empty</value>
   </data>
+  <data name="RestoreNoSolutionFound" xml:space="preserve">
+    <value>No solution found. Restore against a solution or pass in /p:SolutionDir</value>
+  </data>
+  <data name="InstallCommandNothingToInstall" xml:space="preserve">
+    <value>All packages listed in {0} are already installed.</value>
+  </data>
+  <data name="Warning_InvalidPackageSaveMode" xml:space="preserve">
+    <value>Invalid PackageSaveMode value '{0}'.</value>
+  </data>
+  <data name="Error_PackagesConfigParseError" xml:space="preserve">
+    <value>Error parsing packages.config file at {0}: {1}</value>
+  </data>
 </root>

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
@@ -195,7 +195,8 @@ namespace NuGet.Commands
                     || restoreType == ProjectStyle.Standalone
                     || restoreType == ProjectStyle.DotnetCliTool
                     || restoreType == ProjectStyle.ProjectJson
-                    || restoreType == ProjectStyle.DotnetToolReference)
+                    || restoreType == ProjectStyle.DotnetToolReference
+                    || restoreType == ProjectStyle.PackagesConfig)
                 {
 
                     foreach (var source in MSBuildStringUtility.Split(specItem.GetProperty("Sources")))
@@ -216,7 +217,7 @@ namespace NuGet.Commands
                     }
 
                     result.RestoreMetadata.PackagesPath = specItem.GetProperty("PackagesPath");
-
+                    result.RestoreMetadata.RepositoryPath = specItem.GetProperty("RepositoryPath");
                     result.RestoreMetadata.OutputPath = specItem.GetProperty("OutputPath");
                 }
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
@@ -217,7 +217,6 @@ namespace NuGet.Commands
                     }
 
                     result.RestoreMetadata.PackagesPath = specItem.GetProperty("PackagesPath");
-                    result.RestoreMetadata.RepositoryPath = specItem.GetProperty("RepositoryPath");
                     result.RestoreMetadata.OutputPath = specItem.GetProperty("OutputPath");
                 }
 
@@ -280,7 +279,17 @@ namespace NuGet.Commands
                     var pcRestoreMetadata = (PackagesConfigProjectRestoreMetadata)result.RestoreMetadata;
                     // Packages lock file properties
                     pcRestoreMetadata.PackagesConfigPath = specItem.GetProperty("PackagesConfigPath");
+                    pcRestoreMetadata.RepositoryPath = specItem.GetProperty("RepositoryPath");
+                    var solutionDir = specItem.GetProperty("SolutionDir");
+                    if (string.IsNullOrEmpty(pcRestoreMetadata.RepositoryPath) && !string.IsNullOrEmpty(solutionDir) && solutionDir != "*Undefined*")
+                    {
+                        pcRestoreMetadata.RepositoryPath = Path.Combine(
+                            solutionDir,
+                            "packages"
+                        );
+                    }
                     pcRestoreMetadata.RestoreLockProperties = GetRestoreLockProperites(specItem);
+
                 }
 
                 if (restoreType == ProjectStyle.ProjectJson)

--- a/src/NuGet.Core/NuGet.PackageManagement/ConsoleProjectContext.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/ConsoleProjectContext.cs
@@ -6,9 +6,8 @@ using System.Globalization;
 using System.Xml.Linq;
 using NuGet.Common;
 using NuGet.Packaging;
-using NuGet.ProjectManagement;
 
-namespace NuGet.CommandLine
+namespace NuGet.ProjectManagement
 {
     public class ConsoleProjectContext : INuGetProjectContext
     {

--- a/src/NuGet.Core/NuGet.ProjectModel/PackagesConfigProjectRestoreMetadata.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackagesConfigProjectRestoreMetadata.cs
@@ -13,6 +13,11 @@ namespace NuGet.ProjectModel
         /// </summary>
         public string PackagesConfigPath { get; set; }
 
+        /// <summary>
+        /// User packages repository path.
+        /// </summary>
+        public string RepositoryPath { get; set; }
+
         public override int GetHashCode()
         {
             var hashCode = new HashCodeCombiner();
@@ -38,7 +43,7 @@ namespace NuGet.ProjectModel
         {
             var clone = new PackagesConfigProjectRestoreMetadata();
             FillClone(clone);
-            clone.PackagesConfigPath =  PackagesConfigPath;
+            clone.PackagesConfigPath = PackagesConfigPath;
             return clone;
         }
     }

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadata.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadata.cs
@@ -53,6 +53,11 @@ namespace NuGet.ProjectModel
         public string PackagesPath { get; set; }
 
         /// <summary>
+        /// User packages repository path.
+        /// </summary>
+        public string RepositoryPath { get; set; }
+
+        /// <summary>
         /// Cache file path
         /// </summary>
         public string CacheFilePath { get; set; }

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadata.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadata.cs
@@ -53,11 +53,6 @@ namespace NuGet.ProjectModel
         public string PackagesPath { get; set; }
 
         /// <summary>
-        /// User packages repository path.
-        /// </summary>
-        public string RepositoryPath { get; set; }
-
-        /// <summary>
         /// Cache file path
         /// </summary>
         public string CacheFilePath { get; set; }

--- a/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/Msbuild.Integration.Test.csproj
+++ b/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/Msbuild.Integration.Test.csproj
@@ -1,0 +1,44 @@
+﻿<Project>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common.test.props" />
+  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
+
+  <PropertyGroup>
+    <TargetFrameworks>$(NETFXTargetFramework)</TargetFrameworks>
+    <TestProject>true</TestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="compiler\resources\*" />
+    <EmbeddedResource Include="compiler\resources\*" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Build.Runtime" Version="$(MicrosoftBuildPackageVersion)" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Build.Tasks" Version="3.0.0-dev-61717-03" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.0.0-dev-61717-03" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <ProjectReference Include="..\NuGet.XPlat.FuncTest\NuGet.XPlat.FuncTest.csproj" />
+    <ProjectReference Include="$(NuGetCoreSrcDirectory)NuGet.Build.Tasks\NuGet.Build.Tasks.csproj" />
+    <ProjectReference Include="$(TestUtilitiesDirectory)Test.Utility\Test.Utility.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="$(NuGetCoreSrcDirectory)NuGet.Build.Tasks\NuGet.targets">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+  <Target Name="CopyTargets" AfterTargets="AfterBuild">
+    <Copy Condition="'$(TargetFramework)' == '$(NETFXTargetFramework)'" SourceFiles="$(MSBuildProjectDirectory)\$(OutputPath)\Microsoft.CSharp.Core.targets" DestinationFolder="$(MSBuildProjectDirectory)\$(OutputPath)\..\..\$(VisualStudioVersion)\Bin\Roslyn\" />
+  </Target>
+
+  <Import Project="$(BuildCommonDirectory)common.targets" />
+  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
+  <Import Project="$(BuildCommonDirectory)common.targets"/>
+  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
+  
+</Project>

--- a/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/Msbuild.Integration.Test.csproj
+++ b/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/Msbuild.Integration.Test.csproj
@@ -18,7 +18,6 @@
   </ItemGroup>
   
   <ItemGroup>
-    <ProjectReference Include="..\NuGet.XPlat.FuncTest\NuGet.XPlat.FuncTest.csproj" />
     <ProjectReference Include="$(NuGetCoreSrcDirectory)NuGet.Build.Tasks\NuGet.Build.Tasks.csproj" />
     <ProjectReference Include="$(TestUtilitiesDirectory)Test.Utility\Test.Utility.csproj" />
   </ItemGroup>

--- a/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/Msbuild.Integration.Test.csproj
+++ b/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/Msbuild.Integration.Test.csproj
@@ -38,7 +38,5 @@
 
   <Import Project="$(BuildCommonDirectory)common.targets" />
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
-  <Import Project="$(BuildCommonDirectory)common.targets"/>
-  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
   
 </Project>

--- a/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildIntegrationCollection.cs
+++ b/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildIntegrationCollection.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Xunit;
+
+namespace Msbuild.Integration.Test
+{
+    [CollectionDefinition("Msbuild Integration Tests")]
+    public class MsbuildIntegrationCollection : ICollectionFixture<MsbuildIntegrationTestFixture>
+    {
+        // This class has no code, and is never created. Its purpose is simply
+        // to be the place to apply [CollectionDefinition] and all the
+        // ICollectionFixture<> interfaces.
+    }
+}

--- a/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildIntegrationTestFixture.cs
+++ b/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildIntegrationTestFixture.cs
@@ -3,96 +3,23 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
-using System.Linq;
-using System.Threading;
-using NuGet.XPlat.FuncTest;
 using NuGet.Test.Utility;
-using NuGet.Packaging;
-using NuGet.Packaging.Core;
-using NuGet.Packaging.PackageExtraction;
-using NuGet.Protocol;
 using Xunit;
 
 namespace Msbuild.Integration.Test
 {
     public class MsbuildIntegrationTestFixture : IDisposable
     {
-        private readonly TestDirectory _cliDirectory;
-        private readonly string _dotnetCli = DotnetCliUtil.GetDotnetCli();
-        internal readonly string _testDotnetCli;
-        internal readonly string _msBuildSdksPath;
         internal readonly string _testDir;
         private readonly Dictionary<string, string> _processEnvVars = new Dictionary<string, string>();
 
         public MsbuildIntegrationTestFixture()
         {
-            _cliDirectory = CopyLatestCliForPack();
-            _testDotnetCli = Path.Combine(_cliDirectory, "dotnet.exe");
-            _msBuildSdksPath = Path.Combine(Directory.GetDirectories
-                (Path.Combine(_cliDirectory, "sdk"))
-                .First(), "Sdks");
             _testDir = Directory.GetCurrentDirectory();
-            _processEnvVars.Add("MSBuildSDKsPath", _msBuildSdksPath);
             _processEnvVars.Add("UseSharedCompilation", "false");
             _processEnvVars.Add("DOTNET_MULTILEVEL_LOOKUP", "0");
             _processEnvVars.Add("MSBUILDDISABLENODEREUSE ", "true");
-            // We do this here so that dotnet new will extract all the packages on the first run on the machine.
-            InitDotnetNewToExtractPackages();
-        }
-
-        private void InitDotnetNewToExtractPackages()
-        {
-            using (var testDirectory = TestDirectory.Create())
-            {
-                var projectName = "ClassLibrary1";
-                CreateDotnetNewProject(testDirectory.Path, projectName, " classlib", timeOut: 300000);
-            }
-
-            using (var testDirectory = TestDirectory.Create())
-            {
-                var projectName = "ConsoleApp1";
-                CreateDotnetNewProject(testDirectory.Path, projectName, " console", timeOut: 300000);
-            }
-        }
-
-        internal void CreateDotnetNewProject(string solutionRoot, string projectName, string args = "console", int timeOut = 60000)
-        {
-            var workingDirectory = Path.Combine(solutionRoot, projectName);
-            if (!Directory.Exists(workingDirectory))
-            {
-                Directory.CreateDirectory(workingDirectory);
-            }
-            var result = CommandRunner.Run(_testDotnetCli,
-                workingDirectory,
-                $"new {args}",
-                waitForExit: true,
-                timeOutInMilliseconds: timeOut,
-                environmentVariables: _processEnvVars);
-
-            Assert.True(result.Item1 == 0, $"Creating project failed with following log information :\n {result.AllOutput}");
-            Assert.True(string.IsNullOrWhiteSpace(result.Item3), $"Creating project failed with following message in error stream :\n {result.AllOutput}");
-        }
-
-        /// <summary>
-        /// dotnet.exe args
-        /// </summary>
-        internal CommandRunnerResult RunDotnet(string workingDirectory, string args, bool ignoreExitCode = false)
-        {
-
-            var result = CommandRunner.Run(_testDotnetCli,
-                workingDirectory,
-                args,
-                waitForExit: true,
-                environmentVariables: _processEnvVars);
-
-            if (!ignoreExitCode)
-            {
-                Assert.True(result.ExitCode == 0, $"dotnet.exe {args} command failed with following log information :\n {result.AllOutput}");
-            }
-
-            return result;
         }
 
         /// <summary>
@@ -120,211 +47,8 @@ namespace Msbuild.Integration.Test
             return result;
         }
 
-        private CommandRunnerResult PackProjectOrSolution(string workingDirectory, string file, string args, string nuspecOutputPath, bool validateSuccess)
-        {
-            var result = CommandRunner.Run(_testDotnetCli,
-                workingDirectory,
-                $"pack {file} {args} /p:NuspecOutputPath={nuspecOutputPath}",
-                waitForExit: true,
-                environmentVariables: _processEnvVars);
-            if (validateSuccess)
-            {
-                Assert.True(result.Item1 == 0, $"Pack failed with following log information :\n {result.AllOutput}");
-                Assert.True(result.Item3 == "", $"Pack failed with following message in error stream :\n {result.AllOutput}");
-            }
-            return result;
-        }
-
-        private TestDirectory CopyLatestCliForPack()
-        {
-            var cliDirectory = TestDirectory.Create();
-            CopyLatestCliToTestDirectory(cliDirectory);
-            UpdateCliWithLatestNuGetAssemblies(cliDirectory);
-            return cliDirectory;
-        }
-
-        private void CopyLatestCliToTestDirectory(string destinationDir)
-        {
-            var cliDir = Path.GetDirectoryName(_dotnetCli);
-
-            //Create sub-directory structure in destination
-            foreach (var directory in Directory.GetDirectories(cliDir, "*", SearchOption.AllDirectories))
-            {
-                var destDir = destinationDir + directory.Substring(cliDir.Length);
-                if (!Directory.Exists(destDir))
-                {
-                    Directory.CreateDirectory(destDir);
-                }
-            }
-
-            var lastWriteTime = DateTime.Now.AddDays(-2);
-
-            //Copy files recursively to destination directories
-            foreach (var fileName in Directory.GetFiles(cliDir, "*", SearchOption.AllDirectories))
-            {
-                var destFileName = destinationDir + fileName.Substring(cliDir.Length);
-                // TODO - figure out a better solution than this. Why are those long files getting copied here?
-                try
-                {
-                    File.Copy(fileName, destFileName);
-                    File.SetLastWriteTime(destFileName, lastWriteTime);
-                }
-                catch
-                {
-
-                }
-            }
-        }
-
-        private void UpdateCliWithLatestNuGetAssemblies(string cliDirectory)
-        {
-            var nupkgsDirectory = DotnetCliUtil.GetNupkgDirectoryInRepo();
-            var pathToPackNupkg = FindMostRecentNupkg(nupkgsDirectory, "NuGet.Build.Tasks.Pack");
-
-            var nupkgsToCopy = new List<string> { "NuGet.Build.Tasks", "NuGet.Versioning", "NuGet.Protocol", "NuGet.ProjectModel", "NuGet.Packaging", "NuGet.LibraryModel", "NuGet.Frameworks", "NuGet.DependencyResolver.Core", "NuGet.Configuration", "NuGet.Common", "NuGet.Commands", "NuGet.CommandLine.XPlat", "NuGet.Credentials" };
-
-            var pathToSdkInCli = Path.Combine(
-                    Directory.GetDirectories(Path.Combine(cliDirectory, "sdk"))
-                        .First());
-            using (var nupkg = new PackageArchiveReader(pathToPackNupkg))
-            {
-                var pathToPackSdk = Path.Combine(pathToSdkInCli, "Sdks", "NuGet.Build.Tasks.Pack");
-                var files = nupkg.GetFiles()
-                .Where(fileName => fileName.StartsWith("Desktop")
-                                || fileName.StartsWith("CoreCLR")
-                                || fileName.StartsWith("build")
-                                || fileName.StartsWith("buildCrossTargeting"));
-
-                DeleteDirectory(pathToPackSdk);
-                CopyNupkgFilesToTarget(nupkg, pathToPackSdk, files);
-            }
-
-
-            foreach (var nupkgName in nupkgsToCopy)
-            {
-                using (var nupkg = new PackageArchiveReader(FindMostRecentNupkg(nupkgsDirectory, nupkgName)))
-                {
-                    var files = nupkg.GetFiles()
-                    .Where(fileName => fileName.StartsWith("lib/netstandard")
-                                    || fileName.StartsWith("lib/netcoreapp")
-                                    || fileName.Contains("NuGet.targets"));
-
-                    CopyFlatlistOfFilesToTarget(nupkg, pathToSdkInCli, files);
-                }
-            }
-        }
-
-        private void CopyFlatlistOfFilesToTarget(PackageArchiveReader nupkg, string destination, IEnumerable<string> packageFiles)
-        {
-            var packageFileExtractor = new PackageFileExtractor(packageFiles,
-                             PackageExtractionBehavior.XmlDocFileSaveMode);
-            var logger = new TestCommandOutputLogger();
-            var token = CancellationToken.None;
-            var filesCopied = new List<string>();
-
-            foreach (var packageFile in packageFiles)
-            {
-                token.ThrowIfCancellationRequested();
-
-                var entry = nupkg.GetEntry(packageFile);
-
-                var packageFileName = entry.FullName;
-                // An entry in a ZipArchive could start with a '/' based on how it is zipped
-                // Remove it if present
-                if (packageFileName.StartsWith("/", StringComparison.Ordinal))
-                {
-                    packageFileName = packageFileName.Substring(1);
-                }
-                // Get only the name, without the path, since we are extracting to flat list
-                packageFileName = Path.GetFileName(packageFileName);
-
-                // ZipArchive always has forward slashes in them. By replacing them with DirectorySeparatorChar;
-                // in windows, we get the windows-style path
-                var normalizedPath = Uri.UnescapeDataString(packageFileName.Replace('/', Path.DirectorySeparatorChar));
-
-                var targetFilePath = Path.Combine(destination, normalizedPath);
-                if (!targetFilePath.StartsWith(destination, StringComparison.OrdinalIgnoreCase))
-                {
-                    continue;
-                }
-                try
-                {
-                    File.Delete(targetFilePath);
-                }
-                catch
-                {
-                    // Do nothing
-                }
-                using (var stream = entry.Open())
-                {
-                    var copiedFile = packageFileExtractor.ExtractPackageFile(packageFileName, targetFilePath, stream);
-                    if (copiedFile != null)
-                    {
-                        entry.UpdateFileTimeFromEntry(copiedFile, logger);
-
-                        filesCopied.Add(copiedFile);
-                    }
-                }
-            }
-
-        }
-
-        private void CopyNupkgFilesToTarget(PackageArchiveReader nupkg, string destPath, IEnumerable<string> files)
-        {
-            var packageFileExtractor = new PackageFileExtractor(files,
-                                         PackageExtractionBehavior.XmlDocFileSaveMode);
-
-            nupkg.CopyFiles(destPath, files, packageFileExtractor.ExtractPackageFile, new TestCommandOutputLogger(),
-                CancellationToken.None);
-
-        }
-
-        private static string FindMostRecentNupkg(string nupkgDirectory, string id)
-        {
-            var info = LocalFolderUtility.GetPackagesV2(nupkgDirectory, new TestLogger());
-
-            return info.Where(t => t.Identity.Id.Equals(id, StringComparison.OrdinalIgnoreCase))
-                .Where(t => !Path.GetExtension(Path.GetFileNameWithoutExtension(t.Path)).Equals(".symbols"))
-                .OrderByDescending(p => p.LastWriteTimeUtc)
-                .First().Path;
-        }
-
         public void Dispose()
         {
-            RunDotnet(Path.GetDirectoryName(_testDotnetCli), "build-server shutdown");
-            KillDotnetExe(_testDotnetCli);
-            _cliDirectory.Dispose();
-        }
-
-        private static void KillDotnetExe(string pathToDotnetExe)
-        {
-            var processes = Process.GetProcessesByName("dotnet")
-                .Where(t => string.Compare(t.MainModule.FileName, Path.GetFullPath(pathToDotnetExe), ignoreCase: true) == 0);
-            var testDirProcesses = Process.GetProcesses()
-                .Where(t => t.MainModule.FileName.StartsWith(TestFileSystemUtility.NuGetTestFolder, StringComparison.OrdinalIgnoreCase));
-            try
-            {
-                if (processes != null)
-                {
-                    foreach (var process in processes)
-                    {
-                        if (string.Compare(process.MainModule.FileName, Path.GetFullPath(pathToDotnetExe), true) == 0)
-                        {
-                            process.Kill();
-                        }
-                    }
-                }
-
-                if (testDirProcesses != null)
-                {
-                    foreach (var process in testDirProcesses)
-                    {
-                        process.Kill();
-                    }
-                }
-
-            }
-            catch { }
         }
 
         /// <summary>

--- a/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildIntegrationTestFixture.cs
+++ b/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildIntegrationTestFixture.cs
@@ -1,0 +1,359 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using NuGet.XPlat.FuncTest;
+using NuGet.Test.Utility;
+using NuGet.Packaging;
+using NuGet.Packaging.Core;
+using NuGet.Packaging.PackageExtraction;
+using NuGet.Protocol;
+using Xunit;
+
+namespace Msbuild.Integration.Test
+{
+    public class MsbuildIntegrationTestFixture : IDisposable
+    {
+        private readonly TestDirectory _cliDirectory;
+        private readonly string _dotnetCli = DotnetCliUtil.GetDotnetCli();
+        internal readonly string _testDotnetCli;
+        internal readonly string _msBuildSdksPath;
+        internal readonly string _testDir;
+        private readonly Dictionary<string, string> _processEnvVars = new Dictionary<string, string>();
+
+        public MsbuildIntegrationTestFixture()
+        {
+            _cliDirectory = CopyLatestCliForPack();
+            _testDotnetCli = Path.Combine(_cliDirectory, "dotnet.exe");
+            _msBuildSdksPath = Path.Combine(Directory.GetDirectories
+                (Path.Combine(_cliDirectory, "sdk"))
+                .First(), "Sdks");
+            _testDir = Directory.GetCurrentDirectory();
+            _processEnvVars.Add("MSBuildSDKsPath", _msBuildSdksPath);
+            _processEnvVars.Add("UseSharedCompilation", "false");
+            _processEnvVars.Add("DOTNET_MULTILEVEL_LOOKUP", "0");
+            _processEnvVars.Add("MSBUILDDISABLENODEREUSE ", "true");
+            // We do this here so that dotnet new will extract all the packages on the first run on the machine.
+            InitDotnetNewToExtractPackages();
+        }
+
+        private void InitDotnetNewToExtractPackages()
+        {
+            using (var testDirectory = TestDirectory.Create())
+            {
+                var projectName = "ClassLibrary1";
+                CreateDotnetNewProject(testDirectory.Path, projectName, " classlib", timeOut: 300000);
+            }
+
+            using (var testDirectory = TestDirectory.Create())
+            {
+                var projectName = "ConsoleApp1";
+                CreateDotnetNewProject(testDirectory.Path, projectName, " console", timeOut: 300000);
+            }
+        }
+
+        internal void CreateDotnetNewProject(string solutionRoot, string projectName, string args = "console", int timeOut = 60000)
+        {
+            var workingDirectory = Path.Combine(solutionRoot, projectName);
+            if (!Directory.Exists(workingDirectory))
+            {
+                Directory.CreateDirectory(workingDirectory);
+            }
+            var result = CommandRunner.Run(_testDotnetCli,
+                workingDirectory,
+                $"new {args}",
+                waitForExit: true,
+                timeOutInMilliseconds: timeOut,
+                environmentVariables: _processEnvVars);
+
+            Assert.True(result.Item1 == 0, $"Creating project failed with following log information :\n {result.AllOutput}");
+            Assert.True(string.IsNullOrWhiteSpace(result.Item3), $"Creating project failed with following message in error stream :\n {result.AllOutput}");
+        }
+
+        /// <summary>
+        /// dotnet.exe args
+        /// </summary>
+        internal CommandRunnerResult RunDotnet(string workingDirectory, string args, bool ignoreExitCode = false)
+        {
+
+            var result = CommandRunner.Run(_testDotnetCli,
+                workingDirectory,
+                args,
+                waitForExit: true,
+                environmentVariables: _processEnvVars);
+
+            if (!ignoreExitCode)
+            {
+                Assert.True(result.ExitCode == 0, $"dotnet.exe {args} command failed with following log information :\n {result.AllOutput}");
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// msbuild.exe args
+        /// </summary>
+        internal CommandRunnerResult RunMsBuild(string workingDirectory, string args, bool ignoreExitCode = false)
+        {
+
+            var msBuildExe = Path.Combine(_testDir, "MSBuild.exe");
+            var restoreDllPath = Path.Combine(_testDir, "NuGet.Build.Tasks.dll");
+            var nugetRestoreTargetsPath = Path.Combine(_testDir, "NuGet.targets");
+            // Uncomment to debug the msbuild call
+            // _processEnvVars.Add("DEBUG_RESTORE_TASK", "true");
+            var result = CommandRunner.Run(msBuildExe,
+                workingDirectory,
+                $"/p:NuGetRestoreTargets={nugetRestoreTargetsPath} /p:RestoreTaskAssemblyFile={restoreDllPath} /p:ImportNuGetBuildTasksPackTargetsFromSdk=\"true\" {args}",
+                waitForExit: true,
+                environmentVariables: _processEnvVars);
+
+            if (!ignoreExitCode)
+            {
+                Assert.True(result.ExitCode == 0, $"msbuild.exe {args} command failed with following log information :\n {result.AllOutput}");
+            }
+
+            return result;
+        }
+
+        private CommandRunnerResult PackProjectOrSolution(string workingDirectory, string file, string args, string nuspecOutputPath, bool validateSuccess)
+        {
+            var result = CommandRunner.Run(_testDotnetCli,
+                workingDirectory,
+                $"pack {file} {args} /p:NuspecOutputPath={nuspecOutputPath}",
+                waitForExit: true,
+                environmentVariables: _processEnvVars);
+            if (validateSuccess)
+            {
+                Assert.True(result.Item1 == 0, $"Pack failed with following log information :\n {result.AllOutput}");
+                Assert.True(result.Item3 == "", $"Pack failed with following message in error stream :\n {result.AllOutput}");
+            }
+            return result;
+        }
+
+        private TestDirectory CopyLatestCliForPack()
+        {
+            var cliDirectory = TestDirectory.Create();
+            CopyLatestCliToTestDirectory(cliDirectory);
+            UpdateCliWithLatestNuGetAssemblies(cliDirectory);
+            return cliDirectory;
+        }
+
+        private void CopyLatestCliToTestDirectory(string destinationDir)
+        {
+            var cliDir = Path.GetDirectoryName(_dotnetCli);
+
+            //Create sub-directory structure in destination
+            foreach (var directory in Directory.GetDirectories(cliDir, "*", SearchOption.AllDirectories))
+            {
+                var destDir = destinationDir + directory.Substring(cliDir.Length);
+                if (!Directory.Exists(destDir))
+                {
+                    Directory.CreateDirectory(destDir);
+                }
+            }
+
+            var lastWriteTime = DateTime.Now.AddDays(-2);
+
+            //Copy files recursively to destination directories
+            foreach (var fileName in Directory.GetFiles(cliDir, "*", SearchOption.AllDirectories))
+            {
+                var destFileName = destinationDir + fileName.Substring(cliDir.Length);
+                // TODO - figure out a better solution than this. Why are those long files getting copied here?
+                try
+                {
+                    File.Copy(fileName, destFileName);
+                    File.SetLastWriteTime(destFileName, lastWriteTime);
+                }
+                catch
+                {
+
+                }
+            }
+        }
+
+        private void UpdateCliWithLatestNuGetAssemblies(string cliDirectory)
+        {
+            var nupkgsDirectory = DotnetCliUtil.GetNupkgDirectoryInRepo();
+            var pathToPackNupkg = FindMostRecentNupkg(nupkgsDirectory, "NuGet.Build.Tasks.Pack");
+
+            var nupkgsToCopy = new List<string> { "NuGet.Build.Tasks", "NuGet.Versioning", "NuGet.Protocol", "NuGet.ProjectModel", "NuGet.Packaging", "NuGet.LibraryModel", "NuGet.Frameworks", "NuGet.DependencyResolver.Core", "NuGet.Configuration", "NuGet.Common", "NuGet.Commands", "NuGet.CommandLine.XPlat", "NuGet.Credentials" };
+
+            var pathToSdkInCli = Path.Combine(
+                    Directory.GetDirectories(Path.Combine(cliDirectory, "sdk"))
+                        .First());
+            using (var nupkg = new PackageArchiveReader(pathToPackNupkg))
+            {
+                var pathToPackSdk = Path.Combine(pathToSdkInCli, "Sdks", "NuGet.Build.Tasks.Pack");
+                var files = nupkg.GetFiles()
+                .Where(fileName => fileName.StartsWith("Desktop")
+                                || fileName.StartsWith("CoreCLR")
+                                || fileName.StartsWith("build")
+                                || fileName.StartsWith("buildCrossTargeting"));
+
+                DeleteDirectory(pathToPackSdk);
+                CopyNupkgFilesToTarget(nupkg, pathToPackSdk, files);
+            }
+
+
+            foreach (var nupkgName in nupkgsToCopy)
+            {
+                using (var nupkg = new PackageArchiveReader(FindMostRecentNupkg(nupkgsDirectory, nupkgName)))
+                {
+                    var files = nupkg.GetFiles()
+                    .Where(fileName => fileName.StartsWith("lib/netstandard")
+                                    || fileName.StartsWith("lib/netcoreapp")
+                                    || fileName.Contains("NuGet.targets"));
+
+                    CopyFlatlistOfFilesToTarget(nupkg, pathToSdkInCli, files);
+                }
+            }
+        }
+
+        private void CopyFlatlistOfFilesToTarget(PackageArchiveReader nupkg, string destination, IEnumerable<string> packageFiles)
+        {
+            var packageFileExtractor = new PackageFileExtractor(packageFiles,
+                             PackageExtractionBehavior.XmlDocFileSaveMode);
+            var logger = new TestCommandOutputLogger();
+            var token = CancellationToken.None;
+            var filesCopied = new List<string>();
+
+            foreach (var packageFile in packageFiles)
+            {
+                token.ThrowIfCancellationRequested();
+
+                var entry = nupkg.GetEntry(packageFile);
+
+                var packageFileName = entry.FullName;
+                // An entry in a ZipArchive could start with a '/' based on how it is zipped
+                // Remove it if present
+                if (packageFileName.StartsWith("/", StringComparison.Ordinal))
+                {
+                    packageFileName = packageFileName.Substring(1);
+                }
+                // Get only the name, without the path, since we are extracting to flat list
+                packageFileName = Path.GetFileName(packageFileName);
+
+                // ZipArchive always has forward slashes in them. By replacing them with DirectorySeparatorChar;
+                // in windows, we get the windows-style path
+                var normalizedPath = Uri.UnescapeDataString(packageFileName.Replace('/', Path.DirectorySeparatorChar));
+
+                var targetFilePath = Path.Combine(destination, normalizedPath);
+                if (!targetFilePath.StartsWith(destination, StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+                try
+                {
+                    File.Delete(targetFilePath);
+                }
+                catch
+                {
+                    // Do nothing
+                }
+                using (var stream = entry.Open())
+                {
+                    var copiedFile = packageFileExtractor.ExtractPackageFile(packageFileName, targetFilePath, stream);
+                    if (copiedFile != null)
+                    {
+                        entry.UpdateFileTimeFromEntry(copiedFile, logger);
+
+                        filesCopied.Add(copiedFile);
+                    }
+                }
+            }
+
+        }
+
+        private void CopyNupkgFilesToTarget(PackageArchiveReader nupkg, string destPath, IEnumerable<string> files)
+        {
+            var packageFileExtractor = new PackageFileExtractor(files,
+                                         PackageExtractionBehavior.XmlDocFileSaveMode);
+
+            nupkg.CopyFiles(destPath, files, packageFileExtractor.ExtractPackageFile, new TestCommandOutputLogger(),
+                CancellationToken.None);
+
+        }
+
+        private static string FindMostRecentNupkg(string nupkgDirectory, string id)
+        {
+            var info = LocalFolderUtility.GetPackagesV2(nupkgDirectory, new TestLogger());
+
+            return info.Where(t => t.Identity.Id.Equals(id, StringComparison.OrdinalIgnoreCase))
+                .Where(t => !Path.GetExtension(Path.GetFileNameWithoutExtension(t.Path)).Equals(".symbols"))
+                .OrderByDescending(p => p.LastWriteTimeUtc)
+                .First().Path;
+        }
+
+        public void Dispose()
+        {
+            RunDotnet(Path.GetDirectoryName(_testDotnetCli), "build-server shutdown");
+            KillDotnetExe(_testDotnetCli);
+            _cliDirectory.Dispose();
+        }
+
+        private static void KillDotnetExe(string pathToDotnetExe)
+        {
+            var processes = Process.GetProcessesByName("dotnet")
+                .Where(t => string.Compare(t.MainModule.FileName, Path.GetFullPath(pathToDotnetExe), ignoreCase: true) == 0);
+            var testDirProcesses = Process.GetProcesses()
+                .Where(t => t.MainModule.FileName.StartsWith(TestFileSystemUtility.NuGetTestFolder, StringComparison.OrdinalIgnoreCase));
+            try
+            {
+                if (processes != null)
+                {
+                    foreach (var process in processes)
+                    {
+                        if (string.Compare(process.MainModule.FileName, Path.GetFullPath(pathToDotnetExe), true) == 0)
+                        {
+                            process.Kill();
+                        }
+                    }
+                }
+
+                if (testDirProcesses != null)
+                {
+                    foreach (var process in testDirProcesses)
+                    {
+                        process.Kill();
+                    }
+                }
+
+            }
+            catch { }
+        }
+
+        /// <summary>
+        /// Depth-first recursive delete, with handling for descendant 
+        /// directories open in Windows Explorer or used by another process
+        /// </summary>
+        private static void DeleteDirectory(string path)
+        {
+            foreach (string directory in Directory.GetDirectories(path))
+            {
+                DeleteDirectory(directory);
+            }
+
+            try
+            {
+                Directory.Delete(path, true);
+            }
+            catch (IOException)
+            {
+                Directory.Delete(path, true);
+            }
+            catch (UnauthorizedAccessException)
+            {
+                Directory.Delete(path, true);
+            }
+            catch
+            {
+
+            }
+        }
+    }
+}

--- a/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildRestoreTaskTests.cs
+++ b/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildRestoreTaskTests.cs
@@ -178,7 +178,7 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
                 // Assert
                 Assert.True(result.ExitCode == 0, result.AllOutput);
                 Assert.Contains("Installing x 1.0.0", result.AllOutput);
-                Assert.DoesNotContain(configAPath, result.AllOutput);
+                Assert.Contains(configAPath, result.AllOutput);
             }
         }
 

--- a/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildRestoreTaskTests.cs
+++ b/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildRestoreTaskTests.cs
@@ -1,0 +1,368 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using System.Linq;
+using System.Xml.Linq;
+using FluentAssertions;
+using NuGet.Common;
+using NuGet.Frameworks;
+using NuGet.Test.Utility;
+using NuGet.ProjectModel;
+using Xunit;
+
+namespace Msbuild.Integration.Test
+{
+    [Collection("Msbuild Integration Tests")]
+    public class MsbuildRestoreTaskTests
+    {
+        private MsbuildIntegrationTestFixture _msbuildFixture;
+
+        public MsbuildRestoreTaskTests(MsbuildIntegrationTestFixture fixture)
+        {
+            _msbuildFixture = fixture;
+        }
+
+        [PlatformFact(Platform.Windows)]
+        public async Task MsbuildRestore_PackagesConfigDependencyAsync()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Set up solution, project, and packages
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+
+                var net461 = NuGetFramework.Parse("net461");
+
+                var projectA = new SimpleTestProjectContext(
+                    "a",
+                    ProjectStyle.PackagesConfig,
+                    pathContext.SolutionRoot);
+                projectA.Frameworks.Add(new SimpleTestProjectFrameworkContext(net461));
+
+                var packageX = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.0"
+                };
+                packageX.Files.Clear();
+                packageX.AddFile("lib/net461/a.dll");
+
+                solution.Projects.Add(projectA);
+                solution.Create(pathContext.SolutionRoot);
+
+                using (var writer = new StreamWriter(Path.Combine(Path.GetDirectoryName(projectA.ProjectPath), "packages.config")))
+                {
+                    writer.Write(
+@"<packages>
+  <package id=""x"" version=""1.0.0"" targetFramework=""net461"" />
+</packages>");
+                }
+
+                await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                    pathContext.PackageSource,
+                    packageX);
+
+                // Act
+                var result = _msbuildFixture.RunMsBuild(pathContext.WorkingDirectory, $"/t:restore {pathContext.SolutionRoot} /p:RestorePackagesConfig=true", ignoreExitCode: true);
+
+
+                // Assert
+                Assert.True(result.ExitCode == 0, result.AllOutput);
+                Assert.Contains("Added package 'x.1.0.0' to folder", result.AllOutput);
+            }
+        }
+
+        [PlatformFact(Platform.Windows)]
+        public async Task MsbuildRestore_PackagesConfigIsOptInAsync()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Set up solution, project, and packages
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+
+                var net461 = NuGetFramework.Parse("net461");
+
+                var projectA = new SimpleTestProjectContext(
+                    "a",
+                    ProjectStyle.PackagesConfig,
+                    pathContext.SolutionRoot);
+                projectA.Frameworks.Add(new SimpleTestProjectFrameworkContext(net461));
+
+                var packageX = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.0"
+                };
+                packageX.Files.Clear();
+                packageX.AddFile("lib/net461/a.dll");
+
+                solution.Projects.Add(projectA);
+                solution.Create(pathContext.SolutionRoot);
+
+                using (var writer = new StreamWriter(Path.Combine(Path.GetDirectoryName(projectA.ProjectPath), "packages.config")))
+                {
+                    writer.Write(
+@"<packages>
+  <package id=""x"" version=""1.0.0"" targetFramework=""net461"" />
+</packages>");
+                }
+
+                await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                    pathContext.PackageSource,
+                    packageX);
+
+                // Act
+                var result = _msbuildFixture.RunMsBuild(pathContext.WorkingDirectory, $"/t:restore {pathContext.SolutionRoot}", ignoreExitCode: true);
+
+
+                // Assert
+                Assert.True(result.ExitCode == 0, result.AllOutput);
+                Assert.Contains("Nothing to do. None of the projects specified contain packages to restore.", result.AllOutput);
+            }
+        }
+
+        [PlatformFact(Platform.Windows)]
+        public async Task MsbuildRestore_PackageReferenceDependencyAsync()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Set up solution, project, and packages
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+
+                var net461 = NuGetFramework.Parse("net461");
+
+                var projectA = new SimpleTestProjectContext(
+                    "a",
+                    ProjectStyle.PackageReference,
+                    pathContext.SolutionRoot);
+                projectA.Frameworks.Add(new SimpleTestProjectFrameworkContext(net461));
+
+                var packageX = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.0"
+                };
+                packageX.Files.Clear();
+                projectA.AddPackageToAllFrameworks(packageX);
+                packageX.AddFile("lib/net461/a.dll");
+
+                solution.Projects.Add(projectA);
+                solution.Create(pathContext.SolutionRoot);
+
+                var configAPath = Path.Combine(Path.GetDirectoryName(projectA.ProjectPath), "NuGet.Config");
+                var configText =
+$@"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+    <packageSources>
+        <add key=""LocalSource"" value=""{pathContext.PackageSource}"" />
+    </packageSources>
+</configuration>";
+                using (var writer = new StreamWriter(configAPath))
+                {
+                    writer.Write(configText);
+                }
+
+                await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                    pathContext.PackageSource,
+                    packageX);
+
+                // Act
+                var result = _msbuildFixture.RunMsBuild(pathContext.WorkingDirectory, $"/t:restore {pathContext.SolutionRoot}", ignoreExitCode: true);
+
+
+                // Assert
+                Assert.True(result.ExitCode == 0, result.AllOutput);
+                Assert.Contains("Installing x 1.0.0", result.AllOutput);
+                Assert.DoesNotContain(configAPath, result.AllOutput);
+            }
+        }
+
+        [PlatformFact(Platform.Windows)]
+        public async Task MsbuildRestore_PackageReferenceDependencyCsProjAsync()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Set up solution, project, and packages
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+
+                var net461 = NuGetFramework.Parse("net461");
+
+                var projectA = new SimpleTestProjectContext(
+                    "a",
+                    ProjectStyle.PackageReference,
+                    pathContext.SolutionRoot);
+                projectA.Frameworks.Add(new SimpleTestProjectFrameworkContext(net461));
+
+                var packageX = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.0"
+                };
+                packageX.Files.Clear();
+                projectA.AddPackageToAllFrameworks(packageX);
+                packageX.AddFile("lib/net461/a.dll");
+
+                solution.Projects.Add(projectA);
+                solution.Create(pathContext.SolutionRoot);
+
+                var configAPath = Path.Combine(Path.GetDirectoryName(projectA.ProjectPath), "NuGet.Config");
+                var configText =
+$@"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+    <packageSources>
+        <add key=""LocalSource"" value=""{pathContext.PackageSource}"" />
+    </packageSources>
+</configuration>";
+                using (var writer = new StreamWriter(configAPath))
+                {
+                    writer.Write(configText);
+                }
+
+                await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                    pathContext.PackageSource,
+                    packageX);
+
+                // Act
+                var result = _msbuildFixture.RunMsBuild(pathContext.WorkingDirectory, $"/t:restore {projectA.ProjectPath}", ignoreExitCode: true);
+
+
+                // Assert
+                Assert.True(result.ExitCode == 0, result.AllOutput);
+                Assert.Contains("Installing x 1.0.0", result.AllOutput);
+                Assert.Contains(configAPath, result.AllOutput);
+            }
+        }
+
+        [PlatformFact(Platform.Windows)]
+        public async Task MsbuildRestore_RequiresSolutionDirAsync()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Set up solution, project, and packages
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+
+                var net461 = NuGetFramework.Parse("net461");
+
+                var projectA = new SimpleTestProjectContext(
+                    "a",
+                    ProjectStyle.PackagesConfig,
+                    pathContext.SolutionRoot);
+                projectA.Frameworks.Add(new SimpleTestProjectFrameworkContext(net461));
+
+                var packageX = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.0"
+                };
+                packageX.Files.Clear();
+                packageX.AddFile("lib/net461/a.dll");
+
+                solution.Projects.Add(projectA);
+                solution.Create(pathContext.SolutionRoot);
+
+                using (var writer = new StreamWriter(Path.Combine(Path.GetDirectoryName(projectA.ProjectPath), "packages.config")))
+                {
+                    writer.Write(
+@"<packages>
+  <package id=""x"" version=""1.0.0"" targetFramework=""net461"" />
+</packages>");
+                }
+
+                // SimpleTestPathContext adds a NuGet.Config with a repositoryPath,
+                // so we go ahead and remove that config before running MSBuild.
+                var configPath = Path.Combine(Path.GetDirectoryName(pathContext.SolutionRoot), "NuGet.Config");
+                var doc = XDocument.Parse(File.ReadAllText(configPath));
+                var root = doc.Element(XName.Get("configuration"));
+                var config = root.Element(XName.Get("config"));
+                foreach (var item in config.Elements(XName.Get("add")).Where(e => ((string)e.Attribute("key")).Equals("repositoryPath", StringComparison.OrdinalIgnoreCase)).ToArray())
+                {
+                    item.Remove();
+                }
+                File.Delete(configPath);
+                File.WriteAllText(configPath, doc.ToString());
+
+                await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                    pathContext.PackageSource,
+                    packageX);
+
+                // Act
+                var result = _msbuildFixture.RunMsBuild(pathContext.WorkingDirectory, $"/t:restore {projectA.ProjectPath} /p:RestorePackagesConfig=true", ignoreExitCode: true);
+
+
+                // Assert
+                Assert.True(result.ExitCode == 1, result.AllOutput);
+                Assert.Contains("No solution found", result.AllOutput);
+            }
+        }
+
+        [PlatformFact(Platform.Windows)]
+        public async Task MsbuildRestore_SupportsPackageSaveModeAsync()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Set up solution, project, and packages
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+
+                var net461 = NuGetFramework.Parse("net461");
+
+                var projectA = new SimpleTestProjectContext(
+                    "a",
+                    ProjectStyle.PackagesConfig,
+                    pathContext.SolutionRoot);
+                projectA.Frameworks.Add(new SimpleTestProjectFrameworkContext(net461));
+
+                var packageX = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.0"
+                };
+                packageX.Files.Clear();
+                packageX.AddFile("lib/net461/a.dll");
+
+                solution.Projects.Add(projectA);
+                solution.Create(pathContext.SolutionRoot);
+
+                using (var writer = new StreamWriter(Path.Combine(Path.GetDirectoryName(projectA.ProjectPath), "packages.config")))
+                {
+                    writer.Write(
+@"<packages>
+  <package id=""x"" version=""1.0.0"" targetFramework=""net461"" />
+</packages>");
+                }
+
+                var configPath = Path.Combine(Path.GetDirectoryName(pathContext.SolutionRoot), "NuGet.Config");
+                var doc = XDocument.Parse(File.ReadAllText(configPath));
+                var root = doc.Element(XName.Get("configuration"));
+                var config = root.Element(XName.Get("config"));
+                var setting = new XElement(XName.Get("add"));
+                setting.Add(new XAttribute(XName.Get("key"), "PackageSaveMode"));
+                setting.Add(new XAttribute(XName.Get("value"), "nuspec;nupkg"));
+                config.Add(setting);
+                File.Delete(configPath);
+                File.WriteAllText(configPath, doc.ToString());
+
+                await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                    pathContext.PackageSource,
+                    packageX);
+
+                var pkgPath = Path.Combine(pathContext.SolutionRoot, "packages", "x.1.0.0");
+                // Act
+                var result = _msbuildFixture.RunMsBuild(pathContext.WorkingDirectory, $"/t:restore {pathContext.SolutionRoot} /p:RestorePackagesConfig=true", ignoreExitCode: true);
+
+
+                // Assert
+                Assert.True(result.ExitCode == 0, result.AllOutput);
+                Assert.True(File.Exists(Path.Combine(pkgPath, "x.1.0.0.nupkg")));
+                Assert.True(File.Exists(Path.Combine(pkgPath, "x.nuspec")));
+            }
+        }
+    }
+}

--- a/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestSolutionContext.cs
+++ b/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestSolutionContext.cs
@@ -57,11 +57,30 @@ namespace NuGet.Test.Utility
 
             foreach (var project in Projects)
             {
-                sb.AppendLine("Project(\"{" + SolutionGuid.ToString() + "}" + $"\") = \"{project.ProjectName}\", " + "\"" + project.ProjectPath +"\", \"{" + project.ProjectGuid +"}\"");
+                sb.AppendLine("Project(\"{" + SolutionGuid.ToString() + "}" + $"\") = \"{project.ProjectName}\", " + "\"" + project.ProjectPath + "\", \"{" + project.ProjectGuid + "}\"");
                 sb.AppendLine("EndProject");
             }
 
             sb.AppendLine("Global");
+            sb.AppendLine("  GlobalSection(SolutionConfigurationPlatforms) = preSolution");
+            sb.AppendLine("    Debug|Any CPU = Debug|Any CPU");
+            sb.AppendLine("    Release|Any CPU = Release|Any CPU");
+            sb.AppendLine("  EndGlobalSection");
+            sb.AppendLine("  GlobalSection(ProjectConfigurationPlatforms) = postSolution");
+            foreach (var project in Projects)
+            {
+                sb.AppendLine("    {" + project.ProjectGuid + "}.Debug|Any CPU.ActiveCfg = Debug|Any CPU");
+                sb.AppendLine("    {" + project.ProjectGuid + "}.Debug|Any CPU.Build.0 = Debug|Any CPU");
+                sb.AppendLine("    {" + project.ProjectGuid + "}.Release|Any CPU.ActiveCfg = Release|Any CPU");
+                sb.AppendLine("    {" + project.ProjectGuid + "}.Release|Any CPU.Build.0 = Release|Any CPU");
+            }
+            sb.AppendLine("  EndGlobalSection");
+            sb.AppendLine("  GlobalSection(SolutionProperties) = preSolution");
+            sb.AppendLine("    HideSolutionNode = FALSE");
+            sb.AppendLine("  EndGlobalSection");
+            sb.AppendLine("  GlobalSection(ExtensibilityGlobals) = postSolution");
+            sb.AppendLine("    SolutionGuid = {" + SolutionGuid.ToString() + "}");
+            sb.AppendLine("  EndGlobalSection");
             sb.AppendLine("EndGlobal");
 
             return sb;


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/8676
Fixes: https://github.com/NuGet/Home/issues/8677
Fixes: https://github.com/NuGet/Home/issues/8506
  
Regression: No  

## Fix

Spec: https://github.com/NuGet/Home/wiki/Backporting-PC-to-msbuild--restore

This adds support for `packages.config` to `msbuild /restore` when using `/p:RestorePackagesConfig=true`. Cheers to @jeffkl for writing the initial code for this.

## Testing/Validation

Tests Added: Yes 

