### PR TITLE
Revert: Improve MSBuild SDK resolver by parsing global.json with System.Runtime.Serialization.Json #3157

### DIFF
--- a/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/GlobalJsonReader.cs
+++ b/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/GlobalJsonReader.cs
@@ -1,11 +1,14 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using Microsoft.Build.Shared;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
-using System.Xml;
+using System.Linq;
+using System.Runtime.CompilerServices;
 using Microsoft.Build.Framework;
 
 namespace Microsoft.Build.NuGetSdkResolver
@@ -25,26 +28,27 @@ namespace Microsoft.Build.NuGetSdkResolver
         /// <returns>A <see cref="Dictionary{String,String}"/> of MSBuild SDK versions from a global.json if found, otherwise <code>null</code>.</returns>
         public static Dictionary<string, string> GetMSBuildSdkVersions(SdkResolverContext context)
         {
-            var projectFile = new FileInfo(context.ProjectFilePath);
+            var projectDirectory = Directory.GetParent(context.ProjectFilePath);
 
-            if (!TryGetPathOfFileAbove(GlobalJsonFileName, projectFile.Directory, out var globalJsonPath))
+            if (projectDirectory == null
+                || !projectDirectory.Exists
+                || !TryGetPathOfFileAbove(GlobalJsonFileName, projectDirectory.FullName, out var globalJsonPath))
             {
                 return null;
             }
 
-            // Read the contents of global.json
-            var globalJsonContents = File.ReadAllText(globalJsonPath);
+            var contents = File.ReadAllText(globalJsonPath);
 
             // Look ahead in the contents to see if there is an msbuild-sdks section.  Deserializing the file requires us to load
-            // additional assemblies which can be a waste since global.json is usually ~100 bytes of text.
-            if (globalJsonContents.IndexOf(MSBuildSdksPropertyName, StringComparison.Ordinal) == -1)
+            // Newtonsoft.Json which is 500 KB while a global.json is usually ~100 bytes of text.
+            if (contents.IndexOf(MSBuildSdksPropertyName, StringComparison.Ordinal) == -1)
             {
                 return null;
             }
 
             try
             {
-                return ParseMSBuildSdksFromGlobalJson(globalJsonPath);
+                return Deserialize(contents);
             }
             catch (Exception e)
             {
@@ -56,86 +60,85 @@ namespace Microsoft.Build.NuGetSdkResolver
         }
 
         /// <summary>
-        /// Searches for a file based on the specified starting directory.
+        /// Deserializes a global.json and returns the MSBuild SDK versions
         /// </summary>
-        /// <param name="fileName">The name of the file to search for.</param>
-        /// <param name="startingDirectory">An optional <see cref="DirectoryInfo" /> representing the directory to start the search in.</param>
-        /// <param name="result">Receives the <see cref="FileInfo" /> of the file if found, otherwise <code>null</code>.</param>
-        /// <returns><code>true</code> if a file was found in the directory or any parent directory, otherwise <code>false</code>.</returns>
-        public static bool TryGetPathOfFileAbove(string fileName, DirectoryInfo startingDirectory, out string result)
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static Dictionary<string, string> Deserialize(string value)
         {
-            result = null;
+            return JsonConvert.DeserializeObject<GlobalJsonFile>(value).MSBuildSdks;
+        }
 
-            if (startingDirectory == null || !startingDirectory.Exists)
-            {
-                return false;
-            }
-
-            var lookInDirectory = startingDirectory;
-
-            do
-            {
-                var possibleFile = new FileInfo(Path.Combine(lookInDirectory.FullName, fileName));
-
-                if (possibleFile.Exists)
-                {
-                    result = possibleFile.FullName;
-
-                    return true;
-                }
-
-                lookInDirectory = lookInDirectory.Parent;
-            }
-            while (lookInDirectory != null);
-
-            return false;
+        private sealed class GlobalJsonFile
+        {
+            [JsonProperty(MSBuildSdksPropertyName)]
+            public Dictionary<string, string> MSBuildSdks { get; set; }
         }
 
         /// <summary>
-        /// Parses a global.json and returns the MSBuild SDK versions.
+        /// Searches for a file based on the specified starting directory.
         /// </summary>
-        /// <remarks>
-        /// NoInlining is enabled ensure that System.Runtime.Serialization.Json.dll isn't loaded unless the method is called.
-        /// </remarks>
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        private static Dictionary<string, string> ParseMSBuildSdksFromGlobalJson(string path)
+        /// <param name="file">The file to search for.</param>
+        /// <param name="startingDirectory">An optional directory to start the search in.  The default location is the directory
+        /// of the file containing the property function.</param>
+        /// <returns>The full path of the file if it is found, otherwise an empty string.</returns>
+        private static string GetPathOfFileAbove(string file, string startingDirectory)
         {
-            Dictionary<string, string> sdks = null;
+            // Search for a directory that contains that file
+            var directoryName = GetDirectoryNameOfFileAbove(startingDirectory, file);
 
-            using (var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read))
-            using (var reader = System.Runtime.Serialization.Json.JsonReaderWriterFactory.CreateJsonReader(stream, XmlDictionaryReaderQuotas.Max))
+            return string.IsNullOrEmpty(directoryName) ? string.Empty : NormalizePath(Path.Combine(directoryName, file));
+        }
+
+        private static bool TryGetPathOfFileAbove(string file, string startingDirectory, out string fullPath)
+        {
+            fullPath = GetPathOfFileAbove(file, startingDirectory);
+
+            return fullPath != string.Empty;
+        }
+
+        /// <summary>
+        /// Locate a file in either the directory specified or a location in the
+        /// directory structure above that directory.
+        /// </summary>
+        private static string GetDirectoryNameOfFileAbove(string startingDirectory, string fileName)
+        {
+            // Canonicalize our starting location
+            var lookInDirectory = Path.GetFullPath(startingDirectory);
+
+            do
             {
-                while (reader.Read())
+                // Construct the path that we will use to test against
+                var possibleFileDirectory = Path.Combine(lookInDirectory, fileName);
+
+                // If we successfully locate the file in the directory that we're
+                // looking in, simply return that location. Otherwise we'll
+                // keep moving up the tree.
+                if (File.Exists(possibleFileDirectory))
                 {
-                    if (reader.LocalName.Equals(MSBuildSdksPropertyName) && reader.Depth == 1)
-                    {
-                        while (reader.Read())
-                        {
-                            if (reader.NodeType == XmlNodeType.Element)
-                            {
-                                string name = reader.LocalName.Trim();
-
-                                if (!string.IsNullOrWhiteSpace(name) && reader.Read() && reader.NodeType == XmlNodeType.Text)
-                                {
-                                    if (sdks == null)
-                                    {
-                                        sdks = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-                                    }
-
-                                    var value = reader.Value.Trim();
-
-                                    if (!string.IsNullOrWhiteSpace(value))
-                                    {
-                                        sdks[name] = value;
-                                    }
-                                }
-                            }
-                        }
-                    }
+                    // We've found the file, return the directory we found it in
+                    return lookInDirectory;
+                }
+                else
+                {
+                    // GetDirectoryName will return null when we reach the root
+                    // terminating our search
+                    lookInDirectory = Path.GetDirectoryName(lookInDirectory);
                 }
             }
+            while (lookInDirectory != null);
 
-            return sdks;
+            // When we didn't find the location, then return an empty string
+            return string.Empty;
+        }
+
+        private static string NormalizePath(string path)
+        {
+            return FixFilePath(Path.GetFullPath(path));
+
+        }
+        private static string FixFilePath(string path)
+        {
+            return string.IsNullOrEmpty(path) || Path.DirectorySeparatorChar == '\\' ? path : path.Replace('\\', '/');
         }
     }
 }

