### PR TITLE
Fixes missing icon in PM UI due to backlash icon entry

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Converters/IconUrlToImageCacheConverter.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Converters/IconUrlToImageCacheConverter.cs
@@ -80,8 +80,6 @@ namespace NuGet.PackageManagement.UI
 
             if (IsEmbeddedIconUri(iconUrl))
             {
-                var iconEntry = Uri.UnescapeDataString(iconUrl.Fragment).Substring(1); // skip the '#' in a URI fragment
-                var iconEntryNormalized = PathUtility.StripLeadingDirectorySeparators(iconEntry) ;
                 // Check if we have enough info to read the icon from the package
                 if (values.Length == 2 && values[1] is Func<PackageReaderBase> lazyReader)
                 {
@@ -90,6 +88,9 @@ namespace NuGet.PackageManagement.UI
                         PackageReaderBase reader = lazyReader(); // Always returns a new reader. That avoids using an already disposed one
                         if (reader is PackageArchiveReader par) // This reader is closed in BitmapImage events
                         {
+                            var iconEntryNormalized = PathUtility.StripLeadingDirectorySeparators(
+                                Uri.UnescapeDataString(iconUrl.Fragment)
+                                    .Substring(1)); // Substring skips the '#' in the URI fragment
                             iconBitmapImage.StreamSource = par.GetEntry(iconEntryNormalized).Open();
 
                             iconBitmapImage.DecodeFailed += (sender, args) =>
@@ -119,9 +120,8 @@ namespace NuGet.PackageManagement.UI
                             imageResult = defaultPackageIcon;
                         }
                     }
-                    catch (Exception ex)
+                    catch (Exception)
                     {
-                        System.Diagnostics.Debug.WriteLine($"msg: {ex.Message} stack: {ex.StackTrace}");
                         AddToCache(iconUrl, defaultPackageIcon);
                         imageResult = defaultPackageIcon;
                     }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Converters/IconUrlToImageCacheConverter.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Converters/IconUrlToImageCacheConverter.cs
@@ -9,6 +9,7 @@ using System.Net.Cache;
 using System.Runtime.Caching;
 using System.Windows.Data;
 using System.Windows.Media.Imaging;
+using NuGet.Common;
 using NuGet.Packaging;
 
 namespace NuGet.PackageManagement.UI
@@ -80,6 +81,7 @@ namespace NuGet.PackageManagement.UI
             if (IsEmbeddedIconUri(iconUrl))
             {
                 var iconEntry = Uri.UnescapeDataString(iconUrl.Fragment).Substring(1); // skip the '#' in a URI fragment
+                var iconEntryNormalized = PathUtility.StripLeadingDirectorySeparators(iconEntry) ;
                 // Check if we have enough info to read the icon from the package
                 if (values.Length == 2 && values[1] is Func<PackageReaderBase> lazyReader)
                 {
@@ -88,7 +90,7 @@ namespace NuGet.PackageManagement.UI
                         PackageReaderBase reader = lazyReader(); // Always returns a new reader. That avoids using an already disposed one
                         if (reader is PackageArchiveReader par) // This reader is closed in BitmapImage events
                         {
-                            iconBitmapImage.StreamSource = par.GetEntry(iconEntry).Open();
+                            iconBitmapImage.StreamSource = par.GetEntry(iconEntryNormalized).Open();
 
                             iconBitmapImage.DecodeFailed += (sender, args) =>
                             {
@@ -117,8 +119,9 @@ namespace NuGet.PackageManagement.UI
                             imageResult = defaultPackageIcon;
                         }
                     }
-                    catch (Exception)
+                    catch (Exception ex)
                     {
+                        System.Diagnostics.Debug.WriteLine($"msg: {ex.Message} stack: {ex.StackTrace}");
                         AddToCache(iconUrl, defaultPackageIcon);
                         imageResult = defaultPackageIcon;
                     }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
@@ -5645,16 +5645,19 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
             TestPackIconSuccess(testDir, "utils/icon.jpg");
         }
 
-        [Fact]
-        public void PackCommand_PackIcon_FolderNested_Succeeds()
+        [Theory]
+        [InlineData('/')]
+        [InlineData('\\')]
+        public void PackCommand_PackIcon_FolderNested_Succeeds(char iconSeparator)
         {
             var nuspec = NuspecBuilder.Create();
             var testDirBuilder = TestDirectoryBuilder.Create();
             var s = Path.DirectorySeparatorChar;
+            var u = iconSeparator;
 
             nuspec
                 .WithFile($"content{s}**", "utils")
-                .WithIcon($"utils/nested/icon.jpg");
+                .WithIcon($"utils{u}nested{u}icon.jpg");
 
             testDirBuilder
                 .WithFile($"content{s}nested{s}icon.jpg", 6)
@@ -5907,7 +5910,7 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
         /// </list>
         /// </remarks>
         /// <param name="testDirBuilder">A TestDirectory builder with the info for creating the package</param>
-        /// <param name="iconEntry">Zip entry to validate</param>
+        /// <param name="iconEntry">Normalized Zip entry to validate</param>
         /// <param name="message">If not nulll, check that the message is in the command output</param>
         private void TestPackIconSuccess(TestDirectoryBuilder testDirBuilder, string iconEntry = "icon.jpg", string message = null)
         {
@@ -5931,8 +5934,9 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
                     var nuspecReader = nupkgReader.NuspecReader;
 
                     Assert.NotNull(nuspecReader.GetIcon());
-                    Assert.True(nupkgReader.GetEntry(iconEntry) != null);
-                    Assert.True(iconEntry.Equals(nuspecReader.GetIcon()));
+                    Assert.NotNull(nupkgReader.GetEntry(iconEntry));
+                    var normalizedPackedIconEntry = Common.PathUtility.StripLeadingDirectorySeparators(nuspecReader.GetIcon());
+                    Assert.Equal(iconEntry, normalizedPackedIconEntry);
                 }
             }
         }

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Converters/IconUrlToImageCacheConverterTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Converters/IconUrlToImageCacheConverterTests.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.IO.Compression;
 using System.Windows;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
@@ -31,7 +30,7 @@ namespace NuGet.PackageManagement.UI.Test
             this.output = output;
         }
 
