### PR TITLE
Fix more warnings reported by CodeAnalysis

### DIFF
--- a/build/common.targets
+++ b/build/common.targets
@@ -24,11 +24,6 @@
     <DefineConstants>$(DefineConstants);IS_SIGNING_SUPPORTED</DefineConstants>
   </PropertyGroup>
 
-  <!-- TODO: remove the definition of NET5_0 https://github.com/NuGet/Home/issues/9573 -->
-  <PropertyGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND '[MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion),5.0)' ">
-    <DefineConstants>$(DefineConstants);NET5_0</DefineConstants>
-  </PropertyGroup>
-
   <!-- Include shared files for netcore projects -->
   <ItemGroup Condition=" ('$(IsNetCoreProject)' == 'true' AND '$(SkipShared)' != 'true' AND '$(TestProject)' != 'true') OR '$(IncludeNuGetSharedFiles)' == 'true'">
     <Compile Include="$(SharedDirectory)\*.cs" Exclude="bin\**;obj\**;**\*.xproj;packages\**" />

--- a/build/common.targets
+++ b/build/common.targets
@@ -24,6 +24,11 @@
     <DefineConstants>$(DefineConstants);IS_SIGNING_SUPPORTED</DefineConstants>
   </PropertyGroup>
 
+  <!-- TODO: remove the definition of NET5_0 https://github.com/NuGet/Home/issues/9573 -->
+  <PropertyGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND '[MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion),5.0)' ">
+    <DefineConstants>$(DefineConstants);NET5_0</DefineConstants>
+  </PropertyGroup>
+
   <!-- Include shared files for netcore projects -->
   <ItemGroup Condition=" ('$(IsNetCoreProject)' == 'true' AND '$(SkipShared)' != 'true' AND '$(TestProject)' != 'true') OR '$(IncludeNuGetSharedFiles)' == 'true'">
     <Compile Include="$(SharedDirectory)\*.cs" Exclude="bin\**;obj\**;**\*.xproj;packages\**" />

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PackageBuilder.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PackageBuilder.cs
@@ -780,7 +780,11 @@ namespace NuGet.Packaging
                         }
                         else
                         {
+#if NET5_0
+                            filesWithoutExtensions.Add($"/{file.Path.Replace("\\", "/", StringComparison.Ordinal)}");
+#else
                             filesWithoutExtensions.Add($"/{file.Path.Replace("\\", "/")}");
+#endif
                         }
                     }
                     catch

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PackageBuilder.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PackageBuilder.cs
@@ -780,7 +780,7 @@ namespace NuGet.Packaging
                         }
                         else
                         {
-#if NET5_0
+#if NETCOREAPP
                             filesWithoutExtensions.Add($"/{file.Path.Replace("\\", "/", StringComparison.Ordinal)}");
 #else
                             filesWithoutExtensions.Add($"/{file.Path.Replace("\\", "/")}");

--- a/src/NuGet.Core/NuGet.Packaging/PackageExtraction/ZipArchiveExtensions.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageExtraction/ZipArchiveExtensions.cs
@@ -35,7 +35,11 @@ namespace NuGet.Packaging
         private static string UnescapePath(string path)
         {
             if (path != null
+#if NET5_0
+                && path.IndexOf('%', StringComparison.Ordinal) > -1)
+#else
                 && path.IndexOf('%') > -1)
+#endif
             {
                 return Uri.UnescapeDataString(path);
             }

--- a/src/NuGet.Core/NuGet.Packaging/PackageExtraction/ZipArchiveExtensions.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageExtraction/ZipArchiveExtensions.cs
@@ -35,7 +35,7 @@ namespace NuGet.Packaging
         private static string UnescapePath(string path)
         {
             if (path != null
-#if NET5_0
+#if NETCOREAPP
                 && path.IndexOf('%', StringComparison.Ordinal) > -1)
 #else
                 && path.IndexOf('%') > -1)

--- a/src/NuGet.Core/NuGet.Packaging/PackageFolderReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageFolderReader.cs
@@ -150,7 +150,7 @@ namespace NuGet.Packaging
         /// </summary>
         private static bool IsFileInRoot(string path)
         {
-#if NET5_0
+#if NETCOREAPP
             return path.IndexOf('/', StringComparison.Ordinal) == -1;
 #else
             return path.IndexOf('/') == -1;

--- a/src/NuGet.Core/NuGet.Packaging/PackageFolderReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageFolderReader.cs
@@ -150,7 +150,11 @@ namespace NuGet.Packaging
         /// </summary>
         private static bool IsFileInRoot(string path)
         {
+#if NET5_0
+            return path.IndexOf('/', StringComparison.Ordinal) == -1;
+#else
             return path.IndexOf('/') == -1;
+#endif
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Packaging/Rules/UpholdBuildConventionRule.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Rules/UpholdBuildConventionRule.cs
@@ -103,7 +103,11 @@ namespace NuGet.Packaging.Rules
 
             public ConventionViolator(string filePath, string extension, string expectedFile)
             {
+#if NET5_0
+                Path = filePath.Replace(filePath.Split('/')[filePath.Count(p => p == '/')], string.Empty, StringComparison.OrdinalIgnoreCase);
+#else
                 Path = filePath.Replace(filePath.Split('/')[filePath.Count(p => p == '/')], string.Empty);
+#endif
                 Extension = extension;
                 ExpectedPath = expectedFile;
             }

--- a/src/NuGet.Core/NuGet.Packaging/Rules/UpholdBuildConventionRule.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Rules/UpholdBuildConventionRule.cs
@@ -103,7 +103,7 @@ namespace NuGet.Packaging.Rules
 
             public ConventionViolator(string filePath, string extension, string expectedFile)
             {
-#if NET5_0
+#if NETCOREAPP
                 Path = filePath.Replace(filePath.Split('/')[filePath.Count(p => p == '/')], string.Empty, StringComparison.OrdinalIgnoreCase);
 #else
                 Path = filePath.Replace(filePath.Split('/')[filePath.Count(p => p == '/')], string.Empty);

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Archive/EndOfCentralDirectoryRecord.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Archive/EndOfCentralDirectoryRecord.cs
@@ -106,7 +106,11 @@ namespace NuGet.Packaging.Signing
             throw new InvalidDataException(
                 string.Format(CultureInfo.CurrentCulture,
                 Strings.ErrorByteSignatureNotFound,
+#if NET5_0
+                BitConverter.ToString(signature).Replace("-", "", StringComparison.Ordinal)));
+#else
                 BitConverter.ToString(signature).Replace("-", "")));
+#endif
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Archive/EndOfCentralDirectoryRecord.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Archive/EndOfCentralDirectoryRecord.cs
@@ -106,7 +106,7 @@ namespace NuGet.Packaging.Signing
             throw new InvalidDataException(
                 string.Format(CultureInfo.CurrentCulture,
                 Strings.ErrorByteSignatureNotFound,
-#if NET5_0
+#if NETCOREAPP
                 BitConverter.ToString(signature).Replace("-", "", StringComparison.Ordinal)));
 #else
                 BitConverter.ToString(signature).Replace("-", "")));

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Content/KeyPairFileReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Content/KeyPairFileReader.cs
@@ -73,7 +73,7 @@ namespace NuGet.Packaging.Signing
 
         private static KeyValuePair<string, string> GetProperty(string line)
         {
-#if NET5_0
+#if NETCOREAPP
             var pos = line.IndexOf(':', StringComparison.Ordinal);
 #else
             var pos = line.IndexOf(':');

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Content/KeyPairFileReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Content/KeyPairFileReader.cs
@@ -73,7 +73,11 @@ namespace NuGet.Packaging.Signing
 
         private static KeyValuePair<string, string> GetProperty(string line)
         {
+#if NET5_0
+            var pos = line.IndexOf(':', StringComparison.Ordinal);
+#else
             var pos = line.IndexOf(':');
+#endif
 
             if (pos > 0)
             {

--- a/src/NuGet.Core/NuGet.Packaging/Signing/DerEncoding/DerGeneralizedTime.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/DerEncoding/DerGeneralizedTime.cs
@@ -32,7 +32,11 @@ namespace NuGet.Packaging.Signing.DerEncoding
                 throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
             }
 
+#if NET5_0
+            var decimalIndex = decodedTime.IndexOf('.', StringComparison.Ordinal);
+#else
             var decimalIndex = decodedTime.IndexOf('.');
+#endif
             var stringToParse = decodedTime;
             string format;
 

--- a/src/NuGet.Core/NuGet.Packaging/Signing/DerEncoding/DerGeneralizedTime.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/DerEncoding/DerGeneralizedTime.cs
@@ -32,7 +32,7 @@ namespace NuGet.Packaging.Signing.DerEncoding
                 throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
             }
 
-#if NET5_0
+#if NETCOREAPP
             var decimalIndex = decodedTime.IndexOf('.', StringComparison.Ordinal);
 #else
             var decimalIndex = decodedTime.IndexOf('.');

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/Rfc3161TimestampVerificationUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/Rfc3161TimestampVerificationUtility.cs
@@ -37,7 +37,7 @@ namespace NuGet.Packaging.Signing
             out IRfc3161TimestampTokenInfo tstInfo)
         {
             tstInfo = null;
-            if (timestampCms.ContentInfo.ContentType.Value.Equals(Oids.TSTInfoContentType))
+            if (timestampCms.ContentInfo.ContentType.Value.Equals(Oids.TSTInfoContentType, StringComparison.Ordinal))
             {
                 tstInfo = Rfc3161TimestampTokenInfoFactory.Create(timestampCms.ContentInfo.Content);
                 return true;

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Utility/CertificateUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Utility/CertificateUtility.cs
@@ -263,7 +263,7 @@ namespace NuGet.Packaging.Signing
             }
 
             var certificateFingerprint = GetHash(certificate, hashAlgorithm);
-#if NET5_0
+#if NETCOREAPP
             return BitConverter.ToString(certificateFingerprint).Replace("-", "", StringComparison.Ordinal);
 #else
             return BitConverter.ToString(certificateFingerprint).Replace("-", "");
@@ -329,7 +329,7 @@ namespace NuGet.Packaging.Signing
                     if (reader.HasTag(keyIdentifierTag))
                     {
                         var keyIdentifier = reader.ReadValue(keyIdentifierTag);
-#if NET5_0
+#if NETCOREAPP
                         var akiKeyIdentifier = BitConverter.ToString(keyIdentifier).Replace("-", "", StringComparison.Ordinal);
 #else
                         var akiKeyIdentifier = BitConverter.ToString(keyIdentifier).Replace("-", "");

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Utility/CertificateUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Utility/CertificateUtility.cs
@@ -263,7 +263,11 @@ namespace NuGet.Packaging.Signing
             }
 
             var certificateFingerprint = GetHash(certificate, hashAlgorithm);
+#if NET5_0
+            return BitConverter.ToString(certificateFingerprint).Replace("-", "", StringComparison.Ordinal);
+#else
             return BitConverter.ToString(certificateFingerprint).Replace("-", "");
+#endif
         }
 
         /// <summary>
@@ -325,7 +329,11 @@ namespace NuGet.Packaging.Signing
                     if (reader.HasTag(keyIdentifierTag))
                     {
                         var keyIdentifier = reader.ReadValue(keyIdentifierTag);
+#if NET5_0
+                        var akiKeyIdentifier = BitConverter.ToString(keyIdentifier).Replace("-", "", StringComparison.Ordinal);
+#else
                         var akiKeyIdentifier = BitConverter.ToString(keyIdentifier).Replace("-", "");
+#endif
 
                         return string.Equals(skiExtension.SubjectKeyIdentifier, akiKeyIdentifier, StringComparison.OrdinalIgnoreCase);
                     }


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9562
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: fix more warnings raised by CodeAnalysis.FxCopAnalyzer
As string.Replace(), string.IndexOf(), string.Equals() have new overload methods in new TFM(what we target for xplat verification)
string.GetHashCode() won't be fixed.

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  
Validation:  