--- a/test/NuGet.Core.Tests/Microsoft.Build.NuGetSdkResolver.Tests/GlobalJsonReader_Tests.cs
+++ b/test/NuGet.Core.Tests/Microsoft.Build.NuGetSdkResolver.Tests/GlobalJsonReader_Tests.cs
@@ -60,6 +60,39 @@ namespace Microsoft.Build.NuGetSdkResolver.Test
         }
 
         [Fact]
+        public void GlobalJsonWithComments()
+        {
+            using (var testEnvironment = TestEnvironment.Create())
+            {
+                TransientTestFolder folder = testEnvironment.CreateFolder();
+
+                try
+                {
+                    File.WriteAllText(
+                        Path.Combine(folder.FolderPath, GlobalJsonReader.GlobalJsonFileName),
+                        @"{
+  // This is a comment
+  ""msbuild-sdks"": {
+    /* This is another comment */
+    ""foo"": ""1.0.0""
+  }
+}");
+
+                    var context = new MockSdkResolverContext(Path.Combine(folder.FolderPath, "foo.proj"));
+
+                    GlobalJsonReader.GetMSBuildSdkVersions(context).ShouldAllBeEquivalentTo(new Dictionary<string, string>
+                    {
+                        ["foo"] = "1.0.0"
+                    });
+                }
+                finally
+                {
+                    folder.Revert();
+                }
+            }
+        }
+
+        [Fact]
         public void InvalidJsonLogsMessage()
         {
             var expectedVersions = new Dictionary<string, string>

--- a/test/NuGet.Core.Tests/Microsoft.Build.NuGetSdkResolver.Tests/GlobalJsonReader_Tests.cs
+++ b/test/NuGet.Core.Tests/Microsoft.Build.NuGetSdkResolver.Tests/GlobalJsonReader_Tests.cs
@@ -6,47 +6,56 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using FluentAssertions;
-using NuGet.Test.Utility;
 using Xunit;
 
 namespace Microsoft.Build.NuGetSdkResolver.Test
 {
     public class GlobalJsonReaderTests
     {
-        [Fact]
-        public void EmptyGlobalJson()
+        public static string WriteGlobalJson(string directory, Dictionary<string, string> sdkVersions, string additionalcontent = "")
         {
-            using (var testDirectory = TestDirectory.Create())
+            var path = Path.Combine(directory, GlobalJsonReader.GlobalJsonFileName);
+
+            using (var writer = File.CreateText(path))
             {
-                File.WriteAllText(Path.Combine(testDirectory.Path, GlobalJsonReader.GlobalJsonFileName), @" { } ");
+                writer.WriteLine("{");
+                if (sdkVersions != null)
+                {
+                    writer.WriteLine("    \"msbuild-sdks\": {");
+                    writer.WriteLine(string.Join($",{Environment.NewLine}        ", sdkVersions.Select(i => $"\"{i.Key}\": \"{i.Value}\"")));
+                    writer.WriteLine("    }");
+                }
 
-                var context = new MockSdkResolverContext(Path.Combine(testDirectory.Path, "foo.proj"));
+                if (!string.IsNullOrWhiteSpace(additionalcontent))
+                {
+                    writer.Write(additionalcontent);
+                }
 
-                GlobalJsonReader.GetMSBuildSdkVersions(context).Should().BeNull();
+                writer.WriteLine("}");
             }
+
+            return path;
         }
 
         [Fact]
-        public void EmptyVersionsAreIgnored()
+        public void EmptyGlobalJson()
         {
-            using (var testDirectory = TestDirectory.Create())
+            using (var testEnvironment = TestEnvironment.Create())
             {
-                var context = new MockSdkResolverContext(Path.Combine(testDirectory.Path, "foo.proj"));
+                TransientTestFolder folder = testEnvironment.CreateFolder();
 
-                WriteGlobalJson(
-                    testDirectory,
-                    new Dictionary<string, string>
-                    {
-                        ["foo"] = "1.0.0",
-                        ["bar"] = "",
-                        ["baz"] = "  ",
-                        ["bax"] = null
-                    });
-
-                GlobalJsonReader.GetMSBuildSdkVersions(context).Should().Equal(new Dictionary<string, string>
+                try
                 {
-                    ["foo"] = "1.0.0"
-                });
+                    File.WriteAllText(Path.Combine(folder.FolderPath, GlobalJsonReader.GlobalJsonFileName), @" { } ");
+
+                    var context = new MockSdkResolverContext(Path.Combine(folder.FolderPath, "foo.proj"));
+
+                    GlobalJsonReader.GetMSBuildSdkVersions(context).Should().BeNull();
+                }
+                finally
+                {
+                    folder.Revert();
+                }
             }
         }
 
@@ -59,17 +68,27 @@ namespace Microsoft.Build.NuGetSdkResolver.Test
                 {"bar", "2.0.0"}
             };
 
-            using (var testDirectory = TestDirectory.Create())
+            using (var testEnvironment = TestEnvironment.Create())
             {
-                var globalJsonPath = WriteGlobalJson(testDirectory, expectedVersions, additionalContent: ", abc");
+                var testFolder = testEnvironment.CreateFolder();
 
-                var context = new MockSdkResolverContext(Path.Combine(testDirectory.Path, "foo.proj"));
+                try
+                {
+                    var projectFile = testEnvironment.CreateFile(testFolder, ".proj");
+                    var globalJsonPath = WriteGlobalJson(testFolder.FolderPath, expectedVersions, additionalcontent: ", abc");
 
-                GlobalJsonReader.GetMSBuildSdkVersions(context).Should().BeNull();
+                    var context = new MockSdkResolverContext(projectFile.Path);
 
-                context.MockSdkLogger.LoggedMessages.Count.Should().Be(1);
-                context.MockSdkLogger.LoggedMessages.First().Key.Should().Be(
-                    $"Failed to parse \"{globalJsonPath}\". Encountered unexpected character 'a'.");
+                    GlobalJsonReader.GetMSBuildSdkVersions(context).Should().BeNull();
+
+                    context.MockSdkLogger.LoggedMessages.Count.Should().Be(1);
+                    context.MockSdkLogger.LoggedMessages.First().Key.Should().Be(
+                        $"Failed to parse \"{globalJsonPath}\". Invalid JavaScript property identifier character: }}. Path \'msbuild-sdks\', line 6, position 5.");
+                }
+                finally
+                {
+                    testFolder.Revert();
+                }
             }
         }
 
@@ -82,70 +101,25 @@ namespace Microsoft.Build.NuGetSdkResolver.Test
                 {"bar", "2.0.0"}
             };
 
-            using (var testDirectory = TestDirectory.Create())
+            using (var testEnvironment = TestEnvironment.Create())
             {
-                WriteGlobalJson(testDirectory, expectedVersions);
+                var testFolder = testEnvironment.CreateFolder();
 
-                var context = new MockSdkResolverContext(Path.Combine(testDirectory.Path, "foo.proj"));
-
-                GlobalJsonReader.GetMSBuildSdkVersions(context).Should().Equal(expectedVersions);
-            }
-        }
-
-        [Theory]
-        [InlineData("one")]
-        [InlineData("one", "two")]
-        [InlineData("one", "two", "three")]
-        public void TryGetPathOfFileAboveRecursive(params string[] directories)
-        {
-            const string filename = "test.txt";
-
-            using (var testDirectory = TestDirectory.Create())
-            {
-                var paths = new List<string>
+                try
                 {
-                    testDirectory.Path
-                };
+                    var projectFile = testEnvironment.CreateFile(testFolder, ".proj");
 
-                paths.AddRange(directories);
+                    WriteGlobalJson(testFolder.FolderPath, expectedVersions);
 
-                var directory = new DirectoryInfo(Path.Combine(paths.ToArray()));
+                    var context = new MockSdkResolverContext(projectFile.Path);
 
-                directory.Create();
-
-                var expected = Path.Combine(testDirectory.Path, filename);
-
-                File.WriteAllText(expected, string.Empty);
-
-                GlobalJsonReader.TryGetPathOfFileAbove(filename, directory, out string result).Should().BeTrue();
-
-                result.Should().Be(expected);
-            }
-        }
-
-        internal static string WriteGlobalJson(TestDirectory testDirectory, Dictionary<string, string> sdkVersions, string additionalContent = "")
-        {
-            var path = Path.Combine(testDirectory, GlobalJsonReader.GlobalJsonFileName);
-
-            using (var writer = File.CreateText(path))
-            {
-                writer.WriteLine("{");
-                if (sdkVersions != null)
-                {
-                    writer.WriteLine("    \"msbuild-sdks\": {");
-                    writer.WriteLine(string.Join($",{Environment.NewLine}        ", sdkVersions.Select(i => $"\"{i.Key}\": {(i.Value == null ? "null" : $"\"{i.Value}\"")}")));
-                    writer.WriteLine("    }");
+                    GlobalJsonReader.GetMSBuildSdkVersions(context).Should().Equal(expectedVersions);
                 }
-
-                if (!string.IsNullOrWhiteSpace(additionalContent))
+                finally
                 {
-                    writer.Write(additionalContent);
+                    testFolder.Revert();
                 }
-
-                writer.WriteLine("}");
             }
-
-            return path;
         }
     }
 }

