### PR TITLE
NuGet PMUI Window no longer auto reopens when reopening Solution

### DIFF
--- a/src/NuGet.Clients/NuGet.Tools/NuGetPackage.cs
+++ b/src/NuGet.Clients/NuGet.Tools/NuGetPackage.cs
@@ -508,6 +508,7 @@ namespace NuGetVSExtension
                 if (windowFrame != null)
                 {
                     WindowFrameHelper.AddF1HelpKeyword(windowFrame, keywordValue: F1KeywordValuePmUI);
+                    WindowFrameHelper.DisableWindowAutoReopen(windowFrame);
                 }
             }
             finally
@@ -756,6 +757,7 @@ namespace NuGetVSExtension
                 if (windowFrame != null)
                 {
                     WindowFrameHelper.AddF1HelpKeyword(windowFrame, keywordValue: F1KeywordValuePmUI);
+                    WindowFrameHelper.DisableWindowAutoReopen(windowFrame);
                 }
             }
             finally

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/WindowFrameHelper.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/WindowFrameHelper.cs
@@ -23,5 +23,11 @@ namespace NuGet.VisualStudio
                 }
             }
         }
+
+        public static void DisableWindowAutoReopen(IVsWindowFrame windowFrame)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+            ErrorHandler.ThrowOnFailure(windowFrame.SetProperty((int)__VSFPROPID5.VSFPROPID_DontAutoOpen, true));
+        }
     }
 }


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9239 
Regression: Yes in 16.6 due to VS Editor changes
* Last working version:   16.5

The NuGet Package Manager Window (PMUI) has traditionally remained closed when the Solution is reopened. However, this was not by design, but was by accident. A recent change going into 16.6 by the VS Editor Team is now displaying errors for failed-to-reopen Document Windows. This is causing PMUI to show an error upon reopen.

## Fix

Explicitly set our PMUI Window object with a property that indicates it should not auto-reopen.
This maintains existing behavior. If we decide PMUI should automatically reopen, additional investigation should be done to understand why we are in an error-state upon reopen.

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  APEX testing feels overkill for simply ensuring that a window reopens.
Manual testing already identified this bug, so I believe the scenario is already being coverred.

Validation:  

- Open Project PMUI Window, reopen Solution, ensure PMUI window does not automatically open.
- Open Solution PMUI Window, reopen Solution, ensure PMUI window does not automatically open.
