### PR TITLE
Switch to ToolWindowPane for PMUI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,9 +34,6 @@ mergelog.txt
 *.user
 *.sln.docstates
 
-# NT.cmd
-nt.cmd
-
 # Build results
 
 # Roslyn cache directories

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,9 @@ mergelog.txt
 *.user
 *.sln.docstates
 
+# NT.cmd
+nt.cmd
+
 # Build results
 
 # Roslyn cache directories

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/GlobalSuppressions.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/GlobalSuppressions.cs
@@ -1,4 +1,4 @@
-﻿// This file is used by Code Analysis to maintain SuppressMessage
+// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.
@@ -149,3 +149,4 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: SuppressMessage("Build", "CA1501:'TabItemButton' has an object hierarchy '10' levels deep within the defining module. If possible, eliminate base classes within the hierarchy to decrease its hierarchy level below '6': 'Button, ButtonBase, ContentControl, Control, FrameworkElement, UIElement, Visual, DependencyObject, DispatcherObject, Object'", Justification = "<Pending>", Scope = "type", Target = "~T:NuGet.PackageManagement.UI.TabItemButton")]
 [assembly: SuppressMessage("Build", "CA1501:'VsDialogWindow' has an object hierarchy '11' levels deep within the defining module. If possible, eliminate base classes within the hierarchy to decrease its hierarchy level below '6': 'DialogWindow, DialogWindowBase, Window, ContentControl, Control, FrameworkElement, UIElement, Visual, DependencyObject, DispatcherObject, Object'", Justification = "<Pending>", Scope = "type", Target = "~T:NuGet.PackageManagement.UI.VsDialogWindow")]
 [assembly: SuppressMessage("Build", "CA1821:Remove empty Finalizers", Justification = "<Pending>", Scope = "member", Target = "~M:NuGet.PackageManagement.UI.DataStreamFromComStream.Finalize")]
+[assembly: SuppressMessage("Usage", "CA1816:Dispose methods should call SuppressFinalize", Justification = "<Pending>", Scope = "member", Target = "~M:NuGet.PackageManagement.UI.PackageManagerToolWindowPane.Dispose(System.Boolean)")]

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/NuGet.PackageManagement.UI.csproj
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/NuGet.PackageManagement.UI.csproj
@@ -113,6 +113,7 @@
       <DependentUpon>PackageSourcesOptionsControl.cs</DependentUpon>
     </Compile>
     <Compile Include="PackageLicenseUtilities.cs" />
+    <Compile Include="PackageManagerToolWindowPane.cs" />
     <Compile Include="PackageManagerWindowPane.cs" />
     <Compile Include="Resources\Resources.xaml.cs">
       <DependentUpon>Resources.xaml</DependentUpon>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/PackageManagerToolWindowPane.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/PackageManagerToolWindowPane.cs
