### PR TITLE
Clean up redundant code in the VS extensibility service

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/NetCorePackageReferenceProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/NetCorePackageReferenceProject.cs
@@ -41,7 +41,6 @@ namespace NuGet.PackageManagement.VisualStudio
         private readonly string _projectFullPath;
 
         private readonly IProjectSystemCache _projectSystemCache;
-        private readonly IVsProjectAdapter _vsProjectAdapter;
         private readonly UnconfiguredProject _unconfiguredProject;
 
         public NetCorePackageReferenceProject(
@@ -49,7 +48,6 @@ namespace NuGet.PackageManagement.VisualStudio
             string projectUniqueName,
             string projectFullPath,
             IProjectSystemCache projectSystemCache,
-            IVsProjectAdapter vsProjectAdapter,
             UnconfiguredProject unconfiguredProject,
             INuGetProjectServices projectServices,
             string projectId)
@@ -65,7 +63,6 @@ namespace NuGet.PackageManagement.VisualStudio
             ProjectStyle = ProjectStyle.PackageReference;
 
             _projectSystemCache = projectSystemCache;
-            _vsProjectAdapter = vsProjectAdapter;
             _unconfiguredProject = unconfiguredProject;
             ProjectServices = projectServices;
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/NetCorePackageReferenceProjectProvider.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/NetCorePackageReferenceProjectProvider.cs
@@ -99,7 +99,6 @@ namespace NuGet.PackageManagement.VisualStudio
                 return null;
             }
 
-            var projectNames = vsProject.ProjectNames;
             var fullProjectPath = vsProject.FullProjectPath;
             var unconfiguredProject = GetUnconfiguredProject(vsProject.Project);
 
@@ -110,7 +109,6 @@ namespace NuGet.PackageManagement.VisualStudio
                 vsProject.CustomUniqueName,
                 fullProjectPath,
                 _projectSystemCache,
-                vsProject,
                 unconfiguredProject,
                 projectServices,
                 vsProject.ProjectId);

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/PackageServiceUtilities.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/PackageServiceUtilities.cs
@@ -1,0 +1,43 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NuGet.Packaging;
+using NuGet.Versioning;
+
+namespace NuGet.VisualStudio
+{
+    internal static class PackageServiceUtilities
+    {
+        /// <summary>
+        /// Checks whether the specified package and version are in the list.
+        /// If the nugetVersion is null, then this method only checks whether given package id is in list.
+        /// </summary>
+        /// <param name="installedPackageReferences">installed package references</param>
+        /// <param name="packageId">packageId to check, can't be null or empty.</param>
+        /// <param name="nugetVersion">nuGetVersion to check, can be null.</param>
+        /// <returns>Whether the package is in the list.</returns>
+        /// <exception cref="ArgumentNullException"> if <paramref name="installedPackageReferences"/> is null</exception>
+        /// <exception cref="ArgumentException"> if <paramref name="packageId"/> is null or empty</exception>
+        internal static bool IsPackageInList(IEnumerable<PackageReference> installedPackageReferences, string packageId, NuGetVersion nugetVersion)
+        {
+            if (installedPackageReferences == null)
+            {
+                throw new ArgumentNullException(nameof(installedPackageReferences));
+            }
+
+            if (string.IsNullOrEmpty(packageId))
+            {
+                throw new ArgumentException(CommonResources.Argument_Cannot_Be_Null_Or_Empty, nameof(packageId));
+            }
+
+            return installedPackageReferences.Any(p =>
+                StringComparer.OrdinalIgnoreCase.Equals(p.PackageIdentity.Id, packageId) &&
+                (nugetVersion != null ?
+                    VersionComparer.VersionRelease.Equals(p.PackageIdentity.Version, nugetVersion) :
+                    true));
+        }
+    }
+}

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPackageInstaller.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPackageInstaller.cs
@@ -213,8 +213,8 @@ namespace NuGet.VisualStudio
                     // Skip assembly references and disable binding redirections should be done together
                     var disableBindingRedirects = skipAssemblyReferences;
 
