### PR TITLE
remove WorkaroundNetStandard target, change SDK for build from 3.0 preview to 3.1 stable

### DIFF
--- a/build/common.targets
+++ b/build/common.targets
@@ -327,15 +327,3 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\packages\Microsoft.VisualStudioEng.MicroBuild.Core.0.4.1\build\Microsoft.VisualStudioEng.MicroBuild.Core.targets" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), &quot;README.md&quot;))\packages\Microsoft.VisualStudioEng.MicroBuild.Core.0.4.1\build\Microsoft.VisualStudioEng.MicroBuild.Core.targets')" />
 
 </Project>
-  <!--
-    ==========================================================================================
-    Temporary Workaround Target related to issue https://github.com/dotnet/cli/issues/11378
-    ==========================================================================================
-  -->
-  <Target Name="WorkaroundNetStandard" AfterTargets="ResolvePackageAssets" Condition=" '$(TargetFramework)' == 'netcoreapp3.0' ">
-    <ItemGroup>
-      <TransitiveFrameworkReference Remove="NETStandard.Library" />
-    </ItemGroup>
-  </Target>
-
-</Project>

--- a/build/config.props
+++ b/build/config.props
@@ -36,11 +36,11 @@
     <VsTargetChannel Condition="'$(IsEscrowMode)' == 'true'">int.d$(VsTargetMajorVersion).$(MinorNuGetVersion)</VsTargetChannel>
 
     <!-- when LockSDKVersion is true,  it will use the specific version in CliVersionForBuilding for building, and specific version in OverrideCliBranchForTesting for testing,  -->
-    <!-- when LockSDKVersion is not true, it will ignore the properties and just use the latest version for the channel specified in CliVersionForBuilding for building, CliBranchForTesting for testing -->
-    <LockSDKVersion></LockSDKVersion>
-    <OverrideCliBranchForTesting Condition="'$(LockSDKVersion)' == ''"></OverrideCliBranchForTesting>
+    <!-- when LockSDKVersion is flase, it will ignore the properties and just use the latest version for the channel specified in CliVersionForBuilding for building, CliBranchForTesting for testing -->
+    <LockSDKVersion>false</LockSDKVersion>
+    <OverrideCliBranchForTesting Condition="'$(LockSDKVersion)' == 'false'"></OverrideCliBranchForTesting>
     <OverrideCliBranchForTesting Condition="'$(LockSDKVersion)' == 'true'">release/3.0.1xx 3.0.100-preview7-012802</OverrideCliBranchForTesting>
-    <CliVersionForBuilding Condition="'$(LockSDKVersion)' == ''">3.1.x</CliVersionForBuilding>
+    <CliVersionForBuilding Condition="'$(LockSDKVersion)' == 'false'">3.1.x</CliVersionForBuilding>
     <CliVersionForBuilding Condition="'$(LockSDKVersion)' == 'true'">3.0.100-preview6-012264</CliVersionForBuilding>
 
     <!-- .NET Core SDK Insertion Logic -->    

--- a/build/config.props
+++ b/build/config.props
@@ -32,18 +32,16 @@
     <VsTargetMajorVersion>$([MSBuild]::Add(11, $(MajorNuGetVersion)))</VsTargetMajorVersion>
     <VsTargetBranch>master</VsTargetBranch>
     <VsTargetChannel>int.$(VsTargetBranch)</VsTargetChannel>
-    <!-- when LockSDKVersion is true,  it will use the specific version in CliVersionForBuilding for building, and specific version in OverrideCliBranchForTesting for testing,  -->
-    <!-- when LockSDKVersion is not true, it will ignore the properties and just use the latest version for the channel specified in CliVersionForBuilding for building, CliBranchForTesting for testing -->
-    <LockSDKVersion>true</LockSDKVersion>
-    <OverrideCliBranchForTesting Condition="'$(LockSDKVersion)' == ''"></OverrideCliBranchForTesting>
-    <OverrideCliBranchForTesting Condition="'$(LockSDKVersion)' == 'true'">release/3.0.1xx 3.0.100-preview7-012802</OverrideCliBranchForTesting>
-    <CliBranchForTesting Condition="'$(OverrideCliBranchForTesting)' != ''">$(OverrideCliBranchForTesting)</CliBranchForTesting>
-    <CliBranchForTesting Condition="'$(OverrideCliBranchForTesting)' == ''">release/3.0.1xx</CliBranchForTesting>
-    <CliVersionForBuilding Condition="'$(LockSDKVersion)' == ''">3.0.x</CliVersionForBuilding>
-    <CliVersionForBuilding Condition="'$(LockSDKVersion)' == 'true'">3.0.100-preview6-012264</CliVersionForBuilding>
-    <!-- This branches are used for creating insertion PRs -->
     <VsTargetBranch Condition="'$(IsEscrowMode)' == 'true'">rel/d$(VsTargetMajorVersion).$(MinorNuGetVersion)</VsTargetBranch>
     <VsTargetChannel Condition="'$(IsEscrowMode)' == 'true'">int.d$(VsTargetMajorVersion).$(MinorNuGetVersion)</VsTargetChannel>
