### PR TITLE
Restore:  fix bad IncludeExcludeFiles.Equals(...) implementation

### DIFF
--- a/src/NuGet.Core/NuGet.LibraryModel/LibraryDependencyTypeFlag.cs
+++ b/src/NuGet.Core/NuGet.LibraryModel/LibraryDependencyTypeFlag.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -8,7 +8,7 @@ namespace NuGet.LibraryModel
 {
     public class LibraryDependencyTypeFlag
     {
-        private static ConcurrentDictionary<string, LibraryDependencyTypeFlag> _flags = new ConcurrentDictionary<string, LibraryDependencyTypeFlag>();
+        private static readonly ConcurrentDictionary<string, LibraryDependencyTypeFlag> Flags = new ConcurrentDictionary<string, LibraryDependencyTypeFlag>();
         private readonly string _value;
 
         public static readonly LibraryDependencyTypeFlag MainReference = Declare("MainReference");
@@ -29,7 +29,7 @@ namespace NuGet.LibraryModel
 
         public static LibraryDependencyTypeFlag Declare(string keyword)
         {
-            return _flags.GetOrAdd(keyword, x => new LibraryDependencyTypeFlag(x));
+            return Flags.GetOrAdd(keyword, x => new LibraryDependencyTypeFlag(x));
         }
 
         public override bool Equals(object obj)

--- a/src/NuGet.Core/NuGet.LibraryModel/LibraryDependencyTypeKeyword.cs
+++ b/src/NuGet.Core/NuGet.LibraryModel/LibraryDependencyTypeKeyword.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -10,7 +10,7 @@ namespace NuGet.LibraryModel
 {
     public class LibraryDependencyTypeKeyword
     {
-        private static ConcurrentDictionary<string, LibraryDependencyTypeKeyword> _keywords = new ConcurrentDictionary<string, LibraryDependencyTypeKeyword>(StringComparer.OrdinalIgnoreCase);
+        private static readonly ConcurrentDictionary<string, LibraryDependencyTypeKeyword> Keywords = new ConcurrentDictionary<string, LibraryDependencyTypeKeyword>(StringComparer.OrdinalIgnoreCase);
 
         public static readonly LibraryDependencyTypeKeyword Default;
         public static readonly LibraryDependencyTypeKeyword Platform;
@@ -20,18 +20,9 @@ namespace NuGet.LibraryModel
         public static readonly LibraryDependencyTypeKeyword Dev;
 
         private readonly string _value;
-        private readonly IEnumerable<LibraryDependencyTypeFlag> _flagsToAdd;
-        private readonly IEnumerable<LibraryDependencyTypeFlag> _flagsToRemove;
 
-        public IEnumerable<LibraryDependencyTypeFlag> FlagsToAdd
-        {
-            get { return _flagsToAdd; }
-        }
-
-        public IEnumerable<LibraryDependencyTypeFlag> FlagsToRemove
-        {
-            get { return _flagsToRemove; }
-        }
+        public IEnumerable<LibraryDependencyTypeFlag> FlagsToAdd { get; private set; }
+        public IEnumerable<LibraryDependencyTypeFlag> FlagsToRemove { get; private set; }
 
         static LibraryDependencyTypeKeyword()
         {
@@ -133,8 +124,8 @@ namespace NuGet.LibraryModel
             IEnumerable<LibraryDependencyTypeFlag> flagsToRemove)
         {
             _value = value;
-            _flagsToAdd = flagsToAdd;
-            _flagsToRemove = flagsToRemove;
+            FlagsToAdd = flagsToAdd;
+            FlagsToRemove = flagsToRemove;
         }
 
         internal static LibraryDependencyTypeKeyword Declare(
@@ -142,13 +133,13 @@ namespace NuGet.LibraryModel
             IEnumerable<LibraryDependencyTypeFlag> flagsToAdd,
             IEnumerable<LibraryDependencyTypeFlag> flagsToRemove)
         {
-            return _keywords.GetOrAdd(keyword, _ => new LibraryDependencyTypeKeyword(keyword, flagsToAdd, flagsToRemove));
+            return Keywords.GetOrAdd(keyword, _ => new LibraryDependencyTypeKeyword(keyword, flagsToAdd, flagsToRemove));
         }
 
         internal static LibraryDependencyTypeKeyword Parse(string keyword)
         {
             LibraryDependencyTypeKeyword value;
-            if (_keywords.TryGetValue(keyword?.Trim(), out value))
+            if (Keywords.TryGetValue(keyword?.Trim(), out value))
             {
                 return value;
             }

--- a/src/NuGet.Core/NuGet.ProjectModel/IncludeExcludeFiles.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/IncludeExcludeFiles.cs
@@ -18,6 +18,11 @@ namespace NuGet.ProjectModel
 
         public bool HandleIncludeExcludeFiles(JObject jsonObject)
         {
+            if (jsonObject == null)
+            {
+                throw new ArgumentNullException(nameof(jsonObject));
+            }
+
             var rawInclude = jsonObject["include"];
             var rawExclude = jsonObject["exclude"];
             var rawIncludeFiles = jsonObject["includeFiles"];
@@ -81,10 +86,10 @@ namespace NuGet.ProjectModel
                 return true;
             }
 
-            return Include.SequenceEqualWithNullCheck(Include) &&
-                   Exclude.SequenceEqualWithNullCheck(Exclude) &&
-                   IncludeFiles.SequenceEqualWithNullCheck(IncludeFiles) &&
-                   ExcludeFiles.SequenceEqualWithNullCheck(ExcludeFiles);
+            return Include.SequenceEqualWithNullCheck(other.Include) &&
+                Exclude.SequenceEqualWithNullCheck(other.Exclude) &&
+                IncludeFiles.SequenceEqualWithNullCheck(other.IncludeFiles) &&
+                ExcludeFiles.SequenceEqualWithNullCheck(other.ExcludeFiles);
         }
 
         public IncludeExcludeFiles Clone()

--- a/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
@@ -13,7 +13,6 @@ using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Frameworks;
 using NuGet.LibraryModel;
-using NuGet.Packaging;
 using NuGet.Packaging.Core;
 using NuGet.RuntimeModel;
 using NuGet.Versioning;
@@ -114,7 +113,6 @@ namespace NuGet.ProjectModel
             packageSpec.Dependencies = new List<LibraryDependency>();
             packageSpec.Copyright = rawPackageSpec.GetValue<string>("copyright");
             packageSpec.Language = rawPackageSpec.GetValue<string>("language");
-
 
             var buildOptions = rawPackageSpec["buildOptions"] as JObject;
             if (buildOptions != null)
@@ -290,6 +288,7 @@ namespace NuGet.ProjectModel
                     msbuildMetadata.TargetFrameworks.Add(frameworkGroup);
                 }
             }
+
             // Add the config file paths to the equals method
             msbuildMetadata.ConfigFilePaths = new List<string>();
 
@@ -301,7 +300,6 @@ namespace NuGet.ProjectModel
                     msbuildMetadata.ConfigFilePaths.Add(fallbackFolder);
                 }
             }
