### PR TITLE
Read XML content using XmlReader

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/DownloadCommandBase.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/DownloadCommandBase.cs
@@ -7,10 +7,10 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Xml;
-using System.Xml.Linq;
 using NuGet.Configuration;
 using NuGet.Packaging;
 using NuGet.Protocol;
+using NuGet.Common;
 
 namespace NuGet.CommandLine
 {
@@ -75,7 +75,7 @@ namespace NuGet.CommandLine
                     }
                     else
                     {
-                        string message = String.Format(
+                        string message = string.Format(
                             CultureInfo.CurrentCulture,
                             LocalizedResourceManager.GetString("Warning_InvalidPackageSaveMode"),
                             v);
@@ -98,7 +98,7 @@ namespace NuGet.CommandLine
             {
                 try
                 {
-                    var xDocument = XDocument.Load(projectConfigFilePath);
+                    var xDocument = Common.XmlUtility.Load(projectConfigFilePath);
                     var reader = new PackagesConfigReader(xDocument);
                     return reader.GetPackages(allowDuplicatePackageIds);
                 }

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/DownloadCommandBase.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/DownloadCommandBase.cs
@@ -7,10 +7,11 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Xml;
+using System.Xml.Linq;
 using NuGet.Configuration;
 using NuGet.Packaging;
 using NuGet.Protocol;
-using NuGet.Common;
+using XmlUtility = NuGet.Common.XmlUtility;
 
 namespace NuGet.CommandLine
 {
@@ -98,7 +99,7 @@ namespace NuGet.CommandLine
             {
                 try
                 {
-                    var xDocument = Common.XmlUtility.Load(projectConfigFilePath);
+                    XDocument xDocument = XmlUtility.Load(projectConfigFilePath);
                     var reader = new PackagesConfigReader(xDocument);
                     return reader.GetPackages(allowDuplicatePackageIds);
                 }

--- a/src/NuGet.Core/NuGet.Build.Tasks/BuildTasksUtility.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/BuildTasksUtility.cs
@@ -29,6 +29,7 @@ using NuGet.Packaging.Signing;
 using NuGet.PackageManagement;
 using NuGet.ProjectManagement;
 using NuGet.Shared;
+using XmlUtility = NuGet.Common.XmlUtility;
 #endif
 
 namespace NuGet.Build.Tasks
@@ -542,7 +543,7 @@ namespace NuGet.Build.Tasks
             {
                 try
                 {
-                    var xDocument = Common.XmlUtility.Load(projectConfigFilePath);
+                    XDocument xDocument = XmlUtility.Load(projectConfigFilePath);
                     var reader = new PackagesConfigReader(xDocument);
                     return reader.GetPackages(allowDuplicatePackageIds);
                 }
@@ -551,9 +552,9 @@ namespace NuGet.Build.Tasks
                     var message = string.Format(
                        Strings.Error_PackagesConfigParseError,
                        projectConfigFilePath,
-                       ex.Message);
-
-                    throw new XmlException(message);
+                       ex.Message);                    
+                    
+                    throw new XmlException(message,ex);
                 }
             }
 

--- a/src/NuGet.Core/NuGet.Build.Tasks/BuildTasksUtility.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/BuildTasksUtility.cs
@@ -542,7 +542,7 @@ namespace NuGet.Build.Tasks
             {
                 try
                 {
-                    var xDocument = XDocument.Load(projectConfigFilePath);
+                    var xDocument = Common.XmlUtility.Load(projectConfigFilePath);
                     var reader = new PackagesConfigReader(xDocument);
                     return reader.GetPackages(allowDuplicatePackageIds);
                 }

--- a/src/NuGet.Core/NuGet.Build.Tasks/BuildTasksUtility.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/BuildTasksUtility.cs
@@ -554,7 +554,7 @@ namespace NuGet.Build.Tasks
                        projectConfigFilePath,
                        ex.Message);
 
-                    throw new XmlException(message,ex);
+                    throw new XmlException(message, ex);
                 }
             }
 

--- a/src/NuGet.Core/NuGet.Build.Tasks/BuildTasksUtility.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/BuildTasksUtility.cs
@@ -552,8 +552,8 @@ namespace NuGet.Build.Tasks
                     var message = string.Format(
                        Strings.Error_PackagesConfigParseError,
                        projectConfigFilePath,
-                       ex.Message);                    
-                    
+                       ex.Message);
+
                     throw new XmlException(message,ex);
                 }
             }

