### PR TITLE
Restore:  improve DependencyGraphSpec memory usage

### DIFF
--- a/src/NuGet.Core/NuGet.ProjectModel/FileFormatException.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/FileFormatException.cs
@@ -30,10 +30,19 @@ namespace NuGet.ProjectModel
 
             return this;
         }
+
         private FileFormatException WithLineInfo(JsonReaderException exception)
         {
             Line = exception.LinePosition;
             Column = exception.LineNumber;
+
+            return this;
+        }
+
+        private FileFormatException WithLineInfo(int line, int column)
+        {
+            Line = line;
+            Column = column;
 
             return this;
         }
@@ -62,6 +71,20 @@ namespace NuGet.ProjectModel
             return ex.WithFilePath(path).WithLineInfo(lineInfo);
         }
 
+        internal static FileFormatException Create(Exception exception, int line, int column, string path)
+        {
+            var message = string.Format(CultureInfo.CurrentCulture,
+                Strings.Log_ErrorReadingProjectJsonWithLocation,
+                path,
+                line,
+                column,
+                exception.Message);
+
+            var ex = new FileFormatException(message, exception);
+
+            return ex.WithFilePath(path).WithLineInfo(line, column);
+        }
+
         public static FileFormatException Create(string message, JToken value, string path)
         {
             var lineInfo = (IJsonLineInfo)value;
@@ -69,6 +92,13 @@ namespace NuGet.ProjectModel
             var ex = new FileFormatException(message);
 
             return ex.WithFilePath(path).WithLineInfo(lineInfo);
+        }
+
+        internal static FileFormatException Create(string message, int line, int column, string path)
+        {
+            var ex = new FileFormatException(message);
+
+            return ex.WithFilePath(path).WithLineInfo(line, column);
         }
 
         internal static FileFormatException Create(Exception exception, string path)

--- a/src/NuGet.Core/NuGet.ProjectModel/IncludeExcludeFiles.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/IncludeExcludeFiles.cs
@@ -23,34 +23,34 @@ namespace NuGet.ProjectModel
                 throw new ArgumentNullException(nameof(jsonObject));
             }
 
-            var rawInclude = jsonObject["include"];
-            var rawExclude = jsonObject["exclude"];
-            var rawIncludeFiles = jsonObject["includeFiles"];
-            var rawExcludeFiles = jsonObject["excludeFiles"];
+            JToken rawInclude = jsonObject["include"];
+            JToken rawExclude = jsonObject["exclude"];
+            JToken rawIncludeFiles = jsonObject["includeFiles"];
+            JToken rawExcludeFiles = jsonObject["excludeFiles"];
 
-            IEnumerable<string> include;
-            IEnumerable<string> exclude;
-            IEnumerable<string> includeFiles;
-            IEnumerable<string> excludeFiles;
-            bool foundOne = false;
-            if (rawInclude != null && JsonPackageSpecReader.TryGetStringEnumerableFromJArray(rawInclude, out include))
+            var foundOne = false;
+
+            if (rawInclude != null && TryGetStringEnumerableFromJArray(rawInclude, out IReadOnlyList<string> include))
             {
-                Include = include.ToList();
+                Include = include;
                 foundOne = true;
             }
-            if (rawExclude != null && JsonPackageSpecReader.TryGetStringEnumerableFromJArray(rawExclude, out exclude))
+
+            if (rawExclude != null && TryGetStringEnumerableFromJArray(rawExclude, out IReadOnlyList<string> exclude))
             {
-                Exclude = exclude.ToList();
+                Exclude = exclude;
                 foundOne = true;
             }
-            if (rawIncludeFiles != null && JsonPackageSpecReader.TryGetStringEnumerableFromJArray(rawIncludeFiles, out includeFiles))
+
+            if (rawIncludeFiles != null && TryGetStringEnumerableFromJArray(rawIncludeFiles, out IReadOnlyList<string> includeFiles))
             {
-                IncludeFiles = includeFiles.ToList();
+                IncludeFiles = includeFiles;
                 foundOne = true;
             }
-            if (rawExcludeFiles != null && JsonPackageSpecReader.TryGetStringEnumerableFromJArray(rawExcludeFiles, out excludeFiles))
+
+            if (rawExcludeFiles != null && TryGetStringEnumerableFromJArray(rawExcludeFiles, out IReadOnlyList<string> excludeFiles))
             {
-                ExcludeFiles = excludeFiles.ToList();
+                ExcludeFiles = excludeFiles;
                 foundOne = true;
             }
 
@@ -100,6 +100,33 @@ namespace NuGet.ProjectModel
             clonedObject.IncludeFiles = IncludeFiles.ToList();
             clonedObject.ExcludeFiles = ExcludeFiles.ToList();
             return clonedObject;
+        }
+
+        private static bool TryGetStringEnumerableFromJArray(JToken token, out IReadOnlyList<string> result)
+        {
+            result = null;
+
+            if (token == null)
+            {
+                return false;
+            }
+            else if (token.Type == JTokenType.String)
+            {
+                result = new[]
+                {
+                    token.Value<string>()
+                };
+            }
+            else if (token.Type == JTokenType.Array)
+            {
+                result = token.ValueAsArray<string>();
+            }
+            else
+            {
+                return false;
+            }
+
+            return true;
         }
     }
 }

--- a/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
@@ -13,7 +13,6 @@ using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Frameworks;
 using NuGet.LibraryModel;
-using NuGet.Packaging;
 using NuGet.Packaging.Core;
 using NuGet.RuntimeModel;
 using NuGet.Versioning;
@@ -22,6 +21,9 @@ namespace NuGet.ProjectModel
 {
     public class JsonPackageSpecReader
     {
+        private static readonly char[] DelimitedStringSeparators = { ' ', ',' };
+        private static readonly char[] VersionSeparators = new[] { ';' };
+
         public static readonly string RestoreOptions = "restore";
         public static readonly string RestoreSettings = "restoreSettings";
         public static readonly string HideWarningsAndErrors = "hideWarningsAndErrors";
@@ -47,6 +49,7 @@ namespace NuGet.ProjectModel
             }
         }
 
+        [Obsolete("This method is obsolete and will be removed in a future release.")]
         public static PackageSpec GetPackageSpec(JObject json)
         {
             return GetPackageSpec(json, name: null, packageSpecPath: null, snapshotValue: null);
@@ -54,119 +57,172 @@ namespace NuGet.ProjectModel
 
         public static PackageSpec GetPackageSpec(Stream stream, string name, string packageSpecPath, string snapshotValue)
         {
-            // Load the raw JSON into the package spec object
-            JObject rawPackageSpec;
-
-            using (var reader = new JsonTextReader(new StreamReader(stream)))
+            using (var streamReader = new StreamReader(stream))
+            using (var jsonReader = new JsonTextReader(streamReader))
             {
-                try
-                {
-                    rawPackageSpec = JObject.Load(reader);
-                }
-                catch (JsonReaderException ex)
-                {
-                    throw FileFormatException.Create(ex, packageSpecPath);
-                }
+                return GetPackageSpec(jsonReader, name, packageSpecPath, snapshotValue);
             }
-
-            return GetPackageSpec(rawPackageSpec, name, packageSpecPath, snapshotValue);
         }
 
+        [Obsolete("This method is obsolete and will be removed in a future release.")]
         public static PackageSpec GetPackageSpec(JObject rawPackageSpec, string name, string packageSpecPath, string snapshotValue)
+        {
+            using (var stringReader = new StringReader(rawPackageSpec.ToString()))
+            using (var jsonReader = new JsonTextReader(stringReader))
+            {
+                return GetPackageSpec(jsonReader, name, packageSpecPath, snapshotValue);
+            }
+        }
+
+        internal static PackageSpec GetPackageSpec(JsonTextReader jsonReader, string packageSpecPath)
+        {
+            return GetPackageSpec(jsonReader, name: null, packageSpecPath, snapshotValue: null);
+        }
+
+        private static PackageSpec GetPackageSpec(JsonTextReader jsonReader, string name, string packageSpecPath, string snapshotValue)
         {
             var packageSpec = new PackageSpec();
 
-            // Parse properties we know about
-            var version = rawPackageSpec["version"];
-            var authors = rawPackageSpec["authors"];
-            var contentFiles = rawPackageSpec["contentFiles"];
+            string[] authors = null;
+            BuildOptions buildOptions = null;
+            List<CompatibilityProfile> compatibilityProfiles = null;
+            IList<string> contentFiles = null;
+            List<RuntimeDescription> runtimeDescriptions = null;
+            string title = null;
+            string version = null;
+            var wasPackOptionsSet = false;
+            var isMappingsNull = false;
+
+            string filePath = name == null ? null : Path.GetFullPath(packageSpecPath);
+
+            jsonReader.ReadObject(propertyName =>
+            {
+                if (string.IsNullOrWhiteSpace(propertyName))
+                {
+                    return;
+                }
+
+                switch (propertyName)
+                {
+                    case "authors":
+                        authors = ReadStringArray(jsonReader);
+                        break;
+
+                    case "buildOptions":
+                        buildOptions = ReadBuildOptions(jsonReader);
+                        break;
+
+                    case "contentFiles":
+                        contentFiles = jsonReader.ReadStringArrayAsList();
+                        break;
+
+                    case "copyright":
+                        packageSpec.Copyright = jsonReader.ReadNextTokenAsString();
+                        break;
+
+                    case "dependencies":
+                        ReadDependencies(
+                            jsonReader,
+                            packageSpec.Dependencies,
+                            filePath,
+                            isGacOrFrameworkReference: false);
+                        break;
+
+                    case "description":
+                        packageSpec.Description = jsonReader.ReadNextTokenAsString();
+                        break;
+
+                    case "frameworks":
+                        ReadFrameworks(jsonReader, packageSpec);
+                        break;
+
+                    case "language":
+                        packageSpec.Language = jsonReader.ReadNextTokenAsString();
+                        break;
+
+                    case "packInclude":
+                        ReadPackInclude(jsonReader, packageSpec);
+                        break;
+
+                    case "packOptions":
+                        ReadPackOptions(packageSpec, jsonReader, ref isMappingsNull);
+                        wasPackOptionsSet = true;
+                        break;
+
+                    case "restore":
+                        packageSpec.RestoreMetadata = ReadMSBuildMetadata(packageSpec, jsonReader);
+                        break;
+
+                    case "restoreSettings":
+                        packageSpec.RestoreSettings = ReadRestoreSettings(packageSpec, jsonReader);
+                        break;
+
+                    case "runtimes":
+                        runtimeDescriptions = ReadRuntimes(jsonReader);
+                        break;
+
+                    case "scripts":
+                        ReadScripts(jsonReader, packageSpec);
+                        break;
+
+                    case "supports":
+                        compatibilityProfiles = ReadSupports(jsonReader);
+                        break;
+
+                    case "title":
+                        title = jsonReader.ReadNextTokenAsString();
+                        break;
+
+                    case "version":
+                        version = jsonReader.ReadAsString();
+
+                        if (version != null)
+                        {
+                            try
+                            {
+                                packageSpec.HasVersionSnapshot = PackageSpecUtility.IsSnapshotVersion(version);
+                                packageSpec.Version = PackageSpecUtility.SpecifySnapshot(version, snapshotValue);
+                            }
+                            catch (Exception ex)
+                            {
+                                throw FileFormatException.Create(ex, version, packageSpec.FilePath);
+                            }
+                        }
+                        break;
+                }
+            });
+
+            packageSpec.Authors = authors ?? Array.Empty<string>();
+            packageSpec.BuildOptions = buildOptions;
+
+            if (contentFiles != null)
+            {
+                packageSpec.ContentFiles = contentFiles;
+            }
 
             packageSpec.Name = name;
             packageSpec.FilePath = name == null ? null : Path.GetFullPath(packageSpecPath);
 
-            if (version != null)
+            if (!wasPackOptionsSet)
             {
-                try
+                packageSpec.Owners = Array.Empty<string>();
+                packageSpec.PackOptions = new PackOptions()
                 {
-                    var versionString = version.Value<string>();
-                    packageSpec.HasVersionSnapshot = PackageSpecUtility.IsSnapshotVersion(versionString);
-                    packageSpec.Version = PackageSpecUtility.SpecifySnapshot(versionString, snapshotValue);
-                }
-                catch (Exception ex)
-                {
-                    throw FileFormatException.Create(ex, version, packageSpec.FilePath);
-                }
-            }
-
-            var packInclude = rawPackageSpec["packInclude"] as JObject;
-            if (packInclude != null)
-            {
-                foreach (var include in packInclude)
-                {
-                    packageSpec.PackInclude.Add(new KeyValuePair<string, string>(include.Key, include.Value.ToString()));
-                }
-            }
-
-            packageSpec.Title = rawPackageSpec.GetValue<string>("title");
-            packageSpec.Description = rawPackageSpec.GetValue<string>("description");
-            packageSpec.Authors = authors == null ? new string[] { } : authors.ValueAsArray<string>();
-            packageSpec.ContentFiles = contentFiles == null ? new string[] { } : contentFiles.ValueAsArray<string>();
-            packageSpec.Dependencies = new List<LibraryDependency>();
-            packageSpec.Copyright = rawPackageSpec.GetValue<string>("copyright");
-            packageSpec.Language = rawPackageSpec.GetValue<string>("language");
-
-            var buildOptions = rawPackageSpec["buildOptions"] as JObject;
-            if (buildOptions != null)
-            {
-                packageSpec.BuildOptions = new BuildOptions()
-                {
-                    OutputName = buildOptions.GetValue<string>("outputName")
+                    PackageType = Array.Empty<PackageType>()
                 };
+                packageSpec.Tags = Array.Empty<string>();
             }
 
-            var scripts = rawPackageSpec["scripts"] as JObject;
-            if (scripts != null)
+            if (isMappingsNull)
             {
-                foreach (var script in scripts)
-                {
-                    var value = script.Value;
-                    if (value.Type == JTokenType.String)
-                    {
-                        packageSpec.Scripts[script.Key] = new string[] { value.Value<string>() };
-                    }
-                    else if (value.Type == JTokenType.Array)
-                    {
-                        packageSpec.Scripts[script.Key] = script.Value.ValueAsArray<string>();
-                    }
-                    else
-                    {
-                        throw FileFormatException.Create(
-                            string.Format("The value of a script in '{0}' can only be a string or an array of strings", PackageSpec.PackageSpecFileName),
-                            value,
-                            packageSpec.FilePath);
-                    }
-                }
+                packageSpec.PackOptions.Mappings = null;
             }
 
-            BuildTargetFrameworks(packageSpec, rawPackageSpec);
+            packageSpec.RuntimeGraph = new RuntimeGraph(
+                runtimeDescriptions ?? Enumerable.Empty<RuntimeDescription>(),
+                compatibilityProfiles ?? Enumerable.Empty<CompatibilityProfile>());
+            packageSpec.Title = title;
 
-            PopulateDependencies(
-                packageSpec.FilePath,
-                packageSpec.Dependencies,
-                rawPackageSpec,
-                "dependencies",
-                isGacOrFrameworkReference: false);
-
-            packageSpec.PackOptions = GetPackOptions(packageSpec, rawPackageSpec);
-
-            packageSpec.RestoreSettings = GetRestoreSettings(packageSpec, rawPackageSpec);
-
-            packageSpec.RestoreMetadata = GetMSBuildMetadata(packageSpec, rawPackageSpec);
-
-            // Read the runtime graph
-            packageSpec.RuntimeGraph = JsonRuntimeFormat.ReadRuntimeGraph(rawPackageSpec);
-
-            // Read the name/path if it exists
             if (packageSpec.Name == null)
             {
                 packageSpec.Name = packageSpec.RestoreMetadata?.ProjectName;
@@ -182,314 +238,134 @@ namespace NuGet.ProjectModel
             return packageSpec;
         }
 
-        private static ProjectRestoreSettings GetRestoreSettings(PackageSpec packageSpec, JObject rawPackageSpec)
+        private static PackageType CreatePackageType(JsonTextReader jsonReader)
         {
-            var rawRestoreSettings = rawPackageSpec.Value<JToken>(RestoreSettings) as JObject;
-            var restoreSettings = new ProjectRestoreSettings();
+            var name = (string)jsonReader.Value;
 
-            if (rawRestoreSettings != null)
-            {
-                restoreSettings.HideWarningsAndErrors = GetBoolOrFalse(rawRestoreSettings, HideWarningsAndErrors, packageSpec.FilePath);
-            }
-
-            return restoreSettings;
+            return new PackageType(name, Packaging.Core.PackageType.EmptyVersion);
         }
 
-        private static ProjectRestoreMetadata GetMSBuildMetadata(PackageSpec packageSpec, JObject rawPackageSpec)
+        private static BuildOptions ReadBuildOptions(JsonTextReader jsonReader)
         {
-            var rawMSBuildMetadata = rawPackageSpec.Value<JToken>(RestoreOptions) as JObject;
-            if (rawMSBuildMetadata == null)
+            var buildOptions = new BuildOptions();
+
+            jsonReader.ReadObject(buildOptionsPropertyName =>
             {
-                return null;
-            }
-
-            var projectStyleString = rawMSBuildMetadata.GetValue<string>("projectStyle");
-
-            ProjectStyle? projectStyle = null;
-            if (!string.IsNullOrEmpty(projectStyleString)
-                && Enum.TryParse<ProjectStyle>(projectStyleString, ignoreCase: true, result: out var projectStyleValue))
-            {
-                projectStyle = projectStyleValue;
-            }
-
-            var msbuildMetadata = projectStyle == ProjectStyle.PackagesConfig
-                ? new PackagesConfigProjectRestoreMetadata()
-                : new ProjectRestoreMetadata();
-
-            if (projectStyle.HasValue)
-            {
-                msbuildMetadata.ProjectStyle = projectStyle.Value;
-            }
-
-            msbuildMetadata.ProjectUniqueName = rawMSBuildMetadata.GetValue<string>("projectUniqueName");
-            msbuildMetadata.OutputPath = rawMSBuildMetadata.GetValue<string>("outputPath");
-
-            msbuildMetadata.PackagesPath = rawMSBuildMetadata.GetValue<string>("packagesPath");
-            msbuildMetadata.ProjectJsonPath = rawMSBuildMetadata.GetValue<string>("projectJsonPath");
-            msbuildMetadata.ProjectName = rawMSBuildMetadata.GetValue<string>("projectName");
-            msbuildMetadata.ProjectPath = rawMSBuildMetadata.GetValue<string>("projectPath");
-            msbuildMetadata.CrossTargeting = GetBoolOrFalse(rawMSBuildMetadata, "crossTargeting", packageSpec.FilePath);
-            msbuildMetadata.LegacyPackagesDirectory = GetBoolOrFalse(rawMSBuildMetadata, "legacyPackagesDirectory", packageSpec.FilePath);
-            msbuildMetadata.ValidateRuntimeAssets = GetBoolOrFalse(rawMSBuildMetadata, "validateRuntimeAssets", packageSpec.FilePath);
-            msbuildMetadata.SkipContentFileWrite = GetBoolOrFalse(rawMSBuildMetadata, "skipContentFileWrite", packageSpec.FilePath);
-            msbuildMetadata.CentralPackageVersionsEnabled = GetBoolOrFalse(rawMSBuildMetadata, "centralPackageVersionsManagementEnabled", packageSpec.FilePath);
-
-            msbuildMetadata.Sources = new List<PackageSource>();
-
-            var sourcesObj = rawMSBuildMetadata.GetValue<JObject>("sources");
-            if (sourcesObj != null)
-            {
-                foreach (var prop in sourcesObj.Properties())
+                if (buildOptionsPropertyName == "outputName")
                 {
-                    msbuildMetadata.Sources.Add(new PackageSource(prop.Name));
+                    buildOptions.OutputName = jsonReader.ReadNextTokenAsString();
                 }
-            }
+            });
 
-            var filesObj = rawMSBuildMetadata.GetValue<JObject>("files");
-            if (filesObj != null)
-            {
-                foreach (var prop in filesObj.Properties())
-                {
-                    msbuildMetadata.Files.Add(new ProjectRestoreMetadataFile(prop.Name, prop.Value.ToObject<string>()));
-                }
-            }
-
-            var frameworksObj = rawMSBuildMetadata.GetValue<JObject>("frameworks");
-            if (frameworksObj != null)
-            {
-                foreach (var frameworkProperty in frameworksObj.Properties())
-                {
-                    var framework = NuGetFramework.Parse(frameworkProperty.Name);
-                    var frameworkGroup = new ProjectRestoreMetadataFrameworkInfo(framework);
-
-                    var projectsObj = frameworkProperty.Value.GetValue<JObject>("projectReferences");
-                    if (projectsObj != null)
-                    {
-                        foreach (var prop in projectsObj.Properties())
-                        {
-                            frameworkGroup.ProjectReferences.Add(new ProjectRestoreReference()
-                            {
-                                ProjectUniqueName = prop.Name,
-                                ProjectPath = prop.Value.GetValue<string>("projectPath"),
-
-                                IncludeAssets = LibraryIncludeFlagUtils.GetFlags(
-                                    flags: prop.Value.GetValue<string>("includeAssets"),
-                                    defaultFlags: LibraryIncludeFlags.All),
-
-                                ExcludeAssets = LibraryIncludeFlagUtils.GetFlags(
-                                    flags: prop.Value.GetValue<string>("excludeAssets"),
-                                    defaultFlags: LibraryIncludeFlags.None),
-
-                                PrivateAssets = LibraryIncludeFlagUtils.GetFlags(
-                                    flags: prop.Value.GetValue<string>("privateAssets"),
-                                    defaultFlags: LibraryIncludeFlagUtils.DefaultSuppressParent),
-                            });
-                        }
-                    }
-
-                    msbuildMetadata.TargetFrameworks.Add(frameworkGroup);
-                }
-            }
-
-            // Add the config file paths to the equals method
-            msbuildMetadata.ConfigFilePaths = new List<string>();
-
-            var configFilePaths = rawMSBuildMetadata.GetValue<JArray>("configFilePaths");
-            if (configFilePaths != null)
-            {
-                foreach (var fallbackFolder in configFilePaths.Select(t => t.Value<string>()))
-                {
-                    msbuildMetadata.ConfigFilePaths.Add(fallbackFolder);
-                }
-            }
-
-            msbuildMetadata.FallbackFolders = new List<string>();
-
-            var fallbackObj = rawMSBuildMetadata.GetValue<JArray>("fallbackFolders");
-            if (fallbackObj != null)
-            {
-                foreach (var fallbackFolder in fallbackObj.Select(t => t.Value<string>()))
-                {
-                    msbuildMetadata.FallbackFolders.Add(fallbackFolder);
-                }
-            }
-
-            msbuildMetadata.OriginalTargetFrameworks = new List<string>();
-
-            var originalFrameworksObj = rawMSBuildMetadata.GetValue<JArray>("originalTargetFrameworks");
-            if (originalFrameworksObj != null)
-            {
-                foreach (var orignalFramework in originalFrameworksObj.Select(t => t.Value<string>()))
-                {
-                    msbuildMetadata.OriginalTargetFrameworks.Add(orignalFramework);
-                }
-            }
-
-            var warningPropertiesObj = rawMSBuildMetadata.GetValue<JObject>("warningProperties");
-            if (warningPropertiesObj != null)
-            {
-                var allWarningsAsErrors = warningPropertiesObj.GetValue<bool>("allWarningsAsErrors");
-                var warnAsError = new HashSet<NuGetLogCode>(GetNuGetLogCodeEnumerableFromJArray(warningPropertiesObj["warnAsError"]));
-                var noWarn = new HashSet<NuGetLogCode>(GetNuGetLogCodeEnumerableFromJArray(warningPropertiesObj["noWarn"]));
-
-                msbuildMetadata.ProjectWideWarningProperties = new WarningProperties(warnAsError, noWarn, allWarningsAsErrors);
-            }
-
-            // read NuGet lock file msbuild properties
-            var restoreLockProperties = rawMSBuildMetadata.GetValue<JObject>("restoreLockProperties");
-
-            if (restoreLockProperties != null)
-            {
-                msbuildMetadata.RestoreLockProperties = new RestoreLockProperties(
-                    restoreLockProperties.GetValue<string>("restorePackagesWithLockFile"),
-                    restoreLockProperties.GetValue<string>("nuGetLockFilePath"),
-                    GetBoolOrFalse(restoreLockProperties, "restoreLockedMode", packageSpec.FilePath));
-            }
-
-            if (msbuildMetadata is PackagesConfigProjectRestoreMetadata pcMsbuildMetadata)
-            {
-                pcMsbuildMetadata.PackagesConfigPath = rawMSBuildMetadata.GetValue<string>("packagesConfigPath");
-            }
-
-            return msbuildMetadata;
+            return buildOptions;
         }
 
-        private static PackOptions GetPackOptions(PackageSpec packageSpec, JObject rawPackageSpec)
+        private static void ReadCentralPackageVersions(
+            JsonTextReader jsonReader,
+            IDictionary<string, CentralPackageVersion> centralPackageVersions,
+            string filePath)
         {
-            var rawPackOptions = rawPackageSpec.Value<JToken>(PackOptions) as JObject;
-            if (rawPackOptions == null)
+            jsonReader.ReadObject(propertyName =>
             {
-                packageSpec.Owners = new string[] { };
-                packageSpec.Tags = new string[] { };
-                return new PackOptions
+                int line = jsonReader.LineNumber;
+                int column = jsonReader.LinePosition;
+
+                if (string.IsNullOrEmpty(propertyName))
                 {
-                    PackageType = new PackageType[0]
-                };
-            }
-            var owners = rawPackOptions["owners"];
-            var tags = rawPackOptions["tags"];
-            packageSpec.Owners = owners == null ? Array.Empty<string>() : owners.ValueAsArray<string>();
-            packageSpec.Tags = tags == null ? Array.Empty<string>() : tags.ValueAsArray<string>();
-            packageSpec.ProjectUrl = rawPackOptions.GetValue<string>("projectUrl");
-            packageSpec.IconUrl = rawPackOptions.GetValue<string>("iconUrl");
-            packageSpec.Summary = rawPackOptions.GetValue<string>("summary");
-            packageSpec.ReleaseNotes = rawPackOptions.GetValue<string>("releaseNotes");
-            packageSpec.LicenseUrl = rawPackOptions.GetValue<string>("licenseUrl");
-
-            packageSpec.RequireLicenseAcceptance = GetBoolOrFalse(rawPackOptions, "requireLicenseAcceptance", packageSpec.FilePath);
-
-            var rawPackageType = rawPackOptions[PackageType];
-            if (rawPackageType != null &&
-                rawPackageType.Type != JTokenType.String &&
-                (rawPackageType.Type != JTokenType.Array || // The array must be all strings.
-                 rawPackageType.Type == JTokenType.Array && rawPackageType.Any(t => t.Type != JTokenType.String)) &&
-                rawPackageType.Type != JTokenType.Null)
-            {
-                throw FileFormatException.Create(
-                    string.Format(
-                        CultureInfo.CurrentCulture,
-                        Strings.InvalidPackageType,
-                        PackageSpec.PackageSpecFileName),
-                    rawPackageType,
-                    packageSpec.FilePath);
-            }
-
-            IEnumerable<string> packageTypeNames;
-            if (!TryGetStringEnumerableFromJArray(rawPackageType, out packageTypeNames))
-            {
-                packageTypeNames = Enumerable.Empty<string>();
-            }
-
-            Dictionary<string, IncludeExcludeFiles> mappings = null;
-            IncludeExcludeFiles files = null;
-            var rawFiles = rawPackOptions[Files] as JObject;
-            if (rawFiles != null)
-            {
-                files = new IncludeExcludeFiles();
-                if (!files.HandleIncludeExcludeFiles(rawFiles))
-                {
-                    files = null;
+                    throw FileFormatException.Create(
+                        "Unable to resolve central version ''.",
+                        line,
+                        column,
+                        filePath);
                 }
 
-                var rawMappings = rawFiles["mappings"] as JObject;
+                string version = jsonReader.ReadNextTokenAsString();
 
-                if (rawMappings != null)
+                if (string.IsNullOrEmpty(version))
                 {
-                    mappings = new Dictionary<string, IncludeExcludeFiles>();
-                    foreach (var pair in rawMappings)
-                    {
-                        var key = pair.Key;
-                        var value = pair.Value;
-                        if (value.Type == JTokenType.String ||
-                            value.Type == JTokenType.Array)
-                        {
-                            IEnumerable<string> includeFiles;
-                            TryGetStringEnumerableFromJArray(value, out includeFiles);
-                            var includeExcludeFiles = new IncludeExcludeFiles()
-                            {
-                                Include = includeFiles?.ToList()
-                            };
-                            mappings.Add(key, includeExcludeFiles);
-                        }
-                        else if (value.Type == JTokenType.Object)
-                        {
-                            var includeExcludeFiles = new IncludeExcludeFiles();
-                            if (includeExcludeFiles.HandleIncludeExcludeFiles(value as JObject))
-                            {
-                                mappings.Add(key, includeExcludeFiles);
-                            }
-                        }
-                    }
+                    throw FileFormatException.Create(
+                        "The version cannot be null or empty.",
+                        line,
+                        column,
+                        filePath);
                 }
-            }
 
-            return new PackOptions
-            {
-                PackageType = packageTypeNames
-                    .Select(name => new PackageType(name, Packaging.Core.PackageType.EmptyVersion))
-                    .ToList(),
-                IncludeExcludeFiles = files,
-                Mappings = mappings
-            };
+                centralPackageVersions[propertyName] = new CentralPackageVersion(propertyName, VersionRange.Parse(version));
+            });
         }
 