--- a/test/NuGet.Core.Tests/Microsoft.Build.NuGetSdkResolver.Tests/Microsoft.Build.NuGetSdkResolver.Test.csproj
+++ b/test/NuGet.Core.Tests/Microsoft.Build.NuGetSdkResolver.Tests/Microsoft.Build.NuGetSdkResolver.Test.csproj
@@ -1,4 +1,4 @@
-<Project>
+﻿<Project>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common.test.props" />
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
   
@@ -11,7 +11,6 @@
 
   <ItemGroup>
     <ProjectReference Include="$(NuGetCoreSrcDirectory)Microsoft.Build.NuGetSdkResolver\Microsoft.Build.NuGetSdkResolver.csproj" />
-    <ProjectReference Include="$(TestUtilitiesDirectory)Test.Utility\Test.Utility.csproj" />
     <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildPackageVersion)" />
   </ItemGroup>
 

--- a/test/NuGet.Core.Tests/Microsoft.Build.NuGetSdkResolver.Tests/NuGetSdkResolver_Tests.cs
+++ b/test/NuGet.Core.Tests/Microsoft.Build.NuGetSdkResolver.Tests/NuGetSdkResolver_Tests.cs
@@ -1,12 +1,14 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Collections.Generic;
-using System.IO;
-using FluentAssertions;
-using NuGet.Test.Utility;
+using System;
 using NuGet.Versioning;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using FluentAssertions;
 using Xunit;
+
 using SdkResolverContextBase = Microsoft.Build.Framework.SdkResolverContext;
 
 namespace Microsoft.Build.NuGetSdkResolver.Test
@@ -22,11 +24,14 @@ namespace Microsoft.Build.NuGetSdkResolver.Test
                 {"bar", "2.0.0"}
             };
 
