### PR TITLE
Use a different public key for NuGet.indexing

### DIFF
--- a/build/sign.targets
+++ b/build/sign.targets
@@ -9,7 +9,8 @@
   <!-- Use MSFT SNK for all NuGet.Core test and source projects and since we do not own MSFT SNK we can only delay sign the assemblies. -->
   <PropertyGroup Condition = " $(MSBuildProjectFullPath.Contains('src\NuGet.Core')) == 'true' or $(MSBuildProjectFullPath.Contains('test/NuGet.Core')) == 'true' or
                                $(MSBuildProjectFullPath.Contains('src/NuGet.Core')) == 'true' or $(MSBuildProjectFullPath.Contains('test\NuGet.Core')) == 'true' or
-                               $(MSBuildProjectFullPath.Contains('NuGet.CommandLine.csproj')) == 'true' ">
+                               $(MSBuildProjectFullPath.Contains('NuGet.CommandLine.csproj')) == 'true' or
+                               (MSBuildProjectFullPath.Contains('NuGet.Indexing.csproj')) == 'true' ">
 
     <StrongNameKey>$(MS_PFX_PATH)</StrongNameKey>
     <DefaultStrongNameCert>MsSharedLib72</DefaultStrongNameCert>

--- a/build/sign.targets
+++ b/build/sign.targets
@@ -10,7 +10,7 @@
   <PropertyGroup Condition = " $(MSBuildProjectFullPath.Contains('src\NuGet.Core')) == 'true' or $(MSBuildProjectFullPath.Contains('test/NuGet.Core')) == 'true' or
                                $(MSBuildProjectFullPath.Contains('src/NuGet.Core')) == 'true' or $(MSBuildProjectFullPath.Contains('test\NuGet.Core')) == 'true' or
                                $(MSBuildProjectFullPath.Contains('NuGet.CommandLine.csproj')) == 'true' or
-                               (MSBuildProjectFullPath.Contains('NuGet.Indexing.csproj')) == 'true' ">
+                               $(MSBuildProjectFullPath.Contains('NuGet.Indexing.csproj')) == 'true' ">
 
     <StrongNameKey>$(MS_PFX_PATH)</StrongNameKey>
     <DefaultStrongNameCert>MsSharedLib72</DefaultStrongNameCert>


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9481
Regression: No
* Last working version:  
* How are we preventing it in future:   

## Fix

Details: 
https://github.com/NuGet/Home/issues/9481 is self descriptive.
Broken in https://github.com/NuGet/NuGet.Client/pull/3309.   

## Testing/Validation

Tests Added: No  
Reason for not adding tests: Infrastructure.
Validation:  
