### PR TITLE
Standard VS scenarios should not load NuGet.VisualStudio.Internal.Contracts assembly 

### DIFF
--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/BrokeredServicesUtility.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/BrokeredServicesUtility.cs
@@ -1,7 +1,10 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Threading.Tasks;
+
+using Microsoft.ServiceHub.Framework;
 using Microsoft.VisualStudio.Shell.ServiceBroker;
 
 namespace NuGet.SolutionRestoreManager
@@ -12,5 +15,13 @@ namespace NuGet.SolutionRestoreManager
         {
             return (mk, options, sb, ct) => new ValueTask<object>(new NuGetSolutionService());
         }
+
+        internal static string NuGetSolutionServiceName = "NuGetSolutionService";
+        internal static string NuGetSolutionServiceVersion = "1.0.0";
+
+        public static ServiceRpcDescriptor NuGetSolutionService = new ServiceJsonRpcDescriptor(
+            new ServiceMoniker(NuGetSolutionServiceName, new Version(NuGetSolutionServiceVersion)),
+            ServiceJsonRpcDescriptor.Formatters.UTF8,
+            ServiceJsonRpcDescriptor.MessageDelimiters.HttpLikeHeaders);
     }
 }

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/BrokeredServicesUtility.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/BrokeredServicesUtility.cs
@@ -11,8 +11,8 @@ namespace NuGet.SolutionRestoreManager
     internal static class BrokeredServicesUtility
     {
         // It is very important that these names and versions are kept the same as the ones in NuGet.VisualStudio.Internal.Contracts.NuGetServices.
-        internal static const string NuGetSolutionServiceName = "NuGetSolutionService";
-        internal static string NuGetSolutionServiceVersion = "1.0.0";
+        internal const string NuGetSolutionServiceName = "NuGetSolutionService";
+        internal const string NuGetSolutionServiceVersion = "1.0.0";
 
         internal static ServiceRpcDescriptor NuGetSolutionService = new ServiceJsonRpcDescriptor(
             new ServiceMoniker(NuGetSolutionServiceName, new Version(NuGetSolutionServiceVersion)),

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/BrokeredServicesUtility.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/BrokeredServicesUtility.cs
@@ -11,17 +11,18 @@ namespace NuGet.SolutionRestoreManager
 {
     internal static class BrokeredServicesUtility
     {
+        // It is very important that these names and versions are kept the same as the ones in NuGet.VisualStudio.Internal.Contracts.NuGetServices.
+        internal static string NuGetSolutionServiceName = "NuGetSolutionService";
+        internal static string NuGetSolutionServiceVersion = "1.0.0";
+
+        internal static ServiceRpcDescriptor NuGetSolutionService = new ServiceJsonRpcDescriptor(
+            new ServiceMoniker(NuGetSolutionServiceName, new Version(NuGetSolutionServiceVersion)),
+            ServiceJsonRpcDescriptor.Formatters.UTF8,
+            ServiceJsonRpcDescriptor.MessageDelimiters.HttpLikeHeaders);
+
         internal static BrokeredServiceFactory GetNuGetSolutionServicesFactory()
         {
             return (mk, options, sb, ct) => new ValueTask<object>(new NuGetSolutionService());
         }
-
-        internal static string NuGetSolutionServiceName = "NuGetSolutionService";
-        internal static string NuGetSolutionServiceVersion = "1.0.0";
-
-        public static ServiceRpcDescriptor NuGetSolutionService = new ServiceJsonRpcDescriptor(
-            new ServiceMoniker(NuGetSolutionServiceName, new Version(NuGetSolutionServiceVersion)),
-            ServiceJsonRpcDescriptor.Formatters.UTF8,
-            ServiceJsonRpcDescriptor.MessageDelimiters.HttpLikeHeaders);
     }
 }

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/BrokeredServicesUtility.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/BrokeredServicesUtility.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Threading.Tasks;
-
 using Microsoft.ServiceHub.Framework;
 using Microsoft.VisualStudio.Shell.ServiceBroker;
 
@@ -12,7 +11,7 @@ namespace NuGet.SolutionRestoreManager
     internal static class BrokeredServicesUtility
     {
         // It is very important that these names and versions are kept the same as the ones in NuGet.VisualStudio.Internal.Contracts.NuGetServices.
-        internal static string NuGetSolutionServiceName = "NuGetSolutionService";
+        internal static const string NuGetSolutionServiceName = "NuGetSolutionService";
         internal static string NuGetSolutionServiceVersion = "1.0.0";
 
         internal static ServiceRpcDescriptor NuGetSolutionService = new ServiceJsonRpcDescriptor(

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/BrokeredServicesUtility.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/BrokeredServicesUtility.cs
@@ -14,7 +14,7 @@ namespace NuGet.SolutionRestoreManager
         internal const string NuGetSolutionServiceName = "NuGetSolutionService";
         internal const string NuGetSolutionServiceVersion = "1.0.0";
 
-        internal static ServiceRpcDescriptor NuGetSolutionService = new ServiceJsonRpcDescriptor(
+        internal static readonly ServiceRpcDescriptor NuGetSolutionService = new ServiceJsonRpcDescriptor(
             new ServiceMoniker(NuGetSolutionServiceName, new Version(NuGetSolutionServiceVersion)),
             ServiceJsonRpcDescriptor.Formatters.UTF8,
             ServiceJsonRpcDescriptor.MessageDelimiters.HttpLikeHeaders);

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/RestoreManagerPackage.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/RestoreManagerPackage.cs
@@ -46,9 +46,9 @@ namespace NuGet.SolutionRestoreManager
 
             await SolutionRestoreCommand.InitializeAsync(this);
 
-            // Set up brokered services
+            // Set up brokered services - Do not reference NuGet.VisualStudio.Internals.Contract explicitly to avoid an unnecessary assembly load
             IBrokeredServiceContainer brokeredServiceContainer = await this.GetServiceAsync<SVsBrokeredServiceContainer, IBrokeredServiceContainer>();
-            brokeredServiceContainer.Proffer(NuGetServices.NuGetSolutionService, factory: BrokeredServicesUtility.GetNuGetSolutionServicesFactory());
+            brokeredServiceContainer.Proffer(BrokeredServicesUtility.NuGetSolutionService, factory: BrokeredServicesUtility.GetNuGetSolutionServicesFactory());
 
             await base.InitializeAsync(cancellationToken, progress);
         }

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/RestoreManagerPackage.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/RestoreManagerPackage.cs
@@ -27,7 +27,7 @@ namespace NuGet.SolutionRestoreManager
     [ProvideAutoLoad(VSConstants.UICONTEXT.SolutionExists_string, PackageAutoLoadFlags.BackgroundLoad)]	    
     // Ensure that this package is loaded in time to listen to solution build events, in order to always be able to restore before build.
     [ProvideAutoLoad(VSConstants.UICONTEXT.SolutionBuilding_string)]
-    [ProvideBrokeredService("NuGetSolutionService", "1.0.0", Audience = ServiceAudience.RemoteExclusiveClient)]
+    [ProvideBrokeredService(BrokeredServicesUtility.NuGetSolutionServiceName, BrokeredServicesUtility.NuGetSolutionServiceVersion, Audience = ServiceAudience.RemoteExclusiveClient)]
     [Guid(PackageGuidString)]
     public sealed class RestoreManagerPackage : AsyncPackage
     {

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/NuGetServices.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/NuGetServices.cs
@@ -8,14 +8,14 @@ namespace NuGet.VisualStudio.Internal.Contracts
 {
     public static class NuGetServices
     {
-        public static string NuGetSolutionServiceName = "NuGetSolutionService";
-        public static string NuGetSolutionServiceVersion = "1.0.0";
+        internal static string NuGetSolutionServiceName = "NuGetSolutionService";
+        internal static string NuGetSolutionServiceVersion = "1.0.0";
         /// <summary>
         /// A service descriptor for the NuGetSolutionService service. 
         /// </summary>
         public static ServiceRpcDescriptor NuGetSolutionService = new ServiceJsonRpcDescriptor(
-          new ServiceMoniker(NuGetSolutionServiceName, new Version(NuGetSolutionServiceVersion)),
-          ServiceJsonRpcDescriptor.Formatters.UTF8,
-          ServiceJsonRpcDescriptor.MessageDelimiters.HttpLikeHeaders);
+            new ServiceMoniker(NuGetSolutionServiceName, new Version(NuGetSolutionServiceVersion)),
+            ServiceJsonRpcDescriptor.Formatters.UTF8,
+            ServiceJsonRpcDescriptor.MessageDelimiters.HttpLikeHeaders);
     }
 }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/NuGetServices.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/NuGetServices.cs
@@ -8,8 +8,8 @@ namespace NuGet.VisualStudio.Internal.Contracts
 {
     public static class NuGetServices
     {
-        internal static string NuGetSolutionServiceName = "NuGetSolutionService";
-        internal static string NuGetSolutionServiceVersion = "1.0.0";
+        private const string NuGetSolutionServiceName = "NuGetSolutionService";
+        private const string NuGetSolutionServiceVersion = "1.0.0";
         /// <summary>
         /// A service descriptor for the NuGetSolutionService service. 
         /// </summary>


### PR DESCRIPTION
## Bug

Fixes: https://github.com/nuget/client.engineering/issues/253
Regression: Yes  
* Last working version: https://github.com/NuGet/NuGet.Client/commit/69276891c4a2e391b3711c6b7d5276886a5d857b
* How are we preventing it in future:  This was caught by a test, so the correct medium

## Fix

Details: 
The RestoreManagerPackage is loaded on solution load/solution build and when it registers the by calling `InitializeAsync` https://github.com/NuGet/NuGet.Client/blob/dev/src/NuGet.Clients/NuGet.SolutionRestoreManager/RestoreManagerPackage.cs#L41

This leads to loading the contracts assembly because of referring to NuGetServices.NuGetSolutionService which triggers the load. 

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  We don't have any tests that will capture this. 
Validation:  Manual, inspected that the assembly is not loaded. 
