### PR TITLE
adding dummy namespaces so this XSD is actually usable

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/compiler/resources/nuspec.xsd
+++ b/src/NuGet.Core/NuGet.Packaging/compiler/resources/nuspec.xsd
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xs:schema id="nuspec"
-    targetNamespace="{0}"
+    targetNamespace="http://file-is-unusable-as-xsd-without-the-right-values-here"
     elementFormDefault="qualified"
-    xmlns="{0}"
-    xmlns:mstns="{0}"
+    xmlns="http://i-been-waiting-for-years-for-this-answer"
+    xmlns:mstns="http://this-should-be-distributed-in-visual-studio"
     xmlns:xs="http://www.w3.org/2001/XMLSchema"
 >
     <xs:complexType name="dependency">


### PR DESCRIPTION
I am sure that these are incorrect namespaces, but they are more correct than the `{0}` that has been in the file and making it useless as an xsd.

The hope is that someone will fill in the correct values so this gets fixed and is actually usable within VS.
