### PR TITLE
Restore:  eliminate unnecessary call to DependencyGraphSpec.GetClosure(...)

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/DependencyGraphSpecRequestProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/DependencyGraphSpecRequestProvider.cs
@@ -85,8 +85,8 @@ namespace NuGet.Commands
                         rootProject,
                         externalClosure,
                         restoreContext,
-                        projectDgSpec: projectDependencyGraphSpec,
-                        settingsLoadingContext: settingsLoadingContext);
+                        projectDependencyGraphSpec,
+                        settingsLoadingContext);
 
                     if (request.Request.ProjectStyle == ProjectStyle.DotnetCliTool)
                     {

--- a/src/NuGet.Core/NuGet.ProjectModel/DependencyGraphSpec.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/DependencyGraphSpec.cs
@@ -145,6 +145,39 @@ namespace NuGet.ProjectModel
         }
 
         /// <summary>
+        /// Creates a new <see cref="DependencyGraphSpec" /> from a project name and project closure.
+        /// </summary>
+        /// <param name="projectUniqueName">The project's unique name.</param>
+        /// <param name="closure">The project's closure</param>
+        /// <returns>A <see cref="DependencyGraphSpec" />.</returns>
+        /// <exception cref="ArgumentException">Thrown if <paramref name="projectUniqueName" />
+        /// is <c>null</c> or an empty string.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="closure" /> is <c>null</c>.</exception>
+        public DependencyGraphSpec CreateFromClosure(string projectUniqueName, IReadOnlyList<PackageSpec> closure)
+        {
+            if (string.IsNullOrEmpty(projectUniqueName))
+            {
+                throw new ArgumentException(Strings.ArgumentNullOrEmpty, nameof(projectUniqueName));
+            }
+
+            if (closure == null)
+            {
+                throw new ArgumentNullException(nameof(closure));
+            }
+
+            var dgSpec = new DependencyGraphSpec();
+
+            dgSpec.AddRestore(projectUniqueName);
+
+            foreach (PackageSpec packageSpec in closure)
+            {
+                dgSpec.AddProject(_isReadOnly ? packageSpec : packageSpec.Clone());
+            }
+
+            return dgSpec;
+        }
+
+        /// <summary>
         /// Retrieve the full project closure including the root project itself.
         /// </summary>
         /// <remarks>Results are not sorted in any form.</remarks>


### PR DESCRIPTION
## Bug

Fixes:  https://github.com/NuGet/Home/issues/9042
Regression:  No

## Fix

Details:  `DependencyGraphSpec.GetClosure(...)` is called 4 times for each project during a no-op restore.  This results in unnecessary time and memory spent during a no-op restore.

The basic outline of events for no-op restore with respect to `DependencyGraphSpec.GetClosure(...)` calls is:

1.  Create an empty solution DG spec and populate it with the persisted DG spec for each project.  [This is `GetClosure(...)` call 1.](https://github.com/NuGet/NuGet.Client/blob/f67a6083f8a49502f52f0c50492db03452785359/src/NuGet.Core/NuGet.PackageManagement/BuildIntegration/DependencyGraphRestoreUtility.cs#L259)
2.  Create restore requests, one for each project.
  a.  From the solution DG spec obtain the project's closure.  [This is `GetClosure(...)` call 2.](https://github.com/NuGet/NuGet.Client/blob/f67a6083f8a49502f52f0c50492db03452785359/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/DependencyGraphSpecRequestProvider.cs#L75)
  b.  From the solution DG spec create a new DG spec for the project's closure.  [This is `GetClosure(...)` call 3.](https://github.com/NuGet/NuGet.Client/blob/f67a6083f8a49502f52f0c50492db03452785359/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/DependencyGraphSpecRequestProvider.cs#L77)
3.  During cache file evaluation get the no-op DG spec for each project.  [This is `GetClosure(...)` call 4.](https://github.com/NuGet/NuGet.Client/blob/f67a6083f8a49502f52f0c50492db03452785359/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/NoOpRestoreUtilities.cs#L204)

After examining all usages, call 1 cannot be easily avoided.  See https://github.com/NuGet/Home/issues/9201 for details.  2a and 3 are necessary but 2b can be eliminated.

## Testing/Validation

Tests Added:  Yes 
Validation:  

Measuring the improvement in Visual Studio is difficult because there is too much noise to get a clean comparison.  To isolate the impact of this change, I created a simple console app that loaded the solution DG spec for NuGet.Client solution and then called `GetClosure(...)` for each of the 84 projects.  The "before" test called `GetClosure(...)` 2 times for each project while the "after" test called `GetClosure(...)` only 1 time for each project.  This essential mirrors the change from 2a+2b to just 2a.
```C#
// My VM had 4 processors
var options = new ParallelOptions() { MaxDegreeOfParallelism = Environment.ProcessorCount };
int iend = isAfterTest ? 1 : 2;

// Fire an ETW start event
eventSource.LoadAllStart();

try
{
    Parallel.ForEach(projectUniqueNames, options, projectUniqueName => dgSpec.GetClosure(projectUniqueName));
}
finally
{
    eventSource.LoadAllStop();
}
```
Based on 5 iterations each (before and after), the average improvements are:
| Metric | Before | After | Delta | % Delta |
| --- | --- | --- | --- | --- |
| total time reading all files in parallel | 22.72 ms | 13.68 ms | -9.04 ms | -39.81% |
| heap allocations | 1.45 MB | 0.68 MB | -0.76 MB | -52.80% |