### PR TITLE
Make SolutionRestoreManager load in time to hear Solution Build events

### DIFF
--- a/build/common.ps1
+++ b/build/common.ps1
@@ -188,13 +188,12 @@ Function Install-DotnetCLI {
 
     $env:DOTNET_HOME=$cli.Root
     $env:DOTNET_INSTALL_DIR=$NuGetClientRoot
+    $DotNetInstall = Join-Path $cli.Root 'dotnet-install.ps1'
 
     if ($Force -or -not (Test-Path $DotNetExe)) {
         Trace-Log 'Downloading .NET CLI'
 
         New-Item -ItemType Directory -Force -Path $cli.Root | Out-Null
-
-        $DotNetInstall = Join-Path $cli.Root 'dotnet-install.ps1'
 
         Invoke-WebRequest 'https://dot.net/v1/dotnet-install.ps1' -OutFile $DotNetInstall
         & $DotNetInstall -Channel $cli.Channel -i $cli.Root -Version $cli.Version -Architecture $arch

--- a/build/sign.targets
+++ b/build/sign.targets
@@ -8,7 +8,8 @@
 
   <!-- Use MSFT SNK for all NuGet.Core test and source projects and since we do not own MSFT SNK we can only delay sign the assemblies. -->
   <PropertyGroup Condition = " $(MSBuildProjectFullPath.Contains('src\NuGet.Core')) == 'true' or $(MSBuildProjectFullPath.Contains('test/NuGet.Core')) == 'true' or
-                               $(MSBuildProjectFullPath.Contains('src/NuGet.Core')) == 'true' or $(MSBuildProjectFullPath.Contains('test\NuGet.Core')) == 'true' ">
+                               $(MSBuildProjectFullPath.Contains('src/NuGet.Core')) == 'true' or $(MSBuildProjectFullPath.Contains('test\NuGet.Core')) == 'true' or
+                               $(MSBuildProjectFullPath.Contains('NuGet.CommandLine.csproj')) == 'true' ">
 
     <StrongNameKey>$(MS_PFX_PATH)</StrongNameKey>
     <DefaultStrongNameCert>MsSharedLib72</DefaultStrongNameCert>

--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -89,7 +89,7 @@ phases:
       scriptType: "inlineScript"
       inlineScript: |
         Write-Host "##vso[build.updatebuildnumber]$env:FullVstsBuildNumber"
-        gci env:* | sort-object name
+        Get-ChildItem Env: | Sort-Object Name | Format-Table -Wrap -AutoSize
 
   - task: PowerShell@1
     displayName: "Define variables"
@@ -128,7 +128,7 @@ phases:
     inputs:
       scriptType: "inlineScript"
       inlineScript: |
-        gci env:* | sort-object name
+        Get-ChildItem Env: | Sort-Object Name | Format-Table -Wrap -AutoSize
 
   - task: NuGetCommand@2
     displayName: 'MicroBuild:  install core package'
@@ -559,7 +559,7 @@ phases:
       scriptType: "inlineScript"
       inlineScript: |
         Write-Host "##vso[build.updatebuildnumber]$env:FullVstsBuildNumber"
-        gci env:* | sort-object name
+        Get-ChildItem Env: | Sort-Object Name | Format-Table -Wrap -AutoSize
 
   - task: PowerShell@1
     displayName: "Download Config Files"
@@ -744,7 +744,7 @@ phases:
       scriptType: "inlineScript"
       inlineScript: |
         Write-Host "##vso[build.updatebuildnumber]$env:FullVstsBuildNumber"
-        gci env:* | sort-object name
+        Get-ChildItem Env: | Sort-Object Name | Format-Table -Wrap -AutoSize
 
   - task: DownloadBuildArtifacts@0
     displayName: "Download Build artifacts"
@@ -844,7 +844,7 @@ phases:
       scriptType: "inlineScript"
       inlineScript: |
         Write-Host "##vso[build.updatebuildnumber]$env:FullVstsBuildNumber"
-        gci env:* | sort-object name
+        Get-ChildItem Env: | Sort-Object Name | Format-Table -Wrap -AutoSize
 
   - task: DownloadBuildArtifacts@0
     displayName: "Download Build artifacts"

--- a/src/NuGet.Clients/NuGet.CommandLine/app.manifest
+++ b/src/NuGet.Clients/NuGet.CommandLine/app.manifest
@@ -5,4 +5,18 @@
       <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
     </windowsSettings>
   </application>
+
+  <!-- Supported operating systems -->
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- Windows 7 -->
+      <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+      <!-- Windows 8 -->
+      <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
+      <!-- Windows 8.1 -->
+      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
+      <!-- Windows 10 -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+    </application>
+  </compatibility>
 </assembly>

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/RestoreManagerPackage.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/RestoreManagerPackage.cs
@@ -6,9 +6,6 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell;
-using Microsoft.VisualStudio.Shell.Interop;
-using NuGet.Protocol.Core.Types;
-using NuGet.VisualStudio;
 using Task = System.Threading.Tasks.Task;
 
 namespace NuGet.SolutionRestoreManager

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/RestoreManagerPackage.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/RestoreManagerPackage.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -20,7 +20,10 @@ namespace NuGet.SolutionRestoreManager
     // Flag AllowsBackgroundLoading is set to True and Flag PackageAutoLoadFlags is set to BackgroundLoad
     // which will allow this package to be loaded asynchronously
     [PackageRegistration(UseManagedResourcesOnly = true, AllowsBackgroundLoading = true)]
+    // BackgroundLoad this package as soon as a Solution exists.
     [ProvideAutoLoad(VSConstants.UICONTEXT.SolutionExists_string, PackageAutoLoadFlags.BackgroundLoad)]
+    // Ensure that this package is loaded in time to listen to solution build events, in order to always be able to restore before build.
+    [ProvideAutoLoad(VSConstants.UICONTEXT.SolutionBuilding_string)]
     [Guid(PackageGuidString)]
     public sealed class RestoreManagerPackage : AsyncPackage
     {

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/ExtensionsTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/ExtensionsTests.cs
@@ -10,7 +10,7 @@ namespace NuGet.CommandLine.Test
 {
     public class ExtensionsTests
     {
-        [Fact(Skip = "https://github.com/NuGet/Home/issues/8887")]
+        [Fact]
         public void TestExtensionsFsromProgramDirLoaded()
         {
             var nugetexe = Util.GetNuGetExePath();

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGet.CommandLine.Test.csproj
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGet.CommandLine.Test.csproj
@@ -55,7 +55,7 @@
     <PostBuildEvent>
       xcopy /diy $(ArtifactsDirectory)TestableCredentialProvider\$(BuildVariationFolder)\bin\$(Configuration)\$(TargetFramework)\CredentialProvider.Testable.exe $(OutputPath)TestableCredentialProvider\
       xcopy /diy $(ArtifactsDirectory)TestableCredentialProvider\$(BuildVariationFolder)\bin\$(Configuration)\$(TargetFramework)\*.dll $(OutputPath)TestableCredentialProvider\
-      xcopy /diy $(ArtifactsDirectory)SampleCommandLineExtensions\$(BuildVariationFolder)\bin\$(Configuration)\$(TargetFramework)\SampleCommandLineExtensions.dll $(OutputPath)
+      xcopy /diy $(ArtifactsDirectory)SampleCommandLineExtensions\$(BuildVariationFolder)\bin\$(Configuration)\$(TargetFramework)\SampleCommandLineExtensions.dll $(OutputPath)NuGet\
       xcopy /diy $(ArtifactsDirectory)$(VsixOutputDirName)\NuGet.exe $(OutputPath)NuGet\
     </PostBuildEvent>
   </PropertyGroup>

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Apex/ApexTestContext.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Apex/ApexTestContext.cs
@@ -22,7 +22,7 @@ namespace NuGet.Tests.Apex
 
         public NuGetApexTestService NuGetApexTestService { get; }
 
-        public ApexTestContext(VisualStudioHost visualStudio, ProjectTemplate projectTemplate, ILogger logger, bool noAutoRestore = false)
+        public ApexTestContext(VisualStudioHost visualStudio, ProjectTemplate projectTemplate, ILogger logger, bool noAutoRestore = false, bool addNetStandardFeeds = false)
         {
             logger.LogInformation("Creating test context");
             _pathContext = new SimpleTestPathContext();
@@ -30,6 +30,11 @@ namespace NuGet.Tests.Apex
             if (noAutoRestore)
             {
                 _pathContext.Settings.DisableAutoRestore();
+            }
+
+            if (addNetStandardFeeds)
+            {
+                _pathContext.Settings.AddNetStandardFeeds();
             }
 
             _visualStudio = visualStudio;

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NetCoreProjectTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NetCoreProjectTestCase.cs
@@ -21,7 +21,7 @@ namespace NuGet.Tests.Apex
             // Arrange
             EnsureVisualStudioHost();
 
-            using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, XunitLogger))
+            using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, XunitLogger, addNetStandardFeeds: true))
             {
                 VisualStudio.AssertNoErrors();
             }
@@ -35,7 +35,7 @@ namespace NuGet.Tests.Apex
             // Arrange
             EnsureVisualStudioHost();
 
-            using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, XunitLogger))
+            using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, XunitLogger, addNetStandardFeeds: true))
             {
                 var project2 = testContext.SolutionService.AddProject(ProjectLanguage.CSharp, projectTemplate, ProjectTargetFramework.V46, "TestProject2");
                 project2.Build();

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetConsoleTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetConsoleTestCase.cs
@@ -26,7 +26,7 @@ namespace NuGet.Tests.Apex
             // Arrange
             EnsureVisualStudioHost();
 
-            using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, XunitLogger, noAutoRestore: true))
+            using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, XunitLogger, noAutoRestore: true, addNetStandardFeeds: true))
             {
                 var packageName = "TestPackage";
                 var packageVersion = "1.0.0";
@@ -204,7 +204,7 @@ namespace NuGet.Tests.Apex
             // Arrange
             EnsureVisualStudioHost();
 
-            using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, XunitLogger))
+            using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, XunitLogger, addNetStandardFeeds: true))
             {
                 var project2 = testContext.SolutionService.AddProject(ProjectLanguage.CSharp, projectTemplate, ProjectTargetFramework.V46, "TestProject2");
                 project2.Build();
@@ -252,7 +252,7 @@ namespace NuGet.Tests.Apex
             var packageVersion2 = "2.0.0";
             var source = "https://api.nuget.org/v3/index.json";
 
-            using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, XunitLogger))
+            using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, XunitLogger, addNetStandardFeeds: true))
             {
                 // Arrange
                 var solutionService = VisualStudio.Get<SolutionService>();

--- a/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestSettingsContext.cs
+++ b/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestSettingsContext.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Linq;
 using System.Xml.Linq;
 using NuGet.Common;
+using Xunit;
 
 namespace NuGet.Test.Utility
 {
@@ -137,5 +138,46 @@ namespace NuGet.Test.Utility
                 item.Remove();
             }
         }
