### PR TITLE
The restore command should not write any assets itself, everything should be written when the RestoreResult is committed

### DIFF
--- a/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/NuGetSdkResolver.cs
+++ b/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/NuGetSdkResolver.cs
@@ -109,7 +109,7 @@ namespace Microsoft.Build.NuGetSdkResolver
         /// IMPORTANT: This class is used to ensure that <see cref="NuGetSdkResolver"/> does not consume any NuGet classes directly.  This ensures that no NuGet assemblies
         /// are loaded unless they are needed.  Do not implement anything in <see cref="NuGetSdkResolver"/> that uses a NuGet class and instead place it here.
         /// </summary>
-        internal static class NuGetAbstraction
+        private static class NuGetAbstraction
         {
             public static SdkResult GetSdkResult(SdkReference sdk, object nuGetVersion, SdkResolverContext context, SdkResultFactory factory)
             {

--- a/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/NuGetSdkResolver.cs
+++ b/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/NuGetSdkResolver.cs
@@ -109,7 +109,7 @@ namespace Microsoft.Build.NuGetSdkResolver
         /// IMPORTANT: This class is used to ensure that <see cref="NuGetSdkResolver"/> does not consume any NuGet classes directly.  This ensures that no NuGet assemblies
         /// are loaded unless they are needed.  Do not implement anything in <see cref="NuGetSdkResolver"/> that uses a NuGet class and instead place it here.
         /// </summary>
-        private static class NuGetAbstraction
+        internal static class NuGetAbstraction
         {
             public static SdkResult GetSdkResult(SdkReference sdk, object nuGetVersion, SdkResolverContext context, SdkResultFactory factory)
             {

--- a/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/RestoreRunnerEx.cs
+++ b/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/RestoreRunnerEx.cs
@@ -44,87 +44,76 @@ namespace NuGet.Commands
                 IgnoreFailedSources = true,
             })
             {
-                // Create a unique temporary directory for the project, use the utility method because the temp folder on linux is machine wide.
-                var projectDirectoryPath = Path.Combine(NuGetEnvironment.GetFolderPath(NuGetFolderPath.Temp), Guid.NewGuid().ToString("N"));
-                DirectoryUtility.CreateSharedDirectory(projectDirectoryPath);
-                var projectDirectory = new DirectoryInfo(projectDirectoryPath);
+                var projectDirectory = Path.Combine(NuGetEnvironment.GetFolderPath(NuGetFolderPath.Temp), Guid.NewGuid().ToString("N"));
 
-                try
+                var projectName = Guid.NewGuid().ToString("N");
+
+                var projectFullPath = Path.Combine(projectDirectory, $"{projectName}.proj");
+
+                // The package spec details what packages to restore
+                var packageSpec = new PackageSpec(TargetFrameworks.Select(i => new TargetFrameworkInformation
                 {
-                    var projectName = Guid.NewGuid().ToString("N");
-
-                    var projectFullPath = Path.Combine(projectDirectory.FullName, $"{projectName}.proj");
-
-                    // The package spec details what packages to restore
-                    var packageSpec = new PackageSpec(TargetFrameworks.Select(i => new TargetFrameworkInformation
-                    {
-                        FrameworkName = i,
-                    }).ToList())
-                    {
-                        Dependencies = new List<LibraryDependency>
-                        {
-                            new LibraryDependency
-                            {
-                                LibraryRange = new LibraryRange(
-                                    libraryIdentity.Name,
-                                    new VersionRange(
-                                        minVersion: libraryIdentity.Version,
-                                        includeMinVersion: true,
-                                        maxVersion: libraryIdentity.Version,
-                                        includeMaxVersion: true),
-                                    LibraryDependencyTarget.Package),
-                                SuppressParent = LibraryIncludeFlags.All,
-                                AutoReferenced = true,
-                                IncludeType = LibraryIncludeFlags.None,
-                                Type = LibraryDependencyType.Build
-                            }
-                        },
-                        RestoreMetadata = new ProjectRestoreMetadata
-                        {
-                            ProjectPath = projectFullPath,
-                            ProjectName = projectName,
-                            ProjectStyle = ProjectStyle.PackageReference,
-                            ProjectUniqueName = projectFullPath,
-                            OutputPath = projectDirectory.FullName,
-                            OriginalTargetFrameworks = TargetFrameworks.Select(i => i.ToString()).ToList(),
-                            ConfigFilePaths = settings.GetConfigFilePaths(),
-                            PackagesPath = SettingsUtility.GetGlobalPackagesFolder(settings),
-                            Sources = SettingsUtility.GetEnabledSources(settings).ToList(),
-                            FallbackFolders = SettingsUtility.GetFallbackPackageFolders(settings).ToList()
-                        },
-                        FilePath = projectFullPath,
-                        Name = projectName,
-                    };
-
-                    var dependencyGraphSpec = new DependencyGraphSpec();
-
-                    dependencyGraphSpec.AddProject(packageSpec);
-
-                    dependencyGraphSpec.AddRestore(packageSpec.RestoreMetadata.ProjectUniqueName);
-
-                    IPreLoadedRestoreRequestProvider requestProvider = new DependencyGraphSpecRequestProvider(new RestoreCommandProvidersCache(), dependencyGraphSpec);
-
-                    var restoreArgs = new RestoreArgs
-                    {
-                        AllowNoOp = false,
-                        CacheContext = sourceCacheContext,
-    #pragma warning disable CS0618 // Type or member is obsolete
-                        CachingSourceProvider = new CachingSourceProvider(new PackageSourceProvider(settings, enablePackageSourcesChangedEvent: false)),
-    #pragma warning restore CS0618 // Type or member is obsolete
-                        Log = logger,
-                    };
-
-                    // Create requests from the arguments
-                    var requests = requestProvider.CreateRequests(restoreArgs).Result;
-
-                    // Restore the package without generating extra files
-                    return RestoreRunner.RunWithoutCommit(requests, restoreArgs);
-
-                }
-                finally
+                    FrameworkName = i,
+                }).ToList())
                 {
-                    LocalResourceUtils.DeleteDirectoryTree(projectDirectory.FullName, new List<string>());
-                }
+                    Dependencies = new List<LibraryDependency>
+                    {
+                        new LibraryDependency
+                        {
+                            LibraryRange = new LibraryRange(
+                                libraryIdentity.Name,
+                                new VersionRange(
+                                    minVersion: libraryIdentity.Version,
+                                    includeMinVersion: true,
+                                    maxVersion: libraryIdentity.Version,
+                                    includeMaxVersion: true),
+                                LibraryDependencyTarget.Package),
+                            SuppressParent = LibraryIncludeFlags.All,
+                            AutoReferenced = true,
+                            IncludeType = LibraryIncludeFlags.None,
+                            Type = LibraryDependencyType.Build
+                        }
+                    },
+                    RestoreMetadata = new ProjectRestoreMetadata
+                    {
+                        ProjectPath = projectFullPath,
+                        ProjectName = projectName,
+                        ProjectStyle = ProjectStyle.PackageReference,
+                        ProjectUniqueName = projectFullPath,
+                        OutputPath = projectDirectory,
+                        OriginalTargetFrameworks = TargetFrameworks.Select(i => i.ToString()).ToList(),
+                        ConfigFilePaths = settings.GetConfigFilePaths(),
+                        PackagesPath = SettingsUtility.GetGlobalPackagesFolder(settings),
+                        Sources = SettingsUtility.GetEnabledSources(settings).ToList(),
+                        FallbackFolders = SettingsUtility.GetFallbackPackageFolders(settings).ToList()
+                    },
+                    FilePath = projectFullPath,
+                    Name = projectName,
+                };
+
+                var dependencyGraphSpec = new DependencyGraphSpec();
+
+                dependencyGraphSpec.AddProject(packageSpec);
+
+                dependencyGraphSpec.AddRestore(packageSpec.RestoreMetadata.ProjectUniqueName);
+
+                IPreLoadedRestoreRequestProvider requestProvider = new DependencyGraphSpecRequestProvider(new RestoreCommandProvidersCache(), dependencyGraphSpec);
+
+                var restoreArgs = new RestoreArgs
+                {
+                    AllowNoOp = false,
+                    CacheContext = sourceCacheContext,
+#pragma warning disable CS0618 // Type or member is obsolete
+                    CachingSourceProvider = new CachingSourceProvider(new PackageSourceProvider(settings, enablePackageSourcesChangedEvent: false)),
+#pragma warning restore CS0618 // Type or member is obsolete
+                    Log = logger,
+                };
+
+                // Create requests from the arguments
+                var requests = requestProvider.CreateRequests(restoreArgs).Result;
+
+                // Restore the package without generating extra files
+                return RestoreRunner.RunWithoutCommit(requests, restoreArgs);
             }
         }
     }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/NoOpRestoreResult.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/NoOpRestoreResult.cs
