### PR TITLE
Adding CMD wrappers for PS1 scripts.

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -1,0 +1,2 @@
+@echo off
+powershell.exe -NoProfile -ExecutionPolicy RemoteSigned -Command "%~dpn0.ps1" %*

--- a/configure.cmd
+++ b/configure.cmd
@@ -1,0 +1,2 @@
+@echo off
+powershell.exe -NoProfile -ExecutionPolicy RemoteSigned -Command "%~dpn0.ps1" %*

--- a/runTests.cmd
+++ b/runTests.cmd
@@ -1,0 +1,2 @@
+@echo off
+powershell.exe -NoProfile -ExecutionPolicy RemoteSigned -Command "%~dpn0.ps1" %*


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9519
Regression: No

## Fix

Details: Providing tiny CMD wrappers around PS1 scripts help usability of NuGet.Client repo from CMD windows.

## Testing/Validation

Tests Added: No  
Reason for not adding tests: Not a product issue.
Validation: configure.cmd/build.cmd/runTests.cmd correctly invoke wrapped PS1 scripts
