### PR TITLE
Fix apex test : clear output and error list

### DIFF
--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Apex/ApexTestContext.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Apex/ApexTestContext.cs
@@ -37,6 +37,8 @@ namespace NuGet.Tests.Apex
             SolutionService = _visualStudio.Get<SolutionService>();
             NuGetApexTestService = _visualStudio.Get<NuGetApexTestService>();
 
+            VisualStudioHostExtension.ClearWindows(_visualStudio);
+
             Project = CommonUtility.CreateAndInitProject(projectTemplate, _pathContext, SolutionService, logger);
 
             NuGetApexTestService.WaitForAutoRestore();

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NetCoreProjectTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NetCoreProjectTestCase.cs
@@ -46,6 +46,7 @@ namespace NuGet.Tests.Apex
                 testContext.SolutionService.Build();
                 testContext.NuGetApexTestService.WaitForAutoRestore();
 
+                VisualStudio.AssertNoErrors();
                 CommonUtility.AssertPackageInAssetsFile(VisualStudio, testContext.Project, "TestProject2", "1.0.0", XunitLogger);
             }
         }


### PR DESCRIPTION
## Bug

Fixes: [NuGet/Home/8884](https://github.com/NuGet/Home/issues/8884)
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: 
Clear output and error list in VS at the beginning of the test.
Add an assertion for test CreateNetCoreProject_AddProjectReference.

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  
Validation:  
