### PR TITLE
Use the same strongname for NuGet.Commandline as NuGet.exe

### DIFF
--- a/build/sign.targets
+++ b/build/sign.targets
@@ -8,7 +8,8 @@
 
   <!-- Use MSFT SNK for all NuGet.Core test and source projects and since we do not own MSFT SNK we can only delay sign the assemblies. -->
   <PropertyGroup Condition = " $(MSBuildProjectFullPath.Contains('src\NuGet.Core')) == 'true' or $(MSBuildProjectFullPath.Contains('test/NuGet.Core')) == 'true' or
-                               $(MSBuildProjectFullPath.Contains('src/NuGet.Core')) == 'true' or $(MSBuildProjectFullPath.Contains('test\NuGet.Core')) == 'true' ">
+                               $(MSBuildProjectFullPath.Contains('src/NuGet.Core')) == 'true' or $(MSBuildProjectFullPath.Contains('test\NuGet.Core')) == 'true' or
+                               $(MSBuildProjectFullPath.Contains('NuGet.CommandLine.csproj')) == 'true' ">
 
     <StrongNameKey>$(MS_PFX_PATH)</StrongNameKey>
     <DefaultStrongNameCert>MsSharedLib72</DefaultStrongNameCert>

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/ExtensionsTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/ExtensionsTests.cs
@@ -10,7 +10,7 @@ namespace NuGet.CommandLine.Test
 {
     public class ExtensionsTests
     {
-        [Fact(Skip = "https://github.com/NuGet/Home/issues/8887")]
+        [Fact]
         public void TestExtensionsFsromProgramDirLoaded()
         {
             var nugetexe = Util.GetNuGetExePath();

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGet.CommandLine.Test.csproj
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGet.CommandLine.Test.csproj
@@ -55,7 +55,7 @@
     <PostBuildEvent>
       xcopy /diy $(ArtifactsDirectory)TestableCredentialProvider\$(BuildVariationFolder)\bin\$(Configuration)\$(TargetFramework)\CredentialProvider.Testable.exe $(OutputPath)TestableCredentialProvider\
       xcopy /diy $(ArtifactsDirectory)TestableCredentialProvider\$(BuildVariationFolder)\bin\$(Configuration)\$(TargetFramework)\*.dll $(OutputPath)TestableCredentialProvider\
-      xcopy /diy $(ArtifactsDirectory)SampleCommandLineExtensions\$(BuildVariationFolder)\bin\$(Configuration)\$(TargetFramework)\SampleCommandLineExtensions.dll $(OutputPath)
+      xcopy /diy $(ArtifactsDirectory)SampleCommandLineExtensions\$(BuildVariationFolder)\bin\$(Configuration)\$(TargetFramework)\SampleCommandLineExtensions.dll $(OutputPath)NuGet\
       xcopy /diy $(ArtifactsDirectory)$(VsixOutputDirName)\NuGet.exe $(OutputPath)NuGet\
     </PostBuildEvent>
   </PropertyGroup>


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/8887
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: 
The NuGet.CommandLine strongname is different than NuGet.exe ilmerged strong name.

That means if we run tests such as: https://github.com/NuGet/NuGet.Client/blob/dev/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/ExtensionsTests.cs#L13 with the ilmerged assembly instead of the regular one, it will fail.

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  Re-enabling one
Validation:  
