### PR TITLE
Set rollforward on NuGet.Build.Tasks.Console

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Console/NuGet.Build.Tasks.Console.csproj
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Console/NuGet.Build.Tasks.Console.csproj
@@ -12,6 +12,9 @@
     <Description>NuGet restore console application.</Description>
     <!-- NU5100: Suppress warning about a DLL not in a lib folder since on .NET Core the EXE is technically a DLL -->
     <NoWarn>$(NoWarn);CS1591;NU5100</NoWarn>
+    <!-- Set rollforward which propagates into runtimeconfig.json to make it loadable with an SDK that 
+         contains a higher shared framework than the one this project builds against. -->
+    <RollForward>LatestMajor</RollForward>
     <XPLATProject>true</XPLATProject>
     <EnableDefaultNoneItems>false</EnableDefaultNoneItems>
     <ServerGarbageCollection>true</ServerGarbageCollection>


### PR DESCRIPTION
Set rollforward on NuGet.Build.Tasks.Console which propagates into its runtimeconfig.json to make it loadable with an SDK that contains a higher shared framework than the one this project builds against.

cc @jeffkl @nkolev92 
