### PR TITLE
Restore:  improve DependencyGraphSpec.Save(...) performance

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/RuntimeModel/IObjectWriter.cs
+++ b/src/NuGet.Core/NuGet.Packaging/RuntimeModel/IObjectWriter.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 
 namespace NuGet.RuntimeModel
@@ -12,6 +13,17 @@ namespace NuGet.RuntimeModel
     public interface IObjectWriter
     {
         /// <summary>
+        /// Writes the start of the root object or an object in an array.
+        ///
+        /// This new object becomes the scope for all other method calls until either WriteObjectStart
+        /// is called again to start a new nested object or WriteObjectEnd is called.
+        ///
+        /// Every call to WriteObjectStart must be balanced by a corresponding call to WriteObjectEnd.
+        /// </summary>
+        /// <exception cref="ObjectDisposedException">Thrown if this object is disposed.</exception>
+        void WriteObjectStart();
+
+        /// <summary>
         /// Writes the start of a nested object.
         ///
         /// This new object becomes the scope for all other method calls until either WriteObjectStart
@@ -19,7 +31,9 @@ namespace NuGet.RuntimeModel
         ///
         /// Every call to WriteObjectStart must be balanced by a corresponding call to WriteObjectEnd.
         /// </summary>
-        /// <param name="name">The name of the object.  Throws if <c>null</c>.</param>
+        /// <param name="name">The name of the object.</param>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="name" /> is <c>null</c>.</exception>
+        /// <exception cref="ObjectDisposedException">Thrown if this object is disposed.</exception>
         void WriteObjectStart(string name);
 
         /// <summary>
@@ -30,42 +44,53 @@ namespace NuGet.RuntimeModel
         ///
         /// Every call to WriteObjectStart must be balanced by a corresponding call to WriteObjectEnd.
         /// </summary>
+        /// <exception cref="ObjectDisposedException">Thrown if this object is disposed.</exception>
         void WriteObjectEnd();
 
         /// <summary>
         /// Writes a name-value pair.
         /// </summary>
-        /// <param name="name">The name of the datum.  Throws if <c>null</c>.</param>
+        /// <param name="name">The name of the datum.</param>
         /// <param name="value">The datum.</param>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="name" /> is <c>null</c>.</exception>
+        /// <exception cref="ObjectDisposedException">Thrown if this object is disposed.</exception>
         void WriteNameValue(string name, int value);
 
         /// <summary>
         /// Writes a name-value pair.
         /// </summary>
-        /// <param name="name">The name of the datum.  Throws if <c>null</c>.</param>
+        /// <param name="name">The name of the datum.</param>
         /// <param name="value">The datum.</param>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="name" /> is <c>null</c>.</exception>
+        /// <exception cref="ObjectDisposedException">Thrown if this object is disposed.</exception>
         void WriteNameValue(string name, bool value);
 
         /// <summary>
         /// Writes a name-value pair.
         /// </summary>
-        /// <param name="name">The name of the datum.  Throws if <c>null</c>.</param>
+        /// <param name="name">The name of the datum.</param>
         /// <param name="value">The datum.</param>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="name" /> is <c>null</c>.</exception>
+        /// <exception cref="ObjectDisposedException">Thrown if this object is disposed.</exception>
         void WriteNameValue(string name, string value);
 
         /// <summary>
         /// Writes a name-collection pair.
         /// </summary>
-        /// <param name="name">The name of the data.  Throws if <c>null</c>.</param>
+        /// <param name="name">The name of the data.</param>
         /// <param name="values">The data.</param>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="name" /> is <c>null</c>.</exception>
+        /// <exception cref="ObjectDisposedException">Thrown if this object is disposed.</exception>
         void WriteNameArray(string name, IEnumerable<string> values);
 
         /// <summary>
         /// Writes the start of an array.
-        /// The new object becomes the scope of all other methods until WriteObjectInArrayStart is called to start a new object in the array, or WriteArrayEnd is called.
+        /// The new object becomes the scope of all other methods until WriteArrayStart is called to start a new object in the array, or WriteArrayEnd is called.
         /// Every call to WriteArrayStart needs to be balanced with a corresponding call to WriteArrayEnd and not WriteObjectEnd.
         /// </summary>
         /// <param name="name">The array name</param>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="name" /> is <c>null</c>.</exception>
+        /// <exception cref="ObjectDisposedException">Thrown if this object is disposed.</exception>
         void WriteArrayStart(string name);
 
         /// <summary>
@@ -76,18 +101,7 @@ namespace NuGet.RuntimeModel
         ///
         /// Every call to WriteArrayStart needs to be balanced with a corresponding call to WriteArrayEnd and not WriteObjectEnd.
         /// </summary>
+        /// <exception cref="ObjectDisposedException">Thrown if this object is disposed.</exception>
         void WriteArrayEnd();
-
-        /// <summary>
-        /// Writes the start of a nested object in array.
-        ///
-        /// This new object becomes the scope for all other method calls until either WriteObjectInArrayStart
-        /// is called again to start a new nested object or WriteObjectEnd is called.
-        ///
-        /// Every call to WriteObjectInArrayStart must be balanced by a corresponding call to WriteObjectEnd.
-        /// </summary>
-        void WriteObjectInArrayStart();
-
-
     }
 }

