### PR TITLE
Pack should use AssemblyVersion when it can't use AssemblyInformationVersion

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/Pack/AssemblyMetadata.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/Pack/AssemblyMetadata.cs
@@ -1,4 +1,6 @@
-﻿using NuGet.Versioning;
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 
@@ -16,6 +18,7 @@ namespace NuGet.CommandLine
 
         public string Name { get; set; }
         public string Version { get; set; }
+        public string InformationalVersion { get; set; }
         public string Title { get; set; }
         public string Description { get; set; }
         public string Company { get; set; }

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/Pack/AssemblyMetadataExtractor.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/Pack/AssemblyMetadataExtractor.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
@@ -5,20 +8,24 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using NuGet.Common;
+using NuGet.Packaging;
+using NuGet.Versioning;
 
 namespace NuGet.CommandLine
 {
-    using Packaging;
-    using Versioning;
-
-    public static class AssemblyMetadataExtractor
+    internal sealed class AssemblyMetadataExtractor
     {
-        private static T CreateInstance<T>(this AppDomain domain)
+        private readonly ILogger _logger;
+
+        public AssemblyMetadataExtractor(ILogger logger) => _logger = logger ?? NullLogger.Instance;
+
+        private static T CreateInstance<T>(AppDomain domain)
         {
             return (T)domain.CreateInstanceFromAndUnwrap(Assembly.GetExecutingAssembly().Location, typeof(T).FullName);
         }
 
-        public static AssemblyMetadata GetMetadata(string assemblyPath)
+        public AssemblyMetadata GetMetadata(string assemblyPath)
         {
             var setup = new AppDomainSetup
             {
@@ -28,8 +35,8 @@ namespace NuGet.CommandLine
             AppDomain domain = AppDomain.CreateDomain("metadata", AppDomain.CurrentDomain.Evidence, setup);
             try
             {
-                var extractor = domain.CreateInstance<MetadataExtractor>();
-                return extractor.GetMetadata(assemblyPath);
+                var extractor = CreateInstance<MetadataExtractor>(domain);
+                return extractor.GetAssemblyMetadata(assemblyPath);
             }
             finally
             {
@@ -37,13 +44,26 @@ namespace NuGet.CommandLine
             }
         }
 
-        public static void ExtractMetadata(PackageBuilder builder, string assemblyPath)
+        public void ExtractMetadata(PackageBuilder builder, string assemblyPath)
         {
             AssemblyMetadata assemblyMetadata = GetMetadata(assemblyPath);
-            builder.Version = NuGetVersion.Parse(assemblyMetadata.Version);
             builder.Title = assemblyMetadata.Title;
             builder.Description = assemblyMetadata.Description;
             builder.Copyright = assemblyMetadata.Copyright;
+
+            // using InformationalVersion if possible, fallback to Version otherwise
+            if (NuGetVersion.TryParse(assemblyMetadata.InformationalVersion, out var informationalVersion))
+            {
+                builder.Version = informationalVersion;
+            }
+            else
+            {
+                _logger.LogInformation(string.Format(
+                    CultureInfo.CurrentCulture, NuGetResources.InvalidAssemblyInformationalVersion,
+                    assemblyMetadata.InformationalVersion, assemblyPath, assemblyMetadata.Version));
+
+                builder.Version = NuGetVersion.Parse(assemblyMetadata.Version);
+            }
 
             if (!builder.Authors.Any())
             {
@@ -51,7 +71,7 @@ namespace NuGet.CommandLine
                 {
                     builder.Authors.AddRange(assemblyMetadata.Properties["authors"].Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries));
                 }
-                else if (!String.IsNullOrEmpty(assemblyMetadata.Company))
+                else if (!string.IsNullOrEmpty(assemblyMetadata.Company))
                 {
                     builder.Authors.Add(assemblyMetadata.Company);
                 }
@@ -79,7 +99,6 @@ namespace NuGet.CommandLine
         [SuppressMessage("Microsoft.Performance", "CA1812:AvoidUninstantiatedInternalClasses", Justification = "It's constructed using CreateInstanceAndUnwrap in another app domain")]
         private sealed class MetadataExtractor : MarshalByRefObject
         {
-
             private class AssemblyResolver
             {
                 private readonly string _lookupPath;
@@ -93,14 +112,14 @@ namespace NuGet.CommandLine
                 {
                     var name = new AssemblyName(AppDomain.CurrentDomain.ApplyPolicy(args.Name));
                     var assemblyPath = Path.Combine(_lookupPath, name.Name + ".dll");
-                    return File.Exists(assemblyPath) ? 
+                    return File.Exists(assemblyPath) ?
                         Assembly.ReflectionOnlyLoadFrom(assemblyPath) : // load from same folder as parent assembly
                         Assembly.ReflectionOnlyLoad(name.FullName);     // load from GAC
                 }
             }
 
             [SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic", Justification = "It's a marshal by ref object used to collection information in another app domain")]
-            public AssemblyMetadata GetMetadata(string path)
+            public AssemblyMetadata GetAssemblyMetadata(string path)
             {
                 var resolver = new AssemblyResolver(path);
                 AppDomain.CurrentDomain.ReflectionOnlyAssemblyResolve += resolver.ReflectionOnlyAssemblyResolve;
@@ -112,24 +131,18 @@ namespace NuGet.CommandLine
 
                     var attributes = CustomAttributeData.GetCustomAttributes(assembly);
 
-                    NuGetVersion version;
-                    string assemblyInformationalVersion = GetAttributeValueOrDefault<AssemblyInformationalVersionAttribute>(attributes);
-                    if (!NuGetVersion.TryParse(assemblyInformationalVersion, out version))
-                    {
-                        if (string.IsNullOrEmpty(assemblyInformationalVersion))
-                        {
-                            version = NuGetVersion.Parse(assemblyName.Version.ToString());
-                        }
-                        else
-                        {
-                            throw new InvalidDataException(String.Format(CultureInfo.CurrentCulture, NuGetResources.Error_AssemblyInformationalVersion, assemblyInformationalVersion, path));
-                        }
-                    }
+                    // We should not try to parse the version and eventually throw here: this leads to incorrect errors when, later on, ProjectFactory is trying to retrieve Authors and Description
+                    // Best to parse the version into a NuGetVersion later.
+                    // We should also not decide here whether to use informationalVersion or assembly version. Let's let consumers decide.
+                    var version = assemblyName.Version.ToString();
+                    var informationalVersion = GetAttributeValueOrDefault<AssemblyInformationalVersionAttribute>(attributes);
+                    informationalVersion = string.IsNullOrEmpty(informationalVersion) ? version : informationalVersion;
 
                     return new AssemblyMetadata(GetProperties(attributes))
                     {
                         Name = assemblyName.Name,
-                        Version = version.ToFullString(),
+                        Version = version,
+                        InformationalVersion = informationalVersion,
                         Title = GetAttributeValueOrDefault<AssemblyTitleAttribute>(attributes),
                         Company = GetAttributeValueOrDefault<AssemblyCompanyAttribute>(attributes),
                         Description = GetAttributeValueOrDefault<AssemblyDescriptionAttribute>(attributes),
@@ -160,7 +173,7 @@ namespace NuGet.CommandLine
                     string key = attribute.ConstructorArguments[0].Value.ToString();
                     string value = attribute.ConstructorArguments[1].Value.ToString();
                     // Return the value only if it isn't null or empty so that we can use ?? to fall back
-                    if (!String.IsNullOrEmpty(key) && !String.IsNullOrEmpty(value))
+                    if (!string.IsNullOrEmpty(key) && !string.IsNullOrEmpty(value))
                     {
                         properties[key] = value;
                     }
@@ -177,7 +190,7 @@ namespace NuGet.CommandLine
                     {
                         string value = attribute.ConstructorArguments[0].Value.ToString();
                         // Return the value only if it isn't null or empty so that we can use ?? to fall back
-                        if (!String.IsNullOrEmpty(value))
+                        if (!string.IsNullOrEmpty(value))
                         {
                             return value;
                         }

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/ProjectFactory.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/ProjectFactory.cs
@@ -773,7 +773,7 @@ namespace NuGet.CommandLine
                 // path or the gac. In this case, we should just skip it and extract metadata from the project.
                 try
                 {
-                    AssemblyMetadataExtractor.ExtractMetadata(builder, TargetPath);
+                    new AssemblyMetadataExtractor(Logger).ExtractMetadata(builder, TargetPath);
                 }
                 catch (Exception ex)
                 {

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.Designer.cs
@@ -2365,15 +2365,6 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Invalid AssemblyInformationalVersion {0} on assembly {1}..
-        /// </summary>
-        public static string Error_AssemblyInformationalVersion {
-            get {
-                return ResourceManager.GetString("Error_AssemblyInformationalVersion", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Cannot find the specified version of msbuild: &apos;{0}&apos;.
         /// </summary>
         public static string Error_CannotFindMsbuild {
@@ -5034,6 +5025,15 @@ namespace NuGet.CommandLine {
         public static string InvalidArguments_trk {
             get {
                 return ResourceManager.GetString("InvalidArguments_trk", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Invalid AssemblyInformationalVersion &apos;{0}&apos; on assembly &apos;{1}&apos;; falling back to AssemblyVersion &apos;{2}&apos;..
+        /// </summary>
+        public static string InvalidAssemblyInformationalVersion {
+            get {
+                return ResourceManager.GetString("InvalidAssemblyInformationalVersion", resourceCulture);
             }
         }
         

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
@@ -5333,8 +5333,8 @@ Oluşturma sırasında NuGet'in paketleri indirmesini önlemek için, Visual Stu
   <data name="PushCommandTimeoutError" xml:space="preserve">
     <value>Pushing took too long. You can change the default timeout of 300 seconds by using the -Timeout &lt;seconds&gt; option with the push command.</value>
   </data>
-  <data name="Error_AssemblyInformationalVersion" xml:space="preserve">
-    <value>Invalid AssemblyInformationalVersion {0} on assembly {1}.</value>
+  <data name="InvalidAssemblyInformationalVersion" xml:space="preserve">
+    <value>Invalid AssemblyInformationalVersion '{0}' on assembly '{1}'; falling back to AssemblyVersion '{2}'.</value>
   </data>
   <data name="Credentials_ForbiddenCredentials" xml:space="preserve">
     <value>The remote server indicated that the previous request was forbidden. Please provide credentials for: {0}</value>


### PR DESCRIPTION
…Assembly Version when Informational Version cannot be parsed to a semver version.

## Bug

Fixes: https://github.com/NuGet/Home/issues/5548
Regression: No

## Fix

This PR started with the assumption that error messages were mixed up (a non-semver AssemblyInformationalVersionAttribute value would have nuget pack emit "Authors is required." and "Description is required." messages). It appears the problem was somewhat deeper.

The root problem takes place here: 

https://github.com/NuGet/NuGet.Client/blob/3803820961f4d61c06d07b179dab1d0439ec0d91/src/NuGet.Clients/NuGet.CommandLine/Commands/Pack/AssemblyMetadataExtractor.cs#L117-L126

If `AssemblyInformationalVersion` is invalid, an exception is thrown (and caught only quite up in the call stack). Hence, several properties that should be set in the `AssemblyMetadata` object returned by `GetMetadata` are not. 

The exception is handled in [`ProjectFactory.CreateBuilder`](https://github.com/NuGet/NuGet.Client/blob/9dd12283e7b69c5428a7db25c04511247283fe50/src/NuGet.Clients/NuGet.CommandLine/Commands/ProjectFactory.cs#L217) by considering nothing could be extracted from the assembly metadata and the version to apply is set to `1.0.0` (the version defaults to this somewhere in the call path between `ProjectFactory.CreateBuilder` and `AssemblyMetadataExtractor.GetMetadata`.

This explains why we end up with the weird (and obviously wrong) "Authors is required.\nDescription is required." message.

----

What I did is to fallback to using the assembly's version when the informational version cannot be parsed into a semver version. This is consistent with the existing logic that already fell back to the assembly's version when no informational version could be found.

Doing this fixes:

* The wrong messages: they don't appear because we do not throw and hence the other attributes of the assembly (Company, Description) are correctly passed up.
* Another related mis-behavior: when not using a nuspec, but directly packing from a csproj (with an invalid informational version), there was no error, but version `1.0.0` was assigned to the resulting package. With the fix, the package version is set to the assembly version if the informational version is not usable.

## Testing/Validation

Tests Added: Yes
Reason for not adding tests:  
Validation:  I also exercised my version of nuget.exe against the test project described here: https://github.com/NuGet/Home/issues/5548#issuecomment-611943024

