### PR TITLE
NoWarn NU5100 for NuGet.Build.Tasks.Console

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Console/NuGet.Build.Tasks.Console.csproj
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Console/NuGet.Build.Tasks.Console.csproj
@@ -10,7 +10,7 @@
     <PackProject>true</PackProject>
     <SkipShared>true</SkipShared>
     <Description>NuGet Build tasks for MSBuild and dotnet restore. Contains restore logic using the MSBuild static graph functionality.</Description>
-    <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <NoWarn>$(NoWarn);CS1591;NU5100</NoWarn>
     <XPLATProject>true</XPLATProject>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);PackBuildOutputs</TargetsForTfmSpecificContentInPackage>


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Client.Engineering/issues/238
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: 

Specifically you'd get something like: 

```console
C:\Users\Nikolche\Documents\Code\NuGet\NuGet.Client\packages\nuget.build.tasks.pack\4.9.2\build\NuGet.Build.Tasks.Pack.tar gets(202,5): error NU5100: The assembly 'contentFiles\any\netcoreapp2.1\NuGet.Build.Tasks.Console.dll' is not inside the 'lib' folder and hence it won't be added as a reference when the package is installed into a project. Move it into the 'lib' folder if it needs to be referenced. [C:\Users\Nikolche\Documents\Code\NuGet\NuGet.Client\src\NuGet.Core\NuGet.Bui ld.Tasks.Console\NuGet.Build.Tasks.Console.csproj]
```

This is a payload package so this warning is ok. 

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  
Validation:  
