### PR TITLE
Fix VSSDK004, VSSDK005 & VSSDK006 analyzer warnings

### DIFF
--- a/build/common.project.props
+++ b/build/common.project.props
@@ -84,7 +84,7 @@
     <Prefer32Bit>false</Prefer32Bit>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <NoWarn>$(NoWarn);1762;VSTHRD003;VSTHRD010;VSTHRD109;VSSDK004;VSSDK005;VSSDK006</NoWarn>
+    <NoWarn>$(NoWarn);NU5105;VSTHRD003;VSTHRD010;VSTHRD109</NoWarn>
     <!-- Code Analysis is OFF by default -->
     <RunCodeAnalysis Condition=" '$(RunCodeAnalysis)' == ''">false</RunCodeAnalysis>
     <!--This property ensures that if you build the exact sources twice,

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/PackageSourcesOptionsControl.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/PackageSourcesOptionsControl.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Windows.Forms;
+using Microsoft;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
@@ -607,7 +608,7 @@ namespace NuGet.Options
             const int BIF_BROWSEINCLUDEURLS = 0x00000080; // Allow URLs to be displayed or entered.
 
             var uiShell = (IVsUIShell2)_serviceProvider.GetService(typeof(SVsUIShell));
-
+            Assumes.Present(uiShell);
             var rgch = new char[MaxDirectoryLength + 1];
 
             // allocate a buffer in unmanaged memory for file name (string)

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/GlobalSuppressions.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/GlobalSuppressions.cs
@@ -5,4 +5,4 @@
 // a specific target and scoped to a namespace, type, member, etc.
 
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "VSTHRD110:Observe result of async calls", Justification = "https://github.com/NuGet/Home/issues/7674", Scope = "member", Target = "~M:NuGet.SolutionRestoreManager.RestoreEventPublisher.OnSolutionRestoreCompleted(NuGet.VisualStudio.SolutionRestoredEventArgs)")]
-
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Performance", "VSSDK004:Use BackgroundLoad flag in ProvideAutoLoad attribute for asynchronous auto load.", Justification = "https://github.com/NuGet/Home/issues/8796", Scope = "type", Target = "~T:NuGet.SolutionRestoreManager.RestoreManagerPackage")]

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreCommand.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreCommand.cs
@@ -77,6 +77,7 @@ namespace NuGet.SolutionRestoreManager
             commandService.AddCommand(menuItem);
 
             _vsMonitorSelection = await serviceProvider.GetServiceAsync(typeof(IVsMonitorSelection)) as IVsMonitorSelection;
+            Assumes.Present(_vsMonitorSelection);
 
             // get the solution not building and not debugging cookie
             var guidCmdUI = VSConstants.UICONTEXT.SolutionExistsAndFullyLoaded_guid;

--- a/src/NuGet.Clients/NuGet.Tools/NuGetPackage.cs
+++ b/src/NuGet.Clients/NuGet.Tools/NuGetPackage.cs
@@ -11,6 +11,7 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using EnvDTE;
+using Microsoft;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.OLE.Interop;
@@ -146,7 +147,7 @@ namespace NuGetVSExtension
 
                     // get the UI context cookie for the debugging mode
                     var vsMonitorSelection = await GetServiceAsync(typeof(IVsMonitorSelection)) as IVsMonitorSelection;
