### PR TITLE
Use Item update to manage the dependencies

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -105,6 +105,8 @@ else {
 Invoke-BuildStep 'Running Restore' {
 
     # Restore
+    Trace-Log ". `"$MSBuildExe`" build\build.proj /t:EnsurePackageReferenceVersionsInSolution /p:Configuration=$Configuration"
+    & $MSBuildExe build\build.proj /t:EnsurePackageReferenceVersionsInSolution /p:Configuration=$Configuration
     Trace-Log ". `"$MSBuildExe`" build\build.proj /t:RestoreVS /p:Configuration=$Configuration /p:ReleaseLabel=$ReleaseLabel /p:BuildNumber=$BuildNumber /v:m /m:1"
     & $MSBuildExe build\build.proj /t:RestoreVS /p:Configuration=$Configuration /p:ReleaseLabel=$ReleaseLabel /p:BuildNumber=$BuildNumber /v:m /m:1
 

--- a/build/build.proj
+++ b/build/build.proj
@@ -19,7 +19,7 @@
   -->
   <Target Name="GetXPLATProjects">
       <MsBuild
-      Projects="@(AllSolutionProjects)"
+      Projects="@(ProductProjects)"
       Targets="GetXPLATProject">
       <Output
           TaskParameter="TargetOutputs"
@@ -320,6 +320,19 @@
                   $(CommonMSBuildProperties);
                   VisualStudioVersion=$(VisualStudioVersion)">
     </MSBuild>
+  </Target>
+
+    <!--
+    ============================================================
+    EnsurePackageReferenceVersionsInSolution
+    ============================================================
+  -->
+  <Target Name="EnsurePackageReferenceVersionsInSolution">
+      <MsBuild
+        Projects="@(AllRepoProjects)"
+        Targets="EnsurePackageReferenceVersions"
+        Properties="SkipCentralPackageVersions=true">
+    </MsBuild>
   </Target>
 
   <!--

--- a/build/common.project.props
+++ b/build/common.project.props
@@ -47,22 +47,6 @@
     <NoWarn>$(NoWarn);NU5105</NoWarn>
   </PropertyGroup>
 
-  <!-- Dependency versions -->
-  <PropertyGroup>
-    <VSFrameworkVersion>16.4.29519.181</VSFrameworkVersion>
-    <VSServicesVersion>16.153.0</VSServicesVersion>
-    <VSComponentsVersion>16.4.280</VSComponentsVersion>
-    <VSThreadingVersion>16.4.43</VSThreadingVersion>
-    <SystemPackagesVersion>4.3.0</SystemPackagesVersion>
-    <NewtonsoftJsonVersionCore Condition="$(NewtonsoftJsonPackageVersion) == ''">9.0.1</NewtonsoftJsonVersionCore>
-    <NewtonsoftJsonVersionCore Condition="$(NewtonsoftJsonPackageVersion) != ''">$(NewtonsoftJsonPackageVersion)</NewtonsoftJsonVersionCore>
-    <XunitVersion>2.4.1</XunitVersion>
-    <TestSDKVersion>15.5.0</TestSDKVersion>
-    <MoqVersion>4.12.0</MoqVersion>
-    <FluentAssertionsVersion>4.19.4</FluentAssertionsVersion>
-    <MicrosoftBuildPackageVersion Condition="'$(MicrosoftBuildPackageVersion)' == ''">16.5.0-preview-19606-01</MicrosoftBuildPackageVersion>
-  </PropertyGroup>
-
   <!-- Defaults -->
   <PropertyGroup>
     <TreatWarningsAsErrors Condition=" '$(TreatWarningsAsErrors)' == '' ">true</TreatWarningsAsErrors>
@@ -76,7 +60,6 @@
     <NuGetTargets>$(MSBuildExtensionsPath)\Microsoft\NuGet\$(VisualStudioVersion)\Microsoft.NuGet.targets</NuGetTargets>
     <ComVisible>false</ComVisible>
   </PropertyGroup>
-
 
   <!-- Common project build settings -->
   <PropertyGroup>
@@ -281,16 +264,21 @@
   </ItemGroup>
 
   <ItemGroup>
-      <AllSolutionProjects Include="$(RepositoryRootDirectory)src\*\*\*.csproj" />
+    <ProductProjects Include="$(RepositoryRootDirectory)src\*\*\*.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition=" '$(IsXPlat)' != 'true' ">
    <ApexProjects Include="$(RepositoryRootDirectory)test\NuGet.Tests.Apex\*\*.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(IsXPlat)' != 'true' ">
+    <AllRepoProjects Include="@(SolutionProjects)" />
+    <AllRepoProjects Include="@(ApexProjects)" />
   </ItemGroup>
 
   <!-- source link -->
   <ItemGroup Condition="'$(Shipping)' == 'true' AND '$(IsXPlat)' != 'true'">
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19351-01" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All"/>
   </ItemGroup>
 
   <Import Project="OptProfV2.props"/>

--- a/build/common.targets
+++ b/build/common.targets
@@ -46,8 +46,13 @@
     <Import Project="test.targets" />
   </ImportGroup>
 
+  <!-- Centrally managed packages -->
+  <ImportGroup Condition=" '$(SkipCentralPackageVersions)' != 'true' ">
+    <Import Project="packages.targets" />
+  </ImportGroup>
+
   <!-- Allow WPF projects to run under NETCore SDK -->
-  <!-- Errors occur if the output ptah is not set correctly -->
+  <!-- Errors occur if the output path is not set correctly -->
   <PropertyGroup Condition=" '$(NETCoreWPFProject)' == 'true' ">
     <TargetFrameworkVersion>$(NETFXTargetFrameworkVersion)</TargetFrameworkVersion>
     <BaseOutputPath>bin\</BaseOutputPath>
@@ -316,8 +321,14 @@
   -->
   <Target Name="EnsureNewtonsoftJsonVersion" AfterTargets="ResolveAssemblyReferences">
     <Error
-      Text="Newtonsoft.Json must be version $(NewtonsoftJsonVersionCore) but resolved %(Reference.NuGetPackageVersion)"
-      Condition=" %(Reference.NuGetPackageId) == 'Newtonsoft.Json' AND %(Reference.NuGetPackageVersion) != '$(NewtonsoftJsonVersionCore)' " />
+      Text="Newtonsoft.Json must be version $(NewtonsoftJsonPackageVersion) but resolved %(Reference.NuGetPackageVersion)"
+      Condition=" %(Reference.NuGetPackageId) == 'Newtonsoft.Json' AND %(Reference.NuGetPackageVersion) != '$(NewtonsoftJsonPackageVersion)' " />
+  </Target>
+
+  <Target Name="EnsurePackageReferenceVersions">
+    <Error
+      Text="%(PackageReference.Identity) should not have a version declared outside of packages.targets but found %(PackageReference.Version)"
+      Condition=" '%(PackageReference.Version)' != '' AND '%(PackageReference.IsImplicitlyDefined)' != 'true' AND '%(PackageReference.Identity)' != 'Microsoft.NET.Test.Sdk' " />
   </Target>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\packages\Microsoft.VisualStudioEng.MicroBuild.Core.0.4.1\build\Microsoft.VisualStudioEng.MicroBuild.Core.targets" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), &quot;README.md&quot;))\packages\Microsoft.VisualStudioEng.MicroBuild.Core.0.4.1\build\Microsoft.VisualStudioEng.MicroBuild.Core.targets')" />

--- a/build/common.targets
+++ b/build/common.targets
@@ -46,7 +46,7 @@
     <Import Project="test.targets" />
   </ImportGroup>
 
-  <!-- Centrally managed packages -->
+  <!-- Centrally managed packages. SkipCentralPackageVersions is used to enforce that the packages are centrally managed through a check in build.proj -->
   <ImportGroup Condition=" '$(SkipCentralPackageVersions)' != 'true' ">
     <Import Project="packages.targets" />
   </ImportGroup>

--- a/build/packages.targets
+++ b/build/packages.targets
@@ -1,0 +1,99 @@
+<Project>
+    <PropertyGroup>
+        <MicrosoftBuildPackageVersion Condition="'$(MicrosoftBuildPackageVersion)' == ''">16.5.0-preview-19606-01</MicrosoftBuildPackageVersion>
+        <NewtonsoftJsonPackageVersion Condition="$(NewtonsoftJsonPackageVersion) == ''">9.0.1</NewtonsoftJsonPackageVersion>
+        <SystemPackagesVersion>4.3.0</SystemPackagesVersion>
+        <VSComponentsVersion>16.4.280</VSComponentsVersion>
+        <VSFrameworkVersion>16.4.29519.181</VSFrameworkVersion>
+        <VSServicesVersion>16.153.0</VSServicesVersion>
+        <VSThreadingVersion>16.4.43</VSThreadingVersion>
+    </PropertyGroup>
+
+    <!-- Test and package versions -->
+    <PropertyGroup>
+        <FluentAssertionsVersion>4.19.4</FluentAssertionsVersion>
+        <MoqVersion>4.12.0</MoqVersion>
+        <TestSDKVersion>15.5.0</TestSDKVersion>
+        <XunitVersion>2.4.1</XunitVersion>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Update="EnvDTE80" Version="8.0.1" />
+        <PackageReference Update="Lucene.Net" Version="3.0.3" />
+        <PackageReference Update="Microsoft.Build" Version="$(MicrosoftBuildPackageVersion)" />
+        <PackageReference Update="Microsoft.Build.Framework" Version="$(MicrosoftBuildPackageVersion)" />
+        <PackageReference Update="Microsoft.Build.Locator" Version="1.2.2" />
+        <PackageReference Update="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildPackageVersion)" />
+        <PackageReference Update="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildPackageVersion)" />
+        <PackageReference Update="Microsoft.Extensions.CommandLineUtils" Version="1.0.1" />
+        <PackageReference Update="Microsoft.Internal.VisualStudio.Shell.Embeddable" Version="16.3.28923.271" />
+        <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19351-01" />
+        <PackageReference Update="Microsoft.TeamFoundationServer.ExtendedClient" Version="$(VSServicesVersion)" />
+        <PackageReference Update="Microsoft.VisualStudio.ComponentModelHost" Version="$(VSComponentsVersion)" />
+        <PackageReference Update="Microsoft.VisualStudio.CoreUtility" Version="$(VSComponentsVersion)" />
+        <PackageReference Update="Microsoft.VisualStudio.Editor" Version="$(VSComponentsVersion)" />
+        <PackageReference Update="Microsoft.VisualStudio.ImageCatalog" Version="$(VSFrameworkVersion)" />
+        <PackageReference Update="Microsoft.VisualStudio.Language.Intellisense" Version="$(VSComponentsVersion)" />
+        <PackageReference Update="Microsoft.VisualStudio.Language.StandardClassification" Version="$(VSComponentsVersion)" />
+        <PackageReference Update="Microsoft.VisualStudio.Services.Client" Version="$(VSServicesVersion)" />
+        <PackageReference Update="Microsoft.VisualStudio.Services.InteractiveClient" Version="$(VSServicesVersion)" />
+        <PackageReference Update="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="1.16.30" />
+        <PackageReference Update="Microsoft.VisualStudio.Shell.15.0" Version="$(VSFrameworkVersion)" />
+        <PackageReference Update="Microsoft.VisualStudio.Shell.Immutable.15.0" Version="15.0.25123-Dev15Preview" />
+        <PackageReference Update="Microsoft.VisualStudio.Shell.Interop.12.0" Version="12.0.30111" />
+        <PackageReference Update="Microsoft.VisualStudio.Shell.Interop.16.0.DesignTime" Version="16.0.0" />
+        <PackageReference Update="Microsoft.VisualStudio.Telemetry" Version="16.3.2" />
+        <PackageReference Update="Microsoft.VisualStudio.Text.Data" Version="$(VSComponentsVersion)" />
+        <PackageReference Update="Microsoft.VisualStudio.Text.Logic" Version="$(VSComponentsVersion)" />
+        <PackageReference Update="Microsoft.VisualStudio.Text.UI" Version="$(VSComponentsVersion)" />
+        <PackageReference Update="Microsoft.VisualStudio.Text.UI.Wpf" Version="$(VSComponentsVersion)" />
+        <PackageReference Update="Microsoft.VisualStudio.TextManager.Interop" Version="7.10.6071" />
+        <PackageReference Update="Microsoft.VisualStudio.TextManager.Interop.10.0" Version="10.0.30319" />
+        <PackageReference Update="Microsoft.VisualStudio.Threading" Version="$(VSThreadingVersion)" />
+        <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers" Version="$(VSThreadingVersion)" />
+        <PackageReference Update="Microsoft.VisualStudio.Workspace.VSIntegration" Version="15.0.198-pre" />
+        <PackageReference Update="Microsoft.Web.Xdt" Version="2.1.2" />
+        <PackageReference Update="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
+        <PackageReference Update="System.Collections.Immutable" Version="1.5.0" />
+        <PackageReference Update="System.Diagnostics.Process" Version="$(SystemPackagesVersion)" />
+        <PackageReference Update="System.Dynamic.Runtime" Version="$(SystemPackagesVersion)" /> 
+        <PackageReference Update="System.Runtime.Serialization.Formatters" Version="$(SystemPackagesVersion)" />
+        <PackageReference Update="System.Runtime.Serialization.Primitives" Version="$(SystemPackagesVersion)" />
+        <PackageReference Update="System.Security.Cryptography.ProtectedData" Version="$(SystemPackagesVersion)" />
+        <PackageReference Update="System.Threading.Tasks.Dataflow" Version="4.9.0" />
+        <PackageReference Update="System.Threading.Thread" Version="$(SystemPackagesVersion)" />
+        <PackageReference Update="VSLangProj" Version="7.0.3300" />
+        <PackageReference Update="VSLangProj110" Version="11.0.61030" />
+        <PackageReference Update="VSLangProj157" Version="15.7.0" />
+        <PackageReference Update="VSLangProj2" Version="7.0.5000" />
+        <PackageReference Update="VSSDK.TemplateWizardInterface" Version="12.0.4" />
+    </ItemGroup>
+
+    <!-- Test and utility packages -->
+    <ItemGroup>
+        <PackageReference Update="EnvDTE" Version="8.0.1" />
+        <PackageReference Update="FluentAssertions" Version="$(FluentAssertionsVersion)" />
+        <PackageReference Update="Microsoft.Build.Runtime" Version="$(MicrosoftBuildPackageVersion)" />
+        <PackageReference Update="Microsoft.CSharp" Version="$(SystemPackagesVersion)" />
+        <PackageReference Update="Microsoft.CodeAnalysis" Version="3.0.0" />
+        <PackageReference Update="Microsoft.CodeAnalysis.Build.Tasks" Version="3.0.0-dev-61717-03" />
+        <PackageReference Update="Microsoft.CodeAnalysis.CSharp" Version="3.0.0-dev-61717-03" />
+        <PackageReference Update="Microsoft.NET.Test.Sdk" Version="$(TestSDKVersion)" />
+        <PackageReference Update="Microsoft.Net.Compilers.netcore" Version="3.0.0-dev-61717-03" />
+        <PackageReference Update="Microsoft.PowerShell.3.ReferenceAssemblies" Version="1.0.0" />
+        <PackageReference Update="Microsoft.Test.Apex.VisualStudio" Version="16.3.29131.53-pre" />
+        <PackageReference Update="Microsoft.VisualStudio.ProjectSystem" Version="15.0.751" PrivateAssets="All" />
+        <PackageReference Update="Microsoft.VisualStudio.Shell.Interop.15.0.DesignTime" Version="15.0.26932" />
+        <PackageReference Update="Moq" Version="$(MoqVersion)" />
+        <PackageReference Update="NuGet.Core" Version="2.14.0-rtm-832" />
+        <PackageReference Update="Portable.BouncyCastle" Version="1.8.1.3" />
+        <PackageReference Update="System.Diagnostics.TraceSource" Version="$(SystemPackagesVersion)" />
+        <PackageReference Update="System.IO.Compression.ZipFile" Version="$(SystemPackagesVersion)" />
+        <PackageReference Update="System.Runtime.Loader" Version="$(SystemPackagesVersion)" />
+        <PackageReference Update="System.Security.Cryptography.Pkcs" Version="4.5.2" />
+        <PackageReference Update="System.Threading.Tasks.Parallel" Version="$(SystemPackagesVersion)" />
+        <PackageReference Update="Xunit.StaFact" Version="0.2.9" />
+        <PackageReference Update="xunit" Version="$(XunitVersion)" />
+        <PackageReference Update="xunit.runner.visualstudio" Version="$(XunitVersion)" />
+    </ItemGroup>
+</Project>

--- a/build/test.targets
+++ b/build/test.targets
@@ -10,11 +10,11 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSDKVersion)" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
-    <PackageReference Include="xunit" Version="$(XunitVersion)" />
-    <PackageReference Include="Moq" Version="$(MoqVersion)" />
-    <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="FluentAssertions" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -190,6 +190,16 @@ jobs:
       msbuildVersion: "16.0"
       msbuildArguments: "/t:EnsureNewtonsoftJsonVersion"
     condition: "succeeded()"
+  
+  - task: MSBuild@1
+    displayName: "Ensure package versions are declared in packages.targets"
+    continueOnError: "false"
+    inputs:
+      solution: "build\\build.proj"
+      msbuildVersion: "16.0"
+      msbuildArguments: "/t:EnsurePackageReferenceVersionsInSolution"
+    condition: "succeeded()"
+
 
   - task: MSBuild@1	
     displayName: "Localize Assemblies"	

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGet.CommandLine.csproj
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGet.CommandLine.csproj
@@ -87,7 +87,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="1.16.30" />
+    <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop" />
     <ProjectReference Include="$(NuGetCoreSrcDirectory)NuGet.PackageManagement\NuGet.PackageManagement.csproj" />
     <ProjectReference Include="$(NuGetCoreSrcDirectory)NuGet.Build.Tasks\NuGet.Build.Tasks.csproj" />
   </ItemGroup>

--- a/src/NuGet.Clients/NuGet.Console/NuGet.Console.csproj
+++ b/src/NuGet.Clients/NuGet.Console/NuGet.Console.csproj
@@ -148,9 +148,9 @@
     </Page>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.TextManager.Interop" Version="7.10.6071" />
-    <PackageReference Include="Microsoft.VisualStudio.TextManager.Interop.10.0" Version="10.0.30319" />
-    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersionCore)" NoWarn="NU1605" />
+    <PackageReference Include="Microsoft.VisualStudio.TextManager.Interop" />
+    <PackageReference Include="Microsoft.VisualStudio.TextManager.Interop.10.0" />
+    <PackageReference Include="Newtonsoft.Json" NoWarn="NU1605" />
   </ItemGroup>
   <Import Project="$(BuildCommonDirectory)common.targets" />
   <Import Project="$(BuildCommonDirectory)embedinterop.targets" />

