### PR TITLE
Embedded Icon PM UI bugfixes

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Converters/IconUrlToImageCacheConverter.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Converters/IconUrlToImageCacheConverter.cs
@@ -86,7 +86,6 @@ namespace NuGet.PackageManagement.UI
 
             BitmapSource imageResult;
 
-            // Check if the URI is an Embedded Icon URI
             if (IsEmbeddedIconUri(iconUrl))
             {
                 var iconEntry = Uri.UnescapeDataString(iconUrl.Fragment).Substring(1); // skip the '#' in a URI fragment
@@ -238,7 +237,7 @@ namespace NuGet.PackageManagement.UI
 
             var uri = bitmapImage.UriSource;
 
-            string cacheKey = uri != null ? uri.ToString() : string.Empty;
+            string cacheKey = uri == null ? string.Empty : uri.ToString();
             // Fix the bitmap image cache to have default package icon, if some other failure didn't already do that.            
             var cachedBitmapImage = BitmapImageCache.Get(cacheKey) as BitmapSource;
             if (cachedBitmapImage != Images.DefaultPackageIcon)

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Converters/IconUrlToImageCacheConverter.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Converters/IconUrlToImageCacheConverter.cs
@@ -43,15 +43,15 @@ namespace NuGet.PackageManagement.UI
         /// <param name="values">
         /// <list type="bullet">
         /// <item>
-        /// <description>values[0]: IconUrl that points to a URL o a local file</description>
+        /// <description><c>values[0]</c>: IconUrl that points to a URL o a local file</description>
         /// </item>
         /// <item>
-        /// <description>values[1]: An <c>PackageArchiveReader</c> to read from the local package for embedded icons</description>
+        /// <description><c>values[1]</c>: An <c>Lazy&lt;PackageReaderBase&gt;</c> to read the icon from the local package</description>
         /// </item>
         /// </list>
         /// </param>
         /// <param name="targetType">unused</param>
-        /// <param name="parameter">A BitmapImage with the default package icon</param>
+        /// <param name="parameter">A <c>BitmapImage<c> that will be used as the default package icon</param>
         /// <param name="culture">unused</param>
         /// <returns>A BitmapSource with the image</returns>
         public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
@@ -94,8 +94,8 @@ namespace NuGet.PackageManagement.UI
                 {
                     try
                     {
-                        var reader = lazyPar(); // This reader is closed in BitmapImage events
-                        if (reader is PackageArchiveReader par)
+                        var reader = lazyPar(); // Always returns a new reader. That avoids using an already disposed one
+                        if (reader is PackageArchiveReader par) // This reader is closed in BitmapImage events
                         {
                             iconBitmapImage.StreamSource = par.GetEntry(iconEntry).Open();
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Converters/IconUrlToImageCacheConverter.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Converters/IconUrlToImageCacheConverter.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Net;

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Converters/IconUrlToImageCacheConverter.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Converters/IconUrlToImageCacheConverter.cs
@@ -43,10 +43,10 @@ namespace NuGet.PackageManagement.UI
         /// <param name="values">
         /// <list type="bullet">
         /// <item>
-        /// <description><c>values[0]</c>: IconUrl that points to a URL o a local file</description>
+        /// <description><c>values[0]</c>: Icon URI that points to a URL o a local file</description>
         /// </item>
         /// <item>
-        /// <description><c>values[1]</c>: An <c>Lazy&lt;PackageReaderBase&gt;</c> to read the icon from the local package</description>
+        /// <description><c>values[1]</c>: An <c>Lazy&lt;PackageReaderBase&gt;</c> function to read the icon from the local package</description>
         /// </item>
         /// </list>
         /// </param>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Converters/IconUrlToImageCacheConverter.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Converters/IconUrlToImageCacheConverter.cs
@@ -95,23 +95,10 @@ namespace NuGet.PackageManagement.UI
                     try
                     {
                         var reader = lazyPar(); // This reader is closed in BitmapImage events
-                        bool iconRead = true;
-
-                        switch (reader)
+                        if (reader is PackageArchiveReader par)
                         {
-                            case PackageArchiveReader par:
-                                iconBitmapImage.StreamSource = par.GetEntry(iconEntry).Open();
-                                break;
-                            case PackageFolderReader pfr:
-                                iconBitmapImage.StreamSource = pfr.GetStream(iconEntry);
-                                break;
-                            default:
-                                iconRead = false;
-                                break;
-                        }
+                            iconBitmapImage.StreamSource = par.GetEntry(iconEntry).Open();
 
-                        if (iconRead)
-                        {
                             iconBitmapImage.DecodeFailed += (sender, args) =>
                             {
                                 reader.Dispose();
@@ -132,9 +119,8 @@ namespace NuGet.PackageManagement.UI
 
                             imageResult = FinishImageProcessing(iconBitmapImage, iconUrl, defaultPackageIcon);
                         }
-                        else
+                        else // we cannot use the reader object
                         {
-                            // we cannot use the packagearchive reader
                             AddToCache(iconUrl, defaultPackageIcon);
                             imageResult = defaultPackageIcon;
                         }
@@ -145,9 +131,7 @@ namespace NuGet.PackageManagement.UI
                         imageResult = defaultPackageIcon;
                     }
                 }
-                // Identified an embedded icon URI but, we are unable to process it
-                // cache and return the default image
-                else
+                else // Identified an embedded icon URI but, we are unable to process it
                 {
                     AddToCache(iconUrl, defaultPackageIcon);
                     imageResult = defaultPackageIcon;

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Converters/IconUrlToImageCacheConverter.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Converters/IconUrlToImageCacheConverter.cs
@@ -81,11 +81,11 @@ namespace NuGet.PackageManagement.UI
             {
                 var iconEntry = Uri.UnescapeDataString(iconUrl.Fragment).Substring(1); // skip the '#' in a URI fragment
                 // Check if we have enough info to read the icon from the package
-                if (values.Length == 2 && values[1] is Func<PackageReaderBase> lazyPar)
+                if (values.Length == 2 && values[1] is Func<PackageReaderBase> lazyReader)
                 {
                     try
                     {
-                        var reader = lazyPar(); // Always returns a new reader. That avoids using an already disposed one
+                        PackageReaderBase reader = lazyReader(); // Always returns a new reader. That avoids using an already disposed one
                         if (reader is PackageArchiveReader par) // This reader is closed in BitmapImage events
                         {
                             iconBitmapImage.StreamSource = par.GetEntry(iconEntry).Open();
@@ -112,6 +112,7 @@ namespace NuGet.PackageManagement.UI
                         }
                         else // we cannot use the reader object
                         {
+                            reader?.Dispose();
                             AddToCache(iconUrl, defaultPackageIcon);
                             imageResult = defaultPackageIcon;
                         }
@@ -122,7 +123,7 @@ namespace NuGet.PackageManagement.UI
                         imageResult = defaultPackageIcon;
                     }
                 }
-                else // Identified an embedded icon URI but, we are unable to process it
+                else // Identified an embedded icon URI, but we are unable to process it
                 {
                     AddToCache(iconUrl, defaultPackageIcon);
                     imageResult = defaultPackageIcon;

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Converters/IconUrlToImageCacheConverter.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Converters/IconUrlToImageCacheConverter.cs
@@ -36,24 +36,15 @@ namespace NuGet.PackageManagement.UI
         /// <summary>
         /// Converts IconUrl from PackageItemListViewModel to an image represented by a BitmapSource
         /// </summary>
+        /// <param name="values">An array of two elements containing the IconUri and a generator function of PackageReaderBase objects</param>
+        /// <param name="targetType">unused</param>
+        /// <param name="parameter">A BitmapImage that will be used as the default package icon</param>
+        /// <param name="culture">unused</param>
+        /// <returns>A BitmapSource with the image</returns>
         /// <remarks>
         /// We bind to a BitmapImage instead of a Uri so that we can control the decode size, since we are displaying 32x32 images, while many of the images are 128x128 or larger.
         /// This leads to a memory savings.
         /// </remarks>
-        /// <param name="values">
-        /// <list type="bullet">
-        /// <item>
-        /// <description><c>values[0]</c>: Icon URI that points to a URL o a local file</description>
-        /// </item>
-        /// <item>
-        /// <description><c>values[1]</c>: An <c>Lazy&lt;PackageReaderBase&gt;</c> function to read the icon from the local package</description>
-        /// </item>
-        /// </list>
-        /// </param>
-        /// <param name="targetType">unused</param>
-        /// <param name="parameter">A <c>BitmapImage<c> that will be used as the default package icon</param>
-        /// <param name="culture">unused</param>
-        /// <returns>A BitmapSource with the image</returns>
         public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
         {
             if (values == null || values.Length == 0)

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailControlModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailControlModel.cs
@@ -636,7 +636,7 @@ namespace NuGet.PackageManagement.UI
             }
         }
 
-        public Lazy<PackageReaderBase> PackageReader => _searchResultPackage?.PackageReader;
+        public Func<PackageReaderBase> PackageReader => _searchResultPackage?.PackageReader;
 
         protected void AddBlockedVersions(NuGetVersion[] blockedVersions)
         {

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailControlModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailControlModel.cs
@@ -78,7 +78,7 @@ namespace NuGet.PackageManagement.UI
             _searchResultPackage = searchResultPackage;
             _filter = filter;
             OnPropertyChanged(nameof(Id));
-            OnPropertyChanged(nameof(IconUrl));
+            OnPropertyChanged(nameof(PackageReader));
             OnPropertyChanged(nameof(PrefixReserved));
 
             var getVersionsTask = searchResultPackage.GetVersionsAsync();

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageItemListViewModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageItemListViewModel.cs
@@ -408,7 +408,7 @@ namespace NuGet.PackageManagement.UI
             }
         }
 
-        public Lazy<PackageReaderBase> PackageReader { get; set; }
+        public Func<PackageReaderBase> PackageReader { get; set; }
 
         public override string ToString()
         {

--- a/src/NuGet.Core/NuGet.Protocol/Model/LocalPackageSearchMetadata.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Model/LocalPackageSearchMetadata.cs
@@ -18,7 +18,6 @@ namespace NuGet.Protocol
     {
         private readonly NuspecReader _nuspec;
         private readonly LocalPackageInfo _package;
-        private Lazy<PackageReaderBase> _reader;
 
         public LocalPackageSearchMetadata(LocalPackageInfo package)
         {
@@ -71,15 +70,12 @@ namespace NuGet.Protocol
 
         public string Title => !string.IsNullOrEmpty(_nuspec.GetTitle()) ? _nuspec.GetTitle() : _nuspec.GetId();
 
-        public Lazy<PackageReaderBase> PackageReader
+        public Func<PackageReaderBase> PackageReader
         {
             get
             {
-                if (_reader == null)
-                {
-                    _reader = new Lazy<PackageReaderBase>(() => _package.GetReader() );
-                }
-                return _reader;
+                //return _package.GetReader();
+                return new Func<PackageReaderBase>(() => _package.GetReader());
             }
         }
 

--- a/src/NuGet.Core/NuGet.Protocol/Model/LocalPackageSearchMetadata.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Model/LocalPackageSearchMetadata.cs
@@ -70,11 +70,16 @@ namespace NuGet.Protocol
 
         public string Title => !string.IsNullOrEmpty(_nuspec.GetTitle()) ? _nuspec.GetTitle() : _nuspec.GetId();
 
+        /// <summary>
+        /// Gets a function that provides <c>PackageReaderBase</c>-like objects, for reading package content
+        /// </summary>
+        /// <remarks>
+        /// This property depends from the reader contained in the <c>LocalPackageInfo</c> specified at object creation time
+        /// </remarks>
         public Func<PackageReaderBase> PackageReader
         {
             get
             {
-                //return _package.GetReader();
                 return new Func<PackageReaderBase>(() => _package.GetReader());
             }
         }

--- a/src/NuGet.Core/NuGet.Protocol/Model/PackageSearchMetadataBuilder.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Model/PackageSearchMetadataBuilder.cs
@@ -53,7 +53,7 @@ namespace NuGet.Protocol.Core.Types
             internal AsyncLazy<PackageDeprecationMetadata> LazyDeprecationFactory { get; set; }
             public async Task<PackageDeprecationMetadata> GetDeprecationMetadataAsync() => await (LazyDeprecationFactory ?? LazyNullDeprecationMetadata);
             public bool IsListed { get; set; }
-            public Lazy<PackageReaderBase> PackageReader { get; set; }
+            public Func<PackageReaderBase> PackageReader { get; set; }
         }
 
         private PackageSearchMetadataBuilder(IPackageSearchMetadata metadata)

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Converters/IconUrlToImageCacheConverterTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Converters/IconUrlToImageCacheConverterTests.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
-using System.Threading;
 using System.Windows;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Converters/IconUrlToImageCacheConverterTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Converters/IconUrlToImageCacheConverterTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
@@ -124,8 +123,10 @@ namespace NuGet.PackageManagement.UI.Test
 
                 // Act
                 var result = converter.Convert(
-                    new object[] { builder.Uri, new PackageArchiveReader(zipPath) },
-                    typeof(ImageSource),
+                    new object[] {
+                        builder.Uri,
+                        new Func<PackageReaderBase>(() => new PackageArchiveReader(zipPath)) },
+                    null,
                     DefaultPackageIcon,
                     Thread.CurrentThread.CurrentCulture);
 
@@ -206,13 +207,6 @@ namespace NuGet.PackageManagement.UI.Test
         {
             var result = IconUrlToImageCacheConverter.IsEmbeddedIconUri(testUri);
             Assert.Equal(expectedResult, result);
-        }
-
-        [Fact]
-        public void test3()
-        {
-            object x = null;
-            Assert.False(x is PackageArchiveReader);
         }
 
         public static IEnumerable<object[]> TestData()

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Converters/IconUrlToImageCacheConverterTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Converters/IconUrlToImageCacheConverterTests.cs
@@ -40,10 +40,10 @@ namespace NuGet.PackageManagement.UI.Test
             var converter = new IconUrlToImageCacheConverter();
 
             var image = converter.Convert(
-                new object[] { iconUrl, DependencyProperty.UnsetValue },
-                typeof(ImageSource),
-                DefaultPackageIcon,
-                Thread.CurrentThread.CurrentCulture);
+                values: new object[] { iconUrl, DependencyProperty.UnsetValue },
+                targetType: null,
+                parameter: DefaultPackageIcon,
+                culture: null);
 
             Assert.Same(DefaultPackageIcon, image);
         }
@@ -56,10 +56,10 @@ namespace NuGet.PackageManagement.UI.Test
             var converter = new IconUrlToImageCacheConverter();
 
             var image = converter.Convert(
-                new object[] { iconUrl, DependencyProperty.UnsetValue },
-                typeof(ImageSource),
-                DefaultPackageIcon,
-                Thread.CurrentThread.CurrentCulture);
+                values: new object[] { iconUrl, DependencyProperty.UnsetValue },
+                targetType: null,
+                parameter: DefaultPackageIcon,
+                culture: null);
 
             Assert.Same(DefaultPackageIcon, image);
         }
@@ -72,10 +72,10 @@ namespace NuGet.PackageManagement.UI.Test
             var converter = new IconUrlToImageCacheConverter();
 
             var image = converter.Convert(
-                new object[] { iconUrl, DependencyProperty.UnsetValue },
-                typeof(ImageSource),
-                DefaultPackageIcon,
-                Thread.CurrentThread.CurrentCulture) as BitmapImage;
+                values: new object[] { iconUrl, DependencyProperty.UnsetValue },
+                targetType: null,
+                parameter: DefaultPackageIcon,
+                culture: null) as BitmapImage;
 
             Assert.NotNull(image);
             Assert.NotSame(DefaultPackageIcon, image);
@@ -90,10 +90,10 @@ namespace NuGet.PackageManagement.UI.Test
             var converter = new IconUrlToImageCacheConverter();
 
             var image = converter.Convert(
-                new object[] { iconUrl, DependencyProperty.UnsetValue },
-                typeof(ImageSource),
-                DefaultPackageIcon,
-                Thread.CurrentThread.CurrentCulture) as BitmapImage;
+                values: new object[] { iconUrl, DependencyProperty.UnsetValue },
+                targetType: null,
+                parameter: DefaultPackageIcon,
+                culture: null) as BitmapImage;
 
             Assert.NotNull(image);
             Assert.NotSame(DefaultPackageIcon, image);
@@ -123,12 +123,10 @@ namespace NuGet.PackageManagement.UI.Test
 
                 // Act
                 var result = converter.Convert(
-                    new object[] {
-                        builder.Uri,
-                        new Func<PackageReaderBase>(() => new PackageArchiveReader(zipPath)) },
-                    null,
-                    DefaultPackageIcon,
-                    Thread.CurrentThread.CurrentCulture);
+                    values: new object[] { builder.Uri, new Func<PackageReaderBase>(() => new PackageArchiveReader(zipPath)) },
+                    targetType: null,
+                    parameter: DefaultPackageIcon,
+                    culture: null);
 
                 var image = result as BitmapImage;
 
