### PR TITLE
Update NuGet to use Newtonsoft.Json 11.0.1

### DIFF
--- a/build/bootstrap.proj
+++ b/build/bootstrap.proj
@@ -17,7 +17,7 @@
         <PackageDownload Include="Microsoft.VisualStudio.Composition" version="[15.8.98]" />
         <PackageDownload Include="Microsoft.VisualStudio.ProjectSystem" version="[16.0.201-pre-g7d366164d0]" />
         <PackageDownload Include="Microsoft.Web.Xdt" version="[2.1.2]" />
-        <PackageDownload Include="Newtonsoft.Json" version="[9.0.1]" />
+        <PackageDownload Include="Newtonsoft.Json" version="[11.0.1]" />
         <PackageDownload Include="NuGet.Build.Tasks.Pack" version="[4.9.2]" />
         <PackageDownload Include="NuGet.Client.EndToEnd.TestData" version="[1.0.0]" />
         <PackageDownload Include="NuGet.Core" version="[2.14.0-rtm-832]" />

--- a/build/packages.targets
+++ b/build/packages.targets
@@ -1,7 +1,7 @@
 <Project>
     <PropertyGroup>
         <MicrosoftBuildPackageVersion Condition="'$(MicrosoftBuildPackageVersion)' == ''">16.5.0-preview-19606-01</MicrosoftBuildPackageVersion>
-        <NewtonsoftJsonPackageVersion Condition="$(NewtonsoftJsonPackageVersion) == ''">9.0.1</NewtonsoftJsonPackageVersion>
+        <NewtonsoftJsonPackageVersion Condition="$(NewtonsoftJsonPackageVersion) == ''">11.0.1</NewtonsoftJsonPackageVersion>
         <SystemPackagesVersion>4.3.0</SystemPackagesVersion>
         <VSComponentsVersion>16.4.280</VSComponentsVersion>
         <VSFrameworkVersion>16.5.29714.20</VSFrameworkVersion>

--- a/build/sign.proj
+++ b/build/sign.proj
@@ -23,7 +23,7 @@
       <FilesToSign Include="$(SolutionPackagesFolder)lucene.net\3.0.3\lib\NET40\Lucene.Net.dll">
         <Authenticode>3PartySHA2</Authenticode>
       </FilesToSign>
-      <FilesToSign Include="$(SolutionPackagesFolder)newtonsoft.json\9.0.1\lib\net45\Newtonsoft.Json.dll">
+      <FilesToSign Include="$(SolutionPackagesFolder)newtonsoft.json\11.0.1\lib\net45\Newtonsoft.Json.dll">
         <Authenticode>3PartySHA2</Authenticode>
       </FilesToSign>
       <FilesToSign Include="$(ArtifactsDirectory)microsoft.web.xdt\2.1.2\lib\net40\**\Microsoft.Web.XmlTransform.resources.dll">

--- a/setup/Microsoft.VisualStudio.NuGet.BuildTools.swixproj
+++ b/setup/Microsoft.VisualStudio.NuGet.BuildTools.swixproj
@@ -18,7 +18,7 @@
     <ReferenceOutputPath>$(ArtifactsDirectory)NuGet.VisualStudio.Client\$(VisualStudioVersion)\bin\$(Configuration)\</ReferenceOutputPath>
     <NuGetTargetsBasePath>$(RepositoryRootDirectory)src\NuGet.Core\NuGet.Build.Tasks\</NuGetTargetsBasePath>
     <XmlTransformPath>$(ArtifactsDirectory)microsoft.web.xdt\2.1.2\lib\net40\</XmlTransformPath>
-    <NewtonsoftJsonPath>$(SolutionPackagesFolder)newtonsoft.json\9.0.1\lib\net45\</NewtonsoftJsonPath>
+    <NewtonsoftJsonPath>$(SolutionPackagesFolder)newtonsoft.json\11.0.1\lib\net45\</NewtonsoftJsonPath>
   
 </PropertyGroup>
 

--- a/src/NuGet.Clients/NuGet.VisualStudio.Client/NuGet.VisualStudio.Client.csproj
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Client/NuGet.VisualStudio.Client.csproj
@@ -63,7 +63,7 @@
       <Link>Modules\NuGet\NuGet.PackageManagement.PowerShellCmdlets.dll-Help.xml</Link>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