--- a/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/NuGet.PackageManagement.PowerShellCmdlets.csproj
+++ b/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/NuGet.PackageManagement.PowerShellCmdlets.csproj
@@ -81,7 +81,7 @@
     <ProjectReference Include="..\NuGet.VisualStudio.Common\NuGet.VisualStudio.Common.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersionCore)" NoWarn="NU1605" />
+    <PackageReference Include="Newtonsoft.Json" NoWarn="NU1605" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(NuGetCoreSrcDirectory)NuGet.Commands\NuGet.Commands.csproj">

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/NuGet.PackageManagement.UI.csproj
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/NuGet.PackageManagement.UI.csproj
@@ -503,7 +503,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersionCore)" NoWarn="NU1605" />
+    <PackageReference Include="Newtonsoft.Json" NoWarn="NU1605" />
   </ItemGroup>
   <ItemGroup>
     <Resource Include="Resources\StatusOK_32x.png" />

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/NuGet.PackageManagement.VisualStudio.csproj
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/NuGet.PackageManagement.VisualStudio.csproj
@@ -292,11 +292,11 @@
   </ItemGroup>
   <ItemGroup>
     <!-- This causes a NU5104 warning. When upgrading to a stable version of this package, remove the above no warn. -->
-    <PackageReference Include="Microsoft.VisualStudio.Workspace.VSIntegration" Version="15.0.198-pre" />
-    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersionCore)" NoWarn="NU1605" />
-    <PackageReference Include="VSLangProj110" Version="11.0.61030" />
-    <PackageReference Include="VSLangProj2" Version="7.0.5000" />
-    <PackageReference Include="VSLangProj157" Version="15.7.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Workspace.VSIntegration" />
+    <PackageReference Include="Newtonsoft.Json" NoWarn="NU1605" />
+    <PackageReference Include="VSLangProj110" />
+    <PackageReference Include="VSLangProj2" />
+    <PackageReference Include="VSLangProj157" />
   </ItemGroup>
   <Import Project="$(BuildCommonDirectory)common.targets" />
   <Import Project="$(BuildCommonDirectory)embedinterop.targets" />

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/NuGet.SolutionRestoreManager.csproj
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/NuGet.SolutionRestoreManager.csproj
@@ -71,7 +71,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersionCore)" NoWarn="NU1605" />
+    <PackageReference Include="Newtonsoft.Json" NoWarn="NU1605" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Resources.resx">

