### PR TITLE
Do not pass empty SolutionPath in Static Graph restore

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Console/Program.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Console/Program.cs
@@ -64,7 +64,7 @@ namespace NuGet.Build.Tasks.Console
             MSBuildFeatureFlags.SkipEagerWildcardEvaluations = true;
 
             // Only wire up an AssemblyResolve event handler if being debugged.
-            if (IsDebug())
+            if (debug)
             {
                 // The App.config contains relative paths to MSBuild which won't work for locally built copies so an AssemblyResolve event
                 // handler is used in order to locate the MSBuild assemblies
@@ -108,7 +108,7 @@ namespace NuGet.Build.Tasks.Console
                 .Split(Semicolon, StringSplitOptions.RemoveEmptyEntries)
                 .Where(i => !string.IsNullOrWhiteSpace(i))
                 .Select(i => i.Split(EqualSign, 2))
-                .Where(i => i.Length == 2 && !string.IsNullOrWhiteSpace(i[0])))
+                .Where(i => i.Length == 2 && !string.IsNullOrWhiteSpace(i[0]) && !string.IsNullOrWhiteSpace(i[1])))
             {
                 properties[pair[0].Trim()] = pair[1].Trim();
             }


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9061 
Regression: No
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: Check for a value to SolutionPath and guard against empty global properties

## Testing/Validation

Tests Added: Yes/No  
Reason for not adding tests:  
Validation:  
