### PR TITLE
disable correctly

### DIFF
--- a/test/EndToEnd/tests/GetPackageTest.ps1
+++ b/test/EndToEnd/tests/GetPackageTest.ps1
@@ -39,6 +39,8 @@ function Test-GetPackageWithUpdatesListsUpdates {
 
 function Test-GetPackageCollapsesPackageVersionsForListAvailable {
     [SkipTest('https://github.com/NuGet/Home/issues/8849')]
+    param()
+
     # Act
     $packages = Get-Package -ListAvailable jQuery
     $packagesWithMoreThanOne = $packages | group "Id" | Where { $_.count -gt 1 }


### PR DESCRIPTION
Progress on [NuGet/Home#8849](https://github.com/NuGet/Home/issues/8849).
Flaky test GetPackageCollapsesPackageVersionsForListAvailable is not disabled correctly.
Correct it by adding param()

Checked test reuslts, the GetPackageCollapsesPackageVersionsForListAvailable is skipped now.