### PR TITLE
Add a Package Manager UI menu item for online scenarios

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.OnlineEnvironment.Client/Input/PkgCmdIDList.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.OnlineEnvironment.Client/Input/PkgCmdIDList.cs
@@ -6,5 +6,6 @@ namespace NuGet.VisualStudio.OnlineEnvironment.Client
     internal static class PkgCmdIDList
     {
         public const int CmdidRestorePackages = 0x0100;
+        public const int CmdIdManageProjectUI = 0x0200;
     }
 }

--- a/src/NuGet.Clients/NuGet.VisualStudio.OnlineEnvironment.Client/NuGet.VisualStudio.OnlineEnvironment.Client.csproj
+++ b/src/NuGet.Clients/NuGet.VisualStudio.OnlineEnvironment.Client/NuGet.VisualStudio.OnlineEnvironment.Client.csproj
@@ -41,6 +41,7 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
+    <Compile Include="SolutionExplorer\PackageManagerUICommandHandler.cs" />
     <Compile Include="SolutionExplorer\RestoreCommandHandler.cs" />
     <Compile Include="SolutionExplorer\NuGetWorkspaceCommandHandler.cs" />
     <Compile Include="SolutionExplorer\NuGetNodeExtender.cs" />

--- a/src/NuGet.Clients/NuGet.VisualStudio.OnlineEnvironment.Client/NuGetClientPackage.vsct
+++ b/src/NuGet.Clients/NuGet.VisualStudio.OnlineEnvironment.Client/NuGetClientPackage.vsct
@@ -52,7 +52,7 @@
               <CommandFlag>DefaultInvisible</CommandFlag>
               <CommandFlag>DynamicVisibility</CommandFlag>
           If you do not want an image next to your command, remove the Icon node /> -->
-      <Button guid="guidNuGetClientPackageCmdSet" id="CmdidRestorePackages" priority="0x0100" type="Button">
+      <Button guid="guidNuGetClientPackageCmdSet" id="cmdIdRestorePackages" priority="0x0100" type="Button">
         <Parent guid="guidNuGetClientPackageCmdSet" id="NuGetClientMenuGroup" />
         <Icon guid="guidToolbarImages" id="bmpPackageRestore" />
         <CommandFlag>DefaultInvisible</CommandFlag>
@@ -62,6 +62,20 @@
           <CommandName>SolutionExplorer.Solution.RestoreNuGetPackages</CommandName>
           <CanonicalName>SolutionExplorer.Solution.RestoreNuGetPackages</CanonicalName>
           <LocCanonicalName>SolutionExplorer.Solution.RestoreNuGetPackages</LocCanonicalName>
+        </Strings>
+      </Button>
+
+      <Button guid="guidNuGetClientPackageCmdSet" id="cmdIdManageProjectUI" priority="0x0100" type="Button">
+        <Parent guid="guidNuGetClientPackageCmdSet" id="NuGetClientMenuGroup" />
+        <Icon guid="guidToolbarImages" id="bmpAddNuGetPackage" />        
+        <CommandFlag>AllowParams</CommandFlag>
+        <CommandFlag>DefaultInvisible</CommandFlag>
+        <CommandFlag>DynamicVisibility</CommandFlag>
+        <Strings>
+          <CommandName>SolutionExplorer.Project.ManageNuGetPackages</CommandName>
+          <CanonicalName>SolutionExplorer.Project.ManageNuGetPackages</CanonicalName>
+          <LocCanonicalName>SolutionExplorer.Project.ManageNuGetPackages</LocCanonicalName>
+          <ButtonText>Manage &amp;NuGet Packages...</ButtonText>
         </Strings>
       </Button>
     </Buttons>
@@ -78,7 +92,8 @@
     <!-- This is the guid used to group the menu commands together -->
     <GuidSymbol name="guidNuGetClientPackageCmdSet" value="{282008cc-d0db-45e1-80d1-00fabac5de92}">
       <IDSymbol name="NuGetClientMenuGroup" value="0x1020" />
-      <IDSymbol name="CmdidRestorePackages" value="0x0100" />
+      <IDSymbol name="cmdIdRestorePackages" value="0x0100" />
+      <IDSymbol name="cmdIdManageProjectUI" value="0x0200" />
     </GuidSymbol>
 
     <GuidSymbol name="guidWorkspaceExplorerToolWindowPackageCmdSet" value="{cfb400f1-5c60-4f3c-856e-180d28def0b7}">

