### PR TITLE
Update build label and 4th part of the version

### DIFF
--- a/build/config.props
+++ b/build/config.props
@@ -19,12 +19,12 @@
     
     <!-- ** Change for each new preview/rtm -->
     <!-- Check the VS schedule and manually enter a preview number here that makes sense. -->
-    <ReleaseLabel Condition=" '$(ReleaseLabel)' == '' ">preview.2</ReleaseLabel>
+    <ReleaseLabel Condition=" '$(ReleaseLabel)' == '' ">preview.3</ReleaseLabel>
     
     <!-- ** Increment each insertion, set to zero after incrementing Major/Minor or Patch version -->
     <!-- We need to update this netcoreassembly build number with EVERY insertion into VS to workaround any breaking api
     changes we might have made. -->
-    <NetCoreAssemblyBuildNumber Condition=" '$(NetCoreAssemblyBuildNumber)' == '' ">2</NetCoreAssemblyBuildNumber>
+    <NetCoreAssemblyBuildNumber Condition=" '$(NetCoreAssemblyBuildNumber)' == '' ">3</NetCoreAssemblyBuildNumber>
 
     <IsEscrowMode>false</IsEscrowMode>
 


### PR DESCRIPTION
## Bug

Fixes: 
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: We're inserting into VS P3, so change to preview.3.
             We're inserting into SDK, so increase the build number from 2 to 3. 

## Testing/Validation

Tests Added: Yes/No  
Reason for not adding tests:  
Validation:  
