### PR TITLE
Write nomination errors to assets file

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
@@ -284,7 +284,7 @@ namespace NuGet.PackageManagement.VisualStudio
             {
                 // check if this .Net core project is nominated or not.
                 DependencyGraphSpec projectRestoreInfo;
-                if (!_projectSystemCache.TryGetProjectRestoreInfo(project.MSBuildProjectPath, out projectRestoreInfo) ||
+                if (!_projectSystemCache.TryGetProjectRestoreInfo(project.MSBuildProjectPath, out projectRestoreInfo, nominationMessages: out _) ||
                     projectRestoreInfo == null)
                 {
                     // there are projects still to be nominated.

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyPackageReferenceProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyPackageReferenceProject.cs
@@ -106,8 +106,13 @@ namespace NuGet.PackageManagement.VisualStudio
         #region IDependencyGraphProject
 
         public override string MSBuildProjectPath => _projectFullPath;
-
         public override async Task<IReadOnlyList<PackageSpec>> GetPackageSpecsAsync(DependencyGraphCacheContext context)
+        {
+            var (dgSpec, _) = await GetPackageSpecsAndAdditionalMessagesAsync(context);
+            return dgSpec;
+        }
+
+        public override async Task<(IReadOnlyList<PackageSpec> dgSpecs, IReadOnlyList<IAssetsLogMessage> additionalMessages)> GetPackageSpecsAndAdditionalMessagesAsync(DependencyGraphCacheContext context)
         {
             PackageSpec packageSpec;
             if (context == null || !context.PackageSpecCache.TryGetValue(MSBuildProjectPath, out packageSpec))
@@ -121,7 +126,7 @@ namespace NuGet.PackageManagement.VisualStudio
                 context?.PackageSpecCache.Add(_projectFullPath, packageSpec);
             }
 
-            return new[] { packageSpec };
+            return (new[] { packageSpec }, null);
         }
 
         #endregion

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyPackageReferenceProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyPackageReferenceProject.cs
@@ -106,6 +106,7 @@ namespace NuGet.PackageManagement.VisualStudio
         #region IDependencyGraphProject
 
         public override string MSBuildProjectPath => _projectFullPath;
+
         public override async Task<IReadOnlyList<PackageSpec>> GetPackageSpecsAsync(DependencyGraphCacheContext context)
         {
             var (dgSpec, _) = await GetPackageSpecsAndAdditionalMessagesAsync(context);

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/ProjectSystemCache.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/ProjectSystemCache.cs
@@ -80,17 +80,24 @@ namespace NuGet.PackageManagement.VisualStudio
 
         public bool TryGetProjectRestoreInfo(string name, out DependencyGraphSpec projectRestoreInfo)
         {
+            return TryGetProjectRestoreInfo(name, out projectRestoreInfo, out _);
+        }
+
+        public bool TryGetProjectRestoreInfo(string name, out DependencyGraphSpec projectRestoreInfo, out IReadOnlyList<IAssetsLogMessage> additionalMessages)
+        {
             if (string.IsNullOrEmpty(name))
             {
                 throw new ArgumentException(CommonResources.Argument_Cannot_Be_Null_Or_Empty, nameof(name));
             }
 
             projectRestoreInfo = null;
+            additionalMessages = null;
 
             CacheEntry cacheEntry;
             if (TryGetCacheEntry(name, out cacheEntry))
             {
                 projectRestoreInfo = cacheEntry.ProjectRestoreInfo;
+                additionalMessages = cacheEntry.AdditionalMessages;
             }
 
             return projectRestoreInfo != null;
@@ -268,7 +275,7 @@ namespace NuGet.PackageManagement.VisualStudio
             return true;
         }
 
-        public bool AddProjectRestoreInfo(ProjectNames projectNames, DependencyGraphSpec projectRestoreInfo)
+        public bool AddProjectRestoreInfo(ProjectNames projectNames, DependencyGraphSpec projectRestoreInfo, IReadOnlyList<IAssetsLogMessage> additionalMessages)
         {
             if (projectNames == null)
             {
@@ -293,11 +300,13 @@ namespace NuGet.PackageManagement.VisualStudio
                     projectNames.FullName,
                     addEntryFactory: k => new CacheEntry
                     {
-                        ProjectRestoreInfo = projectRestoreInfo
+                        ProjectRestoreInfo = projectRestoreInfo,
+                        AdditionalMessages = additionalMessages
                     },
                     updateEntryFactory: (k, e) =>
                     {
                         e.ProjectRestoreInfo = projectRestoreInfo;
+                        e.AdditionalMessages = additionalMessages;
                         return e;
                     });
             }
@@ -479,6 +488,7 @@ namespace NuGet.PackageManagement.VisualStudio
             public IVsProjectAdapter VsProjectAdapter { get; set; }
             public DependencyGraphSpec ProjectRestoreInfo { get; set; }
             public ProjectNames ProjectNames { get; set; }
+            public IReadOnlyList<IAssetsLogMessage> AdditionalMessages { get; set; }
         }
 
         private void FireCacheUpdatedEvent(string projectFullName)

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/ProjectSystemCache.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/ProjectSystemCache.cs
@@ -78,11 +78,6 @@ namespace NuGet.PackageManagement.VisualStudio
             return project != null;
         }
 
-        public bool TryGetProjectRestoreInfo(string name, out DependencyGraphSpec projectRestoreInfo)
-        {
-            return TryGetProjectRestoreInfo(name, out projectRestoreInfo, out _);
-        }
-
         public bool TryGetProjectRestoreInfo(string name, out DependencyGraphSpec projectRestoreInfo, out IReadOnlyList<IAssetsLogMessage> additionalMessages)
         {
             if (string.IsNullOrEmpty(name))

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/Resources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/Resources.Designer.cs
@@ -106,6 +106,15 @@ namespace NuGet.SolutionRestoreManager {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Unable to read the project information: {0}.
+        /// </summary>
+        internal static string NU1010 {
+            get {
+                return ResourceManager.GetString("NU1010", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to ========== Finished ==========.
         /// </summary>
         internal static string Operation_Finished {

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/Resources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/Resources.Designer.cs
@@ -106,11 +106,11 @@ namespace NuGet.SolutionRestoreManager {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Unable to read the project information: {0}.
+        ///   Looks up a localized string similar to Unable to read project information for &apos;{0}&apos;: {1}.
         /// </summary>
-        internal static string NU1010 {
+        internal static string NU1105 {
             get {
-                return ResourceManager.GetString("NU1010", resourceCulture);
+                return ResourceManager.GetString("NU1105", resourceCulture);
             }
         }
         

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/Resources.resx
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/Resources.resx
@@ -133,6 +133,10 @@
   <data name="NothingToRestore" xml:space="preserve">
     <value>All packages are already installed and there is nothing to restore.</value>
   </data>
+  <data name="NU1010" xml:space="preserve">
+    <value>Unable to read the project information: {0}</value>
+    <comment>0 - Message explaining what couldn't be read. Typically an exception's message</comment>
+  </data>
   <data name="Operation_Finished" xml:space="preserve">
     <value>========== Finished ==========</value>
   </data>

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/Resources.resx
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/Resources.resx
@@ -133,9 +133,10 @@
   <data name="NothingToRestore" xml:space="preserve">
     <value>All packages are already installed and there is nothing to restore.</value>
   </data>
-  <data name="NU1010" xml:space="preserve">
-    <value>Unable to read the project information: {0}</value>
-    <comment>0 - Message explaining what couldn't be read. Typically an exception's message</comment>
+  <data name="NU1105" xml:space="preserve">
+    <value>Unable to read project information for '{0}': {1}</value>
+    <comment>0 - The name of the project with the error.
+1 - Message explaining what couldn't be read. Typically an exception's message</comment>
   </data>
   <data name="Operation_Finished" xml:space="preserve">
     <value>========== Finished ==========</value>

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreJob.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreJob.cs
@@ -326,9 +326,10 @@ namespace NuGet.SolutionRestoreManager
                 var pathContext = NuGetPathContext.Create(_settings);
 
                 // Get full dg spec
-                var dgSpec = await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(_solutionManager, cacheContext);
+                var (dgSpec, additionalMessages) = await DependencyGraphRestoreUtility.GetSolutionRestoreSpecAndAdditionalMessages(_solutionManager, cacheContext);
                 intervalTracker.EndIntervalMeasure(RestoreTelemetryEvent.SolutionDependencyGraphSpecCreation);
                 intervalTracker.StartIntervalMeasure();
+
                 // Avoid restoring solutions with zero potential PackageReference projects.
                 if (DependencyGraphRestoreUtility.IsRestoreRequired(dgSpec))
                 {
@@ -359,6 +360,7 @@ namespace NuGet.SolutionRestoreManager
                                 _nuGetProjectContext.OperationId,
                                 forceRestore,
                                 isRestoreOriginalAction,
+                                additionalMessages,
                                 l,
                                 t);
 

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
@@ -125,7 +125,7 @@ namespace NuGet.SolutionRestoreManager
                 }
                 catch (Exception e)
                 {
-                    var restoreLogMessage = RestoreLogMessage.CreateError(NuGetLogCode.NU1000, "Unable to read project information: " + e.Message);
+                    var restoreLogMessage = RestoreLogMessage.CreateError(NuGetLogCode.NU1010, string.Format(Resources.NU1010, e.Message));
                     restoreLogMessage.ProjectPath = projectUniqueName;
 
                     nominationErrors = new List<IAssetsLogMessage>()

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
@@ -16,6 +16,7 @@ using NuGet.Configuration;
 using NuGet.ProjectModel;
 using NuGet.Shared;
 using NuGet.VisualStudio;
+using NuGet.VisualStudio.Telemetry;
 
 namespace NuGet.SolutionRestoreManager
 {
@@ -157,7 +158,7 @@ namespace NuGet.SolutionRestoreManager
             catch (Exception e)
             {
                 _logger.LogError(e.ToString());
-                throw;
+                TelemetryUtility.EmitException(nameof(VsSolutionRestoreService), nameof(NominateProjectAsync), e);
             }
         }
 

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
@@ -159,6 +159,7 @@ namespace NuGet.SolutionRestoreManager
             {
                 _logger.LogError(e.ToString());
                 TelemetryUtility.EmitException(nameof(VsSolutionRestoreService), nameof(NominateProjectAsync), e);
+                return Task.FromResult(false);
             }
         }
 

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
@@ -125,8 +125,8 @@ namespace NuGet.SolutionRestoreManager
                 }
                 catch (Exception e)
                 {
-                    var restoreLogMessage = RestoreLogMessage.CreateError(NuGetLogCode.NU1010, string.Format(Resources.NU1010, e.Message));
-                    restoreLogMessage.ProjectPath = projectUniqueName;
+                    var restoreLogMessage = RestoreLogMessage.CreateError(NuGetLogCode.NU1105, string.Format(Resources.NU1105, projectNames.ShortName, e.Message));
+                    restoreLogMessage.LibraryId = projectUniqueName;
 
                     nominationErrors = new List<IAssetsLogMessage>()
                     {
@@ -138,7 +138,7 @@ namespace NuGet.SolutionRestoreManager
                         ? projectRestoreInfo2.BaseIntermediatePath
                         : projectRestoreInfo.BaseIntermediatePath;
                     var dgSpecOutputPath = GetProjectOutputPath(projectDirectory, projectIntermediatePath);
-                    dgSpec = DependencyGraphSpec.CreateMinimal(projectUniqueName, dgSpecOutputPath);
+                    dgSpec = CreateMinimalDependencyGraphSpec(projectUniqueName, dgSpecOutputPath);
                 }
 
                 _projectSystemCache.AddProjectRestoreInfo(projectNames, dgSpec, nominationErrors);
@@ -259,6 +259,21 @@ namespace NuGet.SolutionRestoreManager
                 Path.Combine(
                     projectDirectory,
                     msbuildProjectExtensionsPath));
+        }
+
+        private static DependencyGraphSpec CreateMinimalDependencyGraphSpec(string projectPath, string outputPath)
+        {
+            var packageSpec = new PackageSpec();
+            packageSpec.FilePath = projectPath;
+            packageSpec.RestoreMetadata = new ProjectRestoreMetadata();
+            packageSpec.RestoreMetadata.ProjectUniqueName = projectPath;
+            packageSpec.RestoreMetadata.ProjectStyle = ProjectStyle.PackageReference;
+            packageSpec.RestoreMetadata.OutputPath = outputPath;
+
+            var dgSpec = new DependencyGraphSpec();
+            dgSpec.AddProject(packageSpec);
+
+            return dgSpec;
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/ProjectSystems/IProjectSystemCache.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/ProjectSystems/IProjectSystemCache.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -49,8 +49,9 @@ namespace NuGet.VisualStudio
         /// </summary>
         /// <param name="name">Project name, full path or unique name.</param>
         /// <param name="projectRestoreInfo">Desired project restore info object, or null if not found.</param>
+        /// <param name="nominationMessages"></param>
         /// <returns>True if found, false otherwise.</returns>
-        bool TryGetProjectRestoreInfo(string name, out DependencyGraphSpec projectRestoreInfo);
+        bool TryGetProjectRestoreInfo(string name, out DependencyGraphSpec projectRestoreInfo, out IReadOnlyList<IAssetsLogMessage> nominationMessages);
 
         /// <summary>
         /// Finds a project name by short name, unique name or custom unique name.
@@ -109,7 +110,7 @@ namespace NuGet.VisualStudio
         /// <param name="projectNames">Primary key.</param>
         /// <param name="projectRestoreInfo">The project restore info including tools.</param>
         /// <returns>True if operation succeeded.</returns>
-        bool AddProjectRestoreInfo(ProjectNames projectNames, DependencyGraphSpec projectRestoreInfo);
+        bool AddProjectRestoreInfo(ProjectNames projectNames, DependencyGraphSpec projectRestoreInfo, IReadOnlyList<IAssetsLogMessage> additionalMessages);
 
         /// <summary>
         /// Removes a project associated with given name out of the cache.

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/TelemetryUtility.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/TelemetryUtility.cs
@@ -25,6 +25,16 @@ namespace NuGet.VisualStudio.Telemetry
             return $"{VSTelemetrySession.VSEventNamePrefix}fileandforget/{typeName}/{memberName}";
         }
 
+        public static void EmitException(string className, string methodName, Exception exception)
+        {
+            TelemetryEvent telemetryEvent = new TelemetryEvent($"errors/{className}.{methodName}");
+            telemetryEvent["Message"] = exception.Message;
+            telemetryEvent["ExceptionType"] = exception.GetType().FullName;
+            telemetryEvent["StackTrace"] = exception.StackTrace;
+
+            TelemetryActivity.EmitTelemetryEvent(telemetryEvent);
+        }
+
         /// <summary>
         /// True if the source is http and ends with index.json
         /// </summary>

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/TelemetryUtility.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/TelemetryUtility.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.IO;
+using System.Linq;
+using System.Windows.Documents;
 using NuGet.Common;
 using NuGet.Configuration;
 
@@ -27,11 +29,44 @@ namespace NuGet.VisualStudio.Telemetry
 
         public static void EmitException(string className, string methodName, Exception exception)
         {
-            TelemetryEvent telemetryEvent = new TelemetryEvent($"errors/{className}.{methodName}");
-            telemetryEvent["Message"] = exception.Message;
-            telemetryEvent["ExceptionType"] = exception.GetType().FullName;
-            telemetryEvent["StackTrace"] = exception.StackTrace;
+            if (className == null)
+            {
+                throw new ArgumentNullException(nameof(className));
+            }
+            if (methodName == null)
+            {
+                throw new ArgumentNullException(nameof(methodName));
+            }
+            if (exception == null)
+            {
+                throw new ArgumentNullException(nameof(exception));
+            }
 
+            TelemetryEvent ToTelemetryEvent(Exception e, string name)
+            {
+                TelemetryEvent te = new TelemetryEvent(name);
+                te["Message"] = e.Message;
+                te["ExceptionType"] = e.GetType().FullName;
+                te["StackTrace"] = e.StackTrace;
+
+                if (e is AggregateException aggregateException)
+                {
+                    var exceptions =
+                        aggregateException.InnerExceptions
+                        .Select(ie => ToTelemetryEvent(ie, name: null))
+                        .ToList();
+                    te.ComplexData["InnerExceptions"] = exceptions;
+                }
+                else if (e.InnerException != null)
+                {
+                    var inner = ToTelemetryEvent(e.InnerException, name: null);
+                    te.ComplexData["InnerException"] = inner;
+                }
+
+                return te;
+            }
+
+            TelemetryEvent telemetryEvent = ToTelemetryEvent(exception, $"errors/{className}.{methodName}");
             TelemetryActivity.EmitTelemetryEvent(telemetryEvent);
         }
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/DependencyGraphSpecRequestProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/DependencyGraphSpecRequestProvider.cs
@@ -242,7 +242,7 @@ namespace NuGet.Commands
             }
         }
 
-        private static IReadOnlyList<IAssetsLogMessage> GetMessagesForProject(IReadOnlyList<IAssetsLogMessage> allMessages, string projectPath)
+        internal static IReadOnlyList<IAssetsLogMessage> GetMessagesForProject(IReadOnlyList<IAssetsLogMessage> allMessages, string projectPath)
         {
             List<IAssetsLogMessage> projectAdditionalMessages = null;
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/DependencyGraphSpecRequestProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/DependencyGraphSpecRequestProvider.cs
@@ -159,6 +159,8 @@ namespace NuGet.Commands
 
             var rootPath = Path.GetDirectoryName(project.PackageSpec.FilePath);
 
+            IReadOnlyList<IAssetsLogMessage> projectAdditionalMessages = GetMessagesForProject(restoreArgs.AdditionalMessages, project.PackageSpec.FilePath);
+
             // Create request
             var request = new RestoreRequest(
                 project.PackageSpec,
@@ -172,7 +174,8 @@ namespace NuGet.Commands
                 //  Project.json is special cased to put assets file and generated .props and targets in the project folder
                 RestoreOutputPath = project.PackageSpec.RestoreMetadata.ProjectStyle == ProjectStyle.ProjectJson ? rootPath : project.PackageSpec.RestoreMetadata.OutputPath,
                 DependencyGraphSpec = projectDgSpec,
-                MSBuildProjectExtensionsPath = projectPackageSpec.RestoreMetadata.OutputPath
+                MSBuildProjectExtensionsPath = projectPackageSpec.RestoreMetadata.OutputPath,
+                AdditionalMessages = projectAdditionalMessages
             };
 
             var restoreLegacyPackagesDirectory = project.PackageSpec?.RestoreMetadata?.LegacyPackagesDirectory
@@ -229,6 +232,26 @@ namespace NuGet.Commands
                     CollectReferences(childProject, allProjects, references);
                 }
             }
+        }
+
+        private static IReadOnlyList<IAssetsLogMessage> GetMessagesForProject(IReadOnlyList<IAssetsLogMessage> allMessages, string projectPath)
+        {
+            List<IAssetsLogMessage> projectAdditionalMessages = null;
+
+            foreach (var message in allMessages)
+            {
+                if (message.ProjectPath == projectPath)
+                {
+                    if (projectAdditionalMessages == null)
+                    {
+                        projectAdditionalMessages = new List<IAssetsLogMessage>();
+                    }
+
+                    projectAdditionalMessages.Add(message);
+                }
+            }
+
+            return projectAdditionalMessages;
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/RestoreArgs.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/RestoreArgs.cs
@@ -66,6 +66,8 @@ namespace NuGet.Commands
 
         public bool RestoreForceEvaluate { get; set; }
 
+        public IReadOnlyList<IAssetsLogMessage> AdditionalMessages { get; set; }
+
         // Cache directory -> ISettings
         private ConcurrentDictionary<string, ISettings> _settingsCache
             = new ConcurrentDictionary<string, ISettings>(StringComparer.Ordinal);

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/RestoreArgs.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/RestoreArgs.cs
@@ -66,6 +66,9 @@ namespace NuGet.Commands
 
         public bool RestoreForceEvaluate { get; set; }
 
+        /// <summary>
+        /// Messages that should be written to the assets file, in addition to any messages generated during the restore.
+        /// </summary>
         public IReadOnlyList<IAssetsLogMessage> AdditionalMessages { get; set; }
 
         // Cache directory -> ISettings

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -599,7 +599,7 @@ namespace NuGet.Commands
             // DgSpec doesn't contain log messages, so skip no-op if there are any, as it's not taken into account in the hash
             if (_request.AllowNoOp &&
                 !_request.RestoreForceEvaluate &&
-                File.Exists(_request.Project.RestoreMetadata.CacheFilePath) &&
+                File.Exists(_request.Project.RestoreMetadata.CacheFilePath) ||
                 _request.AdditionalMessages?.Count > 0)
             {
                 cacheFile = FileUtility.SafeRead(_request.Project.RestoreMetadata.CacheFilePath, (stream, path) => CacheFileFormat.Read(stream, _logger, path));

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRequest.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRequest.cs
@@ -184,5 +184,7 @@ namespace NuGet.Commands
         public bool IsRestoreOriginalAction { get; set; } = true;
 
         public bool RestoreForceEvaluate { get; set; }
+
+        public IReadOnlyList<IAssetsLogMessage> AdditionalMessages { get; set; }
     }
 }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/NoOpRestoreUtilities.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/NoOpRestoreUtilities.cs
@@ -22,11 +22,11 @@ namespace NuGet.Commands
         internal const string NoOpCacheFileName = "project.nuget.cache";
 
         /// <summary>
-        /// If the dependencyGraphSpec is not set, or there are additional log messages, we cannot no-op on this project restore.
+        /// If the dependencyGraphSpec is not set, we cannot no-op on this project restore.
         /// </summary>
         internal static bool IsNoOpSupported(RestoreRequest request)
         {
-            return request.DependencyGraphSpec != null && request.AdditionalMessages.Count == 0;
+            return request.DependencyGraphSpec != null;
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/NoOpRestoreUtilities.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/NoOpRestoreUtilities.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using NuGet.Common;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
 using NuGet.ProjectModel;
@@ -21,11 +22,11 @@ namespace NuGet.Commands
         internal const string NoOpCacheFileName = "project.nuget.cache";
 
         /// <summary>
-        /// If the dependencyGraphSpec is not set, we cannot no-op on this project restore. 
+        /// If the dependencyGraphSpec is not set, or there are additional log messages, we cannot no-op on this project restore.
         /// </summary>
         internal static bool IsNoOpSupported(RestoreRequest request)
         {
-            return request.DependencyGraphSpec != null;
+            return request.DependencyGraphSpec != null && request.AdditionalMessages.Count == 0;
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/SpecValidationUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/SpecValidationUtility.cs
@@ -17,6 +17,14 @@ namespace NuGet.Commands
         /// </summary>
         public static void ValidateDependencySpec(DependencyGraphSpec spec)
         {
+            ValidateDependencySpec(spec, projectsToSkip: new HashSet<string>());
+        }
+
+        /// <summary>
+        /// Validate a dg file. This will throw a RestoreSpecException if there are errors.
+        /// </summary>
+        public static void ValidateDependencySpec(DependencyGraphSpec spec, HashSet<string> projectsToSkip)
+        {
             if (spec == null)
             {
                 throw new ArgumentNullException(nameof(spec));
@@ -27,7 +35,10 @@ namespace NuGet.Commands
                 // Verify projects
                 foreach (var projectSpec in spec.Projects)
                 {
-                    ValidateProjectSpec(projectSpec);
+                    if (!projectsToSkip.Contains(projectSpec.FilePath))
+                    {
+                        ValidateProjectSpec(projectSpec);
+                    }
                 }
 
                 var restoreSet = new HashSet<string>(spec.Restore, StringComparer.Ordinal);

--- a/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
@@ -93,6 +93,11 @@ namespace NuGet.Common
         NU1009 = 1009,
 
         /// <summary>
+        /// Unable to parse project information.
+        /// </summary>
+        NU1010 = 1010,
+
+        /// <summary>
         /// Unable to resolve package, generic message for unknown type constraints.
         /// </summary>
         NU1100 = 1100,

--- a/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
@@ -93,11 +93,6 @@ namespace NuGet.Common
         NU1009 = 1009,
 
         /// <summary>
-        /// Unable to parse project information.
-        /// </summary>
-        NU1010 = 1010,
-
-        /// <summary>
         /// Unable to resolve package, generic message for unknown type constraints.
         /// </summary>
         NU1100 = 1100,
@@ -124,7 +119,7 @@ namespace NuGet.Common
         NU1104 = 1104,
 
         /// <summary>
-        /// Project reference was not in the dg spec.
+        /// Unable to read project information for 'ProjectFile'. The project file may be invalid or missing targets required for restore.
         /// </summary>
         NU1105 = 1105,
 

--- a/src/NuGet.Core/NuGet.PackageManagement/BuildIntegration/DependencyGraphRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/BuildIntegration/DependencyGraphRestoreUtility.cs
@@ -258,7 +258,7 @@ namespace NuGet.PackageManagement
             return dgSpec;
         }
 
-        public static async Task<(DependencyGraphSpec dgSpec, IReadOnlyList<IAssetsLogMessage> additioalMessages)> GetSolutionRestoreSpecAndAdditionalMessages(
+        public static async Task<(DependencyGraphSpec dgSpec, IReadOnlyList<IAssetsLogMessage> additionalMessages)> GetSolutionRestoreSpecAndAdditionalMessages(
             ISolutionManager solutionManager,
             DependencyGraphCacheContext context)
         {

--- a/src/NuGet.Core/NuGet.PackageManagement/BuildIntegration/DependencyGraphRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/BuildIntegration/DependencyGraphRestoreUtility.cs
@@ -28,6 +28,36 @@ namespace NuGet.PackageManagement
         /// <summary>
         /// Restore a solution and cache the dg spec to context.
         /// </summary>
+        public static Task<IReadOnlyList<RestoreSummary>> RestoreAsync(
+            ISolutionManager solutionManager,
+            DependencyGraphSpec dgSpec,
+            DependencyGraphCacheContext context,
+            RestoreCommandProvidersCache providerCache,
+            Action<SourceCacheContext> cacheContextModifier,
+            IEnumerable<SourceRepository> sources,
+            Guid parentId,
+            bool forceRestore,
+            bool isRestoreOriginalAction,
+            ILogger log,
+            CancellationToken token)
+        {
+            return RestoreAsync(solutionManager,
+                dgSpec,
+                context,
+                providerCache,
+                cacheContextModifier,
+                sources,
+                parentId,
+                forceRestore,
+                isRestoreOriginalAction,
+                additionalMessages: null,
+                log,
+                token);
+        }
+
+        /// <summary>
+        /// Restore a solution and cache the dg spec to context.
+        /// </summary>
         public static async Task<IReadOnlyList<RestoreSummary>> RestoreAsync(
             ISolutionManager solutionManager,
             DependencyGraphSpec dgSpec,
@@ -38,6 +68,7 @@ namespace NuGet.PackageManagement
             Guid parentId,
             bool forceRestore,
             bool isRestoreOriginalAction,
+            IReadOnlyList<IAssetsLogMessage> additionalMessages,
             ILogger log,
             CancellationToken token)
         {
@@ -61,7 +92,8 @@ namespace NuGet.PackageManagement
                         parentId,
                         forceRestore,
                         isRestoreOriginalAction,
-                        restoreForceEvaluate);
+                        restoreForceEvaluate,
+                        additionalMessages);
 
                     var restoreSummaries = await RestoreRunner.RunAsync(restoreContext, token);
 
@@ -144,7 +176,8 @@ namespace NuGet.PackageManagement
                     parentId,
                     forceRestore: true,
                     isRestoreOriginalAction: false,
-                    restoreForceEvaluate: true);
+                    restoreForceEvaluate: true,
+                    additionalMessasges: null);
 
                 var requests = await RestoreRunner.GetRequests(restoreContext);
                 var results = await RestoreRunner.RunWithoutCommit(requests, restoreContext);
@@ -221,14 +254,33 @@ namespace NuGet.PackageManagement
             ISolutionManager solutionManager,
             DependencyGraphCacheContext context)
         {
+            var (dgSpec, _) = await GetSolutionRestoreSpecAndAdditionalMessages(solutionManager, context);
+            return dgSpec;
+        }
+
+        public static async Task<(DependencyGraphSpec dgSpec, IReadOnlyList<IAssetsLogMessage> additioalMessages)> GetSolutionRestoreSpecAndAdditionalMessages(
+            ISolutionManager solutionManager,
+            DependencyGraphCacheContext context)
+        {
             var dgSpec = new DependencyGraphSpec();
+            List<IAssetsLogMessage> allAdditionalMessages = null;
 
             var projects = (await solutionManager.GetNuGetProjectsAsync()).OfType<IDependencyGraphProject>().ToList();
             var knownProjects = projects.Select(e => e.MSBuildProjectPath).ToHashSet(PathUtility.GetStringComparerBasedOnOS());
 
             for (var i = 0; i < projects.Count; i++)
             {
-                var packageSpecs = await projects[i].GetPackageSpecsAsync(context);
+                var (packageSpecs, projectAdditionalMessages) = await projects[i].GetPackageSpecsAndAdditionalMessagesAsync(context);
+
+                if (projectAdditionalMessages != null && projectAdditionalMessages.Count > 0)
+                {
+                    if (allAdditionalMessages == null)
+                    {
+                        allAdditionalMessages = new List<IAssetsLogMessage>();
+                    }
+
+                    allAdditionalMessages.AddRange(projectAdditionalMessages);
+                }
 
                 foreach (var packageSpec in packageSpecs)
                 {
@@ -274,7 +326,7 @@ namespace NuGet.PackageManagement
             }
 
             // Return dg file
-            return dgSpec;
+            return (dgSpec, allAdditionalMessages);
         }
 
         /// <summary>
@@ -289,7 +341,8 @@ namespace NuGet.PackageManagement
             Guid parentId,
             bool forceRestore,
             bool isRestoreOriginalAction,
-            bool restoreForceEvaluate)
+            bool restoreForceEvaluate,
+            IReadOnlyList<IAssetsLogMessage> additionalMessasges)
         {
 #pragma warning disable CS0618 // Type or member is obsolete
             var caching = new CachingSourceProvider(new PackageSourceProvider(context.Settings, enablePackageSourcesChangedEvent: false));
@@ -310,7 +363,8 @@ namespace NuGet.PackageManagement
                 CachingSourceProvider = caching,
                 ParentId = parentId,
                 IsRestoreOriginalAction = isRestoreOriginalAction,
-                RestoreForceEvaluate = restoreForceEvaluate
+                RestoreForceEvaluate = restoreForceEvaluate,
+                AdditionalMessages = additionalMessasges
             };
 
             return restoreContext;

--- a/src/NuGet.Core/NuGet.PackageManagement/IDependencyGraphProject.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/IDependencyGraphProject.cs
@@ -1,11 +1,8 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using NuGet.Packaging;
-using NuGet.Packaging.Core;
 using NuGet.ProjectModel;
 
 namespace NuGet.ProjectManagement
@@ -27,5 +24,11 @@ namespace NuGet.ProjectManagement
         /// optionally include more specs to restore such as tools.
         /// </summary>
         Task<IReadOnlyList<PackageSpec>> GetPackageSpecsAsync(DependencyGraphCacheContext context);
+
+        /// <summary>
+        /// Project specs related to this project. This must include the project's own spec, and may
+        /// optionally include more specs to restore such as tools.
+        /// </summary>
+        Task<(IReadOnlyList<PackageSpec> dgSpecs, IReadOnlyList<IAssetsLogMessage> additionalMessages)> GetPackageSpecsAndAdditionalMessagesAsync(DependencyGraphCacheContext context);
     }
 }

