### PR TITLE
Set NuGet 5.5 to RTM branding

### DIFF
--- a/build/config.props
+++ b/build/config.props
@@ -19,12 +19,12 @@
     
     <!-- ** Change for each new preview/rtm -->
     <!-- Check the VS schedule and manually enter a preview number here that makes sense. -->
-    <ReleaseLabel Condition=" '$(ReleaseLabel)' == '' ">preview.3</ReleaseLabel>
+    <ReleaseLabel Condition=" '$(ReleaseLabel)' == '' ">rtm</ReleaseLabel>
     
     <!-- ** Increment each insertion, set to zero after incrementing Major/Minor or Patch version -->
     <!-- We need to update this netcoreassembly build number with EVERY insertion into VS to workaround any breaking api
     changes we might have made. -->
-    <NetCoreAssemblyBuildNumber Condition=" '$(NetCoreAssemblyBuildNumber)' == '' ">3</NetCoreAssemblyBuildNumber>
+    <NetCoreAssemblyBuildNumber Condition=" '$(NetCoreAssemblyBuildNumber)' == '' ">4</NetCoreAssemblyBuildNumber>
 
     <IsEscrowMode>false</IsEscrowMode>
 


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9127
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: change label & .net core build number

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  version label change
Validation:  
