### PR TITLE
Visual Studio PackageReference partial restore, solution based up to date check

### DIFF
--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/ISolutionRestoreChecker.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/ISolutionRestoreChecker.cs
@@ -1,0 +1,42 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+using NuGet.Commands;
+using NuGet.ProjectModel;
+
+namespace NuGet.SolutionRestoreManager
+{
+    /// <summary>
+    /// An up to date checker for a solution.
+    /// </summary>
+    public interface ISolutionRestoreChecker
+    {
+        /// <summary>
+        /// Given the current dependency graph spec, perform a fast up to date check and return the dirty projects.
+        /// The checker itself caches the DependencyGraphSpec it is provided & the last restore status, reported through <see cref="ReportStatus(IReadOnlyList{RestoreSummary})"/>.
+        /// Accounts for changes in the PackageSpec and marks all the parent projects as dirty as well.
+        /// Additionally also ensures that the expected output files have the same timestamps as the last time a succesful status was reported through <see cref="ReportStatus(IReadOnlyList{RestoreSummary})"/>.
+        /// </summary>
+        /// <param name="dependencyGraphSpec">The current dependency graph spec.</param>
+        /// <returns>Unique ids of the dirty projects</returns>
+        /// <remarks>Note that this call is stateful. This method may end up caching the dependency graph spec, so do not invoke multiple times. Ideally <see cref="PerformUpToDateCheck(DependencyGraphSpec)"/> call should be followed by a <see cref="ReportStatus(IReadOnlyList{RestoreSummary})"/> call.</remarks>
+        IEnumerable<string> PerformUpToDateCheck(DependencyGraphSpec dependencyGraphSpec);
+
+        /// <summary>
+        /// Report the status of all the projects restored. 
+        /// </summary>
+        /// <param name="restoreSummaries"></param>
+        /// <remarks>Note that this call is stateful. This method may end up caching the dependency graph spec, so do not invoke multiple times. Ideally <see cref="PerformUpToDateCheck(DependencyGraphSpec)"/> call should be followed by a <see cref="ReportStatus(IReadOnlyList{RestoreSummary})"/> call.</remarks>
+
+        void ReportStatus(IReadOnlyList<RestoreSummary> restoreSummaries);
+
+        /// <summary>
+        /// Clears any cached values. This is meant to mimic restores that overwrite the incremental restore optimizations.
+        /// </summary>
+        /// <returns></returns>
+        void CleanCache();
+    }
+}

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/ISolutionRestoreChecker.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/ISolutionRestoreChecker.cs
@@ -16,7 +16,7 @@ namespace NuGet.SolutionRestoreManager
     {
         /// <summary>
         /// Given the current dependency graph spec, perform a fast up to date check and return the dirty projects.
-        /// The checker itself caches the DependencyGraphSpec it is provided & the last restore status, reported through <see cref="ReportStatus(IReadOnlyList{RestoreSummary})"/>.
+        /// The checker itself caches the DependencyGraphSpec it is provided and the last restore status, reported through <see cref="ReportStatus(IReadOnlyList{RestoreSummary})"/>.
         /// Accounts for changes in the PackageSpec and marks all the parent projects as dirty as well.
         /// Additionally also ensures that the expected output files have the same timestamps as the last time a succesful status was reported through <see cref="ReportStatus(IReadOnlyList{RestoreSummary})"/>.
         /// </summary>
@@ -30,7 +30,6 @@ namespace NuGet.SolutionRestoreManager
         /// </summary>
         /// <param name="restoreSummaries"></param>
         /// <remarks>Note that this call is stateful. This method may end up caching the dependency graph spec, so do not invoke multiple times. Ideally <see cref="PerformUpToDateCheck(DependencyGraphSpec)"/> call should be followed by a <see cref="ReportStatus(IReadOnlyList{RestoreSummary})"/> call.</remarks>
-
         void ReportStatus(IReadOnlyList<RestoreSummary> restoreSummaries);
 
         /// <summary>

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/ISolutionRestoreChecker.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/ISolutionRestoreChecker.cs
@@ -18,18 +18,23 @@ namespace NuGet.SolutionRestoreManager
         /// Given the current dependency graph spec, perform a fast up to date check and return the dirty projects.
         /// The checker itself caches the DependencyGraphSpec it is provided and the last restore status, reported through <see cref="ReportStatus(IReadOnlyList{RestoreSummary})"/>.
         /// Accounts for changes in the PackageSpec and marks all the parent projects as dirty as well.
-        /// Additionally also ensures that the expected output files have the same timestamps as the last time a succesful status was reported through <see cref="ReportStatus(IReadOnlyList{RestoreSummary})"/>.
+        /// Additionally, ensures that the expected output files have the same timestamps as the last reported status
+        /// <see cref="ReportStatus(IReadOnlyList{RestoreSummary})"/>.
         /// </summary>
         /// <param name="dependencyGraphSpec">The current dependency graph spec.</param>
         /// <returns>Unique ids of the dirty projects</returns>
-        /// <remarks>Note that this call is stateful. This method may end up caching the dependency graph spec, so do not invoke multiple times. Ideally <see cref="PerformUpToDateCheck(DependencyGraphSpec)"/> call should be followed by a <see cref="ReportStatus(IReadOnlyList{RestoreSummary})"/> call.</remarks>
+        /// <remarks>Note that this call is stateful. This method may end up caching the dependency graph spec, so do not invoke multiple times. 
+        /// Ideally <see cref="PerformUpToDateCheck(DependencyGraphSpec)"/> call should be followed by a <see cref="ReportStatus(IReadOnlyList{RestoreSummary})"/> call.
+        /// </remarks>
         IEnumerable<string> PerformUpToDateCheck(DependencyGraphSpec dependencyGraphSpec);
 
         /// <summary>
         /// Report the status of all the projects restored. 
         /// </summary>
         /// <param name="restoreSummaries"></param>
-        /// <remarks>Note that this call is stateful. This method may end up caching the dependency graph spec, so do not invoke multiple times. Ideally <see cref="PerformUpToDateCheck(DependencyGraphSpec)"/> call should be followed by a <see cref="ReportStatus(IReadOnlyList{RestoreSummary})"/> call.</remarks>
+        /// <remarks>Note that this call is stateful. This method may end up caching the dependency graph spec, so do not invoke multiple times.
+        ///  Ideally <see cref="PerformUpToDateCheck(DependencyGraphSpec)"/> call should be followed by a <see cref="ReportStatus(IReadOnlyList{RestoreSummary})"/> call.
+        /// </remarks>
         void ReportStatus(IReadOnlyList<RestoreSummary> restoreSummaries);
 
         /// <summary>

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/NuGet.SolutionRestoreManager.csproj
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/NuGet.SolutionRestoreManager.csproj
@@ -32,6 +32,7 @@
     <Compile Include="BrokeredServicesUtility.cs" />
     <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="Guids.cs" />
+    <Compile Include="ISolutionRestoreChecker.cs" />
     <Compile Include="ISolutionRestoreJob.cs" />
     <Compile Include="NuGetSolutionService.cs" />
     <Compile Include="PkgCmdID.cs" />
@@ -49,6 +50,7 @@
     <Compile Include="SolutionRestoreJob.cs" />
     <Compile Include="SolutionRestoreJobContext.cs" />
     <Compile Include="SolutionRestoreWorker.cs" />
+    <Compile Include="SolutionUpToDateChecker.cs" />
     <Compile Include="VerbosityLevel.cs" />
     <Compile Include="VSNominationUtilities.cs" />
     <Compile Include="VsSolutionRestoreService.cs" />

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreJob.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreJob.cs
@@ -355,8 +355,8 @@ namespace NuGet.SolutionRestoreManager
                     var projectsNeedingRestore = _solutionUpToDateChecker.PerformUpToDateCheck(originalDgSpec).AsList();
 
                     dgSpec = originalDgSpec;
-                    // Only use the optimization results if the restore is not force.
-                    // Still run the optimization check anyways to prep the cache for a potential future non-force optimization
+                    // Only use the optimization results if the restore is not `force`.
+                    // Still run the optimization check anyways to prep the cache.
                     if (!forceRestore)
                     {
                         // Update the dg spec.
@@ -365,7 +365,7 @@ namespace NuGet.SolutionRestoreManager
                         {
                             dgSpec.AddRestore(uniqueProjectId);
                         }
-                        // loop through all legacy PackageReference projects. We don't know how to replay their warnings & errors yet.
+                        // loop through all legacy PackageReference projects. We don't know how to replay their warnings & errors yet. TODO: https://github.com/NuGet/Home/issues/9565
                         foreach(var project in (await _solutionManager.GetNuGetProjectsAsync()).Where(e => e is LegacyPackageReferenceProject).Select(e => e as LegacyPackageReferenceProject))
                         {
                             dgSpec.AddRestore(project.MSBuildProjectPath);

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionUpToDateChecker.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionUpToDateChecker.cs
@@ -1,0 +1,264 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.IO;
+using System.Linq;
+using NuGet.Commands;
+using NuGet.Common;
+using NuGet.ProjectModel;
+
+namespace NuGet.SolutionRestoreManager
+{
+    [Export(typeof(ISolutionRestoreChecker))]
+    [PartCreationPolicy(CreationPolicy.Shared)]
+    public class SolutionUpToDateChecker : ISolutionRestoreChecker
+    {
+        private IList<string> _failedProjects = new List<string>();
+        private DependencyGraphSpec _cachedDependencyGraphSpec;
+        private Dictionary<string, RestoreOutputData> _outputWriteTimes = new Dictionary<string, RestoreOutputData>();
+
+        public void ReportStatus(IReadOnlyList<RestoreSummary> restoreSummaries)
+        {
+            _failedProjects.Clear();
+
+            foreach (var summary in restoreSummaries)
+            {
+                if (summary.Success)
+                {
+                    var packageSpec = _cachedDependencyGraphSpec.GetProjectSpec(summary.InputPath);
+                    GetOutputFilePaths(packageSpec, out string assetsFilePath, out string cacheFilePath, out string targetsFilePath, out string propsFilePath, out string lockFilePath);
+
+                    _outputWriteTimes[summary.InputPath] = new RestoreOutputData()
+                    {
+                        _lastAssetsFileWriteTime = GetLastWriteTime(assetsFilePath),
+                        _lastCacheFileWriteTime = GetLastWriteTime(cacheFilePath),
+                        _lastTargetsFileWriteTime = GetLastWriteTime(targetsFilePath),
+                        _lastPropsFileWriteTime = GetLastWriteTime(propsFilePath),
+                        _lastLockFileWriteTime = GetLastWriteTime(lockFilePath),
+                        _globalPackagesFolderCreationTime = GetCreationTime(packageSpec.RestoreMetadata.PackagesPath)
+                    };
+                }
+                else
+                {
+                    _failedProjects.Add(summary.InputPath);
+                }
+
+            }
+        }
+
+        // The algorithm here is a 2 pass. In reality the 2nd pass can do a lot but for huge benefits :)
+        // Pass #1
+        // We check all the specs against the cached ones if any. Any project with a change in the spec is considered dirty.
+        // If a project had previously been restored and it failed, it is considered dirty.
+        // Every project that is considered to have a dirty spec will be important in pass #2.
+        // In the first pass, we also validate the outputs for the projects. Note that these are independent and project specific. Outputs not being up to date it irrelevant for transitivity.
+        // Pass #2
+        // For every project with a dirty spec (the outputs don't matter here), we want to ensure that its parent projects are marked as dirty as well.
+        // This is a bit more expensive since PackageSpecs do not retain pointers to the projects that reference them as ProjectReference.
+        // Finally we only update the cache specs if Pass #1 determined that there are projects that are not up to date.
+        // Result
+        // Lastly all the projects marked as having dirty specs & dirty outputs are returned.
+        public IEnumerable<string> PerformUpToDateCheck(DependencyGraphSpec dependencyGraphSpec)
+        {
+            if (_cachedDependencyGraphSpec != null)
+            {
+                var dirtySpecs = new List<string>();
+                var dirtyOutputs = new List<string>();
+                bool hasDirtyNonTransitiveSpecs = false;
+
+                // Pass #1. Validate all the data (i/o)
+                // 1a. Validate the package specs (references & settings)
+                // 1b. Validate the expected outputs (assets file, nuget.g.*, lock file)
+                foreach (var project in dependencyGraphSpec.Projects)
+                {
+                    var projectUniqueName = project.RestoreMetadata.ProjectUniqueName;
+                    var cache = _cachedDependencyGraphSpec.GetProjectSpec(projectUniqueName);
+
+                    if (cache == null || !project.Equals(cache))
+                    {
+                        dirtySpecs.Add(projectUniqueName);
+                    }
+
+                    if (project.RestoreMetadata.ProjectStyle == ProjectStyle.PackageReference ||
+                        project.RestoreMetadata.ProjectStyle == ProjectStyle.ProjectJson)
+                    {
+                        if (!_failedProjects.Contains(projectUniqueName) && _outputWriteTimes.TryGetValue(projectUniqueName, out RestoreOutputData outputWriteTime))
+                        {
+                            GetOutputFilePaths(project, out string assetsFilePath, out string cacheFilePath, out string targetsFilePath, out string propsFilePath, out string lockFilePath);
+                            if (!AreOutputsUpToDate(assetsFilePath, cacheFilePath, targetsFilePath, propsFilePath, lockFilePath, project.RestoreMetadata.PackagesPath, outputWriteTime))
+                            {
+                                dirtyOutputs.Add(projectUniqueName);
+                            }
+                        }
+                        else
+                        {
+                            dirtyOutputs.Add(projectUniqueName);
+                        }
+                    }
+                    else
+                    {
+                        hasDirtyNonTransitiveSpecs = true;
+                    }
+                }
+
+                // Fast path. Skip Pass #2
+                if (dirtySpecs.Count == 0 && dirtyOutputs.Count == 0)
+                {
+                    return Enumerable.Empty<string>();
+                }
+                // Update the cache before Pass #2
+                _cachedDependencyGraphSpec = dependencyGraphSpec;
+
+                // Pass #2 For any dirty specs discrepancies, mark them and their parents as needing restore.
+                var dirtyProjects = GetParents(dirtySpecs, dependencyGraphSpec);
+
+                // All dirty projects + projects with outputs that need to be restored
+                // - the projects that are non transitive that never needed restore anyways, hence the insertion with the provider restore projects!
+                var resultSpecs = dirtyProjects.Union(dirtyOutputs);
+                if (hasDirtyNonTransitiveSpecs)
+                {
+                    resultSpecs = dependencyGraphSpec.Restore.Intersect(resultSpecs);
+                }
+                return resultSpecs;
+            }
+            else
+            {
+                _cachedDependencyGraphSpec = dependencyGraphSpec;
+
+                return dependencyGraphSpec.Restore;
+            }
+        }
+
+        /// <summary>
+        /// Given a list of project unique names, goes through the dg spec and returns the current projects + all their parents
+        /// </summary>
+        /// <param name="DirtySpecs">The projects for which we need to find the parents</param>
+        /// <param name="dependencyGraphSpec">The dependency graph spec contain the projects passed in dirty specs at the minimum.</param>
+        /// <returns>The list of the projects passed in and their parents in the dependencyGraphSpec</returns>
+        internal static IList<string> GetParents(List<string> DirtySpecs, DependencyGraphSpec dependencyGraphSpec)
+        {
+            var projectsByUniqueName = dependencyGraphSpec.Projects
+                .ToDictionary(t => t.RestoreMetadata.ProjectUniqueName, t => t, PathUtility.GetStringComparerBasedOnOS());
+
+            var DirtyProjects = new HashSet<string>(DirtySpecs, PathUtility.GetStringComparerBasedOnOS());
+
+            var sortedProjects = DependencyGraphSpec.SortPackagesByDependencyOrder(dependencyGraphSpec.Projects);
+
+            foreach (var project in sortedProjects)
+            {
+                if (!DirtyProjects.Contains(project.RestoreMetadata.ProjectUniqueName))
+                {
+                    var projectReferences = GetPackageSpecDependencyIds(project);
+
+                    foreach (var projectReference in projectReferences)
+                    {
+                        if (DirtyProjects.Contains(projectReference))
+                        {
+                            DirtyProjects.Add(project.RestoreMetadata.ProjectUniqueName);
+                        }
+                    }
+                }
+            }
+            return DirtyProjects.ToList();
+        }
+
+        private static string[] GetPackageSpecDependencyIds(PackageSpec spec)
+        {
+            return spec.RestoreMetadata
+                .TargetFrameworks
+                .SelectMany(r => r.ProjectReferences)
+                .Select(r => r.ProjectUniqueName)
+                .Distinct(PathUtility.GetStringComparerBasedOnOS())
+                .ToArray();
+        }
+
+        internal static void GetOutputFilePaths(PackageSpec packageSpec, out string assetsFilePath, out string cacheFilePath, out string targetsFilePath, out string propsFilePath, out string lockFilePath)
+        {
+            assetsFilePath = GetAssetsFilePath(packageSpec);
+            cacheFilePath = NoOpRestoreUtilities.GetProjectCacheFilePath(packageSpec.RestoreMetadata.OutputPath);
+            targetsFilePath = BuildAssetsUtils.GetMSBuildFilePath(packageSpec, BuildAssetsUtils.TargetsExtension);
+            propsFilePath = BuildAssetsUtils.GetMSBuildFilePath(packageSpec, BuildAssetsUtils.PropsExtension);
+            lockFilePath = packageSpec.RestoreMetadata.ProjectStyle == ProjectStyle.PackageReference ?
+                PackagesLockFileUtilities.GetNuGetLockFilePath(packageSpec) :
+                null;
+        }
+
+        private static bool AreOutputsUpToDate(string assetsFilePath, string cacheFilePath, string targetsFilePath, string propsFilePath, string lockFilePath, string globalPackagesFolderPath, RestoreOutputData outputWriteTime)
+        {
+            DateTime currentAssetsFileWriteTime = GetLastWriteTime(assetsFilePath);
+            DateTime currentCacheFilePath = GetLastWriteTime(cacheFilePath);
+            DateTime currentTargetsFilePath = GetLastWriteTime(targetsFilePath);
+            DateTime currentPropsFilePath = GetLastWriteTime(propsFilePath);
+            DateTime currentLockFilePath = GetLastWriteTime(lockFilePath);
+            DateTime globalPackagesFolderCreationTime = GetCreationTime(globalPackagesFolderPath);
+
+            return outputWriteTime._lastAssetsFileWriteTime.Equals(currentAssetsFileWriteTime) &&
+                   outputWriteTime._lastCacheFileWriteTime.Equals(currentCacheFilePath) &&
+                   outputWriteTime._lastTargetsFileWriteTime.Equals(currentTargetsFilePath) &&
+                   outputWriteTime._lastPropsFileWriteTime.Equals(currentPropsFilePath) &&
+                   outputWriteTime._lastLockFileWriteTime.Equals(currentLockFilePath) &&
+                   outputWriteTime._globalPackagesFolderCreationTime.Equals(globalPackagesFolderCreationTime);
+        }
+
+        private static DateTime GetLastWriteTime(string assetsFilePath)
+        {
+            if (!string.IsNullOrWhiteSpace(assetsFilePath))
+            {
+                var fileInfo = new FileInfo(assetsFilePath);
+                if (fileInfo.Exists)
+                {
+                    return fileInfo.LastWriteTimeUtc;
+                }
+            }
+            return default;
+        }
+
+        private static DateTime GetCreationTime(string assetsFilePath)
+        {
+            if (!string.IsNullOrWhiteSpace(assetsFilePath))
+            {
+                var fileInfo = new FileInfo(assetsFilePath);
+                if (fileInfo.Exists || ((fileInfo.Attributes & FileAttributes.Directory) == FileAttributes.Directory))
+                {
+                    return fileInfo.CreationTimeUtc;
+                }
+            }
+            return default;
+        }
+
+        private static string GetAssetsFilePath(PackageSpec packageSpec)
+        {
+            if (packageSpec.RestoreMetadata?.ProjectStyle == ProjectStyle.PackageReference)
+            {
+                return Path.Combine(
+                    packageSpec.RestoreMetadata.OutputPath,
+                    LockFileFormat.AssetsFileName);
+            }
+            else if (packageSpec.RestoreMetadata?.ProjectStyle == ProjectStyle.ProjectJson)
+            {
+                return ProjectJsonPathUtilities.GetLockFilePath(packageSpec.FilePath);
+            }
+            return null;
+        }
+
+        public void CleanCache()
+        {
+            _failedProjects.Clear();
+            _cachedDependencyGraphSpec = null;
+            _outputWriteTimes.Clear();
+        }
+
+        internal struct RestoreOutputData
+        {
+            internal DateTime _lastAssetsFileWriteTime;
+            internal DateTime _lastCacheFileWriteTime;
+            internal DateTime _lastTargetsFileWriteTime;
+            internal DateTime _lastPropsFileWriteTime;
+            internal DateTime _lastLockFileWriteTime;
+            internal DateTime _globalPackagesFolderCreationTime;
+        }
+    }
+}

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/GlobalSuppressions.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/GlobalSuppressions.cs
@@ -8,10 +8,6 @@
 
 using System.Diagnostics.CodeAnalysis;
 
-[assembly: SuppressMessage("Build", "CA2211:Non-constant fields should not be visible", Justification = "<Pending>", Scope = "member", Target = "~F:NuGet.VisualStudio.RestoreTelemetryEvent.PackageReferenceRestoreDuration")]
-[assembly: SuppressMessage("Build", "CA2211:Non-constant fields should not be visible", Justification = "<Pending>", Scope = "member", Target = "~F:NuGet.VisualStudio.RestoreTelemetryEvent.PackagesConfigRestore")]
-[assembly: SuppressMessage("Build", "CA2211:Non-constant fields should not be visible", Justification = "<Pending>", Scope = "member", Target = "~F:NuGet.VisualStudio.RestoreTelemetryEvent.RestoreOperationChecks")]
-[assembly: SuppressMessage("Build", "CA2211:Non-constant fields should not be visible", Justification = "<Pending>", Scope = "member", Target = "~F:NuGet.VisualStudio.RestoreTelemetryEvent.SolutionDependencyGraphSpecCreation")]
 [assembly: SuppressMessage("Build", "CA1802:Field 'EventName' is declared as 'readonly' but is initialized with a constant value. Mark this field as 'const' instead.", Justification = "<Pending>", Scope = "member", Target = "~F:NuGet.VisualStudio.Telemetry.PackageSourceTelemetry.EventName")]
 [assembly: SuppressMessage("Build", "CA1062:In externally visible method 'bool PathValidator.IsValidLocalPath(string path)', validate parameter 'path' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.", Justification = "<Pending>", Scope = "member", Target = "~M:NuGet.PackageManagement.VisualStudio.PathValidator.IsValidLocalPath(System.String)~System.Boolean")]
 [assembly: SuppressMessage("Build", "CA1062:In externally visible method 'bool PathValidator.IsValidUncPath(string path)', validate parameter 'path' is non-null before using it. If appropriate, throw an ArgumentNullException when the argument is null or add a Code Contract precondition asserting non-null argument.", Justification = "<Pending>", Scope = "member", Target = "~M:NuGet.PackageManagement.VisualStudio.PathValidator.IsValidUncPath(System.String)~System.Boolean")]

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/RestoreTelemetryEvent.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/RestoreTelemetryEvent.cs
@@ -12,10 +12,12 @@ namespace NuGet.VisualStudio
     /// </summary>
     public class RestoreTelemetryEvent : ActionEventBase
     {
-        public static string RestoreOperationChecks = nameof(RestoreOperationChecks);
-        public static string PackagesConfigRestore = nameof(PackagesConfigRestore);
-        public static string SolutionDependencyGraphSpecCreation = nameof(SolutionDependencyGraphSpecCreation);
-        public static string PackageReferenceRestoreDuration = nameof(PackageReferenceRestoreDuration);
+        public const string RestoreOperationChecks = nameof(RestoreOperationChecks);
+        public const string PackagesConfigRestore = nameof(PackagesConfigRestore);
+        public const string SolutionDependencyGraphSpecCreation = nameof(SolutionDependencyGraphSpecCreation);
+        public const string PackageReferenceRestoreDuration = nameof(PackageReferenceRestoreDuration);
+        public const string SolutionUpToDateCheck = nameof(SolutionUpToDateCheck);
+        private const string UpToDateProjectCount = nameof(UpToDateProjectCount);
 
         public RestoreTelemetryEvent(
             string operationId,
@@ -25,12 +27,14 @@ namespace NuGet.VisualStudio
             NuGetOperationStatus status,
             int packageCount,
             int noOpProjectsCount,
+            int upToDateProjectsCount,
             DateTimeOffset endTime,
             double duration,
             IntervalTracker intervalTimingTracker) : base(RestoreActionEventName, operationId, projectIds, startTime, status, packageCount, endTime, duration)
         {
             base[nameof(OperationSource)] = source;
             base[nameof(NoOpProjectsCount)] = noOpProjectsCount;
+            base[UpToDateProjectCount] = upToDateProjectsCount;
 
             foreach (var (intervalName, intervalDuration) in intervalTimingTracker.GetIntervals())
             {

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/NoOpRestoreUtilities.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/NoOpRestoreUtilities.cs
@@ -130,13 +130,13 @@ namespace NuGet.Commands
 
             if (request.ProjectStyle == ProjectStyle.PackageReference || request.ProjectStyle == ProjectStyle.Standalone)
             {
-                var targetsFilePath = BuildAssetsUtils.GetMSBuildFilePath(request.Project, request, BuildAssetsUtils.TargetsExtension);
+                var targetsFilePath = BuildAssetsUtils.GetMSBuildFilePath(request.Project, BuildAssetsUtils.TargetsExtension);
                 if (!File.Exists(targetsFilePath))
                 {
                     request.Log.LogVerbose(string.Format(CultureInfo.CurrentCulture, Strings.Log_TargetsFileNotOnDisk, request.Project.Name, targetsFilePath));
                     return false;
                 }
-                var propsFilePath = BuildAssetsUtils.GetMSBuildFilePath(request.Project, request, BuildAssetsUtils.PropsExtension);
+                var propsFilePath = BuildAssetsUtils.GetMSBuildFilePath(request.Project, BuildAssetsUtils.PropsExtension);
                 if (!File.Exists(propsFilePath))
                 {
                     request.Log.LogVerbose(string.Format(CultureInfo.CurrentCulture, Strings.Log_PropsFileNotOnDisk, request.Project.Name, propsFilePath));

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Telemetry/RestoreTelemetryServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Telemetry/RestoreTelemetryServiceTests.cs
@@ -46,6 +46,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 status: status,
                 packageCount: 2,
                 noOpProjectsCount: noopProjectsCount,
+                upToDateProjectsCount: 0,
                 endTime: DateTimeOffset.Now,
                 duration: 2.10,
                 new IntervalTracker("Activity"));
@@ -89,6 +90,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 status: NuGetOperationStatus.Succeeded,
                 packageCount: 1,
                 noOpProjectsCount: 0,
+                upToDateProjectsCount: 0,
                 endTime: DateTimeOffset.Now,
                 duration: 2.10,
                 tracker
@@ -102,7 +104,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
             Assert.NotNull(lastTelemetryEvent);
             Assert.Equal(RestoreTelemetryEvent.RestoreActionEventName, lastTelemetryEvent.Name);
-            Assert.Equal(12, lastTelemetryEvent.Count);
+            Assert.Equal(13, lastTelemetryEvent.Count);
 
             Assert.Equal(restoreTelemetryData.OperationSource.ToString(), lastTelemetryEvent["OperationSource"].ToString());
 
@@ -115,7 +117,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         {
             Assert.NotNull(actual);
             Assert.Equal(RestoreTelemetryEvent.RestoreActionEventName, actual.Name);
-            Assert.Equal(10, actual.Count);
+            Assert.Equal(11, actual.Count);
 
             Assert.Equal(expected.OperationSource.ToString(), actual["OperationSource"].ToString());
 

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/SolutionRestoreBuildHandlerTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/SolutionRestoreBuildHandlerTests.cs
@@ -32,9 +32,10 @@ namespace NuGet.SolutionRestoreManager.Test
             var settings = Mock.Of<ISettings>();
             var restoreWorker = Mock.Of<ISolutionRestoreWorker>();
             var buildManager = Mock.Of<IVsSolutionBuildManager3>();
+            var restoreChecker = Mock.Of<ISolutionRestoreChecker>();
             var buildAction = (uint)VSSOLNBUILDUPDATEFLAGS.SBF_OPERATION_CLEAN;
 
-            using (var handler = new SolutionRestoreBuildHandler(settings, restoreWorker, buildManager))
+            using (var handler = new SolutionRestoreBuildHandler(settings, restoreWorker, buildManager, restoreChecker))
             {
                 await _jtf.SwitchToMainThreadAsync();
 
@@ -45,7 +46,9 @@ namespace NuGet.SolutionRestoreManager.Test
 
             Mock.Get(restoreWorker)
                 .Verify(x => x.CleanCacheAsync(), Times.Once);
- 
+            Mock.Get(restoreChecker)
+               .Verify(x => x.CleanCache(), Times.Once);
+
             Mock.Get(restoreWorker)
                 .Verify(x => x.ScheduleRestoreAsync(It.IsAny<SolutionRestoreRequest>(), It.IsAny<CancellationToken>()), Times.Never);
         }
@@ -56,6 +59,7 @@ namespace NuGet.SolutionRestoreManager.Test
             var settings = Mock.Of<ISettings>();
             var restoreWorker = Mock.Of<ISolutionRestoreWorker>();
             var buildManager = Mock.Of<IVsSolutionBuildManager3>();
+            var restoreChecker = Mock.Of<ISolutionRestoreChecker>();
 
             var buildAction = (uint)VSSOLNBUILDUPDATEFLAGS.SBF_OPERATION_BUILD;
 
@@ -64,7 +68,7 @@ namespace NuGet.SolutionRestoreManager.Test
                 .Returns(() => new VirtualSettingSection("packageRestore",
                     new AddItem("automatic", bool.FalseString)));
 
-            using (var handler = new SolutionRestoreBuildHandler(settings, restoreWorker, buildManager))
+            using (var handler = new SolutionRestoreBuildHandler(settings, restoreWorker, buildManager, restoreChecker))
             {
                 await _jtf.SwitchToMainThreadAsync();
 
@@ -83,6 +87,7 @@ namespace NuGet.SolutionRestoreManager.Test
             var settings = Mock.Of<ISettings>();
             var restoreWorker = Mock.Of<ISolutionRestoreWorker>();
             var buildManager = Mock.Of<IVsSolutionBuildManager3>();
+            var restoreChecker = Mock.Of<ISolutionRestoreChecker>();
 
             var buildAction = (uint)VSSOLNBUILDUPDATEFLAGS.SBF_OPERATION_BUILD + (uint)VSSOLNBUILDUPDATEFLAGS3.SBF_FLAGS_UPTODATE_CHECK;
 
@@ -91,7 +96,7 @@ namespace NuGet.SolutionRestoreManager.Test
                 .Returns(() => new VirtualSettingSection("packageRestore",
                     new AddItem("automatic", bool.TrueString)));
 
-            using (var handler = new SolutionRestoreBuildHandler(settings, restoreWorker, buildManager))
+            using (var handler = new SolutionRestoreBuildHandler(settings, restoreWorker, buildManager, restoreChecker))
             {
                 await _jtf.SwitchToMainThreadAsync();
 
@@ -110,6 +115,7 @@ namespace NuGet.SolutionRestoreManager.Test
             var settings = Mock.Of<ISettings>();
             var restoreWorker = Mock.Of<ISolutionRestoreWorker>();
             var buildManager = Mock.Of<IVsSolutionBuildManager3>();
+            var restoreChecker = Mock.Of<ISolutionRestoreChecker>();
 
             var buildAction = (uint)VSSOLNBUILDUPDATEFLAGS.SBF_OPERATION_BUILD;
 
@@ -124,7 +130,7 @@ namespace NuGet.SolutionRestoreManager.Test
                 .Setup(x => x.RestoreAsync(It.IsAny<SolutionRestoreRequest>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(true);
 
-            using (var handler = new SolutionRestoreBuildHandler(settings, restoreWorker, buildManager))
+            using (var handler = new SolutionRestoreBuildHandler(settings, restoreWorker, buildManager, restoreChecker))
             {
                 await _jtf.SwitchToMainThreadAsync();
 

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/SolutionUpToDateCheckerTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/SolutionUpToDateCheckerTests.cs
@@ -1,0 +1,726 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Linq;
+using FluentAssertions;
+using NuGet.Commands;
+using NuGet.Commands.Test;
+using NuGet.Common;
+using NuGet.ProjectModel;
+using NuGet.Test.Utility;
+using Xunit;
+
+namespace NuGet.SolutionRestoreManager.Test
+{
+    public class SolutionUpToDateCheckerTests
+    {
+        [Fact]
+        public void GetOutputFilePaths_GetOutputFilePaths_AllIntermediateOutputsGoToTheOutputFolder()
+        {
+            var packageSpec = GetPackageSpec("A");
+            packageSpec.RestoreMetadata.RestoreLockProperties = new RestoreLockProperties(restorePackagesWithLockFile: "true", nuGetLockFilePath: null, restoreLockedMode: true);
+
+            SolutionUpToDateChecker.GetOutputFilePaths(packageSpec, out string assetsFilePath, out string cacheFilePath, out string targetsFilePath, out string propsFilePath, out string lockFilePath);
+
+            var expectedIntermediateFolder = packageSpec.RestoreMetadata.OutputPath;
+            var expectedLockFileFolder = Path.GetDirectoryName(packageSpec.RestoreMetadata.ProjectPath);
+
+            Path.GetDirectoryName(assetsFilePath).Should().Be(expectedIntermediateFolder);
+            Path.GetDirectoryName(cacheFilePath).Should().Be(expectedIntermediateFolder);
+            Path.GetDirectoryName(targetsFilePath).Should().Be(expectedIntermediateFolder);
+            Path.GetDirectoryName(propsFilePath).Should().Be(expectedIntermediateFolder);
+            Path.GetDirectoryName(lockFilePath).Should().Be(expectedLockFileFolder);
+        }
+
+        [Fact]
+        public void GetOutputFilePaths_WorksForProjectJson()
+        {
+            var packageSpec = GetProjectJsonPackageSpec("A");
+            SolutionUpToDateChecker.GetOutputFilePaths(packageSpec, out string assetsFilePath, out string cacheFilePath, out string targetsFilePath, out string propsFilePath, out string lockFilePath);
+
+            var expectedIntermediateFolder = packageSpec.RestoreMetadata.OutputPath;
+            var expectedAssetsFolder = Path.GetDirectoryName(packageSpec.FilePath);
+
+            Path.GetDirectoryName(assetsFilePath).Should().Be(expectedAssetsFolder);
+            Path.GetDirectoryName(cacheFilePath).Should().Be(expectedIntermediateFolder);
+            Path.GetDirectoryName(targetsFilePath).Should().Be(expectedIntermediateFolder);
+            Path.GetDirectoryName(propsFilePath).Should().Be(expectedIntermediateFolder);
+            lockFilePath.Should().BeNull();
+        }
+
+        // A => B => C
+        [Fact]
+        public void GetParents_WhenDirtySpecsListIsEmpty_ReturnsEmpty()
+        {
+            var projectA = GetPackageSpec("A");
+            var projectB = GetPackageSpec("B");
+            var projectC = GetPackageSpec("C");
+
+            // A => B => C
+            projectA = projectA.WithTestProjectReference(projectB);
+            projectB = projectB.WithTestProjectReference(projectC);
+
+            var dgSpec = new DependencyGraphSpec();
+            dgSpec.AddProject(projectA);
+            dgSpec.AddRestore(projectA.RestoreMetadata.ProjectUniqueName);
+            dgSpec.AddProject(projectB);
+            dgSpec.AddRestore(projectB.RestoreMetadata.ProjectUniqueName);
+            dgSpec.AddProject(projectC);
+            dgSpec.AddRestore(projectC.RestoreMetadata.ProjectUniqueName);
+
+            Assert.Empty(SolutionUpToDateChecker.GetParents(new List<string>(), dgSpec));
+        }
+
+        // A => B => D
+        //   => C => E
+        // D & E are dirty
+        [Fact]
+        public void GetParents_WhenEveryLeafNodeIsDirty_ReturnsAllProjectsInTheSolution()
+        {
+            var projectA = GetPackageSpec("A");
+            var projectB = GetPackageSpec("B");
+            var projectC = GetPackageSpec("C");
+            var projectD = GetPackageSpec("D");
+            var projectE = GetPackageSpec("E");
+
+            // A => B & C
+            projectA = projectA.WithTestProjectReference(projectB).WithTestProjectReference(projectC);
+            // B => D
+            projectB = projectB.WithTestProjectReference(projectD);
+            // C => E
+            projectC = projectC.WithTestProjectReference(projectE);
+
+            var dgSpec = new DependencyGraphSpec();
+            dgSpec.AddProject(projectA);
+            dgSpec.AddRestore(projectA.RestoreMetadata.ProjectUniqueName);
+            dgSpec.AddProject(projectB);
+            dgSpec.AddRestore(projectB.RestoreMetadata.ProjectUniqueName);
+            dgSpec.AddProject(projectC);
+            dgSpec.AddRestore(projectC.RestoreMetadata.ProjectUniqueName);
+            dgSpec.AddProject(projectD);
+            dgSpec.AddRestore(projectD.RestoreMetadata.ProjectUniqueName);
+            dgSpec.AddProject(projectE);
+            dgSpec.AddRestore(projectE.RestoreMetadata.ProjectUniqueName);
+
+            var expected = GetUniqueNames(projectA, projectB, projectC, projectD, projectE);
+            var actual = SolutionUpToDateChecker.GetParents(GetUniqueNames(projectD, projectE), dgSpec);
+
+            actual.Should().BeEquivalentTo(expected);
+        }
+
+        // A => B => D
+        //   => C => E
+        // F => D
+        [Fact]
+        public void GetParents_WhenOnlyRootSpecsAreDirty_ReturnsOnlyTheSameDirtyProjects()
+        {
+            var projectA = GetPackageSpec("A");
+            var projectB = GetPackageSpec("B");
+            var projectC = GetPackageSpec("C");
+            var projectD = GetPackageSpec("D");
+            var projectE = GetPackageSpec("E");
+            var projectF = GetPackageSpec("F");
+
+            // A => B & C
+            projectA = projectA.WithTestProjectReference(projectB).WithTestProjectReference(projectC);
+            // B => D
+            projectB = projectB.WithTestProjectReference(projectD);
+            // C => E
+            projectC = projectC.WithTestProjectReference(projectE);
+            // F => D
+            projectF = projectF.WithTestProjectReference(projectD);
+
+            var dgSpec = new DependencyGraphSpec();
+            dgSpec.AddProject(projectA);
+            dgSpec.AddRestore(projectA.RestoreMetadata.ProjectUniqueName);
+            dgSpec.AddProject(projectB);
+            dgSpec.AddRestore(projectB.RestoreMetadata.ProjectUniqueName);
+            dgSpec.AddProject(projectC);
+            dgSpec.AddRestore(projectC.RestoreMetadata.ProjectUniqueName);
+            dgSpec.AddProject(projectD);
+            dgSpec.AddRestore(projectD.RestoreMetadata.ProjectUniqueName);
+            dgSpec.AddProject(projectE);
+            dgSpec.AddRestore(projectE.RestoreMetadata.ProjectUniqueName);
+            dgSpec.AddProject(projectF);
+            dgSpec.AddRestore(projectF.RestoreMetadata.ProjectUniqueName);
+
+            var expected = GetUniqueNames(projectA, projectF);
+            var actual = SolutionUpToDateChecker.GetParents(GetUniqueNames(projectA, projectF), dgSpec);
+
+            actual.Should().BeEquivalentTo(expected);
+        }
+
+        // A => B => D => F
+        //   => C => E
+        // G => D => F
+        // H => C => E
+        //   => I => F
+        //   => J => K => L
+        // M => L
+        // E & L are dirty
+        [Fact]
+        public void GetParents_WithMultiLevelGraph_WhenALeafIsDirty_ReturnsProjectsFromEveryLevelAsDirty()
+        {
+            var projectA = GetPackageSpec("A");
+            var projectB = GetPackageSpec("B");
+            var projectC = GetPackageSpec("C");
+            var projectD = GetPackageSpec("D");
+            var projectE = GetPackageSpec("E");
+            var projectF = GetPackageSpec("F");
+            var projectG = GetPackageSpec("G");
+            var projectH = GetPackageSpec("H");
+            var projectI = GetPackageSpec("I");
+            var projectJ = GetPackageSpec("J");
+            var projectK = GetPackageSpec("K");
+            var projectL = GetPackageSpec("L");
+            var projectM = GetPackageSpec("M");
+
+            // A => B & C
+            projectA = projectA.WithTestProjectReference(projectB).WithTestProjectReference(projectC);
+            // B => D
+            projectB = projectB.WithTestProjectReference(projectD);
+            // D => F
+            projectD = projectD.WithTestProjectReference(projectF);
+            // C => E
+            projectC = projectC.WithTestProjectReference(projectE);
+            // G => D
+            projectG = projectG.WithTestProjectReference(projectD);
+            // H => C
+            projectH = projectH.WithTestProjectReference(projectC);
+            // I => F
+            projectI = projectI.WithTestProjectReference(projectF);
+            // H => I
+            projectH = projectH.WithTestProjectReference(projectI);
+            // K => L
+            projectK = projectK.WithTestProjectReference(projectL);
+            // J => K
+            projectJ = projectJ.WithTestProjectReference(projectK);
+            // H => J
+            projectH = projectH.WithTestProjectReference(projectJ);
+            // M => L
+            projectM = projectM.WithTestProjectReference(projectL);
+
+
+            var dgSpec = new DependencyGraphSpec();
+            dgSpec.AddProject(projectA);
+            dgSpec.AddRestore(projectA.RestoreMetadata.ProjectUniqueName);
+            dgSpec.AddProject(projectB);
+            dgSpec.AddRestore(projectB.RestoreMetadata.ProjectUniqueName);
+            dgSpec.AddProject(projectC);
+            dgSpec.AddRestore(projectC.RestoreMetadata.ProjectUniqueName);
+            dgSpec.AddProject(projectD);
+            dgSpec.AddRestore(projectD.RestoreMetadata.ProjectUniqueName);
+            dgSpec.AddProject(projectE);
+            dgSpec.AddRestore(projectE.RestoreMetadata.ProjectUniqueName);
+            dgSpec.AddProject(projectF);
+            dgSpec.AddRestore(projectF.RestoreMetadata.ProjectUniqueName);
+            dgSpec.AddProject(projectG);
+            dgSpec.AddRestore(projectG.RestoreMetadata.ProjectUniqueName);
+            dgSpec.AddProject(projectH);
+            dgSpec.AddRestore(projectH.RestoreMetadata.ProjectUniqueName);
+            dgSpec.AddProject(projectI);
+            dgSpec.AddRestore(projectI.RestoreMetadata.ProjectUniqueName);
+            dgSpec.AddProject(projectJ);
+            dgSpec.AddRestore(projectJ.RestoreMetadata.ProjectUniqueName);
+            dgSpec.AddProject(projectK);
+            dgSpec.AddRestore(projectK.RestoreMetadata.ProjectUniqueName);
+            dgSpec.AddProject(projectL);
+            dgSpec.AddRestore(projectL.RestoreMetadata.ProjectUniqueName);
+            dgSpec.AddProject(projectM);
+            dgSpec.AddRestore(projectM.RestoreMetadata.ProjectUniqueName);
+
+            var expected = GetUniqueNames(projectA, projectC, projectE, projectH, projectJ, projectK, projectL, projectM);
+            var actual = SolutionUpToDateChecker.GetParents(GetUniqueNames(projectE, projectL), dgSpec);
+
+            actual.Should().BeEquivalentTo(expected);
+        }
+
+        // This behavior is off, but it is consistent with how no-op is handled right now in the RestoreCommand.
+        // A change in *any* child affects the parents, even if the child is not PR.
+        // A => B => C
+        //   => D
+        //   => E => F
+        // F is not a standard project.
+        [Fact]
+        public void PerformUpToDateCheck_WhenNonBuildIntegratedProjectIsAParentOfADirtySpec_ReturnsAListWithoutNonBuildIntegratedProjects()
+        {
+            var projectA = GetPackageSpec("A");
+            var projectB = GetPackageSpec("B");
+            var projectC = GetPackageSpec("C");
+            var projectD = GetPackageSpec("D");
+            var projectE = GetPackageSpec("E");
+            var projectF = GetUnknownPackageSpec("F");
+
+            // A => B & D & E
+            projectA = projectA.WithTestProjectReference(projectB).WithTestProjectReference(projectD).WithTestProjectReference(projectE);
+            // B => C
+            projectB = projectB.WithTestProjectReference(projectC);
+            // E => F
+            projectE = projectE.WithTestProjectReference(projectF);
+
+            DependencyGraphSpec dgSpec = ProjectJsonTestHelpers.GetDGSpecFromPackageSpecs(projectA, projectB, projectC, projectD, projectE, projectF);
+
+            var checker = new SolutionUpToDateChecker();
+
+            var actual = checker.PerformUpToDateCheck(dgSpec);
+            var expected = GetUniqueNames(projectA, projectB, projectC, projectD, projectE);
+            actual.Should().BeEquivalentTo(expected);
+
+            // Now we run 
+            var results = RunRestore(failedProjects: new HashSet<string>(), projectA, projectB, projectC, projectD, projectE);
+            checker.ReportStatus(results);
+
+            // Prepare the new DG Spec:
+            // Make projectE dirty by setting a random value that's usually not there :)
+            projectF = projectF.Clone();
+            projectF.RestoreMetadata.PackagesPath = @"C:\";
+            dgSpec = ProjectJsonTestHelpers.GetDGSpecFromPackageSpecs(projectA, projectB, projectC, projectD, projectE, projectF);
+
+            // Act & Assert.
+            expected = GetUniqueNames(projectA, projectE);
+            actual = checker.PerformUpToDateCheck(dgSpec);
+            actual.Should().BeEquivalentTo(expected);
+        }
+
+        [Fact]
+        public void PerformUpToDateCheck_WithNoChanges_ReturnsEmpty()
+        {
+            using (var testDirectory = TestDirectory.Create())
+            {
+                var projectA = GetPackageSpec("A", testDirectory.Path);
+                var projectB = GetPackageSpec("B", testDirectory.Path);
+                var projectC = GetPackageSpec("C", testDirectory.Path);
+
+                // A => B
+                projectA = projectA.WithTestProjectReference(projectB);
+                // B => C
+                projectB = projectB.WithTestProjectReference(projectC);
+
+                var dgSpec = new DependencyGraphSpec();
+                dgSpec.AddProject(projectA);
+                dgSpec.AddRestore(projectA.RestoreMetadata.ProjectUniqueName);
+                dgSpec.AddProject(projectB);
+                dgSpec.AddRestore(projectB.RestoreMetadata.ProjectUniqueName);
+                dgSpec.AddProject(projectC);
+                dgSpec.AddRestore(projectC.RestoreMetadata.ProjectUniqueName);
+
+                var checker = new SolutionUpToDateChecker();
+
+                // Preconditions, run 1st check
+                var actual = checker.PerformUpToDateCheck(dgSpec);
+                var expected = GetUniqueNames(projectA, projectB, projectC);
+                actual.Should().BeEquivalentTo(expected);
+                var results = RunRestore(failedProjects: new HashSet<string>(), projectA, projectB, projectC);
+                checker.ReportStatus(results);
+
+                // Act & Asset.
+                actual = checker.PerformUpToDateCheck(dgSpec);
+                actual.Should().BeEmpty();
+            }
+        }
+
+        // A -> B -> C
+        // D
+        // B is dirty when a reference B -> D gets added, A & B are returned.
+        [Fact]
+        public void PerformUpToDateCheck_LeafProjectChanges_ReturnsAllItsParents()
+        {
+            using (var testDirectory = TestDirectory.Create())
+            {
+                var projectA = GetPackageSpec("A", testDirectory.Path);
+                var projectB = GetPackageSpec("B", testDirectory.Path);
+                var projectC = GetPackageSpec("C", testDirectory.Path);
+                var projectD = GetPackageSpec("D", testDirectory.Path);
+
+                // A => B
+                projectA = projectA.WithTestProjectReference(projectB);
+                // B => C
+                projectB = projectB.WithTestProjectReference(projectC);
+                DependencyGraphSpec dgSpec = ProjectJsonTestHelpers.GetDGSpecFromPackageSpecs(projectA, projectB, projectC, projectD);
+
+                var checker = new SolutionUpToDateChecker();
+
+                // Preconditions, run 1st check
+                var actual = checker.PerformUpToDateCheck(dgSpec);
+                var expected = GetUniqueNames(projectA, projectB, projectC, projectD);
+                actual.Should().BeEquivalentTo(expected);
+                var results = RunRestore(failedProjects: new HashSet<string>(), projectA, projectB, projectC, projectD);
+                checker.ReportStatus(results);
+
+                // Set-up, B => D
+                projectB = projectB.WithTestProjectReference(projectD);
+                dgSpec = ProjectJsonTestHelpers.GetDGSpecFromPackageSpecs(projectA, projectB, projectC, projectD);
+
+                // Act & Assert
+                actual = checker.PerformUpToDateCheck(dgSpec);
+                expected = GetUniqueNames(projectA, projectB);
+                actual.Should().BeEquivalentTo(expected);
+            }
+        }
+
+        // A => B => C
+        // Delete the outputs of C. Forces only that project to restore.
+        [Fact]
+        public void PerformUpToDateCheck_WhenALeafProjectHasDirtyOutputs_ReturnsOnlyThatProject()
+        {
+            using (var testDirectory = TestDirectory.Create())
+            {
+                var projectA = GetPackageSpec("A", testDirectory.Path);
+                var projectB = GetPackageSpec("B", testDirectory.Path);
+                var projectC = GetPackageSpec("C", testDirectory.Path);
+
+                // A => B
+                projectA = projectA.WithTestProjectReference(projectB);
+                // B => C
+                projectB = projectB.WithTestProjectReference(projectC);
+                DependencyGraphSpec dgSpec = ProjectJsonTestHelpers.GetDGSpecFromPackageSpecs(projectA, projectB, projectC);
+
+                var checker = new SolutionUpToDateChecker();
+
+                // Preconditions, run 1st check
+                var actual = checker.PerformUpToDateCheck(dgSpec);
+                var expected = GetUniqueNames(projectA, projectB, projectC);
+                actual.Should().BeEquivalentTo(expected);
+                var results = RunRestore(failedProjects: new HashSet<string>(), projectA, projectB, projectC);
+                checker.ReportStatus(results);
+
+                // Set-up, delete C's outputs
+                SolutionUpToDateChecker.GetOutputFilePaths(projectC, out string assetsFilePath, out string _, out string _, out string _, out string _);
+                File.Delete(assetsFilePath);
+
+                // Act & Assert
+                actual = checker.PerformUpToDateCheck(dgSpec);
+                expected = GetUniqueNames(projectC);
+                actual.Should().BeEquivalentTo(expected);
+            }
+        }
+
+        // A => B => C
+        // Delete the outputs of C. Forces only that project to restore.
+        [Fact]
+        public void PerformUpToDateCheck_WhenALeafProjectHasNoCacheFile_ReturnsOnlyThatProject()
+        {
+            using (var testDirectory = TestDirectory.Create())
+            {
+                var projectA = GetPackageSpec("A", testDirectory.Path);
+                var projectB = GetPackageSpec("B", testDirectory.Path);
+                var projectC = GetPackageSpec("C", testDirectory.Path);
+
+                // A => B
+                projectA = projectA.WithTestProjectReference(projectB);
+                // B => C
+                projectB = projectB.WithTestProjectReference(projectC);
+                DependencyGraphSpec dgSpec = ProjectJsonTestHelpers.GetDGSpecFromPackageSpecs(projectA, projectB, projectC);
+
+                var checker = new SolutionUpToDateChecker();
+
+                // Preconditions, run 1st check
+                var actual = checker.PerformUpToDateCheck(dgSpec);
+                var expected = GetUniqueNames(projectA, projectB, projectC);
+                actual.Should().BeEquivalentTo(expected);
+                var results = RunRestore(failedProjects: new HashSet<string>(), projectA, projectB, projectC);
+                checker.ReportStatus(results);
+
+                // Set-up, delete C's outputs
+                SolutionUpToDateChecker.GetOutputFilePaths(projectC, out string _, out string cacheFilePath, out string _, out string _, out string _);
+                File.Delete(cacheFilePath);
+
+                // Act & Assert
+                actual = checker.PerformUpToDateCheck(dgSpec);
+                expected = GetUniqueNames(projectC);
+                actual.Should().BeEquivalentTo(expected);
+            }
+        }
+
+        // A => B
+        //   => C
+        // D
+        //
+        // C & D are project.json, C is dirty, returns A & C.
+        [Fact]
+        public void PerformUpToDateCheck_WithProjectJsonProjects_ReturnsOnlyDirtyProjects()
+        {
+            using (var testDirectory = TestDirectory.Create())
+            {
+                var projectA = GetPackageSpec("A", testDirectory.Path);
+                var projectB = GetPackageSpec("B", testDirectory.Path);
+                var projectC = GetProjectJsonPackageSpec("C", testDirectory.Path);
+                var projectD = GetProjectJsonPackageSpec("D", testDirectory.Path);
+
+                // A => B & C
+                projectA = projectA.WithTestProjectReference(projectB).WithTestProjectReference(projectC);
+                DependencyGraphSpec dgSpec = ProjectJsonTestHelpers.GetDGSpecFromPackageSpecs(projectA, projectB, projectC, projectD);
+
+                var checker = new SolutionUpToDateChecker();
+
+                // Preconditions, run 1st check
+                var actual = checker.PerformUpToDateCheck(dgSpec);
+                var expected = GetUniqueNames(projectA, projectB, projectC, projectD);
+                actual.Should().BeEquivalentTo(expected);
+                var results = RunRestore(failedProjects: new HashSet<string>(), projectA, projectB, projectC, projectD);
+                checker.ReportStatus(results);
+
+                // Set-up, make C dirty.
+                projectC = projectC.Clone();
+                projectC.RestoreMetadata.ConfigFilePaths = new List<string>() { "newFeed" };
+                dgSpec = ProjectJsonTestHelpers.GetDGSpecFromPackageSpecs(projectA, projectB, projectC, projectD);
+
+                // Act & Assert
+                actual = checker.PerformUpToDateCheck(dgSpec);
+                expected = GetUniqueNames(projectA, projectC);
+                actual.Should().BeEquivalentTo(expected);
+            }
+        }
+
+        [Fact]
+        public void PerformUpToDateCheck_WithFailedPastRestore_ReturnsADirtyProject()
+        {
+            using (var testDirectory = TestDirectory.Create())
+            {
+                var projectA = GetPackageSpec("A", testDirectory.Path);
+                var projectB = GetPackageSpec("B", testDirectory.Path);
+                var projectC = GetPackageSpec("C", testDirectory.Path);
+
+                // A => B
+                projectA = projectA.WithTestProjectReference(projectB);
+                // B => C
+                projectB = projectB.WithTestProjectReference(projectC);
+                DependencyGraphSpec dgSpec = ProjectJsonTestHelpers.GetDGSpecFromPackageSpecs(projectA, projectB, projectC);
+
+                var checker = new SolutionUpToDateChecker();
+
+                // Preconditions, run 1st check
+                var actual = checker.PerformUpToDateCheck(dgSpec);
+                new List<string>() { projectA.RestoreMetadata.ProjectUniqueName, projectB.RestoreMetadata.ProjectUniqueName, projectC.RestoreMetadata.ProjectUniqueName }.Should().BeEquivalentTo(actual);
+
+                // Set-up, ensure the last status for projectC is a failure.
+                var results = RunRestore(failedProjects: new HashSet<string>() { projectC.RestoreMetadata.ProjectUniqueName }, projectA, projectB, projectC);
+                checker.ReportStatus(results);
+
+                // Act & Assert
+                actual = checker.PerformUpToDateCheck(dgSpec);
+                var expected = new List<string>() { projectC.RestoreMetadata.ProjectUniqueName };
+                actual.Should().BeEquivalentTo(expected);
+            }
+        }
+
+        // A => B => C
+        // Delete the outputs of C. Forces only that project to restore.
+        [Fact]
+        public void PerformUpToDateCheck_WhenALeafProjectHasNoGlobalPackagesFolder_ReturnsOnlyThatProject()
+        {
+            using (var testDirectory = TestDirectory.Create())
+            {
+                var projectA = GetPackageSpec("A", testDirectory.Path);
+                var projectB = GetPackageSpec("B", testDirectory.Path);
+                var projectC = GetPackageSpec("C", testDirectory.Path);
+                projectC.RestoreMetadata.PackagesPath = Path.Combine(testDirectory.Path, "gpf");
+                // A => B
+                projectA = projectA.WithTestProjectReference(projectB);
+                // B => C
+                projectB = projectB.WithTestProjectReference(projectC);
+                DependencyGraphSpec dgSpec = ProjectJsonTestHelpers.GetDGSpecFromPackageSpecs(projectA, projectB, projectC);
+
+                var checker = new SolutionUpToDateChecker();
+
+                // Preconditions, run 1st check
+                var actual = checker.PerformUpToDateCheck(dgSpec);
+                var expected = GetUniqueNames(projectA, projectB, projectC);
+                actual.Should().BeEquivalentTo(expected);
+                var results = RunRestore(failedProjects: new HashSet<string>(), projectA, projectB, projectC);
+                checker.ReportStatus(results);
+
+                // Set-up, delete C's outputs
+                Directory.Delete(projectC.RestoreMetadata.PackagesPath, recursive: true);
+
+                // Act & Assert
+                actual = checker.PerformUpToDateCheck(dgSpec);
+                expected = GetUniqueNames(projectC);
+                actual.Should().BeEquivalentTo(expected);
+            }
+        }
+
+        // A => B => C
+        //   => D
+        // E
+        // D is gonna be marked dirty when a project reference to E is added
+        // The 2nd check should return D & A.
+        // The 3rd check should return nothing.
+        [Fact]
+        public void ReportStatus_WhenPartialResultsAreAvailable_OldStatusIsRetained()
+        {
+            using (var testDirectory = TestDirectory.Create())
+            {
+                var projectA = GetPackageSpec("A", testDirectory.Path);
+                var projectB = GetPackageSpec("B", testDirectory.Path);
+                var projectC = GetPackageSpec("C", testDirectory.Path);
+                var projectD = GetPackageSpec("D", testDirectory.Path);
+                var projectE = GetPackageSpec("E", testDirectory.Path);
+
+                // A => B
+                projectA = projectA.WithTestProjectReference(projectB);
+                // B => C
+                projectB = projectB.WithTestProjectReference(projectC);
+                // A => D
+                projectA = projectA.WithTestProjectReference(projectD);
+
+                DependencyGraphSpec dgSpec = ProjectJsonTestHelpers.GetDGSpecFromPackageSpecs(projectA, projectB, projectC, projectD, projectE);
+
+                var checker = new SolutionUpToDateChecker();
+
+                // Preconditions, run 1st check
+                var actual = checker.PerformUpToDateCheck(dgSpec);
+                var expected = GetUniqueNames(projectA, projectB, projectC, projectD, projectE);
+                actual.Should().BeEquivalentTo(expected);
+                var results = RunRestore(failedProjects: new HashSet<string>(), projectA, projectB, projectC, projectD, projectE);
+                checker.ReportStatus(results);
+
+                // D => E
+                projectD = projectD.WithTestProjectReference(projectE);
+
+                // Set-up dg spec
+                dgSpec = ProjectJsonTestHelpers.GetDGSpecFromPackageSpecs(projectA, projectB, projectC, projectD, projectE);
+                // 2nd check
+                actual = checker.PerformUpToDateCheck(dgSpec);
+                expected = GetUniqueNames(projectA, projectD);
+                actual.Should().BeEquivalentTo(expected);
+                results = RunRestore(failedProjects: new HashSet<string>(), projectA, projectD);
+                checker.ReportStatus(results);
+
+                // Finally, last check. Run for a 3rd time. Everything should be up to date
+                actual = checker.PerformUpToDateCheck(dgSpec);
+                expected = GetUniqueNames();
+                actual.Should().BeEquivalentTo(expected);
+            }
+        }
+
+        private List<string> GetUniqueNames(params PackageSpec[] packageSpecs)
+        {
+            var projects = new List<string>();
+            foreach (var package in packageSpecs)
+            {
+                projects.Add(package.RestoreMetadata.ProjectUniqueName);
+            }
+            return projects;
+        }
+
+        private static PackageSpec GetUnknownPackageSpec(string projectName)
+        {
+            var packageSpec = new PackageSpec();
+            var projectPath = Path.Combine(@"C:\", projectName, $"{projectName}.csproj");
+            packageSpec.RestoreMetadata = new ProjectRestoreMetadata()
+            {
+                ProjectUniqueName = projectPath,
+                ProjectName = projectPath
+            };
+            packageSpec.FilePath = projectPath;
+
+            return packageSpec;
+        }
+
+        private static PackageSpec GetPackageSpec(string projectName, string rootPath = @"C:\")
+        {
+            const string referenceSpec = @"
+                {
+                    ""frameworks"": {
+                        ""net5.0"": {
+                            ""dependencies"": {
+                            }
+                        }
+                    }
+                }";
+            return JsonPackageSpecReader.GetPackageSpec(referenceSpec, projectName, Path.Combine(rootPath, projectName, projectName)).WithTestRestoreMetadata();
+        }
+
+        private static PackageSpec GetProjectJsonPackageSpec(string projectName, string rootPath = @"C:\")
+        {
+            const string referenceSpec = @"
+                {
+                    ""frameworks"": {
+                        ""net5.0"": {
+                            ""dependencies"": {
+                            }
+                        }
+                    }
+                }";
+            var packageSpec = JsonPackageSpecReader.GetPackageSpec(referenceSpec, projectName, Path.Combine(rootPath, projectName, projectName));
+
+            var packageSpecFile = new FileInfo(packageSpec.FilePath);
+            var projectDir = packageSpecFile.Directory.FullName;
+            var projectPath = Path.Combine(projectDir, packageSpec.Name + ".csproj");
+
+            packageSpec.RestoreMetadata = new ProjectRestoreMetadata();
+            packageSpec.RestoreMetadata.CrossTargeting = packageSpec.TargetFrameworks.Count > 0;
+            packageSpec.RestoreMetadata.OriginalTargetFrameworks = packageSpec.TargetFrameworks.Select(e => e.FrameworkName.GetShortFolderName()).ToList();
+            packageSpec.RestoreMetadata.OutputPath = projectDir;
+            packageSpec.RestoreMetadata.ProjectStyle = ProjectStyle.ProjectJson;
+            packageSpec.RestoreMetadata.ProjectName = packageSpec.Name;
+            packageSpec.RestoreMetadata.ProjectUniqueName = projectPath;
+            packageSpec.RestoreMetadata.ProjectPath = projectPath;
+            packageSpec.RestoreMetadata.ConfigFilePaths = new List<string>();
+            packageSpec.RestoreMetadata.CentralPackageVersionsEnabled = false;
+
+            foreach (var framework in packageSpec.TargetFrameworks.Select(e => e.FrameworkName))
+            {
+                packageSpec.RestoreMetadata.TargetFrameworks.Add(new ProjectRestoreMetadataFrameworkInfo(framework));
+            }
+
+            return packageSpec;
+        }
+
+        private static IReadOnlyList<RestoreSummary> RunRestore(HashSet<string> failedProjects, params PackageSpec[] packageSpecs)
+        {
+            foreach (var spec in packageSpecs)
+            {
+                CreateDummyOutputFiles(spec);
+            }
+
+            return CreateRestoreSummaries(failedProjects, packageSpecs).ToImmutableList();
+        }
+
+        private static IEnumerable<RestoreSummary> CreateRestoreSummaries(HashSet<string> failedProjects, params PackageSpec[] packageSpecs)
+        {
+            foreach (var spec in packageSpecs)
+            {
+                var status = !failedProjects.Contains(spec.RestoreMetadata.ProjectUniqueName);
+                yield return CreateRestoreSummary(spec, success: status);
+            }
+        }
+
+        private static RestoreSummary CreateRestoreSummary(PackageSpec spec, bool success)
+        {
+            return new RestoreSummary(
+                success: success,
+                inputPath: spec.RestoreMetadata.ProjectUniqueName,
+                configFiles: new ReadOnlyCollection<string>(new List<string>()),
+                feedsUsed: new ReadOnlyCollection<string>(new List<string>()),
+                installCount: 0,
+                errors: new ReadOnlyCollection<IRestoreLogMessage>(new List<IRestoreLogMessage>()));
+        }
+
+        internal static void CreateDummyOutputFiles(PackageSpec packageSpec)
+        {
+            SolutionUpToDateChecker.GetOutputFilePaths(packageSpec, out string assetsFilePath, out string cacheFilePath, out string targetsFilePath, out string propsFilePath, out string lockFilePath);
+            var globalPackagesFolderDummyFilePath = packageSpec.RestoreMetadata.PackagesPath != null ?
+                Path.Combine(packageSpec.RestoreMetadata.PackagesPath, "dummyFile.txt") :
+                null;
+            CreateFile(assetsFilePath, cacheFilePath, targetsFilePath, propsFilePath, lockFilePath, globalPackagesFolderDummyFilePath);
+        }
+
+        private static void CreateFile(params string[] paths)
+        {
+            foreach (var path in paths)
+            {
+                if (path != null)
+                {
+                    Directory.CreateDirectory(Path.GetDirectoryName(path));
+                    File.Create(path).Dispose();
+                }
+            }
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/BuildAssetsUtilsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/BuildAssetsUtilsTests.cs
@@ -9,7 +9,6 @@ using System.Threading.Tasks;
 using System.Xml.Linq;
 using NuGet.Common;
 using NuGet.Configuration;
-using NuGet.Frameworks;
 using NuGet.LibraryModel;
 using NuGet.Packaging.Core;
 using NuGet.ProjectModel;
@@ -622,7 +621,6 @@ namespace NuGet.Commands.Test
         public async Task BuildAssetsUtils_GeneratePathProperty()
         {
             using (var pathContext = new SimpleTestPathContext())
-            using (var randomProjectDirectory = TestDirectory.Create())
             {
                 // Arrange
                 var identity = new PackageIdentity("packagea", NuGetVersion.Parse("1.0.0"));
@@ -638,17 +636,20 @@ namespace NuGet.Commands.Test
 
                 var logger = new TestLogger();
 
-                var spec = ToolRestoreUtility.GetSpec(
-                    Path.Combine(pathContext.SolutionRoot, "tool", "fake.csproj"),
-                    "a",
-                    VersionRange.Parse("1.0.0"),
-                    NuGetFramework.Parse("netcoreapp1.0"),
-                    pathContext.UserPackagesFolder,
-                    new List<string>() { pathContext.FallbackFolder },
-                    new List<PackageSource>() { new PackageSource(pathContext.PackageSource) },
-                    projectWideWarningProperties: null);
+                const string referenceSpec = @"
+                {
+                    ""frameworks"": {
+                        ""netcoreapp1.0"": {
+                            ""dependencies"": {
+                            }
+                        }
+                    }
+                }";
+                var projectName = "a";
+                var rootProjectsPath = pathContext.WorkingDirectory;
+                var projectDirectory = Path.Combine(rootProjectsPath, projectName);
 
-                spec.RestoreMetadata.ProjectStyle = ProjectStyle.PackageReference;
+                var spec = JsonPackageSpecReader.GetPackageSpec(referenceSpec, projectName, Path.Combine(projectDirectory, projectName)).WithTestRestoreMetadata();
 
                 spec.Dependencies.Add(new LibraryDependency
                 {
@@ -704,7 +705,7 @@ namespace NuGet.Commands.Test
                     ProjectStyle = spec.RestoreMetadata.ProjectStyle
                 };
 
-                var assetsFilePath = Path.Combine(randomProjectDirectory, "obj", "project.assets.json");
+                var assetsFilePath = Path.Combine(projectDirectory, "obj", "project.assets.json");
 
                 // Act
                 var outputFiles = BuildAssetsUtils.GetMSBuildOutputFiles(spec, lockFile, targetGraphs, repositories, restoreRequest, assetsFilePath, true, logger);
@@ -732,7 +733,6 @@ namespace NuGet.Commands.Test
         public async Task BuildAssetsUtils_GeneratePathPropertyForTools(bool hasTools)
         {
             using (var pathContext = new SimpleTestPathContext())
-            using (var randomProjectDirectory = TestDirectory.Create())
             {
                 // Arrange
                 var identity = new PackageIdentity("packagea", NuGetVersion.Parse("1.0.0"));
@@ -748,17 +748,20 @@ namespace NuGet.Commands.Test
 
                 var logger = new TestLogger();
 
-                var spec = ToolRestoreUtility.GetSpec(
-                    Path.Combine(pathContext.SolutionRoot, "tool", "fake.csproj"),
-                    "a",
-                    VersionRange.Parse("1.0.0"),
-                    NuGetFramework.Parse("netcoreapp1.0"),
-                    pathContext.UserPackagesFolder,
-                    new List<string>() { pathContext.FallbackFolder },
-                    new List<PackageSource>() { new PackageSource(pathContext.PackageSource) },
-                    projectWideWarningProperties: null);
+                const string referenceSpec = @"
+                {
+                    ""frameworks"": {
+                        ""netcoreapp1.0"": {
+                            ""dependencies"": {
+                            }
+                        }
+                    }
+                }";
+                var projectName = "a";
+                var rootProjectsPath = pathContext.WorkingDirectory;
+                var projectDirectory = Path.Combine(rootProjectsPath, projectName);
 
-                spec.RestoreMetadata.ProjectStyle = ProjectStyle.PackageReference;
+                var spec = JsonPackageSpecReader.GetPackageSpec(referenceSpec, projectName, Path.Combine(projectDirectory, projectName)).WithTestRestoreMetadata();
 
                 spec.Dependencies.Add(new LibraryDependency
                 {
@@ -814,7 +817,7 @@ namespace NuGet.Commands.Test
                     ProjectStyle = spec.RestoreMetadata.ProjectStyle
                 };
 
-                var assetsFilePath = Path.Combine(randomProjectDirectory, "obj", "project.assets.json");
+                var assetsFilePath = Path.Combine(projectDirectory, "obj", "project.assets.json");
 
                 // Act
                 var outputFiles = BuildAssetsUtils.GetMSBuildOutputFiles(spec, lockFile, targetGraphs, repositories, restoreRequest, assetsFilePath, true, logger);

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreRunnerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreRunnerTests.cs
@@ -64,7 +64,7 @@ namespace NuGet.Commands.Test
                 spec1.RestoreMetadata.PackagesPath = packagesDir.FullName;
                 var dgSpec = new DependencyGraphSpec();
                 dgSpec.AddProject(spec1);
-                dgSpec.AddRestore(projectName);
+                dgSpec.AddRestore(spec1.RestoreMetadata.ProjectUniqueName);
 
                 var logger = new TestLogger();
                 var lockPath = Path.Combine(project1.FullName, "project.assets.json");
@@ -144,7 +144,7 @@ namespace NuGet.Commands.Test
                 spec1.RestoreMetadata.PackagesPath = packagesDir.FullName;
                 var dgFile = new DependencyGraphSpec();
                 dgFile.AddProject(spec1);
-                dgFile.AddRestore("project1");
+                dgFile.AddRestore(spec1.RestoreMetadata.ProjectUniqueName);
 
                 var logger = new TestLogger();
                 var lockPath = Path.Combine(project1.FullName, "project.assets.json");
@@ -345,7 +345,7 @@ namespace NuGet.Commands.Test
                 spec1.RestoreMetadata.PackagesPath = packagesDir.FullName;
 
                 dgFile.AddProject(spec1);
-                dgFile.AddRestore("project1");
+                dgFile.AddRestore(spec1.RestoreMetadata.ProjectUniqueName);
 
                 var logger = new TestLogger();
                 var lockPath = Path.Combine(project1.FullName, "project.assets.json");
@@ -485,7 +485,7 @@ namespace NuGet.Commands.Test
 
                 foreach (var spec in specs)
                 {
-                    dgFile.AddRestore(spec.RestoreMetadata.ProjectName);
+                    dgFile.AddRestore(spec.RestoreMetadata.ProjectUniqueName);
                     dgFile.AddProject(spec);
                 }
 
@@ -634,7 +634,7 @@ namespace NuGet.Commands.Test
 
                 foreach (var spec in specs)
                 {
-                    dgFile.AddRestore(spec.RestoreMetadata.ProjectName);
+                    dgFile.AddRestore(spec.RestoreMetadata.ProjectUniqueName);
                     dgFile.AddProject(spec);
                 }
 
@@ -719,7 +719,7 @@ namespace NuGet.Commands.Test
                 spec1.RestoreMetadata.PackagesPath = packagesDir.FullName;
                 var dgSpec = new DependencyGraphSpec();
                 dgSpec.AddProject(spec1);
-                dgSpec.AddRestore("project1");
+                dgSpec.AddRestore(spec1.RestoreMetadata.ProjectUniqueName);
 
                 var logger = new TestLogger();
                 var lockPath1 = Path.Combine(project1.FullName, "project.assets.json");
@@ -795,7 +795,7 @@ namespace NuGet.Commands.Test
                 // set up the dg spec.
                 var dgFile = new DependencyGraphSpec();
                 dgFile.AddProject(projectSpec);
-                dgFile.AddRestore(projectSpec.Name);
+                dgFile.AddRestore(projectSpec.RestoreMetadata.ProjectUniqueName);
                 // set up the packages
                 var packageX = new SimpleTestPackageContext()
                 {
@@ -884,7 +884,7 @@ namespace NuGet.Commands.Test
                 // set up the dg spec.
                 var dgFile = new DependencyGraphSpec();
                 dgFile.AddProject(projectSpec);
-                dgFile.AddRestore(projectSpec.Name);
+                dgFile.AddRestore(projectSpec.RestoreMetadata.ProjectUniqueName);
                 // set up the packages
 
                 await SimpleTestPackageUtility.CreateFullPackageAsync(packageSource.FullName, new SimpleTestPackageContext()
@@ -983,7 +983,7 @@ namespace NuGet.Commands.Test
                 // set up the dg spec.
                 var dgFile = new DependencyGraphSpec();
                 dgFile.AddProject(projectSpec);
-                dgFile.AddRestore(projectSpec.Name);
+                dgFile.AddRestore(projectSpec.RestoreMetadata.ProjectUniqueName);
                 // set up the packages
                 var packageX = new SimpleTestPackageContext()
                 {
@@ -1075,7 +1075,7 @@ namespace NuGet.Commands.Test
                 // set up the dg spec.
                 var dgFile = new DependencyGraphSpec();
                 dgFile.AddProject(projectSpec);
-                dgFile.AddRestore(projectSpec.Name);
+                dgFile.AddRestore(projectSpec.RestoreMetadata.ProjectUniqueName);
                 // set up the packages
                 var packageX = new SimpleTestPackageContext()
                 {
@@ -1181,7 +1181,7 @@ namespace NuGet.Commands.Test
                 // set up the dg spec.
                 var dgFile = new DependencyGraphSpec();
                 dgFile.AddProject(projectSpec);
-                dgFile.AddRestore(projectSpec.Name);
+                dgFile.AddRestore(projectSpec.RestoreMetadata.ProjectUniqueName);
                 // set up the packages
 
                 await SimpleTestPackageUtility.CreateFullPackageAsync(packageSource.FullName, new SimpleTestPackageContext()
@@ -1286,7 +1286,7 @@ namespace NuGet.Commands.Test
                 // set up the dg spec.
                 var dgFile = new DependencyGraphSpec();
                 dgFile.AddProject(projectSpec);
-                dgFile.AddRestore(projectSpec.Name);
+                dgFile.AddRestore(projectSpec.RestoreMetadata.ProjectUniqueName);
                 // set up the packages
 
                 await SimpleTestPackageUtility.CreateFullPackageAsync(packageSource.FullName, new SimpleTestPackageContext()
@@ -1394,7 +1394,7 @@ namespace NuGet.Commands.Test
                 // set up the dg spec.
                 var dgFile = new DependencyGraphSpec();
                 dgFile.AddProject(projectSpec);
-                dgFile.AddRestore(projectSpec.Name);
+                dgFile.AddRestore(projectSpec.RestoreMetadata.ProjectUniqueName);
                 // set up the packages
 
                 await SimpleTestPackageUtility.CreateFullPackageAsync(packageSource.FullName, new SimpleTestPackageContext()
@@ -1504,7 +1504,7 @@ namespace NuGet.Commands.Test
                 // set up the dg spec.
                 var dgFile = new DependencyGraphSpec();
                 dgFile.AddProject(projectSpec);
-                dgFile.AddRestore(projectSpec.Name);
+                dgFile.AddRestore(projectSpec.RestoreMetadata.ProjectUniqueName);
                 // set up the packages
                 await SimpleTestPackageUtility.CreateFullPackageAsync(packageSource.FullName, new SimpleTestPackageContext()
                 {
@@ -1595,7 +1595,7 @@ namespace NuGet.Commands.Test
                 // set up the dg spec.
                 var dgFile = new DependencyGraphSpec();
                 dgFile.AddProject(projectSpec);
-                dgFile.AddRestore(projectSpec.Name);
+                dgFile.AddRestore(projectSpec.RestoreMetadata.ProjectUniqueName);
                 // set up the packages
                 var packageX = new SimpleTestPackageContext()
                 {
@@ -1673,7 +1673,7 @@ namespace NuGet.Commands.Test
                 // set up the dg spec.
                 var dgFile = new DependencyGraphSpec();
                 dgFile.AddProject(projectSpec);
-                dgFile.AddRestore(projectSpec.Name);
+                dgFile.AddRestore(projectSpec.RestoreMetadata.ProjectUniqueName);
                 // set up the packages
                 var packageX = new SimpleTestPackageContext()
                 {
@@ -1806,7 +1806,7 @@ namespace NuGet.Commands.Test
                     .Add(new ProjectRestoreReference()
                     {
                         ProjectPath = projectSpec2.FilePath,
-                        ProjectUniqueName = projectSpec2.Name
+                        ProjectUniqueName = projectSpec2.RestoreMetadata.ProjectUniqueName
                     }
                     );
 
@@ -1814,8 +1814,8 @@ namespace NuGet.Commands.Test
                 var dgFile = new DependencyGraphSpec();
                 dgFile.AddProject(projectSpec1);
                 dgFile.AddProject(projectSpec2);
-                dgFile.AddRestore(projectSpec1.Name);
-                dgFile.AddRestore(projectSpec2.Name);
+                dgFile.AddRestore(projectSpec1.RestoreMetadata.ProjectUniqueName);
+                dgFile.AddRestore(projectSpec2.RestoreMetadata.ProjectUniqueName);
 
                 // set up the packages
                 var packageX = new SimpleTestPackageContext()

--- a/test/TestUtilities/Test.Utility/Commands/ProjectJsonTestHelpers.cs
+++ b/test/TestUtilities/Test.Utility/Commands/ProjectJsonTestHelpers.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
-using NuGet.Common;
+
 using NuGet.Frameworks;
 using NuGet.ProjectModel;
 
@@ -47,6 +47,26 @@ namespace NuGet.Commands.Test
                 dgSpec.AddProject(EnsureRestoreMetadata(child));
             }
 
+            return dgSpec;
+        }
+
+        /// <summary>
+        /// Creates a dg specs with all PackageReference and project.json projects to be restored.
+        /// </summary>
+        /// <param name="projects"></param>
+        /// <returns></returns>
+        public static DependencyGraphSpec GetDGSpecFromPackageSpecs(params PackageSpec[] projects)
+        {
+            var dgSpec = new DependencyGraphSpec();
+            foreach (var project in projects)
+            {
+                dgSpec.AddProject(project);
+                if (project.RestoreMetadata.ProjectStyle == ProjectStyle.PackageReference ||
+                    project.RestoreMetadata.ProjectStyle == ProjectStyle.ProjectJson)
+                {
+                    dgSpec.AddRestore(project.RestoreMetadata.ProjectUniqueName);
+                }
+            }
             return dgSpec;
         }
 
@@ -102,12 +122,12 @@ namespace NuGet.Commands.Test
             updated.FilePath = projectPath;
 
             updated.RestoreMetadata = new ProjectRestoreMetadata();
-            updated.RestoreMetadata.CrossTargeting = updated.TargetFrameworks.Count > 0;
+            updated.RestoreMetadata.CrossTargeting = updated.TargetFrameworks.Count > 1;
             updated.RestoreMetadata.OriginalTargetFrameworks = updated.TargetFrameworks.Select(e => e.FrameworkName.GetShortFolderName()).ToList();
             updated.RestoreMetadata.OutputPath = projectDir;
             updated.RestoreMetadata.ProjectStyle = ProjectStyle.PackageReference;
             updated.RestoreMetadata.ProjectName = spec.Name;
-            updated.RestoreMetadata.ProjectUniqueName = spec.Name;
+            updated.RestoreMetadata.ProjectUniqueName = projectPath;
             updated.RestoreMetadata.ProjectPath = projectPath;
             updated.RestoreMetadata.ConfigFilePaths = new List<string>();
             updated.RestoreMetadata.CentralPackageVersionsEnabled = spec.RestoreMetadata?.CentralPackageVersionsEnabled ?? false;


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9513
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: 
Design at https://github.com/NuGet/Home/pull/9564. Recommended you read that before reviewing. Specifically the https://github.com/NuGet/Home/blob/dev-nkolev92-partialrestore/designs/VisualStudio-PartialRestoreOptimization.md#solutionuptodatechecker section. 

Pulling up the project level no-op to a solution level one with a few additional assumptions. 

Some numbers:

Product Name | VS 2019.5.5 | VS 2019.6.6 P6 | VS 2019.7 prototype. | VS 2019.7 prototype without legacy projects |   | VS 2019.6.6 P6 | VS 2019.7 prototype. | VS 2019.7 prototype without legacy projects
-- | -- | -- | -- | -- | -- | -- | -- | --
Machine | PC | PC | PC | PC |   | Laptop | Laptop | Laptop
  | 1.6804014 | 1.6156941 | 0.1379934 | 0.4676703 |   | 1.9918262 | 0.8003277 | 0.9779166
  | 2.0785128 | 1.5657122 | 0.2868548 | 0.5782298 |   | 2.1794812 | 0.2650475 | 0.7390993
  | 1.57547 | 1.4855428 | 0.2480139 | 0.465401 |   | 2.1542342 | 0.1249913 | 0.5509775
  | 1.6408717 | 1.3002356 | 0.0922059 | 0.3999576 |   | 2.1923273 | 0.1813558 | 0.9208276
  | 1.9922636 | 1.6086686 | 0.2854186 | 0.4808997 |   | 2.7275282 | 0.3690762 | 0.8273464
Average | 1.7935039 | 1.51517066 | 0.21009732 | 0.47843168 |   | 2.24907942 | 0.3481597 | 0.80323348
Standard Deviation | 0.202169749 | 0.117026633 | 0.080124946 | 0.057287945 |   | 0.249861076 | 0.240594561 | 0.150113474
Compared to earlier releases |   | -15.51896486 | -86.13375209 | -68.4239081 |   |   | -84.51990193 | -64.28612201
  |   | 16.6 to 16.5 | 16.7 to 16.6 | 16.7 prototype to 16.6 |   |   | 16.7 to 16.6 | 16.7 prototype to 16.6


Improvements of 60%+ in the NuGet.sln. 

I will do numbers on more solutions as time progresses, but I am confident that the numbers will be comparable. Especially for SDK based projects. 

## Testing/Validation

Tests Added: Yes
Reason for not adding tests:  
Validation:  
