### PR TITLE
Accessibility fixes, No. 1

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/LicenseAcceptanceWindow.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/LicenseAcceptanceWindow.xaml
@@ -185,7 +185,6 @@
           Margin="0,12"
           Content="{x:Static nuget:Resources.Button_IAccept}"
           AutomationProperties.AutomationId="AcceptButton"
-          AutomationProperties.LabeledBy="{Binding ElementName=_licenseText}"
           Click="OnAcceptButtonClick" />
       <Button
           Grid.Column="2"

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/LicenseAcceptanceWindow.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/LicenseAcceptanceWindow.xaml
@@ -162,7 +162,6 @@
       Grid.Column="0"
       Margin="12,0,12,12"
       x:Name="_licenseText"
-      AutomationProperties.Name="{Binding Text}"
       Text="{x:Static nuget:Resources.Text_LicenseText}"
       TextWrapping="Wrap" />
     <Grid

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PreviewWindow.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PreviewWindow.xaml
@@ -47,7 +47,6 @@
       Margin="12,12,12,0"
       TextWrapping="Wrap"
       x:Name="_changesText"
-      AutomationProperties.Name="{Binding Text}"
       Text="{x:Static nuget:Resources.Text_Changes}" />
       <Button
         Grid.Column="1"

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PreviewWindow.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PreviewWindow.xaml
@@ -10,7 +10,6 @@
   Foreground="{DynamicResource {x:Static nuget:Brushes.UIText}}"
   WindowStartupLocation="CenterOwner"
   Title="{Binding Title}"
-  AutomationProperties.LabeledBy="{Binding ElementName=_changesText}"
   Height="500"
   Width="500"
   MinWidth="{Binding WindowMinwidth}"


### PR DESCRIPTION
## Bug

Fixes:
- https://github.com/NuGet/Home/issues/9077
- https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1049204
- https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1049209

Regression: No

## Fixes

### Preview Window Fix
Removes the AutomationProperties.LabeledBy property that makes Narrator read the text content rather than the title of the preview Window

### License Acceptance Window fix
Removes the AutomationProperties.LabeledBy property that makes Narrator read the 'By clicking ...' statement rather than the text oft the button (I accept).

In both fixes, an unnecessary  AutomationProperties.Name is removed.

## Testing/Validation

### Preview Window Fix

#### Before

Window title reads the text 'Visual Studio is about to make...'. See text in bold.

![image](https://user-images.githubusercontent.com/1192347/73114717-f522b180-3ed1-11ea-86a0-e2aa8bfb730d.png)


#### After

Window title reads the text 'Preview Changes'. See text in bold.

![image](https://user-images.githubusercontent.com/1192347/73114866-50a16f00-3ed3-11ea-9340-7c3ed7b890e5.png)


### License Acceptance Window fix

#### Before

Button reads 'By clicking ...'. See text in bold.

![image](https://user-images.githubusercontent.com/1192347/73114752-619db080-3ed2-11ea-9861-f787d2070272.png)


#### After

Button reads 'I accept'. See text in bold.

![image](https://user-images.githubusercontent.com/1192347/73114901-a5dd8080-3ed3-11ea-8354-a0bbe1951a27.png)


Tests Added: No
Reason for not adding tests: There's no infra for UI/Accessibility testing 
Validation:  Manual Validation with Accessibility Insights tool. See Before/After scenarios
