### PR TITLE
Cleanup restore message 

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRunner.cs
@@ -262,7 +262,7 @@ namespace NuGet.Commands
             log.LogInformation(Strings.Log_Committing);
             await result.CommitAsync(log, token);
 
-            if (result.Success)
+            if (summaryRequest.Request.ProjectStyle == ProjectStyle.DotnetToolReference)
             {
                 // For no-op results, don't log a minimal message since a summary is logged at the end
                 // For regular results, log a minimal message so that users can see which projects were actually restored
@@ -273,17 +273,16 @@ namespace NuGet.Commands
                         summaryRequest.Request.ProjectStyle == ProjectStyle.DotnetToolReference ?
                             Strings.Log_RestoreCompleteDotnetTool :
                             Strings.Log_RestoreComplete,
-                        DatetimeUtility.ToReadableTimeFormat(result.ElapsedTime),
-                        summaryRequest.InputPath));
+                        summaryRequest.InputPath,
+                        DatetimeUtility.ToReadableTimeFormat(result.ElapsedTime)));
             }
             else
             {
                 log.LogMinimal(string.Format(
                     CultureInfo.CurrentCulture,
-                    summaryRequest.Request.ProjectStyle == ProjectStyle.DotnetToolReference ?
-                    Strings.Log_RestoreFailedDotnetTool :
+                    result.Success ?
+                    Strings.Log_RestoreComplete :
                     Strings.Log_RestoreFailed,
-                    DatetimeUtility.ToReadableTimeFormat(result.ElapsedTime),
                     summaryRequest.InputPath));
             }
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRunner.cs
@@ -262,7 +262,7 @@ namespace NuGet.Commands
             log.LogInformation(Strings.Log_Committing);
             await result.CommitAsync(log, token);
 
-            if (summaryRequest.Request.ProjectStyle == ProjectStyle.DotnetToolReference)
+            if (result.Success)
             {
                 // For no-op results, don't log a minimal message since a summary is logged at the end
                 // For regular results, log a minimal message so that users can see which projects were actually restored
@@ -280,10 +280,11 @@ namespace NuGet.Commands
             {
                 log.LogMinimal(string.Format(
                     CultureInfo.CurrentCulture,
-                    result.Success ?
-                    Strings.Log_RestoreComplete :
+                    summaryRequest.Request.ProjectStyle == ProjectStyle.DotnetToolReference ?
+                    Strings.Log_RestoreFailedDotnetTool :
                     Strings.Log_RestoreFailed,
-                    summaryRequest.InputPath));
+                    summaryRequest.InputPath,
+                    DatetimeUtility.ToReadableTimeFormat(result.ElapsedTime)));
             }
 
             // Remote the summary messages from the assets file. This will be removed later.

