### PR TITLE
Use supported CLI version

### DIFF
--- a/scripts/funcTests/runFuncTests.sh
+++ b/scripts/funcTests/runFuncTests.sh
@@ -28,7 +28,7 @@ curl -o cli/dotnet-install.sh -L https://dot.net/v1/dotnet-install.sh
 chmod +x cli/dotnet-install.sh
 
 # Get recommended version for bootstrapping testing version
-cli/dotnet-install.sh -i cli
+cli/dotnet-install.sh -i cli -c 2.2
 
 DOTNET="$(pwd)/cli/dotnet"
 


### PR DESCRIPTION
## Bug

Fixes: 
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: With the new release 3.1 is now the LTS supported version so the default install scripts will get 3.1 instead of 2.2. That causes all our mac builds to fail: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=3294355
Since we are currently on older macs that are not supported by 3.x we should pin down to a lower version.
https://github.com/dotnet/core/blob/master/release-notes/3.0/3.0-supported-os.md

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  
Validation:  