@@ -1,0 +1,101 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+
+namespace NuGet.PackageManagement.UI
+{
+    [ProvideToolWindow(typeof(PackageManagerToolWindowPane), Style = VsDockStyle.Tabbed, DocumentLikeTool = true, Window = EnvDTE.Constants.vsCATIDDocument)]
+    public class PackageManagerToolWindowPane : ToolWindowPane, IVsWindowFrameNotify3
+    {
+        private PackageManagerControl _content;
+
+        /// <summary>
+        /// Initializes a new instance of the EditorPane class.
+        /// </summary>
+        public PackageManagerToolWindowPane(PackageManagerControl control)
+            : base(null)
+        {
+            _content = control;
+        }
+
+        public PackageManagerModel Model
+        {
+            get { return _content.Model; }
+        }
+
+        /// -----------------------------------------------------------------------------
+        /// <summary>
+        /// IVsWindowPane
+        /// </summary>
+        /// -----------------------------------------------------------------------------
+        public override object Content
+        {
+            get { return _content; }
+        }
+
+        private void CleanUp()
+        {
+            if (_content != null)
+            {
+                _content.CleanUp();
+                _content = null;
+            }
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            try
+            {
+                if (disposing)
+                {
+                    CleanUp();
+
+                    // Because Dispose() will do our cleanup, we can tell the GC not to call the finalizer.
+
+                    // TODO: Mirko - Not sure why this is necessary here but not in PpackageManagerWindowPane. Investigate.
+
+#pragma warning disable CA1816 // Dispose methods should call SuppressFinalize
+                    GC.SuppressFinalize(this);
+#pragma warning restore CA1816 // Dispose methods should call SuppressFinalize
+                }
+            }
+            finally
+            {
+                base.Dispose(disposing);
+            }
+        }
+
+        public int OnClose(ref uint pgrfSaveOptions)
+        {
+            _content.SaveSettings();
+            _content.Model.Context.UserSettingsManager.PersistSettings();
+
+            pgrfSaveOptions = (uint)__FRAMECLOSE.FRAMECLOSE_NoSave;
+            return VSConstants.S_OK;
+        }
+
+        public int OnDockableChange(int fDockable, int x, int y, int w, int h)
+        {
+            return VSConstants.S_OK;
+        }
+
+        public int OnMove(int x, int y, int w, int h)
+        {
+            return VSConstants.S_OK;
+        }
+
+        public int OnShow(int fShow)
+        {
+            return VSConstants.S_OK;
+        }
+
+        public int OnSize(int x, int y, int w, int h)
+        {
+            return VSConstants.S_OK;
+        }
+    }
+}

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/PackageManagerToolWindowPane.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/PackageManagerToolWindowPane.cs
@@ -55,12 +55,7 @@ namespace NuGet.PackageManagement.UI
                     CleanUp();
 
                     // Because Dispose() will do our cleanup, we can tell the GC not to call the finalizer.
-
-                    // TODO: Mirko - Not sure why this is necessary here but not in PpackageManagerWindowPane. Investigate.
-
-#pragma warning disable CA1816 // Dispose methods should call SuppressFinalize
                     GC.SuppressFinalize(this);
-#pragma warning restore CA1816 // Dispose methods should call SuppressFinalize
                 }
             }
             finally

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -635,9 +635,10 @@ namespace NuGet.PackageManagement.UI
             }
             else
             {
-                var project = Model.Context.Projects.First();
-                string projectName = null;
-                if (!project.TryGetMetadata(NuGetProjectMetadataKeys.Name, out projectName))
+                var project = Model.Context.Projects.FirstOrDefault();
+
+                if (project == null ||
+                    !project.TryGetMetadata<string>(NuGetProjectMetadataKeys.Name, out var projectName))
                 {
                     projectName = "unknown";
                 }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/WindowFrameHelper.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/WindowFrameHelper.cs
@@ -29,5 +29,11 @@ namespace NuGet.VisualStudio
             ThreadHelper.ThrowIfNotOnUIThread();
             ErrorHandler.ThrowOnFailure(windowFrame.SetProperty((int)__VSFPROPID5.VSFPROPID_DontAutoOpen, true));
         }
+
+        public static void DockToolWindow(IVsWindowFrame windowFrame)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+            ErrorHandler.ThrowOnFailure(windowFrame.SetProperty((int)__VSFPROPID.VSFPROPID_FrameMode, VSFRAMEMODE.VSFM_MdiChild));
+        }
     }
 }

--- a/src/NuGet.Clients/NuGet.VisualStudio.OnlineEnvironment.Client/SolutionExplorer/NuGetWorkspaceCommandHandler.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.OnlineEnvironment.Client/SolutionExplorer/NuGetWorkspaceCommandHandler.cs
@@ -86,8 +86,7 @@ namespace NuGet.VisualStudio.OnlineEnvironment.Client
                             if (IsSolutionOnlySelection(selection))
                             {
                                 var isRestoreActionInProgress = _restoreCommandHandler.IsRestoreActionInProgress();
-                                cmdf = (uint)((isRestoreActionInProgress ? 0 : OLECMDF.OLECMDF_ENABLED)
-                                    | OLECMDF.OLECMDF_SUPPORTED);
+                                cmdf = (uint)((isRestoreActionInProgress ? 0 : OLECMDF.OLECMDF_ENABLED) | OLECMDF.OLECMDF_SUPPORTED);
                                 handled = true;
                             }
                             break;