-
 
             msbuildMetadata.FallbackFolders = new List<string>();
 
@@ -485,13 +483,13 @@ namespace NuGet.ProjectModel
                     var dependencyExcludeFlagsValue = LibraryIncludeFlags.None;
                     var suppressParentFlagsValue = LibraryIncludeFlagUtils.DefaultSuppressParent;
                     var noWarn = new List<NuGetLogCode>();
-                    
+
                     // This method handles both the dependencies and framework assembly sections.
                     // Framework references should be limited to references.
                     // Dependencies should allow everything but framework references.
                     var targetFlagsValue = isGacOrFrameworkReference
-                                                    ? LibraryDependencyTarget.Reference
-                                                    : LibraryDependencyTarget.All & ~LibraryDependencyTarget.Reference;
+                        ? LibraryDependencyTarget.Reference
+                        : LibraryDependencyTarget.All & ~LibraryDependencyTarget.Reference;
 
                     var autoReferenced = false;
                     var generatePathProperty = false;
@@ -647,16 +645,18 @@ namespace NuGet.ProjectModel
             else if (token.Type == JTokenType.String)
             {
                 values = new[]
-                    {
-                        token.Value<string>()
-                    };
+                {
+                    token.Value<string>()
+                };
             }
             else
             {
                 values = token.Value<string[]>();
             }
