### PR TITLE
Change VS bootstrap channel to public preview to match the one on CI

### DIFF
--- a/scripts/e2etests/VSUtils.ps1
+++ b/scripts/e2etests/VSUtils.ps1
@@ -217,9 +217,9 @@ function UpdateVSInstaller {
 
     $vsMajorVersion = [System.Version]::Parse($VSVersion).Major
 
-    # The internal Preview channel is intentional since the --update command will update the installer to the latest internal preview version.  
+    # The public Preview channel is intentional since the --update command will update the installer to the latest public preview version.  
     # It matches the channel of VS installed on CI 
-    $vsBootstrapperUrl = "https://aka.ms/vs/$vsMajorVersion/IntPreview/vs_enterprise.exe"
+    $vsBootstrapperUrl = "https://aka.ms/vs/$vsMajorVersion/pre/vs_enterprise.exe"
 
     $tempdir = [System.IO.Path]::GetTempPath()
     $VSBootstrapperPath =  "$tempdir" + "vs_enterprise.exe"


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Client.Engineering/issues/328
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: 
Since we changed the VS on CI from internal preview to public preview, we need to change the channel when updating VS installer.

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  
Validation:  
