### PR TITLE
Add logging for BAR publishing

### DIFF
--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -106,7 +106,10 @@ jobs:
     inputs:
       scriptType: "inlineScript"
       inlineScript: |
+        Write-Host "##vso[task.setvariable variable=BarDirectory]$(Build.Repository.LocalPath)\artifacts\manifests\"
         Write-Host "##vso[task.setvariable variable=ManifestFilePath]$(Build.Repository.LocalPath)\artifacts\manifests\nuget.client.xml"
+        Write-Host "##vso[task.setvariable variable=BarBinariesLogFilePath]$(Build.Repository.LocalPath)\artifacts\manifests\bar-binaries.binlog"
+        Write-Host "##vso[task.setvariable variable=BarManifestLogFilePath]$(Build.Repository.LocalPath)\artifacts\manifests\bar-manifest.binlog"
 
   - task: NuGetToolInstaller@0
     displayName: "Use NuGet 5.0.0"
@@ -531,7 +534,7 @@ jobs:
   - task: CmdLine@2
     displayName: "Publish the packages to the .NET Core build asset registry (BAR)"
     inputs:
-      script: dotnet msbuild ..\build\publish.proj /t:PublishPackagesToBuildAssetRegistry /p:NuGetClientNupkgsDirectoryPath=$(Build.Repository.LocalPath)\artifacts\$(NupkgOutputDir) /p:FeedUrl=$(DotNetFeedUrl) /p:BuildId=$(Build.BuildNumber) /p:RepoBranch=$(Build.SourceBranchName) /p:RepoCommit=$(Build.SourceVersion) /p:RepoUri=$(Build.Repository.Uri) /p:ManifestFilePath=$(ManifestFilePath) /p:AccountKey=$(dotnetfeed-storage-access-key-1)
+      script: dotnet msbuild ..\build\publish.proj /t:PublishPackagesToBuildAssetRegistry /p:NuGetClientNupkgsDirectoryPath=$(Build.Repository.LocalPath)\artifacts\$(NupkgOutputDir) /p:FeedUrl=$(DotNetFeedUrl) /p:BuildId=$(Build.BuildNumber) /p:RepoBranch=$(Build.SourceBranchName) /p:RepoCommit=$(Build.SourceVersion) /p:RepoUri=$(Build.Repository.Uri) /p:ManifestFilePath=$(ManifestFilePath) /p:AccountKey=$(dotnetfeed-storage-access-key-1) /bl:$(BarBinariesLogFilePath)
       workingDirectory: cli
       failOnStderr: true
     env:
@@ -553,7 +556,15 @@ jobs:
       solution: 'build\\publish.proj'
       msbuildVersion: 16.0
       configuration: '$(BuildConfiguration)'
-      msbuildArguments: '/t:PublishManifestToBuildAssetRegistry /p:MaestroApiEndpoint=$(MaestroApiEndpoint) /p:ManifestsDirectoryPath=$(Build.Repository.LocalPath)\artifacts\manifests /p:MaestroAccessToken=$(MaestroAccessToken)'
+      msbuildArguments: '/t:PublishManifestToBuildAssetRegistry /p:MaestroApiEndpoint=$(MaestroApiEndpoint) /p:ManifestsDirectoryPath=$(Build.Repository.LocalPath)\artifacts\manifests /p:MaestroAccessToken=$(MaestroAccessToken) /bl:$(BarManifestLogFilePath)'
+    condition: " and(succeeded(),eq(variables['PublishArtifactsToDotNetBuildAssetRegistry'], 'true'), eq(variables['BuildRTM'], 'false')) "
+
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish BAR logs as an artifact'
+    inputs:
+      ArtifactName: 'BAR logs'
+      ArtifactType: 'Container'
+      PathToPublish: '$(BarDirectory)'
     condition: " and(succeeded(),eq(variables['PublishArtifactsToDotNetBuildAssetRegistry'], 'true'), eq(variables['BuildRTM'], 'false')) "
 
   - task: MicroBuildCleanup@1

--- a/test/EndToEnd/tests/UpdatePackageTest.ps1
+++ b/test/EndToEnd/tests/UpdatePackageTest.ps1
@@ -507,24 +507,25 @@ function Test-UpdateProjectLevelPackageNotInstalledInAnyProject {
     Assert-Throws { Update-Package Ninject } "'Ninject' was not installed in any project. Update failed."
 }
 
-function Test-UpdatePackageMissingPackage {
-    # Arrange
-    # create project and install package
-    $proj = New-ClassLibrary
-    $proj | Install-Package Castle.Core -Version 1.2.0
-    Assert-Package $proj Castle.Core 1.2.0
-
-    # delete the packages folder
-    $packagesDir = Get-PackagesDir
-    RemoveDirectory $packagesDir
-    Assert-False (Test-Path $packagesDir)
-
-    # Act
-	Update-Package Castle.Core -Version 2.5.1
-	
-    # Assert
-	Assert-Package $proj Castle.Core 2.5.1
-}
+# https://github.com/NuGet/Home/issues/9283
+#function Test-UpdatePackageMissingPackage {
+#    # Arrange
+#    # create project and install package
+#    $proj = New-ClassLibrary
+#    $proj | Install-Package Castle.Core -Version 1.2.0
+#    Assert-Package $proj Castle.Core 1.2.0
+#
+#    # delete the packages folder
+#    $packagesDir = Get-PackagesDir
+#    RemoveDirectory $packagesDir
+#    Assert-False (Test-Path $packagesDir)
+#
+#    # Act
+#	Update-Package Castle.Core -Version 2.5.1
+#	
+#    # Assert
+#	Assert-Package $proj Castle.Core 2.5.1
+#}
 
 function Test-UpdatePackageMissingPackageNoConsent {
 	try {


### PR DESCRIPTION
## Bug

Fixes: no tracking item
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: Collect msbuild binlog for the two msbuild invocations related to publishing to BAR, and publish them, plus the manifest, as build artifacts

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  build definition change
Validation:  
