### PR TITLE
Stop emitting <requireLicenseAcceptance> with the default value

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTaskLogic.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTaskLogic.cs
@@ -122,6 +122,7 @@ namespace NuGet.Build.Tasks.Pack
                 Copyright = request.Copyright,
                 ReleaseNotes = request.ReleaseNotes,
                 RequireLicenseAcceptance = request.RequireLicenseAcceptance,
+                SuppressRequireLicenseAcceptance = !request.RequireLicenseAcceptance,
                 PackageTypes = ParsePackageTypes(request)
             };
 

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTaskLogic.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTaskLogic.cs
@@ -122,7 +122,7 @@ namespace NuGet.Build.Tasks.Pack
                 Copyright = request.Copyright,
                 ReleaseNotes = request.ReleaseNotes,
                 RequireLicenseAcceptance = request.RequireLicenseAcceptance,
-                SuppressRequireLicenseAcceptance = !request.RequireLicenseAcceptance,
+                EmitRequireLicenseAcceptance = request.RequireLicenseAcceptance,
                 PackageTypes = ParsePackageTypes(request)
             };
 

--- a/src/NuGet.Core/NuGet.Commands/CommandRunners/PackCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/CommandRunners/PackCommandRunner.cs
@@ -782,7 +782,7 @@ namespace NuGet.Commands
 
             InitCommonPackageBuilderProperties(mainPackageBuilder);
 
-            mainPackageBuilder.SuppressRequireLicenseAcceptance = !mainPackageBuilder.RequireLicenseAcceptance;
+            mainPackageBuilder.EmitRequireLicenseAcceptance = mainPackageBuilder.RequireLicenseAcceptance;
 
             bool successful = true;
             // Build the main package

--- a/src/NuGet.Core/NuGet.Commands/CommandRunners/PackCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/CommandRunners/PackCommandRunner.cs
@@ -782,6 +782,8 @@ namespace NuGet.Commands
 
             InitCommonPackageBuilderProperties(mainPackageBuilder);
 
+            mainPackageBuilder.SuppressRequireLicenseAcceptance = !mainPackageBuilder.RequireLicenseAcceptance;
+
             bool successful = true;
             // Build the main package
             if (GenerateNugetPackage)

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/ManifestMetadata.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/ManifestMetadata.cs
@@ -350,9 +350,17 @@ namespace NuGet.Packaging
                 yield return NuGetResources.IconMissingRequiredValue;
             }
 
-            if (RequireLicenseAcceptance && (string.IsNullOrWhiteSpace(_licenseUrl) && LicenseMetadata == null))
+            if (RequireLicenseAcceptance)
             {
-                yield return NuGetResources.Manifest_RequireLicenseAcceptanceRequiresLicenseUrl;
+                if ((string.IsNullOrWhiteSpace(_licenseUrl) && LicenseMetadata == null))
+                {
+                    yield return NuGetResources.Manifest_RequireLicenseAcceptanceRequiresLicenseUrl;
+                }
+
+                if (!EmitRequireLicenseAcceptance)
+                {
+                    yield return NuGetResources.Manifest_RequireLicenseAcceptanceRequiresEmit;
+                }
             }
 
             if (_licenseUrl != null && LicenseMetadata != null && (string.IsNullOrWhiteSpace(_licenseUrl) || !LicenseUrl.Equals(LicenseMetadata.LicenseUrl)))

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/ManifestMetadata.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/ManifestMetadata.cs
@@ -46,6 +46,7 @@ namespace NuGet.Packaging
             _projectUrl = copy.ProjectUrl?.OriginalString;
             _iconUrl = copy.IconUrl?.OriginalString;
             RequireLicenseAcceptance = copy.RequireLicenseAcceptance;
+            SuppressRequireLicenseAcceptance = (copy as PackageBuilder)?.SuppressRequireLicenseAcceptance ?? false;
             Description = copy.Description?.Trim();
             Copyright = copy.Copyright?.Trim();
             Summary = copy.Summary?.Trim();
