### PR TITLE
enable 4 tests on Mac

### DIFF
--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/CertificateChainUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/CertificateChainUtilityTests.cs
@@ -73,7 +73,7 @@ namespace NuGet.Packaging.Test
             Assert.Equal("certificateType", exception.ParamName);
         }
 
-        [PlatformFact(Platform.Windows, Platform.Linux)] // https://github.com/NuGet/Home/issues/8047
+        [Fact]
         public void GetCertificateChain_WithUntrustedRoot_Throws()
         {
             using (var chainHolder = new X509ChainHolder())
@@ -119,7 +119,7 @@ namespace NuGet.Packaging.Test
             }
         }
 
-        [PlatformFact(Platform.Windows, Platform.Linux)] // https://github.com/NuGet/Home/issues/8047
+        [Fact]
         public void GetCertificateChain_WithUntrustedSelfIssuedCertificate_ReturnsChain()
         {
             using (var certificate = _fixture.GetDefaultCertificate())

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/SigningUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/SigningUtilityTests.cs
@@ -94,7 +94,7 @@ namespace NuGet.Packaging.Test
             }
         }
 
-        [PlatformFact(Platform.Windows, Platform.Linux)] // https://github.com/NuGet/Home/issues/8047
+        [Fact]
         public void Verify_WhenChainBuildingFails_Throws()
         {
             using (var certificate = _fixture.GetExpiredCertificate())
@@ -129,7 +129,7 @@ namespace NuGet.Packaging.Test
             }
         }
 
-        [PlatformFact(Platform.Windows, Platform.Linux)] // https://github.com/NuGet/Home/issues/8047
+        [Fact]
         public void Verify_WithUntrustedSelfSignedCertificate_Succeeds()
         {
             using (var certificate = _fixture.GetDefaultCertificate())


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9013
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: 
Those 4 tests are disabled on Mac before.
We should enable them and make sure they pass.  

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  enabling tests
Validation:  
