### PR TITLE
Move WaitAsync outside try/catch

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpSourceAuthenticationHandler.cs
+++ b/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpSourceAuthenticationHandler.cs
@@ -140,11 +140,11 @@ namespace NuGet.Protocol
 
         private async Task<ICredentials> AcquireCredentialsAsync(HttpStatusCode statusCode, Guid credentialsVersion, ILogger log, CancellationToken cancellationToken)
         {
+            // Only one request may prompt and attempt to auth at a time
+            await _httpClientLock.WaitAsync();
+
             try
             {
-                // Only one request may prompt and attempt to auth at a time
-                await _httpClientLock.WaitAsync();
-
                 cancellationToken.ThrowIfCancellationRequested();
 
                 // Auth may have happened on another thread, if so just continue
@@ -227,11 +227,11 @@ namespace NuGet.Protocol
         {
             ICredentials promptCredentials;
 
+            // Only one prompt may display at a time.
+            await _credentialPromptLock.WaitAsync();
+
             try
             {
-                // Only one prompt may display at a time.
-                await _credentialPromptLock.WaitAsync();
-
                 // Get the proxy for this URI so we can pass it to the credentialService methods
                 // this lets them use the proxy if they have to hit the network.
                 var proxyCache = ProxyCache.Instance;


### PR DESCRIPTION
## Fix

Details: In case `WaitAsync` throws, `Release` should not be called. Although, `WaitAsync` only is documented to throw `ObjectDisposedException`, which would cause `Release` to throw `ObjectDisposeException` later on, this would make the code resilient to changes to other overloads, which can throw other exceptions too, like `OperationCanceledException` if a cancellation token is passed. 

Fixes https://github.com/NuGet/Home/issues/9463