--- a/src/NuGet.Core/NuGet.ProjectModel/DependencyGraphSpec.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/DependencyGraphSpec.cs
@@ -19,7 +19,7 @@ namespace NuGet.ProjectModel
         private readonly SortedSet<string> _restore = new SortedSet<string>(PathUtility.GetStringComparerBasedOnOS());
         private readonly SortedDictionary<string, PackageSpec> _projects = new SortedDictionary<string, PackageSpec>(PathUtility.GetStringComparerBasedOnOS());
 
-        private const int _version = 1;
+        private const int Version = 1;
 
         private readonly bool _isReadOnly;
 
@@ -238,22 +238,15 @@ namespace NuGet.ProjectModel
 
         public void Save(string path)
         {
-            var json = GetJson();
-
             using (var fileStream = new FileStream(path, FileMode.Create))
             using (var textWriter = new StreamWriter(fileStream))
+            using (var jsonWriter = new JsonTextWriter(textWriter))
+            using (var writer = new RuntimeModel.JsonObjectWriter(jsonWriter))
             {
-                textWriter.Write(json);
+                jsonWriter.Formatting = Formatting.Indented;
+
+                Write(writer, PackageSpecWriter.Write);
             }
-        }
-
-        private string GetJson()
-        {
-            var writer = new RuntimeModel.JsonObjectWriter();
-
-            Write(writer, PackageSpecWriter.Write);
-
-            return writer.GetJson();
         }
 
         private void ParseJson(JObject json)
@@ -309,7 +302,8 @@ namespace NuGet.ProjectModel
 
         private void Write(RuntimeModel.IObjectWriter writer, Action<PackageSpec, RuntimeModel.IObjectWriter> writeAction)
         {
-            writer.WriteNameValue("format", _version);
+            writer.WriteObjectStart();
+            writer.WriteNameValue("format", Version);
 
             writer.WriteObjectStart("restore");
 
@@ -334,6 +328,7 @@ namespace NuGet.ProjectModel
                 writer.WriteObjectEnd();
             }
 
+            writer.WriteObjectEnd();
             writer.WriteObjectEnd();
         }
 

--- a/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileFormat.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileFormat.cs
@@ -195,16 +195,23 @@ namespace NuGet.ProjectModel
             {
                 if (lockFile.PackageSpec != null)
                 {
-                    var writer = new JsonObjectWriter();
-                    PackageSpecWriter.Write(lockFile.PackageSpec, writer);
-                    var packageSpec = writer.GetJObject();
-                    json[PackageSpecProperty] = packageSpec;
+                    using (var jsonWriter = new JTokenWriter())
+                    using (var writer = new JsonObjectWriter(jsonWriter))
+                    {
+                        writer.WriteObjectStart();
+
+                        PackageSpecWriter.Write(lockFile.PackageSpec, writer);
+
+                        writer.WriteObjectEnd();
+
+                        json[PackageSpecProperty] = (JObject)jsonWriter.Token;
+                    }
                 }
             }
 
-            if(lockFile.Version >= 3)
+            if (lockFile.Version >= 3)
             {
-                if(lockFile.LogMessages.Count > 0)
+                if (lockFile.LogMessages.Count > 0)
                 {
                     var projectPath = lockFile.PackageSpec?.RestoreMetadata?.ProjectPath;
                     json[LogsProperty] = WriteLogMessages(lockFile.LogMessages, projectPath);
@@ -270,7 +277,7 @@ namespace NuGet.ProjectModel
             }
 
             WritePathArray(json, FilesProperty, library.Files, JsonUtility.WriteString);
-            
+
             return new JProperty(
                 library.Name + "/" + library.Version.ToNormalizedString(),
                 json);
@@ -318,7 +325,7 @@ namespace NuGet.ProjectModel
                 logJObject[LogMessageProperties.WARNING_LEVEL] = (int)logMessage.WarningLevel;
             }
 
