### PR TITLE
Update all the VS dependency packages

### DIFF
--- a/build/common.project.props
+++ b/build/common.project.props
@@ -73,7 +73,7 @@
     <Prefer32Bit>false</Prefer32Bit>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <NoWarn>$(NoWarn);1762;VSTHRD010;VSSDK005;VSTHRD109;VSTHRD003;VSTHRD100;VSSDK006;VSSDK004</NoWarn>
+    <NoWarn>$(NoWarn);1762;VSTHRD003;VSTHRD010;VSTHRD100;VSTHRD109;VSSDK004;VSSDK005;VSSDK006</NoWarn>
     <!-- Code Analysis is OFF by default -->
     <RunCodeAnalysis Condition=" '$(RunCodeAnalysis)' == ''">false</RunCodeAnalysis>
     <!--This property ensures that if you build the exact sources twice,

--- a/build/common.project.props
+++ b/build/common.project.props
@@ -46,8 +46,8 @@
     <MicrosoftDotNetMaestroTasksFilePath>$(SolutionPackagesFolder)microsoft.dotnet.maestro.tasks\1.1.0-beta.19178.1\tools\net472\Microsoft.DotNet.Maestro.Tasks.dll</MicrosoftDotNetMaestroTasksFilePath>
     <NoWarn>$(NoWarn);NU5105</NoWarn>
     <!-- These cause a NU5104 warning. When upgrading to a stable version of this package, remove the no warns from the respective projects -->
-    <VSServicesVersion>16.144.1-preview</VSServicesVersion>
-    <VSComponentsVersion>16.0.189-g83e7c53a57</VSComponentsVersion>
+    <VSServicesVersion>16.153.0</VSServicesVersion>
+    <VSComponentsVersion>16.4.280</VSComponentsVersion>
     <SystemPackagesVersion>4.3.0</SystemPackagesVersion>
   </PropertyGroup>
 
@@ -72,7 +72,7 @@
     <Prefer32Bit>false</Prefer32Bit>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <NoWarn>$(NoWarn);1762</NoWarn>
+    <NoWarn>$(NoWarn);1762;VSTHRD010;VSSDK005;VSTHRD109;VSTHRD003;VSTHRD100;VSSDK006</NoWarn> <!-- Revert the vsthrd-->
     <!-- Code Analysis is OFF by default -->
     <RunCodeAnalysis Condition=" '$(RunCodeAnalysis)' == ''">false</RunCodeAnalysis>
     <!--This property ensures that if you build the exact sources twice,

--- a/build/common.project.props
+++ b/build/common.project.props
@@ -45,9 +45,10 @@
     <MicrosoftDotNetBuildTasksFeedFilePath>$(SolutionPackagesFolder)microsoft.dotnet.build.tasks.feed\2.2.0-beta.19178.1\tools\net472\Microsoft.DotNet.Build.Tasks.Feed.dll</MicrosoftDotNetBuildTasksFeedFilePath>
     <MicrosoftDotNetMaestroTasksFilePath>$(SolutionPackagesFolder)microsoft.dotnet.maestro.tasks\1.1.0-beta.19178.1\tools\net472\Microsoft.DotNet.Maestro.Tasks.dll</MicrosoftDotNetMaestroTasksFilePath>
     <NoWarn>$(NoWarn);NU5105</NoWarn>
-    <!-- These cause a NU5104 warning. When upgrading to a stable version of this package, remove the no warns from the respective projects -->
+    <VSFrameworkVersion>16.4.29519.181</VSFrameworkVersion>
     <VSServicesVersion>16.153.0</VSServicesVersion>
     <VSComponentsVersion>16.4.280</VSComponentsVersion>
+    <VSThreadingVersion>16.4.43</VSThreadingVersion>
     <SystemPackagesVersion>4.3.0</SystemPackagesVersion>
   </PropertyGroup>
 
@@ -72,7 +73,7 @@
     <Prefer32Bit>false</Prefer32Bit>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <NoWarn>$(NoWarn);1762;VSTHRD010;VSSDK005;VSTHRD109;VSTHRD003;VSTHRD100;VSSDK006</NoWarn> <!-- Revert the vsthrd-->
+    <NoWarn>$(NoWarn);1762;VSTHRD010;VSSDK005;VSTHRD109;VSTHRD003;VSTHRD100;VSSDK006;VSSDK004</NoWarn>
     <!-- Code Analysis is OFF by default -->
     <RunCodeAnalysis Condition=" '$(RunCodeAnalysis)' == ''">false</RunCodeAnalysis>
     <!--This property ensures that if you build the exact sources twice,

