### PR TITLE
Publish settings members

### DIFF
--- a/src/NuGet.Core/NuGet.Configuration/Settings/ParsedSettingSection.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/ParsedSettingSection.cs
@@ -7,14 +7,14 @@ using System.Xml.Linq;
 
 namespace NuGet.Configuration
 {
-    internal sealed class ParsedSettingSection : SettingSection
+    public sealed class ParsedSettingSection : SettingSection
     {
-        internal ParsedSettingSection(XElement element, SettingsFile origin)
+        public ParsedSettingSection(XElement element, SettingsFile origin)
             : base(element, origin)
         {
         }
 
-        internal ParsedSettingSection(string name, params SettingItem[] children)
+        public ParsedSettingSection(string name, params SettingItem[] children)
             : base(name, attributes: null, children: new HashSet<SettingItem>(children))
         {
             foreach (var child in Children)

--- a/src/NuGet.Core/NuGet.Configuration/Settings/SettingsFile.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/SettingsFile.cs
@@ -11,7 +11,7 @@ using NuGet.Common;
 
 namespace NuGet.Configuration
 {
-    internal sealed class SettingsFile
+    public sealed class SettingsFile
     {
         /// <summary>
         /// Full path to the settings file

--- a/src/NuGet.Core/NuGet.Configuration/Settings/SettingsGroup.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/SettingsGroup.cs
@@ -85,7 +85,7 @@ namespace NuGet.Configuration
             }
         }
 
-        internal virtual bool Add(T setting)
+        public virtual bool Add(T setting)
         {
             if (setting == null)
             {
@@ -115,7 +115,7 @@ namespace NuGet.Configuration
             return false;
         }
 
-        internal virtual void Remove(T setting)
+        public virtual void Remove(T setting)
         {
             if (setting == null)
             {

--- a/src/NuGet.Core/NuGet.Configuration/Settings/VirtualSettingSection.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/VirtualSettingSection.cs
@@ -8,24 +8,24 @@ using System.Linq;
 
 namespace NuGet.Configuration
 {
-    public sealed class VirtualSettingSection : SettingSection
+    public class VirtualSettingSection : SettingSection
     {
-        internal VirtualSettingSection(SettingSection section)
+        public VirtualSettingSection(SettingSection section)
             : this(section.ElementName, section.Attributes, section.Items)
         {
         }
 
-        internal VirtualSettingSection(string name, params SettingItem[] children)
+        public VirtualSettingSection(string name, params SettingItem[] children)
             : this(name, attributes: null, children: new HashSet<SettingItem>(children))
         {
         }
 
-        internal VirtualSettingSection(string name, IReadOnlyDictionary<string, string> attributes, IEnumerable<SettingItem> children)
+        public VirtualSettingSection(string name, IReadOnlyDictionary<string, string> attributes, IEnumerable<SettingItem> children)
             : base(name, attributes, children)
         {
         }
 
-        internal VirtualSettingSection Merge(SettingSection other)
+        public VirtualSettingSection Merge(SettingSection other)
         {
             if (!Equals(other))
             {
@@ -66,7 +66,7 @@ namespace NuGet.Configuration
             return this;
         }
 
-        internal override bool Add(SettingItem setting)
+        public override bool Add(SettingItem setting)
         {
             if (setting == null)
             {
@@ -83,7 +83,7 @@ namespace NuGet.Configuration
             return false;
         }
 
-        internal override void Remove(SettingItem setting)
+        public override void Remove(SettingItem setting)
         {
             if (setting == null)
             {


### PR DESCRIPTION
## Fix

Details: 
I need to implement ISettings by hand in my project, but there is some internal and sealed members of Settings implementation that I would like to use in my implementation.
Puprose of this PR is to make that members public.