### PR TITLE
Fix Issue 9255 - NuGetVersion.TryParseStrict() appropriate return

### DIFF
--- a/src/NuGet.Core/NuGet.Versioning/NuGetVersionFactory.cs
+++ b/src/NuGet.Core/NuGet.Versioning/NuGetVersionFactory.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -110,9 +110,10 @@ namespace NuGet.Versioning
             if (TryParse(value, out semVer))
             {
                 version = new NuGetVersion(semVer.Major, semVer.Minor, semVer.Patch, 0, semVer.ReleaseLabels, semVer.Metadata);
+                return true;
             }
 
-            return true;
+            return false;
         }
 
         /// <summary>

--- a/test/NuGet.Core.Tests/NuGet.Versioning.Test/NuGetVersionTest.cs
+++ b/test/NuGet.Core.Tests/NuGet.Versioning.Test/NuGetVersionTest.cs
@@ -344,5 +344,23 @@ namespace NuGet.Versioning.Test
             Assert.Equal(new Version("1.3.2.0"), version.Version);
             Assert.Equal("CTP-2-Refresh-Alpha", version.Release);
         }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("NotAVersion")]
+        [InlineData("1")]
+        [InlineData("1.0")]
+        [InlineData("v1.0.0")]
+        [InlineData("1.0.3.120")]
+        public void TryParseReturnsFalseWhenUnableToParseString(string versionString)
+        {
+            // Act
+            NuGetVersion version;
+            var result = NuGetVersion.TryParseStrict(versionString, out version);
+
+            // Assert
+            Assert.False(result);
+            Assert.Null(version);
+        }
     }
 }


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9255  
Regression: No  
* Last working version:  N/A
* How are we preventing it in future:  A number of unit test cases added for negative cases

## Fix

Details: 
Updated method to return true if the internal TryParse() succeeded, otherwise return false, instead of always returning true

## Testing/Validation

Tests Added: Yes  
