### PR TITLE
Fix output path issues with customized builds

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.targets
@@ -43,7 +43,6 @@ Copyright (c) .NET Foundation. All rights reserved.
     <IsInnerBuild Condition="'$(TargetFramework)' != '' AND '$(TargetFrameworks)' != ''">true</IsInnerBuild>
     <SymbolPackageFormat Condition="'$(SymbolPackageFormat)' == ''">symbols.nupkg</SymbolPackageFormat>
     <AddPriFileDependsOn Condition="'$(MicrosoftPortableCurrentVersionPropsHasBeenImported)' == 'true'">DeterminePortableBuildCapabilities</AddPriFileDependsOn>
-    <NuspecOutputPath Condition="'$(NuspecOutputPath)' == ''">$(BaseIntermediateOutputPath)$(Configuration)\</NuspecOutputPath>
     <WarnOnPackingNonPackableProject Condition="'$(WarnOnPackingNonPackableProject)' == ''">false</WarnOnPackingNonPackableProject>
     <ImportNuGetBuildTasksPackTargetsFromSdk Condition="'$(ImportNuGetBuildTasksPackTargetsFromSdk)' == ''">false</ImportNuGetBuildTasksPackTargetsFromSdk>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>.dll; .exe; .winmd; .json; .pri; .xml; $(AllowedOutputExtensionsInPackageBuildOutputFolder)</AllowedOutputExtensionsInPackageBuildOutputFolder>
@@ -70,8 +69,27 @@ Copyright (c) .NET Foundation. All rights reserved.
     </BuildOutputInPackage>
   </ItemDefinitionGroup>
 
-  <Target Name="_GetOutputItemsFromPack"
-          Returns="@(_OutputPackItems)">
+  <PropertyGroup>
+    <PackageOutputPath Condition="'$(PackageOutputPath)' == ''">$(BaseOutputPath)$(Configuration)\</PackageOutputPath>
+    <NuspecOutputPath Condition="'$(NuspecOutputPath)' == ''">$(BaseIntermediateOutputPath)$(Configuration)\</NuspecOutputPath>
+  </PropertyGroup>
+
+  <!--
+    ============================================================
+    _GetAbsoluteOutputPathsForPack
+    Gets the absolute output paths for Pack.
+    ============================================================
+  -->
+  <Target Name="_GetAbsoluteOutputPathsForPack">
+    <PropertyGroup>
+      <RestoreOutputPath Condition="'$(RestoreOutputPath)' == ''">$(MSBuildProjectExtensionsPath)</RestoreOutputPath>
+      <PackageOutputPath Condition="'$(PackageOutputPath)' == ''">$(BaseOutputPath)$(Configuration)\</PackageOutputPath>
+      <NuspecOutputPath Condition="'$(NuspecOutputPath)' == ''">$(BaseIntermediateOutputPath)$(Configuration)\</NuspecOutputPath>
+    </PropertyGroup>
+
+    <ConvertToAbsolutePath Paths="$(RestoreOutputPath)">
+      <Output TaskParameter="AbsolutePaths" PropertyName="RestoreOutputAbsolutePath" />
+    </ConvertToAbsolutePath>
 
     <ConvertToAbsolutePath Paths="$(PackageOutputPath)">
       <Output TaskParameter="AbsolutePaths" PropertyName="PackageOutputAbsolutePath" />
@@ -80,6 +98,19 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ConvertToAbsolutePath Paths="$(NuspecOutputPath)">
       <Output TaskParameter="AbsolutePaths" PropertyName="NuspecOutputAbsolutePath" />
     </ConvertToAbsolutePath>
+  </Target>
+
+  <!--
+    ============================================================
+    _GetOutputItemsFromPack
+    Gets the output '.nupkg' and '.nuspec' absolute file paths.
+    ============================================================
+  -->
+  <Target Name="_GetOutputItemsFromPack"
+          DependsOnTargets="_GetAbsoluteOutputPathsForPack"
+          Returns="@(_OutputPackItems)">
+
+    <!-- 'PackageOutputAbsolutePath' and 'NuspecOutputAbsolutePath' will be provided by '_GetAbsoluteOutputPathsForPack' target -->
 
     <GetPackOutputItemsTask
         PackageOutputPath="$(PackageOutputAbsolutePath)"
@@ -153,23 +184,6 @@ Copyright (c) .NET Foundation. All rights reserved.
     <PropertyGroup Condition="$(ContinuePackingAfterGeneratingNuspec) == '' ">
       <ContinuePackingAfterGeneratingNuspec>false</ContinuePackingAfterGeneratingNuspec>
     </PropertyGroup>
