### PR TITLE
Stop synthesizing owners

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/ManifestMetadata.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/ManifestMetadata.cs
@@ -97,7 +97,7 @@ namespace NuGet.Packaging
 
         public IEnumerable<string> Owners
         {
-            get { return (_owners == null || !_owners.Any()) ? _authors : _owners; }
+            get { return _owners; }
             set { _owners = value ?? Enumerable.Empty<string>(); }
         }
 

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Xml/PackageMetadataXmlExtensions.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Xml/PackageMetadataXmlExtensions.cs
@@ -43,7 +43,7 @@ namespace NuGet.Packaging.Xml
             if (!metadata.PackageTypes.Contains(PackageType.SymbolsPackage))
             {
                 AddElementIfNotNull(elem, ns, "authors", metadata.Authors, authors => string.Join(",", authors));
-                AddElementIfNotNull(elem, ns, "owners", metadata.Owners, owners => string.Join(",", owners));
+                AddElementIfNotEmpty(elem, ns, "owners", metadata.Owners, owners => string.Join(",", owners));
             }
             if (metadata.DevelopmentDependency)
             {
@@ -366,6 +366,18 @@ namespace NuGet.Packaging.Xml
             where T : class
         {
             if (value != null)
+            {
+                var processed = process(value);
+                if (processed != null)
+                {
+                    parent.Add(new XElement(ns + name, processed));
+                }
+            }
+        }
+
+        private static void AddElementIfNotEmpty<T>(XElement parent, XNamespace ns, string name, IEnumerable<T> value, Func<IEnumerable<T>, object> process)
+        {
+            if (value.Any())
             {
                 var processed = process(value);
                 if (processed != null)

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
@@ -55,7 +55,6 @@ namespace NuGet.CommandLine.Test
     <version>1.0.0.2</version>
     <title>packageA</title>
     <authors>test</authors>
-    <owners>test</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Description</description>
     <copyright>Copyright ©  2013</copyright>
@@ -128,7 +127,6 @@ namespace NuGet.CommandLine.Test
     <version>1.0.0.2</version>
     <title>packageA</title>
     <authors>test</authors>
-    <owners>test</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Description</description>
     <copyright>Copyright ©  2013</copyright>
@@ -200,7 +198,6 @@ namespace NuGet.CommandLine.Test
     <version>1.0.0</version>
     <title>packageA</title>
     <authors>test</authors>
-    <owners>test</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Description</description>
     <copyright>Copyright © 2013</copyright>
@@ -250,7 +247,6 @@ namespace NuGet.CommandLine.Test
     <version>1.0.0</version>
     <title>packageA</title>
     <authors>test</authors>
-    <owners>test</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Description</description>
     <copyright>Copyright © 2013</copyright>
@@ -316,7 +312,6 @@ namespace NuGet.CommandLine.Test
     <version>1.0.0</version>
     <title>packageA</title>
     <authors>test</authors>
-    <owners>test</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Description</description>
     <copyright>Copyright ©  2013</copyright>
@@ -372,7 +367,6 @@ namespace NuGet.CommandLine.Test
     <version>1.0.0</version>
     <title>packageA</title>
     <authors>test</authors>
-    <owners>test</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Description</description>
     <copyright>Copyright ©  2013</copyright>
@@ -441,7 +435,6 @@ namespace NuGet.CommandLine.Test
     <version>1.0.0</version>
     <title>packageA</title>
     <authors>test</authors>
-    <owners>test</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Description</description>
     <copyright>Copyright ©  2013</copyright>
@@ -522,7 +515,6 @@ namespace NuGet.CommandLine.Test
     <version>1.0.0</version>
     <title>packageA</title>
     <authors>test</authors>
-    <owners>test</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Description</description>
     <copyright>Copyright ©  2013</copyright>
@@ -608,7 +600,6 @@ namespace NuGet.CommandLine.Test
     <version>1.0.0</version>
     <title>packageA</title>
     <authors>test</authors>
-    <owners>test</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Description</description>
     <copyright>Copyright ©  2013</copyright>
@@ -687,7 +678,6 @@ namespace NuGet.CommandLine.Test
     <version>1.0.0</version>
     <title>packageA</title>
     <authors>test</authors>
-    <owners>test</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Description</description>
     <copyright>Copyright ©  2013</copyright>
@@ -1380,7 +1370,6 @@ public class B
     <version>1.0.0.0</version>
     <title>Proj2</title>
     <authors>test</authors>
-    <owners>test</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Description</description>
     <copyright>Copyright ©  2013</copyright>
@@ -1398,7 +1387,6 @@ public class B
     <version>2.0.0.0</version>
     <title>Proj6</title>
     <authors>test</authors>
-    <owners>test</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Description</description>
     <copyright>Copyright ©  2013</copyright>
@@ -1608,7 +1596,6 @@ public class B
     <version>1.0.0.0</version>
     <title>Proj2</title>
     <authors>test</authors>
-    <owners>test</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Description</description>
     <copyright>Copyright ©  2013</copyright>
@@ -1626,7 +1613,6 @@ public class B
     <version>2.0.0.0</version>
     <title>Proj6</title>
     <authors>test</authors>
-    <owners>test</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Description</description>
     <copyright>Copyright ©  2013</copyright>
@@ -1720,7 +1706,6 @@ public class B
     <version>1.0.0.0</version>
     <title>Proj2</title>
     <authors>test</authors>
-    <owners>test</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Description</description>
     <copyright>Copyright ©  2013</copyright>
@@ -1738,7 +1723,6 @@ public class B
     <version>2.0.0.0</version>
     <title>Proj6</title>
     <authors>test</authors>
-    <owners>test</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Description</description>
     <copyright>Copyright ©  2013</copyright>
@@ -2065,7 +2049,6 @@ public class B
     <version>1.0.0.0</version>
     <title>Proj2</title>
     <authors>test</authors>
-    <owners>test</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Description</description>
     <copyright>Copyright ©  2013</copyright>
@@ -2083,7 +2066,6 @@ public class B
     <version>2.0.0.0</version>
     <title>Proj6</title>
     <authors>test</authors>
-    <owners>test</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Description</description>
     <copyright>Copyright ©  2013</copyright>
@@ -2143,7 +2125,6 @@ public class B
     <version>$version$</version>
     <title>Proj2</title>
     <authors>test</authors>
-    <owners>test</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Description</description>
     <copyright>Copyright ©  2013</copyright>
@@ -3349,7 +3330,6 @@ namespace Proj1
     <id>Package</id>
     <version>1.0.0</version>
     <authors>author</authors>
-    <owners>author</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>description</description>
     <releaseNotes>release notes</releaseNotes>
@@ -4235,7 +4215,6 @@ namespace " + projectName + @"
     <version>1.0.0</version>
     <title>packageA&lt;T&gt;</title>
     <authors>test &lt;test@microsoft.com&gt;</authors>
-    <owners>test</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Description &lt;with&gt; &lt;&lt;bad
 stuff \n &lt;&lt;
@@ -4372,7 +4351,6 @@ stuff \n <<".Replace("\r\n", "\n");
     <version>1.0.0-beta.1.build.234+git.hash.6f3ae2d59140f5ea97eb7573535de1c286d6d336</version>
     <title>packageA</title>
     <authors>test</authors>
-    <owners>test</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Description</description>
     <copyright>Copyright ©  2013</copyright>
@@ -4642,7 +4620,6 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
     <version>{version}</version>
     <title>packageA</title>
     <authors>test</authors>
-    <owners>test</owners>
     <requireLicenseAcceptance>{requireLicenseAcceptance.ToString().ToLowerInvariant()}</requireLicenseAcceptance>
     <description>Description</description>
     <copyright>Copyright ©  2013</copyright>
@@ -4707,7 +4684,6 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
     <version>{version}</version>
     <title>packageA</title>
     <authors>test</authors>
-    <owners>test</owners>
     <requireLicenseAcceptance>{requireLicenseAcceptance.ToString().ToLowerInvariant()}</requireLicenseAcceptance>
     <description>Description</description>
     <copyright>Copyright ©  2013</copyright>
@@ -4773,7 +4749,6 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
     <version>{version}</version>
     <title>packageA</title>
     <authors>test</authors>
-    <owners>test</owners>
     <requireLicenseAcceptance>{requireLicenseAcceptance.ToString().ToLowerInvariant()}</requireLicenseAcceptance>
     <description>Description</description>
     <copyright>Copyright ©  2013</copyright>
@@ -4822,7 +4797,6 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
     <version>{version}</version>
     <title>packageA</title>
     <authors>test</authors>
-    <owners>test</owners>
     <requireLicenseAcceptance>{requireLicenseAcceptance.ToString().ToLowerInvariant()}</requireLicenseAcceptance>
     <description>Description</description>
     <copyright>Copyright ©  2013</copyright>
@@ -4871,7 +4845,6 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
     <version>{version}</version>
     <title>packageA</title>
     <authors>test</authors>
-    <owners>test</owners>
     <requireLicenseAcceptance>{requireLicenseAcceptance.ToString().ToLowerInvariant()}</requireLicenseAcceptance>
     <description>Description</description>
     <copyright>Copyright ©  2013</copyright>
@@ -4926,7 +4899,6 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
     <version>{version}</version>
     <title>packageA</title>
     <authors>test</authors>
-    <owners>test</owners>
     <requireLicenseAcceptance>{requireLicenseAcceptance.ToString().ToLowerInvariant()}</requireLicenseAcceptance>
     <description>Description</description>
     <copyright>Copyright ©  2013</copyright>
@@ -4992,7 +4964,6 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
     <version>{version}</version>
     <title>packageA</title>
     <authors>test</authors>
-    <owners>test</owners>
     <requireLicenseAcceptance>{requireLicenseAcceptance.ToString().ToLowerInvariant()}</requireLicenseAcceptance>
     <description>Description</description>
     <copyright>Copyright ©  2013</copyright>
@@ -5047,7 +5018,6 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
     <version>{version}</version>
     <title>packageA</title>
     <authors>test</authors>
-    <owners>test</owners>
     <requireLicenseAcceptance>{requireLicenseAcceptance.ToString().ToLowerInvariant()}</requireLicenseAcceptance>
     <description>Description</description>
     <copyright>Copyright ©  2013</copyright>
@@ -5100,7 +5070,6 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
     <version>{version}</version>
     <title>packageA</title>
     <authors>test</authors>
-    <owners>test</owners>
     <requireLicenseAcceptance>{requireLicenseAcceptance.ToString().ToLowerInvariant()}</requireLicenseAcceptance>
     <description>Description</description>
     <copyright>Copyright ©  2013</copyright>
@@ -5150,7 +5119,6 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
     <version>{version}</version>
     <title>packageA</title>
     <authors>test</authors>
-    <owners>test</owners>
     <requireLicenseAcceptance>{requireLicenseAcceptance.ToString().ToLowerInvariant()}</requireLicenseAcceptance>
     <description>Description</description>
     <copyright>Copyright ©  2013</copyright>
@@ -5197,7 +5165,6 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
     <version>{version}</version>
     <title>packageA</title>
     <authors>test</authors>
-    <owners>test</owners>
     <requireLicenseAcceptance>{requireLicenseAcceptance.ToString().ToLowerInvariant()}</requireLicenseAcceptance>
     <description>Description</description>
     <copyright>Copyright ©  2013</copyright>
@@ -5264,7 +5231,6 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
     <version>{version}</version>
     <title>packageA</title>
     <authors>test</authors>
-    <owners>test</owners>
     <requireLicenseAcceptance>{requireLicenseAcceptance.ToString().ToLowerInvariant()}</requireLicenseAcceptance>
     <description>Description</description>
     <copyright>Copyright ©  2013</copyright>
@@ -5467,7 +5433,6 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
     <version>1.0.0.2</version>
     <title>packageA</title>
     <authors>test</authors>
-    <owners>test</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Description</description>
     <copyright>Copyright ©  2013</copyright>
@@ -5531,7 +5496,6 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
     <version>1.0.0.2</version>
     <title>packageA</title>
     <authors>test</authors>
-    <owners>test</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Description</description>
     <copyright>Copyright ©  2013</copyright>
@@ -6010,7 +5974,6 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
     <version>1.0.0-beta.1</version>
     <title>packageA</title>
     <authors>test</authors>
-    <owners>test</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Description</description>
     <copyright>Copyright ©  2013</copyright>

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetSpecCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetSpecCommandTest.cs
@@ -42,7 +42,6 @@ namespace NuGet.CommandLine.Test
     <id>Package</id>
     <version>1.0.0</version>
     <authors>{Environment.UserName}</authors>
-    <owners>{Environment.UserName}</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <license type=""expression"">MIT</license>
     <projectUrl>http://project_url_here_or_delete_this_line/</projectUrl>
@@ -85,7 +84,6 @@ namespace NuGet.CommandLine.Test
     <id>Whatnot</id>
     <version>1.0.0</version>
     <authors>{Environment.UserName}</authors>
-    <owners>{Environment.UserName}</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <license type=""expression"">MIT</license>
     <projectUrl>http://project_url_here_or_delete_this_line/</projectUrl>
@@ -141,7 +139,6 @@ namespace NuGet.CommandLine.Test
     <version>$version$</version>
     <title>$title$</title>
     <authors>$author$</authors>
-    <owners>$author$</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <license type=""expression"">MIT</license>
     <projectUrl>http://project_url_here_or_delete_this_line/</projectUrl>

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
@@ -57,7 +57,7 @@ namespace Dotnet.Integration.Test
                     Assert.Equal("ClassLibrary1", nuspecReader.GetId());
                     Assert.Equal("1.0.0", nuspecReader.GetVersion().ToFullString());
                     Assert.Equal("ClassLibrary1", nuspecReader.GetAuthors());
-                    Assert.Equal("ClassLibrary1", nuspecReader.GetOwners());
+                    Assert.Equal("", nuspecReader.GetOwners());
                     Assert.Equal("Package Description", nuspecReader.GetDescription());
                     Assert.False(nuspecReader.GetRequireLicenseAcceptance());
 
@@ -1057,7 +1057,7 @@ namespace Dotnet.Integration.Test
                     Assert.Equal("ClassLibrary1", nuspecReader.GetId());
                     Assert.Equal("1.0.0", nuspecReader.GetVersion().ToFullString());
                     Assert.Equal("ClassLibrary1", nuspecReader.GetAuthors());
-                    Assert.Equal("ClassLibrary1", nuspecReader.GetOwners());
+                    Assert.Equal("", nuspecReader.GetOwners());
                     Assert.Equal("Package Description", nuspecReader.GetDescription());
                     Assert.False(nuspecReader.GetRequireLicenseAcceptance());
 
@@ -1699,7 +1699,7 @@ namespace Dotnet.Integration.Test
                     Assert.Equal("ClassLibrary1", nuspecReader.GetId());
                     Assert.Equal("1.0.0", nuspecReader.GetVersion().ToFullString());
                     Assert.Equal("ClassLibrary1", nuspecReader.GetAuthors());
-                    Assert.Equal("ClassLibrary1", nuspecReader.GetOwners());
+                    Assert.Equal("", nuspecReader.GetOwners());
                     Assert.Equal("Package Description", nuspecReader.GetDescription());
                     Assert.False(nuspecReader.GetRequireLicenseAcceptance());
 
@@ -1767,7 +1767,7 @@ namespace Dotnet.Integration.Test
                     Assert.Equal("ClassLibrary1", nuspecReader.GetId());
                     Assert.Equal("1.0.0", nuspecReader.GetVersion().ToFullString());
                     Assert.Equal("ClassLibrary1", nuspecReader.GetAuthors());
-                    Assert.Equal("ClassLibrary1", nuspecReader.GetOwners());
+                    Assert.Equal("", nuspecReader.GetOwners());
                     Assert.Equal("Package Description", nuspecReader.GetDescription());
                     Assert.False(nuspecReader.GetRequireLicenseAcceptance());
 
@@ -1832,7 +1832,7 @@ namespace Dotnet.Integration.Test
                     Assert.Equal("ClassLibrary1", nuspecReader.GetId());
                     Assert.Equal("1.0.0", nuspecReader.GetVersion().ToFullString());
                     Assert.Equal("ClassLibrary1", nuspecReader.GetAuthors());
-                    Assert.Equal("ClassLibrary1", nuspecReader.GetOwners());
+                    Assert.Equal("", nuspecReader.GetOwners());
                     Assert.Equal("Package Description", nuspecReader.GetDescription());
                     Assert.False(nuspecReader.GetRequireLicenseAcceptance());
 
@@ -2130,7 +2130,7 @@ namespace Dotnet.Integration.Test
                     Assert.Equal("1.0.0", nuspecReader.GetVersion().ToFullString());
                     Assert.Equal("MyPackageTitle", nuspecReader.GetTitle());
                     Assert.Equal("ClassLibrary1", nuspecReader.GetAuthors());
-                    Assert.Equal("ClassLibrary1", nuspecReader.GetOwners());
+                    Assert.Equal("", nuspecReader.GetOwners());
                     Assert.Equal("Package Description", nuspecReader.GetDescription());
                     Assert.False(nuspecReader.GetRequireLicenseAcceptance());
 

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Pack.Test/PackTaskLogicTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Pack.Test/PackTaskLogicTests.cs
@@ -39,7 +39,7 @@ namespace NuGet.Build.Tasks.Pack.Test
                     Assert.Equal(tc.Request.PackageId, nuspecReader.GetId());
                     Assert.Equal(tc.Request.PackageVersion, nuspecReader.GetVersion().ToFullString());
                     Assert.Equal(string.Join(",", tc.Request.Authors), nuspecReader.GetAuthors());
-                    Assert.Equal(string.Join(",", tc.Request.Authors), nuspecReader.GetOwners());
+                    Assert.Equal("", nuspecReader.GetOwners());
                     Assert.Equal(tc.Request.Description, nuspecReader.GetDescription());
                     Assert.False(nuspecReader.GetRequireLicenseAcceptance());
 
@@ -124,7 +124,7 @@ namespace NuGet.Build.Tasks.Pack.Test
                     Assert.Equal(tc.Request.PackageId, nuspecReader.GetId());
                     Assert.Equal(tc.Request.PackageVersion, nuspecReader.GetVersion().ToFullString());
                     Assert.Equal(string.Join(",", tc.Request.Authors), nuspecReader.GetAuthors());
-                    Assert.Equal(string.Join(",", tc.Request.Authors), nuspecReader.GetOwners());
+                    Assert.Equal("", nuspecReader.GetOwners());
                     Assert.Equal(tc.Request.Description, nuspecReader.GetDescription());
                     Assert.False(nuspecReader.GetRequireLicenseAcceptance());
                     

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/ManifestTest.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/ManifestTest.cs
@@ -308,7 +308,6 @@ namespace NuGet.Packaging.Test
     <id>A</id>
     <version>1.0</version>
     <authors>Luan</authors>
-    <owners>Luan</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Descriptions</description>
 
@@ -341,7 +340,6 @@ namespace NuGet.Packaging.Test
     <id>A</id>
     <version>1.0</version>
     <authors>Luan</authors>
-    <owners>Luan</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <developmentDependency>true</developmentDependency>
     <description>Descriptions</description>
@@ -375,7 +373,6 @@ namespace NuGet.Packaging.Test
     <id>A</id>
     <version>1.0</version>
     <authors>Luan</authors>
-    <owners>Luan</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <developmentDependency>true</developmentDependency>
     <description>Descriptions</description>
@@ -522,7 +519,6 @@ namespace NuGet.Packaging.Test
     <id>A</id>
     <version>1.0</version>
     <authors>Luan</authors>
-    <owners>Luan</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Descriptions</description>
   </metadata>
@@ -546,7 +542,6 @@ namespace NuGet.Packaging.Test
     <id>A</id>
     <version>1.0</version>
     <authors>Luan</authors>
-    <owners>Luan</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Descriptions</description>
     <references>
@@ -586,7 +581,6 @@ namespace NuGet.Packaging.Test
     <id>A</id>
     <version>1.0</version>
     <authors>Luan</authors>
-    <owners>Luan</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Descriptions</description>
     <references>

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageBuilderTest.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageBuilderTest.cs
@@ -122,7 +122,6 @@ namespace NuGet.Packaging.Test
     <id>A</id>
     <version>1.0.0</version>
     <authors>testAuthor</authors>
-    <owners>testAuthor</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Descriptions</description>
     <dependencies>
@@ -181,7 +180,6 @@ namespace NuGet.Packaging.Test
     <id>A</id>
     <version>1.0.0</version>
     <authors>testAuthor</authors>
-    <owners>testAuthor</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Descriptions</description>
     <dependencies>
@@ -276,7 +274,6 @@ namespace NuGet.Packaging.Test
     <id>A</id>
     <version>1.0.0</version>
     <authors>testAuthor</authors>
-    <owners>testAuthor</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Descriptions</description>
     <contentFiles>
@@ -312,7 +309,6 @@ namespace NuGet.Packaging.Test
     <id>A</id>
     <version>1.0.0</version>
     <authors>JohnDoe</authors>
-    <owners>JohnDoe</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Description</description>
   </metadata>
@@ -344,7 +340,6 @@ namespace NuGet.Packaging.Test
     <id>A</id>
     <version>1.0.0</version>
     <authors>JohnDoe</authors>
-    <owners>JohnDoe</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Description</description>
     <releaseNotes>Release Notes</releaseNotes>
@@ -377,7 +372,6 @@ namespace NuGet.Packaging.Test
     <id>A</id>
     <version>1.0.0</version>
     <authors>JohnDoe</authors>
-    <owners>JohnDoe</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Descriptions</description>
     <frameworkAssemblies>
@@ -412,7 +406,6 @@ namespace NuGet.Packaging.Test
     <id>A</id>
     <version>1.0.0</version>
     <authors>JohnDoe</authors>
-    <owners>JohnDoe</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Descriptions</description>
     <references>
@@ -452,7 +445,6 @@ namespace NuGet.Packaging.Test
     <id>A</id>
     <version>1.0.0</version>
     <authors>testAuthor</authors>
-    <owners>testAuthor</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Descriptions</description>
     <dependencies>
@@ -493,7 +485,6 @@ namespace NuGet.Packaging.Test
     <id>A</id>
     <version>1.0.0</version>
     <authors>testAuthor</authors>
-    <owners>testAuthor</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Descriptions</description>
     <dependencies>
@@ -533,7 +524,6 @@ namespace NuGet.Packaging.Test
     <id>A</id>
     <version>1.0.0</version>
     <authors>testAuthor</authors>
-    <owners>testAuthor</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Descriptions</description>
   </metadata>
@@ -573,7 +563,6 @@ namespace NuGet.Packaging.Test
     <id>A</id>
     <version>1.0.0</version>
     <authors>testAuthor</authors>
-    <owners>testAuthor</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Description</description>
     <serviceable>true</serviceable>
@@ -618,7 +607,6 @@ namespace NuGet.Packaging.Test
     <id>A</id>
     <version>1.0.0</version>
     <authors>testAuthor</authors>
-    <owners>testAuthor</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Description</description>
     <packageTypes>
@@ -658,7 +646,6 @@ namespace NuGet.Packaging.Test
     <id>A</id>
     <version>1.0.0</version>
     <authors>testAuthor</authors>
-    <owners>testAuthor</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Descriptions</description>
   </metadata>
@@ -694,7 +681,6 @@ namespace NuGet.Packaging.Test
     <id>A</id>
     <version>1.0.0</version>
     <authors>testAuthor</authors>
-    <owners>testAuthor</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Descriptions</description>
   </metadata>
@@ -730,7 +716,6 @@ namespace NuGet.Packaging.Test
     <id>A</id>
     <version>1.0.0</version>
     <authors>testAuthor</authors>
-    <owners>testAuthor</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Descriptions</description>
   </metadata>
@@ -769,7 +754,6 @@ namespace NuGet.Packaging.Test
     <id>A</id>
     <version>1.0.0</version>
     <authors>testAuthor</authors>
-    <owners>testAuthor</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Descriptions</description>
   </metadata>
@@ -809,7 +793,6 @@ namespace NuGet.Packaging.Test
     <id>A</id>
     <version>1.0.0</version>
     <authors>testAuthor</authors>
-    <owners>testAuthor</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Descriptions</description>
   </metadata>
@@ -846,7 +829,6 @@ namespace NuGet.Packaging.Test
     <id>A</id>
     <version>1.0.0</version>
     <authors>testAuthor</authors>
-    <owners>testAuthor</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Descriptions</description>
   </metadata>
@@ -886,7 +868,6 @@ namespace NuGet.Packaging.Test
     <id>A</id>
     <version>1.0.0</version>
     <authors>testAuthor</authors>
-    <owners>testAuthor</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Descriptions</description>
   </metadata>
@@ -927,7 +908,6 @@ namespace NuGet.Packaging.Test
     <id>A</id>
     <version>1.0.0</version>
     <authors>testAuthor</authors>
-    <owners>testAuthor</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Descriptions</description>
   </metadata>
@@ -967,7 +947,6 @@ namespace NuGet.Packaging.Test
     <id>A</id>
     <version>1.0.0</version>
     <authors>testAuthor</authors>
-    <owners>testAuthor</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Descriptions</description>
     <references>
@@ -1013,7 +992,6 @@ namespace NuGet.Packaging.Test
     <id>A</id>
     <version>1.0.0</version>
     <authors>testAuthor</authors>
-    <owners>testAuthor</owners>
     <developmentDependency>true</developmentDependency>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Descriptions</description>
@@ -1059,7 +1037,6 @@ namespace NuGet.Packaging.Test
     <id>A</id>
     <version>1.0.0</version>
     <authors>testAuthor</authors>
-    <owners>testAuthor</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Descriptions</description>
     <references>
@@ -1099,7 +1076,6 @@ namespace NuGet.Packaging.Test
     <id>A</id>
     <version>1.0.0</version>
     <authors>testAuthor</authors>
-    <owners>testAuthor</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Descriptions</description>
   </metadata>
@@ -1208,7 +1184,6 @@ namespace NuGet.Packaging.Test
     <id>A</id>
     <version>1.0.0</version>
     <authors>JohnDoe</authors>
-    <owners>JohnDoe</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Descriptions</description>
     <summary>Summary</summary>
@@ -1692,7 +1667,6 @@ Description is required.");
             Assert.Equal("Some awesome package", builder.Title);
             Assert.Equal(1, builder.Authors.Count);
             Assert.Equal("These are the authors", authors[0]);
-            Assert.Equal("These are the authors", owners[0]);
             Assert.Equal(3, builder.Tags.Count);
             Assert.Equal("t1", tags[0]);
             Assert.Equal("t2", tags[1]);
@@ -2323,7 +2297,6 @@ Enabling license acceptance requires a license or a licenseUrl to be specified. 
         <id>SourceDepotClient</id>
         <version>2.8.0.0</version>
            <authors>pranjalg</authors>
-           <owners>pranjalg</owners>
            <licenseUrl>http://cbt-userguide/NugetCanUseInLabs.html</licenseUrl>
         <requireLicenseAcceptance>true</requireLicenseAcceptance>
         <description>Source Depot Client assembly with SDApi.</description>
@@ -2355,7 +2328,6 @@ Enabling license acceptance requires a license or a licenseUrl to be specified. 
     <id>SourceDepotClient</id>
     <version>2.8.0</version>
     <authors>pranjalg</authors>
-    <owners>pranjalg</owners>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <licenseUrl>http://cbt-userguide/NugetCanUseInLabs.html</licenseUrl>
     <description>Source Depot Client assembly with SDApi.</description>


### PR DESCRIPTION
## Bug

Fixes: NuGet/Home#5134
Regression: No

## Fix

Details: `<owners>` is no longer forced to appear when not specified.

## Testing/Validation

Tests Added: Yes
Validation: Integration tests failed before fix, passed after fix
