### PR TITLE
Disable xplat verification dynamic revoke tests on Mac 

### DIFF
--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignatureTrustAndValidityVerificationProviderTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignatureTrustAndValidityVerificationProviderTests.cs
@@ -1378,7 +1378,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            [CIOnlyTheory]
+            [PlatformTheory(Platform.Windows, Platform.Linux)] // https://github.com/NuGet/Home/issues/9501
             [InlineData(true)]
             [InlineData(false)]
             public async Task GetTrustResultAsync_WithRevokedPrimaryCertificate_ReturnsSuspectAsync(bool allowEverything)
@@ -1423,7 +1423,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            [CIOnlyTheory]
+            [PlatformTheory(Platform.Windows, Platform.Linux)] // https://github.com/NuGet/Home/issues/9501
             [InlineData(true, SignatureVerificationStatus.Valid)]
             [InlineData(false, SignatureVerificationStatus.Disallowed)]
             public async Task GetTrustResultAsync_WithRevokedTimestampCertificate_ReturnsStatusAsync(
@@ -1653,7 +1653,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            [CIOnlyTheory]
+            [PlatformTheory(Platform.Windows, Platform.Linux)] // https://github.com/NuGet/Home/issues/9501
             [InlineData(true)]
             [InlineData(false)]
             public async Task GetTrustResultAsync_WithRevokedPrimaryCertificate_ReturnsSuspectAsync(bool allowEverything)
@@ -1698,7 +1698,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            [CIOnlyTheory]
+            [PlatformTheory(Platform.Windows, Platform.Linux)] // https://github.com/NuGet/Home/issues/9501
             [InlineData(true, SignatureVerificationStatus.Valid)]
             [InlineData(false, SignatureVerificationStatus.Disallowed)]
             public async Task GetTrustResultAsync_WithRevokedTimestampCertificate_ReturnsStatusAsync(
@@ -2010,7 +2010,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            [CIOnlyTheory]
+            [PlatformTheory(Platform.Windows, Platform.Linux)] // https://github.com/NuGet/Home/issues/9501
             [InlineData(true)]
             [InlineData(false)]
             public async Task VerifyAsync_WithRevokedCountersignatureCertificate_ReturnsSuspectAsync(bool allowEverything)
@@ -2057,7 +2057,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            [CIOnlyTheory]
+            [PlatformTheory(Platform.Windows, Platform.Linux)] // https://github.com/NuGet/Home/issues/9501
             [InlineData(true, SignatureVerificationStatus.Valid)]
             [InlineData(false, SignatureVerificationStatus.Disallowed)]
             public async Task VerifyAsync_WithRevokedTimestampCertificate_ReturnsStatusAsync(


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/8934
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: 
Disabled the following tests on Mac. Those tests pass on Windows and Linux, but not for macOS.
```
GetTrustResultAsync_WithRevokedPrimaryCertificate_ReturnsSuspectAsync
GetTrustResultAsync_WithRevokedTimestampCertificate_ReturnsStatusAsync
VerifyAsync_WithRevokedCountersignatureCertificate_ReturnsSuspectAsync
VerifyAsync_WithRevokedTimestampCertificate_ReturnsStatusAsync
```
Those tests dynamically revoke a certificate. During debugging, the OCSP responder sends the response, but the chain.build results has the status of "RevocationStatusUnknown" on Mac.
It may be the problem of simulated OCSP responder( but Windows and Linux works fine with the OCSP responder)
How it works with OCSP responder is in Apple’s SecTrust* functions from Security.framework used in X509Chain.build. Have no idea how should we change the tests for macOS.
So we disabled those tests for Mac only (tests are kept on Windows and Linux) for now.
This issue looks the same with dotnet/runtime#31249

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  disable tests
Validation:  