@@ -20,7 +20,7 @@ namespace NuGet.Commands
         public NoOpRestoreResult(bool success, string lockFilePath, Lazy<LockFile> lockFileLazy, CacheFile cacheFile, string cacheFilePath, ProjectStyle projectStyle, TimeSpan elapsedTime) :
             base(success : success, restoreGraphs : null, compatibilityCheckResults : new List<CompatibilityCheckResult>() , 
                 msbuildFiles : null, lockFile : null, previousLockFile : null, lockFilePath: lockFilePath,
-                cacheFile: cacheFile, cacheFilePath: cacheFilePath, packagesLockFilePath:null, packagesLockFile:null, projectStyle: projectStyle, elapsedTime: elapsedTime)
+                cacheFile: cacheFile, cacheFilePath: cacheFilePath, packagesLockFilePath:null, packagesLockFile:null, dependencyGraphSpecFilePath: null, dependencyGraphSpec: null, projectStyle: projectStyle, elapsedTime: elapsedTime)
         {
             _lockFileLazy = lockFileLazy ?? throw new ArgumentNullException(nameof(lockFileLazy));
         }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -184,6 +184,8 @@ namespace NuGet.Commands
                         packagesLockFilePath: null,
                         packagesLockFile: null,
                         projectStyle: _request.ProjectStyle,