--- a/src/NuGet.Clients/NuGet.CommandLine/Common/MSBuildUser.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Common/MSBuildUser.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -31,24 +31,9 @@ namespace NuGet.Common
             }
 
             _msbuildDirectory = msbuildDirectory;
-            var msbuildAssemblyPath = Path.Combine(msbuildDirectory, "Microsoft.Build.dll");
-            var msbuildFrameworkAssemblyPath = Path.Combine(msbuildDirectory, "Microsoft.Build.Framework.dll");
-            try
-            {
-                _msbuildAssembly = Assembly.LoadFile(msbuildAssemblyPath);
-            }
-            catch (Exception e)
-            {
-                throw new Exception(e.Message + $"Path: {msbuildAssemblyPath}", e);
-            }
-            try
-            {
-                _frameworkAssembly = Assembly.LoadFile(msbuildFrameworkAssemblyPath);
-            }
-            catch (Exception e)
-            {
-                throw new Exception(e.Message + $"Path: {msbuildFrameworkAssemblyPath}", e);
-            }
+            _msbuildAssembly = Assembly.LoadFile(Path.Combine(msbuildDirectory, "Microsoft.Build.dll"));
+            _frameworkAssembly = Assembly.LoadFile(Path.Combine(msbuildDirectory, "Microsoft.Build.Framework.dll"));
+
             LoadTypes();
         }
 

--- a/src/NuGet.Clients/NuGet.CommandLine/Common/MSBuildUser.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Common/MSBuildUser.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -31,9 +31,24 @@ namespace NuGet.Common
             }
 
             _msbuildDirectory = msbuildDirectory;
-            _msbuildAssembly = Assembly.LoadFile(Path.Combine(msbuildDirectory, "Microsoft.Build.dll"));
-            _frameworkAssembly = Assembly.LoadFile(Path.Combine(msbuildDirectory, "Microsoft.Build.Framework.dll"));
-
+            var msbuildAssemblyPath = Path.Combine(msbuildDirectory, "Microsoft.Build.dll");
+            var msbuildFrameworkAssemblyPath = Path.Combine(msbuildDirectory, "Microsoft.Build.Framework.dll");
+            try
+            {
+                _msbuildAssembly = Assembly.LoadFile(msbuildAssemblyPath);
+            }
+            catch (Exception e)
+            {
+                throw new Exception(e.Message + $"Path: {msbuildAssemblyPath}", e);
+            }
+            try
+            {
+                _frameworkAssembly = Assembly.LoadFile(msbuildFrameworkAssemblyPath);
+            }
+            catch (Exception e)
+            {
+                throw new Exception(e.Message + $"Path: {msbuildFrameworkAssemblyPath}", e);
+            }
             LoadTypes();
         }
 

--- a/src/NuGet.Clients/NuGet.VisualStudio.Client/.vsixignore
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Client/.vsixignore
@@ -1,14 +1,18 @@
 # assemblies not to be included in VSIX
 
+Ben.Demystifier.dll
 ICSharpCode.SharpZipLib.dll
 Microsoft.ApplicationInsights.dll
 Microsoft.ApplicationInsights.PersistenceChannel.dll
 Microsoft.ApplicationInsights.UniversalTelemetryChannel.dll
 Microsoft.IdentityModel.Clients.ActiveDirectory.dll
 Microsoft.IdentityModel.Clients.ActiveDirectory.Platform.dll
+Microsoft.IdentityModel.JsonWebTokens.dll
 Microsoft.IdentityModel.Logging.dll
 Microsoft.IdentityModel.Tokens.dll
 Microsoft.Internal.VisualStudio.Shell.Embeddable.dll
+Microsoft.ServiceHub.Framework.dll
+Microsoft.ServiceHub.Framework.resources.dll
 Microsoft.TeamFoundation.Build.Client.dll
 Microsoft.TeamFoundation.Build.Client.resources.dll
 Microsoft.TeamFoundation.Build.Common.dll
@@ -84,8 +88,18 @@ Microsoft.VisualStudio.Workspace.dll
 Microsoft.VisualStudio.Workspace.Extensions.dll
 Microsoft.VisualStudio.Workspace.Extensions.VS.dll
 Microsoft.VisualStudio.Workspace.VSIntegration.Contracts.dll
+Microsoft.Win32.Registry.dll
+Nerdbank.Streams.dll
+System.Buffers.dll
 System.IdentityModel.Tokens.Jwt.dll
+System.IO.Pipelines.dll
 System.Net.Http.Formatting.dll
+System.Memory.dll
+System.Numerics.Vectors.dll
 System.Resources.Extensions.dll
+System.Runtime.CompilerServices.Unsafe.dll
+System.Security.AccessControl.dll
+System.Security.Principal.Windows.dll
+System.Threading.Tasks.Extensions.dll
 System.Web.Http.dll
 VSLangProj157.dll