--- a/src/NuGet.Clients/NuGet.Tools/NuGet.Tools.csproj
+++ b/src/NuGet.Clients/NuGet.Tools/NuGet.Tools.csproj
@@ -128,10 +128,8 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Internal.VisualStudio.Shell.Embeddable" ExcludeAssets="build">
-      <Version>16.3.28923.271</Version>
-    </PackageReference>
-    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersionCore)" NoWarn="NU1605" />
+    <PackageReference Include="Microsoft.Internal.VisualStudio.Shell.Embeddable" ExcludeAssets="build" />
+    <PackageReference Include="Newtonsoft.Json" NoWarn="NU1605" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="Resources\nuget_256.png">

--- a/src/NuGet.Clients/NuGet.VisualStudio.Client/NuGet.VisualStudio.Client.csproj
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Client/NuGet.VisualStudio.Client.csproj
@@ -319,6 +319,11 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <!-- This is important because otherwise the VSSDK will include the unsigned version coming from the global packages folder instead of the in-place signed one from the bootstrapped packages folder -->
+    <PackageReference Include="Lucene.Net" ExcludeAssets="all" />
+    <PackageReference Include="Newtonsoft.Json" NoWarn="NU1605" />
+  </ItemGroup>
+  <ItemGroup>
     <Content Include="eula.rtf">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>
