### PR TITLE
Run Windows func tests on VS2019 pool

### DIFF
--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -27,7 +27,7 @@ jobs:
     inputs:
       scriptType: "inlineScript"
       inlineScript: |
-        . $(Build.Repository.LocalPath)\\scripts\\utils\\PostGitCommitStatus.ps1 
+        . $(Build.Repository.LocalPath)\\scripts\\utils\\PostGitCommitStatus.ps1
         CheckVstsPersonalAccessToken -VstsPersonalAccessToken $(VstsPersonalAccessToken)
 
   - task: PowerShell@1
@@ -82,7 +82,7 @@ jobs:
 
   pool:
     name: VSEng-MicroBuildVS2019
-    demands: 
+    demands:
       - DotNetFramework
       - msbuild
   strategy:
@@ -183,7 +183,7 @@ jobs:
       msbuildVersion: "16.0"
       msbuildArguments: "/t:EnsureNewtonsoftJsonVersion"
     condition: "succeeded()"
-  
+
   - task: MSBuild@1
     displayName: "Ensure package versions are declared in packages.targets"
     continueOnError: "false"
@@ -194,28 +194,28 @@ jobs:
     condition: "succeeded()"
 
 
-  - task: MSBuild@1	
-    displayName: "Localize Assemblies"	
-    inputs:	
-      solution: "build\\loc.proj"	
-      msbuildVersion: "16.0"	
-      configuration: "$(BuildConfiguration)"	
-      msbuildArguments: "/t:AfterBuild"	
+  - task: MSBuild@1
+    displayName: "Localize Assemblies"
+    inputs:
+      solution: "build\\loc.proj"
+      msbuildVersion: "16.0"
+      configuration: "$(BuildConfiguration)"
+      msbuildArguments: "/t:AfterBuild"
 
-  - task: MSBuild@1	
-    displayName: "Build Final NuGet.exe (via ILMerge)"	
-    inputs:	
-      solution: "src\\NuGet.Clients\\NuGet.CommandLine\\NuGet.CommandLine.csproj"	
-      msbuildVersion: "16.0"	
-      configuration: "$(BuildConfiguration)"	
+  - task: MSBuild@1
+    displayName: "Build Final NuGet.exe (via ILMerge)"
+    inputs:
+      solution: "src\\NuGet.Clients\\NuGet.CommandLine\\NuGet.CommandLine.csproj"
+      msbuildVersion: "16.0"
+      configuration: "$(BuildConfiguration)"
       msbuildArguments: "/t:ILMergeNuGetExe /p:ExpectedLocalizedArtifactCount=$(LocalizedLanguageCount)"
 
-  - task: MSBuild@1	
-    displayName: "Publish NuGet.exe (ILMerged) into NuGet.CommandLine.Test (Mac tests use this)"	
-    inputs:	
-      solution: "test\\NuGet.Clients.Tests\\NuGet.CommandLine.Test\\NuGet.CommandLine.Test.csproj"	
-      msbuildVersion: "16.0"	
-      configuration: "$(BuildConfiguration)"	
+  - task: MSBuild@1
+    displayName: "Publish NuGet.exe (ILMerged) into NuGet.CommandLine.Test (Mac tests use this)"
+    inputs:
+      solution: "test\\NuGet.Clients.Tests\\NuGet.CommandLine.Test\\NuGet.CommandLine.Test.csproj"
+      msbuildVersion: "16.0"
+      configuration: "$(BuildConfiguration)"
       msbuildArguments: "/t:CopyFinalNuGetExeToOutputPath"
     condition: "and(succeeded(),eq(variables['BuildRTM'], 'true'))"
 
@@ -554,8 +554,8 @@ jobs:
     FullVstsBuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
   condition: "and(succeeded(),eq(variables['RunFunctionalTestsOnWindows'], 'true')) "
   pool:
-    name: VSEng-MicroBuildSxS
-    demands: 
+    name: VSEng-MicroBuildVS2019
+    demands:
         - DotNetFramework
         - msbuild
   strategy:
@@ -564,7 +564,7 @@ jobs:
         SkipCoreAssemblies: "true"
       IsCore:
         SkipDesktopAssemblies: "true"
-        
+
   steps:
   - task: PowerShell@1
     displayName: "Print Environment Variables"

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
@@ -1629,7 +1629,7 @@ public class B
 
         // Same test as PackCommand_ReferencedProjectWithNuspecFile, but with -MSBuidVersion
         // set to 14
