### PR TITLE
implement add cert to store on Mac; display openssl version

### DIFF
--- a/scripts/funcTests/runFuncTests.sh
+++ b/scripts/funcTests/runFuncTests.sh
@@ -12,6 +12,10 @@ done
 
 RESULTCODE=0
 
+# print openssl version
+echo "==================================================================================================="
+openssl version -a
+echo "==================================================================================================="
 # move up to the repo root
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 DIR=$SCRIPTDIR/../..

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/SignCommandRunnerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/SignCommandRunnerTests.cs
@@ -108,7 +108,15 @@ namespace NuGet.Commands.Test
             using (var test = await Test.CreateAsync(_fixture.GetDefaultCertificate()))
             {
                 test.Args.CertificateSubjectName = "Root";
-                test.Args.CertificateStoreLocation = StoreLocation.LocalMachine;
+                if (RuntimeEnvironmentHelper.IsWindows || RuntimeEnvironmentHelper.IsMacOSX)
+                {
+                    test.Args.CertificateStoreLocation = StoreLocation.LocalMachine;
+                }
+                else if (RuntimeEnvironmentHelper.IsLinux)
+                {
+                    test.Args.CertificateStoreLocation = StoreLocation.CurrentUser;
+                }
+                
                 test.Args.CertificateStoreName = StoreName.Root;
 
                 var exception = await Assert.ThrowsAsync<SignCommandException>(

--- a/test/TestUtilities/Test.Utility/Signing/TrustedTestCert.cs
+++ b/test/TestUtilities/Test.Utility/Signing/TrustedTestCert.cs
@@ -2,7 +2,10 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.IO;
 using System.Security.Cryptography.X509Certificates;
+using NuGet.Common;
+using NuGet.Test.Utility;
 
 namespace Test.Utility.Signing
 {
@@ -40,6 +43,8 @@ namespace Test.Utility.Signing
 
         private bool _isDisposed;
 
+        private const string KeychainForMac = "/Library/Keychains/System.keychain";
+
         public TrustedTestCert(T source,
             Func<T, X509Certificate2> getCert,
             StoreName storeName = StoreName.TrustedPeople,
@@ -60,9 +65,17 @@ namespace Test.Utility.Signing
                 throw new InvalidOperationException($"The certificate used is valid for more than {maximumValidityPeriod}.");
             }
 #endif
-            StoreName = storeName;
-            StoreLocation = storeLocation;
-            AddCertificateToStore();
+            if (RuntimeEnvironmentHelper.IsMacOSX)
+            {
+                AddCertificateToStoreForMacOSX();
+            }
+            else
+            {
+                StoreName = storeName;
+                StoreLocation = storeLocation;
+                AddCertificateToStore();
+            }
+
             ExportCrl();
         }
 
@@ -71,6 +84,56 @@ namespace Test.Utility.Signing
             _store = new X509Store(StoreName, StoreLocation);
             _store.Open(OpenFlags.ReadWrite);
             _store.Add(TrustedCert);
+        }
+
+        //According to https://github.com/dotnet/runtime/blob/master/docs/design/features/cross-platform-cryptography.md#x509store,
+        //on macOS the X509Store class is a projection of system trust decisions (read-only), user trust decisions (read-only), and user key storage (read-write).
+        //So we have to run command to add certificate to System.keychain to make it trusted.
+        private void AddCertificateToStoreForMacOSX()
+        {
+            var certFile = new FileInfo(Path.Combine("/tmp", $"{TrustedCert.Thumbprint}.cer"));
+
+            File.WriteAllBytes(certFile.FullName, TrustedCert.RawData);
+
+            string addToKeyChainCmd = $"sudo security add-trusted-cert -d -r trustRoot " +
+                                      $"-k \"{KeychainForMac}\" " +
+                                      $"\"{certFile.FullName}\"";
+
+            RunMacCommand(addToKeyChainCmd);
+        }
+
+        //According to https://github.com/dotnet/runtime/blob/master/docs/design/features/cross-platform-cryptography.md#x509store,
+        //on macOS the X509Store class is a projection of system trust decisions (read-only), user trust decisions (read-only), and user key storage (read-write).
+        //So we have to run command to remove certificate from System.keychain to make it untrusted.
+        private void RemoveTrustedCert()
+        {
+            var certFile = new FileInfo(Path.Combine("/tmp", $"{TrustedCert.Thumbprint}.cer"));
+
+            string removeFromKeyChainCmd = $"sudo security delete-certificate -Z {TrustedCert.Thumbprint} -t {KeychainForMac}";
+
+            RunMacCommand(removeFromKeyChainCmd);
+
+            certFile.Delete();
+        }
+
+        private static void RunMacCommand(string cmd)
+        {
+            string workingDirectory = "/bin";
+            string args = "-c \"" + cmd + "\"";
+
+            CommandRunnerResult result = CommandRunner.Run("/bin/bash",
+                workingDirectory,
+                args,
+                waitForExit: true,
+                timeOutInMilliseconds: 60000);
+
+            if (!result.Success)
+            {
+                throw new SystemToolException($"Run security command failed with following log information :\n" +
+                                              $"exit code   = {result.ExitCode} \n" +
+                                              $"exit output = {result.Output} \n" +
+                                              $"exit error  = {result.Errors} \n");
+            }
         }
 
         private void ExportCrl()
@@ -97,9 +160,16 @@ namespace Test.Utility.Signing
         {
             if (!_isDisposed)
             {
-                using (_store)
+                if (RuntimeEnvironmentHelper.IsMacOSX)
                 {
-                    _store.Remove(TrustedCert);
+                    RemoveTrustedCert();
+                }
+                else
+                {
+                    using (_store)
+                    {
+                        _store.Remove(TrustedCert);
+                    }
                 }
 
                 DisposeCrl();

--- a/test/TestUtilities/Test.Utility/SystemToolException.cs
+++ b/test/TestUtilities/Test.Utility/SystemToolException.cs
@@ -1,0 +1,30 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Globalization;
+
+namespace Test.Utility
+{
+    internal sealed class SystemToolException : Exception
+    {
+        public SystemToolException()
+        {
+        }
+
+        public SystemToolException(string message)
+            : base(message)
+        {
+        }
+
+        public SystemToolException(string format, params object[] args)
+            : base(string.Format(CultureInfo.CurrentCulture, format, args))
+        {
+        }
+
+        public SystemToolException(string message, Exception exception)
+            : base(message, exception)
+        {
+        }
+    }
+}


### PR DESCRIPTION
According to [X509Store](https://github.com/dotnet/corefx/blob/master/Documentation/architecture/cross-platform-cryptography.md#x509store), the LocalMachine\Root store on macOS is an interpretation of the SecTrustSettings results for the admin and system trust domains.
But it's read-only.
So in our tests, if we want to make a root certificate trusted, we have no APIs to add certificate to X509Store(LocalMachine\Root), but we  can run ` security add-trusted-cert ` commands as a workaround.

## Fix

Details: 
1. run  ` security add-trusted-cert ` to add certificate to X509Store(LocalMachine\Root)
2. run `security delete-certificate` to delete certificate from  X509Store(LocalMachine\Root)

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  We will enable tests for xplat verifcation on netcore, then we will have tests for it. 
Validation:  Yes

This PR has a predessesor:
Retarget to netcore5.0 https://github.com/NuGet/NuGet.Client/pull/3162