### PR TITLE
added license header for code analysis suppression files

### DIFF
--- a/build/TestShared/GlobalSuppressions.cs
+++ b/build/TestShared/GlobalSuppressions.cs
@@ -1,3 +1,5 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 // This file is used by Code Analysis to maintain SuppressMessage 
 // attributes that are applied to this project.

--- a/src/NuGet.Clients/NuGet.CommandLine/GlobalSuppressions.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/GlobalSuppressions.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 // This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given

--- a/src/NuGet.Clients/NuGet.Indexing/GlobalSuppressions.cs
+++ b/src/NuGet.Clients/NuGet.Indexing/GlobalSuppressions.cs
@@ -1,4 +1,7 @@
-﻿// This file is used by Code Analysis to maintain SuppressMessage
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.

--- a/src/NuGet.Clients/NuGet.MSSigning.Extensions/GlobalSuppressions.cs
+++ b/src/NuGet.Clients/NuGet.MSSigning.Extensions/GlobalSuppressions.cs
@@ -1,4 +1,7 @@
-﻿// This file is used by Code Analysis to maintain SuppressMessage
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/GlobalSuppressions.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/GlobalSuppressions.cs
@@ -1,4 +1,7 @@
-﻿// This file is used by Code Analysis to maintain SuppressMessage
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager.Interop/GlobalSuppressions.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager.Interop/GlobalSuppressions.cs
@@ -1,4 +1,7 @@
-﻿// This file is used by Code Analysis to maintain SuppressMessage
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/GlobalSuppressions.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/GlobalSuppressions.cs
@@ -1,3 +1,5 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 // This file is used by Code Analysis to maintain SuppressMessage 
 // attributes that are applied to this project.

--- a/src/NuGet.Clients/NuGet.Tools/GlobalSuppressions.cs
+++ b/src/NuGet.Clients/NuGet.Tools/GlobalSuppressions.cs
@@ -1,3 +1,5 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 // This file is used by Code Analysis to maintain SuppressMessage 
 // attributes that are applied to this project.

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/GlobalSuppressions.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/GlobalSuppressions.cs
@@ -1,4 +1,7 @@
-﻿// This file is used by Code Analysis to maintain SuppressMessage
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/GlobalSuppressions.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/GlobalSuppressions.cs
@@ -1,4 +1,7 @@
-﻿// This file is used by Code Analysis to maintain SuppressMessage
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/GlobalSuppressions.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/GlobalSuppressions.cs
@@ -1,4 +1,7 @@
-﻿// This file is used by Code Analysis to maintain SuppressMessage
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.

--- a/src/NuGet.Clients/NuGet.VisualStudio.OnlineEnvironment.Client/GlobalSuppressions.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.OnlineEnvironment.Client/GlobalSuppressions.cs
@@ -1,4 +1,7 @@
-﻿// This file is used by Code Analysis to maintain SuppressMessage
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.

--- a/src/NuGet.Clients/NuGet.VisualStudio/GlobalSuppressions.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio/GlobalSuppressions.cs
@@ -1,4 +1,7 @@
-﻿// This file is used by Code Analysis to maintain SuppressMessage
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.

--- a/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/GlobalSuppressions.cs
+++ b/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/GlobalSuppressions.cs
@@ -1,4 +1,7 @@
-﻿// This file is used by Code Analysis to maintain SuppressMessage
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.

--- a/src/NuGet.Core/NuGet.Build.Tasks.Console/GlobalSuppressions.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Console/GlobalSuppressions.cs
@@ -1,4 +1,7 @@
-﻿// This file is used by Code Analysis to maintain SuppressMessage
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/GlobalSuppressions.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/GlobalSuppressions.cs
@@ -1,4 +1,7 @@
-﻿// This file is used by Code Analysis to maintain SuppressMessage
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.

--- a/src/NuGet.Core/NuGet.Build.Tasks/GlobalSuppressions.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/GlobalSuppressions.cs
@@ -1,4 +1,7 @@
-﻿// This file is used by Code Analysis to maintain SuppressMessage
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/GlobalSuppressions.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/GlobalSuppressions.cs
@@ -1,4 +1,7 @@
-﻿// This file is used by Code Analysis to maintain SuppressMessage
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.

