### PR TITLE
Xplat Signing/Verification : Fix broken tests for setting privatekey of a X509Certificate2

### DIFF
--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignatureTrustAndValidityVerificationProviderTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignatureTrustAndValidityVerificationProviderTests.cs
@@ -115,7 +115,7 @@ namespace NuGet.Packaging.FuncTest
                     packageContext,
                     directory,
                     timestampService.Url,
-                    signatureHashAlgorithm: HashAlgorithmName.SHA512);
+                    signatureHashAlgorithm: NuGet.Common.HashAlgorithmName.SHA512);
 
                 var verifier = new PackageSignatureVerifier(_trustProviders);
                 using (var packageReader = new PackageArchiveReader(signedPackagePath))
@@ -715,7 +715,7 @@ namespace NuGet.Packaging.FuncTest
 
             using (var package = new PackageArchiveReader(await nupkg.CreateAsStreamAsync(), leaveStreamOpen: false))
             using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
-            using (var signatureRequest = new AuthorSignPackageRequest(testCertificate, HashAlgorithmName.SHA256))
+            using (var signatureRequest = new AuthorSignPackageRequest(testCertificate, NuGet.Common.HashAlgorithmName.SHA256))
             {
                 var signature = await SignedArchiveTestUtility.CreatePrimarySignatureForPackageAsync(package, signatureRequest);
                 var timestampedSignature = await SignedArchiveTestUtility.TimestampSignature(timestampProvider, signature, signatureRequest.TimestampHashAlgorithm, SignaturePlacement.PrimarySignature, testLogger);
@@ -929,7 +929,7 @@ namespace NuGet.Packaging.FuncTest
                 var primarySignature = await packageReader.GetPrimarySignatureAsync(CancellationToken.None);
 
                 var provider = new SignatureTrustAndValidityVerificationProvider(allowUntrustedRootList:
-                    new List<KeyValuePair<string, HashAlgorithmName>>() { new KeyValuePair<string, HashAlgorithmName>("abc", HashAlgorithmName.SHA256) });
+                    new List<KeyValuePair<string, NuGet.Common.HashAlgorithmName>>() { new KeyValuePair<string, NuGet.Common.HashAlgorithmName>("abc", NuGet.Common.HashAlgorithmName.SHA256) });
 
                 var status = await provider.GetTrustResultAsync(packageReader, primarySignature, settings, CancellationToken.None);
 
@@ -968,7 +968,7 @@ namespace NuGet.Packaging.FuncTest
                 var primarySignature = await packageReader.GetPrimarySignatureAsync(CancellationToken.None);
 
                 var provider = new SignatureTrustAndValidityVerificationProvider(allowUntrustedRootList:
-                    new List<KeyValuePair<string, HashAlgorithmName>>() { new KeyValuePair<string, HashAlgorithmName>("abc", HashAlgorithmName.SHA256) });
+                    new List<KeyValuePair<string, NuGet.Common.HashAlgorithmName>>() { new KeyValuePair<string, NuGet.Common.HashAlgorithmName>("abc", NuGet.Common.HashAlgorithmName.SHA256) });
 
                 var status = await provider.GetTrustResultAsync(packageReader, primarySignature, settings, CancellationToken.None);
 
@@ -996,7 +996,7 @@ namespace NuGet.Packaging.FuncTest
            revocationMode: RevocationMode.Online);
 
             var timestampService = await _testFixture.GetDefaultTrustedTimestampServiceAsync();