-            if (logMessage.FilePath != null && 
+            if (logMessage.FilePath != null &&
                (projectPath == null || !PathUtility.GetStringComparerBasedOnOS().Equals(logMessage.FilePath, projectPath)))
             {
                 // Do not write the file path if it is the same as the project path.
@@ -356,8 +363,8 @@ namespace NuGet.ProjectModel
                 logJObject[LogMessageProperties.LIBRARY_ID] = logMessage.LibraryId;
             }
 
-            if (logMessage.TargetGraphs != null && 
-                logMessage.TargetGraphs.Any() && 
+            if (logMessage.TargetGraphs != null &&
+                logMessage.TargetGraphs.Any() &&
                 logMessage.TargetGraphs.All(l => !string.IsNullOrEmpty(l)))
             {
                 logJObject[LogMessageProperties.TARGET_GRAPHS] = new JArray(logMessage.TargetGraphs);
@@ -448,7 +455,7 @@ namespace NuGet.ProjectModel
         internal static JArray WriteLogMessages(IEnumerable<IAssetsLogMessage> logMessages, string projectPath)
         {
             var logMessageArray = new JArray();
-            foreach(var logMessage in logMessages)
+            foreach (var logMessage in logMessages)
             {
                 logMessageArray.Add(WriteLogMessage(logMessage, projectPath));
             }
@@ -529,7 +536,7 @@ namespace NuGet.ProjectModel
                 json[RuntimeProperty] = JsonUtility.WriteObject(ordered, WriteFileItem);
             }
 
-            if(library.FrameworkReferences.Count > 0)
+            if (library.FrameworkReferences.Count > 0)
             {
                 var ordered = library.FrameworkReferences.OrderBy(reference => reference, StringComparer.Ordinal);
 
@@ -638,7 +645,7 @@ namespace NuGet.ProjectModel
             return ReadFileItem(property, json, path => new LockFileItem(path));
         }
 
-        private static T ReadFileItem<T>(string property, JToken json, Func<string, T> factory) where T: LockFileItem
+        private static T ReadFileItem<T>(string property, JToken json, Func<string, T> factory) where T : LockFileItem
         {
             var item = factory(property);
             foreach (var subProperty in json.OfType<JProperty>())
@@ -679,7 +686,7 @@ namespace NuGet.ProjectModel
             foreach (var child in json)
             {
                 var item = readItem(child);
-                if(item != null)
+                if (item != null)
                 {
                     items.Add(item);
                 }

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpecWriter.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpecWriter.cs
@@ -82,16 +82,14 @@ namespace NuGet.ProjectModel
                 throw new ArgumentException(Strings.ArgumentNullOrEmpty, nameof(filePath));
             }
 
-            var writer = new JsonObjectWriter();
-
-            Write(packageSpec, writer);
-
             using (var fileStream = new FileStream(filePath, FileMode.Create))
             using (var textWriter = new StreamWriter(fileStream))
             using (var jsonWriter = new JsonTextWriter(textWriter))
+            using (var writer = new JsonObjectWriter(jsonWriter))
             {
                 jsonWriter.Formatting = Formatting.Indented;
-                writer.WriteTo(jsonWriter);
+
+                Write(packageSpec, writer);
             }
         }
 
@@ -144,7 +142,7 @@ namespace NuGet.ProjectModel
             SetArrayValue(writer, "configFilePaths", msbuildMetadata.ConfigFilePaths);
             if (msbuildMetadata.CrossTargeting)
             {
-                SetArrayValue(writer, "originalTargetFrameworks", msbuildMetadata.OriginalTargetFrameworks.OrderBy( c => c, StringComparer.Ordinal)); // This need to stay the original strings because the nuget.g.targets have conditional imports based on the original framework name
+                SetArrayValue(writer, "originalTargetFrameworks", msbuildMetadata.OriginalTargetFrameworks.OrderBy(c => c, StringComparer.Ordinal)); // This need to stay the original strings because the nuget.g.targets have conditional imports based on the original framework name
             }
             else
             {
@@ -359,7 +357,7 @@ namespace NuGet.ProjectModel
             }
 
             writer.WriteObjectEnd();
-        } 
+        }
 
         private static void SetDependencies(IObjectWriter writer, IList<LibraryDependency> libraryDependencies)
         {
@@ -477,7 +475,7 @@ namespace NuGet.ProjectModel
             {
                 var version = string.Join(";", dependency.Select(dep => dep.VersionRange).OrderBy(dep => dep.MinVersion).Select(dep => dep.ToNormalizedString()));
 
-                writer.WriteObjectInArrayStart();
+                writer.WriteObjectStart();
                 SetValue(writer, "name", dependency.Key);
                 SetValue(writer, "version", version);
                 writer.WriteObjectEnd();

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecCloningTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecCloningTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using Newtonsoft.Json.Linq;
 using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Frameworks;
@@ -11,6 +12,7 @@ using NuGet.Packaging.Core;
 using NuGet.RuntimeModel;
 using NuGet.Versioning;
 using Xunit;
+
 namespace NuGet.ProjectModel.Test
 {
     public class PackageSpecCloningTests
@@ -35,7 +37,6 @@ namespace NuGet.ProjectModel.Test
             //Assert
             Assert.Equal(originalBuildOptions.OutputName, clonedBuildOptions.OutputName);
             Assert.False(object.ReferenceEquals(originalBuildOptions, clonedBuildOptions));
-
         }
 
         [Fact]
@@ -146,6 +147,7 @@ namespace NuGet.ProjectModel.Test
             files.ExcludeFiles = new List<string>() { "ExlcludeFiles0" };
             return files;
         }
+
         private PackOptions CreatePackOptions()
         {
             var originalPackOptions = new PackOptions();
@@ -157,39 +159,39 @@ namespace NuGet.ProjectModel.Test
         private PackageSpec CreatePackageSpec()
         {
             var originalTargetFrameworkInformation = CreateTargetFrameworkInformation();
-            var PackageSpec = new PackageSpec(new List<TargetFrameworkInformation>() { originalTargetFrameworkInformation });
-            PackageSpec.RestoreMetadata = CreateProjectRestoreMetadata();
-            PackageSpec.FilePath = "FilePath";
-            PackageSpec.Name = "Name";
-            PackageSpec.Title = "Title";
-            PackageSpec.Version = new Versioning.NuGetVersion("1.0.0");
-            PackageSpec.HasVersionSnapshot = true;
-            PackageSpec.Description = "Description";
-            PackageSpec.Summary = "Summary";
-            PackageSpec.ReleaseNotes = "ReleaseNotes";
-            PackageSpec.Authors = new string[] { "Author1" };
-            PackageSpec.Owners = new string[] { "Owner1" };
-            PackageSpec.ProjectUrl = "ProjectUrl";
-            PackageSpec.IconUrl = "IconUrl";
-            PackageSpec.LicenseUrl = "LicenseUrl";
-            PackageSpec.Copyright = "Copyright";
-            PackageSpec.Language = "Language";
-            PackageSpec.RequireLicenseAcceptance = true;
-            PackageSpec.Tags = new string[] { "Tags" };
-            PackageSpec.BuildOptions = CreateBuildOptions();
-            PackageSpec.ContentFiles = new List<string>() { "contentFile1", "contentFile2" };
-            PackageSpec.Dependencies = new List<LibraryDependency>() { CreateLibraryDependency(), CreateLibraryDependency() };
+            var packageSpec = new PackageSpec(new List<TargetFrameworkInformation>() { originalTargetFrameworkInformation });
+            packageSpec.RestoreMetadata = CreateProjectRestoreMetadata();
+            packageSpec.FilePath = "FilePath";
+            packageSpec.Name = "Name";
+            packageSpec.Title = "Title";
+            packageSpec.Version = new Versioning.NuGetVersion("1.0.0");
+            packageSpec.HasVersionSnapshot = true;
+            packageSpec.Description = "Description";
+            packageSpec.Summary = "Summary";
+            packageSpec.ReleaseNotes = "ReleaseNotes";
+            packageSpec.Authors = new string[] { "Author1" };
+            packageSpec.Owners = new string[] { "Owner1" };
+            packageSpec.ProjectUrl = "ProjectUrl";
+            packageSpec.IconUrl = "IconUrl";
+            packageSpec.LicenseUrl = "LicenseUrl";
+            packageSpec.Copyright = "Copyright";
+            packageSpec.Language = "Language";
+            packageSpec.RequireLicenseAcceptance = true;
+            packageSpec.Tags = new string[] { "Tags" };
+            packageSpec.BuildOptions = CreateBuildOptions();
+            packageSpec.ContentFiles = new List<string>() { "contentFile1", "contentFile2" };
+            packageSpec.Dependencies = new List<LibraryDependency>() { CreateLibraryDependency(), CreateLibraryDependency() };
 
-            PackageSpec.Scripts.Add(Guid.NewGuid().ToString(), new List<string>() { Guid.NewGuid().ToString() });
-            PackageSpec.Scripts.Add(Guid.NewGuid().ToString(), new List<string>() { Guid.NewGuid().ToString() });
+            packageSpec.Scripts.Add(Guid.NewGuid().ToString(), new List<string>() { Guid.NewGuid().ToString() });
+            packageSpec.Scripts.Add(Guid.NewGuid().ToString(), new List<string>() { Guid.NewGuid().ToString() });
 
-            PackageSpec.PackInclude.Add(Guid.NewGuid().ToString(), Guid.NewGuid().ToString());
+            packageSpec.PackInclude.Add(Guid.NewGuid().ToString(), Guid.NewGuid().ToString());
 
-            PackageSpec.PackOptions = CreatePackOptions();
+            packageSpec.PackOptions = CreatePackOptions();
 
-            PackageSpec.RuntimeGraph = CreateRuntimeGraph();
-            PackageSpec.RestoreSettings = CreateProjectRestoreSettings();
-            return PackageSpec;
+            packageSpec.RuntimeGraph = CreateRuntimeGraph();
+            packageSpec.RestoreSettings = CreateProjectRestoreSettings();
+            return packageSpec;
         }
 
         public static RuntimeGraph CreateRuntimeGraph()
@@ -219,39 +221,38 @@ namespace NuGet.ProjectModel.Test
         public void PackageSpecCloneTest(string methodName, bool validateJson)
         {
             // Set up
-            var PackageSpec = CreatePackageSpec();
-            var clonedPackageSpec = PackageSpec.Clone();
+            var packageSpec = CreatePackageSpec();
+            var clonedPackageSpec = packageSpec.Clone();
 
             //Preconditions
-            Assert.Equal(PackageSpec, clonedPackageSpec);
-            var originalPackageSpecWriter = new JsonObjectWriter();
-            var clonedPackageSpecWriter = new JsonObjectWriter();
-            PackageSpecWriter.Write(PackageSpec, originalPackageSpecWriter);
-            PackageSpecWriter.Write(clonedPackageSpec, clonedPackageSpecWriter);
-            Assert.Equal(originalPackageSpecWriter.GetJson().ToString(), clonedPackageSpecWriter.GetJson().ToString());
-            Assert.False(object.ReferenceEquals(PackageSpec, clonedPackageSpec));
+            Assert.Equal(packageSpec, clonedPackageSpec);
+
+            JObject originalJObject = packageSpec.ToJObject();
+            JObject clonedJObject = clonedPackageSpec.ToJObject();
+
+            Assert.Equal(originalJObject.ToString(), clonedJObject.ToString());
+            Assert.False(ReferenceEquals(packageSpec, clonedPackageSpec));
 
             // Act
             var methodInfo = typeof(PackageSpecModify).GetMethod(methodName);
-            methodInfo.Invoke(null, new object[] { PackageSpec });
+            methodInfo.Invoke(null, new object[] { packageSpec });
 
             // Assert
+            Assert.NotEqual(packageSpec, clonedPackageSpec);
 
-            Assert.NotEqual(PackageSpec, clonedPackageSpec);
             if (validateJson)
             {
-                var oPackageSpecWriter = new JsonObjectWriter();
-                var cPackageSpecWriter = new JsonObjectWriter();
-                PackageSpecWriter.Write(PackageSpec, oPackageSpecWriter);
-                PackageSpecWriter.Write(clonedPackageSpec, cPackageSpecWriter);
-                Assert.NotEqual(oPackageSpecWriter.GetJson().ToString(), cPackageSpecWriter.GetJson().ToString());
+                originalJObject = packageSpec.ToJObject();
+                clonedJObject = clonedPackageSpec.ToJObject();
+
+                Assert.NotEqual(originalJObject.ToString(), clonedJObject.ToString());
             }
-            Assert.False(object.ReferenceEquals(PackageSpec, clonedPackageSpec));
+
+            Assert.False(object.ReferenceEquals(packageSpec, clonedPackageSpec));
         }
 
         public class PackageSpecModify
         {
-
             public static void ModifyAuthors(PackageSpec packageSpec)
             {
                 packageSpec.Authors[0] = "NewAuthor";
@@ -334,7 +335,6 @@ namespace NuGet.ProjectModel.Test
             {
                 packageSpec.RestoreSettings.HideWarningsAndErrors = false;
             }
-
         }
 
         private ProjectRestoreMetadata CreateProjectRestoreMetadata()
@@ -766,6 +766,5 @@ namespace NuGet.ProjectModel.Test
             Assert.Equal(3, compat.RestoreContexts.Count);
             Assert.Equal(2, clone.RestoreContexts.Count);
         }
-
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecTestUtility.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecTestUtility.cs
@@ -1,8 +1,11 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using NuGet.Frameworks;
 using NuGet.RuntimeModel;
 
@@ -12,11 +15,48 @@ namespace NuGet.ProjectModel.Test
     {
         public static PackageSpec RoundTrip(this PackageSpec spec)
         {
-            var writer = new JsonObjectWriter();
-            PackageSpecWriter.Write(spec, writer);
-            var json = writer.GetJObject();
+            using (var jsonWriter = new JTokenWriter())
+            using (var writer = new JsonObjectWriter(jsonWriter))
+            {
+                writer.WriteObjectStart();
 
-            return JsonPackageSpecReader.GetPackageSpec(json);
+                PackageSpecWriter.Write(spec, writer);
+
+                writer.WriteObjectEnd();
+
+                return JsonPackageSpecReader.GetPackageSpec((JObject)jsonWriter.Token);
+            }
+        }
+
+        internal static PackageSpec RoundTrip(this PackageSpec spec, string packageSpecName, string packageSpecPath)
+        {
+            using (var stringWriter = new StringWriter())
+            using (var jsonWriter = new JsonTextWriter(stringWriter))
+            using (var writer = new JsonObjectWriter(jsonWriter))
+            {
+                writer.WriteObjectStart();
+
+                PackageSpecWriter.Write(spec, writer);
+
+                writer.WriteObjectEnd();
+
+                return JsonPackageSpecReader.GetPackageSpec(stringWriter.ToString(), packageSpecName, packageSpecPath);
+            }
+        }
+
+        internal static JObject ToJObject(this PackageSpec spec)
+        {
+            using (var jsonWriter = new JTokenWriter())
+            using (var writer = new JsonObjectWriter(jsonWriter))
+            {
+                writer.WriteObjectStart();
+
+                PackageSpecWriter.Write(spec, writer);
+
+                writer.WriteObjectEnd();
+
+                return (JObject)jsonWriter.Token;
+            }
         }
 
         public static PackageSpec GetSpec()


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9031
Regression: No

## Fix

Details: `DependencyGraphSpec.Save(…)` saves a dependency graph spec (DG spec) to disk.  The previous implementation serialized the `JObject` representation of the DG spec into a string and then wrote the string to disk.  This intermediate step of serializing to a string is both unnecessary and a performance issue.  As project and solution DG specs grow beyond 80 KB, these strings will be allocated on the large object heap (LOH).  This has terrible [performance implications](https://docs.microsoft.com/en-us/dotnet/standard/garbage-collection/large-object-heap#loh-performance-implications) given that NuGet restore is triggered automatically in many scenarios (i.e.:  build, rebuild, debug, code analysis, etc.).

## Testing/Validation

Tests Added: Yes
Validation:  Using the NuGet.Client solution as a case study, I profiled performance 5 times before and 5 times after this change.  More iterations than 5 would have been great, but it's time consuming.

Deleting only *.nuget.dgspec.json files before each test (to force calls to `DependencyGraphSpec.Save(…)`), I observed the following "no-op-ish" restore performance changes in Visual Studio.  I say "no-op-ish" because there's no real scenario where only these files are deleted; however, the scenario is no-op in all other respects:  a full restore was performed previous to testing.  It's also important to note that these numbers are based on _all) activity in VS during a restore operation not just NuGet activity; there are many variables which I cannot control within VS.

All numbers below are averages.

| Metric |  Before | After | Delta | % |
| ---  | --- | --- | --- | --- |
| "no-op-ish" restore time |  2,069.96 ms | 1,925.08 ms | -144.88 ms | -7 % |
| heap allocations | 331.61 MB | 308.55 MB | -23.06 MB | -6.95% |
| LOH allocations | 3.80 MB | 0 MB | -3.80 MB | -100% |
| total GC pause | 1,324.60 ms | 1,172.94 ms | -151.66 ms | -11.45% |

A real-life no-op restore --- that is one without me deleting *.nuget.dgspec.json files outside of Visual Studio --- allocated 776,496 bytes on the LOH.  With this change it's 0.