--- a/src/NuGet.Core/NuGet.PackageManagement/Projects/BuildIntegratedNuGetProject.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Projects/BuildIntegratedNuGetProject.cs
@@ -61,6 +61,8 @@ namespace NuGet.ProjectManagement.Projects
 
         public abstract Task<IReadOnlyList<PackageSpec>> GetPackageSpecsAsync(DependencyGraphCacheContext context);
 
+        public abstract Task<(IReadOnlyList<PackageSpec> dgSpecs, IReadOnlyList<IAssetsLogMessage> additionalMessages)> GetPackageSpecsAndAdditionalMessagesAsync(DependencyGraphCacheContext context);
+
         public abstract Task<bool> InstallPackageAsync(
             string packageId,
             VersionRange range,

--- a/src/NuGet.Core/NuGet.PackageManagement/Projects/MSBuildNuGetProject.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Projects/MSBuildNuGetProject.cs
@@ -636,6 +636,12 @@ namespace NuGet.ProjectManagement
 
         public async Task<IReadOnlyList<PackageSpec>> GetPackageSpecsAsync(DependencyGraphCacheContext context)
         {
+            var (dgSpec, _) = await GetPackageSpecsAndAdditionalMessagesAsync(context);
+            return dgSpec;
+        }
+
+        public async Task<(IReadOnlyList<PackageSpec> dgSpecs, IReadOnlyList<IAssetsLogMessage> additionalMessages)> GetPackageSpecsAndAdditionalMessagesAsync(DependencyGraphCacheContext context)
+        {
             if (context == null)
             {
                 throw new ArgumentNullException(nameof(context));
@@ -645,7 +651,7 @@ namespace NuGet.ProjectManagement
             // Return empty list for this case.
             if (string.IsNullOrEmpty(ProjectSystem.ProjectFileFullPath))
             {
-                return new List<PackageSpec>();
+                return (new List<PackageSpec>(), null);
             }
 
             PackageSpec packageSpec = null;
@@ -693,7 +699,7 @@ namespace NuGet.ProjectManagement
                 context.PackageSpecCache.Add(MSBuildProjectPath, packageSpec);
             }
 
-            return new[] { packageSpec };
+            return (new[] { packageSpec }, null);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.PackageManagement/Projects/ProjectJsonNuGetProject.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Projects/ProjectJsonNuGetProject.cs
@@ -164,6 +164,12 @@ namespace NuGet.ProjectManagement.Projects
        
         public override async Task<IReadOnlyList<PackageSpec>> GetPackageSpecsAsync(DependencyGraphCacheContext context)
         {
+            var (dgSpecs, _) = await GetPackageSpecsAndAdditionalMessagesAsync(context);
+            return dgSpecs;
+        }
+
+        public override async Task<(IReadOnlyList<PackageSpec> dgSpecs, IReadOnlyList<IAssetsLogMessage> additionalMessages)> GetPackageSpecsAndAdditionalMessagesAsync(DependencyGraphCacheContext context)
+        {
             PackageSpec packageSpec = null;
             if (context == null || !context.PackageSpecCache.TryGetValue(MSBuildProjectPath, out packageSpec))
             {
@@ -248,7 +254,7 @@ namespace NuGet.ProjectManagement.Projects
                 context?.PackageSpecCache.Add(MSBuildProjectPath, packageSpec);
             }
 
-            return new[] { packageSpec };
+            return (new[] { packageSpec }, null);
         }
 
         public async override Task<bool> InstallPackageAsync(

--- a/src/NuGet.Core/NuGet.ProjectModel/DependencyGraphSpec.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/DependencyGraphSpec.cs
@@ -508,19 +508,6 @@ namespace NuGet.ProjectModel
         }
 
         /// <summary>
-        /// Create a minimal DependencyGraphSpec that will pass restore. Typically used for error handling.
-        /// </summary>
-        /// <param name="projectPath">Full path to project file.</param>
-        /// <returns>DependencyGraphSpec</returns>
-        public static DependencyGraphSpec CreateMinimal(string projectPath, string outputPath)
-        {
-            var dgSpec = new DependencyGraphSpec();
-            dgSpec.AddProject(PackageSpec.CreateMinimal(projectPath, outputPath));
-
-            return dgSpec;
-        }
-
-        /// <summary>
         /// PackageSpec -> id
         /// </summary>
         private static string GetPackageSpecId(PackageSpec spec)

--- a/src/NuGet.Core/NuGet.ProjectModel/DependencyGraphSpec.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/DependencyGraphSpec.cs
@@ -508,6 +508,19 @@ namespace NuGet.ProjectModel
         }
 
         /// <summary>
+        /// Create a minimal DependencyGraphSpec that will pass restore. Typically used for error handling.
+        /// </summary>
+        /// <param name="projectPath">Full path to project file.</param>
+        /// <returns>DependencyGraphSpec</returns>
+        public static DependencyGraphSpec CreateMinimal(string projectPath, string outputPath)
+        {
+            var dgSpec = new DependencyGraphSpec();
+            dgSpec.AddProject(PackageSpec.CreateMinimal(projectPath, outputPath));
+
+            return dgSpec;
+        }
+
+        /// <summary>
         /// PackageSpec -> id
         /// </summary>
         private static string GetPackageSpecId(PackageSpec spec)

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpec.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpec.cs
@@ -223,6 +223,23 @@ namespace NuGet.ProjectModel
             return spec;
         }
 
