### PR TITLE
Check VSTS PAT in Initialize_Build

### DIFF
--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -23,6 +23,13 @@ phases:
     condition: " not(eq(variables['IsOfficialBuild'], 'true')) "
 
   - task: PowerShell@1
+    displayName: "Check VSTS Personal Access Token"
+    inputs:
+      scriptType: "inlineScript"
+      inlineScript:
+        . $(Build.Repository.LocalPath)\\scripts\\utils\\PostGitCommitStatus.ps1 CheckVstsPersonalAccessToken -VstsPersonalAccessToken $(VstsPersonalAccessToken)
+
+  - task: PowerShell@1
     displayName: "Initialize Git Commit Status on GitHub"
     inputs:
       scriptType: "inlineScript"

--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -26,7 +26,7 @@ phases:
     displayName: "Check VSTS Personal Access Token"
     inputs:
       scriptType: "inlineScript"
-      inlineScript:: |
+      inlineScript: |
         . $(Build.Repository.LocalPath)\\scripts\\utils\\PostGitCommitStatus.ps1 
         CheckVstsPersonalAccessToken -VstsPersonalAccessToken $(VstsPersonalAccessToken)
 

--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -27,7 +27,8 @@ phases:
     inputs:
       scriptType: "inlineScript"
       inlineScript:: |
-        . $(Build.Repository.LocalPath)\\scripts\\utils\\PostGitCommitStatus.ps1 CheckVstsPersonalAccessToken -VstsPersonalAccessToken $(VstsPersonalAccessToken)
+        . $(Build.Repository.LocalPath)\\scripts\\utils\\PostGitCommitStatus.ps1 
+        CheckVstsPersonalAccessToken -VstsPersonalAccessToken $(VstsPersonalAccessToken)
 
   - task: PowerShell@1
     displayName: "Initialize Git Commit Status on GitHub"

--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -26,7 +26,7 @@ phases:
     displayName: "Check VSTS Personal Access Token"
     inputs:
       scriptType: "inlineScript"
-      inlineScript:
+      inlineScript:: |
         . $(Build.Repository.LocalPath)\\scripts\\utils\\PostGitCommitStatus.ps1 CheckVstsPersonalAccessToken -VstsPersonalAccessToken $(VstsPersonalAccessToken)
 
   - task: PowerShell@1

