### PR TITLE
Re-enable tests for Narrator notifications fix

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/LoadingStatusIndicator.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/LoadingStatusIndicator.cs
@@ -16,11 +16,17 @@ namespace NuGet.PackageManagement.UI
 
         public LoadingStatus Status
         {
-            get { return _status; }
+            get
+            {
+                return _status;
+            }
             set
             {
-                _status = value;
-                OnPropertyChanged(nameof(Status));
+                if (_status != value)
+                {
+                    _status = value;
+                    OnPropertyChanged(nameof(Status));
+                }
             }
         }
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml
@@ -319,7 +319,9 @@
       <vs:LiveTextBlock
         x:Name="_ltbLoading"
         Visibility="Collapsed"
-        IsFrequencyLimited="True" />
+        IsFrequencyLimited="True"
+        Focusable="False"
+        AutomationProperties.IsOffscreenBehavior="Offscreen" />
     </Grid>
     <nuget:InfiniteScrollListBox
       d:DataContext="{d:DesignData Source=/Design/PackageItemListViewSampleData.xaml,IsDesignTimeCreatable=True}"

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml
@@ -318,6 +318,7 @@
       -->
       <vs:LiveTextBlock
         x:Name="LtbLoading"
+        AutomationProperties.IsOffscreenBehavior="Offscreen"
         Visibility="Collapsed"
         IsFrequencyLimited="True" />
     </Grid>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml
@@ -317,8 +317,7 @@
         Code behind changes to the Text property will trigger a narrator event.
       -->
       <vs:LiveTextBlock
-        x:Name="LtbLoading"
-        AutomationProperties.IsOffscreenBehavior="Offscreen"
+        x:Name="_ltbLoading"
         Visibility="Collapsed"
         IsFrequencyLimited="True" />
     </Grid>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
@@ -13,7 +13,6 @@ using System.Windows.Controls;
 using System.Windows.Data;
 using System.Windows.Input;
 using System.Windows.Media;
-using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Threading;
 using NuGet.Common;
 using NuGet.PackageManagement.VisualStudio;
@@ -21,8 +20,6 @@ using NuGet.Protocol.Core.Types;
 using NuGet.VisualStudio;
 using Mvs = Microsoft.VisualStudio.Shell;
 using Resx = NuGet.PackageManagement.UI;
-using Task = System.Threading.Tasks.Task;
-
 
 namespace NuGet.PackageManagement.UI
 {

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
@@ -13,13 +13,17 @@ using System.Windows.Controls;
 using System.Windows.Data;
 using System.Windows.Input;
 using System.Windows.Media;
+using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Threading;
 using NuGet.Common;
 using NuGet.PackageManagement.VisualStudio;
 using NuGet.Protocol.Core.Types;
 using NuGet.VisualStudio;
+using NuGet.VisualStudio.Telemetry;
 using Mvs = Microsoft.VisualStudio.Shell;
 using Resx = NuGet.PackageManagement.UI;
+using Task = System.Threading.Tasks.Task;
+
 
 namespace NuGet.PackageManagement.UI
 {
@@ -85,14 +89,15 @@ namespace NuGet.PackageManagement.UI
 
         private void LoadingStatusIndicator_PropertyChanged(object sender, PropertyChangedEventArgs e)
         {
-            Mvs.ThreadHelper.ThrowIfNotOnUIThread();
-            if (e.PropertyName == nameof(LoadingStatusIndicator.Status))
+            _joinableTaskFactory.Value.Run(async delegate
             {
-                if (LtbLoading.Text != _loadingStatusIndicator.LocalizedStatus)
+                await _joinableTaskFactory.Value.SwitchToMainThreadAsync();
+                if (e.PropertyName == nameof(LoadingStatusIndicator.Status)
+                    && LtbLoading.Text != _loadingStatusIndicator.LocalizedStatus)
                 {
                     LtbLoading.Text = _loadingStatusIndicator.LocalizedStatus;
                 }
-            }
+            });
         }
 
         // Indicates wether check boxes are enabled on packages

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
@@ -19,7 +19,6 @@ using NuGet.Common;
 using NuGet.PackageManagement.VisualStudio;
 using NuGet.Protocol.Core.Types;
 using NuGet.VisualStudio;
-using NuGet.VisualStudio.Telemetry;
 using Mvs = Microsoft.VisualStudio.Shell;
 using Resx = NuGet.PackageManagement.UI;
 using Task = System.Threading.Tasks.Task;

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
@@ -92,9 +92,9 @@ namespace NuGet.PackageManagement.UI
             {
                 await _joinableTaskFactory.Value.SwitchToMainThreadAsync();
                 if (e.PropertyName == nameof(LoadingStatusIndicator.Status)
-                    && LtbLoading.Text != _loadingStatusIndicator.LocalizedStatus)
+                    && _ltbLoading.Text != _loadingStatusIndicator.LocalizedStatus)
                 {
-                    LtbLoading.Text = _loadingStatusIndicator.LocalizedStatus;
+                    _ltbLoading.Text = _loadingStatusIndicator.LocalizedStatus;
                 }
             });
         }

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Xamls/InfiniteScrollListTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Xamls/InfiniteScrollListTests.cs
@@ -286,7 +286,6 @@ namespace NuGet.PackageManagement.UI.Test
             var searchTask = Task.FromResult(SearchResult.FromItems( searchItems ));
             var testLogger = new TestNuGetUILogger(_output);
             var tcs = new TaskCompletionSource<int>();
-
             var list = new InfiniteScrollList(new Lazy<JoinableTaskFactory>(() => _joinableTaskContext.Factory));
 
             var currentStatus = LoadingStatus.Loading;


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/home/issues/9445
Regression: No
* Last working version:   
* How are we preventing it in future:   

## Fix

- Enabled impacted tests
- Added JTF.Run to run a text update. It is expected to be a short UI thread block
- Fixed INotifyPropertyChanged implementation
- Followed existing naming guidelines
- Added some AutomationProperties to try to mitigate AI flags

## Testing/Validation

Tests Added: Yes. Re-enabled
Reason for not adding tests:  
Validation:  
- Run with scenario
- Accessibility Insights (AI) Run: Failed with a possible false-negative: https://github.com/microsoft/axe-windows/issues/352#issuecomment-618163568

AI Test Result

![image](https://user-images.githubusercontent.com/1192347/80058871-46493e00-84df-11ea-9a38-88e84b9fe11b.png)

Failed AI control details

![image](https://user-images.githubusercontent.com/1192347/80058902-5bbe6800-84df-11ea-95f3-e137bf6e1a62.png)
