### PR TITLE
Fixes 2 accessiblity issues in PackageMetadataControl

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
@@ -727,6 +727,33 @@ namespace NuGet.PackageManagement.UI {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to License.
+        /// </summary>
+        public static string Hyperlink_License {
+            get {
+                return ResourceManager.GetString("Hyperlink_License", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Project URL.
+        /// </summary>
+        public static string Hyperlink_ProjectUrl {
+            get {
+                return ResourceManager.GetString("Hyperlink_ProjectUrl", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Report Abuse.
+        /// </summary>
+        public static string Hyperlink_ReportAbuse {
+            get {
+                return ResourceManager.GetString("Hyperlink_ReportAbuse", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Ignore for now.
         /// </summary>
         public static string IgnoreUpgrade {

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
@@ -888,4 +888,13 @@ Please see https://aka.ms/troubleshoot_nuget_cache for more help.</value>
   <data name="Preview_UnknownProject" xml:space="preserve">
     <value>Unknown project</value>
   </data>
+  <data name="Hyperlink_License" xml:space="preserve">
+    <value>License</value>
+  </data>
+  <data name="Hyperlink_ProjectUrl" xml:space="preserve">
+    <value>Project URL</value>
+  </data>
+  <data name="Hyperlink_ReportAbuse" xml:space="preserve">
+    <value>Report Abuse</value>
+  </data>
 </root>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageMetadataControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageMetadataControl.xaml
@@ -23,7 +23,7 @@ Background="{DynamicResource {x:Static nuget:Brushes.DetailPaneBackground}}"
             AutomationProperties.AutomationId="{Binding Id, Mode=OneWay, StringFormat='LicenseTerm_{0}'}">
                 <Hyperlink
                     AutomationProperties.AutomationId="{Binding Id, Mode=OneWay, StringFormat='LicenseTermLink_{0}'}"
-                    AutomationProperties.Name="{x:Static nuget:Resources.Label_License}"
+                    AutomationProperties.Name="{x:Static nuget:Resources.Hyperlink_License}"
                     Style="{StaticResource HyperlinkStyle}"
                     Command="{x:Static nuget:PackageManagerControlCommands.OpenExternalLink}"
                     ToolTip="{Binding Link}"
@@ -38,7 +38,7 @@ Background="{DynamicResource {x:Static nuget:Brushes.DetailPaneBackground}}"
             AutomationProperties.AutomationId="{Binding Id, Mode=OneWay, StringFormat='LicenseFile'}">
                 <Hyperlink
                     AutomationProperties.AutomationId="{Binding Id, Mode=OneWay, StringFormat='LicenseFileLink'}"
-                    AutomationProperties.Name="{x:Static nuget:Resources.Label_License}"
+                    AutomationProperties.Name="{x:Static nuget:Resources.Hyperlink_License}"
                     Style="{StaticResource WindowHyperlinkStyle}"
                     Click="ViewLicense_Click">
                   <Run Text="{Binding Text}"/>
@@ -262,7 +262,7 @@ Background="{DynamicResource {x:Static nuget:Brushes.DetailPaneBackground}}"
           NavigateUri="{Binding Path=ProjectUrl}"
           Style="{StaticResource HyperlinkStyle}"
           Command="{x:Static nuget:PackageManagerControlCommands.OpenExternalLink}"
-          AutomationProperties.Name="{x:Static nuget:Resources.Label_ProjectUrl}">
+          AutomationProperties.Name="{x:Static nuget:Resources.Hyperlink_ProjectUrl}">
           <Run Text="{Binding Path=ProjectUrl}" />
         </Hyperlink>
       </TextBlock>
@@ -287,7 +287,7 @@ Background="{DynamicResource {x:Static nuget:Brushes.DetailPaneBackground}}"
           NavigateUri="{Binding Path=ReportAbuseUrl}"
           Style="{StaticResource HyperlinkStyle}"
           Command="{x:Static nuget:PackageManagerControlCommands.OpenExternalLink}"
-          AutomationProperties.Name="{x:Static nuget:Resources.Label_ReportAbuse}">
+          AutomationProperties.Name="{x:Static nuget:Resources.Hyperlink_ReportAbuse}">
           <Run Text="{Binding Path=ReportAbuseUrl}" />
         </Hyperlink>
       </TextBlock>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageMetadataControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageMetadataControl.xaml
@@ -20,10 +20,10 @@ Background="{DynamicResource {x:Static nuget:Brushes.DetailPaneBackground}}"
       <nuget:DateTimeConverter x:Key="DateFormatConverter" />
       <DataTemplate DataType="{x:Type nuget:LicenseText}">
         <TextBlock
-            AutomationProperties.LabeledBy="{Binding ElementName=_packageLicenseText}"
             AutomationProperties.AutomationId="{Binding Id, Mode=OneWay, StringFormat='LicenseTerm_{0}'}">
                 <Hyperlink
                     AutomationProperties.AutomationId="{Binding Id, Mode=OneWay, StringFormat='LicenseTermLink_{0}'}"
+                    AutomationProperties.Name="{x:Static nuget:Resources.Label_License}"
                     Style="{StaticResource HyperlinkStyle}"
                     Command="{x:Static nuget:PackageManagerControlCommands.OpenExternalLink}"
                     ToolTip="{Binding Link}"
@@ -35,10 +35,10 @@ Background="{DynamicResource {x:Static nuget:Brushes.DetailPaneBackground}}"
 
       <DataTemplate DataType="{x:Type nuget:LicenseFileText}">
         <TextBlock
-            AutomationProperties.LabeledBy="{Binding ElementName=_packageLicenseText}"
             AutomationProperties.AutomationId="{Binding Id, Mode=OneWay, StringFormat='LicenseFile'}">
                 <Hyperlink
                     AutomationProperties.AutomationId="{Binding Id, Mode=OneWay, StringFormat='LicenseFileLink'}"
+                    AutomationProperties.Name="{x:Static nuget:Resources.Label_License}"
                     Style="{StaticResource WindowHyperlinkStyle}"
                     Click="ViewLicense_Click">
                   <Run Text="{Binding Text}"/>
@@ -190,7 +190,7 @@ Background="{DynamicResource {x:Static nuget:Brushes.DetailPaneBackground}}"
         AutomationProperties.Name="{Binding Text}"
         Text="{x:Static nuget:Resources.Label_License}"/>
 
-      <ItemsControl Grid.Row="3" Grid.Column="1" ItemsSource="{Binding LicenseLinks}">
+      <ItemsControl Grid.Row="3" Grid.Column="1" ItemsSource="{Binding LicenseLinks}" IsTabStop="False">
         <ItemsControl.ItemsPanel>
           <ItemsPanelTemplate>
             <WrapPanel Margin="8,8,0,0" Orientation="Horizontal" />
@@ -257,12 +257,12 @@ Background="{DynamicResource {x:Static nuget:Brushes.DetailPaneBackground}}"
         TextWrapping="Wrap"
         Margin="8,8,0,0"
         Grid.Row="6"
-        Grid.Column="1"
-        AutomationProperties.LabeledBy="{Binding ElementName=_projectUrlLabel}">
+        Grid.Column="1">
         <Hyperlink
           NavigateUri="{Binding Path=ProjectUrl}"
           Style="{StaticResource HyperlinkStyle}"
-          Command="{x:Static nuget:PackageManagerControlCommands.OpenExternalLink}">
+          Command="{x:Static nuget:PackageManagerControlCommands.OpenExternalLink}"
+          AutomationProperties.Name="{x:Static nuget:Resources.Label_ProjectUrl}">
           <Run Text="{Binding Path=ProjectUrl}" />
         </Hyperlink>
       </TextBlock>
@@ -275,7 +275,6 @@ Background="{DynamicResource {x:Static nuget:Brushes.DetailPaneBackground}}"
         FontWeight="Bold"
         Margin="0,8,0,0"
         x:Name="_reportAbuseLabel"
-        AutomationProperties.Name="{Binding Text}"
         Text="{x:Static nuget:Resources.Label_ReportAbuse}" />
 
       <TextBlock
@@ -283,12 +282,12 @@ Background="{DynamicResource {x:Static nuget:Brushes.DetailPaneBackground}}"
         TextWrapping="Wrap"
         Margin="8,8,0,0"
         Grid.Row="7"
-        Grid.Column="1"
-        AutomationProperties.LabeledBy="{Binding ElementName=_reportAbuseLabel}">
+        Grid.Column="1">
         <Hyperlink
           NavigateUri="{Binding Path=ReportAbuseUrl}"
           Style="{StaticResource HyperlinkStyle}"
-          Command="{x:Static nuget:PackageManagerControlCommands.OpenExternalLink}">
+          Command="{x:Static nuget:PackageManagerControlCommands.OpenExternalLink}"
+          AutomationProperties.Name="{x:Static nuget:Resources.Label_ReportAbuse}">
           <Run Text="{Binding Path=ReportAbuseUrl}" />
         </Hyperlink>
       </TextBlock>


### PR DESCRIPTION
## Bug

Fixes: 
- https://github.com/NuGet/Home/issues/9077
- https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1049191
- https://devdiv.visualstudio.com/DevDiv/_workitems/edit/994497

Regression: No

Details: 
- Added `AutomationProperty.Name` to the hyperlinks in the control. The narrator can read more context about the link, not the hyperlink text itself.
- Removed extra tab stop in license container, by using `IsTabStop=False`


## Testing/Validation

Tests Added: No
Reason for not adding tests: Visual validation
Validation:  
- Accessibility Insights Run
- Narrator run

