### PR TITLE
Add back a binding to Status property to work around viewmodel that raises OnPropertyChanged

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageItemListViewModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageItemListViewModel.cs
@@ -448,7 +448,7 @@ namespace NuGet.PackageManagement.UI
 
             _backgroundDeprecationMetadataLoader = AsyncLazy.New(GetPackageDeprecationMetadataAsync);
 
-            OnPropertyChanged(nameof(Status));
+            TriggerStatusLoader();
         }
 
         private static PackageStatus GetPackageStatus(

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageItemListViewModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageItemListViewModel.cs
@@ -448,7 +448,7 @@ namespace NuGet.PackageManagement.UI
 
             _backgroundDeprecationMetadataLoader = AsyncLazy.New(GetPackageDeprecationMetadataAsync);
 
-            TriggerStatusLoader();
+            OnPropertyChanged(nameof(Status));
         }
 
         private static PackageStatus GetPackageStatus(

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageItemControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageItemControl.xaml
@@ -114,6 +114,7 @@
                       Visibility="{Binding IsLatestInstalled, Converter={StaticResource BooleanToVisibilityConverter}}"
                       ToolTip="{x:Static nuget:Resources.ToolTip_PackageInstalled}"
                       AutomationProperties.Name="{x:Static nuget:Resources.ToolTip_PackageInstalled}"
+                      Tag="{Binding Status}"
                       Moniker="{x:Static nuget:PackageIconMonikers.InstalledIndicator}" />
         <imaging:CrispImage
                       x:Name="_updateMark"


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9196
Regression: Yes
* Last working version:   build before my accessibility fix
* How are we preventing it in future:   more vendor testing when changing this UI.

## Fix

Details: 
Add back a binding to Status property to work around viewmodel that raises OnPropertyChanged

## Testing/Validation

Tests Added: No
Reason for not adding tests:  apex/ui
Validation:  Tested install, update and uninstall buttons (on left pane) and saw correct behavior.
   Also tested buttons on right pane, which had never broken. They still worked.