+                        dependencyGraphSpecFilePath: NoOpRestoreUtilities.GetPersistedDGSpecFilePath(_request),
+                        dependencyGraphSpec: _request.DependencyGraphSpec,
                         elapsedTime: restoreTime.Elapsed);
                 }
 
@@ -234,6 +236,8 @@ namespace NuGet.Commands
                             cacheFilePath: _request.Project.RestoreMetadata.CacheFilePath,
                             packagesLockFilePath: packagesLockFilePath,
                             packagesLockFile: packagesLockFile,
+                            dependencyGraphSpecFilePath: NoOpRestoreUtilities.GetPersistedDGSpecFilePath(_request),
+                            dependencyGraphSpec: _request.DependencyGraphSpec,
                             projectStyle: _request.ProjectStyle,
                             elapsedTime: restoreTime.Elapsed);
                     }
@@ -391,6 +395,8 @@ namespace NuGet.Commands
                     cacheFilePath,
                     packagesLockFilePath,
                     packagesLockFile,
+                    dependencyGraphSpecFilePath: NoOpRestoreUtilities.GetPersistedDGSpecFilePath(_request),
+                    dependencyGraphSpec: _request.DependencyGraphSpec,
                     _request.ProjectStyle,
                     restoreTime.Elapsed);
             }
