### PR TITLE
Return the NuGet menu to Packages node via a new commandset

### DIFF
--- a/src/NuGet.Clients/NuGet.Tools/NuGetTools.vsct
+++ b/src/NuGet.Clients/NuGet.Tools/NuGetTools.vsct
@@ -33,6 +33,9 @@
       <Group guid="guidToolsGroup" id="idToolsGroup" priority="0x100">
         <Parent guid="guidToolsGroup" id="idLibraryPackageManager" />
       </Group>
+      <Group guid="guidPackageManagementCmdSet" id="idPackageManagementGroup" priority="0x0100">
+        <Parent guid="guidSHLMainMenu" id="IDM_VS_CTXT_PACKAGEREFERENCE_GROUP"/>
+      </Group>
     </Groups>
 
     <Buttons>
@@ -203,6 +206,9 @@
     <CommandPlacement guid="guidDialogCmdSet" id="cmdidAddPackages" priority="0xF100">
       <Parent guid="guidVenusCmdId" id="IDG_CTX_REFERENCE"/>
     </CommandPlacement>
+    <CommandPlacement guid="guidDialogCmdSet" id="cmdidAddPackages" priority="0xF100">
+      <Parent guid="guidPackageManagementCmdSet" id="idPackageManagementGroup" />
+    </CommandPlacement>
     <CommandPlacement guid="guidDialogCmdSet" id="cmdidUpgradePackagesConfig" priority="0xF101">
       <Parent guid="guidSHLMainMenu" id="IDG_VS_CTXT_ITEM_OPEN"/>
     </CommandPlacement>
@@ -245,7 +251,7 @@
     <GuidSymbol name="guidToolsGroup" value="{C0D88179-5D25-4982-BFE6-EC5FD59AC103}">
       <IDSymbol name="idLibraryPackageManager" value="0x100" />
       <IDSymbol name="idToolsGroup" value="0x200" />
-      <IDSymobl name="idGeneralSettings" value="0x300" />
+      <IDSymbol name="idGeneralSettings" value="0x300" />
     </GuidSymbol>
     <GuidSymbol name="guidDialogCmdSet" value="{25fd982b-8cae-4cbd-a440-e03ffccde106}">
       <IDSymbol name="cmdidAddPackages" value="0x0100" />
@@ -258,8 +264,10 @@
       <IDSymbol name="IDG_VENUS_CTX_REFERENCE" value="27" />
       <IDSymbol name="IDG_CTX_REFERENCE" value="0x102" />
     </GuidSymbol>
+    <!--guidReferenceContext is aka: ShellMainMenu_guid -->
     <GuidSymbol name="guidReferenceContext" value="{D309F791-903F-11D0-9EFC-00A0C911004F}">
-      <IdSymbol name="cmdAddReferenceGroup" value="0x450" />
+      <IDSymbol name="cmdAddReferenceGroup" value="0x450" />
+      <IDSymbol name="IDM_VS_CTXT_PACKAGEREFERENCE_GROUP" value="0x04A2"/>
     </GuidSymbol>
     <GuidSymbol name="UICONTEXT_SolutionExistsAndNotBuildingAndNotDebugging" value="{D0E4DEEC-1B53-4CDA-8559-D454583AD23B}" />
     <GuidSymbol name="guidNuGetDebugConsoleCmdSet" value="{DDC61543-6CA7-4A6F-A5B7-984BE723C52F}">
@@ -272,6 +280,9 @@
       <IDSymbol name="DownloadIndicator" value="4" />
       <IDSymbol name="InstalledIndicator" value="5" />
       <IDSymbol name="MigratorHelpIcon" value="6" />
+    </GuidSymbol>
+    <GuidSymbol name="guidPackageManagementCmdSet" value="{E586270E-92EC-427D-B218-0E81A25226F5}">
+      <IDSymbol name="idPackageManagementGroup" value="0x0100" />
     </GuidSymbol>
   </Symbols>
 


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9449
Regression: Yes
* Last working version:  VS 16.5.3
* How are we preventing it in future: Caused by rework going on within VS and our menus no longer appearing where they used to. I have more context menu work upcoming which will utilize these new groups/commandsets more extensively.

## Fix

Details: 
1. Created a new guid to represent a commandset.
(Note: I will plan to use this commandset and group for further work in this area, like adding the Update context menu)

2. Hang my new commandset off of the new Project System package reference group (ie, Packages node).

3. Hang "Manage NuGet Packages" off the new commandset.

4. Fix 2 random typos (<IDSymobl> and <IdSymbol>) (...yikes)

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  
Validation:  Tested via Experimental Instance of VS. 
1. Right-clicked on Packages, verified I could Manage NuGet Packages.
![image](https://user-images.githubusercontent.com/49205731/79527063-b0239c80-8034-11ea-8375-90d828e8ee58.png)

2. Right-clicked on Packages/PackageName, verified there was not a Manage NuGet Packages item.
![image](https://user-images.githubusercontent.com/49205731/79527091-be71b880-8034-11ea-9509-b532441aa5d7.png)

/cc @chgill-MSFT 