### PR TITLE
Add unit tests for RestoreTaskEx

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks/RestoreTaskEx.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/RestoreTaskEx.cs
@@ -19,7 +19,7 @@ namespace NuGet.Build.Tasks
     /// </summary>
     public sealed class RestoreTaskEx : Task, ICancelableTask, IDisposable
     {
-        public readonly CancellationTokenSource CancellationTokenSource = new CancellationTokenSource();
+        internal readonly CancellationTokenSource _cancellationTokenSource = new CancellationTokenSource();
 
         /// <summary>
         /// Gets the full path to this assembly.
@@ -97,12 +97,12 @@ namespace NuGet.Build.Tasks
         public string SolutionPath { get; set; }
 
         /// <inheritdoc cref="ICancelableTask.Cancel" />
-        public void Cancel() => CancellationTokenSource.Cancel();
+        public void Cancel() => _cancellationTokenSource.Cancel();
 
         /// <inheritdoc cref="IDisposable.Dispose" />
         public void Dispose()
         {
-            CancellationTokenSource.Dispose();
+            _cancellationTokenSource.Dispose();
         }
 
         /// <inheritdoc cref="Task.Execute()" />
@@ -138,7 +138,7 @@ namespace NuGet.Build.Tasks
 
                         process.BeginOutputReadLine();
 
-                        semaphore.Wait(CancellationTokenSource.Token);
+                        semaphore.Wait(_cancellationTokenSource.Token);
 
                         if (!process.HasExited)
                         {
@@ -171,7 +171,7 @@ namespace NuGet.Build.Tasks
         /// Gets the command-line arguments to use when launching the process that executes the restore.
         /// </summary>
         /// <returns>An <see cref="IEnumerable{String}" /> containing the command-line arguments that need to separated by spaces and surrounded by quotes.</returns>
-        public IEnumerable<string> GetCommandLineArguments()
+        internal IEnumerable<string> GetCommandLineArguments()
         {
 #if IS_CORECLR
             // The full path to the executable for dotnet core
@@ -215,7 +215,7 @@ namespace NuGet.Build.Tasks
         /// Gets the file name of the process.
         /// </summary>
         /// <returns>The full path to the file for the process.</returns>
-        public string GetProcessFileName()
+        internal string GetProcessFileName()
         {
 #if IS_CORECLR
             // In .NET Core, the path to dotnet is the file to run

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/RestoreTaskExTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/RestoreTaskExTests.cs
@@ -1,0 +1,112 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using FluentAssertions;
+using NuGet.Test.Utility;
+using Xunit;
+
+namespace NuGet.Build.Tasks.Test
+{
+    public class RestoreTaskExTests
+    {
+        [Fact]
+        public void Cancel_WhenCanceled_CancellationTokenSourceIsCancellationRequestedIsTrue()
+        {
+            var task = new RestoreTaskEx();
+
+            task.Cancel();
+
+            task.CancellationTokenSource.IsCancellationRequested.Should().BeTrue();
+        }
+
+        [Fact]
+        public void GetCommandLineArguments_WhenOptionsSpecified_CorrectValuesReturned()
+        {
+            using (var testDirectory = TestDirectory.Create())
+            {
+                string msbuildBinPath = Path.Combine(testDirectory, "MSBuild", "Current", "Bin");
+                string projectPath = Path.Combine(testDirectory, "src", "project1", "project1.csproj");
+
+                var globalProperties = new Dictionary<string, string>
+                {
+                    ["Property1"] = "Value1",
+                    ["Property2"] = "  Value2  "
+                };
+
+                var buildEngine = new TestBuildEngine(globalProperties);
+
+                var task = new RestoreTaskEx
+                {
+                    BuildEngine = buildEngine,
+                    DisableParallel = true,
+                    Force = true,
+                    ForceEvaluate = true,
+                    HideWarningsAndErrors = true,
+                    IgnoreFailedSources = true,
+                    Interactive = true,
+                    MSBuildBinPath = msbuildBinPath,
+                    NoCache = true,
+                    ProjectFullPath = projectPath,
+                    Recursive = true,
+                    RestorePackagesConfig = true
+                };
+
+                task.GetCommandLineArguments().ToList().Should().BeEquivalentTo(
+#if IS_CORECLR
+                    Path.ChangeExtension(typeof(RestoreTaskEx).Assembly.Location, ".Console.dll"),
+#endif
+                    "DisableParallel=True;Force=True;ForceEvaluate=True;HideWarningsAndErrors=True;IgnoreFailedSources=True;Interactive=True;NoCache=True;Recursive=True;RestorePackagesConfig=True",
+#if IS_CORECLR
+                    Path.Combine(msbuildBinPath, "MSBuild.dll"),
+#else
+                    Path.Combine(msbuildBinPath, "MSBuild.exe"),
+#endif
+                    projectPath,
+                    "Property1=Value1;Property2=  Value2  ;ExcludeRestorePackageImports=true");
+            }
+        }
+
+        [Fact]
+        public void GetProcessFileName_WhenCalled_ReturnsCorrectValue()
+        {
+            using (var testDirectory = TestDirectory.Create())
+            {
+                string msbuildBinPath = Path.Combine(testDirectory, "MSBuild", "Current", "Bin");
+
+                var task = new RestoreTaskEx
+                {
+                    MSBuildBinPath = msbuildBinPath
+                };
+#if IS_CORECLR
+                task.GetProcessFileName().Should().Be(Path.Combine(testDirectory, "MSBuild", "dotnet"));
+#else
+                task.GetProcessFileName().Should().Be(Path.ChangeExtension(typeof(RestoreTaskEx).Assembly.Location, ".Console.exe"));
+#endif
+            }
+        }
+
+        [Theory]
+        [InlineData("", false)]
+        [InlineData("*Undefined*", false)]
+        [InlineData(@"C:\foo\bar.sln", true)]
+        public void IsSolutionPathDefined_WhenDifferentValuesSpecified_CorrectValueReturned(string value, bool expected)
+        {
+            var task = new RestoreTaskEx
+            {
+                SolutionPath = value
+            };
+
+            if (expected)
+            {
+                task.IsSolutionPathDefined.Should().BeTrue();
+            }
+            else
+            {
+                task.IsSolutionPathDefined.Should().BeFalse();
+            }
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/RestoreTaskExTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/RestoreTaskExTests.cs
@@ -15,11 +15,12 @@ namespace NuGet.Build.Tasks.Test
         [Fact]
         public void Cancel_WhenCanceled_CancellationTokenSourceIsCancellationRequestedIsTrue()
         {
-            var task = new RestoreTaskEx();
+            using (var task = new RestoreTaskEx())
+            {
+                task.Cancel();
 
-            task.Cancel();
-
-            task.CancellationTokenSource.IsCancellationRequested.Should().BeTrue();
+                task._cancellationTokenSource.IsCancellationRequested.Should().BeTrue();
+            }
         }
 
         [Fact]
@@ -38,7 +39,7 @@ namespace NuGet.Build.Tasks.Test
 
                 var buildEngine = new TestBuildEngine(globalProperties);
 
-                var task = new RestoreTaskEx
+                using (var task = new RestoreTaskEx
                 {
                     BuildEngine = buildEngine,
                     DisableParallel = true,
@@ -52,9 +53,9 @@ namespace NuGet.Build.Tasks.Test
                     ProjectFullPath = projectPath,
                     Recursive = true,
                     RestorePackagesConfig = true
-                };
-
-                task.GetCommandLineArguments().ToList().Should().BeEquivalentTo(
+                })
+                {
+                    task.GetCommandLineArguments().ToList().Should().BeEquivalentTo(
 #if IS_CORECLR
                     Path.ChangeExtension(typeof(RestoreTaskEx).Assembly.Location, ".Console.dll"),
 #endif
@@ -65,7 +66,8 @@ namespace NuGet.Build.Tasks.Test
                     Path.Combine(msbuildBinPath, "MSBuild.exe"),
 #endif
                     projectPath,
-                    "Property1=Value1;Property2=  Value2  ;ExcludeRestorePackageImports=true");
+                        "Property1=Value1;Property2=  Value2  ;ExcludeRestorePackageImports=true");
+                }
             }
         }
 
@@ -76,15 +78,17 @@ namespace NuGet.Build.Tasks.Test
             {
                 string msbuildBinPath = Path.Combine(testDirectory, "MSBuild", "Current", "Bin");
 
-                var task = new RestoreTaskEx
+                using (var task = new RestoreTaskEx
                 {
                     MSBuildBinPath = msbuildBinPath
-                };
+                })
+                {
 #if IS_CORECLR
-                task.GetProcessFileName().Should().Be(Path.Combine(testDirectory, "MSBuild", "dotnet"));
+                    task.GetProcessFileName().Should().Be(Path.Combine(testDirectory, "MSBuild", "dotnet"));
 #else
-                task.GetProcessFileName().Should().Be(Path.ChangeExtension(typeof(RestoreTaskEx).Assembly.Location, ".Console.exe"));
+                    task.GetProcessFileName().Should().Be(Path.ChangeExtension(typeof(RestoreTaskEx).Assembly.Location, ".Console.exe"));
 #endif
+                }
             }
         }
 
@@ -94,18 +98,19 @@ namespace NuGet.Build.Tasks.Test
         [InlineData(@"C:\foo\bar.sln", true)]
         public void IsSolutionPathDefined_WhenDifferentValuesSpecified_CorrectValueReturned(string value, bool expected)
         {
-            var task = new RestoreTaskEx
+            using (var task = new RestoreTaskEx
             {
                 SolutionPath = value
-            };
-
-            if (expected)
+            })
             {
-                task.IsSolutionPathDefined.Should().BeTrue();
-            }
-            else
-            {
-                task.IsSolutionPathDefined.Should().BeFalse();
+                if (expected)
+                {
+                    task.IsSolutionPathDefined.Should().BeTrue();
+                }
+                else
+                {
+                    task.IsSolutionPathDefined.Should().BeFalse();
+                }
             }
         }
     }

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/TestBuildEngine.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/TestBuildEngine.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using Microsoft.Build.Framework;
 using NuGet.Common;
 using NuGet.Test.Utility;