-    <PropertyGroup>
-      <PackageOutputPath Condition=" '$(PackageOutputPath)' == '' ">$(OutputPath)</PackageOutputPath>
-      <RestoreOutputPath Condition=" '$(RestoreOutputPath)' == '' " >$(MSBuildProjectExtensionsPath)</RestoreOutputPath>
-    </PropertyGroup>
-
-    <ConvertToAbsolutePath Paths="$(NuspecOutputPath)">
-      <Output TaskParameter="AbsolutePaths" PropertyName="NuspecOutputAbsolutePath" />
-    </ConvertToAbsolutePath>
-    <ConvertToAbsolutePath Paths="$(RestoreOutputPath)">
-      <Output TaskParameter="AbsolutePaths" PropertyName="RestoreOutputAbsolutePath" />
-    </ConvertToAbsolutePath>
-    <ConvertToAbsolutePath Paths="$(PackageOutputPath)">
-      <Output TaskParameter="AbsolutePaths" PropertyName="PackageOutputAbsolutePath" />
-    </ConvertToAbsolutePath>
-    <ConvertToAbsolutePath Condition="$(NuspecFile) != ''" Paths="$(NuspecFile)">
-      <Output TaskParameter="AbsolutePaths" PropertyName="NuspecFileAbsolutePath" />
-    </ConvertToAbsolutePath>
 
     <ItemGroup>
       <!--This catches changes to properties-->
@@ -203,6 +217,11 @@ Copyright (c) .NET Foundation. All rights reserved.
           Condition="$(IsPackable) == 'true'"
           Inputs="@(NuGetPackInput)" Outputs="@(NuGetPackOutput)"
           DependsOnTargets="$(GenerateNuspecDependsOn);_CalculateInputsOutputsForPack;_GetProjectReferenceVersions;_InitializeNuspecRepositoryInformationProperties">
+
+    <ConvertToAbsolutePath Condition="$(NuspecFile) != ''" Paths="$(NuspecFile)">
+      <Output TaskParameter="AbsolutePaths" PropertyName="NuspecFileAbsolutePath" />
+    </ConvertToAbsolutePath>
+
     <!-- Call Pack -->
     <PackTask PackItem="$(PackProjectInputFile)"
               PackageFiles="@(_PackageFiles)"
@@ -294,10 +313,9 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <Target Name="_GetProjectReferenceVersions"
           Condition="'$(NuspecFile)' == ''"
-          DependsOnTargets="_CalculateInputsOutputsForPack;$(GetPackageVersionDependsOn)">
-    <ConvertToAbsolutePath Paths="$(RestoreOutputPath)">
-      <Output TaskParameter="AbsolutePaths" PropertyName="RestoreOutputAbsolutePath" />
-    </ConvertToAbsolutePath>
+          DependsOnTargets="_GetAbsoluteOutputPathsForPack;$(GetPackageVersionDependsOn)">
+
+    <!-- 'RestoreOutputAbsolutePath' will be provided by '_GetAbsoluteOutputPathsForPack' target -->
 
     <ConvertToAbsolutePath Condition="'$(ProjectAssetsFile)' != ''" Paths="$(ProjectAssetsFile)">
       <Output TaskParameter="AbsolutePaths" PropertyName="ProjectAssetsFileAbsolutePath" />

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.targets
@@ -70,6 +70,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   </ItemDefinitionGroup>
 
   <PropertyGroup>
+    <RestoreOutputPath Condition="'$(RestoreOutputPath)' == ''">$(MSBuildProjectExtensionsPath)</RestoreOutputPath>
     <PackageOutputPath Condition="'$(PackageOutputPath)' == ''">$(BaseOutputPath)$(Configuration)\</PackageOutputPath>
     <NuspecOutputPath Condition="'$(NuspecOutputPath)' == ''">$(BaseIntermediateOutputPath)$(Configuration)\</NuspecOutputPath>
   </PropertyGroup>
@@ -81,12 +82,6 @@ Copyright (c) .NET Foundation. All rights reserved.
     ============================================================
   -->
   <Target Name="_GetAbsoluteOutputPathsForPack">
-    <PropertyGroup>
-      <RestoreOutputPath Condition="'$(RestoreOutputPath)' == ''">$(MSBuildProjectExtensionsPath)</RestoreOutputPath>
-      <PackageOutputPath Condition="'$(PackageOutputPath)' == ''">$(BaseOutputPath)$(Configuration)\</PackageOutputPath>
-      <NuspecOutputPath Condition="'$(NuspecOutputPath)' == ''">$(BaseIntermediateOutputPath)$(Configuration)\</NuspecOutputPath>
-    </PropertyGroup>
-
     <ConvertToAbsolutePath Paths="$(RestoreOutputPath)">
       <Output TaskParameter="AbsolutePaths" PropertyName="RestoreOutputAbsolutePath" />
     </ConvertToAbsolutePath>

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
@@ -6070,7 +6070,6 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
     <OutputPath>out</OutputPath>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <PackageIconUrl>https://test/icon.jpg</PackageIconUrl>
-    <PackageOutputPath>bin\Debug\</PackageOutputPath>
     <Authors>Alice</Authors>
   </PropertyGroup>
   <ItemGroup>

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
@@ -4374,7 +4374,6 @@ namespace ClassLibrary
             projectBuilder
                 .WithProjectName("test")
                 .WithProperty("Authors", "Alice")
-                .WithProperty("PackageOutputPath", "bin\\Debug\\")
                 .WithProperty("NuspecFile", "test.nuspec")
                 .WithPackageIconUrl("https://test/icon.jpg");
 


### PR DESCRIPTION
This PR Fixes NuGet/Home#9234

 - This fixes a host of path related issues when doing a customized build with Pack targets.
 - It also obsoletes the `PackageOutputPath` in the SDK's `DefaultOutputPaths` targets.
 - It also ensures non-sdk style projects doesn't have to specify some default paths.

Requires microsoft/msbuild#5238