### PR TITLE
Clean up restore assets for projects that don't support restore

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs
@@ -117,7 +117,7 @@ namespace NuGet.Build.Tasks.Console
                     forceEvaluate: IsOptionTrue(nameof(RestoreTaskEx.ForceEvaluate), options),
                     hideWarningsAndErrors: IsOptionTrue(nameof(RestoreTaskEx.HideWarningsAndErrors), options),
                     restorePC: IsOptionTrue(nameof(RestoreTaskEx.RestorePackagesConfig), options),
-                    cleanupAssetsForUnsupportedProjects: true,
+                    cleanupAssetsForUnsupportedProjects: IsOptionTrue(nameof(RestoreTaskEx.CleanupAssetsForUnsupportedProjects), options),
                     log: MSBuildLogger,
                     cancellationToken: CancellationToken.None);
             }

--- a/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs
@@ -117,6 +117,7 @@ namespace NuGet.Build.Tasks.Console
                     forceEvaluate: IsOptionTrue(nameof(RestoreTaskEx.ForceEvaluate), options),
                     hideWarningsAndErrors: IsOptionTrue(nameof(RestoreTaskEx.HideWarningsAndErrors), options),
                     restorePC: IsOptionTrue(nameof(RestoreTaskEx.RestorePackagesConfig), options),
+                    cleanupAssetsForUnsupportedProjects: true,
                     log: MSBuildLogger,
                     cancellationToken: CancellationToken.None);
             }

--- a/src/NuGet.Core/NuGet.Build.Tasks.Console/Program.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Console/Program.cs
@@ -63,8 +63,8 @@ namespace NuGet.Build.Tasks.Console
             MSBuildFeatureFlags.LoadAllFilesAsReadonly = true;
             MSBuildFeatureFlags.SkipEagerWildcardEvaluations = true;
 
-            // Only wire up an AssemblyResolve event handler if being debugged.
-            if (debug)
+            // Only wire up an AssemblyResolve event handler if being debugged or running under a unit test
+            if (debug || string.Equals(Environment.GetEnvironmentVariable("UNIT_TEST_RESTORE_TASK"), bool.TrueString, StringComparison.OrdinalIgnoreCase))
             {
                 // The App.config contains relative paths to MSBuild which won't work for locally built copies so an AssemblyResolve event
                 // handler is used in order to locate the MSBuild assemblies

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.RestoreEx.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.RestoreEx.targets
@@ -8,6 +8,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <Target Name="Restore">
     <RestoreTaskEx
+        CleanupAssetsForUnsupportedProjects="$([MSBuild]::ValueOrDefault('$(RestoreCleanupAssetsForUnsupportedProjects)', 'true'))"
         DisableParallel="$(RestoreDisableParallel)"
         Force="$(RestoreForce)"
         ForceEvaluate="$(RestoreForceEvaluate)"

--- a/src/NuGet.Core/NuGet.Build.Tasks/RestoreTaskEx.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/RestoreTaskEx.cs
@@ -27,6 +27,11 @@ namespace NuGet.Build.Tasks
         private static readonly Lazy<FileInfo> ThisAssemblyLazy = new Lazy<FileInfo>(() => new FileInfo(typeof(RestoreTaskEx).Assembly.Location));
 
         /// <summary>
+        /// Gets or sets a value indicating whether or not assets should be deleted for projects that don't support PackageReference.
+        /// </summary>
+        public bool CleanupAssetsForUnsupportedProjects { get; set; } = true;
+
+        /// <summary>
         /// Gets or sets a value indicating whether or not parallel restore should be enabled.
         /// Defaults to <code>false</code> if the current machine only has a single processor.
         /// </summary>
@@ -180,6 +185,7 @@ namespace NuGet.Build.Tasks
 
             var options = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase)
             {
+                [nameof(CleanupAssetsForUnsupportedProjects)] = CleanupAssetsForUnsupportedProjects,
                 [nameof(DisableParallel)] = DisableParallel,
                 [nameof(Force)] = Force,
                 [nameof(ForceEvaluate)] = ForceEvaluate,

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
@@ -363,23 +363,22 @@ namespace NuGet.Commands
             return result;
         }
 
