### PR TITLE
Align Tabs, Searchbox, and Checkboxes in PMUI

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Converters/BooleanToVisibilityConverter.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Converters/BooleanToVisibilityConverter.cs
@@ -18,6 +18,7 @@ namespace NuGet.PackageManagement.UI
     public class BooleanToVisibilityConverter : IValueConverter
     {
         public bool Inverted { get; set; }
+        public bool HiddenWhenFalse { get; set; }
 
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
@@ -27,7 +28,7 @@ namespace NuGet.PackageManagement.UI
                 boolValue = !boolValue;
             }
 
-            return boolValue ? Visibility.Visible : Visibility.Collapsed;
+            return boolValue ? Visibility.Visible : HiddenWhenFalse ? Visibility.Hidden : Visibility.Collapsed;
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Converters/BooleanToVisibilityConverter.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Converters/BooleanToVisibilityConverter.cs
@@ -18,7 +18,7 @@ namespace NuGet.PackageManagement.UI
     public class BooleanToVisibilityConverter : IValueConverter
     {
         public bool Inverted { get; set; }
-        public bool HiddenWhenFalse { get; set; }
+        public Visibility NonVisualState { get; set; } = Visibility.Collapsed;
 
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
@@ -28,7 +28,7 @@ namespace NuGet.PackageManagement.UI
                 boolValue = !boolValue;
             }
 
-            return boolValue ? Visibility.Visible : HiddenWhenFalse ? Visibility.Hidden : Visibility.Collapsed;
+            return boolValue ? Visibility.Visible : NonVisualState;
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources/Resources.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources/Resources.xaml
@@ -34,6 +34,9 @@
   <nuget:BooleanToVisibilityConverter
     Inverted="True"
     x:Key="InvertedBooleanToVisibilityConverter" />
+  <nuget:BooleanToVisibilityConverter
+    HiddenWhenFalse="True"
+    x:Key="HiddenWhenFalseBooleanToVisibilityConverter" />
   <nuget:DownloadCountToVisibilityConverter
     x:Key="DownloadCountToVisibilityConverter" />
   <nuget:FontSizeConverter

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources/Resources.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources/Resources.xaml
@@ -35,8 +35,8 @@
     Inverted="True"
     x:Key="InvertedBooleanToVisibilityConverter" />
   <nuget:BooleanToVisibilityConverter
-    HiddenWhenFalse="True"
-    x:Key="HiddenWhenFalseBooleanToVisibilityConverter" />
+    NonVisualState="Hidden"
+    x:Key="NonVisualStateHiddenBooleanToVisibilityConverter" />
   <nuget:DownloadCountToVisibilityConverter
     x:Key="DownloadCountToVisibilityConverter" />
   <nuget:FontSizeConverter

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml
@@ -285,7 +285,7 @@
         <CheckBox
           x:Name="_selectAllPackages"
           Grid.Column="0"
-          Margin="16, 8"
+          Margin="4, 8"
           VerticalAlignment="Center"
           Checked="SelectAllPackagesCheckBox_Checked"
           Unchecked="SelectAllPackagesCheckBox_Unchecked"

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageItemControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageItemControl.xaml
@@ -73,7 +73,7 @@
                 Background="Transparent"
                 Padding="0,8,0,0">
     <Grid
-                  Margin="16,0,7,0">
+                  Margin="0,0,7,0">
       <Grid.ColumnDefinitions>
         <ColumnDefinition Width="Auto" />
         <ColumnDefinition Width="Auto" />
@@ -84,9 +84,9 @@
       <!-- check box -->
       <CheckBox
                     Grid.Column="0"
-                    Margin="0,12,8,0"
+                    Margin="4,12,4,0"
                     VerticalAlignment="top"
-                    Visibility="{Binding CheckBoxesEnabled, RelativeSource={RelativeSource AncestorType={x:Type nuget:InfiniteScrollList}}, Converter={StaticResource BooleanToVisibilityConverter}}"
+                    Visibility="{Binding CheckBoxesEnabled, RelativeSource={RelativeSource AncestorType={x:Type nuget:InfiniteScrollList}}, Converter={StaticResource HiddenWhenFalseBooleanToVisibilityConverter}}"
                     AutomationProperties.Name="{x:Static nuget:Resources.CheckBox_Selected}"
                     IsChecked="{Binding Selected}" />
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageItemControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageItemControl.xaml
@@ -86,7 +86,7 @@
                     Grid.Column="0"
                     Margin="4,12,4,0"
                     VerticalAlignment="top"