--- a/src/NuGet.Clients/NuGet.VisualStudio.OnlineEnvironment.Client/NuGetClientPackage.vsct
+++ b/src/NuGet.Clients/NuGet.VisualStudio.OnlineEnvironment.Client/NuGetClientPackage.vsct
@@ -36,7 +36,7 @@
          group as the part of a menu contained between two lines. The parent of a group
          must be a menu. -->
     <Groups>
-      <Group guid="guidNuGetClientPackageCmdSet" id="NuGetClientMenuGroup" priority="0x0600">
+      <Group guid="guidNuGetClientPackageCmdSet" id="nuGetClientMenuGroup" priority="0x0600">
         <Parent guid="guidWorkspaceExplorerToolWindowPackageCmdSet" id="idmWSE_ContextMenu"/>
       </Group>
     </Groups>
@@ -53,7 +53,7 @@
               <CommandFlag>DynamicVisibility</CommandFlag>
           If you do not want an image next to your command, remove the Icon node /> -->
       <Button guid="guidNuGetClientPackageCmdSet" id="cmdIdRestorePackages" priority="0x0100" type="Button">
-        <Parent guid="guidNuGetClientPackageCmdSet" id="NuGetClientMenuGroup" />
+        <Parent guid="guidNuGetClientPackageCmdSet" id="nuGetClientMenuGroup" />
         <Icon guid="guidToolbarImages" id="bmpPackageRestore" />
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
@@ -66,7 +66,7 @@
       </Button>
 
       <Button guid="guidNuGetClientPackageCmdSet" id="cmdIdManageProjectUI" priority="0x0100" type="Button">
-        <Parent guid="guidNuGetClientPackageCmdSet" id="NuGetClientMenuGroup" />
+        <Parent guid="guidNuGetClientPackageCmdSet" id="nuGetClientMenuGroup" />
         <Icon guid="guidToolbarImages" id="bmpAddNuGetPackage" />        
         <CommandFlag>AllowParams</CommandFlag>
         <CommandFlag>DefaultInvisible</CommandFlag>
@@ -91,7 +91,7 @@
 
     <!-- This is the guid used to group the menu commands together -->
     <GuidSymbol name="guidNuGetClientPackageCmdSet" value="{282008cc-d0db-45e1-80d1-00fabac5de92}">
-      <IDSymbol name="NuGetClientMenuGroup" value="0x1020" />
+      <IDSymbol name="nuGetClientMenuGroup" value="0x1020" />
       <IDSymbol name="cmdIdRestorePackages" value="0x0100" />
       <IDSymbol name="cmdIdManageProjectUI" value="0x0200" />
     </GuidSymbol>

--- a/src/NuGet.Clients/NuGet.VisualStudio.OnlineEnvironment.Client/NuGetClientPackage.vsct
+++ b/src/NuGet.Clients/NuGet.VisualStudio.OnlineEnvironment.Client/NuGetClientPackage.vsct
@@ -36,7 +36,7 @@
          group as the part of a menu contained between two lines. The parent of a group
          must be a menu. -->
     <Groups>
-      <Group guid="guidNuGetClientPackageCmdSet" id="guidNuGetClientMenuGroup" priority="0x0600">
+      <Group guid="guidNuGetClientPackageCmdSet" id="idNuGetClientMenuGroup" priority="0x0600">
         <Parent guid="guidWorkspaceExplorerToolWindowPackageCmdSet" id="idmWSE_ContextMenu"/>
       </Group>
     </Groups>
@@ -53,7 +53,7 @@
               <CommandFlag>DynamicVisibility</CommandFlag>
           If you do not want an image next to your command, remove the Icon node /> -->
       <Button guid="guidNuGetClientPackageCmdSet" id="cmdIdRestorePackages" priority="0x0100" type="Button">
-        <Parent guid="guidNuGetClientPackageCmdSet" id="guidNuGetClientMenuGroup" />
+        <Parent guid="guidNuGetClientPackageCmdSet" id="idNuGetClientMenuGroup" />
         <Icon guid="guidToolbarImages" id="bmpPackageRestore" />
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
@@ -66,7 +66,7 @@
       </Button>
 
       <Button guid="guidNuGetClientPackageCmdSet" id="cmdIdManageProjectUI" priority="0x0100" type="Button">
