### PR TITLE
Checking User Setting for showing Error List after failed build

### DIFF
--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/RestoreOperationLogger.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/RestoreOperationLogger.cs
@@ -130,7 +130,7 @@ namespace NuGet.SolutionRestoreManager
             if (_showErrorList)
             {
                 // Give the error list focus
-                _errorListDataSource.Value.BringToFront();
+                _errorListDataSource.Value.BringToFrontIfSettingsPermit();
             }
         }
 
@@ -324,7 +324,7 @@ namespace NuGet.SolutionRestoreManager
             var entry = new ErrorListTableEntry(errorText, LogLevel.Error);
 
             _errorListDataSource.Value.AddNuGetEntries(entry);
-            _errorListDataSource.Value.BringToFront();
+            _errorListDataSource.Value.BringToFrontIfSettingsPermit();
         }
 
         public Task WriteHeaderAsync()

--- a/src/NuGet.Clients/NuGet.Tools/OutputConsoleLogger.cs
+++ b/src/NuGet.Clients/NuGet.Tools/OutputConsoleLogger.cs
@@ -91,7 +91,7 @@ namespace NuGetVSExtension
                 OutputConsole.WriteLine(string.Empty);
 
                 // Give the error list focus
-                ErrorListTableDataSource.Value.BringToFront();
+                ErrorListTableDataSource.Value.BringToFrontIfSettingsPermit();
             });
         }
 

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/ErrorListTableDataSource.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/ErrorListTableDataSource.cs
@@ -167,7 +167,7 @@ namespace NuGet.VisualStudio.Common
         }
 
         /// <summary>
-        /// Show error window.
+        /// Show error window if settings permit.
         /// </summary>
         public void BringToFrontIfSettingsPermit()
         {
@@ -180,11 +180,14 @@ namespace NuGet.VisualStudio.Common
                 IVsShell vsShell = await _asyncServiceProvider.GetServiceAsync<IVsShell>();
                 object propertyShowTaskListOnBuildEnd;
                 int getPropertyReturnCode = vsShell.GetProperty((int)__VSSPROPID.VSSPROPID_ShowTasklistOnBuildEnd, out propertyShowTaskListOnBuildEnd);
-                bool showErrorListOnBuildEnd = true; //Default to showing the Error List.
+                bool showErrorListOnBuildEnd = true;
 
                 if (getPropertyReturnCode == VSConstants.S_OK)
                 {
-                    bool.TryParse(propertyShowTaskListOnBuildEnd?.ToString(), out showErrorListOnBuildEnd);
+                    if (bool.TryParse(propertyShowTaskListOnBuildEnd?.ToString(), out bool result))
+                    {
+                        showErrorListOnBuildEnd = result;
+                    }
                 }
                
                 if (showErrorListOnBuildEnd)

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/ErrorListTableDataSource.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/ErrorListTableDataSource.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Linq;
+using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Shell.TableControl;
@@ -176,9 +177,22 @@ namespace NuGet.VisualStudio.Common
             {
                 await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
-                // Give the error list focus.
-                var vsErrorList = _errorList as IVsErrorList;
-                vsErrorList?.BringToFront();
+                IVsShell vsShell = await _asyncServiceProvider.GetServiceAsync<IVsShell>();
+                object propertyShowTaskListOnBuildEnd;
+                int getPropertyReturnCode = vsShell.GetProperty((int)__VSSPROPID.VSSPROPID_ShowTasklistOnBuildEnd, out propertyShowTaskListOnBuildEnd);
+                bool showErrorListOnBuildEnd = true; //Default to showing the Error List.
+
+                if (getPropertyReturnCode == VSConstants.S_OK)
+                {
+                    bool.TryParse(propertyShowTaskListOnBuildEnd?.ToString(), out showErrorListOnBuildEnd);
+                }
+               
+                if (showErrorListOnBuildEnd)
+                {
+                    // Give the error list focus.
+                    var vsErrorList = _errorList as IVsErrorList;
+                    vsErrorList?.BringToFront();
+                }
             });
         }
 

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/ErrorListTableDataSource.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/ErrorListTableDataSource.cs
@@ -169,7 +169,7 @@ namespace NuGet.VisualStudio.Common
         /// <summary>
         /// Show error window.
         /// </summary>
-        public void BringToFront()
+        public void BringToFrontIfSettingsPermit()
         {
             EnsureInitialized();
 


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/8190
Regression: No  

## Fix

Check the VS Setting to see if the user enabled "Always show Error List if build finishes with errors."
![image](https://user-images.githubusercontent.com/49205731/73899181-a3b6e280-4840-11ea-9c6c-e9117c8fc6cf.png)

## Testing/Validation

Tests Added: No
Reason for not adding tests:  Current test infrastructure doesn't support checking for Pane visibility in VS. 
Validation:  

1. Set the VS Setting to show Error List after Build. 

2. Break NuGet Restore to cause an error (eg, set package version to a version that doesn't exist). 

3. Build the project, and ensure the Error List pane pops up with the NuGet error.

4. Disable the VS Setting to show Error List after Build.

5. Repeat step 2-3, but this time ensure the Error List does not pop up. 

6. Open the Error List and ensure the NuGet error is there (just that it did not pop up).