@@ -362,14 +367,6 @@
   </ItemGroup>
   <ItemGroup>
     <VsixIgnoreFile Include=".vsixignore" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Lucene.Net">
-      <Version>3.0.3</Version>
-      <!-- This is important because otherwise the VSSDK will include the unsigned version coming from the global packages folder instead of the in-place signed one from the bootstrapped packages folder -->
-      <ExcludeAssets>all</ExcludeAssets>
-    </PackageReference>
-    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersionCore)" NoWarn="NU1605" />
   </ItemGroup>
   <Target Name="AfterBuild" DependsOnTargets="PublishVS" />
   <Target Name="PublishVS">

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/NuGet.VisualStudio.Common.csproj
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/NuGet.VisualStudio.Common.csproj
@@ -20,30 +20,31 @@
       <HintPath>$(EnlistmentRoot)\packages\microsoft.build\15.1.262-preview5\lib\net46\Microsoft.Build.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <PackageReference Include="Microsoft.TeamFoundationServer.ExtendedClient" Version="$(VSServicesVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.ComponentModelHost" Version="$(VSComponentsVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.CoreUtility" Version="$(VSComponentsVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Editor" Version="$(VSComponentsVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Language.Intellisense" Version="$(VSComponentsVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Language.StandardClassification" Version="$(VSComponentsVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Services.Client" Version="$(VSServicesVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Services.InteractiveClient" Version="$(VSServicesVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="$(VSFrameworkVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Shell.Immutable.15.0" Version="15.0.25123-Dev15Preview">
-      <PrivateAssets>All</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.16.0.DesignTime" Version="16.0.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Telemetry" Version="16.3.2" />
-    <PackageReference Include="Microsoft.VisualStudio.Text.Data" Version="$(VSComponentsVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Text.Logic" Version="$(VSComponentsVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Text.UI" Version="$(VSComponentsVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Text.UI.Wpf" Version="$(VSComponentsVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.ImageCatalog" Version="$(VSFrameworkVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="$(VSThreadingVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="$(VSThreadingVersion)" />
-    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersionCore)" NoWarn="NU1605" />
-    <PackageReference Include="VSLangProj" Version="7.0.3300" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
+    <PackageReference Include="Microsoft.TeamFoundationServer.ExtendedClient" />
+    <PackageReference Include="Microsoft.VisualStudio.ComponentModelHost" />
+    <PackageReference Include="Microsoft.VisualStudio.CoreUtility" />
+    <PackageReference Include="Microsoft.VisualStudio.Editor" />
+    <PackageReference Include="Microsoft.VisualStudio.Language.Intellisense" />
+    <PackageReference Include="Microsoft.VisualStudio.Language.StandardClassification" />
+    <PackageReference Include="Microsoft.VisualStudio.Services.Client" />
+    <PackageReference Include="Microsoft.VisualStudio.Services.InteractiveClient" />
+    <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Shell.Immutable.15.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.16.0.DesignTime" />
+    <PackageReference Include="Microsoft.VisualStudio.Telemetry" />
+    <PackageReference Include="Microsoft.VisualStudio.Text.Data" />
+    <PackageReference Include="Microsoft.VisualStudio.Text.Logic" />
+    <PackageReference Include="Microsoft.VisualStudio.Text.UI" />
+    <PackageReference Include="Microsoft.VisualStudio.Text.UI.Wpf" />
+    <PackageReference Include="Microsoft.VisualStudio.ImageCatalog" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" />
+    <PackageReference Include="Newtonsoft.Json" NoWarn="NU1605" />
+    <PackageReference Include="VSLangProj" />
+    <PackageReference Include="System.Collections.Immutable" />
+    <PackageReference Include="EnvDTE80" />
+    <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.12.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Workspace.VSIntegration" />  
   </ItemGroup>
   <ItemGroup>
     <Reference Include="PresentationCore" />
@@ -51,11 +52,6 @@
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.IO.Compression" />
     <Reference Include="WindowsBase" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="EnvDTE80" Version="8.0.1" />
-    <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.12.0" Version="12.0.30111" />
-    <PackageReference Include="Microsoft.VisualStudio.Workspace.VSIntegration" Version="15.0.198-pre" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(NuGetCoreSrcDirectory)NuGet.PackageManagement\NuGet.PackageManagement.csproj" />

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/NuGet.VisualStudio.Implementation.csproj
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/NuGet.VisualStudio.Implementation.csproj
@@ -34,7 +34,7 @@
     <ProjectReference Include="..\NuGet.VisualStudio.Common\NuGet.VisualStudio.Common.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersionCore)" NoWarn="NU1605" />
+    <PackageReference Include="Newtonsoft.Json" NoWarn="NU1605" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.ProjectSystem">

--- a/src/NuGet.Clients/NuGet.VisualStudio.Interop/NuGet.VisualStudio.Interop.csproj
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Interop/NuGet.VisualStudio.Interop.csproj
@@ -19,9 +19,9 @@
     <ProjectReference Include="..\NuGet.VisualStudio\NuGet.VisualStudio.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="$(VSFrameworkVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.ComponentModelHost" Version="$(VSComponentsVersion)" />
-    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersionCore)" NoWarn="NU1605" />
+    <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" />
+    <PackageReference Include="Microsoft.VisualStudio.ComponentModelHost" />
+    <PackageReference Include="Newtonsoft.Json" NoWarn="NU1605" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.ComponentModel.Composition" />

--- a/src/NuGet.Clients/NuGet.VisualStudio/NuGet.VisualStudio.csproj
+++ b/src/NuGet.Clients/NuGet.VisualStudio/NuGet.VisualStudio.csproj
@@ -24,9 +24,9 @@
     <Reference Include="System.ComponentModel.Composition" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="EnvDTE80" Version="8.0.1" />
-    <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.12.0" Version="12.0.30111" />
-    <PackageReference Include="VSSDK.TemplateWizardInterface" Version="12.0.4" />
+    <PackageReference Include="EnvDTE80" />
+    <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.12.0" />
+    <PackageReference Include="VSSDK.TemplateWizardInterface" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NuGet.Clients/NuGetConsole.Host.PowerShell/NuGetConsole.Host.PowerShell.csproj
+++ b/src/NuGet.Clients/NuGetConsole.Host.PowerShell/NuGetConsole.Host.PowerShell.csproj
@@ -135,7 +135,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersionCore)" NoWarn="NU1605" />
+    <PackageReference Include="Newtonsoft.Json" NoWarn="NU1605" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Scripts\about_NuGet.PackageManagement.PowerShellCmdlets.help.txt" />