-        <Parent guid="guidNuGetClientPackageCmdSet" id="guidNuGetClientMenuGroup" />
+        <Parent guid="guidNuGetClientPackageCmdSet" id="idNuGetClientMenuGroup" />
         <Icon guid="guidToolbarImages" id="bmpAddNuGetPackage" />        
         <CommandFlag>AllowParams</CommandFlag>
         <CommandFlag>DefaultInvisible</CommandFlag>
@@ -91,7 +91,7 @@
 
     <!-- This is the guid used to group the menu commands together -->
     <GuidSymbol name="guidNuGetClientPackageCmdSet" value="{282008cc-d0db-45e1-80d1-00fabac5de92}">
-      <IDSymbol name="guidNuGetClientMenuGroup" value="0x1020" />
+      <IDSymbol name="idNuGetClientMenuGroup" value="0x1020" />
       <IDSymbol name="cmdIdRestorePackages" value="0x0100" />
       <IDSymbol name="cmdIdManageProjectUI" value="0x0200" />
     </GuidSymbol>

--- a/src/NuGet.Clients/NuGet.VisualStudio.OnlineEnvironment.Client/NuGetClientPackage.vsct
+++ b/src/NuGet.Clients/NuGet.VisualStudio.OnlineEnvironment.Client/NuGetClientPackage.vsct
@@ -36,7 +36,7 @@
          group as the part of a menu contained between two lines. The parent of a group
          must be a menu. -->
     <Groups>
-      <Group guid="guidNuGetClientPackageCmdSet" id="nuGetClientMenuGroup" priority="0x0600">
+      <Group guid="guidNuGetClientPackageCmdSet" id="guidNuGetClientMenuGroup" priority="0x0600">
         <Parent guid="guidWorkspaceExplorerToolWindowPackageCmdSet" id="idmWSE_ContextMenu"/>
       </Group>
     </Groups>
@@ -53,7 +53,7 @@
               <CommandFlag>DynamicVisibility</CommandFlag>
           If you do not want an image next to your command, remove the Icon node /> -->
       <Button guid="guidNuGetClientPackageCmdSet" id="cmdIdRestorePackages" priority="0x0100" type="Button">
-        <Parent guid="guidNuGetClientPackageCmdSet" id="nuGetClientMenuGroup" />
+        <Parent guid="guidNuGetClientPackageCmdSet" id="guidNuGetClientMenuGroup" />
         <Icon guid="guidToolbarImages" id="bmpPackageRestore" />
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
@@ -66,7 +66,7 @@
       </Button>
 
       <Button guid="guidNuGetClientPackageCmdSet" id="cmdIdManageProjectUI" priority="0x0100" type="Button">
-        <Parent guid="guidNuGetClientPackageCmdSet" id="nuGetClientMenuGroup" />
+        <Parent guid="guidNuGetClientPackageCmdSet" id="guidNuGetClientMenuGroup" />
         <Icon guid="guidToolbarImages" id="bmpAddNuGetPackage" />        
         <CommandFlag>AllowParams</CommandFlag>
         <CommandFlag>DefaultInvisible</CommandFlag>
@@ -91,7 +91,7 @@
 
     <!-- This is the guid used to group the menu commands together -->
     <GuidSymbol name="guidNuGetClientPackageCmdSet" value="{282008cc-d0db-45e1-80d1-00fabac5de92}">
-      <IDSymbol name="nuGetClientMenuGroup" value="0x1020" />
+      <IDSymbol name="guidNuGetClientMenuGroup" value="0x1020" />
       <IDSymbol name="cmdIdRestorePackages" value="0x0100" />
       <IDSymbol name="cmdIdManageProjectUI" value="0x0200" />
     </GuidSymbol>

--- a/src/NuGet.Clients/NuGet.VisualStudio.OnlineEnvironment.Client/SolutionExplorer/NuGetWorkspaceCommandHandler.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.OnlineEnvironment.Client/SolutionExplorer/NuGetWorkspaceCommandHandler.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.OLE.Interop;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Threading;
 using Microsoft.VisualStudio.Workspace.VSIntegration.UI;
