### PR TITLE
Cleanup unnecessary thread affinity in the Visual Studio logging codepath 

### DIFF
--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/RestoreOperationLogger.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/RestoreOperationLogger.cs
@@ -391,20 +391,6 @@ namespace NuGet.SolutionRestoreManager
         }
 
         /// <summary>
-        /// Helper async method to run batch of logging call on the main UI thread.
-        /// </summary>
-        /// <param name="action">Sync callback invoking logger.</param>
-        /// <returns>An awaitable task.</returns>
-        public async Task DoAsync(Action<RestoreOperationLogger, RestoreOperationProgressUI> action)
-        {
-            // capture current progress from the current execution context
-            var progress = RestoreOperationProgressUI.Current;
-
-            await _taskFactory.SwitchToMainThreadAsync();
-            action(this, progress);
-        }
-
-        /// <summary>
         /// Helper synchronous method to run batch of logging call on the main UI thread.
         /// </summary>
         /// <param name="action">Sync callback invoking logger.</param>

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/RestoreOperationLogger.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/RestoreOperationLogger.cs
@@ -137,9 +137,6 @@ namespace NuGet.SolutionRestoreManager
             Log(LogLevel.Debug, data);
         }
 
-        /// <summary>
-        /// Same as LogAsync but uses Do instead of DoAsync.
-        /// </summary>
         public sealed override void Log(ILogMessage logMessage)
         {
             HandleErrorsAndWarnings(logMessage);
@@ -417,7 +414,7 @@ namespace NuGet.SolutionRestoreManager
         /// </remarks>
         private async Task<int> GetMSBuildOutputVerbositySettingAsync()
         {
-            await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            await _taskFactory.SwitchToMainThreadAsync();
 
             var dte = await _asyncServiceProvider.GetDTEAsync();
 
@@ -525,7 +522,7 @@ namespace NuGet.SolutionRestoreManager
                 uint currentStep,
                 uint totalSteps)
             {
-                await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                await _taskFactory.SwitchToMainThreadAsync();
 
                 // When both currentStep and totalSteps are 0, we get a marquee on the dialog
                 var progressData = new ThreadedWaitDialogProgressData(
@@ -599,7 +596,7 @@ namespace NuGet.SolutionRestoreManager
                 uint currentStep,
                 uint totalSteps)
             {
-                await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                await _taskFactory.SwitchToMainThreadAsync();
 
                 // Make sure the status bar is not frozen
                 int frozen;

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/RestoreOperationLogger.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/RestoreOperationLogger.cs
@@ -159,19 +159,16 @@ namespace NuGet.SolutionRestoreManager
                     // to actually show it.
                     _loggedMessages.Enqueue(Tuple.Create(reportProgress, showAsOutputMessage, logMessage));
 
-                    // Run on the UI thread
                     var _ = _taskFactory.RunAsync(async () =>
                     {
                         // capture current progress from the current execution context
                         var progress = RestoreOperationProgressUI.Current;
 
-                        await _taskFactory.SwitchToMainThreadAsync();
-
                         // This might be a different message than the one enqueued above, but overall the printing order
                         // will match the order of calls to LogAsync.
                         if (_loggedMessages.TryDequeue(out var message))
                         {
-                            LogToVS(reportProgress: message.Item1, showAsOutputMessage: message.Item2, logMessage: message.Item3, progress: progress);
+                            await LogToVSAsync(reportProgress: message.Item1, showAsOutputMessage: message.Item2, logMessage: message.Item3, progress: progress);
                         }
                     });
                 }
@@ -189,20 +186,25 @@ namespace NuGet.SolutionRestoreManager
             return Task.CompletedTask;
         }
 
-        private void LogToVS(bool reportProgress, bool showAsOutputMessage, ILogMessage logMessage, RestoreOperationProgressUI progress)
+        private async Task LogToVSAsync(bool reportProgress, bool showAsOutputMessage, ILogMessage logMessage, RestoreOperationProgressUI progress)
         {
             var verbosityLevel = GetMSBuildLevel(logMessage.Level);
 
             // Progress dialog
             if (reportProgress)
             {
-                progress?.ReportProgress(logMessage.Message);
+                NuGetUIThreadHelper.JoinableTaskFactory.Run(async () =>
+                {
+                    await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                    progress?.ReportProgress(logMessage.Message);
+                });
+
             }
 
             // Output console
             if (showAsOutputMessage)
             {
-                WriteLine(verbosityLevel, logMessage.FormatWithCode());
+                await WriteLineAsync(verbosityLevel, logMessage.FormatWithCode());
             }
         }
 
@@ -240,14 +242,13 @@ namespace NuGet.SolutionRestoreManager
         /// <param name="verbosity">The verbosity level.</param>
         /// <param name="format">The format string.</param>
         /// <param name="args">An array of objects to write using format. </param>
-        public void WriteLine(MSBuildVerbosityLevel verbosity, string format, params object[] args)
+        public Task WriteLineAsync(MSBuildVerbosityLevel verbosity, string format, params object[] args)
         {
-            ThreadHelper.ThrowIfNotOnUIThread();
-
             if (ShouldShowMessageAsOutput(verbosity))
             {
-                NuGetUIThreadHelper.JoinableTaskFactory.Run(() => _outputConsole.WriteLineAsync(format, args));
+                return _outputConsole.WriteLineAsync(format, args);
             }
+            return Task.CompletedTask;
         }
 
         /// <summary>
@@ -284,36 +285,33 @@ namespace NuGet.SolutionRestoreManager
             return _outputConsole != null && OutputVerbosity >= (int)verbosity;
         }
 