@@ -12,25 +13,44 @@ namespace NuGet.Build.Tasks.Test
     /// <summary>
     /// MSBuild logger -> TestLogger
     /// </summary>
-    public class TestBuildEngine : IBuildEngine
+    public class TestBuildEngine : IBuildEngine6
     {
         /// <summary>
         /// Test logger
         /// </summary>
         public TestLogger TestLogger = new TestLogger();
 
+        private readonly IReadOnlyDictionary<string, string> _globalProperties;
+
+        public TestBuildEngine()
+        {
+        }
+
+        public TestBuildEngine(IReadOnlyDictionary<string, string> globalProperties)
+        {
+            _globalProperties = globalProperties;
+        }
+        public int ColumnNumberOfTaskNode => 0;
+
         public bool ContinueOnError => false;
+
+        public bool IsRunningMultipleNodes { get; }
 
         public int LineNumberOfTaskNode => 0;
 
-        public int ColumnNumberOfTaskNode => 0;
-
         public string ProjectFileOfTaskNode => string.Empty;
 
-        public bool BuildProjectFile(string projectFileName, string[] targetNames, IDictionary globalProperties, IDictionary targetOutputs)
-        {
-            return true;
-        }
+        public bool BuildProjectFile(string projectFileName, string[] targetNames, IDictionary globalProperties, IDictionary targetOutputs) => true;
+
+        public bool BuildProjectFile(string projectFileName, string[] targetNames, IDictionary globalProperties, IDictionary targetOutputs, string toolsVersion) => throw new NotImplementedException();
+
+        public bool BuildProjectFilesInParallel(string[] projectFileNames, string[] targetNames, IDictionary[] globalProperties, IDictionary[] targetOutputsPerProject, string[] toolsVersion, bool useResultsCache, bool unloadProjectsOnCompletion) => throw new NotImplementedException();
+
+        public BuildEngineResult BuildProjectFilesInParallel(string[] projectFileNames, string[] targetNames, IDictionary[] globalProperties, IList<string>[] removeGlobalProperties, string[] toolsVersion, bool returnTargetOutputs) => throw new NotImplementedException();
+
+        public IReadOnlyDictionary<string, string> GetGlobalProperties() => _globalProperties;
+
+        public object GetRegisteredTaskObject(object key, RegisteredTaskObjectLifetime lifetime) => throw new NotImplementedException();
 
         public void LogCustomEvent(CustomBuildEventArgs e)
         {
@@ -41,7 +61,6 @@ namespace NuGet.Build.Tasks.Test
         {
             var message = new RestoreLogMessage(LogLevel.Error, e.Message)
             {
-
                 FilePath = e.File,
                 ProjectPath = e.ProjectFile
             };
@@ -77,6 +96,8 @@ namespace NuGet.Build.Tasks.Test
             TestLogger.Log(message);
         }
 
+        public void LogTelemetry(string eventName, IDictionary<string, string> properties) => throw new NotImplementedException();
+
         public void LogWarningEvent(BuildWarningEventArgs e)
         {
             var message = new RestoreLogMessage(LogLevel.Warning, e.Message)
@@ -92,5 +113,13 @@ namespace NuGet.Build.Tasks.Test
 
             TestLogger.Log(message);
         }
+
+        public void Reacquire() => throw new NotImplementedException();
+
+        public void RegisterTaskObject(object key, object obj, RegisteredTaskObjectLifetime lifetime, bool allowEarlyCollection) => throw new NotImplementedException();
+
+        public object UnregisterTaskObject(object key, RegisteredTaskObjectLifetime lifetime) => throw new NotImplementedException();
+
+        public void Yield() => throw new NotImplementedException();
     }
 }


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9067  
Regression: No
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: Adding new unit tests for `RestoreTaskEx`

## Testing/Validation

Tests Added: Yes
Reason for not adding tests:  
Validation:  
