### PR TITLE
Improve chain build log and assertion

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/Signing/Signatures/Signature.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Signatures/Signature.cs
@@ -220,7 +220,7 @@ namespace NuGet.Packaging.Signing
                         var statusFlags = CertificateChainUtility.DefaultObservedStatusFlags;
 
                         IEnumerable<string> messages;
-                        if (CertificateChainUtility.TryGetStatusMessage(chainStatuses, statusFlags, out messages))
+                        if (CertificateChainUtility.TryGetStatusAndMessage(chainStatuses, statusFlags, out messages))
                         {
                             foreach (var message in messages)
                             {
@@ -234,7 +234,7 @@ namespace NuGet.Packaging.Signing
                         // For all the special cases, chain status list only has unique elements for each chain status flag present
                         // therefore if we are checking for one specific chain status we can use the first of the returned list
                         // if we are combining checks for more than one, then we have to use the whole list.
-                        if (CertificateChainUtility.TryGetStatusMessage(chainStatuses, X509ChainStatusFlags.Revoked, out messages))
+                        if (CertificateChainUtility.TryGetStatusAndMessage(chainStatuses, X509ChainStatusFlags.Revoked, out messages))
                         {
                             issues.Add(SignatureLog.Error(NuGetLogCode.NU3012, string.Format(CultureInfo.CurrentCulture, Strings.VerifyChainBuildingIssue, FriendlyName, messages.First())));
                             flags |= SignatureVerificationStatusFlags.CertificateRevoked;
@@ -242,7 +242,7 @@ namespace NuGet.Packaging.Signing
                             return new SignatureVerificationSummary(Type, SignatureVerificationStatus.Suspect, flags, timestamp, issues);
                         }
 
-                        if (CertificateChainUtility.TryGetStatusMessage(chainStatuses, X509ChainStatusFlags.UntrustedRoot, out messages))
+                        if (CertificateChainUtility.TryGetStatusAndMessage(chainStatuses, X509ChainStatusFlags.UntrustedRoot, out messages))
                         {
                             if (settings.ReportUntrustedRoot)
                             {
@@ -256,8 +256,8 @@ namespace NuGet.Packaging.Signing
                             }
                         }
 
-                        var offlineRevocationErrors = CertificateChainUtility.TryGetStatusMessage(chainStatuses, X509ChainStatusFlags.OfflineRevocation, out var _);
-                        var unknownRevocationErrors = CertificateChainUtility.TryGetStatusMessage(chainStatuses, X509ChainStatusFlags.RevocationStatusUnknown, out var unknownRevocationStatusMessages);
+                        var offlineRevocationErrors = CertificateChainUtility.TryGetStatusAndMessage(chainStatuses, X509ChainStatusFlags.OfflineRevocation, out var _);
+                        var unknownRevocationErrors = CertificateChainUtility.TryGetStatusAndMessage(chainStatuses, X509ChainStatusFlags.RevocationStatusUnknown, out var unknownRevocationStatusMessages);
                         if (offlineRevocationErrors || unknownRevocationErrors)
                         {
                             if (settings.ReportUnknownRevocation)

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/Timestamp.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/Timestamp.cs
@@ -178,7 +178,7 @@ namespace NuGet.Packaging.Signing
 
                     var timestampInvalidCertificateFlags = CertificateChainUtility.DefaultObservedStatusFlags;
 
-                    if (CertificateChainUtility.TryGetStatusMessage(chainStatusList, timestampInvalidCertificateFlags, out messages))
+                    if (CertificateChainUtility.TryGetStatusAndMessage(chainStatusList, timestampInvalidCertificateFlags, out messages))
                     {
                         foreach (var message in messages)
                         {
@@ -193,7 +193,7 @@ namespace NuGet.Packaging.Signing
                     // therefore if we are checking for one specific chain status we can use the first of the returned list
                     // if we are combining checks for more than one, then we have to use the whole list.
 
-                    if (CertificateChainUtility.TryGetStatusMessage(chainStatusList, X509ChainStatusFlags.UntrustedRoot, out messages))
+                    if (CertificateChainUtility.TryGetStatusAndMessage(chainStatusList, X509ChainStatusFlags.UntrustedRoot, out messages))
                     {
                         issues.Add(SignatureLog.Error(NuGetLogCode.NU3028, string.Format(CultureInfo.CurrentCulture, Strings.VerifyError_TimestampVerifyChainBuildingIssue, signature.FriendlyName, messages.First())));
 
@@ -201,7 +201,7 @@ namespace NuGet.Packaging.Signing
                         chainBuildingHasIssues = true;
                     }
 
-                    if (CertificateChainUtility.TryGetStatusMessage(chainStatusList, X509ChainStatusFlags.Revoked, out messages))
+                    if (CertificateChainUtility.TryGetStatusAndMessage(chainStatusList, X509ChainStatusFlags.Revoked, out messages))
                     {
                         issues.Add(SignatureLog.Error(NuGetLogCode.NU3028, string.Format(CultureInfo.CurrentCulture, Strings.VerifyError_TimestampVerifyChainBuildingIssue, signature.FriendlyName, messages.First())));
                         flags |= SignatureVerificationStatusFlags.CertificateRevoked;
@@ -209,8 +209,8 @@ namespace NuGet.Packaging.Signing
                         return flags;
                     }
 
-                    var offlineRevocationErrors = CertificateChainUtility.TryGetStatusMessage(chainStatusList, X509ChainStatusFlags.OfflineRevocation, out var _);
-                    var unknownRevocationErrors = CertificateChainUtility.TryGetStatusMessage(chainStatusList, X509ChainStatusFlags.RevocationStatusUnknown, out var unknownRevocationStatusMessages);
+                    var offlineRevocationErrors = CertificateChainUtility.TryGetStatusAndMessage(chainStatusList, X509ChainStatusFlags.OfflineRevocation, out var _);
+                    var unknownRevocationErrors = CertificateChainUtility.TryGetStatusAndMessage(chainStatusList, X509ChainStatusFlags.RevocationStatusUnknown, out var unknownRevocationStatusMessages);
                     if (offlineRevocationErrors || unknownRevocationErrors)
                     {
                         if (treatIssueAsError)

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Utility/CertificateChainUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Utility/CertificateChainUtility.cs
@@ -83,11 +83,11 @@ namespace NuGet.Packaging.Signing
                     if ((chainStatus.Status & errorStatusFlags) != 0)
                     {
                         fatalStatuses.Add(chainStatus);
-                        logger.Log(LogMessage.CreateError(logCode, chainStatus.StatusInformation?.Trim()));
+                        logger.Log(LogMessage.CreateError(logCode, $"{chainStatus.Status}: {chainStatus.StatusInformation?.Trim()}"));
                     }
                     else if ((chainStatus.Status & warningStatusFlags) != 0)
                     {
-                        logger.Log(LogMessage.CreateWarning(logCode, chainStatus.StatusInformation?.Trim()));
+                        logger.Log(LogMessage.CreateWarning(logCode, $"{chainStatus.Status}: {chainStatus.StatusInformation?.Trim()}"));
                     }
                 }
 
@@ -212,13 +212,13 @@ namespace NuGet.Packaging.Signing
             return chainStatus.Any();
         }
 
-        internal static bool TryGetStatusMessage(X509ChainStatus[] chainStatuses, X509ChainStatusFlags status, out IEnumerable<string> messages)
+        internal static bool TryGetStatusAndMessage(X509ChainStatus[] chainStatuses, X509ChainStatusFlags status, out IEnumerable<string> statusAndMessages)
         {
-            messages = null;
+            statusAndMessages = null;
 
             if (ChainStatusListIncludesStatus(chainStatuses, status, out var chainStatus))
             {
-                messages = GetMessagesFromChainStatuses(chainStatus);
+                statusAndMessages = GetStatusAndMessagesFromChainStatuses(chainStatus);
 
                 return true;
             }
@@ -226,11 +226,11 @@ namespace NuGet.Packaging.Signing
             return false;
         }
 
-        internal static IEnumerable<string> GetMessagesFromChainStatuses(IEnumerable<X509ChainStatus> chainStatuses)
+        internal static IEnumerable<string> GetStatusAndMessagesFromChainStatuses(IEnumerable<X509ChainStatus> chainStatuses)
         {
             return chainStatuses
-                .Select(x => x.StatusInformation?.Trim())
-                .Where(x => !string.IsNullOrEmpty(x))
+                .Where(x => !string.IsNullOrEmpty(x.StatusInformation?.Trim()))
+                .Select(x => $"{x.Status}: {x.StatusInformation?.Trim()}")
                 .Distinct(StringComparer.Ordinal)
                 .OrderBy(x => x, StringComparer.Ordinal);
         }

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/InstallCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/InstallCommandTests.cs
@@ -27,9 +27,9 @@ namespace NuGet.CommandLine.FuncTest.Commands
         private static readonly string _NU3008 = "NU3008: {0}";
         private static readonly string _NU3027Message = "The signature should be timestamped to enable long-term signature validity after the certificate has expired.";
         private static readonly string _NU3027 = "NU3027: {0}";
-        private static readonly string _NU3012Message = "The author primary signature found a chain building issue: The certificate is revoked.";
+        private static readonly string _NU3012Message = "The author primary signature found a chain building issue: Revoked: The certificate is revoked.";
         private static readonly string _NU3012 = "NU3012: {0}";
-        private static readonly string _NU3018Message = "The author primary signature found a chain building issue: A certificate chain processed, but terminated in a root certificate which is not trusted by the trust provider.";
+        private static readonly string _NU3018Message = "The author primary signature found a chain building issue: UntrustedRoot: A certificate chain processed, but terminated in a root certificate which is not trusted by the trust provider.";
         private static readonly string _NU3018 = "NU3018: {0}";
 
         private SignCommandTestFixture _testFixture;

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/CertificateChainUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/CertificateChainUtilityTests.cs
@@ -98,17 +98,17 @@ namespace NuGet.Packaging.Test
                 Assert.Equal(1, logger.Errors);
                 SigningTestUtility.AssertUntrustedRoot(logger.LogMessages, LogLevel.Error);
 
-                SigningTestUtility.AssertOfflineRevocation(logger.LogMessages, LogLevel.Warning);
+                SigningTestUtility.AssertRevocationStatusUnknown(logger.LogMessages, LogLevel.Warning);
                 if (RuntimeEnvironmentHelper.IsWindows)
                 {
                     Assert.Equal(2, logger.Warnings);
-                    SigningTestUtility.AssertRevocationStatusUnknown(logger.LogMessages, LogLevel.Warning);
+                    SigningTestUtility.AssertOfflineRevocation(logger.LogMessages, LogLevel.Warning);
                 }
                 else if (RuntimeEnvironmentHelper.IsLinux)
                 {
 #if NETCORE5_0
                     Assert.Equal(2, logger.Warnings);
-                    SigningTestUtility.AssertRevocationStatusUnknown(logger.LogMessages, LogLevel.Warning);
+                    SigningTestUtility.AssertOfflineRevocation(logger.LogMessages, LogLevel.Warning);
 #else
                     Assert.Equal(1, logger.Warnings);
 #endif
@@ -149,7 +149,7 @@ namespace NuGet.Packaging.Test
 #if !NETCORE5_0
                 if (RuntimeEnvironmentHelper.IsLinux)
                 {
-                    SigningTestUtility.AssertOfflineRevocation(logger.LogMessages, LogLevel.Warning);
+                    SigningTestUtility.AssertRevocationStatusUnknown(logger.LogMessages, LogLevel.Warning);
                 }
 #endif
             }

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/SigningUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/SigningUtilityTests.cs
@@ -152,7 +152,7 @@ namespace NuGet.Packaging.Test
 #if !NETCORE5_0
                 if (RuntimeEnvironmentHelper.IsLinux)
                 {
-                    SigningTestUtility.AssertOfflineRevocation(logger.LogMessages, LogLevel.Warning);
+                    SigningTestUtility.AssertRevocationStatusUnknown(logger.LogMessages, LogLevel.Warning);
                 }
 #endif
             }


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9226
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: 
X509ChainStatus has Status and StatusInformation. We used to log StatusInformation, which is different cross platform.
We changed to log {Status}: {StatusInformation} when encountering chain building issues.
We also changed assertion to use Status instead of StatusInformation.

Also fixed following 3 tests:
(Those 3 tests mixed OfflineRevocation and RevocationStatusUnknown on Linux, as the status information are of the same)
```
 Verify_WithUntrustedSelfSignedCertificate_Succeeds
GetCertificateChain_WithUntrustedSelfIssuedCertificate_ReturnsChain
GetCertificateChain_WithUntrustedRoot_Throws
```

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  There're already lots of tests for chain build issue.
Validation:  
