### PR TITLE
Update .NET BAR publishing

### DIFF
--- a/build/bootstrap.proj
+++ b/build/bootstrap.proj
@@ -12,8 +12,8 @@
         <PackageDownload Include="Lucene.Net" version="[3.0.3]" />
         <PackageDownload Include="MicroBuild.Core" version="[0.2.0]" />
         <PackageDownload Include="Microsoft.Build" version="[15.1.262-preview5]" />
-        <PackageDownload Include="Microsoft.DotNet.Build.Tasks.Feed" version="[2.2.0-beta.19178.1]" />  <!-- for publishing to the .NET Core build asset registry (BAR) -->
-        <PackageDownload Include="Microsoft.DotNet.Maestro.Tasks" version="[1.1.0-beta.19178.1]" />  <!-- for publishing to the .NET Core build asset registry (BAR) -->
+        <PackageDownload Include="Microsoft.DotNet.Build.Tasks.Feed" version="[5.0.0-beta.20159.1]" />  <!-- for publishing to the .NET Core build asset registry (BAR) -->
+        <PackageDownload Include="Microsoft.DotNet.Maestro.Tasks" version="[1.1.0-beta.20065.7]" />  <!-- for publishing to the .NET Core build asset registry (BAR) -->
         <PackageDownload Include="Microsoft.VisualStudio.Composition" version="[15.8.98]" />
         <PackageDownload Include="Microsoft.VisualStudio.ProjectSystem" version="[16.0.201-pre-g7d366164d0]" />
         <PackageDownload Include="Microsoft.VSSDK.BuildTools" version="[15.9.3032]" />

--- a/build/common.project.props
+++ b/build/common.project.props
@@ -42,8 +42,8 @@
     <LocalizationFilesDirectory>$(ArtifactsDirectory)LocalizedFiles</LocalizationFilesDirectory>
     <MicroBuildDirectory>$(SolutionPackagesFolder)microbuild.core\0.2.0\build\</MicroBuildDirectory>
     <IsBuildOnlyXPLATProjects>$(DotNetBuildFromSource)</IsBuildOnlyXPLATProjects>
-    <MicrosoftDotNetBuildTasksFeedFilePath>$(SolutionPackagesFolder)microsoft.dotnet.build.tasks.feed\2.2.0-beta.19178.1\tools\net472\Microsoft.DotNet.Build.Tasks.Feed.dll</MicrosoftDotNetBuildTasksFeedFilePath>
-    <MicrosoftDotNetMaestroTasksFilePath>$(SolutionPackagesFolder)microsoft.dotnet.maestro.tasks\1.1.0-beta.19178.1\tools\net472\Microsoft.DotNet.Maestro.Tasks.dll</MicrosoftDotNetMaestroTasksFilePath>
+    <MicrosoftDotNetBuildTasksFeedFilePath>$(SolutionPackagesFolder)microsoft.dotnet.build.tasks.feed\5.0.0-beta.20159.1\tools\net472\Microsoft.DotNet.Build.Tasks.Feed.dll</MicrosoftDotNetBuildTasksFeedFilePath>
+    <MicrosoftDotNetMaestroTasksFilePath>$(SolutionPackagesFolder)microsoft.dotnet.maestro.tasks\1.1.0-beta.20065.7\tools\net472\Microsoft.DotNet.Maestro.Tasks.dll</MicrosoftDotNetMaestroTasksFilePath>
     <NoWarn>$(NoWarn);NU5105</NoWarn>
   </PropertyGroup>
 

--- a/build/common.project.props
+++ b/build/common.project.props
@@ -42,8 +42,8 @@
     <LocalizationFilesDirectory>$(ArtifactsDirectory)LocalizedFiles</LocalizationFilesDirectory>
     <MicroBuildDirectory>$(SolutionPackagesFolder)microbuild.core\0.2.0\build\</MicroBuildDirectory>
     <IsBuildOnlyXPLATProjects>$(DotNetBuildFromSource)</IsBuildOnlyXPLATProjects>