@@ -160,6 +161,8 @@ namespace NuGet.Packaging
         }
 
         public bool RequireLicenseAcceptance { get; set; }
+
+        public bool SuppressRequireLicenseAcceptance { get; set; }
 
         public bool DevelopmentDependency { get; set; }
 

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/ManifestMetadata.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/ManifestMetadata.cs
@@ -46,7 +46,7 @@ namespace NuGet.Packaging
             _projectUrl = copy.ProjectUrl?.OriginalString;
             _iconUrl = copy.IconUrl?.OriginalString;
             RequireLicenseAcceptance = copy.RequireLicenseAcceptance;
-            SuppressRequireLicenseAcceptance = (copy as PackageBuilder)?.SuppressRequireLicenseAcceptance ?? false;
+            EmitRequireLicenseAcceptance = (copy as PackageBuilder)?.EmitRequireLicenseAcceptance ?? true;
             Description = copy.Description?.Trim();
             Copyright = copy.Copyright?.Trim();
             Summary = copy.Summary?.Trim();
@@ -162,7 +162,7 @@ namespace NuGet.Packaging
 
         public bool RequireLicenseAcceptance { get; set; }
 
-        public bool SuppressRequireLicenseAcceptance { get; set; }
+        public bool EmitRequireLicenseAcceptance { get; set; } = true;
 
         public bool DevelopmentDependency { get; set; }
 

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PackageBuilder.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PackageBuilder.cs
@@ -179,11 +179,11 @@ namespace NuGet.Packaging
             set;
         }
 
-        public bool SuppressRequireLicenseAcceptance
+        public bool EmitRequireLicenseAcceptance
         {
             get;
             set;
-        }
+        } = true;
 
         public bool Serviceable
         {

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PackageBuilder.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PackageBuilder.cs
@@ -179,6 +179,12 @@ namespace NuGet.Packaging
             set;
         }
 