-        [WpfFact]
+        [Fact]
         public void Convert_WithMalformedUrlScheme_ReturnsDefault()
         {
             var iconUrl = new Uri("ttp://fake.com/image.png");
@@ -47,7 +46,7 @@ namespace NuGet.PackageManagement.UI.Test
             Assert.Same(DefaultPackageIcon, image);
         }
 
-        [WpfFact]
+        [Fact]
         public void Convert_WhenFileNotFound_ReturnsDefault()
         {
             var iconUrl = new Uri(@"C:\path\to\image.png");
@@ -63,7 +62,7 @@ namespace NuGet.PackageManagement.UI.Test
             Assert.Same(DefaultPackageIcon, image);
         }
 
-        [WpfFact]
+        [Fact]
         public void Convert_WithLocalPath_LoadsImage()
         {
             var iconUrl = new Uri(@"resources/packageicon.png", UriKind.Relative);
@@ -81,7 +80,7 @@ namespace NuGet.PackageManagement.UI.Test
             Assert.Equal(iconUrl, image.UriSource);
         }
 
-        [WpfFact]
+        [Fact(Skip = "Fails on CI. Tracking issue: https://github.com/NuGet/Home/issues/2474")]
         public void Convert_WithValidImageUrl_DownloadsImage()
         {
             var iconUrl = new Uri("http://fake.com/image.png");
@@ -99,7 +98,7 @@ namespace NuGet.PackageManagement.UI.Test
             Assert.Equal(iconUrl, image.UriSource);
         }
 
-        [WpfTheory]
+        [Theory(Skip = "Runs only on Windows Desktop with WPF support")]
         [InlineData("icon.png", "icon.png", "icon.png", "")]
         [InlineData("folder/icon.png", "folder\\icon.png", "folder/icon.png", "folder")]
         [InlineData("folder\\icon.png", "folder\\icon.png", "folder\\icon.png", "folder")]
@@ -154,7 +153,7 @@ namespace NuGet.PackageManagement.UI.Test
             }
         }
 
-        [WpfFact]
+        [Fact]
         public void Convert_FileUri_LoadsImage()
         {
             // Prepare
@@ -183,9 +182,9 @@ namespace NuGet.PackageManagement.UI.Test
             }
         }
 