@@ -156,10 +154,10 @@ namespace NuGet.PackageManagement.UI.Test
 
                 // Act
                 var result = converter.Convert(
-                    new object[] { uri, DependencyProperty.UnsetValue },
-                    typeof(ImageSource),
-                    DefaultPackageIcon,
-                    Thread.CurrentThread.CurrentCulture);
+                    values: new object[] { uri, DependencyProperty.UnsetValue },
+                    targetType: null,
+                    parameter: DefaultPackageIcon,
+                    culture: null);
 
                 var image = result as BitmapImage;
                 
@@ -190,10 +188,10 @@ namespace NuGet.PackageManagement.UI.Test
 
                 // Act
                 var result = converter.Convert(
-                    new object[] { builder.Uri, new PackageArchiveReader(zipPath) },
-                    typeof(ImageSource),
-                    DefaultPackageIcon,
-                    Thread.CurrentThread.CurrentCulture);
+                    values: new object[] { builder.Uri, new Func<PackageReaderBase>(() => new PackageArchiveReader(zipPath)) },
+                    targetType: null,
+                    parameter: DefaultPackageIcon,
+                    culture: null);
 
                 // Assert
                 Assert.NotNull(result);

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/DetailControlModelTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/DetailControlModelTests.cs
@@ -10,6 +10,7 @@ using Microsoft.VisualStudio.Threading;
 using NuGet.VisualStudio;
 using System.Threading;
 using System;
