### PR TITLE
Increase timeout on DDNuGet-Windows pools

### DIFF
--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -738,7 +738,7 @@ jobs:
   dependsOn:
   - Build_and_UnitTest
   - Initialize_Build
-  timeoutInMinutes: 90
+  timeoutInMinutes: 150
   variables:
     FullVstsBuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
   condition: "and(succeeded(),eq(variables['RunEndToEndTests'], 'true')) "
@@ -834,7 +834,7 @@ jobs:
   dependsOn:
   - Build_and_UnitTest
   - Initialize_Build
-  timeoutInMinutes: 60
+  timeoutInMinutes: 120
   variables:
     BuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.BuildNumber']]
     FullVstsBuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Client.Engineering/issues/259
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: Increase timeout on DDNuGet-Windows agent pools, as the agents were scaled down to have less CPU and therefore tests are running slower than previously.

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  CI build script
Validation:  
