### PR TITLE
Dev zivkan increase linux timeout

### DIFF
--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -645,7 +645,7 @@ jobs:
 
 - job: Tests_On_Linux
   dependsOn: Initialize_Build
-  timeoutInMinutes: 15
+  timeoutInMinutes: 120
   variables:
     FULLVSTSBUILDNUMBER: $[dependencies.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
     MSBUILDDISABLENODEREUSE: 1

--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -645,7 +645,7 @@ jobs:
 
 - job: Tests_On_Linux
   dependsOn: Initialize_Build
-  timeoutInMinutes: 120
+  timeoutInMinutes: 60
   variables:
     FULLVSTSBUILDNUMBER: $[dependencies.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
     MSBUILDDISABLENODEREUSE: 1


### PR DESCRIPTION
Since switching to the AzDO hosted agent machines, the timeout was decreased to 15 minutes because most successful runs take less than 5 minutes. However, there have been several builds fail because that 15 minutes has been exceeded.

Until we understand what's causing some of these builds to take over 3x the normal time to complete, let's increase the timeout in the hope that they'll actually complete and we'll get fewer failed builds.