### PR TITLE
fix 2 warnings in CodeAnalysis

### DIFF
--- a/build/common.project.props
+++ b/build/common.project.props
@@ -54,7 +54,7 @@
 
   <!-- Defaults -->
   <PropertyGroup>
-    <TreatWarningsAsErrors Condition=" '$(TreatWarningsAsErrors)' == '' ">true</TreatWarningsAsErrors>
+    <TreatWarningsAsErrors Condition=" '$(TreatWarningsAsErrors)' == '' ">false</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <!-- Default project configuration -->

--- a/build/common.project.props
+++ b/build/common.project.props
@@ -54,7 +54,7 @@
 
   <!-- Defaults -->
   <PropertyGroup>
-    <TreatWarningsAsErrors Condition=" '$(TreatWarningsAsErrors)' == '' ">false</TreatWarningsAsErrors>
+    <TreatWarningsAsErrors Condition=" '$(TreatWarningsAsErrors)' == '' ">true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <!-- Default project configuration -->

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Cms/ManagedCmsWrapper.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Cms/ManagedCmsWrapper.cs
@@ -47,7 +47,10 @@ namespace NuGet.Packaging.Signing
         {
             foreach (var cert in certificates)
             {
-                _signedCms.AddCertificate(new X509Certificate2(cert));
+                using (var certificate = new X509Certificate2(cert))
+                {
+                    _signedCms.AddCertificate(certificate);
+                }
             }
         }
 

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Cms/ManagedCmsWrapper.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Cms/ManagedCmsWrapper.cs
@@ -47,10 +47,7 @@ namespace NuGet.Packaging.Signing
         {
             foreach (var cert in certificates)
             {
-                using (var certificate = new X509Certificate2(cert))
-                {
-                    _signedCms.AddCertificate(certificate);
-                }
+                    _signedCms.AddCertificate(cert);
             }
         }
 

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/Rfc3161TimestampProvider.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/Rfc3161TimestampProvider.cs
@@ -26,8 +26,9 @@ namespace NuGet.Packaging.Signing
     {
         // Url to an RFC 3161 timestamp server
         private readonly Uri _timestamperUrl;
+#if IS_SIGNING_SUPPORTED
         private static readonly TimeSpan RequestTimeout = TimeSpan.FromSeconds(10);
-
+#endif
         public Rfc3161TimestampProvider(Uri timeStampServerUrl)
         {
 #if IS_SIGNING_SUPPORTED


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9546
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: fix 2 warnings raised by CodeAnalysis.FxCopAnalyzer

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  
Validation:  
