### PR TITLE
Set copyToOutput in NuGet.Build.Tasks.Console pkg

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Console/NuGet.Build.Tasks.Console.csproj
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Console/NuGet.Build.Tasks.Console.csproj
@@ -13,6 +13,8 @@
     <!-- NU5100: Suppress warning about a DLL not in a lib folder since on .NET Core the EXE is technically a DLL -->
     <NoWarn>$(NoWarn);CS1591;NU5100</NoWarn>
     <XPLATProject>true</XPLATProject>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);PackBuildOutputs</TargetsForTfmSpecificContentInPackage>
     <EnableDefaultNoneItems>false</EnableDefaultNoneItems>
     <ServerGarbageCollection>true</ServerGarbageCollection>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
@@ -56,6 +58,13 @@
       <_Parameter1>NuGet.Build.Tasks.Console.Test</_Parameter1>
     </AssemblyAttribute>
   </ItemGroup>
+
+  <Target Name="PackBuildOutputs">
+    <ItemGroup>
+      <TfmSpecificPackageFile Include="$(TargetPath)" PackagePath="contentFiles\any\$(TargetFramework)\" PackageCopyToOutput="true" />
+      <TfmSpecificPackageFile Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'" Include="$(ProjectRuntimeConfigFilePath)" PackagePath="contentFiles\any\$(TargetFramework)\" PackageCopyToOutput="true" />
+    </ItemGroup>
+  </Target>
 
   <Import Project="$(BuildCommonDirectory)common.targets" />
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />

--- a/src/NuGet.Core/NuGet.Build.Tasks.Console/NuGet.Build.Tasks.Console.csproj
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Console/NuGet.Build.Tasks.Console.csproj
@@ -62,7 +62,7 @@
   <Target Name="PackBuildOutputs">
     <ItemGroup>
       <TfmSpecificPackageFile Include="$(TargetPath)" PackagePath="contentFiles\any\$(TargetFramework)\" PackageCopyToOutput="true" />
-      <TfmSpecificPackageFile Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'" Include="$(ProjectRuntimeConfigFilePath)" PackagePath="contentFiles\any\$(TargetFramework)\" PackageCopyToOutput="true" />
+      <TfmSpecificPackageFile Include="$(ProjectRuntimeConfigFilePath)" Condition="'$(TargetFramework)' == '$(NetCoreTargetFramework)'" PackagePath="contentFiles\any\$(TargetFramework)\" PackageCopyToOutput="true" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
## Fix

Fixes the redistribution of the Console pkg in dotnet/sdk by moving the files into contentFiles (as recommended) and applying the copyToOutput metadata.

## Testing/Validation

Tests Added: No
Reason for not adding tests:  
Validation:  manual

## Nuspec

```
<?xml version="1.0" encoding="utf-8"?>
<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
  <metadata>
    <id>NuGet.Build.Tasks.Console</id>
    <version>5.6.0-preview.2</version>
    <authors>Microsoft</authors>
    <owners>Microsoft</owners>
    <requireLicenseAcceptance>true</requireLicenseAcceptance>
    <license type="expression">Apache-2.0</license>
    <projectUrl>https://aka.ms/nugetprj</projectUrl>
    <iconUrl>https://raw.githubusercontent.com/NuGet/Media/master/Images/MainLogo/256x256/nuget_256.png</iconUrl>
    <description>NuGet restore console application.</description>
    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
    <tags>nuget</tags>
    <serviceable>true</serviceable>
    <repository type="git" url="https://github.com/NuGet/NuGet.Client" commit="1cba4def30901e781aabc48986aee32c41781e43" />
    <dependencies>
      <group targetFramework=".NETFramework4.7.2">
        <dependency id="NuGet.Build.Tasks" version="5.6.0-preview.2" exclude="Build,Analyzers" />
        <dependency id="Microsoft.Build" version="16.5.0-preview-19606-01" exclude="Runtime,Build,Analyzers" />
        <dependency id="Microsoft.Build.Framework" version="16.5.0-preview-19606-01" exclude="Runtime,Build,Analyzers" />
        <dependency id="Microsoft.Build.Tasks.Core" version="16.5.0-preview-19606-01" exclude="Runtime,Build,Analyzers" />
        <dependency id="Microsoft.Build.Utilities.Core" version="16.5.0-preview-19606-01" exclude="Runtime,Build,Analyzers" />
      </group>
      <group targetFramework=".NETCoreApp2.1">
        <dependency id="NuGet.Build.Tasks" version="5.6.0-preview.2" exclude="Build,Analyzers" />
        <dependency id="Microsoft.Build" version="16.5.0-preview-19606-01" exclude="Runtime,Build,Analyzers" />
        <dependency id="Microsoft.Build.Framework" version="16.5.0-preview-19606-01" exclude="Runtime,Build,Analyzers" />
        <dependency id="Microsoft.Build.Tasks.Core" version="16.5.0-preview-19606-01" exclude="Runtime,Build,Analyzers" />
        <dependency id="Microsoft.Build.Utilities.Core" version="16.5.0-preview-19606-01" exclude="Runtime,Build,Analyzers" />
      </group>
    </dependencies>
    <frameworkAssemblies>
      <frameworkAssembly assemblyName="Microsoft.Build.Utilities.v4.0" targetFramework=".NETFramework4.7.2" />
    </frameworkAssemblies>
    <contentFiles>
      <files include="any/net472/NuGet.Build.Tasks.Console.exe" buildAction="None" copyToOutput="true" />
      <files include="any/netcoreapp2.1/NuGet.Build.Tasks.Console.dll" buildAction="None" copyToOutput="true" />
      <files include="any/netcoreapp2.1/NuGet.Build.Tasks.Console.runtimeconfig.json" buildAction="None" copyToOutput="true" />
    </contentFiles>
  </metadata>
</package>
```

## Layout 

![image](https://user-images.githubusercontent.com/7412651/76654265-e8821780-656a-11ea-85a5-0b8115457f78.png)

cc @nkolev92 @jeffkl