@@ -20,7 +21,7 @@ namespace NuGet.VisualStudio.OnlineEnvironment.Client
         private readonly RestoreCommandHandler _restoreCommandHandler;
         private readonly PackageManagerUICommandHandler _packageManagerUICommandHandler;
 
-        public NuGetWorkspaceCommandHandler(JoinableTaskContext taskContext, IAsyncServiceProvider asyncServiceProvider)
+        internal NuGetWorkspaceCommandHandler(JoinableTaskContext taskContext, IAsyncServiceProvider asyncServiceProvider)
         {
             if (taskContext == null)
             {
@@ -53,7 +54,6 @@ namespace NuGet.VisualStudio.OnlineEnvironment.Client
                     case PkgCmdIDList.CmdidRestorePackages:
                         if (IsSolutionOnlySelection(selection))
                         {
-
                             _restoreCommandHandler.RunSolutionRestore();
                             return VSConstants.S_OK;
                         }
@@ -69,7 +69,7 @@ namespace NuGet.VisualStudio.OnlineEnvironment.Client
                         break;
                 }
             }
-            return (int)Microsoft.VisualStudio.OLE.Interop.Constants.OLECMDERR_E_NOTSUPPORTED;
+            return (int)Constants.OLECMDERR_E_NOTSUPPORTED;
         }
 
         public bool QueryStatus(List<WorkspaceVisualNodeBase> selection, Guid pguidCmdGroup, uint nCmdID, ref uint cmdf, ref string customTitle)
@@ -85,10 +85,9 @@ namespace NuGet.VisualStudio.OnlineEnvironment.Client
                         case PkgCmdIDList.CmdidRestorePackages:
                             if (IsSolutionOnlySelection(selection))
                             {
-
                                 var isRestoreActionInProgress = _restoreCommandHandler.IsRestoreActionInProgress();
-                                cmdf = (uint)((isRestoreActionInProgress ? 0 : Microsoft.VisualStudio.OLE.Interop.OLECMDF.OLECMDF_ENABLED)
-                                    | Microsoft.VisualStudio.OLE.Interop.OLECMDF.OLECMDF_SUPPORTED);
+                                cmdf = (uint)((isRestoreActionInProgress ? 0 : OLECMDF.OLECMDF_ENABLED)
+                                    | OLECMDF.OLECMDF_SUPPORTED);
                                 handled = true;
                             }
                             break;
@@ -97,8 +96,8 @@ namespace NuGet.VisualStudio.OnlineEnvironment.Client
                             {
                                 var isPackageManagerUISupported = _packageManagerUICommandHandler.IsPackageManagerUISupported(selection.Single());
                                 cmdf = (uint)(isPackageManagerUISupported ?
-                                    (Microsoft.VisualStudio.OLE.Interop.OLECMDF.OLECMDF_ENABLED | Microsoft.VisualStudio.OLE.Interop.OLECMDF.OLECMDF_SUPPORTED) :
-                                    Microsoft.VisualStudio.OLE.Interop.OLECMDF.OLECMDF_INVISIBLE);
+                                    (OLECMDF.OLECMDF_ENABLED | OLECMDF.OLECMDF_SUPPORTED) :
+                                    OLECMDF.OLECMDF_INVISIBLE);
                                 handled = true;
                             }
                             break;

--- a/src/NuGet.Clients/NuGet.VisualStudio.OnlineEnvironment.Client/SolutionExplorer/NuGetWorkspaceCommandHandler.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.OnlineEnvironment.Client/SolutionExplorer/NuGetWorkspaceCommandHandler.cs
@@ -96,8 +96,9 @@ namespace NuGet.VisualStudio.OnlineEnvironment.Client
                             if (IsSupportedProjectSelection(selection))
                             {
                                 var isPackageManagerUISupported = _packageManagerUICommandHandler.IsPackageManagerUISupported(selection.Single());
-                                cmdf = (uint)((isPackageManagerUISupported ? 0 : Microsoft.VisualStudio.OLE.Interop.OLECMDF.OLECMDF_ENABLED)
-                                    | Microsoft.VisualStudio.OLE.Interop.OLECMDF.OLECMDF_SUPPORTED);
+                                cmdf = (uint)(isPackageManagerUISupported ?
+                                    (Microsoft.VisualStudio.OLE.Interop.OLECMDF.OLECMDF_ENABLED | Microsoft.VisualStudio.OLE.Interop.OLECMDF.OLECMDF_SUPPORTED) :
+                                    Microsoft.VisualStudio.OLE.Interop.OLECMDF.OLECMDF_INVISIBLE);
                                 handled = true;
                             }
                             break;

