### PR TITLE
Retarget xplat verification to netcoreapp5.0

### DIFF
--- a/build/common.project.props
+++ b/build/common.project.props
@@ -54,7 +54,7 @@
 
   <!-- Defaults -->
   <PropertyGroup>
-    <TreatWarningsAsErrors Condition=" '$(TreatWarningsAsErrors)' == '' ">true</TreatWarningsAsErrors>
+    <TreatWarningsAsErrors Condition=" '$(TreatWarningsAsErrors)' == '' ">false</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <!-- Default project configuration -->

--- a/build/common.project.props
+++ b/build/common.project.props
@@ -20,7 +20,7 @@
     <NetStandardVersion>netstandard2.0</NetStandardVersion>
     <TargetFrameworksExe>$(NETFXTargetFramework);$(NETCoreTargetFrameworks)</TargetFrameworksExe>
     <TargetFrameworksLibrary  Condition=" '$(RequiresSigningXplatAPIs)' != 'true' ">$(NETFXTargetFramework);$(NetStandardVersion)</TargetFrameworksLibrary>
-    <TargetFrameworksLibrary  Condition=" '$(RequiresSigningXplatAPIs)' == 'true' ">$(NETFXTargetFramework);$(NetStandardVersion);netstandard2.1</TargetFrameworksLibrary>
+    <TargetFrameworksLibrary  Condition=" '$(RequiresSigningXplatAPIs)' == 'true' ">$(NETFXTargetFramework);$(NetStandardVersion);netcoreapp5.0</TargetFrameworksLibrary>
     <RepositoryRootDirectory>$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\</RepositoryRootDirectory>
     <BuildCommonDirectory>$(RepositoryRootDirectory)build\</BuildCommonDirectory>
     <SolutionFile>$(RepositoryRootDirectory)$(RepositoryName).sln</SolutionFile>

--- a/build/common.project.props
+++ b/build/common.project.props
@@ -54,7 +54,7 @@
 
   <!-- Defaults -->
   <PropertyGroup>
-    <TreatWarningsAsErrors Condition=" '$(TreatWarningsAsErrors)' == '' ">false</TreatWarningsAsErrors>
+    <TreatWarningsAsErrors Condition=" '$(TreatWarningsAsErrors)' == '' ">true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <!-- Default project configuration -->

--- a/build/common.targets
+++ b/build/common.targets
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <SigningNotSupported Condition=" '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netcoreapp2.1'">true</SigningNotSupported>
+    <SigningNotSupported Condition=" '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netcoreapp2.1' OR '$(TargetFramework)' == 'netstandard2.1'">true</SigningNotSupported>
     <SigningNotSupported Condition=" '$(SigningNotSupported)' != 'true'">false</SigningNotSupported>
   </PropertyGroup>
 

--- a/build/packages.targets
+++ b/build/packages.targets
@@ -7,7 +7,7 @@
         <VSFrameworkVersion>16.5.29714.20</VSFrameworkVersion>
         <VSServicesVersion>16.153.0</VSServicesVersion>
         <VSThreadingVersion>16.5.126</VSThreadingVersion>
-        <!-- TODO - remove this when temporary patching is no longer necessary. See https://github.com/NuGet/Home/issues/8508 -->
+        <!-- TODO - remove this when temporary patching is no longer necessary. See https://github.com/nuget/home/issues/8952 -->
         <PatchedSystemPackagesVersion>5.0.0-preview.3.20214.6</PatchedSystemPackagesVersion>
     </PropertyGroup>
 

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.csproj
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.csproj
@@ -1,8 +1,4 @@
 ﻿<Project>
-  <PropertyGroup>
-    <RequiresSigningXplatAPIs>true</RequiresSigningXplatAPIs>
-  </PropertyGroup>
-
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common.props" />
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
@@ -154,7 +150,6 @@
     </ItemGroup>
   </Target>
 
-  <!--These targets help get files for packing the first NuGet.Build.Tasks.Pack package, for netstandard2.1.-->
   <Target Name="CreatePackNupkg">
     <PropertyGroup>
       <!-- Build from source can't use ILMerge. -->
@@ -168,7 +163,7 @@
         <PackagePath>Desktop/</PackagePath>
       </TfmSpecificPackageFile>
     </ItemGroup>
-    <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
+    <ItemGroup Condition="'$(TargetFramework)' == '$(NetStandardVersion)'">
       <TfmSpecificPackageFile Include="$(OutputPath)\$(ILMergeSubpath)NuGet.Build.Tasks.Pack.dll">
         <PackagePath>CoreCLR/</PackagePath>
       </TfmSpecificPackageFile>

--- a/src/NuGet.Core/NuGet.Commands/NuGet.Commands.csproj
+++ b/src/NuGet.Core/NuGet.Commands/NuGet.Commands.csproj
@@ -11,7 +11,7 @@
     <TargetFrameworks>$(TargetFrameworksLibrary)</TargetFrameworks>
     <TargetFramework />
     <NoWarn>$(NoWarn);CS1591;CS1574;CS1573;CS1584;CS1658</NoWarn>
-    <NoWarn Condition=" $(TargetFramework.StartsWith('netstandard')) ">$(NoWarn);CS1998</NoWarn>
+    <NoWarn Condition=" $(TargetFramework.StartsWith('netstandard')) OR $(TargetFramework.StartsWith('netcoreapp')) ">$(NoWarn);CS1998</NoWarn>
     <PackProject>true</PackProject>
     <IncludeInVSIX>true</IncludeInVSIX>
     <Shipping>true</Shipping>

