### PR TITLE
Improve solution restore performance by avoiding unnecessary disk hits when the projects are in Visual Studio

### DIFF
--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreJob.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreJob.cs
@@ -156,6 +156,7 @@ namespace NuGet.SolutionRestoreManager
 
             // start timer for telemetry event
             var stopWatch = Stopwatch.StartNew();
+            var intervalTracker = new IntervalTracker();
             var projects = Enumerable.Empty<NuGetProject>();
 
             _packageRestoreManager.PackageRestoredEvent += PackageRestoreManager_PackageRestored;
@@ -166,6 +167,7 @@ namespace NuGet.SolutionRestoreManager
             {
                 try
                 {
+                    intervalTracker.StartIntervalMeasure();
                     var solutionDirectory = _solutionManager.SolutionDirectory;
                     var isSolutionAvailable = await _solutionManager.IsSolutionAvailableAsync();
 
@@ -181,6 +183,8 @@ namespace NuGet.SolutionRestoreManager
 
                         return;
                     }
+                    intervalTracker.EndIntervalMeasure(RestoreTelemetryEvent.RestoreOperationChecks);
+                    intervalTracker.StartIntervalMeasure();
 
                     // Check if there are any projects that are not INuGetIntegratedProject, that is,
                     // projects with packages.config. OR 
@@ -194,6 +198,7 @@ namespace NuGet.SolutionRestoreManager
                             restoreSource,
                             token);
                     }
+                    intervalTracker.EndIntervalMeasure(RestoreTelemetryEvent.PackagesConfigRestore);
 
                     var dependencyGraphProjects = projects
                         .OfType<IDependencyGraphProject>()
@@ -204,6 +209,7 @@ namespace NuGet.SolutionRestoreManager
                         forceRestore,
                         isSolutionAvailable,
                         restoreSource,
+                        intervalTracker,
                         token);
 
                     // TODO: To limit risk, we only publish the event when there is a cross-platform PackageReference
@@ -242,7 +248,8 @@ namespace NuGet.SolutionRestoreManager
                         restoreSource,
                         startTime,
                         duration.TotalSeconds,
-                        protocolDiagnosticsTotals);
+                        protocolDiagnosticsTotals,
+                        intervalTracker);
                 }
             }
         }
@@ -251,7 +258,8 @@ namespace NuGet.SolutionRestoreManager
             RestoreOperationSource source,
             DateTimeOffset startTime,
             double duration,
-            PackageSourceTelemetry.Totals protocolDiagnosticTotals)
+            PackageSourceTelemetry.Totals protocolDiagnosticTotals,
+            IntervalTracker intervalTimingTracker)
         {
             var sortedProjects = projects.OrderBy(
                 project => project.GetMetadata<string>(NuGetProjectMetadataKeys.UniqueName));
@@ -267,7 +275,8 @@ namespace NuGet.SolutionRestoreManager
                 _packageCount,
                 _noOpProjectsCount,
                 DateTimeOffset.Now,
-                duration);
+                duration,
+                intervalTimingTracker);
 
             TelemetryActivity.EmitTelemetryEvent(restoreTelemetryEvent);
 
@@ -282,6 +291,7 @@ namespace NuGet.SolutionRestoreManager
             bool forceRestore,
             bool isSolutionAvailable,
             RestoreOperationSource restoreSource,
+            IntervalTracker intervalTracker,
             CancellationToken token)
         {
             // Only continue if there are some build integrated type projects.
@@ -310,14 +320,15 @@ namespace NuGet.SolutionRestoreManager
                         return;
                     }
                 }
-
+                intervalTracker.StartIntervalMeasure();
                 // Cache p2ps discovered from DTE
                 var cacheContext = new DependencyGraphCacheContext(_logger, _settings);
                 var pathContext = NuGetPathContext.Create(_settings);
 
                 // Get full dg spec
                 var dgSpec = await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(_solutionManager, cacheContext);
-
+                intervalTracker.EndIntervalMeasure(RestoreTelemetryEvent.SolutionDependencyGraphSpecCreation);
+                intervalTracker.StartIntervalMeasure();
                 // Avoid restoring solutions with zero potential PackageReference projects.
                 if (DependencyGraphRestoreUtility.IsRestoreRequired(dgSpec))
                 {
@@ -366,6 +377,8 @@ namespace NuGet.SolutionRestoreManager
                         },
                         token);
                 }
