### PR TITLE
Fix all the rest warnings raised by code analysis

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/MSBuildProjectFactory.cs
+++ b/src/NuGet.Core/NuGet.Commands/MSBuildProjectFactory.cs
@@ -259,12 +259,20 @@ namespace NuGet.Commands
             }
             var projectName = Path.GetFileName(projectDirectory);
             var targetPath = Path.Combine(SourcesFolder, projectName);
+#if NETCOREAPP
+            if (sourcePath.Contains(projectDirectory, StringComparison.Ordinal))
+#else
             if (sourcePath.Contains(projectDirectory))
+#endif
             {
                 // This is needed because Path.GetDirectoryName returns a path with Path.DirectorySepartorChar
                 var projectDirectoryWithSeparatorChar = PathUtility.GetPathWithDirectorySeparator(projectDirectory);
 
+#if NETCOREAPP
+                var relativePath = Path.GetDirectoryName(sourcePath).Replace(projectDirectoryWithSeparatorChar, string.Empty, StringComparison.Ordinal);
+#else
                 var relativePath = Path.GetDirectoryName(sourcePath).Replace(projectDirectoryWithSeparatorChar, string.Empty);
+#endif
                 if (!string.IsNullOrEmpty(relativePath) && PathUtility.IsDirectorySeparatorChar(relativePath[0]))
                 {
                     relativePath = relativePath.Substring(1, relativePath.Length - 1);

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Diagnostics/UnresolvedMessages.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Diagnostics/UnresolvedMessages.cs
@@ -74,7 +74,11 @@ namespace NuGet.Commands
             {
                 // Project
                 // Check if the name is a path and if it exists. All project paths should have been normalized and converted to full paths before this.
+#if NETCOREAPP
+                if (unresolved.Name.IndexOf(Path.DirectorySeparatorChar, StringComparison.Ordinal) > -1 && File.Exists(unresolved.Name))
+#else
                 if (unresolved.Name.IndexOf(Path.DirectorySeparatorChar) > -1 && File.Exists(unresolved.Name))
+#endif
                 {
                     // File exists but the dg spec did not contain the spec
                     code = NuGetLogCode.NU1105;

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
@@ -758,7 +758,11 @@ namespace NuGet.Commands
 
         private static XElement GeneratePackagePathProperty(LocalPackageInfo localPackageInfo)
         {
+#if NETCOREAPP
+            return GenerateProperty($"Pkg{localPackageInfo.Id.Replace(".", "_", StringComparison.Ordinal)}", localPackageInfo.ExpandedPath);
+#else
             return GenerateProperty($"Pkg{localPackageInfo.Id.Replace(".", "_")}", localPackageInfo.ExpandedPath);
+#endif
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/LockFileUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/LockFileUtils.cs
@@ -826,7 +826,11 @@ namespace NuGet.Commands
                 var fileName = Path.GetFileName(firstItem.Path);
 
                 Debug.Assert(!string.IsNullOrEmpty(fileName));
+#if NETCOREAPP
+                Debug.Assert(firstItem.Path.IndexOf('/', StringComparison.Ordinal) > 0);
+#else
                 Debug.Assert(firstItem.Path.IndexOf('/') > 0);
+#endif
 
                 var emptyDir = firstItem.Path.Substring(0, firstItem.Path.Length - fileName.Length)
                     + PackagingCoreConstants.EmptyFolder;

--- a/src/NuGet.Core/NuGet.Protocol/Providers/RepositorySignatureResourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Providers/RepositorySignatureResourceProvider.cs
@@ -104,7 +104,11 @@ namespace NuGet.Protocol
 
         private static string GenerateCacheKey(ServiceIndexEntry serviceEntry)
         {
+#if NETCOREAPP
+            var index = serviceEntry.Type.IndexOf('/', StringComparison.Ordinal);
+#else
             var index = serviceEntry.Type.IndexOf('/');
+#endif
             var version = serviceEntry.Type.Substring(index + 1).Trim();
 
             return $"repository_signatures_{version}";

--- a/src/NuGet.Core/NuGet.Protocol/Resources/PackageDetailsUriResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/PackageDetailsUriResourceV3.cs
@@ -50,8 +50,13 @@ namespace NuGet.Protocol
         public Uri GetUri(string id, NuGetVersion version)
         {
             var uriString = _template
+#if NETCOREAPP
+               .Replace("{id}", id, StringComparison.OrdinalIgnoreCase)
+               .Replace("{version}", version.ToNormalizedString(), StringComparison.OrdinalIgnoreCase);
+#else
                .Replace("{id}", id)
                .Replace("{version}", version.ToNormalizedString());
+#endif
 
             return new Uri(uriString);
         }

--- a/src/NuGet.Core/NuGet.Protocol/Resources/PackageUpdateResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/PackageUpdateResource.cs
@@ -827,7 +827,11 @@ namespace NuGet.Protocol.Core.Types
             }
             catch(HttpRequestException ex)
             {
+#if NETCOREAPP
+                if (ex.Message.Contains("Response status code does not indicate success: 403 (Forbidden).", StringComparison.OrdinalIgnoreCase))
+#else
                 if (ex.Message.Contains("Response status code does not indicate success: 403 (Forbidden)."))
+#endif
                 {
                     return InvalidApiKey;
                 }

--- a/src/NuGet.Core/NuGet.Protocol/Resources/ReportAbuseResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/ReportAbuseResourceV3.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -33,8 +33,13 @@ namespace NuGet.Protocol
         public Uri GetReportAbuseUrl(string id, NuGetVersion version)
         {
             var uriString = _uriTemplate
+#if NETCOREAPP
+               .Replace("{id}", id, StringComparison.OrdinalIgnoreCase)
+               .Replace("{version}", version.ToNormalizedString(), StringComparison.OrdinalIgnoreCase);
+#else
                .Replace("{id}", id)
                .Replace("{version}", version.ToNormalizedString());
+#endif
 
             return new Uri(uriString);
         }

--- a/src/NuGet.Core/NuGet.Protocol/Utility/CachingUtility.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Utility/CachingUtility.cs
@@ -86,10 +86,17 @@ namespace NuGet.Protocol
         {
             var invalid = Path.GetInvalidFileNameChars();
             return new string(
+#if NETCOREAPP
+                value.Select(ch => invalid.Contains(ch) ? '_' : ch).ToArray()
+                )
+                .Replace("__", "_", StringComparison.Ordinal)
+                .Replace("__", "_", StringComparison.Ordinal);
+#else
                 value.Select(ch => invalid.Contains(ch) ? '_' : ch).ToArray()
                 )
                 .Replace("__", "_")
                 .Replace("__", "_");
+#endif
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/Utility/LocalFolderUtility.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Utility/LocalFolderUtility.cs
@@ -964,7 +964,11 @@ namespace NuGet.Protocol
 
         private static string EnsurePackageExtension(string packagePath, bool isSnupkg)
         {
+#if NETCOREAPP
+            if (packagePath.IndexOf('*', StringComparison.Ordinal) == -1)
+#else
             if (packagePath.IndexOf('*') == -1)
+#endif
             {
                 // If there's no wildcard in the path to begin with, assume that it's an absolute path.
                 return packagePath;

--- a/src/NuGet.Core/NuGet.Protocol/Utility/OfflineFeedUtility.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Utility/OfflineFeedUtility.cs
@@ -87,7 +87,11 @@ namespace NuGet.Protocol.Core.Types
             }
 
             var invalidPathChars = Path.GetInvalidPathChars();
+#if NETCOREAPP
+            if (invalidPathChars.Any(p => path.Contains(p, StringComparison.Ordinal)))
+#else
             if (invalidPathChars.Any(p => path.Contains(p)))
+#endif
             {
                 throw new ArgumentException(string.Format(CultureInfo.CurrentCulture,
                     Strings.Path_Invalid,


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9583
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: fix 15 warnings raised by CodeAnalysis.FxCopAnalyzer (should be all the rest warnings)
As string.Contains(), string.IndexOf(), string.Replace() have new overload methods in new TFM(what we target for xplat verification)
string.GetHashCode() won't be fixed.

## Testing/Validation

Tests Added: Yes/No  
Reason for not adding tests:  
Validation:  