-
+                    Assumes.Present(vsMonitorSelection);
                     // get the solution not building and not debugging cookie
                     var guidCmdUI = VSConstants.UICONTEXT.SolutionExistsAndFullyLoaded_guid;
                     vsMonitorSelection.GetCmdUIContextCookie(
@@ -173,6 +174,7 @@ namespace NuGetVSExtension
             _initialized = true;
 
             var componentModel = await GetServiceAsync(typeof(SComponentModel)) as IComponentModel;
+            Assumes.Present(componentModel);
             componentModel.DefaultCompositionService.SatisfyImportsOnce(this);
 
             await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
@@ -182,6 +184,7 @@ namespace NuGetVSExtension
             Brushes.LoadVsBrushes();
 
             _dte = (DTE)await GetServiceAsync(typeof(SDTE));
+            Assumes.Present(_dte);
 
             _dteEvents = _dte.Events.DTEEvents;
             _dteEvents.OnBeginShutdown += OnBeginShutDown;
@@ -389,6 +392,7 @@ namespace NuGetVSExtension
             // Find existing hierarchy and item id of the document window if it's
             // already registered.
             var rdt = await GetServiceAsync(typeof(IVsRunningDocumentTable)) as IVsRunningDocumentTable;
+            Assumes.Present(rdt);
             IVsHierarchy hier;
             uint itemId;
             var docData = IntPtr.Zero;
@@ -478,7 +482,7 @@ namespace NuGetVSExtension
 
             IVsWindowFrame windowFrame;
             var uiShell = await GetServiceAsync(typeof(SVsUIShell)) as IVsUIShell;
-
+            Assumes.Present(uiShell);
             var ppunkDocView = IntPtr.Zero;
             var ppunkDocData = IntPtr.Zero;
             var hr = 0;

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/NuGetUIThreadHelper.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/NuGetUIThreadHelper.cs
@@ -61,32 +61,6 @@ namespace NuGet.VisualStudio
             }
         }
 
