### PR TITLE
Focusing on PMUI tabs will select with theme-appropriate color

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerTopPanel.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerTopPanel.xaml
@@ -38,6 +38,7 @@
             <Setter Property="FontSize" Value="{Binding FontSize, RelativeSource={RelativeSource AncestorType=UserControl},Converter={StaticResource Font122PercentSizeConverter}}"/>
             <Setter Property="Foreground" Value="{DynamicResource {x:Static nuget:Brushes.UIText}}" />
             <Setter Property="Padding" Value="20,0,20,0" />
+            <Setter Property="FocusVisualStyle" Value="{DynamicResource ControlsFocusVisualStyle}" />
             <Setter Property="Template">
               <Setter.Value>
                 <ControlTemplate TargetType="{x:Type TabItem}">


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9336
Regression: Yes
* Last working version:   Before a11y work on tabs in 16.5

## Fix

Details: 
When keyboard-focusing on a PMUI Tab, the focus outline color must be set explicitly to use a dynamic style. Otherwise, it's apparently always black.

Found that we were previously setting a [FocusVisualStyle on the old FilterLabel Control](https://github.com/NuGet/NuGet.Client/blob/release-5.4.x/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/FilterLabel.xaml#L28
), which I did not bring over into the new TabControl in recent work. 

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  Visual UI change
Validation:  
Tried all the available color-themes in VS to make sure this color dynamically changes.

(Note the white dotted line around the Updates tab)
![image](https://user-images.githubusercontent.com/49205731/77666606-87d5e000-6f57-11ea-98e2-ac50b0eb4aef.png)

//cc: @rrelyea 

