### PR TITLE
Fix error when restoring with older versions of MSBuild

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -443,7 +443,16 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Target Name="_GetRestoreProjectStyle"
     DependsOnTargets="_GetProjectJsonPath;CollectPackageReferences"
     Returns="$(RestoreProjectStyle);$(PackageReferenceCompatibleProjectStyle)">
-    <PropertyGroup>
+
+    <!--
+      Older versions of MSBuild do not support the Count() item function which is an optimization.  Expanding the
+      entire item list into a semicolon delimited string is slower but older versions of MSBuild don't support it so
+      use the older logic if necessary
+    -->
+    <PropertyGroup Condition="'$(MSBuildAssemblyVersion)' &lt; '15.0'">
+      <_HasPackageReferenceItems Condition="'@(PackageReference)' != ''">true</_HasPackageReferenceItems>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(MSBuildAssemblyVersion)' &gt;= '15.0'">
       <_HasPackageReferenceItems Condition="@(PackageReference->Count()) > 0">true</_HasPackageReferenceItems>
     </PropertyGroup>
 


### PR DESCRIPTION
I added logic get an item count not knowing that the logic wasn't introduced until some version of MSBuild 14.0.  The fix here is to only use the newer optimized logic for MSBuild 15 and above.

## Bug

Fixes: https://github.com/NuGet/Home/issues/9458  
Regression: Yes
* Last working version:  5.4
* How are we preventing it in future: 

## Fix

Details: For older versions of MSBuild, use the less optimal comparison of the entire list to an empty string.

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  An old version of MSBuild is required to test it
Validation:  Manually tested in the broken scenario