+
+        // Add NetStandard.Library and NetCorePlatforms to the feed and save the file.
+        public void AddNetStandardFeeds()
+        {
+            var reposRoot = GetRepositoryRootDirectory();
+            var netStandardLibraryPackageFeed = GetRepoPackageDirectoryPath(reposRoot, "netstandard.library");
+            var netCorePlatformsPackageFeed = GetRepoPackageDirectoryPath(reposRoot, "microsoft.netcore.platforms");
+
+            Assert.True(Directory.Exists(netStandardLibraryPackageFeed));
+            Assert.True(Directory.Exists(netCorePlatformsPackageFeed));
+
+            var section = GetOrAddSection(XML, "packageSources");
+            AddEntry(section, "NetStandardLibrary", netStandardLibraryPackageFeed);
+            AddEntry(section, "NetCorePlatforms", netCorePlatformsPackageFeed);
+
+            Save();
+        }
+
+        private static DirectoryInfo GetRepositoryRootDirectory()
+        {
+            DirectoryInfo currentDir = new DirectoryInfo(Directory.GetCurrentDirectory());
+            while (currentDir != null)
+            {
+                if (File.Exists(Path.Combine(currentDir.FullName, "NuGet.sln")))
+                {
+                    // We have found the repo root.
+                    return currentDir;
+                }
+
+                currentDir = currentDir.Parent;
+            }
+
+            throw new DirectoryNotFoundException($"Starting from {Directory.GetCurrentDirectory()} the directory containing 'NuGet.sln' could not be found.");
+        }
+
+        private static string GetRepoPackageDirectoryPath(DirectoryInfo reposRoot, string packageId)
+        {
+            var repoPackageDir = Path.Combine(reposRoot.FullName, "packages", packageId);
+            return repoPackageDir;
+        }
+           
     }
 }


### PR DESCRIPTION
## Bug

Fixes: Visual Studio NuGet packages (RestoreManagerPackage package) needs to auto load on solution build events [#8796](https://github.com/nuget/home/issues/8796)
Regression: Yes
* Last working version:   16.2??
* How are we preventing it in future:   Xaml Team test caught the VS caused Regression

## Fix

Details: Adding an attribute to communicate to the VSIX loading system that the SolutionRestoreManager package needs to load in time to listen to solution build events.

## Testing/Validation

Tests Added: No
Reason for not adding tests:  Covered by partner tests, Apex needs more investment for NuGet.
Validation:  manually validated with 16.5p2 int preview bits, which contain the VS Platform fix enabling our change.
