### PR TITLE
Add new NuGet.Build.Tasks.Console.Test assembly

### DIFF
--- a/NuGet.sln
+++ b/NuGet.sln
@@ -239,6 +239,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Msbuild.Integration.Test", 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NuGet.Build.Tasks.Console", "src\NuGet.Core\NuGet.Build.Tasks.Console\NuGet.Build.Tasks.Console.csproj", "{3ED13630-90EB-420E-8083-0959B2955C6E}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGet.Build.Tasks.Console.Test", "test\NuGet.Core.Tests\NuGet.Build.Tasks.Console.Test\NuGet.Build.Tasks.Console.Test.csproj", "{2011B5A4-2184-4F94-9897-E5BC2425DCDA}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -577,6 +579,10 @@ Global
 		{3ED13630-90EB-420E-8083-0959B2955C6E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3ED13630-90EB-420E-8083-0959B2955C6E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3ED13630-90EB-420E-8083-0959B2955C6E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2011B5A4-2184-4F94-9897-E5BC2425DCDA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2011B5A4-2184-4F94-9897-E5BC2425DCDA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2011B5A4-2184-4F94-9897-E5BC2425DCDA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2011B5A4-2184-4F94-9897-E5BC2425DCDA}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -675,6 +681,7 @@ Global
 		{437C6B7E-B625-4AE5-A4CE-F2B3747FE1CE} = {01BC4531-1E25-48D7-A8FD-A47D6FEC47FB}
 		{92EF44DB-4F40-4610-A1AD-3A554A0CA8B9} = {BB63CACA-866F-454F-BA4C-78B788D032BB}
 		{3ED13630-90EB-420E-8083-0959B2955C6E} = {506AF844-92E0-4404-BBFC-0AB073890A72}
+		{2011B5A4-2184-4F94-9897-E5BC2425DCDA} = {7323F93B-D141-4001-BB9E-7AF14031143E}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {3747A66A-00D1-41B8-A9C5-ED0D7BEA9D25}

--- a/src/NuGet.Core/NuGet.Build.Tasks.Console/NuGet.Build.Tasks.Console.csproj
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Console/NuGet.Build.Tasks.Console.csproj
@@ -40,13 +40,13 @@
 
   <ItemGroup Condition="$(DefineConstants.Contains(SIGNED_BUILD))">
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
-      <_Parameter1>NuGet.Build.Tasks.Test, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9</_Parameter1>
+      <_Parameter1>NuGet.Build.Tasks.Console.Test, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9</_Parameter1>
     </AssemblyAttribute>
   </ItemGroup>
 
   <ItemGroup Condition="!$(DefineConstants.Contains(SIGNED_BUILD))">
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
-      <_Parameter1>NuGet.Build.Tasks.Test</_Parameter1>
+      <_Parameter1>NuGet.Build.Tasks.Console.Test</_Parameter1>
     </AssemblyAttribute>
   </ItemGroup>
 

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Console.Test/MSBuildStaticGraphRestoreTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Console.Test/MSBuildStaticGraphRestoreTests.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using FluentAssertions;
-using NuGet.Build.Tasks.Console;
 using NuGet.Commands;
 using NuGet.Common;
 using NuGet.Configuration;
@@ -18,7 +17,7 @@ using NuGet.Versioning;
 using Test.Utility;
 using Xunit;
 
-namespace NuGet.Build.Tasks.Test
+namespace NuGet.Build.Tasks.Console.Test
 {
     public class MSBuildStaticGraphRestoreTests
     {

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Console.Test/MockMSBuildProject.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Console.Test/MockMSBuildProject.cs
@@ -3,11 +3,10 @@
 
 using System.Collections.Generic;
 using System.IO;
-using NuGet.Build.Tasks.Console;
 using NuGet.Commands;
 using NuGet.Test.Utility;
 
-namespace NuGet.Build.Tasks.Test
+namespace NuGet.Build.Tasks.Console.Test
 {
     public class MockMSBuildProject : MSBuildItem, IMSBuildProject
     {

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Console.Test/NuGet.Build.Tasks.Console.Test.csproj
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Console.Test/NuGet.Build.Tasks.Console.Test.csproj
@@ -1,0 +1,33 @@
+<Project>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common.test.props" />
+  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
+
+  <PropertyGroup>
+    <TargetFrameworks>$(TargetFrameworksExe)</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(IsXPlat)' == 'true' ">$(NETCoreTargetFramework)</TargetFrameworks>
+    <TestProject>true</TestProject>
+    <UseParallelXunit>true</UseParallelXunit>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="$(TestUtilitiesDirectory)Test.Utility\Test.Utility.csproj" />
+    <ProjectReference Include="$(NuGetCoreSrcDirectory)NuGet.Build.Tasks.Console\NuGet.Build.Tasks.Console.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildPackageVersion)" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildPackageVersion)" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildPackageVersion)" PrivateAssets="All" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == '$(NETFXTargetFramework)' ">
+    <Reference Include="Microsoft.Build.Utilities.v4.0" Aliases="MicrosoftBuildUtilitiesv4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+
+  <Import Project="$(BuildCommonDirectory)common.targets" />
+  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
+</Project>

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Console.Test/ProjectItemInstanceEvaluatedIncludeComparerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Console.Test/ProjectItemInstanceEvaluatedIncludeComparerTests.cs
@@ -4,11 +4,10 @@
 using System;
 using System.Collections.Generic;
 using FluentAssertions;
-using NuGet.Build.Tasks.Console;
 using NuGet.Commands;
 using Xunit;
 
-namespace NuGet.Build.Tasks.Test
+namespace NuGet.Build.Tasks.Console.Test
 {
     public class ProjectItemInstanceEvaluatedIncludeComparerTests
     {


### PR DESCRIPTION
This is a follow-up to https://github.com/NuGet/NuGet.Client/pull/3109

## Bug

Fixes: https://github.com/NuGet/Home/issues/9065
Regression: No
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: New test assembly for `NuGet.Build.Tasks.Console` and moved the unit tests over from `NuGet.Build.Tasks.Test`.

## Testing/Validation

Tests Added: Yes
Reason for not adding tests:  
Validation:  