-            var untrustedCertFingerprint = SignatureTestUtility.GetFingerprint(_testFixture.UntrustedTestCertificate.Cert, HashAlgorithmName.SHA256);
+            var untrustedCertFingerprint = SignatureTestUtility.GetFingerprint(_testFixture.UntrustedTestCertificate.Cert, NuGet.Common.HashAlgorithmName.SHA256);
 
             using (var test = await Test.CreateRepositoryPrimarySignedPackageAsync(
                 _testFixture.UntrustedTestCertificate.Cert,
@@ -1006,7 +1006,7 @@ namespace NuGet.Packaging.FuncTest
                 var primarySignature = await packageReader.GetPrimarySignatureAsync(CancellationToken.None);
 
                 var provider = new SignatureTrustAndValidityVerificationProvider(allowUntrustedRootList:
-                    new List<KeyValuePair<string, HashAlgorithmName>>() { new KeyValuePair<string, HashAlgorithmName>(untrustedCertFingerprint, HashAlgorithmName.SHA256) });
+                    new List<KeyValuePair<string, NuGet.Common.HashAlgorithmName>>() { new KeyValuePair<string, NuGet.Common.HashAlgorithmName>(untrustedCertFingerprint, NuGet.Common.HashAlgorithmName.SHA256) });
 
                 var status = await provider.GetTrustResultAsync(packageReader, primarySignature, settings, CancellationToken.None);
 
@@ -1034,7 +1034,7 @@ namespace NuGet.Packaging.FuncTest
                revocationMode: RevocationMode.Online);
 
             var timestampService = await _testFixture.GetDefaultTrustedTimestampServiceAsync();
