### PR TITLE
Add the IVsTargetFrameworkInfo3

### DIFF
--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager.Interop/IVsTargetFrameworkInfo3.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager.Interop/IVsTargetFrameworkInfo3.cs
@@ -1,0 +1,21 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace NuGet.SolutionRestoreManager
+{
+    /// <summary>
+    /// Contains target framework metadata needed for restore operation. Compared to IVsTargetFrameworkInfo2, this adds support for CentralPackageVersions
+    /// </summary>
+    [ComImport]
+    [Guid("3B2E8CAA-123B-47D3-9160-9CF422E4C277")]
+    public interface IVsTargetFrameworkInfo3 : IVsTargetFrameworkInfo2
+    {
+        /// <summary>
+        /// Collection of central package versions.
+        /// </summary>
+        IVsReferenceItems CentralPackageVersions { get; }
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/IVsTargetFrameworkInfo3Test.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/IVsTargetFrameworkInfo3Test.cs
@@ -25,6 +25,5 @@ namespace NuGet.SolutionRestoreManager.Test
             Assert.True(targetFrameworkInfo3 is IVsTargetFrameworkInfo2);
             Assert.Equal(0, ((IVsTargetFrameworkInfo3)targetFrameworkInfo3).CentralPackageVersions.Count);
         }
-
     }
 }

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/IVsTargetFrameworkInfo3Test.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/IVsTargetFrameworkInfo3Test.cs
@@ -1,0 +1,30 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Xunit;
+
+namespace NuGet.SolutionRestoreManager.Test
+{
+    public class IVsTargetFrameworkInfo3Test
+    {
+        [Fact]
+        public void IVsTargetFrameworkInfo3_IsIVsTargetFrameworkInfo2WithCentralPackageVersions()
+        {
+            // Arrange
+            var targetFrameworkInfo3 = new VsTargetFrameworkInfo3(
+                targetFrameworkMoniker: "4.0",
+                packageReferences: new List<IVsReferenceItem>(),
+                projectReferences: new List<IVsReferenceItem>(),
+                packageDownloads: new List<IVsReferenceItem>(),
+                frameworkReferences: new List<IVsReferenceItem>(),
+                projectProperties: new List<IVsProjectProperty>(),
+                centralPackageVersions: new List<IVsReferenceItem>());
+
+            // Assert
+            Assert.True(targetFrameworkInfo3 is IVsTargetFrameworkInfo2);
+            Assert.Equal(0, ((IVsTargetFrameworkInfo3)targetFrameworkInfo3).CentralPackageVersions.Count);
+        }
+
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsTargetFrameworkInfo3.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsTargetFrameworkInfo3.cs
@@ -1,0 +1,78 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace NuGet.SolutionRestoreManager.Test
+{
+    internal class VsTargetFrameworkInfo3 : IVsTargetFrameworkInfo3
+    {
+        public IVsReferenceItems PackageReferences { get; }
+
+        public IVsReferenceItems ProjectReferences { get; }
+
+        public IVsReferenceItems PackageDownloads { get; }
+
+        public IVsProjectProperties Properties { get; }
+
+        public string TargetFrameworkMoniker { get; }
+
+        public IVsReferenceItems FrameworkReferences { get; }
+
+        public IVsReferenceItems CentralPackageVersions { get; }
+
+        public VsTargetFrameworkInfo3(
+            string targetFrameworkMoniker,
+            IEnumerable<IVsReferenceItem> packageReferences,
+            IEnumerable<IVsReferenceItem> projectReferences,
+            IEnumerable<IVsReferenceItem> packageDownloads,
+            IEnumerable<IVsReferenceItem> frameworkReferences,
+            IEnumerable<IVsProjectProperty> projectProperties,
+            IEnumerable<IVsReferenceItem> centralPackageVersions)
+        {
+            if (string.IsNullOrEmpty(targetFrameworkMoniker))
+            {
+                throw new ArgumentException("Argument cannot be null or empty", nameof(targetFrameworkMoniker));
+            }
+
+            if (packageReferences == null)
+            {
+                throw new ArgumentNullException(nameof(packageReferences));
+            }
+
+            if (projectReferences == null)
+            {
+                throw new ArgumentNullException(nameof(projectReferences));
+            }
+
+            if (packageDownloads == null)
+            {
+                throw new ArgumentNullException(nameof(packageDownloads));
+            }
+
+            if (frameworkReferences == null)
+            {
+                throw new ArgumentNullException(nameof(frameworkReferences));
+            }
+
+            if (projectProperties == null)
+            {
+                throw new ArgumentNullException(nameof(projectProperties));
+            }
+
+            if (centralPackageVersions == null)
+            {
+                throw new ArgumentNullException(nameof(centralPackageVersions));
+            }
+
+            TargetFrameworkMoniker = targetFrameworkMoniker;
+            PackageReferences = new VsReferenceItems(packageReferences);
+            ProjectReferences = new VsReferenceItems(projectReferences);
+            PackageDownloads = new VsReferenceItems(packageDownloads);
+            FrameworkReferences = new VsReferenceItems(frameworkReferences);
+            Properties = new VsProjectProperties(projectProperties);
+            CentralPackageVersions = new VsReferenceItems(centralPackageVersions);
+        }      
+    }
+}


### PR DESCRIPTION
##New feature 

Support for CentralPackage Version in VS Nomination
Spec : https://github.com/NuGet/Home/blob/dev/designs/CentrallyManagingNuGetPackageVersions-Restore.md

Details: 

The PR contains only the interface definition.  The consumption will be added to a different PR.

The PR will not be merged until the branch is not open for 16.6. 

## Testing/Validation

Tests Added: Yes  
Validation:  Unit tests