@@ -600,13 +606,6 @@ namespace NuGet.Commands
             {
                 cacheFile = new CacheFile(newDgSpecHash);
 
-            }
-
-            // We only persist the dg spec file if it nooped or the dg spec does not exist.
-            var dgPath = NoOpRestoreUtilities.GetPersistedDGSpecFilePath(_request);
-            if (dgPath != null && (!noOp || !File.Exists(dgPath)))
-            {
-                NoOpRestoreUtilities.PersistDGSpecFile(noOpDgSpec, dgPath, _logger);
             }
 
             // DotnetCliTool restores are special because the the assets file location is not known until after the restore itself. So we just clean up.

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreResult.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreResult.cs
@@ -69,17 +69,17 @@ namespace NuGet.Commands
         /// <summary>
         /// New Packages lock file path
         /// </summary>
-        private string NewPackagesLockFilePath { get; }
+        private readonly string _newPackagesLockFilePath;
 
         /// <summary>
         /// NuGet lock file which is either generated or updated to lock down NuGet packages version
         /// </summary>
-        private PackagesLockFile NewPackagesLockFile { get; }
+        private readonly PackagesLockFile _newPackagesLockFile;
 
 
-        private string DependencyGraphSpecFilePath { get; }
+        private readonly string _dependencyGraphSpecFilePath;
 
-        private DependencyGraphSpec DependencyGraphSpec { get; }
+        private readonly DependencyGraphSpec _dependencyGraphSpec;
 
         public RestoreResult(
             bool success,
@@ -107,10 +107,10 @@ namespace NuGet.Commands
             PreviousLockFile = previousLockFile;
             CacheFile = cacheFile;
             CacheFilePath = cacheFilePath;
-            NewPackagesLockFilePath = packagesLockFilePath;
-            NewPackagesLockFile = packagesLockFile;
-            DependencyGraphSpecFilePath = dependencyGraphSpecFilePath;
-            DependencyGraphSpec = dependencyGraphSpec;
+            _newPackagesLockFilePath = packagesLockFilePath;
+            _newPackagesLockFile = packagesLockFile;
+            _dependencyGraphSpecFilePath = dependencyGraphSpecFilePath;
+            _dependencyGraphSpec = dependencyGraphSpec;
             ProjectStyle = projectStyle;
             ElapsedTime = elapsedTime;
         }
@@ -265,27 +265,27 @@ namespace NuGet.Commands
         private async Task CommitLockFileAsync(ILogger log, bool toolCommit)
         {
             // write packages lock file if it's not tool commit
-            if (!toolCommit && NewPackagesLockFile != null && !string.IsNullOrEmpty(NewPackagesLockFilePath))
+            if (!toolCommit && _newPackagesLockFile != null && !string.IsNullOrEmpty(_newPackagesLockFilePath))
             {
                 log.LogInformation(string.Format(CultureInfo.CurrentCulture,
                 Strings.Log_WritingPackagesLockFile,
-                NewPackagesLockFilePath));
+                _newPackagesLockFilePath));
 
                 await FileUtility.ReplaceWithLock(
-                    (outputPath) => PackagesLockFileFormat.Write(outputPath, NewPackagesLockFile),
-                    NewPackagesLockFilePath);
+                    (outputPath) => PackagesLockFileFormat.Write(outputPath, _newPackagesLockFile),
+                    _newPackagesLockFilePath);
             }
         }
 
         private async Task CommitDgSpecFileAsync(ILogger log, bool toolCommit)
         {
-            if (!toolCommit && DependencyGraphSpecFilePath != null && DependencyGraphSpec != null)
+            if (!toolCommit && _dependencyGraphSpecFilePath != null && _dependencyGraphSpec != null)
             {
-                log.LogVerbose($"Persisting dg to {DependencyGraphSpecFilePath}");
+                log.LogVerbose($"Persisting dg to {_dependencyGraphSpecFilePath}");
 
                 await FileUtility.ReplaceWithLock(
-                    (outputPath) => DependencyGraphSpec.Save(outputPath),
-                    DependencyGraphSpecFilePath);
+                    (outputPath) => _dependencyGraphSpec.Save(outputPath),
+                    _dependencyGraphSpecFilePath);
             }
         }
     }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/NoOpRestoreUtilities.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/NoOpRestoreUtilities.cs
