### PR TITLE
add attribute to ensure package is loaded before solution build events

### DIFF
--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/RestoreManagerPackage.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/RestoreManagerPackage.cs
@@ -6,9 +6,6 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell;
-using Microsoft.VisualStudio.Shell.Interop;
-using NuGet.Protocol.Core.Types;
-using NuGet.VisualStudio;
 using Task = System.Threading.Tasks.Task;
 
 namespace NuGet.SolutionRestoreManager
@@ -20,8 +17,10 @@ namespace NuGet.SolutionRestoreManager
     // Flag AllowsBackgroundLoading is set to True and Flag PackageAutoLoadFlags is set to BackgroundLoad
     // which will allow this package to be loaded asynchronously
     [PackageRegistration(UseManagedResourcesOnly = true, AllowsBackgroundLoading = true)]
-    [ProvideAutoLoad(VSConstants.UICONTEXT.SolutionExists_string, PackageAutoLoadFlags.BackgroundLoad)]
-    [Guid(PackageGuidString)]
+    // BackgroundLoad this package as soon as a Solution exists.
+    [ProvideAutoLoad(VSConstants.UICONTEXT.SolutionExists_string, PackageAutoLoadFlags.BackgroundLoad)]	    [ProvideAutoLoad(VSConstants.UICONTEXT.SolutionExists_string, PackageAutoLoadFlags.BackgroundLoad)]
+    // Ensure that this package is loaded in time to listen to solution build events, in order to always be able to restore before build.
+    [ProvideAutoLoad(VSConstants.UICONTEXT.SolutionBuilding_string)][Guid(PackageGuidString)]
     public sealed class RestoreManagerPackage : AsyncPackage
     {
         /// <summary>

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/RestoreManagerPackage.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/RestoreManagerPackage.cs
@@ -20,7 +20,8 @@ namespace NuGet.SolutionRestoreManager
     // BackgroundLoad this package as soon as a Solution exists.
     [ProvideAutoLoad(VSConstants.UICONTEXT.SolutionExists_string, PackageAutoLoadFlags.BackgroundLoad)]	    [ProvideAutoLoad(VSConstants.UICONTEXT.SolutionExists_string, PackageAutoLoadFlags.BackgroundLoad)]
     // Ensure that this package is loaded in time to listen to solution build events, in order to always be able to restore before build.
-    [ProvideAutoLoad(VSConstants.UICONTEXT.SolutionBuilding_string)][Guid(PackageGuidString)]
+    [ProvideAutoLoad(VSConstants.UICONTEXT.SolutionBuilding_string)]
+    [Guid(PackageGuidString)]
     public sealed class RestoreManagerPackage : AsyncPackage
     {
         /// <summary>

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/RestoreManagerPackage.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/RestoreManagerPackage.cs
@@ -18,7 +18,7 @@ namespace NuGet.SolutionRestoreManager
     // which will allow this package to be loaded asynchronously
     [PackageRegistration(UseManagedResourcesOnly = true, AllowsBackgroundLoading = true)]
     // BackgroundLoad this package as soon as a Solution exists.
-    [ProvideAutoLoad(VSConstants.UICONTEXT.SolutionExists_string, PackageAutoLoadFlags.BackgroundLoad)]	    [ProvideAutoLoad(VSConstants.UICONTEXT.SolutionExists_string, PackageAutoLoadFlags.BackgroundLoad)]
+    [ProvideAutoLoad(VSConstants.UICONTEXT.SolutionExists_string, PackageAutoLoadFlags.BackgroundLoad)]	    
     // Ensure that this package is loaded in time to listen to solution build events, in order to always be able to restore before build.
     [ProvideAutoLoad(VSConstants.UICONTEXT.SolutionBuilding_string)]
     [Guid(PackageGuidString)]


### PR DESCRIPTION
## Bug

Fixes: Visual Studio NuGet packages (RestoreManagerPackage package) needs to auto load on solution build events [#8796](https://github.com/nuget/home/issues/8796)
Regression: Yes
* Last working version:   16.1 or 16.2? (not sure exactly when VS Platform changed this load behavior)
* How are we preventing it in future:   Xaml Team test caught the VS caused Regression

## Fix

Details: Adding an attribute to communicate to the VSIX loading system that the SolutionRestoreManager package needs to load in time to listen to solution build events.

## Testing/Validation

Tests Added: No
Reason for not adding tests:  Covered by partner tests, Apex needs more investment for NuGet.
Validation:  manually validated with 16.5p2 int preview bits, which contain the VS Platform fix enabling our change.