--- a/src/NuGet.Core/NuGet.Commands/GlobalSuppressions.cs
+++ b/src/NuGet.Core/NuGet.Commands/GlobalSuppressions.cs
@@ -1,4 +1,7 @@
-﻿// This file is used by Code Analysis to maintain SuppressMessage
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.

--- a/src/NuGet.Core/NuGet.Common/GlobalSuppressions.cs
+++ b/src/NuGet.Core/NuGet.Common/GlobalSuppressions.cs
@@ -1,4 +1,7 @@
-﻿// This file is used by Code Analysis to maintain SuppressMessage
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.

--- a/src/NuGet.Core/NuGet.Configuration/GlobalSuppressions.cs
+++ b/src/NuGet.Core/NuGet.Configuration/GlobalSuppressions.cs
@@ -1,4 +1,7 @@
-﻿// This file is used by Code Analysis to maintain SuppressMessage
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.

--- a/src/NuGet.Core/NuGet.Credentials/GlobalSuppressions.cs
+++ b/src/NuGet.Core/NuGet.Credentials/GlobalSuppressions.cs
@@ -1,4 +1,7 @@
-﻿// This file is used by Code Analysis to maintain SuppressMessage
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/GlobalSuppressions.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/GlobalSuppressions.cs
@@ -1,4 +1,7 @@
-﻿// This file is used by Code Analysis to maintain SuppressMessage
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.

--- a/src/NuGet.Core/NuGet.Frameworks/GlobalSuppressions.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/GlobalSuppressions.cs
@@ -1,4 +1,7 @@
-﻿// This file is used by Code Analysis to maintain SuppressMessage
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.

--- a/src/NuGet.Core/NuGet.LibraryModel/GlobalSuppressions.cs
+++ b/src/NuGet.Core/NuGet.LibraryModel/GlobalSuppressions.cs
@@ -1,4 +1,7 @@
-﻿// This file is used by Code Analysis to maintain SuppressMessage
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.

--- a/src/NuGet.Core/NuGet.PackageManagement/GlobalSuppressions.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/GlobalSuppressions.cs
@@ -1,4 +1,7 @@
-﻿// This file is used by Code Analysis to maintain SuppressMessage
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.

--- a/src/NuGet.Core/NuGet.Packaging/GlobalSuppressions.cs
+++ b/src/NuGet.Core/NuGet.Packaging/GlobalSuppressions.cs
@@ -1,4 +1,7 @@
-﻿// This file is used by Code Analysis to maintain SuppressMessage
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.

--- a/src/NuGet.Core/NuGet.ProjectModel/GlobalSuppressions.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/GlobalSuppressions.cs
@@ -1,4 +1,7 @@
-﻿// This file is used by Code Analysis to maintain SuppressMessage
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.

--- a/src/NuGet.Core/NuGet.Protocol/GlobalSuppressions.cs
+++ b/src/NuGet.Core/NuGet.Protocol/GlobalSuppressions.cs
@@ -1,4 +1,7 @@
-﻿// This file is used by Code Analysis to maintain SuppressMessage
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.

--- a/src/NuGet.Core/NuGet.Resolver/GlobalSuppressions.cs
+++ b/src/NuGet.Core/NuGet.Resolver/GlobalSuppressions.cs
@@ -1,4 +1,7 @@
-﻿// This file is used by Code Analysis to maintain SuppressMessage
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.

--- a/src/NuGet.Core/NuGet.Versioning/GlobalSuppressions.cs
+++ b/src/NuGet.Core/NuGet.Versioning/GlobalSuppressions.cs
@@ -1,4 +1,7 @@
-﻿// This file is used by Code Analysis to maintain SuppressMessage
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/GlobalSuppressions.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/GlobalSuppressions.cs
@@ -1,4 +1,6 @@
-﻿
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 // This file is used by Code Analysis to maintain SuppressMessage 
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given 


### PR DESCRIPTION
## Bug

Fixes: NuGet/Client.Engineering#272
Regression: No

## Fix

Details: Added Apache2.0 license information at the top of the file to `GlobalSupressions.cs` files as per [this](https://github.com/NuGet/NuGet.Client/pull/3331#pullrequestreview-393825837) conversation.

## Testing/Validation

Tests Added: No
Reason for not adding tests:  No code change to the product.
Validation:  
