### PR TITLE
Enable timestamp provider test and fix 3 broken tests

### DIFF
--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignatureUtilityTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignatureUtilityTests.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#if IS_DESKTOP
+#if IS_SIGNING_SUPPORTED
 
 using System;
 using System.Collections.Generic;

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignedPackageArchiveTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignedPackageArchiveTests.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#if IS_DESKTOP
+#if IS_SIGNING_SUPPORTED
 using System;
 using System.IO;
 using System.Security.Cryptography.X509Certificates;

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SigningUtilityTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SigningUtilityTests.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#if IS_DESKTOP
+#if IS_SIGNING_SUPPORTED
 
 using System;
 using System.Diagnostics;

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/TimestampProviderTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/TimestampProviderTests.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#if IS_DESKTOP
+#if IS_SIGNING_SUPPORTED
 
 using System;
 using System.Collections.Generic;

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/TimestampProviderTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/TimestampProviderTests.cs
@@ -27,7 +27,7 @@ namespace NuGet.Packaging.FuncTest
 #if IS_DESKTOP
         private const string ArgumentNullExceptionMessage = "Value cannot be null.\r\nParameter name: {0}";
 #else
-        private const string ArgumentNullExceptionMessage = "Value cannot be null. (Parameter name: '{0}')";
+        private const string ArgumentNullExceptionMessage = "Value cannot be null. (Parameter '{0}')";
 #endif
         private const string OperationCancelledExceptionMessage = "The operation was canceled.";
 

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/TimestampProviderTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/TimestampProviderTests.cs
@@ -70,7 +70,7 @@ namespace NuGet.Packaging.FuncTest
         }
 
         [CIOnlyFact]
-        public async Task GetTimestamp_AssertCompleteChain_SuccessAsync()
+        public async Task GetTimestampAsync_AssertCompleteChain_SuccessAsync()
         {
             var timestampService = await _testFixture.GetDefaultTrustedTimestampServiceAsync();
             var timestampProvider = new Rfc3161TimestampProvider(timestampService.Url);
@@ -157,16 +157,15 @@ namespace NuGet.Packaging.FuncTest
                     target: SignaturePlacement.PrimarySignature
                 );
 
-                // Act
-                Action timestampAction = async () => await timestampProvider.GetTimestampAsync(null, logger, CancellationToken.None);
-
                 // Assert
-                timestampAction.ShouldThrow<ArgumentNullException>()
-                    .WithMessage(string.Format(ArgumentNullExceptionMessage, nameof(request)));
+                var exception = await Assert.ThrowsAsync<ArgumentNullException>(
+                    () => timestampProvider.GetTimestampAsync(null, logger, CancellationToken.None));
+
+                Assert.Equal(string.Format(ArgumentNullExceptionMessage, nameof(request)), exception.Message);
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task GetTimestampAsync_WhenLoggerNull_ThrowsAsync()
         {
             var timestampService = await _testFixture.GetDefaultTrustedTimestampServiceAsync();
@@ -188,12 +187,11 @@ namespace NuGet.Packaging.FuncTest
                     target: SignaturePlacement.PrimarySignature
                 );
 
-                // Act
-                Action timestampAction = async () => await timestampProvider.GetTimestampAsync(request, null, CancellationToken.None);
-
                 // Assert
-                timestampAction.ShouldThrow<ArgumentNullException>()
-                    .WithMessage(string.Format(ArgumentNullExceptionMessage, "logger"));
+                var exception = await Assert.ThrowsAsync<ArgumentNullException>(
+                    () => timestampProvider.GetTimestampAsync(request, null, CancellationToken.None));
+
+                Assert.Equal(string.Format(ArgumentNullExceptionMessage, "logger"), exception.Message);
             }
         }
 
@@ -220,12 +218,11 @@ namespace NuGet.Packaging.FuncTest
                    target: SignaturePlacement.PrimarySignature
                );
 
-                // Act
-                Action timestampAction = async () => await timestampProvider.GetTimestampAsync(request, logger, new CancellationToken(canceled: true));
-
                 // Assert