--- a/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/Microsoft.Build.NuGetSdkResolver.csproj
+++ b/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/Microsoft.Build.NuGetSdkResolver.csproj
@@ -20,7 +20,7 @@
 
   <ItemGroup>
     <ProjectReference Include="$(NuGetCoreSrcDirectory)NuGet.Commands\NuGet.Commands.csproj" />
-    <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildPackageVersion)" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Build.Framework" ExcludeAssets="runtime" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NuGet.Core/NuGet.Build.Tasks.Console/NuGet.Build.Tasks.Console.csproj
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Console/NuGet.Build.Tasks.Console.csproj
@@ -24,10 +24,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildPackageVersion)" ExcludeAssets="Runtime" />
-    <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildPackageVersion)" ExcludeAssets="Runtime" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildPackageVersion)" ExcludeAssets="Runtime" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildPackageVersion)" ExcludeAssets="Runtime" />
+    <PackageReference Include="Microsoft.Build.Framework" ExcludeAssets="Runtime" />
+    <PackageReference Include="Microsoft.Build" ExcludeAssets="Runtime" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" ExcludeAssets="Runtime" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" ExcludeAssets="Runtime" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == '$(NETFXTargetFramework)' ">

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.csproj
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.csproj
@@ -40,9 +40,9 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == '$(NetStandardVersion)' ">
-    <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildPackageVersion)" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildPackageVersion)" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildPackageVersion)" />
+    <PackageReference Include="Microsoft.Build.Framework" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.Build.Tasks.csproj
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.Build.Tasks.csproj
@@ -48,13 +48,13 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == '$(NetStandardVersion)' ">
-    <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildPackageVersion)" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildPackageVersion)" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildPackageVersion)" />
+    <PackageReference Include="Microsoft.Build.Framework" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.9.0" />
+    <PackageReference Include="System.Threading.Tasks.Dataflow" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/NuGet.CommandLine.XPlat.csproj
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/NuGet.CommandLine.XPlat.csproj
@@ -18,8 +18,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.CommandLineUtils" Version="1.0.1" />
-    <PackageReference Include="System.Runtime.Serialization.Primitives" Version="$(SystemPackagesVersion)" />
+    <PackageReference Include="Microsoft.Extensions.CommandLineUtils" />
+    <PackageReference Include="System.Runtime.Serialization.Primitives" />
   </ItemGroup>
 
   <!-- Microsoft.Build.Locator is needed when debugging, but should not be used in the assemblies we insert.
@@ -27,13 +27,13 @@
   <Choose>
     <When Condition=" '$(Configuration)' == 'Debug' ">
       <ItemGroup>
-        <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildPackageVersion)" ExcludeAssets="runtime" />
-        <PackageReference Include="Microsoft.Build.Locator" Version="1.2.2" />
+        <PackageReference Include="Microsoft.Build" ExcludeAssets="runtime" />
+        <PackageReference Include="Microsoft.Build.Locator" />
       </ItemGroup>
     </When>
     <Otherwise>
       <ItemGroup>
-        <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildPackageVersion)" />
+        <PackageReference Include="Microsoft.Build" />
       </ItemGroup>
     </Otherwise>
   </Choose>

--- a/src/NuGet.Core/NuGet.Common/NuGet.Common.csproj
+++ b/src/NuGet.Core/NuGet.Common/NuGet.Common.csproj
@@ -23,8 +23,8 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == '$(NetStandardVersion)' ">
-    <PackageReference Include="System.Diagnostics.Process" Version="$(SystemPackagesVersion)" />
-    <PackageReference Include="System.Threading.Thread" Version="$(SystemPackagesVersion)" />
+    <PackageReference Include="System.Diagnostics.Process" />
+    <PackageReference Include="System.Threading.Thread" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NuGet.Core/NuGet.Configuration/NuGet.Configuration.csproj
+++ b/src/NuGet.Core/NuGet.Configuration/NuGet.Configuration.csproj
@@ -29,7 +29,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == '$(NetStandardVersion)' ">
-    <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="$(SystemPackagesVersion)" />
+    <PackageReference Include="System.Security.Cryptography.ProtectedData" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/NuGet.Core/NuGet.Credentials/NuGet.Credentials.csproj
+++ b/src/NuGet.Core/NuGet.Credentials/NuGet.Credentials.csproj
@@ -31,7 +31,7 @@
 
   <ItemGroup>
     <ProjectReference Include="$(NuGetCoreSrcDirectory)\NuGet.Protocol\NuGet.Protocol.csproj" />
-    <PackageReference Include="System.Runtime.Serialization.Formatters" Version="$(SystemPackagesVersion)" Condition=" '$(TargetFramework)' == '$(NetStandardVersion)'" />
+    <PackageReference Include="System.Runtime.Serialization.Formatters" Condition=" '$(TargetFramework)' == '$(NetStandardVersion)'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NuGet.Core/NuGet.Indexing/NuGet.Indexing.csproj
+++ b/src/NuGet.Core/NuGet.Indexing/NuGet.Indexing.csproj
@@ -4,6 +4,7 @@
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
   <PropertyGroup>