+
+    <!-- when LockSDKVersion is true,  it will use the specific version in CliVersionForBuilding for building, and specific version in OverrideCliBranchForTesting for testing,  -->
+    <!-- when LockSDKVersion is not true, it will ignore the properties and just use the latest version for the channel specified in CliVersionForBuilding for building, CliBranchForTesting for testing -->
+    <LockSDKVersion></LockSDKVersion>
+    <OverrideCliBranchForTesting Condition="'$(LockSDKVersion)' == ''"></OverrideCliBranchForTesting>
+    <OverrideCliBranchForTesting Condition="'$(LockSDKVersion)' == 'true'">release/3.0.1xx 3.0.100-preview7-012802</OverrideCliBranchForTesting>
+    <CliVersionForBuilding Condition="'$(LockSDKVersion)' == ''">3.1.x</CliVersionForBuilding>
+    <CliVersionForBuilding Condition="'$(LockSDKVersion)' == 'true'">3.0.100-preview6-012264</CliVersionForBuilding>
 
     <!-- .NET Core SDK Insertion Logic -->    
     <CliBranchForTesting Condition="'$(OverrideCliBranchForTesting)' != ''">$(OverrideCliBranchForTesting)</CliBranchForTesting>

--- a/global.json
+++ b/global.json
@@ -1,5 +1,0 @@
-{
-    "sdk": {
-        "version": "3.0.100-preview"
-      }
-}

--- a/scripts/funcTests/runFuncTests.sh
+++ b/scripts/funcTests/runFuncTests.sh
@@ -53,7 +53,9 @@ do
 	fi
 	echo "Channel is: $Channel"
 	echo "Version is: $Version"
-	cli/dotnet-install.sh -i cli -c $Channel -v $Version -nopath
+	# Issue 8936 - DISABLED TEMPORARILY cli/dotnet-install.sh -i cli -c 2.2
+    scripts/funcTests/dotnet-install.sh -i cli -c $Channel -v $Version -nopath
+	#cli/dotnet-install.sh -i cli -c $Channel -v $Version -nopath
 
 	# Display current version
 	$DOTNET --version

--- a/scripts/funcTests/runFuncTests.sh
+++ b/scripts/funcTests/runFuncTests.sh
@@ -35,13 +35,6 @@ scripts/funcTests/dotnet-install.sh -i cli -c 2.2 -NoPath
 
 DOTNET="$(pwd)/cli/dotnet"
 
-#restore solution packages
-$DOTNET msbuild -t:restore "$DIR/build/bootstrap.proj"
-if [ $? -ne 0 ]; then
-	echo "Restore failed!!"
-	exit 1
-fi
-
 echo "dotnet msbuild build/config.props /v:m /nologo /t:GetCliBranchForTesting"
 
 # run it twice so dotnet cli can expand and decompress without affecting the result of the target
@@ -75,6 +68,13 @@ echo "Deleting .NET Core temporary files"
 rm -rf "/tmp/"dotnet.*
 
 echo "================="
+
+#restore solution packages
+$DOTNET msbuild -t:restore "$DIR/build/bootstrap.proj"
+if [ $? -ne 0 ]; then
+	echo "Restore failed!!"
+	exit 1
+fi
 
 # init the repo
 

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
@@ -228,12 +228,6 @@ EndGlobal";
                     ProjectFileUtils.SetTargetFrameworkForProject(xml, "TargetFrameworks", tfm);
 
                     var attributes = new Dictionary<string, string>() { { "Version", "1.0.0" } };
-
-                    ProjectFileUtils.ChangeProperty(
-                        xml,
-                        "TargetFramework",
-                        "netstandard2.1");
-
                     ProjectFileUtils.AddItem(
                         xml,
                         "PackageReference",


### PR DESCRIPTION
We may need to bring xplat verification/signing changes back to SDK3.x
So this will be a base to start with.

## Fix

Details:
1. Remove WorkaroundNetStandard target, fix [/NuGet/Home/issues/8364](https://github.com/NuGet/Home/issues/8364)
2. We retargeted to netcoreapp3.0 when there was no stable version of SDK 3.x. 
So now we need to change SDK for build from 3.0 preview to 3.1 stable version, and turn off the lock of SDK for testing(so that we can test with the latest SDK preview version).remove global.json(as we build with stable SDK version)
3. Fix several errors brought in by rebase.


## Testing/Validation

Tests Added: No  
Reason for not adding tests:  
Validation:  