-                timestampAction.ShouldThrow<OperationCanceledException>()
-                    .WithMessage(OperationCancelledExceptionMessage);
+                var exception = await Assert.ThrowsAsync<ArgumentNullException>(
+                    () => timestampProvider.GetTimestampAsync(request, logger, new CancellationToken(canceled: true)));
+
+                Assert.Equal(OperationCancelledExceptionMessage, exception.Message);
             }
         }
 

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/TimestampProviderTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/TimestampProviderTests.cs
@@ -24,7 +24,11 @@ namespace NuGet.Packaging.FuncTest
     [Collection(SigningTestCollection.Name)]
     public class TimestampProviderTests
     {
+#if IS_DESKTOP
         private const string ArgumentNullExceptionMessage = "Value cannot be null.\r\nParameter name: {0}";
+#else
+        private const string ArgumentNullExceptionMessage = "Value cannot be null. (Parameter name: '{0}')";
+#endif
         private const string OperationCancelledExceptionMessage = "The operation was canceled.";
 
         private SigningTestFixture _testFixture;

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/TimestampProviderTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/TimestampProviderTests.cs
@@ -163,7 +163,7 @@ namespace NuGet.Packaging.FuncTest
 
                 // Assert
                 var exception = await Assert.ThrowsAsync<ArgumentNullException>(
-                    () => timestampProvider.GetTimestampAsync(request : null, logger, CancellationToken.None));
+                    () => timestampProvider.GetTimestampAsync(request: null, logger, CancellationToken.None));
 
                 Assert.Equal(string.Format(ArgumentNullExceptionMessage, nameof(request)), exception.Message);
             }
@@ -193,7 +193,7 @@ namespace NuGet.Packaging.FuncTest
 
                 // Assert
                 var exception = await Assert.ThrowsAsync<ArgumentNullException>(
-                    () => timestampProvider.GetTimestampAsync(request, logger : null, CancellationToken.None));
+                    () => timestampProvider.GetTimestampAsync(request, logger: null, CancellationToken.None));
 
                 Assert.Equal(string.Format(ArgumentNullExceptionMessage, "logger"), exception.Message);
             }

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/TimestampProviderTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/TimestampProviderTests.cs
@@ -163,7 +163,7 @@ namespace NuGet.Packaging.FuncTest
 
                 // Assert
                 var exception = await Assert.ThrowsAsync<ArgumentNullException>(
-                    () => timestampProvider.GetTimestampAsync(null, logger, CancellationToken.None));
+                    () => timestampProvider.GetTimestampAsync(request : null, logger, CancellationToken.None));
 
                 Assert.Equal(string.Format(ArgumentNullExceptionMessage, nameof(request)), exception.Message);
             }
@@ -193,7 +193,7 @@ namespace NuGet.Packaging.FuncTest
 
                 // Assert
                 var exception = await Assert.ThrowsAsync<ArgumentNullException>(
-                    () => timestampProvider.GetTimestampAsync(request, null, CancellationToken.None));
+                    () => timestampProvider.GetTimestampAsync(request, logger : null, CancellationToken.None));
 
                 Assert.Equal(string.Format(ArgumentNullExceptionMessage, "logger"), exception.Message);
             }

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/TimestampProviderTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/TimestampProviderTests.cs
@@ -24,11 +24,6 @@ namespace NuGet.Packaging.FuncTest
     [Collection(SigningTestCollection.Name)]
     public class TimestampProviderTests
     {
-#if IS_DESKTOP
-        private const string ArgumentNullExceptionMessage = "Value cannot be null.\r\nParameter name: {0}";
-#else
-        private const string ArgumentNullExceptionMessage = "Value cannot be null. (Parameter '{0}')";
-#endif
         private const string OperationCancelledExceptionMessage = "The operation was canceled.";
 
         private SigningTestFixture _testFixture;
@@ -165,7 +160,8 @@ namespace NuGet.Packaging.FuncTest
                 var exception = await Assert.ThrowsAsync<ArgumentNullException>(
                     () => timestampProvider.GetTimestampAsync(request: null, logger, CancellationToken.None));
 
-                Assert.Equal(string.Format(ArgumentNullExceptionMessage, nameof(request)), exception.Message);
+                Assert.Equal("request", exception.ParamName);
+                Assert.StartsWith("Value cannot be null.", exception.Message);
             }
         }
 
@@ -195,7 +191,8 @@ namespace NuGet.Packaging.FuncTest
                 var exception = await Assert.ThrowsAsync<ArgumentNullException>(
                     () => timestampProvider.GetTimestampAsync(request, logger: null, CancellationToken.None));
 