--- a/src/NuGet.Clients/NuGet.VisualStudio.OnlineEnvironment.Client/SolutionExplorer/PackageManagerUICommandHandler.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.OnlineEnvironment.Client/SolutionExplorer/PackageManagerUICommandHandler.cs
@@ -1,0 +1,43 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.VisualStudio.Threading;
+using Microsoft.VisualStudio.Workspace.VSIntegration.UI;
+using IAsyncServiceProvider = Microsoft.VisualStudio.Shell.IAsyncServiceProvider;
+using Task = System.Threading.Tasks.Task;
+
+namespace NuGet.VisualStudio.OnlineEnvironment.Client
+{
+    internal class PackageManagerUICommandHandler
+    {
+        private const bool IsPackageManagerUISupportAvailable = false;
+        private readonly JoinableTaskFactory _joinableTaskFactory;
+        private readonly IAsyncServiceProvider _asyncServiceProvider;
+
+        public PackageManagerUICommandHandler(JoinableTaskFactory joinableTaskFactory, IAsyncServiceProvider asyncServiceProvider)
+        {
+            _joinableTaskFactory = joinableTaskFactory ?? throw new ArgumentNullException(nameof(joinableTaskFactory));
+            _asyncServiceProvider = asyncServiceProvider ?? throw new ArgumentNullException(nameof(asyncServiceProvider));
+        }
+
+
+        public bool IsPackageManagerUISupported(WorkspaceVisualNodeBase workspaceVisualNodeBase)
+        {
+            if (workspaceVisualNodeBase is null)
+            {
+                return false;
+            }
+            return IsPackageManagerUISupportAvailable;
+        }
+        public void OpenPackageManagerUI(WorkspaceVisualNodeBase workspaceVisualNodeBase)
+        {
+            _joinableTaskFactory.RunAsync(() => OpenPackageManagerUIAsync(workspaceVisualNodeBase));
+        }
+
+        private Task OpenPackageManagerUIAsync(WorkspaceVisualNodeBase workspaceVisualNodeBase)
+        {
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/NuGet.Clients/NuGet.VisualStudio.OnlineEnvironment.Client/SolutionExplorer/PackageManagerUICommandHandler.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.OnlineEnvironment.Client/SolutionExplorer/PackageManagerUICommandHandler.cs
@@ -21,7 +21,6 @@ namespace NuGet.VisualStudio.OnlineEnvironment.Client
             _asyncServiceProvider = asyncServiceProvider ?? throw new ArgumentNullException(nameof(asyncServiceProvider));
         }
 
-
         public bool IsPackageManagerUISupported(WorkspaceVisualNodeBase workspaceVisualNodeBase)
         {
             if (workspaceVisualNodeBase is null)
@@ -30,6 +29,7 @@ namespace NuGet.VisualStudio.OnlineEnvironment.Client
             }
             return IsPackageManagerUISupportAvailable;
         }
+
         public void OpenPackageManagerUI(WorkspaceVisualNodeBase workspaceVisualNodeBase)
         {
             _joinableTaskFactory.RunAsync(() => OpenPackageManagerUIAsync(workspaceVisualNodeBase));


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9428
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: Update the commands to add support for the PM UI on projects.
Currently we don't have the ability to check for capabilities, so everything is disabled.

Some screenshots on how it's supposed to look when enabled (include the sln node for completeness, only adding the item for the project level pm ui)

![SolutionLevelPMU-RestoreSolution](https://user-images.githubusercontent.com/2878341/79817697-ea45b480-833a-11ea-9449-812147e4231c.png)
![ManageNuGetPackages](https://user-images.githubusercontent.com/2878341/79817699-ec0f7800-833a-11ea-90d5-25196133c224.png)


## Testing/Validation

Tests Added: No  
Reason for not adding tests: No automation for these things yet. The test team is running tests for regressions.   
Validation:  Manual