--- a/src/NuGet.Core/NuGet.Build.Tasks/BuildTasksUtility.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/BuildTasksUtility.cs
@@ -553,7 +553,7 @@ namespace NuGet.Build.Tasks
                        projectConfigFilePath,
                        ex.Message);
 
-                    log.LogError(message);
+                    throw new XmlException(message);
                 }
             }
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
@@ -351,10 +351,7 @@ namespace NuGet.Commands
             {
                 try
                 {
-                    using (var output = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.None))
-                    {
-                        result = XDocument.Load(output);
-                    }
+                    result = Common.XmlUtility.Load(path);
                 }
                 catch (Exception ex)
                 {

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
@@ -16,6 +16,7 @@ using NuGet.Packaging.Core;
 using NuGet.ProjectModel;
 using NuGet.Repositories;
 using NuGet.Versioning;
+using XmlUtility = NuGet.Common.XmlUtility;
 
 namespace NuGet.Commands
 {
@@ -351,10 +352,7 @@ namespace NuGet.Commands
             {
                 try
                 {
-                    using (var output = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.None))
-                    {
-                        result = XDocument.Load(output);
-                    }
+                    result = XmlUtility.Load(path);
                 }
                 catch (Exception ex)
                 {

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
@@ -351,7 +351,10 @@ namespace NuGet.Commands
             {
                 try
                 {
-                    result = Common.XmlUtility.Load(path);
+                    using (var output = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.None))
+                    {
+                        result = XDocument.Load(output);
+                    }
                 }
                 catch (Exception ex)
                 {

--- a/src/NuGet.Core/NuGet.Common/XmlUtility.cs
+++ b/src/NuGet.Core/NuGet.Common/XmlUtility.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Xml;
+using System.Xml.Linq;
+
+namespace NuGet.Common
+{
+    public static class XmlUtility
+    {
+        //
+        // Summary:
+        //     Creates a new System.Xml.Linq.XDocument from an System.Xml.XmlReader.
+        //
+        // Parameters:
+        //   filePath:
+        //     The URI for the file containing the XML data.
+        //
+        // Returns:
+        //     An System.Xml.Linq.XDocument that contains the contents of the specified System.Xml.XmlReader.
+        public static XDocument Load(string filePath)
+        {
+            if (string.IsNullOrEmpty(filePath))
+                throw new ArgumentNullException(nameof(filePath));
+
+            using (var reader = XmlReader.Create(filePath))
+            {
+                return XDocument.Load(reader);
+            }
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Common/XmlUtility.cs
+++ b/src/NuGet.Core/NuGet.Common/XmlUtility.cs
@@ -6,21 +6,18 @@ namespace NuGet.Common
 {
     public static class XmlUtility
     {
-        //
-        // Summary:
-        //     Creates a new System.Xml.Linq.XDocument from an System.Xml.XmlReader.
-        //
-        // Parameters:
-        //   filePath:
-        //     The URI for the file containing the XML data.
-        //
-        // Returns:
-        //     An System.Xml.Linq.XDocument that contains the contents of the specified System.Xml.XmlReader.
+        /// <summary>
+        /// Creates a new System.Xml.Linq.XDocument from an System.Xml.XmlReader.
+        /// </summary>
+        /// <param name="filePath">Path for the file containing the XML data.</param>
+        /// <returns>An <see cref="System.Xml.Linq.XDocument"/> contains the contents of the specified Xml file.</returns>
         public static XDocument Load(string filePath)
         {
             if (string.IsNullOrEmpty(filePath))
                 throw new ArgumentNullException(nameof(filePath));
 
+            //This overloaded method of XmlReader.Create creates an instance of
+            //XmlReaderSettings with default values that are safe
             using (var reader = XmlReader.Create(filePath))
             {
                 return XDocument.Load(reader);

--- a/src/NuGet.Core/NuGet.Common/XmlUtility.cs
+++ b/src/NuGet.Core/NuGet.Common/XmlUtility.cs
@@ -27,6 +27,10 @@ namespace NuGet.Common
             }
         }
 
+        /// <summary>
+        /// Creates an instance of System.Xml.XmlReaderSettings with safe settings
+        /// </summary>
+        /// <returns></returns>
         private static XmlReaderSettings GetXmlReaderSettings()
         {
             return new XmlReaderSettings()

--- a/src/NuGet.Core/NuGet.Common/XmlUtility.cs
+++ b/src/NuGet.Core/NuGet.Common/XmlUtility.cs
@@ -1,4 +1,6 @@
-using System;
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Xml;
 using System.Xml.Linq;
 
@@ -7,10 +9,10 @@ namespace NuGet.Common
     public static class XmlUtility
     {
         /// <summary>
-        /// Creates a new System.Xml.Linq.XDocument from an System.Xml.XmlReader.
+        /// Creates a new System.Xml.Linq.XDocument from a file.
         /// </summary>
-        /// <param name="filePath">Path for the file containing the XML data.</param>
-        /// <returns>An <see cref="System.Xml.Linq.XDocument"/> contains the contents of the specified Xml file.</returns>
+        /// <param name="filePath">A URI string that references the file to load into a new <see cref="System.Xml.Linq.XDocument"/></param>
+        /// <returns>An <see cref="System.Xml.Linq.XDocument"/> that contains the contents of the specified file.</returns>
         public static XDocument Load(string filePath)
         {
             //This overloaded method of XmlReader.Create creates an instance of

--- a/src/NuGet.Core/NuGet.Common/XmlUtility.cs
+++ b/src/NuGet.Core/NuGet.Common/XmlUtility.cs
@@ -21,12 +21,22 @@ namespace NuGet.Common
                 throw new ArgumentException(Strings.ArgumentNullOrEmpty, nameof(filePath));
             }
 
-            //This overloaded method of XmlReader.Create creates an instance of
-            //XmlReaderSettings with default values that are safe
-            using (var reader = XmlReader.Create(filePath))
+            using (var reader = XmlReader.Create(filePath,GetXmlReaderSettings()))
             {
                 return XDocument.Load(reader);
             }
+        }
+
+        private static XmlReaderSettings GetXmlReaderSettings()
+        {
+            return new XmlReaderSettings()
+            {
+                IgnoreWhitespace = true,
+                IgnoreProcessingInstructions = true,
+                IgnoreComments = true,
+                DtdProcessing = DtdProcessing.Prohibit,
+                XmlResolver = null                
+            };
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Common/XmlUtility.cs
+++ b/src/NuGet.Core/NuGet.Common/XmlUtility.cs
@@ -21,7 +21,7 @@ namespace NuGet.Common
                 throw new ArgumentException(Strings.ArgumentNullOrEmpty, nameof(filePath));
             }
 
-            using (var reader = XmlReader.Create(filePath,GetXmlReaderSettings()))
+            using (var reader = XmlReader.Create(filePath, GetXmlReaderSettings()))
             {
                 return XDocument.Load(reader);
             }
@@ -38,7 +38,7 @@ namespace NuGet.Common
                 IgnoreProcessingInstructions = true,
                 IgnoreComments = true,
                 DtdProcessing = DtdProcessing.Prohibit,
-                XmlResolver = null                
+                XmlResolver = null
             };
         }
     }

--- a/src/NuGet.Core/NuGet.Common/XmlUtility.cs
+++ b/src/NuGet.Core/NuGet.Common/XmlUtility.cs
@@ -30,7 +30,6 @@ namespace NuGet.Common
         /// <summary>
         /// Creates an instance of System.Xml.XmlReaderSettings with safe settings
         /// </summary>
-        /// <returns></returns>
         private static XmlReaderSettings GetXmlReaderSettings()
         {
             return new XmlReaderSettings()

--- a/src/NuGet.Core/NuGet.Common/XmlUtility.cs
+++ b/src/NuGet.Core/NuGet.Common/XmlUtility.cs
@@ -13,9 +13,6 @@ namespace NuGet.Common
         /// <returns>An <see cref="System.Xml.Linq.XDocument"/> contains the contents of the specified Xml file.</returns>
         public static XDocument Load(string filePath)
         {
-            if (string.IsNullOrEmpty(filePath))
-                throw new ArgumentNullException(nameof(filePath));
-
             //This overloaded method of XmlReader.Create creates an instance of
             //XmlReaderSettings with default values that are safe
             using (var reader = XmlReader.Create(filePath))

--- a/src/NuGet.Core/NuGet.Common/XmlUtility.cs
+++ b/src/NuGet.Core/NuGet.Common/XmlUtility.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Xml;
 using System.Xml.Linq;
 
@@ -15,6 +16,11 @@ namespace NuGet.Common
         /// <returns>An <see cref="System.Xml.Linq.XDocument"/> that contains the contents of the specified file.</returns>
         public static XDocument Load(string filePath)
         {
+            if (string.IsNullOrEmpty(filePath))
+            {
+                throw new ArgumentException(Strings.ArgumentNullOrEmpty, nameof(filePath));
+            }
+
             //This overloaded method of XmlReader.Create creates an instance of
             //XmlReaderSettings with default values that are safe
             using (var reader = XmlReader.Create(filePath))

--- a/src/NuGet.Core/NuGet.Common/XmlUtility.cs
+++ b/src/NuGet.Core/NuGet.Common/XmlUtility.cs
@@ -36,9 +36,7 @@ namespace NuGet.Common
             {
                 IgnoreWhitespace = true,
                 IgnoreProcessingInstructions = true,
-                IgnoreComments = true,
-                DtdProcessing = DtdProcessing.Prohibit,
-                XmlResolver = null
+                IgnoreComments = true
             };
         }
     }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
@@ -2352,6 +2352,8 @@ EndProject";
             using (var workingPath = TestDirectory.Create())
             {
                 var repositoryPath = Path.Combine(workingPath, "Repository");
+                var outputDir = "outputDir";
+                var outputPath = Path.Combine(workingPath, outputDir);
                 Directory.CreateDirectory(repositoryPath);
                 Util.CreateTestPackage("packageA", "1.1.0", repositoryPath);
                 Util.CreateTestPackage("packageB", "2.2.0", repositoryPath);
@@ -2367,19 +2369,18 @@ EndProject";
     <package id=""packageB"" version=""2.2.0"" targetFramework=""net45"" />
 </packages>");
 
-                string[] args = new string[] { "restore", "-PackagesDirectory", "outputDir", "-Source", repositoryPath };
+                string[] args = new string[] { "restore", "-PackagesDirectory", outputDir, "-Source", repositoryPath };
 
                 // Act
-                var r = CommandRunner.Run(
+                CommandRunnerResult result = CommandRunner.Run(
                     nugetexe,
                     workingPath,
                     string.Join(" ", args),
                     waitForExit: true);
 
                 // Assert
-                Assert.Equal(_failureCode, r.Item1);
-                Assert.Contains("Error parsing packages.config file", r.AllOutput);
-                var outputPath = Path.Combine(workingPath, @"outputDir");                
+                Assert.False(result.Success);
+                Assert.Contains("Error parsing packages.config file", result.AllOutput);                                
                 Assert.False(Directory.Exists(outputPath));
             }
         }

--- a/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildRestoreTaskTests.cs
+++ b/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildRestoreTaskTests.cs
@@ -126,7 +126,7 @@ namespace Msbuild.Integration.Test
         }
 
         [PlatformFact(Platform.Windows)]
-        public async Task MsbuildRestore_PackagesConfigDependencyAsync_WithInvalidPC_Throws()
+        public async Task MsbuildRestore_InsecurePackagesConfigDependencyAsync_Throws()
         {
             // Arrange
             using (var pathContext = new SimpleTestPathContext())

--- a/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildRestoreTaskTests.cs
+++ b/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildRestoreTaskTests.cs
@@ -174,7 +174,6 @@ namespace Msbuild.Integration.Test
                 // Act
                 var result = _msbuildFixture.RunMsBuild(pathContext.WorkingDirectory, $"/t:restore {pathContext.SolutionRoot} /p:RestorePackagesConfig=true",ignoreExitCode:true);
 
-
                 // Assert
                 Assert.True(result.ExitCode == 1);
                 Assert.Contains("Error parsing packages.config file", result.AllOutput);

--- a/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildRestoreTaskTests.cs
+++ b/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildRestoreTaskTests.cs
@@ -134,7 +134,7 @@ namespace Msbuild.Integration.Test
                 // Set up solution, project, and packages
                 var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
 
-                var net461 = NuGetFramework.Parse("net461");
+                NuGetFramework net461 = NuGetFramework.Parse("net461");
 
                 var projectA = new SimpleTestProjectContext(
                     "a",
@@ -172,10 +172,10 @@ namespace Msbuild.Integration.Test
                     packageX);
 
                 // Act
-                var result = _msbuildFixture.RunMsBuild(pathContext.WorkingDirectory, $"/t:restore {pathContext.SolutionRoot} /p:RestorePackagesConfig=true",ignoreExitCode:true);
+                CommandRunnerResult result = _msbuildFixture.RunMsBuild(pathContext.WorkingDirectory, $"/t:restore {pathContext.SolutionRoot} /p:RestorePackagesConfig=true", ignoreExitCode:true);
 
                 // Assert
-                Assert.True(result.ExitCode == 1);
+                Assert.Equal(1, result.ExitCode);
                 Assert.Contains("Error parsing packages.config file", result.AllOutput);
             }
         }

--- a/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildRestoreTaskTests.cs
+++ b/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildRestoreTaskTests.cs
@@ -126,6 +126,62 @@ namespace Msbuild.Integration.Test
         }
 
         [PlatformFact(Platform.Windows)]
+        public async Task MsbuildRestore_PackagesConfigDependencyAsync_WithInvalidPC_Throws()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Set up solution, project, and packages
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+
+                var net461 = NuGetFramework.Parse("net461");
+
+                var projectA = new SimpleTestProjectContext(
+                    "a",
+                    ProjectStyle.PackagesConfig,
+                    pathContext.SolutionRoot);
+                projectA.Frameworks.Add(new SimpleTestProjectFrameworkContext(net461));
+
+                var packageX = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.0"
+                };
+                packageX.Files.Clear();
+                packageX.AddFile("lib/net461/a.dll");
+
+                solution.Projects.Add(projectA);
+                solution.Create(pathContext.SolutionRoot);
+
+                using (var writer = new StreamWriter(Path.Combine(Path.GetDirectoryName(projectA.ProjectPath), "packages.config")))
+                {
+                    writer.Write(
+@"<!DOCTYPE package [
+   <!ENTITY greeting ""Hello"">
+   <!ENTITY name ""NuGet Client "">
+   <!ENTITY sayhello ""&greeting; &name;"">
+]>
+<packages>
+    <package id=""&sayhello;"" version=""1.1.0"" targetFramework=""net45"" /> 
+    <package id=""x"" version=""1.0.0"" targetFramework=""net45"" />
+</packages>");
+                }
+
+                await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                    pathContext.PackageSource,
+                    packageX);
+
+                // Act
+                var result = _msbuildFixture.RunMsBuild(pathContext.WorkingDirectory, $"/t:restore {pathContext.SolutionRoot} /p:RestorePackagesConfig=true",ignoreExitCode:true);
+
+
+                // Assert
+                Assert.True(result.ExitCode == 1);
+                Assert.Contains("Error parsing packages.config file", result.AllOutput);
+            }
+        }
+
+        [PlatformFact(Platform.Windows)]
         public async Task MsbuildRestore_PackageReferenceDependencyAsync()
         {
             // Arrange

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/BuildAssetsUtilsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/BuildAssetsUtilsTests.cs
@@ -912,7 +912,6 @@ namespace NuGet.Commands.Test
                 XDocument doc = BuildAssetsUtils.GenerateEmptyImportsFile();
                 doc.Save(filePath);
 
-                //add insecure content to xml
                 XDocument newdoc = XDocument.Load(filePath);
                 newdoc.AddFirst(new XDocumentType("Project", null, null, internalSubset));
                 XAttribute attribute = newdoc.Root.Attributes(XName.Get("ToolsVersion")).FirstOrDefault();
@@ -922,10 +921,8 @@ namespace NuGet.Commands.Test
                 string newxml = File.ReadAllText(filePath);
                 File.WriteAllText(filePath, newxml.Replace("&amp;", "&"));
 
-                //Act
-                bool result = BuildAssetsUtils.HasChanges(doc, filePath, NullLogger.Instance);
-                
-                Assert.True(result);
+                //Act & Assert
+                Assert.True(BuildAssetsUtils.HasChanges(doc, filePath, NullLogger.Instance));
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/BuildAssetsUtilsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/BuildAssetsUtilsTests.cs
@@ -896,5 +896,54 @@ namespace NuGet.Commands.Test
                 Assert.Equal("$(MSBuildThisFileDirectory)project.assets.json".Replace('/', Path.DirectorySeparatorChar), props["ProjectAssetsFile"]);
             }
         }