+
             result = values
                 .SelectMany(value => value.Split(new[] { ' ', ',' }, StringSplitOptions.RemoveEmptyEntries));
+
             return true;
         }
 
@@ -687,9 +687,9 @@ namespace NuGet.ProjectModel
             else if (token.Type == JTokenType.String)
             {
                 values = new[]
-                    {
-                        token.Value<string>()
-                    };
+                {
+                    token.Value<string>()
+                };
             }
             else if (token.Type == JTokenType.Array)
             {
@@ -785,7 +785,7 @@ namespace NuGet.ProjectModel
                 Warn = GetWarnSetting(properties),
                 AssetTargetFallback = assetTargetFallback,
                 RuntimeIdentifierGraphPath = GetRuntimeIdentifierGraphPath(properties)
-        };
+            };
 
             PopulateDependencies(
                 packageSpec.FilePath,
@@ -811,8 +811,8 @@ namespace NuGet.ProjectModel
                 targetFrameworkInformation.FrameworkReferences,
                 properties,
                 "frameworkReferences",
-                packageSpec.FilePath
-                );
+                packageSpec.FilePath);
+
             frameworkAssemblies.ForEach(d => targetFrameworkInformation.Dependencies.Add(d));
 
             packageSpec.TargetFrameworks.Add(targetFrameworkInformation);
@@ -908,9 +908,9 @@ namespace NuGet.ProjectModel
                     else
                     {
                         throw FileFormatException.Create(
-                                $"The version cannot be null or empty",
-                                dependencyVersionToken,
-                                packageSpecPath);
+                            "The version cannot be null or empty",
+                            dependencyVersionToken,
+                            packageSpecPath);
                     }
                 }
             }
@@ -934,12 +934,12 @@ namespace NuGet.ProjectModel
             if (frameworks.Any(p => !p.IsSpecificFramework))
             {
                 throw FileFormatException.Create(
-                           string.Format(
-                               Strings.Log_InvalidImportFramework,
-                               importsProperty.ToString().Replace(Environment.NewLine, string.Empty),
-                               PackageSpec.PackageSpecFileName),
-                           importsProperty,
-                           packageSpec.FilePath);
+                    string.Format(
+                        Strings.Log_InvalidImportFramework,
+                        importsProperty.ToString().Replace(Environment.NewLine, string.Empty),
+                        PackageSpec.PackageSpecFileName),
+                    importsProperty,
+                    packageSpec.FilePath);
             }
 
             return frameworks;
@@ -956,7 +956,6 @@ namespace NuGet.ProjectModel
 
             return null;
         }
