### PR TITLE
Increase the time out for apex tests

### DIFF
--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -834,7 +834,7 @@ jobs:
   dependsOn:
   - Build_and_UnitTest
   - Initialize_Build
-  timeoutInMinutes: 45
+  timeoutInMinutes: 60
   variables:
     BuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.BuildNumber']]
     FullVstsBuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]


### PR DESCRIPTION
## Bug

Fixes: 
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details:

Whenever a cancellation happens in the middle of VSIX installation we run a resume installer. 

That can take 30 mins, and it unfortunately blows through the timeout. 

See:
https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=3576214&view=logs&j=54d34e6c-10d1-5f6f-0d73-85c1fa19385b&t=7a50ef31-7260-52d8-be3d-4816fe868fe2

Increasing the timeout by ~15ish minutes to account for that.

## Testing/Validation

Tests Added: Yes/No  
Reason for not adding tests:  
Validation:  