-        public static string GetMSBuildFilePath(PackageSpec project, RestoreRequest request, string extension)
+        public static string GetMSBuildFilePath(PackageSpec project, string extension)
         {
-            string path;
-
-            if (request.ProjectStyle == ProjectStyle.PackageReference || request.ProjectStyle == ProjectStyle.DotnetToolReference) 
+            if (project.RestoreMetadata.ProjectStyle == ProjectStyle.PackageReference || project.RestoreMetadata.ProjectStyle == ProjectStyle.DotnetToolReference)
             {
                 // PackageReference style projects
-                var projFileName = Path.GetFileName(request.Project.RestoreMetadata.ProjectPath);
-                path = Path.Combine(request.RestoreOutputPath, $"{projFileName}.nuget.g{extension}");
+                return GetMSBuildFilePathForPackageReferenceStyleProject(project, extension);
             }
-            else
-            {
-                // Project.json style projects
-                var dir = Path.GetDirectoryName(project.FilePath);
-                path = Path.Combine(dir, $"{project.Name}.nuget{extension}");
-            }
-            return path;
+
+            // Project.json style projects
+            var dir = Path.GetDirectoryName(project.FilePath);
+            return Path.Combine(dir, $"{project.Name}.nuget{extension}");
+        }
+
+        public static string GetMSBuildFilePath(PackageSpec project, RestoreRequest request, string extension)
+        {
+            return GetMSBuildFilePath(project, extension);
         }
 
         public static string GetMSBuildFilePathForPackageReferenceStyleProject(PackageSpec project, string extension)

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
@@ -363,22 +363,23 @@ namespace NuGet.Commands
             return result;
         }
 
-        public static string GetMSBuildFilePath(PackageSpec project, string extension)
-        {
-            if (project.RestoreMetadata.ProjectStyle == ProjectStyle.PackageReference || project.RestoreMetadata.ProjectStyle == ProjectStyle.DotnetToolReference)
-            {
-                // PackageReference style projects
-                return GetMSBuildFilePathForPackageReferenceStyleProject(project, extension);
-            }
-
-            // Project.json style projects
-            var dir = Path.GetDirectoryName(project.FilePath);
-            return Path.Combine(dir, $"{project.Name}.nuget{extension}");
-        }
-
         public static string GetMSBuildFilePath(PackageSpec project, RestoreRequest request, string extension)
         {
-            return GetMSBuildFilePath(project, extension);
+            string path;
+
+            if (request.ProjectStyle == ProjectStyle.PackageReference || request.ProjectStyle == ProjectStyle.DotnetToolReference)
+            {
+                // PackageReference style projects
+                var projFileName = Path.GetFileName(request.Project.RestoreMetadata.ProjectPath);
+                path = Path.Combine(request.RestoreOutputPath, $"{projFileName}.nuget.g{extension}");
+            }
+            else
+            {
+                // Project.json style projects
+                var dir = Path.GetDirectoryName(project.FilePath);
+                path = Path.Combine(dir, $"{project.Name}.nuget{extension}");
+            }
+            return path;
         }
 
         public static string GetMSBuildFilePathForPackageReferenceStyleProject(PackageSpec project, string extension)
@@ -387,7 +388,6 @@ namespace NuGet.Commands
 
             return Path.Combine(project.RestoreMetadata.OutputPath, $"{projFileName}.nuget.g{extension}");
         }
-
 
         public static List<MSBuildOutputFile> GetMSBuildOutputFiles(PackageSpec project,
             LockFile assetsFile,

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
@@ -28,8 +28,8 @@ namespace NuGet.Commands
         internal static readonly string LanguageCondition = "'$(Language)' == '{0}'";
         internal static readonly string NegativeLanguageCondition = "'$(Language)' != '{0}'";
         internal static readonly string ExcludeAllCondition = "'$(ExcludeRestorePackageImports)' != 'true'";
-        private const string TargetsExtension = ".targets";
-        private const string PropsExtension = ".props";
+        public const string TargetsExtension = ".targets";
+        public const string PropsExtension = ".props";
 
         /// <summary>
         /// The macros that we may use in MSBuild to replace path roots.
@@ -371,15 +371,22 @@ namespace NuGet.Commands
             {
                 // PackageReference style projects
                 var projFileName = Path.GetFileName(request.Project.RestoreMetadata.ProjectPath);
-                path = Path.Combine(request.RestoreOutputPath, $"{projFileName}.nuget.g.{extension}");
+                path = Path.Combine(request.RestoreOutputPath, $"{projFileName}.nuget.g{extension}");
             }
             else
             {
                 // Project.json style projects
                 var dir = Path.GetDirectoryName(project.FilePath);
-                path = Path.Combine(dir, $"{project.Name}.nuget.{extension}");
+                path = Path.Combine(dir, $"{project.Name}.nuget{extension}");
             }
             return path;
+        }
+
+        public static string GetMSBuildFilePathForPackageReferenceStyleProject(PackageSpec project, string extension)
+        {
+            var projFileName = Path.GetFileName(project.RestoreMetadata.ProjectPath);
+
+            return Path.Combine(project.RestoreMetadata.OutputPath, $"{projFileName}.nuget.g{extension}");
         }
 
 
