### PR TITLE
Skip PushCommand_AbsolutePathSourceAsync test

### DIFF
--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/PushCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/PushCommandTests.cs
@@ -18,7 +18,7 @@ namespace NuGet.Commands.Test
 {
     public class PushCommandTests
     {
-        [Fact]
+        [Fact(Skip = "https://github.com/NuGet/Home/issues/9299")]
         public async Task PushCommand_AbsolutePathSourceAsync()
         {
             using (var workingDir = TestDirectory.Create())

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/PushCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/PushCommandTests.cs
@@ -18,7 +18,8 @@ namespace NuGet.Commands.Test
 {
     public class PushCommandTests
     {
-        [Fact(Skip = "https://github.com/NuGet/Home/issues/9299")]
+        // Skipping linux: https://github.com/NuGet/Home/issues/9299
+        [PlatformFact(Platform.Windows, Platform.Darwin)]
         public async Task PushCommand_AbsolutePathSourceAsync()
         {
             using (var workingDir = TestDirectory.Create())


### PR DESCRIPTION
The test started, but never finished, on every timed out linux build I checked.