-        public Task LogExceptionAsync(Exception ex)
+        public async Task LogExceptionAsync(Exception ex)
         {
-            return DoAsync((_, __) =>
+            string message;
+            if (OutputVerbosity < 3)
             {
-                string message;
-                if (OutputVerbosity < 3)
-                {
-                    message = string.Format(CultureInfo.CurrentCulture,
-                        Resources.ErrorOccurredRestoringPackages,
-                        ex.Message);
-                }
-                else
-                {
-                    // output exception detail when _msBuildOutputVerbosity is >= Detailed.
-                    message = string.Format(CultureInfo.CurrentCulture, Resources.ErrorOccurredRestoringPackages, ex);
-                }
+                message = string.Format(CultureInfo.CurrentCulture,
+                    Resources.ErrorOccurredRestoringPackages,
+                    ex.Message);
+            }
+            else
+            {
+                // output exception detail when _msBuildOutputVerbosity is >= Detailed.
+                message = string.Format(CultureInfo.CurrentCulture, Resources.ErrorOccurredRestoringPackages, ex);
+            }
 
-                if (_operationSource == RestoreOperationSource.Explicit)
-                {
-                    // Write to the error window and console
-                    Log(LogMessage.Create(LogLevel.Error, message));
-                }
-                else
-                {
-                    // Write to console
-                    WriteLine(MSBuildVerbosityLevel.Quiet, message);
-                }
+            if (_operationSource == RestoreOperationSource.Explicit)
+            {
+                // Write to the error window and console
+                Log(LogMessage.Create(LogLevel.Error, message));
+            }
+            else
+            {
+                // Write to console
+                await WriteLineAsync(MSBuildVerbosityLevel.Quiet, message);
+            }
 
-                ExceptionHelper.WriteErrorToActivityLog(ex);
-            });
+            ExceptionHelper.WriteErrorToActivityLog(ex);
         }
 
         public void ShowError(string errorText)
@@ -330,74 +328,66 @@ namespace NuGet.SolutionRestoreManager
             {
                 _hasHeaderBeenShown = true;
 
-                return DoAsync((_, __) =>
+                switch (_operationSource)
                 {
-                    switch (_operationSource)
-                    {
-                        case RestoreOperationSource.Implicit:
-                            WriteLine(MSBuildVerbosityLevel.Normal, Resources.RestoringPackages);
-                            break;
-                        case RestoreOperationSource.OnBuild:
-                            WriteLine(MSBuildVerbosityLevel.Normal, Resources.PackageRestoreOptOutMessage);
-                            break;
-                        case RestoreOperationSource.Explicit:
-                            WriteLine(MSBuildVerbosityLevel.Normal, Resources.RestoringPackages);
-                            break;
-                    }
-                });
+                    case RestoreOperationSource.Implicit:
+                        return WriteLineAsync(MSBuildVerbosityLevel.Normal, Resources.RestoringPackages);
+                    case RestoreOperationSource.OnBuild:
+                        return WriteLineAsync(MSBuildVerbosityLevel.Normal, Resources.PackageRestoreOptOutMessage);
+                    case RestoreOperationSource.Explicit:
+                        return WriteLineAsync(MSBuildVerbosityLevel.Normal, Resources.RestoringPackages);
+                }
             }
