### PR TITLE
PluginFactory should default to `dotnet` in the path to start a plugin if DOTNET_HOST_PATH is not set

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginFactory.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginFactory.cs
@@ -11,6 +11,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
+
 namespace NuGet.Protocol.Plugins
 {
     /// <summary>
@@ -166,7 +167,7 @@ namespace NuGet.Protocol.Plugins
             var startInfo = new ProcessStartInfo
             {
                 FileName = Environment.GetEnvironmentVariable("DOTNET_HOST_PATH") ??
-                           (RuntimeEnvironmentHelper.IsWindows ?
+                           (NuGet.Common.RuntimeEnvironmentHelper.IsWindows ?
                                 "dotnet.exe" :
                                 "dotnet"),
                 Arguments = $"\"{filePath}\" " + args,

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginFactory.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginFactory.cs
@@ -165,7 +165,8 @@ namespace NuGet.Protocol.Plugins
 #else
             var startInfo = new ProcessStartInfo
             {
-                FileName = Environment.GetEnvironmentVariable("DOTNET_HOST_PATH"),
+                FileName = Environment.GetEnvironmentVariable("DOTNET_HOST_PATH")
+                            ?? (RuntimeEnvironmentHelper.IsWindows ? "dotnet.exe" : "dotnet"),
                 Arguments = $"\"{filePath}\" " + args,
                 UseShellExecute = false,
                 RedirectStandardError = false,

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginFactory.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginFactory.cs
@@ -165,8 +165,10 @@ namespace NuGet.Protocol.Plugins
 #else
             var startInfo = new ProcessStartInfo
             {
-                FileName = Environment.GetEnvironmentVariable("DOTNET_HOST_PATH")
-                            ?? (RuntimeEnvironmentHelper.IsWindows ? "dotnet.exe" : "dotnet"),
+                FileName = Environment.GetEnvironmentVariable("DOTNET_HOST_PATH") ??
+                           (RuntimeEnvironmentHelper.IsWindows ?
+                                "dotnet.exe" :
+                                "dotnet"),
                 Arguments = $"\"{filePath}\" " + args,
                 UseShellExecute = false,
                 RedirectStandardError = false,


### PR DESCRIPTION
### Bug
Fixes: NuGet/Home#7438
Regression: No

Last working version:
How are we preventing it in future:

### Fix
Simple fallback on "dotnet.exe" or "dotnet" when DOTNET_HOST_PATH environment variable is not defined.

Testing/Validation
Tests Added: No
Reason for not adding tests: Relying on the existing tests.