+        /// <summary>
+        /// Create a minimal PackageSpec that will pass restore. Typically used for error handling.
+        /// </summary>
+        /// <param name="projectPath">Full path to the project file.</param>
+        /// <returns>PackageSpec</returns>
+        public static PackageSpec CreateMinimal(string projectPath, string outputPath)
+        {
+            var packageSpec = new PackageSpec();
+            packageSpec.FilePath = projectPath;
+            packageSpec.RestoreMetadata = new ProjectRestoreMetadata();
+            packageSpec.RestoreMetadata.ProjectUniqueName = projectPath;
+            packageSpec.RestoreMetadata.ProjectStyle = ProjectStyle.PackageReference;
+            packageSpec.RestoreMetadata.OutputPath = outputPath;
+
+            return packageSpec;
+        }
+
         private IDictionary<string, IEnumerable<string>> CloneScripts(IDictionary<string, IEnumerable<string>> toBeCloned)
         {
             if (toBeCloned != null)

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpec.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpec.cs
@@ -223,23 +223,6 @@ namespace NuGet.ProjectModel
             return spec;
         }
 
-        /// <summary>
-        /// Create a minimal PackageSpec that will pass restore. Typically used for error handling.
-        /// </summary>
-        /// <param name="projectPath">Full path to the project file.</param>
-        /// <returns>PackageSpec</returns>
-        public static PackageSpec CreateMinimal(string projectPath, string outputPath)
-        {
-            var packageSpec = new PackageSpec();
-            packageSpec.FilePath = projectPath;
-            packageSpec.RestoreMetadata = new ProjectRestoreMetadata();
-            packageSpec.RestoreMetadata.ProjectUniqueName = projectPath;
-            packageSpec.RestoreMetadata.ProjectStyle = ProjectStyle.PackageReference;
-            packageSpec.RestoreMetadata.OutputPath = outputPath;
-
-            return packageSpec;
-        }
-
         private IDictionary<string, IEnumerable<string>> CloneScripts(IDictionary<string, IEnumerable<string>> toBeCloned)
         {
             if (toBeCloned != null)

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/ProjectSystemCacheTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/ProjectSystemCacheTests.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
+using System.Windows.Documents;
 using Moq;
 using NuGet.ProjectModel;
 using NuGet.VisualStudio;
@@ -15,11 +17,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         {
             // Arrange
             var target = new ProjectSystemCache();
-            var projectNames = new ProjectNames(
-                fullName: @"C:\src\project\project.csproj",
-                uniqueName: @"folder\project",
-                shortName: "project",
-                customUniqueName: @"folder\project");
+            var projectNames = GetTestProjectNames();
             var vsProjectAdapter = new Mock<IVsProjectAdapter>();
 
             target.AddProject(projectNames, vsProjectAdapter.Object, nuGetProject: null);
@@ -38,11 +36,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         {
             // Arrange
             var target = new ProjectSystemCache();
-            var projectNames = new ProjectNames(
-                fullName: @"C:\src\project\project.csproj",
-                uniqueName: @"folder\project",
-                shortName: "project",
-                customUniqueName: @"custom");
+            var projectNames = GetTestProjectNames();
             var vsProjectAdapter = new Mock<IVsProjectAdapter>();
 
             target.AddProject(projectNames, vsProjectAdapter.Object, nuGetProject: null);
@@ -61,11 +55,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         {
             // Arrange
             var target = new ProjectSystemCache();
-            var projectNames = new ProjectNames(
-                fullName: @"C:\src\project\project.csproj",
-                uniqueName: @"folder\project",
-                shortName: "project",
-                customUniqueName: @"folder\project");
+            var projectNames = GetTestProjectNames();
             var vsProjectAdapter = new Mock<IVsProjectAdapter>();
 
             target.AddProject(projectNames, vsProjectAdapter.Object, nuGetProject: null);
@@ -84,11 +74,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         {
             // Arrange
             var target = new ProjectSystemCache();
-            var projectNames = new ProjectNames(
-                fullName: @"C:\src\project\project.csproj",
-                uniqueName: @"folder\project",
-                shortName: "project",
-                customUniqueName: @"folder\project");
+            var projectNames = GetTestProjectNames();
             var vsProjectAdapter = new Mock<IVsProjectAdapter>();
 
             target.AddProject(projectNames, vsProjectAdapter.Object, nuGetProject: null);
@@ -138,12 +124,8 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         {
             // Arrange
             var target = new ProjectSystemCache();
-            var projectNames = new ProjectNames(
-                fullName: @"C:\src\project\project.csproj",
-                uniqueName: @"folder\project",
-                shortName: "project",
-                customUniqueName: @"folder\project");
-            var projectNamesFromFullPath = ProjectNames.FromFullProjectPath(@"C:\src\project\project.csproj");
+            var projectNames = GetTestProjectNames();
+            var projectNamesFromFullPath = ProjectNames.FromFullProjectPath(projectNames.FullName);
             var projectRestoreInfo = new DependencyGraphSpec();
 
             target.AddProject(projectNames, vsProjectAdapter: null, nuGetProject: null);
@@ -152,7 +134,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             target.AddProjectRestoreInfo(projectNamesFromFullPath, projectRestoreInfo, additionalMessages: null);
 
             // Assert
-            var getPackageSpecSuccess = target.TryGetProjectRestoreInfo(projectNames.FullName, out var actual);
+            var getPackageSpecSuccess = target.TryGetProjectRestoreInfo(projectNames.FullName, out var actual, out _);
             var getProjectNameFromUniqueNameSuccess = target.TryGetProjectNames(projectNames.UniqueName, out var names1);
             var getProjectNameFromFullNameSuccess = target.TryGetProjectNames(projectNames.FullName, out var names2);
 
@@ -169,12 +151,8 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         {
             // Arrange
             var target = new ProjectSystemCache();
-            var projectNames = new ProjectNames(
-                fullName: @"C:\src\project\project.csproj",
-                uniqueName: @"folder\project",
-                shortName: "project",
-                customUniqueName: @"folder\project");
-            var projectNamesFromFullPath = ProjectNames.FromFullProjectPath(@"C:\src\project\project.csproj");
+            var projectNames = GetTestProjectNames();
+            var projectNamesFromFullPath = ProjectNames.FromFullProjectPath(projectNames.FullName);
             var projectRestoreInfo = new DependencyGraphSpec();
 
             target.AddProjectRestoreInfo(projectNamesFromFullPath, projectRestoreInfo, additionalMessages: null);
@@ -186,7 +164,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             DependencyGraphSpec actual;
             ProjectNames names;
 
-            var getPackageSpecSuccess = target.TryGetProjectRestoreInfo(projectNames.FullName, out actual);
+            var getPackageSpecSuccess = target.TryGetProjectRestoreInfo(projectNames.FullName, out actual, out _);
             var getProjectNameSuccess = target.TryGetProjectNames(projectNames.UniqueName, out names);
 
             Assert.True(getPackageSpecSuccess);
@@ -200,12 +178,8 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         {
             // Arrange
             var target = new ProjectSystemCache();
-            var projectNames = new ProjectNames(
-                fullName: @"C:\src\project\project.csproj",
-                uniqueName: @"folder\project",
-                shortName: "project",
-                customUniqueName: @"folder\project");
-            var projectNamesFromFullPath = ProjectNames.FromFullProjectPath(@"C:\src\project\project.csproj");
+            var projectNames = GetTestProjectNames();
+            var projectNamesFromFullPath = ProjectNames.FromFullProjectPath(projectNames.FullName);
             var projectRestoreInfo = new DependencyGraphSpec();
 
             // Act
@@ -215,7 +189,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             // Assert
             DependencyGraphSpec actual;
             ProjectNames names;
-            var getPackageSpecSuccess = target.TryGetProjectRestoreInfo(projectNames.FullName, out actual);
+            var getPackageSpecSuccess = target.TryGetProjectRestoreInfo(projectNames.FullName, out actual, out _);
             var getProjectNameSuccess = target.TryGetProjectNames(projectNames.UniqueName, out names);
 
             Assert.True(getPackageSpecSuccess);
@@ -231,12 +205,8 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         {
             // Arrange
             var target = new ProjectSystemCache();
-            var projectNames = new ProjectNames(
-                fullName: @"C:\src\project\project.csproj",
-                uniqueName: @"folder\project",
-                shortName: "project",
-                customUniqueName: @"folder\project");
-            var projectNamesFromFullPath = ProjectNames.FromFullProjectPath(@"C:\src\project\project.csproj");
+            var projectNames = GetTestProjectNames();
+            var projectNamesFromFullPath = ProjectNames.FromFullProjectPath(projectNames.FullName);
             var projectRestoreInfo = new DependencyGraphSpec();
             var eventCount = 0;
             target.CacheUpdated += delegate (object sender, NuGetEventArgs<string> e)
@@ -254,7 +224,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             // Assert
             DependencyGraphSpec actual;
             ProjectNames names;
-            var getPackageSpecSuccess = target.TryGetProjectRestoreInfo(projectNames.FullName, out actual);
+            var getPackageSpecSuccess = target.TryGetProjectRestoreInfo(projectNames.FullName, out actual, out _);
             var getProjectNameSuccess = target.TryGetProjectNames(projectNames.UniqueName, out names);
 
             Assert.True(getPackageSpecSuccess);
@@ -270,12 +240,8 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         {
             // Arrange
             var target = new ProjectSystemCache();
-            var projectNames = new ProjectNames(
-                fullName: @"C:\src\project\project.csproj",
-                uniqueName: @"folder\project",
-                shortName: "project",
-                customUniqueName: @"folder\project");
-            var projectNamesFromFullPath = ProjectNames.FromFullProjectPath(@"C:\src\project\project.csproj");
+            var projectNames = GetTestProjectNames();
+            var projectNamesFromFullPath = ProjectNames.FromFullProjectPath(projectNames.FullName);
             var projectRestoreInfo = new DependencyGraphSpec();
             var eventCount = 0;
             target.CacheUpdated += delegate (object sender, NuGetEventArgs<string> e)
@@ -291,7 +257,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             // Assert
             DependencyGraphSpec actual;
             ProjectNames names;
-            var getPackageSpecSuccess = target.TryGetProjectRestoreInfo(projectNames.FullName, out actual);
+            var getPackageSpecSuccess = target.TryGetProjectRestoreInfo(projectNames.FullName, out actual, out _);
             var getProjectNameSuccess = target.TryGetProjectNames(projectNames.UniqueName, out names);
 
             Assert.True(getPackageSpecSuccess);
@@ -309,12 +275,8 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         {
             // Arrange
             var target = new ProjectSystemCache();
-            var projectNames = new ProjectNames(
-                fullName: @"C:\src\project\project.csproj",
-                uniqueName: @"folder\project",
-                shortName: "project",
-                customUniqueName: @"folder\project");
-            var projectNamesFromFullPath = ProjectNames.FromFullProjectPath(@"C:\src\project\project.csproj");
+            var projectNames = GetTestProjectNames();
+            var projectNamesFromFullPath = ProjectNames.FromFullProjectPath(projectNames.FullName);
             var projectRestoreInfo = new DependencyGraphSpec();
             var eventCount = 0;
             target.CacheUpdated += delegate (object sender, NuGetEventArgs<string> e)
@@ -337,16 +299,33 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         }
 
         [Fact]
+        public void AddProjectRestoreInfo_WithAdditionalMessages_ReturnsMessagesOnGet()
+        {
+            // Arrange
+            var target = new ProjectSystemCache();
+            var projectNames = GetTestProjectNames();
+            var additionalMessages = new List<IAssetsLogMessage>()
+            {
+                new AssetsLogMessage(Common.LogLevel.Error, Common.NuGetLogCode.NU1000, "Test error")
+            };
+            var projectRestoreInfo = new DependencyGraphSpec();
+
+            // Act
+            target.AddProjectRestoreInfo(projectNames, projectRestoreInfo, additionalMessages);
+
+            // Assert
+            target.TryGetProjectRestoreInfo(projectNames.FullName, out _, out var projectAdditionalMessages);
+            Assert.NotNull(projectAdditionalMessages);
+            Assert.Equal(additionalMessages.Count, projectAdditionalMessages.Count);
+        }
+
+        [Fact]
         public void AddProject_RemoveProject_Clear_TriggerNoEvent_WithEventHandler()
         {
             // Arrange
             var target = new ProjectSystemCache();
-            var projectNames = new ProjectNames(
-                fullName: @"C:\src\project\project.csproj",
-                uniqueName: @"folder\project",
-                shortName: "project",
-                customUniqueName: @"folder\project");
-            var projectNamesFromFullPath = ProjectNames.FromFullProjectPath(@"C:\src\project\project.csproj");
+            var projectNames = GetTestProjectNames();
+            var projectNamesFromFullPath = ProjectNames.FromFullProjectPath(projectNames.FullName);
             var projectRestoreInfo = new DependencyGraphSpec();
             var eventCount = 0;
             target.CacheUpdated += delegate (object sender, NuGetEventArgs<string> e)
@@ -365,6 +344,16 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             // Assert
             Assert.Equal(target.IsCacheDirty, 0);
             Assert.Equal(eventCount, 0);
+        }
+
+        private ProjectNames GetTestProjectNames()
+        {
+            var projectNames = new ProjectNames(
+                fullName: @"C:\src\project\project.csproj",
+                uniqueName: @"folder\project",
+                shortName: "project",
+                customUniqueName: @"folder\project");
+            return projectNames;
         }
     }
 }

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/ProjectSystemCacheTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/ProjectSystemCacheTests.cs
@@ -149,7 +149,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             target.AddProject(projectNames, vsProjectAdapter: null, nuGetProject: null);
 
             // Act
-            target.AddProjectRestoreInfo(projectNamesFromFullPath, projectRestoreInfo);
+            target.AddProjectRestoreInfo(projectNamesFromFullPath, projectRestoreInfo, additionalMessages: null);
 
             // Assert
             var getPackageSpecSuccess = target.TryGetProjectRestoreInfo(projectNames.FullName, out var actual);
@@ -177,7 +177,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             var projectNamesFromFullPath = ProjectNames.FromFullProjectPath(@"C:\src\project\project.csproj");
             var projectRestoreInfo = new DependencyGraphSpec();
 
-            target.AddProjectRestoreInfo(projectNamesFromFullPath, projectRestoreInfo);
+            target.AddProjectRestoreInfo(projectNamesFromFullPath, projectRestoreInfo, additionalMessages: null);
 
             // Act
             target.AddProject(projectNames, vsProjectAdapter: null, nuGetProject: null);
@@ -209,7 +209,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             var projectRestoreInfo = new DependencyGraphSpec();
 
             // Act
-            target.AddProjectRestoreInfo(projectNamesFromFullPath, projectRestoreInfo);
+            target.AddProjectRestoreInfo(projectNamesFromFullPath, projectRestoreInfo, additionalMessages: null);
             target.AddProject(projectNames, vsProjectAdapter: null, nuGetProject: null);
 
             // Assert
@@ -248,7 +248,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             };
 
             // Act
-            target.AddProjectRestoreInfo(projectNamesFromFullPath, projectRestoreInfo);            
+            target.AddProjectRestoreInfo(projectNamesFromFullPath, projectRestoreInfo, additionalMessages: null);
             target.AddProject(projectNames, vsProjectAdapter: null, nuGetProject: null);
 
             // Assert
@@ -284,8 +284,8 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             };
 
             // Act
-            target.AddProjectRestoreInfo(projectNamesFromFullPath, projectRestoreInfo);
-            target.AddProjectRestoreInfo(projectNamesFromFullPath, projectRestoreInfo);
+            target.AddProjectRestoreInfo(projectNamesFromFullPath, projectRestoreInfo, additionalMessages: null);
+            target.AddProjectRestoreInfo(projectNamesFromFullPath, projectRestoreInfo, additionalMessages: null);
             target.AddProject(projectNames, vsProjectAdapter: null, nuGetProject: null);
 
             // Assert
@@ -326,10 +326,10 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             };
 
             // Act
-            target.AddProjectRestoreInfo(projectNamesFromFullPath, projectRestoreInfo);
-            target.AddProjectRestoreInfo(projectNamesFromFullPath, projectRestoreInfo);
-            target.AddProjectRestoreInfo(projectNamesFromFullPath, projectRestoreInfo);
-            target.AddProjectRestoreInfo(projectNamesFromFullPath, projectRestoreInfo);
+            target.AddProjectRestoreInfo(projectNamesFromFullPath, projectRestoreInfo, additionalMessages: null);
+            target.AddProjectRestoreInfo(projectNamesFromFullPath, projectRestoreInfo, additionalMessages: null);
+            target.AddProjectRestoreInfo(projectNamesFromFullPath, projectRestoreInfo, additionalMessages: null);
+            target.AddProjectRestoreInfo(projectNamesFromFullPath, projectRestoreInfo, additionalMessages: null);
 
             // Assert
             Assert.Equal(target.IsCacheDirty, 0);

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsSolutionRestoreServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsSolutionRestoreServiceTests.cs
@@ -50,7 +50,8 @@ namespace NuGet.SolutionRestoreManager.Test
             Mock.Get(cache)
                 .Setup(x => x.AddProjectRestoreInfo(
                     It.IsAny<ProjectNames>(),
-                    It.IsAny<DependencyGraphSpec>()))
+                    It.IsAny<DependencyGraphSpec>(),
+                    It.IsAny<IReadOnlyList<IAssetsLogMessage>>()))
                 .Returns(true);
 
             var completedRestoreTask = Task.FromResult(true);
@@ -1702,7 +1703,8 @@ namespace NuGet.SolutionRestoreManager.Test
             Mock.Get(cache)
                 .Setup(x => x.AddProjectRestoreInfo(
                     It.IsAny<ProjectNames>(),
-                    It.IsAny<DependencyGraphSpec>()))
+                    It.IsAny<DependencyGraphSpec>(),
+                    It.IsAny<IReadOnlyList<IAssetsLogMessage>>()))
                 .Returns(true);
 
             var completedRestoreTask = Task.FromResult(true);
@@ -1725,7 +1727,8 @@ namespace NuGet.SolutionRestoreManager.Test
             var cache = new Mock<IProjectSystemCache>();
             cache.Setup(x => x.AddProjectRestoreInfo(
                     It.IsAny<ProjectNames>(),
-                    It.IsAny<DependencyGraphSpec>()))
+                    It.IsAny<DependencyGraphSpec>(),
+                    It.IsAny<IReadOnlyList<IAssetsLogMessage>>()))
                 .Returns(true);
 
             var restoreWorker = new Mock<ISolutionRestoreWorker>();
