### PR TITLE
Update ResumeVSInstall to get latest VS_Installer

### DIFF
--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -743,7 +743,9 @@ phases:
   queue:
     timeoutInMinutes: 90
     name: DDNuGet-Windows
-    demands: DotNetFramework
+    demands:
+    - DotNetFramework
+    - Agent.Name -equals DDNuGetW001
 
   steps:
   - task: PowerShell@1
@@ -839,7 +841,9 @@ phases:
   condition: "and(succeeded(),eq(variables['RunApexTests'], 'true')) "
   queue:
     name: DDNuGet-Windows
-    demands: DotNetFramework
+    demands:
+    - DotNetFramework
+    - Agent.Name -equals DDNuGetW001
 
   steps:
   - checkout: self

--- a/scripts/e2etests/VSUtils.ps1
+++ b/scripts/e2etests/VSUtils.ps1
@@ -215,6 +215,19 @@ function ResumeVSInstall {
         [int]$ProcessExitTimeoutInSeconds
     )
 
+    # Ensure we have the latest VS_Installer
+    
+    $VSBootstrapperUrl = "https://aka.ms/vs/16/intpreview/vs_enterprise.exe"
+    $tempdir = [System.IO.Path]::GetTempPath()
+    $VSBootstrapperPath =  "$tempdir" + "vs_enterprise.exe"
+    Write-Host "Downloading [$VSBootstrapperUrl]`nSaving at [$VSBootstrapperPath]" 
+    $client = new-object System.Net.WebClient 
+    $client.DownloadFile($VSBootstrapperUrl, $VSBootstrapperPath)
+
+    Write-Host "Running bootstrapper to update the locally installed VS Installer"
+    Start-Process -FilePath "$VSBootstrapperPath" -ArgumentList "--update", "--quiet"
+
+
     $ProgramFilesPath = ${env:ProgramFiles}
     if (Test-Path ${env:ProgramFiles(x86)}) {
         $ProgramFilesPath = ${env:ProgramFiles(x86)}

--- a/scripts/e2etests/VSUtils.ps1
+++ b/scripts/e2etests/VSUtils.ps1
@@ -225,8 +225,8 @@ function ResumeVSInstall {
     $client.DownloadFile($VSBootstrapperUrl, $VSBootstrapperPath)
 
     Write-Host "Running bootstrapper to update the locally installed VS Installer"
+    Write-Host "$VSBootstrapperPath --update --quiet"
     Start-Process -FilePath "$VSBootstrapperPath" -ArgumentList "--update", "--quiet"
-
 
     $ProgramFilesPath = ${env:ProgramFiles}
     if (Test-Path ${env:ProgramFiles(x86)}) {


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Client.Engineering/issues/261
Regression: No

## Fix

Details: download and execute the VS_Bootstrapper exe to update the VS_Installer.exe

## Testing/Validation

Tests Added: No
Reason for not adding tests:  E2E test script
Validation:  Running on CI and then will reenable machine that is current broken to test.