+        [Theory]
         [InlineData(@"/")]
         [InlineData(@"\")]
-        [WpfTheory]
         public void Convert_EmbeddedIcon_RelativeParentPath_ReturnsDefault(string separator)
         {
             using (var testDir = TestDirectory.Create())
@@ -214,8 +213,8 @@ namespace NuGet.PackageManagement.UI.Test
             }
         }
 
+        [Theory]
         [MemberData(nameof(TestData))]
-        [WpfTheory]
         public void IsEmbeddedIconUri_Tests(Uri testUri, bool expectedResult)
         {
             var result = IconUrlToImageCacheConverter.IsEmbeddedIconUri(testUri);
@@ -266,7 +265,7 @@ namespace NuGet.PackageManagement.UI.Test
         /// <summary>
         /// Creates a NuGet package with .nupkg extension and with a PNG image named "icon.png"
         /// </summary>
-        /// <param name="path">Final path to the dummy .nupkg</param>
+        /// <param name="path">Path to NuGet package</param>
         /// <param name="iconName">Icon filename with .png extension</param>
         private static void CreateDummyPackage(
             string zipPath,

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Converters/IconUrlToImageCacheConverterTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Converters/IconUrlToImageCacheConverterTests.cs
@@ -80,7 +80,7 @@ namespace NuGet.PackageManagement.UI.Test
             Assert.Equal(iconUrl, image.UriSource);
         }
 
-        [Fact(Skip = "Fails on CI. Tracking issue: https://github.com/NuGet/Home/issues/2474")]
+        [Fact(Skip="Fails on CI. Tracking issue: https://github.com/NuGet/Home/issues/2474")]
         public void Convert_WithValidImageUrl_DownloadsImage()
         {
             var iconUrl = new Uri("http://fake.com/image.png");
@@ -300,7 +300,7 @@ namespace NuGet.PackageManagement.UI.Test
                 nuspec.Write(writer);
                 writer.Flush();
                 nuspecStream.Position = 0;
-                var pkgBuilder = new PackageBuilder( stream: nuspecStream, basePath: folderPath);
+                var pkgBuilder = new PackageBuilder(stream: nuspecStream, basePath: folderPath);
                 pkgBuilder.Save(nupkgStream);
             }
         }

--- a/test/TestUtilities/Test.Utility/NuspecBuilder.cs
+++ b/test/TestUtilities/Test.Utility/NuspecBuilder.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text;
 
 namespace NuGet.Test.Utility
@@ -74,41 +75,55 @@ namespace NuGet.Test.Utility
         /// <returns>A <c>StringBuilder</c> object with the .nuspec content</returns>
         public StringBuilder Build()
         {
-            StringBuilder sb = new StringBuilder();
+            var sb = new StringBuilder();
+            var sw = new StringWriter(sb);
 
-            sb.AppendLine("<?xml version=\"1.0\" encoding=\"utf-8\"?>");
-            sb.AppendLine("<package>");
-            sb.AppendLine("  <metadata>");
-            sb.Append("    <id>").Append(PackageIdEntry).AppendLine("</id>");
-            sb.Append("    <version>").Append(PackageVersionEntry).AppendLine("</version>");
-            sb.AppendLine("    <authors>Author1, author2</authors>");
-            sb.AppendLine("    <description>A short sample description</description>");
+            Write(sw);
+
+            return sb;
+        }
+
+        public void Write(TextWriter sb)
+        {
+            sb.WriteLine("<?xml version=\"1.0\" encoding=\"utf-8\"?>");
+            sb.WriteLine("<package>");
+            sb.WriteLine("  <metadata>");
+            sb.Write("    <id>");
+            sb.Write(PackageIdEntry);
+            sb.WriteLine("</id>");
+            sb.Write("    <version>");
+            sb.Write(PackageVersionEntry);
+            sb.WriteLine("</version>");
+            sb.WriteLine("    <authors>Author1, author2</authors>");
+            sb.WriteLine("    <description>A short sample description</description>");
 
             if (IconEntry != null)
             {
-                sb.Append("    <icon>").Append(IconEntry).AppendLine("</icon>");
+                sb.Write("    <icon>");
+                sb.Write(IconEntry);
+                sb.WriteLine("</icon>");
             }
 
             if (IconUrlEntry != null)
             {
-                sb.Append("    <iconUrl>").Append(IconUrlEntry).AppendLine("</iconUrl>");
+                sb.Write("    <iconUrl>");
+                sb.Write(IconUrlEntry);
+                sb.WriteLine("</iconUrl>");
             }
 
-            sb.AppendLine("  </metadata>");
-            sb.AppendLine("  <files>");
+            sb.WriteLine("  </metadata>");
+            sb.WriteLine("  <files>");
             foreach (var fe in FileEntries)
             {
-                sb.Append($"    <file src=\"{fe.Item1}\"");
+                sb.Write($"    <file src=\"{fe.Item1}\"");
                 if (!string.Empty.Equals(fe.Item2))
                 {
-                    sb.Append($" target=\"{fe.Item2}\"");
+                    sb.Write($" target=\"{fe.Item2}\"");
                 }
-                sb.AppendLine(" />");
+                sb.WriteLine(" />");
             }
-            sb.AppendLine("  </files>");
-            sb.AppendLine("</package>");
-
-            return sb;
+            sb.WriteLine("  </files>");
+            sb.WriteLine("</package>");
         }
     }
 }


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9225
Regression: Yes?
* Last working version: 16.5 p3
* How are we preventing it in future: Testing with corner cases.

## Fix

Details: When converting an embedded Icon URI, it normalizes the icon entry from internal nuspec.

## Testing/Validation

Tests Added: Yes. Updated tests.
Validation: Manual run.

Note: This fix only works with packages produced with NuGet