@@ -130,6 +129,7 @@ namespace NuGet.VisualStudio.OnlineEnvironment.Client
                 {
                     return false;
                 }
+
                 // We do not know if the project is supported
                 return fileExtension.EndsWith("proj", StringComparison.OrdinalIgnoreCase);
             }
@@ -142,6 +142,5 @@ namespace NuGet.VisualStudio.OnlineEnvironment.Client
                 selection.Count.Equals(1) &&
                 selection.First().NodeMoniker.Equals(string.Empty);
         }
-
     }
 }

--- a/src/NuGet.Clients/NuGet.VisualStudio.OnlineEnvironment.Client/SolutionExplorer/PackageManagerUICommandHandler.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.OnlineEnvironment.Client/SolutionExplorer/PackageManagerUICommandHandler.cs
@@ -87,6 +87,7 @@ namespace NuGet.VisualStudio.OnlineEnvironment.Client
 
         //TODO: need GetService or to convert to use GetServiceAsync
         private IDisposable ProjectRetargetingHandler { get; set; }
+
         private IDisposable ProjectUpgradeHandler { get; set; }
 
 		private void Initialize()
@@ -99,6 +100,7 @@ namespace NuGet.VisualStudio.OnlineEnvironment.Client
                     // get the UI context cookie for the debugging mode
                     var vsMonitorSelection = await _asyncServiceProvider.GetServiceAsync(typeof(vsShellInterop.IVsMonitorSelection)) as vsShellInterop.IVsMonitorSelection;
                     Assumes.Present(vsMonitorSelection);
+
                     // get the solution not building and not debugging cookie
                     var guidCmdUI = VSConstants.UICONTEXT.SolutionExistsAndFullyLoaded_guid;
                     vsMonitorSelection.GetCmdUIContextCookie(
@@ -188,23 +190,12 @@ namespace NuGet.VisualStudio.OnlineEnvironment.Client
                 await InitializeMEFAsync();
             }
 
-            // vsShellInterop.IVsWindowFrame windowFrame = null;
-            // if (windowFrame == null)
-            // {
-            //     windowFrame = await CreateNewWindowFrameAsync(projectPath);
-            // }
-
             var window = await CreateNewWindowFrameAsync(projectPath);
             if (window != null)
             {
                 Search(window, string.Empty);
                 window.Show();
             }
-            // if (windowFrame != null)
-            // {
-            //     Search(windowFrame, string.Empty);
-            //     windowFrame.Show();
-            // }
         }
 
 
@@ -213,7 +204,6 @@ namespace NuGet.VisualStudio.OnlineEnvironment.Client
         {
             ThreadHelper.ThrowIfNotOnUIThread();
 
-            // TODO: moved from GetService to GetServiceAsync -- work? any other changes?
             var uiShell = (vsShellInterop.IVsUIShell)_asyncServiceProvider.GetServiceAsync(typeof(vsShellInterop.SVsUIShell));
             foreach (var windowFrame in VsUtility.GetDocumentWindows(uiShell))
             {
@@ -249,16 +239,13 @@ namespace NuGet.VisualStudio.OnlineEnvironment.Client
             return null;
         }
 
-        // private async Task<System.Windows.Window> CreateNewWindowFrameAsync(string projectPath)
         private async Task<vsShellInterop.IVsWindowFrame> CreateNewWindowFrameAsync(string projectPath)
         {
             await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
-            //var vsProject = VsHierarchyUtility.ToVsHierarchy(project);
             var documentName = projectPath;
 
-            // Find existing hierarchy and item id of the document window if it's
-            // already registered.
+            // Find existing hierarchy and item id of the document window if it's already registered.
             var rdt = await _asyncServiceProvider.GetServiceAsync(typeof(vsShellInterop.IVsRunningDocumentTable)) as vsShellInterop.IVsRunningDocumentTable;
             Assumes.Present(rdt);
             vsShellInterop.IVsHierarchy hier;
@@ -276,10 +263,10 @@ namespace NuGet.VisualStudio.OnlineEnvironment.Client
                     out itemId,
                     out docData,
                     out cookie);
+
                 if (hr != VSConstants.S_OK)
                 {
                     // the docuemnt window is not registered yet. So use the hierarchy from the current selection.
-                    //hier = vsUIHierarchy;
                     itemId = (uint)VSConstants.VSITEMID.Root;
                 }
             }
