### PR TITLE
Functional tests are broken due to a machine upgrade to 16.4 - upgrade the msbuild dependency to fix that.

### DIFF
--- a/build/common.project.props
+++ b/build/common.project.props
@@ -45,11 +45,22 @@
     <MicrosoftDotNetBuildTasksFeedFilePath>$(SolutionPackagesFolder)microsoft.dotnet.build.tasks.feed\2.2.0-beta.19178.1\tools\net472\Microsoft.DotNet.Build.Tasks.Feed.dll</MicrosoftDotNetBuildTasksFeedFilePath>
     <MicrosoftDotNetMaestroTasksFilePath>$(SolutionPackagesFolder)microsoft.dotnet.maestro.tasks\1.1.0-beta.19178.1\tools\net472\Microsoft.DotNet.Maestro.Tasks.dll</MicrosoftDotNetMaestroTasksFilePath>
     <NoWarn>$(NoWarn);NU5105</NoWarn>
+  </PropertyGroup>
+
+  <!-- Dependency versions -->
+  <PropertyGroup>
     <VSFrameworkVersion>16.4.29519.181</VSFrameworkVersion>
     <VSServicesVersion>16.153.0</VSServicesVersion>
     <VSComponentsVersion>16.4.280</VSComponentsVersion>
     <VSThreadingVersion>16.4.43</VSThreadingVersion>
     <SystemPackagesVersion>4.3.0</SystemPackagesVersion>
+    <NewtonsoftJsonVersionCore Condition="$(NewtonsoftJsonPackageVersion) == ''">9.0.1</NewtonsoftJsonVersionCore>
+    <NewtonsoftJsonVersionCore Condition="$(NewtonsoftJsonPackageVersion) != ''">$(NewtonsoftJsonPackageVersion)</NewtonsoftJsonVersionCore>
+    <XunitVersion>2.4.1</XunitVersion>
+    <TestSDKVersion>15.5.0</TestSDKVersion>
+    <MoqVersion>4.12.0</MoqVersion>
+    <FluentAssertionsVersion>4.19.4</FluentAssertionsVersion>
+    <MicrosoftBuildPackageVersion Condition="$(MicrosoftBuildPackageVersion) == ''">16.4.0</MicrosoftBuildPackageVersion>
   </PropertyGroup>
 
   <!-- Defaults -->

--- a/build/config.props
+++ b/build/config.props
@@ -46,17 +46,6 @@
     <ToolsetTargetBranches Condition="'$(OverrideToolsetTargetBranches)' == ''">master</ToolsetTargetBranches>
   </PropertyGroup>
 
-  <!-- Dependency versions -->
-  <PropertyGroup>
-    <NewtonsoftJsonVersionCore Condition="$(NewtonsoftJsonPackageVersion) == ''">9.0.1</NewtonsoftJsonVersionCore>
-    <NewtonsoftJsonVersionCore Condition="$(NewtonsoftJsonPackageVersion) != ''">$(NewtonsoftJsonPackageVersion)</NewtonsoftJsonVersionCore>
-    <XunitVersion>2.4.1</XunitVersion>
-    <TestSDKVersion>15.5.0</TestSDKVersion>
-    <MoqVersion>4.12.0</MoqVersion>
-    <FluentAssertionsVersion>4.19.4</FluentAssertionsVersion>
-    <MicrosoftBuildPackageVersion Condition="$(MicrosoftBuildPackageVersion) == ''">16.0.461</MicrosoftBuildPackageVersion>
-  </PropertyGroup>
-
   <!-- Config -->
   <PropertyGroup>
     <RepositoryName>NuGet</RepositoryName>


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9000
Regression: No
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: 

Specifically: 

AddPkg_ConditionalAddAsUpdate_Success
AddPkg_UnconditionalAddAsUpdate_Succcess
AddPkg_UnconditionalAddTwoPackages_Success

The root cause is: 

```console
System.AggregateException : One or more errors occurred.\r\n---- Microsoft.Build.Exceptions.InvalidProjectFileException : The expression \"\"E:\\A\\_work\\345\\s\\.test\\work\\3358da78\\9313099e\\globalPackages\\pkgx\\1.0.0\\contentFiles\\cs\\net45\\code.cs\".GetPathsOfAllDirectoriesAbove()\" cannot be evaluated. Method 'System.String.GetPathsOfAllDirectoriesAbove' not found. C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Enterprise\\MSBuild\\Current\\Bin\\Roslyn\\Microsoft.Managed.Core.targets

```

Likely same rootcause as https://github.com/dotnet/roslyn/issues/40532. 

## Testing/Validation

Tests Added: No  
Reason for not adding tests: Fixing tests  
Validation:  
