### PR TITLE
Changes displayed installed version to max installed version in PM UI

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageItemListViewModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageItemListViewModel.cs
@@ -438,7 +438,7 @@ namespace NuGet.PackageManagement.UI
 
         public void UpdatePackageStatus(IEnumerable<PackageCollectionItem> installedPackages)
         {
-            // Get the maxium version installed in any target project/solution
+            // Get the maximum version installed in any target project/solution
             InstalledVersion = installedPackages
                 .GetPackageVersions(Id)
                 .MaxOrDefault();

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageItemListViewModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageItemListViewModel.cs
@@ -438,7 +438,7 @@ namespace NuGet.PackageManagement.UI
 
         public void UpdatePackageStatus(IEnumerable<PackageCollectionItem> installedPackages)
         {
-            // Get the minimum version installed in any target project/solution
+            // Get the maxium version installed in any target project/solution
             InstalledVersion = installedPackages
                 .GetPackageVersions(Id)
                 .MaxOrDefault();

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageItemListViewModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageItemListViewModel.cs
@@ -441,7 +441,7 @@ namespace NuGet.PackageManagement.UI
             // Get the minimum version installed in any target project/solution
             InstalledVersion = installedPackages
                 .GetPackageVersions(Id)
-                .MinOrDefault();
+                .MaxOrDefault();
 
             // Set auto referenced to true any reference for the given id contains the flag.
             AutoReferenced = installedPackages.IsAutoReferenced(Id);

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/OutputConsoleLogger.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/OutputConsoleLogger.cs
@@ -128,15 +128,23 @@ namespace NuGet.VisualStudio.Common
         private async Task<int> GetMSBuildVerbosityLevelAsync()
         {
             await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            int verbosity = DefaultVerbosityLevel;
 
-            var properties = _dte.get_Properties(DTEEnvironmentCategory, DTEProjectPage);
-            var value = properties.Item(MSBuildVerbosityKey).Value;
-            if (value is int)
+            try 
             {
-                return (int)value;
+                var properties = _dte.get_Properties(DTEEnvironmentCategory, DTEProjectPage);
+                var val = properties.Item(MSBuildVerbosityKey).Value;
+                if (val is int val_int)
+                {
+                    verbosity = val_int;
+                }
+            }
+            catch
+            {
+                verbosity = DefaultVerbosityLevel;
             }
 
-            return DefaultVerbosityLevel;
+            return verbosity;
         }
 
         public void Start()

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/OutputConsoleLogger.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/OutputConsoleLogger.cs
@@ -128,23 +128,15 @@ namespace NuGet.VisualStudio.Common
         private async Task<int> GetMSBuildVerbosityLevelAsync()
         {
             await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-            int verbosity = DefaultVerbosityLevel;
 
-            try 
+            var properties = _dte.get_Properties(DTEEnvironmentCategory, DTEProjectPage);
+            var value = properties.Item(MSBuildVerbosityKey).Value;
+            if (value is int)
             {
-                var properties = _dte.get_Properties(DTEEnvironmentCategory, DTEProjectPage);
-                var val = properties.Item(MSBuildVerbosityKey).Value;
-                if (val is int val_int)
-                {
-                    verbosity = val_int;
-                }
-            }
-            catch
-            {
-                verbosity = DefaultVerbosityLevel;
+                return (int)value;
             }
 
-            return verbosity;
+            return DefaultVerbosityLevel;
         }
 
         public void Start()


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9321
Regression: No
* Last working version:   
* How are we preventing it in future:   

## Fix

Instead of getting the min version, get the max installed version in the ViewModel

## Testing/Validation

Tests Added: No
Reason for not adding tests:  
Validation:  


#### Before

See comment in issue: https://github.com/NuGet/Home/issues/9321#issuecomment-620972610

#### After

Browse:

![image](https://user-images.githubusercontent.com/1192347/80998847-828e6f80-8df8-11ea-8203-df70b60ac11e.png)


Installed:

![image](https://user-images.githubusercontent.com/1192347/80998887-90dc8b80-8df8-11ea-8427-b5c67a2c3aeb.png)


Updates:

![image](https://user-images.githubusercontent.com/1192347/80998914-9934c680-8df8-11ea-9893-247eaef2f091.png)


Consolidate:

![image](https://user-images.githubusercontent.com/1192347/80998944-a81b7900-8df8-11ea-858a-a0c7e040ab8b.png)


#### AI run

Tested InfiniteScrollList instance ("Packages list")

![image](https://user-images.githubusercontent.com/1192347/80999795-16ad0680-8dfa-11ea-8ed1-a215469f5356.png)
