### PR TITLE
Accessibility Fixes - batch 1 from issue 9059

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
@@ -169,7 +169,7 @@ namespace NuGet.PackageManagement.UI {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Thumb.
+        ///   Looks up a localized string similar to splitter for Packages list.
         /// </summary>
         public static string Accessibility_ThumbName {
             get {

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
@@ -824,7 +824,7 @@ Please see https://aka.ms/troubleshoot_nuget_cache for more help.</value>
     <value>Use arrow keys to change the size of the sections</value>
   </data>
   <data name="Accessibility_ThumbName" xml:space="preserve">
-    <value>Thumb</value>
+    <value>splitter for Packages list</value>
   </data>
   <data name="ImageCaption_HelpIcon" xml:space="preserve">
     <value>Help icon</value>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageItemControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageItemControl.xaml
@@ -109,6 +109,7 @@
                     </Grid.RowDefinitions>
                     <Image
                       Grid.Row="0"
+                      AutomationProperties.Name="{x:Static nuget:Resources.Accessibility_PackageIcon}"
                       Style="{StaticResource PackageIconImageStyle}"
                       VerticalAlignment="Top"
                       Margin="0,0,16,0" />

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/ProjectView.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/ProjectView.xaml
@@ -48,6 +48,7 @@
 
     <!-- row 0 -->
     <TextBlock
+      Name="_InstalledVersion"
       Grid.Row="0"
       Grid.Column="0"
       FontWeight="Bold"
@@ -66,7 +67,7 @@
       <TextBox
         Style="{DynamicResource SelectableTextBlockStyle}"
         VerticalAlignment="Center"
-        AutomationProperties.AutomationId="InstalledVersion"
+        AutomationProperties.LabeledBy="{Binding ElementName=_InstalledVersion}"
         Margin="4,0,0,0"
         Text="{Binding InstalledVersion, Converter={StaticResource VersionToStringConverter}, Mode=OneWay}" />
     </Border>


### PR DESCRIPTION
## Bug

Fixes: 9059 - batch 1 -  [Accessibility Fixes in PM UI - altText, etc...](https://github.com/nuget/home/issues/9059)
Regression: No
* Last working version:   
* How are we preventing it in future:   checking UI changes with Accessibility Insights

## Fix

Details of 3 fixes:
 - [x] PM UI - Thumb control needs better accessibility name - don't just repeat control name.
[1049222](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1049222) - A11y_VS ASP.NET and Web Development_ Manage Nugent's-Browse_ Screen Reader : Narrator/NVDA is mentioning the vertical bar as "Thumb".

Test of fix with Accessibility Insights:
![image](https://user-images.githubusercontent.com/8865080/72912736-ef21aa80-3cf0-11ea-81fe-0ad52e5cf144.png)

- [x] PackageItemControl - Package Icon should have "Package Icon" altText
[994454](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/994454) - A11y_NuGetClient-MinorUIChanges_Installed_ScreenReader : Alternative text is not provided for "Package Icon" image for screen reader users.

Test of fix with Accessibility Insights:
![image](https://user-images.githubusercontent.com/8865080/72912940-3c9e1780-3cf1-11ea-8a2d-be63a2d0c555.png)

- [x] ProjectView - Installed textbox needs an accessibility name
[994499](https://devdiv.visualstudio.com/DevDiv/_queries/edit/994499) - A11y_NuGetClient-MinorUIChanges_TestPackage.Deprecation.CriticalBugs.AlternatePackage_Installed_AI4D: Name property does not exists for "Installed" edit box

Test of fix with Accessibility Insights:
![image](https://user-images.githubusercontent.com/8865080/72913110-7d962c00-3cf1-11ea-8402-f7b2c1d39d6e.png)


## Testing/Validation

Tests Added: No
Reason for not adding tests: Don't currently have automated tests for correct accessibility
Validation:  Used Accessibility Insights to verify. See images above
