### PR TITLE
enable TrustedSignerActionsProvider on netcore, along with tests

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/TrustedSignersCommand/TrustedSignerActionsProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/TrustedSignersCommand/TrustedSignerActionsProvider.cs
@@ -67,7 +67,7 @@ namespace NuGet.Commands
             throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, Strings.Error_TrustedRepositoryDoesNotExist, name));
         }
 
-#if IS_DESKTOP
+#if IS_SIGNING_SUPPORTED
         /// <summary>
         /// Adds a trusted signer item to the settings based a signed package.
         /// </summary>
@@ -257,7 +257,7 @@ namespace NuGet.Commands
             }
         }
 
-#if IS_DESKTOP
+#if IS_SIGNING_SUPPORTED
         private CertificateItem GetCertificateItemForSignature(ISignature signature, bool allowUntrustedRoot = false)
         {
             var defaultHashAlgorithm = HashAlgorithmName.SHA256;

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/TrustedSignerActionsProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/TrustedSignerActionsProviderTests.cs
@@ -5,7 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-#if IS_DESKTOP
+#if IS_SIGNING_SUPPORTED
 using System.Security.Cryptography.Pkcs;
 #endif
 using System.Threading;
@@ -195,7 +195,7 @@ namespace NuGet.Commands.Test
                     SettingsTestUtils.DeepEquals(i.Certificates.First(), expectedCert))));
         }
 
-#if IS_DESKTOP
+#if IS_SIGNING_SUPPORTED
         [Fact]
         public async Task AddTrustedSignerAsync_WithNullPackage_ThrowsAsync()
         {
@@ -305,7 +305,7 @@ namespace NuGet.Commands.Test
         }
 
         [Fact]
-        public async Task AddTrustedSignersAsync_UnsignedPackage_ThrowsAsync()
+        public async Task AddTrustedSignerAsync_UnsignedPackage_ThrowsAsync()
         {
             // Arrange
             var trustedSignersProvider = new Mock<ITrustedSignersProvider>();
@@ -332,7 +332,7 @@ namespace NuGet.Commands.Test
         }
 
         [CIOnlyFact]
-        public async Task AddTrustedSignersAsync_TargetRepository_NonRepositorySignedPackage_ThrowsAsync()
+        public async Task AddTrustedSignerAsync_TargetRepository_NonRepositorySignedPackage_ThrowsAsync()
         {
             // Arrange
             var trustedSignersProvider = new Mock<ITrustedSignersProvider>();
@@ -364,7 +364,7 @@ namespace NuGet.Commands.Test
         }
 
         [CIOnlyFact]
-        public async Task AddTrustedSignersAsync_NameAlreadyExists_ThrowsAsync()
+        public async Task AddTrustedSignerAsync_NameAlreadyExists_ThrowsAsync()
         {
             // Arrange
             var trustedSignersProvider = new Mock<ITrustedSignersProvider>();
@@ -403,7 +403,7 @@ namespace NuGet.Commands.Test
         }
 
         [CIOnlyFact]
-        public async Task AddTrustedSignersAsync_ServiceIndexAlreadyExists_ThrowsAsync()
+        public async Task AddTrustedSignerAsync_ServiceIndexAlreadyExists_ThrowsAsync()
         {
             // Arrange
             var trustedSignersProvider = new Mock<ITrustedSignersProvider>();
@@ -443,7 +443,7 @@ namespace NuGet.Commands.Test
         }
 
         [CIOnlyFact]
-        public async Task AddTrustedSignersAsync_WithUnknownPrimarySignature_ThrowsAsync()
+        public async Task AddTrustedSignerAsync_WithUnknownPrimarySignature_ThrowsAsync()
         {
             // Arrange
             var trustedSignersProvider = new Mock<ITrustedSignersProvider>();
@@ -491,7 +491,7 @@ namespace NuGet.Commands.Test
         }
 
         [CIOnlyFact]