@@ -1769,7 +1772,8 @@ namespace NuGet.SolutionRestoreManager.Test
             var cache = new Mock<IProjectSystemCache>();
             cache.Setup(x => x.AddProjectRestoreInfo(
                     It.IsAny<ProjectNames>(),
-                    It.IsAny<DependencyGraphSpec>()))
+                    It.IsAny<DependencyGraphSpec>(),
+                    It.IsAny<IReadOnlyList<IAssetsLogMessage>>()))
                 .Returns(true);
 
             var restoreWorker = new Mock<ISolutionRestoreWorker>();
@@ -1819,7 +1823,8 @@ namespace NuGet.SolutionRestoreManager.Test
             var cache = new Mock<IProjectSystemCache>();
             cache.Setup(x => x.AddProjectRestoreInfo(
                     It.IsAny<ProjectNames>(),
-                    It.IsAny<DependencyGraphSpec>()))
+                    It.IsAny<DependencyGraphSpec>(),
+                    It.IsAny<IReadOnlyList<IAssetsLogMessage>>()))
                 .Returns(true);
 
             var restoreWorker = new Mock<ISolutionRestoreWorker>();
@@ -1974,7 +1979,8 @@ namespace NuGet.SolutionRestoreManager.Test
             Mock.Get(cache)
                 .Setup(x => x.AddProjectRestoreInfo(
                     It.IsAny<ProjectNames>(),
-                    It.IsAny<DependencyGraphSpec>()))
+                    It.IsAny<DependencyGraphSpec>(),
+                    It.IsAny<IReadOnlyList<IAssetsLogMessage>>()))
                 .Callback<ProjectNames, DependencyGraphSpec>(
                     (_, dg) => { capturedRestoreSpec = dg; })
                 .Returns(true);