@@ -5,8 +5,6 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
-using NuGet.Common;
-using NuGet.LibraryModel;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
 using NuGet.ProjectModel;

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/NoOpRestoreUtilities.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/NoOpRestoreUtilities.cs
@@ -226,20 +226,6 @@ namespace NuGet.Commands
         }
 
         /// <summary>
-        /// Persists the dg file for the given restore request.
-        /// This does not do a dirty check!
-        /// </summary>
-        /// <param name="spec">spec</param>
-        /// <param name="dgPath">the dg path</param>
-        /// <param name="log">logger</param>
-        internal static void PersistDGSpecFile(DependencyGraphSpec spec, string dgPath, ILogger log)
-        {
-            Directory.CreateDirectory(Path.GetDirectoryName(dgPath));
-            log.LogVerbose($"Persisting no-op dg to {dgPath}");
-            spec.Save(dgPath);
-        }
-
-        /// <summary>
         /// Gets the path for dgpsec.json.
         /// The project style that support dgpsec.json persistance are
         /// <see cref="ProjectStyle.PackageReference"/>, <see cref="ProjectStyle.ProjectJson"/>, <see cref="ProjectStyle.Standalone"/>

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
@@ -6440,8 +6440,6 @@ namespace NuGet.CommandLine.Test
                     Version = "1.0.0"
                 };
 
-                var projects = new List<SimpleTestProjectContext>();
-
                 var project = SimpleTestProjectContext.CreateNETCore(
                    $"proj",
                    pathContext.SolutionRoot,
@@ -6462,7 +6460,7 @@ namespace NuGet.CommandLine.Test
                 Assert.Equal(0, result.Item1);
                 Assert.Contains("Writing cache file", result.Item2);
                 Assert.Contains("Writing assets file to disk", result.Item2);
-                Assert.Contains("Persisting no-op dg", result.Item2);
+                Assert.Contains("Persisting dg", result.Item2);
 
                 var dgSpecFileName = Path.Combine(Path.GetDirectoryName(project.AssetsFileOutputPath), $"{Path.GetFileName(project.ProjectPath)}.nuget.dgspec.json");
 
@@ -6477,73 +6475,11 @@ namespace NuGet.CommandLine.Test
                 Assert.Equal(0, result.Item1);
                 Assert.DoesNotContain("Writing cache file", result.Item2);
                 Assert.DoesNotContain("Writing assets file to disk", result.Item2);
-                Assert.DoesNotContain("Persisting no-op dg", result.Item2);
+                Assert.DoesNotContain("Persisting dg", result.Item2);
 
                 fileInfo = new FileInfo(dgSpecFileName);
                 Assert.True(fileInfo.Exists);
                 Assert.Equal(lastWriteTime, fileInfo.LastWriteTime);
-            }
-        }
-
-        [Fact]
-        public async Task RestoreNetCore_NoOp_DgSpecJsonIsWrittenInNoopCaseIfNotExists()
-        {
-            // Arrange
-            using (var pathContext = new SimpleTestPathContext())
-            {
-                // Set up solution, project, and packages
-                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
-
-                var packageX = new SimpleTestPackageContext()
-                {
-                    Id = "x",
-                    Version = "1.0.0"
-                };
-
-                var projects = new List<SimpleTestProjectContext>();
-
-                var project = SimpleTestProjectContext.CreateNETCore(
-                   $"proj",
-                   pathContext.SolutionRoot,
-                   NuGetFramework.Parse("net45"));
-
-                project.AddPackageToAllFrameworks(packageX);
-                solution.Projects.Add(project);
-                solution.Create(pathContext.SolutionRoot);
-
-
-                await SimpleTestPackageUtility.CreateFolderFeedV3Async(
-                   pathContext.PackageSource,
-                   PackageSaveMode.Defaultv3,
-                   packageX);
-
-                // Prerequisites
-                var result = Util.Restore(pathContext, project.ProjectPath, additionalArgs: "-verbosity Detailed");
-                Assert.Equal(0, result.Item1);
-                Assert.Contains("Writing cache file", result.Item2);
-                Assert.Contains("Writing assets file to disk", result.Item2);
-                Assert.Contains("Persisting no-op dg", result.Item2);
-
-                var dgSpecFileName = Path.Combine(Path.GetDirectoryName(project.AssetsFileOutputPath), $"{Path.GetFileName(project.ProjectPath)}.nuget.dgspec.json");
-
-                var fileInfo = new FileInfo(dgSpecFileName);
-                Assert.True(fileInfo.Exists);
-                fileInfo.Delete();
-                fileInfo = new FileInfo(dgSpecFileName);
-                Assert.False(fileInfo.Exists);
-
-
-                // Act
-                result = Util.Restore(pathContext, project.ProjectPath, additionalArgs: "-verbosity Detailed");
-
-                // Assert
-                Assert.Equal(0, result.Item1);
-                Assert.DoesNotContain("Writing cache file", result.Item2);
-                Assert.DoesNotContain("Writing assets file to disk", result.Item2);
-                Assert.Contains("Persisting no-op dg", result.Item2);
-
-                fileInfo = new FileInfo(dgSpecFileName);
-                Assert.True(fileInfo.Exists);
             }
         }
 

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
@@ -2588,6 +2588,104 @@ namespace NuGet.Commands.FuncTest
             }
         }
 