-    <MicrosoftDotNetBuildTasksFeedFilePath>$(SolutionPackagesFolder)microsoft.dotnet.build.tasks.feed\5.0.0-beta.20159.1\tools\net472\Microsoft.DotNet.Build.Tasks.Feed.dll</MicrosoftDotNetBuildTasksFeedFilePath>
-    <MicrosoftDotNetMaestroTasksFilePath>$(SolutionPackagesFolder)microsoft.dotnet.maestro.tasks\1.1.0-beta.20065.7\tools\net472\Microsoft.DotNet.Maestro.Tasks.dll</MicrosoftDotNetMaestroTasksFilePath>
+    <MicrosoftDotNetBuildTasksFeedFilePath>$(SolutionPackagesFolder)microsoft.dotnet.build.tasks.feed\5.0.0-beta.20159.1\tools\netcoreapp2.1\Microsoft.DotNet.Build.Tasks.Feed.dll</MicrosoftDotNetBuildTasksFeedFilePath>
+    <MicrosoftDotNetMaestroTasksFilePath>$(SolutionPackagesFolder)microsoft.dotnet.maestro.tasks\1.1.0-beta.20065.7\tools\netcoreapp2.1\Microsoft.DotNet.Maestro.Tasks.dll</MicrosoftDotNetMaestroTasksFilePath>
     <NoWarn>$(NoWarn);NU5105</NoWarn>
   </PropertyGroup>
 

--- a/build/publish.proj
+++ b/build/publish.proj
@@ -18,7 +18,6 @@
     <Error Condition="!Exists($(NuGetClientNupkgsDirectoryPath))" Text="The package directory path '$(NuGetClientNupkgsDirectoryPath)' does not exist." />
     <Error Condition="Exists($(ManifestFilePath))" Text="The manifest file '$(ManifestFilePath)' already exists." />
     <Error Condition="'$(FeedUrl)' == ''" Text="The FeedUrl property is required." />
-    <Error Condition="'$(TempWorkingDirectory)' == ''" Text="The TempWorkingDirectory property is required" />
 
     <CreateItem Include="$([System.IO.Path]::Combine($(NuGetClientNupkgsDirectoryPath), '*.nupkg'))">
       <Output TaskParameter="Include" ItemName="ItemsToPush" />
@@ -41,8 +40,7 @@
       ManifestBranch="$(RepoBranch)"
       ManifestBuildId="$(BuildId)"
       ManifestCommit="$(RepoCommit)"
-      AssetManifestPath="$(ManifestFilePath)"
-      AssetsTemporaryDirectory="$(TempWorkingDirectory)" />
+      AssetManifestPath="$(ManifestFilePath)" />
   </Target>
 
 

--- a/build/publish.proj
+++ b/build/publish.proj
@@ -52,7 +52,7 @@
 
     <PushToAzureDevOpsArtifacts
       ItemsToPush="@(ItemsToPush)"
-      ManifestBuildData="Location=$(FeedUrl)"
+      ManifestBuildData="@(ManifestBuildData)"
       ManifestRepoUri="$(BUILD_REPOSITORY_URI)"
       ManifestBranch="$(BUILD_SOURCEBRANCH)"
       ManifestBuildId="$(BUILD_BUILDNUMBER)"

--- a/build/publish.proj
+++ b/build/publish.proj
@@ -59,10 +59,6 @@
       ManifestCommit="$(BUILD_SOURCEVERSION)"
       AssetManifestPath="$(AssetManifestPath)" />
 
-    <Message
-      Text="##vso[artifact.upload containerfolder=AssetManifests;artifactname=AssetManifests]$(AssetManifestPath)"
-      Importance="high" />
-
     <PushMetadataToBuildAssetRegistry
       BuildAssetRegistryToken="$(MaestroAccessToken)"
       MaestroApiEndpoint="$(MaestroApiEndpoint)"

--- a/build/publish.proj
+++ b/build/publish.proj
@@ -10,7 +10,7 @@
 
   <Import Project="$(BuildCommonDirectory)common.targets" />
 
-  <UsingTask TaskName="Microsoft.DotNet.Build.Tasks.Feed.PushToBlobFeed" AssemblyFile="$(MicrosoftDotNetBuildTasksFeedFilePath)" />
+  <UsingTask TaskName="Microsoft.DotNet.Build.Tasks.Feed.PushToAzureDevOpsArtifacts" AssemblyFile="$(MicrosoftDotNetBuildTasksFeedFilePath)" />
   <UsingTask TaskName="Microsoft.DotNet.Maestro.Tasks.PushMetadataToBuildAssetRegistry" AssemblyFile="$(MicrosoftDotNetMaestroTasksFilePath)" />
 
 
