### PR TITLE
Fix Waiting for debugger logging

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Console/Program.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Console/Program.cs
@@ -38,7 +38,7 @@ namespace NuGet.Build.Tasks.Console
             if (debug)
             {
 #if IS_CORECLR
-                System.Console.WriteLine("Waiting for debugger to attach to Process ID: {Process.GetCurrentProcess().Id}");
+                System.Console.WriteLine($"Waiting for debugger to attach to Process ID: {Process.GetCurrentProcess().Id}");
 
                 while (!Debugger.IsAttached)
                 {


### PR DESCRIPTION
Fixes the logging when debugging:

C:\Users\vihofer>C:\git\runtime4\.dotnet\dotnet.exe C:\git\runtime4\.dotnet\sdk\5.0.100-preview.2.20157.1\NuGet.Build.Tasks.Console.dll
Waiting for debugger to attach to Process ID: {Process.GetCurrentProcess().Id}