+        [Fact]
+        public async Task RestoreCommand_WithoutCommit_DoesNotWriteAnyAssetsInMSBuildProjectExtensionsPath()
+        {
+            using (var pathContext = new SimpleTestPathContext())
+            using (var context = new SourceCacheContext())
+            {
+                var configJson = JObject.Parse(@"
+                {
+                    ""dependencies"": {
+                    },
+                     ""frameworks"": {
+                        ""net45"": { }
+                    }
+                }");
+
+                // Arrange
+                var sources = new List<PackageSource>
+                {
+                    new PackageSource(pathContext.PackageSource)
+                };
+                var logger = new TestLogger();
+
+                var projectDirectory = Path.Combine(pathContext.SolutionRoot, "TestProject");
+                var cachingSourceProvider = new CachingSourceProvider(new PackageSourceProvider(NullSettings.Instance));
+
+                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", Path.Combine(projectDirectory, "project.csproj")).WithTestRestoreMetadata();
+                var dgSpec = new DependencyGraphSpec();
+                dgSpec.AddProject(spec);
+                dgSpec.AddRestore(spec.Name);
+
+                var request = new TestRestoreRequest(spec, sources, pathContext.UserPackagesFolder, logger)
+                {
+                    ProjectStyle = ProjectStyle.PackageReference,
+                    DependencyGraphSpec = dgSpec,
+                };
+                var command = new RestoreCommand(request);
+
+                // Act
+                var result = await command.ExecuteAsync();
+
+                // Assert
+                Assert.True(result.Success);
+                Assert.False(Directory.Exists(projectDirectory));
+            }
+        }
+
+        [Fact]
+        public async Task RestoreCommand_WithCommit_WritesAllAssetsInMSBuildProjectExtensionsPath()
+        {
+            using (var pathContext = new SimpleTestPathContext())
+            using (var context = new SourceCacheContext())
+            {
+                var configJson = JObject.Parse(@"
+                {
+                    ""dependencies"": {
+                    },
+                     ""frameworks"": {
+                        ""net45"": { }
+                    }
+                }");
+
+                // Arrange
+                var sources = new List<PackageSource>
+                {
+                    new PackageSource(pathContext.PackageSource)
+                };
+                var logger = new TestLogger();
+
+                var projectDirectory = Path.Combine(pathContext.SolutionRoot, "TestProject");
+                var cachingSourceProvider = new CachingSourceProvider(new PackageSourceProvider(NullSettings.Instance));
+
+                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", Path.Combine(projectDirectory, "project.csproj")).WithTestRestoreMetadata();
+                var dgSpec = new DependencyGraphSpec();
+                dgSpec.AddProject(spec);
+                dgSpec.AddRestore(spec.Name);
+
+                var request = new TestRestoreRequest(spec, sources, pathContext.UserPackagesFolder, logger)
+                {
+                    ProjectStyle = ProjectStyle.PackageReference,
+                    DependencyGraphSpec = dgSpec,
+                };
+                var command = new RestoreCommand(request);
+
+                // Act
+                var result = await command.ExecuteAsync();
+                await result.CommitAsync(logger, CancellationToken.None);
+
+                // Assert
+                Assert.True(result.Success);
+                Assert.True(Directory.Exists(projectDirectory));
+                Assert.True(File.Exists(Path.Combine(projectDirectory, "project.assets.json")));
+                Assert.True(File.Exists(Path.Combine(projectDirectory, "project.nuget.cache")));
+                Assert.True(File.Exists(Path.Combine(projectDirectory, "TestProject.csproj.nuget.dgspec.json")));
+                Assert.True(File.Exists(Path.Combine(projectDirectory, "TestProject.csproj.nuget.g.props")));
+                Assert.True(File.Exists(Path.Combine(projectDirectory, "TestProject.csproj.nuget.g.targets")));
+            }
+        }
+
         private static byte[] GetTestUtilityResource(string name)
         {
             return ResourceTestUtility.GetResourceBytes(

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreResultTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreResultTests.cs
@@ -35,6 +35,8 @@ namespace NuGet.Commands.Test
                     cacheFilePath: null,
                     packagesLockFilePath: null,
                     packagesLockFile: null,
+                    dependencyGraphSpecFilePath: null,
+                    dependencyGraphSpec: null,
                     projectStyle: ProjectStyle.Unknown,
                     elapsedTime: TimeSpan.MinValue);
 
@@ -71,6 +73,8 @@ namespace NuGet.Commands.Test
                     cacheFilePath: null,
                     packagesLockFilePath: null,
                     packagesLockFile: null,
+                    dependencyGraphSpecFilePath: null,
+                    dependencyGraphSpec: null,
                     projectStyle: ProjectStyle.Unknown,
                     elapsedTime: TimeSpan.MinValue);
 
@@ -107,6 +111,8 @@ namespace NuGet.Commands.Test
                     cacheFilePath: cachePath,
                     packagesLockFilePath: null,
                     packagesLockFile: null,
+                    dependencyGraphSpecFilePath: null,
+                    dependencyGraphSpec: null,
                     projectStyle: ProjectStyle.Unknown,
                     elapsedTime: TimeSpan.MinValue);
 
@@ -229,5 +235,7 @@ namespace NuGet.Commands.Test
                 Assert.Equal("System.Runtime", actual.Libraries[0].Name);
             }
         }
+
+        // TODO NK - Add tests for this.
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/InstallationCompatibilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/InstallationCompatibilityTests.cs
@@ -510,6 +510,8 @@ namespace NuGet.PackageManagement.Test
                     null,
                     null,
                     null,
+                    null,
+                    null,
                     ProjectStyle.Unknown,
                     TimeSpan.MinValue);
             }


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/8793
Regression: Yes
* Last working version: 5.4
* How are we preventing it in future:   We have a test now

## Fix

Details: When restore is run without a commit, it should not generate any assets. 
This caused a permissions problem with the resolver on linux where, because the temp folder is machine-wide while the restore process was running without admin permissions. 

Note that this is a regression and ideally is reviewed with high priority :) 

## Testing/Validation

Tests Added: Yes  
Reason for not adding tests:  
Validation:  
