### PR TITLE
vs/nuget/nugetaction should also log existing packages

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/UIActionEngine.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/UIActionEngine.cs
@@ -330,6 +330,8 @@ namespace NuGet.PackageManagement.UI
             // Enable granular level telemetry events for nuget ui operation
             uiService.ProjectContext.OperationId = Guid.NewGuid();
 
+            Stopwatch packageEnumerationTime = new Stopwatch();
+            packageEnumerationTime.Start();
             try
             {
                 // collect the install state of the existing packages
@@ -350,6 +352,7 @@ namespace NuGet.PackageManagement.UI
             {
                 // don't teardown the process if we have a telemetry failure
             }
+            packageEnumerationTime.Stop();
 
             await _lockService.ExecuteNuGetOperationAsync(async () =>
             {
@@ -510,6 +513,8 @@ namespace NuGet.PackageManagement.UI
                         duration.TotalSeconds);
 
                     AddUiActionEngineTelemetryProperties(actionTelemetryEvent, continueAfterPreview, acceptedLicense, userAction, existingPackages, addedPackages, removedPackages, updatedPackagesOld, updatedPackagesNew);
+
+                    actionTelemetryEvent["InstalledPackageEnumerationTimeInMilliseconds"] = packageEnumerationTime.ElapsedMilliseconds;
 
                     TelemetryActivity.EmitTelemetryEvent(actionTelemetryEvent);
                 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/UIActionEngine.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/UIActionEngine.cs
@@ -338,7 +338,11 @@ namespace NuGet.PackageManagement.UI
                     var result = await project.GetInstalledPackagesAsync(token);
                     foreach (var package in result)
                     {
-                        existingPackages.Add(new Tuple<string, string>(package.PackageIdentity.Id, (package.PackageIdentity.Version == null ? "" : package.PackageIdentity.Version.ToNormalizedString())));
+                        Tuple<string, string> packageInfo = new Tuple<string, string>(package.PackageIdentity.Id, (package.PackageIdentity.Version == null ? "" : package.PackageIdentity.Version.ToNormalizedString()));
+                        if (!existingPackages.Contains(packageInfo))
+                        {
+                            existingPackages.Add(packageInfo);
+                        }
                     }
                 }
             }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/UIActionEngine.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/UIActionEngine.cs
@@ -322,7 +322,7 @@ namespace NuGet.PackageManagement.UI
             bool acceptedLicense = true;
 
             List<string> removedPackages = null;
-            List<Tuple<string, string>> existingPackages = new List<Tuple<string, string>>();
+            HashSet<Tuple<string, string>> existingPackages = new HashSet<Tuple<string, string>>();
             List<Tuple<string,string>> addedPackages = null;
             List<Tuple<string,string>> updatedPackagesOld = null;
             List<Tuple<string,string>> updatedPackagesNew = null;
@@ -521,7 +521,7 @@ namespace NuGet.PackageManagement.UI
             bool continueAfterPreview,
             bool acceptedLicense,
             UserAction userAction,
-            List<Tuple<string, string>> existingPackages,
+            HashSet<Tuple<string, string>> existingPackages,
             List<Tuple<string, string>> addedPackages,
             List<string> removedPackages,
             List<Tuple<string, string>> updatedPackagesOld,


### PR DESCRIPTION
## Bug 

Fixes: https://github.com/NuGet/Home/issues/8925
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: Modify UIActionEngine to grab existing packages off of uIService.  Log them as a new complex property

## Testing/Validation

Manual testing of both dotnetcore and bigdotnet projects.

Tests Added: No  
Reason for not adding tests:  
Validation:  