@@ -18,16 +18,13 @@
     <Error Condition="!Exists($(NuGetClientNupkgsDirectoryPath))" Text="The package directory path '$(NuGetClientNupkgsDirectoryPath)' does not exist." />
     <Error Condition="Exists($(ManifestFilePath))" Text="The manifest file '$(ManifestFilePath)' already exists." />
     <Error Condition="'$(FeedUrl)' == ''" Text="The FeedUrl property is required." />
+    <Error Condition="'$(TempWorkingDirectory)' == ''" Text="The TempWorkingDirectory property is required" />
 
     <CreateItem Include="$([System.IO.Path]::Combine($(NuGetClientNupkgsDirectoryPath), '*.nupkg'))">
       <Output TaskParameter="Include" ItemName="ItemsToPush" />
     </CreateItem>
 
     <Error Condition="'@(ItemsToPush)' == ''" Text="No packages to push." />
-
-    <ItemGroup>
-      <BuildData Include="Location=$(FeedUrl)" />
-    </ItemGroup>
 
     <Error Condition="'$(BuildId)' == ''" Text="The BuildId property is required." />
     <Error Condition="'$(ManifestFilePath)' == ''" Text="The ManifestFilePath property is required." />
@@ -39,7 +36,7 @@
 
     <PushToAzureDevOpsArtifacts
       ItemsToPush="@(ItemsToPush)"
-      ManifestBuildData="BuildData"
+      ManifestBuildData="Location=$(FeedUrl)"
       ManifestRepoUri="$(RepoUri)"
       ManifestBranch="$(RepoBranch)"
       ManifestBuildId="$(BuildId)"

--- a/build/publish.proj
+++ b/build/publish.proj
@@ -29,7 +29,6 @@
       <BuildData Include="Location=$(FeedUrl)" />
     </ItemGroup>
 
-    <Error Condition="'$(AccountKey)' == ''" Text="The AccountKey property is required." />
     <Error Condition="'$(BuildId)' == ''" Text="The BuildId property is required." />
     <Error Condition="'$(ManifestFilePath)' == ''" Text="The ManifestFilePath property is required." />
     <Error Condition="'$(RepoBranch)' == ''" Text="The RepoBranch property is required." />
@@ -38,19 +37,15 @@
 
     <Message Text="Publishing %(ItemsToPush.Identity)" Importance="normal" />
 
-    <PushToBlobFeed
-      AccountKey="$(AccountKey)"
-      AssetManifestPath="$(ManifestFilePath)"
-      ExpectedFeedUrl="$(FeedUrl)"
+    <PushToAzureDevOpsArtifacts
       ItemsToPush="@(ItemsToPush)"
+      ManifestBuildData="BuildData"
+      ManifestRepoUri="$(RepoUri)"
       ManifestBranch="$(RepoBranch)"
       ManifestBuildId="$(BuildId)"
-      ManifestBuildData="$(BuildData)"
       ManifestCommit="$(RepoCommit)"
-      ManifestRepoUri="$(RepoUri)"
-      MaxClients="8"
-      Overwrite="false"
-      PassIfExistingItemIdentical="true" />
+      AssetManifestPath="$(ManifestFilePath)"
+      AssetsTemporaryDirectory="$(TempWorkingDirectory)" />
   </Target>
 
 

--- a/build/publish.proj
+++ b/build/publish.proj
@@ -40,6 +40,16 @@
 
     <Message Text="Publishing %(ItemsToPush.Identity)" Importance="normal" />
 
+    <ItemGroup>
+      <ManifestBuildData Include="InitialAssetsLocation=$(SYSTEM_TEAMFOUNDATIONCOLLECTIONURI)$(SYSTEM_TEAMPROJECT)/_apis/build/builds/$(BUILD_BUILDID)/artifacts" />
+      <ManifestBuildData Include="AzureDevOpsBuildId=$(BUILD_BUILDID)" />
+      <ManifestBuildData Include="AzureDevOpsBuildDefinitionId=$(SYSTEM_DEFINITIONID)" />
+      <ManifestBuildData Include="AzureDevOpsProject=$(SYSTEM_TEAMPROJECT)" />
+      <ManifestBuildData Include="AzureDevOpsBuildNumber=$(BUILD_BUILDNUMBER)" />
+      <ManifestBuildData Include="AzureDevOpsRepository=$(BUILD_REPOSITORY_URI)" />
+      <ManifestBuildData Include="AzureDevOpsBranch=$(BUILD_SOURCEBRANCH)" />
+    </ItemGroup>
+
     <PushToAzureDevOpsArtifacts
       ItemsToPush="@(ItemsToPush)"
       ManifestBuildData="Location=$(FeedUrl)"

