### PR TITLE
Build scripts: move project selection to build.proj

### DIFF
--- a/build/build.proj
+++ b/build/build.proj
@@ -12,6 +12,66 @@
     </CommonMSBuildProperties>
   </PropertyGroup>
 
+  <!-- The project that builds the VSIX -->
+  <PropertyGroup>
+    <VSIXProject>$(RepositoryRootDirectory)src\NuGet.Clients\NuGet.VisualStudio.Client\NuGet.VisualStudio.Client.csproj</VSIXProject>
+  </PropertyGroup>
+
+  <!-- Find all test projects  -->
+  <ItemGroup Condition=" '$(IsXPlat)' != 'true' ">
+    <CoreUnitTestProjects Include="$(RepositoryRootDirectory)test\NuGet.Core.Tests\*\*.csproj"
+                          Exclude="$(RepositoryRootDirectory)test\NuGet.Core.Tests\NuGet.PackageManagement.Test\*.csproj"/>
+    <VSUnitTestProjects Include="$(RepositoryRootDirectory)test\NuGet.Clients.Tests\*\*.csproj"
+                        Exclude="$(RepositoryRootDirectory)test\NuGet.Clients.Tests\NuGet.CommandLine.Test\*.csproj" />
+    <CoreFuncTestProjects Include="$(RepositoryRootDirectory)test\NuGet.Core.FuncTests\*\*.csproj;
+                                   $(RepositoryRootDirectory)test\NuGet.Clients.Tests\NuGet.CommandLine.Test\*.csproj;
+                                   $(RepositoryRootDirectory)test\NuGet.Core.Tests\NuGet.PackageManagement.Test\*.csproj;
+                                   $(RepositoryRootDirectory)test\NuGet.Clients.FuncTests\*\*.csproj" />
+  </ItemGroup>
+
+  <!-- start with only nuget.versioning for xplat -->
+  <ItemGroup Condition=" '$(IsXPlat)' == 'true' ">
+    <CoreUnitTestProjects Include="$(RepositoryRootDirectory)test\NuGet.Core.Tests\*\*.csproj"
+                          Exclude="$(RepositoryRootDirectory)test\NuGet.Core.Tests\*PackageManagement*\*.csproj;
+                                   $(RepositoryRootDirectory)test\NuGet.Core.Tests\*ProjectManagement*\*.csproj;
+                                   $(RepositoryRootDirectory)test\NuGet.Core.Tests\*VisualStudio*\*.csproj;
+                                   $(RepositoryRootDirectory)test\NuGet.Core.Tests\*.Utility\*.csproj;
+                                   $(RepositoryRootDirectory)test\NuGet.Core.Tests\NuGet.Credentials.Test\*.csproj;" />
+    <CoreFuncTestProjects Include="$(RepositoryRootDirectory)test\NuGet.Core.FuncTests\*\*.csproj"
+                          Exclude="$(RepositoryRootDirectory)test\NuGet.Core.FuncTests\Msbuild.Integration.Test\*.csproj" />
+  </ItemGroup>
+
+  <!-- All projects in the repository -->
+  <ItemGroup Condition=" '$(IsXPlat)' != 'true' ">
+    <SolutionProjects Include="$(RepositoryRootDirectory)test\*\*\*.csproj"
+                      Exclude="$(RepositoryRootDirectory)test\EndToEnd\*\*.csproj;
+                               $(RepositoryRootDirectory)test\NuGet.Tests.Apex\*\NuGet.Tests.Apex.csproj"
+                      Condition=" '$(ExcludeTestProjects)' != 'true' " />
+
+    <SolutionProjects Include="$(RepositoryRootDirectory)src\*\*\*.csproj" />
+    <SolutionProjectsWithoutVSIX Include="@(SolutionProjects)"
+                                Exclude="$(VSIXProject)" />
+  </ItemGroup>
+
+  <!-- All projects in the repository that support cross platform builds -->
+  <ItemGroup Condition=" '$(IsXPlat)' == 'true' ">
+    <SolutionProjects Include="@(CoreUnitTestProjects)" />
+    <SolutionProjects Include="@(CoreFuncTestProjects)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProductProjects Include="$(RepositoryRootDirectory)src\*\*\*.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(IsXPlat)' != 'true' ">
+   <ApexProjects Include="$(RepositoryRootDirectory)test\NuGet.Tests.Apex\*\*.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(IsXPlat)' != 'true' ">
+    <AllRepoProjects Include="@(SolutionProjects)" />
+    <AllRepoProjects Include="@(ApexProjects)" />
+  </ItemGroup>
+
   <!--
     ============================================================
     Get XPLAT projects

