### PR TITLE
Run Mac tests on AzDO hosted pool

### DIFF
--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -711,7 +711,7 @@ jobs:
     FULLVSTSBUILDNUMBER: $[dependencies.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
   condition: "and(succeeded(),eq(variables['RunTestsOnMac'], 'true')) "
   pool:
-    name: macos-latest
+    vmImage: macos-latest
 
   steps:
   - task: PowerShell@2

--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -711,11 +711,7 @@ jobs:
     FULLVSTSBUILDNUMBER: $[dependencies.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
   condition: "and(succeeded(),eq(variables['RunTestsOnMac'], 'true')) "
   pool:
-    name: VSEng-MicroBuildMacCustom
-    demands: 
-    - sh
-    - VSTS_OS -equals Mac_Mojave_10.14
-    - Team -equals NuGet Client Team
+    name: macos-latest
 
   steps:
   - task: PowerShell@2


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Client.Engineering/issues/161
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: Change hosted agent to AzDO/Microsoft hosted pool.

We have been increasingly seeing timeouts on the Microbuild pool, plus the DD-Fun and .NET Engineering teams recommend using the hosted pools, rather than customer pools, when possible. AzDO have more resources to manage the pools, since they do it for all customers.

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  Build YAML change.
Validation:  