+        public bool SuppressRequireLicenseAcceptance
+        {
+            get;
+            set;
+        }
+
         public bool Serviceable
         {
             get;

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Resources/NuGetResources.Designer.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Resources/NuGetResources.Designer.cs
@@ -304,6 +304,15 @@ namespace NuGet.Packaging.PackageCreation.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to EmitRequireLicenseAcceptance must not be set to false if RequireLicenseAcceptance is set to true..
+        /// </summary>
+        internal static string Manifest_RequireLicenseAcceptanceRequiresEmit {
+            get {
+                return ResourceManager.GetString("Manifest_RequireLicenseAcceptanceRequiresEmit", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Enabling license acceptance requires a license or a licenseUrl to be specified. The licenseUrl will be deprecated, consider using the license metadata..
         /// </summary>
         internal static string Manifest_RequireLicenseAcceptanceRequiresLicenseUrl {

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Resources/NuGetResources.resx
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Resources/NuGetResources.resx
@@ -224,4 +224,7 @@
     <value>The 'icon' element '{0}' has an invalid file extension. Valid options are .png, .jpg or .jpeg.</value>
     <comment>0 - Icon entry in the nuspec</comment>
   </data>
+  <data name="Manifest_RequireLicenseAcceptanceRequiresEmit" xml:space="preserve">
+    <value>EmitRequireLicenseAcceptance must not be set to false if RequireLicenseAcceptance is set to true.</value>
+  </data>
 </root>

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Xml/PackageMetadataXmlExtensions.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Xml/PackageMetadataXmlExtensions.cs
@@ -51,7 +51,7 @@ namespace NuGet.Packaging.Xml
             }
             if (!metadata.PackageTypes.Contains(PackageType.SymbolsPackage))
             {
-                if (!metadata.SuppressRequireLicenseAcceptance)
+                if (metadata.EmitRequireLicenseAcceptance)
                 {
                     elem.Add(new XElement(ns + "requireLicenseAcceptance", metadata.RequireLicenseAcceptance));
                 }

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Xml/PackageMetadataXmlExtensions.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Xml/PackageMetadataXmlExtensions.cs
@@ -51,7 +51,10 @@ namespace NuGet.Packaging.Xml
             }
             if (!metadata.PackageTypes.Contains(PackageType.SymbolsPackage))
             {
-                elem.Add(new XElement(ns + "requireLicenseAcceptance", metadata.RequireLicenseAcceptance));
+                if (!metadata.SuppressRequireLicenseAcceptance)
+                {
+                    elem.Add(new XElement(ns + "requireLicenseAcceptance", metadata.RequireLicenseAcceptance));
+                }
                 var licenseUrlToWrite = metadata.LicenseUrl?.ToString();
                 if (metadata.LicenseMetadata != null)
                 {

--- a/src/NuGet.Core/NuGet.Packaging/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Packaging/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -1,9 +1,9 @@
-NuGet.Packaging.ManifestMetadata.SuppressRequireLicenseAcceptance.get -> bool
-NuGet.Packaging.ManifestMetadata.SuppressRequireLicenseAcceptance.set -> void
+NuGet.Packaging.ManifestMetadata.EmitRequireLicenseAcceptance.get -> bool
+NuGet.Packaging.ManifestMetadata.EmitRequireLicenseAcceptance.set -> void
 NuGet.Packaging.NupkgMetadataFile.Source.get -> string
 NuGet.Packaging.NupkgMetadataFile.Source.set -> void
-NuGet.Packaging.PackageBuilder.SuppressRequireLicenseAcceptance.get -> bool
-NuGet.Packaging.PackageBuilder.SuppressRequireLicenseAcceptance.set -> void
+NuGet.Packaging.PackageBuilder.EmitRequireLicenseAcceptance.get -> bool
+NuGet.Packaging.PackageBuilder.EmitRequireLicenseAcceptance.set -> void
 static NuGet.Packaging.Rules.AnalysisResources.InvalidUndottedFrameworkInDependencyGroupsWarning.get -> string
 static NuGet.Packaging.Rules.AnalysisResources.InvalidUndottedFrameworkInFilesWarning.get -> string
 static NuGet.Packaging.Rules.AnalysisResources.InvalidUndottedFrameworkInFrameworkAssemblyGroupsWarning.get -> string

--- a/src/NuGet.Core/NuGet.Packaging/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Packaging/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -1,5 +1,9 @@
+NuGet.Packaging.ManifestMetadata.SuppressRequireLicenseAcceptance.get -> bool
+NuGet.Packaging.ManifestMetadata.SuppressRequireLicenseAcceptance.set -> void
 NuGet.Packaging.NupkgMetadataFile.Source.get -> string
 NuGet.Packaging.NupkgMetadataFile.Source.set -> void
+NuGet.Packaging.PackageBuilder.SuppressRequireLicenseAcceptance.get -> bool
+NuGet.Packaging.PackageBuilder.SuppressRequireLicenseAcceptance.set -> void
 static NuGet.Packaging.Rules.AnalysisResources.InvalidUndottedFrameworkInDependencyGroupsWarning.get -> string
 static NuGet.Packaging.Rules.AnalysisResources.InvalidUndottedFrameworkInFilesWarning.get -> string
 static NuGet.Packaging.Rules.AnalysisResources.InvalidUndottedFrameworkInFrameworkAssemblyGroupsWarning.get -> string

--- a/src/NuGet.Core/NuGet.Packaging/PublicAPI/netcoreapp5.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Packaging/PublicAPI/netcoreapp5.0/PublicAPI.Unshipped.txt
@@ -1,9 +1,9 @@
-NuGet.Packaging.ManifestMetadata.SuppressRequireLicenseAcceptance.get -> bool
-NuGet.Packaging.ManifestMetadata.SuppressRequireLicenseAcceptance.set -> void
+NuGet.Packaging.ManifestMetadata.EmitRequireLicenseAcceptance.get -> bool
+NuGet.Packaging.ManifestMetadata.EmitRequireLicenseAcceptance.set -> void
 NuGet.Packaging.NupkgMetadataFile.Source.get -> string
 NuGet.Packaging.NupkgMetadataFile.Source.set -> void
-NuGet.Packaging.PackageBuilder.SuppressRequireLicenseAcceptance.get -> bool
-NuGet.Packaging.PackageBuilder.SuppressRequireLicenseAcceptance.set -> void
+NuGet.Packaging.PackageBuilder.EmitRequireLicenseAcceptance.get -> bool
+NuGet.Packaging.PackageBuilder.EmitRequireLicenseAcceptance.set -> void
 static NuGet.Packaging.Rules.AnalysisResources.InvalidUndottedFrameworkInDependencyGroupsWarning.get -> string
 static NuGet.Packaging.Rules.AnalysisResources.InvalidUndottedFrameworkInFilesWarning.get -> string
 static NuGet.Packaging.Rules.AnalysisResources.InvalidUndottedFrameworkInFrameworkAssemblyGroupsWarning.get -> string

--- a/src/NuGet.Core/NuGet.Packaging/PublicAPI/netcoreapp5.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Packaging/PublicAPI/netcoreapp5.0/PublicAPI.Unshipped.txt
@@ -1,5 +1,9 @@
+NuGet.Packaging.ManifestMetadata.SuppressRequireLicenseAcceptance.get -> bool
+NuGet.Packaging.ManifestMetadata.SuppressRequireLicenseAcceptance.set -> void
 NuGet.Packaging.NupkgMetadataFile.Source.get -> string
 NuGet.Packaging.NupkgMetadataFile.Source.set -> void
+NuGet.Packaging.PackageBuilder.SuppressRequireLicenseAcceptance.get -> bool
+NuGet.Packaging.PackageBuilder.SuppressRequireLicenseAcceptance.set -> void
 static NuGet.Packaging.Rules.AnalysisResources.InvalidUndottedFrameworkInDependencyGroupsWarning.get -> string
 static NuGet.Packaging.Rules.AnalysisResources.InvalidUndottedFrameworkInFilesWarning.get -> string
 static NuGet.Packaging.Rules.AnalysisResources.InvalidUndottedFrameworkInFrameworkAssemblyGroupsWarning.get -> string

--- a/src/NuGet.Core/NuGet.Packaging/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Packaging/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,9 +1,9 @@
-NuGet.Packaging.ManifestMetadata.SuppressRequireLicenseAcceptance.get -> bool
-NuGet.Packaging.ManifestMetadata.SuppressRequireLicenseAcceptance.set -> void
+NuGet.Packaging.ManifestMetadata.EmitRequireLicenseAcceptance.get -> bool
+NuGet.Packaging.ManifestMetadata.EmitRequireLicenseAcceptance.set -> void
 NuGet.Packaging.NupkgMetadataFile.Source.get -> string
 NuGet.Packaging.NupkgMetadataFile.Source.set -> void
-NuGet.Packaging.PackageBuilder.SuppressRequireLicenseAcceptance.get -> bool
-NuGet.Packaging.PackageBuilder.SuppressRequireLicenseAcceptance.set -> void
+NuGet.Packaging.PackageBuilder.EmitRequireLicenseAcceptance.get -> bool
+NuGet.Packaging.PackageBuilder.EmitRequireLicenseAcceptance.set -> void
 static NuGet.Packaging.Rules.AnalysisResources.InvalidUndottedFrameworkInDependencyGroupsWarning.get -> string
 static NuGet.Packaging.Rules.AnalysisResources.InvalidUndottedFrameworkInFilesWarning.get -> string
 static NuGet.Packaging.Rules.AnalysisResources.InvalidUndottedFrameworkInFrameworkAssemblyGroupsWarning.get -> string

--- a/src/NuGet.Core/NuGet.Packaging/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Packaging/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,5 +1,9 @@
+NuGet.Packaging.ManifestMetadata.SuppressRequireLicenseAcceptance.get -> bool
+NuGet.Packaging.ManifestMetadata.SuppressRequireLicenseAcceptance.set -> void
 NuGet.Packaging.NupkgMetadataFile.Source.get -> string
 NuGet.Packaging.NupkgMetadataFile.Source.set -> void
+NuGet.Packaging.PackageBuilder.SuppressRequireLicenseAcceptance.get -> bool
+NuGet.Packaging.PackageBuilder.SuppressRequireLicenseAcceptance.set -> void
 static NuGet.Packaging.Rules.AnalysisResources.InvalidUndottedFrameworkInDependencyGroupsWarning.get -> string
 static NuGet.Packaging.Rules.AnalysisResources.InvalidUndottedFrameworkInFilesWarning.get -> string
 static NuGet.Packaging.Rules.AnalysisResources.InvalidUndottedFrameworkInFrameworkAssemblyGroupsWarning.get -> string

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
@@ -5039,6 +5039,130 @@ namespace ClassLibrary
                 Assert.Null(document.Root.Element(ns + "metadata").Element(ns + "owners"));
             }
         }
+
+        [PlatformTheory(Platform.Windows)]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void PackCommand_RequireLicenseAcceptanceNotEmittedWhenUnspecified(bool withLicense)
+        {
+            using (var testDirectory = TestDirectory.Create())
+            {
+                var projectName = "ClassLibrary1";
+                var workingDirectory = Path.Combine(testDirectory, projectName);
+                var projectFile = Path.Combine(workingDirectory, $"{projectName}.csproj");
+
+                msbuildFixture.CreateDotnetNewProject(testDirectory.Path, projectName, " classlib");
+
+                using (var stream = new FileStream(projectFile, FileMode.Open, FileAccess.ReadWrite))
+                {
+                    var xml = XDocument.Load(stream);
+                    ProjectFileUtils.SetTargetFrameworkForProject(xml, "TargetFramework", "netstandard1.4");
+
+                    if (withLicense)
+                    {
+                        ProjectFileUtils.AddProperty(xml, "PackageLicenseExpression", "MIT");
+                    }
+
+                    ProjectFileUtils.WriteXmlToFile(xml, stream);
+                }
+
+                msbuildFixture.RestoreProject(workingDirectory, projectName, string.Empty);
+                msbuildFixture.PackProject(workingDirectory, projectName, $"/p:PackageOutputPath={workingDirectory}");
+
+                var nupkgPath = Path.Combine(workingDirectory, $"{projectName}.1.0.0.nupkg");
+                var nuspecPath = Path.Combine(workingDirectory, "obj", $"{projectName}.1.0.0.nuspec");
+
+                Assert.True(File.Exists(nupkgPath), "The output .nupkg is not in the expected place");
+                Assert.True(File.Exists(nuspecPath), "The intermediate nuspec file is not in the expected place");
+
+                var document = XDocument.Load(nuspecPath);
+                var ns = document.Root.GetDefaultNamespace();
+
+                Assert.Null(document.Root.Element(ns + "metadata").Element(ns + "requireLicenseAcceptance"));
+            }
+        }
+
+        [PlatformTheory(Platform.Windows)]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void PackCommand_RequireLicenseAcceptanceNotEmittedWhenSpecifiedAsDefault(bool withLicense)
+        {
+            using (var testDirectory = TestDirectory.Create())
+            {
+                var projectName = "ClassLibrary1";
+                var workingDirectory = Path.Combine(testDirectory, projectName);
+                var projectFile = Path.Combine(workingDirectory, $"{projectName}.csproj");
+
+                msbuildFixture.CreateDotnetNewProject(testDirectory.Path, projectName, " classlib");
+
+                using (var stream = new FileStream(projectFile, FileMode.Open, FileAccess.ReadWrite))
+                {
+                    var xml = XDocument.Load(stream);
+                    ProjectFileUtils.SetTargetFrameworkForProject(xml, "TargetFramework", "netstandard1.4");
+
+                    ProjectFileUtils.AddProperty(xml, "PackageRequireLicenseAcceptance", "false");
+
+                    if (withLicense)
+                    {
+                        ProjectFileUtils.AddProperty(xml, "PackageLicenseExpression", "MIT");
+                    }
+
+                    ProjectFileUtils.WriteXmlToFile(xml, stream);
+                }
+
+                msbuildFixture.RestoreProject(workingDirectory, projectName, string.Empty);
+                msbuildFixture.PackProject(workingDirectory, projectName, $"/p:PackageOutputPath={workingDirectory}");
+
+                var nupkgPath = Path.Combine(workingDirectory, $"{projectName}.1.0.0.nupkg");
+                var nuspecPath = Path.Combine(workingDirectory, "obj", $"{projectName}.1.0.0.nuspec");
+
+                Assert.True(File.Exists(nupkgPath), "The output .nupkg is not in the expected place");
+                Assert.True(File.Exists(nuspecPath), "The intermediate nuspec file is not in the expected place");
+
+                var document = XDocument.Load(nuspecPath);
+                var ns = document.Root.GetDefaultNamespace();
+
+                Assert.Null(document.Root.Element(ns + "metadata").Element(ns + "requireLicenseAcceptance"));
+            }
+        }
+
+        [PlatformFact(Platform.Windows)]
+        public void PackCommand_RequireLicenseAcceptanceEmittedWhenSpecifiedAsTrue()
+        {
+            using (var testDirectory = TestDirectory.Create())
+            {
+                var projectName = "ClassLibrary1";
+                var workingDirectory = Path.Combine(testDirectory, projectName);
+                var projectFile = Path.Combine(workingDirectory, $"{projectName}.csproj");
+
+                msbuildFixture.CreateDotnetNewProject(testDirectory.Path, projectName, " classlib");
+
+                using (var stream = new FileStream(projectFile, FileMode.Open, FileAccess.ReadWrite))
+                {
+                    var xml = XDocument.Load(stream);
+                    ProjectFileUtils.SetTargetFrameworkForProject(xml, "TargetFramework", "netstandard1.4");
+
+                    ProjectFileUtils.AddProperty(xml, "PackageRequireLicenseAcceptance", "true");
+                    ProjectFileUtils.AddProperty(xml, "PackageLicenseExpression", "MIT");
+
+                    ProjectFileUtils.WriteXmlToFile(xml, stream);
+                }
+
+                msbuildFixture.RestoreProject(workingDirectory, projectName, string.Empty);
+                msbuildFixture.PackProject(workingDirectory, projectName, $"/p:PackageOutputPath={workingDirectory}");
+
+                var nupkgPath = Path.Combine(workingDirectory, $"{projectName}.1.0.0.nupkg");
+                var nuspecPath = Path.Combine(workingDirectory, "obj", $"{projectName}.1.0.0.nuspec");
+
+                Assert.True(File.Exists(nupkgPath), "The output .nupkg is not in the expected place");
+                Assert.True(File.Exists(nuspecPath), "The intermediate nuspec file is not in the expected place");
+
+                var document = XDocument.Load(nuspecPath);
+                var ns = document.Root.GetDefaultNamespace();
+
+                Assert.Equal(document.Root.Element(ns + "metadata").Element(ns + "requireLicenseAcceptance").Value, "true");
+            }
+        }
     }
 
 }


### PR DESCRIPTION
## Bug

Fixes: NuGet/Home#5133
Regression: No

## Fix

Details: `<requireLicenseAcceptance>false</requireLicenseAcceptance>` is now never emitted because `false` is specified to be the default. This seems like the most intuitive starting point.

## Testing/Validation

Tests Added: Yes
Validation: Integration tests failed before fix, passed after fix
