### PR TITLE
Enable PIN prompt for netcore

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/Signing/Authoring/X509SignatureProvider.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Authoring/X509SignatureProvider.cs
@@ -136,7 +136,12 @@ namespace NuGet.Packaging.Signing
 
             try
             {
+#if IS_DESKTOP
                 cms.ComputeSignature(cmsSigner);
+#else
+                // In .NET Framework, this parameter is not used and a PIN prompt is always shown. In .NET Core, the silent flag needs to be set to false to show a PIN prompt.
+                cms.ComputeSignature(cmsSigner, silent: false);
+#endif
             }
             catch (CryptographicException ex) when (ex.HResult == INVALID_PROVIDER_TYPE_HRESULT)
             {


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9555
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: 
Enable the PIN prompt for .NET Core, by setting silent flag to false.
For .NET Framework, the silent parameter is not used and a PIN prompt is always shown.

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  
Validation:  