-                Assert.Equal(string.Format(ArgumentNullExceptionMessage, "logger"), exception.Message);
+                Assert.Equal("logger", exception.ParamName);
+                Assert.StartsWith("Value cannot be null.", exception.Message);
             }
         }
 

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/TimestampProviderTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/TimestampProviderTests.cs
@@ -165,7 +165,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Fact]
+        [CIOnlyFact]
         public async Task GetTimestampAsync_WhenLoggerNull_ThrowsAsync()
         {
             var timestampService = await _testFixture.GetDefaultTrustedTimestampServiceAsync();

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/TimestampProviderTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/TimestampProviderTests.cs
@@ -219,7 +219,7 @@ namespace NuGet.Packaging.FuncTest
                );
 
                 // Assert
-                var exception = await Assert.ThrowsAsync<ArgumentNullException>(
+                var exception = await Assert.ThrowsAsync<OperationCanceledException>(
                     () => timestampProvider.GetTimestampAsync(request, logger, new CancellationToken(canceled: true)));
 
                 Assert.Equal(OperationCancelledExceptionMessage, exception.Message);

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
@@ -969,7 +969,7 @@ namespace NuGet.Commands.Test
             }
         }
 
-#if IS_DESKTOP
+#if IS_SIGNING_SUPPORTED
         [Fact]
         public async Task RestoreCommand_InvalidSignedPackageAsync()
         {

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageArchiveReaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageArchiveReaderTests.cs
@@ -1597,7 +1597,7 @@ namespace NuGet.Packaging.Test
             }
         }
 
-#if IS_DESKTOP
+#if IS_SIGNING_SUPPORTED
         [Fact]
         public async Task ValidateIntegrityAsync_WhenSignatureContentNull_Throws()
         {
@@ -1835,7 +1835,7 @@ namespace NuGet.Packaging.Test
             }
         }
 
-#if IS_DESKTOP
+#if IS_SIGNING_SUPPORTED
         [CIOnlyFact]
         public async Task GetContentHash_IsSameForUnsignedAndSignedPackageAsync()
         {

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/AttributeUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/AttributeUtilityTests.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#if IS_DESKTOP
+#if IS_SIGNING_SUPPORTED
 using System;
 using System.Linq;
 using System.Security.Cryptography;

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/EssCertIdTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/EssCertIdTests.cs
@@ -36,7 +36,7 @@ namespace NuGet.Packaging.Test
                 () => EssCertId.Read(new byte[] { 0x30, 0x0b }));
         }
 
-#if !IS_CORECLR
+#if IS_SIGNING_SUPPORTED
         [Fact]
         public void Read_WithValidInput_ReturnsEssCertId()
         {

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/EssCertIdV2Tests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/EssCertIdV2Tests.cs
@@ -168,7 +168,7 @@ namespace NuGet.Packaging.Test
             SigningTestUtility.VerifyByteArrays(bcIssuerSerial.Serial.Value.ToByteArray(), essCertIdV2.IssuerSerial.SerialNumber);
         }
 
-#if !IS_CORECLR
+#if IS_SIGNING_SUPPORTED
         [Fact]
         public void Read_WithValidInput_ReturnsEssCertId()
         {

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/PrimarySignatureTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/PrimarySignatureTests.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#if IS_DESKTOP
+#if IS_SIGNING_SUPPORTED
 using System;
 using System.Security.Cryptography.Pkcs;
 using System.Security.Cryptography.X509Certificates;

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/ReadOnlyBufferedStreamTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/ReadOnlyBufferedStreamTests.cs
@@ -249,7 +249,7 @@ namespace NuGet.Packaging.Test
             }
         }
 
-#if IS_DESKTOP
+#if IS_SIGNING_SUPPORTED
         [Fact]
         public void Close_WhenLeaveOpenFalse_DisposesUnderlyingStream()
         {

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/RepositoryCountersignatureTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/RepositoryCountersignatureTests.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#if IS_DESKTOP
+#if IS_SIGNING_SUPPORTED
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/SignatureTrustAndValidityVerificationProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/SignatureTrustAndValidityVerificationProviderTests.cs
@@ -14,7 +14,7 @@ namespace NuGet.Packaging.Test
 {
     public class SignatureTrustAndValidityVerificationProviderTests
     {
-#if IS_DESKTOP
+#if IS_SIGNING_SUPPORTED
         private static readonly Lazy<PrimarySignature> _signature = new Lazy<PrimarySignature>(
             () => PrimarySignature.Load(SigningTestUtility.GetResourceBytes(".signature.p7s")));
 #endif
@@ -25,7 +25,7 @@ namespace NuGet.Packaging.Test
             _provider = new SignatureTrustAndValidityVerificationProvider();
         }
 
-#if IS_DESKTOP
+#if IS_SIGNING_SUPPORTED
         [Fact]
         public async Task GetTrustResultAsync_WhenPackageIsNull_Throws()
         {
@@ -53,7 +53,7 @@ namespace NuGet.Packaging.Test
             Assert.Equal("signature", exception.ParamName);
         }
 
-#if IS_DESKTOP
+#if IS_SIGNING_SUPPORTED
         [Fact]
         public async Task GetTrustResultAsync_WhenSettingsIsNull_Throws()
         {

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/SignatureUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/SignatureUtilityTests.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#if IS_DESKTOP
+#if IS_SIGNING_SUPPORTED
 using System;
 using System.IO;
 using System.Threading;

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/SignedPackageArchiveIOUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/SignedPackageArchiveIOUtilityTests.cs
@@ -165,7 +165,7 @@ namespace NuGet.Packaging.Test
             }
         }
 
-#if !IS_CORECLR
+#if IS_SIGNING_SUPPORTED
         [Fact]
         public void ReadAndHashUntilPosition_WhenPositionAtStart_ReadsAndHashes()
         {
@@ -248,7 +248,7 @@ namespace NuGet.Packaging.Test
             }
         }
 