+
+        [Fact]
+        public void HasChanges_WhenXDocumentDoesNotMatchFileContent_Success()
+        {
+            // Arrange
+            using (var randomProjectDirectory = TestDirectory.Create())
+            {
+                var filePath = Path.Combine(randomProjectDirectory, "propsXML.xml");
+                var internalSubset = @"<!ENTITY greeting ""Hello"">	
+   <!ENTITY name ""NuGet Client "">	
+   <!ENTITY sayhello ""&greeting; &name;"">";
+                var newValue = "&sayhello;";
+
+                XDocument doc = BuildAssetsUtils.GenerateEmptyImportsFile();
+                doc.Save(filePath);
+
+                //add insecure content to xml
+                XDocument newdoc = XDocument.Load(filePath);
+                newdoc.AddFirst(new XDocumentType("Project", null, null, internalSubset));
+                XAttribute attribute = newdoc.Root.Attributes(XName.Get("ToolsVersion")).FirstOrDefault();
+                attribute.Value = newValue;
+                newdoc.Save(filePath);
+
+                string newxml = File.ReadAllText(filePath);
+                File.WriteAllText(filePath, newxml.Replace("&amp;", "&"));
+
+                //Act
+                bool result = BuildAssetsUtils.HasChanges(doc, filePath, NullLogger.Instance);
+                
+                Assert.True(result);
+            }
+        }
+
+        [Fact]
+        public void HasChanges_WhenXDocumentMatchesFileContent_Fails()
+        {
+            // Arrange
+            using (var randomProjectDirectory = TestDirectory.Create())
+            {
+                var filePath = Path.Combine(randomProjectDirectory, "propsXML.xml");
+                XDocument doc = BuildAssetsUtils.GenerateEmptyImportsFile();
+                doc.Save(filePath);
+
+                //Act
+                bool result = BuildAssetsUtils.HasChanges(doc, filePath, NullLogger.Instance);
+
+                Assert.False(result);
+            }
+        }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreBuildTargetsAndPropsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreBuildTargetsAndPropsTests.cs
@@ -443,6 +443,7 @@ namespace NuGet.Commands.Test
                 CacheContext = cacheContext,
                 DisableParallel = true,
                 GlobalPackagesFolder = pathContext.UserPackagesFolder,