--- a/build/publish.proj
+++ b/build/publish.proj
@@ -14,9 +14,14 @@
   <UsingTask TaskName="Microsoft.DotNet.Maestro.Tasks.PushMetadataToBuildAssetRegistry" AssemblyFile="$(MicrosoftDotNetMaestroTasksFilePath)" />
 
 
-  <Target Name="PublishPackagesToBuildAssetRegistry">
+  <Target Name="PublishToBuildAssetRegistry">
+    <PropertyGroup>
+      <AssetManifestFileName>nuget.client.xml</AssetManifestFileName>
+      <AssetManifestPath>$(ArtifactsLogDir)AssetManifest\$(AssetManifestFileName)</AssetManifestPath>
+    </PropertyGroup>
+
     <Error Condition="!Exists($(NuGetClientNupkgsDirectoryPath))" Text="The package directory path '$(NuGetClientNupkgsDirectoryPath)' does not exist." />
-    <Error Condition="Exists($(ManifestFilePath))" Text="The manifest file '$(ManifestFilePath)' already exists." />
+    <Error Condition="Exists($(AssetManifestPath))" Text="The manifest file '$(AssetManifestPath)' already exists." />
     <Error Condition="'$(FeedUrl)' == ''" Text="The FeedUrl property is required." />
 
     <CreateItem Include="$([System.IO.Path]::Combine($(NuGetClientNupkgsDirectoryPath), '*.nupkg'))">
@@ -25,33 +30,33 @@
 
     <Error Condition="'@(ItemsToPush)' == ''" Text="No packages to push." />
 
-    <Error Condition="'$(BuildId)' == ''" Text="The BuildId property is required." />
-    <Error Condition="'$(ManifestFilePath)' == ''" Text="The ManifestFilePath property is required." />
-    <Error Condition="'$(RepoBranch)' == ''" Text="The RepoBranch property is required." />
-    <Error Condition="'$(RepoCommit)' == ''" Text="The RepoCommit property is required." />
-    <Error Condition="'$(RepoUri)' == ''" Text="The RepoUri property is required." />
+    <Error Condition="'$(BUILD_BUILDNUMBER)' == ''" Text="The BUILD_BUILDNUMBER property is required." />
+    <Error Condition="'$(ArtifactsLogDir)' == ''" Text="The ArtifactsLogDir property is required." />
+    <Error Condition="'$(BUILD_SOURCEBRANCH)' == ''" Text="The BUILD_SOURCEBRANCH property is required." />
+    <Error Condition="'$(BUILD_SOURCEVERSION)' == ''" Text="The BUILD_SOURCEVERSION property is required." />
+    <Error Condition="'$(BUILD_REPOSITORY_URI)' == ''" Text="The BUILD_REPOSITORY_URI property is required." />
+    <Error Condition="'$(MaestroAccessToken)' == ''" Text="The MaestroAccessToken property is required." />
+    <Error Condition="'$(MaestroApiEndpoint)' == ''" Text="The MaestroApiEndpoint property is required." />
 
     <Message Text="Publishing %(ItemsToPush.Identity)" Importance="normal" />
 
     <PushToAzureDevOpsArtifacts
       ItemsToPush="@(ItemsToPush)"
       ManifestBuildData="Location=$(FeedUrl)"
-      ManifestRepoUri="$(RepoUri)"
-      ManifestBranch="$(RepoBranch)"
-      ManifestBuildId="$(BuildId)"
-      ManifestCommit="$(RepoCommit)"
-      AssetManifestPath="$(ManifestFilePath)" />
-  </Target>
+      ManifestRepoUri="$(BUILD_REPOSITORY_URI)"
+      ManifestBranch="$(BUILD_SOURCEBRANCH)"
+      ManifestBuildId="$(BUILD_BUILDNUMBER)"
+      ManifestCommit="$(BUILD_SOURCEVERSION)"
+      AssetManifestPath="$(AssetManifestPath)" />
 