+using NuGet.Packaging;
 using NuGet.Versioning;
 
 namespace NuGet.PackageManagement.UI.Test.Models
@@ -81,6 +82,11 @@ namespace NuGet.PackageManagement.UI.Test.Models
         public void PackageReader_NotNull()
         {
             Assert.NotNull(_testInstance.PackageReader);
+
+            Func<PackageReaderBase> lazyReader = _testInstance.PackageReader;
+
+            PackageReaderBase reader = lazyReader();
+            Assert.IsType(typeof(PackageArchiveReader), reader);
         }
     }
 
@@ -107,6 +113,11 @@ namespace NuGet.PackageManagement.UI.Test.Models
         public void PackageReader_NotNull()
         {
             Assert.NotNull(_testInstance.PackageReader);
+
+            Func<PackageReaderBase> lazyReader = _testInstance.PackageReader;
+
+            PackageReaderBase reader = lazyReader();
+            Assert.IsType(typeof(PackageArchiveReader), reader);
         }
     }
 }

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/DetailControlModelTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/DetailControlModelTests.cs
@@ -104,7 +104,7 @@ namespace NuGet.PackageManagement.UI.Test.Models
         }
 
         [Fact]
-        public void PackageArchiveReader_NotNull()
+        public void PackageReader_NotNull()
         {
             Assert.NotNull(_testInstance.PackageReader);
         }

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/PackageItemListViewModelTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/PackageItemListViewModelTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using NuGet.Packaging;
 using NuGet.Protocol;
 using NuGet.Test.Utility;
 using Xunit;
