### PR TITLE
Restore  fix PackageSpec.Clone() bug

### DIFF
--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpec.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpec.cs
@@ -110,7 +110,7 @@ namespace NuGet.ProjectModel
         public override int GetHashCode()
         {
             var hashCode = new HashCodeCombiner();
-            
+
             hashCode.AddObject(Title);
             hashCode.AddObject(Version);
             hashCode.AddObject(IsDefaultVersion);
@@ -195,22 +195,22 @@ namespace NuGet.ProjectModel
             spec.Name = Name;
             spec.FilePath = FilePath;
             spec.Title = Title;
-            spec.IsDefaultVersion = IsDefaultVersion;
             spec.HasVersionSnapshot = HasVersionSnapshot;
             spec.Description = Description;
             spec.Summary = Summary;
             spec.ReleaseNotes = ReleaseNotes;
-            spec.Authors = (string[]) Authors?.Clone();
-            spec.Owners = (string[]) Owners?.Clone();
+            spec.Authors = (string[])Authors?.Clone();
+            spec.Owners = (string[])Owners?.Clone();
             spec.ProjectUrl = ProjectUrl;
             spec.IconUrl = IconUrl;
             spec.LicenseUrl = LicenseUrl;
             spec.RequireLicenseAcceptance = RequireLicenseAcceptance;
             spec.Language = Language;
             spec.Copyright = Copyright;
-            spec.Version = Version; 
+            spec.Version = Version;
+            spec.IsDefaultVersion = IsDefaultVersion;
             spec.BuildOptions = BuildOptions?.Clone();
-            spec.Tags = (string[]) Tags?.Clone();    
+            spec.Tags = (string[])Tags?.Clone();
             spec.ContentFiles = ContentFiles != null ? new List<string>(ContentFiles) : null;
             spec.Dependencies = Dependencies?.Select(item => item.Clone()).ToList();
             spec.Scripts = CloneScripts(Scripts);

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecCloningTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecCloningTests.cs
@@ -766,5 +766,23 @@ namespace NuGet.ProjectModel.Test
             Assert.Equal(3, compat.RestoreContexts.Count);
             Assert.Equal(2, clone.RestoreContexts.Count);
         }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void Clone_WhenIsDefaultVersionVaries_ReturnsEqualClone(bool expectedResult)
+        {
+            var packageSpec = new PackageSpec();
+
+            packageSpec.IsDefaultVersion = expectedResult;
+
+            Assert.Equal(expectedResult, packageSpec.IsDefaultVersion);
+
+            PackageSpec clone = packageSpec.Clone();
+
+            Assert.Equal(expectedResult, packageSpec.IsDefaultVersion);
+            Assert.Equal(expectedResult, clone.IsDefaultVersion);
+            Assert.True(packageSpec.Equals(clone));
+        }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/compiler/resources/DependencyGraphSpec_CentralVersionDependencies.json
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/compiler/resources/DependencyGraphSpec_CentralVersionDependencies.json
@@ -5,7 +5,6 @@
   },
   "projects": {
     "a": {
-      "version": "1.0.0",
       "restore": {
         "projectUniqueName": "a",
         "centralPackageVersionsManagementEnabled": true


### PR DESCRIPTION
## Bug

Fixes:  https://github.com/NuGet/Home/issues/9211  
Regression:  Yes  
* Last working version:  4.5
* How are we preventing it in future:  Adding a test

## Fix

Details:  Change the order of statements in `PackageSpec.Clone()`.

## Testing/Validation

Tests Added: Yes  
Validation:  Tests pass.