### PR TITLE
PMConsole Install will selectively perform PackageReference Migration

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/PackageActionBaseCommand.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/PackageActionBaseCommand.cs
@@ -297,23 +297,15 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
 
             if (Project.ProjectStyle == ProjectModel.ProjectStyle.PackagesConfig)
             {
-                try
-                {
-                    packagesConfigAndSupportsPackageReferences = Project.ProjectServices.Capabilities.SupportsPackageReferences;
-                }
-                catch (NotImplementedException)
-                {
-                    //If Capabilities aren't implemented, then we assume it doesn't support Package References.
-                    return;
-                }
+                packagesConfigAndSupportsPackageReferences = Project.ProjectServices.Capabilities.SupportsPackageReferences;
             }
 
-            // If Package Reference is supported, then check if Project has any packages installed.
+            // The Project is compatible with, but is currently not a PackageReference-style project, and no packages are currently installed.
             if (packagesConfigAndSupportsPackageReferences && !(await Project.GetInstalledPackagesAsync(Token)).Any())
             {
                 var packageManagementFormat = new PackageManagementFormat(ConfigSettings);
 
-                // if default format is PackageReference then update NuGet Project
+                // The "Default Package Management Format" setting is PackageReference, so we can migrate this NuGet Project.
                 if (packageManagementFormat.SelectedPackageManagementFormat == 1)
                 {
                     var newProject = await VsSolutionManager.UpgradeProjectToPackageReferenceAsync(Project);

--- a/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/PackageActionBaseCommand.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/PackageActionBaseCommand.cs
@@ -293,8 +293,23 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
 
         protected async Task CheckPackageManagementFormat()
         {
-            // check if Project has any packages installed
-            if (!(await Project.GetInstalledPackagesAsync(Token)).Any())
+            bool packagesConfigAndSupportsPackageReferences = false;
+
+            if (Project.ProjectStyle == ProjectModel.ProjectStyle.PackagesConfig)
+            {
+                try
+                {
+                    packagesConfigAndSupportsPackageReferences = Project.ProjectServices.Capabilities.SupportsPackageReferences;
+                }
+                catch (NotImplementedException)
+                {
+                    //If Capabilities aren't implemented, then we assume it doesn't support Package References.
+                    return;
+                }
+            }
+
+            // If Package Reference is supported, then check if Project has any packages installed.
+            if (packagesConfigAndSupportsPackageReferences && !(await Project.GetInstalledPackagesAsync(Token)).Any())
             {
                 var packageManagementFormat = new PackageManagementFormat(ConfigSettings);
 


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9203
Regression: No

## Fix

#### Details
When performing an `Install-Package` in Package Manager Console (PMC) for a new project, we were always performing the logic for a Migration to PackageReference. This caused a bug in SDK-style projects, because it clears the `ProjectRestoreInfo` from the cache. Since `ProjectSystemCache.AddProjectRestoreInfo` doesn't get called again, this cache is never repopulated, and further PMC logic fails without it.

#### Code comment
I wrapped a try/catch around the `ProjectModel.Capabilities` accessor because it seems many project types throw `NotImplemented` exceptions. I'm not sure if I can reliably predict/detect if the Capabilities object will throw or not (ie, perhaps `ProjectStyle.PackagesConfig` is a guarantee for this?). Open to suggestions if this approach isn't ideal.

## Testing/Validation

Tests Added: No (..not yet?)
Reason for not adding tests: I believe this will need to be an APEX test, which I'll need to investigate and discuss with the team.  
Validation:  

### Non-SDK:
1. Create a new ConsoleApp with NetFramework
2. Set VS NuGet Settings such that "PackagesConfig" is the default style.
3. Perform an `Install-Package` command in PMC.
4. Verify that the Migration logic **doesn't occur**, and that the package installs successfully.
5. Repeat step 2-3 but this time with the default style of "PackageReference".
6. Verify that the Migration **occurs**, and that the package installs successfully.

### SDK:
1. Create a new ConsoleApp with NetCore.
2. Set VS NuGet Settings such that "PackagesConfig" is the default style.
3. Perform an `Install-Package` command in PMC.
4. Verify that the Migration logic **doesn't occur**, and that the package installs successfully.
5. Repeat step 2-3 but this time with the default style of "PackageReference".
6. Verify that the Migration logic **doesn't occur (already SDK style)**, and that the package installs successfully.