--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -1286,7 +1286,7 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Restored {0}.
+        ///   Looks up a localized string similar to Restored {0} (in {1}).
         /// </summary>
         internal static string Log_RestoreComplete {
             get {
@@ -1304,7 +1304,7 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Failed to restore {0}.
+        ///   Looks up a localized string similar to Failed to restore {0} (in {1}).
         /// </summary>
         internal static string Log_RestoreFailed {
             get {

--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -1286,7 +1286,7 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Restore completed in {0} for {1}..
+        ///   Looks up a localized string similar to Restored {0}.
         /// </summary>
         internal static string Log_RestoreComplete {
             get {
@@ -1304,7 +1304,7 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Restore failed in {0} for {1}..
+        ///   Looks up a localized string similar to Failed to restore {0}.
         /// </summary>
         internal static string Log_RestoreFailed {
             get {

--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -1286,7 +1286,7 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Restored {0} (in {1}).
+        ///   Looks up a localized string similar to Restored {0} (in {1})..
         /// </summary>
         internal static string Log_RestoreComplete {
             get {
@@ -1295,7 +1295,7 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Restore completed in {0}..
+        ///   Looks up a localized string similar to Restored {0} (in {1})..
         /// </summary>
         internal static string Log_RestoreCompleteDotnetTool {
             get {
@@ -1304,7 +1304,7 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Failed to restore {0} (in {1}).
+        ///   Looks up a localized string similar to Failed to restore {0} (in {1})..
         /// </summary>
         internal static string Log_RestoreFailed {
             get {
@@ -1313,7 +1313,7 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Restore failed in {0}..
+        ///   Looks up a localized string similar to Failed to restore {0} (in {1})..
         /// </summary>
         internal static string Log_RestoreFailedDotnetTool {
             get {

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -250,14 +250,12 @@
     <value>Found project root directory: {0}.</value>
   </data>
   <data name="Log_RestoreComplete" xml:space="preserve">
-    <value>Restore completed in {0} for {1}.</value>
-    <comment>{0} is the restore duration.
-{1} is the path to the project file.</comment>
+    <value>Restored {0} (in {1})</value>
+    <comment>{0} is the path to the project file. {1} is the restore duration.</comment>
   </data>
   <data name="Log_RestoreFailed" xml:space="preserve">
-    <value>Restore failed in {0} for {1}.</value>
-    <comment>{0} is the restore duration.
-{1} is the path to the project file.</comment>
+    <value>Failed to restore {0}</value>
+    <comment>{0} is the path to the project file.</comment>
   </data>
   <data name="Log_RunningNonParallelRestore" xml:space="preserve">
     <value>Running non-parallel restore.</value>
@@ -881,8 +879,8 @@ For more information, visit https://docs.nuget.org/docs/reference/command-line-r
     <comment>{0} is the restore duration.</comment>
   </data>
   <data name="Log_RestoreFailedDotnetTool" xml:space="preserve">
-    <value>Restore failed in {0}.</value>
-    <comment>{0} is the restore duration.</comment>
+    <value>Failed to restore {0} (in {1})</value>
+    <comment>{0} is the path to the project file. {1} is the restore duration.</comment>
   </data>
   <data name="Error_PackageDownload_OnlyExactVersionsAreAllowed" xml:space="preserve">
     <value>'{0}' is not an exact version like '[1.0.0]'. Only exact versions are allowed with PackageDownload.</value>

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -254,8 +254,9 @@
     <comment>{0} is the path to the project file. {1} is the restore duration.</comment>
   </data>
   <data name="Log_RestoreFailed" xml:space="preserve">
-    <value>Failed to restore {0}</value>
-    <comment>{0} is the path to the project file.</comment>
+    <value>Failed to restore {0} (in {1})</value>
+    <comment>{0} is the path to the project file.
+    {1} is the restore duration.</comment>
   </data>
   <data name="Log_RunningNonParallelRestore" xml:space="preserve">
     <value>Running non-parallel restore.</value>

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -250,11 +250,11 @@
     <value>Found project root directory: {0}.</value>
   </data>
   <data name="Log_RestoreComplete" xml:space="preserve">
-    <value>Restored {0} (in {1})</value>
+    <value>Restored {0} (in {1}).</value>
     <comment>{0} is the path to the project file. {1} is the restore duration.</comment>
   </data>
   <data name="Log_RestoreFailed" xml:space="preserve">
-    <value>Failed to restore {0} (in {1})</value>
+    <value>Failed to restore {0} (in {1}).</value>
     <comment>{0} is the path to the project file.
     {1} is the restore duration.</comment>
   </data>
@@ -876,11 +876,11 @@ For more information, visit https://docs.nuget.org/docs/reference/command-line-r
     <comment>0 - name</comment>
   </data>
   <data name="Log_RestoreCompleteDotnetTool" xml:space="preserve">
-    <value>Restore completed in {0}.</value>
+    <value>Restored {0} (in {1}).</value>
     <comment>{0} is the restore duration.</comment>
   </data>
   <data name="Log_RestoreFailedDotnetTool" xml:space="preserve">
-    <value>Failed to restore {0} (in {1})</value>
+    <value>Failed to restore {0} (in {1}).</value>
     <comment>{0} is the path to the project file. {1} is the restore duration.</comment>
   </data>
   <data name="Error_PackageDownload_OnlyExactVersionsAreAllowed" xml:space="preserve">

--- a/src/NuGet.Core/NuGet.Common/DatetimeUtility.cs
+++ b/src/NuGet.Core/NuGet.Common/DatetimeUtility.cs
@@ -24,6 +24,16 @@ namespace NuGet.Common
             if (time.TotalSeconds < 1)
             {
                 result = time.TotalMilliseconds;
+                // If less than 1 ms, show only 1 significant figure
+                if (result >= 1)
+                {
+                    result = Math.Round(result, 0);
+                }
+                else if (result >= 0.1) 
+                {
+                    result = Math.Round(result, 1);
+                }
+
                 type = "ms"; // milliseconds
             }
             else if (time.TotalMinutes < 1)

--- a/src/NuGet.Core/NuGet.Common/DatetimeUtility.cs
+++ b/src/NuGet.Core/NuGet.Common/DatetimeUtility.cs
@@ -29,7 +29,7 @@ namespace NuGet.Common
                 {
                     result = Math.Round(result, 0);
                 }
-                else if (result >= 0.1) 
+                else if (result >= 0.1)
                 {
                     result = Math.Round(result, 1);
                 }

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectStyle.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectStyle.cs
@@ -35,7 +35,7 @@ namespace NuGet.ProjectModel
         /// </summary>
         PackagesConfig = 5, 
 
-                /// <summary>
+        /// <summary>
         /// DotnetToolReference project
         /// </summary>
         DotnetToolReference = 6

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
@@ -248,7 +248,7 @@ EndGlobal";
 
                 // Assert
                 Assert.True(result.ExitCode == 0, result.AllOutput);
-                Assert.Contains("Restore completed", result.AllOutput);
+                Assert.Contains("Restored ", result.AllOutput);
 
                 Directory.Move(projectDirectory, movedDirectory);
 
@@ -256,7 +256,7 @@ EndGlobal";
 
                 // Assert
                 Assert.True(result.ExitCode == 0, result.AllOutput);
-                Assert.DoesNotContain("Restore completed", result.AllOutput);
+                Assert.DoesNotContain("Restored ", result.AllOutput);
 
             }
         }


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/8977
Regression: No  

## Fix

Remove timestamp except for "DotnetToolReference" (I can remove for that too if you like)

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  Didn't see tests for these messages
Validation:   Forced each path in debugger.
