### PR TITLE
this enables configuring runtime dependencies

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreProjectReferencesTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreProjectReferencesTask.cs
@@ -59,11 +59,15 @@ namespace NuGet.Build.Tasks
             foreach (var project in ProjectReferences)
             {
                 var refOutput = BuildTasksUtility.GetPropertyIfExists(project, "ReferenceOutputAssembly");
+                var copyToOutputProperty = BuildTasksUtility.GetPropertyIfExists(project, "CopyToOutputDirectory");
+                bool copyToOutput = !string.Equals(copyToOutputProperty, "never", StringComparison.OrdinalIgnoreCase) 
+                                       || string.IsNullOrWhiteSpace(copyToOutputProperty);
 
                 // Match the same behavior as NuGet.targets
-                // ReferenceOutputAssembly == '' OR ReferenceOutputAssembly == 'true'
+                // ReferenceOutputAssembly == '' OR ReferenceOutputAssembly == 'true' OR CopyToOuputProperty is not set to 'Never'
                 if (string.IsNullOrEmpty(refOutput)
-                    || Boolean.TrueString.Equals(refOutput, StringComparison.OrdinalIgnoreCase))
+                    || Boolean.TrueString.Equals(refOutput, StringComparison.OrdinalIgnoreCase) 
+                    || copyToOutput)
                 {
                     // Get the absolute path
                     var referencePath = Path.GetFullPath(Path.Combine(parentDirectory, project.ItemSpec));


### PR DESCRIPTION
## Bug

Fixes: 9376  
Regression: No  
## Fix

Details: This will add a ProjectReference if the 'CopyToOutputDirectory' is not set to never or empty. So somebody made the effort to set it to set it to 'Always' or ' PreserveNewest'  

## Testing/Validation

Tests Added: --Yes--/No  
Reason for not adding tests:  Want to assert first that maintainers agree with the functionality
Validation:  
