### PR TITLE
Improve degenerative glob filtering case and fix nuspec filtering on Linux

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/CommandRunners/PackCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/CommandRunners/PackCommandRunner.cs
@@ -853,7 +853,7 @@ namespace NuGet.Commands
             // Always exclude the nuspec file
             // Review: This exclusion should be done by the package builder because it knows which file would collide with the auto-generated
             // manifest file.
-            IEnumerable<string> wildCards = _excludes.Concat(new[] { @"**\*" + NuGetConstants.ManifestExtension });
+            IEnumerable<string> wildCards = _excludes.Concat(new[] { "**"+ NuGetConstants.ManifestExtension });
 
             if (!_packArgs.NoDefaultExcludes)
             {

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/PathResolverTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/PathResolverTests.cs
@@ -150,6 +150,28 @@ namespace NuGet.Common.Test
         }
 
         [Fact]
+        public void GetMatches_WithGlobstarDotFileName_ReturnsFileNameMatches()
+        {
+            IEnumerable<string> sources = GetPlatformSpecificPaths(new[] { ".{0}.c", "a{0}.c", "a{0}{0}.c", "a{0}bc", "bc", "b.c", "a{0}b{0}bc.c", "a{0}b{0}.c", "a{0}b{0}c" });
+            IEnumerable<string> wildcards = GetPlatformSpecificPaths(new[] { "**.c" });
+            IEnumerable<string> actualResults = PathResolver.GetMatches(sources, source => source, wildcards);
+            IEnumerable<string> expectedResults = GetPlatformSpecificPaths(new[] { ".{0}.c", "a{0}.c", "a{0}{0}.c", "b.c", "a{0}b{0}bc.c", "a{0}b{0}.c" });
+
+            Assert.Equal(expectedResults, actualResults);
+        }
+
+        [Fact]
+        public void GetMatches_WithGlobstarSlashDotFileName_ReturnsFileNameMatches()
+        {
+            IEnumerable<string> sources = GetPlatformSpecificPaths(new[] { ".{0}.c", "a{0}.c", "a{0}{0}.c", "a{0}bc", "bc", "b.c", "a{0}b{0}bc.c", "a{0}b{0}.c", "a{0}b{0}c" });
+            IEnumerable<string> wildcards = GetPlatformSpecificPaths(new[] { "**.c" });
+            IEnumerable<string> actualResults = PathResolver.GetMatches(sources, source => source, wildcards);
+            IEnumerable<string> expectedResults = GetPlatformSpecificPaths(new[] { ".{0}.c", "a{0}.c", "a{0}{0}.c", "b.c", "a{0}b{0}bc.c", "a{0}b{0}.c" });
+
+            Assert.Equal(expectedResults, actualResults);
+        }
+
+        [Fact]
         public void GetMatches_WithGlobstarSlashFileName_ReturnsFileNameMatches()
         {
             IEnumerable<string> sources = GetPlatformSpecificPaths(new[] { ".{0}c", "a{0}c", "a{0}bc", "bc" });


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9451
Regression: No?

## Fix

Nuget wants to remove all .nuspec files from the pack. To do this, it currently adds a filtering pattern
of **\*.nuspec. This is then translated into Regex later on. The regex generated for this
is pretty complicated and very very slow. Furthermore, the globbing pattern is specific
to Windows (it doesn't use Path.DirectorySeparatorChar), and so does not filter on Linux.

Eliminate the \, which still matches the same patterns based on globbing rules and drastically
improves performance. Add a few additional tests too.

This was discovered in an investigation of some packages that were taking a long time to pack in
the dotnet/sdk repo. These packages have nuspecs with a large number of files, and the files
also have long-ish file paths. On my local machine, here are the pack times:

| NuGet Version | Time (sec) (n = 10) | Diff from 5.4.0 |
| ------------- | ------------- | --------------- |
| 5.4.0         | 121.25        | N/A             |
| 5.5.1         | 50.86         | -56.83%         |
| w/ Fix        | 1.48          | -99.98%         |


## Testing/Validation

Tests Added: Yes 
Reason for not adding tests:  
Validation:  Locally verified