-        public async Task AddTrustedSignersAsync_RepositorySignedPackage_AddsRepositoryCorrectlyAsync()
+        public async Task AddTrustedSignerAsync_RepositorySignedPackage_AddsRepositoryCorrectlyAsync()
         {
             // Arrange
             var trustedSignersProvider = new Mock<ITrustedSignersProvider>();
@@ -536,7 +536,7 @@ namespace NuGet.Commands.Test
         }
 
         [CIOnlyFact]
-        public async Task AddTrustedSignersAsync_RepositorySignedPackage_WithOwners_AddsRepositoryCorrectlyAsync()
+        public async Task AddTrustedSignerAsync_RepositorySignedPackage_WithOwners_AddsRepositoryCorrectlyAsync()
         {
             // Arrange
             var trustedSignersProvider = new Mock<ITrustedSignersProvider>();
@@ -582,7 +582,7 @@ namespace NuGet.Commands.Test
         }
 
         [CIOnlyFact]
-        public async Task AddTrustedSignersAsync_RepositorySignedPackage_WithAllowUntrustedRoot_AddsRepositoryCorrectlyAsync()
+        public async Task AddTrustedSignerAsync_RepositorySignedPackage_WithAllowUntrustedRoot_AddsRepositoryCorrectlyAsync()
         {
             // Arrange
             var trustedSignersProvider = new Mock<ITrustedSignersProvider>();
@@ -628,7 +628,7 @@ namespace NuGet.Commands.Test
         }
 
         [CIOnlyFact]
-        public async Task AddTrustedSignersAsync_RepositoryCountersignedPackage_AddsRepositoryCorrectlyAsync()
+        public async Task AddTrustedSignerAsync_RepositoryCountersignedPackage_AddsRepositoryCorrectlyAsync()
         {
             // Arrange
             var trustedSignersProvider = new Mock<ITrustedSignersProvider>();
@@ -675,7 +675,7 @@ namespace NuGet.Commands.Test
         }
 
         [CIOnlyFact]
-        public async Task AddTrustedSignersAsync_RepositoryCountersignedPackage_WithOwners_AddsRepositoryCorrectlyAsync()
+        public async Task AddTrustedSignerAsync_RepositoryCountersignedPackage_WithOwners_AddsRepositoryCorrectlyAsync()
         {
             // Arrange
             var trustedSignersProvider = new Mock<ITrustedSignersProvider>();
@@ -723,7 +723,7 @@ namespace NuGet.Commands.Test
         }
 
         [CIOnlyFact]
-        public async Task AddTrustedSignersAsync_RepositoryCountersignedPackage_WithAllowUntrustedRoot_AddsRepositoryCorrectlyAsync()
+        public async Task AddTrustedSignerAsync_RepositoryCountersignedPackage_WithAllowUntrustedRoot_AddsRepositoryCorrectlyAsync()
         {
             // Arrange
             var trustedSignersProvider = new Mock<ITrustedSignersProvider>();
@@ -771,7 +771,7 @@ namespace NuGet.Commands.Test
         }
 
         [CIOnlyFact]
-        public async Task AddTrustedSignersAsync_AuthorSignedPackage_AddsAuthorCorrectlyAsync()
+        public async Task AddTrustedSignerAsync_AuthorSignedPackage_AddsAuthorCorrectlyAsync()
         {
             // Arrange
             var trustedSignersProvider = new Mock<ITrustedSignersProvider>();
@@ -813,7 +813,7 @@ namespace NuGet.Commands.Test
         }
 
         [CIOnlyFact]
-        public async Task AddTrustedSignersAsync_AuthorSignedPackage_WithAllowUntrustedRoot_AddsAuthorCorrectlyAsync()
+        public async Task AddTrustedSignerAsync_AuthorSignedPackage_WithAllowUntrustedRoot_AddsAuthorCorrectlyAsync()
         {
             // Arrange
             var trustedSignersProvider = new Mock<ITrustedSignersProvider>();


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Home/issues/8921