### PR TITLE
Write to the Package Manager output in VS OE scenarios

### DIFF
--- a/src/NuGet.Clients/NuGet.Console/OutputConsole/OutputConsoleProvider.cs
+++ b/src/NuGet.Clients/NuGet.Console/OutputConsole/OutputConsoleProvider.cs
@@ -21,6 +21,7 @@ namespace NuGetConsole
     {
         private readonly IEnumerable<Lazy<IHostProvider, IHostMetadata>> _hostProviders;
         private readonly AsyncLazy<IConsole> _cachedOutputConsole;
+        private readonly AsyncLazy<bool> _isServerMode;
         private IAsyncServiceProvider _asyncServiceProvider;
 
         private readonly AsyncLazy<IVsOutputWindow> _vsOutputWindow;
@@ -49,7 +50,7 @@ namespace NuGetConsole
             _cachedOutputConsole = new AsyncLazy<IConsole>(
                 async () =>
                 {
-                    if (await IsInServerModeAsync(CancellationToken.None))
+                    if (await _isServerMode.GetValueAsync())
                     {
                         // This is disposable, but it lives for the duration of the process.
                         return new ChannelOutputConsole(
@@ -65,12 +66,23 @@ namespace NuGetConsole
                         return new OutputConsole(vsOutputWindow, vsUIShell);
                     }
                 }, NuGetUIThreadHelper.JoinableTaskFactory);
+
+            _isServerMode = new AsyncLazy<bool>(() => {
+                return IsInServerModeAsync(CancellationToken.None);
+            }, NuGetUIThreadHelper.JoinableTaskFactory);
         }
 
         public async Task<IOutputConsole> CreateBuildOutputConsoleAsync()
         {
-            var vsOutputWindow = await _vsOutputWindow.GetValueAsync();
-            return new BuildOutputConsole(vsOutputWindow);
+            if (await _isServerMode.GetValueAsync())
+            {
+                return await _cachedOutputConsole.GetValueAsync();
+            }
+            else
+            {
+                var vsOutputWindow = await _vsOutputWindow.GetValueAsync();
+                return new BuildOutputConsole(vsOutputWindow);
+            }
         }
 
         public async Task<IOutputConsole> CreatePackageManagerConsoleAsync()

--- a/src/NuGet.Clients/NuGet.Console/OutputConsole/OutputConsoleProvider.cs
+++ b/src/NuGet.Clients/NuGet.Console/OutputConsole/OutputConsoleProvider.cs
@@ -67,9 +67,11 @@ namespace NuGetConsole
                     }
                 }, NuGetUIThreadHelper.JoinableTaskFactory);
 
-            _isServerMode = new AsyncLazy<bool>(() => {
-                return IsInServerModeAsync(CancellationToken.None);
-            }, NuGetUIThreadHelper.JoinableTaskFactory);
+            _isServerMode = new AsyncLazy<bool>(
+                () =>
+                {
+                    return IsInServerModeAsync(CancellationToken.None);
+                }, NuGetUIThreadHelper.JoinableTaskFactory);
         }
 
         public async Task<IOutputConsole> CreateBuildOutputConsoleAsync()


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9362
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: In on-build restore scenarios, NuGet usually writes to the build output window.
In Online Environments we can't do that yet, so as a workaround until we have the ability to do it, we will write to the same output window as auto-restore and explicit restore.

Specifically this is a workaround until #9270 is unblocked.

cc @rrelyea This is what we discussed during our sync. 

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  Not test infra yet.
Validation:  