--- a/src/NuGet.Clients/NuGet.VisualStudio.Client/.vsixignore
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Client/.vsixignore
@@ -90,6 +90,7 @@ System.Net.Http.Formatting.dll
 System.Memory.dll
 System.Numerics.Vectors.dll
 System.Runtime.CompilerServices.Unsafe.dll
+System.Resources.Extensions.dll
 System.Security.AccessControl.dll
 System.Security.Principal.Windows.dll
 System.Threading.Tasks.Extensions.dll

--- a/src/NuGet.Clients/NuGet.VisualStudio.Client/.vsixignore
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Client/.vsixignore
@@ -2,9 +2,6 @@
 
 Ben.Demystifier.dll
 ICSharpCode.SharpZipLib.dll
-Microsoft.ApplicationInsights.dll
-Microsoft.ApplicationInsights.PersistenceChannel.dll
-Microsoft.ApplicationInsights.UniversalTelemetryChannel.dll
 Microsoft.IdentityModel.Clients.ActiveDirectory.dll
 Microsoft.IdentityModel.Clients.ActiveDirectory.Platform.dll
 Microsoft.IdentityModel.JsonWebTokens.dll
@@ -70,11 +67,7 @@ Microsoft.TeamFoundation.WorkItemTracking.Process.WebApi.dll
 Microsoft.TeamFoundation.WorkItemTracking.Proxy.dll
 Microsoft.TeamFoundation.WorkItemTracking.Proxy.resources.dll
 Microsoft.TeamFoundation.WorkItemTracking.WebApi.dll
-Microsoft.Threading.Tasks.dll
-Microsoft.Threading.Tasks.Extensions.Desktop.dll
-Microsoft.Threading.Tasks.Extensions.dll
 Microsoft.VisualStudio.Language.dll
-Microsoft.VisualStudio.Language.resources.dll
 Microsoft.VisualStudio.Services.Client.Interactive.dll
 Microsoft.VisualStudio.Services.Client.Interactive.resources.dll
 Microsoft.VisualStudio.Services.Common.dll
@@ -96,7 +89,6 @@ System.IO.Pipelines.dll
 System.Net.Http.Formatting.dll
 System.Memory.dll
 System.Numerics.Vectors.dll
