### PR TITLE
Add pkcs and cng package, temp fix on patching SDK

### DIFF
--- a/build/common.project.props
+++ b/build/common.project.props
@@ -53,6 +53,8 @@
     <VSServicesVersion>16.144.1-preview</VSServicesVersion>
     <VSComponentsVersion>16.0.189-g83e7c53a57</VSComponentsVersion>
     <SystemPackagesVersion>4.3.0</SystemPackagesVersion>
+    <!-- TODO - remove this when temporary patching is no longer necessary. See https://github.com/NuGet/Home/issues/8508 -->
+    <PatchedSystemPackagesVersion>5.0.0-alpha1.19473.1</PatchedSystemPackagesVersion>
   </PropertyGroup>
 
   <!-- Defaults -->

--- a/src/NuGet.Core/NuGet.Packaging/NuGet.Packaging.csproj
+++ b/src/NuGet.Core/NuGet.Packaging/NuGet.Packaging.csproj
@@ -49,6 +49,8 @@
 
   <ItemGroup Condition=" '$(IsCore)' == 'true' ">
     <PackageReference Include="System.Dynamic.Runtime" Version="$(SystemPackagesVersion)" />
+    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="5.0.0-alpha1.19473.1" />
+    <PackageReference Include="System.Security.Cryptography.Cng" Version="5.0.0-alpha1.19473.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NuGet.Core/NuGet.Packaging/NuGet.Packaging.csproj
+++ b/src/NuGet.Core/NuGet.Packaging/NuGet.Packaging.csproj
@@ -49,8 +49,9 @@
 
   <ItemGroup Condition=" '$(IsCore)' == 'true' ">
     <PackageReference Include="System.Dynamic.Runtime" Version="$(SystemPackagesVersion)" />
-    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="5.0.0-alpha1.19473.1" />
-    <PackageReference Include="System.Security.Cryptography.Cng" Version="5.0.0-alpha1.19473.1" />
+    <!-- TODO - remove this when temporary patching is no longer necessary. See https://github.com/NuGet/Home/issues/8508 -->
+    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="$(PatchedSystemPackagesVersion)" />
+    <PackageReference Include="System.Security.Cryptography.Cng" Version="$(PatchedSystemPackagesVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/MsbuildIntegrationTestFixture.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/MsbuildIntegrationTestFixture.cs
@@ -6,19 +6,18 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Reflection;
+using System.Text;
 using System.Threading;
-using NuGet.XPlat.FuncTest;
-using NuGet.Test.Utility;
+using Newtonsoft.Json.Linq;
+using NuGet.Common;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
 using NuGet.Packaging.PackageExtraction;
 using NuGet.Protocol;
+using NuGet.Test.Utility;
+using NuGet.XPlat.FuncTest;
 using Xunit;
-using NuGet.Common;
-using Newtonsoft.Json.Linq;
-using System.Text;
-using System.IO.Enumeration;
-using System.Runtime.CompilerServices;
 
 namespace Dotnet.Integration.Test
 {
@@ -37,31 +36,16 @@ namespace Dotnet.Integration.Test
 
             var sdkPaths = Directory.GetDirectories(Path.Combine(_cliDirectory, "sdk"));
 
-            //Temporary patching process for System.Security.Cryptography.Pkcs.dll and deps.json files
-            //Will be removed when shipping
-            var patchDir = sdkPaths.Where(path => path.Split(Path.DirectorySeparatorChar).Last().StartsWith("5")).First();
-            TempPatching(patchDir);
-
-            string packagePath = null;
-            if (RuntimeEnvironmentHelper.IsWindows)
-            {
-                packagePath = Path.Combine(Environment.GetEnvironmentVariable("USERPROFILE"), ".nuget", "packages");
-            }
-            else
-            {
-                packagePath = Path.Combine(Environment.GetEnvironmentVariable("HOME"), ".local", "share", "NuGet", "v3-cache");
-            }
-
-            var pathCopyFrom = Path.Combine(packagePath, "system.security.cryptography.pkcs", "5.0.0-alpha1.19473.1", "lib", "netstandard2.1");
-            var pathCopyTo = patchDir;
-            var dlls = new string[1] { "System.Security.Cryptography.Pkcs.dll" };
-            TempCopyNewlyAddedDlls(dlls, pathCopyFrom, pathCopyTo);
-            //end of Temporary patching
+            // TODO - remove when shipping. See https://github.com/NuGet/Home/issues/8508
+            // const string dotnetMajorVersion = "3.";
+            const string dotnetMajorVersion = "5.";
+            PatchSDKWithCryptographyDlls(dotnetMajorVersion, sdkPaths);
 
             MsBuildSdksPath = Path.Combine(
-             sdkPaths.Where(path => path.Split(Path.DirectorySeparatorChar).Last().StartsWith("5")).First()
-             , "Sdks");
-     
+                sdkPaths.Where(path => path.Split(Path.DirectorySeparatorChar).Last().StartsWith(dotnetMajorVersion)).First(),
+                "Sdks"
+            );
+
             _processEnvVars.Add("MSBuildSDKsPath", MsBuildSdksPath);
             _processEnvVars.Add("UseSharedCompilation", "false");
             _processEnvVars.Add("DOTNET_MULTILEVEL_LOOKUP", "0");
