### PR TITLE
fix broken test case ExecuteCommandAsync_WithAmbiguousMatch_ThrowsAsync

### DIFF
--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/SignCommandRunnerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/SignCommandRunnerTests.cs
@@ -109,7 +109,8 @@ namespace NuGet.Commands.Test
             using (var test = await Test.CreateAsync(_fixture.GetDefaultCertificate()))
             {
                 test.Args.CertificateSubjectName = "Root";
-                test.Args.CertificateStoreLocation = CertificateStoreUtilities.GetTrustedCertificateStoreLocation();                
+                //X509 store is opened in ReadOnly mode in this code path. Hence StoreLocation is set to LocalMachine.
+                test.Args.CertificateStoreLocation = StoreLocation.LocalMachine;                
                 test.Args.CertificateStoreName = StoreName.Root;
 
                 var exception = await Assert.ThrowsAsync<SignCommandException>(

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/SignCommandRunnerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/SignCommandRunnerTests.cs
@@ -110,7 +110,7 @@ namespace NuGet.Commands.Test
             {
                 test.Args.CertificateSubjectName = "Root";
                 //X509 store is opened in ReadOnly mode in this code path. Hence StoreLocation is set to LocalMachine.
-                test.Args.CertificateStoreLocation = StoreLocation.LocalMachine;                
+                test.Args.CertificateStoreLocation = CertificateStoreUtilities.GetTrustedCertificateStoreLocation(readOnly: true);         
                 test.Args.CertificateStoreName = StoreName.Root;
 
                 var exception = await Assert.ThrowsAsync<SignCommandException>(

--- a/test/TestUtilities/Test.Utility/Signing/CertificateStoreUtilities.cs
+++ b/test/TestUtilities/Test.Utility/Signing/CertificateStoreUtilities.cs
@@ -8,10 +8,14 @@ namespace Test.Utility.Signing
 {
     public static class CertificateStoreUtilities
     {
-        public static StoreLocation GetTrustedCertificateStoreLocation()
+        public static StoreLocation GetTrustedCertificateStoreLocation(bool readOnly = false)
         {
             // According to https://github.com/dotnet/runtime/blob/master/docs/design/features/cross-platform-cryptography.md#x509store   
             // use different approaches for Windows, Mac and Linux.
+            if(readOnly)
+            {
+                return StoreLocation.LocalMachine;
+            }
             return (RuntimeEnvironmentHelper.IsWindows || RuntimeEnvironmentHelper.IsMacOSX) ? StoreLocation.LocalMachine : StoreLocation.CurrentUser;
         }
     }


### PR DESCRIPTION
## Bug

Fixes: NuGet/Home#9011
Regression: No

## Fix

Details:  This test failed in Linux because Store Location was set to `CurrentUser\Root` where as in Windows and Mac it was set to `LocalMachine\Root`. In Linux environment  `CurrentUser\Root` returned 0 certificates matching specified criteria causing test failure. As per [doc](https://github.com/dotnet/runtime/blob/master/docs/design/features/cross-platform-cryptography.md#x509store), `LocalMachine\Root` throws `Cryptographic Exception` in `Linux` when X509 Store is opened in `ReadWrite` mode.

Modified Store Location to `LocalMachine\Root` for this test case because Store is opened in [`ReadOnly`](https://github.com/NuGet/NuGet.Client/blob/aeea23839f1270319cb0d1ca5772c810e6674c5c/src/NuGet.Core/NuGet.Commands/SignCommand/CertificateProvider.cs#L189) mode so that it passes in all the environments.

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  Fixed broken test case.
Validation:  
