### PR TITLE
Fix the assembly metadata extractor to use the filename instead of the full name

### DIFF
--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -863,9 +863,9 @@ jobs:
       downloadPath: "$(Build.Repository.LocalPath)/artifacts"
 
   - task: NuGetToolInstaller@0
-    displayName: "Use NuGet 4.5.0"
+    displayName: "Use NuGet 5.5.0"
     inputs:
-      versionSpec: "4.5.0"
+      versionSpec: "5.5.0"
 
   - task: MSBuild@1
     displayName: "Bootstrap NuGet packages"

--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -862,11 +862,6 @@ jobs:
       artifactName: "$(VsixPublishDir)"
       downloadPath: "$(Build.Repository.LocalPath)/artifacts"
 
-  - task: NuGetToolInstaller@0
-    displayName: "Use NuGet 5.5.0"
-    inputs:
-      versionSpec: "5.5.0"
-
   - task: MSBuild@1
     displayName: "Bootstrap NuGet packages"
     inputs:

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/Pack/AssemblyMetadataExtractor.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/Pack/AssemblyMetadataExtractor.cs
@@ -15,7 +15,7 @@ namespace NuGet.CommandLine
     {
         private static T CreateInstance<T>(this AppDomain domain)
         {
-            return (T)domain.CreateInstanceAndUnwrap(typeof(T).Assembly.FullName, typeof(T).FullName);
+            return (T)domain.CreateInstanceFromAndUnwrap(Assembly.GetExecutingAssembly().Location, typeof(T).FullName);
         }
 
         public static AssemblyMetadata GetMetadata(string assemblyPath)


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/4234
Regression: yes
* Last working version:   3.4.x
* How are we preventing it in future: Test

## Fix

Details: 
Use CreateInstanceFromAndUnwrap instead of CreateInstanceAndUnwrap to allow the assembly resolution to work when the exe is renamed. 

## Testing/Validation

Tests Added: Yes
Reason for not adding tests:  
Validation:  Manual, tests