-System.Resources.Extensions.dll
 System.Runtime.CompilerServices.Unsafe.dll
 System.Security.AccessControl.dll
 System.Security.Principal.Windows.dll

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/NuGet.VisualStudio.Common.csproj
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/NuGet.VisualStudio.Common.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Language.StandardClassification" Version="$(VSComponentsVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Services.Client" Version="$(VSServicesVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Services.InteractiveClient" Version="$(VSServicesVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="16.4.29519.181" />
+    <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="$(VSFrameworkVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.Immutable.15.0" Version="15.0.25123-Dev15Preview">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
@@ -38,9 +38,9 @@
     <PackageReference Include="Microsoft.VisualStudio.Text.Logic" Version="$(VSComponentsVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Text.UI" Version="$(VSComponentsVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Text.UI.Wpf" Version="$(VSComponentsVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.ImageCatalog" Version="16.4.29519.181" />
-    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="16.4.43" />
-    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="16.4.43" />
+    <PackageReference Include="Microsoft.VisualStudio.ImageCatalog" Version="$(VSFrameworkVersion)" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="$(VSThreadingVersion)" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="$(VSThreadingVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersionCore)" NoWarn="NU1605" />
     <PackageReference Include="VSLangProj" Version="7.0.3300" />
     <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/NuGet.VisualStudio.Common.csproj
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/NuGet.VisualStudio.Common.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Language.StandardClassification" Version="$(VSComponentsVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Services.Client" Version="$(VSServicesVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Services.InteractiveClient" Version="$(VSServicesVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="15.8.28010" />
+    <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="16.4.29519.181" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.Immutable.15.0" Version="15.0.25123-Dev15Preview">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
@@ -38,9 +38,9 @@
     <PackageReference Include="Microsoft.VisualStudio.Text.Logic" Version="$(VSComponentsVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Text.UI" Version="$(VSComponentsVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Text.UI.Wpf" Version="$(VSComponentsVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.ImageCatalog" Version="15.8.28010" />
-    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="15.8.132" />
-    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="15.8.132" />
+    <PackageReference Include="Microsoft.VisualStudio.ImageCatalog" Version="16.4.29519.181" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="16.4.43" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="16.4.43" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersionCore)" NoWarn="NU1605" />
     <PackageReference Include="VSLangProj" Version="7.0.3300" />
     <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />

--- a/src/NuGet.Clients/NuGet.VisualStudio.Interop/NuGet.VisualStudio.Interop.csproj
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Interop/NuGet.VisualStudio.Interop.csproj
@@ -19,8 +19,8 @@
     <ProjectReference Include="..\NuGet.VisualStudio\NuGet.VisualStudio.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="15.0.26201" />
-    <PackageReference Include="Microsoft.VisualStudio.ComponentModelHost" Version="15.0.26201" />
+    <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="16.4.29519.181" />
+    <PackageReference Include="Microsoft.VisualStudio.ComponentModelHost" Version="16.4.280" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.ComponentModel.Composition" />

--- a/src/NuGet.Clients/NuGet.VisualStudio.Interop/NuGet.VisualStudio.Interop.csproj
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Interop/NuGet.VisualStudio.Interop.csproj
@@ -19,8 +19,9 @@
     <ProjectReference Include="..\NuGet.VisualStudio\NuGet.VisualStudio.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="16.4.29519.181" />
-    <PackageReference Include="Microsoft.VisualStudio.ComponentModelHost" Version="16.4.280" />
+    <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="$(VSFrameworkVersion)" />
+    <PackageReference Include="Microsoft.VisualStudio.ComponentModelHost" Version="$(VSComponentsVersion)" />
+    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersionCore)" NoWarn="NU1605" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.ComponentModel.Composition" />

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Util.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Util.cs
@@ -1178,13 +1178,7 @@ EndProject");
 
         public static string GetMsbuildPathOnWindows()
         {
-            var msbuildPath = @"C:\Program Files (x86)\MSBuild\14.0\Bin";
-            if (!Directory.Exists(msbuildPath))
-            {
-                msbuildPath = @"C:\Program Files\MSBuild\14.0\Bin";
-            }
-
-            return msbuildPath;
+            return MsBuildUtility.GetMsBuildDirectoryFromMsBuildPath(null, null, null).Value.Path;
         }
 
         public static string GetHintPath(string path)

--- a/test/TestExtensions/API.Test/API.Test.csproj
+++ b/test/TestExtensions/API.Test/API.Test.csproj
@@ -19,10 +19,10 @@
 
   <ItemGroup>  
     <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.15.0.DesignTime" Version="15.0.26932" />
-    <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="15.8.28010" />
+    <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="16.4.29519.181" />
     <PackageReference Include="Microsoft.VisualStudio.ComponentModelHost" Version="$(VSComponentsVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="15.8.132" />
-    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="15.8.132" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="16.4.43" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="16.4.43" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersionCore)" NoWarn="NU1605" />
   </ItemGroup>
 

--- a/test/TestExtensions/API.Test/API.Test.csproj
+++ b/test/TestExtensions/API.Test/API.Test.csproj
@@ -19,10 +19,10 @@
 
   <ItemGroup>  
     <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.15.0.DesignTime" Version="15.0.26932" />
-    <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="16.4.29519.181" />
+    <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="$(VSFrameworkVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.ComponentModelHost" Version="$(VSComponentsVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="16.4.43" />
-    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="16.4.43" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="$(VSThreadingVersion)" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="$(VSThreadingVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersionCore)" NoWarn="NU1605" />
   </ItemGroup>
 

--- a/test/TestUtilities/Test.Utility/Test.Utility.csproj
+++ b/test/TestUtilities/Test.Utility/Test.Utility.csproj
@@ -49,7 +49,7 @@
     <PackageReference Include="Microsoft.VisualStudio.ProjectSystem" Version="15.0.751">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="15.0.26201">
+    <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="16.4.29519.181">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/test/TestUtilities/Test.Utility/Test.Utility.csproj
+++ b/test/TestUtilities/Test.Utility/Test.Utility.csproj
@@ -10,6 +10,7 @@
     <Shipping>true</Shipping>
     <IsPackable>true</IsPackable>
     <SkipShared>true</SkipShared>
+    <NoWarn>$(NoWarn);VSTHRD001;VSTHRD002;VSTHRD110</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -43,13 +44,14 @@
 
   <ItemGroup>
     <PackageReference Include="Portable.BouncyCastle" Version="1.8.1.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersionCore)" NoWarn="NU1605" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == '$(NETFXTargetFramework)' ">
     <PackageReference Include="Microsoft.VisualStudio.ProjectSystem" Version="15.0.751">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="16.4.29519.181">
+    <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="$(VSFrameworkVersion)">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
   </ItemGroup>


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/8967
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: Update all the VS service packages to the latest published. This is necessary in order for us to be able to transition to Service Broker powered services.

Follow up task: https://github.com/NuGet/Home/issues/8968
address all the threading warnings.

## Testing/Validation

Tests Added: Noe
Reason for not adding tests:  
Validation:  
