### PR TITLE
change PortReserver to use ConcurrentDictionary

### DIFF
--- a/test/TestUtilities/Test.Utility/TestServer/PortReserver.cs
+++ b/test/TestUtilities/Test.Utility/TestServer/PortReserver.cs
@@ -1,4 +1,5 @@
-// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Concurrent;

--- a/test/TestUtilities/Test.Utility/TestServer/PortReserver.cs
+++ b/test/TestUtilities/Test.Utility/TestServer/PortReserver.cs
@@ -1,6 +1,7 @@
-﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Concurrent;
 using System.Linq;
 using System.Net;
 using System.Net.NetworkInformation;
@@ -20,6 +21,7 @@ namespace NuGet.Test.Server
     /// </summary>
     public class PortReserver
     {
+        private static ConcurrentDictionary<string, bool> PortLock = new ConcurrentDictionary<string, bool>();
         private readonly int _basePort;
 
         public PortReserver(int basePort = 50231)
@@ -57,21 +59,26 @@ namespace NuGet.Test.Server
 
                 // WaitForLockAsync prevents port contention with this app.
                 string portLockName = $"NuGet-Port-{port}";
-                var tryOnceCts = new CancellationTokenSource(TimeSpan.Zero);
+
                 try
                 {
-                    var attemptedPort = port;
-                    return await ConcurrencyUtilities.ExecuteWithFileLockedAsync<T>(
-                        portLockName,
-                        t => action(attemptedPort, token),
-                        tryOnceCts.Token);
+                    if (PortLock.TryAdd(portLockName, true))
+                    {
+                        // Run the action within the lock
+                        return await action(port, token);
+                    }
                 }
-                catch (OperationCanceledException)
+                catch (OverflowException)
                 {
+                    throw;
+                }
+                finally
+                {
+                    PortLock.TryRemove(portLockName, out _);
                 }
             }
         }
-        
+
         private static bool IsTcpPortAvailable(int port)
         {
             var tcpListener = new TcpListener(IPAddress.Loopback, port);


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9339
Regression: Yes  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: 
Use ConcurrentDictionary to lock the attempt port instead of ConcurrencyUtilities
(Since PortReserver is only used for test projects, and we don't run tests in multiple process, it's good to use  ConcurrentDictionary)

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  
Validation:  manually in both xplat and dev branch