+    <!-- TODO NK Move to clients, this is dumb-->
     <Description>NuGet.Indexing Class Library.</Description>
     <TargetFramework>$(NETFXTargetFramework)</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
@@ -17,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Lucene.Net" Version="3.0.3" />
+    <PackageReference Include="Lucene.Net" />
   </ItemGroup>
 
   <Import Project="$(BuildCommonDirectory)common.targets"/>

--- a/src/NuGet.Core/NuGet.Indexing/NuGet.Indexing.csproj
+++ b/src/NuGet.Core/NuGet.Indexing/NuGet.Indexing.csproj
@@ -4,7 +4,6 @@
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
   <PropertyGroup>
-    <!-- TODO NK Move to clients, this is dumb-->
     <Description>NuGet.Indexing Class Library.</Description>
     <TargetFramework>$(NETFXTargetFramework)</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>

--- a/src/NuGet.Core/NuGet.PackageManagement/NuGet.PackageManagement.csproj
+++ b/src/NuGet.Core/NuGet.PackageManagement/NuGet.PackageManagement.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.Web.Xdt" Version="2.1.2" />
+    <PackageReference Include="Microsoft.Web.Xdt" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == '$(NETFXTargetFramework)' ">

--- a/src/NuGet.Core/NuGet.Packaging/NuGet.Packaging.csproj
+++ b/src/NuGet.Core/NuGet.Packaging/NuGet.Packaging.csproj
@@ -40,11 +40,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersionCore)" />
+    <PackageReference Include="Newtonsoft.Json" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(IsCore)' == 'true' ">
-    <PackageReference Include="System.Dynamic.Runtime" Version="$(SystemPackagesVersion)" />
+    <PackageReference Include="System.Dynamic.Runtime" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NuGet.Core/NuGet.ProjectModel/NuGet.ProjectModel.csproj
+++ b/src/NuGet.Core/NuGet.ProjectModel/NuGet.ProjectModel.csproj
@@ -22,8 +22,8 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == '$(NetStandardVersion)' ">
-    <PackageReference Include="System.Dynamic.Runtime" Version="$(SystemPackagesVersion)" />
-    <PackageReference Include="System.Threading.Thread" Version="$(SystemPackagesVersion)" />
+    <PackageReference Include="System.Dynamic.Runtime" />
+    <PackageReference Include="System.Threading.Thread" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NuGet.Core/NuGet.Protocol/NuGet.Protocol.csproj
+++ b/src/NuGet.Core/NuGet.Protocol/NuGet.Protocol.csproj
@@ -46,7 +46,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == '$(NetStandardVersion)' ">
-    <PackageReference Include="System.Dynamic.Runtime" Version="$(SystemPackagesVersion)" />
+    <PackageReference Include="System.Dynamic.Runtime" />
   </ItemGroup>
 
   <Import Project="$(BuildCommonDirectory)common.targets" />

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/NuGet.PackageManagement.UI.Test.csproj
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/NuGet.PackageManagement.UI.Test.csproj
@@ -57,7 +57,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersionCore)" NoWarn="NU1605" />
+    <PackageReference Include="Newtonsoft.Json" NoWarn="NU1605" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/NuGet.PackageManagement.VisualStudio.Test.csproj
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/NuGet.PackageManagement.VisualStudio.Test.csproj
@@ -53,7 +53,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersionCore)" NoWarn="NU1605" />
+    <PackageReference Include="Newtonsoft.Json" NoWarn="NU1605" />
   </ItemGroup>
 
   <ItemGroup>
@@ -79,7 +79,7 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="EnvDTE" Version="8.0.1" />
+    <PackageReference Include="EnvDTE" />
   </ItemGroup>
 
   <Import Project="$(BuildCommonDirectory)common.targets" />

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/NuGet.SolutionRestoreManager.Test.csproj
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/NuGet.SolutionRestoreManager.Test.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersionCore)" NoWarn="NU1605" />
+    <PackageReference Include="Newtonsoft.Json" NoWarn="NU1605" />
   </ItemGroup>
 
   <Import Project="$(BuildCommonDirectory)common.targets"/>

--- a/test/NuGet.Clients.Tests/NuGet.Tools.Test/NuGet.Tools.Test.csproj
+++ b/test/NuGet.Clients.Tests/NuGet.Tools.Test/NuGet.Tools.Test.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersionCore)" NoWarn="NU1605" />
+    <PackageReference Include="Newtonsoft.Json" NoWarn="NU1605" />
   </ItemGroup>
 
   <Import Project="$(BuildCommonDirectory)common.targets"/>

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/NuGet.VisualStudio.Implementation.Test.csproj
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/NuGet.VisualStudio.Implementation.Test.csproj
@@ -52,7 +52,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersionCore)" NoWarn="NU1605" />
+    <PackageReference Include="Newtonsoft.Json" NoWarn="NU1605" />
   </ItemGroup>
 
   <Import Project="$(BuildCommonDirectory)common.targets"/>

--- a/test/NuGet.Clients.Tests/NuGetConsole.Host.PowerShell.Test/NuGetConsole.Host.PowerShell.Test.csproj
+++ b/test/NuGet.Clients.Tests/NuGetConsole.Host.PowerShell.Test/NuGetConsole.Host.PowerShell.Test.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersionCore)" NoWarn="NU1605" />
+    <PackageReference Include="Newtonsoft.Json" NoWarn="NU1605" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/Msbuild.Integration.Test.csproj
+++ b/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/Msbuild.Integration.Test.csproj
@@ -12,9 +12,9 @@
     <EmbeddedResource Include="compiler\resources\*" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build.Runtime" Version="$(MicrosoftBuildPackageVersion)" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Build.Tasks" Version="3.0.0-dev-61717-03" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.0.0-dev-61717-03" />
+    <PackageReference Include="Microsoft.Build.Runtime" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Build.Tasks" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
   </ItemGroup>
   
   <ItemGroup>

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/NuGet.XPlat.FuncTest.csproj
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/NuGet.XPlat.FuncTest.csproj
@@ -9,9 +9,9 @@
     <TestProjectType>functional</TestProjectType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build.Runtime" Version="$(MicrosoftBuildPackageVersion)" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Build.Tasks" Version="3.0.0-dev-61717-03" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.0.0-dev-61717-03" />
+    <PackageReference Include="Microsoft.Build.Runtime" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Build.Tasks" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
   </ItemGroup>
 
   <ItemGroup>
@@ -32,7 +32,7 @@
     </None>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == '$(NETCoreTargetFramework)'">