--- a/src/NuGet.Core/NuGet.Packaging/NuGet.Packaging.csproj
+++ b/src/NuGet.Core/NuGet.Packaging/NuGet.Packaging.csproj
@@ -1,4 +1,4 @@
-<Project>
+﻿<Project>
   <PropertyGroup>
     <RequiresSigningXplatAPIs>true</RequiresSigningXplatAPIs>
   </PropertyGroup>
@@ -11,7 +11,7 @@
     <TargetFrameworks>$(TargetFrameworksLibrary)</TargetFrameworks>
     <TargetFramework />
     <NoWarn>$(NoWarn);CS1591;CS1574;CS1573;CS1572</NoWarn>
-    <NoWarn Condition=" $(TargetFramework.StartsWith('netstandard')) ">$(NoWarn);CS0414</NoWarn>
+    <NoWarn Condition=" $(TargetFramework.StartsWith('netstandard')) OR $(TargetFramework.StartsWith('netcoreapp'))">$(NoWarn);CS0414</NoWarn>
     <PackProject>true</PackProject>
     <Shipping>true</Shipping>
     <IncludeInVSIX>true</IncludeInVSIX>

--- a/src/NuGet.Core/NuGet.Packaging/NuGet.Packaging.csproj
+++ b/src/NuGet.Core/NuGet.Packaging/NuGet.Packaging.csproj
@@ -49,7 +49,7 @@
 
   <ItemGroup Condition=" '$(IsCore)' == 'true' ">
     <PackageReference Include="System.Dynamic.Runtime" />
-    <!-- TODO - remove this when temporary patching is no longer necessary. See https://github.com/NuGet/Home/issues/8508 -->
+    <!-- TODO - remove this when temporary patching is no longer necessary. See https://github.com/nuget/home/issues/8952 -->
     <PackageReference Include="System.Security.Cryptography.Pkcs" />
     <PackageReference Include="System.Security.Cryptography.Cng" />
   </ItemGroup>

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/MsbuildIntegrationTestFixture.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/MsbuildIntegrationTestFixture.cs
@@ -295,7 +295,7 @@ namespace Dotnet.Integration.Test
             {
                 var projectArtifactsFolder = new DirectoryInfo(Path.Combine(artifactsDirectory, projectName, toolsetVersion, "bin", configuration));
 
-                IEnumerable<DirectoryInfo> frameworkArtifactFolders = projectArtifactsFolder.EnumerateDirectories().Where(folder => folder.FullName.Contains("netstandard2.1") || folder.FullName.Contains("netcoreapp5.0"));
+                IEnumerable<DirectoryInfo> frameworkArtifactFolders = projectArtifactsFolder.EnumerateDirectories().Where(folder => folder.FullName.Contains("netcoreapp5.0"));
 
                 if (!frameworkArtifactFolders.Any())
                 {
@@ -328,8 +328,8 @@ namespace Dotnet.Integration.Test
             const string packProjectName = "NuGet.Build.Tasks.Pack";
             const string packTargetsName = "NuGet.Build.Tasks.Pack.targets";
             // Copy the pack SDK.
-            //Order by fullname so that we can get the latest nestandard version. E.g. if we have both netstandard2.0 and netstandard2.1, netstandard2.1 will be selected.
-            var packProjectCoreArtifactsDirectory = new DirectoryInfo(Path.Combine(artifactsDirectory, packProjectName, toolsetVersion, "bin", configuration)).EnumerateDirectories("netstandard*").OrderBy(x => x.FullName).Last();
+            // Pick the netstandard2.0 NuGet.Build.Tasks.Pack dll
+            var packProjectCoreArtifactsDirectory = new DirectoryInfo(Path.Combine(artifactsDirectory, packProjectName, toolsetVersion, "bin", configuration)).EnumerateDirectories("netstandard*").Single();
             var packAssemblyDestinationDirectory = Path.Combine(pathToPackSdk, "CoreCLR");
             // Be smart here so we don't have to call ILMerge in the VS build. It takes ~15s total.
             // In VisualStudio, simply use the non il merged version.
@@ -505,7 +505,7 @@ namespace Dotnet.Integration.Test
                     var assemblyPath = Path.Combine(Directory.GetCurrentDirectory(), assemblyName);
                     var assemblyVersion = Assembly.LoadFile(assemblyPath).GetName().Version.ToString();
                     var assemblyFileVersion = FileVersionInfo.GetVersionInfo(assemblyPath).FileVersion;
-                    var jproperty = new JProperty("lib/netstandard2.1/" + assemblyName,
+                    var jproperty = new JProperty("lib/netcoreapp5.0/" + assemblyName,
                         new JObject
                         {
                             new JProperty("assemblyVersion", assemblyVersion),


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9505
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: 
1.Retarget xplat verification projects to netcoreapp5.0 instead of netstandard2.1
2.Add netstandard2.1 to the list of `SigningNotSupported` 
3.Generate NuGet.Build.Tasks.Pack nupkg with TFM netstandard2.0 instead of netstandard2.1. (pack will not be affected by xplat verification, so it  still use the netstandard2.0 bits.

Our final goal is to retarget xplat verication to net5.0.
But since VSEng-MicroBuildVS2019(and SXS) agent pool will only install stable version of VS on it. And the net5.0 could only be "recognized" correctly by the VS which is in preview. We will encounter build error if we retarget to net5.0 for now.
So we use this workaround(netcoreapp5.0 instead of net5.0)

## Testing/Validation

Tests Added: Yes/No  
Reason for not adding tests:  
Validation:  
