### PR TITLE
Fix package sources option page title

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/PackageSourcesOptionsControl.resx
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/PackageSourcesOptionsControl.resx
@@ -139,7 +139,7 @@
     <value>0</value>
   </data>
   <data name="HeaderLabel.Text" xml:space="preserve">
-    <value>Available &amp;package sources:</value>
+    <value>Package sources:</value>
   </data>
   <data name="HeaderLabel.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
     <value>MiddleLeft</value>


### PR DESCRIPTION
## Bug

Fixes: [948057](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/948057)  
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details:
The current title is Available Package Sources, changing it to Package Source per feedback.

I noticed this issue while doing triage work, and seemed super easy and annoying so I just created a quick PR :D 

fyi @karann-msft this was marked as a spec issue, but I'm fixing the value in the current product.

## Testing/Validation

Tests Added: No
Reason for not adding tests: UI string   
Validation:  Manual