-    <Content Include="$(SolutionPackagesFolder)newtonsoft.json\9.0.1\lib\net45\Newtonsoft.Json.dll">
+    <Content Include="$(SolutionPackagesFolder)newtonsoft.json\11.0.1\lib\net45\Newtonsoft.Json.dll">
       <Link>Newtonsoft.Json.dll</Link>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/NuGet.VisualStudio.Internal.Contracts.csproj
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/NuGet.VisualStudio.Internal.Contracts.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.ServiceHub.Framework" NoWarn="NU1605"/>
     <PackageReference Include="Microsoft.VisualStudio.RpcContracts" />
-    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersionCore)" NoWarn="NU1605" PrivateAssets="all" ExcludeAssets="all" />
+    <PackageReference Include="Newtonsoft.Json" NoWarn="NU1605" PrivateAssets="all" ExcludeAssets="all" />
   </ItemGroup>
   <Import Project="$(BuildCommonDirectory)common.targets" />
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGet.PackageManagement.Test.csproj
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGet.PackageManagement.Test.csproj
@@ -16,10 +16,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" NoWarn="NU1605" />
-  </ItemGroup>
-
-  <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 

--- a/test/NuGet.Core.Tests/NuGet.Shared.Tests/NuGet.Shared.Tests.csproj
+++ b/test/NuGet.Core.Tests/NuGet.Shared.Tests/NuGet.Shared.Tests.csproj
@@ -10,6 +10,10 @@
     <Description>Unit tests for the utilities included using shared compilation.</Description>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" />
+  </ItemGroup>
+
   <!-- Include shared files for netcore projects -->
   <ItemGroup>
     <Compile Include="$(SharedDirectory)\*.cs" Exclude="bin\**;obj\**;**\*.xproj;packages\**" />

--- a/test/NuGet.Core.Tests/NuGet.Versioning.Test/NuGet.Versioning.Test.csproj
+++ b/test/NuGet.Core.Tests/NuGet.Versioning.Test/NuGet.Versioning.Test.csproj
@@ -15,6 +15,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 

--- a/test/NuGet.Tests.Apex/NuGet.Console.TestContract/NuGet.Console.TestContract.csproj
+++ b/test/NuGet.Tests.Apex/NuGet.Console.TestContract/NuGet.Console.TestContract.csproj
@@ -12,9 +12,6 @@
     <ProjectReference Include="$(NuGetClientsSrcDirectory)NuGet.Console\NuGet.Console.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" NoWarn="NU1605" />
-  </ItemGroup>
-  <ItemGroup>
     <Reference Include="System.ComponentModel.Composition" />
   </ItemGroup>
 

--- a/test/NuGet.Tests.Apex/NuGet.PackageManagement.UI.TestContract/NuGet.PackageManagement.UI.TestContract.csproj
+++ b/test/NuGet.Tests.Apex/NuGet.PackageManagement.UI.TestContract/NuGet.PackageManagement.UI.TestContract.csproj
@@ -18,9 +18,6 @@
     <ProjectReference Include="$(NuGetClientsSrcDirectory)NuGet.PackageManagement.UI\NuGet.PackageManagement.UI.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" NoWarn="NU1605" />
-  </ItemGroup>
-  <ItemGroup>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="System.ComponentModel.Composition" />

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGet.Tests.Apex.csproj
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGet.Tests.Apex.csproj
@@ -63,7 +63,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Test.Apex.VisualStudio" />
-    <PackageReference Include="Newtonsoft.Json" NoWarn="NU1605" />
     <PackageReference Include="Xunit.StaFact" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9263
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details:
The [.NET 5 SDK is targeting Newtonsoft.Json 11.0.1](https://github.com/dotnet/sdk/blob/b37a6d1b319ec6ef2beb489ec7f78280e3b615c8/eng/Versions.props#L21). Although the [.NET Core 3.1.3xx SDK is targeting Newtonsoft.Json 9.0.1](https://github.com/dotnet/sdk/blob/6f0edb1dfaf5a6c780719794a7dd7d945c320ebf/eng/Versions.props#L20), when I look at the install on my machine, I see they're shipping 11.0.1 already, so us upgrading shouldn't be harmful (I've also contacted them, and won't merge this PR until they say it's ok).

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  package version update. Existing tests should cover it.
Validation:  
