### PR TITLE
Revert CI timeout for official build

### DIFF
--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -72,7 +72,7 @@ jobs:
 
 - job: Build_and_UnitTest
   dependsOn: Initialize_Build
-  timeoutInMinutes: 30
+  timeoutInMinutes: 90
   variables:
     BuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.BuildNumber']]
     FullVstsBuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]


### PR DESCRIPTION
## Bug

Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: CI builds for PRs for the "build and unit test" phase is much faster than official builds. When moving linux tests to the hosted pool, I reduced phase timeouts, but didn't account for this official build vs private build difference.

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  CI timeout change
Validation:  
