### PR TITLE
compare props and targets xml content using XDocument.DeepEquals API.

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
@@ -335,9 +335,7 @@ namespace NuGet.Commands
 
                 if (existing != null)
                 {
-                    // Use a simple string compare to check if the files match
-                    // This can be optimized in the future, but generally these are very small files.
-                    return !newFile.ToString().Equals(existing.ToString(), StringComparison.Ordinal);
+                    return !XDocument.DeepEquals(existing, newFile);
                 }
             }
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
@@ -185,6 +185,7 @@ namespace NuGet.Commands
 
                 new XElement(Namespace + "Project",
                     new XAttribute("ToolsVersion", "14.0"),
+                    new XAttribute("xmlns", Namespace),
                     new XElement(Namespace + "PropertyGroup",
                         new XElement(Namespace + "MSBuildAllProjects", "$(MSBuildAllProjects);$(MSBuildThisFileFullPath)"))));
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
@@ -185,7 +185,7 @@ namespace NuGet.Commands
 
                 new XElement(Namespace + "Project",
                     new XAttribute("ToolsVersion", "14.0"),
-                    new XAttribute("xmlns", Namespace),
+                    new XAttribute("xmlns", Namespace.NamespaceName),
                     new XElement(Namespace + "PropertyGroup",
                         new XElement(Namespace + "MSBuildAllProjects", "$(MSBuildAllProjects);$(MSBuildThisFileFullPath)"))));
 


### PR DESCRIPTION
## Bug

Fixes: NuGet/Home#9131 
Regression: No

## Fix

Details:  In the existing implementation, `.props` and `.targets` XMLs are compared by converting to their string representation. Modified code to compare XML content using [XDocument.DeepEquals](https://docs.microsoft.com/en-us/dotnet/api/system.xml.linq.xnode.deepequals?view=netcore-3.1) API. This fix improves perf by making better usage of .NET API to compare XDocument instead of string comparison. 
XDocument comparison failed after invoking `DeepEquals` API and hence added `xmlns` attribute explicitly to the XML [doc reference](https://docs.microsoft.com/en-us/dotnet/api/system.xml.linq.xnamespace?view=netcore-3.1#creating-a-default-namespace).


## Testing/Validation

Tests Added: No  
Reason for not adding tests:  Existing unit and func tests are sufficient to validate this change.
Validation:  
