### PR TITLE
Rework the self updater with the new APIs that support semver2 and validate signatures

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/UpdateCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/UpdateCommand.cs
@@ -68,8 +68,8 @@ namespace NuGet.CommandLine
             // update with self as parameter
             if (Self)
             {
-                var selfUpdater = new SelfUpdater(repositoryFactory: RepositoryFactory) { Console = Console };
-                selfUpdater.UpdateSelf(Prerelease);
+                var selfUpdater = new SelfUpdater(Console);
+                await selfUpdater.UpdateSelfAsync(Prerelease, NuGetConstants.V3FeedUrl);
                 return;
             }
 

--- a/src/NuGet.Clients/NuGet.CommandLine/Common/SelfUpdater.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Common/SelfUpdater.cs
@@ -1,19 +1,20 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-extern alias CoreV2;
-
 using System;
-using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using NuGet.Configuration;
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.Common;
+using NuGet.PackageManagement;
+using NuGet.Packaging;
+using NuGet.Packaging.Core;
+using NuGet.Protocol;
+using NuGet.Protocol.Core.Types;
+using NuGet.Versioning;
 
-using static CoreV2.NuGet.PackageRepositoryExtensions;
-using static CoreV2.NuGet.CustomAttributeProviderExtensions;
-
-//TODO: This can be reworked with V3 APIs - tracked in https://github.com/NuGet/Home/issues/4197
 namespace NuGet.CommandLine
 {
     /// <summary>
@@ -27,27 +28,25 @@ namespace NuGet.CommandLine
         private string _assemblyLocation;
         private readonly Lazy<string> _lazyAssemblyLocation = new Lazy<string>(() =>
         {
-            var assembly = typeof(SelfUpdater).Assembly;
-            return assembly.Location;
+            return typeof(SelfUpdater).Assembly.Location;
         });
-        private readonly CoreV2.NuGet.IPackageRepositoryFactory _repositoryFactory;
 
-        public SelfUpdater(CoreV2.NuGet.IPackageRepositoryFactory repositoryFactory)
+        private readonly IConsole _console;
+
+        public SelfUpdater(IConsole console)
         {
-            if (repositoryFactory == null)
+            if (console == null)
             {
-                throw new ArgumentNullException("repositoryFactory");
+                throw new ArgumentNullException(nameof(console));
             }
-            _repositoryFactory = repositoryFactory;
+            _console = console;
         }
-
-        public IConsole Console { get; set; }
 
         /// <summary>
         /// This property is used only for testing (so that the self updater does not replace the running test
         /// assembly).
         /// </summary>
-        public string AssemblyLocation
+        internal string AssemblyLocation
         {
             get
             {
@@ -59,96 +58,95 @@ namespace NuGet.CommandLine
             }
         }
 
-        public void UpdateSelf(bool prerelease)
+        public async Task UpdateSelfAsync(bool prerelease, string updateFeed)
         {
             Assembly assembly = typeof(SelfUpdater).Assembly;
-            CoreV2.NuGet.SemanticVersion version = GetNuGetVersion(assembly) ?? new CoreV2.NuGet.SemanticVersion(assembly.GetName().Version);
-            SelfUpdate(AssemblyLocation, prerelease, version);
+            var version = GetNuGetVersion(assembly) ?? new NuGetVersion(assembly.GetName().Version);
+            await SelfUpdateAsync(AssemblyLocation, prerelease, version, updateFeed, CancellationToken.None);
         }
 
-        internal void SelfUpdate(string exePath, bool prerelease, CoreV2.NuGet.SemanticVersion version)
+        internal async Task SelfUpdateAsync(string exePath, bool prerelease, NuGetVersion currentVersion, string source, CancellationToken cancellationToken)
         {
-            Console.WriteLine(LocalizedResourceManager.GetString("UpdateCommandCheckingForUpdates"), NuGetConstants.V2FeedUrl);
+            var sourceCacheContext = new SourceCacheContext();
+            _console.WriteLine(LocalizedResourceManager.GetString("UpdateCommandCheckingForUpdates"), source);
 
-            // Get the nuget command line package from the specified repository
-            CoreV2.NuGet.IPackageRepository packageRepository = _repositoryFactory.CreateRepository(NuGetConstants.V2FeedUrl);
-            CoreV2.NuGet.IPackage package = packageRepository.GetUpdates(
-                new [] { new CoreV2.NuGet.PackageName(NuGetCommandLinePackageId, version) },
-                includePrerelease: prerelease, 
-                includeAllVersions: false, 
-                targetFrameworks: null,
-                versionConstraints: null).FirstOrDefault();
- 
-            Console.WriteLine(LocalizedResourceManager.GetString("UpdateCommandCurrentlyRunningNuGetExe"), version); // SemanticVersion is the problem
+            var sourceRepository = Repository.Factory.GetCoreV3(source);
+            var metadataResource = await sourceRepository.GetResourceAsync<MetadataResource>(cancellationToken);
+            var latestVersion = await metadataResource.GetLatestVersion(NuGetCommandLinePackageId, prerelease, includeUnlisted: false, sourceCacheContext, _console, cancellationToken);
+
+            _console.WriteLine(LocalizedResourceManager.GetString("UpdateCommandCurrentlyRunningNuGetExe"), currentVersion);
 
             // Check to see if an update is needed
-            if (package == null || version >= package.Version)
+            if (latestVersion == null || currentVersion >= latestVersion)
             {
-                Console.WriteLine(LocalizedResourceManager.GetString("UpdateCommandNuGetUpToDate"));
+                _console.WriteLine(LocalizedResourceManager.GetString("UpdateCommandNuGetUpToDate"));
             }
             else
             {
-                Console.WriteLine(LocalizedResourceManager.GetString("UpdateCommandUpdatingNuGet"), package.Version);
+                _console.WriteLine(LocalizedResourceManager.GetString("UpdateCommandUpdatingNuGet"), latestVersion);
 
-                // Get NuGet.exe file from the package
-                CoreV2.NuGet.IPackageFile file = package.GetFiles().FirstOrDefault(f => Path.GetFileName(f.Path).Equals(NuGetExe, StringComparison.OrdinalIgnoreCase));
+                var packageIdentity = new PackageIdentity(NuGetCommandLinePackageId, latestVersion);
 
-                // If for some reason this package doesn't have NuGet.exe then we don't want to use it
-                if (file == null)
+                var tempDir = Path.Combine(NuGetEnvironment.GetFolderPath(NuGetFolderPath.Temp), "updateSelf");
+                var nupkgPath = FileUtility.GetTempFilePath(tempDir);
+                try
                 {
-                    throw new CommandLineException(LocalizedResourceManager.GetString("UpdateCommandUnableToLocateNuGetExe"));
+                    DirectoryUtility.CreateSharedDirectory(tempDir);
+
+                    var downloadResourceResult = await PackageDownloader.GetDownloadResourceResultAsync(
+                                        sourceRepository,
+                                        packageIdentity,
+                                        new PackageDownloadContext(sourceCacheContext),
+                                        tempDir,
+                                        _console,
+                                        cancellationToken);
+
+                    // Get the exe path and move it to a temp file (NuGet.exe.old) so we can replace the running exe with the bits we got 
+                    // from the package repository
+                    var nugetExeFile = (await downloadResourceResult.PackageReader.GetFilesAsync(CancellationToken.None)).FirstOrDefault(f => Path.GetFileName(f).Equals(NuGetExe, StringComparison.OrdinalIgnoreCase));
+
+                    // If for some reason this package doesn't have NuGet.exe then we don't want to use it
+                    if (nugetExeFile == null)
+                    {
+                        throw new CommandLineException(LocalizedResourceManager.GetString("UpdateCommandUnableToLocateNuGetExe"));
+                    }
+
+                    string renamedPath = exePath + ".old";
+
+                    FileUtility.Move(exePath, renamedPath);
+
+                    using (Stream fromStream = await downloadResourceResult.PackageReader.GetStreamAsync(nugetExeFile, cancellationToken), toStream = File.Create(exePath))
+                    {
+                        fromStream.CopyTo(toStream);
+                    }
                 }
-
-                // Get the exe path and move it to a temp file (NuGet.exe.old) so we can replace the running exe with the bits we got 
-                // from the package repository
-                string renamedPath = exePath + ".old";
-                Move(exePath, renamedPath);
-
-                // Update the file
-                UpdateFile(exePath, file);
-
-                Console.WriteLine(LocalizedResourceManager.GetString("UpdateCommandUpdateSuccessful"));
+                finally
+                {
+                    // Delete the temporary directory
+                    try
+                    {
+                        Directory.Delete(tempDir, recursive: true);
+                    }
+                    catch
+                    {
+                    }
+                }
             }
+            _console.WriteLine(LocalizedResourceManager.GetString("UpdateCommandUpdateSuccessful"));
         }
 
-        [SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes", Justification = "We don't want this method to throw.")]
-        internal static CoreV2.NuGet.SemanticVersion GetNuGetVersion(ICustomAttributeProvider assembly)
+        internal static NuGetVersion GetNuGetVersion(Assembly assembly)
         {
             try
             {
                 var assemblyInformationalVersion = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>();
-                return new CoreV2.NuGet.SemanticVersion(assemblyInformationalVersion.InformationalVersion);
+                return new NuGetVersion(assemblyInformationalVersion.InformationalVersion);
             }
             catch
             {
                 // Don't let GetCustomAttributes throw.
             }
             return null;
-        }
-
-        protected virtual void UpdateFile(string exePath, CoreV2.NuGet.IPackageFile file)
-        {
-            using (Stream fromStream = file.GetStream(), toStream = File.Create(exePath))
-            {
-                fromStream.CopyTo(toStream);
-            }
-        }
-
-        protected virtual void Move(string oldPath, string newPath)
-        {
-            try
-            {
-                if (File.Exists(newPath))
-                {
-                    File.Delete(newPath);
-                }
-            }
-            catch (FileNotFoundException)
-            {
-
-            }
-
-            File.Move(oldPath, newPath);
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.CommandLine/Common/SelfUpdater.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Common/SelfUpdater.cs
@@ -62,10 +62,10 @@ namespace NuGet.CommandLine
         {
             Assembly assembly = typeof(SelfUpdater).Assembly;
             var version = GetNuGetVersion(assembly) ?? new NuGetVersion(assembly.GetName().Version);
-            await SelfUpdateAsync(AssemblyLocation, prerelease, version, updateFeed, CancellationToken.None);
+            await UpdateSelfFromVersionAsync(AssemblyLocation, prerelease, version, updateFeed, CancellationToken.None);
         }
 
-        internal async Task SelfUpdateAsync(string exePath, bool prerelease, NuGetVersion currentVersion, string source, CancellationToken cancellationToken)
+        internal async Task UpdateSelfFromVersionAsync(string exePath, bool prerelease, NuGetVersion currentVersion, string source, CancellationToken cancellationToken)
         {
             var sourceCacheContext = new SourceCacheContext();
             _console.WriteLine(LocalizedResourceManager.GetString("UpdateCommandCheckingForUpdates"), source);

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGet.CommandLine.csproj
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGet.CommandLine.csproj
@@ -1,4 +1,4 @@
-﻿<Project>
+<Project>
 
   <PropertyGroup>
     <IsCommandLinePackage>true</IsCommandLinePackage>
@@ -53,6 +53,18 @@
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
       <_Parameter1>NuGet.CommandLine.FuncTest</_Parameter1>
     </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>NuGet.CommandLine.Test</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
+  <ItemGroup Condition="$(DefineConstants.Contains(SIGNED_BUILD))">
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>NuGet.CommandLine.Test, PublicKey=002400000480000094000000060200000024000052534131000400000100010007d1fa57c4aed9f0a32e84aa0faefd0de9e8fd6aec8f87fb03766c834c99921eb23be79ad9d5dcc1dd9ad236132102900b723cf980957fc4e177108fc607774f29e8320e92ea05ece4e821c0a5efe8f1645c4c0c93c1ab99285d622caa652c1dfad63d745d6f2de5f17e5eaf0fc4963d261c8a12436518206dc093344d5ad293</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
+  <ItemGroup Condition="!$(DefineConstants.Contains(SIGNED_BUILD))">
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
       <_Parameter1>NuGet.CommandLine.Test</_Parameter1>
     </AssemblyAttribute>

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Caching/CachingTestContext.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Caching/CachingTestContext.cs
@@ -176,7 +176,7 @@ namespace NuGet.CommandLine.Test.Caching
                             return;
                         }
 
-                        var mockResponse = builder.BuildRegistrationIndexResponse(MockServer, identity);
+                        var mockResponse = builder.BuildRegistrationIndexResponse(MockServer, new PackageIdentity[] { identity });
 
                         response.ContentType = mockResponse.ContentType;
                         MockServer.SetResponseContent(response, mockResponse.Content);

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Common/SelfUpdaterTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Common/SelfUpdaterTests.cs
@@ -33,7 +33,7 @@ namespace NuGet.CommandLine.Test
                     mockServer.Start();
 
                     // Act
-                    await tc.Target.SelfUpdateAsync(
+                    await tc.Target.UpdateSelfFromVersionAsync(
                         tc.Target.AssemblyLocation,
                         prerelease: false,
                         currentVersion: new NuGetVersion("5.5.0"),
@@ -60,7 +60,7 @@ namespace NuGet.CommandLine.Test
 
                 // Act & Assert
                 await Assert.ThrowsAsync<CommandLineException>(() =>
-                    tc.Target.SelfUpdateAsync(
+                    tc.Target.UpdateSelfFromVersionAsync(
                            tc.Target.AssemblyLocation,
                            prerelease: false,
                            currentVersion,
@@ -85,7 +85,7 @@ namespace NuGet.CommandLine.Test
                     mockServer.Start();
 
                     // Act
-                    await tc.Target.SelfUpdateAsync(
+                    await tc.Target.UpdateSelfFromVersionAsync(
                         tc.Target.AssemblyLocation,
                         prerelease: false,
                         currentVersion: new NuGetVersion("5.5.0"),
@@ -117,7 +117,7 @@ namespace NuGet.CommandLine.Test
 
                 // Act
                 var currentVersion = new NuGetVersion(5, 5, 0);
-                await tc.Target.SelfUpdateAsync(
+                await tc.Target.UpdateSelfFromVersionAsync(
                     tc.Target.AssemblyLocation,
                     prerelease,
                     currentVersion,
@@ -150,7 +150,7 @@ namespace NuGet.CommandLine.Test
 
                 // Act
                 var currentVersion = new NuGetVersion(4, 0, 0);
-                await tc.Target.SelfUpdateAsync(
+                await tc.Target.UpdateSelfFromVersionAsync(
                     tc.Target.AssemblyLocation,
                     prerelease,
                     currentVersion,

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Common/SelfUpdaterTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Common/SelfUpdaterTests.cs
@@ -1,9 +1,9 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.IO;
-using System.Linq;
-using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
 using Moq;
 using NuGet.Test.Utility;
 using NuGet.Versioning;
@@ -13,6 +13,91 @@ namespace NuGet.CommandLine.Test
 {
     public class SelfUpdaterTests
     {
+        [Fact]
+        public async Task SelfUpdater_V3Server_WithUnlistedPackages_IgnoresUnlistedPackagesAsync()
+        {
+            using (var testDirectory = TestDirectory.Create())
+            {
+                var tc = new TestContext(testDirectory);
+                using (var mockServer = new FileSystemBackedV3MockServer(tc.SourceDirectory))
+                {
+                    var expectedPackage = GetNuGetCommandLinePackage(tc, "6.0.0", isExpected: false);
+                    // This package is unlisted, so we expect 6.0.0 to be chosen.
+                    var unlistedPackage = GetNuGetCommandLinePackage(tc, "6.5.0", isExpected: true);
+
+                    await SimpleTestPackageUtility.CreatePackagesAsync(tc.SourceDirectory,
+                        expectedPackage,
+                        unlistedPackage
+                        );
+                    mockServer.UnlistedPackages.Add(unlistedPackage.Identity);
+                    mockServer.Start();
+
+                    // Act
+                    await tc.Target.SelfUpdateAsync(
+                        tc.Target.AssemblyLocation,
+                        prerelease: false,
+                        currentVersion: new NuGetVersion("5.5.0"),
+                        mockServer.ServiceIndexUri,
+                        CancellationToken.None);
+
+                    // Assert
+                    tc.VerifyReplacedState(replaced: true);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task SelfUpdater_PackageWithoutNuGetExe_FailsAsync()
+        {
+            // Arrange
+            using (var testDirectory = TestDirectory.Create())
+            {
+                var currentVersion = new NuGetVersion("5.5.0");
+                var tc = new TestContext(testDirectory);
+                await SimpleTestPackageUtility.CreatePackagesAsync(
+                    tc.SourceDirectory,
+                    new SimpleTestPackageContext("NuGet.CommandLine", "6.0.0"));
+
+                // Act & Assert
+                await Assert.ThrowsAsync<CommandLineException>(() =>
+                    tc.Target.SelfUpdateAsync(
+                           tc.Target.AssemblyLocation,
+                           prerelease: false,
+                           currentVersion,
+                           tc.SourceDirectory,
+                           CancellationToken.None));
+                tc.VerifyReplacedState(replaced: false);
+            }
+        }
+
+        [Fact]
+        public async Task SelfUpdater_WithV3Server_SucceedsAsync()
+        {
+            using (var testDirectory = TestDirectory.Create())
+            {
+                var tc = new TestContext(testDirectory);
+                using (var mockServer = new FileSystemBackedV3MockServer(tc.SourceDirectory))
+                {
+                    await SimpleTestPackageUtility.CreatePackagesAsync(tc.SourceDirectory,
+                        GetNuGetCommandLinePackage(tc, "6.0.0", isExpected: false),
+                        GetNuGetCommandLinePackage(tc, "6.5.0", isExpected: true)
+                        );
+                    mockServer.Start();
+
+                    // Act
+                    await tc.Target.SelfUpdateAsync(
+                        tc.Target.AssemblyLocation,
+                        prerelease: false,
+                        currentVersion: new NuGetVersion("5.5.0"),
+                        mockServer.ServiceIndexUri,
+                        CancellationToken.None);
+
+                    // Assert
+                    tc.VerifyReplacedState(replaced: true);
+                }
+            }
+        }
+
         [Theory]
         [InlineData("1.1.1", true, false)]
         [InlineData("1.1.1", false, false)]
@@ -22,19 +107,22 @@ namespace NuGet.CommandLine.Test
         [InlineData("99.99.99", false, true)]
         [InlineData("99.99.99-beta", true, true)]
         [InlineData("99.99.99-beta", false, false)]
-        public void SelfUpdater_WithArbitraryVersions_UpdateSelf(string version, bool prerelease, bool replaced)
+        public async Task SelfUpdater_WithArbitraryVersions_SucceedsAsync(string version, bool prerelease, bool replaced)
         {
             // Arrange
             using (var testDirectory = TestDirectory.Create())
             {
                 var tc = new TestContext(testDirectory);
-                tc
-                    .Package
-                    .Setup(x => x.Version)
-                    .Returns(new SemanticVersion(version));
+                await SimpleTestPackageUtility.CreatePackagesAsync(tc.SourceDirectory, GetNuGetCommandLinePackage(tc, version, replaced));
 
                 // Act
-                tc.Target.UpdateSelf(prerelease);
+                var currentVersion = new NuGetVersion(5, 5, 0);
+                await tc.Target.SelfUpdateAsync(
+                    tc.Target.AssemblyLocation,
+                    prerelease,
+                    currentVersion,
+                    tc.SourceDirectory,
+                    CancellationToken.None);
 
                 // Assert
                 tc.VerifyReplacedState(replaced);
@@ -44,20 +132,49 @@ namespace NuGet.CommandLine.Test
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        public void SelfUpdater_WithCurrentVersion(bool prerelease)
+        public async Task SelfUpdater_WithNewerStableAndPrereleaseVersions_PrereleaseSwitchIsRespectedAsync(bool prerelease)
         {
             // Arrange
             using (var testDirectory = TestDirectory.Create())
             {
                 var tc = new TestContext(testDirectory);
-                tc.Package.Setup(x => x.Version).Returns(tc.ClientVersion);
+                var latestPrereleaseVersion = "5.0.0-preview1";
+                var latestStableVersion = "4.6.0";
+
+                var package100 = GetNuGetCommandLinePackage(tc, "1.0.0", false);
+                var package450 = GetNuGetCommandLinePackage(tc, "4.5.0", false);
+                var package460 = GetNuGetCommandLinePackage(tc, latestStableVersion, !prerelease);
+                var package500preview = GetNuGetCommandLinePackage(tc, latestPrereleaseVersion, prerelease);
+
+                await SimpleTestPackageUtility.CreatePackagesAsync(tc.SourceDirectory, package100, package450, package460, package500preview);
 
                 // Act
-                tc.Target.UpdateSelf(prerelease);
+                var currentVersion = new NuGetVersion(4, 0, 0);
+                await tc.Target.SelfUpdateAsync(
+                    tc.Target.AssemblyLocation,
+                    prerelease,
+                    currentVersion,
+                    tc.SourceDirectory,
+                    CancellationToken.None);
 
                 // Assert
-                tc.VerifyReplacedState(replaced: false);
+                tc.VerifyReplacedState(replaced: true);
             }
+        }
+
+        private static SimpleTestPackageContext GetNuGetCommandLinePackage(TestContext tc, string version, bool isExpected)
+        {
+            var package = new SimpleTestPackageContext("NuGet.CommandLine", version);
+            package.Files.Clear();
+            if (isExpected)
+            {
+                package.Files.Add(new System.Collections.Generic.KeyValuePair<string, byte[]>(@"tools/NuGet.exe", tc.NewContent));
+            }
+            else
+            {
+                package.Files.Add(new System.Collections.Generic.KeyValuePair<string, byte[]>(@"tools/NuGet.exe", tc.WrongContent));
+            }
+            return package;
         }
 
         private class TestContext
@@ -65,64 +182,27 @@ namespace NuGet.CommandLine.Test
             public TestContext(TestDirectory directory)
             {
                 Directory = directory;
-                Factory = new Mock<IPackageRepositoryFactory>();
-                Repository = new Mock<IPackageRepository>();
                 Console = new Mock<IConsole>();
-                Package = new Mock<IPackage>();
-                PackageFile = new Mock<IPackageFile>();
                 OriginalContent = new byte[] { 0 };
                 NewContent = new byte[] { 1 };
+                WrongContent = new byte[] { 2 };
 
-                var clientVersion = typeof(SelfUpdater)
-                    .Assembly
-                    .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
-                    .InformationalVersion;
-                ClientVersion = new SemanticVersion(clientVersion);
-                IsClientPrerelease = NuGetVersion
-                    .Parse(clientVersion)
-                    .IsPrerelease;
+                Target = new SelfUpdater(Console.Object)
+                {
+                    AssemblyLocation = Path.Combine(Directory, "nuget.exe")
+                };
 
-                PackageFile.Setup(x => x.Path).Returns("nuget.exe");
-                PackageFile.Setup(x => x.GetStream()).Returns(() => new MemoryStream(NewContent));
-
-                Package.Setup(x => x.Id).Returns("NuGet.CommandLine");
-                Package.Setup(x => x.Version).Returns(new SemanticVersion("99.99.99"));
-                Package.Setup(x => x.Listed).Returns(true);
-                Package
-                    .Setup(x => x.GetFiles())
-                    .Returns(() => PackageFile != null ? new[] { PackageFile.Object }.AsEnumerable() : null);
-
-                var zero = new Mock<IPackage>();
-                zero.Setup(x => x.Id).Returns("NuGet.CommandLine");
-                zero.Setup(x => x.Version).Returns(new SemanticVersion("0.0.0"));
-                zero.Setup(x => x.Listed).Returns(true);
-
-                Target = new SelfUpdater(Factory.Object);
-                Target.Console = Console.Object;
-                Target.AssemblyLocation = Path.Combine(Directory, "nuget.exe");
-
-                Factory
-                    .Setup(x => x.CreateRepository(It.IsAny<string>()))
-                    .Returns(Repository.Object);
-
-                Repository
-                    .Setup(x => x.GetPackages())
-                    .Returns(() => Package != null ? new[] { zero.Object, Package.Object }.AsQueryable() : null);
-
+                SourceDirectory = Path.Combine(Directory, "source");
                 File.WriteAllBytes(Target.AssemblyLocation, OriginalContent);
             }
 
-            public Mock<IPackageRepositoryFactory> Factory { get; }
-            public Mock<IPackageRepository> Repository { get; }
             public Mock<IConsole> Console { get; }
             public SelfUpdater Target { get; }
-            public Mock<IPackage> Package { get; set; }
             public TestDirectory Directory { get; }
-            public Mock<IPackageFile> PackageFile { get; }
             public byte[] NewContent { get; set; }
             public byte[] OriginalContent { get; }
-            public SemanticVersion ClientVersion { get; }
-            public bool IsClientPrerelease { get; }
+            public byte[] WrongContent { get; set; }
+            public string SourceDirectory { get; }
 
             public void VerifyReplacedState(bool replaced)
             {

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Common/SelfUpdaterTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Common/SelfUpdaterTests.cs
@@ -13,8 +13,8 @@ namespace NuGet.CommandLine.Test
 {
     public class SelfUpdaterTests
     {
-        [Fact]
-        public async Task SelfUpdater_V3Server_WithUnlistedPackages_IgnoresUnlistedPackagesAsync()
+        [SkipMono(Skip = "Mono has issues if the MockServer has anything else running in the same process https://github.com/NuGet/Home/issues/8594")]
+        public async Task SelfUpdater_WithV3Server_WithUnlistedPackages_IgnoresUnlistedPackagesAsync()
         {
             using (var testDirectory = TestDirectory.Create())
             {
@@ -70,7 +70,7 @@ namespace NuGet.CommandLine.Test
             }
         }
 
-        [Fact]
+        [SkipMono(Skip = "Mono has issues if the MockServer has anything else running in the same process https://github.com/NuGet/Home/issues/8594")]
         public async Task SelfUpdater_WithV3Server_SucceedsAsync()
         {
             using (var testDirectory = TestDirectory.Create())

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Common/SelfUpdaterTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Common/SelfUpdaterTests.cs
@@ -21,9 +21,9 @@ namespace NuGet.CommandLine.Test
                 var tc = new TestContext(testDirectory);
                 using (var mockServer = new FileSystemBackedV3MockServer(tc.SourceDirectory))
                 {
-                    var expectedPackage = GetNuGetCommandLinePackage(tc, "6.0.0", isExpected: false);
+                    var expectedPackage = GetNuGetCommandLinePackage(tc, "6.0.0", isExpected: true);
                     // This package is unlisted, so we expect 6.0.0 to be chosen.
-                    var unlistedPackage = GetNuGetCommandLinePackage(tc, "6.5.0", isExpected: true);
+                    var unlistedPackage = GetNuGetCommandLinePackage(tc, "6.5.0", isExpected: false);
 
                     await SimpleTestPackageUtility.CreatePackagesAsync(tc.SourceDirectory,
                         expectedPackage,

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/FileSystemBackedV3MockServer.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/FileSystemBackedV3MockServer.cs
@@ -59,7 +59,7 @@ namespace NuGet.CommandLine.Test
                 {
                     return new Action<HttpListenerResponse>(response =>
                     {
-                        response.ContentType = "text/javascript";
+                        response.ContentType = "application/javascript";
 
                         var versionsJson = JObject.Parse(@"{ ""versions"": [] }");
                         var array = versionsJson["versions"] as JArray;

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/FileSystemBackedV3MockServer.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/FileSystemBackedV3MockServer.cs
@@ -1,0 +1,143 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using Newtonsoft.Json.Linq;
+using NuGet.Packaging.Core;
+using NuGet.Protocol;
+
+namespace NuGet.CommandLine.Test
+{
+    public class FileSystemBackedV3MockServer : MockServer
+    {
+        private string _packageDirectory;
+        private readonly MockResponseBuilder _builder;
+        public FileSystemBackedV3MockServer(string packageDirectory)
+        {
+            _packageDirectory = packageDirectory;
+            _builder = new MockResponseBuilder(Uri.TrimEnd(new[] { '/' }));
+            InitializeServer();
+        }
+
+        public ISet<PackageIdentity> UnlistedPackages { get; } = new HashSet<PackageIdentity>();
+
+        public string ServiceIndexUri => Uri + _builder.GetV3IndexPath();
+
+        private void InitializeServer()
+        {
+            Get.Add(
+                _builder.GetV3IndexPath(),
+                request =>
+                {
+                    return new Action<HttpListenerResponse>(response =>
+                    {
+                        var mockResponse = _builder.BuildV3IndexResponse(this);
+                        response.ContentType = mockResponse.ContentType;
+                        SetResponseContent(response, mockResponse.Content);
+                    });
+                });
+
+            Get.Add("/", request =>
+            {
+                return ServerHandlerV3(request);
+            });
+
+        }
+
+        private Action<HttpListenerResponse> ServerHandlerV3(HttpListenerRequest request)
+        {
+            try
+            {
+                var path = GetRequestUrlAbsolutePath(request);
+                var parts = request.Url.AbsolutePath.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
+
+                if (path.StartsWith("/flat/") && path.EndsWith("/index.json"))
+                {
+                    return new Action<HttpListenerResponse>(response =>
+                    {
+                        response.ContentType = "text/javascript";
+
+                        var versionsJson = JObject.Parse(@"{ ""versions"": [] }");
+                        var array = versionsJson["versions"] as JArray;
+
+                        var id = parts[parts.Length - 2];
+
+                        foreach (var pkg in LocalFolderUtility.GetPackagesV2(_packageDirectory, id, Common.NullLogger.Instance))
+                        {
+                            array.Add(pkg.Identity.Version.ToNormalizedString());
+                        }
+
+                        SetResponseContent(response, versionsJson.ToString());
+                    });
+                }
+                else if (path.StartsWith("/flat/") && path.EndsWith(".nupkg"))
+                {
+                    var file = new FileInfo(Path.Combine(_packageDirectory, parts.Last()));
+
+                    if (file.Exists)
+                    {
+                        return new Action<HttpListenerResponse>(response =>
+                        {
+                            response.ContentType = "application/zip";
+                            using (var stream = file.OpenRead())
+                            {
+                                var content = stream.ReadAllBytes();
+                                SetResponseContent(response, content);
+                            }
+                        });
+                    }
+                    else
+                    {
+                        return new Action<HttpListenerResponse>(response =>
+                        {
+                            response.StatusCode = 404;
+                        });
+                    }
+                }
+                else if (path == "/nuget")
+                {
+                    return new Action<HttpListenerResponse>(response =>
+                    {
+                        response.StatusCode = 200;
+                    });
+                }
+                else if (path.StartsWith("/reg/") && path.EndsWith("/index.json"))
+                {
+                    var id = parts[parts.Length - 2];
+                    var packages = LocalFolderUtility.GetPackagesV2(_packageDirectory, id, Common.NullLogger.Instance);
+
+                    if (packages.Any())
+                    {
+                        return new Action<HttpListenerResponse>(response =>
+                        {
+                            response.ContentType = "text/javascript";
+                            var packageToListedMapping = packages.Select(e => new KeyValuePair<PackageIdentity, bool>(e.Identity, !UnlistedPackages.Contains(e.Identity))).ToArray();
+                            MockResponse mockResponse = _builder.BuildRegistrationIndexResponse(this, packageToListedMapping);
+                            SetResponseContent(response, mockResponse.Content);
+                        });
+                    }
+                    else
+                    {
+                        return new Action<HttpListenerResponse>(response =>
+                        {
+                            response.StatusCode = 404;
+                        });
+                    }
+                }
+                else
+                {
+                    throw new Exception("This test needs to be updated to support: " + path);
+                }
+            }
+            catch (Exception)
+            {
+                // Debug here
+                throw;
+            }
+        }
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/MockResponses/MockResponse.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/MockResponses/MockResponse.cs
@@ -1,4 +1,4 @@
-﻿namespace NuGet.CommandLine.Test.Caching
+namespace NuGet.CommandLine.Test
 {
     public class MockResponse
     {

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGet.CommandLine.Test.csproj
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGet.CommandLine.Test.csproj
@@ -60,6 +60,6 @@
     </PostBuildEvent>
   </PropertyGroup>
 
-  <Import Project="$(BuildCommonDirectory)common.targets"/>
+  <Import Project="$(BuildCommonDirectory)common.targets" />
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 </Project>

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Util.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Util.cs
@@ -691,10 +691,19 @@ namespace NuGet.CommandLine.Test
         /// </summary>
         public static JObject CreateSinglePackageRegistrationBlob(MockServer server, string id, string version)
         {
+            return CreatePackageRegistrationBlob(server, id, new KeyValuePair<string, bool>[] { new KeyValuePair<string, bool>(version, true) });
+        }
+
+        /// <summary>
+        /// Create a registration blob for a package
+        /// </summary>
+        public static JObject CreatePackageRegistrationBlob(MockServer server, string id, IEnumerable<KeyValuePair<string, bool>> versionToListedMap)
+        {
             var indexUrl = string.Format(CultureInfo.InvariantCulture,
                                     "{0}reg/{1}/index.json", server.Uri, id);
-
-            JObject regBlob = new JObject();
+            var lowerBound = "0.0.0";
+            var upperBound = "9.0.0";
+            var regBlob = new JObject();
             regBlob.Add(new JProperty("@id", indexUrl));
             var typeArray = new JArray();
             regBlob.Add(new JProperty("@type", typeArray));
@@ -712,20 +721,28 @@ namespace NuGet.CommandLine.Test
             var page = new JObject();
             pages.Add(page);
 
-            page.Add(new JProperty("@id", indexUrl + "#page/0.0.0/9.0.0"));
+            page.Add(new JProperty("@id", indexUrl + $"#page/{lowerBound}/{upperBound}"));
             page.Add(new JProperty("@type", indexUrl + "catalog:CatalogPage"));
             page.Add(new JProperty("commitId", Guid.NewGuid()));
             page.Add(new JProperty("commitTimeStamp", "2015-06-22T22:30:00.1487642Z"));
-            page.Add(new JProperty("count", "1"));
+            page.Add(new JProperty("count", versionToListedMap.Count()));
             page.Add(new JProperty("parent", indexUrl));
-            page.Add(new JProperty("lower", "0.0.0"));
-            page.Add(new JProperty("upper", "9.0.0"));
+            page.Add(new JProperty("lower", lowerBound));
+            page.Add(new JProperty("upper", upperBound));
 
             var items = new JArray();
             page.Add(new JProperty("items", items));
+            foreach (var versionToListed in versionToListedMap)
+            {
+                var item = GetPackageRegistrationItem(server, id, version: versionToListed.Key, listed: versionToListed.Value, indexUrl);
+                items.Add(item);
+            }
+            return regBlob;
+        }
 
+        private static JObject GetPackageRegistrationItem(MockServer server, string id, string version, bool listed, string indexUrl)
+        {
             var item = new JObject();
-            items.Add(item);
 
             item.Add(new JProperty("@id",
                     string.Format("{0}reg/{1}/{2}.json", server.Uri, id, version)));
@@ -749,7 +766,7 @@ namespace NuGet.CommandLine.Test
             catalogEntry.Add(new JProperty("id", id));
             catalogEntry.Add(new JProperty("language", "en-us"));
             catalogEntry.Add(new JProperty("licenseUrl", ""));
-            catalogEntry.Add(new JProperty("listed", true));
+            catalogEntry.Add(new JProperty("listed", listed));
             catalogEntry.Add(new JProperty("minClientVersion", ""));
             catalogEntry.Add(new JProperty("projectUrl", ""));
             catalogEntry.Add(new JProperty("published", "2015-06-22T22:30:00.1487642Z"));
@@ -759,7 +776,7 @@ namespace NuGet.CommandLine.Test
             catalogEntry.Add(new JProperty("version", version));
             catalogEntry.Add(new JProperty("tags", new JArray()));
 
-            return regBlob;
+            return item;
         }
 
         public static string CreateProjFileContent(


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/4197
Regression: No
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: 
Remove the dependency to NuGet.Core in the self-updater part of NuGet.exe. 
Use the APIs that go through the signature validation code.   

## Testing/Validation

Tests Added: Yes  
Reason for not adding tests:  
Validation:  
