### PR TITLE
Remove unused format placeholder

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -1790,7 +1790,7 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Package source {0}.
+        ///   Looks up a localized string similar to Package source .
         /// </summary>
         internal static string Source_DefaultNamePrefix {
             get {

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -973,8 +973,7 @@ For more information, visit https://docs.nuget.org/docs/reference/command-line-r
     <value>Enabled</value>
   </data>
   <data name="Source_DefaultNamePrefix" xml:space="preserve">
-    <value>Package source {0}</value>
-    <comment>{0} will be a number</comment>
+    <value>Package source </value>
   </data>
   <data name="Source_InvalidFormatValue" xml:space="preserve">
     <value>invalid value for --format: {0}. Allowed values: 'detailed' or 'short'</value>


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9277
Regression: No (new feature)

## Fix

Simply remove the unused format placeholder.

## Testing/Validation

Tests Added: No  
Reason for not adding tests: First contribution here. Please review and advise.
Validation:  
