### PR TITLE
Revert "Add logging for BAR publishing (#3286)"

### DIFF
--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -106,10 +106,7 @@ jobs:
     inputs:
       scriptType: "inlineScript"
       inlineScript: |
-        Write-Host "##vso[task.setvariable variable=BarDirectory]$(Build.Repository.LocalPath)\artifacts\manifests\"
         Write-Host "##vso[task.setvariable variable=ManifestFilePath]$(Build.Repository.LocalPath)\artifacts\manifests\nuget.client.xml"
-        Write-Host "##vso[task.setvariable variable=BarBinariesLogFilePath]$(Build.Repository.LocalPath)\artifacts\manifests\bar-binaries.binlog"
-        Write-Host "##vso[task.setvariable variable=BarManifestLogFilePath]$(Build.Repository.LocalPath)\artifacts\manifests\bar-manifest.binlog"
 
   - task: NuGetToolInstaller@0
     displayName: "Use NuGet 5.0.0"
@@ -534,7 +531,7 @@ jobs:
   - task: CmdLine@2
     displayName: "Publish the packages to the .NET Core build asset registry (BAR)"
     inputs:
-      script: dotnet msbuild ..\build\publish.proj /t:PublishPackagesToBuildAssetRegistry /p:NuGetClientNupkgsDirectoryPath=$(Build.Repository.LocalPath)\artifacts\$(NupkgOutputDir) /p:FeedUrl=$(DotNetFeedUrl) /p:BuildId=$(Build.BuildNumber) /p:RepoBranch=$(Build.SourceBranchName) /p:RepoCommit=$(Build.SourceVersion) /p:RepoUri=$(Build.Repository.Uri) /p:ManifestFilePath=$(ManifestFilePath) /p:AccountKey=$(dotnetfeed-storage-access-key-1) /bl:$(BarBinariesLogFilePath)
+      script: dotnet msbuild ..\build\publish.proj /t:PublishPackagesToBuildAssetRegistry /p:NuGetClientNupkgsDirectoryPath=$(Build.Repository.LocalPath)\artifacts\$(NupkgOutputDir) /p:FeedUrl=$(DotNetFeedUrl) /p:BuildId=$(Build.BuildNumber) /p:RepoBranch=$(Build.SourceBranchName) /p:RepoCommit=$(Build.SourceVersion) /p:RepoUri=$(Build.Repository.Uri) /p:ManifestFilePath=$(ManifestFilePath) /p:AccountKey=$(dotnetfeed-storage-access-key-1)
       workingDirectory: cli
       failOnStderr: true
     env:
@@ -556,15 +553,7 @@ jobs:
       solution: 'build\\publish.proj'
       msbuildVersion: 16.0
       configuration: '$(BuildConfiguration)'
-      msbuildArguments: '/t:PublishManifestToBuildAssetRegistry /p:MaestroApiEndpoint=$(MaestroApiEndpoint) /p:ManifestsDirectoryPath=$(Build.Repository.LocalPath)\artifacts\manifests /p:MaestroAccessToken=$(MaestroAccessToken) /bl:$(BarManifestLogFilePath)'
-    condition: " and(succeeded(),eq(variables['PublishArtifactsToDotNetBuildAssetRegistry'], 'true'), eq(variables['BuildRTM'], 'false')) "
-
-  - task: PublishBuildArtifacts@1
-    displayName: 'Publish BAR logs as an artifact'
-    inputs:
-      ArtifactName: 'BAR logs'
-      ArtifactType: 'Container'
-      PathToPublish: '$(BarDirectory)'
+      msbuildArguments: '/t:PublishManifestToBuildAssetRegistry /p:MaestroApiEndpoint=$(MaestroApiEndpoint) /p:ManifestsDirectoryPath=$(Build.Repository.LocalPath)\artifacts\manifests /p:MaestroAccessToken=$(MaestroAccessToken)'
     condition: " and(succeeded(),eq(variables['PublishArtifactsToDotNetBuildAssetRegistry'], 'true'), eq(variables['BuildRTM'], 'false')) "
 
   - task: MicroBuildCleanup@1


### PR DESCRIPTION
## Bug

Fixes: the build
Regression: Yes
* Last working version:   just before PR 3286
* How are we preventing it in future:   get BAR publishing working in private builds, so we can test there

## Fix

Details: revert previous change

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  build script
Validation:  
