### PR TITLE
TelemetryActivity: Log start event when possible.

### DIFF
--- a/src/NuGet.Core/NuGet.Common/Telemetry/TelemetryActivity.cs
+++ b/src/NuGet.Core/NuGet.Common/Telemetry/TelemetryActivity.cs
@@ -43,6 +43,12 @@ namespace NuGet.Common
         private TelemetryActivity(Guid parentId, TelemetryEvent telemetryEvent, Guid operationId)
         {
             TelemetryEvent = telemetryEvent;
+            if (telemetryEvent != null)
+            {
+                var startTelemetryEvent = new TelemetryEvent(telemetryEvent.Name + "/Start");
+                NuGetTelemetryService.EmitTelemetryEvent(startTelemetryEvent);
+            }
+
             ParentId = parentId;
             OperationId = operationId;
 


### PR DESCRIPTION
## Issue

**Improvements as a part of:** https://github.com/NuGet/Client.Engineering/issues/302
**Regression:** No  

## Fix

**Details:** Post an additional /Start event whenever new TelemetryActivity is started with an event.

## Testing/Validation

**Tests Added:** Unit tests to verify correct events are fired.
**Reason for not adding tests:**  N/A
**Validation:** Start events are generated as expected, confirmed with VS Telemetry Monitor.