-        private static void PopulateDependencies(
-            string packageSpecPath,
+        private static CompatibilityProfile ReadCompatibilityProfile(JsonTextReader jsonReader, string profileName)
+        {
+            List<FrameworkRuntimePair> sets = null;
+
+            jsonReader.ReadObject(propertyName =>
+            {
+                sets = sets ?? new List<FrameworkRuntimePair>();
+
+                IEnumerable<FrameworkRuntimePair> profiles = ReadCompatibilitySets(jsonReader, propertyName);
+
+                sets.AddRange(profiles);
+            });
+
+            return new CompatibilityProfile(profileName, sets ?? Enumerable.Empty<FrameworkRuntimePair>());
+        }
+
+        private static IEnumerable<FrameworkRuntimePair> ReadCompatibilitySets(JsonTextReader jsonReader, string compatibilitySetName)
+        {
+            NuGetFramework framework = NuGetFramework.Parse(compatibilitySetName);
+
+            IReadOnlyList<string> values = jsonReader.ReadStringOrArrayOfStringsAsReadOnlyList() ?? Array.Empty<string>();
+
+            foreach (string value in values)
+            {
+                yield return new FrameworkRuntimePair(framework, value);
+            }
+        }
+
+        private static void ReadDependencies(
+            JsonTextReader jsonReader,
             IList<LibraryDependency> results,
-            JObject settings,
-            string propertyName,
+            string packageSpecPath,
             bool isGacOrFrameworkReference)
         {
-            var dependencies = settings[propertyName] as JObject;
-            if (dependencies != null)
+            jsonReader.ReadObject(propertyName =>
             {
-                foreach (var dependency in dependencies)
+                if (string.IsNullOrEmpty(propertyName))
                 {
-                    if (string.IsNullOrEmpty(dependency.Key))
-                    {
-                        throw FileFormatException.Create(
-                            "Unable to resolve dependency ''.",
-                            dependency.Value,
-                            packageSpecPath);
-                    }
+                    // Advance the reader's position to be able to report the line and column for the property value.
+                    jsonReader.ReadNextToken();
 
-                    // Support
-                    // "dependencies" : {
-                    //    "Name" : "1.0"
-                    // }
+                    throw FileFormatException.Create(
+                        "Unable to resolve dependency ''.",
+                        jsonReader.LineNumber,
+                        jsonReader.LinePosition,
+                        packageSpecPath);
+                }
 
-                    var dependencyValue = dependency.Value;
+                // Support
+                // "dependencies" : {
+                //    "Name" : "1.0"
+                // }
+
+                if (jsonReader.ReadNextToken())
+                {
+                    int dependencyValueLine = jsonReader.LineNumber;
+                    int dependencyValueColumn = jsonReader.LinePosition;
+                    var versionLine = 0;
+                    var versionColumn = 0;
+
                     var dependencyTypeValue = LibraryDependencyType.Default;
-
                     var dependencyIncludeFlagsValue = LibraryIncludeFlags.All;
                     var dependencyExcludeFlagsValue = LibraryIncludeFlags.None;
                     var suppressParentFlagsValue = LibraryIncludeFlagUtils.DefaultSuppressParent;
-                    var noWarn = new List<NuGetLogCode>();
+                    List<NuGetLogCode> noWarn = null;
+                    var wasDependencyIncludeFlagsValueSet = false;
+                    var wasSuppressParentFlagsValueSet = false;
 
                     // This method handles both the dependencies and framework assembly sections.
                     // Framework references should be limited to references.
                     // Dependencies should allow everything but framework references.
-                    var targetFlagsValue = isGacOrFrameworkReference
+                    LibraryDependencyTarget targetFlagsValue = isGacOrFrameworkReference
                         ? LibraryDependencyTarget.Reference
                         : LibraryDependencyTarget.All & ~LibraryDependencyTarget.Reference;
 
@@ -498,88 +374,93 @@ namespace NuGet.ProjectModel
                     var versionCentrallyManaged = false;
 
                     string dependencyVersionValue = null;
-                    var dependencyVersionToken = dependencyValue;
 
-                    if (dependencyValue.Type == JTokenType.String)
+                    if (jsonReader.TokenType == JsonToken.String)
                     {
-                        dependencyVersionValue = dependencyValue.Value<string>();
+                        dependencyVersionValue = (string)jsonReader.Value;
                     }
-                    else
+                    else if (jsonReader.TokenType == JsonToken.StartObject)
                     {
-                        if (dependencyValue.Type == JTokenType.Object)
+                        jsonReader.ReadProperties(dependenciesPropertyName =>
                         {
-                            dependencyVersionToken = dependencyValue["version"];
-                            if (dependencyVersionToken != null
-                                && dependencyVersionToken.Type == JTokenType.String)
+                            IEnumerable<string> values = null;
+
+                            switch (dependenciesPropertyName)
                             {
-                                dependencyVersionValue = dependencyVersionToken.Value<string>();
+                                case "autoReferenced":
+                                    autoReferenced = ReadNextTokenAsBoolOrFalse(jsonReader, packageSpecPath);
+                                    break;
+
+                                case "exclude":
+                                    values = jsonReader.ReadDelimitedString();
+                                    dependencyExcludeFlagsValue = LibraryIncludeFlagUtils.GetFlags(values);
+                                    break;
+
+                                case "generatePathProperty":
+                                    generatePathProperty = ReadNextTokenAsBoolOrFalse(jsonReader, packageSpecPath);
+                                    break;
+
+                                case "include":
+                                    values = jsonReader.ReadDelimitedString();
+                                    dependencyIncludeFlagsValue = LibraryIncludeFlagUtils.GetFlags(values);
+                                    wasDependencyIncludeFlagsValueSet = true;
+                                    break;
+
+                                case "noWarn":
+                                    noWarn = ReadNuGetLogCodesList(jsonReader);
+                                    break;
+
+                                case "suppressParent":
+                                    values = jsonReader.ReadDelimitedString();
+                                    suppressParentFlagsValue = LibraryIncludeFlagUtils.GetFlags(values);
+                                    wasSuppressParentFlagsValueSet = true;
+                                    break;
+
+                                case "target":
+                                    targetFlagsValue = ReadTarget(jsonReader, packageSpecPath, targetFlagsValue);
+                                    break;
+
+                                case "type":
+                                    values = jsonReader.ReadDelimitedString();
+                                    dependencyTypeValue = LibraryDependencyType.Parse(values);
+
+                                    // Types are used at pack time, they should be translated to suppressParent to 
+                                    // provide a matching effect for project to project references.
+                                    // This should be set before suppressParent is checked.
+                                    if (!dependencyTypeValue.Contains(LibraryDependencyTypeFlag.BecomesNupkgDependency))
+                                    {
+                                        if (!wasSuppressParentFlagsValueSet)
+                                        {
+                                            suppressParentFlagsValue = LibraryIncludeFlags.All;
+                                        }
+                                    }
+                                    else if (dependencyTypeValue.Contains(LibraryDependencyTypeFlag.SharedFramework))
+                                    {
+                                        if (!wasDependencyIncludeFlagsValueSet)
+                                        {
+                                            dependencyIncludeFlagsValue =
+                                                LibraryIncludeFlags.Build |
+                                                LibraryIncludeFlags.Compile |
+                                                LibraryIncludeFlags.Analyzers;
+                                        }
+                                    }
+                                    break;
+
+                                case "version":
+                                    if (jsonReader.ReadNextToken())
+                                    {
+                                        versionLine = jsonReader.LineNumber;
+                                        versionColumn = jsonReader.LinePosition;
+
+                                        dependencyVersionValue = (string)jsonReader.Value;
+                                    }
+                                    break;
+
+                                case "versionCentrallyManaged":
+                                    versionCentrallyManaged = ReadNextTokenAsBoolOrFalse(jsonReader, packageSpecPath);
+                                    break;
                             }
-                        }
-
-                        IEnumerable<string> strings;
-                        if (TryGetStringEnumerable(dependencyValue["type"], out strings))
-                        {
-                            dependencyTypeValue = LibraryDependencyType.Parse(strings);
-
-                            // Types are used at pack time, they should be translated to suppressParent to 
-                            // provide a matching effect for project to project references.
-                            // This should be set before suppressParent is checked.
-                            if (!dependencyTypeValue.Contains(LibraryDependencyTypeFlag.BecomesNupkgDependency))
-                            {
-                                suppressParentFlagsValue = LibraryIncludeFlags.All;
-                            }
-                            else if (dependencyTypeValue.Contains(LibraryDependencyTypeFlag.SharedFramework))
-                            {
-                                dependencyIncludeFlagsValue =
-                                    LibraryIncludeFlags.Build |
-                                    LibraryIncludeFlags.Compile |
-                                    LibraryIncludeFlags.Analyzers;
-                            }
-                        }
-
-                        if (TryGetStringEnumerable(dependencyValue["include"], out strings))
-                        {
-                            dependencyIncludeFlagsValue = LibraryIncludeFlagUtils.GetFlags(strings);
-                        }
-
-                        if (TryGetStringEnumerable(dependencyValue["exclude"], out strings))
-                        {
-                            dependencyExcludeFlagsValue = LibraryIncludeFlagUtils.GetFlags(strings);
-                        }
-
-                        if (TryGetStringEnumerable(dependencyValue["suppressParent"], out strings))
-                        {
-                            // This overrides any settings that came from the type property.
-                            suppressParentFlagsValue = LibraryIncludeFlagUtils.GetFlags(strings);
-                        }
-
-                        noWarn = GetNuGetLogCodeEnumerableFromJArray(dependencyValue["noWarn"])
-                            .ToList();
-
-                        var targetToken = dependencyValue["target"];
-
-                        if (targetToken != null)
-                        {
-                            var targetString = targetToken.Value<string>();
-
-                            targetFlagsValue = LibraryDependencyTargetUtils.Parse(targetString);
-
-                            // Verify that the value specified is package, project, or external project
-                            if (!ValidateDependencyTarget(targetFlagsValue))
-                            {
-                                var message = string.Format(
-                                    CultureInfo.CurrentCulture,
-                                    Strings.InvalidDependencyTarget,
-                                    targetString);
-
-                                throw FileFormatException.Create(message, targetToken, packageSpecPath);
-                            }
-                        }
-
-                        autoReferenced = GetBoolOrFalse(dependencyValue, "autoReferenced", packageSpecPath);
-                        versionCentrallyManaged = GetBoolOrFalse(dependencyValue, "versionCentrallyManaged", packageSpecPath);
-
-                        generatePathProperty = GetBoolOrFalse(dependencyValue, "generatePathProperty", packageSpecPath);
+                        });
                     }
 
                     VersionRange dependencyVersionRange = null;
@@ -594,7 +475,8 @@ namespace NuGet.ProjectModel
                         {
                             throw FileFormatException.Create(
                                 ex,
-                                dependencyVersionToken,
+                                versionLine,
+                                versionColumn,
                                 packageSpecPath);
                         }
                     }
@@ -606,7 +488,8 @@ namespace NuGet.ProjectModel
                         {
                             throw FileFormatException.Create(
                                 new ArgumentException(Strings.MissingVersionOnDependency),
-                                dependency.Value,
+                                dependencyValueLine,
+                                dependencyValueColumn,
                                 packageSpecPath);
                         }
                         else
@@ -618,51 +501,1106 @@ namespace NuGet.ProjectModel
 
                     // the dependency flags are: Include flags - Exclude flags
                     var includeFlags = dependencyIncludeFlagsValue & ~dependencyExcludeFlagsValue;
-
-                    results.Add(new LibraryDependency()
+                    var libraryDependency = new LibraryDependency()
                     {
                         LibraryRange = new LibraryRange()
                         {
-                            Name = dependency.Key,
+                            Name = propertyName,
                             TypeConstraint = targetFlagsValue,
-                            VersionRange = dependencyVersionRange,
+                            VersionRange = dependencyVersionRange
                         },
                         Type = dependencyTypeValue,
                         IncludeType = includeFlags,
                         SuppressParent = suppressParentFlagsValue,
                         AutoReferenced = autoReferenced,
-                        NoWarn = noWarn.ToList(),
                         GeneratePathProperty = generatePathProperty,
                         VersionCentrallyManaged = versionCentrallyManaged
-                    });
+                    };
+
+                    if (noWarn != null)
+                    {
+                        libraryDependency.NoWarn = noWarn;
+                    }
+
+                    results.Add(libraryDependency);
+                }
+            });
+        }
+
+        private static void ReadDownloadDependencies(
+            JsonTextReader jsonReader,
+            IList<DownloadDependency> downloadDependencies,
+            string packageSpecPath)
+        {
+            var seenIds = new HashSet<string>();
+
+            if (jsonReader.ReadNextToken() && jsonReader.TokenType == JsonToken.StartArray)
+            {
+                do
+                {
+                    string name = null;
+                    string versionValue = null;
+                    var isNameDefined = false;
+                    var isVersionDefined = false;
+                    int line = jsonReader.LineNumber;
+                    int column = jsonReader.LinePosition;
+                    int versionLine = 0;
+                    int versionColumn = 0;
+
+                    jsonReader.ReadObject(propertyName =>
+                    {
+                        switch (propertyName)
+                        {
+                            case "name":
+                                isNameDefined = true;
+                                name = jsonReader.ReadNextTokenAsString();
+                                break;
+
+                            case "version":
+                                isVersionDefined = true;
+                                versionValue = jsonReader.ReadNextTokenAsString();
+                                versionLine = jsonReader.LineNumber;
+                                versionColumn = jsonReader.LinePosition;
+                                break;
+                        }
+                    }, out line, out column);
+
+                    if (jsonReader.TokenType == JsonToken.EndArray)
+                    {
+                        break;
+                    }
+
+                    if (!isNameDefined)
+                    {
+                        throw FileFormatException.Create(
+                            "Unable to resolve downloadDependency ''.",
+                            line,
+                            column,
+                            packageSpecPath);
+                    }
+
+                    if (!seenIds.Add(name))
+                    {
+                        // package ID already seen, only use first definition.
+                        continue;
+                    }
+
+                    if (string.IsNullOrEmpty(versionValue))
+                    {
+                        throw FileFormatException.Create(
+                            "The version cannot be null or empty",
+                            isVersionDefined ? versionLine : line,
+                            isVersionDefined ? versionColumn : column,
+                            packageSpecPath);
+                    }
+
+                    string[] versions = versionValue.Split(VersionSeparators, StringSplitOptions.RemoveEmptyEntries);
+
+                    foreach (string singleVersionValue in versions)
+                    {
+                        try
+                        {
+                            VersionRange version = VersionRange.Parse(singleVersionValue);
+
+                            downloadDependencies.Add(new DownloadDependency(name, version));
+                        }
+                        catch (Exception ex)
+                        {
+                            throw FileFormatException.Create(
+                                ex,
+                                isVersionDefined ? versionLine : line,
+                                isVersionDefined ? versionColumn : column,
+                                packageSpecPath);
+                        }
+                    }
+                } while (jsonReader.TokenType == JsonToken.EndObject);
+            }
+        }
+
+        private static IReadOnlyList<string> ReadEnumerableOfString(JsonTextReader jsonReader)
+        {
+            string value = jsonReader.ReadNextTokenAsString();
+
+            return value.Split(DelimitedStringSeparators, StringSplitOptions.RemoveEmptyEntries);
+        }
+
+        private static void ReadFrameworkReferences(
+            JsonTextReader jsonReader,
+            ISet<FrameworkDependency> frameworkReferences,
+            string packageSpecPath)
+        {
+            jsonReader.ReadObject(frameworkName =>
+            {
+                if (string.IsNullOrEmpty(frameworkName))
+                {
+                    // Advance the reader's position to be able to report the line and column for the property value.
+                    jsonReader.ReadNextToken();
+
+                    throw FileFormatException.Create(
+                        "Unable to resolve frameworkReference.",
+                        jsonReader.LineNumber,
+                        jsonReader.LinePosition,
+                        packageSpecPath);
+                }
+
+                var privateAssets = FrameworkDependencyFlagsUtils.Default;
+
+                jsonReader.ReadObject(propertyName =>
+                {
+                    if (propertyName == "privateAssets")
+                    {
+                        IEnumerable<string> strings = ReadEnumerableOfString(jsonReader);
+
+                        privateAssets = FrameworkDependencyFlagsUtils.GetFlags(strings);
+                    }
+                });
+
+                frameworkReferences.Add(new FrameworkDependency(frameworkName, privateAssets));
+            });
+        }
+
+        private static void ReadFrameworks(JsonTextReader jsonReader, PackageSpec packageSpec)
+        {
+            jsonReader.ReadObject(_ =>
+            {
+                var frameworkLine = 0;
+                var frameworkColumn = 0;
+
+                try
+                {
+                    ReadTargetFrameworks(packageSpec, jsonReader, out frameworkLine, out frameworkColumn);
+                }
+                catch (Exception ex)
+                {
+                    throw FileFormatException.Create(ex, frameworkLine, frameworkColumn, packageSpec.FilePath);
+                }
+            });
+        }
+
+        private static void ReadImports(PackageSpec packageSpec, JsonTextReader jsonReader, TargetFrameworkInformation targetFrameworkInformation)
+        {
+            int lineNumber = jsonReader.LineNumber;
+            int linePosition = jsonReader.LinePosition;
+
+            IReadOnlyList<string> imports = jsonReader.ReadStringOrArrayOfStringsAsReadOnlyList();
+
+            if (imports != null && imports.Count > 0)
+            {
+                foreach (string import in imports.Where(element => !string.IsNullOrEmpty(element)))
+                {
+                    NuGetFramework framework = NuGetFramework.Parse(import);
+
+                    if (!framework.IsSpecificFramework)
+                    {
+                        throw FileFormatException.Create(
+                            string.Format(
+                                Strings.Log_InvalidImportFramework,
+                                import,
+                                PackageSpec.PackageSpecFileName),
+                            lineNumber,
+                            linePosition,
+                            packageSpec.FilePath);
+                    }
+
+                    targetFrameworkInformation.Imports.Add(framework);
                 }
             }
         }
 
