### PR TITLE
Suppress CA1307 warning for string.GetHashCode() method

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/GlobalSuppressions.cs
+++ b/src/NuGet.Core/NuGet.Commands/GlobalSuppressions.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 // This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given

--- a/src/NuGet.Core/NuGet.Commands/GlobalSuppressions.cs
+++ b/src/NuGet.Core/NuGet.Commands/GlobalSuppressions.cs
@@ -1,4 +1,4 @@
-﻿// This file is used by Code Analysis to maintain SuppressMessage
+// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.
@@ -261,3 +261,4 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: SuppressMessage("Build", "CA2237:Add [Serializable] to RestoreSpecException as this type implements ISerializable", Justification = "<Pending>", Scope = "type", Target = "~T:NuGet.Commands.RestoreSpecException")]
 [assembly: SuppressMessage("Build", "CA2237:Add [Serializable] to SignCommandException as this type implements ISerializable", Justification = "<Pending>", Scope = "type", Target = "~T:NuGet.Commands.SignCommandException")]
 [assembly: SuppressMessage("Build", "CA1052:Type 'UpdateSourceRunner' is a static holder type but is neither static nor NotInheritable", Justification = "<Pending>", Scope = "type", Target = "~T:NuGet.Commands.UpdateSourceRunner")]
+[assembly: SuppressMessage("Globalization", "CA1307:Specify StringComparison", Justification = "<Pending>", Scope = "member", Target = "~M:Microsoft.Extensions.Internal.HashCodeCombiner.Add(System.String)")]

--- a/src/NuGet.Core/NuGet.Commands/GlobalSuppressions.cs
+++ b/src/NuGet.Core/NuGet.Commands/GlobalSuppressions.cs
@@ -1,7 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
-
-// This file is used by Code Analysis to maintain SuppressMessage
+﻿// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.
@@ -264,4 +261,4 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: SuppressMessage("Build", "CA2237:Add [Serializable] to RestoreSpecException as this type implements ISerializable", Justification = "<Pending>", Scope = "type", Target = "~T:NuGet.Commands.RestoreSpecException")]
 [assembly: SuppressMessage("Build", "CA2237:Add [Serializable] to SignCommandException as this type implements ISerializable", Justification = "<Pending>", Scope = "type", Target = "~T:NuGet.Commands.SignCommandException")]
 [assembly: SuppressMessage("Build", "CA1052:Type 'UpdateSourceRunner' is a static holder type but is neither static nor NotInheritable", Justification = "<Pending>", Scope = "type", Target = "~T:NuGet.Commands.UpdateSourceRunner")]
-[assembly: SuppressMessage("Globalization", "CA1307:Specify StringComparison", Justification = "<Pending>", Scope = "member", Target = "~M:Microsoft.Extensions.Internal.HashCodeCombiner.Add(System.String)")]
+[assembly: SuppressMessage("Build", "CA1307:The behavior of 'string.GetHashCode()' could vary based on the current user's locale settings. Replace this call in 'Microsoft.Extensions.Internal.HashCodeCombiner.Add(string)' with a call to 'string.GetHashCode(System.StringComparison)'.", Justification = "<Pending>", Scope = "member", Target = "~M:Microsoft.Extensions.Internal.HashCodeCombiner.Add(System.String)")]

--- a/src/NuGet.Core/NuGet.Packaging/GlobalSuppressions.cs
+++ b/src/NuGet.Core/NuGet.Packaging/GlobalSuppressions.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 // This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given

--- a/src/NuGet.Core/NuGet.Packaging/GlobalSuppressions.cs
+++ b/src/NuGet.Core/NuGet.Packaging/GlobalSuppressions.cs
@@ -1,4 +1,4 @@
-﻿// This file is used by Code Analysis to maintain SuppressMessage
+// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.
@@ -297,3 +297,6 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: SuppressMessage("Build", "CA1012:Abstract type VerificationAllowListEntry should not have constructors", Justification = "<Pending>", Scope = "type", Target = "~T:NuGet.Packaging.Signing.VerificationAllowListEntry")]
 [assembly: SuppressMessage("Build", "CA1067:Type NuGet.RuntimeModel.RuntimeGraph.RuntimeCompatKey should override Equals because it implements IEquatable<T>", Justification = "<Pending>", Scope = "type", Target = "~T:NuGet.RuntimeModel.RuntimeGraph.RuntimeCompatKey")]
 [assembly: SuppressMessage("Build", "CA1067:Type NuGet.RuntimeModel.RuntimeGraph.RuntimeDependencyKey should override Equals because it implements IEquatable<T>", Justification = "<Pending>", Scope = "type", Target = "~T:NuGet.RuntimeModel.RuntimeGraph.RuntimeDependencyKey")]
