### PR TITLE
Update the editor config, do not separate usings directives

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -36,6 +36,7 @@ indent_size = 4
 [*.{cs,vb}]
 ; Sort using and Import directives with System.* appearing first
 dotnet_sort_system_directives_first = true
+dotnet_separate_import_directive_groups = false
 
 ; IDE0003 Avoid "this." and "Me." if not necessary
 dotnet_style_qualification_for_field = false:warning


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9558
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: 

`dotnet_separate_import_directive_groups = false` leads to

```
using System.Collections.Generic;
using System.Collections.Immutable;
using System.Collections.ObjectModel;
using System.IO;
using System.Linq;
using FluentAssertions;
using NuGet.Commands;
using NuGet.Commands.Test;
using NuGet.Common;
using NuGet.ProjectModel;
using NuGet.Test.Utility;
using Xunit;
```

`dotnet_separate_import_directive_groups = true` leads to

```
using System.Collections.Generic;
using System.Collections.Immutable;
using System.Collections.ObjectModel;
using System.IO;
using System.Linq;

using FluentAssertions;

using NuGet.Commands;
using NuGet.Commands.Test;
using NuGet.Common;
using NuGet.ProjectModel;
using NuGet.Test.Utility;

using Xunit;
```

We use the first one in our code. Adding it to overwrite any local settings one may have (somehow my VS had it set to true and it drove me crazy :) 

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  Editoconfig style change
Validation:  