@@ -30,6 +31,11 @@ namespace NuGet.PackageManagement.UI.Test
         public void LocalSources_PackageReader_NotNull()
         {
             Assert.NotNull(_testInstance.PackageReader);
+
+            Func<PackageReaderBase> func = _testInstance.PackageReader;
+
+            PackageReaderBase reader = func();
+            Assert.IsType(typeof(PackageArchiveReader), reader);
         }
     }
 }


### PR DESCRIPTION
## Bug

* Fixes: 
  - https://github.com/NuGet/Home/issues/9069
  - https://github.com/NuGet/Home/issues/9072
* Regression: Yes
* Last working version: 16.4.1
* How are we preventing it in future: 
  - Don't leave files open. It might cause file deadlocks.
  - Close resources _when you really need it to_ 

## Fix

- NuGet/Home#9069 : Changed type from `Lazy<PackageArchiveReader>` to `Func<PackageReaderBase>`, so that each time it is needed, it gives a new package reader.
- NuGet/Home#9072 : Triggers a `PropertyChanged` event when the PackageReader is changed, instead  of triggering the event for the IconUrl property
- Updated tests to reflect type changes

## Testing/Validation

Tests Added: No
Reason for not adding tests: Modified existing tests
Validation: Manual testing:

- Install a package with an embedded icon
- Upgrade a package with an embedded icon
- Artificial cache expiration to test `PackageReaderBase` objects

## Notes

### Why `Func<PackageReaderBase>` is preferred over `Lazy<PackageReaderBase>` ?

Suppose that the actual implemtation uses `Lazy<PackageReaderBase>` for getting the `PackageArchiveReader`. Then, the following use case could happen in the PM UI:

- At 0 min.: Get a Lazy value, materialize it, disposed immediately after the icon is read.
- Leave the PM UI open for 10 min.
- After 10min.: Get the lazy value but, it is already materialized. Hence, it is not created created and,
  because it is already disposed, we cannot read the icon from that reader.

With `Func<PackageReaderBase>`, every time we ask for a reader, it is fresly created. After the icon is read
the reader is disposed. That eliminates the problem of using already disposed readers.