--- a/scripts/utils/PostGitCommitStatus.ps1
+++ b/scripts/utils/PostGitCommitStatus.ps1
@@ -192,7 +192,8 @@ function CheckVstsPersonalAccessToken {
     }
 
     try {
-        $response = Invoke-WebRequest -Uri $url -Method GET -Headers $Headers
+        # Basic Parsing prevents the need for Internet Explorer availability.
+        $response = Invoke-WebRequest -Uri $url -Method GET -Headers $Headers -UseBasicParsing
 
         # This will only execute if the Invoke-WebRequest is successful.
         $StatusCode = $response.StatusCode

--- a/scripts/utils/PostGitCommitStatus.ps1
+++ b/scripts/utils/PostGitCommitStatus.ps1
@@ -175,3 +175,39 @@ function Get-TestRun {
     $failedTests = $matchingRun.unanalyzedTests
     return $testUrl,$failedTests
 }
+
+function CheckVstsPersonalAccessToken {
+    param(
+        [Parameter(Mandatory = $True)]
+        [string]$VstsPersonalAccessToken
+    )
+    Write-Output 'starting!'
+    $url = "$env:VSTSTESTRUNSRESTAPI$env:BUILD_BUILDID"
+    Write-Host $url
+    $Token = ":$VstsPersonalAccessToken"
+    $Base64Token = [System.Convert]::ToBase64String([char[]]$Token)
+
+    $Headers = @{
+        Authorization = 'Basic {0}' -f $Base64Token;
+    }
+
+    try {
+        $response = Invoke-WebRequest -Uri $url -Method GET -Headers $Headers
+
+        # This will only execute if the Invoke-WebRequest is successful.
+        $StatusCode = $response.StatusCode
+
+        if ($StatusCode -ne 200)
+        {
+            throw $StatusCode
+        }
+
+        Write-Host 'VstsPersonalAccessToken Valid! (HTTP Status Code: ' $StatusCode ')'
+    }
+    catch {
+        $exceptionMessage = 'Invalid HTTP Status Code for VstsPersonalAccessToken ! ' + $PSItem.Exception.Message
+        throw $exceptionMessage
+    }
+
+    return 0
+}

--- a/scripts/utils/PostGitCommitStatus.ps1
+++ b/scripts/utils/PostGitCommitStatus.ps1
@@ -161,7 +161,7 @@ function Get-TestRun {
         Authorization = 'Basic {0}' -f $Base64Token;
     }
     
-    $testRuns = Invoke-RestMethod -Uri $url -Method GET -Headers $Headers
+    $testRuns = Invoke-RestMethod -Uri $url -Method HEAD -Headers $Headers
     Write-Host $testRuns
     $matchingRun = $testRuns.value | where { $_.name -ieq $TestName }
     if(-not $matchingRun)
@@ -181,9 +181,8 @@ function CheckVstsPersonalAccessToken {
         [Parameter(Mandatory = $True)]
         [string]$VstsPersonalAccessToken
     )
-    Write-Output 'starting!'
     $url = "$env:VSTSTESTRUNSRESTAPI$env:BUILD_BUILDID"
-    Write-Host $url
+    Write-Host "Checking $url"
     $Token = ":$VstsPersonalAccessToken"
     $Base64Token = [System.Convert]::ToBase64String([char[]]$Token)
 
@@ -195,12 +194,11 @@ function CheckVstsPersonalAccessToken {
         # Basic Parsing prevents the need for Internet Explorer availability.
         $response = Invoke-WebRequest -Uri $url -Method GET -Headers $Headers -UseBasicParsing
 
-        # This will only execute if the Invoke-WebRequest is successful.
         $StatusCode = $response.StatusCode
 
         if ($StatusCode -ne 200)
         {
-            throw $StatusCode
+            throw "The remote server returned HTTP status code $StatusCode"
         }
 
         Write-Host 'VstsPersonalAccessToken Valid! (HTTP Status Code: ' $StatusCode ')'
@@ -209,6 +207,4 @@ function CheckVstsPersonalAccessToken {
         $exceptionMessage = 'Invalid HTTP Status Code for VstsPersonalAccessToken ! ' + $PSItem.Exception.Message
         throw $exceptionMessage
     }
-
-    return 0
 }

--- a/scripts/utils/PostGitCommitStatus.ps1
+++ b/scripts/utils/PostGitCommitStatus.ps1
@@ -161,7 +161,7 @@ function Get-TestRun {
         Authorization = 'Basic {0}' -f $Base64Token;
     }
     
-    $testRuns = Invoke-RestMethod -Uri $url -Method HEAD -Headers $Headers
+    $testRuns = Invoke-RestMethod -Uri $url -Method GET -Headers $Headers
     Write-Host $testRuns
     $matchingRun = $testRuns.value | where { $_.name -ieq $TestName }
     if(-not $matchingRun)
@@ -192,7 +192,7 @@ function CheckVstsPersonalAccessToken {
 
     try {
         # Basic Parsing prevents the need for Internet Explorer availability.
-        $response = Invoke-WebRequest -Uri $url -Method GET -Headers $Headers -UseBasicParsing
+        $response = Invoke-WebRequest -Uri $url -Method HEAD -Headers $Headers -UseBasicParsing
 
         $StatusCode = $response.StatusCode
 

--- a/scripts/utils/PostGitCommitStatus.ps1
+++ b/scripts/utils/PostGitCommitStatus.ps1
@@ -192,7 +192,7 @@ function CheckVstsPersonalAccessToken {
 
     try {
         # Basic Parsing prevents the need for Internet Explorer availability.
-        $response = Invoke-WebRequest -Uri $url -Method HEAD -Headers $Headers -UseBasicParsing
+        $response = Invoke-WebRequest -Uri $url -Method GET -Headers $Headers -UseBasicParsing
 
         $StatusCode = $response.StatusCode
 


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/8899
Regression: No

## Fix

Details: 
(This is a low-priority (P3) PR which I created mainly as an exercise. I'd appreciate commits from those knowledgeable with YAML/PS1 to learn from. I do think it's a CI improvement for us. )

Made a call to the VSTS API in the Initialize_Build step, and check for a 200 HTTP Response Code. If any other code is returned, an exception is raised and the build halted.

[Example Successful Build](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=3308256) with a Good VSTS Token
Log output:
> **VstsPersonalAccessToken Valid! (HTTP Status Code:  200 )**

[Example Failing Build](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=3308259) with a Bad VSTS Token
Log output:
> **##[error]Invalid HTTP Status Code for VstsPersonalAccessToken ! 203**
> At E:\A\_work\60\s\scripts\utils\PostGitCommitStatus.ps1:210 char:9
>          throw $exceptionMessage
>          ~~~~~~~~~~~~~~~~~~~~~~~
>      CategoryInfo          : OperationStopped: (Invalid HTTP St...cessToken ! 203:String) [], RuntimeException
>     FullyQualifiedErrorId : Invalid HTTP Status Code for VstsPersonalAccessToken ! 203
>  
> 