--- a/build/common.project.props
+++ b/build/common.project.props
@@ -214,66 +214,6 @@
     <CodeAnalysisRuleSet>$(BuildCommonDirectory)NuGet.Tests.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
-  <!-- The project that builds the VSIX -->
-  <PropertyGroup>
-    <VSIXProject>$(RepositoryRootDirectory)src\NuGet.Clients\NuGet.VisualStudio.Client\NuGet.VisualStudio.Client.csproj</VSIXProject>
-  </PropertyGroup>
-
-  <!-- Find all test projects  -->
-  <ItemGroup Condition=" '$(IsXPlat)' != 'true' ">
-    <CoreUnitTestProjects Include="$(RepositoryRootDirectory)test\NuGet.Core.Tests\*\*.csproj"
-                          Exclude="$(RepositoryRootDirectory)test\NuGet.Core.Tests\NuGet.PackageManagement.Test\*.csproj"/>
-    <VSUnitTestProjects Include="$(RepositoryRootDirectory)test\NuGet.Clients.Tests\*\*.csproj"
-                        Exclude="$(RepositoryRootDirectory)test\NuGet.Clients.Tests\NuGet.CommandLine.Test\*.csproj" />
-    <CoreFuncTestProjects Include="$(RepositoryRootDirectory)test\NuGet.Core.FuncTests\*\*.csproj;
-                                   $(RepositoryRootDirectory)test\NuGet.Clients.Tests\NuGet.CommandLine.Test\*.csproj;
-                                   $(RepositoryRootDirectory)test\NuGet.Core.Tests\NuGet.PackageManagement.Test\*.csproj;
-                                   $(RepositoryRootDirectory)test\NuGet.Clients.FuncTests\*\*.csproj" />
-  </ItemGroup>
-
-  <!-- start with only nuget.versioning for xplat -->
-  <ItemGroup Condition=" '$(IsXPlat)' == 'true' ">
-    <CoreUnitTestProjects Include="$(RepositoryRootDirectory)test\NuGet.Core.Tests\*\*.csproj"
-                          Exclude="$(RepositoryRootDirectory)test\NuGet.Core.Tests\*PackageManagement*\*.csproj;
-                                   $(RepositoryRootDirectory)test\NuGet.Core.Tests\*ProjectManagement*\*.csproj;
-                                   $(RepositoryRootDirectory)test\NuGet.Core.Tests\*VisualStudio*\*.csproj;
-                                   $(RepositoryRootDirectory)test\NuGet.Core.Tests\*.Utility\*.csproj;
-                                   $(RepositoryRootDirectory)test\NuGet.Core.Tests\NuGet.Credentials.Test\*.csproj;" />
-    <CoreFuncTestProjects Include="$(RepositoryRootDirectory)test\NuGet.Core.FuncTests\*\*.csproj"
-                          Exclude="$(RepositoryRootDirectory)test\NuGet.Core.FuncTests\Msbuild.Integration.Test\*.csproj" />
-  </ItemGroup>
-
-  <!-- All projects in the repository -->
-  <ItemGroup Condition=" '$(IsXPlat)' != 'true' ">
-    <SolutionProjects Include="$(RepositoryRootDirectory)test\*\*\*.csproj"
-                      Exclude="$(RepositoryRootDirectory)test\EndToEnd\*\*.csproj;
-                               $(RepositoryRootDirectory)test\NuGet.Tests.Apex\*\NuGet.Tests.Apex.csproj"
-                      Condition=" '$(ExcludeTestProjects)' != 'true' " />
-
-    <SolutionProjects Include="$(RepositoryRootDirectory)src\*\*\*.csproj" />
-    <SolutionProjectsWithoutVSIX Include="@(SolutionProjects)"
-                                Exclude="$(VSIXProject)" />
-  </ItemGroup>
-
-  <!-- All projects in the repository that support cross platform builds -->
-  <ItemGroup Condition=" '$(IsXPlat)' == 'true' ">
-    <SolutionProjects Include="@(CoreUnitTestProjects)" />
-    <SolutionProjects Include="@(CoreFuncTestProjects)" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProductProjects Include="$(RepositoryRootDirectory)src\*\*\*.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(IsXPlat)' != 'true' ">
-   <ApexProjects Include="$(RepositoryRootDirectory)test\NuGet.Tests.Apex\*\*.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(IsXPlat)' != 'true' ">
-    <AllRepoProjects Include="@(SolutionProjects)" />
-    <AllRepoProjects Include="@(ApexProjects)" />
-  </ItemGroup>
-
   <!-- source link -->
   <ItemGroup Condition="'$(Shipping)' == 'true' AND '$(IsXPlat)' != 'true'">
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All"/>