-    <PackageReference Include="Microsoft.Net.Compilers.netcore" Version="3.0.0-dev-61717-03" />
+    <PackageReference Include="Microsoft.Net.Compilers.netcore" />
   </ItemGroup>
   <Target Name="CopyTargets" AfterTargets="AfterBuild">
     <Copy Condition="'$(TargetFramework)' == '$(NETCoreTargetFramework)'" SourceFiles="$(MSBuildProjectDirectory)\$(OutputPath)\Microsoft.CSharp.Core.targets" DestinationFolder="$(MSBuildProjectDirectory)\$(OutputPath)\Roslyn\" />

--- a/test/NuGet.Core.Tests/Microsoft.Build.NuGetSdkResolver.Tests/Microsoft.Build.NuGetSdkResolver.Test.csproj
+++ b/test/NuGet.Core.Tests/Microsoft.Build.NuGetSdkResolver.Tests/Microsoft.Build.NuGetSdkResolver.Test.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <ProjectReference Include="$(NuGetCoreSrcDirectory)Microsoft.Build.NuGetSdkResolver\Microsoft.Build.NuGetSdkResolver.csproj" />
     <ProjectReference Include="$(TestUtilitiesDirectory)Test.Utility\Test.Utility.csproj" />
-    <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildPackageVersion)" />
+    <PackageReference Include="Microsoft.Build.Framework" />
   </ItemGroup>
 
   <Import Project="$(BuildCommonDirectory)common.targets" />

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Console.Test/NuGet.Build.Tasks.Console.Test.csproj
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Console.Test/NuGet.Build.Tasks.Console.Test.csproj
@@ -15,9 +15,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildPackageVersion)" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildPackageVersion)" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildPackageVersion)" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.Build.Framework" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == '$(NETFXTargetFramework)' ">

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Pack.Test/NuGet.Build.Tasks.Pack.Test.csproj
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Pack.Test/NuGet.Build.Tasks.Pack.Test.csproj
@@ -20,10 +20,10 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == '$(NETCoreTargetFramework)' ">
-    <PackageReference Include="System.Diagnostics.TraceSource" Version="$(SystemPackagesVersion)" />
-    <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildPackageVersion)" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildPackageVersion)" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildPackageVersion)" PrivateAssets="All" />
+    <PackageReference Include="System.Diagnostics.TraceSource" />
+    <PackageReference Include="Microsoft.Build.Framework" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == '$(NETFXTargetFramework)' ">

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/NuGet.Build.Tasks.Test.csproj
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/NuGet.Build.Tasks.Test.csproj
@@ -22,10 +22,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Diagnostics.TraceSource" Version="$(SystemPackagesVersion)" />
-    <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildPackageVersion)" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildPackageVersion)" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildPackageVersion)" PrivateAssets="All" />
+    <PackageReference Include="System.Diagnostics.TraceSource" />
+    <PackageReference Include="Microsoft.Build.Framework" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == '$(NETFXTargetFramework)' ">

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/NuGet.Commands.Test.csproj
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/NuGet.Commands.Test.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == '$(NETCoreTargetFramework)' ">
-    <PackageReference Include="System.Diagnostics.TraceSource" Version="$(SystemPackagesVersion)" />
+    <PackageReference Include="System.Diagnostics.TraceSource" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == '$(NETFXTargetFramework)' ">

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/NuGet.Common.Test.csproj
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/NuGet.Common.Test.csproj
@@ -14,9 +14,9 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == '$(NETCoreTargetFramework)' ">
-    <PackageReference Include="System.Threading.Tasks.Parallel" Version="$(SystemPackagesVersion)" />
-    <PackageReference Include="System.Threading.Thread" Version="$(SystemPackagesVersion)" />
-    <PackageReference Include="System.Diagnostics.TraceSource" Version="$(SystemPackagesVersion)" />
+    <PackageReference Include="System.Threading.Tasks.Parallel" />
+    <PackageReference Include="System.Threading.Thread" />
+    <PackageReference Include="System.Diagnostics.TraceSource" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == '$(NETFXTargetFramework)' ">

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/NuGet.Configuration.Test.csproj
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/NuGet.Configuration.Test.csproj
@@ -14,9 +14,9 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == '$(NETCoreTargetFramework)' ">
-    <PackageReference Include="System.Diagnostics.TraceSource" Version="$(SystemPackagesVersion)" />
-    <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="$(SystemPackagesVersion)" />
-    <PackageReference Include="System.Threading.Tasks.Parallel" Version="$(SystemPackagesVersion)" />
+    <PackageReference Include="System.Diagnostics.TraceSource" />
+    <PackageReference Include="System.Security.Cryptography.ProtectedData" />
+    <PackageReference Include="System.Threading.Tasks.Parallel" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == '$(NETFXTargetFramework)' ">

--- a/test/NuGet.Core.Tests/NuGet.Frameworks.Test/NuGet.Frameworks.Test.csproj
+++ b/test/NuGet.Core.Tests/NuGet.Frameworks.Test/NuGet.Frameworks.Test.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == '$(NETCoreTargetFramework)' ">
-    <PackageReference Include="System.Diagnostics.TraceSource" Version="$(SystemPackagesVersion)" />
+    <PackageReference Include="System.Diagnostics.TraceSource" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGet.PackageManagement.Test.csproj
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGet.PackageManagement.Test.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersionCore)" NoWarn="NU1605" />
+    <PackageReference Include="Newtonsoft.Json" NoWarn="NU1605" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/NuGet.Packaging.Test.csproj
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/NuGet.Packaging.Test.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == '$(NETCoreTargetFramework)' ">
-    <PackageReference Include="System.Diagnostics.TraceSource" Version="$(SystemPackagesVersion)" />
+    <PackageReference Include="System.Diagnostics.TraceSource" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == '$(NETFXTargetFramework)' ">

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/NuGet.Protocol.Tests.csproj
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/NuGet.Protocol.Tests.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == '$(NETCoreTargetFramework)' ">
-    <PackageReference Include="System.Diagnostics.TraceSource" Version="$(SystemPackagesVersion)" />
+    <PackageReference Include="System.Diagnostics.TraceSource" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == '$(NETFXTargetFramework)' ">

--- a/test/NuGet.Tests.Apex/NuGet.Console.TestContract/NuGet.Console.TestContract.csproj
+++ b/test/NuGet.Tests.Apex/NuGet.Console.TestContract/NuGet.Console.TestContract.csproj
@@ -11,7 +11,7 @@
     <ProjectReference Include="$(NuGetClientsSrcDirectory)NuGet.Console\NuGet.Console.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersionCore)" NoWarn="NU1605" />
+    <PackageReference Include="Newtonsoft.Json" NoWarn="NU1605" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.ComponentModel.Composition" />