-                    Visibility="{Binding CheckBoxesEnabled, RelativeSource={RelativeSource AncestorType={x:Type nuget:InfiniteScrollList}}, Converter={StaticResource HiddenWhenFalseBooleanToVisibilityConverter}}"
+                    Visibility="{Binding CheckBoxesEnabled, RelativeSource={RelativeSource AncestorType={x:Type nuget:InfiniteScrollList}}, Converter={StaticResource NonVisualStateHiddenBooleanToVisibilityConverter}}"
                     AutomationProperties.Name="{x:Static nuget:Resources.CheckBox_Selected}"
                     IsChecked="{Binding Selected}" />
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml
@@ -57,7 +57,7 @@
     <nuget:PackageManagerTopPanel
       DockPanel.Dock="Top"
       x:Name="_topPanel"
-      Margin="24,0,24,17"
+      Margin="0,0,24,17"
       SettingsButtonClicked="SettingsButtonClicked"
       FilterChanged="Filter_SelectionChanged"
       PrereleaseCheckChanged="CheckboxPrerelease_CheckChanged"

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerTopPanel.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerTopPanel.xaml
@@ -94,7 +94,7 @@
                     <Grid.RowDefinitions>
                       <RowDefinition x:Name="RowDefinition0" Height="Auto"/>
                     </Grid.RowDefinitions>
-                    <TabPanel x:Name="headerPanel" Background="Transparent" Grid.Column="0" IsItemsHost="true" Margin="2,2,2,0" Grid.Row="0" KeyboardNavigation.TabIndex="1" Panel.ZIndex="1"/>
+                    <TabPanel x:Name="headerPanel" Background="Transparent" Grid.Column="0" IsItemsHost="true" Margin="0,0,0,0" Grid.Row="0" KeyboardNavigation.TabIndex="1" Panel.ZIndex="1"/>
                   </Grid>
                 </ControlTemplate>
               </Setter.Value>
@@ -102,7 +102,7 @@
           </Style>
         </TabControl.Resources>
 
-        <TabItem Name="tabBrowse" Tag="{x:Static nuget:ItemFilter.All}" Header="{x:Static nuget:Resources.Label_Browse}" IsSelected="True"/>
+        <TabItem Name="tabBrowse" Tag="{x:Static nuget:ItemFilter.All}" Header="{x:Static nuget:Resources.Label_Browse}" IsSelected="True" />
         <TabItem Name="tabInstalled" Tag="{x:Static nuget:ItemFilter.Installed}">
           <AutomationProperties.Name>
             <MultiBinding StringFormat="{}{0}{1}">
@@ -169,7 +169,7 @@
     </Grid>
 
     <!-- search control and include prerelease checkbox -->
-    <Grid Grid.Row="2">
+    <Grid Grid.Row="2" Margin="20,0,0,0">
       <Grid.ColumnDefinitions>
         <ColumnDefinition Width="*" MinWidth="269"/>
         <ColumnDefinition Width="0.01*" MinWidth="5" />


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9559
Regression: No

## Fix

Details: Modified some margins so that these controls have a more linear appearance. Updates tab will show checkboxes, so not always a perfect line, but looks much cleaner.

PMUI perf work lead me to make changes so that the checkboxes take up minimal space (less margins/etc) so they can simply show/hide without changing the flow of Package text and causing a harsher redraw.

#### Before
![image](https://user-images.githubusercontent.com/49205731/82703337-b9aab080-9c41-11ea-9a55-78cda2cd77cc.png)

#### After
![image](https://user-images.githubusercontent.com/49205731/82703369-c7603600-9c41-11ea-8c54-44884091ce48.png)


## Testing/Validation

Tests Added: No
Reason for not adding tests:  Observation by our test team found this misalignment. 
Validation:  Open PMUI and verify the controls are aligned.