-
-  <Target Name="PublishManifestToBuildAssetRegistry">
-    <Error Condition="'$(MaestroAccessToken)' == ''" Text="The MaestroAccessToken property is required." />
-    <Error Condition="'$(MaestroApiEndpoint)' == ''" Text="The MaestroApiEndpoint property is required." />
-    <Error Condition="!Exists($(ManifestsDirectoryPath))" Text="The manifests directory path '$(ManifestsDirectoryPath)' does not exist." />
+    <Message
+      Text="##vso[artifact.upload containerfolder=AssetManifests;artifactname=AssetManifests]$(AssetManifestPath)"
+      Importance="high" />
 
     <PushMetadataToBuildAssetRegistry
       BuildAssetRegistryToken="$(MaestroAccessToken)"
       MaestroApiEndpoint="$(MaestroApiEndpoint)"
-      ManifestsPath="$(ManifestsDirectoryPath)" />
+      ManifestsPath="$(ArtifactsLogDir)AssetManifest\" />
   </Target>
+
 </Project>

--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -79,9 +79,8 @@ jobs:
     VsTargetChannel: $[dependencies.Initialize_Build.outputs['updatebuildnumber.VsTargetChannel']]
     VsTargetMajorVersion: $[dependencies.Initialize_Build.outputs['updatebuildnumber.VsTargetMajorVersion']]
     LocalizedLanguageCount: "13"
-    ManifestsDirectoryPath: $[Build.Repository.LocalPath]\artifacts\manifests\publish\
-    ManifestFilePath: $[Build.Repository.LocalPath]\artifacts\manifests\publish\nuget.client.xml
-    ManifestFileTempPath: $[Build.Repository.LocalPath]\artifacts\manifests\temp\
+    ManifestsDirectoryPath: $(Build.Repository.LocalPath)\artifacts\manifests\
+    ManifestFilePath: $(Build.Repository.LocalPath)\artifacts\manifests\nuget.client.xml
 
   pool:
     name: VSEng-MicroBuildVS2019
@@ -527,7 +526,7 @@ jobs:
   - task: CmdLine@2
     displayName: "Publish the packages to the .NET Core build asset registry (BAR)"
     inputs:
-      script: dotnet msbuild ..\build\publish.proj /t:PublishPackagesToBuildAssetRegistry /p:NuGetClientNupkgsDirectoryPath=$(Build.Repository.LocalPath)\artifacts\$(NupkgOutputDir) /p:FeedUrl=$(DotNetFeedUrl) /p:BuildId=$(Build.BuildNumber) /p:RepoBranch=$(Build.SourceBranchName) /p:RepoCommit=$(Build.SourceVersion) /p:RepoUri=$(Build.Repository.Uri) /p:ManifestFilePath=$(ManifestFilePath) /p:AccountKey=$(dotnetfeed-storage-access-key-1) /p:TempWorkingDirectory=$(ManifestFileTempPath)
+      script: dotnet msbuild ..\build\publish.proj /t:PublishPackagesToBuildAssetRegistry /p:NuGetClientNupkgsDirectoryPath=$(Build.Repository.LocalPath)\artifacts\$(NupkgOutputDir) /p:FeedUrl=$(DotNetFeedUrl) /p:BuildId=$(Build.BuildNumber) /p:RepoBranch=$(Build.SourceBranchName) /p:RepoCommit=$(Build.SourceVersion) /p:RepoUri=$(Build.Repository.Uri) /p:ManifestFilePath=$(ManifestFilePath) /p:AccountKey=$(dotnetfeed-storage-access-key-1)
       workingDirectory: cli
       failOnStderr: true
     env:

--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -72,7 +72,7 @@ jobs:
 
 - job: Build_and_UnitTest
   dependsOn: Initialize_Build
-  timeoutInMinutes: 90
+  timeoutInMinutes: 110
   variables:
     BuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.BuildNumber']]
     FullVstsBuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]

--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -79,8 +79,6 @@ jobs:
     VsTargetChannel: $[dependencies.Initialize_Build.outputs['updatebuildnumber.VsTargetChannel']]
     VsTargetMajorVersion: $[dependencies.Initialize_Build.outputs['updatebuildnumber.VsTargetMajorVersion']]
     LocalizedLanguageCount: "13"
-    ManifestsDirectoryPath: $(Build.Repository.LocalPath)\artifacts\manifests\
-    ManifestFilePath: $(Build.Repository.LocalPath)\artifacts\manifests\nuget.client.xml
 
   pool:
     name: VSEng-MicroBuildVS2019