@@ -315,9 +302,7 @@ namespace NuGet.VisualStudio.OnlineEnvironment.Client
             var vsWindowSearchHostfactory = await _asyncServiceProvider.GetServiceAsync(typeof(vsShellInterop.SVsWindowSearchHostFactory)) as vsShellInterop.IVsWindowSearchHostFactory;
             var vsShell = await _asyncServiceProvider.GetServiceAsync(typeof(vsShellInterop.SVsShell)) as vsShellInterop.IVsShell4;
 
-            // TODO: rob to fix assembly loading problem.
             var control = new PackageManagerControl(model, Settings.Value, vsWindowSearchHostfactory, vsShell, OutputConsoleLogger.Value);
-
             var windowPane = new PackageManagerToolWindowPane(control);
             var guidEditorType = GuidList.NuGetEditorType;
             var guidCommandUI = Guid.Empty;
@@ -327,12 +312,6 @@ namespace NuGet.VisualStudio.OnlineEnvironment.Client
                 CultureInfo.CurrentCulture,
                 Resx.Label_NuGetWindowCaption,
                 projectPath);
-
-            //workaround assembly loading problem.
-            //var control = new Button() { Content = "Package Manager UI - under construction" };
-            //var win = new System.Windows.Window();
-            //win.Title = caption;
-            //win.Content = control;
 
             vsShellInterop.IVsWindowFrame windowFrame;
             var uiShell = await _asyncServiceProvider.GetServiceAsync(typeof(vsShellInterop.SVsUIShell)) as vsShellInterop.IVsUIShell;
@@ -363,11 +342,6 @@ namespace NuGet.VisualStudio.OnlineEnvironment.Client
             }
             finally
             {
-                //if (ppunkToolView != IntPtr.Zero)
-                //{
-                //    Marshal.Release(ppunkDocData);
-                //}
-
                 if (windowPane != null)
                 {
                     windowPane.Dispose();
@@ -376,8 +350,6 @@ namespace NuGet.VisualStudio.OnlineEnvironment.Client
 
             ErrorHandler.ThrowOnFailure(hr);
             return windowFrame;
-            // win.Tag = F1KeywordValuePmUI;
-            // return win;
         }
 
         private async Task<vsShellInterop.IVsWindowFrame> FindExistingSolutionWindowFrameAsync()
@@ -441,14 +413,12 @@ namespace NuGet.VisualStudio.OnlineEnvironment.Client
                 return;
             }
 
-            // var packageManagerControl = windowFrame.Content as PackageManagerControl;
             var packageManagerControl = VsUtility.GetPackageManagerControl(windowFrame);
             if (packageManagerControl != null)
             {
                 packageManagerControl.Search(searchText);
             }
         }
-
 
         private bool ShouldMEFBeInitialized()
         {


### PR DESCRIPTION
Merging work for 9516 to Rob's feature branch to enable ToolWindowPane

- Docking doesn't work yet
- For some reason GC.SuppressFinalize is throwing build errors in the new ToolWindowPane class, but not in the original WindowPane implementation I copied from.
- Much code cleanup to do still
- Project name isn't passed to pane title because hierarchy isn't found.