### PR TITLE
Fix configure.ps1 failure due to dotnet-install failure

### DIFF
--- a/build/common.ps1
+++ b/build/common.ps1
@@ -196,6 +196,7 @@ Function Install-DotnetCLI {
         New-Item -ItemType Directory -Force -Path $cli.Root | Out-Null
 
         Invoke-WebRequest 'https://dot.net/v1/dotnet-install.ps1' -OutFile $DotNetInstall
+        Trace-Log "$DotNetInstall -Channel $($cli.Channel) -i $($cli.Root) -Version $($cli.Version) -Architecture $arch"
         & $DotNetInstall -Channel $cli.Channel -i $cli.Root -Version $cli.Version -Architecture $arch
     }
 
@@ -204,6 +205,7 @@ Function Install-DotnetCLI {
     }
 
     # Install the 2.x runtime because our tests target netcoreapp2x
+    Trace-Log "$DotNetInstall -Runtime dotnet -Channel 2.2 -i $CLIRoot -NoPath"
     & $DotNetInstall -Runtime dotnet -Channel 2.2 -i $CLIRoot -NoPath
     # Display build info
     & $DotNetExe --info

--- a/build/config.props
+++ b/build/config.props
@@ -37,7 +37,7 @@
 
     <!-- .NET Core SDK Insertion Logic -->    
     <CliBranchForTesting Condition="'$(OverrideCliBranchForTesting)' != ''">$(OverrideCliBranchForTesting)</CliBranchForTesting>
-    <CliBranchForTesting Condition="'$(OverrideCliBranchForTesting)' == ''">release/3.1.2xx</CliBranchForTesting>
+    <CliBranchForTesting Condition="'$(OverrideCliBranchForTesting)' == ''">3.1</CliBranchForTesting>
     <CliTargetBranches Condition="'$(OverrideCliTargetBranches)' != ''">$(OverrideCliTargetBranches)</CliTargetBranches>
     <CliTargetBranches Condition="'$(OverrideCliTargetBranches)' == ''">master</CliTargetBranches>
     <SdkTargetBranches Condition="'$(OverrideCliTargetBranches)' != ''">$(OverrideCliTargetBranches)</SdkTargetBranches>


### PR DESCRIPTION
## Bug

Fixes: 
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: dotnet-install.ps1, run as part of our configure.ps1 script, expects the dotnet sdk to be installed at `$install_dir\sdk\$sdk_version`, which for a preview release is something like `3.1.200-preview-12345`. However, it was getting installed at `cli\sdk\3.1.200`, so the script thinks the install failed.

For now we can just install the last released version, rather than a prerelease. It's the same major.minor version.

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  build configuration script
Validation:  