@@ -2006,7 +2012,8 @@ namespace NuGet.SolutionRestoreManager.Test
             Mock.Get(cache)
                 .Setup(x => x.AddProjectRestoreInfo(
                     It.IsAny<ProjectNames>(),
-                    It.IsAny<DependencyGraphSpec>()))
+                    It.IsAny<DependencyGraphSpec>(),
+                    It.IsAny<IReadOnlyList<IAssetsLogMessage>>()))
                 .Callback<ProjectNames, DependencyGraphSpec>(
                     (_, dg) => { capturedRestoreSpec = dg; })
                 .Returns(true);

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsSolutionRestoreServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsSolutionRestoreServiceTests.cs
@@ -1993,8 +1993,8 @@ namespace NuGet.SolutionRestoreManager.Test
                     It.IsAny<ProjectNames>(),
                     It.IsAny<DependencyGraphSpec>(),
                     It.IsAny<IReadOnlyList<IAssetsLogMessage>>()))
-                .Callback<ProjectNames, DependencyGraphSpec>(
-                    (_, dg) => { capturedRestoreSpec = dg; })
+                .Callback<ProjectNames, DependencyGraphSpec, IReadOnlyList<IAssetsLogMessage>>(
+                    (_, dg, __) => { capturedRestoreSpec = dg; })
                 .Returns(true);
 
             var restoreWorker = Mock.Of<ISolutionRestoreWorker>();
