### PR TITLE
Exec should return not supported instead of 1

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.OnlineEnvironment.Client/SolutionExplorer/NuGetWorkspaceCommandHandler.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.OnlineEnvironment.Client/SolutionExplorer/NuGetWorkspaceCommandHandler.cs
@@ -55,7 +55,7 @@ namespace NuGet.VisualStudio.OnlineEnvironment.Client
                             return VSConstants.S_OK;                    }
                 }
             }
-            return VSConstants.S_OK;
+            return (int) Microsoft.VisualStudio.OLE.Interop.Constants.OLECMDERR_E_NOTSUPPORTED;
         }
 
         public bool QueryStatus(List<WorkspaceVisualNodeBase> selection, Guid pguidCmdGroup, uint nCmdID, ref uint cmdf, ref string customTitle)

--- a/src/NuGet.Clients/NuGet.VisualStudio.OnlineEnvironment.Client/SolutionExplorer/NuGetWorkspaceCommandHandler.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.OnlineEnvironment.Client/SolutionExplorer/NuGetWorkspaceCommandHandler.cs
@@ -52,7 +52,8 @@ namespace NuGet.VisualStudio.OnlineEnvironment.Client
                     {
                         case PkgCmdIDList.CmdidRestorePackages:
                             _restoreCommandHandler.RunSolutionRestore();
-                            return VSConstants.S_OK;                    }
+                            return VSConstants.S_OK;                    
+                    }
                 }
             }
             return (int) Microsoft.VisualStudio.OLE.Interop.Constants.OLECMDERR_E_NOTSUPPORTED;

--- a/src/NuGet.Clients/NuGet.VisualStudio.OnlineEnvironment.Client/SolutionExplorer/NuGetWorkspaceCommandHandler.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.OnlineEnvironment.Client/SolutionExplorer/NuGetWorkspaceCommandHandler.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Threading;
@@ -52,7 +51,7 @@ namespace NuGet.VisualStudio.OnlineEnvironment.Client
                     {
                         case PkgCmdIDList.CmdidRestorePackages:
                             _restoreCommandHandler.RunSolutionRestore();
-                            return VSConstants.S_OK;                    
+                            return VSConstants.S_OK;
                     }
                 }
             }

--- a/src/NuGet.Clients/NuGet.VisualStudio.OnlineEnvironment.Client/SolutionExplorer/NuGetWorkspaceCommandHandler.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.OnlineEnvironment.Client/SolutionExplorer/NuGetWorkspaceCommandHandler.cs
@@ -4,6 +4,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+
+using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Threading;
 using Microsoft.VisualStudio.Workspace.VSIntegration.UI;
@@ -50,11 +52,10 @@ namespace NuGet.VisualStudio.OnlineEnvironment.Client
                     {
                         case PkgCmdIDList.CmdidRestorePackages:
                             _restoreCommandHandler.RunSolutionRestore();
-                            return 0;
-                    }
+                            return VSConstants.S_OK;                    }
                 }
             }
-            return 1;
+            return VSConstants.S_OK;
         }
 
         public bool QueryStatus(List<WorkspaceVisualNodeBase> selection, Guid pguidCmdGroup, uint nCmdID, ref uint cmdf, ref string customTitle)


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9381
Regression: Yes
* Last working version: The solution explorer is effectively broken   
* How are we preventing it in future: Gonna add test in the future

## Fix

Details: 
Specifically the bug is here:

https://github.com/NuGet/NuGet.Client/blob/9d97fbb3e401ba99fb67f2165d8045ca850a1524/src/NuGet.Clients/NuGet.VisualStudio.OnlineEnvironment.Client/SolutionExplorer/NuGetWorkspaceCommandHandler.cs#L57

We should return Microsoft.VisualStudio.OLE.Interop.Constants.OLECMDERR_E_NOTSUPPORTED

Follow up issue to understand why this happened: https://github.com/NuGet/Client.Engineering/issues/248

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  Need to quickly do the fix
Validation:  
