### PR TITLE
Fix common.ps1. Define variable in correct scope

### DIFF
--- a/build/common.ps1
+++ b/build/common.ps1
@@ -188,13 +188,12 @@ Function Install-DotnetCLI {
 
     $env:DOTNET_HOME=$cli.Root
     $env:DOTNET_INSTALL_DIR=$NuGetClientRoot
+    $DotNetInstall = Join-Path $cli.Root 'dotnet-install.ps1'
 
     if ($Force -or -not (Test-Path $DotNetExe)) {
         Trace-Log 'Downloading .NET CLI'
 
         New-Item -ItemType Directory -Force -Path $cli.Root | Out-Null
-
-        $DotNetInstall = Join-Path $cli.Root 'dotnet-install.ps1'
 
         Invoke-WebRequest 'https://dot.net/v1/dotnet-install.ps1' -OutFile $DotNetInstall
         & $DotNetInstall -Channel $cli.Channel -i $cli.Root -Version $cli.Version -Architecture $arch


### PR DESCRIPTION
## Bug

Fixes: NuGet/Home#8893
Regression: No
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: Define variable in scope where it's used

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  powershell/build script.
Validation:  
