### PR TITLE
Fix 1 tests in SignatureTrustAndValidityVerificationProviderTests

### DIFF
--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignatureTrustAndValidityVerificationProviderTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignatureTrustAndValidityVerificationProviderTests.cs
@@ -1208,8 +1208,7 @@ namespace NuGet.Packaging.FuncTest
                 result.IsValid.Should().BeFalse();
                 resultsWithErrors.Count().Should().Be(1);
                 totalErrorIssues.Count().Should().Be(1);
-                totalErrorIssues.First().Code.Should().Be(NuGetLogCode.NU3028);
-                totalErrorIssues.First().Message.Should().Contain("A certificate chain processed, but terminated in a root certificate which is not trusted by the trust provider");
+                SigningTestUtility.AssertUntrustedRoot(totalErrorIssues, NuGetLogCode.NU3028, LogLevel.Error);
             }
         }
 

--- a/test/TestUtilities/Test.Utility/Signing/SigningTestUtility.cs
+++ b/test/TestUtilities/Test.Utility/Signing/SigningTestUtility.cs
@@ -731,7 +731,7 @@ namespace Test.Utility.Signing
                 issue.Message.Contains(revocationStatusUnknown));
         }
 
-        public static void AssertUntrustedRoot(IEnumerable<ILogMessage> issues, LogLevel logLevel)
+        public static void AssertUntrustedRoot(IEnumerable<ILogMessage> issues, NuGetLogCode code, LogLevel logLevel)
         {
             string untrustedRoot;
 
@@ -749,9 +749,14 @@ namespace Test.Utility.Signing
             }
 
             Assert.Contains(issues, issue =>
-                issue.Code == NuGetLogCode.NU3018 &&
+                issue.Code == code &&
                 issue.Level == logLevel &&
                 issue.Message.Contains(untrustedRoot));
+        }
+
+        public static void AssertUntrustedRoot(IEnumerable<ILogMessage> issues, LogLevel logLevel)
+        {
+            AssertUntrustedRoot(issues, NuGetLogCode.NU3018, logLevel);
         }
 
         public static void AssertNotTimeValid(IEnumerable<ILogMessage> issues, LogLevel logLevel)


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/8934
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details:  fix 1 test in issue NuGet/Home#8934  
`GetTrustResultAsync_WithTimestampChainingToUntrustedRoot_NotAllowIgnoreTimestamp_FailAsync`
## Testing/Validation

Tests Added: No  
Reason for not adding tests:  fix a newly enabled test for xplat verifying
Validation:  
