### PR TITLE
Update the spec command tests - use the current year

### DIFF
--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetSpecCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetSpecCommandTest.cs
@@ -48,7 +48,7 @@ namespace NuGet.CommandLine.Test
     <iconUrl>http://icon_url_here_or_delete_this_line/</iconUrl>
     <description>Package description</description>
     <releaseNotes>Summary of changes made in this release of the package.</releaseNotes>
-    <copyright>Copyright 2019</copyright>
+    <copyright>Copyright {DateTime.Now.Year}</copyright>
     <tags>Tag1 Tag2</tags>
     <dependencies>
       <group targetFramework="".NETStandard2.1"">
@@ -91,7 +91,7 @@ namespace NuGet.CommandLine.Test
     <iconUrl>http://icon_url_here_or_delete_this_line/</iconUrl>
     <description>Package description</description>
     <releaseNotes>Summary of changes made in this release of the package.</releaseNotes>
-    <copyright>Copyright 2019</copyright>
+    <copyright>Copyright {DateTime.Now.Year}</copyright>
     <tags>Tag1 Tag2</tags>
     <dependencies>
       <group targetFramework="".NETStandard2.1"">
@@ -147,7 +147,7 @@ namespace NuGet.CommandLine.Test
     <iconUrl>http://icon_url_here_or_delete_this_line/</iconUrl>
     <description>$description$</description>
     <releaseNotes>Summary of changes made in this release of the package.</releaseNotes>
-    <copyright>Copyright 2019</copyright>
+    <copyright>Copyright {DateTime.Now.Year}</copyright>
     <tags>Tag1 Tag2</tags>
   </metadata>
 </package>".Replace("\r\n", "\n"), nuspec.Replace("\r\n", "\n"));


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/8984
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: There's a chance this still fails if it runs at midnight on new years eve, but I don't think it's worth optimizing for it. 

## Testing/Validation

Tests Added: No
Reason for not adding tests: Fixing a test.  
Validation:  