@@ -92,7 +76,7 @@ namespace Dotnet.Integration.Test
             {
                 Directory.CreateDirectory(workingDirectory);
             }
- 
+
             var result = CommandRunner.Run(TestDotnetCli,
                 workingDirectory,
                 $"new {args}",
@@ -118,7 +102,8 @@ namespace Dotnet.Integration.Test
             var restoreSolutionDirectory = workingDirectory;
             var msbuildProjectExtensionsPath = Path.Combine(workingDirectory);
             var packageReference = string.Empty;
-            foreach (var package in packages) {
+            foreach (var package in packages)
+            {
                 packageReference = string.Concat(packageReference, Environment.NewLine, $@"<PackageReference Include=""{ package.Id }"" Version=""{ package.Version.ToString()}""/>");
             }
 
@@ -190,7 +175,7 @@ namespace Dotnet.Integration.Test
         /// <summary>
         /// dotnet.exe args
         /// </summary>
-        internal CommandRunnerResult RunDotnet(string workingDirectory, string args, bool ignoreExitCode=false)
+        internal CommandRunnerResult RunDotnet(string workingDirectory, string args, bool ignoreExitCode = false)
         {
 
             var result = CommandRunner.Run(TestDotnetCli,
@@ -302,14 +287,16 @@ namespace Dotnet.Integration.Test
             }
 
 
-            foreach (var nupkgName in nupkgsToCopy) {
+            foreach (var nupkgName in nupkgsToCopy)
+            {
                 using (var nupkg = new PackageArchiveReader(FindMostRecentNupkg(nupkgsDirectory, nupkgName)))
                 {
-                     var files = nupkg.GetFiles()
-                    .Where(fileName => fileName.StartsWith("lib/netstandard2.1")
-                                    || fileName.StartsWith("lib/netcoreapp5.0")
-                                    || fileName.Contains("NuGet.targets"));
-                    if (!files.Any()) {
+                    var files = nupkg.GetFiles()
+                   .Where(fileName => fileName.StartsWith("lib/netstandard2.1")
+                                   || fileName.StartsWith("lib/netcoreapp5.0")
+                                   || fileName.Contains("NuGet.targets"));
+                    if (!files.Any())
+                    {
                         files = nupkg.GetFiles()
                         .Where(fileName => fileName.StartsWith("lib/netstandard2.0")
                                     || fileName.Contains("NuGet.targets"));
@@ -460,7 +447,7 @@ namespace Dotnet.Integration.Test
 
                 for (var i = 0; i < MaxTries; i++)
                 {
-                    
+
                     try
                     {
                         Directory.Delete(path, recursive: true);
@@ -478,62 +465,79 @@ namespace Dotnet.Integration.Test
             }
         }
 
-        //temporary added methods for processing deps.json files for patching
-        private void TempPatching(string patchDir)
-        {
-            var prefix = patchDir;
-            string[] filenames = new string[3] { "dotnet.deps.json", "MSBuild.deps.json", "NuGet.CommandLine.XPlat.deps.json" };
-            string[] fullnames = new string[3];
-            for(int i = 0; i < filenames.Length; i++) 
-            {
-                fullnames[i] = prefix + Path.DirectorySeparatorChar + filenames[i];
-            }
-            TempPatchingDepsJsonForNewlyAddedDlls(fullnames);
+        // Temporary added methods for processing deps.json files for patching
 
-        }
-        private void TempCopyNewlyAddedDlls(string[] dlls, string pathCopyFrom, string PathCopyTo)
+        /// <summary>
+        /// Temporary patching process to bring in Cryptography DLLs for testing while SDK gets around to including them in 5.0.
+        /// See also: https://github.com/NuGet/Home/issues/8508
+        /// </summary>
+        private void PatchSDKWithCryptographyDlls(string dotnetMajorVersion, string[] sdkPaths)
         {
-            foreach (var dll in dlls) 
+            string directoryToPatch = sdkPaths.Where(path => path.Split(Path.DirectorySeparatorChar).Last().StartsWith(dotnetMajorVersion)).First();
+            var assemblyNames = new string[1] { "System.Security.Cryptography.Pkcs.dll" };
+            PatchDepsJsonFiles(assemblyNames, directoryToPatch);
+
+            string userProfilePath = Environment.GetEnvironmentVariable(RuntimeEnvironmentHelper.IsWindows ? "USERPROFILE" : "HOME");
+            string globalPackagesPath = Path.Combine(userProfilePath, ".nuget", "packages");
+
+            CopyNewlyAddedDlls(assemblyNames, Directory.GetCurrentDirectory(), directoryToPatch);
+        }
+
+        private void PatchDepsJsonFiles(string[] assemblyNames, string patchDir)
+        {
+            string[] fileNames = new string[3] { "dotnet.deps.json", "MSBuild.deps.json", "NuGet.CommandLine.XPlat.deps.json" };
+            string[] fullNames = fileNames.Select(filename => Path.Combine(patchDir, filename)).ToArray();
+            PatchDepsJsonWithNewlyAddedDlls(assemblyNames, fullNames);
+        }
+
+        private void CopyNewlyAddedDlls(string[] assemblyNames, string copyFromPath, string copyToPath)
+        {
+            foreach (var assemblyName in assemblyNames)
             {
-                var copyFromFullName = Path.Combine(pathCopyFrom, dll);
-                var copyToFullName = Path.Combine(PathCopyTo, dll);
-                File.Copy(copyFromFullName, copyToFullName);
+                File.Copy(
+                    Path.Combine(copyFromPath, assemblyName),
+                    Path.Combine(copyToPath, assemblyName)
+                );
             }
         }
-        private void TempPatchingDepsJsonForNewlyAddedDlls(string[] filePaths)
+
+        private void PatchDepsJsonWithNewlyAddedDlls(string[] assemblyNames, string[] filePaths)
         {
             string nugetBuildTasksName = "NuGet.Build.Tasks/5.3.0-rtm.6251";
-            foreach (string file in filePaths)
+            foreach (string assemblyName in assemblyNames)
             {
-                JObject JsonFile = GetJson(file);
+                foreach (string filePath in filePaths)
+                {
+                    JObject jsonFile = GetJson(filePath);
 
-                JObject targets = null;
-                targets = JsonFile.GetJObjectProperty<JObject>("targets");
+                    JObject targets = jsonFile.GetJObjectProperty<JObject>("targets");
 
-                JObject netcoreapp50 = null;
-                netcoreapp50 = targets.GetJObjectProperty<JObject>(".NETCoreApp,Version=v5.0");
+                    JObject netcoreapp50 = targets.GetJObjectProperty<JObject>(".NETCoreApp,Version=v5.0");
 
-                JObject NuGet_Build_Tasks = null;
-                NuGet_Build_Tasks = netcoreapp50.GetJObjectProperty<JObject>(nugetBuildTasksName);
+                    JObject nugetBuildTasks = netcoreapp50.GetJObjectProperty<JObject>(nugetBuildTasksName);
 
-                JObject runtime = null;
-                runtime = NuGet_Build_Tasks.GetJObjectProperty<JObject>("runtime");
+                    JObject runtime = nugetBuildTasks.GetJObjectProperty<JObject>("runtime");
 
-                var jproperty = new JProperty("lib/netstandard2.1/System.Security.Cryptography.Pkcs.dll",
-                            new JObject
-                                {
-                                    new JProperty("assemblyVersion","4.0.4.0"),
-                                    new JProperty("fileVersion", "5.0.19.47301"),
-                                }
-                            );
-                runtime.Add(jproperty);
-                NuGet_Build_Tasks["runtime"] = runtime;
-                netcoreapp50[nugetBuildTasksName] = NuGet_Build_Tasks;
-                targets[".NETCoreApp,Version=v5.0"] = netcoreapp50;
-                JsonFile["targets"] = targets;
-                SaveJson(JsonFile, file);
+                    var assemblyPath = Path.Combine(Directory.GetCurrentDirectory(), assemblyName);
+                    var assemblyVersion = Assembly.LoadFile(assemblyPath).GetName().Version.ToString();
+                    var assemblyFileVersion = FileVersionInfo.GetVersionInfo(assemblyPath).FileVersion;
+                    var jproperty = new JProperty("lib/netstandard2.1/" + assemblyName,
+                        new JObject
+                        {
+                            new JProperty("assemblyVersion", assemblyVersion),
+                            new JProperty("fileVersion", assemblyFileVersion),
+                        }
+                    );
+                    runtime.Add(jproperty);
+                    nugetBuildTasks["runtime"] = runtime;
+                    netcoreapp50[nugetBuildTasksName] = nugetBuildTasks;
+                    targets[".NETCoreApp,Version=v5.0"] = netcoreapp50;
+                    jsonFile["targets"] = targets;
+                    SaveJson(jsonFile, filePath);
+                }
             }
         }
+
         private JObject GetJson(string jsonFilePath)
         {
             try
@@ -549,7 +553,9 @@ namespace Dotnet.Integration.Test
             catch (Exception ex)
             {
                 throw new InvalidOperationException(
-                    string.Format(jsonFilePath, ex.Message), ex);
+                    string.Format("Failed to read json file at {0}: {1}", jsonFilePath, ex.Message),
+                    ex
+                );
             }
         }
 
@@ -557,7 +563,7 @@ namespace Dotnet.Integration.Test
         {
             FileUtility.Replace((outputPath) =>
             {
-                using (var writer = new StreamWriter(outputPath, false, Encoding.UTF8))
+                using (var writer = new StreamWriter(outputPath, append: false, encoding: Encoding.UTF8))
                 {
                     writer.Write(json.ToString());
                 }

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/MsbuildIntegrationTestFixture.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/MsbuildIntegrationTestFixture.cs
@@ -14,6 +14,11 @@ using NuGet.Packaging.Core;
 using NuGet.Packaging.PackageExtraction;
 using NuGet.Protocol;
 using Xunit;
+using NuGet.Common;
+using Newtonsoft.Json.Linq;
+using System.Text;
+using System.IO.Enumeration;
+using System.Runtime.CompilerServices;
 
 namespace Dotnet.Integration.Test
 {
@@ -31,6 +36,27 @@ namespace Dotnet.Integration.Test
             TestDotnetCli = Path.Combine(_cliDirectory, "dotnet.exe");
 
             var sdkPaths = Directory.GetDirectories(Path.Combine(_cliDirectory, "sdk"));
+
+            //Temporary patching process for System.Security.Cryptography.Pkcs.dll and deps.json files
+            //Will be removed when shipping
+            var patchDir = sdkPaths.Where(path => path.Split(Path.DirectorySeparatorChar).Last().StartsWith("5")).First();
+            TempPatching(patchDir);
+
+            string packagePath = null;
+            if (RuntimeEnvironmentHelper.IsWindows)
+            {
+                packagePath = Path.Combine(Environment.GetEnvironmentVariable("USERPROFILE"), ".nuget", "packages");
+            }
+            else
+            {
+                packagePath = Path.Combine(Environment.GetEnvironmentVariable("HOME"), ".local", "share", "NuGet", "v3-cache");
+            }
+
+            var pathCopyFrom = Path.Combine(packagePath, "system.security.cryptography.pkcs", "5.0.0-alpha1.19473.1", "lib", "netstandard2.1");
+            var pathCopyTo = patchDir;
+            var dlls = new string[1] { "System.Security.Cryptography.Pkcs.dll" };
+            TempCopyNewlyAddedDlls(dlls, pathCopyFrom, pathCopyTo);
+            //end of Temporary patching
 
             MsBuildSdksPath = Path.Combine(
              sdkPaths.Where(path => path.Split(Path.DirectorySeparatorChar).Last().StartsWith("5")).First()
@@ -450,6 +476,93 @@ namespace Dotnet.Integration.Test
             {
 
             }
+        }
+
+        //temporary added methods for processing deps.json files for patching
+        private void TempPatching(string patchDir)
+        {
+            var prefix = patchDir;
+            string[] filenames = new string[3] { "dotnet.deps.json", "MSBuild.deps.json", "NuGet.CommandLine.XPlat.deps.json" };
+            string[] fullnames = new string[3];
+            for(int i = 0; i < filenames.Length; i++) 
+            {
+                fullnames[i] = prefix + Path.DirectorySeparatorChar + filenames[i];
+            }
+            TempPatchingDepsJsonForNewlyAddedDlls(fullnames);
+
+        }
+        private void TempCopyNewlyAddedDlls(string[] dlls, string pathCopyFrom, string PathCopyTo)
+        {
+            foreach (var dll in dlls) 
+            {
+                var copyFromFullName = Path.Combine(pathCopyFrom, dll);
+                var copyToFullName = Path.Combine(PathCopyTo, dll);
+                File.Copy(copyFromFullName, copyToFullName);
+            }
+        }
+        private void TempPatchingDepsJsonForNewlyAddedDlls(string[] filePaths)
+        {
+            string nugetBuildTasksName = "NuGet.Build.Tasks/5.3.0-rtm.6251";
+            foreach (string file in filePaths)
+            {
+                JObject JsonFile = GetJson(file);
+
+                JObject targets = null;
+                targets = JsonFile.GetJObjectProperty<JObject>("targets");
+
+                JObject netcoreapp50 = null;
+                netcoreapp50 = targets.GetJObjectProperty<JObject>(".NETCoreApp,Version=v5.0");
+
+                JObject NuGet_Build_Tasks = null;
+                NuGet_Build_Tasks = netcoreapp50.GetJObjectProperty<JObject>(nugetBuildTasksName);
+
+                JObject runtime = null;
+                runtime = NuGet_Build_Tasks.GetJObjectProperty<JObject>("runtime");
+
+                var jproperty = new JProperty("lib/netstandard2.1/System.Security.Cryptography.Pkcs.dll",
+                            new JObject
+                                {
+                                    new JProperty("assemblyVersion","4.0.4.0"),
+                                    new JProperty("fileVersion", "5.0.19.47301"),
+                                }
+                            );
+                runtime.Add(jproperty);
+                NuGet_Build_Tasks["runtime"] = runtime;
+                netcoreapp50[nugetBuildTasksName] = NuGet_Build_Tasks;
+                targets[".NETCoreApp,Version=v5.0"] = netcoreapp50;
+                JsonFile["targets"] = targets;
+                SaveJson(JsonFile, file);
+            }
+        }
+        private JObject GetJson(string jsonFilePath)
+        {
+            try
+            {
+                return FileUtility.SafeRead(jsonFilePath, (stream, filePath) =>
+                {
+                    using (var reader = new StreamReader(stream))
+                    {
+                        return JObject.Parse(reader.ReadToEnd());
+                    }
+                });
+            }
+            catch (Exception ex)
+            {
+                throw new InvalidOperationException(
+                    string.Format(jsonFilePath, ex.Message), ex);
+            }
+        }
+
+        private void SaveJson(JObject json, string jsonFilePath)
+        {
+            FileUtility.Replace((outputPath) =>
+            {
+                using (var writer = new StreamWriter(outputPath, false, Encoding.UTF8))
+                {
+                    writer.Write(json.ToString());
+                }
+            },
+            jsonFilePath);
         }
     }
 }

--- a/test/TestUtilities/Test.Utility/Test.Utility.csproj
+++ b/test/TestUtilities/Test.Utility/Test.Utility.csproj
@@ -74,7 +74,8 @@
   <ItemGroup Condition=" '$(IsCore)' == 'true' ">
     <PackageReference Include="System.Diagnostics.Process" Version="$(SystemPackagesVersion)" />
     <PackageReference Include="System.IO.Compression.ZipFile" Version="$(SystemPackagesVersion)" />
-    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="5.0.0-alpha1.19473.1" />
+    <!-- TODO - remove this when temporary patching is no longer necessary. See https://github.com/NuGet/Home/issues/8508 -->
+    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="$(PatchedSystemPackagesVersion)" />
   </ItemGroup>
 
   <!-- Remove files that do not support netcore -->

--- a/test/TestUtilities/Test.Utility/Test.Utility.csproj
+++ b/test/TestUtilities/Test.Utility/Test.Utility.csproj
@@ -74,7 +74,7 @@
   <ItemGroup Condition=" '$(IsCore)' == 'true' ">
     <PackageReference Include="System.Diagnostics.Process" Version="$(SystemPackagesVersion)" />
     <PackageReference Include="System.IO.Compression.ZipFile" Version="$(SystemPackagesVersion)" />
-    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="4.5.2" />
+    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="5.0.0-alpha1.19473.1" />
   </ItemGroup>
 
   <!-- Remove files that do not support netcore -->


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/8508
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: 
1.add package reference of System.Security.Cryptography.Pkcs and System.Security.Cryptography.Cng
2.add temp fix on patching.

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  
Validation:  Yes

This PR has a predessesor: 
Retarget to netcore5.0 https://github.com/NuGet/NuGet.Client/pull/3162
