### PR TITLE
nuget sources list should default to detailed format

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/SourcesCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/SourcesCommand.cs
@@ -78,6 +78,10 @@ namespace NuGet.CommandLine
                     EnableSourceRunner.Run(enableSourceArgs, () => Console);
                     break;
                 case SourcesAction.List:
+                    if (Format == SourcesListFormat.None)
+                    {
+                        Format = SourcesListFormat.Detailed;
+                    }
                     var listSourceArgs = new ListSourceArgs() { Configfile = ConfigFile, Format = Format.ToString() };
                     ListSourceRunner.Run(listSourceArgs, () => Console);
                     break;

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetSourcesCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetSourcesCommandTest.cs
@@ -349,7 +349,7 @@ namespace NuGet.CommandLine.Test
         }
 
         [Fact]
-        public void SourcesCommandTest_ListSource()
+        public void SourcesList_WithDefaultFormat_UsesDetailedFormat()
         {
             // Arrange
             var nugetexe = Util.GetNuGetExePath();

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetSourcesCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetSourcesCommandTest.cs
@@ -348,6 +348,47 @@ namespace NuGet.CommandLine.Test
             }
         }
 
+        [Fact]
+        public void SourcesCommandTest_ListSource()
+        {
+            // Arrange
+            var nugetexe = Util.GetNuGetExePath();
+
+            using (var configFileDirectory = TestDirectory.Create())
+            {
+                var configFileName = "nuget.config";
+                var configFilePath = Path.Combine(configFileDirectory, configFileName);
+
+                Util.CreateFile(configFileDirectory, configFileName,
+                    @"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+  <packageSources>
+    <add key=""test_source"" value=""http://test_source"" />
+  </packageSources>
+</configuration>");
+
+                var args = new string[] {
+                    "sources",
+                    "list",
+                    "-ConfigFile",
+                    configFilePath
+                };
+
+                // Main Act
+                var result = CommandRunner.Run(
+                    nugetexe,
+                    Directory.GetCurrentDirectory(),
+                    string.Join(" ", args),
+                    true);
+
+                // Assert
+                Util.VerifyResultSuccess(result);
+
+                // test to ensure detailed format is the default
+                Assert.True(result.Output.StartsWith("Registered Sources:"));
+            }
+        }
+
         [Theory]
         [InlineData("sources a b")]
         [InlineData("sources a b c")]


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9337
Regression: Yes
* Last working version:   5.4
* How are we preventing it in future:   added a test

## Fix

If short or detailed isn't chosen, default to detailed

## Testing/Validation

Tests Added: Yes
Validation:  
   manual test.
   functional test.