### PR TITLE
Fix msbuild version parsing on non-english cultures

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/MsBuildToolset.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/MsBuildToolset.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices.ComTypes;
@@ -134,7 +135,7 @@ namespace NuGet.CommandLine
         {
             var dirName = new DirectoryInfo(directoryName).Name;
             float dirValue;
-            if (float.TryParse(dirName, out dirValue))
+            if (float.TryParse(dirName, NumberStyles.Float, CultureInfo.InvariantCulture, out dirValue))
             {
                 return dirValue;
             }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/MSBuildUtilityTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/MSBuildUtilityTest.cs
@@ -232,10 +232,7 @@ namespace NuGet.CommandLine.Test
 
                 // Create dummy msbuild.exe files
                 var msBuild15ExePath = Path.Combine(msBuild15BinPath, "msbuild.exe").ToString();
-                using (var fs15 = File.CreateText(msBuild15ExePath))
-                {
-                    fs15.Write("foo 15");
-                }
+                File.WriteAllText(msBuild15ExePath, "foo 15");
 
                 var msBuild151ExePath = Path.Combine(msBuild151BinPath, "msbuild.exe").ToString();
                 using (var fs151 = File.CreateText(msBuild151ExePath))

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/MSBuildUtilityTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/MSBuildUtilityTest.cs
@@ -235,10 +235,7 @@ namespace NuGet.CommandLine.Test
                 File.WriteAllText(msBuild15ExePath, "foo 15");
 
                 var msBuild151ExePath = Path.Combine(msBuild151BinPath, "msbuild.exe").ToString();
-                using (var fs151 = File.CreateText(msBuild151ExePath))
-                {
-                    fs151.Write("foo 15.1");
-                }
+                File.WriteAllText(msBuild151ExePath, "foo 15.1");
 
                 // Act
                 var msBuildExePath = MsBuildToolset.GetMsBuildDirFromVsDir(vsPath);


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9322
Regression: No
* Last working version:   pre-4.0, if ever
* How are we preventing it in future:   added test coverage

## Fix

Details: use invariant culture when parsing version numbers as a float

## Testing/Validation

Tests Added: Yes
Validation:  
    built new test that failed before fix and works now.