@@ -524,31 +522,14 @@ jobs:
     # The Microsoft.DotNet.Build.Tasks.Feed package includes NuGet.Common 4.9.0.6 and a binding redirection in Microsoft.DotNet.Build.Tasks.Feed.dll.config but the binding redirection is not processed.
     # This would probably solve it:  https://github.com/Microsoft/msbuild/issues/1309
   - task: CmdLine@2
-    displayName: "Publish the packages to the .NET Core build asset registry (BAR)"
+    displayName: "Publish to the .NET Core build asset registry (BAR)"
     inputs:
-      script: dotnet msbuild ..\build\publish.proj /t:PublishPackagesToBuildAssetRegistry /p:NuGetClientNupkgsDirectoryPath=$(Build.Repository.LocalPath)\artifacts\$(NupkgOutputDir) /p:FeedUrl=$(DotNetFeedUrl) /p:BuildId=$(Build.BuildNumber) /p:RepoBranch=$(Build.SourceBranchName) /p:RepoCommit=$(Build.SourceVersion) /p:RepoUri=$(Build.Repository.Uri) /p:ManifestFilePath=$(ManifestFilePath) /p:AccountKey=$(dotnetfeed-storage-access-key-1)
+      script: dotnet msbuild ..\build\publish.proj /t:PublishToBuildAssetRegistry /p:NuGetClientNupkgsDirectoryPath=$(Build.Repository.LocalPath)\artifacts\$(NupkgOutputDir) /p:FeedUrl=$(DotNetFeedUrl) /p:BUILD_BUILDNUMBER=$(Build.BuildNumber) /p:BUILD_SOURCEBRANCH=$(Build.SourceBranchName) /p:BUILD_SOURCEVERSION=$(Build.SourceVersion) /p:BUILD_REPOSITORY_URI=$(Build.Repository.Uri) /p:ArtifactsLogDir=$(Build.Repository.LocalPath)\artifacts\manifests\ /p:MaestroApiEndpoint=$(MaestroApiEndpoint) /p:MaestroAccessToken=$(MaestroAccessToken)
       workingDirectory: cli
       failOnStderr: true
     env:
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
       DOTNET_MULTILEVEL_LOOKUP: true
-    condition: " and(succeeded(),eq(variables['PublishArtifactsToDotNetBuildAssetRegistry'], 'true'), eq(variables['BuildRTM'], 'false')) "
-
-  - task: PowerShell@1
-    displayName: "Upload the build manifest file as a build artifact"
-    inputs:
-      scriptType: "inlineScript"
-      inlineScript: |
-        Write-Host "##vso[task.uploadfile]$(ManifestFilePath)"
-    condition: " and(succeeded(),eq(variables['PublishArtifactsToDotNetBuildAssetRegistry'], 'true'), eq(variables['BuildRTM'], 'false')) "
-
-  - task: MSBuild@1
-    displayName: "Publish the build manifest file to the .NET Core build asset registry (BAR)"
-    inputs:
-      solution: 'build\\publish.proj'
-      msbuildVersion: 16.0
-      configuration: '$(BuildConfiguration)'
-      msbuildArguments: '/t:PublishManifestToBuildAssetRegistry /p:MaestroApiEndpoint=$(MaestroApiEndpoint) /p:ManifestsDirectoryPath=$(ManifestsDirectoryPath) /p:MaestroAccessToken=$(MaestroAccessToken)'
     condition: " and(succeeded(),eq(variables['PublishArtifactsToDotNetBuildAssetRegistry'], 'true'), eq(variables['BuildRTM'], 'false')) "
 
   - task: MicroBuildCleanup@1

--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -79,6 +79,7 @@ jobs:
     VsTargetChannel: $[dependencies.Initialize_Build.outputs['updatebuildnumber.VsTargetChannel']]
     VsTargetMajorVersion: $[dependencies.Initialize_Build.outputs['updatebuildnumber.VsTargetMajorVersion']]
     LocalizedLanguageCount: "13"
+    ManifestsDirectoryPath: $[Build.Repository.LocalPath]\artifacts\manifests\publish\
     ManifestFilePath: $[Build.Repository.LocalPath]\artifacts\manifests\publish\nuget.client.xml
     ManifestFileTempPath: $[Build.Repository.LocalPath]\artifacts\manifests\temp\
 
@@ -548,7 +549,7 @@ jobs:
       solution: 'build\\publish.proj'
       msbuildVersion: 16.0
       configuration: '$(BuildConfiguration)'