+[assembly: SuppressMessage("Globalization", "CA1307:Specify StringComparison", Justification = "<Pending>", Scope = "member", Target = "~M:NuGet.ContentModel.ContentItemCollection.GroupComparer.GetHashCode(NuGet.ContentModel.ContentItem)~System.Int32")]
+[assembly: SuppressMessage("Globalization", "CA1307:Specify StringComparison", Justification = "<Pending>", Scope = "member", Target = "~M:NuGet.Packaging.FrameworkSpecificGroup.GetHashCode~System.Int32")]
+[assembly: SuppressMessage("Globalization", "CA1307:Specify StringComparison", Justification = "<Pending>", Scope = "member", Target = "~M:NuGet.Packaging.PhysicalPackageFile.GetHashCode~System.Int32")]

--- a/src/NuGet.Core/NuGet.Packaging/GlobalSuppressions.cs
+++ b/src/NuGet.Core/NuGet.Packaging/GlobalSuppressions.cs
@@ -1,7 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
-
-// This file is used by Code Analysis to maintain SuppressMessage
+﻿// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.
@@ -300,6 +297,6 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: SuppressMessage("Build", "CA1012:Abstract type VerificationAllowListEntry should not have constructors", Justification = "<Pending>", Scope = "type", Target = "~T:NuGet.Packaging.Signing.VerificationAllowListEntry")]
 [assembly: SuppressMessage("Build", "CA1067:Type NuGet.RuntimeModel.RuntimeGraph.RuntimeCompatKey should override Equals because it implements IEquatable<T>", Justification = "<Pending>", Scope = "type", Target = "~T:NuGet.RuntimeModel.RuntimeGraph.RuntimeCompatKey")]
 [assembly: SuppressMessage("Build", "CA1067:Type NuGet.RuntimeModel.RuntimeGraph.RuntimeDependencyKey should override Equals because it implements IEquatable<T>", Justification = "<Pending>", Scope = "type", Target = "~T:NuGet.RuntimeModel.RuntimeGraph.RuntimeDependencyKey")]
-[assembly: SuppressMessage("Globalization", "CA1307:Specify StringComparison", Justification = "<Pending>", Scope = "member", Target = "~M:NuGet.ContentModel.ContentItemCollection.GroupComparer.GetHashCode(NuGet.ContentModel.ContentItem)~System.Int32")]
-[assembly: SuppressMessage("Globalization", "CA1307:Specify StringComparison", Justification = "<Pending>", Scope = "member", Target = "~M:NuGet.Packaging.FrameworkSpecificGroup.GetHashCode~System.Int32")]
-[assembly: SuppressMessage("Globalization", "CA1307:Specify StringComparison", Justification = "<Pending>", Scope = "member", Target = "~M:NuGet.Packaging.PhysicalPackageFile.GetHashCode~System.Int32")]
+[assembly: SuppressMessage("Build", "CA1307:The behavior of 'string.GetHashCode()' could vary based on the current user's locale settings. Replace this call in 'NuGet.ContentModel.ContentItemCollection.GroupComparer.GetHashCode(NuGet.ContentModel.ContentItem)' with a call to 'string.GetHashCode(System.StringComparison)'.", Justification = "<Pending>", Scope = "member", Target = "~M:NuGet.ContentModel.ContentItemCollection.GroupComparer.GetHashCode(NuGet.ContentModel.ContentItem)~System.Int32")]
+[assembly: SuppressMessage("Build", "CA1307:The behavior of 'string.GetHashCode()' could vary based on the current user's locale settings. Replace this call in 'NuGet.Packaging.FrameworkSpecificGroup.GetHashCode()' with a call to 'string.GetHashCode(System.StringComparison)'.", Justification = "<Pending>", Scope = "member", Target = "~M:NuGet.Packaging.FrameworkSpecificGroup.GetHashCode~System.Int32")]
+[assembly: SuppressMessage("Build", "CA1307:The behavior of 'string.GetHashCode()' could vary based on the current user's locale settings. Replace this call in 'NuGet.Packaging.PhysicalPackageFile.GetHashCode()' with a call to 'string.GetHashCode(System.StringComparison)'.", Justification = "<Pending>", Scope = "member", Target = "~M:NuGet.Packaging.PhysicalPackageFile.GetHashCode~System.Int32")]


### PR DESCRIPTION
## Bug

Fixes: NuGet/Client.Engineering#323
Regression: No
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: Suppressed CA1307 analyzer warning for `string.GetHashCode()` method due to false positives discussed [here](https://github.com/dotnet/roslyn-analyzers/issues/3629#issuecomment-628289439).

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  No change in the business logic.
Validation:  A successful build