-        [WindowsNTFact]
+        [WindowsNTFact(Skip = "https://github.com/NuGet/Home/issues/9303")]
         public void PackCommand_ReferencedProjectWithNuspecFileWithMsbuild14()
         {
             var nugetexe = Util.GetNuGetExePath();
@@ -1851,7 +1851,7 @@ public class B
 
         // Same test as PackCommand_ReferencedProjectWithJsonFile, but with -MSBuidVersion
         // set to 14
-        [WindowsNTFact]
+        [WindowsNTFact(Skip = "https://github.com/NuGet/Home/issues/9303")]
         public void PackCommand_ReferencedProjectWithJsonFileWithMsbuild14()
         {
             var nugetexe = Util.GetNuGetExePath();
@@ -2349,7 +2349,7 @@ public class B
 
                 // Act
 
-                // Execute the pack command and feed in some properties for token replacements and 
+                // Execute the pack command and feed in some properties for token replacements and
                 // set the flag to save the resolved nuspec to output directory.\
                 var arguments = string.Format(
                     "pack {0} -ConfigFile {1} -properties tagVar=CustomTag;author=test1@microsoft.com -InstallPackageToOutputPath -OutputFileNamesWithoutVersion",
@@ -2399,7 +2399,7 @@ public class B
                 var resolveNuSpecPath = Path.Combine(workingDirectory, nuspecName);
                 Assert.True(File.Exists(resolveNuSpecPath));
 
-                // Verify the nuspec contents in the zip file and the resolved nuspec side by 
+                // Verify the nuspec contents in the zip file and the resolved nuspec side by
                 // side with the package are the same
                 var resolvedNuSpecContents = File.ReadAllText(resolveNuSpecPath);
                 var packageOutputDirectoryNuSpecXml = XDocument.Parse(resolvedNuSpecContents);
@@ -2456,7 +2456,7 @@ public class B
 
                 // Act
 
-                // Execute the pack command and feed in some properties for token replacements and 
+                // Execute the pack command and feed in some properties for token replacements and
                 // set the flag to save the resolved nuspec to output directory.\
                 var commandRunner = CommandRunner.Run(
                     Util.GetNuGetExePath(),
@@ -3114,8 +3114,8 @@ namespace Proj1
             }
         }
 
-        // Test that NuGet packages of the project are added as dependencies 
-        // even if there is already an indirect depenency, provided that the 
+        // Test that NuGet packages of the project are added as dependencies
+        // even if there is already an indirect depenency, provided that the
         // project requires a higher version number than the indirect dependency.
         [Theory]
         [InlineData("packages.config")]
@@ -3134,7 +3134,7 @@ namespace Proj1
                 Util.CreateFile(
                     proj1Directory,
                     "proj1.csproj",
-@"<Project ToolsVersion='4.0' DefaultTargets='Build' 
+@"<Project ToolsVersion='4.0' DefaultTargets='Build'
     xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
   <PropertyGroup>
     <OutputType>Library</OutputType>
@@ -3153,7 +3153,7 @@ namespace Proj1
                     proj1Directory,
                     "proj1_file1.cs",
 @"using System;
- 
+
 namespace Proj1
 {
     public class Class1
@@ -3221,7 +3221,7 @@ namespace Proj1
                 Assert.Equal(1, package.DependencySets.Count());
                 var dependencySet = package.DependencySets.First();
 
-                // Verify that testPackage2 is added as dependency in addition to testPackage1. 
+                // Verify that testPackage2 is added as dependency in addition to testPackage1.
                 // testPackage3 and testPackage4 are not added because they are already referenced by testPackage1 with the correct version range.
                 Assert.Equal(4, dependencySet.Dependencies.Count);
                 var dependency1 = dependencySet.Dependencies.Single(d => d.Id == "testPackage1");
@@ -3235,8 +3235,8 @@ namespace Proj1
             }
         }
 
-        // Test that NuGet packages of the project are added as dependencies 
-        // even if there is already an indirect depenency, provided that the 
+        // Test that NuGet packages of the project are added as dependencies
+        // even if there is already an indirect depenency, provided that the
         // project requires a higher version number than the indirect dependency.
         [Theory]
         [InlineData("packages.config")]
@@ -3255,7 +3255,7 @@ namespace Proj1
                 Util.CreateFile(
                     proj1Directory,
                     "proj1.csproj",
-@"<Project ToolsVersion='4.0' DefaultTargets='Build' 
+@"<Project ToolsVersion='4.0' DefaultTargets='Build'
     xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
   <PropertyGroup>
     <OutputType>Library</OutputType>
@@ -3274,7 +3274,7 @@ namespace Proj1
                     proj1Directory,
                     "proj1_file1.cs",
 @"using System;
- 
+
 namespace Proj1
 {
     public class Class1
@@ -3447,7 +3447,7 @@ namespace Proj1
 
         // Tests that with -MSBuildVersion set to 14, a projec using C# 6.0 features (nameof in this test)
         // can be built successfully.
-        [WindowsNTFact]
+        [WindowsNTFact(Skip = "https://github.com/NuGet/Home/issues/9303")]
         public void PackCommand_WithMsBuild14()
         {
             var nugetexe = Util.GetNuGetExePath();
@@ -5661,7 +5661,7 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
                 }
             }
         }
-        
+
         [Fact]
         public void PackCommand_PackIcon_HappyPath_Succeeds()
         {
@@ -5696,7 +5696,7 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
 
             TestPackIconSuccess(testDir);
         }
-                
+
         [Fact]
         public void PackCommand_PackIcon_Folder_Succeeds()
         {
@@ -5885,7 +5885,7 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
 
                 // Verify
                 Util.VerifyResultSuccess(r);
-                
+
                 Assert.True(File.Exists(nupkgPath));
                 Assert.True(File.Exists(snupkgPath));
 

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
@@ -454,7 +454,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 
         }
 
-        [CIOnlyTheory]
+        [CIOnlyTheory(Skip = "https://github.com/NuGet/Home/issues/9303")]
         [InlineData("packages.config")]
         [InlineData("packages.proj2.config")]
         public void RestoreCommand_FromSolutionFileWithMsbuild12(string configFileName)
@@ -540,7 +540,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
             }
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/NuGet/Home/issues/9303")]
         public void RestoreCommand_FromSolutionFileWithMsbuildPathAndMsbuildVersion()
         {
             // Arrange


### PR DESCRIPTION
Also skip tests that need multiple VS installs

Sorry about all the whitespace changes. I installed a VSCode plugin to respect .editorconfig settings, and it appears that we have a lot of trailing whitespace, despite the .editorconfig setting to remove trailing whitespace being enabled for a very long time.

## Bug

Fixes: https://github.com/NuGet/Client.Engineering/issues/300
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: run on Microbuild's 2019 pool.

There are some tests that some tests for nuget.exe's MSBuild detection, but need very specific versions of MSBuild installed to run. These tests have been disabled until someone can improve the tests to not actually need multiple msbuilds installed to test.

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  CI script.
Validation:  