-      msbuildArguments: '/t:PublishManifestToBuildAssetRegistry /p:MaestroApiEndpoint=$(MaestroApiEndpoint) /p:ManifestsDirectoryPath=$(Build.Repository.LocalPath)\artifacts\manifests /p:MaestroAccessToken=$(MaestroAccessToken)'
+      msbuildArguments: '/t:PublishManifestToBuildAssetRegistry /p:MaestroApiEndpoint=$(MaestroApiEndpoint) /p:ManifestsDirectoryPath=$(ManifestsDirectoryPath) /p:MaestroAccessToken=$(MaestroAccessToken)'
     condition: " and(succeeded(),eq(variables['PublishArtifactsToDotNetBuildAssetRegistry'], 'true'), eq(variables['BuildRTM'], 'false')) "
 
   - task: MicroBuildCleanup@1

--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -79,6 +79,8 @@ jobs:
     VsTargetChannel: $[dependencies.Initialize_Build.outputs['updatebuildnumber.VsTargetChannel']]
     VsTargetMajorVersion: $[dependencies.Initialize_Build.outputs['updatebuildnumber.VsTargetMajorVersion']]
     LocalizedLanguageCount: "13"
+    ManifestFilePath: $[Build.Repository.LocalPath]\artifacts\manifests\publish\nuget.client.xml
+    ManifestFileTempPath: $[Build.Repository.LocalPath]\artifacts\manifests\temp\
 
   pool:
     name: VSEng-MicroBuildVS2019
@@ -100,13 +102,6 @@ jobs:
       inlineScript: |
         Write-Host "##vso[build.updatebuildnumber]$env:FullVstsBuildNumber"
         Get-ChildItem Env: | Sort-Object Name | Format-Table -Wrap -AutoSize
-
-  - task: PowerShell@1
-    displayName: "Define variables"
-    inputs:
-      scriptType: "inlineScript"
-      inlineScript: |
-        Write-Host "##vso[task.setvariable variable=ManifestFilePath]$(Build.Repository.LocalPath)\artifacts\manifests\nuget.client.xml"
 
   - task: NuGetToolInstaller@0
     displayName: "Use NuGet 5.0.0"
@@ -531,7 +526,7 @@ jobs:
   - task: CmdLine@2
     displayName: "Publish the packages to the .NET Core build asset registry (BAR)"
     inputs:
-      script: dotnet msbuild ..\build\publish.proj /t:PublishPackagesToBuildAssetRegistry /p:NuGetClientNupkgsDirectoryPath=$(Build.Repository.LocalPath)\artifacts\$(NupkgOutputDir) /p:FeedUrl=$(DotNetFeedUrl) /p:BuildId=$(Build.BuildNumber) /p:RepoBranch=$(Build.SourceBranchName) /p:RepoCommit=$(Build.SourceVersion) /p:RepoUri=$(Build.Repository.Uri) /p:ManifestFilePath=$(ManifestFilePath) /p:AccountKey=$(dotnetfeed-storage-access-key-1)
+      script: dotnet msbuild ..\build\publish.proj /t:PublishPackagesToBuildAssetRegistry /p:NuGetClientNupkgsDirectoryPath=$(Build.Repository.LocalPath)\artifacts\$(NupkgOutputDir) /p:FeedUrl=$(DotNetFeedUrl) /p:BuildId=$(Build.BuildNumber) /p:RepoBranch=$(Build.SourceBranchName) /p:RepoCommit=$(Build.SourceVersion) /p:RepoUri=$(Build.Repository.Uri) /p:ManifestFilePath=$(ManifestFilePath) /p:AccountKey=$(dotnetfeed-storage-access-key-1) /p:TempWorkingDirectory=$(ManifestFileTempPath)
       workingDirectory: cli
       failOnStderr: true
     env:


### PR DESCRIPTION
## Bug

Fixes: https://github.com/nuget/client.engineering/issues/203
Fixes: https://github.com/dotnet/arcade/issues/5008
Fixes: https://github.com/NuGet/Client.Engineering/issues/226
Regression: Yes
* Last working version:   not a product bug, but the pipeline was working 3-4 weeks ago.
* How are we preventing it in future:   Working with .NET Engineering team to onboard onto more Arcade SDK things

## Fix

Details: Update dotnet packages related to BAR publishing. Updated scripts to use new task.

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  CI build scripts.
Validation:  