-            var untrustedCertFingerprint = SignatureTestUtility.GetFingerprint(_testFixture.UntrustedTestCertificate.Cert, HashAlgorithmName.SHA256);
+            var untrustedCertFingerprint = SignatureTestUtility.GetFingerprint(_testFixture.UntrustedTestCertificate.Cert, NuGet.Common.HashAlgorithmName.SHA256);
 
             using (var test = await Test.CreateAuthorSignedRepositoryCountersignedPackageAsync(
                 _testFixture.TrustedTestCertificate.Source.Cert,
@@ -1046,7 +1046,7 @@ namespace NuGet.Packaging.FuncTest
                 var primarySignature = await packageReader.GetPrimarySignatureAsync(CancellationToken.None);
 
                 var provider = new SignatureTrustAndValidityVerificationProvider(allowUntrustedRootList:
-                    new List<KeyValuePair<string, HashAlgorithmName>>() { new KeyValuePair<string, HashAlgorithmName>(untrustedCertFingerprint, HashAlgorithmName.SHA256) });
+                    new List<KeyValuePair<string, NuGet.Common.HashAlgorithmName>>() { new KeyValuePair<string, NuGet.Common.HashAlgorithmName>(untrustedCertFingerprint, NuGet.Common.HashAlgorithmName.SHA256) });
 
                 var status = await provider.GetTrustResultAsync(packageReader, primarySignature, settings, CancellationToken.None);
 

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignatureTrustAndValidityVerificationProviderTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignatureTrustAndValidityVerificationProviderTests.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
@@ -146,8 +147,17 @@ namespace NuGet.Packaging.FuncTest
 
             using (var directory = TestDirectory.Create())
             {
-
+#if IS_DESKTOP
                 var privateKey = DotNetUtilities.ToRSA(keyPair.Private as RsaPrivateCrtKeyParameters);
+#else
+                var rsaParameters = DotNetUtilities.ToRSAParameters(keyPair.Private as RsaPrivateCrtKeyParameters);
+
+                RSACryptoServiceProvider rsaCsp = new RSACryptoServiceProvider();
+
+                rsaCsp.ImportParameters(rsaParameters);
+
+                var privateKey = rsaCsp;
+#endif
 #if IS_DESKTOP
                 using (var certificate = new X509Certificate2(bcCertificate.GetEncoded()))
                 {
@@ -212,7 +222,18 @@ namespace NuGet.Packaging.FuncTest
             using (testServer.RegisterResponder(timestampService))
             using (var directory = TestDirectory.Create())
             {
+#if IS_DESKTOP
                 var privateKey = DotNetUtilities.ToRSA(keyPair.Private as RsaPrivateCrtKeyParameters);
+#else
+                var rsaParameters = DotNetUtilities.ToRSAParameters(keyPair.Private as RsaPrivateCrtKeyParameters);
+
+                RSACryptoServiceProvider rsaCsp = new RSACryptoServiceProvider();
+
+                rsaCsp.ImportParameters(rsaParameters);
+
+                var privateKey = rsaCsp;
+#endif
+
 #if IS_DESKTOP
                 using (var certificate = new X509Certificate2(bcCertificate.GetEncoded()))
                 {
@@ -1394,14 +1415,24 @@ namespace NuGet.Packaging.FuncTest
                 var issueCertificateOptions = IssueCertificateOptions.CreateDefaultForEndCertificate();
                 var bcCertificate = certificateAuthority.IssueCertificate(issueCertificateOptions);
                 var timestampService = await _fixture.GetDefaultTrustedTimestampServiceAsync();
-
+#if IS_DESKTOP
                 var privateKey = DotNetUtilities.ToRSA(issueCertificateOptions.KeyPair.Private as RsaPrivateCrtKeyParameters);
+#else
+                var rsaParameters = DotNetUtilities.ToRSAParameters(issueCertificateOptions.KeyPair.Private as RsaPrivateCrtKeyParameters);
+ 
+                RSACryptoServiceProvider rsaCsp = new RSACryptoServiceProvider();
+
+                rsaCsp.ImportParameters(rsaParameters);
+
+                var privateKey = rsaCsp;
+#endif
+
 #if IS_DESKTOP
                 using (var certificate = new X509Certificate2(bcCertificate.GetEncoded()))
                 {
                     certificate.PrivateKey = privateKey;
 #else
-                    using (var certificateTmp = new X509Certificate2(bcCertificate.GetEncoded()))
+                using (var certificateTmp = new X509Certificate2(bcCertificate.GetEncoded()))
                     using (var certificate = RSACertificateExtensions.CopyWithPrivateKey(certificateTmp, privateKey))
                     {
 #endif
@@ -1679,8 +1710,17 @@ namespace NuGet.Packaging.FuncTest
                 var issueCertificateOptions = IssueCertificateOptions.CreateDefaultForEndCertificate();
                 var bcCertificate = certificateAuthority.IssueCertificate(issueCertificateOptions);
                 var timestampService = await _fixture.GetDefaultTrustedTimestampServiceAsync();
-
+#if IS_DESKTOP
                 var privateKey = DotNetUtilities.ToRSA(issueCertificateOptions.KeyPair.Private as RsaPrivateCrtKeyParameters);
+#else
+                var rsaParameters = DotNetUtilities.ToRSAParameters(issueCertificateOptions.KeyPair.Private as RsaPrivateCrtKeyParameters);
+
+                RSACryptoServiceProvider rsaCsp = new RSACryptoServiceProvider();
+
+                rsaCsp.ImportParameters(rsaParameters);
+
+                var privateKey = rsaCsp;
+#endif
 #if IS_DESKTOP
                 using (var certificate = new X509Certificate2(bcCertificate.GetEncoded()))
                 {
@@ -2046,8 +2086,18 @@ namespace NuGet.Packaging.FuncTest
                 var issueCertificateOptions = IssueCertificateOptions.CreateDefaultForEndCertificate();
                 var bcCertificate = certificateAuthority.IssueCertificate(issueCertificateOptions);
                 var timestampService = await _fixture.GetDefaultTrustedTimestampServiceAsync();
-
+#if IS_DESKTOP
                 var privateKey = DotNetUtilities.ToRSA(issueCertificateOptions.KeyPair.Private as RsaPrivateCrtKeyParameters);
+#else
+                var rsaParameters = DotNetUtilities.ToRSAParameters(issueCertificateOptions.KeyPair.Private as RsaPrivateCrtKeyParameters);
+
+                RSACryptoServiceProvider rsaCsp = new RSACryptoServiceProvider();
+
+                rsaCsp.ImportParameters(rsaParameters);
+
+                var privateKey = rsaCsp;
+#endif
+
 #if IS_DESKTOP
                 using (var certificate = new X509Certificate2(bcCertificate.GetEncoded()))
                 {

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignatureTrustAndValidityVerificationProviderTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignatureTrustAndValidityVerificationProviderTests.cs
@@ -147,7 +147,9 @@ namespace NuGet.Packaging.FuncTest
             using (var certificate = new X509Certificate2(bcCertificate.GetEncoded()))
             using (var directory = TestDirectory.Create())
             {
+#if IS_DESKTOP
                 certificate.PrivateKey = DotNetUtilities.ToRSA(keyPair.Private as RsaPrivateCrtKeyParameters);
+#endif
                 var notAfter = certificate.NotAfter.ToUniversalTime();
 
                 var packageContext = new SimpleTestPackageContext();
@@ -203,7 +205,9 @@ namespace NuGet.Packaging.FuncTest
             using (var certificate = new X509Certificate2(bcCertificate.GetEncoded()))
             using (var directory = TestDirectory.Create())
             {
+#if IS_DESKTOP
                 certificate.PrivateKey = DotNetUtilities.ToRSA(keyPair.Private as RsaPrivateCrtKeyParameters);
+#endif
 
                 var packageContext = new SimpleTestPackageContext();
                 var signedPackagePath = await SignedArchiveTestUtility.AuthorSignPackageAsync(
@@ -1379,7 +1383,9 @@ namespace NuGet.Packaging.FuncTest
 
                 using (var certificate = new X509Certificate2(bcCertificate.GetEncoded()))
                 {
+#if IS_DESKTOP
                     certificate.PrivateKey = DotNetUtilities.ToRSA(issueCertificateOptions.KeyPair.Private as RsaPrivateCrtKeyParameters);
+#endif
 
                     using (var test = await Test.CreateAuthorSignedPackageAsync(
                         certificate,
@@ -1658,7 +1664,9 @@ namespace NuGet.Packaging.FuncTest
 
                 using (var certificate = new X509Certificate2(bcCertificate.GetEncoded()))
                 {
+#if IS_DESKTOP
                     certificate.PrivateKey = DotNetUtilities.ToRSA(issueCertificateOptions.KeyPair.Private as RsaPrivateCrtKeyParameters);
+#endif
 
                     using (var test = await Test.CreateRepositoryPrimarySignedPackageAsync(
                         certificate,
@@ -2019,8 +2027,9 @@ namespace NuGet.Packaging.FuncTest
 
                 using (var certificate = new X509Certificate2(bcCertificate.GetEncoded()))
                 {
+#if IS_DESKTOP
                     certificate.PrivateKey = DotNetUtilities.ToRSA(issueCertificateOptions.KeyPair.Private as RsaPrivateCrtKeyParameters);
-
+#endif
                     using (var test = await Test.CreateAuthorSignedRepositoryCountersignedPackageAsync(
                         _fixture.TrustedTestCertificate.Source.Cert,
                         certificate,

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignatureTrustAndValidityVerificationProviderTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignatureTrustAndValidityVerificationProviderTests.cs
@@ -23,6 +23,8 @@ using Test.Utility.Signing;
 using Xunit;
 using BcAccuracy = Org.BouncyCastle.Asn1.Tsp.Accuracy;
 using DotNetUtilities = Org.BouncyCastle.Security.DotNetUtilities;
+using HashAlgorithmName = NuGet.Common.HashAlgorithmName;
+
 
 namespace NuGet.Packaging.FuncTest
 {
@@ -115,7 +117,7 @@ namespace NuGet.Packaging.FuncTest
                     packageContext,
                     directory,
                     timestampService.Url,
-                    signatureHashAlgorithm: NuGet.Common.HashAlgorithmName.SHA512);
+                    signatureHashAlgorithm: HashAlgorithmName.SHA512);
 
                 var verifier = new PackageSignatureVerifier(_trustProviders);
                 using (var packageReader = new PackageArchiveReader(signedPackagePath))
@@ -715,7 +717,7 @@ namespace NuGet.Packaging.FuncTest
 
             using (var package = new PackageArchiveReader(await nupkg.CreateAsStreamAsync(), leaveStreamOpen: false))
             using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
-            using (var signatureRequest = new AuthorSignPackageRequest(testCertificate, NuGet.Common.HashAlgorithmName.SHA256))
+            using (var signatureRequest = new AuthorSignPackageRequest(testCertificate, HashAlgorithmName.SHA256))
             {
                 var signature = await SignedArchiveTestUtility.CreatePrimarySignatureForPackageAsync(package, signatureRequest);
                 var timestampedSignature = await SignedArchiveTestUtility.TimestampSignature(timestampProvider, signature, signatureRequest.TimestampHashAlgorithm, SignaturePlacement.PrimarySignature, testLogger);
@@ -929,7 +931,7 @@ namespace NuGet.Packaging.FuncTest
                 var primarySignature = await packageReader.GetPrimarySignatureAsync(CancellationToken.None);
 
                 var provider = new SignatureTrustAndValidityVerificationProvider(allowUntrustedRootList:
-                    new List<KeyValuePair<string, NuGet.Common.HashAlgorithmName>>() { new KeyValuePair<string, NuGet.Common.HashAlgorithmName>("abc", NuGet.Common.HashAlgorithmName.SHA256) });
+                    new List<KeyValuePair<string, HashAlgorithmName>>() { new KeyValuePair<string, HashAlgorithmName>("abc", HashAlgorithmName.SHA256) });
 
                 var status = await provider.GetTrustResultAsync(packageReader, primarySignature, settings, CancellationToken.None);
 
@@ -968,7 +970,7 @@ namespace NuGet.Packaging.FuncTest
                 var primarySignature = await packageReader.GetPrimarySignatureAsync(CancellationToken.None);
 
                 var provider = new SignatureTrustAndValidityVerificationProvider(allowUntrustedRootList:
-                    new List<KeyValuePair<string, NuGet.Common.HashAlgorithmName>>() { new KeyValuePair<string, NuGet.Common.HashAlgorithmName>("abc", NuGet.Common.HashAlgorithmName.SHA256) });
+                    new List<KeyValuePair<string, HashAlgorithmName>>() { new KeyValuePair<string, HashAlgorithmName>("abc", HashAlgorithmName.SHA256) });
 
                 var status = await provider.GetTrustResultAsync(packageReader, primarySignature, settings, CancellationToken.None);
 
@@ -996,7 +998,7 @@ namespace NuGet.Packaging.FuncTest
            revocationMode: RevocationMode.Online);
 
             var timestampService = await _testFixture.GetDefaultTrustedTimestampServiceAsync();
-            var untrustedCertFingerprint = SignatureTestUtility.GetFingerprint(_testFixture.UntrustedTestCertificate.Cert, NuGet.Common.HashAlgorithmName.SHA256);
+            var untrustedCertFingerprint = SignatureTestUtility.GetFingerprint(_testFixture.UntrustedTestCertificate.Cert, HashAlgorithmName.SHA256);
 
             using (var test = await Test.CreateRepositoryPrimarySignedPackageAsync(
                 _testFixture.UntrustedTestCertificate.Cert,
@@ -1006,7 +1008,7 @@ namespace NuGet.Packaging.FuncTest
                 var primarySignature = await packageReader.GetPrimarySignatureAsync(CancellationToken.None);
 
                 var provider = new SignatureTrustAndValidityVerificationProvider(allowUntrustedRootList:
-                    new List<KeyValuePair<string, NuGet.Common.HashAlgorithmName>>() { new KeyValuePair<string, NuGet.Common.HashAlgorithmName>(untrustedCertFingerprint, NuGet.Common.HashAlgorithmName.SHA256) });
+                    new List<KeyValuePair<string, HashAlgorithmName>>() { new KeyValuePair<string, HashAlgorithmName>(untrustedCertFingerprint, HashAlgorithmName.SHA256) });
 
                 var status = await provider.GetTrustResultAsync(packageReader, primarySignature, settings, CancellationToken.None);
 
@@ -1034,7 +1036,7 @@ namespace NuGet.Packaging.FuncTest
                revocationMode: RevocationMode.Online);
 
             var timestampService = await _testFixture.GetDefaultTrustedTimestampServiceAsync();
-            var untrustedCertFingerprint = SignatureTestUtility.GetFingerprint(_testFixture.UntrustedTestCertificate.Cert, NuGet.Common.HashAlgorithmName.SHA256);
+            var untrustedCertFingerprint = SignatureTestUtility.GetFingerprint(_testFixture.UntrustedTestCertificate.Cert, HashAlgorithmName.SHA256);
 
             using (var test = await Test.CreateAuthorSignedRepositoryCountersignedPackageAsync(
                 _testFixture.TrustedTestCertificate.Source.Cert,
@@ -1046,7 +1048,7 @@ namespace NuGet.Packaging.FuncTest
                 var primarySignature = await packageReader.GetPrimarySignatureAsync(CancellationToken.None);
 
                 var provider = new SignatureTrustAndValidityVerificationProvider(allowUntrustedRootList:
-                    new List<KeyValuePair<string, NuGet.Common.HashAlgorithmName>>() { new KeyValuePair<string, NuGet.Common.HashAlgorithmName>(untrustedCertFingerprint, NuGet.Common.HashAlgorithmName.SHA256) });
+                    new List<KeyValuePair<string, HashAlgorithmName>>() { new KeyValuePair<string, HashAlgorithmName>(untrustedCertFingerprint, HashAlgorithmName.SHA256) });
 
                 var status = await provider.GetTrustResultAsync(packageReader, primarySignature, settings, CancellationToken.None);
 

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignatureTrustAndValidityVerificationProviderTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignatureTrustAndValidityVerificationProviderTests.cs
@@ -25,7 +25,6 @@ using BcAccuracy = Org.BouncyCastle.Asn1.Tsp.Accuracy;
 using DotNetUtilities = Org.BouncyCastle.Security.DotNetUtilities;
 using HashAlgorithmName = NuGet.Common.HashAlgorithmName;
 
-
 namespace NuGet.Packaging.FuncTest
 {
     [Collection(SigningTestCollection.Name)]
@@ -1654,8 +1653,8 @@ namespace NuGet.Packaging.FuncTest
 
                 using (X509Certificate2 certificate = CertificateUtilities.GetCertificateWithPrivateKey(bcCertificate, issueCertificateOptions.KeyPair))
                 using (var test = await Test.CreateRepositoryPrimarySignedPackageAsync(
-                certificate,
-                timestampService.Url))
+                    certificate,
+                    timestampService.Url))
                 using (var packageReader = new PackageArchiveReader(test.PackageFile.FullName))
                 {
                     await certificateAuthority.OcspResponder.WaitForResponseExpirationAsync(bcCertificate);

--- a/test/TestUtilities/Test.Utility/Signing/CertificateUtilities.cs
+++ b/test/TestUtilities/Test.Utility/Signing/CertificateUtilities.cs
@@ -2,15 +2,18 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
 using NuGet.Common;
 using Org.BouncyCastle.Crypto;
 using Org.BouncyCastle.Crypto.Generators;
+using Org.BouncyCastle.Crypto.Parameters;
 using Org.BouncyCastle.Security;
-using Org.BouncyCastle.X509;
+using X509Certificate = Org.BouncyCastle.X509.X509Certificate;
 
 namespace Test.Utility.Signing
 {
-    internal static class CertificateUtilities
+    public static class CertificateUtilities
     {
         internal static AsymmetricCipherKeyPair CreateKeyPair(int strength = 2048)
         {
@@ -34,6 +37,30 @@ namespace Test.Utility.Signing
         internal static string GenerateRandomId()
         {
             return Guid.NewGuid().ToString();
+        }
+
+        public static X509Certificate2 GetCertificateWithPrivateKey(X509Certificate bcCertificate, AsymmetricCipherKeyPair keyPair)
+        {
+#if IS_DESKTOP
+            RSA privateKey = DotNetUtilities.ToRSA(keyPair.Private as RsaPrivateCrtKeyParameters);
+
+            var certificate = new X509Certificate2(bcCertificate.GetEncoded());
+
+            certificate.PrivateKey = privateKey;
+#else
+            RSAParameters rsaParameters = DotNetUtilities.ToRSAParameters(keyPair.Private as RsaPrivateCrtKeyParameters);
+
+            var rsaCsp = new RSACryptoServiceProvider();
+
+            rsaCsp.ImportParameters(rsaParameters);
+
+            var privateKey = rsaCsp;
+
+            var certificateTmp = new X509Certificate2(bcCertificate.GetEncoded());
+
+            X509Certificate2 certificate = RSACertificateExtensions.CopyWithPrivateKey(certificateTmp, privateKey);
+#endif
+            return certificate;
         }
     }
 }

--- a/test/TestUtilities/Test.Utility/Signing/CertificateUtilities.cs
+++ b/test/TestUtilities/Test.Utility/Signing/CertificateUtilities.cs
@@ -50,15 +50,16 @@ namespace Test.Utility.Signing
 #else
             RSAParameters rsaParameters = DotNetUtilities.ToRSAParameters(keyPair.Private as RsaPrivateCrtKeyParameters);
 
-            var rsaCsp = new RSACryptoServiceProvider();
+            var privateKey = new RSACryptoServiceProvider();
 
-            rsaCsp.ImportParameters(rsaParameters);
+            privateKey.ImportParameters(rsaParameters);
 
-            var privateKey = rsaCsp;
+            X509Certificate2 certificate;
 
-            var certificateTmp = new X509Certificate2(bcCertificate.GetEncoded());
-
-            X509Certificate2 certificate = RSACertificateExtensions.CopyWithPrivateKey(certificateTmp, privateKey);
+            using (var certificateTmp = new X509Certificate2(bcCertificate.GetEncoded()))
+            {
+                certificate = RSACertificateExtensions.CopyWithPrivateKey(certificateTmp, privateKey);
+            } 
 #endif
             return certificate;
         }

--- a/test/TestUtilities/Test.Utility/Signing/CertificateUtilities.cs
+++ b/test/TestUtilities/Test.Utility/Signing/CertificateUtilities.cs
@@ -9,6 +9,7 @@ using Org.BouncyCastle.Crypto;
 using Org.BouncyCastle.Crypto.Generators;
 using Org.BouncyCastle.Crypto.Parameters;
 using Org.BouncyCastle.Security;
+using Xunit;
 using X509Certificate = Org.BouncyCastle.X509.X509Certificate;
 
 namespace Test.Utility.Signing
@@ -41,14 +42,17 @@ namespace Test.Utility.Signing
 
         public static X509Certificate2 GetCertificateWithPrivateKey(X509Certificate bcCertificate, AsymmetricCipherKeyPair keyPair)
         {
+            Assert.IsType<RsaPrivateCrtKeyParameters>(keyPair.Private);
+
+            var privateKeyParameters = (RsaPrivateCrtKeyParameters)keyPair.Private;
 #if IS_DESKTOP
-            RSA privateKey = DotNetUtilities.ToRSA(keyPair.Private as RsaPrivateCrtKeyParameters);
+            RSA privateKey = DotNetUtilities.ToRSA(privateKeyParameters);
 
             var certificate = new X509Certificate2(bcCertificate.GetEncoded());
 
             certificate.PrivateKey = privateKey;
 #else
-            RSAParameters rsaParameters = DotNetUtilities.ToRSAParameters(keyPair.Private as RsaPrivateCrtKeyParameters);
+            RSAParameters rsaParameters = DotNetUtilities.ToRSAParameters(privateKeyParameters);
 
             var privateKey = new RSACryptoServiceProvider();
 


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/8626
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: 
For exception as following when setting the private key of an X509Certificate2 certificate:
`System.PlatformNotSupportedException : Operation is not supported on this platform.` ,
use the workaround mentioned in this dotnet/corefx issue : 
dotnet/corefx#14284 (comment)
(above issue was moved to https://github.com/dotnet/runtime/issues/19581#issuecomment-265604395)

For exceptions as following when trying to call  Org.BouncyCastle.Security.DotNetUtilities.ToRSA for netcore:
`System.PlatformNotSupportedException : 'CspParameters' requires Windows Cryptographic API (CAPI), which is not available on this platform.`   (https://github.com/bcgit/bc-csharp/issues/160)
use the workaround mentioned in this dotnet/corefx issue:
https://github.com/dotnet/core/issues/3020#issuecomment-510531366

Affected tests are:
```
AuthorPrimarySignatures.GetTrustResultAsync_WithRevokedPrimaryCertificate_ReturnsSuspectAsync
RepositoryPrimarySignatures.GetTrustResultAsync_WithRevokedPrimaryCertificate_ReturnsSuspectAsync
VerifyAsync_WithRevokedCountersignatureCertificate_ReturnsSuspectAsync
VerifySignaturesAsync_ExpiredCertificateAndTimestamp_SuccessAsync
VerifySignaturesAsync_ExpiredCertificateAndTimestampWithTooLargeRange_FailsAsync
```

## Testing/Validation

Tests Added: Yes/No  
Reason for not adding tests:  
Validation:  
