### PR TITLE
Fix NuGet.Build.Tasks.Console package

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Console/NuGet.Build.Tasks.Console.csproj
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Console/NuGet.Build.Tasks.Console.csproj
@@ -15,7 +15,6 @@
     <XPLATProject>true</XPLATProject>
     <EnableDefaultNoneItems>false</EnableDefaultNoneItems>
     <ServerGarbageCollection>true</ServerGarbageCollection>
-    <BuildOutputTargetFolder>contentFiles\any</BuildOutputTargetFolder>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
   </PropertyGroup>
 
@@ -36,6 +35,14 @@
 
   <ItemGroup>
     <None Include="App.config" Condition=" '$(TargetFramework)' == '$(NETFXTargetFramework)' " />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="..\NuGet.Build.Tasks\NuGet.RestoreEx.targets">
+      <Link>%(Filename)%(Extension)</Link>
+      <PackagePath>runtimes\any\native</PackagePath>
+      <Pack>true</Pack>
+    </Content>
   </ItemGroup>
 
   <ItemGroup Condition="$(DefineConstants.Contains(SIGNED_BUILD))">

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.Build.Tasks.csproj
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.Build.Tasks.csproj
@@ -1,4 +1,4 @@
-﻿<Project>
+<Project>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common.props" />
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
@@ -21,8 +21,7 @@
   <ItemGroup>
     <Content Include="NuGet.RestoreEx.targets">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <PackagePath>runtimes\any\native</PackagePath>
-      <Pack>true</Pack>
+      <Pack>false</Pack>
     </Content>
     <Content Include="NuGet.targets">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9267
Regression: No
* Last working version:   
* How are we preventing it in future:   

## Fix

* Remove `NuGet.RestoreEx.targets` from `NuGet.Build.Tasks` package
* Add `NuGet.RestoreEx.targets` to `NuGet.Build.Tasks.Console` package under `runtimes\any\native`
* Package NuGet.Build.Tasks.Console.dll in `lib` instead of `contentFiles\any`

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  Package layout
Validation:  Manual

### NuGet.Build.Tasks
![image](https://user-images.githubusercontent.com/17556515/76234834-7e264b80-61e7-11ea-82b4-c403c7ebd12e.png)
### NuGet.Build.Tasks.Console
![image](https://user-images.githubusercontent.com/17556515/76234910-9302df00-61e7-11ea-803f-e39906cc0b1a.png)