-            else
-            {
-                return Task.CompletedTask;
-            }
+            return Task.CompletedTask;
         }
 
-        public Task WriteSummaryAsync(NuGetOperationStatus operationStatus, TimeSpan duration)
+        public async Task WriteSummaryAsync(NuGetOperationStatus operationStatus, TimeSpan duration)
         {
             var forceStatusWrite = _operationSource == RestoreOperationSource.Explicit;
             var quietOrMinimal = forceStatusWrite ? MSBuildVerbosityLevel.Quiet : MSBuildVerbosityLevel.Minimal;
             var quietOrNormal = forceStatusWrite ? MSBuildVerbosityLevel.Quiet : MSBuildVerbosityLevel.Normal;
             var quietOrDetailed = forceStatusWrite ? MSBuildVerbosityLevel.Quiet : MSBuildVerbosityLevel.Detailed;
 
-            return DoAsync((_, __) =>
+            switch (operationStatus)
             {
-                switch (operationStatus)
-                {
-                    case NuGetOperationStatus.Cancelled:
-                        WriteLine(
-                            quietOrMinimal,
-                            Resources.PackageRestoreCanceled);
-                        break;
-                    case NuGetOperationStatus.NoOp:
-                        if (forceStatusWrite)
-                        {
-                            WriteLine(
+                case NuGetOperationStatus.Cancelled:
+                    await WriteLineAsync(
+                        quietOrMinimal,
+                        Resources.PackageRestoreCanceled);
+                    break;
+                case NuGetOperationStatus.NoOp:
+                    if (forceStatusWrite)
+                    {
+                        await WriteLineAsync(
                                 quietOrDetailed,
                                 Resources.NothingToRestore);
-                        }
-                        break;
-                    case NuGetOperationStatus.Failed:
-                        WriteLine(
+                    }
+                    break;
+                case NuGetOperationStatus.Failed:
+                    await WriteLineAsync(
                             quietOrMinimal,
                             Resources.PackageRestoreFinishedWithError);
-                        break;
-                    case NuGetOperationStatus.Succeeded:
-                        WriteLine(
+                    break;
+                case NuGetOperationStatus.Succeeded:
+                    await WriteLineAsync(
                             quietOrNormal,
                             Resources.PackageRestoreFinished);
-                        break;
-                }
+                    break;
+            }
 
-                if (_operationSource != RestoreOperationSource.OnBuild && (_hasHeaderBeenShown || forceStatusWrite))
-                {
-                    WriteLine(
-                        quietOrMinimal,
-                        Resources.Operation_TotalTime,
-                        duration);
-                    WriteLine(quietOrMinimal, Resources.Operation_Finished);
-                    WriteLine(quietOrMinimal, string.Empty);
-                }
-            });
+            if (_operationSource != RestoreOperationSource.OnBuild && (_hasHeaderBeenShown || forceStatusWrite))
+            {
+                // Submit all messages at once. Avoid needless thread switching
+                var fullMessage =
+                    string.Format(CultureInfo.CurrentCulture, Resources.Operation_TotalTime, duration) +
+                    Environment.NewLine +
+                    Resources.Operation_Finished +
+                    Environment.NewLine +
+                    string.Empty +
+                    Environment.NewLine;
+
+                await WriteLineAsync(quietOrMinimal, fullMessage);
+            }
         }
 
         /// <summary>

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/RestoreOperationProgressUI.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/RestoreOperationProgressUI.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/RestoreOperationProgressUI.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/RestoreOperationProgressUI.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace NuGet.SolutionRestoreManager
 {
@@ -24,7 +25,7 @@ namespace NuGet.SolutionRestoreManager
 
         public CancellationToken UserCancellationToken { get; protected set; } = CancellationToken.None;
 
-        public abstract void ReportProgress(
+        public abstract Task ReportProgressAsync(
             string progressMessage,
             uint currentStep = 0,
             uint totalSteps = 0);

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreJob.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreJob.cs
@@ -369,11 +369,7 @@ namespace NuGet.SolutionRestoreManager
             }
             else if (restoreSource == RestoreOperationSource.Explicit)
             {
-                // Log an error when restore is disabled and user explicitly restore.
-                await _logger.DoAsync((l, _) =>
-                {
-                    l.ShowError(Resources.PackageRefNotRestoredBecauseOfNoConsent);
-                });
+                _logger.ShowError(Resources.PackageRefNotRestoredBecauseOfNoConsent);
             }
         }
 
@@ -561,21 +557,19 @@ namespace NuGet.SolutionRestoreManager
         /// Checks if there are missing packages that should be restored. If so, a warning will
         /// be added to the error list.
         /// </summary>
-        private async Task CheckForMissingPackagesAsync(IEnumerable<PackageRestoreData> installedPackages)
+        private Task CheckForMissingPackagesAsync(IEnumerable<PackageRestoreData> installedPackages)
         {
             var missingPackages = installedPackages.Where(p => p.IsMissing);
 
             if (missingPackages.Any())
             {
-                await _logger.DoAsync((l, _) =>
-                {
-                    var errorText = string.Format(
-                        CultureInfo.CurrentCulture,
-                        Resources.PackageNotRestoredBecauseOfNoConsent,
-                        string.Join(", ", missingPackages.Select(p => p.PackageReference.PackageIdentity.ToString())));
-                    l.ShowError(errorText);
-                });
+                var errorText = string.Format(
+                    CultureInfo.CurrentCulture,
+                    Resources.PackageNotRestoredBecauseOfNoConsent,
+                    string.Join(", ", missingPackages.Select(p => p.PackageReference.PackageIdentity.ToString())));
+                _logger.ShowError(errorText);
             }
+            return Task.CompletedTask;
         }
 
         private async Task RestoreMissingPackagesInSolutionAsync(

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreJob.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreJob.cs
@@ -602,26 +602,6 @@ namespace NuGet.SolutionRestoreManager
             }
         }
 
-        /// <summary>
-        /// Returns true if the package restore user consent is granted.
-        /// </summary>
-        /// <returns>True if the package restore user consent is granted.</returns>
-        private static bool IsConsentGranted(ISettings settings)
-        {
-            var packageRestoreConsent = new PackageRestoreConsent(settings);
-            return packageRestoreConsent.IsGranted;
-        }
-
-        /// <summary>
-        /// Returns true if automatic package restore on build is enabled.
-        /// </summary>
-        /// <returns>True if automatic package restore on build is enabled.</returns>
-        private static bool IsAutomatic(ISettings settings)
-        {
-            var packageRestoreConsent = new PackageRestoreConsent(settings);
-            return packageRestoreConsent.IsAutomatic;
-        }
-
         private async Task<bool> CheckPackagesConfigAsync()
         {
             return await NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async () =>

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreJob.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreJob.cs
@@ -383,16 +383,20 @@ namespace NuGet.SolutionRestoreManager
                 var packageIdentity = args.Package;
                 Interlocked.Increment(ref _currentCount);
 
-                _logger.Do((_, progress) =>
+                NuGetUIThreadHelper.JoinableTaskFactory.Run(async () =>
                 {
-                    progress?.ReportProgress(
-                        string.Format(
-                            CultureInfo.CurrentCulture,
-                            Resources.RestoredPackage,
-                            packageIdentity),
-                        (uint)_currentCount,
-                        (uint)_missingPackagesCount);
+                    // capture current progress from the current execution context
+                    var progress = RestoreOperationProgressUI.Current;
+
+                    await progress?.ReportProgressAsync(
+                    string.Format(
+                        CultureInfo.CurrentCulture,
+                        Resources.RestoredPackage,
+                        packageIdentity),
+                    (uint)_currentCount,
+                    (uint)_missingPackagesCount);
                 });
+
             }
         }
 


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9288
Regression: Yes/No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: 
Clean up unnecessary thread affinity in the Visual Studio logging code path. 
By async-ifying everything, we can remove the need to have so many affinitized methods and with that spent less time on the UI thread and only when absolutely necessary. 
It'd be difficult to get a measurable improvement out of these changes, and they often times won't cause a UI delay but general sluggishness. 

This change will especially improve thing in the low verbosity cases where we frequently might have ended up on the UI thread with no real business to do there.

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  Thread affinity changes, I expect the end to end tests and manual tests to capture issues.
Validation:  Manual + waiting for automation. 

**Draft**
Leaving this as draft until I do some more complete manual tests and see all the tests passing. 