### PR TITLE
Remove unhelp test ConcurrencyUtilities_ZeroTimeoutStillGetsLock

### DIFF
--- a/test/NuGet.Core.Tests/NuGet.Common.Test/SynchronizationTest.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/SynchronizationTest.cs
@@ -56,24 +56,6 @@ namespace NuGet.Common.Test
         }
 
         [Fact]
-        public async Task ConcurrencyUtilities_ZeroTimeoutStillGetsLock()
-        {
-            // Arrange
-            var fileId = Guid.NewGuid().ToString();
-            var cts = new CancellationTokenSource(TimeSpan.Zero);
-            var expected = 3;
-
-            // Act
-            var actual = await ConcurrencyUtilities.ExecuteWithFileLockedAsync(
-                fileId,
-                token => Task.FromResult(expected),
-                cts.Token);
-
-            // Assert
-            Assert.Equal(actual, expected);
-        }
-
-        [Fact]
         public async Task ConcurrencyUtilityBlocksInProc()
         {
             // Arrange


### PR DESCRIPTION
The test ConcurrencyUtilities_ZeroTimeoutStillGetsLock is unreliable and has been failing on some CI build recently. Rather than skipping it and creating an issue, I'm deleting it because the test is not helpful. I don't see any benefit to entering the lock when cancellation has already been requested, but only when no lock was hit. It feels like the test was testing implementation and not intent. Good practice is to regularly check the cancellation taken and stop processing if requested. If this guideline is followed, then allowing the utility to throw before entering the lock can save some time.