### PR TITLE
A11y Fixes Batch 5 - hyperlinks should have 1 node in accessibility tree.

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
@@ -88,15 +88,6 @@ namespace NuGet.PackageManagement.UI {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Package details link.
-        /// </summary>
-        public static string Accessibility_PackageDetailsUrlLink {
-            get {
-                return ResourceManager.GetString("Accessibility_PackageDetailsUrlLink", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Package icon.
         /// </summary>
         public static string Accessibility_PackageIcon {

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
@@ -844,9 +844,6 @@ Please see https://aka.ms/troubleshoot_nuget_cache for more help.</value>
   <data name="Accessibility_PackageDetailsUrlIcon" xml:space="preserve">
     <value>Package details URL icon</value>
   </data>
-  <data name="Accessibility_PackageDetailsUrlLink" xml:space="preserve">
-    <value>Package details link</value>
-  </data>
   <data name="Label_Deprecated" xml:space="preserve">
     <value>Deprecated</value>
   </data>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/DetailControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/DetailControl.xaml
@@ -116,8 +116,8 @@
             <Hyperlink
               NavigateUri="{Binding Path=PackageMetadata.PackageDetailsUrl}"
               Style="{StaticResource HyperlinkStyle}"
-              AutomationProperties.Name="{x:Static nuget:Resources.Accessibility_PackageDetailsUrlLink}"
               ToolTip="{Binding Path=PackageMetadata.PackageDetailsUrl}"
+              AutomationProperties.LabeledBy="{Binding ElementName=_packageDetailsUrlIcon}"
               Command="{x:Static nuget:PackageManagerControlCommands.OpenExternalLink}">
               <Run Text="{Binding Path=PackageMetadata.PackageDetailsText}" />
             </Hyperlink>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageMetadataControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageMetadataControl.xaml
@@ -19,11 +19,8 @@
       </ResourceDictionary.MergedDictionaries>
       <nuget:DateTimeConverter x:Key="DateFormatConverter" />
       <DataTemplate DataType="{x:Type nuget:LicenseText}">
-        <TextBlock
-            AutomationProperties.AutomationId="{Binding Id, Mode=OneWay, StringFormat='LicenseTerm_{0}'}">
+        <TextBlock>
                 <Hyperlink
-                    AutomationProperties.AutomationId="{Binding Id, Mode=OneWay, StringFormat='LicenseTermLink_{0}'}"
-                    AutomationProperties.Name="{x:Static nuget:Resources.Hyperlink_License}"
                     Style="{StaticResource HyperlinkStyle}"
                     Command="{x:Static nuget:PackageManagerControlCommands.OpenExternalLink}"
                     ToolTip="{Binding Link}"


### PR DESCRIPTION
## Bug

Fixes: https://github.com/nuget/home/issues/9157 - batch 5

-[1049215](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1049215) - PackageDetail -nuget.org link- A11y_VS ASP.NET and Web Development_ Install Nuget Packages _ Screen Reader: Narrator is not reading the link text for “nuget.org” link
-[994495](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/994495) - PackageDetail - LicenseUI - A11y_NuGetClient-MinorUIChanges_TestPackage.Deprecation.CriticalBugs.AlternatePackage_Installed_ScreenReader : Narrator is not announcing the label association for the "MIT" link.

Regression: No
* How are we preventing it in future:   accessibility insights when changing UI

## Fix Details

Make each one of these cases have fewer nodes in accessibility tree.


## Testing/Validation

Tests Added: No
Reason for not adding tests:  A11Y
Validation:  narrator, accessibility insights