--- a/test/NuGet.Tests.Apex/NuGet.PackageManagement.UI.TestContract/NuGet.PackageManagement.UI.TestContract.csproj
+++ b/test/NuGet.Tests.Apex/NuGet.PackageManagement.UI.TestContract/NuGet.PackageManagement.UI.TestContract.csproj
@@ -16,7 +16,7 @@
     <ProjectReference Include="$(NuGetClientsSrcDirectory)NuGet.PackageManagement.UI\NuGet.PackageManagement.UI.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersionCore)" NoWarn="NU1605" />
+    <PackageReference Include="Newtonsoft.Json" NoWarn="NU1605" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="PresentationCore" />

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGet.Tests.Apex.csproj
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGet.Tests.Apex.csproj
@@ -61,11 +61,9 @@
     <Compile Include="NuGetPackageSigningTests\RepositorySignedPackageTestCase.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Test.Apex.VisualStudio">
-      <Version>16.3.29131.53-pre</Version>
-    </PackageReference>
-    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersionCore)" NoWarn="NU1605" />
-    <PackageReference Include="Xunit.StaFact" Version="0.2.9" />
+    <PackageReference Include="Microsoft.Test.Apex.VisualStudio" />
+    <PackageReference Include="Newtonsoft.Json" NoWarn="NU1605" />
+    <PackageReference Include="Xunit.StaFact" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/test/TestExtensions/API.Test/API.Test.csproj
+++ b/test/TestExtensions/API.Test/API.Test.csproj
@@ -14,17 +14,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="EnvDTE" Version="8.0.1" />
-    <PackageReference Include="Microsoft.PowerShell.3.ReferenceAssemblies" Version="1.0.0" />
-  </ItemGroup>
-
-  <ItemGroup>  
-    <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.15.0.DesignTime" Version="15.0.26932" />
-    <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="$(VSFrameworkVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.ComponentModelHost" Version="$(VSComponentsVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="$(VSThreadingVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="$(VSThreadingVersion)" />
-    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersionCore)" NoWarn="NU1605" />
+    <PackageReference Include="EnvDTE" />
+    <PackageReference Include="Microsoft.PowerShell.3.ReferenceAssemblies" />
+    <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.15.0.DesignTime" />
+    <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" />
+    <PackageReference Include="Microsoft.VisualStudio.ComponentModelHost" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" />
+    <PackageReference Include="Newtonsoft.Json" NoWarn="NU1605" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/TestExtensions/GenerateLicenseList/GenerateLicenseList.csproj
+++ b/test/TestExtensions/GenerateLicenseList/GenerateLicenseList.csproj
@@ -10,12 +10,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersionCore)" />
-    <PackageReference Include="System.Runtime.Loader" Version="$(SystemPackagesVersion)" />
-    <PackageReference Include="Microsoft.CodeAnalysis" Version="2.9.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.9.0" />
+    <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="System.Runtime.Loader" />
+    <PackageReference Include="Microsoft.CodeAnalysis" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
   </ItemGroup>
 
   <Import Project="$(BuildCommonDirectory)common.targets"/>
+
+  <!-- There are some conflicts that are impossible to resolve because of missing package versions-->
+  <ItemGroup Condition=" '$(SkipCentralPackageVersions)' != 'true' ">
+    <PackageReference Update="Microsoft.CodeAnalysis.CSharp" Version="3.0.0" />
+  </ItemGroup>
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 </Project>

--- a/test/TestExtensions/GenerateTestPackages/GenerateTestPackages.csproj
+++ b/test/TestExtensions/GenerateTestPackages/GenerateTestPackages.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NuGet.Core" Version="2.14.0-rtm-832" />
+    <PackageReference Include="NuGet.Core" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/TestExtensions/NuGet.StaFact/NuGet.StaFact.csproj
+++ b/test/TestExtensions/NuGet.StaFact/NuGet.StaFact.csproj
@@ -23,7 +23,7 @@
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="XUnit.StaFact" Version="0.2.9" />
+    <PackageReference Include="XUnit.StaFact" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\TestUtilities\Test.Utility\Test.Utility.csproj" />

--- a/test/TestExtensions/TestablePluginCredentialProvider/TestableCredentialProvider.csproj
+++ b/test/TestExtensions/TestablePluginCredentialProvider/TestableCredentialProvider.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersionCore)" />
-    <PackageReference Include="Microsoft.CSharp" Version="4.3.0" />
+    <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="Microsoft.CSharp" />
   </ItemGroup>
 
   <Import Project="$(BuildCommonDirectory)common.targets"/>

--- a/test/TestUtilities/Test.Utility/Test.Utility.csproj
+++ b/test/TestUtilities/Test.Utility/Test.Utility.csproj
@@ -43,17 +43,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Portable.BouncyCastle" Version="1.8.1.3" />
-    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersionCore)" NoWarn="NU1605" />
+    <PackageReference Include="Portable.BouncyCastle" />
+    <PackageReference Include="Newtonsoft.Json" NoWarn="NU1605" />
+    <PackageReference Include="xunit" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == '$(NETFXTargetFramework)' ">
-    <PackageReference Include="Microsoft.VisualStudio.ProjectSystem" Version="15.0.751">
-      <PrivateAssets>All</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="$(VSFrameworkVersion)">
-      <PrivateAssets>All</PrivateAssets>
-    </PackageReference>
+    <PackageReference Include="Microsoft.VisualStudio.ProjectSystem" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == '$(NETFXTargetFramework)' ">
@@ -65,14 +62,10 @@
     <Reference Include="WindowsBase" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="xunit" Version="$(XunitVersion)" />
-  </ItemGroup>
-
   <ItemGroup Condition=" '$(TargetFramework)' == '$(NETCoreTargetFramework)' ">
-    <PackageReference Include="System.Diagnostics.Process" Version="$(SystemPackagesVersion)" />
-    <PackageReference Include="System.IO.Compression.ZipFile" Version="$(SystemPackagesVersion)" />
-    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="4.5.2" />
+    <PackageReference Include="System.Diagnostics.Process" />
+    <PackageReference Include="System.IO.Compression.ZipFile" />
+    <PackageReference Include="System.Security.Cryptography.Pkcs" />
   </ItemGroup>
 
   <!-- Remove files that do not support netcore -->


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Client.Engineering/issues/181
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: 
As the person managing most of our dependency flow, it can sometimes be painful to align things centrally. So far we've used properties to ensure consistency, and it works great updating dependencies, but adding new ones can be trickier. 
Given that eventually we'd want to our own central package management, this is a good first step towards it.
With my change, migrating to our retail feature when ready will be trivial. 

Note that there's 1 conflict that I was unable to resolve. I chose to violate the "central" management, because the issues were in 2 "extensions" projects. 

Additionally, I have added a target that is run by build.ps1 & the regular build to ensure all versions are managed centrally. 

Note that this won't run in the regular restore/build from without the scripts because there's simply no good place for this check. 
I considered adding it before build, but decided against the extra evaluation. 

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  
Validation:  