-            using (var testDirectory = TestDirectory.Create())
+            using (var testEnvironment = TestEnvironment.Create())
             {
-                GlobalJsonReaderTests.WriteGlobalJson(testDirectory, expectedVersions);
+                var testFolder = testEnvironment.CreateFolder();
+                var projectFile = testEnvironment.CreateFile(testFolder, ".proj");
 
-                var context = new MockSdkResolverContext(Path.Combine(testDirectory.Path, "foo.proj"));
+                GlobalJsonReaderTests.WriteGlobalJson(testFolder.FolderPath, expectedVersions);
+
+                var context = new MockSdkResolverContext(projectFile.Path);
 
                 VerifyTryGetNuGetVersionForSdk(
                     version: null,

--- a/test/NuGet.Core.Tests/Microsoft.Build.NuGetSdkResolver.Tests/TestEnvironment.cs
+++ b/test/NuGet.Core.Tests/Microsoft.Build.NuGetSdkResolver.Tests/TestEnvironment.cs
@@ -1,0 +1,1301 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+// Note: This was taken from:
+// https://github.com/Microsoft/msbuild/blob/6b395a35e3ef2353a5473a718c2262d1f095fd2c/src/Shared/UnitTests/TestEnvironment.cs
+// It is only used for test purposes and no need to keep in sync. All of the test dependencies are included in this file.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Security;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading;
+using FluentAssertions;
+using Microsoft.Build.Framework;
+using Xunit;
+using Xunit.Abstractions;
+
+using TempPaths = System.Collections.Generic.Dictionary<string, string>;
+
+namespace Microsoft.Build.NuGetSdkResolver.Test
+{
+    public class TestEnvironment : IDisposable
+    {
+        /// <summary>
+        ///     List of test invariants to assert value does not change.
+        /// </summary>
+        private readonly List<TestInvariant> _invariants = new List<TestInvariant>();
+
+        /// <summary>
+        ///     List of test variants which need to be reverted when the test completes.
+        /// </summary>
+        private readonly List<TransientTestState> _variants = new List<TransientTestState>();
+
+        private readonly ITestOutputHelper _output;
+
+        private readonly Lazy<TransientTestFolder> _defaultTestDirectory;
+
+        private bool _disposed;
+
+        public TransientTestFolder DefaultTestDirectory => _defaultTestDirectory.Value;
+
+        public static TestEnvironment Create(ITestOutputHelper output = null, bool ignoreBuildErrorFiles = false, bool setDefaultInvariants = false)
+        {
+            var env = new TestEnvironment(output ?? new DefaultOutput(), setDefaultInvariants);
+
+            // In most cases, if MSBuild wrote an MSBuild_*.txt to the temp path something went wrong.
+            if (!ignoreBuildErrorFiles)
+            {
+                env.WithInvariant(new BuildFailureLogInvariant());
+            }
+
+            env.SetEnvironmentVariable("MSBUILDRELOADTRAITSONEACHACCESS", "1");
+
+            return env;
+        }
+
+        private TestEnvironment(ITestOutputHelper output, bool setDefaultInvariants = true)
+        {
+            _output = output;
+            _defaultTestDirectory = new Lazy<TransientTestFolder>(() => CreateFolder());
+            if (setDefaultInvariants) SetDefaultInvariant();
+        }
+
+        public void Dispose()
+        {
+            Cleanup();
+            GC.SuppressFinalize(this);
+        }
+
+        ~TestEnvironment()
+        {
+            Cleanup();
+        }
+
+        /// <summary>
+        ///     Revert / cleanup variants and then assert invariants.
+        /// </summary>
+        private void Cleanup()
+        {
+            if (!_disposed)
+            {
+                _disposed = true;
+
+                // Reset test variants
+                foreach (var variant in _variants)
+                    variant.Revert();
+
+                // Assert invariants
+                foreach (var item in _invariants)
+                    item.AssertInvariant(_output);
+
+                if (_defaultTestDirectory.IsValueCreated)
+                {
+                    _defaultTestDirectory.Value.Revert();
+                }
+            }
+        }
+
+        /// <summary>
+        ///     Evaluate the test with the given invariant.
+        /// </summary>
+        /// <param name="invariant">Test invariant to assert unchanged on completion.</param>
+        public T WithInvariant<T>(T invariant) where T : TestInvariant
+        {
+            _invariants.Add(invariant);
+            return invariant;
+        }
+
+        /// <summary>
+        ///     Evaluate the test with the given transient test state.
+        /// </summary>
+        /// <returns>Test state to revert on completion.</returns>
+        public T WithTransientTestState<T>(T transientState) where T : TransientTestState
+        {
+            _variants.Add(transientState);
+            return transientState;
+        }
+
+        /// <summary>
+        ///     Clears all test invariants. This should only be used if there is a known
+        ///     issue with a test!
+        /// </summary>
+        public void ClearTestInvariants()
+        {
+            _invariants.Clear();
+        }
+
+        #region Common test variants
+
+        private void SetDefaultInvariant()
+        {
+            // Temp folder should not change before and after a test
+            WithInvariant(new StringInvariant("Path.GetTempPath()", Path.GetTempPath));
+
+            // Temp folder should not change before and after a test
+            WithInvariant(new StringInvariant("Directory.GetCurrentDirectory", Directory.GetCurrentDirectory));
+
+            WithEnvironmentInvariant();
+        }
+
+        /// <summary>
+        ///     Creates a test invariant that asserts an environment variable does not change during the test.
+        /// </summary>
+        /// <param name="environmentVariableName">Name of the environment variable.</param>
+        public TestInvariant WithEnvironmentVariableInvariant(string environmentVariableName)
+        {
+            return WithInvariant(new StringInvariant(environmentVariableName,
+                () => Environment.GetEnvironmentVariable(environmentVariableName)));
+        }
+        /// <summary>
+        /// Creates a test invariant which asserts that the environment variables do not change
+        /// </summary>
+        public TestInvariant WithEnvironmentInvariant()
+        {
+            return WithInvariant(new EnvironmentInvariant());
+        }
+
+        /// <summary>
+        ///     Creates a string invariant that will assert the value is the same before and after the test.
+        /// </summary>
+        /// <param name="name">Name of the item to keep track of.</param>
+        /// <param name="value">Delegate to get the value for the invariant.</param>
+        public TestInvariant WithStringInvariant(string name, Func<string> value)
+        {
+            return WithInvariant(new StringInvariant(name, value));
+        }
+
+        /// <summary>
+        /// Creates a new temp path
+        /// </summary>
+        public TransientTempPath CreateNewTempPath()
+        {
+            var folder = CreateFolder();
+            return SetTempPath(folder.FolderPath, true);
+        }
+
+        /// <summary>
+        /// Creates a new temp path
+        /// Sets all OS temp environment variables to the new path
+        ///
+        /// Cleanup:
+        /// - restores OS temp environment variables
+        /// </summary>
+        public TransientTempPath SetTempPath(string tempPath, bool deleteTempDirectory = false)
+        {
+            var transientTempPath = new TransientTempPath(tempPath, deleteTempDirectory);
+            _variants.Add(transientTempPath);
+
+            return transientTempPath;
+        }
+
+        /// <summary>
+        ///     Creates a test variant that corresponds to a temporary file which will be deleted when the test completes.
+        /// </summary>
+        /// <param name="extension">Extensions of the file (defaults to '.tmp')</param>
+        public TransientTestFile CreateFile(string extension = ".tmp")
+        {
+            return WithTransientTestState(new TransientTestFile(extension, createFile:true, expectedAsOutput:false));
+        }
+
+        public TransientTestFile CreateFile(string fileName, string contents = "")
+        {
+            return CreateFile(DefaultTestDirectory, fileName, contents);
+        }
+
+        public TransientTestFile CreateFile(TransientTestFolder transientTestFolder, string fileName, string contents = "")
+        {
+            var file = WithTransientTestState(new TransientTestFile(transientTestFolder.FolderPath, Path.GetFileNameWithoutExtension(fileName), Path.GetExtension(fileName)));
+            File.WriteAllText(file.Path, contents);
+
+            return file;
+        }
+
+        /// <summary>
+        ///     Creates a test variant that corresponds to a temporary file under a specific temporary folder. File will
+        ///     be cleaned up when the test completes.
+        /// </summary>
+        /// <param name="transientTestFolder"></param>
+        /// <param name="extension">Extension of the file (defaults to '.tmp')</param>
+        public TransientTestFile CreateFile(TransientTestFolder transientTestFolder, string extension = ".tmp")
+        {
+            return WithTransientTestState(new TransientTestFile(transientTestFolder.FolderPath, extension,
+                createFile: true, expectedAsOutput: false));
+        }
+
+
+        /// <summary>
+        ///     Gets a transient test file associated with a unique file name but does not create the file.
+        /// </summary>
+        /// <param name="extension">Extension of the file (defaults to '.tmp')</param>
+        /// <returns></returns>
+        public TransientTestFile GetTempFile(string extension = ".tmp")
+        {
+            return WithTransientTestState(new TransientTestFile(extension, createFile: false, expectedAsOutput: false));
+        }
+
+        /// <summary>
+        ///     Gets a transient test file under a specified folder associated with a unique file name but does not create the file.
+        /// </summary>
+        /// <param name="transientTestFolder">Temp folder</param>
+        /// <param name="extension">Extension of the file (defaults to '.tmp')</param>
+        /// <returns></returns>
+        public TransientTestFile GetTempFile(TransientTestFolder transientTestFolder, string extension = ".tmp")
+        {
+            return WithTransientTestState(new TransientTestFile(transientTestFolder.FolderPath, extension,
+                createFile: false, expectedAsOutput: false));
+        }
+
+        /// <summary>
+        ///     Create a temp file name that is expected to exist when the test completes.
+        /// </summary>
+        /// <param name="extension">Extension of the file (defaults to '.tmp')</param>
+        /// <returns></returns>
+        public TransientTestFile ExpectFile(string extension = ".tmp")
+        {
+            return WithTransientTestState(new TransientTestFile(extension, createFile: false, expectedAsOutput: true));
+        }
+
+        /// <summary>
+        /// Create a temp file name under a specific temporary folder. The file is expected to exist when the test completes.
+        /// </summary>
+        /// <param name="transientTestFolder">Temp folder</param>
+        /// <param name="extension">Extension of the file (defaults to '.tmp')</param>
+        /// <returns></returns>
+        public TransientTestFile ExpectFile(TransientTestFolder transientTestFolder, string extension = ".tmp")
+        {
+            return WithTransientTestState(new TransientTestFile(transientTestFolder.FolderPath, extension, createFile: false, expectedAsOutput: true));
+        }
+
+        /// <summary>
+        ///     Creates a test variant used to add a unique temporary folder during a test. Will be deleted when the test
+        ///     completes.
+        /// </summary>
+        public TransientTestFolder CreateFolder(string folderPath = null, bool createFolder = true)
+        {
+            var folder = WithTransientTestState(new TransientTestFolder(folderPath, createFolder));
+
+            Assert.True(!(createFolder ^ Directory.Exists(folder.FolderPath)));
+
+            return folder;
+        }
+
+        /// <summary>
+        ///     Creates a test variant used to add a unique temporary folder during a test. Will be deleted when the test
+        ///     completes.
+        /// </summary>
+        public TransientTestFolder CreateFolder(bool createFolder)
+        {
+            return CreateFolder(null, createFolder);
+        }
+
+        /// <summary>
+        ///     Create an test variant used to change the value of an environment variable during a test. Original value
+        ///     will be restored when complete.
+        /// </summary>
+        public TransientTestState SetEnvironmentVariable(string environmentVariableName, string newValue)
+        {
+            return WithTransientTestState(new TransientTestEnvironmentVariable(environmentVariableName, newValue));
+        }
+
+        public TransientTestState SetCurrentDirectory(string newWorkingDirectory)
+        {
+            return WithTransientTestState(new TransientWorkingDirectory(newWorkingDirectory));
+        }
+
+        #endregion
+
+        private class DefaultOutput : ITestOutputHelper
+        {
+            public void WriteLine(string message)
+            {
+                Console.WriteLine(message);
+            }
+
+            public void WriteLine(string format, params object[] args)
+            {
+                Console.WriteLine(format, args);
+            }
+        }
+
+        /// <summary>
+        ///     Creates a test variant representing a test project with files relative to the project root. All files
+        ///     and the root will be cleaned up when the test completes.
+        /// </summary>
+        /// <param name="projectContents">Contents of the project file to be created.</param>
+        /// <param name="files">Files to be created.</param>
+        /// <param name="relativePathFromRootToProject">Path for the specified files to be created in relative to 
+        /// the root of the project directory.</param>
+        public TransientTestProjectWithFiles CreateTestProjectWithFiles(string projectContents, string[] files = null, string relativePathFromRootToProject = ".")
+        {
+            return WithTransientTestState(
+                new TransientTestProjectWithFiles(projectContents, files, relativePathFromRootToProject));
+        }
+    }
+
+    /// <summary>
+    ///     Things that are expected not to change and should be asserted before and after running.
+    /// </summary>
+    public abstract class TestInvariant
+    {
+        public abstract void AssertInvariant(ITestOutputHelper output);
+    }
+
+    /// <summary>
+    ///     Things that are expected to change and should be reverted after running.
+    /// </summary>
+    public abstract class TransientTestState
+    {
+        public abstract void Revert();
+    }
+
+    public class StringInvariant : TestInvariant
+    {
+        private readonly Func<string> _accessorFunc;
+        private readonly string _name;
+        private readonly string _originalValue;
+
+        public StringInvariant(string name, Func<string> accessorFunc)
+        {
+            _name = name;
+            _accessorFunc = accessorFunc;
+            _originalValue = accessorFunc();
+        }
+
+        public override void AssertInvariant(ITestOutputHelper output)
+        {
+            var currentValue = _accessorFunc();
+
+            //  Something like the following might be preferrable, but the assertion method truncates the values leaving us without
+            //  useful information.  So use Assert.True instead
+            //  Assert.Equal($"{_name}: {_originalValue}", $"{_name}: {_accessorFunc()}");
+
+            Assert.True(currentValue == _originalValue, $"Expected {_name} to be '{_originalValue}', but it was '{currentValue}'");
+        }
+    }
+
+    public class EnvironmentInvariant : TestInvariant
+    {
+        private readonly IDictionary _initialEnvironment;
+
+        public EnvironmentInvariant()
+        {
+            _initialEnvironment = Environment.GetEnvironmentVariables();
+        }
+
+        public override void AssertInvariant(ITestOutputHelper output)
+        {
+            var environment = Environment.GetEnvironmentVariables();
+
+            AssertDictionaryInclusion(_initialEnvironment, environment, "added");
+            AssertDictionaryInclusion(environment, _initialEnvironment, "removed");
+
+            // a includes b
+            void AssertDictionaryInclusion(IDictionary a, IDictionary b, string operation)
+            {
+                foreach (var key in b.Keys)
+                {
+                    a.Contains(key).Should().Be(true, $"environment variable {operation}: {key}");
+                    a[key].Should().Be(b[key]);
+                }
+            }
+        }
+    }
+
+    public class BuildFailureLogInvariant : TestInvariant
+    {
+        private readonly string[] _originalFiles;
+
+        public BuildFailureLogInvariant()
+        {
+            _originalFiles = Directory.GetFiles(Path.GetTempPath(), "MSBuild_*.txt");
+        }
+
+        public override void AssertInvariant(ITestOutputHelper output)
+        {
+            var newFiles = Directory.GetFiles(Path.GetTempPath(), "MSBuild_*.txt");
+
+            var newFilesCount = newFiles.Length;
+            if (newFilesCount > _originalFiles.Length)
+            {
+                foreach (var file in newFiles.Except(_originalFiles).Select(f => new FileInfo(f)))
+                {
+                    var contents = File.ReadAllText(file.FullName);
+
+                    // Delete the file so we don't pollute the build machine
+                    FileUtilities.DeleteNoThrow(file.FullName);
+
+                    // Ignore clean shutdown trace logs.
+                    if (Regex.IsMatch(file.Name, @"MSBuild_NodeShutdown_\d+\.txt") &&
+                        Regex.IsMatch(contents, @"Node shutting down with reason BuildComplete and exception:\s*"))
+                    {
+                        newFilesCount--;
+                        continue;
+                    }
+
+                    // Com trace file. This is probably fine, but output it as it was likely turned on
+                    // for a reason.
+                    if (Regex.IsMatch(file.Name, @"MSBuild_CommTrace_PID_\d+\.txt"))
+                    {
+                        output.WriteLine($"{file.Name}: {contents}");
+                        newFilesCount--;
+                        continue;
+                    }
+
+                    output.WriteLine($"Build Error File {file.Name}: {contents}");
+                }
+            }
+
+            // Assert file count is equal minus any files that were OK
+            Assert.Equal(_originalFiles.Length, newFilesCount);
+        }
+    }
+
+    public class TransientTempPath : TransientTestState
+    {
+        private const string TMP = "TMP";
+        private const string TMPDIR = "TMPDIR";
+        private const string TEMP = "TEMP";
+
+        private readonly bool _deleteTempDirectory;
+
+        private readonly TempPaths _oldtempPaths;
+
+        public string TempPath { get; }
+
+        public TransientTempPath(string tempPath, bool deleteTempDirectory)
+        {
+            TempPath = tempPath;
+            _deleteTempDirectory = deleteTempDirectory;
+
+            _oldtempPaths = SetTempPath(tempPath);
+        }
+
+        private static TempPaths SetTempPath(string tempPath)
+        {
+            var oldTempPaths = GetTempPaths();
+
+            foreach (var key in oldTempPaths.Keys)
+            {
+                Environment.SetEnvironmentVariable(key, tempPath);
+            }
+
+            return oldTempPaths;
+        }
+
+        private static TempPaths SetTempPaths(TempPaths tempPaths)
+        {
+            var oldTempPaths = GetTempPaths();
+
+            foreach (var key in oldTempPaths.Keys)
+            {
+                Environment.SetEnvironmentVariable(key, tempPaths[key]);
+            }
+
+            return oldTempPaths;
+        }
+
+        private static TempPaths GetTempPaths()
+        {
+            var tempPaths = new TempPaths
+            {
+                [TMP] = Environment.GetEnvironmentVariable(TMP),
+                [TEMP] = Environment.GetEnvironmentVariable(TEMP)
+            };
+
+            if (NuGet.Common.RuntimeEnvironmentHelper.IsLinux || NuGet.Common.RuntimeEnvironmentHelper.IsMacOSX)
+            {
+                tempPaths[TMPDIR] = Environment.GetEnvironmentVariable(TMPDIR);
+            }
+
+            return tempPaths;
+        }
+
+        public override void Revert()
+        {
+            SetTempPaths(_oldtempPaths);
+
+            if (_deleteTempDirectory)
+            {
+                FileUtilities.DeleteDirectoryNoThrow(TempPath, recursive: true);
+            }
+        }
+    }
+
+
+    public class TransientTestFile : TransientTestState
+    {
+        private readonly bool _createFile;
+        private readonly bool _expectedAsOutput;
+
+        public TransientTestFile(string extension, bool createFile, bool expectedAsOutput)
+        {
+            _createFile = createFile;
+            _expectedAsOutput = expectedAsOutput;
+            Path = FileUtilities.GetTemporaryFile(null, extension, createFile);
+        }
+
+        public TransientTestFile(string rootPath, string extension, bool createFile, bool expectedAsOutput)
+        {
+            _createFile = createFile;
+            _expectedAsOutput = expectedAsOutput;
+            Path = FileUtilities.GetTemporaryFile(rootPath, extension, createFile);
+        }
+
+        public TransientTestFile(string rootPath, string fileNameWithoutExtension, string extension)
+        {
+            Path = System.IO.Path.Combine(rootPath, fileNameWithoutExtension + extension);
+
+            File.WriteAllText(Path, string.Empty);
+        }
+
+        public string Path { get; }
+
+        public override void Revert()
+        {
+            try
+            {
+                if (_expectedAsOutput)
+                {
+                    Assert.True(File.Exists(Path), $"A file expected as an output does not exist: {Path}");
+                }
+            }
+            finally
+            {
+                FileUtilities.DeleteNoThrow(Path);
+            }
+        }
+    }
+
+    public class TransientTestFolder : TransientTestState
+    {
+        public TransientTestFolder(string folderPath = null, bool createFolder = true)
+        {
+            FolderPath = folderPath ?? FileUtilities.GetTemporaryDirectory(createFolder);
+
+            if (createFolder)
+            {
+                Directory.CreateDirectory(FolderPath);
+            }
+        }
+
+        public string FolderPath { get; }
+
+        public override void Revert()
+        {
+            // Basic checks to make sure we're not deleting something very obviously wrong (e.g.
+            // the entire temp drive).
+            Assert.NotNull(FolderPath);
+            Assert.NotEqual(string.Empty, FolderPath);
+            Assert.NotEqual(@"\", FolderPath);
+            Assert.NotEqual(@"/", FolderPath);
+            Assert.NotEqual(Path.GetFullPath(Path.GetTempPath()), Path.GetFullPath(FolderPath));
+            Assert.True(Path.IsPathRooted(FolderPath));
+
+            FileUtilities.DeleteDirectoryNoThrow(FolderPath, true);
+        }
+    }
+
+    public class TransientTestEnvironmentVariable : TransientTestState
+    {
+        private readonly string _environmentVariableName;
+        private readonly string _originalValue;
+
+        public TransientTestEnvironmentVariable(string environmentVariableName, string newValue)
+        {
+            _environmentVariableName = environmentVariableName;
+            _originalValue = Environment.GetEnvironmentVariable(environmentVariableName);
+
+            Environment.SetEnvironmentVariable(environmentVariableName, newValue);
+        }
+
+        public override void Revert()
+        {
+            Environment.SetEnvironmentVariable(_environmentVariableName, _originalValue);
+        }
+    }
+
+    public class TransientWorkingDirectory : TransientTestState
+    {
+        private readonly string _originalValue;
+
+        public TransientWorkingDirectory(string newWorkingDirectory)
+        {
+            _originalValue = Directory.GetCurrentDirectory();
+            Directory.SetCurrentDirectory(newWorkingDirectory);
+        }
+
+        public override void Revert()
+        {
+            Directory.SetCurrentDirectory(_originalValue);
+        }
+    }
+
+    public class TransientTestProjectWithFiles : TransientTestState
+    {
+        private readonly TransientTestFolder _folder;
+
+        public string TestRoot => _folder.FolderPath;
+
+        public string[] CreatedFiles { get; }
+
+        public string ProjectFile { get; }
+
+        public TransientTestProjectWithFiles(string projectContents, string[] files,
+            string relativePathFromRootToProject = ".")
+        {
+            _folder = new TransientTestFolder();
+
+            var projectDir = Path.Combine(TestRoot, relativePathFromRootToProject);
+            Directory.CreateDirectory(projectDir);
+
+            ProjectFile = Path.Combine(projectDir, "build.proj");
+            File.WriteAllText(ProjectFile, FileUtilities.CleanupFileContents(projectContents));
+
+            CreatedFiles = FileUtilities.CreateFilesInDirectory(TestRoot, files);
+        }
+
+        public override void Revert()
+        {
+            _folder.Revert();
+        }
+    }
+
+    public static class FileUtilities
+    {
+        internal static void DeleteDirectoryNoThrow(string path, bool recursive, int retryCount = 0, int retryTimeOut = 0)
+        {
+            // Try parse will set the out parameter to 0 if the string passed in is null, or is outside the range of an int.
+            if (!int.TryParse(Environment.GetEnvironmentVariable("MSBUILDDIRECTORYDELETERETRYCOUNT"), out retryCount))
+            {
+                retryCount = 0;
+            }
+
+            if (!int.TryParse(Environment.GetEnvironmentVariable("MSBUILDDIRECTORYDELETRETRYTIMEOUT"), out retryTimeOut))
+            {
+                retryTimeOut = 0;
+            }
+
+            retryCount = retryCount < 1 ? 2 : retryCount;
+            retryTimeOut = retryTimeOut < 1 ? 500 : retryTimeOut;
+
+            path = FixFilePath(path);
+
+            for (var i = 0; i < retryCount; i++)
+            {
+                try
+                {
+                    if (Directory.Exists(path))
+                    {
+                        Directory.Delete(path, recursive);
+                        break;
+                    }
+                }
+                catch (Exception ex) when (IsIoRelatedException(ex))
+                {
+                }
+
+                if (i + 1 < retryCount) // should not wait for the final iteration since we not gonna check anyway
+                {
+                    Thread.Sleep(retryTimeOut);
+                }
+            }
+        }
+
+        internal static string FixFilePath(string path)
+        {
+            return string.IsNullOrEmpty(path) || Path.DirectorySeparatorChar == '\\' ? path : path.Replace('\\', '/');//.Replace("//", "/");
+        }
+
+        /// <summary>
+        /// Generates a unique directory name in the temporary folder.  
+        /// Caller must delete when finished. 
+        /// </summary>
+        /// <param name="createDirectory"></param>
+        internal static string GetTemporaryDirectory(bool createDirectory = true)
+        {
+            var temporaryDirectory = Path.Combine(Path.GetTempPath(), "Temporary" + Guid.NewGuid().ToString("N"));
+
+            if (createDirectory)
+            {
+                Directory.CreateDirectory(temporaryDirectory);
+            }
+
+            return temporaryDirectory;
+        }
+
+        /// <summary>
+        /// A variation on File.Delete that will throw ExceptionHandling.NotExpectedException exceptions
+        /// </summary>
+        internal static void DeleteNoThrow(string path)
+        {
+            try
+            {
+                File.Delete(FixFilePath(path));
+            }
+            catch (Exception ex) when (IsIoRelatedException(ex))
+            {
+            }
+        }
+
+        /// <summary>
+        /// Generates a unique temporary file name with a given extension in the temporary folder.
+        /// If no extension is provided, uses ".tmp".
+        /// File is guaranteed to be unique.
+        /// Caller must delete it when finished.
+        /// </summary>
+        internal static string GetTemporaryFile()
+        {
+            return GetTemporaryFile(".tmp");
+        }
+
+        /// <summary>
+        /// Generates a unique temporary file name with a given extension in the temporary folder.
+        /// File is guaranteed to be unique.
+        /// Extension may have an initial period.
+        /// Caller must delete it when finished.
+        /// May throw IOException.
+        /// </summary>
+        internal static string GetTemporaryFile(string extension)
+        {
+            return GetTemporaryFile(null, extension);
+        }
+
+        /// <summary>
+        /// Creates a file with unique temporary file name with a given extension in the specified folder.
+        /// File is guaranteed to be unique.
+        /// Extension may have an initial period.
+        /// If folder is null, the temporary folder will be used.
+        /// Caller must delete it when finished.
+        /// May throw IOException.
+        /// </summary>
+        internal static string GetTemporaryFile(string directory, string extension, bool createFile = true)
+        {
+            if (extension[0] != '.')
+            {
+                extension = '.' + extension;
+            }
+
+            directory = directory ?? Path.GetTempPath();
+
+            Directory.CreateDirectory(directory);
+
+            var file = Path.Combine(directory, $"tmp{Guid.NewGuid():N}{extension}");
+
+            if (createFile)
+            {
+                File.WriteAllText(file, string.Empty);
+            }
+
+            return file;
+        }
+
+        internal static bool IsIoRelatedException(Exception e)
+        {
+            // These all derive from IOException
+            //     DirectoryNotFoundException
+            //     DriveNotFoundException
+            //     EndOfStreamException
+            //     FileLoadException
+            //     FileNotFoundException
+            //     PathTooLongException
+            //     PipeException
+            return e is UnauthorizedAccessException
+                   || e is NotSupportedException
+                   || (e is ArgumentException && !(e is ArgumentNullException))
+                   || e is SecurityException
+                   || e is IOException;
+        }
+
+        /// <summary>
+        /// Does certain replacements in a string representing the project file contents.
+        /// This makes it easier to write unit tests because the author doesn't have
+        /// to worry about escaping double-quotes, etc.
+        /// </summary>
+        /// <param name="projectFileContents"></param>
+        /// <returns></returns>
+        internal static string CleanupFileContents(string projectFileContents)
+        {
+            // Replace reverse-single-quotes with double-quotes.
+            projectFileContents = projectFileContents.Replace("`", "\"");
+
+            // Place the correct MSBuild namespace into the <Project> tag.
+            projectFileContents = projectFileContents.Replace("msbuildnamespace", "http://schemas.microsoft.com/developer/msbuild/2003");
+            projectFileContents = projectFileContents.Replace("msbuilddefaulttoolsversion", "15.0");
+            projectFileContents = projectFileContents.Replace("msbuildassemblyversion", "15.1");
+
+            return projectFileContents;
+        }
+
+        /// <summary>
+        /// Creates a bunch of temporary files in the given directory with the specified names and returns
+        /// their full paths (so they can ultimately be cleaned up)
+        /// </summary>
+        internal static string[] CreateFilesInDirectory(string rootDirectory, params string[] files)
+        {
+            if (files == null)
+            {
+                return null;
+            }
+
+            Assert.True(Directory.Exists(rootDirectory), $"Directory {rootDirectory} does not exist");
+
+            var result = new string[files.Length];
+
+            for (var i = 0; i < files.Length; i++)
+            {
+                // On Unix there is the risk of creating one file with '\' in its name instead of directories.
+                // Therefore split the arguments into path fragments and recompose the path.
+                var fileFragments = SplitPathIntoFragments(files[i]);
+                var rootDirectoryFragments = SplitPathIntoFragments(rootDirectory);
+                var pathFragments = rootDirectoryFragments.Concat(fileFragments);
+
+                var fullPath = Path.Combine(pathFragments.ToArray());
+
+                var directoryName = Path.GetDirectoryName(fullPath);
+
+                Directory.CreateDirectory(directoryName);
+                Assert.True(Directory.Exists(directoryName));
+
+                File.WriteAllText(fullPath, string.Empty);
+                Assert.True(File.Exists(fullPath));
+
+                result[i] = fullPath;
+            }
+
+            return result;
+        }
+
+        private static string[] SplitPathIntoFragments(string path)
+        {
+            // Both Path.AltDirectorSeparatorChar and Path.DirectorySeparator char return '/' on OSX,
+            // which renders them useless for the following case where I want to split a path that may contain either separator
+            var splits = path.Split('/', '\\');
+
+            // if the path is rooted then the first split is either empty (Unix) or 'c:' (Windows)
+            // in this case the root must be restored back to '/' (Unix) or 'c:\' (Windows)
+            if (Path.IsPathRooted(path))
+            {
+                splits[0] = Path.GetPathRoot(path);
+            }
+
+            return splits;
+        }
+    }
+
+    #region MockLogger
+    /*
+     * Class:   MockLogger
+     *
+     * Mock logger class. Keeps track of errors and warnings and also builds
+     * up a raw string (fullLog) that contains all messages, warnings, errors.
+     *
+     */
+    internal sealed class MockLogger : ILogger
+    {
+        #region Properties
+
+        private StringBuilder _fullLog = new StringBuilder();
+        private readonly ITestOutputHelper _testOutputHelper;
+
+        /// <summary>
+        /// Should the build finished event be logged in the log file. This is to work around the fact we have different
+        /// localized strings between env and xmake for the build finished event.
+        /// </summary>
+        internal bool LogBuildFinished { get; set; } = true;
+
+        /*
+         * Method:  ErrorCount
+         *
+         * The count of all errors seen so far.
+         *
+         */
+        internal int ErrorCount { get; private set; } = 0;
+
+        /*
+         * Method:  WarningCount
+         *
+         * The count of all warnings seen so far.
+         *
+         */
+        internal int WarningCount { get; private set; } = 0;
+
+        /// <summary>
+        /// Return the list of logged errors
+        /// </summary>
+        internal List<BuildErrorEventArgs> Errors { get; } = new List<BuildErrorEventArgs>();
+
+        /// <summary>
+        /// Returns the list of logged warnings
+        /// </summary>
+        internal List<BuildWarningEventArgs> Warnings { get; } = new List<BuildWarningEventArgs>();
+
+        /// <summary>
+        /// When set to true, allows task crashes to be logged without causing an assert.
+        /// </summary>
+        internal bool AllowTaskCrashes
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// List of ExternalProjectStarted events
+        /// </summary>
+        internal List<ExternalProjectStartedEventArgs> ExternalProjectStartedEvents { get; } = new List<ExternalProjectStartedEventArgs>();
+
+        /// <summary>
+        /// List of ExternalProjectFinished events
+        /// </summary>
+        internal List<ExternalProjectFinishedEventArgs> ExternalProjectFinishedEvents { get; } = new List<ExternalProjectFinishedEventArgs>();
+
+        /// <summary>
+        /// List of ProjectStarted events
+        /// </summary>
+        internal List<ProjectStartedEventArgs> ProjectStartedEvents { get; } = new List<ProjectStartedEventArgs>();
+
+        /// <summary>
+        /// List of ProjectFinished events
+        /// </summary>
+        internal List<ProjectFinishedEventArgs> ProjectFinishedEvents { get; } = new List<ProjectFinishedEventArgs>();
+
+        /// <summary>
+        /// List of TargetStarted events
+        /// </summary>
+        internal List<TargetStartedEventArgs> TargetStartedEvents { get; } = new List<TargetStartedEventArgs>();
+
+        /// <summary>
+        /// List of TargetFinished events
+        /// </summary>
+        internal List<TargetFinishedEventArgs> TargetFinishedEvents { get; } = new List<TargetFinishedEventArgs>();
+
+        /// <summary>
+        /// List of TaskStarted events
+        /// </summary>
+        internal List<TaskStartedEventArgs> TaskStartedEvents { get; } = new List<TaskStartedEventArgs>();
+
+        /// <summary>
+        /// List of TaskFinished events
+        /// </summary>
+        internal List<TaskFinishedEventArgs> TaskFinishedEvents { get; } = new List<TaskFinishedEventArgs>();
+
+        /// <summary>
+        /// List of BuildMessage events
+        /// </summary>
+        internal List<BuildMessageEventArgs> BuildMessageEvents { get; } = new List<BuildMessageEventArgs>();
+
+        /// <summary>
+        /// List of BuildStarted events, thought we expect there to only be one, a valid check is to make sure this list is length 1
+        /// </summary>
+        internal List<BuildStartedEventArgs> BuildStartedEvents { get; } = new List<BuildStartedEventArgs>();
+
+        /// <summary>
+        /// List of BuildFinished events, thought we expect there to only be one, a valid check is to make sure this list is length 1
+        /// </summary>
+        internal List<BuildFinishedEventArgs> BuildFinishedEvents { get; } = new List<BuildFinishedEventArgs>();
+
+        internal List<BuildEventArgs> AllBuildEvents { get; } = new List<BuildEventArgs>();
+
+        /*
+         * Method:  FullLog
+         *
+         * The raw concatenation of all messages, errors and warnings seen so far.
+         *
+         */
+        internal string FullLog => _fullLog.ToString();
+
+        #endregion
+
+        #region Minimal ILogger implementation
+
+        /*
+         * Property:    Verbosity
+         *
+         * The level of detail to show in the event log.
+         *
+         */
+        public LoggerVerbosity Verbosity
+        {
+            get => LoggerVerbosity.Normal;
+            set {/* do nothing */}
+        }
+
+        /*
+         * Property:    Parameters
+         * 
+         * The mock logger does not take parameters.
+         * 
+         */
+        public string Parameters
+        {
+            get => null;
+
+            set
+            {
+                // do nothing
+            }
+        }
+
+        /*
+         * Method:  Initialize
+         *
+         * Add a new build event.
+         *
+         */
+        public void Initialize(IEventSource eventSource)
+        {
+            eventSource.AnyEventRaised += LoggerEventHandler;
+        }
+
+        /// <summary>
+        /// Clears the content of the log "file"
+        /// </summary>
+        public void ClearLog()
+        {
+            _fullLog = new StringBuilder();
+        }
+
+        /*
+         * Method:  Shutdown
+         * 
+         * The mock logger does not need to release any resources.
+         * 
+         */
+        public void Shutdown()
+        {
+            // do nothing
+        }
+        #endregion
+
+        public MockLogger()
+        {
+            _testOutputHelper = null;
+        }
+
+        public MockLogger(ITestOutputHelper testOutputHelper)
+        {
+            _testOutputHelper = testOutputHelper;
+        }
+
+        public List<Action<object, BuildEventArgs>> AdditionalHandlers { get; set; } = new List<Action<object, BuildEventArgs>>();
+
+        /*
+         * Method:  LoggerEventHandler
+         *
+         * Receives build events and logs them the way we like.
+         *
+         */
+        internal void LoggerEventHandler(object sender, BuildEventArgs eventArgs)
+        {
+            AllBuildEvents.Add(eventArgs);
+
+            foreach (var handler in AdditionalHandlers)
+            {
+                handler(sender, eventArgs);
+            }
+
+            if (eventArgs is BuildWarningEventArgs)
+            {
+                var w = (BuildWarningEventArgs)eventArgs;
+
+                // hack: disregard the MTA warning.
+                // need the second condition to pass on ploc builds
+                if (w.Code != "MSB4056" && !w.Message.Contains("MSB4056"))
+                {
+                    var logMessage =
+                        $"{w.File}({w.LineNumber},{w.ColumnNumber}): {w.Subcategory} warning {w.Code}: {w.Message}";
+
+                    _fullLog.AppendLine(logMessage);
+                    _testOutputHelper?.WriteLine(logMessage);
+
+                    ++WarningCount;
+                    Warnings.Add(w);
+                }
+            }
+            else if (eventArgs is BuildErrorEventArgs)
+            {
+                var e = (BuildErrorEventArgs)eventArgs;
+
+                var logMessage =
+                    $"{e.File}({e.LineNumber},{e.ColumnNumber}): {e.Subcategory} error {e.Code}: {e.Message}";
+                _fullLog.AppendLine(logMessage);
+                _testOutputHelper?.WriteLine(logMessage);
+
+                ++ErrorCount;
+                Errors.Add(e);
+            }
+            else
+            {
+                // Log the message unless we are a build finished event and logBuildFinished is set to false.
+                var logMessage = !(eventArgs is BuildFinishedEventArgs) ||
+                                  (eventArgs is BuildFinishedEventArgs && LogBuildFinished);
+                if (logMessage)
+                {
+                    _fullLog.AppendLine(eventArgs.Message);
+                    _testOutputHelper?.WriteLine(eventArgs.Message);
+                }
+            }
+
+            if (eventArgs is ExternalProjectStartedEventArgs)
+            {
+                ExternalProjectStartedEvents.Add((ExternalProjectStartedEventArgs)eventArgs);
+            }
+            else if (eventArgs is ExternalProjectFinishedEventArgs)
+            {
+                ExternalProjectFinishedEvents.Add((ExternalProjectFinishedEventArgs)eventArgs);
+            }
+
+            if (eventArgs is ProjectStartedEventArgs)
+            {
+                ProjectStartedEvents.Add((ProjectStartedEventArgs)eventArgs);
+            }
+            else if (eventArgs is ProjectFinishedEventArgs)
+            {
+                ProjectFinishedEvents.Add((ProjectFinishedEventArgs)eventArgs);
+            }
+            else if (eventArgs is TargetStartedEventArgs)
+            {
+                TargetStartedEvents.Add((TargetStartedEventArgs)eventArgs);
+            }
+            else if (eventArgs is TargetFinishedEventArgs)
+            {
+                TargetFinishedEvents.Add((TargetFinishedEventArgs)eventArgs);
+            }
+            else if (eventArgs is TaskStartedEventArgs)
+            {
+                TaskStartedEvents.Add((TaskStartedEventArgs)eventArgs);
+            }
+            else if (eventArgs is TaskFinishedEventArgs)
+            {
+                TaskFinishedEvents.Add((TaskFinishedEventArgs)eventArgs);
+            }
+            else if (eventArgs is BuildMessageEventArgs)
+            {
+                BuildMessageEvents.Add((BuildMessageEventArgs)eventArgs);
+            }
+            else if (eventArgs is BuildStartedEventArgs)
+            {
+                BuildStartedEvents.Add((BuildStartedEventArgs)eventArgs);
+            }
+            else if (eventArgs is BuildFinishedEventArgs)
+            {
+                BuildFinishedEvents.Add((BuildFinishedEventArgs)eventArgs);
+
+                if (!AllowTaskCrashes)
+                {
+                    // We should not have any task crashes. Sometimes a test will validate that their expected error
+                    // code appeared, but not realize it then crashed.
+                    AssertLogDoesntContain("MSB4018");
+                }
+
+                // We should not have any Engine crashes.
+                AssertLogDoesntContain("MSB0001");
+
+                // Console.Write in the context of a unit test is very expensive.  A hundred
+                // calls to Console.Write can easily take two seconds on a fast machine.  Therefore, only
+                // do the Console.Write once at the end of the build.
+                Console.Write(FullLog);
+            }
+        }
+
+        /// <summary>
+        /// Assert that the log file contains the given strings, in order.
+        /// </summary>
+        /// <param name="contains"></param>
+        internal void AssertLogContains(params string[] contains)
+        {
+            AssertLogContains(true, contains);
+        }
+
+        /// <summary>
+        /// Assert that the log file contains the given string, in order. Includes the option of case invariance
+        /// </summary>
+        /// <param name="isCaseSensitive">False if we do not care about case sensitivity</param>
+        /// <param name="contains"></param>
+        internal void AssertLogContains(bool isCaseSensitive, params string[] contains)
+        {
+            var reader = new StringReader(FullLog);
+            var index = 0;
+
+            var currentLine = reader.ReadLine();
+            if (!isCaseSensitive)
+            {
+                currentLine = currentLine.ToUpper();
+            }
+
+            while (currentLine != null)
+            {
+                var comparer = contains[index];
+                if (!isCaseSensitive)
+                {
+                    comparer = comparer.ToUpper();
+                }
+
+                if (currentLine.Contains(comparer))
+                {
+                    index++;
+                    if (index == contains.Length) break;
+                }
+
+                currentLine = reader.ReadLine();
+                if (!isCaseSensitive)
+                {
+                    currentLine = currentLine?.ToUpper();
+                }
+            }
+            if (index != contains.Length)
+            {
+                if (_testOutputHelper != null)
+                {
+                    _testOutputHelper.WriteLine(FullLog);
+                }
+                else
+                {
+                    Console.WriteLine(FullLog);
+                }
+                Assert.True(false, $"Log was expected to contain '{contains[index]}', but did not.\n=======\n{FullLog}\n=======");
+            }
+        }
+
+        /// <summary>
+        /// Assert that the log file contains the given string.
+        /// </summary>
+        /// <param name="contains"></param>
+        internal void AssertLogDoesntContain(string contains)
+        {
+            if (FullLog.Contains(contains))
+            {
+                if (_testOutputHelper != null)
+                {
+                    _testOutputHelper.WriteLine(FullLog);
+                }
+                else
+                {
+                    Console.WriteLine(FullLog);
+                }
+                Assert.True(false, $"Log was not expected to contain '{contains}', but did.");
+            }
+        }
+
+        /// <summary>
+        /// Assert that no errors were logged
+        /// </summary>
+        internal void AssertNoErrors()
+        {
+            Assert.Equal(0, ErrorCount);
+        }
+
+        /// <summary>
+        /// Assert that no warnings were logged
+        /// </summary>
+        internal void AssertNoWarnings()
+        {
+            Assert.Equal(0, WarningCount);
+        }
+    }
+#endregion
+}


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9098
Regression: Yes
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: Reverted https://github.com/NuGet/NuGet.Client/pull/3157 and added unit tests to make sure this doesn't regress again.

## Testing/Validation

Tests Added: Yes
Reason for not adding tests:  
Validation:  
