### PR TITLE
Add an async IsSolutionOpen check

### DIFF
--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreStatusProvider.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreStatusProvider.cs
@@ -38,7 +38,7 @@ namespace NuGet.SolutionRestoreManager
             var complete = true;
 
             // Check if the solution is open, if there are no projects then consider it restored.
-            if (_solutionManager.Value.IsSolutionOpen)
+            if (await _solutionManager.Value.IsSolutionOpenAsync())
             {
                 var graphContext = new DependencyGraphCacheContext();
                 var projects = (await _solutionManager.Value.GetNuGetProjectsAsync()).AsList();

--- a/src/NuGet.Clients/NuGet.Tools/NuGetPackage.cs
+++ b/src/NuGet.Clients/NuGet.Tools/NuGetPackage.cs
@@ -196,7 +196,7 @@ namespace NuGetVSExtension
             // when NuGet loads, if the current solution has some package
             // folders marked for deletion (because a previous uninstalltion didn't succeed),
             // delete them now.
-            if (SolutionManager.Value.IsSolutionOpen)
+            if (await SolutionManager.Value.IsSolutionOpenAsync())
             {
                 await DeleteOnRestartManager.Value.DeleteMarkedPackageDirectoriesAsync(ProjectContext.Value);
             }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/IDE/IVsSolutionManager.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/IDE/IVsSolutionManager.cs
@@ -86,5 +86,10 @@ namespace NuGet.PackageManagement.VisualStudio
         /// </summary>
         /// <returns></returns>
         Task<string> GetSolutionFilePathAsync();
+
+        /// <summary>
+        /// Returns whether the solution is open.
+        /// </summary>
+        Task<bool> IsSolutionOpenAsync();
     }
 }

--- a/src/NuGet.Clients/NuGetConsole.Host.PowerShell/PowerShellHost.cs
+++ b/src/NuGet.Clients/NuGetConsole.Host.PowerShell/PowerShellHost.cs
@@ -403,7 +403,7 @@ namespace NuGetConsole.Host.PowerShell.Implementation
                 if (Runspace.RunspaceAvailability == RunspaceAvailability.Available)
                 {
                     // if there is no solution open, we set the active directory to be user profile folder
-                    var targetDir = _solutionManager.Value.IsSolutionOpen ?
+                    var targetDir = await _solutionManager.Value.IsSolutionOpenAsync() ?
                         _solutionManager.Value.SolutionDirectory :
                         Environment.GetEnvironmentVariable("USERPROFILE");
 
@@ -418,7 +418,7 @@ namespace NuGetConsole.Host.PowerShell.Implementation
             // Fix for Bug 1426 Disallow ExecuteInitScripts from being executed concurrently by multiple threads.
             using (await _initScriptsLock.EnterAsync())
             {
-                if (!_solutionManager.Value.IsSolutionOpen)
+                if (!await _solutionManager.Value.IsSolutionOpenAsync())
                 {
                     return;
                 }


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9096
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: Our code contains a mix of sync/async code. 
Whenever possible we should prefer async code especially when interacting with VS services. 

See:
https://github.com/microsoft/vs-threading/blob/master/doc/analyzers/VSTHRD102.md
https://github.com/microsoft/vs-threading/blob/master/doc/analyzers/VSTHRD104.md

In here, I am just cleaning up the references to IsSolutionOpen from async codepaths to avoid JTF.Run nesting. 
In a method invocation, whenever possible JTF.Run should be called only once. 

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  Internal VS scenarios tested by E2E/Apex tests. 
Validation:  Existing automation, some manual tests. 