-
 
         private static bool GetWarnSetting(JObject properties)
         {

--- a/src/NuGet.Core/NuGet.ProjectModel/Properties/AssemblyInfo.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/Properties/AssemblyInfo.cs
@@ -1,0 +1,11 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Runtime.CompilerServices;
+
+#if SIGNED_BUILD
+[assembly: InternalsVisibleTo("NuGet.ProjectModel.Test, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
+#else
+[assembly: InternalsVisibleTo("NuGet.ProjectModel.Test")]
+#endif

--- a/test/NuGet.Core.Tests/NuGet.LibraryModel.Tests/LibraryIncludeFlagUtilsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.LibraryModel.Tests/LibraryIncludeFlagUtilsTests.cs
@@ -1,0 +1,73 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using Xunit;
+
+namespace NuGet.LibraryModel.Tests
+{
+    public class LibraryIncludeFlagUtilsTests
+    {
+        [Fact]
+        public void GetFlags_WhenFlagsIsNull_Throws()
+        {
+            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
+                () => LibraryIncludeFlagUtils.GetFlags(flags: null));
+
+            Assert.Equal("flags", exception.ParamName);
+        }
+
+        [Fact]
+        public void GetFlags_WhenFlagsIsEmpty_ReturnsNone()
+        {
+            LibraryIncludeFlags flags = LibraryIncludeFlagUtils.GetFlags(Enumerable.Empty<string>());
+
+            Assert.Equal(LibraryIncludeFlags.None, flags);
+        }
+
+        [Theory]
+        [InlineData(LibraryIncludeFlags.All, LibraryIncludeFlags.All)]
+        [InlineData(LibraryIncludeFlags.Analyzers, LibraryIncludeFlags.Analyzers)]
+        [InlineData(LibraryIncludeFlags.Build, LibraryIncludeFlags.Build)]
+        [InlineData(LibraryIncludeFlags.BuildTransitive, LibraryIncludeFlags.BuildTransitive | LibraryIncludeFlags.Build)]
+        [InlineData(LibraryIncludeFlags.Compile, LibraryIncludeFlags.Compile)]
+        [InlineData(LibraryIncludeFlags.ContentFiles, LibraryIncludeFlags.ContentFiles)]
+        [InlineData(LibraryIncludeFlags.Native, LibraryIncludeFlags.Native)]
+        [InlineData(LibraryIncludeFlags.None, LibraryIncludeFlags.None)]
+        [InlineData(LibraryIncludeFlags.Runtime, LibraryIncludeFlags.Runtime)]
+        public void GetFlags_WhenFlagsIsSingleValue_ReturnsFlag(
+            LibraryIncludeFlags input,
+            LibraryIncludeFlags expectedResult)
+        {
+            LibraryIncludeFlags actualResult = LibraryIncludeFlagUtils.GetFlags(new[] { input.ToString() });
+
+            Assert.Equal(expectedResult, actualResult);
+        }
+
+        [Theory]
+        [InlineData("compile")]
+        [InlineData("COMPILE")]
+        public void GetFlags_WhenFlagsCasingDiffers_ReturnsFlag(string flag)
+        {
+            LibraryIncludeFlags flags = LibraryIncludeFlagUtils.GetFlags(new[] { flag });
+
+            Assert.Equal(LibraryIncludeFlags.Compile, flags);
+        }
+
+        [Fact]
+        public void GetFlags_WhenFlagsIsMultipleValues_ReturnsCombinationOfValues()
+        {
+            LibraryIncludeFlags[] expectedFlags = new[]
+            {
+                LibraryIncludeFlags.Runtime,
+                LibraryIncludeFlags.Compile,
+                LibraryIncludeFlags.Build
+            };
+
+            LibraryIncludeFlags flags = LibraryIncludeFlagUtils.GetFlags(expectedFlags.Select(flag => flag.ToString()));
+
+            Assert.Equal("Runtime, Compile, Build", flags.ToString());
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/DependencyGraphSpecTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/DependencyGraphSpecTests.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using Newtonsoft.Json.Linq;
@@ -141,6 +140,33 @@ namespace NuGet.ProjectModel.Test
             Assert.Equal(0, dg.Json.Properties().Count());
             Assert.Equal(0, dg.Restore.Count);
             Assert.Equal(0, dg.Projects.Count);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("[]")]
+        public void Load_WithPath_WhenJsonIsInvalid_Throws(string json)
+        {
+            using (var test = Test.Create(json))
+            {
+                Assert.Throws<InvalidDataException>(() => DependencyGraphSpec.Load(test.FilePath));
+            }
+        }
+
+        [Fact]
+        public void Load_WithPath_WhenJsonStartsWithComment_SkipsComment()
+        {
+            var json = @"/*
+*/
+{
+}";
+
+            using (var test = Test.Create(json))
+            { 
+                DependencyGraphSpec dgSpec = DependencyGraphSpec.Load(test.FilePath);
+
+                Assert.NotNull(dgSpec);
+            }
         }
 
         [Fact]
@@ -425,6 +451,40 @@ namespace NuGet.ProjectModel.Test
                 dgSpec.Save(filePath);
 
                 return File.ReadAllText(filePath);
+            }
+        }
+
+        private sealed class Test : IDisposable
+        {
+            private readonly TestDirectory _directory;
+            private bool _isDisposed;
+
+            internal string FilePath { get; }
+
+            private Test(TestDirectory directory, string filePath)
+            {
+                _directory = directory;
+                FilePath = filePath;
+            }
+
+            internal static Test Create(string json = null)
+            {
+                TestDirectory directory = TestDirectory.Create();
+                string filePath = Path.Combine(directory.Path, "dg.spec");
+
+                File.WriteAllText(filePath, json ?? string.Empty);
+
+                return new Test(directory, filePath);
+            }
+
+            public void Dispose()
+            {
+                if (!_isDisposed)
+                {
+                    _directory.Dispose();
+
+                    _isDisposed = true;
+                }
             }
         }
     }

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/IncludeExcludeFilesTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/IncludeExcludeFilesTests.cs
@@ -1,0 +1,266 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace NuGet.ProjectModel.Test
+{
+    public class IncludeExcludeFilesTests
+    {
+        private const long Seed = 0x1505L;
+
+        [Fact]
+        public void Constructor_Always_InitializesProperties()
+        {
+            var files = new IncludeExcludeFiles();
+
+            Assert.Null(files.Exclude);
+            Assert.Null(files.ExcludeFiles);
+            Assert.Null(files.Include);
+            Assert.Null(files.IncludeFiles);
+        }
+
+        [Fact]
+        public void HandleIncludeExcludeFiles_WhenJsonObjectIsNull_Throws()
+        {
+            var files = new IncludeExcludeFiles();
+
+            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
+                () => files.HandleIncludeExcludeFiles(jsonObject: null));
+
+            Assert.Equal("jsonObject", exception.ParamName);
+        }
+
+        [Theory]
+        [InlineData("{}")]
+        [InlineData("{\"exclude\":null}")]
+        [InlineData("{\"excludeFiles\":null}")]
+        [InlineData("{\"include\":null}")]
+        [InlineData("{\"includeFiles\":null}")]
+        public void HandleIncludeExcludeFiles_WithNullForFiles_ReturnsFalse(string json)
+        {
+            JObject jsonObject = JObject.Parse(json);
+            var files = new IncludeExcludeFiles();
+
+            Assert.False(files.HandleIncludeExcludeFiles(jsonObject));
+            Assert.Null(files.Exclude);
+            Assert.Null(files.ExcludeFiles);
+            Assert.Null(files.Include);
+            Assert.Null(files.IncludeFiles);
+        }
+
+        [Theory]
+        [InlineData("{\"exclude\":[]}")]
+        [InlineData("{\"exclude\":[\"a\"]}", "a")]
+        public void HandleIncludeExcludeFiles_WithValidValueForExclude_ReturnsTrue(
+            string json,
+            params string[] expectedResults)
+        {
+            JObject jsonObject = JObject.Parse(json);
+            var files = new IncludeExcludeFiles();
+
+            Assert.True(files.HandleIncludeExcludeFiles(jsonObject));
+
+            Assert.Equal(expectedResults, files.Exclude);
+            Assert.Null(files.ExcludeFiles);
+            Assert.Null(files.Include);
+            Assert.Null(files.IncludeFiles);
+        }
+
+        [Theory]
+        [InlineData("{\"excludeFiles\":[]}")]
+        [InlineData("{\"excludeFiles\":[\"a\"]}", "a")]
+        public void HandleIncludeExcludeFiles_WithValidValueForExcludeFiles_ReturnsTrue(
+            string json,
+            params string[] expectedResults)
+        {
+            JObject jsonObject = JObject.Parse(json);
+            var files = new IncludeExcludeFiles();
+
+            Assert.True(files.HandleIncludeExcludeFiles(jsonObject));
+
+            Assert.Null(files.Exclude);
+            Assert.Equal(expectedResults, files.ExcludeFiles);
+            Assert.Null(files.Include);
+            Assert.Null(files.IncludeFiles);
+        }
+
+        [Theory]
+        [InlineData("{\"include\":[]}")]
+        [InlineData("{\"include\":[\"a\"]}", "a")]
+        public void HandleIncludeExcludeFiles_WithValidValueForInclude_ReturnsTrue(
+            string json,
+            params string[] expectedResults)
+        {
+            JObject jsonObject = JObject.Parse(json);
+            var files = new IncludeExcludeFiles();
+
+            Assert.True(files.HandleIncludeExcludeFiles(jsonObject));
+
+            Assert.Null(files.Exclude);
+            Assert.Null(files.ExcludeFiles);
+            Assert.Equal(expectedResults, files.Include);
+            Assert.Null(files.IncludeFiles);
+        }
+
+        [Theory]
+        [InlineData("{\"includeFiles\":[]}")]
+        [InlineData("{\"includeFiles\":[\"a\"]}", "a")]
+        public void HandleIncludeExcludeFiles_WithValidValueForIncludeFiles_ReturnsTrue(
+            string json,
+            params string[] expectedResults)
+        {
+            JObject jsonObject = JObject.Parse(json);
+            var files = new IncludeExcludeFiles();
+
+            Assert.True(files.HandleIncludeExcludeFiles(jsonObject));
+
+            Assert.Null(files.Exclude);
+            Assert.Null(files.ExcludeFiles);
+            Assert.Null(files.Include);
+            Assert.Equal(expectedResults, files.IncludeFiles);
+        }
+
+        [Fact]
+        public void GetHashCode_Always_HashesAllProperties()
+        {
+            IReadOnlyList<string> exclude = new[] { "a" };
+            IReadOnlyList<string> excludeFiles = new[] { "b" };
+            IReadOnlyList<string> include = new[] { "c" };
+            IReadOnlyList<string> includeFiles = new[] { "d" };
+
+            int expectedResult = GetExpectedHashCode(exclude, excludeFiles, include, includeFiles);
+
+            var files = new IncludeExcludeFiles();
+
+            Assert.Equal(0, files.GetHashCode());
+
+            files.Exclude = exclude;
+            files.ExcludeFiles = excludeFiles;
+            files.Include = include;
+            files.IncludeFiles = includeFiles;
+
+            int actualResult = files.GetHashCode();
+
+            Assert.Equal(expectedResult, actualResult);
+        }
+
+        [Fact]
+        public void Equals_WithOther_ReturnsCorrectValue()
+        {
+            var files1 = new IncludeExcludeFiles();
+            var files2 = new IncludeExcludeFiles();
+
+            Assert.False(files1.Equals(other: null));
+            Assert.True(files1.Equals(other: files1));
+            Assert.True(files1.Equals(other: files2));
+
+            var files = new List<string>() { "a" };
+
+            files1.Exclude = files;
+            Assert.False(files1.Equals(files2));
+            files2.Exclude = files;
+            Assert.True(files1.Equals(files2));
+
+            files1.ExcludeFiles = files;
+            Assert.False(files1.Equals(files2));
+            files2.ExcludeFiles = files;
+            Assert.True(files1.Equals(files2));
+
+            files1.Include = files;
+            Assert.False(files1.Equals(files2));
+            files2.Include = files;
+            Assert.True(files1.Equals(files2));
+
+            files1.IncludeFiles = files;
+            Assert.False(files1.Equals(files2));
+            files2.IncludeFiles = files;
+            Assert.True(files1.Equals(files2));
+        }
+
+        [Fact]
+        public void Equals_WithObj_ReturnsCorrectValue()
+        {
+            var files1 = new IncludeExcludeFiles();
+            var files2 = new IncludeExcludeFiles();
+
+            Assert.False(files1.Equals(obj: null));
+            Assert.False(files1.Equals(obj: "b"));
+            Assert.False(files1.Equals(obj: new object()));
+            Assert.True(files1.Equals(obj: files1));
+            Assert.True(files1.Equals(obj: files2));
+        }
+
+        [Fact]
+        public void Clone_Always_CreatesDeepClone()
+        {
+            IReadOnlyList<string> exclude = new[] { "a" };
+            IReadOnlyList<string> excludeFiles = new[] { "b" };
+            IReadOnlyList<string> include = new[] { "c" };
+            IReadOnlyList<string> includeFiles = new[] { "d" };
+
+            var expectedResult = new IncludeExcludeFiles()
+            {
+                Exclude = exclude,
+                ExcludeFiles = excludeFiles,
+                Include = include,
+                IncludeFiles = includeFiles
+            };
+            int expectedHashCode = expectedResult.GetHashCode();
+
+            IncludeExcludeFiles actualResult = expectedResult.Clone();
+            int actualHashCode = actualResult.GetHashCode();
+
+            Assert.NotSame(expectedResult, actualResult);
+            Assert.Equal(expectedResult, actualResult);
+            Assert.Equal(expectedHashCode, actualHashCode);
+            Assert.NotSame(expectedResult.Exclude, actualResult.Exclude);
+            Assert.Equal(exclude, actualResult.Exclude);
+            Assert.NotSame(expectedResult.ExcludeFiles, actualResult.ExcludeFiles);
+            Assert.Equal(excludeFiles, actualResult.ExcludeFiles);
+            Assert.NotSame(expectedResult.Include, actualResult.Include);
+            Assert.Equal(include, actualResult.Include);
+            Assert.NotSame(expectedResult.IncludeFiles, actualResult.IncludeFiles);
+            Assert.Equal(includeFiles, actualResult.IncludeFiles);
+        }
+
+        private static int GetExpectedHashCode(
+            IReadOnlyList<string> exclude,
+            IReadOnlyList<string> excludeFiles,
+            IReadOnlyList<string> include,
+            IReadOnlyList<string> includeFiles)
+        {
+            long hashCode = Seed;
+
+            hashCode = AddHashCodes(hashCode, include);
+            hashCode = AddHashCodes(hashCode, exclude);
+            hashCode = AddHashCodes(hashCode, includeFiles);
+            hashCode = AddHashCodes(hashCode, excludeFiles);
+
+            return hashCode.GetHashCode();
+        }
+
+        private static long AddHashCode(long runningHashCode, int newHashCode)
+        {
+            return ((runningHashCode << 5) + runningHashCode) ^ newHashCode;
+        }
+
+        private static long AddHashCodes<T>(long hashCode, IEnumerable<T> items)
+        {
+            long combinedHashCode = hashCode;
+
+            if (items != null)
+            {
+                foreach (T item in items)
+                {
+                    combinedHashCode = AddHashCode(combinedHashCode, item.GetHashCode());
+                }
+            }
+
+            return combinedHashCode;
+        }
+    }
+}


### PR DESCRIPTION
## Bug

Fixes:  https://github.com/NuGet/Home/issues/9167  
Regression:  No
* How are we preventing it in future:  Added tests.

## Fix

Details:  Fixed the bad `IncludeExcludeFiles.Equals(…)` implementation.

Also included in this PR are style changes and additional, unrelated tests.

## Testing/Validation

Tests Added: Yes