--- a/build/docs.proj
+++ b/build/docs.proj
@@ -1,5 +1,6 @@
 <Project DefaultTargets="GenerateDocsOverview">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common.props" />
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\build.proj" />
 
   <PropertyGroup>
     <MarkdownAssemblyPath>$(ArtifactsDirectory)doc.tasks\$(VisualStudioVersion)\bin\$(Configuration)\$(NetStandardVersion)\doc.tasks.dll</MarkdownAssemblyPath>

--- a/build/loc.proj
+++ b/build/loc.proj
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="AfterBuild" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common.props" />
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\build.proj" />
   <Import Project="$(MicroBuildDirectory)MicroBuild.Core.props"/>
 
   <!-- Configuration/global properties -->

--- a/build/sign.proj
+++ b/build/sign.proj
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="AfterBuild" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common.props" />
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\build.proj" />
   <Import Project="$(MicroBuildDirectory)MicroBuild.Core.props"/>
 
   <!-- Configuration/global properties -->

--- a/build/symbols.proj
+++ b/build/symbols.proj
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="GetSymbolsAndAssembliesToIndex" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common.props" />
-  
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\build.proj" />
+
   <!-- Configuration/global properties -->
   <PropertyGroup>
     <CommonMSBuildProperties>

--- a/src/NuGet.Core/NuGet.Localization/NuGet.Localization.csproj
+++ b/src/NuGet.Core/NuGet.Localization/NuGet.Localization.csproj
@@ -1,5 +1,6 @@
 <Project>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common.props" />
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\build.proj" />
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
   <PropertyGroup>
@@ -19,13 +20,13 @@
   <!--
     ============================================================
     Get localized files from all projects and move them to a common location.
-    It is conditioned on the existence of the NuGet.Build.Localization repository which will 
+    It is conditioned on the existence of the NuGet.Build.Localization repository which will
     only be on the CI Machines as an empty repository is checked out locally.
     ============================================================
   -->
 
   <Target Name="MoveLocalizedFilesToLocalizedArtifacts" Condition="'$(BuildRTM)' == 'false' AND Exists($(LocalizationRootDirectory)) " BeforeTargets="GenerateNuspec">
-    <MakeDir  
+    <MakeDir
             Directories="$(LocalizationFilesDirectory)"/>
     <ItemGroup>
       <LocalizationProjects Include="@(SolutionProjectsWithoutVSIX)" Exclude="$(NuGetCoreSrcDirectory)NuGet.Build.Tasks.Pack\NuGet.Build.Tasks.Pack.csproj"/>
@@ -36,8 +37,8 @@
                          Configuration=$(Configuration);
                          AppendTargetFrameworkToOutputPath=false"
              Targets="GetNetCoreLocalizedFilesInProjectOutputPath">
-      
-      <Output TaskParameter="TargetOutputs" 
+
+      <Output TaskParameter="TargetOutputs"
               ItemName="_LocalizedFilesForLocalizationPackage" />
     </MSBuild>
 
@@ -49,7 +50,7 @@
 
     <Copy SourceFiles="@(_LocalizedFilePaths->'%(Identity)')" DestinationFiles="@(_LocalizedFilePaths->'%(TargetPath)')" />
   </Target>
-  
+
   <Import Project="$(BuildCommonDirectory)common.targets"/>
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 </Project>


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Client.Engineering/issues/289
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: Moved MSBuild properties and items from `build\common.project.props` to `build\build.proj`

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  build script
Validation:  
