### PR TITLE
Linux test failure due to generic exception

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/SignCommand/CertificateProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/SignCommand/CertificateProvider.cs
@@ -32,11 +32,8 @@ namespace NuGet.Commands
 
         private const int MACOS_INVALID_CERT = -25257;
 
-        // OpenSSL:  error:0D07803A:asn1 encoding routines:ASN1_ITEM_EX_D2I:nested asn1 error
-        private const int OPENSSL_ERR_R_NESTED_ASN1_ERROR = 0x0D07803A;
-
-        //Generic exception ASN1 corrupted data
-        private const int OPENSSL_ASN1_CORRUPTED_DATA_ERROR = unchecked((int)0x80131501);
+        // error:0x80131501 generic exception raised by dotnet before using OpenSSL
+        private const int OPENSSL_READER_ASN1_ERROR = unchecked((int)0x80131501);
 
         /// <summary>
         /// Looks for X509Certificates using the CertificateSourceOptions.
@@ -80,8 +77,7 @@ namespace NuGet.Commands
                                     options.CertificatePath)));
 
                         case CRYPT_E_NO_MATCH_HRESULT:
-                        case OPENSSL_ERR_R_NESTED_ASN1_ERROR:
-                        case OPENSSL_ASN1_CORRUPTED_DATA_ERROR:
+                        case OPENSSL_READER_ASN1_ERROR:
                         case MACOS_INVALID_CERT:
                             throw new SignCommandException(
                                 LogMessage.CreateError(NuGetLogCode.NU3001,

--- a/src/NuGet.Core/NuGet.Commands/SignCommand/CertificateProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/SignCommand/CertificateProvider.cs
@@ -32,11 +32,14 @@ namespace NuGet.Commands
 
         private const int MACOS_INVALID_CERT = -25257;
 
-        // OpenSSL:  error:0D07803A:asn1 encoding routines:ASN1_ITEM_EX_D2I:nested asn1 error
-        private const int OPENSSL_ERR_R_NESTED_ASN1_ERROR = 0x0D07803A;
 
+#if IS_SIGNING_SUPPORTED && IS_CORECLR
         //Generic exception ASN1 corrupted data
         private const int OPENSSL_ASN1_CORRUPTED_DATA_ERROR = unchecked((int)0x80131501);
+#else
+        // OpenSSL:  error:0D07803A:asn1 encoding routines:ASN1_ITEM_EX_D2I:nested asn1 error
+        private const int OPENSSL_ERR_R_NESTED_ASN1_ERROR = 0x0D07803A;
+#endif
 
         /// <summary>
         /// Looks for X509Certificates using the CertificateSourceOptions.

--- a/src/NuGet.Core/NuGet.Commands/SignCommand/CertificateProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/SignCommand/CertificateProvider.cs
@@ -32,8 +32,11 @@ namespace NuGet.Commands
 
         private const int MACOS_INVALID_CERT = -25257;
 
-        // error:0x80131501 generic exception raised by dotnet before using OpenSSL
-        private const int OPENSSL_READER_ASN1_ERROR = unchecked((int)0x80131501);
+        // OpenSSL:  error:0D07803A:asn1 encoding routines:ASN1_ITEM_EX_D2I:nested asn1 error
+        private const int OPENSSL_ERR_R_NESTED_ASN1_ERROR = 0x0D07803A;
+
+        //Generic exception ASN1 corrupted data
+        private const int OPENSSL_ASN1_CORRUPTED_DATA_ERROR = unchecked((int)0x80131501);
 
         /// <summary>
         /// Looks for X509Certificates using the CertificateSourceOptions.
@@ -77,7 +80,8 @@ namespace NuGet.Commands
                                     options.CertificatePath)));
 
                         case CRYPT_E_NO_MATCH_HRESULT:
-                        case OPENSSL_READER_ASN1_ERROR:
+                        case OPENSSL_ERR_R_NESTED_ASN1_ERROR:
+                        case OPENSSL_ASN1_CORRUPTED_DATA_ERROR:
                         case MACOS_INVALID_CERT:
                             throw new SignCommandException(
                                 LogMessage.CreateError(NuGetLogCode.NU3001,

--- a/src/NuGet.Core/NuGet.Commands/SignCommand/CertificateProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/SignCommand/CertificateProvider.cs
@@ -32,8 +32,8 @@ namespace NuGet.Commands
 
         private const int MACOS_INVALID_CERT = -25257;
 
-        // error:0x80131501 generic exception raised by dotnet before using OpenSSL
-        private const int OPENSSL_READER_ASN1_ERROR = unchecked((int)0x80131501);
+        // OpenSSL:  error:0D07803A:asn1 encoding routines:ASN1_ITEM_EX_D2I:nested asn1 error
+        private const int OPENSSL_ERR_R_NESTED_ASN1_ERROR = 0x0D07803A;
 
         /// <summary>
         /// Looks for X509Certificates using the CertificateSourceOptions.
@@ -77,7 +77,7 @@ namespace NuGet.Commands
                                     options.CertificatePath)));
 
                         case CRYPT_E_NO_MATCH_HRESULT:
-                        case OPENSSL_READER_ASN1_ERROR:
+                        case OPENSSL_ERR_R_NESTED_ASN1_ERROR:
                         case MACOS_INVALID_CERT:
                             throw new SignCommandException(
                                 LogMessage.CreateError(NuGetLogCode.NU3001,

--- a/src/NuGet.Core/NuGet.Commands/SignCommand/CertificateProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/SignCommand/CertificateProvider.cs
@@ -80,8 +80,11 @@ namespace NuGet.Commands
                                     options.CertificatePath)));
 
                         case CRYPT_E_NO_MATCH_HRESULT:
-                        case OPENSSL_ERR_R_NESTED_ASN1_ERROR:
+#if IS_SIGNING_SUPPORTED && IS_CORECLR
                         case OPENSSL_ASN1_CORRUPTED_DATA_ERROR:
+#else
+                        case OPENSSL_ERR_R_NESTED_ASN1_ERROR:
+#endif
                         case MACOS_INVALID_CERT:
                             throw new SignCommandException(
                                 LogMessage.CreateError(NuGetLogCode.NU3001,

--- a/src/NuGet.Core/NuGet.Commands/SignCommand/CertificateProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/SignCommand/CertificateProvider.cs
@@ -35,6 +35,9 @@ namespace NuGet.Commands
         // OpenSSL:  error:0D07803A:asn1 encoding routines:ASN1_ITEM_EX_D2I:nested asn1 error
         private const int OPENSSL_ERR_R_NESTED_ASN1_ERROR = 0x0D07803A;
 
+        //Generic exception ASN1 corrupted data
+        private const int OPENSSL_ASN1_CORRUPTED_DATA_ERROR = unchecked((int)0x80131501);
+
         /// <summary>
         /// Looks for X509Certificates using the CertificateSourceOptions.
         /// Throws an InvalidOperationException if the option specifies a CertificateFilePath with invalid password.
@@ -78,6 +81,7 @@ namespace NuGet.Commands
 
                         case CRYPT_E_NO_MATCH_HRESULT:
                         case OPENSSL_ERR_R_NESTED_ASN1_ERROR:
+                        case OPENSSL_ASN1_CORRUPTED_DATA_ERROR:
                         case MACOS_INVALID_CERT:
                             throw new SignCommandException(
                                 LogMessage.CreateError(NuGetLogCode.NU3001,

--- a/src/NuGet.Core/NuGet.Commands/SignCommand/CertificateProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/SignCommand/CertificateProvider.cs
@@ -32,8 +32,8 @@ namespace NuGet.Commands
 
         private const int MACOS_INVALID_CERT = -25257;
 
-        // OpenSSL:  error:0D07803A:asn1 encoding routines:ASN1_ITEM_EX_D2I:nested asn1 error
-        private const int OPENSSL_ERR_R_NESTED_ASN1_ERROR = 0x0D07803A;
+        // error:0x80131501 generic exception raised by dotnet before using OpenSSL
+        private const int OPENSSL_READER_ASN1_ERROR = unchecked((int)0x80131501);
 
         /// <summary>
         /// Looks for X509Certificates using the CertificateSourceOptions.
@@ -77,7 +77,7 @@ namespace NuGet.Commands
                                     options.CertificatePath)));
 
                         case CRYPT_E_NO_MATCH_HRESULT:
-                        case OPENSSL_ERR_R_NESTED_ASN1_ERROR:
+                        case OPENSSL_READER_ASN1_ERROR:
                         case MACOS_INVALID_CERT:
                             throw new SignCommandException(
                                 LogMessage.CreateError(NuGetLogCode.NU3001,


### PR DESCRIPTION
## Bug

Fixes: NuGet/Home#9523
Regression: No  

## Fix

Details: As per this [comment](https://github.com/dotnet/runtime/issues/31536#issuecomment-556931858), exception with HRResult `0x80131501` has no further info and it is raised by `dotnet` libraries as `OpenSSL` is not used at this step. [NU3001](https://docs.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu3001) is raised in 3 scenarios when certificate has invalid password or file not found or file has corrupted data. This PR is to fix the HRResult for last scenario.

## Testing/Validation

Tests Added: No 
Reason for not adding tests: This PR is to fix a test failure.
Validation:  
