### PR TITLE
Find projects in Solution Folders in context provider

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPathContextProvider.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPathContextProvider.cs
@@ -9,7 +9,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using EnvDTE;
-using EnvDTE80;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Threading;
 using NuGet.Common;

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPathContextProvider.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPathContextProvider.cs
@@ -171,7 +171,7 @@ namespace NuGet.VisualStudio
             await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
             var dte = await _asyncServiceprovider.GetDTEAsync();
-            var supportedProjects = GetProjectsInSolution(dte);
+            IList<Project> supportedProjects = GetProjectsInSolution(dte);
 
             foreach (var solutionProject in supportedProjects)
             {
@@ -315,14 +315,14 @@ namespace NuGet.VisualStudio
 
         private IList<Project> GetProjectsInSolution(DTE dte)
         {
-            var supportedProjects = dte.Solution.Projects;
             Projects projects = dte.Solution.Projects;
 
-            List<Project> projectList = new List<Project>();
-            var item = projects.GetEnumerator();
-            while (item.MoveNext())
+            var projectList = new List<Project>();
+
+            foreach (var item in projects)
             {
-                var project = item.Current as Project;
+                Project project = item as Project;
+
                 if (project == null)
                 {
                     continue;
@@ -348,10 +348,10 @@ namespace NuGet.VisualStudio
         /// </summary>
         private IEnumerable<Project> GetSolutionFolderProjects(Project solutionFolder)
         {
-            List<Project> projectList = new List<Project>();
+            var projectList = new List<Project>();
             for (var i = 1; i <= solutionFolder.ProjectItems.Count; i++)
             {
-                var subProject = solutionFolder.ProjectItems.Item(i).SubProject;
+                Project subProject = solutionFolder.ProjectItems.Item(i).SubProject;
                 if (subProject == null)
                 {
                     continue;

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPathContextProvider.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPathContextProvider.cs
@@ -315,7 +315,7 @@ namespace NuGet.VisualStudio
 
         private IList<Project> GetProjectsInSolution(DTE dte)
         {
-            var supportedProjects = dte.Solution.Projects; // dte.Solution.Projects.Cast<EnvDTE.Project>();
+            var supportedProjects = dte.Solution.Projects;
             Projects projects = dte.Solution.Projects;
 
             List<Project> projectList = new List<Project>();

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPathContextProvider.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPathContextProvider.cs
@@ -313,7 +313,7 @@ namespace NuGet.VisualStudio
                 trie);
         }
 
-        private IList<Project> GetProjectsInSolution(DTE dte)
+        private IReadOnlyList<Project> GetProjectsInSolution(DTE dte)
         {
             Projects projects = dte.Solution.Projects;
 
@@ -330,7 +330,7 @@ namespace NuGet.VisualStudio
 
                 if (project.Kind == ProjectKinds.vsProjectKindSolutionFolder)
                 {
-                    IEnumerable<Project> solutionFolderProjects = GetSolutionFolderProjects(project);
+                    IReadOnlyList<Project> solutionFolderProjects = GetSolutionFolderProjects(project);
                     projectList.AddRange(solutionFolderProjects);
                 }
                 else
@@ -346,7 +346,7 @@ namespace NuGet.VisualStudio
         /// Gets all projects that are not solution folders within the given solutionFolder.
         /// (i.e. If the hierarchy is src\a\b.xproj, src\c.xproj; the resulting list will contain b.xproj and c.xproj).
         /// </summary>
-        private IEnumerable<Project> GetSolutionFolderProjects(Project solutionFolder)
+        private IReadOnlyList<Project> GetSolutionFolderProjects(Project solutionFolder)
         {
             var projectList = new List<Project>();
             for (var i = 1; i <= solutionFolder.ProjectItems.Count; i++)

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPathContextProvider.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPathContextProvider.cs
@@ -171,7 +171,7 @@ namespace NuGet.VisualStudio
             await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
             var dte = await _asyncServiceprovider.GetDTEAsync();
-            IList<Project> supportedProjects = GetProjectsInSolution(dte);
+            IReadOnlyList<Project> supportedProjects = GetProjectsInSolution(dte);
 
             foreach (var solutionProject in supportedProjects)
             {

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPathContextProvider.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPathContextProvider.cs
@@ -10,7 +10,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using EnvDTE;
 using EnvDTE80;
-using Microsoft.IdentityModel.Clients.ActiveDirectory;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Threading;
 using NuGet.Common;
@@ -345,7 +344,7 @@ namespace NuGet.VisualStudio
 
         /// <summary>
         /// Gets all projects that are not solution folders within the given solutionFolder.
-        /// (i.e. If the heirarchy is src\a\b.xproj, src\c.xproj; the resulting list will contain b.xproj and c.xproj)
+        /// (i.e. If the hierarchy is src\a\b.xproj, src\c.xproj; the resulting list will contain b.xproj and c.xproj).
         /// </summary>
         private IEnumerable<Project> GetSolutionFolderProjects(Project solutionFolder)
         {

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPathContextProvider.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPathContextProvider.cs
@@ -321,7 +321,7 @@ namespace NuGet.VisualStudio
 
             foreach (var item in projects)
             {
-                Project project = item as Project;
+                var project = item as Project;
 
                 if (project == null)
                 {


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/8868
Regression: No

## Fix
Followed the recursive technique for finding Projects that's used in another VS Repo (Microsoft.WebTools.Azure.WebJobs). 

It iterates the Project collection, and if it sees a Solution Folder type (`ProjectKinds.vsProjectKindSolutionFolder`), it recursively looks for Projects within that folder.

Now, if the project hierarchy is:
`src\a\b.xproj`
`src\c.xproj` 
...the resulting project list will contain `b.xproj` and `c.xproj`.

I also looked into converting over to an implementation of `Microsoft.VisualStudio.Shell.Interop.IVsSolution`. However, this seemed like a major effort and not appropriate to do now (maybe never needed, but I can create a tracking issue if anyone has thoughts that we should). For now, recursion with the DTE API seems acceptable.

## Testing/Validation

Tests Added: No
Reason for not adding tests: 
My understanding is we can't mock DTE due to its complexity and scope. I'm open to suggestions if there's any automated testing we can do here.

The IVsSolution method of obtaining the Projects may be more testable if/when we go there.

Validation:  
Opened a project **without a solution folder** before/after this commit. Toolbox loaded the items as expected in both cases.

Opened a project **with a solution folder** before this commit, and no Toolbox items were loaded.
After this commit, the Toolbox items were loaded as expected.

There may be more intricate WPF scenarios I could validate.... //cc @rrelyea thoughts?
