### PR TITLE
Add -binlog option to build.ps1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,9 @@ test/EndToEnd/nuget.exe
 # remove ilmerge log
 mergelog.txt
 
+# MSBuild binlog
+*.binlog
+
 # User-specific files
 *.suo
 *.user


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9482
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: added `-binlog` switch to `build.ps1`

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  build script
Validation:  