+                intervalTracker.EndIntervalMeasure(RestoreTelemetryEvent.PackageReferenceRestoreDuration);
+
             }
             else if (restoreSource == RestoreOperationSource.Explicit)
             {

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/IntervalTracker.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/IntervalTracker.cs
@@ -1,0 +1,35 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace NuGet.VisualStudio
+{
+    public class IntervalTracker
+    {
+        private readonly Stopwatch _intervalWatch = new Stopwatch();
+        private readonly List<Tuple<string, TimeSpan>> _intervalList = new List<Tuple<string, TimeSpan>>();
+
+        public void StartIntervalMeasure()
+        {
+            _intervalWatch.Restart();
+        }
+
+        public void EndIntervalMeasure(string propertyName)
+        {
+            _intervalWatch.Stop();
+            _intervalList.Add(new Tuple<string, TimeSpan>(propertyName, _intervalWatch.Elapsed));
+        }
+
+        public IEnumerable<(string, double)> GetIntervals()
+        {
+            foreach (var interval in _intervalList)
+            {
+                yield return (interval.Item1, interval.Item2.TotalSeconds);
+            }
+        }
+    }
+}

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/IntervalTracker.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/IntervalTracker.cs
@@ -8,6 +8,12 @@ using System.Diagnostics;
 
 namespace NuGet.VisualStudio
 {
+    /// <summary>
+    /// A utility to help us measure named intervals.
+    /// To start a tracking call <see cref="StartIntervalMeasure"/> and to complete an interval call <see cref="EndIntervalMeasure(string)"/>.
+    /// Overlapping internals are not supported.
+    /// This utility is not thread safe.
+    /// </summary>
     public class IntervalTracker
     {
         private readonly Stopwatch _intervalWatch = new Stopwatch();

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/RestoreTelemetryEvent.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/RestoreTelemetryEvent.cs
@@ -12,6 +12,11 @@ namespace NuGet.VisualStudio
     /// </summary>
     public class RestoreTelemetryEvent : ActionEventBase
     {
+        public static string RestoreOperationChecks = nameof(RestoreOperationChecks);
+        public static string PackagesConfigRestore = nameof(PackagesConfigRestore);
+        public static string SolutionDependencyGraphSpecCreation = nameof(SolutionDependencyGraphSpecCreation);
+        public static string PackageReferenceRestoreDuration = nameof(PackageReferenceRestoreDuration);
+
         public RestoreTelemetryEvent(
             string operationId,
             string[] projectIds,
@@ -21,10 +26,16 @@ namespace NuGet.VisualStudio
             int packageCount,
             int noOpProjectsCount,
             DateTimeOffset endTime,
-            double duration) : base(RestoreActionEventName, operationId, projectIds, startTime, status, packageCount, endTime, duration)
+            double duration,
+            IntervalTracker intervalTimingTracker) : base(RestoreActionEventName, operationId, projectIds, startTime, status, packageCount, endTime, duration)
         {
             base[nameof(OperationSource)] = source;
             base[nameof(NoOpProjectsCount)] = noOpProjectsCount;
+
+            foreach (var (intervalName, intervalDuration) in intervalTimingTracker.GetIntervals())
+            {
+                base[intervalName] = intervalDuration;
+            }
         }
 
         public const string RestoreActionEventName = "RestoreInformation";

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -14,7 +14,6 @@ using NuGet.Common;
 using NuGet.DependencyResolver;
 using NuGet.Frameworks;
 using NuGet.LibraryModel;
-using NuGet.Packaging;
 using NuGet.Packaging.Core;
 using NuGet.ProjectModel;
 using NuGet.Repositories;

--- a/src/NuGet.Core/NuGet.PackageManagement/BuildIntegration/DependencyGraphRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/BuildIntegration/DependencyGraphRestoreUtility.cs
@@ -223,10 +223,8 @@ namespace NuGet.PackageManagement
         {
             var dgSpec = new DependencyGraphSpec();
 
-            var stringComparer = PathUtility.GetStringComparerBasedOnOS();
-
             var projects = (await solutionManager.GetNuGetProjectsAsync()).OfType<IDependencyGraphProject>().ToList();
-            var knownProjects = projects.Select(e => e.MSBuildProjectPath).ToHashSet();
+            var knownProjects = projects.Select(e => e.MSBuildProjectPath).ToHashSet(PathUtility.GetStringComparerBasedOnOS());
 
             for (var i = 0; i < projects.Count; i++)
             {
@@ -265,7 +263,6 @@ namespace NuGet.PackageManagement
                                                 // Figuring out exactly what we need would be too and an overkill. That will happen later in the DependencyGraphSpecRequestProvider
                                                 knownProjects.Add(dependentPackageSpec.RestoreMetadata.ProjectPath);
                                                 dgSpec.AddProject(dependentPackageSpec);
-
                                             }
                                         }
                                     }

--- a/src/NuGet.Core/NuGet.PackageManagement/BuildIntegration/DependencyGraphRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/BuildIntegration/DependencyGraphRestoreUtility.cs
@@ -259,15 +259,13 @@ namespace NuGet.PackageManagement
                                         if (File.Exists(persistedDGSpecPath))
                                         {
                                             var persistedDGSpec = DependencyGraphSpec.Load(persistedDGSpecPath);
-                                            foreach (var dependentPackageSpec in persistedDGSpec.GetClosure(packageSpec.RestoreMetadata.ProjectUniqueName))
+                                            foreach (var dependentPackageSpec in persistedDGSpec.Projects.Where(e => !knownProjects.Contains(e.RestoreMetadata.ProjectPath)))
                                             {
                                                 // Include all the missing projects from the closure.
                                                 // Figuring out exactly what we need would be too and an overkill. That will happen later in the DependencyGraphSpecRequestProvider
-                                                if (!knownProjects.Any(projectName => stringComparer.Equals(projectName, dependentPackageSpec.RestoreMetadata.ProjectPath)))
-                                                {
-                                                    knownProjects.Add(dependentPackageSpec.RestoreMetadata.ProjectPath);
-                                                    dgSpec.AddProject(dependentPackageSpec);
-                                                }
+                                                knownProjects.Add(dependentPackageSpec.RestoreMetadata.ProjectPath);
+                                                dgSpec.AddProject(dependentPackageSpec);
+
                                             }
                                         }
                                     }

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/NuGet.PackageManagement.VisualStudio.Test.csproj
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/NuGet.PackageManagement.VisualStudio.Test.csproj
@@ -21,7 +21,7 @@
     <Reference Include="WindowsBase" />
     <Reference Include="System.IO.Compression" />
   </ItemGroup>
-  <ItemGroup >
+  <ItemGroup>
     <Compile Include="ProjectSystems\LegacyPackageReferenceProjectTests.cs" />
     <Compile Include="DispatcherThreadCollection.cs" />
     <Compile Include="Feeds\MultiSourcePackageMetadataProviderTests.cs" />
@@ -34,6 +34,7 @@
     <Compile Include="ProjectSystems\TestVSProjectAdapter.cs" />
     <Compile Include="Services\NuGetLockServiceTests.cs" />
     <Compile Include="Telemetry\ActionsTelemetryServiceTests.cs" />
+    <Compile Include="Telemetry\IntervalTrackerTests.cs" />
     <Compile Include="Telemetry\NuGetTelemetryServiceTests.cs" />
     <Compile Include="Telemetry\RestoreTelemetryServiceTests.cs" />
     <Compile Include="Telemetry\TestTelemetryUtility.cs" />

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Telemetry/IntervalTrackerTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Telemetry/IntervalTrackerTests.cs
@@ -1,0 +1,82 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq;
+using NuGet.VisualStudio;
+using Xunit;
+
+namespace NuGet.PackageManagement.VisualStudio.Test
+{
+    public class IntervalTrackerTests
+    {
+
+        [Fact]
+        public void GetIntervals_WhenNoIntervalsAreCaptured_ReturnsEmpty()
+        {
+            // Setup
+            var tracker = new IntervalTracker();
+
+            // Act - do nothing
+
+            // Assert
+            Assert.Equal(0, tracker.GetIntervals().Count());
+        }
+
+        [Fact]
+        public void GetIntervals_WhenNoEndIntervalMeasureIsCalled_ReturnsEmpty()
+        {
+            // Setup
+            var tracker = new IntervalTracker();
+
+            // Act - do nothing
+            tracker.StartIntervalMeasure();
+            tracker.StartIntervalMeasure();
+            tracker.StartIntervalMeasure();
+            // Assert
+            Assert.Equal(0, tracker.GetIntervals().Count());
+        }
+
+        [Fact]
+        public void GetIntervals_WhenStartIntervalIsNotCalled_IntervalsAreEmpty()
+        {
+            // Setup
+            var tracker = new IntervalTracker();
+
+            // Act - do nothing
+            tracker.EndIntervalMeasure("one");
+            tracker.EndIntervalMeasure("two");
+            // Assert
+
+            var allTimings = tracker.GetIntervals().ToList();
+
+            Assert.Equal(2, allTimings.Count);
+            Assert.True(allTimings.All(e => e.Item2.Equals(0)));
+        }
+
+        [Fact]
+        public void IntervalTracker_AllIntervalsAreCaptured()
+        {
+            // Setup
+            var tracker = new IntervalTracker();
+
+            // Act
+            tracker.StartIntervalMeasure();
+            tracker.EndIntervalMeasure("first");
+
+            tracker.StartIntervalMeasure();
+            tracker.EndIntervalMeasure("second");
+
+            tracker.StartIntervalMeasure();
+            tracker.EndIntervalMeasure("third");
+
+            // Assert
+
+            var allTimings = tracker.GetIntervals().ToList();
+
+            Assert.Equal(3, allTimings.Count);
+            Assert.True(allTimings.Any(e => e.Item1.Equals("first")));
+            Assert.True(allTimings.Any(e => e.Item1.Equals("second")));
+            Assert.True(allTimings.Any(e => e.Item1.Equals("third")));
+        }
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Telemetry/RestoreTelemetryServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Telemetry/RestoreTelemetryServiceTests.cs
@@ -47,7 +47,8 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 packageCount: 2,
                 noOpProjectsCount: noopProjectsCount,
                 endTime: DateTimeOffset.Now,
-                duration: 2.10);
+                duration: 2.10,
+                new IntervalTracker());
             var service = new NuGetVSTelemetryService(telemetrySession.Object);
 
             // Act
@@ -55,6 +56,56 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
             // Assert
             VerifyTelemetryEventData(operationId, restoreTelemetryData, lastTelemetryEvent);
+        }
+
+        [Fact]
+        public void RestoreTelemetryService_EmitRestoreEvent_IntervalsAreCaptured()
+        {
+            // Arrange
+            var first = "first";
+            var second = "second";
+            var telemetrySession = new Mock<ITelemetrySession>();
+            TelemetryEvent lastTelemetryEvent = null;
+            telemetrySession
+                .Setup(x => x.PostEvent(It.IsAny<TelemetryEvent>()))
+                .Callback<TelemetryEvent>(x => lastTelemetryEvent = x);
+            var tracker = new IntervalTracker();
+
+            tracker.StartIntervalMeasure();
+            tracker.EndIntervalMeasure(first);
+            tracker.StartIntervalMeasure();
+            tracker.EndIntervalMeasure(second);
+
+            var operationId = Guid.NewGuid().ToString();
+
+            var restoreTelemetryData = new RestoreTelemetryEvent(
+                operationId,
+                projectIds: new[] { Guid.NewGuid().ToString() },
+                source: RestoreOperationSource.OnBuild,
+                startTime: DateTimeOffset.Now.AddSeconds(-3),
+                status: NuGetOperationStatus.Succeeded,
+                packageCount: 1,
+                noOpProjectsCount: 0,
+                endTime: DateTimeOffset.Now,
+                duration: 2.10,
+                tracker
+                );
+            var service = new NuGetVSTelemetryService(telemetrySession.Object);
+
+            // Act
+            service.EmitTelemetryEvent(restoreTelemetryData);
+
+            // Assert
+
+            Assert.NotNull(lastTelemetryEvent);
+            Assert.Equal(RestoreTelemetryEvent.RestoreActionEventName, lastTelemetryEvent.Name);
+            Assert.Equal(12, lastTelemetryEvent.Count);
+
+            Assert.Equal(restoreTelemetryData.OperationSource.ToString(), lastTelemetryEvent["OperationSource"].ToString());
+
+            Assert.Equal(restoreTelemetryData.NoOpProjectsCount, (int)lastTelemetryEvent["NoOpProjectsCount"]);
+            Assert.Equal(restoreTelemetryData[first], lastTelemetryEvent[first]);
+            Assert.Equal(restoreTelemetryData[second], lastTelemetryEvent[second]);
         }
 
         private void VerifyTelemetryEventData(string operationId, RestoreTelemetryEvent expected, TelemetryEvent actual)


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9201
Regression: Yes  
* Last working version: 4.9
* How are we preventing it in future:  We are gonna measure the performance of this step.

