### PR TITLE
Add powershell utilities to allow users to choose which version of Vi…

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -106,7 +106,7 @@ else {
 Invoke-BuildStep 'Running Restore' {
 
     # Restore
-    $args = "build\build.proj", "/t:EnsurePackageReferenceVersionsInSolution", "/p:Configuration=$Configuration"
+    $args = "$PSScriptRoot\build\build.proj", "/t:EnsurePackageReferenceVersionsInSolution", "/p:Configuration=$Configuration"
     if ($Binlog)
     {
         $args += "-bl:msbuild.ensurepr.binlog"
@@ -115,7 +115,7 @@ Invoke-BuildStep 'Running Restore' {
     Trace-Log ". `"$MSBuildExe`" $args"
     & $MSBuildExe @args
 
-    $args = "build\build.proj", "/t:RestoreVS", "/p:Configuration=$Configuration", "/p:ReleaseLabel=$ReleaseLabel", "/p:BuildNumber=$BuildNumber", "/v:m", "/m:1"
+    $args = "$PSScriptRoot\build\build.proj", "/t:RestoreVS", "/p:Configuration=$Configuration", "/p:ReleaseLabel=$ReleaseLabel", "/p:BuildNumber=$BuildNumber", "/v:m", "/m:1"
     if ($Binlog)
     {
         $args += "-bl:msbuild.restore.binlog"
@@ -134,7 +134,7 @@ Invoke-BuildStep 'Running Restore' {
 
 Invoke-BuildStep $VSMessage {
 
-    $args = 'build\build.proj', "/t:$VSTarget", "/p:Configuration=$Configuration", "/p:ReleaseLabel=$ReleaseLabel", "/p:BuildNumber=$BuildNumber", '/v:m', '/m:1'
+    $args = "$PSScriptRoot\build\build.proj", "/t:$VSTarget", "/p:Configuration=$Configuration", "/p:ReleaseLabel=$ReleaseLabel", "/p:BuildNumber=$BuildNumber", '/v:m', '/m:1'
 
     If ($SkipDelaySigning)
     {
@@ -173,7 +173,7 @@ Invoke-BuildStep 'Publishing the EndToEnd test package' {
 Invoke-BuildStep 'Running Restore RTM' {
 
     # Restore for VS
-    $args = "build\build.proj", "/t:RestoreVS", "/p:Configuration=$Configuration", "/p:BuildRTM=true", "/p:ReleaseLabel=$ReleaseLabel", "/p:BuildNumber=$BuildNumber", "/p:ExcludeTestProjects=true", "/v:m", "/m:1"
+    $args = "$PSScriptRoot\build\build.proj", "/t:RestoreVS", "/p:Configuration=$Configuration", "/p:BuildRTM=true", "/p:ReleaseLabel=$ReleaseLabel", "/p:BuildNumber=$BuildNumber", "/p:ExcludeTestProjects=true", "/v:m", "/m:1"
 
     if ($Binlog)
     {
@@ -196,7 +196,7 @@ Invoke-BuildStep 'Running Restore RTM' {
 Invoke-BuildStep 'Packing RTM' {
 
     # Build and (If not $SkipUnitTest) Pack, Core unit tests, and Unit tests for VS
-    $args = "build\build.proj", "/t:BuildVS`;Pack", "/p:Configuration=$Configuration", "/p:BuildRTM=true", "/p:ReleaseLabel=$ReleaseLabel", "/p:BuildNumber=$BuildNumber", "/p:ExcludeTestProjects=true", "/v:m", "/m:1"
+    $args = "$PSScriptRoot\build\build.proj", "/t:BuildVS`;Pack", "/p:Configuration=$Configuration", "/p:BuildRTM=true", "/p:ReleaseLabel=$ReleaseLabel", "/p:BuildNumber=$BuildNumber", "/p:ExcludeTestProjects=true", "/v:m", "/m:1"
     if ($Binlog)
     {
         $args += "-bl:msbuild.pack.binlog"

--- a/build/VSUtilities.psm1
+++ b/build/VSUtilities.psm1
@@ -10,7 +10,7 @@ function Start-VsDevShell {
     Enter-VsDevShell -DevCmdArguments "-no_logo" -StartInPath "$pwd" $chosenVisualStudioVersion.InstanceId
 }
 
-function Get-VsComnToolsPath {
+function Get-VsCommonToolsPath {
     if([string]::IsNullOrEmpty($env:VSINSTALLDIR)) {
         $chosenVisualStudioVersion = ChooseVisualStudioInstallation @(Get-VSInstalls)
         $installDir = $chosenVisualStudioVersion.InstallationPath
@@ -116,4 +116,4 @@ function ChooseVisualStudioInstallation {
     return $match
 }
 
-Export-ModuleMember -Function Start-VsDevShell,Get-VsComnToolsPath
+Export-ModuleMember -Function Start-VsDevShell,Get-VsCommonToolsPath

--- a/build/VSUtilities.psm1
+++ b/build/VSUtilities.psm1
@@ -1,0 +1,119 @@
+function Start-VsDevShell {
+    $chosenVisualStudioVersion = ChooseVisualStudioInstallation @(Get-VSInstalls)
+    if ($chosenVisualStudioVersion -eq $null) {
+            return
+    }
+
+    $installDir = $chosenVisualStudioVersion.InstallationPath
+    $devShellModule = Join-Path $installDir 'Common7\Tools\Microsoft.VisualStudio.DevShell.dll'
+    Import-Module $devShellModule
+    Enter-VsDevShell -DevCmdArguments "-no_logo" -StartInPath "$pwd" $chosenVisualStudioVersion.InstanceId
+}
+
+function Get-VsComnToolsPath {
+    if([string]::IsNullOrEmpty($env:VSINSTALLDIR)) {
+        $chosenVisualStudioVersion = ChooseVisualStudioInstallation @(Get-VSInstalls)
+        $installDir = $chosenVisualStudioVersion.InstallationPath
+    }
+    else {
+        $installDir = $env:VSINSTALLDIR
+    }
+
+    if([string]::IsNullOrEmpty($installDir)) {
+        return
+    }
+
+    $vsComnToolsPath = Join-Path $installDir 'Common7\Tools\'
+    return $vsComnToolsPath
+}
+
+function Get-VSWhere {
+    $ProgramFile = ${env:ProgramFiles(x86)}
+
+    if ($null -eq $ProgramFile) {
+        $ProgramFile = (Get-ChildItem env:ProgramFiles).Value
+    }
+
+    $vsWhereVersion = "2.8.4"
+    $vsWhereDir = Join-Path $ProgramFile 'Microsoft Visual Studio\Installer'
+    $vsWhereExe = "$vsWhereDir\vswhere.exe"
+    
+    if (!(Test-Path $vsWhereExe)) {
+        if (!(Test-Path $vsWhereDir)) {
+            Write-Host "Creating folder $vsWhereDir"
+            New-Item -ItemType Directory -Path $vsWhereDir
+        }
+
+        Write-Host "Downloading vswhere"
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+        Invoke-WebRequest "http://github.com/Microsoft/vswhere/releases/download/$vsWhereVersion/vswhere.exe" -OutFile $vswhereExe
+    }
+
+    return $vsWhereExe
+}
+
+function Get-VSInstalls {
+
+    $vsWhereExe = Get-VSWhere
+
+    $temp = & "$vsWhereExe" -nologo -all -prerelease -format text | select-string "instanceId|installationPath|installationName|catalog_productSemanticVersion"
+
+    [System.Collections.ArrayList]$vsSkus = @()
+
+    for($i = 0; $i -lt $temp.line.Length; $i++) {
+        $vsInstall = New-Object -TypeName PSObject
+        $vsInstall | Add-Member -MemberType NoteProperty -Name InstanceId -Value $temp.line[$i].split(":", 2)[1].Trim()
+        $vsInstall | Add-Member -MemberType NoteProperty -Name InstallationName -Value $temp.line[++$i].split(":", 2)[1].Trim()
+        $vsInstall | Add-Member -MemberType NoteProperty -Name InstallationPath -Value $temp.line[++$i].split(":", 2)[1].Trim()
+        $vsInstall | Add-Member -MemberType NoteProperty -Name CatalogName -Value $temp.line[++$i].split(":", 2)[1].Trim()
+
+        
+        $vsSkus.Add($vsInstall) | Out-Null
+    }
+
+    return $vsSkus
+}
+
+function ChooseVisualStudioInstallation {
+    param ([parameter(mandatory=$true)][AllowEmptyCollection()][collections.arraylist]$options)
+
+    if(!$options) {
+        Write-Host "No Visual Studio was found on the machine..." -foreground Red
+        return
+    }
+
+    Write-Host ""
+    Write-Host "Choose an installation..." -foreground Yellow
+      
+    for ($i = 0; $i -lt $options.Count -and $i -le 9; $i++) {
+        if ($i -eq 0) { 
+            Write-Host "[$i] $($options[$i].InstallationName)" -foreground Cyan 
+        }
+        else {
+            Write-Host "[$i] $($options[$i].InstallationName)"
+        }
+    }
+
+    Write-Host "[x] Exit without doing anything" -foreground Red
+
+    do {
+        Write-Host "Select Installation (or Enter for " -foreground Yellow -nonewline
+        Write-Host "default" -foreground Cyan   -nonewline
+        Write-Host "): "    -foreground Yellow -nonewline
+        $i = Read-Host
+    }
+    until ((($i -ge 0) -and ($i -le 9)) -or [string]::IsNullOrEmpty($i) -or $i -eq 'x')
+
+    if ($i -eq 'x') {
+        return
+    }
+    
+    if ([string]::IsNullOrEmpty($i)) {
+        $match = $options[0] } else {
+             $match = $options[$i]
+    }
+
+    return $match
+}
+
+Export-ModuleMember -Function Start-VsDevShell,Get-VsComnToolsPath

--- a/build/common.ps1
+++ b/build/common.ps1
@@ -1,9 +1,8 @@
+# Check if running in a non-interactive shell and do not import/prompt if we are
 if(![bool]([Environment]::GetCommandLineArgs() -like '-noni*')) {
     import-module $PSScriptRoot/VSUtilities.psm1
 
     if([string]::IsNullOrEmpty($env:VSINSTALLDIR)) {
-        # We could use Trace-Log here but then we would have to move those functions above this or into a seperate module, if we import as a seperate module
-        # powershell will complain about undiscoverable function names using improper verbs
         Write-Host "Not running from a Developer Command Prompt, choose an install or none for legacy behavior"
         Start-VsDevShell
     }

--- a/build/common.ps1
+++ b/build/common.ps1
@@ -1,3 +1,12 @@
+import-module $PSScriptRoot/VSUtilities.psm1
+
+if([string]::IsNullOrEmpty($env:VSINSTALLDIR)) {
+    # We could use Trace-Log here but then we would have to move those functions above this or into a seperate module, if we import as a seperate module
+    # powershell will complain about undiscoverable function names using improper verbs
+    Write-Host "Not running from a Developer Command Prompt, choose an install or none for legacy behavior"
+    Start-VsDevShell
+}
+
 ### Constants ###
 $NuGetClientRoot = Split-Path -Path $PSScriptRoot -Parent
 $CLIRoot = Join-Path $NuGetClientRoot cli

--- a/build/common.ps1
+++ b/build/common.ps1
@@ -1,10 +1,12 @@
-import-module $PSScriptRoot/VSUtilities.psm1
+if(![bool]([Environment]::GetCommandLineArgs() -like '-noni*')) {
+    import-module $PSScriptRoot/VSUtilities.psm1
 
-if([string]::IsNullOrEmpty($env:VSINSTALLDIR)) {
-    # We could use Trace-Log here but then we would have to move those functions above this or into a seperate module, if we import as a seperate module
-    # powershell will complain about undiscoverable function names using improper verbs
-    Write-Host "Not running from a Developer Command Prompt, choose an install or none for legacy behavior"
-    Start-VsDevShell
+    if([string]::IsNullOrEmpty($env:VSINSTALLDIR)) {
+        # We could use Trace-Log here but then we would have to move those functions above this or into a seperate module, if we import as a seperate module
+        # powershell will complain about undiscoverable function names using improper verbs
+        Write-Host "Not running from a Developer Command Prompt, choose an install or none for legacy behavior"
+        Start-VsDevShell
+    }
 }
 
 ### Constants ###


### PR DESCRIPTION
## Bug

Fixes: [NuGet/Client.Engineering#304](https://github.com/NuGet/Client.Engineering/issues/304)
Regression: No  

## Fix

Details: Add a prompt to let the user choose which version of Visual Studio to run configure/build against if not already running in a developer prompt

## Testing/Validation

Tests Added: No  
Reason for not adding tests: Not a product issue  
Validation:  Ran configure.ps1/build.ps1 and made sure they ran with and without choosing a product version (legacy)
