### PR TITLE
Draft: A different approach to invalidate lock file for cpvm enabled projects

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -18,6 +18,7 @@ using NuGet.Packaging.Core;
 using NuGet.ProjectModel;
 using NuGet.Repositories;
 using NuGet.RuntimeModel;
+using NuGet.Shared;
 using NuGet.Versioning;
 
 namespace NuGet.Commands
@@ -1152,6 +1153,22 @@ namespace NuGet.Commands
             foreach (var provider in request.DependencyProviders.RemoteProviders)
             {
                 context.RemoteLibraryProviders.Add(provider);
+            }
+
+            foreach (TargetFrameworkInformation tfi in request.Project.TargetFrameworks)
+            {
+                List<string> projectDependencies = tfi.Dependencies.Select(d => d.Name).ToList();
+                var centralPackageVersionsThatAreNotDirectDependencies = new Dictionary<string, CentralPackageVersion>(StringComparer.OrdinalIgnoreCase);
+
+                tfi.CentralPackageVersions.ForEach(kvp =>
+                {
+                    if (!projectDependencies.Contains(kvp.Key))
+                    {
+                        centralPackageVersionsThatAreNotDirectDependencies.Add(kvp.Key, kvp.Value);
+                    }
+                });
+
+                context.CentralPackageVersions.Add(tfi.FrameworkName, centralPackageVersionsThatAreNotDirectDependencies);
             }
 
             return context;

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/Remote/RemoteWalkContext.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/Remote/RemoteWalkContext.cs
@@ -26,6 +26,8 @@ namespace NuGet.DependencyResolver
             FindLibraryEntryCache = new ConcurrentDictionary<LibraryRangeCacheKey, Task<GraphItem<RemoteResolveResult>>>();
 
             LockFileLibraries = new Dictionary<LockFileCacheKey, IList<LibraryIdentity>>();
+
+            CentralPackageVersions = new Dictionary<NuGetFramework, Dictionary<string, CentralPackageVersion>>();
         }
 
         public SourceCacheContext CacheContext { get; }
@@ -39,6 +41,8 @@ namespace NuGet.DependencyResolver
         /// Packages lock file libraries to be used while generating restore graph.
         /// </summary>
         public IDictionary<LockFileCacheKey, IList<LibraryIdentity>> LockFileLibraries { get; }
+
+        public Dictionary<NuGetFramework, Dictionary<string, CentralPackageVersion>> CentralPackageVersions { get; }
 
         /// <summary>
         /// Library entry cache.


### PR DESCRIPTION
## Feature
A different approach to invalidate lock file for cpvm enabled projects  

## Fix

Move the lock file evaluation post restore. 

## Testing/Validation
Draft PR 

Tests Added: Yes/No  
Reason for not adding tests:  
Validation:  