-#if !IS_CORECLR
+#if IS_SIGNING_SUPPORTED
         [Fact]
         public void HashBytes_WithInputBytes_Hashes()
         {
@@ -486,7 +486,7 @@ namespace NuGet.Packaging.Test
 
             internal string GetHash()
             {
-#if !IS_CORECLR
+#if IS_SIGNING_SUPPORTED
                 HashAlgorithm.TransformFinalBlock(new byte[0], inputOffset: 0, inputCount: 0);
 
                 return Convert.ToBase64String(HashAlgorithm.Hash);

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/SignedPackageArchiveTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/SignedPackageArchiveTests.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#if IS_DESKTOP
+#if IS_SIGNING_SUPPORTED
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/SignedPackageArchiveUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/SignedPackageArchiveUtilityTests.cs
@@ -257,7 +257,7 @@ namespace NuGet.Packaging.Test
             }
         }
 
-#if IS_DESKTOP
+#if IS_SIGNING_SUPPORTED
         [Fact]
         public async Task RemoveRepositorySignaturesAsync_WithNullInput_Throws()
         {
@@ -542,7 +542,7 @@ namespace NuGet.Packaging.Test
             }
         }
 
-#if IS_DESKTOP
+#if IS_SIGNING_SUPPORTED
         private sealed class RemoveTest : IDisposable
         {
             private bool _isDisposed;

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/SigningOptionsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/SigningOptionsTests.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#if IS_DESKTOP
+#if IS_SIGNING_SUPPORTED
 using System;
 using System.IO;
 using Moq;

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/SigningUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/SigningUtilityTests.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
-#if IS_DESKTOP
+#if IS_SIGNING_SUPPORTED
 using System.Security.Cryptography.Pkcs;
 #endif
 using System.Security.Cryptography.X509Certificates;
@@ -159,7 +159,7 @@ namespace NuGet.Packaging.Test
 
         }
 
-#if IS_DESKTOP
+#if IS_SIGNING_SUPPORTED
         [Fact]
         public void CreateSignedAttributes_SignPackageRequest_WhenRequestNull_Throws()
         {

--- a/test/TestUtilities/Test.Utility/Signing/SigningTestUtility.cs
+++ b/test/TestUtilities/Test.Utility/Signing/SigningTestUtility.cs
@@ -496,7 +496,7 @@ namespace Test.Utility.Signing
 
             return cms;
         }
-#if IS_DESKTOP
+#if IS_SIGNING_SUPPORTED
         /// <summary>
         /// Generates a SignedCMS object for some content.
         /// </summary>


### PR DESCRIPTION
## Bug

Fixes: 
[NuGet/Home/issues/8919  ](https://github.com/NuGet/Home/issues/8919  )
[NuGet/Home/issues/8938](https://github.com/NuGet/Home/issues/8938)
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: 
1.Enable `TimestampProviderTests `for netcore5.0
2.Fix 3 broken tests in TimestampProviderTests, they're:
```
GetTimestampAsync_WhenRequestNull_ThrowsAsync
GetTimestampAsync_WhenLoggerNull_ThrowsAsync
GetTimestampAsync_WhenCancelled_ThrowsAsync
```
3.Enable all unit tests for xplat verification/signing 
4.Enable 8 more functional tests for xplat verification/signing

## Testing/Validation

Tests Added: Yes/No  
Reason for not adding tests:  
Validation:  
