### PR TITLE
Enable test ExecuteCommandAsync_WithMultiplePackagesAndInvalidCertificate_RaisesErrorsOnceAsync

### DIFF
--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -669,7 +669,7 @@ jobs:
 
 - job: Tests_On_Linux
   dependsOn: Initialize_Build
-  timeoutInMinutes: 15
+  timeoutInMinutes: 45
   variables:
     FULLVSTSBUILDNUMBER: $[dependencies.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
     SDKVersionForBuild: $[dependencies.Initialize_Build.outputs['getSDKVersionForBuild.SDKVersionForBuild']]

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/SignCommandRunnerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/SignCommandRunnerTests.cs
@@ -121,8 +121,8 @@ namespace NuGet.Commands.Test
             }
         }
 
-        //skip this test as the signing APIs are not yet implemented. We should enable this test when signing APIs are implemented. Tracking issue:https://github.com/NuGet/Home/issues/8807
-#if IS_DESKTOP
+        //skip this test when signing is not supported, as the signing APIs are not implemented.
+#if IS_SIGNING_SUPPORTED
         [Fact]
         public async Task ExecuteCommandAsync_WithMultiplePackagesAndInvalidCertificate_RaisesErrorsOnceAsync()
         {


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/8807
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: 
1.Enable test ExecuteCommandAsync_WithMultiplePackagesAndInvalidCertificate_RaisesErrorsOnceAsync when the signing API is enabled.
2.Extend the time limit on Linux tests. As xplat verification feature branch enabled many tests on Linux. The 15 mins is not enough for all the tests(according to the tests, it's usually takes 30+ mins to run all the tests on Linux).


## Testing/Validation

Tests Added: No  
Reason for not adding tests:  enable a test
Validation:  Yes