-        private static bool TryGetStringEnumerable(JToken token, out IEnumerable<string> result)
+        private static void ReadMappings(JsonTextReader jsonReader, string mappingKey, IDictionary<string, IncludeExcludeFiles> mappings)
         {
-            IEnumerable<string> values;
-            if (token == null)
+            if (jsonReader.ReadNextToken())
             {
-                result = null;
-                return false;
-            }
-            else if (token.Type == JTokenType.String)
-            {
-                values = new[]
+                switch (jsonReader.TokenType)
                 {
-                    token.Value<string>()
+                    case JsonToken.String:
+                        {
+                            var files = new IncludeExcludeFiles()
+                            {
+                                Include = new[] { (string)jsonReader.Value }
+                            };
+
+                            mappings.Add(mappingKey, files);
+                        }
+                        break;
+
+                    case JsonToken.StartArray:
+                        {
+                            IReadOnlyList<string> include = jsonReader.ReadStringArrayAsReadOnlyListFromArrayStart();
+
+                            var files = new IncludeExcludeFiles()
+                            {
+                                Include = include
+                            };
+
+                            mappings.Add(mappingKey, files);
+                        }
+                        break;
+
+                    case JsonToken.StartObject:
+                        {
+                            IReadOnlyList<string> excludeFiles = null;
+                            IReadOnlyList<string> exclude = null;
+                            IReadOnlyList<string> includeFiles = null;
+                            IReadOnlyList<string> include = null;
+
+                            jsonReader.ReadProperties(filesPropertyName =>
+                            {
+                                switch (filesPropertyName)
+                                {
+                                    case "excludeFiles":
+                                        excludeFiles = jsonReader.ReadStringOrArrayOfStringsAsReadOnlyList();
+                                        break;
+
+                                    case "exclude":
+                                        exclude = jsonReader.ReadStringOrArrayOfStringsAsReadOnlyList();
+                                        break;
+
+                                    case "includeFiles":
+                                        includeFiles = jsonReader.ReadStringOrArrayOfStringsAsReadOnlyList();
+                                        break;
+
+                                    case "include":
+                                        include = jsonReader.ReadStringOrArrayOfStringsAsReadOnlyList();
+                                        break;
+                                }
+                            });
+
+                            if (include != null || includeFiles != null || exclude != null || excludeFiles != null)
+                            {
+                                var files = new IncludeExcludeFiles()
+                                {
+                                    ExcludeFiles = excludeFiles,
+                                    Exclude = exclude,
+                                    IncludeFiles = includeFiles,
+                                    Include = include
+                                };
+
+                                mappings.Add(mappingKey, files);
+                            }
+                        }
+                        break;
+                }
+            }
+        }
+
+        private static ProjectRestoreMetadata ReadMSBuildMetadata(PackageSpec packageSpec, JsonTextReader jsonReader)
+        {
+            var centralPackageVersionsManagementEnabled = false;
+            List<string> configFilePaths = null;
+            var crossTargeting = false;
+            List<string> fallbackFolders = null;
+            List<ProjectRestoreMetadataFile> files = null;
+            var legacyPackagesDirectory = false;
+            ProjectRestoreMetadata msbuildMetadata = null;
+            List<string> originalTargetFrameworks = null;
+            string outputPath = null;
+            string packagesConfigPath = null;
+            string packagesPath = null;
+            string projectJsonPath = null;
+            string projectName = null;
+            string projectPath = null;
+            ProjectStyle? projectStyle = null;
+            string projectUniqueName = null;
+            RestoreLockProperties restoreLockProperties = null;
+            var skipContentFileWrite = false;
+            List<PackageSource> sources = null;
+            List<ProjectRestoreMetadataFrameworkInfo> targetFrameworks = null;
+            var validateRuntimeAssets = false;
+            WarningProperties warningProperties = null;
+
+            jsonReader.ReadObject(propertyName =>
+            {
+                switch (propertyName)
+                {
+                    case "centralPackageVersionsManagementEnabled":
+                        centralPackageVersionsManagementEnabled = ReadNextTokenAsBoolOrFalse(jsonReader, packageSpec.FilePath);
+                        break;
+
+                    case "configFilePaths":
+                        configFilePaths = jsonReader.ReadStringArrayAsList();
+                        break;
+
+                    case "crossTargeting":
+                        crossTargeting = ReadNextTokenAsBoolOrFalse(jsonReader, packageSpec.FilePath);
+                        break;
+
+                    case "fallbackFolders":
+                        fallbackFolders = jsonReader.ReadStringArrayAsList();
+                        break;
+
+                    case "files":
+                        jsonReader.ReadObject(filePropertyName =>
+                        {
+                            files = files ?? new List<ProjectRestoreMetadataFile>();
+
+                            files.Add(new ProjectRestoreMetadataFile(filePropertyName, jsonReader.ReadNextTokenAsString()));
+                        });
+                        break;
+
+                    case "frameworks":
+                        targetFrameworks = ReadTargetFrameworks(jsonReader);
+                        break;
+
+                    case "legacyPackagesDirectory":
+                        legacyPackagesDirectory = ReadNextTokenAsBoolOrFalse(jsonReader, packageSpec.FilePath);
+                        break;
+
+                    case "originalTargetFrameworks":
+                        originalTargetFrameworks = jsonReader.ReadStringArrayAsList();
+                        break;
+
+                    case "outputPath":
+                        outputPath = jsonReader.ReadNextTokenAsString();
+                        break;
+
+                    case "packagesConfigPath":
+                        packagesConfigPath = jsonReader.ReadNextTokenAsString();
+                        break;
+
+                    case "packagesPath":
+                        packagesPath = jsonReader.ReadNextTokenAsString();
+                        break;
+
+                    case "projectJsonPath":
+                        projectJsonPath = jsonReader.ReadNextTokenAsString();
+                        break;
+
+                    case "projectName":
+                        projectName = jsonReader.ReadNextTokenAsString();
+                        break;
+
+                    case "projectPath":
+                        projectPath = jsonReader.ReadNextTokenAsString();
+                        break;
+
+                    case "projectStyle":
+                        string projectStyleString = jsonReader.ReadNextTokenAsString();
+
+                        if (!string.IsNullOrEmpty(projectStyleString)
+                            && Enum.TryParse<ProjectStyle>(projectStyleString, ignoreCase: true, result: out var projectStyleValue))
+                        {
+                            projectStyle = projectStyleValue;
+                        }
+                        break;
+
+                    case "projectUniqueName":
+                        projectUniqueName = jsonReader.ReadNextTokenAsString();
+                        break;
+
+                    case "restoreLockProperties":
+                        string nuGetLockFilePath = null;
+                        var restoreLockedMode = false;
+                        string restorePackagesWithLockFile = null;
+
+                        jsonReader.ReadObject(restoreLockPropertiesPropertyName =>
+                        {
+                            switch (restoreLockPropertiesPropertyName)
+                            {
+                                case "nuGetLockFilePath":
+                                    nuGetLockFilePath = jsonReader.ReadNextTokenAsString();
+                                    break;
+
+                                case "restoreLockedMode":
+                                    restoreLockedMode = ReadNextTokenAsBoolOrFalse(jsonReader, packageSpec.FilePath);
+                                    break;
+
+                                case "restorePackagesWithLockFile":
+                                    restorePackagesWithLockFile = jsonReader.ReadNextTokenAsString();
+                                    break;
+                            }
+                        });
+
+                        restoreLockProperties = new RestoreLockProperties(restorePackagesWithLockFile, nuGetLockFilePath, restoreLockedMode);
+                        break;
+
+                    case "skipContentFileWrite":
+                        skipContentFileWrite = ReadNextTokenAsBoolOrFalse(jsonReader, packageSpec.FilePath);
+                        break;
+
+                    case "sources":
+                        jsonReader.ReadObject(sourcePropertyName =>
+                        {
+                            sources = sources ?? new List<PackageSource>();
+
+                            sources.Add(new PackageSource(sourcePropertyName));
+                        });
+                        break;
+
+                    case "validateRuntimeAssets":
+                        validateRuntimeAssets = ReadNextTokenAsBoolOrFalse(jsonReader, packageSpec.FilePath);
+                        break;
+
+                    case "warningProperties":
+                        var allWarningsAsErrors = false;
+                        var noWarn = new HashSet<NuGetLogCode>();
+                        var warnAsError = new HashSet<NuGetLogCode>();
+
+                        jsonReader.ReadObject(warningPropertiesPropertyName =>
+                        {
+                            switch (warningPropertiesPropertyName)
+                            {
+                                case "allWarningsAsErrors":
+                                    allWarningsAsErrors = ReadNextTokenAsBoolOrFalse(jsonReader, packageSpec.FilePath);
+                                    break;
+
+                                case "noWarn":
+                                    ReadNuGetLogCodes(jsonReader, noWarn);
+                                    break;
+
+                                case "warnAsError":
+                                    ReadNuGetLogCodes(jsonReader, warnAsError);
+                                    break;
+                            }
+                        });
+
+                        warningProperties = new WarningProperties(warnAsError, noWarn, allWarningsAsErrors);
+                        break;
+                }
+            });
+
+            if (projectStyle == ProjectStyle.PackagesConfig)
+            {
+                msbuildMetadata = new PackagesConfigProjectRestoreMetadata()
+                {
+                    PackagesConfigPath = packagesConfigPath
                 };
             }
             else
             {
-                values = token.Value<string[]>();
+                msbuildMetadata = new ProjectRestoreMetadata();
             }
 
-            result = values
-                .SelectMany(value => value.Split(new[] { ' ', ',' }, StringSplitOptions.RemoveEmptyEntries));
+            msbuildMetadata.CentralPackageVersionsEnabled = centralPackageVersionsManagementEnabled;
 
-            return true;
+            if (configFilePaths != null)
+            {
+                msbuildMetadata.ConfigFilePaths = configFilePaths;
+            }
+
+            msbuildMetadata.CrossTargeting = crossTargeting;
+
+            if (fallbackFolders != null)
+            {
+                msbuildMetadata.FallbackFolders = fallbackFolders;
+            }
+
+            if (files != null)
+            {
+                msbuildMetadata.Files = files;
+            }
+
+            msbuildMetadata.LegacyPackagesDirectory = legacyPackagesDirectory;
+
+            if (originalTargetFrameworks != null)
+            {
+                msbuildMetadata.OriginalTargetFrameworks = originalTargetFrameworks;
+            }
+
+            msbuildMetadata.OutputPath = outputPath;
+            msbuildMetadata.PackagesPath = packagesPath;
+            msbuildMetadata.ProjectJsonPath = projectJsonPath;
+            msbuildMetadata.ProjectName = projectName;
+            msbuildMetadata.ProjectPath = projectPath;
+
+            if (projectStyle.HasValue)
+            {
+                msbuildMetadata.ProjectStyle = projectStyle.Value;
+            }
+
+            msbuildMetadata.ProjectUniqueName = projectUniqueName;
+
+            if (restoreLockProperties != null)
+            {
+                msbuildMetadata.RestoreLockProperties = restoreLockProperties;
+            }
+
+            msbuildMetadata.SkipContentFileWrite = skipContentFileWrite;
+
+            if (sources != null)
+            {
+                msbuildMetadata.Sources = sources;
+            }
+
+            if (targetFrameworks != null)
+            {
+                msbuildMetadata.TargetFrameworks = targetFrameworks;
+            }
+
+            msbuildMetadata.ValidateRuntimeAssets = validateRuntimeAssets;
+
+            if (warningProperties != null)
+            {
+                msbuildMetadata.ProjectWideWarningProperties = warningProperties;
+            }
+
+            return msbuildMetadata;
+        }
+
+        private static bool ReadNextTokenAsBoolOrFalse(JsonTextReader jsonReader, string filePath)
+        {
+            if (jsonReader.ReadNextToken() && jsonReader.TokenType == JsonToken.Boolean)
+            {
+                try
+                {
+                    return (bool)jsonReader.Value;
+                }
+                catch (Exception ex)
+                {
+                    throw FileFormatException.Create(ex, jsonReader.LineNumber, jsonReader.LinePosition, filePath);
+                }
+            }
+
+            return false;
+        }
+
+        private static void ReadNuGetLogCodes(JsonTextReader jsonReader, HashSet<NuGetLogCode> hashCodes)
+        {
+            if (jsonReader.ReadNextToken() && jsonReader.TokenType == JsonToken.StartArray)
+            {
+                while (jsonReader.ReadNextToken() && jsonReader.TokenType != JsonToken.EndArray)
+                {
+                    if (jsonReader.TokenType == JsonToken.String && Enum.TryParse((string)jsonReader.Value, out NuGetLogCode code))
+                    {
+                        hashCodes.Add(code);
+                    }
+                }
+            }
+        }
+
+        private static List<NuGetLogCode> ReadNuGetLogCodesList(JsonTextReader jsonReader)
+        {
+            List<NuGetLogCode> items = null;
+
+            if (jsonReader.ReadNextToken() && jsonReader.TokenType == JsonToken.StartArray)
+            {
+                while (jsonReader.ReadNextToken() && jsonReader.TokenType != JsonToken.EndArray)
+                {
+                    if (jsonReader.TokenType == JsonToken.String && Enum.TryParse((string)jsonReader.Value, out NuGetLogCode code))
+                    {
+                        items = items ?? new List<NuGetLogCode>();
+
+                        items.Add(code);
+                    }
+                }
+            }
+
+            return items;
+        }
+
+        private static void ReadPackageTypes(PackageSpec packageSpec, JsonTextReader jsonReader)
+        {
+            var errorLine = 0;
+            var errorColumn = 0;
+
+            IReadOnlyList<PackageType> packageTypes = null;
+            PackageType packageType = null;
+
+            try
+            {
+                if (jsonReader.ReadNextToken())
+                {
+                    errorLine = jsonReader.LineNumber;
+                    errorColumn = jsonReader.LinePosition;
+
+                    switch (jsonReader.TokenType)
+                    {
+                        case JsonToken.String:
+                            packageType = CreatePackageType(jsonReader);
+
+                            packageTypes = new[] { packageType };
+                            break;
+
+                        case JsonToken.StartArray:
+                            var types = new List<PackageType>();
+
+                            while (jsonReader.ReadNextToken() && jsonReader.TokenType != JsonToken.EndArray)
+                            {
+                                if (jsonReader.TokenType != JsonToken.String)
+                                {
+                                    throw FileFormatException.Create(
+                                        string.Format(
+                                            CultureInfo.CurrentCulture,
+                                            Strings.InvalidPackageType,
+                                            PackageSpec.PackageSpecFileName),
+                                        errorLine,
+                                        errorColumn,
+                                        packageSpec.FilePath);
+                                }
+
+                                packageType = CreatePackageType(jsonReader);
+
+                                types.Add(packageType);
+                            }
+
+                            packageTypes = types;
+                            break;
+
+                        case JsonToken.Null:
+                            break;
+
+                        default:
+                            throw new InvalidCastException();
+                    }
+
+                    if (packageTypes != null)
+                    {
+                        packageSpec.PackOptions.PackageType = packageTypes;
+                    }
+                }
+            }
+            catch (Exception)
+            {
+                throw FileFormatException.Create(
+                    string.Format(
+                        CultureInfo.CurrentCulture,
+                        Strings.InvalidPackageType,
+                        PackageSpec.PackageSpecFileName),
+                    errorLine,
+                    errorColumn,
+                    packageSpec.FilePath);
+            }
+        }
+
+        private static void ReadPackInclude(JsonTextReader jsonReader, PackageSpec packageSpec)
+        {
+            jsonReader.ReadObject(propertyName =>
+            {
+                string propertyValue = jsonReader.ReadAsString();
+
+                packageSpec.PackInclude.Add(new KeyValuePair<string, string>(propertyName, propertyValue));
+            });
+        }
+
+        private static void ReadPackOptions(PackageSpec packageSpec, JsonTextReader jsonReader, ref bool isMappingsNull)
+        {
+            var wasMappingsRead = false;
+
+            bool isPackOptionsValueAnObject = jsonReader.ReadObject(propertyName =>
+            {
+                switch (propertyName)
+                {
+                    case "files":
+                        wasMappingsRead = ReadPackOptionsFiles(packageSpec, jsonReader, wasMappingsRead);
+                        break;
+
+                    case "iconUrl":
+                        packageSpec.IconUrl = jsonReader.ReadNextTokenAsString();
+                        break;
+
+                    case "licenseUrl":
+                        packageSpec.LicenseUrl = jsonReader.ReadNextTokenAsString();
+                        break;
+
+                    case "owners":
+                        string[] owners = ReadStringArray(jsonReader);
+
+                        if (owners != null)
+                        {
+                            packageSpec.Owners = owners;
+                        }
+                        break;
+
+                    case "packageType":
+                        ReadPackageTypes(packageSpec, jsonReader);
+                        break;
+
+                    case "projectUrl":
+                        packageSpec.ProjectUrl = jsonReader.ReadNextTokenAsString();
+                        break;
+
+                    case "releaseNotes":
+                        packageSpec.ReleaseNotes = jsonReader.ReadNextTokenAsString();
+                        break;
+
+                    case "requireLicenseAcceptance":
+                        packageSpec.RequireLicenseAcceptance = ReadNextTokenAsBoolOrFalse(jsonReader, packageSpec.FilePath);
+                        break;
+
+                    case "summary":
+                        packageSpec.Summary = jsonReader.ReadNextTokenAsString();
+                        break;
+
+                    case "tags":
+                        string[] tags = ReadStringArray(jsonReader);
+
+                        if (tags != null)
+                        {
+                            packageSpec.Tags = tags;
+                        }
+                        break;
+                }
+            });
+
+            isMappingsNull = isPackOptionsValueAnObject && !wasMappingsRead;
+        }
+
+        private static bool ReadPackOptionsFiles(PackageSpec packageSpec, JsonTextReader jsonReader, bool wasMappingsRead)
+        {
+            IReadOnlyList<string> excludeFiles = null;
+            IReadOnlyList<string> exclude = null;
+            IReadOnlyList<string> includeFiles = null;
+            IReadOnlyList<string> include = null;
+
+            jsonReader.ReadObject(filesPropertyName =>
+            {
+                switch (filesPropertyName)
+                {
+                    case "excludeFiles":
+                        excludeFiles = jsonReader.ReadStringOrArrayOfStringsAsReadOnlyList();
+                        break;
+
+                    case "exclude":
+                        exclude = jsonReader.ReadStringOrArrayOfStringsAsReadOnlyList();
+                        break;
+
+                    case "includeFiles":
+                        includeFiles = jsonReader.ReadStringOrArrayOfStringsAsReadOnlyList();
+                        break;
+
+                    case "include":
+                        include = jsonReader.ReadStringOrArrayOfStringsAsReadOnlyList();
+                        break;
+
+                    case "mappings":
+                        jsonReader.ReadObject(mappingsPropertyName =>
+                        {
+                            wasMappingsRead = true;
+
+                            ReadMappings(jsonReader, mappingsPropertyName, packageSpec.PackOptions.Mappings);
+                        });
+                        break;
+                }
+            });
+
+            if (include != null || includeFiles != null || exclude != null || excludeFiles != null)
+            {
+                packageSpec.PackOptions.IncludeExcludeFiles = new IncludeExcludeFiles()
+                {
+                    ExcludeFiles = excludeFiles,
+                    Exclude = exclude,
+                    IncludeFiles = includeFiles,
+                    Include = include
+                };
+            }
+
+            return wasMappingsRead;
+        }
+
+        private static ProjectRestoreSettings ReadRestoreSettings(PackageSpec packageSpec, JsonTextReader jsonReader)
+        {
+            var restoreSettings = new ProjectRestoreSettings();
+
+            jsonReader.ReadObject(propertyName =>
+            {
+                if (propertyName == JsonPackageSpecReader.HideWarningsAndErrors)
+                {
+                    restoreSettings.HideWarningsAndErrors = ReadNextTokenAsBoolOrFalse(jsonReader, packageSpec.FilePath);
+                }
+            });
+
+            return restoreSettings;
+        }
+
+        private static RuntimeDependencySet ReadRuntimeDependencySet(JsonTextReader jsonReader, string dependencySetName)
+        {
+            List<RuntimePackageDependency> dependencies = null;
+
+            jsonReader.ReadObject(propertyName =>
+            {
+                dependencies = dependencies ?? new List<RuntimePackageDependency>();
+
+                var dependency = new RuntimePackageDependency(propertyName, VersionRange.Parse(jsonReader.ReadNextTokenAsString()));
+
+                dependencies.Add(dependency);
+            });
+
+            return new RuntimeDependencySet(
+                dependencySetName,
+                dependencies ?? Enumerable.Empty<RuntimePackageDependency>());
+        }
+
+        private static RuntimeDescription ReadRuntimeDescription(JsonTextReader jsonReader, string runtimeName)
+        {
+            List<string> inheritedRuntimes = null;
+            List<RuntimeDependencySet> additionalDependencies = null;
+
+            jsonReader.ReadObject(propertyName =>
+            {
+                if (propertyName == "#import")
+                {
+                    inheritedRuntimes = jsonReader.ReadStringArrayAsList();
+                }
+                else
+                {
+                    additionalDependencies = additionalDependencies ?? new List<RuntimeDependencySet>();
+
+                    RuntimeDependencySet dependency = ReadRuntimeDependencySet(jsonReader, propertyName);
+
+                    additionalDependencies.Add(dependency);
+                }
+            });
+
+            return new RuntimeDescription(
+                runtimeName,
+                inheritedRuntimes ?? Enumerable.Empty<string>(),
+                additionalDependencies ?? Enumerable.Empty<RuntimeDependencySet>());
+        }
+
+        private static List<RuntimeDescription> ReadRuntimes(JsonTextReader jsonReader)
+        {
+            var runtimeDescriptions = new List<RuntimeDescription>();
+
+            jsonReader.ReadObject(propertyName =>
+            {
+                RuntimeDescription runtimeDescription = ReadRuntimeDescription(jsonReader, propertyName);
+
+                runtimeDescriptions.Add(runtimeDescription);
+            });
+
+            return runtimeDescriptions;
+        }
+
+        private static void ReadScripts(JsonTextReader jsonReader, PackageSpec packageSpec)
+        {
+            jsonReader.ReadObject(propertyName =>
+            {
+                if (jsonReader.ReadNextToken())
+                {
+                    if (jsonReader.TokenType == JsonToken.String)
+                    {
+                        packageSpec.Scripts[propertyName] = new string[] { (string)jsonReader.Value };
+                    }
+                    else if (jsonReader.TokenType == JsonToken.StartArray)
+                    {
+                        var list = new List<string>();
+
+                        while (jsonReader.ReadNextToken() && jsonReader.TokenType == JsonToken.String)
+                        {
+                            list.Add((string)jsonReader.Value);
+                        }
+
+                        packageSpec.Scripts[propertyName] = list;
+                    }
+                    else
+                    {
+                        throw FileFormatException.Create(
+                            string.Format("The value of a script in '{0}' can only be a string or an array of strings", PackageSpec.PackageSpecFileName),
+                            jsonReader.LineNumber,
+                            jsonReader.LinePosition,
+                            packageSpec.FilePath);
+                    }
+                }
+            });
+        }
+
+        private static string[] ReadStringArray(JsonTextReader jsonReader)
+        {
+            List<string> list = jsonReader.ReadStringArrayAsList();
+
+            return list?.ToArray();
+        }
+
+        private static List<CompatibilityProfile> ReadSupports(JsonTextReader jsonReader)
+        {
+            var compatibilityProfiles = new List<CompatibilityProfile>();
+
+            jsonReader.ReadObject(propertyName =>
+            {
+                CompatibilityProfile compatibilityProfile = ReadCompatibilityProfile(jsonReader, propertyName);
+
+                compatibilityProfiles.Add(compatibilityProfile);
+            });
+
+            return compatibilityProfiles;
+        }
+
+        private static LibraryDependencyTarget ReadTarget(
+            JsonTextReader jsonReader,
+            string packageSpecPath,
+            LibraryDependencyTarget targetFlagsValue)
+        {
+            if (jsonReader.ReadNextToken())
+            {
+                var targetString = (string)jsonReader.Value;
+
+                targetFlagsValue = LibraryDependencyTargetUtils.Parse(targetString);
+
+                // Verify that the value specified is package, project, or external project
+                if (!ValidateDependencyTarget(targetFlagsValue))
+                {
+                    string message = string.Format(
+                        CultureInfo.CurrentCulture,
+                        Strings.InvalidDependencyTarget,
+                        targetString);
+
+                    throw FileFormatException.Create(
+                        message,
+                        jsonReader.LineNumber,
+                        jsonReader.LinePosition,
+                        packageSpecPath);
+                }
+            }
+
+            return targetFlagsValue;
+        }
+
+        private static List<ProjectRestoreMetadataFrameworkInfo> ReadTargetFrameworks(JsonTextReader jsonReader)
+        {
+            var targetFrameworks = new List<ProjectRestoreMetadataFrameworkInfo>();
+
+            jsonReader.ReadObject(frameworkPropertyName =>
+            {
+                NuGetFramework framework = NuGetFramework.Parse(frameworkPropertyName);
+                var frameworkGroup = new ProjectRestoreMetadataFrameworkInfo(framework);
+
+                jsonReader.ReadObject(projectReferencesPropertyName =>
+                {
+                    if (projectReferencesPropertyName == "projectReferences")
+                    {
+                        jsonReader.ReadObject(projectReferencePropertyName =>
+                        {
+                            string excludeAssets = null;
+                            string includeAssets = null;
+                            string privateAssets = null;
+                            string projectReferenceProjectPath = null;
+
+                            jsonReader.ReadObject(projectReferenceObjectPropertyName =>
+                            {
+                                switch (projectReferenceObjectPropertyName)
+                                {
+                                    case "excludeAssets":
+                                        excludeAssets = jsonReader.ReadNextTokenAsString();
+                                        break;
+
+                                    case "includeAssets":
+                                        includeAssets = jsonReader.ReadNextTokenAsString();
+                                        break;
+
+                                    case "privateAssets":
+                                        privateAssets = jsonReader.ReadNextTokenAsString();
+                                        break;
+
+                                    case "projectPath":
+                                        projectReferenceProjectPath = jsonReader.ReadNextTokenAsString();
+                                        break;
+                                }
+                            });
+
+                            frameworkGroup.ProjectReferences.Add(new ProjectRestoreReference()
+                            {
+                                ProjectUniqueName = projectReferencePropertyName,
+                                ProjectPath = projectReferenceProjectPath,
+
+                                IncludeAssets = LibraryIncludeFlagUtils.GetFlags(
+                                    flags: includeAssets,
+                                    defaultFlags: LibraryIncludeFlags.All),
+
+                                ExcludeAssets = LibraryIncludeFlagUtils.GetFlags(
+                                    flags: excludeAssets,
+                                    defaultFlags: LibraryIncludeFlags.None),
+
+                                PrivateAssets = LibraryIncludeFlagUtils.GetFlags(
+                                    flags: privateAssets,
+                                    defaultFlags: LibraryIncludeFlagUtils.DefaultSuppressParent),
+                            });
+                        });
+                    }
+                });
+
+                targetFrameworks.Add(frameworkGroup);
+            });
+
+            return targetFrameworks;
+        }
+
+        private static void ReadTargetFrameworks(PackageSpec packageSpec, JsonTextReader jsonReader, out int frameworkLine, out int frameworkColumn)
+        {
+            frameworkLine = 0;
+            frameworkColumn = 0;
+
+            NuGetFramework frameworkName = NuGetFramework.Parse((string)jsonReader.Value);
+
+            var targetFrameworkInformation = new TargetFrameworkInformation();
+
+            jsonReader.ReadObject(propertyName =>
+            {
+                switch (propertyName)
+                {
+                    case "assetTargetFallback":
+                        targetFrameworkInformation.AssetTargetFallback = ReadNextTokenAsBoolOrFalse(jsonReader, packageSpec.FilePath);
+                        break;
+
+                    case "centralPackageVersions":
+                        ReadCentralPackageVersions(
+                            jsonReader,
+                            targetFrameworkInformation.CentralPackageVersions,
+                            packageSpec.FilePath);
+                        break;
+
+                    case "dependencies":
+                        ReadDependencies(
+                            jsonReader,
+                            targetFrameworkInformation.Dependencies,
+                            packageSpec.FilePath,
+                            isGacOrFrameworkReference: false);
+                        break;
+
+                    case "downloadDependencies":
+                        ReadDownloadDependencies(
+                            jsonReader,
+                            targetFrameworkInformation.DownloadDependencies,
+                            packageSpec.FilePath);
+                        break;
+
+                    case "frameworkAssemblies":
+                        ReadDependencies(
+                            jsonReader,
+                            targetFrameworkInformation.Dependencies,
+                            packageSpec.FilePath,
+                            isGacOrFrameworkReference: true);
+                        break;
+
+                    case "frameworkReferences":
+                        ReadFrameworkReferences(
+                            jsonReader,
+                            targetFrameworkInformation.FrameworkReferences,
+                            packageSpec.FilePath);
+                        break;
+
+                    case "imports":
+                        ReadImports(packageSpec, jsonReader, targetFrameworkInformation);
+                        break;
+
+                    case "runtimeIdentifierGraphPath":
+                        targetFrameworkInformation.RuntimeIdentifierGraphPath = jsonReader.ReadNextTokenAsString();
+                        break;
+
+                    case "warn":
+                        targetFrameworkInformation.Warn = ReadNextTokenAsBoolOrFalse(jsonReader, packageSpec.FilePath);
+                        break;
+                }
+            }, out frameworkLine, out frameworkColumn);
+
+            NuGetFramework updatedFramework = frameworkName;
+
+            if (targetFrameworkInformation.Imports.Count > 0)
+            {
+                NuGetFramework[] imports = targetFrameworkInformation.Imports.ToArray();
+
+                if (targetFrameworkInformation.AssetTargetFallback)
+                {
+                    updatedFramework = new AssetTargetFallbackFramework(frameworkName, imports);
+                }
+                else
+                {
+                    updatedFramework = new FallbackFramework(frameworkName, imports);
+                }
+            }
+
+            targetFrameworkInformation.FrameworkName = updatedFramework;
+
+            packageSpec.TargetFrameworks.Add(targetFrameworkInformation);
         }
 
         private static bool ValidateDependencyTarget(LibraryDependencyTarget targetValue)
@@ -679,384 +1617,6 @@ namespace NuGet.ProjectModel
             }
 
             return isValid;
-        }
-
-        internal static bool TryGetStringEnumerableFromJArray(JToken token, out IEnumerable<string> result)
-        {
-            IEnumerable<string> values;
-            if (token == null)
-            {
-                result = null;
-                return false;
-            }
-            else if (token.Type == JTokenType.String)
-            {
-                values = new[]
-                {
-                    token.Value<string>()
-                };
-            }
-            else if (token.Type == JTokenType.Array)
-            {
-                values = token.ValueAsArray<string>();
-            }
-            else
-            {
-                result = null;
-                return false;
-            }
-
-            result = values;
-            return true;
-        }
-
-        internal static IEnumerable<NuGetLogCode> GetNuGetLogCodeEnumerableFromJArray(JToken token)
-        {
-            var items = new List<NuGetLogCode>();
-            var array = (JArray)token;
-            if (array != null)
-            {
-                foreach (var child in array)
-                {
-                    if (child.Type == JTokenType.String && Enum.TryParse(child.Value<string>(), out NuGetLogCode code))
-                    {
-                        items.Add(code);
-                    }
-                }
-            }
-            return items;
-        }
-
-        private static void BuildTargetFrameworks(PackageSpec packageSpec, JObject rawPackageSpec)
-        {
-            // The frameworks node is where target frameworks go
-            /*
-                {
-                    "frameworks": {
-                        "net45": {
-                        },
-                        "aspnet50": {
-                        }
-                    }
-                }
-            */
-
-            var frameworks = rawPackageSpec["frameworks"] as JObject;
-            if (frameworks != null)
-            {
-                foreach (var framework in frameworks)
-                {
-                    try
-                    {
-                        BuildTargetFrameworkNode(packageSpec, framework, packageSpec.FilePath);
-                    }
-                    catch (Exception ex)
-                    {
-                        throw FileFormatException.Create(ex, framework.Value, packageSpec.FilePath);
-                    }
-                }
-            }
-        }
-
-        private static bool BuildTargetFrameworkNode(PackageSpec packageSpec, KeyValuePair<string, JToken> targetFramework, string filePath)
-        {
-            var frameworkName = GetFramework(targetFramework.Key);
-
-            var properties = targetFramework.Value.Value<JObject>();
-            var assetTargetFallback = GetBoolOrFalse(properties, "assetTargetFallback", filePath);
-
-            var importFrameworks = GetImports(properties, packageSpec);
-
-            // If a fallback framework exists, update the framework to contain both.
-            var updatedFramework = frameworkName;
-
-            if (importFrameworks.Count != 0)
-            {
-                if (assetTargetFallback)
-                {
-                    updatedFramework = new AssetTargetFallbackFramework(frameworkName, importFrameworks);
-                }
-                else
-                {
-                    updatedFramework = new FallbackFramework(frameworkName, importFrameworks);
-                }
-            }
-
-            var targetFrameworkInformation = new TargetFrameworkInformation
-            {
-                FrameworkName = updatedFramework,
-                Dependencies = new List<LibraryDependency>(),
-                Imports = importFrameworks,
-                Warn = GetWarnSetting(properties),
-                AssetTargetFallback = assetTargetFallback,
-                RuntimeIdentifierGraphPath = GetRuntimeIdentifierGraphPath(properties)
-            };
-
-            PopulateDependencies(
-                packageSpec.FilePath,
-                targetFrameworkInformation.Dependencies,
-                properties,
-                "dependencies",
-                isGacOrFrameworkReference: false);
-
-            PopulateDownloadDependencies(
-                targetFrameworkInformation.DownloadDependencies,
-                properties,
-                packageSpec.FilePath);
-
-            PopulateCentralDependencies(
-               packageSpec.FilePath,
-               targetFrameworkInformation,
-               properties);
-
-            var frameworkAssemblies = new List<LibraryDependency>();
-            PopulateDependencies(
-                packageSpec.FilePath,
-                frameworkAssemblies,
-                properties,
-                "frameworkAssemblies",
-                isGacOrFrameworkReference: true);
-
-            PopulateFrameworkReferences(
-                targetFrameworkInformation.FrameworkReferences,
-                properties,
-                "frameworkReferences",
-                packageSpec.FilePath);
-
-            frameworkAssemblies.ForEach(d => targetFrameworkInformation.Dependencies.Add(d));
-
-            packageSpec.TargetFrameworks.Add(targetFrameworkInformation);
-
-            return true;
-        }
-
-        private static void PopulateFrameworkReferences(ISet<FrameworkDependency> frameworkReferences, JObject properties, string frameworkReferenceName, string packageSpecPath)
-        {
-            var frameworkRefs = properties[frameworkReferenceName] as JObject;
-
-            if (frameworkRefs != null)
-            {
-                foreach (var frameworkReference in frameworkRefs)
-                {
-                    if (string.IsNullOrEmpty(frameworkReference.Key))
-                    {
-                        throw FileFormatException.Create(
-                                   "Unable to resolve frameworkReference.",
-                                   frameworkReference.Value,
-                                   packageSpecPath);
-                    }
-
-                    var privateAssets = FrameworkDependencyFlagsUtils.Default;
-
-                    if (frameworkReference.Value is JObject frameworkReferenceToken)
-                    {
-                        if (TryGetStringEnumerable(frameworkReferenceToken["privateAssets"], out var strings))
-                        {
-                            privateAssets = FrameworkDependencyFlagsUtils.GetFlags(strings);
-                        }
-                    }
-                    frameworkReferences.Add(new FrameworkDependency(frameworkReference.Key, privateAssets));
-                }
-            }
-        }
-
-        private static void PopulateDownloadDependencies(IList<DownloadDependency> downloadDependencies, JObject properties, string packageSpecPath)
-        {
-            var splitChars = new[] { ';' };
-
-            var seenIds = new HashSet<string>();
-
-            var downloadDependenciesProperty = properties["downloadDependencies"] as JArray;
-            if (downloadDependenciesProperty != null)
-            {
-                foreach (var dependency in downloadDependenciesProperty.Values<JToken>())
-                {
-                    if (dependency["name"] == null)
-                    {
-                        throw FileFormatException.Create(
-                            "Unable to resolve downloadDependency ''.",
-                            dependency,
-                            packageSpecPath);
-                    }
-                    var name = dependency["name"].Value<string>();
-                    if (!seenIds.Add(name))
-                    {
-                        // package ID already seen, only use first definition.
-                        continue;
-                    }
-
-                    string versionValue = null;
-
-                    var dependencyVersionToken = dependency["version"];
-                    if (dependencyVersionToken != null
-                        && dependencyVersionToken.Type == JTokenType.String)
-                    {
-                        versionValue = dependencyVersionToken.Value<string>();
-                    }
-
-                    VersionRange version = null;
-
-                    if (!string.IsNullOrEmpty(versionValue))
-                    {
-                        var versions = versionValue.Split(splitChars, StringSplitOptions.RemoveEmptyEntries);
-                        foreach (var singleVersionValue in versions)
-                        {
-                            try
-                            {
-                                version = VersionRange.Parse(singleVersionValue);
-                                downloadDependencies.Add(new DownloadDependency(name, version));
-                            }
-                            catch (Exception ex)
-                            {
-                                throw FileFormatException.Create(
-                                    ex,
-                                    dependencyVersionToken,
-                                    packageSpecPath);
-                            }
-                        }
-                    }
-                    else
-                    {
-                        throw FileFormatException.Create(
-                            "The version cannot be null or empty",
-                            dependencyVersionToken,
-                            packageSpecPath);
-                    }
-                }
-            }
-        }
-
-        internal static void PopulateCentralDependencies(
-           string packageSpecPath,
-           TargetFrameworkInformation targetFrameworkInformation,
-           JObject properties)
-        {
-            var centralversions = new Dictionary<string, CentralPackageVersion>();
-            var ventralVersionDependenciesProperty = properties["centralPackageVersions"] as JObject;
-            if (ventralVersionDependenciesProperty != null)
-            {
-                foreach (var dependency in ventralVersionDependenciesProperty.Values<JToken>())
-                {
-                    var depName = ((JProperty)dependency).Name;
-                    var depVersion = (string)((JProperty)dependency).Value;
-
-                    if (depName == null)
-                    {
-                        throw FileFormatException.Create(
-                            "Unable to resolve central version ''.",
-                            dependency,
-                            packageSpecPath);
-                    }
-                    if (depVersion == null)
-                    {
-                        throw FileFormatException.Create(
-                            "The version cannot be null.",
-                            depName,
-                            packageSpecPath);
-                    }
-
-                    centralversions.Add(depName, new CentralPackageVersion(depName, VersionRange.Parse(depVersion)));
-                }
-            }
-
-            targetFrameworkInformation.CentralPackageVersions.AddRange(centralversions);
-        }
-
-        private static List<NuGetFramework> GetImports(JObject properties, PackageSpec packageSpec)
-        {
-            var frameworks = new List<NuGetFramework>();
-
-            var importsProperty = properties["imports"];
-
-            if (importsProperty != null)
-            {
-                IEnumerable<string> importArray = new List<string>();
-                if (TryGetStringEnumerableFromJArray(importsProperty, out importArray))
-                {
-                    frameworks = importArray.Where(p => !string.IsNullOrEmpty(p)).Select(p => NuGetFramework.Parse(p)).ToList();
-                }
-            }
-
-            if (frameworks.Any(p => !p.IsSpecificFramework))
-            {
-                throw FileFormatException.Create(
-                    string.Format(
-                        Strings.Log_InvalidImportFramework,
-                        importsProperty.ToString().Replace(Environment.NewLine, string.Empty),
-                        PackageSpec.PackageSpecFileName),
-                    importsProperty,
-                    packageSpec.FilePath);
-            }
-
-            return frameworks;
-        }
-
-        private static string GetRuntimeIdentifierGraphPath(JObject properties)
-        {
-            var runtimeIdentifierGraphPath = properties["runtimeIdentifierGraphPath"];
-
-            if (runtimeIdentifierGraphPath != null)
-            {
-                return runtimeIdentifierGraphPath.ToObject<string>();
-            }
-
-            return null;
-        }
-
-        private static bool GetWarnSetting(JObject properties)
-        {
-            var warn = false;
-
-            var warnProperty = properties["warn"];
-
-            if (warnProperty != null)
-            {
-                warn = warnProperty.ToObject<bool>();
-            }
-
-            return warn;
-        }
-
-        private static NuGetFramework GetFramework(string key)
-        {
-            return NuGetFramework.Parse(key);
-        }
-
-        /// <summary>
-        /// Returns true if the property is set to true. Otherwise false.
-        /// </summary>
-        private static bool GetBoolOrFalse(JToken parent, string propertyName, string filePath)
-        {
-            var jObj = parent as JObject;
-
-            if (jObj != null)
-            {
-                return GetBoolOrFalse(jObj, propertyName, filePath);
-            }
-
-            return false;
-        }
-
-        /// <summary>
-        /// Returns true if the property is set to true. Otherwise false.
-        /// </summary>
-        private static bool GetBoolOrFalse(JObject parent, string propertyName, string filePath)
-        {
-            var token = parent[propertyName];
-
-            if (token != null)
-            {
-                try
-                {
-                    return parent.GetValue<bool?>(propertyName) ?? false;
-                }
-                catch (Exception ex)
-                {
-                    throw FileFormatException.Create(ex, token, filePath);
-                }
-            }
-
-            return false;
         }
     }
 }