-                    var projectContext = new VSAPIProjectContext
-                    {
+                    var projectContext = new VSAPIProjectContext(skipAssemblyReferences, disableBindingRedirects)
+                    {                        
                         PackageExtractionContext = new PackageExtractionContext(
                             PackageSaveMode.Defaultv2,
                             PackageExtractionBehavior.XmlDocFileSaveMode,
@@ -271,7 +271,7 @@ namespace NuGet.VisualStudio
                     // Skip assembly references and disable binding redirections should be done together
                     var disableBindingRedirects = skipAssemblyReferences;
 
-                    var projectContext = new VSAPIProjectContext
+                    var projectContext = new VSAPIProjectContext(skipAssemblyReferences, disableBindingRedirects)
                     {
                         PackageExtractionContext = new PackageExtractionContext(
                             PackageSaveMode.Defaultv2,

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPackageInstaller.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPackageInstaller.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
-using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -13,6 +12,7 @@ using Microsoft.VisualStudio.ProjectSystem;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Threading;
 using NuGet.Common;
+using NuGet.Configuration;
 using NuGet.PackageManagement;
 using NuGet.PackageManagement.VisualStudio;
 using NuGet.Packaging;
@@ -33,11 +33,9 @@ namespace NuGet.VisualStudio
     public class VsPackageInstaller : IVsPackageInstaller2
     {
         private readonly ISourceRepositoryProvider _sourceRepositoryProvider;
-        private readonly Configuration.ISettings _settings;
+        private readonly ISettings _settings;
         private readonly IVsSolutionManager _solutionManager;
-        private readonly IVsPackageInstallerServices _packageServices;
         private readonly IDeleteOnRestartManager _deleteOnRestartManager;
-        private readonly Lazy<INuGetProjectContext> _projectContext;
         private bool _isCPSJTFLoaded;
 
         // Reason it's lazy<object> is because we don't want to load any CPS assemblies until
@@ -50,30 +48,15 @@ namespace NuGet.VisualStudio
         [ImportingConstructor]
         public VsPackageInstaller(
             ISourceRepositoryProvider sourceRepositoryProvider,
-            Configuration.ISettings settings,
+            ISettings settings,
             IVsSolutionManager solutionManager,
-            IVsPackageInstallerServices packageServices,
             IDeleteOnRestartManager deleteOnRestartManager)
         {
             _sourceRepositoryProvider = sourceRepositoryProvider;
             _settings = settings;
             _solutionManager = solutionManager;
-            _packageServices = packageServices;
             _deleteOnRestartManager = deleteOnRestartManager;
             _isCPSJTFLoaded = false;
-
-            _projectContext = new Lazy<INuGetProjectContext>(() => {
-                var projectContext = new VSAPIProjectContext();
-
-                var logger = new LoggerAdapter(projectContext);
-                projectContext.PackageExtractionContext = new PackageExtractionContext(
-                    PackageSaveMode.Defaultv2,
-                    PackageExtractionBehavior.XmlDocFileSaveMode,
-                    ClientPolicyContext.GetClientPolicy(_settings, logger),
-                    logger);
-
-                return projectContext;
-            });
 
             PumpingJTF = new PumpingJTF(NuGetUIThreadHelper.JoinableTaskFactory);
         }
@@ -164,26 +147,19 @@ namespace NuGet.VisualStudio
                 sources = new[] { source };
             }
 
-            var versionRange = VersionRange.All;
-
-            if (version != null)
-            {
-                versionRange = new VersionRange(version, true, version, true);
-            }
-
             var toInstall = new List<PackageIdentity>
             {
                 new PackageIdentity(packageId, version)
             };
 
-            var projectContext = new VSAPIProjectContext();
-            var logger = new LoggerAdapter(projectContext);
-
-            projectContext.PackageExtractionContext = new PackageExtractionContext(
-                PackageSaveMode.Defaultv2,
-                PackageExtractionBehavior.XmlDocFileSaveMode,
-                ClientPolicyContext.GetClientPolicy(_settings, logger),
-                logger);
+            var projectContext = new VSAPIProjectContext
+            {
+                PackageExtractionContext = new PackageExtractionContext(
+                    PackageSaveMode.Defaultv2,
+                    PackageExtractionBehavior.XmlDocFileSaveMode,
+                    ClientPolicyContext.GetClientPolicy(_settings, NullLogger.Instance),
+                    NullLogger.Instance)
+            };
 
             return InstallInternalAsync(project, toInstall, GetSources(sources), projectContext, includePrerelease, ignoreDependencies, CancellationToken.None);
         }
@@ -237,14 +213,14 @@ namespace NuGet.VisualStudio
                     // Skip assembly references and disable binding redirections should be done together
                     var disableBindingRedirects = skipAssemblyReferences;
 
-                    var projectContext = new VSAPIProjectContext(skipAssemblyReferences, disableBindingRedirects);
-                    var logger = new LoggerAdapter(projectContext);
-
-                    projectContext.PackageExtractionContext = new PackageExtractionContext(
-                        PackageSaveMode.Defaultv2,
-                        PackageExtractionBehavior.XmlDocFileSaveMode,
-                        ClientPolicyContext.GetClientPolicy(_settings, logger),
-                        logger);
+                    var projectContext = new VSAPIProjectContext
+                    {
+                        PackageExtractionContext = new PackageExtractionContext(
+                            PackageSaveMode.Defaultv2,
+                            PackageExtractionBehavior.XmlDocFileSaveMode,
+                            ClientPolicyContext.GetClientPolicy(_settings, NullLogger.Instance),
+                            NullLogger.Instance)
+                    };
 
                     await InstallInternalAsync(
                         project,
@@ -295,13 +271,14 @@ namespace NuGet.VisualStudio
                     // Skip assembly references and disable binding redirections should be done together
                     var disableBindingRedirects = skipAssemblyReferences;
 
-                    var projectContext = new VSAPIProjectContext(skipAssemblyReferences, disableBindingRedirects);
-                    var logger = new LoggerAdapter(projectContext);
-                    projectContext.PackageExtractionContext = new PackageExtractionContext(
-                        PackageSaveMode.Defaultv2,
-                        PackageExtractionBehavior.XmlDocFileSaveMode,
-                        ClientPolicyContext.GetClientPolicy(_settings, logger),
-                        logger);
+                    var projectContext = new VSAPIProjectContext
+                    {
+                        PackageExtractionContext = new PackageExtractionContext(
+                            PackageSaveMode.Defaultv2,
+                            PackageExtractionBehavior.XmlDocFileSaveMode,
+                            ClientPolicyContext.GetClientPolicy(_settings, NullLogger.Instance),
+                            NullLogger.Instance)
+                    };
 
                     return InstallInternalAsync(
                         project,
@@ -337,7 +314,7 @@ namespace NuGet.VisualStudio
 
         private Action<string> ErrorHandler => msg =>
         {
-            _projectContext.Value.Log(ProjectManagement.MessageLevel.Error, msg);
+            // We don't log anything
         };
 
         /// <summary>
@@ -396,100 +373,6 @@ namespace NuGet.VisualStudio
             return repo;
         }
 
-        internal async Task InstallInternalAsync(
-            Project project,
-            List<Packaging.Core.PackageDependency> packages,
-            ISourceRepositoryProvider repoProvider,
-            bool skipAssemblyReferences,
-            bool ignoreDependencies,
-            CancellationToken token)
-        {
-            foreach (var group in packages.GroupBy(e => e.Id, StringComparer.OrdinalIgnoreCase))
-            {
-                if (group.Count() > 1)
-                {
-                    // throw if a package id appears more than once
-                    throw new InvalidOperationException(VsResources.InvalidPackageList);
-                }
-            }
-
-            // find the latest package
-            var metadataResources = new List<MetadataResource>();
-
-            // create the resources for looking up the latest version
-            foreach (var repo in repoProvider.GetRepositories())
-            {
-                var resource = await repo.GetResourceAsync<MetadataResource>();
-                if (resource != null)
-                {
-                    metadataResources.Add(resource);
-                }
-            }
-
-            // find the highest version within the ranges
-            var idToIdentity = new Dictionary<string, PackageIdentity>(StringComparer.OrdinalIgnoreCase);
-
-            using (var sourceCacheContext = new SourceCacheContext())
-            {
-                foreach (var dep in packages)
-                {
-                    NuGetVersion highestVersion = null;
-
-                    if (dep.VersionRange != null
-                        && VersionComparer.Default.Equals(dep.VersionRange.MinVersion, dep.VersionRange.MaxVersion)
-                        && dep.VersionRange.MinVersion != null)
-                    {
-                        // this is a single version, not a range
-                        highestVersion = dep.VersionRange.MinVersion;
-                    }
-                    else
-                    {
-                        var tasks = new List<Task<IEnumerable<NuGetVersion>>>();
-
-                        foreach (var resource in metadataResources)
-                        {
-                            tasks.Add(resource.GetVersions(dep.Id, sourceCacheContext, NullLogger.Instance, token));
-                        }
-
-                        var versions = await Task.WhenAll(tasks.ToArray());
-
-                        highestVersion = versions.SelectMany(v => v).Where(v => dep.VersionRange.Satisfies(v)).Max();
-                    }
-
-                    if (highestVersion == null)
-                    {
-                        throw new InvalidOperationException(String.Format(CultureInfo.InvariantCulture, VsResources.UnknownPackage, dep.Id));
-                    }
-
-                    if (!idToIdentity.ContainsKey(dep.Id))
-                    {
-                        idToIdentity.Add(dep.Id, new PackageIdentity(dep.Id, highestVersion));
-                    }
-                }
-            }
-
-            // Skip assembly references and disable binding redirections should be done together
-            var disableBindingRedirects = skipAssemblyReferences;
-
-            var projectContext = new VSAPIProjectContext(skipAssemblyReferences, disableBindingRedirects);
-            var logger = new LoggerAdapter(projectContext);
-
-            projectContext.PackageExtractionContext = new PackageExtractionContext(
-                PackageSaveMode.Defaultv2,
-                PackageExtractionBehavior.XmlDocFileSaveMode,
-                ClientPolicyContext.GetClientPolicy(_settings, logger),
-                logger);
-
-            await InstallInternalAsync(
-                project,
-                idToIdentity.Values.ToList(),
-                repoProvider,
-                projectContext,
-                includePrerelease: false,
-                ignoreDependencies: ignoreDependencies,
-                token: token);
-        }
-
         /// <summary>
         /// Internal install method. All installs from the VS API and template wizard end up here.
         /// </summary>
@@ -528,7 +411,7 @@ namespace NuGet.VisualStudio
 
                 // Check if default package format is set to `PackageReference` and project has no
                 // package installed yet then upgrade it to `PackageReference` based project.
-                if(preferPackageReference &&
+                if (preferPackageReference &&
                    (nuGetProject is MSBuildNuGetProject) &&
                    !(await nuGetProject.GetInstalledPackagesAsync(token)).Any() &&
                    await NuGetProjectUpgradeUtility.IsNuGetProjectUpgradeableAsync(nuGetProject, project, needsAPackagesConfig: false))
@@ -539,9 +422,10 @@ namespace NuGet.VisualStudio
                 // install the package
                 foreach (var package in packages)
                 {
+                    var installedPackageReferences = await nuGetProject.GetInstalledPackagesAsync(token);
                     // Check if the package is already installed
                     if (package.Version != null &&
-                        _packageServices.IsPackageInstalledEx(project, package.Id, package.Version.ToString()))
+                        PackageServiceUtilities.IsPackageInList(installedPackageReferences, package.Id, package.Version))
                     {
                             continue;
                     }
@@ -587,7 +471,7 @@ namespace NuGet.VisualStudio
 
             using (var sourceCacheContext = new SourceCacheContext())
             {
-                ResolutionContext resolution = new ResolutionContext(
+                var resolution = new ResolutionContext(
                     depBehavior,
                     includePrerelease,
                     includeUnlisted: false,

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPackageUninstaller.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPackageUninstaller.cs
@@ -7,6 +7,7 @@ using System.Globalization;
 using System.Threading;
 using EnvDTE;
 using Microsoft.VisualStudio.Threading;
+using NuGet.Common;
 using NuGet.PackageManagement;
 using NuGet.PackageManagement.VisualStudio;
 using NuGet.Packaging;
@@ -49,9 +50,9 @@ namespace NuGet.VisualStudio
                 throw new ArgumentNullException("project");
             }
 
-            if (String.IsNullOrEmpty(packageId))
+            if (string.IsNullOrEmpty(packageId))
             {
-                throw new ArgumentException(String.Format(CultureInfo.CurrentCulture, CommonResources.Argument_Cannot_Be_Null_Or_Empty, "packageId"));
+                throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, CommonResources.Argument_Cannot_Be_Null_Or_Empty, nameof(packageId)));
             }
 
             PumpingJTF.Run(async delegate
@@ -63,15 +64,15 @@ namespace NuGet.VisualStudio
                            _solutionManager,
                            _deleteOnRestartManager);
 
-                    UninstallationContext uninstallContext = new UninstallationContext(removeDependencies, false);
-                    VSAPIProjectContext projectContext = new VSAPIProjectContext();
-
-                    var logger = new LoggerAdapter(projectContext);
-                    projectContext.PackageExtractionContext = new PackageExtractionContext(
-                        PackageSaveMode.Defaultv2,
-                        PackageExtractionBehavior.XmlDocFileSaveMode,
-                        ClientPolicyContext.GetClientPolicy(_settings, logger),
-                        logger);
+                    var uninstallContext = new UninstallationContext(removeDependencies, forceRemove: false);
+                    var projectContext = new VSAPIProjectContext
+                    {
+                        PackageExtractionContext = new PackageExtractionContext(
+                            PackageSaveMode.Defaultv2,
+                            PackageExtractionBehavior.XmlDocFileSaveMode,
+                            ClientPolicyContext.GetClientPolicy(_settings, NullLogger.Instance),
+                            NullLogger.Instance)
+                    };
 
                     // find the project
                     NuGetProject nuGetProject = await _solutionManager.GetOrCreateProjectAsync(project, projectContext);

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPathContextProvider.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPathContextProvider.cs
@@ -36,7 +36,7 @@ namespace NuGet.VisualStudio
         private readonly IAsyncServiceProvider _asyncServiceprovider;
         private readonly Lazy<ISettings> _settings;
         private readonly Lazy<IVsSolutionManager> _solutionManager;
-        private readonly Lazy<NuGet.Common.ILogger> _logger;
+        private readonly Lazy<ILogger> _logger;
         private readonly Func<BuildIntegratedNuGetProject, Task<LockFile>> _getLockFileOrNullAsync;
 
         private readonly Lazy<INuGetProjectContext> _projectContext;
@@ -47,7 +47,7 @@ namespace NuGet.VisualStudio
             Lazy<ISettings> settings,
             Lazy<IVsSolutionManager> solutionManager,
             [Import("VisualStudioActivityLogger")]
-            Lazy<NuGet.Common.ILogger> logger)
+            Lazy<ILogger> logger)
             : this(AsyncServiceProvider.GlobalProvider,
                   settings,
                   solutionManager,
@@ -58,7 +58,7 @@ namespace NuGet.VisualStudio
             IAsyncServiceProvider asyncServiceProvider,
             Lazy<ISettings> settings,
             Lazy<IVsSolutionManager> solutionManager,
-            Lazy<NuGet.Common.ILogger> logger)
+            Lazy<ILogger> logger)
         {
             _asyncServiceprovider = asyncServiceProvider ?? throw new ArgumentNullException(nameof(asyncServiceProvider));
             _settings = settings ?? throw new ArgumentNullException(nameof(settings));
@@ -66,17 +66,13 @@ namespace NuGet.VisualStudio
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _getLockFileOrNullAsync = BuildIntegratedProjectUtility.GetLockFileOrNull;
 
-            _projectContext = new Lazy<INuGetProjectContext>(() => {
-                var projectContext = new VSAPIProjectContext();
-
-                var adapterLogger = new LoggerAdapter(projectContext);
-                projectContext.PackageExtractionContext = new PackageExtractionContext(
-                    PackageSaveMode.Defaultv2,
-                    PackageExtractionBehavior.XmlDocFileSaveMode,
-                    ClientPolicyContext.GetClientPolicy(_settings.Value, adapterLogger),
-                    adapterLogger);
-
-                return projectContext;
+            _projectContext = new Lazy<INuGetProjectContext>(() => new VSAPIProjectContext
+            {
+                PackageExtractionContext = new PackageExtractionContext(
+                        PackageSaveMode.Defaultv2,
+                        PackageExtractionBehavior.XmlDocFileSaveMode,
+                        ClientPolicyContext.GetClientPolicy(_settings.Value, NullLogger.Instance),
+                        NullLogger.Instance)
             });
         }
 
@@ -86,7 +82,7 @@ namespace NuGet.VisualStudio
         public VsPathContextProvider(
             ISettings settings,
             IVsSolutionManager solutionManager,
-            NuGet.Common.ILogger logger,
+            ILogger logger,
             Func<BuildIntegratedNuGetProject, Task<LockFile>> getLockFileOrNullAsync)
         {
             if (settings == null)
@@ -106,20 +102,18 @@ namespace NuGet.VisualStudio
 
             _settings = new Lazy<ISettings>(() => settings);
             _solutionManager = new Lazy<IVsSolutionManager>(() => solutionManager);
-            _logger = new Lazy<NuGet.Common.ILogger>(() => logger);
+            _logger = new Lazy<ILogger>(() => logger);
             _getLockFileOrNullAsync = getLockFileOrNullAsync ?? BuildIntegratedProjectUtility.GetLockFileOrNull;
 
             _projectContext = new Lazy<INuGetProjectContext>(() => {
-                var projectContext = new VSAPIProjectContext();
-
-                var adapterLogger = new LoggerAdapter(projectContext);
-                projectContext.PackageExtractionContext = new PackageExtractionContext(
-                    PackageSaveMode.Defaultv2,
-                    PackageExtractionBehavior.XmlDocFileSaveMode,
-                    ClientPolicyContext.GetClientPolicy(_settings.Value, adapterLogger),
-                    adapterLogger);
-
-                return projectContext;
+                return new VSAPIProjectContext
+                {
+                    PackageExtractionContext = new PackageExtractionContext(
+                        PackageSaveMode.Defaultv2,
+                        PackageExtractionBehavior.XmlDocFileSaveMode,
+                        ClientPolicyContext.GetClientPolicy(_settings.Value, NullLogger.Instance),
+                        NullLogger.Instance)
+                };
             });
         }
 

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/PreinstalledPackageInstaller.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/PreinstalledPackageInstaller.cs
@@ -177,13 +177,14 @@ namespace NuGet.VisualStudio
             var failedPackageErrors = new List<string>();
 
             // find the project
-            var defaultProjectContext = new VSAPIProjectContext();
-            var logger = new LoggerAdapter(defaultProjectContext);
-            defaultProjectContext.PackageExtractionContext = new PackageExtractionContext(
-                PackageSaveMode.Defaultv2,
-                PackageExtractionBehavior.XmlDocFileSaveMode,
-                ClientPolicyContext.GetClientPolicy(_settings, logger),
-                logger);
+            var defaultProjectContext = new VSAPIProjectContext
+            {
+                PackageExtractionContext = new PackageExtractionContext(
+                    PackageSaveMode.Defaultv2,
+                    PackageExtractionBehavior.XmlDocFileSaveMode,
+                    ClientPolicyContext.GetClientPolicy(_settings, NullLogger.Instance),
+                    NullLogger.Instance)
+            };
 
             var nuGetProject = await _solutionManager.GetOrCreateProjectAsync(project, defaultProjectContext);
             if (preferPackageReferenceFormat && await NuGetProjectUpgradeUtility.IsNuGetProjectUpgradeableAsync(nuGetProject, project, needsAPackagesConfig: false))
@@ -394,14 +395,14 @@ namespace NuGet.VisualStudio
         /// <param name="packageInfos">The packages that were installed.</param>
         private void CopyNativeBinariesToBin(EnvDTE.Project project, string repositoryPath, IEnumerable<PreinstalledPackageInfo> packageInfos)
         {
-            var context = new VSAPIProjectContext();
-            var logger = new LoggerAdapter(context);
-
-            context.PackageExtractionContext = new PackageExtractionContext(
-                PackageSaveMode.Defaultv2,
-                PackageExtractionBehavior.XmlDocFileSaveMode,
-                ClientPolicyContext.GetClientPolicy(_settings, logger),
-                logger);
+            var context = new VSAPIProjectContext
+            {
+                PackageExtractionContext = new PackageExtractionContext(
+                    PackageSaveMode.Defaultv2,
+                    PackageExtractionBehavior.XmlDocFileSaveMode,
+                    ClientPolicyContext.GetClientPolicy(_settings, NullLogger.Instance),
+                    NullLogger.Instance)
+            };
             var projectSystem = new VsMSBuildProjectSystem(_vsProjectAdapterProvider.CreateAdapterForFullyLoadedProject(project), context);
 
             foreach (var packageInfo in packageInfos)

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/VSAPIProjectContext.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/VSAPIProjectContext.cs
@@ -6,8 +6,6 @@ using System.Diagnostics;
 using System.Xml.Linq;
 using NuGet.Common;
 using NuGet.Packaging;
-using NuGet.Packaging.PackageExtraction;
-using NuGet.Packaging.Signing;
 using NuGet.ProjectManagement;
 
 namespace NuGet.VisualStudio
@@ -28,7 +26,7 @@ namespace NuGet.VisualStudio
             BindingRedirectsDisabled = bindingRedirectsDisabled;
         }
 
-        public void Log(ProjectManagement.MessageLevel level, string message, params object[] args)
+        public void Log(MessageLevel level, string message, params object[] args)
         {
             // No logging needed when using the API
         }

--- a/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
@@ -697,7 +697,6 @@ namespace NuGet.PackageManagement
                         updatedResolutionContext,
                         nuGetProjectContext,
                         primarySources,
-                        secondarySources,
                         token)));
             }
 
@@ -786,7 +785,6 @@ namespace NuGet.PackageManagement
             ResolutionContext resolutionContext,
             INuGetProjectContext nuGetProjectContext,
             IEnumerable<SourceRepository> primarySources,
-            IEnumerable<SourceRepository> secondarySources,
             CancellationToken token)
         {
             var projectInstalledPackageReferences = await nuGetProject.GetInstalledPackagesAsync(token);
@@ -2066,16 +2064,9 @@ namespace NuGet.PackageManagement
                 var projectUniqueNamesForBuildIntToUpdate
                     = buildIntegratedProjectsToUpdate.ToDictionary((project) => project.MSBuildProjectPath);
 
-                // get all build integrated projects of the solution which will be used to map project references
-                // of the target projects
-                var allBuildIntegratedProjects =
-                    (await SolutionManager.GetNuGetProjectsAsync()).OfType<BuildIntegratedNuGetProject>().ToList();
-
                 var dgFile = await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(SolutionManager, referenceContext);
                 _buildIntegratedProjectsCache = dgFile;
                 var allSortedProjects = DependencyGraphSpec.SortPackagesByDependencyOrder(dgFile.Projects);
-
-                var msbuildProjectPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
                 foreach (var projectUniqueName in allSortedProjects.Select(e => e.RestoreMetadata.ProjectUniqueName))
                 {


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9074
Regression: Yes/No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: 

Follow up to https://github.com/NuGet/NuGet.Client/pull/3194

As part of the new extensibility work, I've discovered some dead/redundant code.
Extensibility services cleanup, remove dead code, reduce unnecessary allocations reduce unnecessary work, cleanup imports.

The original fix itnroduced a regression. 

https://github.com/NuGet/Home/issues/9129

It's been fixed, see "fix bug" commit. 

Unfortunately there are no templates for ASP.NET framework in Apex and in powershell we can only simulate our own templates. 

My thought currently is to rely on the vendors (I have tested it manually to ensure this is the case). 

## Testing/Validation

Tests Added: Yes
Reason for not adding tests:  
Validation:  Manually ensured the scenarios in https://github.com/NuGet/Home/issues/9129 worked. Specifically used all 5 “ASP.NET Web Application (.NET Framework)” available templates.