@@ -2026,8 +2026,8 @@ namespace NuGet.SolutionRestoreManager.Test
                     It.IsAny<ProjectNames>(),
                     It.IsAny<DependencyGraphSpec>(),
                     It.IsAny<IReadOnlyList<IAssetsLogMessage>>()))
-                .Callback<ProjectNames, DependencyGraphSpec>(
-                    (_, dg) => { capturedRestoreSpec = dg; })
+                .Callback<ProjectNames, DependencyGraphSpec, IReadOnlyList<IAssetsLogMessage>>(
+                    (_, dg, __) => { capturedRestoreSpec = dg; })
                 .Returns(true);
 
             var restoreWorker = Mock.Of<ISolutionRestoreWorker>();

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsSolutionRestoreServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsSolutionRestoreServiceTests.cs
@@ -1767,7 +1767,7 @@ namespace NuGet.SolutionRestoreManager.Test
             logger.Verify(l => l.LogError(It.IsAny<string>()), Times.Never);
             Assert.NotNull(additionalMessages);
             Assert.Equal(1, additionalMessages.Count);
-            Assert.Equal(NuGetLogCode.NU1010, additionalMessages[0].Code);
+            Assert.Equal(NuGetLogCode.NU1105, additionalMessages[0].Code);
             restoreWorker.Verify(rw => rw.ScheduleRestoreAsync(It.IsAny<SolutionRestoreRequest>(), It.IsAny<CancellationToken>()), Times.Once);
         }
 
