### PR TITLE
Sort packages by ID in the Update feed.

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/PackageFeeds/UpdatePackageFeed.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/PackageFeeds/UpdatePackageFeed.cs
@@ -102,8 +102,7 @@ namespace NuGet.PackageManagement.VisualStudio
             var packages = _installedPackages
                 .Where(p => !p.IsAutoReferenced())
                 .GetEarliest()
-                .Where(p => p.Id.IndexOf(searchText, StringComparison.OrdinalIgnoreCase) != -1)
-                .OrderBy(p => p.Id);
+                .Where(p => p.Id.IndexOf(searchText, StringComparison.OrdinalIgnoreCase) != -1);
 
             // Prefetch metadata for all installed packages
             var prefetch = await TaskCombinators.ThrottledAsync(
@@ -164,7 +163,9 @@ namespace NuGet.PackageManagement.VisualStudio
                     p => p.Identity,
                     (id, pl) => pl.First());
 
-            return uniquePackages.ToArray();
+            return uniquePackages
+                .OrderBy(p => p.Identity.Id)
+                .ToArray();
         }
 
         private static IEnumerable<VersionInfo> ToVersionInfo(IEnumerable<IPackageSearchMetadata> packages)


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9278
Regression: No

## Fix

Details: This change sorts the packages by their ID in the Update feed, which is used in the Updates tab in VS:
![image](https://user-images.githubusercontent.com/1618054/75987034-77e65580-5eef-11ea-9949-a0f899b89570.png)

The `OrderBy` at line 106 is removed because it serves no purpose there.

## Testing/Validation

Tests Added: No
Reason for not adding tests:  The existing tests for this class verify that the set of results is correct, none of them look at sorting. I think a better moment to introduce tests is when sorting can be done by users on demand.
Validation: I've verified the change works as intended by launching a Debug instance of NuGet.VisualStudio.Client and I've verified that none of the existing unit tests fail due to this change.
![image](https://user-images.githubusercontent.com/1618054/75985666-00172b80-5eed-11ea-924c-81540908e502.png)