## Fix

Details: 

The performance regression happened in https://github.com/NuGet/NuGet.Client/commit/aee50eaa0dc31a503315ca64d1e8f5a83541b699, and PR: https://github.com/NuGet/NuGet.Client/pull/2521. 

In PR restore, each project has a packagespec/Project spec really. It contains everything needed to restore that project, except the project references!
That's where the dg spec comes in, the dependency graph spec contains the full project closure.
Say you have a project graph where all nodes are projects:
A -> B -> C. 

To restore A, you need the full project closure, so A, B & C. 
To restore B, you need B & C. 

Each of these actions happen independently. 

From the commandline, we will always be able to find all projects, solutions don't matter, the project references are always files on disk which we can get to.
In VS for perf reasons, people sometimes unload a project. 
Say they'll unload project C. At build time, the build will simply ignore the fact that it can't build a new C.dll if the old is there. 

We mimic the same behavior in restore. 

If a project is unloaded, when looking at B, we would see that C is not in the solution, so we go read this temporary file that lives in the obj folder and if it's available we use the same way the build uses C.dll. 

Now the "logic" whether to load a project was not ideal. We hit the disk for every single project in the solution. We don't need to do that. 

The logic is now changed to: 

* For every project loaded, check if the project references are in the solution, or already preloaded from the cache.
* If no, then look if a closure cache exists and load it.
* Go through all the projects in the closure cache and add them to the known projects.

Note that because the dg file cache on disk contains only the closure, we can safely assume that they are all relevant.

## Testing/Validation

Tests Added: Yes  
Reason for not adding tests:  
Validation:  Manual, I also did a perf validation. I'll get some measurements and post in this PR later. 
