### PR TITLE
The SDK Resolver should call DirectoryUtility.CreateSharedDirectory when meddling with the temp folder

### DIFF
--- a/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/RestoreRunnerEx.cs
+++ b/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/RestoreRunnerEx.cs
@@ -44,7 +44,7 @@ namespace NuGet.Commands
                 IgnoreFailedSources = true,
             })
             {
-                // Create a unique temporary directory for the project, use the utility method because 
+                // Create a unique temporary directory for the project, use the utility method because the temp folder on linux is machine wide.
                 var projectDirectoryPath = Path.Combine(NuGetEnvironment.GetFolderPath(NuGetFolderPath.Temp), Guid.NewGuid().ToString("N"));
                 DirectoryUtility.CreateSharedDirectory(projectDirectoryPath);
                 var projectDirectory = new DirectoryInfo(projectDirectoryPath);

--- a/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/RestoreRunnerEx.cs
+++ b/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/RestoreRunnerEx.cs
@@ -44,8 +44,10 @@ namespace NuGet.Commands
                 IgnoreFailedSources = true,
             })
             {
-                // Create a unique temporary directory for the project
-                var projectDirectory = Directory.CreateDirectory(Path.Combine(NuGetEnvironment.GetFolderPath(NuGetFolderPath.Temp), Guid.NewGuid().ToString("N")));
+                // Create a unique temporary directory for the project, use the utility method because 
+                var projectDirectoryPath = Path.Combine(NuGetEnvironment.GetFolderPath(NuGetFolderPath.Temp), Guid.NewGuid().ToString("N"));
+                DirectoryUtility.CreateSharedDirectory(projectDirectoryPath);
+                var projectDirectory = new DirectoryInfo(projectDirectoryPath);
 
                 try
                 {

--- a/test/NuGet.Core.Tests/Microsoft.Build.NuGetSdkResolver.Tests/RestoreRunnerExTests.cs
+++ b/test/NuGet.Core.Tests/Microsoft.Build.NuGetSdkResolver.Tests/RestoreRunnerExTests.cs
@@ -1,0 +1,52 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using NuGet.Commands;
+using NuGet.Configuration;
+using NuGet.LibraryModel;
+using NuGet.Packaging;
+using NuGet.Protocol.Core.Types;
+using NuGet.Test.Utility;
+using NuGet.Versioning;
+using Xunit;
+
+namespace Microsoft.Build.NuGetSdkResolver.Test
+{
+    public class RestoreRunnerExTests
+    {
+        [Fact]
+        public async Task RestoreRunnerEx_WithExistingPackage_DoesNotCreateAnyAssetsAsync()
+        {
+            using (var pathContext = new SimpleTestPathContext())
+            using (var context = new SourceCacheContext())
+            {
+                // Arrange
+                var packageId = "x";
+                var packageVersion = "1.0.0";
+                var logger = new TestLogger();
+                var library = new LibraryIdentity(packageId, NuGetVersion.Parse(packageVersion), LibraryType.Reference);
+
+                var package = new SimpleTestPackageContext(packageId, packageVersion);
+
+                await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                    pathContext.PackageSource,
+                    PackageSaveMode.Defaultv3,
+                    package);
+
+                // Act
+                var results = await RestoreRunnerEx.RunWithoutCommit(library, Settings.LoadDefaultSettings(pathContext.SolutionRoot), logger);
+
+                // Assert
+                results.Count.Should().Be(1);
+                RestoreResult restoreResult = results.Single().Result;
+                restoreResult.Success.Should().BeTrue();
+                File.Exists(restoreResult.LockFilePath).Should().BeFalse();
+                File.Exists(Path.GetDirectoryName(restoreResult.LockFilePath)).Should().BeFalse();
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Bug

Fixes: NuGet/Home#9199
Regression: Yes 
* Last working version:  5.5 P2
* How are we preventing it in future: Test   

## Fix

Details: 
This caused a permissions problem with the resolver on linux where, because the temp folder is machine-wide while the restore process was running without admin permissions.

Note that this is a regression and ideally is reviewed with high priority :)

Note that this is an imperfect and temporary change and will go to 5.5, For 5.6 https://github.com/NuGet/NuGet.Client/pull/3261 is the solution. 

/cc @johntortugo Can we give you a build for you to test?

## Testing/Validation

Tests Added: Yes/No  
Reason for not adding tests:  
Validation:  
