### PR TITLE
add netstandard feeds for Apex tests

### DIFF
--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Apex/ApexTestContext.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Apex/ApexTestContext.cs
@@ -22,7 +22,7 @@ namespace NuGet.Tests.Apex
 
         public NuGetApexTestService NuGetApexTestService { get; }
 
-        public ApexTestContext(VisualStudioHost visualStudio, ProjectTemplate projectTemplate, ILogger logger, bool noAutoRestore = false)
+        public ApexTestContext(VisualStudioHost visualStudio, ProjectTemplate projectTemplate, ILogger logger, bool noAutoRestore = false, bool addNetStandardFeeds = false)
         {
             logger.LogInformation("Creating test context");
             _pathContext = new SimpleTestPathContext();
@@ -30,6 +30,11 @@ namespace NuGet.Tests.Apex
             if (noAutoRestore)
             {
                 _pathContext.Settings.DisableAutoRestore();
+            }
+
+            if (addNetStandardFeeds)
+            {
+                _pathContext.Settings.AddNetStandardFeeds();
             }
 
             _visualStudio = visualStudio;

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NetCoreProjectTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NetCoreProjectTestCase.cs
@@ -21,7 +21,7 @@ namespace NuGet.Tests.Apex
             // Arrange
             EnsureVisualStudioHost();
 
-            using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, XunitLogger))
+            using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, XunitLogger, addNetStandardFeeds: true))
             {
                 VisualStudio.AssertNoErrors();
             }
@@ -35,7 +35,7 @@ namespace NuGet.Tests.Apex
             // Arrange
             EnsureVisualStudioHost();
 
-            using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, XunitLogger))
+            using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, XunitLogger, addNetStandardFeeds: true))
             {
                 var project2 = testContext.SolutionService.AddProject(ProjectLanguage.CSharp, projectTemplate, ProjectTargetFramework.V46, "TestProject2");
                 project2.Build();

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetConsoleTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetConsoleTestCase.cs
@@ -26,7 +26,7 @@ namespace NuGet.Tests.Apex
             // Arrange
             EnsureVisualStudioHost();
 
-            using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, XunitLogger, noAutoRestore: true))
+            using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, XunitLogger, noAutoRestore: true, addNetStandardFeeds: true))
             {
                 var packageName = "TestPackage";
                 var packageVersion = "1.0.0";
@@ -204,7 +204,7 @@ namespace NuGet.Tests.Apex
             // Arrange
             EnsureVisualStudioHost();
 
-            using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, XunitLogger))
+            using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, XunitLogger, addNetStandardFeeds: true))
             {
                 var project2 = testContext.SolutionService.AddProject(ProjectLanguage.CSharp, projectTemplate, ProjectTargetFramework.V46, "TestProject2");
                 project2.Build();
@@ -252,7 +252,7 @@ namespace NuGet.Tests.Apex
             var packageVersion2 = "2.0.0";
             var source = "https://api.nuget.org/v3/index.json";
 
-            using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, XunitLogger))
+            using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, XunitLogger, addNetStandardFeeds: true))
             {
                 // Arrange
                 var solutionService = VisualStudio.Get<SolutionService>();

--- a/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestSettingsContext.cs
+++ b/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestSettingsContext.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Linq;
 using System.Xml.Linq;
 using NuGet.Common;
+using Xunit;
 
 namespace NuGet.Test.Utility
 {
@@ -137,5 +138,46 @@ namespace NuGet.Test.Utility
                 item.Remove();
             }
         }
+
+        // Add NetStandard.Library and NetCorePlatforms to the feed and save the file.
+        public void AddNetStandardFeeds()
+        {
+            var reposRoot = GetRepositoryRootDirectory();
+            var netStandardLibraryPackageFeed = GetRepoPackageDirectoryName(reposRoot, "netstandard.library");
+            var netCorePlatformsPackageFeed = GetRepoPackageDirectoryName(reposRoot, "microsoft.netcore.platforms");
+
+            Assert.True(Directory.Exists(netStandardLibraryPackageFeed));
+            Assert.True(Directory.Exists(netCorePlatformsPackageFeed));
+
+            var section = GetOrAddSection(XML, "packageSources");
+            AddEntry(section, "NetStandardLibrary", netStandardLibraryPackageFeed);
+            AddEntry(section, "NetCorePlatforms", netCorePlatformsPackageFeed);
+
+            Save();
+        }
+
+        private static DirectoryInfo GetRepositoryRootDirectory()
+        {
+            DirectoryInfo currentDir = new DirectoryInfo(Directory.GetCurrentDirectory());
+            while (currentDir != null)
+            {
+                if (File.Exists(Path.Combine(currentDir.FullName, "NuGet.sln")))
+                {
+                    // We have found the repo root.
+                    return currentDir;
+                }
+
+                currentDir = currentDir.Parent;
+            }
+
+            throw new DirectoryNotFoundException("The directory containing 'NuGet.sln' could not be found");
+        }
+
+        private static string GetRepoPackageDirectoryName(DirectoryInfo reposRoot, string packageId)
+        {
+            var repoPackageDir = Path.Combine(reposRoot.FullName, "packages", packageId);
+            return repoPackageDir;
+        }
+           
     }
 }

--- a/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestSettingsContext.cs
+++ b/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestSettingsContext.cs
@@ -143,8 +143,8 @@ namespace NuGet.Test.Utility
         public void AddNetStandardFeeds()
         {
             var reposRoot = GetRepositoryRootDirectory();
-            var netStandardLibraryPackageFeed = GetRepoPackageDirectoryName(reposRoot, "netstandard.library");
-            var netCorePlatformsPackageFeed = GetRepoPackageDirectoryName(reposRoot, "microsoft.netcore.platforms");
+            var netStandardLibraryPackageFeed = GetRepoPackageDirectoryPath(reposRoot, "netstandard.library");
+            var netCorePlatformsPackageFeed = GetRepoPackageDirectoryPath(reposRoot, "microsoft.netcore.platforms");
 
             Assert.True(Directory.Exists(netStandardLibraryPackageFeed));
             Assert.True(Directory.Exists(netCorePlatformsPackageFeed));
@@ -170,10 +170,10 @@ namespace NuGet.Test.Utility
                 currentDir = currentDir.Parent;
             }
 
-            throw new DirectoryNotFoundException("The directory containing 'NuGet.sln' could not be found");
+            throw new DirectoryNotFoundException($"Starting from {Directory.GetCurrentDirectory()} the directory containing 'NuGet.sln' could not be found.");
         }
 
-        private static string GetRepoPackageDirectoryName(DirectoryInfo reposRoot, string packageId)
+        private static string GetRepoPackageDirectoryPath(DirectoryInfo reposRoot, string packageId)
         {
             var repoPackageDir = Path.Combine(reposRoot.FullName, "packages", packageId);
             return repoPackageDir;


### PR DESCRIPTION
## Bug

Fixes: [NuGet/Home/8885](https://github.com/NuGet/Home/issues/8885)
Regression: Yes
* Last working version:   
* How are we preventing it in future:   

## Fix

Details:
Make use of NuGet.Client/packages folder, 
add netstandard.library feed to make sure Apex test creating netstandard2.0 project can restore correctly without NuGetFallbackFolder

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  
Validation:  tested in netcore5.0 and failed tests pass with this change.