@@ -393,8 +400,8 @@ namespace NuGet.Commands
             ILogger log)
         {
             // Generate file names
-            var targetsPath = GetMSBuildFilePath(project, request, "targets");
-            var propsPath = GetMSBuildFilePath(project, request, "props");
+            var targetsPath = GetMSBuildFilePath(project, request, TargetsExtension);
+            var propsPath = GetMSBuildFilePath(project, request, PropsExtension);
 
             // Targets files contain a macro for the repository root. If only the user package folder was used
             // allow a replacement. If fallback folders were used the macro cannot be applied.

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/NoOpRestoreUtilities.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/NoOpRestoreUtilities.cs
@@ -129,13 +129,13 @@ namespace NuGet.Commands
 
             if (request.ProjectStyle == ProjectStyle.PackageReference || request.ProjectStyle == ProjectStyle.Standalone)
             {
-                var targetsFilePath = BuildAssetsUtils.GetMSBuildFilePath(request.Project, request, "targets");
+                var targetsFilePath = BuildAssetsUtils.GetMSBuildFilePath(request.Project, request, BuildAssetsUtils.TargetsExtension);
                 if (!File.Exists(targetsFilePath))
                 {
                     request.Log.LogVerbose(string.Format(CultureInfo.CurrentCulture, Strings.Log_TargetsFileNotOnDisk, request.Project.Name, targetsFilePath));
                     return false;
                 }
-                var propsFilePath = BuildAssetsUtils.GetMSBuildFilePath(request.Project, request, "props");
+                var propsFilePath = BuildAssetsUtils.GetMSBuildFilePath(request.Project, request, BuildAssetsUtils.PropsExtension);
                 if (!File.Exists(propsFilePath))
                 {
                     request.Log.LogVerbose(string.Format(CultureInfo.CurrentCulture, Strings.Log_PropsFileNotOnDisk, request.Project.Name, propsFilePath));

--- a/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/Msbuild.Integration.Test.csproj
+++ b/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/Msbuild.Integration.Test.csproj
@@ -1,4 +1,4 @@
-﻿<Project>
+<Project>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common.test.props" />
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
@@ -20,6 +20,7 @@
   
   <ItemGroup>
     <ProjectReference Include="$(NuGetCoreSrcDirectory)NuGet.Build.Tasks\NuGet.Build.Tasks.csproj" />
+    <ProjectReference Include="$(NuGetCoreSrcDirectory)NuGet.Build.Tasks.Console\NuGet.Build.Tasks.Console.csproj" />
     <ProjectReference Include="$(TestUtilitiesDirectory)Test.Utility\Test.Utility.csproj" />
   </ItemGroup>
 

--- a/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildIntegrationTestFixture.cs
+++ b/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildIntegrationTestFixture.cs
@@ -33,6 +33,7 @@ namespace Msbuild.Integration.Test
             var nugetRestoreTargetsPath = Path.Combine(_testDir, "NuGet.targets");
             // Uncomment to debug the msbuild call
             // _processEnvVars.Add("DEBUG_RESTORE_TASK", "true");
+            _processEnvVars["UNIT_TEST_RESTORE_TASK"] = bool.TrueString;
             var result = CommandRunner.Run(msBuildExe,
                 workingDirectory,
                 $"/p:NuGetRestoreTargets={nugetRestoreTargetsPath} /p:RestoreTaskAssemblyFile={restoreDllPath} /p:ImportNuGetBuildTasksPackTargetsFromSdk=\"true\" {args}",

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/RestoreTaskExTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/RestoreTaskExTests.cs
@@ -59,7 +59,7 @@ namespace NuGet.Build.Tasks.Test
 #if IS_CORECLR
                     Path.ChangeExtension(typeof(RestoreTaskEx).Assembly.Location, ".Console.dll"),
 #endif
-                    "DisableParallel=True;Force=True;ForceEvaluate=True;HideWarningsAndErrors=True;IgnoreFailedSources=True;Interactive=True;NoCache=True;Recursive=True;RestorePackagesConfig=True",
+                    "CleanupAssetsForUnsupportedProjects=True;DisableParallel=True;Force=True;ForceEvaluate=True;HideWarningsAndErrors=True;IgnoreFailedSources=True;Interactive=True;NoCache=True;Recursive=True;RestorePackagesConfig=True",
 #if IS_CORECLR
                     Path.Combine(msbuildBinPath, "MSBuild.dll"),
 #else


### PR DESCRIPTION
## Bug

Addresses https://github.com/nuget/home/issues/8124 in command-line based restores using static graph evaluation.  After this is piloted, we can have the logic run in more scenarios.
Regression: No
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: Deletes restore assets for projects that don't support restore (Unknown, PackagesConfig, etc)

## Testing/Validation

Tests Added: Yes/No
Reason for not adding tests:  
Validation:  