-        /// <summary>
-        /// Set a non-Visual Studio JTF. This is used for standalone mode.
-        /// </summary>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope")]
-        public static void SetCustomJoinableTaskFactory(Thread mainThread, SynchronizationContext synchronizationContext)
-        {
-            if (mainThread == null)
-            {
-                throw new ArgumentNullException(nameof(mainThread));
-            }
-
-            if (synchronizationContext == null)
-            {
-                throw new ArgumentNullException(nameof(synchronizationContext));
-            }
-
-            // This method is not thread-safe and does not have it to be
-            // This is really just a test-hook to be used by test standalone UI and only 1 thread will call into this
-            // And, note that this method throws, when running inside VS, and ThreadHelper.JoinableTaskContext is not null
-            _joinableTaskFactory = new Lazy<JoinableTaskFactory>(() =>
-            {
-                var joinableTaskContext = new JoinableTaskContext(mainThread, synchronizationContext);
-                return joinableTaskContext.Factory;
-            });
-        }
-
         public static void SetCustomJoinableTaskFactory(JoinableTaskFactory joinableTaskFactory)
         {
             Assumes.Present(joinableTaskFactory);

--- a/src/NuGet.Clients/NuGet.VisualStudio.Interop/TemplateWizard.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Interop/TemplateWizard.cs
@@ -6,6 +6,7 @@ using System.ComponentModel.Composition;
 using System.ComponentModel.Composition.Hosting;
 using System.Diagnostics.CodeAnalysis;
 using EnvDTE;
+using Microsoft;
 using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.OLE.Interop;
 using Microsoft.VisualStudio.Shell;
@@ -25,7 +26,7 @@ namespace NuGet.VisualStudio
             using (var serviceProvider = new ServiceProvider((IServiceProvider)automationObject))
             {
                 var componentModel = (IComponentModel)serviceProvider.GetService(typeof(SComponentModel));
-
+                Assumes.Present(componentModel);
                 using (var container = new CompositionContainer(componentModel.DefaultExportProvider))
                 {
                     container.ComposeParts(this);

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Xamls/InfiniteScrollListTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Xamls/InfiniteScrollListTests.cs
@@ -15,13 +15,21 @@ using Xunit;
 
 namespace NuGet.PackageManagement.UI.Test
 {
-    public class InfiniteScrollListTests
+    public class InfiniteScrollListTests : IDisposable
     {
+        private JoinableTaskContext _joinableTaskContext;
         public InfiniteScrollListTests()
         {
-            var joinableTaskContext = new JoinableTaskContext(Thread.CurrentThread, SynchronizationContext.Current);
+#pragma warning disable VSSDK005 // Avoid instantiating JoinableTaskContext
+            _joinableTaskContext = new JoinableTaskContext(Thread.CurrentThread, SynchronizationContext.Current);
+#pragma warning restore VSSDK005 // Avoid instantiating JoinableTaskContext
 
-            NuGetUIThreadHelper.SetCustomJoinableTaskFactory(joinableTaskContext.Factory);
+            NuGetUIThreadHelper.SetCustomJoinableTaskFactory(_joinableTaskContext.Factory);
+        }
+
+        public void Dispose()
+        {
+            _joinableTaskContext?.Dispose();
         }
 
         [WpfFact]
@@ -214,7 +222,9 @@ namespace NuGet.PackageManagement.UI.Test
             var logger = new Mock<INuGetUILogger>();
             var searchResultTask = Task.FromResult(new SearchResult<IPackageSearchMetadata>());
 
+#pragma warning disable VSSDK005 // Avoid instantiating JoinableTaskContext
             using (var joinableTaskContext = new JoinableTaskContext(Thread.CurrentThread, SynchronizationContext.Current))
+#pragma warning restore VSSDK005 // Avoid instantiating JoinableTaskContext
             {
                 var list = new InfiniteScrollList(new Lazy<JoinableTaskFactory>(() => joinableTaskContext.Factory));
                 var taskCompletionSource = new TaskCompletionSource<string>();

--- a/test/NuGet.Tests.Apex/NuGet.PackageManagement.UI.TestContract/NuGet.PackageManagement.UI.TestContract.csproj
+++ b/test/NuGet.Tests.Apex/NuGet.PackageManagement.UI.TestContract/NuGet.PackageManagement.UI.TestContract.csproj
@@ -10,7 +10,7 @@
   <PropertyGroup>
     <TargetFramework>$(NETFXTargetFramework)</TargetFramework>
     <OutputType>Library</OutputType>
-    <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <NoWarn>$(NoWarn);CS1591;1762</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="$(NuGetClientsSrcDirectory)NuGet.PackageManagement.UI\NuGet.PackageManagement.UI.csproj" />

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGet.Tests.Apex.csproj
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGet.Tests.Apex.csproj
@@ -6,6 +6,7 @@
     <TargetFramework>$(NETFXTargetFramework)</TargetFramework>
     <NETCoreWPFProject>true</NETCoreWPFProject>
     <TestProject>true</TestProject>
+    <NoWarn>$(NoWarn);1762</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/TestExtensions/API.Test/API.Test.csproj
+++ b/test/TestExtensions/API.Test/API.Test.csproj
@@ -4,6 +4,7 @@
   <PropertyGroup>
     <TargetFramework>$(NETFXTargetFramework)</TargetFramework>
     <SkipSigning>true</SkipSigning>
+    <NoWarn>$(NoWarn);1762</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/TestUtilities/Test.Utility/Threading/DispatcherThreadFixture.cs
+++ b/test/TestUtilities/Test.Utility/Threading/DispatcherThreadFixture.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -31,7 +31,9 @@ namespace Test.Utility.Threading
             });
 
             _joinableTaskContextNode = new JoinableTaskContextNode(
+#pragma warning disable VSSDK005 // Avoid instantiating JoinableTaskContext
                 new JoinableTaskContext(_dispatcherThread.Thread, _dispatcherThread.SyncContext));
+#pragma warning restore VSSDK005 // Avoid instantiating JoinableTaskContext
         }
 
         public void Dispose()


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/8974
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: Address the analyzer warnings. Most of these are pretty straightforward. In some case we "violate" the recommendations for testing purposes. 

VSSDK deserves a more complex explanation 
After upgrading our threading libraries a bunch of new warnings that are treated as errors are being raised.

One of those warnings is VSSDK004 Use BackgroundLoad flag in ProvideAutoLoad attribute for asynchronous auto load.

This is raised because of a recent change to load our package before the solution build event.
https://github.com/NuGet/NuGet.Client/blob/cb402b5a3340ab5b2605ecc72de7f70aaac95344/src/NuGet.Clients/NuGet.SolutionRestoreManager/RestoreManagerPackage.cs#L23.
However this is done on purpose to support the scenario. - FYI @rrelyea https://github.com/NuGet/Home/issues/8796

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  
Validation:  