@@ -1824,7 +1824,7 @@ namespace NuGet.SolutionRestoreManager.Test
             logger.Verify(l => l.LogError(It.IsAny<string>()), Times.Never);
             Assert.NotNull(additionalMessages);
             Assert.Equal(1, additionalMessages.Count);
-            Assert.Equal(NuGetLogCode.NU1010, additionalMessages[0].Code);
+            Assert.Equal(NuGetLogCode.NU1105, additionalMessages[0].Code);
             restoreWorker.Verify(rw => rw.ScheduleRestoreAsync(It.IsAny<SolutionRestoreRequest>(), It.IsAny<CancellationToken>()), Times.Once);
         }
 

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/Extensibility/VsPathContextProviderTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/Extensibility/VsPathContextProviderTests.cs
@@ -502,6 +502,11 @@ namespace NuGet.VisualStudio.Implementation.Test.Extensibility
                 throw new NotImplementedException();
             }
 
+            public override Task<(IReadOnlyList<PackageSpec> dgSpecs, IReadOnlyList<IAssetsLogMessage> additionalMessages)> GetPackageSpecsAndAdditionalMessagesAsync(DependencyGraphCacheContext context)
+            {
+                throw new NotImplementedException();
+            }
+
             public override Task<bool> InstallPackageAsync(string packageId, VersionRange range, INuGetProjectContext nuGetProjectContext, BuildIntegratedInstallationContext installationContext, CancellationToken token)
             {
                 throw new NotImplementedException();

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommand/RequestFactory/DependencyGraphSpecRequestProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommand/RequestFactory/DependencyGraphSpecRequestProviderTests.cs
@@ -1,0 +1,40 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using NuGet.Common;
+using NuGet.ProjectModel;
+using Xunit;
+
+namespace NuGet.Commands.Test
+{
+    public class DependencyGraphSpecRequestProviderTests
+    {
+        [Fact]
+        public void GetMessagesForProject_WithMultipleMessages_SelectedMessagesForCorrectProject()
+        {
+            // Arrange
+            var project1 = @"z:\src\solution\project1\project1.csproj";
+            var project2 = @"z:\src\solution\project2\project2.csproj";
+
+            var project1Error = RestoreLogMessage.CreateError(NuGetLogCode.NU1001, "project1 error");
+            project1Error.ProjectPath = project1;
+
+            var project2Error = RestoreLogMessage.CreateError(NuGetLogCode.NU1002, "project2 error");
+            project2Error.ProjectPath = project2;
+
+            var solutionMessages = new List<IAssetsLogMessage>()
+            {
+                AssetsLogMessage.Create(project1Error),
+                AssetsLogMessage.Create(project2Error)
+            };
+
+            // Act
+            IReadOnlyList<IAssetsLogMessage> actual = DependencyGraphSpecRequestProvider.GetMessagesForProject(solutionMessages, project1);
+
+            // Assert
+            var actualError = Assert.Single(actual);
+            Assert.Equal(NuGetLogCode.NU1001, actualError.Code);
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
@@ -1363,7 +1363,7 @@ namespace NuGet.Commands.Test
                 project1.Create();
                 sources.Add(new PackageSource(packageSource.FullName));
 
-                var dgspec1 = DependencyGraphSpec.CreateMinimal(Path.Combine(project1.FullName, "project1.csproj"), project1Obj.FullName);
+                var dgspec1 = CreateMinimalDependencyGraphSpec(Path.Combine(project1.FullName, "project1.csproj"), project1Obj.FullName);
                 var spec1 = dgspec1.Projects[0];
 
                 var logger = new TestLogger();
@@ -1695,6 +1695,21 @@ namespace NuGet.Commands.Test
             };
 
             return walker.WalkAsync(range, framework, runtimeIdentifier: null, runtimeGraph: null, recursive: true);
+        }
+        
+        private static DependencyGraphSpec CreateMinimalDependencyGraphSpec(string projectPath, string outputPath)
+        {
+            var packageSpec = new PackageSpec();
+            packageSpec.FilePath = projectPath;
+            packageSpec.RestoreMetadata = new ProjectRestoreMetadata();
+            packageSpec.RestoreMetadata.ProjectUniqueName = projectPath;
+            packageSpec.RestoreMetadata.ProjectStyle = ProjectStyle.PackageReference;
+            packageSpec.RestoreMetadata.OutputPath = outputPath;
+
+            var dgSpec = new DependencyGraphSpec();
+            dgSpec.AddProject(packageSpec);
+
+            return dgSpec;
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
@@ -1347,6 +1347,47 @@ namespace NuGet.Commands.Test
         }
 
         [Fact]
+        public async Task RestoreCommand_MinimalProjectWithAdditionalMessages_WritesAssetsFileWithMessages()
+        {
+            // Arrange
+            var sources = new List<PackageSource>();
+
+            using (var workingDir = TestDirectory.Create())
+            {
+                var packagesDir = new DirectoryInfo(Path.Combine(workingDir, "globalPackages"));
+                var packageSource = new DirectoryInfo(Path.Combine(workingDir, "packageSource"));
+                var project1 = new DirectoryInfo(Path.Combine(workingDir, "projects", "project1"));
+                var project1Obj = new DirectoryInfo(Path.Combine(project1.FullName, "obj"));
+                packagesDir.Create();
+                packageSource.Create();
+                project1.Create();
+                sources.Add(new PackageSource(packageSource.FullName));
+
+                var dgspec1 = DependencyGraphSpec.CreateMinimal(Path.Combine(project1.FullName, "project1.csproj"), project1Obj.FullName);
+                var spec1 = dgspec1.Projects[0];
+
+                var logger = new TestLogger();
+                var request = new TestRestoreRequest(spec1, sources, packagesDir.FullName, logger)
+                {
+                    AdditionalMessages = new List<IAssetsLogMessage>()
+                    {
+                        new AssetsLogMessage(LogLevel.Error, NuGetLogCode.NU1010, "Test error")
+                    }
+                };
+
+                // Act
+                var command = new RestoreCommand(request);
+                var result = await command.ExecuteAsync();
+                var lockFile = result.LockFile;
+                await result.CommitAsync(logger, CancellationToken.None);
+
+                // Assert
+                Assert.False(result.Success);
+                Assert.Equal(1, lockFile.LogMessages.Count);
+            }
+        }
+
+        [Fact]
         public async Task RestoreCommand_CentralVersion_ErrorWhenDependenciesHaveVersion()
         {
             // Arrange

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
@@ -1371,7 +1371,7 @@ namespace NuGet.Commands.Test
                 {
                     AdditionalMessages = new List<IAssetsLogMessage>()
                     {
-                        new AssetsLogMessage(LogLevel.Error, NuGetLogCode.NU1010, "Test error")
+                        new AssetsLogMessage(LogLevel.Error, NuGetLogCode.NU1105, "Test error")
                     }
                 };
 

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegratedTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegratedTests.cs
@@ -2047,6 +2047,11 @@ namespace NuGet.Test
                 return Task.FromResult<IReadOnlyList<PackageSpec>>(new List<PackageSpec>() { PackageSpec });
             }
 
+            public Task<(IReadOnlyList<PackageSpec> dgSpecs, IReadOnlyList<IAssetsLogMessage> additionalMessages)> GetPackageSpecsAndAdditionalMessagesAsync(DependencyGraphCacheContext context)
+            {
+                return Task.FromResult<(IReadOnlyList<PackageSpec>, IReadOnlyList<IAssetsLogMessage>)>((new List<PackageSpec>() { PackageSpec }, null));
+            }
+
             public Task<DependencyGraphSpec> GetDependencyGraphSpecAsync(DependencyGraphCacheContext context)
             {
                 var dgSpec = new DependencyGraphSpec();


### PR DESCRIPTION
## Bug

Fixes: NuGet/Home#7717
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: Pass nomination errors through to restore, to write errors to the assets file, so the project system can display them in Visual Studio's error list.

## Testing/Validation

Tests Added: Yes
Reason for not adding tests:  
Validation:  
