### PR TITLE
Increment the 4th build number

### DIFF
--- a/build/config.props
+++ b/build/config.props
@@ -24,7 +24,7 @@
     <!-- ** Increment each insertion, set to zero after incrementing Major/Minor or Patch version -->
     <!-- We need to update this netcoreassembly build number with EVERY insertion into VS to workaround any breaking api
     changes we might have made. -->
-    <NetCoreAssemblyBuildNumber Condition=" '$(NetCoreAssemblyBuildNumber)' == '' ">1</NetCoreAssemblyBuildNumber>
+    <NetCoreAssemblyBuildNumber Condition=" '$(NetCoreAssemblyBuildNumber)' == '' ">2</NetCoreAssemblyBuildNumber>
 
     <IsEscrowMode>false</IsEscrowMode>
 


### PR DESCRIPTION
## Bug

Fixes: Follow up to https://github.com/NuGet/Home/issues/8971
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: 
Increment the 4th digit after an SDK insertion. 

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  
Validation:  
