### PR TITLE
Accessibility Fixes for Deprecation UI

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
@@ -799,6 +799,15 @@ namespace NuGet.PackageManagement.UI {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Deprecation Reasons.
+        /// </summary>
+        public static string Label_DeprecationReasons {
+            get {
+                return ResourceManager.GetString("Label_DeprecationReasons", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to This package has been deprecated as it has critical bugs..
         /// </summary>
         public static string Label_DeprecationReasons_CriticalBugs {

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
@@ -871,4 +871,7 @@ Please see https://aka.ms/troubleshoot_nuget_cache for more help.</value>
   <data name="Label_Installed_DeprecatedWarning" xml:space="preserve">
     <value>You have {0} deprecated package(s) installed.</value>
   </data>
+  <data name="Label_DeprecationReasons" xml:space="preserve">
+    <value>Deprecation reason</value>
+  </data>
 </root>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/DeprecationControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/DeprecationControl.xaml
@@ -27,11 +27,12 @@
             Margin="0,0,5,0"
             Width="13"
             Height="13"
+            AutomationProperties.LabeledBy="{Binding ElementName=_deprecationLabel}"
             ToolTip="{x:Static nuget:Resources.Label_Deprecated}"
             Moniker="{x:Static catalog:KnownMonikers.StatusWarning}" />
         <TextBlock
+            Name="_deprecationLabel"
             FontWeight="Bold"
-            AutomationProperties.Name="{x:Static nuget:Resources.Label_Deprecated}"
             Text="{x:Static nuget:Resources.Label_Deprecated}"/>
       </StackPanel>
         <TextBox
@@ -39,7 +40,7 @@
           Margin="0,8,0,0"
           TextWrapping="WrapWithOverflow"
           Text="{Binding Path=PackageDeprecationReasons}"
-          AutomationProperties.Name="{Binding Path=PackageDeprecationReasons}"/>
+          AutomationProperties.Name="{x:Static nuget:Resources.Label_DeprecationReasons}"/>
         <StackPanel
           Margin="0,8,0,0"
           Orientation="Vertical"
@@ -47,8 +48,7 @@
           <TextBlock
             Text="{x:Static nuget:Resources.Label_DeprecationAlternatePackage}"
             FontWeight="Bold"
-            x:Name="_alternatePackageLabel"
-            AutomationProperties.Name="{Binding Text}"/>
+            x:Name="_alternatePackageLabel" />
           <StackPanel
             Orientation="Horizontal"
             VerticalAlignment="Center">
@@ -56,7 +56,6 @@
               Style="{DynamicResource SelectableTextBlockStyle}" 
               TextWrapping="Wrap"
               VerticalAlignment="Center"
-              AutomationProperties.Name="{Binding Path=PackageDeprecationAlternatePackageText}"
               AutomationProperties.LabeledBy="{Binding ElementName=_alternatePackageLabel}"
               Text="{Binding Path=PackageDeprecationAlternatePackageText}"/>
           </StackPanel>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageItemControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageItemControl.xaml
@@ -247,6 +247,7 @@
                         Visibility="Visible"
                         VerticalAlignment="Center"
                         ToolTip="{x:Static nuget:Resources.Label_Deprecated}"
+                        AutomationProperties.Name="{x:Static nuget:Resources.Label_Deprecated}"
                         Moniker="{x:Static catalog:KnownMonikers.StatusWarning}"/>
 
                       <!-- installed version -->


### PR DESCRIPTION
Fixes: https://github.com/nuget/home/issues/9059 (batch2)

- [x] Put label on icon. Make reason have label. Fix several other duplications, etc.
[994458](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/994458) - A11y_NuGetClient-MinorUIChanges_TestPackage.Deprecation.Other_Installed_ScreenReader : Narrator is announcing " edit " word unnecessarily after reading deprecated message.

Before fix:
![image](https://user-images.githubusercontent.com/8865080/72936620-6ae51c80-3d1c-11ea-988d-4452685fa154.png)

After fix:
![image](https://user-images.githubusercontent.com/8865080/72984112-c3a5cb00-3d97-11ea-908f-e227c0b7c851.png)

Fixing the following problems.
(CalcAutoName is calculating the effective AutomationName)

```
Fixing src\NuGet.Clients\NuGet.PackageManagement.UI\Xamls\DeprecationControl.xaml...
(25:12) <CrispImage Name="_deprecationWarning" />
  Error AIX100: missing autoName, either implied, explicit, or labeledBy
(32:10) <TextBlock Content="{Static nuget:Resources.Label_Deprecated}" CalcAutoName="{Static nuget:Resources.Label_Deprecated}" />
  Error AIX222: autoname doesn't need to be set. Value is same as content, so it is a wasteful noop.
(37:10) <TextBox Content="{Binding ElementName=PackageDeprecationReasons}" CalcAutoName="{Binding ElementName=PackageDeprecationReasons}" />
  Error AIX222: autoname doesn't need to be set. Value is same as content, so it is a wasteful noop.
(55:14) <TextBox Content="{Binding ElementName=PackageDeprecationAlternatePackageText}" CalcAutoName="{Binding ElementName=PackageDeprecationAlternatePackageText}" />
  Error AIX111: don't set name and labeledby, pick one
  Error AIX222: autoname doesn't need to be set. Value is same as content, so it is a wasteful noop.

Fixing src\NuGet.Clients\NuGet.PackageManagement.UI\Xamls\PackageItemControl.xaml...
(243:24) <CrispImage Name="_deprecationIndicator" />
  Error AIX100: missing autoName, either implied, explicit, or labeledBy
```