--- a/src/NuGet.Core/NuGet.ProjectModel/JsonTextReaderExtensions.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/JsonTextReaderExtensions.cs
@@ -1,0 +1,210 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace NuGet.ProjectModel
+{
+    internal static class JsonTextReaderExtensions
+    {
+        private static readonly char[] DelimitedStringDelimiters = new char[] { ' ', ',' };
+
+        internal static IReadOnlyList<string> ReadDelimitedString(this JsonTextReader reader)
+        {
+            if (reader == null)
+            {
+                throw new ArgumentNullException(nameof(reader));
+            }
+
+            if (ReadNextToken(reader))
+            {
+                switch (reader.TokenType)
+                {
+                    case JsonToken.String:
+                        var value = (string)reader.Value;
+
+                        return value.Split(DelimitedStringDelimiters, StringSplitOptions.RemoveEmptyEntries);
+
+                    default:
+                        throw new InvalidCastException();
+                }
+            }
+
+            return null;
+        }
+
+        internal static bool ReadNextToken(this JsonTextReader reader)
+        {
+            if (reader == null)
+            {
+                throw new ArgumentNullException(nameof(reader));
+            }
+
+            bool wasRead;
+
+            while ((wasRead = reader.Read()) && reader.TokenType == JsonToken.Comment)
+            {
+            }
+
+            return wasRead;
+        }
+
+        internal static string ReadNextTokenAsString(this JsonTextReader reader)
+        {
+            if (ReadNextToken(reader))
+            {
+                return ReadTokenAsString(reader);
+            }
+
+            return null;
+        }
+
+        internal static bool ReadObject(this JsonTextReader reader, Action<string> onProperty)
+        {
+            return ReadObject(reader, onProperty, out int _0, out int _1);
+        }
+
+        internal static bool ReadObject(this JsonTextReader reader, Action<string> onProperty, out int startObjectLine, out int startObjectColumn)
+        {
+            startObjectLine = 0;
+            startObjectColumn = 0;
+
+            if (reader == null)
+            {
+                throw new ArgumentNullException(nameof(reader));
+            }
+
+            if (onProperty == null)
+            {
+                throw new ArgumentNullException(nameof(onProperty));
+            }
+
+            if (ReadNextToken(reader) && reader.TokenType == JsonToken.StartObject)
+            {
+                startObjectLine = reader.LineNumber;
+                startObjectColumn = reader.LinePosition;
+
+                ReadProperties(reader, onProperty);
+
+                return true;
+            }
+
+            return false;
+        }
+
+        internal static void ReadProperties(this JsonTextReader reader, Action<string> onProperty)
+        {
+            if (reader == null)
+            {
+                throw new ArgumentNullException(nameof(reader));
+            }
+
+            if (onProperty == null)
+            {
+                throw new ArgumentNullException(nameof(onProperty));
+            }
+
+            while (ReadNextToken(reader) && reader.TokenType == JsonToken.PropertyName)
+            {
+                var propertyName = (string)reader.Value;
+
+                int lineNumber = reader.LineNumber;
+                int linePosition = reader.LinePosition;
+
+                onProperty(propertyName);
+
+                if (reader.LineNumber == lineNumber && reader.LinePosition == linePosition)
+                {
+                    reader.Skip();
+                }
+            }
+        }
+
+        internal static List<string> ReadStringArrayAsList(this JsonTextReader reader)
+        {
+            if (reader == null)
+            {
+                throw new ArgumentNullException(nameof(reader));
+            }
+
+            List<string> strings = null;
+
+            if (ReadNextToken(reader) && reader.TokenType == JsonToken.StartArray)
+            {
+                while (ReadNextToken(reader) && reader.TokenType != JsonToken.EndArray)
+                {
+                    string value = ReadTokenAsString(reader);
+
+                    strings = strings ?? new List<string>();
+
+                    strings.Add(value);
+                }
+            }
+
+            return strings;
+        }
+
+        internal static IReadOnlyList<string> ReadStringOrArrayOfStringsAsReadOnlyList(this JsonTextReader reader)
+        {
+            if (reader == null)
+            {
+                throw new ArgumentNullException(nameof(reader));
+            }
+
+            if (ReadNextToken(reader))
+            {
+                switch (reader.TokenType)
+                {
+                    case JsonToken.String:
+                        return new[] { (string)reader.Value };
+
+                    case JsonToken.StartArray:
+                        return ReadStringArrayAsReadOnlyListFromArrayStart(reader);
+                }
+            }
+
+            return null;
+        }
+
+        internal static IReadOnlyList<string> ReadStringArrayAsReadOnlyListFromArrayStart(this JsonTextReader reader)
+        {
+            if (reader == null)
+            {
+                throw new ArgumentNullException(nameof(reader));
+            }
+
+            List<string> strings = null;
+
+            while (ReadNextToken(reader) && reader.TokenType != JsonToken.EndArray)
+            {
+                string value = ReadTokenAsString(reader);
+
+                strings = strings ?? new List<string>();
+
+                strings.Add(value);
+            }
+
+            return (IReadOnlyList<string>)strings ?? Array.Empty<string>();
+        }
+
+        private static string ReadTokenAsString(this JsonTextReader reader)
+        {
+            switch (reader.TokenType)
+            {
+                case JsonToken.Boolean:
+                case JsonToken.Float:
+                case JsonToken.Integer:
+                case JsonToken.String:
+                    return reader.Value.ToString();
+
+                case JsonToken.Null:
+                    return null;
+
+                default:
+                    throw new InvalidCastException();
+            }
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileFormat.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileFormat.cs
@@ -626,11 +626,13 @@ namespace NuGet.ProjectModel
                 return null;
             }
 
+#pragma warning disable CS0618
             return JsonPackageSpecReader.GetPackageSpec(
                 json,
                 name: null,
                 packageSpecPath: null,
                 snapshotValue: null);
+#pragma warning restore CS0618
         }
 
         private static JProperty WriteProjectFileDependencyGroup(ProjectFileDependencyGroup frameworkInfo)

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpec.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpec.cs
@@ -89,7 +89,7 @@ namespace NuGet.ProjectModel
 
         public PackOptions PackOptions { get; set; } = new PackOptions();
 
-        public IList<TargetFrameworkInformation> TargetFrameworks { get; private set; } = new List<TargetFrameworkInformation>();
+        public IList<TargetFrameworkInformation> TargetFrameworks { get; private set; }
 
         public RuntimeGraph RuntimeGraph { get; set; } = new RuntimeGraph();
 

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/FileFormatExceptionTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/FileFormatExceptionTests.cs
@@ -1,0 +1,65 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Xunit;
+
+namespace NuGet.ProjectModel.Test
+{
+    public class FileFormatExceptionTests
+    {
+        private const int Column = 7;
+        private static readonly DivideByZeroException InnerException = new DivideByZeroException();
+        private const int Line = 3;
+        private const string Message = "a";
+        private const string Path = "b";
+
+        [Fact]
+        public void Constructor_WithMessageParameter_SetsProperties()
+        {
+            var exception = new FileFormatException(Message);
+
+            Assert.Equal(Message, exception.Message);
+            Assert.Null(exception.Path);
+            Assert.Equal(0, exception.Line);
+            Assert.Equal(0, exception.Column);
+            Assert.Null(exception.InnerException);
+        }
+
+        [Fact]
+        public void Constructor_WithMessageAndExceptionParameters_SetsProperties()
+        {
+            var exception = new FileFormatException(Message, InnerException);
+
+            Assert.Equal(Message, exception.Message);
+            Assert.Null(exception.Path);
+            Assert.Equal(0, exception.Line);
+            Assert.Equal(0, exception.Column);
+            Assert.Same(InnerException, exception.InnerException);
+        }
+
+        [Fact]
+        public void Create_WithExceptionLineColumnAndPathParameters_SetsProperties()
+        {
+            FileFormatException exception = FileFormatException.Create(InnerException, Line, Column, Path);
+
+            Assert.Equal($"Error reading '{Path}' at line {Line} column {Column} : {InnerException.Message}", exception.Message);
+            Assert.Equal(Path, exception.Path);
+            Assert.Equal(Line, exception.Line);
+            Assert.Equal(Column, exception.Column);
+            Assert.Same(InnerException, exception.InnerException);
+        }
+
+        [Fact]
+        public void Create_WithMessageLineColumnAndPathParameters_SetsProperties()
+        {
+            FileFormatException exception = FileFormatException.Create(Message, Line, Column, Path);
+
+            Assert.Equal(Message, exception.Message);
+            Assert.Equal(Path, exception.Path);
+            Assert.Equal(Line, exception.Line);
+            Assert.Equal(Column, exception.Column);
+            Assert.Null(exception.InnerException);
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/ImportFrameworkTest.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/ImportFrameworkTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Linq;
@@ -13,14 +13,14 @@ namespace NuGet.ProjectModel.Test
         [Fact]
         public void ImportFramwork_UnknowFramework()
         {
-            var configJson = JObject.Parse(@"
+            JObject configJson = JObject.Parse(@"
                 {
                     ""dependencies"": {
                         ""Newtonsoft.Json"": ""7.0.1""
                     },
                     ""frameworks"": {
                         ""netstandard1.2"": {
-                            ""imports"": [""dotnet5.3"",""portable-net452+win81"",""furtureFramework""],
+                            ""imports"": [""dotnet5.3"",""portable-net452+win81"",""futureFramework""],
                             ""warn"": false
                         }
                     }
@@ -28,14 +28,13 @@ namespace NuGet.ProjectModel.Test
 
             // Act & Assert
             var ex = Assert.Throws<FileFormatException>(() => JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", "project.json"));
-            Assert.Equal("Imports contains an invalid framework: '[  \"dotnet5.3\",  \"portable-net452+win81\",  \"furtureFramework\"]' in 'project.json'.", ex.InnerException.Message);
-
+            Assert.Equal("Imports contains an invalid framework: 'futureFramework' in 'project.json'.", ex.InnerException.Message);
         }
 
         [Fact]
         public void ImportFramwork_EmptyImport()
         {
-            var configJson = JObject.Parse(@"
+            JObject configJson = JObject.Parse(@"
                 {
                     ""dependencies"": {
                         ""Newtonsoft.Json"": ""7.0.1""
@@ -49,8 +48,8 @@ namespace NuGet.ProjectModel.Test
                 }");
 
             // Act
-            var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", "project.json");
-            var importFramework = spec.TargetFrameworks.First().Imports.ToList();
+            PackageSpec spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", "project.json");
+            System.Collections.Generic.List<NuGetFramework> importFramework = spec.TargetFrameworks.First().Imports.ToList();
 
             // Assert
             Assert.Equal(0, importFramework.Count);
@@ -59,7 +58,7 @@ namespace NuGet.ProjectModel.Test
         [Fact]
         public void ImportFramwork_SingleImport()
         {
-            var configJson = JObject.Parse(@"
+            JObject configJson = JObject.Parse(@"
                 {
                     ""dependencies"": {
                         ""Newtonsoft.Json"": ""7.0.1""
@@ -73,14 +72,13 @@ namespace NuGet.ProjectModel.Test
                 }");
 
             // Act
-            var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", "project.json");
-            var importFramework = spec.TargetFrameworks.First().Imports.ToList();
-            var expectedFramework = NuGetFramework.Parse("dotnet5.3");
+            PackageSpec spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", "project.json");
+            System.Collections.Generic.List<NuGetFramework> importFramework = spec.TargetFrameworks.First().Imports.ToList();
+            NuGetFramework expectedFramework = NuGetFramework.Parse("dotnet5.3");
 
             // Assert
             Assert.Equal(1, importFramework.Count);
             Assert.True(importFramework[0].Equals(expectedFramework));
-           
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/ImportFrameworkTest.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/ImportFrameworkTest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json.Linq;
 using NuGet.Frameworks;
@@ -73,7 +74,7 @@ namespace NuGet.ProjectModel.Test
 
             // Act
             PackageSpec spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", "project.json");
-            System.Collections.Generic.List<NuGetFramework> importFramework = spec.TargetFrameworks.First().Imports.ToList();
+            List<NuGetFramework> importFramework = spec.TargetFrameworks.First().Imports.ToList();
             NuGetFramework expectedFramework = NuGetFramework.Parse("dotnet5.3");
 
             // Assert

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/JsonPackageSpecReaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/JsonPackageSpecReaderTests.cs
@@ -2,12 +2,17 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Text;
 using NuGet.Common;
+using NuGet.Configuration;
+using NuGet.Frameworks;
 using NuGet.LibraryModel;
 using NuGet.Packaging.Core;
+using NuGet.RuntimeModel;
 using NuGet.Versioning;
-using Test.Utility;
 using Xunit;
 
 namespace NuGet.ProjectModel.Test
@@ -1017,6 +1022,2525 @@ namespace NuGet.ProjectModel.Test
 
             // Assert
             Assert.Null(spec.TargetFrameworks.First().RuntimeIdentifierGraphPath);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenAuthorsPropertyIsAbsent_ReturnsEmptyAuthors()
+        {
+            PackageSpec packageSpec = GetPackageSpec("{}");
+
+            Assert.Empty(packageSpec.Authors);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenAuthorsValueIsNull_ReturnsEmptyAuthors()
+        {
+            PackageSpec packageSpec = GetPackageSpec("{\"authors\":null}");
+
+            Assert.Empty(packageSpec.Authors);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenAuthorsValueIsString_ReturnsEmptyAuthors()
+        {
+            PackageSpec packageSpec = GetPackageSpec("{\"authors\":\"b\"}");
+
+            Assert.Empty(packageSpec.Authors);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("/**/")]
+        public void GetPackageSpec_WhenAuthorsValueIsEmptyArray_ReturnsEmptyAuthors(string value)
+        {
+            PackageSpec packageSpec = GetPackageSpec($"{{\"authors\":[{value}]}}");
+
+            Assert.Empty(packageSpec.Authors);
+        }
+
+        [Theory]
+        [InlineData("{}")]
+        [InlineData("[]")]
+        public void GetPackageSpec_WhenAuthorsValueElementIsNotConvertibleToString_Throws(string value)
+        {
+            var json = $"{{\"authors\":[{value}]}}";
+
+            Assert.Throws<InvalidCastException>(() => GetPackageSpec(json));
+        }
+
+        [Theory]
+        [InlineData("\"a\"", "a")]
+        [InlineData("true", "True")]
+        [InlineData("-2", "-2")]
+        [InlineData("3.14", "3.14")]
+        public void GetPackageSpec_WhenAuthorsValueElementIsConvertibleToString_ReturnsAuthor(string value, string expectedValue)
+        {
+            PackageSpec packageSpec = GetPackageSpec($"{{\"authors\":[{value}]}}");
+
+            Assert.Collection(packageSpec.Authors, author => Assert.Equal(expectedValue, author));
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenBuildOptionsPropertyIsAbsent_ReturnsNullBuildOptions()
+        {
+            PackageSpec packageSpec = GetPackageSpec("{}");
+
+            Assert.Null(packageSpec.BuildOptions);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenBuildOptionsValueIsEmptyObject_ReturnsBuildOptions()
+        {
+            PackageSpec packageSpec = GetPackageSpec("{\"buildOptions\":{}}");
+
+            Assert.NotNull(packageSpec.BuildOptions);
+            Assert.Null(packageSpec.BuildOptions.OutputName);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenBuildOptionsValueOutputNameIsNull_ReturnsNullOutputName()
+        {
+            PackageSpec packageSpec = GetPackageSpec("{\"buildOptions\":{\"outputName\":null}}");
+
+            Assert.Null(packageSpec.BuildOptions.OutputName);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenBuildOptionsValueOutputNameIsValid_ReturnsOutputName()
+        {
+            const string expectedResult = "a";
+
+            var json = $"{{\"buildOptions\":{{\"outputName\":\"{expectedResult}\"}}}}";
+
+            PackageSpec packageSpec = GetPackageSpec(json);
+
+            Assert.Equal(expectedResult, packageSpec.BuildOptions.OutputName);
+        }
+
+        [Theory]
+        [InlineData("-2", "-2")]
+        [InlineData("3.14", "3.14")]
+        [InlineData("true", "True")]
+        public void GetPackageSpec_WhenBuildOptionsValueOutputNameIsConvertibleToString_ReturnsOutputName(string outputName, string expectedValue)
+        {
+            PackageSpec packageSpec = GetPackageSpec($"{{\"buildOptions\":{{\"outputName\":{outputName}}}}}");
+
+            Assert.Equal(expectedValue, packageSpec.BuildOptions.OutputName);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenContentFilesPropertyIsAbsent_ReturnsEmptyContentFiles()
+        {
+            PackageSpec packageSpec = GetPackageSpec("{}");
+
+            Assert.Empty(packageSpec.ContentFiles);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenContentFilesValueIsNull_ReturnsEmptyContentFiles()
+        {
+            PackageSpec packageSpec = GetPackageSpec("{\"contentFiles\":null}");
+
+            Assert.Empty(packageSpec.ContentFiles);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenContentFilesValueIsString_ReturnsEmptyContentFiles()
+        {
+            PackageSpec packageSpec = GetPackageSpec("{\"contentFiles\":\"a\"}");
+
+            Assert.Empty(packageSpec.ContentFiles);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("/**/")]
+        public void GetPackageSpec_WhenContentFilesValueIsEmptyArray_ReturnsEmptyContentFiles(string value)
+        {
+            PackageSpec packageSpec = GetPackageSpec($"{{\"contentFiles\":[{value}]}}");
+
+            Assert.Empty(packageSpec.ContentFiles);
+        }
+
+        [Theory]
+        [InlineData("{}")]
+        [InlineData("[]")]
+        public void GetPackageSpec_WhenContentFilesValueElementIsNotConvertibleToString_Throws(string value)
+        {
+            var json = $"{{\"contentFiles\":[{value}]}}";
+
+            Assert.Throws<InvalidCastException>(() => GetPackageSpec(json));
+        }
+
+        [Theory]
+        [InlineData("\"a\"", "a")]
+        [InlineData("true", "True")]
+        [InlineData("-2", "-2")]
+        [InlineData("3.14", "3.14")]
+        public void GetPackageSpec_WhenContentFilesValueElementIsConvertibleToString_ReturnsContentFile(string value, string expectedValue)
+        {
+            PackageSpec packageSpec = GetPackageSpec($"{{\"contentFiles\":[{value}]}}");
+
+            Assert.Collection(packageSpec.ContentFiles, contentFile => Assert.Equal(expectedValue, contentFile));
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenCopyrightPropertyIsAbsent_ReturnsNullCopyright()
+        {
+            PackageSpec packageSpec = GetPackageSpec("{}");
+
+            Assert.Null(packageSpec.Copyright);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenCopyrightValueIsNull_ReturnsNullCopyright()
+        {
+            PackageSpec packageSpec = GetPackageSpec("{\"copyright\":null}");
+
+            Assert.Null(packageSpec.Copyright);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenCopyrightValueIsString_ReturnsCopyright()
+        {
+            const string expectedResult = "a";
+
+            PackageSpec packageSpec = GetPackageSpec($"{{\"copyright\":\"{expectedResult}\"}}");
+
+            Assert.Equal(expectedResult, packageSpec.Copyright);
+        }
+
+        [Theory]
+        [InlineData("\"a\"", "a")]
+        [InlineData("true", "True")]
+        [InlineData("-2", "-2")]
+        [InlineData("3.14", "3.14")]
+        public void GetPackageSpec_WhenCopyrightValueIsConvertibleToString_ReturnsCopyright(string value, string expectedValue)
+        {
+            PackageSpec packageSpec = GetPackageSpec($"{{\"copyright\":{value}}}");
+
+            Assert.Equal(expectedValue, packageSpec.Copyright);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenDependenciesPropertyIsAbsent_ReturnsEmptyDependencies()
+        {
+            PackageSpec packageSpec = GetPackageSpec("{}");
+
+            Assert.Empty(packageSpec.Dependencies);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenDependenciesValueIsNull_ReturnsEmptyDependencies()
+        {
+            PackageSpec packageSpec = GetPackageSpec("{\"dependencies\":null}");
+
+            Assert.Empty(packageSpec.Dependencies);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenDependenciesDependencyNameIsEmptyString_Throws()
+        {
+            const string json = "{\"dependencies\":{\"\":{}}}";
+
+            FileFormatException exception = Assert.Throws<FileFormatException>(() => GetPackageSpec(json));
+
+            Assert.Equal("Unable to resolve dependency ''.", exception.Message);
+            Assert.Equal(1, exception.Line);
+            Assert.Equal(21, exception.Column);
+            Assert.Null(exception.InnerException);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenDependenciesDependencyValueIsVersionString_ReturnsDependencyVersionRange()
+        {
+            var expectedResult = new LibraryRange(
+                name: "a",
+                new VersionRange(new NuGetVersion("1.2.3")),
+                LibraryDependencyTarget.All & ~LibraryDependencyTarget.Reference);
+            var json = $"{{\"dependencies\":{{\"{expectedResult.Name}\":\"{expectedResult.VersionRange.ToShortString()}\"}}}}";
+
+            LibraryDependency dependency = GetDependency(json);
+
+            Assert.Equal(expectedResult, dependency.LibraryRange);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenDependenciesDependencyValueIsVersionRangeString_ReturnsDependencyVersionRange()
+        {
+            var expectedResult = new LibraryRange(
+                name: "a",
+                new VersionRange(new NuGetVersion("1.2.3"), includeMinVersion: true, new NuGetVersion("4.5.6"), includeMaxVersion: false),
+                LibraryDependencyTarget.All & ~LibraryDependencyTarget.Reference);
+            var json = $"{{\"dependencies\":{{\"{expectedResult.Name}\":\"{expectedResult.VersionRange}\"}}}}";
+
+            LibraryDependency dependency = GetDependency(json);
+
+            Assert.Equal(expectedResult, dependency.LibraryRange);
+        }
+
+        [Theory]
+        [InlineData(LibraryDependencyTarget.None)]
+        [InlineData(LibraryDependencyTarget.Assembly)]
+        [InlineData(LibraryDependencyTarget.Reference)]
+        [InlineData(LibraryDependencyTarget.WinMD)]
+        [InlineData(LibraryDependencyTarget.All)]
+        [InlineData(LibraryDependencyTarget.PackageProjectExternal)]
+        public void GetPackageSpec_WhenDependenciesDependencyTargetIsUnsupported_Throws(LibraryDependencyTarget target)
+        {
+            var json = $"{{\"dependencies\":{{\"a\":{{\"version\":\"1.2.3\",\"target\":\"{target}\"}}}}}}";
+
+            FileFormatException exception = Assert.Throws<FileFormatException>(() => GetPackageSpec(json));
+
+            Assert.Equal($"Invalid dependency target value '{target}'.", exception.Message);
+            Assert.Equal(1, exception.Line);
+            // The position is after the target name, which is of variable length.
+            Assert.Equal(json.IndexOf(target.ToString()) + target.ToString().Length + 1, exception.Column);
+            Assert.Null(exception.InnerException);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenDependenciesDependencyAutoreferencedPropertyIsAbsent_ReturnsFalseAutoreferenced()
+        {
+            LibraryDependency dependency = GetDependency($"{{\"dependencies\":{{\"a\":{{\"target\":\"Project\"}}}}}}");
+
+            Assert.False(dependency.AutoReferenced);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void GetPackageSpec_WhenDependenciesDependencyAutoreferencedValueIsBool_ReturnsBoolAutoreferenced(bool expectedValue)
+        {
+            var json = $"{{\"dependencies\":{{\"a\":{{\"autoReferenced\":{expectedValue.ToString().ToLower()},\"target\":\"Project\"}}}}}}";
+
+            LibraryDependency dependency = GetDependency(json);
+
+            Assert.Equal(expectedValue, dependency.AutoReferenced);
+        }
+
+        [Theory]
+        [InlineData("exclude")]
+        [InlineData("include")]
+        [InlineData("suppressParent")]
+        [InlineData("type")]
+        public void GetPackageSpec_WhenDependenciesDependencyValueIsArray_Throws(string propertyName)
+        {
+            var json = $"{{\"dependencies\":{{\"a\":{{\"{propertyName}\":[\"b\"]}}}}}}";
+
+            Assert.Throws<InvalidCastException>(() => GetPackageSpec(json));
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenDependenciesDependencyIncludeAndExcludePropertiesAreAbsent_ReturnsAllIncludeType()
+        {
+            const string json = "{\"dependencies\":{\"a\":{\"version\":\"1.0.0\"}}}";
+
+            LibraryDependency dependency = GetDependency(json);
+
+            Assert.Equal(LibraryIncludeFlags.All, dependency.IncludeType);
+        }
+
+        [Theory]
+        [InlineData("\"Native\"", LibraryIncludeFlags.Native)]
+        [InlineData("\"Analyzers, Native\"", LibraryIncludeFlags.Analyzers | LibraryIncludeFlags.Native)]
+        public void GetPackageSpec_WhenDependenciesDependencyExcludeValueIsValid_ReturnsIncludeType(
+            string value,
+            LibraryIncludeFlags result)
+        {
+            var json = $"{{\"dependencies\":{{\"a\":{{\"exclude\":{value},\"version\":\"1.0.0\"}}}}}}";
+
+            LibraryDependency dependency = GetDependency(json);
+
+            Assert.Equal(LibraryIncludeFlags.All & ~result, dependency.IncludeType);
+        }
+
+        [Theory]
+        [InlineData("\"Native\"", LibraryIncludeFlags.Native)]
+        [InlineData("\"Analyzers, Native\"", LibraryIncludeFlags.Analyzers | LibraryIncludeFlags.Native)]
+        public void GetPackageSpec_WhenDependenciesDependencyIncludeValueIsValid_ReturnsIncludeType(
+            string value,
+            LibraryIncludeFlags expectedResult)
+        {
+            var json = $"{{\"dependencies\":{{\"a\":{{\"include\":{value},\"version\":\"1.0.0\"}}}}}}";
+
+            LibraryDependency dependency = GetDependency(json);
+
+            Assert.Equal(expectedResult, dependency.IncludeType);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenDependenciesDependencyIncludeValueOverridesTypeValue_ReturnsIncludeType()
+        {
+            const string json = "{\"dependencies\":{\"a\":{\"include\":\"ContentFiles\",\"type\":\"BecomesNupkgDependency, SharedFramework\",\"version\":\"1.0.0\"}}}";
+
+            LibraryDependency dependency = GetDependency(json);
+
+            Assert.Equal(LibraryIncludeFlags.ContentFiles, dependency.IncludeType);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenDependenciesDependencySuppressParentValueOverridesTypeValue_ReturnsSuppressParent()
+        {
+            const string json = "{\"dependencies\":{\"a\":{\"suppressParent\":\"ContentFiles\",\"type\":\"SharedFramework\",\"version\":\"1.0.0\"}}}";
+
+            LibraryDependency dependency = GetDependency(json);
+
+            Assert.Equal(LibraryIncludeFlags.ContentFiles, dependency.SuppressParent);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenDependenciesDependencySuppressParentPropertyIsAbsent_ReturnsSuppressParent()
+        {
+            const string json = "{\"dependencies\":{\"a\":{\"version\":\"1.0.0\"}}}";
+
+            LibraryDependency dependency = GetDependency(json);
+
+            Assert.Equal(LibraryIncludeFlagUtils.DefaultSuppressParent, dependency.SuppressParent);
+        }
+
+        [Theory]
+        [InlineData("\"Compile\"", LibraryIncludeFlags.Compile)]
+        [InlineData("\"Analyzers, Compile\"", LibraryIncludeFlags.Analyzers | LibraryIncludeFlags.Compile)]
+        public void GetPackageSpec_WhenDependenciesDependencySuppressParentValueIsValid_ReturnsSuppressParent(
+            string value,
+            LibraryIncludeFlags expectedResult)
+        {
+            var json = $"{{\"dependencies\":{{\"a\":{{\"suppressParent\":{value},\"version\":\"1.0.0\"}}}}}}";
+
+            LibraryDependency dependency = GetDependency(json);
+
+            Assert.Equal(expectedResult, dependency.SuppressParent);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenDependenciesDependencyVersionValueIsInvalid_Throws()
+        {
+            const string json = "{\"dependencies\":{\"a\":{\"version\":\"b\"}}}";
+
+            FileFormatException exception = Assert.Throws<FileFormatException>(() => GetPackageSpec(json));
+
+            Assert.Equal("Error reading '' at line 1 column 35 : 'b' is not a valid version string.", exception.Message);
+            Assert.Equal(1, exception.Line);
+            Assert.Equal(35, exception.Column);
+            Assert.IsType<ArgumentException>(exception.InnerException);
+            Assert.Null(exception.InnerException.InnerException);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenDependenciesDependencyTargetPropertyIsAbsent_ReturnsTarget()
+        {
+            const string json = "{\"dependencies\":{\"a\":{\"version\":\"1.0.0\"}}}";
+
+            LibraryDependency dependency = GetDependency(json);
+
+            Assert.Equal(LibraryDependencyTarget.All & ~LibraryDependencyTarget.Reference, dependency.LibraryRange.TypeConstraint);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenDependenciesDependencyTargetValueIsPackageAndVersionPropertyIsAbsent_Throws()
+        {
+            const string json = "{\"dependencies\":{\"a\":{\"target\":\"Package\"}}}";
+
+            FileFormatException exception = Assert.Throws<FileFormatException>(() => GetPackageSpec(json));
+
+            Assert.Equal("Error reading '' at line 1 column 22 : Package dependencies must specify a version range.", exception.Message);
+            Assert.Equal(1, exception.Line);
+            Assert.Equal(22, exception.Column);
+            Assert.IsType<ArgumentException>(exception.InnerException);
+            Assert.Null(exception.InnerException.InnerException);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenDependenciesDependencyTargetValueIsProjectAndVersionPropertyIsAbsent_ReturnsAllVersionRange()
+        {
+            LibraryDependency dependency = GetDependency("{\"dependencies\":{\"a\":{\"target\":\"Project\"}}}");
+
+            Assert.Equal(VersionRange.All, dependency.LibraryRange.VersionRange);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenDependenciesDependencyNoWarnPropertyIsAbsent_ReturnsEmptyNoWarns()
+        {
+            const string json = "{\"dependencies\":{\"a\":{\"version\":\"1.0.0\"}}}";
+
+            LibraryDependency dependency = GetDependency(json);
+
+            Assert.Empty(dependency.NoWarn);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenDependenciesDependencyNoWarnValueIsValid_ReturnsNoWarns()
+        {
+            NuGetLogCode[] expectedResults = { NuGetLogCode.NU1000, NuGetLogCode.NU3000 };
+            var json = $"{{\"dependencies\":{{\"a\":{{\"noWarn\":[\"{expectedResults[0].ToString()}\",\"{expectedResults[1].ToString()}\"],\"version\":\"1.0.0\"}}}}}}";
+
+            LibraryDependency dependency = GetDependency(json);
+
+            Assert.Collection(
+                dependency.NoWarn,
+                noWarn => Assert.Equal(expectedResults[0], noWarn),
+                noWarn => Assert.Equal(expectedResults[1], noWarn));
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenDependenciesDependencyGeneratePathPropertyPropertyIsAbsent_ReturnsFalseGeneratePathProperty()
+        {
+            const string json = "{\"dependencies\":{\"a\":{\"version\":\"1.0.0\"}}}";
+
+            LibraryDependency dependency = GetDependency(json);
+
+            Assert.False(dependency.GeneratePathProperty);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void GetPackageSpec_WhenDependenciesDependencyGeneratePathPropertyValueIsValid_ReturnsGeneratePathProperty(bool expectedResult)
+        {
+            var json = $"{{\"dependencies\":{{\"a\":{{\"generatePathProperty\":{expectedResult.ToString().ToLowerInvariant()},\"version\":\"1.0.0\"}}}}}}";
+
+            LibraryDependency dependency = GetDependency(json);
+
+            Assert.Equal(expectedResult, dependency.GeneratePathProperty);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenDependenciesDependencyTypePropertyIsAbsent_ReturnsDefaultTypeConstraint()
+        {
+            const string json = "{\"dependencies\":{\"a\":{\"version\":\"1.0.0\"}}}";
+
+            LibraryDependency dependency = GetDependency(json);
+
+            Assert.Equal(
+                LibraryDependencyTarget.All & ~LibraryDependencyTarget.Reference,
+                dependency.LibraryRange.TypeConstraint);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenDependenciesDependencyVersionCentrallyManagedPropertyIsAbsent_ReturnsFalseVersionCentrallyManaged()
+        {
+            LibraryDependency dependency = GetDependency($"{{\"dependencies\":{{\"a\":{{\"target\":\"Package\",\"version\":\"1.0.0\"}}}}}}");
+
+            Assert.False(dependency.VersionCentrallyManaged);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void GetPackageSpec_WhenDependenciesDependencyVersionCentrallyManagedValueIsBool_ReturnsBoolVersionCentrallyManaged(bool expectedValue)
+        {
+            var json = $"{{\"dependencies\":{{\"a\":{{\"versionCentrallyManaged\":{expectedValue.ToString().ToLower()},\"target\":\"Package\",\"version\":\"1.0.0\"}}}}}}";
+
+            LibraryDependency dependency = GetDependency(json);
+
+            Assert.Equal(expectedValue, dependency.VersionCentrallyManaged);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenDescriptionPropertyIsAbsent_ReturnsNullDescription()
+        {
+            PackageSpec packageSpec = GetPackageSpec("{}");
+
+            Assert.Null(packageSpec.Description);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("b")]
+        public void GetPackageSpec_WhenDescriptionValueIsValid_ReturnsDescription(string expectedResult)
+        {
+            string description = expectedResult == null ? "null" : $"\"{expectedResult}\"";
+            PackageSpec packageSpec = GetPackageSpec($"{{\"description\":{description}}}");
+
+            Assert.Equal(expectedResult, packageSpec.Description);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenLanguagePropertyIsAbsent_ReturnsNullLanguage()
+        {
+            PackageSpec packageSpec = GetPackageSpec("{}");
+
+            Assert.Null(packageSpec.Language);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("b")]
+        public void GetPackageSpec_WhenLanguageValueIsValid_ReturnsLanguage(string expectedResult)
+        {
+            string language = expectedResult == null ? "null" : $"\"{expectedResult}\"";
+            PackageSpec packageSpec = GetPackageSpec($"{{\"language\":{language}}}");
+
+            Assert.Equal(expectedResult, packageSpec.Language);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenFrameworksPropertyIsAbsent_ReturnsEmptyFrameworks()
+        {
+            PackageSpec packageSpec = GetPackageSpec("{}");
+
+            Assert.Empty(packageSpec.TargetFrameworks);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenFrameworksValueIsEmptyObject_ReturnsEmptyFrameworks()
+        {
+            PackageSpec packageSpec = GetPackageSpec("{\"frameworks\":{}}");
+
+            Assert.Empty(packageSpec.TargetFrameworks);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenFrameworksAssetTargetFallbackPropertyIsAbsent_ReturnsFalseAssetTargetFallback()
+        {
+            TargetFrameworkInformation framework = GetFramework("{\"frameworks\":{\"a\":{}}}");
+
+            Assert.False(framework.AssetTargetFallback);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void GetPackageSpec_WhenFrameworksAssetTargetFallbackValueIsValid_ReturnsAssetTargetFallback(bool expectedValue)
+        {
+            var json = $"{{\"frameworks\":{{\"a\":{{\"assetTargetFallback\":{expectedValue.ToString().ToLowerInvariant()}}}}}}}";
+
+            TargetFrameworkInformation framework = GetFramework(json);
+
+            Assert.Equal(expectedValue, framework.AssetTargetFallback);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenFrameworksCentralPackageVersionsPropertyIsAbsent_ReturnsEmptyCentralPackageVersions()
+        {
+            TargetFrameworkInformation framework = GetFramework("{\"frameworks\":{\"a\":{}}}");
+
+            Assert.Empty(framework.CentralPackageVersions);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenFrameworksCentralPackageVersionsValueIsEmptyObject_ReturnsEmptyCentralPackageVersions()
+        {
+            TargetFrameworkInformation framework = GetFramework("{\"frameworks\":{\"a\":{\"centralPackageVersions\":{}}}}");
+
+            Assert.Empty(framework.CentralPackageVersions);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenFrameworksCentralPackageVersionsVersionPropertyNameIsEmptyString_Throws()
+        {
+            var json = "{\"frameworks\":{\"a\":{\"centralPackageVersions\":{\"\":\"1.0.0\"}}}}";
+
+            FileFormatException exception = Assert.Throws<FileFormatException>(() => GetPackageSpec(json));
+
+            Assert.Equal("Error reading '' at line 1 column 20 : Unable to resolve central version ''.", exception.Message);
+            Assert.Equal(1, exception.Line);
+            Assert.Equal(20, exception.Column);
+            Assert.IsType<FileFormatException>(exception.InnerException);
+            Assert.Null(exception.InnerException.InnerException);
+        }
+
+        [Theory]
+        [InlineData("null")]
+        [InlineData("\"\"")]
+        public void GetPackageSpec_WhenFrameworksCentralPackageVersionsVersionPropertyValueIsNullOrEmptyString_Throws(string value)
+        {
+            var json = $"{{\"frameworks\":{{\"a\":{{\"centralPackageVersions\":{{\"b\":{value}}}}}}}}}";
+
+            FileFormatException exception = Assert.Throws<FileFormatException>(() => GetPackageSpec(json));
+
+            Assert.Equal("Error reading '' at line 1 column 20 : The version cannot be null or empty.", exception.Message);
+            Assert.Equal(1, exception.Line);
+            Assert.Equal(20, exception.Column);
+            Assert.IsType<FileFormatException>(exception.InnerException);
+            Assert.Null(exception.InnerException.InnerException);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenFrameworksCentralPackageVersionsIsValid_ReturnsCentralPackageVersions()
+        {
+            const string expectedPackageId = "b";
+            VersionRange expectedVersionRange = VersionRange.Parse("[1.2.3,4.5.6)");
+            var expectedCentralPackageVersion = new CentralPackageVersion(expectedPackageId, expectedVersionRange);
+            var json = $"{{\"frameworks\":{{\"a\":{{\"centralPackageVersions\":{{\"{expectedPackageId}\":\"{expectedVersionRange.ToShortString()}\"}}}}}}}}";
+
+            TargetFrameworkInformation framework = GetFramework(json);
+
+            Assert.Collection(
+                framework.CentralPackageVersions,
+                actualResult =>
+                {
+                    Assert.Equal(expectedPackageId, actualResult.Key);
+                    Assert.Equal(expectedCentralPackageVersion, actualResult.Value);
+                });
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenFrameworksCentralPackageVersionsHasDuplicateKey_LastOneWins()
+        {
+            const string expectedPackageId = "b";
+            VersionRange unexpectedVersionRange = VersionRange.Parse("1.2.3");
+            VersionRange expectedVersionRange = VersionRange.Parse("4.5.6");
+            var expectedCentralPackageVersion = new CentralPackageVersion(expectedPackageId, expectedVersionRange);
+            var json = $"{{\"frameworks\":{{\"a\":{{\"centralPackageVersions\":{{\"{expectedPackageId}\":\"{unexpectedVersionRange.ToShortString()}\"," +
+                $"\"{expectedPackageId}\":\"{expectedVersionRange.ToShortString()}\"}}}}}}}}";
+
+            TargetFrameworkInformation framework = GetFramework(json);
+
+            Assert.Collection(
+                framework.CentralPackageVersions,
+                actualResult =>
+                {
+                    Assert.Equal(expectedPackageId, actualResult.Key);
+                    Assert.Equal(expectedCentralPackageVersion, actualResult.Value);
+                });
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenFrameworksDependenciesPropertyIsAbsent_ReturnsEmptyDependencies()
+        {
+            TargetFrameworkInformation framework = GetFramework("{\"frameworks\":{\"a\":{}}}");
+
+            Assert.Empty(framework.Dependencies);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenFrameworksDependenciesValueIsNull_ReturnsEmptyDependencies()
+        {
+            TargetFrameworkInformation framework = GetFramework("{\"frameworks\":{\"a\":{\"dependencies\":null}}}");
+
+            Assert.Empty(framework.Dependencies);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenFrameworksDependenciesDependencyNameIsEmptyString_Throws()
+        {
+            const string json = "{\"frameworks\":{\"a\":{\"dependencies\":{\"\":{}}}}}";
+
+            FileFormatException exception = Assert.Throws<FileFormatException>(() => GetPackageSpec(json));
+
+            Assert.Equal("Error reading '' at line 1 column 20 : Unable to resolve dependency ''.", exception.Message);
+            Assert.Equal(1, exception.Line);
+            Assert.Equal(20, exception.Column);
+            Assert.IsType<FileFormatException>(exception.InnerException);
+            Assert.Null(exception.InnerException.InnerException);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenFrameworksDependenciesDependencyValueIsVersionString_ReturnsDependencyVersionRange()
+        {
+            var expectedResult = new LibraryRange(
+                name: "b",
+                new VersionRange(new NuGetVersion("1.2.3")),
+                LibraryDependencyTarget.All & ~LibraryDependencyTarget.Reference);
+            var json = $"{{\"frameworks\":{{\"a\":{{\"dependencies\":{{\"{expectedResult.Name}\":\"{expectedResult.VersionRange.ToShortString()}\"}}}}}}}}";
+
+            LibraryDependency dependency = GetFrameworksDependency(json);
+
+            Assert.Equal(expectedResult, dependency.LibraryRange);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenFrameworksDependenciesDependencyValueIsVersionRangeString_ReturnsDependencyVersionRange()
+        {
+            var expectedResult = new LibraryRange(
+                name: "b",
+                new VersionRange(new NuGetVersion("1.2.3"), includeMinVersion: true, new NuGetVersion("4.5.6"), includeMaxVersion: false),
+                LibraryDependencyTarget.All & ~LibraryDependencyTarget.Reference);
+            var json = $"{{\"frameworks\":{{\"a\":{{\"dependencies\":{{\"{expectedResult.Name}\":\"{expectedResult.VersionRange}\"}}}}}}}}";
+
+            LibraryDependency dependency = GetFrameworksDependency(json);
+
+            Assert.Equal(expectedResult, dependency.LibraryRange);
+        }
+
+        [Theory]
+        [InlineData(LibraryDependencyTarget.None)]
+        [InlineData(LibraryDependencyTarget.Assembly)]
+        [InlineData(LibraryDependencyTarget.Reference)]
+        [InlineData(LibraryDependencyTarget.WinMD)]
+        [InlineData(LibraryDependencyTarget.All)]
+        [InlineData(LibraryDependencyTarget.PackageProjectExternal)]
+        public void GetPackageSpec_WhenFrameworksDependenciesDependencyTargetValueIsUnsupported_Throws(LibraryDependencyTarget target)
+        {
+            var json = $"{{\"frameworks\":{{\"a\":{{\"dependencies\":{{\"b\":{{\"version\":\"1.2.3\",\"target\":\"{target}\"}}}}}}}}}}";
+
+            FileFormatException exception = Assert.Throws<FileFormatException>(() => GetPackageSpec(json));
+
+            Assert.Equal($"Error reading '' at line 1 column 20 : Invalid dependency target value '{target}'.", exception.Message);
+            Assert.Equal(1, exception.Line);
+            Assert.Equal(20, exception.Column);
+            Assert.IsType<FileFormatException>(exception.InnerException);
+            Assert.Null(exception.InnerException.InnerException);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenFrameworksDependenciesDependencyAutoreferencedPropertyIsAbsent_ReturnsFalseAutoreferenced()
+        {
+            const string json = "{\"frameworks\":{\"a\":{\"dependencies\":{\"b\":{\"target\":\"Project\"}}}}}";
+
+            LibraryDependency dependency = GetFrameworksDependency(json);
+
+            Assert.False(dependency.AutoReferenced);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void GetPackageSpec_WhenFrameworksDependenciesDependencyAutoreferencedValueIsBool_ReturnsBoolAutoreferenced(bool expectedValue)
+        {
+            var json = $"{{\"frameworks\":{{\"a\":{{\"dependencies\":{{\"b\":{{\"autoReferenced\":{expectedValue.ToString().ToLower()},\"target\":\"Project\"}}}}}}}}}}";
+
+            LibraryDependency dependency = GetFrameworksDependency(json);
+
+            Assert.Equal(expectedValue, dependency.AutoReferenced);
+        }
+
+        [Theory]
+        [InlineData("exclude")]
+        [InlineData("include")]
+        [InlineData("suppressParent")]
+        [InlineData("type")]
+        public void GetPackageSpec_WhenFrameworksDependenciesDependencyValueIsArray_Throws(string propertyName)
+        {
+            var json = $"{{\"frameworks\":{{\"a\":{{\"dependencies\":{{\"b\":{{\"{propertyName}\":[\"c\"]}}}}}}}}}}";
+
+            // The exception messages will not be the same because the innermost exception in the baseline
+            // is a Newtonsoft.Json exception, while it's a .NET exception in the improved.
+            FileFormatException exception = Assert.Throws<FileFormatException>(() => GetPackageSpec(json));
+
+            Assert.Equal("Error reading '' at line 1 column 20 : Specified cast is not valid.", exception.Message);
+            Assert.Equal(1, exception.Line);
+            Assert.Equal(20, exception.Column);
+            Assert.IsType<InvalidCastException>(exception.InnerException);
+            Assert.Null(exception.InnerException.InnerException);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenFrameworksDependenciesDependencyIncludeAndExcludePropertiesAreAbsent_ReturnsAllIncludeType()
+        {
+            const string json = "{\"frameworks\":{\"a\":{\"dependencies\":{\"b\":{\"version\":\"1.0.0\"}}}}}";
+
+            LibraryDependency dependency = GetFrameworksDependency(json);
+
+            Assert.Equal(LibraryIncludeFlags.All, dependency.IncludeType);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenFrameworksDependenciesDependencyExcludeValueIsValid_ReturnsIncludeType()
+        {
+            const string json = "{\"frameworks\":{\"a\":{\"dependencies\":{\"b\":{\"exclude\":\"Native\",\"version\":\"1.0.0\"}}}}}";
+
+            LibraryDependency dependency = GetFrameworksDependency(json);
+
+            Assert.Equal(LibraryIncludeFlags.All & ~LibraryIncludeFlags.Native, dependency.IncludeType);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenFrameworksDependenciesDependencyIncludeValueIsValid_ReturnsIncludeType()
+        {
+            const string json = "{\"frameworks\":{\"a\":{\"dependencies\":{\"b\":{\"include\":\"ContentFiles\",\"version\":\"1.0.0\"}}}}}";
+
+            LibraryDependency dependency = GetFrameworksDependency(json);
+
+            Assert.Equal(LibraryIncludeFlags.ContentFiles, dependency.IncludeType);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenFrameworksDependenciesDependencyIncludeValueOverridesTypeValue_ReturnsIncludeType()
+        {
+            const string json = "{\"frameworks\":{\"a\":{\"dependencies\":{\"b\":{\"include\":\"ContentFiles\",\"type\":\"BecomesNupkgDependency, SharedFramework\",\"version\":\"1.0.0\"}}}}}";
+
+            LibraryDependency dependency = GetFrameworksDependency(json);
+
+            Assert.Equal(LibraryIncludeFlags.ContentFiles, dependency.IncludeType);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenFrameworksDependenciesDependencySuppressParentValueOverridesTypeValue_ReturnsSuppressParent()
+        {
+            const string json = "{\"frameworks\":{\"a\":{\"dependencies\":{\"b\":{\"suppressParent\":\"ContentFiles\",\"type\":\"SharedFramework\",\"version\":\"1.0.0\"}}}}}";
+
+            LibraryDependency dependency = GetFrameworksDependency(json);
+
+            Assert.Equal(LibraryIncludeFlags.ContentFiles, dependency.SuppressParent);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenFrameworksDependenciesDependencySuppressParentPropertyIsAbsent_ReturnsSuppressParent()
+        {
+            const string json = "{\"frameworks\":{\"a\":{\"dependencies\":{\"b\":{\"version\":\"1.0.0\"}}}}}";
+
+            LibraryDependency dependency = GetFrameworksDependency(json);
+
+            Assert.Equal(LibraryIncludeFlagUtils.DefaultSuppressParent, dependency.SuppressParent);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenFrameworksDependenciesDependencySuppressParentValueIsValid_ReturnsSuppressParent()
+        {
+            const string json = "{\"frameworks\":{\"a\":{\"dependencies\":{\"b\":{\"suppressParent\":\"Compile\",\"version\":\"1.0.0\"}}}}}";
+
+            LibraryDependency dependency = GetFrameworksDependency(json);
+
+            Assert.Equal(LibraryIncludeFlags.Compile, dependency.SuppressParent);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenFrameworksDependenciesDependencyVersionValueIsInvalid_Throws()
+        {
+            const string json = "{\"frameworks\":{\"a\":{\"dependencies\":{\"b\":{\"version\":\"c\"}}}}}";
+
+            FileFormatException exception = Assert.Throws<FileFormatException>(() => GetPackageSpec(json));
+
+            Assert.Equal("Error reading '' at line 1 column 20 : Error reading '' at line 1 column 54 : 'c' is not a valid version string.", exception.Message);
+            Assert.Equal(1, exception.Line);
+            Assert.Equal(20, exception.Column);
+            Assert.IsType<FileFormatException>(exception.InnerException);
+            Assert.IsType<ArgumentException>(exception.InnerException.InnerException);
+            Assert.Null(exception.InnerException.InnerException.InnerException);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenFrameworksDependenciesDependencyTargetPropertyIsAbsent_ReturnsTarget()
+        {
+            const string json = "{\"frameworks\":{\"a\":{\"dependencies\":{\"b\":{\"version\":\"1.0.0\"}}}}}";
+
+            LibraryDependency dependency = GetFrameworksDependency(json);
+
+            Assert.Equal(
+                LibraryDependencyTarget.All & ~LibraryDependencyTarget.Reference,
+                dependency.LibraryRange.TypeConstraint);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenFrameworksDependenciesDependencyTargetValueIsPackageAndVersionPropertyIsAbsent_Throws()
+        {
+            const string json = "{\"frameworks\":{\"a\":{\"dependencies\":{\"b\":{\"target\":\"Package\"}}}}}";
+
+            FileFormatException exception = Assert.Throws<FileFormatException>(() => GetPackageSpec(json));
+
+            Assert.Equal("Error reading '' at line 1 column 20 : Error reading '' at line 1 column 41 : Package dependencies must specify a version range.", exception.Message);
+            Assert.Equal(1, exception.Line);
+            Assert.Equal(20, exception.Column);
+            Assert.IsType<FileFormatException>(exception.InnerException);
+            Assert.IsType<ArgumentException>(exception.InnerException.InnerException);
+            Assert.Null(exception.InnerException.InnerException.InnerException);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenFrameworksDependenciesDependencyTargetValueIsProjectAndVersionPropertyIsAbsent_ReturnsAllVersionRange()
+        {
+            const string json = "{\"frameworks\":{\"a\":{\"dependencies\":{\"b\":{\"target\":\"Project\"}}}}}";
+
+            LibraryDependency dependency = GetFrameworksDependency(json);
+
+            Assert.Equal(VersionRange.All, dependency.LibraryRange.VersionRange);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenFrameworksDependenciesDependencyNoWarnPropertyIsAbsent_ReturnsEmptyNoWarns()
+        {
+            const string json = "{\"frameworks\":{\"a\":{\"dependencies\":{\"b\":{\"version\":\"1.0.0\"}}}}}";
+
+            LibraryDependency dependency = GetFrameworksDependency(json);
+
+            Assert.Empty(dependency.NoWarn);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenFrameworksDependenciesDependencyNoWarnValueIsValid_ReturnsNoWarns()
+        {
+            NuGetLogCode[] expectedResults = { NuGetLogCode.NU1000, NuGetLogCode.NU3000 };
+            var json = $"{{\"frameworks\":{{\"a\":{{\"dependencies\":{{\"b\":{{\"noWarn\":[\"{expectedResults[0].ToString()}\",\"{expectedResults[1].ToString()}\"],\"version\":\"1.0.0\"}}}}}}}}}}";
+
+            LibraryDependency dependency = GetFrameworksDependency(json);
+
+            Assert.Collection(
+                dependency.NoWarn,
+                noWarn => Assert.Equal(expectedResults[0], noWarn),
+                noWarn => Assert.Equal(expectedResults[1], noWarn));
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenFrameworksDependenciesDependencyGeneratePathPropertyPropertyIsAbsent_ReturnsFalseGeneratePathProperty()
+        {
+            const string json = "{\"frameworks\":{\"a\":{\"dependencies\":{\"b\":{\"version\":\"1.0.0\"}}}}}}}";
+
+            LibraryDependency dependency = GetFrameworksDependency(json);
+
+            Assert.False(dependency.GeneratePathProperty);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void GetPackageSpec_WhenFrameworksDependenciesDependencyGeneratePathPropertyValueIsValid_ReturnsGeneratePathProperty(bool expectedResult)
+        {
+            var json = $"{{\"frameworks\":{{\"a\":{{\"dependencies\":{{\"b\":{{\"generatePathProperty\":{expectedResult.ToString().ToLowerInvariant()},\"version\":\"1.0.0\"}}}}}}}}}}";
+
+            LibraryDependency dependency = GetFrameworksDependency(json);
+
+            Assert.Equal(expectedResult, dependency.GeneratePathProperty);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenFrameworksDependenciesDependencyTypePropertyIsAbsent_ReturnsDefaultTypeConstraint()
+        {
+            const string json = "{\"frameworks\":{\"a\":{\"dependencies\":{\"b\":{\"version\":\"1.0.0\"}}}}}";
+
+            LibraryDependency dependency = GetFrameworksDependency(json);
+
+            Assert.Equal(
+                LibraryDependencyTarget.All & ~LibraryDependencyTarget.Reference,
+                dependency.LibraryRange.TypeConstraint);
+        }
+
+
+        [Fact]
+        public void GetPackageSpec_WhenFrameworksDependenciesDependencyVersionCentrallyManagedPropertyIsAbsent_ReturnsFalseVersionCentrallyManaged()
+        {
+            const string json = "{\"frameworks\":{\"a\":{\"dependencies\":{\"b\":{\"target\":\"Package\",\"version\":\"1.0.0\"}}}}}";
+
+            LibraryDependency dependency = GetFrameworksDependency(json);
+
+            Assert.False(dependency.VersionCentrallyManaged);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void GetPackageSpec_WhenFrameworksDependenciesDependencyVersionCentrallyManagedValueIsBool_ReturnsBoolVersionCentrallyManaged(bool expectedValue)
+        {
+            var json = $"{{\"frameworks\":{{\"a\":{{\"dependencies\":{{\"b\":{{\"versionCentrallyManaged\":{expectedValue.ToString().ToLower()},\"target\":\"Package\",\"version\":\"1.0.0\"}}}}}}}}}}";
+
+            LibraryDependency dependency = GetFrameworksDependency(json);
+
+            Assert.Equal(expectedValue, dependency.VersionCentrallyManaged);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenFrameworksDownloadDependenciesPropertyIsAbsent_ReturnsEmptyDownloadDependencies()
+        {
+            const string json = "{\"frameworks\":{\"a\":{}}}";
+
+            TargetFrameworkInformation framework = GetFramework(json);
+
+            Assert.Empty(framework.DownloadDependencies);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenFrameworksDownloadDependenciesValueIsNull_ReturnsEmptyDownloadDependencies()
+        {
+            const string json = "{\"frameworks\":{\"a\":{\"downloadDependencies\":null}}}";
+
+            TargetFrameworkInformation framework = GetFramework(json);
+
+            Assert.Empty(framework.DownloadDependencies);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenFrameworksDownloadDependenciesValueIsNotArray_ReturnsEmptyDownloadDependencies()
+        {
+            const string json = "{\"frameworks\":{\"a\":{\"downloadDependencies\":\"b\"}}}";
+
+            TargetFrameworkInformation framework = GetFramework(json);
+
+            Assert.Empty(framework.DownloadDependencies);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenFrameworksDownloadDependenciesValueIsEmptyArray_ReturnsEmptyDownloadDependencies()
+        {
+            const string json = "{\"frameworks\":{\"a\":{\"downloadDependencies\":[]}}}";
+
+            TargetFrameworkInformation framework = GetFramework(json);
+
+            Assert.Empty(framework.DownloadDependencies);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenFrameworksDownloadDependenciesDependencyNameIsAbsent_Throws()
+        {
+            const string json = "{\"frameworks\":{\"a\":{\"downloadDependencies\":[{\"version\":\"1.2.3\"}]}}}";
+
+            FileFormatException exception = Assert.Throws<FileFormatException>(() => GetPackageSpec(json));
+
+            Assert.Equal("Error reading '' at line 1 column 20 : Unable to resolve downloadDependency ''.", exception.Message);
+            Assert.Equal(1, exception.Line);
+            Assert.Equal(20, exception.Column);
+            Assert.IsType<FileFormatException>(exception.InnerException);
+            Assert.Null(exception.InnerException.InnerException);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenFrameworksDownloadDependenciesDependencyNameIsNull_ReturnsDownloadDependencies()
+        {
+            var expectedResult = new DownloadDependency(name: null, new VersionRange(new NuGetVersion("1.2.3")));
+            var json = $"{{\"frameworks\":{{\"a\":{{\"downloadDependencies\":[{{\"name\":null,\"version\":\"{expectedResult.VersionRange.ToShortString()}\"}}]}}}}}}";
+
+            TargetFrameworkInformation framework = GetFramework(json);
+
+            DownloadDependency actualResult = framework.DownloadDependencies.Single();
+
+            Assert.Equal(expectedResult.Name, actualResult.Name);
+            Assert.Equal(expectedResult.VersionRange, actualResult.VersionRange);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenFrameworksDownloadDependenciesDependencyVersionIsAbsent_Throws()
+        {
+            const string json = "{\"frameworks\":{\"a\":{\"downloadDependencies\":[{\"name\":\"b\"}]}}}";
+
+            FileFormatException exception = Assert.Throws<FileFormatException>(() => GetPackageSpec(json));
+
+            Assert.Equal("Error reading '' at line 1 column 20 : The version cannot be null or empty", exception.Message);
+            Assert.Equal(1, exception.Line);
+            Assert.Equal(20, exception.Column);
+            Assert.IsType<FileFormatException>(exception.InnerException);
+            Assert.Null(exception.InnerException.InnerException);
+        }
+
+        [Theory]
+        [InlineData("null")]
+        [InlineData("c")]
+        public void GetPackageSpec_WhenFrameworksDownloadDependenciesDependencyVersionIsInvalid_Throws(string version)
+        {
+            var json = $"{{\"frameworks\":{{\"a\":{{\"downloadDependencies\":[{{\"name\":\"b\",\"version\":\"{version}\"}}]}}}}}}";
+
+            FileFormatException exception = Assert.Throws<FileFormatException>(() => GetPackageSpec(json));
+
+            int expectedColumn = json.IndexOf($"\"{version}\"") + version.Length + 2;
+
+            Assert.Equal($"Error reading '' at line 1 column 20 : Error reading '' at line 1 column {expectedColumn} : '{version}' is not a valid version string.", exception.Message);
+            Assert.Equal(1, exception.Line);
+            Assert.Equal(20, exception.Column);
+            Assert.IsType<FileFormatException>(exception.InnerException);
+            Assert.IsType<ArgumentException>(exception.InnerException.InnerException);
+            Assert.Null(exception.InnerException.InnerException.InnerException);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenFrameworksDownloadDependenciesValueIsValid_ReturnsDownloadDependencies()
+        {
+            var expectedResult = new DownloadDependency(name: "b", new VersionRange(new NuGetVersion("1.2.3")));
+            var json = $"{{\"frameworks\":{{\"a\":{{\"downloadDependencies\":[{{\"name\":\"{expectedResult.Name}\",\"version\":\"{expectedResult.VersionRange.ToShortString()}\"}}]}}}}}}";
+
+            TargetFrameworkInformation framework = GetFramework(json);
+
+            Assert.Equal(expectedResult, framework.DownloadDependencies.Single());
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenFrameworksDownloadDependenciesValueHasDuplicates_PrefersFirstByName()
+        {
+            var expectedResult = new DownloadDependency(name: "b", new VersionRange(new NuGetVersion("1.2.3")));
+            var unexpectedResult = new DownloadDependency(name: "b", new VersionRange(new NuGetVersion("4.5.6")));
+            var json = "{\"frameworks\":{\"a\":{\"downloadDependencies\":[" +
+                $"{{\"name\":\"{expectedResult.Name}\",\"version\":\"{expectedResult.VersionRange.ToShortString()}\"}}," +
+                $"{{\"name\":\"{unexpectedResult.Name}\",\"version\":\"{unexpectedResult.VersionRange.ToShortString()}\"}}" +
+                "]}}}";
+
+            TargetFrameworkInformation framework = GetFramework(json);
+
+            Assert.Equal(expectedResult, framework.DownloadDependencies.Single());
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenFrameworksFrameworkAssembliesPropertyIsAbsent_ReturnsEmptyDependencies()
+        {
+            const string json = "{\"frameworks\":{\"a\":{}}}";
+
+            TargetFrameworkInformation framework = GetFramework(json);
+
+            Assert.Empty(framework.Dependencies);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenFrameworksFrameworkAssembliesValueIsNull_ReturnsEmptyDependencies()
+        {
+            const string json = "{\"frameworks\":{\"a\":{\"frameworkAssemblies\":null}}}";
+
+            TargetFrameworkInformation framework = GetFramework(json);
+
+            Assert.Empty(framework.Dependencies);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenFrameworksFrameworkAssembliesValueIsEmptyObject_ReturnsEmptyDependencies()
+        {
+            const string json = "{\"frameworks\":{\"a\":{\"frameworkAssemblies\":{}}}}";
+
+            TargetFrameworkInformation framework = GetFramework(json);
+
+            Assert.Empty(framework.Dependencies);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenFrameworksFrameworkAssembliesDependencyTargetPropertyIsAbsent_ReturnsTarget()
+        {
+            const string json = "{\"frameworks\":{\"a\":{\"frameworkAssemblies\":{\"b\":{\"version\":\"1.0.0\"}}}}}";
+
+            LibraryDependency dependency = GetFrameworksDependency(json);
+
+            Assert.Equal(LibraryDependencyTarget.Reference, dependency.LibraryRange.TypeConstraint);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenFrameworksFrameworkAssembliesDependencyTargetValueIsPackageAndVersionPropertyIsAbsent_Throws()
+        {
+            const string json = "{\"frameworks\":{\"a\":{\"frameworkAssemblies\":{\"b\":{\"target\":\"Package\"}}}}}";
+
+            FileFormatException exception = Assert.Throws<FileFormatException>(() => GetPackageSpec(json));
+
+            Assert.Equal("Error reading '' at line 1 column 20 : Error reading '' at line 1 column 48 : Package dependencies must specify a version range.", exception.Message);
+            Assert.Equal(1, exception.Line);
+            Assert.Equal(20, exception.Column);
+            Assert.IsType<FileFormatException>(exception.InnerException);
+            Assert.IsType<ArgumentException>(exception.InnerException.InnerException);
+            Assert.Null(exception.InnerException.InnerException.InnerException);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenFrameworksFrameworkAssembliesDependencyTargetValueIsProjectAndVersionPropertyIsAbsent_ReturnsAllVersionRange()
+        {
+            const string json = "{\"frameworks\":{\"a\":{\"frameworkAssemblies\":{\"b\":{\"target\":\"Project\"}}}}}";
+
+            LibraryDependency dependency = GetFrameworksDependency(json);
+
+            Assert.Equal(VersionRange.All, dependency.LibraryRange.VersionRange);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenFrameworksFrameworkReferencesPropertyIsAbsent_ReturnsEmptyFrameworkReferences()
+        {
+            const string json = "{\"frameworks\":{\"a\":{}}}";
+
+            TargetFrameworkInformation framework = GetFramework(json);
+
+            Assert.Empty(framework.FrameworkReferences);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenFrameworksFrameworkReferencesValueIsNull_ReturnsEmptyFrameworkReferences()
+        {
+            const string json = "{\"frameworks\":{\"a\":{\"frameworkReferences\":null}}}";
+
+            TargetFrameworkInformation framework = GetFramework(json);
+
+            Assert.Empty(framework.FrameworkReferences);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenFrameworksFrameworkReferencesValueIsEmptyObject_ReturnsEmptyFrameworkReferences()
+        {
+            const string json = "{\"frameworks\":{\"a\":{\"frameworkReferences\":{}}}}";
+
+            TargetFrameworkInformation framework = GetFramework(json);
+
+            Assert.Empty(framework.FrameworkReferences);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenFrameworksFrameworkReferencesFrameworkNameIsEmptyString_Throws()
+        {
+            const string json = "{\"frameworks\":{\"a\":{\"frameworkReferences\":{\"\":{}}}}}";
+
+            FileFormatException exception = Assert.Throws<FileFormatException>(() => GetPackageSpec(json));
+
+            Assert.Equal("Error reading '' at line 1 column 20 : Unable to resolve frameworkReference.", exception.Message);
+            Assert.Equal(1, exception.Line);
+            Assert.Equal(20, exception.Column);
+            Assert.IsType<FileFormatException>(exception.InnerException);
+            Assert.Null(exception.InnerException.InnerException);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenFrameworksFrameworkReferencesPrivateAssetsPropertyIsAbsent_ReturnsNonePrivateAssets()
+        {
+            var expectedResult = new FrameworkDependency(name: "b", FrameworkDependencyFlags.None);
+            var json = $"{{\"frameworks\":{{\"a\":{{\"frameworkReferences\":{{\"{expectedResult.Name}\":{{}}}}}}}}}}";
+
+            FrameworkDependency dependency = GetFrameworksFrameworkReference(json);
+
+            Assert.Equal(expectedResult, dependency);
+        }
+
+        [Theory]
+        [InlineData("\"null\"")]
+        [InlineData("\"\"")]
+        [InlineData("\"c\"")]
+        public void GetPackageSpec_WhenFrameworksFrameworkReferencesPrivateAssetsValueIsInvalidValue_ReturnsNonePrivateAssets(string privateAssets)
+        {
+            var expectedResult = new FrameworkDependency(name: "b", FrameworkDependencyFlags.None);
+            var json = $"{{\"frameworks\":{{\"a\":{{\"frameworkReferences\":{{\"{expectedResult.Name}\":{{\"privateAssets\":{privateAssets}}}}}}}}}}}";
+
+            FrameworkDependency dependency = GetFrameworksFrameworkReference(json);
+
+            Assert.Equal(expectedResult, dependency);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenFrameworksFrameworkReferencesPrivateAssetsValueIsValidString_ReturnsPrivateAssets()
+        {
+            var expectedResult = new FrameworkDependency(name: "b", FrameworkDependencyFlags.All);
+            var json = $"{{\"frameworks\":{{\"a\":{{\"frameworkReferences\":{{\"{expectedResult.Name}\":{{\"privateAssets\":\"{expectedResult.PrivateAssets.ToString().ToLowerInvariant()}\"}}}}}}}}}}";
+
+            FrameworkDependency dependency = GetFrameworksFrameworkReference(json);
+
+            Assert.Equal(expectedResult, dependency);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenFrameworksFrameworkReferencesPrivateAssetsValueIsValidDelimitedString_ReturnsPrivateAssets()
+        {
+            var expectedResult = new FrameworkDependency(name: "b", FrameworkDependencyFlags.All);
+            var json = $"{{\"frameworks\":{{\"a\":{{\"frameworkReferences\":{{\"{expectedResult.Name}\":{{\"privateAssets\":\"none,all\"}}}}}}}}}}";
+
+            FrameworkDependency dependency = GetFrameworksFrameworkReference(json);
+
+            Assert.Equal(expectedResult, dependency);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenFrameworksImportsPropertyIsAbsent_ReturnsEmptyImports()
+        {
+            const string json = "{\"frameworks\":{\"a\":{}}}";
+
+            TargetFrameworkInformation framework = GetFramework(json);
+
+            Assert.Empty(framework.Imports);
+        }
+
+        [Theory]
+        [InlineData("null")]
+        [InlineData("\"\"")]
+        public void GetPackageSpec_WhenFrameworksImportsValueIsArrayOfNullOrEmptyString_ImportIsSkipped(string import)
+        {
+            var json = $"{{\"frameworks\":{{\"a\":{{\"imports\":[{import}]}}}}}}";
+
+            TargetFrameworkInformation framework = GetFramework(json);
+
+            Assert.Empty(framework.Imports);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenFrameworksImportsValueIsNull_ReturnsEmptyList()
+        {
+            const string json = "{\"frameworks\":{\"a\":{\"imports\":null}}}";
+
+            TargetFrameworkInformation framework = GetFramework(json);
+
+            Assert.Empty(framework.Imports);
+        }
+
+        [Theory]
+        [InlineData("true")]
+        [InlineData("-2")]
+        [InlineData("3.14")]
+        [InlineData("{}")]
+        public void GetPackageSpec_WhenFrameworksImportsValueIsInvalidValue_ReturnsEmptyList(string value)
+        {
+            var json = $"{{\"frameworks\":{{\"a\":{{\"imports\":{value}}}}}}}";
+
+            TargetFrameworkInformation framework = GetFramework(json);
+
+            Assert.Empty(framework.Imports);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenFrameworksImportsValueContainsInvalidValue_Throws()
+        {
+            const string expectedImport = "b";
+
+            var json = $"{{\"frameworks\":{{\"a\":{{\"imports\":[\"{expectedImport}\"]}}}}}}";
+
+            FileFormatException exception = Assert.Throws<FileFormatException>(() => GetPackageSpec(json));
+
+            Assert.Equal(
+                $"Error reading '' at line 1 column 20 : Imports contains an invalid framework: '{expectedImport}' in 'project.json'.",
+                exception.Message);
+            Assert.Equal(1, exception.Line);
+            Assert.Equal(20, exception.Column);
+            Assert.IsType<FileFormatException>(exception.InnerException);
+            Assert.Null(exception.InnerException.InnerException);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenFrameworksImportsValueIsString_ReturnsImport()
+        {
+            NuGetFramework expectedResult = NuGetFramework.Parse("net48");
+            var json = $"{{\"frameworks\":{{\"a\":{{\"imports\":\"{expectedResult.GetShortFolderName()}\"}}}}}}";
+
+            TargetFrameworkInformation framework = GetFramework(json);
+
+            Assert.Collection(
+                framework.Imports,
+                actualResult => Assert.Equal(expectedResult, actualResult));
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenFrameworksImportsValueIsArrayOfStrings_ReturnsImports()
+        {
+            NuGetFramework[] expectedResults = { NuGetFramework.Parse("net472"), NuGetFramework.Parse("net48") };
+            var json = $"{{\"frameworks\":{{\"a\":{{\"imports\":[\"{expectedResults[0].GetShortFolderName()}\",\"{expectedResults[1].GetShortFolderName()}\"]}}}}}}";
+
+            TargetFrameworkInformation framework = GetFramework(json);
+
+            Assert.Collection(
+                framework.Imports,
+                actualResult => Assert.Equal(expectedResults[0], actualResult),
+                actualResult => Assert.Equal(expectedResults[1], actualResult));
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenFrameworksRuntimeIdentifierGraphPathPropertyIsAbsent_ReturnsRuntimeIdentifierGraphPath()
+        {
+            const string json = "{\"frameworks\":{\"a\":{}}}}";
+
+            TargetFrameworkInformation framework = GetFramework(json);
+
+            Assert.Null(framework.RuntimeIdentifierGraphPath);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("b")]
+        public void GetPackageSpec_WhenFrameworksRuntimeIdentifierGraphPathValueIsString_ReturnsRuntimeIdentifierGraphPath(string expectedResult)
+        {
+            string runtimeIdentifierGraphPath = expectedResult == null ? "null" : $"\"{expectedResult}\"";
+            var json = $"{{\"frameworks\":{{\"a\":{{\"runtimeIdentifierGraphPath\":{runtimeIdentifierGraphPath}}}}}}}";
+
+            TargetFrameworkInformation framework = GetFramework(json);
+
+            Assert.Equal(expectedResult, framework.RuntimeIdentifierGraphPath);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenFrameworksWarnPropertyIsAbsent_ReturnsWarn()
+        {
+            const string json = "{\"frameworks\":{\"a\":{}}}}";
+
+            TargetFrameworkInformation framework = GetFramework(json);
+
+            Assert.False(framework.Warn);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void GetPackageSpec_WhenFrameworksWarnValueIsValid_ReturnsWarn(bool expectedResult)
+        {
+            var json = $"{{\"frameworks\":{{\"a\":{{\"warn\":{expectedResult.ToString().ToLowerInvariant()}}}}}}}";
+
+            TargetFrameworkInformation framework = GetFramework(json);
+
+            Assert.Equal(expectedResult, framework.Warn);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenPackIncludePropertyIsAbsent_ReturnsEmptyPackInclude()
+        {
+            PackageSpec packageSpec = GetPackageSpec("{}");
+
+            Assert.Empty(packageSpec.PackInclude);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenPackIncludePropertyIsValid_ReturnsPackInclude()
+        {
+            var expectedResults = new List<KeyValuePair<string, string>>() { new KeyValuePair<string, string>("a", "b"), new KeyValuePair<string, string>("c", "d") };
+            var json = $"{{\"packInclude\":{{\"{expectedResults[0].Key}\":\"{expectedResults[0].Value}\",\"{expectedResults[1].Key}\":\"{expectedResults[1].Value}\"}}}}";
+
+            PackageSpec packageSpec = GetPackageSpec(json);
+
+            Assert.Collection(
+                packageSpec.PackInclude,
+                actualResult => Assert.Equal(expectedResults[0], actualResult),
+                actualResult => Assert.Equal(expectedResults[1], actualResult));
+        }
+
+        [Theory]
+        [InlineData("{}")]
+        [InlineData("{\"packOptions\":null}")]
+        public void GetPackageSpec_WhenPackOptionsPropertyIsAbsentOrValueIsNull_ReturnsPackOptions(string json)
+        {
+            PackageSpec packageSpec = GetPackageSpec(json);
+
+            Assert.NotNull(packageSpec.PackOptions);
+            Assert.Null(packageSpec.PackOptions.IncludeExcludeFiles);
+            Assert.Empty(packageSpec.PackOptions.Mappings);
+            Assert.Empty(packageSpec.PackOptions.PackageType);
+
+            Assert.Null(packageSpec.IconUrl);
+            Assert.Null(packageSpec.LicenseUrl);
+            Assert.Empty(packageSpec.Owners);
+            Assert.Null(packageSpec.ProjectUrl);
+            Assert.Null(packageSpec.ReleaseNotes);
+            Assert.False(packageSpec.RequireLicenseAcceptance);
+            Assert.Null(packageSpec.Summary);
+            Assert.Empty(packageSpec.Tags);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenPackOptionsPropertyIsAbsent_OwnersAndTagsAreEmpty()
+        {
+            const string json = "{\"owners\":[\"a\"],\"tags\":[\"b\"]}";
+
+            PackageSpec packageSpec = GetPackageSpec(json);
+
+            Assert.Empty(packageSpec.Owners);
+            Assert.Empty(packageSpec.Tags);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenPackOptionsPropertyIsEmptyObject_ReturnsPackOptions()
+        {
+            string json = "{\"packOptions\":{}}";
+
+            PackageSpec packageSpec = GetPackageSpec(json);
+
+            Assert.NotNull(packageSpec.PackOptions);
+            Assert.Null(packageSpec.PackOptions.IncludeExcludeFiles);
+            Assert.Null(packageSpec.PackOptions.Mappings);
+            Assert.Empty(packageSpec.PackOptions.PackageType);
+
+            Assert.Null(packageSpec.IconUrl);
+            Assert.Null(packageSpec.LicenseUrl);
+            Assert.Empty(packageSpec.Owners);
+            Assert.Null(packageSpec.ProjectUrl);
+            Assert.Null(packageSpec.ReleaseNotes);
+            Assert.False(packageSpec.RequireLicenseAcceptance);
+            Assert.Null(packageSpec.Summary);
+            Assert.Empty(packageSpec.Tags);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenPackOptionsValueIsValid_ReturnsPackOptions()
+        {
+            const string iconUrl = "a";
+            const string licenseUrl = "b";
+            string[] owners = { "c", "d" };
+            const string projectUrl = "e";
+            const string releaseNotes = "f";
+            const bool requireLicenseAcceptance = true;
+            const string summary = "g";
+            string[] tags = { "h", "i" };
+
+            var json = $"{{\"packOptions\":{{\"iconUrl\":\"{iconUrl}\",\"licenseUrl\":\"{licenseUrl}\",\"owners\":[{string.Join(",", owners.Select(owner => $"\"{owner}\""))}]," +
+                $"\"projectUrl\":\"{projectUrl}\",\"releaseNotes\":\"{releaseNotes}\",\"requireLicenseAcceptance\":{requireLicenseAcceptance.ToString().ToLowerInvariant()}," +
+                $"\"summary\":\"{summary}\",\"tags\":[{string.Join(",", tags.Select(tag => $"\"{tag}\""))}]}}}}";
+
+            PackageSpec packageSpec = GetPackageSpec(json);
+
+            Assert.NotNull(packageSpec.PackOptions);
+            Assert.Null(packageSpec.PackOptions.IncludeExcludeFiles);
+            Assert.Null(packageSpec.PackOptions.Mappings);
+            Assert.Empty(packageSpec.PackOptions.PackageType);
+            Assert.Equal(iconUrl, packageSpec.IconUrl);
+            Assert.Equal(licenseUrl, packageSpec.LicenseUrl);
+            Assert.Equal(owners, packageSpec.Owners);
+            Assert.Equal(projectUrl, packageSpec.ProjectUrl);
+            Assert.Equal(releaseNotes, packageSpec.ReleaseNotes);
+            Assert.Equal(requireLicenseAcceptance, packageSpec.RequireLicenseAcceptance);
+            Assert.Equal(summary, packageSpec.Summary);
+            Assert.Equal(tags, packageSpec.Tags);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenPackOptionsPackageTypeValueIsNull_ReturnsEmptyPackageTypes()
+        {
+            const string json = "{\"packOptions\":{\"packageType\":null}}";
+
+            PackageSpec packageSpec = GetPackageSpec(json);
+
+            Assert.Empty(packageSpec.PackOptions.PackageType);
+        }
+
+        [Theory]
+        [InlineData("true", 34)]
+        [InlineData("-2", 32)]
+        [InlineData("3.14", 34)]
+        [InlineData("{}", 31)]
+        [InlineData("[true]", 31)]
+        [InlineData("[-2]", 31)]
+        [InlineData("[3.14]", 31)]
+        [InlineData("[null]", 31)]
+        [InlineData("[{}]", 31)]
+        [InlineData("[[]]", 31)]
+        public void GetPackageSpec_WhenPackOptionsPackageTypeIsInvalid_Throws(string value, int expectedColumn)
+        {
+            var json = $"{{\"packOptions\":{{\"packageType\":{value}}}}}";
+
+            FileFormatException exception = Assert.Throws<FileFormatException>(() => GetPackageSpec(json));
+
+            Assert.Equal("The pack options package type must be a string or array of strings in 'project.json'.", exception.Message);
+            Assert.Equal(1, exception.Line);
+            Assert.Equal(expectedColumn, exception.Column);
+            Assert.Null(exception.InnerException);
+        }
+
+        [Theory]
+        [InlineData("\"a\"", "a")]
+        [InlineData("\"a,b\"", "a,b")]
+        [InlineData("[\"a\"]", "a")]
+        [InlineData("[\"a b\"]", "a b")]
+        public void GetPackageSpec_WhenPackOptionsPackageTypeValueIsValid_ReturnsPackageTypes(string value, string expectedName)
+        {
+            var expectedResult = new PackageType(expectedName, PackageType.EmptyVersion);
+            var json = $"{{\"packOptions\":{{\"packageType\":{value}}}}}";
+
+            PackageSpec packageSpec = GetPackageSpec(json);
+
+            Assert.Collection(
+                packageSpec.PackOptions.PackageType,
+                actualResult => Assert.Equal(expectedResult, actualResult));
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenPackOptionsFilesValueIsNull_ReturnsNullInclude()
+        {
+            const string json = "{\"packOptions\":{\"files\":null}}";
+
+            PackageSpec packageSpec = GetPackageSpec(json);
+
+            Assert.Null(packageSpec.PackOptions.IncludeExcludeFiles);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenPackOptionsFilesValueIsEmptyObject_ReturnsNullInclude()
+        {
+            const string json = "{\"packOptions\":{\"files\":{}}}";
+
+            PackageSpec packageSpec = GetPackageSpec(json);
+
+            Assert.Null(packageSpec.PackOptions.IncludeExcludeFiles);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenPackOptionsFilesIncludeValueIsNull_ReturnsNullIncludeExcludeFiles()
+        {
+            const string json = "{\"packOptions\":{\"files\":{\"include\":null}}}";
+
+            PackageSpec packageSpec = GetPackageSpec(json);
+
+            Assert.Null(packageSpec.PackOptions.IncludeExcludeFiles);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenPackOptionsFilesIncludeValueIsEmptyArray_ReturnsEmptyInclude()
+        {
+            const string json = "{\"packOptions\":{\"files\":{\"include\":[]}}}";
+
+            PackageSpec packageSpec = GetPackageSpec(json);
+
+            Assert.Empty(packageSpec.PackOptions.IncludeExcludeFiles.Include);
+        }
+
+        [Theory]
+        [InlineData("\"a\"", "a")]
+        [InlineData("\"a, b\"", "a, b")]
+        [InlineData("[null]", null)]
+        [InlineData("[\"\"]", "")]
+        [InlineData("[\"a\"]", "a")]
+        [InlineData("[\"a, b\"]", "a, b")]
+        [InlineData("[\"a\", \"b\"]", "a", "b")]
+        public void GetPackageSpec_WhenPackOptionsFilesIncludeValueIsValid_ReturnsInclude(string value, params string[] expectedResults)
+        {
+            expectedResults = expectedResults ?? new string[] { null };
+
+            var json = $"{{\"packOptions\":{{\"files\":{{\"include\":{value}}}}}}}";
+
+            PackageSpec packageSpec = GetPackageSpec(json);
+
+            Assert.Equal(expectedResults, packageSpec.PackOptions.IncludeExcludeFiles.Include);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenPackOptionsFilesIncludeFilesValueIsNull_ReturnsNullIncludeExcludeFiles()
+        {
+            const string json = "{\"packOptions\":{\"files\":{\"includeFiles\":null}}}";
+
+            PackageSpec packageSpec = GetPackageSpec(json);
+
+            Assert.Null(packageSpec.PackOptions.IncludeExcludeFiles);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenPackOptionsFilesIncludeFilesValueIsEmptyArray_ReturnsEmptyIncludeFiles()
+        {
+            const string json = "{\"packOptions\":{\"files\":{\"includeFiles\":[]}}}";
+
+            PackageSpec packageSpec = GetPackageSpec(json);
+
+            Assert.Empty(packageSpec.PackOptions.IncludeExcludeFiles.IncludeFiles);
+        }
+
+        [Theory]
+        [InlineData("\"a\"", "a")]
+        [InlineData("\"a, b\"", "a, b")]
+        [InlineData("[null]", null)]
+        [InlineData("[\"\"]", "")]
+        [InlineData("[\"a\"]", "a")]
+        [InlineData("[\"a, b\"]", "a, b")]
+        [InlineData("[\"a\", \"b\"]", "a", "b")]
+        public void GetPackageSpec_WhenPackOptionsFilesIncludeFilesValueIsValid_ReturnsIncludeFiles(string value, params string[] expectedResults)
+        {
+            expectedResults = expectedResults ?? new string[] { null };
+
+            var json = $"{{\"packOptions\":{{\"files\":{{\"includeFiles\":{value}}}}}}}";
+
+            PackageSpec packageSpec = GetPackageSpec(json);
+
+            Assert.Equal(expectedResults, packageSpec.PackOptions.IncludeExcludeFiles.IncludeFiles);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenPackOptionsFilesExcludeValueIsNull_ReturnsNullIncludeExcludeFiles()
+        {
+            const string json = "{\"packOptions\":{\"files\":{\"exclude\":null}}}";
+
+            PackageSpec packageSpec = GetPackageSpec(json);
+
+            Assert.Null(packageSpec.PackOptions.IncludeExcludeFiles);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenPackOptionsFilesExcludeValueIsEmptyArray_ReturnsEmptyExclude()
+        {
+            const string json = "{\"packOptions\":{\"files\":{\"exclude\":[]}}}";
+
+            PackageSpec packageSpec = GetPackageSpec(json);
+
+            Assert.Empty(packageSpec.PackOptions.IncludeExcludeFiles.Exclude);
+        }
+
+        [Theory]
+        [InlineData("\"a\"", "a")]
+        [InlineData("\"a, b\"", "a, b")]
+        [InlineData("[null]", null)]
+        [InlineData("[\"\"]", "")]
+        [InlineData("[\"a\"]", "a")]
+        [InlineData("[\"a, b\"]", "a, b")]
+        [InlineData("[\"a\", \"b\"]", "a", "b")]
+        public void GetPackageSpec_WhenPackOptionsFilesExcludeValueIsValid_ReturnsExclude(string value, params string[] expectedResults)
+        {
+            expectedResults = expectedResults ?? new string[] { null };
+
+            var json = $"{{\"packOptions\":{{\"files\":{{\"exclude\":{value}}}}}}}";
+
+            PackageSpec packageSpec = GetPackageSpec(json);
+
+            Assert.Equal(expectedResults, packageSpec.PackOptions.IncludeExcludeFiles.Exclude);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenPackOptionsFilesExcludeFilesValueIsNull_ReturnsNullIncludeExcludeFiles()
+        {
+            const string json = "{\"packOptions\":{\"files\":{\"excludeFiles\":null}}}";
+
+            PackageSpec packageSpec = GetPackageSpec(json);
+
+            Assert.Null(packageSpec.PackOptions.IncludeExcludeFiles);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenPackOptionsFilesExcludeFilesValueIsEmptyArray_ReturnsEmptyExcludeFiles()
+        {
+            const string json = "{\"packOptions\":{\"files\":{\"excludeFiles\":[]}}}";
+
+            PackageSpec packageSpec = GetPackageSpec(json);
+
+            Assert.Empty(packageSpec.PackOptions.IncludeExcludeFiles.ExcludeFiles);
+        }
+
+        [Theory]
+        [InlineData("\"a\"", "a")]
+        [InlineData("\"a, b\"", "a, b")]
+        [InlineData("[null]", null)]
+        [InlineData("[\"\"]", "")]
+        [InlineData("[\"a\"]", "a")]
+        [InlineData("[\"a, b\"]", "a, b")]
+        [InlineData("[\"a\", \"b\"]", "a", "b")]
+        public void GetPackageSpec_WhenPackOptionsFilesExcludeFilesValueIsValid_ReturnsExcludeFiles(string value, params string[] expectedResults)
+        {
+            expectedResults = expectedResults ?? new string[] { null };
+
+            var json = $"{{\"packOptions\":{{\"files\":{{\"excludeFiles\":{value}}}}}}}";
+
+            PackageSpec packageSpec = GetPackageSpec(json);
+
+            Assert.Equal(expectedResults, packageSpec.PackOptions.IncludeExcludeFiles.ExcludeFiles);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenPackOptionsFilesMappingsPropertyIsAbsent_ReturnsNullMappings()
+        {
+            const string json = "{\"packOptions\":{\"files\":{}}}";
+
+            PackageSpec packageSpec = GetPackageSpec(json);
+
+            Assert.Null(packageSpec.PackOptions.Mappings);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenPackOptionsFilesMappingsValueIsNull_ReturnsNullMappings()
+        {
+            const string json = "{\"packOptions\":{\"files\":{\"mappings\":null}}}";
+
+            PackageSpec packageSpec = GetPackageSpec(json);
+
+            Assert.Null(packageSpec.PackOptions.Mappings);
+        }
+
+        [Theory]
+        [InlineData("\"b\"", "b")]
+        [InlineData("\"b,c\"", "b,c")]
+        [InlineData("[\"b\", \"c\"]", "b", "c")]
+        public void GetPackageSpec_WhenPackOptionsFilesMappingsValueIsValid_ReturnsMappings(string value, params string[] expectedIncludes)
+        {
+            var expectedResults = new Dictionary<string, IncludeExcludeFiles>()
+            {
+                { "a", new IncludeExcludeFiles() { Include = expectedIncludes } }
+            };
+            var json = $"{{\"packOptions\":{{\"files\":{{\"mappings\":{{\"a\":{value}}}}}}}}}";
+
+            PackageSpec packageSpec = GetPackageSpec(json);
+
+            Assert.Equal(expectedResults, packageSpec.PackOptions.Mappings);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenPackOptionsFilesMappingsValueHasMultipleMappings_ReturnsMappings()
+        {
+            var expectedResults = new Dictionary<string, IncludeExcludeFiles>()
+            {
+                { "a", new IncludeExcludeFiles() { Include = new[] { "b" } } },
+                { "c", new IncludeExcludeFiles() { Include = new[] { "d", "e" } } }
+            };
+            const string json = "{\"packOptions\":{\"files\":{\"mappings\":{\"a\":\"b\",\"c\":[\"d\", \"e\"]}}}}";
+
+            PackageSpec packageSpec = GetPackageSpec(json);
+
+            Assert.Equal(expectedResults, packageSpec.PackOptions.Mappings);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenPackOptionsFilesMappingsValueHasFiles_ReturnsMappings()
+        {
+            var expectedResults = new Dictionary<string, IncludeExcludeFiles>()
+            {
+                {
+                    "a",
+                    new IncludeExcludeFiles()
+                    {
+                        Include = new [] { "b" },
+                        IncludeFiles = new [] { "c" },
+                        Exclude = new [] { "d" },
+                        ExcludeFiles = new [] { "e" }
+                    }
+                }
+            };
+            const string json = "{\"packOptions\":{\"files\":{\"mappings\":{\"a\":{\"include\":\"b\",\"includeFiles\":\"c\",\"exclude\":\"d\",\"excludeFiles\":\"e\"}}}}}";
+
+            PackageSpec packageSpec = GetPackageSpec(json);
+
+            Assert.Equal(expectedResults, packageSpec.PackOptions.Mappings);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenRestorePropertyIsAbsent_ReturnsNullRestoreMetadata()
+        {
+            const string json = "{}";
+            PackageSpec packageSpec = GetPackageSpec(json);
+
+            Assert.Null(packageSpec.RestoreMetadata);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenRestoreValueIsEmptyObject_ReturnsRestoreMetadata()
+        {
+            const string json = "{\"restore\":{}}";
+            PackageSpec packageSpec = GetPackageSpec(json);
+
+            Assert.NotNull(packageSpec.RestoreMetadata);
+        }
+
+        [Theory]
+        [InlineData("null")]
+        [InlineData("\"\"")]
+        [InlineData("\"a\"")]
+        public void GetPackageSpec_WhenRestoreProjectStyleValueIsInvalid_ReturnsProjectStyle(string value)
+        {
+            var json = $"{{\"restore\":{{\"projectStyle\":{value}}}}}";
+            PackageSpec packageSpec = GetPackageSpec(json);
+
+            Assert.Equal(ProjectStyle.Unknown, packageSpec.RestoreMetadata.ProjectStyle);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenRestoreProjectStyleValueIsValid_ReturnsProjectStyle()
+        {
+            const ProjectStyle expectedResult = ProjectStyle.PackageReference;
+
+            var json = $"{{\"restore\":{{\"projectStyle\":\"{expectedResult.ToString().ToLowerInvariant()}\"}}}}";
+            PackageSpec packageSpec = GetPackageSpec(json);
+
+            Assert.Equal(expectedResult, packageSpec.RestoreMetadata.ProjectStyle);
+        }
+
+        [Theory]
+        [InlineData("null", null)]
+        [InlineData("\"\"", "")]
+        [InlineData("\"a\"", "a")]
+        public void GetPackageSpec_WhenRestoreProjectUniqueNameValueIsValid_ReturnsProjectUniqueName(
+            string value,
+            string expectedValue)
+        {
+            var json = $"{{\"restore\":{{\"projectUniqueName\":{value}}}}}";
+            PackageSpec packageSpec = GetPackageSpec(json);
+
+            Assert.Equal(expectedValue, packageSpec.RestoreMetadata.ProjectUniqueName);
+        }
+
+        [Theory]
+        [InlineData("null", null)]
+        [InlineData("\"\"", "")]
+        [InlineData("\"a\"", "a")]
+        public void GetPackageSpec_WhenRestoreOutputPathValueIsValid_ReturnsOutputPath(
+            string value,
+            string expectedValue)
+        {
+            var json = $"{{\"restore\":{{\"outputPath\":{value}}}}}";
+            PackageSpec packageSpec = GetPackageSpec(json);
+
+            Assert.Equal(expectedValue, packageSpec.RestoreMetadata.OutputPath);
+        }
+
+        [Theory]
+        [InlineData("null", null)]
+        [InlineData("\"\"", "")]
+        [InlineData("\"a\"", "a")]
+        public void GetPackageSpec_WhenRestorePackagesPathValueIsValid_ReturnsPackagesPath(
+            string value,
+            string expectedValue)
+        {
+            var json = $"{{\"restore\":{{\"packagesPath\":{value}}}}}";
+            PackageSpec packageSpec = GetPackageSpec(json);
+
+            Assert.Equal(expectedValue, packageSpec.RestoreMetadata.PackagesPath);
+        }
+
+        [Theory]
+        [InlineData("null", null)]
+        [InlineData("\"\"", "")]
+        [InlineData("\"a\"", "a")]
+        public void GetPackageSpec_WhenRestoreProjectJsonPathValueIsValid_ReturnsProjectJsonPath(
+            string value,
+            string expectedValue)
+        {
+            var json = $"{{\"restore\":{{\"projectJsonPath\":{value}}}}}";
+            PackageSpec packageSpec = GetPackageSpec(json);
+
+            Assert.Equal(expectedValue, packageSpec.RestoreMetadata.ProjectJsonPath);
+        }
+
+        [Theory]
+        [InlineData("null", null)]
+        [InlineData("\"\"", "")]
+        [InlineData("\"a\"", "a")]
+        public void GetPackageSpec_WhenRestoreProjectNameValueIsValid_ReturnsProjectName(
+            string value,
+            string expectedValue)
+        {
+            var json = $"{{\"restore\":{{\"projectName\":{value}}}}}";
+            PackageSpec packageSpec = GetPackageSpec(json);
+
+            Assert.Equal(expectedValue, packageSpec.RestoreMetadata.ProjectName);
+        }
+
+        [Theory]
+        [InlineData("null", null)]
+        [InlineData("\"\"", "")]
+        [InlineData("\"a\"", "a")]
+        public void GetPackageSpec_WhenRestoreProjectPathValueIsValid_ReturnsProjectPath(
+            string value,
+            string expectedValue)
+        {
+            var json = $"{{\"restore\":{{\"projectPath\":{value}}}}}";
+            PackageSpec packageSpec = GetPackageSpec(json);
+
+            Assert.Equal(expectedValue, packageSpec.RestoreMetadata.ProjectPath);
+        }
+
+        [Theory]
+        [InlineData(null, false)]
+        [InlineData(true, true)]
+        [InlineData(false, false)]
+        public void GetPackageSpec_WhenCrossTargetingValueIsValid_ReturnsCrossTargeting(
+            bool? value,
+            bool expectedValue)
+        {
+            var json = $"{{\"restore\":{{\"crossTargeting\":{(value.HasValue ? value.ToString().ToLowerInvariant() : "null")}}}}}";
+            PackageSpec packageSpec = GetPackageSpec(json);
+
+            Assert.Equal(expectedValue, packageSpec.RestoreMetadata.CrossTargeting);
+        }
+
+        [Theory]
+        [InlineData(null, false)]
+        [InlineData(true, true)]
+        [InlineData(false, false)]
+        public void GetPackageSpec_WhenLegacyPackagesDirectoryValueIsValid_ReturnsLegacyPackagesDirectory(
+            bool? value,
+            bool expectedValue)
+        {
+            var json = $"{{\"restore\":{{\"legacyPackagesDirectory\":{(value.HasValue ? value.ToString().ToLowerInvariant() : "null")}}}}}";
+            PackageSpec packageSpec = GetPackageSpec(json);
+
+            Assert.Equal(expectedValue, packageSpec.RestoreMetadata.LegacyPackagesDirectory);
+        }
+
+        [Theory]
+        [InlineData(null, false)]
+        [InlineData(true, true)]
+        [InlineData(false, false)]
+        public void GetPackageSpec_WhenValidateRuntimeAssetsValueIsValid_ReturnsValidateRuntimeAssets(
+            bool? value,
+            bool expectedValue)
+        {
+            var json = $"{{\"restore\":{{\"validateRuntimeAssets\":{(value.HasValue ? value.ToString().ToLowerInvariant() : "null")}}}}}";
+            PackageSpec packageSpec = GetPackageSpec(json);
+
+            Assert.Equal(expectedValue, packageSpec.RestoreMetadata.ValidateRuntimeAssets);
+        }
+
+        [Theory]
+        [InlineData(null, false)]
+        [InlineData(true, true)]
+        [InlineData(false, false)]
+        public void GetPackageSpec_WhenSkipContentFileWriteValueIsValid_ReturnsSkipContentFileWrite(
+            bool? value,
+            bool expectedValue)
+        {
+            var json = $"{{\"restore\":{{\"skipContentFileWrite\":{(value.HasValue ? value.ToString().ToLowerInvariant() : "null")}}}}}";
+            PackageSpec packageSpec = GetPackageSpec(json);
+
+            Assert.Equal(expectedValue, packageSpec.RestoreMetadata.SkipContentFileWrite);
+        }
+
+        [Theory]
+        [InlineData(null, false)]
+        [InlineData(true, true)]
+        [InlineData(false, false)]
+        public void GetPackageSpec_WhenCentralPackageVersionsManagementEnabledValueIsValid_ReturnsCentralPackageVersionsManagementEnabled(
+            bool? value,
+            bool expectedValue)
+        {
+            var json = $"{{\"restore\":{{\"centralPackageVersionsManagementEnabled\":{(value.HasValue ? value.ToString().ToLowerInvariant() : "null")}}}}}";
+            PackageSpec packageSpec = GetPackageSpec(json);
+
+            Assert.Equal(expectedValue, packageSpec.RestoreMetadata.CentralPackageVersionsEnabled);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenSourcesValueIsEmptyObject_ReturnsEmptySources()
+        {
+            const string json = "{\"restore\":{\"sources\":{}}}";
+            PackageSpec packageSpec = GetPackageSpec(json);
+
+            Assert.Empty(packageSpec.RestoreMetadata.Sources);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenSourcesValueIsValid_ReturnsSources()
+        {
+            PackageSource[] expectedResults = { new PackageSource(source: "a"), new PackageSource(source: "b") };
+            string values = string.Join(",", expectedResults.Select(expectedResult => $"\"{expectedResult.Name}\":{{}}"));
+            var json = $"{{\"restore\":{{\"sources\":{{{values}}}}}}}";
+            PackageSpec packageSpec = GetPackageSpec(json);
+
+            Assert.Equal(expectedResults, packageSpec.RestoreMetadata.Sources);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenFilesValueIsEmptyObject_ReturnsEmptyFiles()
+        {
+            const string json = "{\"restore\":{\"files\":{}}}";
+            PackageSpec packageSpec = GetPackageSpec(json);
+
+            Assert.Empty(packageSpec.RestoreMetadata.Files);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenFilesValueIsValid_ReturnsFiles()
+        {
+            ProjectRestoreMetadataFile[] expectedResults =
+            {
+                new ProjectRestoreMetadataFile(packagePath: "a", absolutePath: "b"),
+                new ProjectRestoreMetadataFile(packagePath: "c", absolutePath:"d")
+            };
+            string values = string.Join(",", expectedResults.Select(expectedResult => $"\"{expectedResult.PackagePath}\":\"{expectedResult.AbsolutePath}\""));
+            var json = $"{{\"restore\":{{\"files\":{{{values}}}}}}}";
+            PackageSpec packageSpec = GetPackageSpec(json);
+
+            Assert.Equal(expectedResults, packageSpec.RestoreMetadata.Files);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenRestoreFrameworksValueIsEmptyObject_ReturnsEmptyFrameworks()
+        {
+            const string json = "{\"restore\":{\"frameworks\":{}}}";
+            PackageSpec packageSpec = GetPackageSpec(json);
+
+            Assert.Empty(packageSpec.RestoreMetadata.TargetFrameworks);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenRestoreFrameworksFrameworkNameValueIsValid_ReturnsFrameworks()
+        {
+            var expectedResult = new ProjectRestoreMetadataFrameworkInfo(NuGetFramework.ParseFolder("net472"));
+            var json = $"{{\"restore\":{{\"frameworks\":{{\"{expectedResult.FrameworkName.GetShortFolderName()}\":{{}}}}}}}}";
+            PackageSpec packageSpec = GetPackageSpec(json);
+
+            Assert.Collection(
+                packageSpec.RestoreMetadata.TargetFrameworks,
+                actualResult => Assert.Equal(expectedResult, actualResult));
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenRestoreFrameworksFrameworkValueHasProjectReferenceWithoutAssets_ReturnsFrameworks()
+        {
+            var projectReference = new ProjectRestoreReference()
+            {
+                ProjectUniqueName = "a",
+                ProjectPath = "b"
+            };
+            var expectedResult = new ProjectRestoreMetadataFrameworkInfo(NuGetFramework.ParseFolder("net472"));
+
+            expectedResult.ProjectReferences.Add(projectReference);
+
+            var json = $"{{\"restore\":{{\"frameworks\":{{\"{expectedResult.FrameworkName.GetShortFolderName()}\":{{\"projectReferences\":{{" +
+                $"\"{projectReference.ProjectUniqueName}\":{{\"projectPath\":\"{projectReference.ProjectPath}\"}}}}}}}}}}}}";
+            PackageSpec packageSpec = GetPackageSpec(json);
+
+            Assert.Collection(
+                packageSpec.RestoreMetadata.TargetFrameworks,
+                actualResult => Assert.Equal(expectedResult, actualResult));
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenRestoreFrameworksFrameworkValueHasProjectReferenceWithAssets_ReturnsFrameworks()
+        {
+            var projectReference = new ProjectRestoreReference()
+            {
+                ProjectUniqueName = "a",
+                ProjectPath = "b",
+                IncludeAssets = LibraryIncludeFlags.Analyzers,
+                ExcludeAssets = LibraryIncludeFlags.Native,
+                PrivateAssets = LibraryIncludeFlags.Runtime
+            };
+            var expectedResult = new ProjectRestoreMetadataFrameworkInfo(NuGetFramework.ParseFolder("net472"));
+
+            expectedResult.ProjectReferences.Add(projectReference);
+
+            var json = $"{{\"restore\":{{\"frameworks\":{{\"{expectedResult.FrameworkName.GetShortFolderName()}\":{{\"projectReferences\":{{" +
+                $"\"{projectReference.ProjectUniqueName}\":{{\"projectPath\":\"{projectReference.ProjectPath}\"," +
+                $"\"includeAssets\":\"{projectReference.IncludeAssets}\",\"excludeAssets\":\"{projectReference.ExcludeAssets}\"," +
+                $"\"privateAssets\":\"{projectReference.PrivateAssets}\"}}}}}}}}}}}}";
+            PackageSpec packageSpec = GetPackageSpec(json);
+
+            Assert.Collection(
+                packageSpec.RestoreMetadata.TargetFrameworks,
+                actualResult => Assert.Equal(expectedResult, actualResult));
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenRestoreConfigFilePathsValueIsEmptyArray_ReturnsEmptyConfigFilePaths()
+        {
+            const string json = "{\"restore\":{\"configFilePaths\":[]}}";
+            PackageSpec packageSpec = GetPackageSpec(json);
+
+            Assert.Empty(packageSpec.RestoreMetadata.ConfigFilePaths);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenRestoreConfigFilePathsValueIsValid_ReturnsConfigFilePaths()
+        {
+            string[] expectedResults = { "a", "b" };
+            string values = string.Join(",", expectedResults.Select(expectedResult => $"\"{expectedResult}\""));
+            var json = $"{{\"restore\":{{\"configFilePaths\":[{values}]}}}}";
+            PackageSpec packageSpec = GetPackageSpec(json);
+
+            Assert.Equal(expectedResults, packageSpec.RestoreMetadata.ConfigFilePaths);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenRestoreFallbackFoldersValueIsEmptyArray_ReturnsEmptyFallbackFolders()
+        {
+            const string json = "{\"restore\":{\"fallbackFolders\":[]}}";
+            PackageSpec packageSpec = GetPackageSpec(json);
+
+            Assert.Empty(packageSpec.RestoreMetadata.FallbackFolders);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenRestoreFallbackFoldersValueIsValid_ReturnsConfigFilePaths()
+        {
+            string[] expectedResults = { "a", "b" };
+            string values = string.Join(",", expectedResults.Select(expectedResult => $"\"{expectedResult}\""));
+            var json = $"{{\"restore\":{{\"fallbackFolders\":[{values}]}}}}";
+            PackageSpec packageSpec = GetPackageSpec(json);
+
+            Assert.Equal(expectedResults, packageSpec.RestoreMetadata.FallbackFolders);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenRestoreOriginalTargetFrameworksValueIsEmptyArray_ReturnsEmptyOriginalTargetFrameworks()
+        {
+            const string json = "{\"restore\":{\"originalTargetFrameworks\":[]}}";
+            PackageSpec packageSpec = GetPackageSpec(json);
+
+            Assert.Empty(packageSpec.RestoreMetadata.OriginalTargetFrameworks);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenRestoreOriginalTargetFrameworksValueIsValid_ReturnsOriginalTargetFrameworks()
+        {
+            string[] expectedResults = { "a", "b" };
+            string values = string.Join(",", expectedResults.Select(expectedResult => $"\"{expectedResult}\""));
+            var json = $"{{\"restore\":{{\"originalTargetFrameworks\":[{values}]}}}}";
+            PackageSpec packageSpec = GetPackageSpec(json);
+
+            Assert.Equal(expectedResults, packageSpec.RestoreMetadata.OriginalTargetFrameworks);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenRestoreWarningPropertiesValueIsEmptyObject_ReturnsWarningProperties()
+        {
+            var expectedResult = new WarningProperties();
+            const string json = "{\"restore\":{\"warningProperties\":{}}}";
+            PackageSpec packageSpec = GetPackageSpec(json);
+
+            Assert.Equal(expectedResult, packageSpec.RestoreMetadata.ProjectWideWarningProperties);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenRestoreWarningPropertiesValueIsValid_ReturnsWarningProperties()
+        {
+            var expectedResult = new WarningProperties(
+                new HashSet<NuGetLogCode>() { NuGetLogCode.NU3000 },
+                new HashSet<NuGetLogCode>() { NuGetLogCode.NU3001 },
+                allWarningsAsErrors: true);
+            var json = $"{{\"restore\":{{\"warningProperties\":{{\"allWarningsAsErrors\":{expectedResult.AllWarningsAsErrors.ToString().ToLowerInvariant()}," +
+                $"\"warnAsError\":[\"{expectedResult.WarningsAsErrors.Single()}\"],\"noWarn\":[\"{expectedResult.NoWarn.Single()}\"]}}}}}}";
+            PackageSpec packageSpec = GetPackageSpec(json);
+
+            Assert.Equal(expectedResult, packageSpec.RestoreMetadata.ProjectWideWarningProperties);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenRestoreRestoreLockPropertiesValueIsEmptyObject_ReturnsRestoreLockProperties()
+        {
+            var expectedResult = new RestoreLockProperties();
+            const string json = "{\"restore\":{\"restoreLockProperties\":{}}}";
+            PackageSpec packageSpec = GetPackageSpec(json);
+
+            Assert.Equal(expectedResult, packageSpec.RestoreMetadata.RestoreLockProperties);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenRestoreRestoreLockPropertiesValueIsValid_ReturnsRestoreLockProperties()
+        {
+            var expectedResult = new RestoreLockProperties(
+                restorePackagesWithLockFile: "a",
+                nuGetLockFilePath: "b",
+                restoreLockedMode: true); ;
+            var json = $"{{\"restore\":{{\"restoreLockProperties\":{{\"restoreLockedMode\":{expectedResult.RestoreLockedMode.ToString().ToLowerInvariant()}," +
+                $"\"restorePackagesWithLockFile\":\"{expectedResult.RestorePackagesWithLockFile}\"," +
+                $"\"nuGetLockFilePath\":\"{expectedResult.NuGetLockFilePath}\"}}}}}}";
+            PackageSpec packageSpec = GetPackageSpec(json);
+
+            Assert.Equal(expectedResult, packageSpec.RestoreMetadata.RestoreLockProperties);
+        }
+
+        [Theory]
+        [InlineData("null")]
+        [InlineData("\"\"")]
+        [InlineData("\"a\"")]
+        public void GetPackageSpec_WhenRestorePackagesConfigPathValueIsValidAndProjectStyleValueIsNotPackagesConfig_DoesNotReturnPackagesConfigPath(
+            string value)
+        {
+            var json = $"{{\"restore\":{{\"projectStyle\":\"PackageReference\",\"packagesConfigPath\":{value}}}}}";
+            PackageSpec packageSpec = GetPackageSpec(json);
+
+            Assert.IsNotType<PackagesConfigProjectRestoreMetadata>(packageSpec.RestoreMetadata);
+        }
+
+        [Theory]
+        [InlineData("null", null)]
+        [InlineData("\"\"", "")]
+        [InlineData("\"a\"", "a")]
+        public void GetPackageSpec_WhenRestorePackagesConfigPathValueIsValidAndProjectStyleValueIsPackagesConfig_ReturnsPackagesConfigPath(
+            string value,
+            string expectedValue)
+        {
+            var json = $"{{\"restore\":{{\"projectStyle\":\"PackagesConfig\",\"packagesConfigPath\":{value}}}}}";
+            PackageSpec packageSpec = GetPackageSpec(json);
+
+            Assert.IsType<PackagesConfigProjectRestoreMetadata>(packageSpec.RestoreMetadata);
+            Assert.Equal(expectedValue, ((PackagesConfigProjectRestoreMetadata)packageSpec.RestoreMetadata).PackagesConfigPath);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenRestoreSettingsValueIsEmptyObject_ReturnsRestoreSettings()
+        {
+            var expectedResult = new ProjectRestoreSettings();
+            const string json = "{\"restoreSettings\":{}}";
+            PackageSpec packageSpec = GetPackageSpec(json);
+
+            Assert.Equal(expectedResult, packageSpec.RestoreSettings);
+        }
+
+        [Theory]
+        [InlineData(null, false)]
+        [InlineData(true, true)]
+        [InlineData(false, false)]
+        public void GetPackageSpec_WhenRestoreSettingsValueIsValid_ReturnsRestoreSettings(
+            bool? value,
+            bool expectedHide)
+        {
+            var expectedResult = new ProjectRestoreSettings() { HideWarningsAndErrors = expectedHide };
+            var json = $"{{\"restoreSettings\":{{\"hideWarningsAndErrors\":{(value == null ? "null" : value.ToString().ToLowerInvariant())}}}}}";
+            PackageSpec packageSpec = GetPackageSpec(json);
+
+            Assert.Equal(expectedResult, packageSpec.RestoreSettings);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenRuntimesValueIsEmptyObject_ReturnsRuntimes()
+        {
+            var expectedResult = new RuntimeGraph();
+            const string json = "{\"runtimes\":{}}";
+            PackageSpec packageSpec = GetPackageSpec(json);
+
+            Assert.Equal(expectedResult, packageSpec.RuntimeGraph);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenRuntimesValueIsValidWithImports_ReturnsRuntimes()
+        {
+            var runtimeDescription = new RuntimeDescription(
+                runtimeIdentifier: "a",
+                inheritedRuntimes: new[] { "b", "c" },
+                Enumerable.Empty<RuntimeDependencySet>());
+            var expectedResult = new RuntimeGraph(new[] { runtimeDescription });
+            var json = $"{{\"runtimes\":{{\"{runtimeDescription.RuntimeIdentifier}\":{{\"#import\":[" +
+                $"{string.Join(",", runtimeDescription.InheritedRuntimes.Select(runtime => $"\"{runtime}\""))}]}}}}}}";
+            PackageSpec packageSpec = GetPackageSpec(json);
+
+            Assert.Equal(expectedResult, packageSpec.RuntimeGraph);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenRuntimesValueIsValidWithDependencySet_ReturnsRuntimes()
+        {
+            var dependencySet = new RuntimeDependencySet(id: "b");
+            var runtimeDescription = new RuntimeDescription(
+                runtimeIdentifier: "a",
+                inheritedRuntimes: Enumerable.Empty<string>(),
+                runtimeDependencySets: new[] { dependencySet });
+            var expectedResult = new RuntimeGraph(new[] { runtimeDescription });
+            var json = $"{{\"runtimes\":{{\"{runtimeDescription.RuntimeIdentifier}\":{{\"{dependencySet.Id}\":{{}}}}}}}}";
+            PackageSpec packageSpec = GetPackageSpec(json);
+
+            Assert.Equal(expectedResult, packageSpec.RuntimeGraph);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenRuntimesValueIsValidWithDependencySetWithDependency_ReturnsRuntimes()
+        {
+            var dependency = new RuntimePackageDependency("c", VersionRange.Parse("[1.2.3,4.5.6)"));
+            var dependencySet = new RuntimeDependencySet(id: "b", new[] { dependency });
+            var runtimeDescription = new RuntimeDescription(
+                runtimeIdentifier: "a",
+                inheritedRuntimes: Enumerable.Empty<string>(),
+                runtimeDependencySets: new[] { dependencySet });
+            var expectedResult = new RuntimeGraph(new[] { runtimeDescription });
+            var json = $"{{\"runtimes\":{{\"{runtimeDescription.RuntimeIdentifier}\":{{\"{dependencySet.Id}\":{{" +
+                $"\"{dependency.Id}\":\"{dependency.VersionRange.ToLegacyString()}\"}}}}}}}}";
+            PackageSpec packageSpec = GetPackageSpec(json);
+
+            Assert.Equal(expectedResult, packageSpec.RuntimeGraph);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenSupportsValueIsEmptyObject_ReturnsSupports()
+        {
+            var expectedResult = new RuntimeGraph();
+            const string json = "{\"supports\":{}}";
+            PackageSpec packageSpec = GetPackageSpec(json);
+
+            Assert.Equal(expectedResult, packageSpec.RuntimeGraph);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenSupportsValueIsValidWithCompatibilityProfiles_ReturnsSupports()
+        {
+            var profile = new CompatibilityProfile(name: "a");
+            var expectedResult = new RuntimeGraph(new[] { profile });
+            var json = $"{{\"supports\":{{\"{profile.Name}\":{{}}}}}}";
+            PackageSpec packageSpec = GetPackageSpec(json);
+
+            Assert.Equal(expectedResult, packageSpec.RuntimeGraph);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenSupportsValueIsValidWithCompatibilityProfilesAndFrameworkRuntimePairs_ReturnsSupports()
+        {
+            FrameworkRuntimePair[] restoreContexts = new[]
+            {
+                new FrameworkRuntimePair(NuGetFramework.Parse("net472"), "b"),
+                new FrameworkRuntimePair(NuGetFramework.Parse("net48"), "c")
+            };
+            var profile = new CompatibilityProfile(name: "a", restoreContexts);
+            var expectedResult = new RuntimeGraph(new[] { profile });
+            var json = $"{{\"supports\":{{\"{profile.Name}\":{{" +
+                $"\"{restoreContexts[0].Framework.GetShortFolderName()}\":\"{restoreContexts[0].RuntimeIdentifier}\"," +
+                $"\"{restoreContexts[1].Framework.GetShortFolderName()}\":[\"{restoreContexts[1].RuntimeIdentifier}\"]}}}}}}";
+            PackageSpec packageSpec = GetPackageSpec(json);
+
+            Assert.Equal(expectedResult, packageSpec.RuntimeGraph);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenScriptsValueIsEmptyObject_ReturnsScripts()
+        {
+            const string json = "{\"scripts\":{}}";
+            PackageSpec packageSpec = GetPackageSpec(json);
+
+            Assert.Empty(packageSpec.Scripts);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenScriptsValueIsInvalid_Throws()
+        {
+            var json = "{\"scripts\":{\"a\":0}}";
+
+            FileFormatException exception = Assert.Throws<FileFormatException>(() => GetPackageSpec(json));
+
+            Assert.Equal("The value of a script in 'project.json' can only be a string or an array of strings", exception.Message);
+            Assert.Equal(1, exception.Line);
+            Assert.Equal(17, exception.Column);
+            Assert.Null(exception.InnerException);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenScriptsValueIsValid_ReturnsScripts()
+        {
+            const string name0 = "a";
+            const string name1 = "b";
+            const string script0 = "c";
+            const string script1 = "d";
+            const string script2 = "e";
+
+            var json = $"{{\"scripts\":{{\"{name0}\":\"{script0}\",\"{name1}\":[\"{script1}\",\"{script2}\"]}}}}";
+            PackageSpec packageSpec = GetPackageSpec(json);
+
+            Assert.Collection(
+                packageSpec.Scripts,
+                actualResult =>
+                {
+                    Assert.Equal(name0, actualResult.Key);
+                    Assert.Collection(
+                        actualResult.Value,
+                        actualScript => Assert.Equal(script0, actualScript));
+                },
+                actualResult =>
+                {
+                    Assert.Equal(name1, actualResult.Key);
+                    Assert.Collection(
+                        actualResult.Value,
+                        actualScript => Assert.Equal(script1, actualScript),
+                        actualScript => Assert.Equal(script2, actualScript));
+                });
+        }
+
+        [Theory]
+        [InlineData("null", null)]
+        [InlineData("\"\"", "")]
+        [InlineData("\"a\"", "a")]
+        public void GetPackageSpec_WhenTitleValueIsValid_ReturnsTitle(string value, string expectedResult)
+        {
+            var json = $"{{\"title\":{value}}}";
+
+            PackageSpec packageSpec = GetPackageSpec(json);
+
+            Assert.Equal(expectedResult, packageSpec.Title);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WhenNameIsNull_RestoreMetadataProvidesFallbackName()
+        {
+            const string expectedResult = "a";
+            var json = $"{{\"restore\":{{\"projectName\":\"{expectedResult}\"}}}}";
+
+            PackageSpec packageSpec = GetPackageSpec(json);
+
+            Assert.Equal(expectedResult, packageSpec.Name);
+        }
+
+        [Theory]
+        [InlineData("{\"restore\":{\"projectJsonPath\":\"a\"}}")]
+        [InlineData("{\"restore\":{\"projectPath\":\"a\"}}")]
+        [InlineData("{\"restore\":{\"projectJsonPath\":\"a\",\"projectPath\":\"b\"}}")]
+        public void GetPackageSpec_WhenFilePathIsNull_RestoreMetadataProvidesFallbackFilePath(string json)
+        {
+            const string expectedResult = "a";
+
+            PackageSpec packageSpec = GetPackageSpec(json);
+
+            Assert.Equal(expectedResult, packageSpec.FilePath);
+        }
+
+        private static PackageSpec GetPackageSpec(string json)
+        {
+            using (var stream = new MemoryStream(Encoding.UTF8.GetBytes(json)))
+            {
+                return JsonPackageSpecReader.GetPackageSpec(stream, name: null, packageSpecPath: null, snapshotValue: null);
+            }
+        }
+
+        private static LibraryDependency GetDependency(string json)
+        {
+            PackageSpec packageSpec = GetPackageSpec(json);
+
+            return packageSpec.Dependencies.Single();
+        }
+
+        private static TargetFrameworkInformation GetFramework(string json)
+        {
+            PackageSpec packageSpec = GetPackageSpec(json);
+
+            return packageSpec.TargetFrameworks.Single();
+        }
+
+        private static LibraryDependency GetFrameworksDependency(string json)
+        {
+            TargetFrameworkInformation framework = GetFramework(json);
+
+            return framework.Dependencies.Single();
+        }
+
+        private static FrameworkDependency GetFrameworksFrameworkReference(string json)
+        {
+            TargetFrameworkInformation framework = GetFramework(json);
+
+            return framework.FrameworkReferences.Single();
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/JsonTextReaderExtensionsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/JsonTextReaderExtensionsTests.cs
@@ -1,0 +1,855 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace NuGet.ProjectModel.Test
+{
+    public class JsonTextReaderExtensionsTests
+    {
+        [Fact]
+        public void ReadDelimitedString_WhenReaderIsNull_Throws()
+        {
+            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
+                () => JsonTextReaderExtensions.ReadDelimitedString(reader: null));
+
+            Assert.Equal("reader", exception.ParamName);
+        }
+
+        [Fact]
+        public void ReadDelimitedString_WhenValueIsNull_Throws()
+        {
+            const string json = "{\"a\":null}";
+
+            using (var test = new Test(json))
+            {
+                Assert.True(test.Reader.Read());
+                Assert.True(test.Reader.Read());
+                Assert.Equal(JsonToken.PropertyName, test.Reader.TokenType);
+
+                Assert.Throws<InvalidCastException>(() => test.Reader.ReadDelimitedString());
+                Assert.Equal(JsonToken.Null, test.Reader.TokenType);
+            }
+        }
+
+        [Theory]
+        [InlineData("true", JsonToken.Boolean)]
+        [InlineData("-2", JsonToken.Integer)]
+        [InlineData("3.14", JsonToken.Float)]
+        [InlineData("{}", JsonToken.StartObject)]
+        public void ReadDelimitedString_WhenValueIsNotString_Throws(string value, JsonToken expectedTokenType)
+        {
+            var json = $"{{\"a\":{value}}}";
+
+            using (var test = new Test(json))
+            {
+                Assert.True(test.Reader.Read());
+                Assert.True(test.Reader.Read());
+                Assert.Equal(JsonToken.PropertyName, test.Reader.TokenType);
+
+                Assert.Throws<InvalidCastException>(() => test.Reader.ReadDelimitedString());
+                Assert.Equal(expectedTokenType, test.Reader.TokenType);
+            }
+        }
+
+        [Fact]
+        public void ReadDelimitedString_WhenValueIsString_ReturnsValue()
+        {
+            const string expectedResult = "b";
+            var json = $"{{\"a\":\"{expectedResult}\"}}";
+
+            using (var test = new Test(json))
+            {
+                Assert.True(test.Reader.Read());
+                Assert.True(test.Reader.Read());
+                Assert.Equal(JsonToken.PropertyName, test.Reader.TokenType);
+
+                IEnumerable<string> actualResults = test.Reader.ReadDelimitedString();
+
+                Assert.Collection(actualResults, actualResult => Assert.Equal(expectedResult, actualResult));
+                Assert.Equal(JsonToken.String, test.Reader.TokenType);
+            }
+        }
+
+        [Theory]
+        [InlineData("b,c,d")]
+        [InlineData("b c d")]
+        public void ReadDelimitedString_WhenValueIsDelimitedString_ReturnsValues(string value)
+        {
+            string[] expectedResults = value.Split(new[] { ' ', ',' }, StringSplitOptions.RemoveEmptyEntries);
+            var json = $"{{\"a\":\"{value}\"}}";
+
+            using (var test = new Test(json))
+            {
+                Assert.True(test.Reader.Read());
+                Assert.True(test.Reader.Read());
+                Assert.Equal(JsonToken.PropertyName, test.Reader.TokenType);
+
+                IEnumerable<string> actualResults = test.Reader.ReadDelimitedString();
+
+                Assert.Equal(expectedResults, actualResults);
+                Assert.Equal(JsonToken.String, test.Reader.TokenType);
+            }
+        }
+
+        [Fact]
+        public void ReadDelimitedString_WhenValueIsEmptyArray_Throws()
+        {
+            const string json = "{\"a\":[]}";
+
+            using (var test = new Test(json))
+            {
+                Assert.True(test.Reader.Read());
+                Assert.True(test.Reader.Read());
+                Assert.Equal(JsonToken.PropertyName, test.Reader.TokenType);
+
+                Assert.Throws<InvalidCastException>(() => test.Reader.ReadDelimitedString());
+                Assert.Equal(JsonToken.StartArray, test.Reader.TokenType);
+            }
+        }
+
+        [Theory]
+        [InlineData("true")]
+        [InlineData("-2")]
+        [InlineData("3.14")]
+        public void ReadDelimitedString_WhenValueIsConvertibleToString_Throws(string value)
+        {
+            var json = $"{{\"a\":[{value}]}}";
+
+            using (var test = new Test(json))
+            {
+                Assert.True(test.Reader.Read());
+                Assert.True(test.Reader.Read());
+                Assert.Equal(JsonToken.PropertyName, test.Reader.TokenType);
+
+                Assert.Throws<InvalidCastException>(() => test.Reader.ReadDelimitedString());
+                Assert.Equal(JsonToken.StartArray, test.Reader.TokenType);
+            }
+        }
+
+        [Fact]
+        public void ReadDelimitedString_WhenValueIsArrayOfStrings_Throws()
+        {
+            string[] expectedResults = { "b", "c" };
+            var json = $"{{\"a\":[{string.Join(",", expectedResults.Select(expectedResult => $"\"{expectedResult}\""))}]}}";
+
+            using (var test = new Test(json))
+            {
+                Assert.True(test.Reader.Read());
+                Assert.True(test.Reader.Read());
+                Assert.Equal(JsonToken.PropertyName, test.Reader.TokenType);
+
+                Assert.Throws<InvalidCastException>(() => test.Reader.ReadDelimitedString());
+                Assert.Equal(JsonToken.StartArray, test.Reader.TokenType);
+            }
+        }
+
+        [Fact]
+        public void ReadNextToken_WhenReaderIsNull_Throws()
+        {
+            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
+                () => JsonTextReaderExtensions.ReadNextToken(reader: null));
+
+            Assert.Equal("reader", exception.ParamName);
+        }
+
+        [Fact]
+        public void ReadNextToken_WhenAtEndOfStream_ReturnsFalse()
+        {
+            using (var test = new Test())
+            {
+                Assert.False(test.Reader.Read());
+                Assert.False(test.Reader.ReadNextToken());
+                Assert.Equal(JsonToken.None, test.Reader.TokenType);
+            }
+        }
+
+        [Fact]
+        public void ReadNextToken_WhenNextTokenIsComment_SkipsComment()
+        {
+            using (var test = new Test("[/**/3]"))
+            {
+                Assert.True(test.Reader.Read());
+                Assert.Equal(JsonToken.StartArray, test.Reader.TokenType);
+
+                Assert.True(test.Reader.ReadNextToken());
+                Assert.Equal(JsonToken.Integer, test.Reader.TokenType);
+            }
+        }
+
+        [Fact]
+        public void ReadNextTokenAsString_WhenReaderIsNull_Throws()
+        {
+            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
+                () => JsonTextReaderExtensions.ReadNextTokenAsString(reader: null));
+
+            Assert.Equal("reader", exception.ParamName);
+        }
+
+        [Fact]
+        public void ReadNextTokenAsString_WhenValueIsComment_SkipsComment()
+        {
+            using (var test = new Test("{\"a\":/**/\"b\""))
+            {
+                Assert.True(test.Reader.Read());
+                Assert.True(test.Reader.Read());
+                Assert.Equal(JsonToken.PropertyName, test.Reader.TokenType);
+
+                string actualResult = test.Reader.ReadNextTokenAsString();
+
+                Assert.Equal("b", actualResult);
+                Assert.Equal(JsonToken.String, test.Reader.TokenType);
+            }
+        }
+
+        [Fact]
+        public void ReadNextTokenAsString_WhenValueIsNone_ReturnsNull()
+        {
+            using (var test = new Test())
+            {
+                Assert.False(test.Reader.Read());
+                Assert.Equal(JsonToken.None, test.Reader.TokenType);
+
+                string actualResult = test.Reader.ReadNextTokenAsString();
+
+                Assert.Null(actualResult);
+            }
+        }
+
+        [Theory]
+        [InlineData("null", null)]
+        [InlineData("true", "True")]
+        [InlineData("-2", "-2")]
+        [InlineData("3.14", "3.14")]
+        [InlineData("\"b\"", "b")]
+        public void ReadNextTokenAsString_WhenValueIsConvertibleToString_ReturnsValueAsString(
+            string value,
+            string expectedResult)
+        {
+            var json = $"{{\"a\":{value}}}";
+
+            using (var test = new Test(json))
+            {
+                Assert.True(test.Reader.Read());
+                Assert.True(test.Reader.Read());
+                Assert.Equal(JsonToken.PropertyName, test.Reader.TokenType);
+
+                string actualResult = test.Reader.ReadNextTokenAsString();
+
+                Assert.Equal(expectedResult, actualResult);
+            }
+        }
+
+        [Theory]
+        [InlineData("[]")]
+        [InlineData("{}")]
+        public void ReadNextTokenAsString_WhenValueIsNotConvertibleToString_Throws(string value)
+        {
+            var json = $"{{\"a\":{value}}}";
+
+            using (var test = new Test(json))
+            {
+                Assert.True(test.Reader.Read());
+                Assert.True(test.Reader.Read());
+                Assert.Equal(JsonToken.PropertyName, test.Reader.TokenType);
+
+                Assert.Throws< InvalidCastException>(() => test.Reader.ReadNextTokenAsString());
+            }
+        }
+
+        [Fact]
+        public void ReadObject_WithReaderAndOnProperty_WhenReaderIsNull_Throws()
+        {
+            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
+                () => JsonTextReaderExtensions.ReadObject(reader: null, onProperty: _ => { }));
+
+            Assert.Equal("reader", exception.ParamName);
+        }
+
+        [Fact]
+        public void ReadObject_WithReaderAndOnProperty_WhenOnPropertyIsNull_Throws()
+        {
+            using (var test = new Test())
+            {
+                ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
+                    () => JsonTextReaderExtensions.ReadObject(test.Reader, onProperty: null));
+
+                Assert.Equal("onProperty", exception.ParamName);
+            }
+        }
+
+        [Fact]
+        public void ReadObject_WithReaderAndOnProperty_WhenNextTokenIsObject_EnumeratesProperties()
+        {
+            using (var test = new Test("{\"a\":3,\"b\":true}"))
+            {
+                var propertyNames = new List<string>();
+
+                test.Reader.ReadObject(propertyName =>
+                {
+                    propertyNames.Add(propertyName);
+
+                    switch (propertyName)
+                    {
+                        case "a":
+                            {
+                                int? actualValue = test.Reader.ReadAsInt32();
+
+                                Assert.Equal(3, actualValue);
+                            }
+                            break;
+
+                        case "b":
+                            {
+                                bool? actualValue = test.Reader.ReadAsBoolean();
+
+                                Assert.True(actualValue);
+                            }
+                            break;
+                    }
+                });
+
+                Assert.Collection(
+                    propertyNames,
+                    propertyName => Assert.Equal("a", propertyName),
+                    propertyName => Assert.Equal("b", propertyName));
+                Assert.Equal(JsonToken.EndObject, test.Reader.TokenType);
+            }
+        }
+
+        [Fact]
+        public void ReadObject_WithReaderAndOnProperty_WhenPropertyValueIsNotRead_SkipsPropertyValue()
+        {
+            using (var test = new Test("{\"a\":3,\"b\":true}"))
+            {
+                var propertyNames = new List<string>();
+
+                test.Reader.ReadObject(propertyName =>
+                {
+                    propertyNames.Add(propertyName);
+                });
+
+                Assert.Collection(
+                    propertyNames,
+                    propertyName => Assert.Equal("a", propertyName),
+                    propertyName => Assert.Equal("b", propertyName));
+                Assert.Equal(JsonToken.EndObject, test.Reader.TokenType);
+            }
+        }
+
+        [Fact]
+        public void ReadObject_WithReaderAndOnPropertyAndStartObjectLineAndStartObjectColumn_WhenReaderIsNull_Throws()
+        {
+            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
+                () => JsonTextReaderExtensions.ReadObject(
+                    reader: null,
+                    onProperty: _ => { },
+                    out int startObjectLine,
+                    out int startObjectColumn));
+
+            Assert.Equal("reader", exception.ParamName);
+        }
+
+        [Fact]
+        public void ReadObject_WithReaderAndOnPropertyAndStartObjectLineAndStartObjectColumn_WhenOnPropertyIsNull_Throws()
+        {
+            using (var test = new Test())
+            {
+                ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
+                    () => JsonTextReaderExtensions.ReadObject(
+                        test.Reader,
+                        onProperty: null,
+                        out int startObjectLine,
+                        out int startObjectColum));
+
+                Assert.Equal("onProperty", exception.ParamName);
+            }
+        }
+
+        [Fact]
+        public void ReadObject_WithReaderAndOnPropertyAndStartObjectLineAndStartObjectColumn_WhenNextTokenIsObject_EnumeratesProperties()
+        {
+            using (var test = new Test("{\"a\":3,\"b\":true}"))
+            {
+                var propertyNames = new List<string>();
+
+                test.Reader.ReadObject(
+                    propertyName =>
+                    {
+                        propertyNames.Add(propertyName);
+
+                        switch (propertyName)
+                        {
+                            case "a":
+                                {
+                                    int? actualValue = test.Reader.ReadAsInt32();
+
+                                    Assert.Equal(3, actualValue);
+                                }
+                                break;
+
+                            case "b":
+                                {
+                                    bool? actualValue = test.Reader.ReadAsBoolean();
+
+                                    Assert.True(actualValue);
+                                }
+                                break;
+                        }
+                    },
+                    out int startObjectLine,
+                    out int startObjectColumn);
+
+                Assert.Collection(
+                    propertyNames,
+                    propertyName => Assert.Equal("a", propertyName),
+                    propertyName => Assert.Equal("b", propertyName));
+                Assert.Equal(1, startObjectLine);
+                Assert.Equal(1, startObjectColumn);
+                Assert.Equal(JsonToken.EndObject, test.Reader.TokenType);
+            }
+        }
+
+        [Fact]
+        public void ReadObject_WithReaderAndOnPropertyAndStartObjectLineAndStartObjectColumn_WhenPropertyValueIsNotRead_SkipsPropertyValue()
+        {
+            using (var test = new Test("{\"a\":3,\"b\":true}"))
+            {
+                var propertyNames = new List<string>();
+
+                test.Reader.ReadObject(
+                    propertyName =>
+                    {
+                        propertyNames.Add(propertyName);
+                    },
+                    out int startObjectLine,
+                    out int startObjectColumn);
+
+                Assert.Collection(
+                    propertyNames,
+                    propertyName => Assert.Equal("a", propertyName),
+                    propertyName => Assert.Equal("b", propertyName));
+                Assert.Equal(1, startObjectLine);
+                Assert.Equal(1, startObjectColumn);
+                Assert.Equal(JsonToken.EndObject, test.Reader.TokenType);
+            }
+        }
+
+        [Fact]
+        public void ReadProperties_WithReaderAndOnProperty_WhenReaderIsNull_Throws()
+        {
+            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
+                () => JsonTextReaderExtensions.ReadProperties(reader: null, onProperty: _ => { }));
+
+            Assert.Equal("reader", exception.ParamName);
+        }
+
+        [Fact]
+        public void ReadProperties_WithReaderAndOnProperty_WhenOnPropertyIsNull_Throws()
+        {
+            using (var test = new Test())
+            {
+                ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
+                    () => JsonTextReaderExtensions.ReadProperties(test.Reader, onProperty: null));
+
+                Assert.Equal("onProperty", exception.ParamName);
+            }
+        }
+
+        [Fact]
+        public void ReadProperties_WithReaderAndOnProperty_WhenNextTokenIsPropertyName_EnumeratesProperties()
+        {
+            using (var test = new Test("{\"a\":3,\"b\":true}"))
+            {
+                Assert.True(test.Reader.Read());
+                Assert.Equal(JsonToken.StartObject, test.Reader.TokenType);
+
+                var propertyNames = new List<string>();
+
+                test.Reader.ReadProperties(propertyName =>
+                {
+                    propertyNames.Add(propertyName);
+
+                    switch (propertyName)
+                    {
+                        case "a":
+                            {
+                                int? actualValue = test.Reader.ReadAsInt32();
+
+                                Assert.Equal(3, actualValue);
+                            }
+                            break;
+
+                        case "b":
+                            {
+                                bool? actualValue = test.Reader.ReadAsBoolean();
+
+                                Assert.True(actualValue);
+                            }
+                            break;
+                    }
+                });
+
+                Assert.Collection(
+                    propertyNames,
+                    propertyName => Assert.Equal("a", propertyName),
+                    propertyName => Assert.Equal("b", propertyName));
+                Assert.Equal(JsonToken.EndObject, test.Reader.TokenType);
+            }
+        }
+
+        [Fact]
+        public void ReadProperties_WithReaderAndOnProperty_WhenPropertyValueIsNotRead_SkipsPropertyValue()
+        {
+            using (var test = new Test("{\"a\":3,\"b\":true}"))
+            {
+                Assert.True(test.Reader.Read());
+                Assert.Equal(JsonToken.StartObject, test.Reader.TokenType);
+
+                var propertyNames = new List<string>();
+
+                test.Reader.ReadProperties(propertyName =>
+                {
+                    propertyNames.Add(propertyName);
+                });
+
+                Assert.Collection(
+                    propertyNames,
+                    propertyName => Assert.Equal("a", propertyName),
+                    propertyName => Assert.Equal("b", propertyName));
+                Assert.Equal(JsonToken.EndObject, test.Reader.TokenType);
+            }
+        }
+
+        [Fact]
+        public void ReadStringArrayAsList_WhenReaderIsNull_Throws()
+        {
+            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
+                () => JsonTextReaderExtensions.ReadStringArrayAsList(reader: null));
+
+            Assert.Equal("reader", exception.ParamName);
+        }
+
+        [Theory]
+        [InlineData("null")]
+        [InlineData("\"b\"")]
+        [InlineData("{}")]
+        public void ReadStringArrayAsList_WhenValueIsNotArray_ReturnsNull(string value)
+        {
+            using (var test = new Test($"{{\"a\":{value}}}"))
+            {
+                Assert.True(test.Reader.Read());
+                Assert.Equal(JsonToken.StartObject, test.Reader.TokenType);
+                Assert.True(test.Reader.Read());
+                Assert.Equal(JsonToken.PropertyName, test.Reader.TokenType);
+
+                List<string> actualValues = test.Reader.ReadStringArrayAsList();
+
+                Assert.Null(actualValues);
+            }
+        }
+
+        [Fact]
+        public void ReadStringArrayAsList_WhenValueIsEmptyArray_ReturnsNull()
+        {
+            using (var test = new Test("{\"a\":[]}"))
+            {
+                Assert.True(test.Reader.Read());
+                Assert.Equal(JsonToken.StartObject, test.Reader.TokenType);
+                Assert.True(test.Reader.Read());
+                Assert.Equal(JsonToken.PropertyName, test.Reader.TokenType);
+
+                List<string> actualValues = test.Reader.ReadStringArrayAsList();
+
+                Assert.Null(actualValues);
+            }
+        }
+
+        [Fact]
+        public void ReadStringArrayAsList_WithSupportedTypes_ReturnsStringArray()
+        {
+            using (var test = new Test("[\"a\",-2,3.14,true,null]"))
+            {
+                List<string> actualValues = test.Reader.ReadStringArrayAsList();
+
+                Assert.Collection(
+                    actualValues,
+                    actualValue => Assert.Equal("a", actualValue),
+                    actualValue => Assert.Equal("-2", actualValue),
+                    actualValue => Assert.Equal("3.14", actualValue),
+                    actualValue => Assert.Equal("True", actualValue),
+                    actualValue => Assert.Equal(null, actualValue));
+                Assert.Equal(JsonToken.EndArray, test.Reader.TokenType);
+            }
+        }
+
+        [Theory]
+        [InlineData("[]")]
+        [InlineData("{}")]
+        public void ReadStringArrayAsList_WithUnsupportedTypes_Throws(string element)
+        {
+            using (var test = new Test($"[{element}]"))
+            {
+                Assert.Throws<InvalidCastException>(() => test.Reader.ReadStringArrayAsList());
+            }
+        }
+
+        [Fact]
+        public void ReadStringOrArrayOfStringsAsReadOnlyList_WhenReaderIsNull_Throws()
+        {
+            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
+                () => JsonTextReaderExtensions.ReadStringOrArrayOfStringsAsReadOnlyList(reader: null));
+
+            Assert.Equal("reader", exception.ParamName);
+        }
+
+        [Fact]
+        public void ReadStringOrArrayOfStringsAsReadOnlyList_WhenValueIsNull_ReturnsNull()
+        {
+            const string json = "{\"a\":null}";
+
+            using (var test = new Test(json))
+            {
+                Assert.True(test.Reader.Read());
+                Assert.True(test.Reader.Read());
+                Assert.Equal(JsonToken.PropertyName, test.Reader.TokenType);
+
+                IEnumerable<string> actualResults = test.Reader.ReadStringOrArrayOfStringsAsReadOnlyList();
+
+                Assert.Null(actualResults);
+                Assert.Equal(JsonToken.Null, test.Reader.TokenType);
+            }
+        }
+
+        [Theory]
+        [InlineData("true", JsonToken.Boolean)]
+        [InlineData("-2", JsonToken.Integer)]
+        [InlineData("3.14", JsonToken.Float)]
+        [InlineData("{}", JsonToken.StartObject)]
+        public void ReadStringOrArrayOfStringsAsReadOnlyList_WhenValueIsNotString_ReturnsNull(
+            string value,
+            JsonToken expectedTokenType)
+        {
+            var json = $"{{\"a\":{value}}}";
+
+            using (var test = new Test(json))
+            {
+                Assert.True(test.Reader.Read());
+                Assert.True(test.Reader.Read());
+                Assert.Equal(JsonToken.PropertyName, test.Reader.TokenType);
+
+                IEnumerable<string> actualResults = test.Reader.ReadStringOrArrayOfStringsAsReadOnlyList();
+
+                Assert.Null(actualResults);
+                Assert.Equal(expectedTokenType, test.Reader.TokenType);
+            }
+        }
+
+        [Fact]
+        public void ReadStringOrArrayOfStringsAsReadOnlyList_WhenValueIsString_ReturnsValue()
+        {
+            const string expectedResult = "b";
+            var json = $"{{\"a\":\"{expectedResult}\"}}";
+
+            using (var test = new Test(json))
+            {
+                Assert.True(test.Reader.Read());
+                Assert.True(test.Reader.Read());
+                Assert.Equal(JsonToken.PropertyName, test.Reader.TokenType);
+
+                IEnumerable<string> actualResults = test.Reader.ReadStringOrArrayOfStringsAsReadOnlyList();
+
+                Assert.Collection(actualResults, actualResult => Assert.Equal(expectedResult, actualResult));
+                Assert.Equal(JsonToken.String, test.Reader.TokenType);
+            }
+        }
+
+        [Theory]
+        [InlineData("b,c,d")]
+        [InlineData("b c d")]
+        public void ReadStringOrArrayOfStringsAsReadOnlyList_WhenValueIsDelimitedString_ReturnsValue(string expectedResult)
+        {
+            var json = $"{{\"a\":\"{expectedResult}\"}}";
+
+            using (var test = new Test(json))
+            {
+                Assert.True(test.Reader.Read());
+                Assert.True(test.Reader.Read());
+                Assert.Equal(JsonToken.PropertyName, test.Reader.TokenType);
+
+                IEnumerable<string> actualResults = test.Reader.ReadStringOrArrayOfStringsAsReadOnlyList();
+
+                Assert.Collection(actualResults, actualResult => Assert.Equal(expectedResult, actualResult));
+                Assert.Equal(JsonToken.String, test.Reader.TokenType);
+            }
+        }
+
+        [Fact]
+        public void ReadStringOrArrayOfStringsAsReadOnlyList_WhenValueIsEmptyArray_ReturnsEmptyList()
+        {
+            const string json = "{\"a\":[]}";
+
+            using (var test = new Test(json))
+            {
+                Assert.True(test.Reader.Read());
+                Assert.True(test.Reader.Read());
+                Assert.Equal(JsonToken.PropertyName, test.Reader.TokenType);
+
+                IReadOnlyList<string> actualResults = test.Reader.ReadStringOrArrayOfStringsAsReadOnlyList();
+
+                Assert.Empty(actualResults);
+                Assert.Equal(JsonToken.EndArray, test.Reader.TokenType);
+            }
+        }
+
+        [Theory]
+        [InlineData("null", null)]
+        [InlineData("true", "True")]
+        [InlineData("-2", "-2")]
+        [InlineData("3.14", "3.14")]
+        [InlineData("\"b\"", "b")]
+        public void ReadStringOrArrayOfStringsAsReadOnlyList_WhenValueIsConvertibleToString_ReturnsValueAsString(
+            string value,
+            string expectedResult)
+        {
+            var json = $"{{\"a\":[{value}]}}";
+
+            using (var test = new Test(json))
+            {
+                Assert.True(test.Reader.Read());
+                Assert.True(test.Reader.Read());
+                Assert.Equal(JsonToken.PropertyName, test.Reader.TokenType);
+
+                IEnumerable<string> actualResults = test.Reader.ReadStringOrArrayOfStringsAsReadOnlyList();
+
+                Assert.Collection(actualResults, actualResult => Assert.Equal(expectedResult, actualResult));
+                Assert.Equal(JsonToken.EndArray, test.Reader.TokenType);
+            }
+        }
+
+        [Theory]
+        [InlineData("[]", JsonToken.StartArray)]
+        [InlineData("{}", JsonToken.StartObject)]
+        public void ReadStringOrArrayOfStringsAsReadOnlyList_WhenValueIsNotConvertibleToString_ReturnsValueAsString(
+            string value,
+            JsonToken expectedToken)
+        {
+            var json = $"{{\"a\":[{value}]}}";
+
+            using (var test = new Test(json))
+            {
+                Assert.True(test.Reader.Read());
+                Assert.True(test.Reader.Read());
+                Assert.Equal(JsonToken.PropertyName, test.Reader.TokenType);
+
+                Assert.Throws<InvalidCastException>(() => test.Reader.ReadStringOrArrayOfStringsAsReadOnlyList());
+                Assert.Equal(expectedToken, test.Reader.TokenType);
+            }
+        }
+
+        [Fact]
+        public void ReadStringOrArrayOfStringsAsReadOnlyList_WhenValueIsArrayOfStrings_ReturnsValues()
+        {
+            string[] expectedResults = { "b", "c" };
+            var json = $"{{\"a\":[{string.Join(",", expectedResults.Select(expectedResult => $"\"{expectedResult}\""))}]}}";
+
+            using (var test = new Test(json))
+            {
+                Assert.True(test.Reader.Read());
+                Assert.True(test.Reader.Read());
+                Assert.Equal(JsonToken.PropertyName, test.Reader.TokenType);
+
+                IEnumerable<string> actualResults = test.Reader.ReadStringOrArrayOfStringsAsReadOnlyList();
+
+                Assert.Equal(expectedResults, actualResults);
+                Assert.Equal(JsonToken.EndArray, test.Reader.TokenType);
+            }
+        }
+
+        [Fact]
+        public void ReadStringArrayAsReadOnlyListFromArrayStart_WhenReaderIsNull_Throws()
+        {
+            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
+                () => JsonTextReaderExtensions.ReadStringArrayAsReadOnlyListFromArrayStart(reader: null));
+
+            Assert.Equal("reader", exception.ParamName);
+        }
+
+        [Fact]
+        public void ReadStringArrayAsReadOnlyListFromArrayStart_WhenValuesAreConvertibleToString_ReturnsReadOnlyList()
+        {
+            const string json = "[null, true, -2, 3.14, \"a\"]";
+
+            using (var test = new Test(json))
+            {
+                Assert.True(test.Reader.Read());
+                Assert.Equal(JsonToken.StartArray, test.Reader.TokenType);
+
+                IEnumerable<string> actualResults = test.Reader.ReadStringArrayAsReadOnlyListFromArrayStart();
+
+                Assert.Collection(
+                    actualResults,
+                    actualResult => Assert.Equal(null, actualResult),
+                    actualResult => Assert.Equal("True", actualResult),
+                    actualResult => Assert.Equal("-2", actualResult),
+                    actualResult => Assert.Equal("3.14", actualResult),
+                    actualResult => Assert.Equal("a", actualResult));
+                Assert.Equal(JsonToken.EndArray, test.Reader.TokenType);
+            }
+        }
+
+        [Theory]
+        [InlineData("[]", JsonToken.StartArray)]
+        [InlineData("{}", JsonToken.StartObject)]
+        public void ReadStringArrayAsReadOnlyListFromArrayStart_WhenValuesAreNotConvertibleToString_Throws(
+            string value,
+            JsonToken expectedToken)
+        {
+            var json = $"[{value}]";
+
+            using (var test = new Test(json))
+            {
+                Assert.True(test.Reader.Read());
+                Assert.Equal(JsonToken.StartArray, test.Reader.TokenType);
+
+                Assert.Throws<InvalidCastException>(() => test.Reader.ReadStringArrayAsReadOnlyListFromArrayStart());
+                Assert.Equal(expectedToken, test.Reader.TokenType);
+            }
+        }
+
+        private sealed class Test : IDisposable
+        {
+            private bool _isDisposed;
+            private readonly StringReader _stringReader;
+
+            internal JsonTextReader Reader { get; }
+
+            public Test()
+                : this(string.Empty)
+            {
+            }
+
+            public Test(string json)
+            {
+                _stringReader = new StringReader(json);
+                Reader = new JsonTextReader(_stringReader);
+            }
+
+            public void Dispose()
+            {
+                if (!_isDisposed)
+                {
+                    ((IDisposable)Reader).Dispose();
+                    _stringReader.Dispose();
+
+                    _isDisposed = true;
+                }
+            }
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecTestUtility.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecTestUtility.cs
@@ -24,7 +24,9 @@ namespace NuGet.ProjectModel.Test
 
                 writer.WriteObjectEnd();
 
+#pragma warning disable CS0618
                 return JsonPackageSpecReader.GetPackageSpec((JObject)jsonWriter.Token);
+#pragma warning restore CS0618
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecWriterTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecWriterTests.cs
@@ -18,7 +18,9 @@ namespace NuGet.ProjectModel.Test
 {
     public class PackageSpecWriterTests
     {
+#pragma warning disable CS0618
         private static readonly PackageSpec EmptyPackageSpec = JsonPackageSpecReader.GetPackageSpec(new JObject());
+#pragma warning restore CS0618
 
         [Fact]
         public void RoundTripAutoReferencedProperty()

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/compiler/resources/DependencyGraphSpec_CentralVersionDependencies.json
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/compiler/resources/DependencyGraphSpec_CentralVersionDependencies.json
@@ -14,7 +14,7 @@
           "dependencies": {
             "foo": {
               "suppressParent": "All",
-              "target": "All",
+              "target": "Package",
               "version": "[1.0.0, )",
               "generatePathProperty": true,
               "versionCentrallyManaged": true


### PR DESCRIPTION
## Bug

Fixes:  https://github.com/NuGet/Home/issues/9040 
Regression:  No

## Fix

Details:
1. Obsolesce the unnecessary `DependencyGraphSpec.Json` property.
2. Load/read a dependency graph spec file using a forward only JSON reader.

## Testing/Validation

Tests Added:  Yes 
Validation:  

Measuring the improvement in Visual Studio is difficult because there is too much noise to get a clean comparison.  To isolate the impact of this change, I created a simple console app that loaded all 84 NuGet Client project .dgspec.json files using the old and new readers:
```C#
// My VM had 4 processors
var options = new ParallelOptions() { MaxDegreeOfParallelism = Environment.ProcessorCount };

// Fire an ETW start event
eventSource.LoadAllStart();

try
{
    Parallel.ForEach(DgSpecFilePaths, options, dgSpecFilePath => DependencyGraphSpec.Load(dgSpecFilePath));
}
finally
{
    eventSource.LoadAllStop();
}
```
Based on 5 iterations each (before and after), the average improvements are:
| Metric | Before | After | Delta | % Delta |
| --- | --- | --- | --- | --- |
| total time reading all files in parallel | 385.4 ms | 289.2 ms | -96.2 ms | -25.0% |
| heap allocations | 58.8 MB | 33.2 MB | -25.6 MB | -43.5% |