### PR TITLE
Fix for missing icon in details pane

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailControlModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailControlModel.cs
@@ -79,6 +79,7 @@ namespace NuGet.PackageManagement.UI
             _filter = filter;
             OnPropertyChanged(nameof(Id));
             OnPropertyChanged(nameof(PackageReader));
+            OnPropertyChanged(nameof(IconUrl));
             OnPropertyChanged(nameof(PrefixReserved));
 
             var getVersionsTask = searchResultPackage.GetVersionsAsync();


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9113
Regression: Yes
* Last working version: 5.5.0.6368
* How are we preventing it in future: Testing thoughtfully

## Fix

Details: Triggers OnPropertyChange event for `PackageReader` and `IconUrl` properties, in that specific order.

## Testing/Validation

Tests Added: No
Reason for not adding tests:
Validation:  Manual validation

### Before

![before](https://user-images.githubusercontent.com/1192347/73402476-3c2def80-42a2-11ea-96e8-866dbdec1b2d.gif)


### After

![after](https://user-images.githubusercontent.com/1192347/73400962-0afff000-429f-11ea-9ed7-d0deeed8982c.gif)
