### PR TITLE
Add switch to package list command to show HTTP start and stop logs

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackage/ListPackageCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackage/ListPackageCommand.cs
@@ -17,7 +17,10 @@ namespace NuGet.CommandLine.XPlat
 {
     public static class ListPackageCommand
     {
-        public static void Register(CommandLineApplication app, Func<ILogger> getLogger,
+        public static void Register(
+            CommandLineApplication app,
+            Func<ILogger> getLogger,
+            Action<LogLevel> setLogLevel,
             Func<IListPackageCommandRunner> getCommandRunner)
         {
             app.Command("list", listpkg =>
@@ -85,9 +88,16 @@ namespace NuGet.CommandLine.XPlat
                     Strings.NuGetXplatCommand_Interactive,
                     CommandOptionType.NoValue);
 
+                var verbosity = listpkg.Option(
+                    "-v|--verbosity",
+                    Strings.Verbosity_Description,
+                    CommandOptionType.SingleValue);
+
                 listpkg.OnExecute(async () =>
                 {
                     var logger = getLogger();
+
+                    setLogLevel(XPlatUtility.MSBuildVerbosityToNuGetLogLevel(verbosity.Value()));
 
                     var settings = ProcessConfigFile(config.Value(), path.Value);
                     var sources = source.Values;

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackage/ListPackageCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackage/ListPackageCommandRunner.cs
@@ -611,7 +611,13 @@ namespace NuGet.CommandLine.XPlat
             var sourceRepository = Repository.CreateSource(providers, packageSource, FeedType.Undefined);
             var packageMetadataResource = await sourceRepository.GetResourceAsync<PackageMetadataResource>(listPackageArgs.CancellationToken);
 
-            var packages = (await packageMetadataResource.GetMetadataAsync(package, true, false, new SourceCacheContext(), NullLogger.Instance, listPackageArgs.CancellationToken));
+            var packages = await packageMetadataResource.GetMetadataAsync(
+                package,
+                includePrerelease: true,
+                includeUnlisted: false,
+                sourceCacheContext: new SourceCacheContext(),
+                log: listPackageArgs.Logger,
+                token: listPackageArgs.CancellationToken);
 
             var latestVersionsForPackage = packagesVersionsDict.Where(p => p.Key.Equals(package, StringComparison.OrdinalIgnoreCase)).Single().Value;
             latestVersionsForPackage.AddRange(packages);
@@ -646,7 +652,7 @@ namespace NuGet.CommandLine.XPlat
                 includePrerelease: true,
                 includeUnlisted: true, // Include unlisted because deprecated packages may be unlisted.
                 sourceCacheContext: new SourceCacheContext(),
-                log: NullLogger.Instance,
+                log: listPackageArgs.Logger,
                 token: listPackageArgs.CancellationToken);
 
             var resolvedVersionsForPackage = packagesVersionsDict

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Program.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Program.cs
@@ -166,12 +166,15 @@ namespace NuGet.CommandLine.XPlat
 
         private static CommandLineApplication InitializeApp(string[] args, CommandOutputLogger log)
         {
-            // Many commands don't want prefixes output. Use loggerFunc(log) instead of log to set the HidePrefix property first.
-            Func<CommandOutputLogger, Func<ILogger>> loggerFunc = (commandOutputLogger) =>
-             {
-                 commandOutputLogger.HidePrefixForInfoAndMinimal = true;
-                 return () => commandOutputLogger;
-             };
+            // Many commands don't want prefixes output. Use this func instead of () => log to set the HidePrefix property first.
+            Func<ILogger> getHidePrefixLogger = () =>
+            {
+                log.HidePrefixForInfoAndMinimal = true;
+                return log;
+            };
+
+            // Allow commands to set the NuGet log level
+            Action<LogLevel> setLogLevel = (logLevel) => log.LogLevel = logLevel;
 
             var app = new CommandLineApplication();
 
@@ -181,16 +184,16 @@ namespace NuGet.CommandLine.XPlat
                 app.Name = DotnetPackageAppName;
                 AddPackageReferenceCommand.Register(app, () => log, () => new AddPackageReferenceCommandRunner());
                 RemovePackageReferenceCommand.Register(app, () => log, () => new RemovePackageReferenceCommandRunner());
-                ListPackageCommand.Register(app, () => log, () => new ListPackageCommandRunner());
+                ListPackageCommand.Register(app, getHidePrefixLogger, setLogLevel, () => new ListPackageCommandRunner());
             }
             else
             {
                 // "dotnet nuget *" commands
                 app.Name = DotnetNuGetAppName;
-                CommandParsers.Register(app, loggerFunc(log));
-                DeleteCommand.Register(app, () => log);
-                PushCommand.Register(app, () => log);
-                LocalsCommand.Register(app, () => log);
+                CommandParsers.Register(app, getHidePrefixLogger);
+                DeleteCommand.Register(app, getHidePrefixLogger);
+                PushCommand.Register(app, getHidePrefixLogger);
+                LocalsCommand.Register(app, getHidePrefixLogger);
             }
 
             app.FullName = Strings.App_FullName;

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
@@ -1608,15 +1608,6 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The verbosity of logging to use. Allowed values: Debug, Verbose, Information, Minimal, Warning, Error..
-        /// </summary>
-        internal static string Switch_Verbosity {
-            get {
-                return ResourceManager.GetString("Switch_Verbosity", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to The API key for the symbol server..
         /// </summary>
         internal static string SymbolApiKey_Description {
@@ -1676,6 +1667,15 @@ namespace NuGet.CommandLine.XPlat {
         internal static string UpdateSourceCommandDescription {
             get {
                 return ResourceManager.GetString("UpdateSourceCommandDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Set the verbosity level of the command. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic]..
+        /// </summary>
+        internal static string Verbosity_Description {
+            get {
+                return ResourceManager.GetString("Verbosity_Description", resourceCulture);
             }
         }
         

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
@@ -204,10 +204,6 @@
   <data name="Source_Description" xml:space="preserve">
     <value>Package source (URL, UNC/folder path or package source name) to use. Defaults to DefaultPushSource if specified in NuGet.Config.</value>
   </data>
-  <data name="Switch_Verbosity" xml:space="preserve">
-    <value>The verbosity of logging to use. Allowed values: Debug, Verbose, Information, Minimal, Warning, Error.</value>
-    <comment>The allowed values should not be localized as they are Enum variants</comment>
-  </data>
   <data name="Error_MissingSourceParameter" xml:space="preserve">
     <value>Source parameter was not specified.</value>
   </data>
@@ -648,7 +644,7 @@ For more information, visit https://docs.nuget.org/docs/reference/command-line-r
   <data name="Option_ConfigFile" xml:space="preserve">
     <value>The NuGet configuration file. If specified, only the settings from this file will be used. If not specified, the hierarchy of configuration files from the current directory will be used. For more information, see https://docs.microsoft.com/nuget/consume-packages/configuring-nuget-behavior.</value>
   </data>
-   <data name="Option_ConfigFile_Docs" xml:space="preserve">
+  <data name="Option_ConfigFile_Docs" xml:space="preserve">
     <value>The NuGet configuration file. If specified, only the settings from this file will be used. If not specified, the hierarchy of configuration files from the current directory will be used. For more information, see [Common NuGet Configurations](https://docs.microsoft.com/nuget/consume-packages/configuring-nuget-behavior).</value>
   </data>
   <data name="Option_PackageSource" xml:space="preserve">
@@ -711,5 +707,9 @@ For more information, visit https://docs.nuget.org/docs/reference/command-line-r
   </data>
   <data name="AddClientCertCommandDescription" xml:space="preserve">
     <value>Adds a client certificate configuration that matches the given package source name.</value>
+  </data>
+  <data name="Verbosity_Description" xml:space="preserve">
+    <value>Set the verbosity level of the command. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</value>
+    <comment>Please don't localize "q[uiet]", "m[inimal]", "n[ormal]", "d[etailed]", or "diag[nostic]"</comment>
   </data>
 </root>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/XPlatUtility.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/XPlatUtility.cs
@@ -18,7 +18,31 @@ namespace NuGet.CommandLine.XPlat
     internal static class XPlatUtility
     {
         public const string HelpOption = "-h|--help";
-        public const string VerbosityOption = "-v|--verbosity <verbosity>";
+
+        /// <summary>
+        /// Note that the .NET CLI itself has parameter parsing which limits the values that will be passed here by the
+        /// user. In other words, the default case should only be hit with <c>m</c> or <c>minimal</c> but we use <see cref="Common.LogLevel.Minimal"/>
+        /// as the default case to avoid errors.
+        /// </summary>
+        public static LogLevel MSBuildVerbosityToNuGetLogLevel(string verbosity)
+        {
+            switch (verbosity?.ToUpperInvariant())
+            {
+                case "Q":
+                case "QUIET":
+                    return LogLevel.Warning;
+                case "N":
+                case "NORMAL":
+                    return LogLevel.Information;
+                case "D":
+                case "DETAILED":
+                case "DIAG":
+                case "DIAGNOSTIC":
+                    return LogLevel.Debug;
+                default:
+                    return LogLevel.Minimal;
+            }
+        }
 
         public static ISettings CreateDefaultSettings()
         {

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
@@ -4296,10 +4296,10 @@ namespace ClassLibrary
                 .WithProjectName("test")
                 .WithPackageIcon("icon.jpg")
                 .WithPackageIconUrl("http://test.icon")
-                .WithItem("None", "icon.jpg", string.Empty)
-                .WithItem("None", "other\\files.txt", null)
-                .WithItem("None", "folder\\**", "media")
-                .WithItem("None", "utils\\*", "utils");
+                .WithItem(itemType: "None", itemPath: "icon.jpg", packagePath: string.Empty, pack: "true")
+                .WithItem(itemType: "None", itemPath: "other\\files.txt", packagePath: null, pack: "true")
+                .WithItem(itemType: "None", itemPath: "folder\\**", packagePath: "media", pack: "true")
+                .WithItem(itemType: "None", itemPath: "utils\\*", packagePath: "utils", pack: "true");
 
             using (var srcDir = msbuildFixture.Build(testDirBuilder))
             {
@@ -4354,7 +4354,7 @@ namespace ClassLibrary
             projectBuilder
                 .WithProjectName("test")
                 .WithPackageIcon("icon.jpg")
-                .WithItem("None", "icon.jpg", "icon.jpg");
+                .WithItem(itemType: "None", itemPath: "icon.jpg", packagePath: "icon.jpg", pack: "true");
 
             using (var srcDir = msbuildFixture.Build(testDirBuilder))
             {

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/ProjectFileBuilder.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/ProjectFileBuilder.cs
@@ -52,9 +52,14 @@ namespace NuGet.Test.Utility
         /// Adds and intem inside a &lt;ItemGroup/&gt; node in the following form:
         /// <c>&lt;{itemType} Include="{itemPath}" [PackagePath="{packagePath}"] /&gt;</c>
         /// </summary>
-        public ProjectFileBuilder WithItem(string itemType, string itemPath, string packagePath)
+        public ProjectFileBuilder WithItem(
+            string itemType,
+            string itemPath,
+            string packagePath = null,
+            string pack = null,
+            string version = null)
         {
-            ItemGroupEntries.Add(new ItemEntry(itemType, itemPath, packagePath));
+            ItemGroupEntries.Add(new ItemEntry(itemType, itemPath, packagePath, pack, version));
 
             return this;
         }
@@ -105,16 +110,24 @@ namespace NuGet.Test.Utility
 
                 ProjectFileUtils.AddProperties(xml, Properties);
 
-                var attributes = new Dictionary<string, string>();
-                var properties = new Dictionary<string, string>();
-                attributes["Pack"] = "true";
                 foreach (var tup in ItemGroupEntries)
                 {
-                    attributes.Remove("PackagePath");
+                    var attributes = new Dictionary<string, string>();
+                    var properties = new Dictionary<string, string>();
 
                     if (tup.PackagePath != null)
                     {
                         attributes["PackagePath"] = tup.PackagePath;
+                    }
+
+                    if (tup.Pack != null)
+                    {
+                        attributes["Pack"] = tup.Pack;
+                    }
+
+                    if (tup.Version != null)
+                    {
+                        attributes["Version"] = tup.Version;
                     }
 
                     ProjectFileUtils.AddItem(xml, tup.ItemType, tup.ItemPath, string.Empty, properties, attributes);
@@ -133,12 +146,21 @@ namespace NuGet.Test.Utility
             public string ItemType { get; }
             public string ItemPath { get; }
             public string PackagePath { get; }
+            public string Version { get; }
+            public string Pack { get; }
 
-            public ItemEntry(string itemType, string itemPath, string packagePath)
+            public ItemEntry(
+                string itemType,
+                string itemPath,
+                string packagePath,
+                string pack,
+                string version)
             {
                 ItemType = itemType;
                 ItemPath = itemPath;
                 PackagePath = packagePath;
+                Version = version;
+                Pack = pack;
             }
         }
     }

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/ProjectFileBuilder.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/ProjectFileBuilder.cs
@@ -50,7 +50,7 @@ namespace NuGet.Test.Utility
 
         /// <summary>
         /// Adds and intem inside a &lt;ItemGroup/&gt; node in the following form:
-        /// <c>&lt;{itemType} Include="{itemPath}" [PackagePath="{packagePath}"] /&gt;</c>
+        /// <c>&lt;{itemType} Include="{itemPath}" [PackagePath="{packagePath}" Pack="{pack}" Version="{version}"] /&gt;</c>
         /// </summary>
         public ProjectFileBuilder WithItem(
             string itemType,

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/ListPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/ListPackageTests.cs
@@ -38,7 +38,7 @@ namespace NuGet.XPlat.FuncTest
         }
 
         [Fact]
-        public void BasicListPackageParsing_InteractiveTakesNoArguments()
+        public void BasicListPackageParsing_InteractiveTakesNoArguments_ThrowsException()
         {
             VerifyCommand(
                 (projectPath, mockCommandRunner, testApp, getLogLevel) =>

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/ListPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/ListPackageTests.cs
@@ -1,12 +1,14 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using Microsoft.Extensions.CommandLineUtils;
 using Moq;
 using NuGet.CommandLine.XPlat;
+using NuGet.Common;
 using NuGet.Protocol;
 using NuGet.Test.Utility;
 using Xunit;
@@ -19,43 +21,83 @@ namespace NuGet.XPlat.FuncTest
         [Fact]
         public void BasicListPackageParsing_Interactive()
         {
-            // Arrange
-            using (var testDirectory = TestDirectory.Create())
-            {
-                var projectPath = Path.Combine(testDirectory, "project.csproj");
-                File.WriteAllText(projectPath, string.Empty);
+            VerifyCommand(
+                (projectPath, mockCommandRunner, testApp, getLogLevel) =>
+                {
+                    // Arrange
+                    var argList = new List<string> { "list", "--interactive", projectPath };
 
-                var argList = new List<string>() {
-                    "list",
-                    "--interactive",
-                    projectPath};
+                    // Act
+                    var result = testApp.Execute(argList.ToArray());
 
-                var logger = new TestCommandOutputLogger();
-                var testApp = new CommandLineApplication();
-                var mockCommandRunner = new Mock<IListPackageCommandRunner>();
-                mockCommandRunner
-                    .Setup(m => m.ExecuteCommandAsync(It.IsAny<ListPackageArgs>()))
-                    .Returns(Task.CompletedTask);
-
-                testApp.Name = "dotnet nuget_test";
-                ListPackageCommand.Register(testApp,
-                    () => logger,
-                    () => mockCommandRunner.Object);
-
-                // Act
-                var result = testApp.Execute(argList.ToArray());
-
-                XPlatTestUtils.DisposeTemporaryFile(projectPath);
-
-                // Assert
-                mockCommandRunner.Verify();
-                Assert.NotNull(HttpHandlerResourceV3.CredentialService);
-                Assert.Equal(0, result);
-            }
+                    // Assert
+                    mockCommandRunner.Verify();
+                    Assert.NotNull(HttpHandlerResourceV3.CredentialService);
+                    Assert.Equal(0, result);
+                });
         }
 
         [Fact]
         public void BasicListPackageParsing_InteractiveTakesNoArguments()
+        {
+            VerifyCommand(
+                (projectPath, mockCommandRunner, testApp, getLogLevel) =>
+                {
+                    // Arrange
+                    var argList = new List<string>() { "list", "--interactive", "no", projectPath };
+
+                    // Act & Assert
+                    Assert.Throws<CommandParsingException>(() => testApp.Execute(argList.ToArray()));
+                });
+        }
+
+        [Theory]
+        [InlineData("q", LogLevel.Warning)]
+        [InlineData("quiet", LogLevel.Warning)]
+        [InlineData("m", LogLevel.Minimal)]
+        [InlineData("minimal", LogLevel.Minimal)]
+        [InlineData("something-else", LogLevel.Minimal)]
+        [InlineData("n", LogLevel.Information)]
+        [InlineData("normal", LogLevel.Information)]
+        [InlineData("d", LogLevel.Debug)]
+        [InlineData("detailed", LogLevel.Debug)]
+        [InlineData("diag", LogLevel.Debug)]
+        [InlineData("diagnostic", LogLevel.Debug)]
+        public void BasicListPackageParsing_VerbosityOption(string verbosity, LogLevel logLevel)
+        {
+            VerifyCommand(
+                (projectPath, mockCommandRunner, testApp, getLogLevel) =>
+                {
+                    // Arrange
+                    var argList = new List<string> { "list", projectPath, "--verbosity", verbosity };
+
+                    // Act
+                    var result = testApp.Execute(argList.ToArray());
+
+                    // Assert
+                    Assert.Equal(logLevel, getLogLevel());
+                    Assert.Equal(0, result);
+                });
+        }
+
+        [Fact]
+        public void BasicListPackageParsing_NoVerbosityOption()
+        {
+            VerifyCommand((projectPath, mockCommandRunner, testApp, getLogLevel) =>
+                {
+                    // Arrange
+                    var argList = new List<string> { "list", projectPath };
+
+                    // Act
+                    var result = testApp.Execute(argList.ToArray());
+
+                    // Assert
+                    Assert.Equal(LogLevel.Minimal, getLogLevel());
+                    Assert.Equal(0, result);
+                });
+        }
+
+        private void VerifyCommand(Action<string, Mock<IListPackageCommandRunner>, CommandLineApplication, Func<LogLevel>> verify)
         {
             // Arrange
             using (var testDirectory = TestDirectory.Create())
@@ -63,12 +105,7 @@ namespace NuGet.XPlat.FuncTest
                 var projectPath = Path.Combine(testDirectory, "project.csproj");
                 File.WriteAllText(projectPath, string.Empty);
 
-                var argList = new List<string>() {
-                    "list",
-                    "--interactive",
-                    "no",
-                    projectPath};
-
+                var logLevel = LogLevel.Information;
                 var logger = new TestCommandOutputLogger();
                 var testApp = new CommandLineApplication();
                 var mockCommandRunner = new Mock<IListPackageCommandRunner>();
@@ -79,10 +116,18 @@ namespace NuGet.XPlat.FuncTest
                 testApp.Name = "dotnet nuget_test";
                 ListPackageCommand.Register(testApp,
                     () => logger,
+                    ll => logLevel = ll,
                     () => mockCommandRunner.Object);
 
-                // Act
-                Assert.Throws<CommandParsingException>(() => testApp.Execute(argList.ToArray()));
+                // Act & Assert
+                try
+                {
+                    verify(projectPath, mockCommandRunner, testApp, () => logLevel);
+                }
+                finally
+                {
+                    XPlatTestUtils.DisposeTemporaryFile(projectPath);
+                }
             }
         }
     }

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/NuGet.CommandLine.Xplat.Tests.csproj
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/NuGet.CommandLine.Xplat.Tests.csproj
@@ -23,6 +23,6 @@
     <Reference Include="System.IO.Compression" />
   </ItemGroup>
 
-  <Import Project="$(BuildCommonDirectory)common.targets"/>
+  <Import Project="$(BuildCommonDirectory)common.targets" />
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 </Project>

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Utility/XPlatUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Utility/XPlatUtilityTests.cs
@@ -1,0 +1,41 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using NuGet.CommandLine.XPlat;
+using NuGet.Common;
+using Xunit;
+
+namespace NuGet.CommandLine.Xplat.Tests.Utility
+{
+    public class XPlatUtilityTests
+    {
+        [Theory]
+        [InlineData("", LogLevel.Minimal)]
+        [InlineData(null, LogLevel.Minimal)]
+        [InlineData("  ", LogLevel.Minimal)]
+        [InlineData("qu", LogLevel.Minimal)]
+        [InlineData("quiet ", LogLevel.Minimal)]
+        [InlineData(" q", LogLevel.Minimal)]
+        [InlineData("m", LogLevel.Minimal)]
+        [InlineData("M", LogLevel.Minimal)]
+        [InlineData("mInImAl", LogLevel.Minimal)]
+        [InlineData("MINIMAL", LogLevel.Minimal)]
+        [InlineData("something-else-entirely", LogLevel.Minimal)]
+        [InlineData("q", LogLevel.Warning)]
+        [InlineData("quiet", LogLevel.Warning)]
+        [InlineData("Q", LogLevel.Warning)]
+        [InlineData("QUIET", LogLevel.Warning)]
+        [InlineData("n", LogLevel.Information)]
+        [InlineData("normal", LogLevel.Information)]
+        [InlineData("d", LogLevel.Debug)]
+        [InlineData("detailed", LogLevel.Debug)]
+        [InlineData("diag", LogLevel.Debug)]
+        [InlineData("diagnostic", LogLevel.Debug)]
+        public void MSBuildVerbosityToNuGetLogLevel_HasProperMapping(string verbosity, LogLevel expected)
+        {
+            LogLevel actual = XPlatUtility.MSBuildVerbosityToNuGetLogLevel(verbosity);
+
+            Assert.Equal(expected, actual);
+        }
+    }
+}


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9600
Regression: No

## Fix

This introduces a switch `--show-protocol-logs` to the `package list` command in NuGet.CommandLine.Xplat. For example:

```
> dotnet run --framework netcoreapp2.1 -- package list .\NuGet.CommandLine.XPlat.csproj --deprecated --verbosity normal

The following sources were used:
   https://api.nuget.org/v3/index.json
   C:\Users\joelv\.nuget\packages
   C:\Program Files (x86)\Microsoft SDKs\NuGetPackages\

  GET https://api.nuget.org/v3/registration5-gz-semver2/microsoft.sourcelink.github/index.json
  GET https://api.nuget.org/v3/registration5-gz-semver2/microsoft.netcore.app/index.json
  GET https://api.nuget.org/v3/registration5-gz-semver2/system.runtime.serialization.primitives/index.json
  GET https://api.nuget.org/v3/registration5-gz-semver2/microsoft.extensions.commandlineutils/index.json
  GET https://api.nuget.org/v3/registration5-gz-semver2/microsoft.codeanalysis.fxcopanalyzers/index.json
  GET https://api.nuget.org/v3/registration5-gz-semver2/microsoft.build/index.json
  GET https://api.nuget.org/v3/registration5-gz-semver2/microsoft.build.locator/index.json
  OK https://api.nuget.org/v3/registration5-gz-semver2/microsoft.build/index.json 248ms
  OK https://api.nuget.org/v3/registration5-gz-semver2/microsoft.sourcelink.github/index.json 345ms
  OK https://api.nuget.org/v3/registration5-gz-semver2/microsoft.netcore.app/index.json 363ms
  OK https://api.nuget.org/v3/registration5-gz-semver2/microsoft.extensions.commandlineutils/index.json 1205ms
  OK https://api.nuget.org/v3/registration5-gz-semver2/microsoft.codeanalysis.fxcopanalyzers/index.json 1360ms
  OK https://api.nuget.org/v3/registration5-gz-semver2/system.runtime.serialization.primitives/index.json 3338ms
  OK https://api.nuget.org/v3/registration5-gz-semver2/microsoft.build.locator/index.json 3417ms
The given project `NuGet.CommandLine.XPlat` has no deprecated packages given the current sources
```

And without the switch (today's behavior):

```
> dotnet run --framework netcoreapp2.1 -- package list .\NuGet.CommandLine.XPlat.csproj --deprecated

The following sources were used:
   https://api.nuget.org/v3/index.json
   C:\Users\joelv\.nuget\packages
   C:\Program Files (x86)\Microsoft SDKs\NuGetPackages\

The given project `NuGet.CommandLine.XPlat` has no deprecated packages given the current sources.
```
## Alternatives

I'm not totally sold on my own implementation, but it's the best of the options I considered. I considered these other options:

1. Adding a `-v|--verbosity <verbosity>` option. This seems like the best option but it poses two problems:
   1. The log level is [hard coded at the root of the application](https://github.com/NuGet/NuGet.Client/blob/eb9ad919724e5ef435d6321b775868c9f2c0f9a2/src/NuGet.Core/NuGet.CommandLine.XPlat/Program.cs#L76), so it would be strange to have a sub-command override it. In fact it would be tricky since log level is not mutable on `ILogger` which is what `list packages` receives.
   1. If the default log level (`Information`) is left, then HTTP logs would always be visible since they are [logged at the `Information` level](https://github.com/NuGet/NuGet.Client/blob/eb9ad919724e5ef435d6321b775868c9f2c0f9a2/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpRetryHandler.cs#L111-L115). But I don't think we could safely change the default to `Minimal` (thus hiding HTTP logs by default) because that could affect other command's output in undesirable ways.
1. Adding a `--verbose` switch. If I recall correctly, this was removed from nuget.exe at some point in favor of `--verbosity`. Seems like it's the wrong word because of that.
1. Adding a `-d|--diagnostics` switch similar to `dotnet --diagnostics`. I chose not to go this route because I don't know how it would interact with the top level option and from [a GitHub issue](https://github.com/dotnet/sdk/issues/10309#issuecomment-499211751) it seems like the semantics are different.

~So I went with another switch that is more descriptive of what's actually happening. If we introduce `--verbosity` later, it could interact with this new switch however we want (e.g. automatically turn on protocol logs when verbosity is more verbose than `Information` or something like that).~

~I'm totally open to other ideas. I just wanted to put this PR out there to show that I'm willing to do the work. I'm happy to take another approach if it's better.~

I went with option 1 per the design spec.

## Testing/Validation

Tests Added: Yes
Validation: Manual testing with `dotnet run`

I would like to try making the changes to the [.NET SDK wrapper](https://github.com/dotnet/sdk/blob/master/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/ListPackageReferencesCommandParser.cs) but I don't know how to patch the bits locally. Any pointer in this direction would be great!