+                AllowNoOp = true,
                 Sources = new List<string>() { pathContext.PackageSource },
                 Log = logger,
                 CachingSourceProvider = new CachingSourceProvider(new TestPackageSourceProvider(sources)),

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreBuildTargetsAndPropsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreBuildTargetsAndPropsTests.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
-using System.Xml;
 using System.Xml.Linq;
 using NuGet.Configuration;
 using NuGet.Frameworks;
@@ -84,95 +83,6 @@ namespace NuGet.Commands.Test
 
                 Assert.Equal("'$(TargetFramework)' == 'net462' AND '$(ExcludeRestorePackageImports)' != 'true'", propsItemGroups[0].Attribute(XName.Get("Condition")).Value.Trim());
                 Assert.Equal("'$(TargetFramework)' == 'netstandard1.6' AND '$(ExcludeRestorePackageImports)' != 'true'", propsItemGroups[1].Attribute(XName.Get("Condition")).Value.Trim());
-            }
-        }
-
-        [Fact]
-        public async Task RestoreBuildTargetsAndProps_VerifyPropsAndTargetsGeneratedAsyncWithFilesModifiedAfterRestore_Success()
-        {
-            // Arrange
-            using (var cacheContext = new SourceCacheContext())
-            using (var pathContext = new SimpleTestPathContext())
-            {
-                var logger = new TestLogger();
-                var sources = new List<PackageSource>
-                {
-                    new PackageSource(pathContext.PackageSource)
-                };
-
-                var spec = GetProject("projectA", "net462", "netstandard1.6");
-
-                spec.RestoreMetadata.CrossTargeting = true;
-                spec.Dependencies.Add(new LibraryDependency()
-                {
-                    LibraryRange = new LibraryRange("x", VersionRange.Parse("1.0.0"), LibraryDependencyTarget.Package)
-                });
-
-                // Create fake projects, the real data is in the specs
-                var projects = CreateProjectsFromSpecs(pathContext, spec);
-
-                // Create dg file
-                var dgFile = new DependencyGraphSpec();
-                dgFile.AddProject(spec);
-                dgFile.AddRestore(spec.RestoreMetadata.ProjectUniqueName);
-                dgFile.Save(Path.Combine(pathContext.WorkingDirectory, "out.dg"));
-
-                var packageX = new SimpleTestPackageContext()
-                {
-                    Id = "x",
-                    Version = "1.0.0"
-                };
-
-                packageX.AddFile("build/x.targets");
-                packageX.AddFile("build/x.props");
-                packageX.AddFile("contentFiles/any/any/_._");
-
-                await SimpleTestPackageUtility.CreatePackagesAsync(pathContext.PackageSource, packageX);
-
-                var project = projects[0];
-                var importGroup = "ImportGroup";
-                var condition = "Condition";
-                var internalSubset = @"<!ENTITY greeting ""Hello"">
-   <!ENTITY name ""NuGet Client "">
-   <!ENTITY sayhello ""&greeting; &name;"">";
-                var newValue = "&sayhello;";
-
-                var summaries = await RunRestoreAsync(pathContext, logger, sources, dgFile, cacheContext);
-
-                var targetsXML = XDocument.Parse(File.ReadAllText(project.TargetsOutput));
-                targetsXML.AddFirst(new XDocumentType(importGroup, null, null, internalSubset));
-                XAttribute targetsConditionAttribute = targetsXML.Root.Elements().Where(e => e.Name.LocalName == importGroup).Attributes(XName.Get(condition)).FirstOrDefault();
-                targetsConditionAttribute.Value = newValue;
-                targetsXML.Save(project.TargetsOutput);
-                string targets = File.ReadAllText(project.TargetsOutput);
-                File.WriteAllText(project.TargetsOutput, targets.Replace("&amp;", "&"));
-
-                var propsXML = XDocument.Parse(File.ReadAllText(project.PropsOutput));
-                propsXML.AddFirst(new XDocumentType(importGroup, null, null, internalSubset));
-                XAttribute propsConditionAttribute = propsXML.Root.Elements().Where(e => e.Name.LocalName == importGroup).Attributes(XName.Get(condition)).FirstOrDefault();
-                propsConditionAttribute.Value = newValue;
-                propsXML.Save(project.PropsOutput);
-                string props = File.ReadAllText(project.PropsOutput);
-                File.WriteAllText(project.PropsOutput, props.Replace("&amp;", "&"));
-
-                // Act
-                summaries = await RunRestoreAsync(pathContext, logger, sources, dgFile, cacheContext);
-
-                targetsXML = XDocument.Parse(File.ReadAllText(project.TargetsOutput));
-                propsXML = XDocument.Parse(File.ReadAllText(project.PropsOutput));
-
-                var success = summaries.All(s => s.Success);
-                var targetItemGroups = targetsXML.Root.Elements().Where(e => e.Name.LocalName == importGroup).ToList();
-                var propsItemGroups = propsXML.Root.Elements().Where(e => e.Name.LocalName == importGroup).ToList();
-
-                // Assert
-                Assert.True(success, "Failed: " + string.Join(Environment.NewLine, logger.Messages));
-
-                Assert.Equal("'$(TargetFramework)' == 'net462' AND '$(ExcludeRestorePackageImports)' != 'true'", targetItemGroups[0].Attribute(XName.Get(condition)).Value.Trim());
-                Assert.Equal("'$(TargetFramework)' == 'netstandard1.6' AND '$(ExcludeRestorePackageImports)' != 'true'", targetItemGroups[1].Attribute(XName.Get(condition)).Value.Trim());
-
-                Assert.Equal("'$(TargetFramework)' == 'net462' AND '$(ExcludeRestorePackageImports)' != 'true'", propsItemGroups[0].Attribute(XName.Get(condition)).Value.Trim());
-                Assert.Equal("'$(TargetFramework)' == 'netstandard1.6' AND '$(ExcludeRestorePackageImports)' != 'true'", propsItemGroups[1].Attribute(XName.Get(condition)).Value.Trim());
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/XmlUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/XmlUtilityTests.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.IO;
 using System.Linq;
@@ -11,25 +14,29 @@ namespace NuGet.Common.Test
     public class XmlUtilityTests
     {
         [Fact]
-        public void XmlUtility_Load_NullFilePathParameter_Throws()
+        public void Load_WhenFilePathIsNull_Throws()
         {
-            //Act & Assert
-            Assert.Throws(typeof(ArgumentException), () => XmlUtility.Load(null));
+            //Act
+            var exception = Assert.Throws<ArgumentException>(() => XmlUtility.Load(filePath: null));
+           
+            //Assert
+            Assert.Equal("filePath", exception.ParamName);
         }
 
         [Fact]
-        public void XmlUtility_Load_SecureXml_Success()
+        public void Load_WhenFileWithSecureXmlIsPassedAsArgument_Success()
         {
             using (var root = TestDirectory.Create())
             {
                 //Arrange
                 string path = Path.Combine(Path.GetDirectoryName(root), "packages.config");
+
                 using (var writer = new StreamWriter(path))
                 {
                     writer.Write(
 @"<packages>
-    <package id=""x"" version=""1.1.0"" targetFramework=""net45"" /> 
-    <package id=""y"" version=""1.0.0"" targetFramework=""net45"" />
+<package id=""x"" version=""1.1.0"" targetFramework=""net45"" /> 
+<package id=""y"" version=""1.0.0"" targetFramework=""net45"" />
 </packages>");
                 }
 
@@ -43,7 +50,7 @@ namespace NuGet.Common.Test
         }
 
         [Fact]
-        public void XmlUtility_Load_InSecureXml_Throws()
+        public void Load_WhenFileWithInSecureXmlIsPassedAsArgument_Throws()
         {
             using (var root = TestDirectory.Create())
             {
@@ -64,7 +71,7 @@ namespace NuGet.Common.Test
                 }
 
                 //Act & Assert
-                Assert.Throws(typeof(XmlException), () => XmlUtility.Load(path));
+                Assert.Throws<XmlException>(() => XmlUtility.Load(path));
             }
         }
     }

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/XmlUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/XmlUtilityTests.cs
@@ -1,0 +1,71 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Xml;
+using System.Xml.Linq;
+using NuGet.Test.Utility;
+using Xunit;
+
+namespace NuGet.Common.Test
+{
+    public class XmlUtilityTests
+    {
+        [Fact]
+        public void XmlUtility_Load_NullFilePathParameter_Throws()
+        {
+            //Act & Assert
+            Assert.Throws(typeof(ArgumentException), () => XmlUtility.Load(null));
+        }
+
+        [Fact]
+        public void XmlUtility_Load_SecureXml_Success()
+        {
+            using (var root = TestDirectory.Create())
+            {
+                //Arrange
+                string path = Path.Combine(Path.GetDirectoryName(root), "packages.config");
+                using (var writer = new StreamWriter(path))
+                {
+                    writer.Write(
+@"<packages>
+    <package id=""x"" version=""1.1.0"" targetFramework=""net45"" /> 
+    <package id=""y"" version=""1.0.0"" targetFramework=""net45"" />
+</packages>");
+                }
+
+                //Act
+                XDocument doc = XmlUtility.Load(path);
+
+                //Assert
+                Assert.Equal("packages", doc.Root.Name);
+                Assert.Equal(2, doc.Root.Elements().Count());
+            }
+        }
+
+        [Fact]
+        public void XmlUtility_Load_InSecureXml_Throws()
+        {
+            using (var root = TestDirectory.Create())
+            {
+                //Arrange
+                string path = Path.Combine(Path.GetDirectoryName(root), "packages.config");
+                using (var writer = new StreamWriter(path))
+                {
+                    writer.Write(
+@"<!DOCTYPE package [
+   <!ENTITY greeting ""Hello"">
+   <!ENTITY name ""NuGet Client "">
+   <!ENTITY sayhello ""&greeting; &name;"">
+]>
+<packages>
+    <package id=""&sayhello;"" version=""1.1.0"" targetFramework=""net45"" /> 
+    <package id=""x"" version=""1.0.0"" targetFramework=""net45"" />
+</packages>");
+                }
+
+                //Act & Assert
+                Assert.Throws(typeof(XmlException), () => XmlUtility.Load(path));
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Bug

Fixes: NuGet/Engineering#2769
Regression: No
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: Creates XDocument from an XmlReader. As per [doc](https://docs.microsoft.com/en-us/dotnet/api/system.xml.xmlreader.create?view=netcore-3.1#System_Xml_XmlReader_Create_System_String_), an XmlReaderSettings object with default secure settings is used to create the reader. As per [reference](http://index/?rightProject=System.Xml.Linq&file=System%5CXml%5CLinq%5CXLinq.cs&line=1989), `XDocument.Load(string inputUri)` uses `XmlReadersettings` with `DtdProcessing = DtdProcessing.Parse;` which is not secure option.

Simplified couple of lines of code by replacing `String` with `string` as suggested by IDE analyzers.

## Testing/Validation

Tests Added: Yes
Reason for not adding tests:  
Validation:  
