### PR TITLE
run signing integration tests cross plat

### DIFF
--- a/build/common.targets
+++ b/build/common.targets
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <SigningNotSupported Condition=" '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netcoreapp2.1' OR '$(TargetFramework)' == 'netstandard2.1'">true</SigningNotSupported>
+    <SigningNotSupported Condition=" '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netcoreapp2.1' OR '$(TargetFramework)' == 'netstandard2.1' OR '$(TargetFramework)' == 'netcoreapp3.1'">true</SigningNotSupported>
     <SigningNotSupported Condition=" '$(SigningNotSupported)' != 'true'">false</SigningNotSupported>
   </PropertyGroup>
 

--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -669,7 +669,7 @@ jobs:
 
 - job: Tests_On_Linux
   dependsOn: Initialize_Build
-  timeoutInMinutes: 45
+  timeoutInMinutes: 180
   variables:
     FULLVSTSBUILDNUMBER: $[dependencies.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
     SDKVersionForBuild: $[dependencies.Initialize_Build.outputs['getSDKVersionForBuild.SDKVersionForBuild']]
@@ -738,7 +738,7 @@ jobs:
   dependsOn:
   - Build_and_UnitTest
   - Initialize_Build
-  timeoutInMinutes: 75
+  timeoutInMinutes: 180
   variables:
     FULLVSTSBUILDNUMBER: $[dependencies.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
     SDKVersionForBuild: $[dependencies.Initialize_Build.outputs['getSDKVersionForBuild.SDKVersionForBuild']]

--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -577,7 +577,7 @@ jobs:
     BuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.BuildNumber']]
     FullVstsBuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
     SDKVersionForBuild: $[dependencies.Initialize_Build.outputs['getSDKVersionForBuild.SDKVersionForBuild']]
-  condition: "and(succeeded(),eq(variables['RunFunctionalTestsOnWindows'], 'true')) "
+  condition: "failed() "
   pool:
     name: VSEng-MicroBuildVS2019
     demands:
@@ -928,7 +928,7 @@ jobs:
     BuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.BuildNumber']]
     FullVstsBuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
     SDKVersionForBuild: $[dependencies.Initialize_Build.outputs['getSDKVersionForBuild.SDKVersionForBuild']]
-  condition: "and(succeeded(),eq(variables['RunApexTests'], 'true')) "
+  condition: "failed() "
   pool:
     name: DDNuGet-Windows
     demands:

--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -577,7 +577,7 @@ jobs:
     BuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.BuildNumber']]
     FullVstsBuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
     SDKVersionForBuild: $[dependencies.Initialize_Build.outputs['getSDKVersionForBuild.SDKVersionForBuild']]
-  condition: "failed() "
+  condition: "and(succeeded(),eq(variables['RunFunctionalTestsOnWindows'], 'true')) "
   pool:
     name: VSEng-MicroBuildVS2019
     demands:
@@ -669,7 +669,7 @@ jobs:
 
 - job: Tests_On_Linux
   dependsOn: Initialize_Build
-  timeoutInMinutes: 180
+  timeoutInMinutes: 45
   variables:
     FULLVSTSBUILDNUMBER: $[dependencies.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
     SDKVersionForBuild: $[dependencies.Initialize_Build.outputs['getSDKVersionForBuild.SDKVersionForBuild']]
@@ -738,7 +738,7 @@ jobs:
   dependsOn:
   - Build_and_UnitTest
   - Initialize_Build
-  timeoutInMinutes: 180
+  timeoutInMinutes: 75
   variables:
     FULLVSTSBUILDNUMBER: $[dependencies.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
     SDKVersionForBuild: $[dependencies.Initialize_Build.outputs['getSDKVersionForBuild.SDKVersionForBuild']]
@@ -815,7 +815,7 @@ jobs:
   variables:
     FullVstsBuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
     SDKVersionForBuild: $[dependencies.Initialize_Build.outputs['getSDKVersionForBuild.SDKVersionForBuild']]
-  condition: "failed() "
+  condition: "and(succeeded(),eq(variables['RunEndToEndTests'], 'true')) "
   pool:
     name: DDNuGet-Windows
     demands:
@@ -928,7 +928,7 @@ jobs:
     BuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.BuildNumber']]
     FullVstsBuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
     SDKVersionForBuild: $[dependencies.Initialize_Build.outputs['getSDKVersionForBuild.SDKVersionForBuild']]
-  condition: "failed() "
+  condition: "and(succeeded(),eq(variables['RunApexTests'], 'true')) "
   pool:
     name: DDNuGet-Windows
     demands:

--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -815,7 +815,7 @@ jobs:
   variables:
     FullVstsBuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
     SDKVersionForBuild: $[dependencies.Initialize_Build.outputs['getSDKVersionForBuild.SDKVersionForBuild']]
-  condition: "and(succeeded(),eq(variables['RunEndToEndTests'], 'true')) "
+  condition: "failed() "
   pool:
     name: DDNuGet-Windows
     demands:

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
@@ -150,6 +150,7 @@ EndGlobal";
                 var projectFile = Path.Combine(workingDirectory, $"{projectName}.csproj");                
 
                 _msbuildFixture.CreateDotnetNewProject(pathContext.SolutionRoot, projectName, "classlib");
+                _msbuildFixture.RunDotnet(workingDirectory, "nuget locals all --clear");
 
                 using (var stream = File.Open(projectFile, FileMode.Open, FileAccess.ReadWrite))
                 {
@@ -185,8 +186,7 @@ EndGlobal";
 
                 var args = $"restore --source \"{pathContext.PackageSource}\" -v d";
 
-                // Act
-                _msbuildFixture.RunDotnet(workingDirectory, "nuget locals all --clear");
+                // Act                
                 var result = _msbuildFixture.RunDotnet(workingDirectory, args, ignoreExitCode: true);
 
                 result.AllOutput.Should().Contain($"error NU3004: Package '{packageX.Id} {packageX.Version}' from source '{pathContext.PackageSource}': signatureValidationMode is set to require, so packages are allowed only if signed by trusted signers; however, this package is unsigned.");

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
@@ -83,7 +83,7 @@ EndGlobal";
             }
         }
 
-        [PlatformFact(Platform.Windows)]
+        [Fact]
         public void DotnetRestore_WithAuthorSignedPackage_Succeeds()
         {
             using (var pathContext = _msbuildFixture.CreateSimpleTestPathContext())
@@ -185,7 +185,7 @@ EndGlobal";
             }
         }
 
-        [PlatformFact(Platform.Windows)]
+        [Fact]
         public void WithAuthorSignedPackageAndSignatureValidationModeAsRequired_Succeeds()
         {
             using (var packageSourceDirectory = TestDirectory.Create())

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
@@ -147,9 +147,7 @@ EndGlobal";
 
                 var projectName = "ClassLibrary1";
                 var workingDirectory = Path.Combine(pathContext.SolutionRoot, projectName);
-                var projectFile = Path.Combine(workingDirectory, $"{projectName}.csproj");
-
-                _msbuildFixture.RunDotnet(workingDirectory, "nuget locals all --clear");
+                var projectFile = Path.Combine(workingDirectory, $"{projectName}.csproj");                
 
                 _msbuildFixture.CreateDotnetNewProject(pathContext.SolutionRoot, projectName, "classlib");
 
@@ -187,7 +185,8 @@ EndGlobal";
 
                 var args = $"restore --source \"{pathContext.PackageSource}\" -v d";
 
-                // Act                
+                // Act
+                _msbuildFixture.RunDotnet(workingDirectory, "nuget locals all --clear");
                 var result = _msbuildFixture.RunDotnet(workingDirectory, args, ignoreExitCode: true);
 
                 result.AllOutput.Should().Contain($"error NU3004: Package '{packageX.Id} {packageX.Version}' from source '{pathContext.PackageSource}': signatureValidationMode is set to require, so packages are allowed only if signed by trusted signers; however, this package is unsigned.");

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
@@ -119,6 +119,7 @@ EndGlobal";
             }
         }
 
+#if IS_SIGNING_SUPPORTED
         [Fact]
         public async Task WithUnSignedPackageAndSignatureValidationModeAsRequired_Fails()
         {
@@ -265,6 +266,7 @@ EndGlobal";
                 _msbuildFixture.RestoreProject(workingDirectory, projectName, args);
             }
         }
+#endif //IS_SIGNING_SUPPORTED
 
         [PlatformFact(Platform.Windows)]
         public async Task DotnetRestore_OneLinePerRestore()

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
@@ -188,9 +188,9 @@ EndGlobal";
                 // Act                
                 var result = _msbuildFixture.RunDotnet(workingDirectory, args, ignoreExitCode: true);
 
-                result.Success.Should().BeFalse();
-                result.ExitCode.Should().Be(1, because: "error text should be displayed as restore failed");
                 result.AllOutput.Should().Contain($"error NU3004: Package '{packageX.Id} {packageX.Version}' from source '{pathContext.PackageSource}': signatureValidationMode is set to require, so packages are allowed only if signed by trusted signers; however, this package is unsigned.");
+                result.Success.Should().BeFalse();
+                result.ExitCode.Should().Be(1, because: "error text should be displayed as restore failed");                
             }
         }
 

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
@@ -121,7 +121,7 @@ EndGlobal";
 
 #if IS_SIGNING_SUPPORTED
         [Fact]
-        public async Task WithUnSignedPackageAndSignatureValidationModeAsRequired_Fails()
+        public async Task DotnetRestore_WithUnSignedPackageAndSignatureValidationModeAsRequired_Fails()
         {
             using (var pathContext = _msbuildFixture.CreateSimpleTestPathContext())
             {
@@ -193,7 +193,7 @@ EndGlobal";
         }
 
         [Fact]
-        public void WithAuthorSignedPackageAndSignatureValidationModeAsRequired_Succeeds()
+        public void DotnetRestore_WithAuthorSignedPackageAndSignatureValidationModeAsRequired_Succeeds()
         {
             using (var pathContext = _msbuildFixture.CreateSimpleTestPathContext())
             {

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Runtime.ConstrainedExecution;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 using FluentAssertions;

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
@@ -149,6 +149,8 @@ EndGlobal";
                 var workingDirectory = Path.Combine(pathContext.SolutionRoot, projectName);
                 var projectFile = Path.Combine(workingDirectory, $"{projectName}.csproj");
 
+                _msbuildFixture.RunDotnet(workingDirectory, "nuget locals all --clear");
+
                 _msbuildFixture.CreateDotnetNewProject(pathContext.SolutionRoot, projectName, "classlib");
 
                 using (var stream = File.Open(projectFile, FileMode.Open, FileAccess.ReadWrite))
@@ -183,7 +185,7 @@ EndGlobal";
 
                 File.WriteAllText(Path.Combine(workingDirectory, "NuGet.Config"), doc.ToString());
 
-                var args = $"restore --source \"{pathContext.PackageSource}\" ";
+                var args = $"restore --source \"{pathContext.PackageSource}\" -v d";
 
                 // Act                
                 var result = _msbuildFixture.RunDotnet(workingDirectory, args, ignoreExitCode: true);

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
@@ -111,7 +111,7 @@ EndGlobal";
                         xml,
                         "PackageReference",
                         "TestPackage.AuthorSigned",
-                        "net472",
+                        string.Empty,
                         new Dictionary<string, string>(),
                         attributes);
 
@@ -122,19 +122,11 @@ EndGlobal";
             }
         }
 
-        [PlatformFact(Platform.Windows)]
+        [Fact]
         public async Task WithUnSignedPackageAndSignatureValidationModeAsRequired_Fails()
         {
             using (var pathContext = new SimpleTestPathContext())
             {
-                // Set up solution, and project
-                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
-
-                var projectA = SimpleTestProjectContext.CreateNETCore(
-                   "a",
-                   pathContext.SolutionRoot,
-                   NuGetFramework.Parse("net472"));
-
                 //Setup packages and feed
                 var packageX = new SimpleTestPackageContext()
                 {
@@ -152,12 +144,33 @@ EndGlobal";
                     PackageSaveMode.Defaultv3,
                     packageX);
 
-                //add the packe to the project
-                projectA.AddPackageToAllFrameworks(packageX);
-                solution.Projects.Add(projectA);
-                solution.Create(pathContext.SolutionRoot);
-                solution.Save();
-                projectA.Save();
+                // Set up solution, and project
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+
+                var projectName = "ClassLibrary1";
+                var workingDirectory = Path.Combine(pathContext.SolutionRoot, projectName);
+                var projectFile = Path.Combine(workingDirectory, $"{projectName}.csproj");
+
+                _msbuildFixture.CreateDotnetNewProject(pathContext.SolutionRoot, projectName, " classlib");
+
+                using (var stream = File.Open(projectFile, FileMode.Open, FileAccess.ReadWrite))
+                {
+                    var xml = XDocument.Load(stream);
+
+                    //ProjectFileUtils.SetTargetFrameworkForProject(xml, "TargetFrameworks", "net472");
+
+                    var attributes = new Dictionary<string, string>() { { "Version", "1.0.0" } };
+
+                    ProjectFileUtils.AddItem(
+                        xml,
+                        "PackageReference",
+                        packageX.Id,
+                        string.Empty,
+                        new Dictionary<string, string>(),
+                        attributes);
+
+                    ProjectFileUtils.WriteXmlToFile(xml, stream);
+                }
 
                 //set nuget.config properties
                 var doc = new XDocument();
@@ -177,7 +190,7 @@ EndGlobal";
                 var args = $"restore --source \"{pathContext.PackageSource}\" ";
 
                 // Act                
-                var result = _msbuildFixture.RunDotnet(pathContext.SolutionRoot, args, ignoreExitCode: true);
+                var result = _msbuildFixture.RunDotnet(workingDirectory, args, ignoreExitCode: true);
 
                 result.Success.Should().BeFalse();
                 result.ExitCode.Should().Be(1, because: "error text should be displayed as restore failed");
@@ -206,7 +219,7 @@ EndGlobal";
                 {
                     var xml = XDocument.Load(stream);
 
-                    ProjectFileUtils.SetTargetFrameworkForProject(xml, "TargetFrameworks", "net472");
+                    //ProjectFileUtils.SetTargetFrameworkForProject(xml, "TargetFrameworks", "net472");
 
                     var attributes = new Dictionary<string, string>() { { "Version", "1.0.0" } };
 
@@ -214,7 +227,7 @@ EndGlobal";
                         xml,
                         "PackageReference",
                         "TestPackage.AuthorSigned",
-                        "net472",
+                        string.Empty,
                         new Dictionary<string, string>(),
                         attributes);
 

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
@@ -149,7 +149,7 @@ EndGlobal";
                 var workingDirectory = Path.Combine(pathContext.SolutionRoot, projectName);
                 var projectFile = Path.Combine(workingDirectory, $"{projectName}.csproj");
 
-                _msbuildFixture.CreateDotnetNewProject(pathContext.SolutionRoot, projectName, " classlib");
+                _msbuildFixture.CreateDotnetNewProject(pathContext.SolutionRoot, projectName, "classlib");
 
                 using (var stream = File.Open(projectFile, FileMode.Open, FileAccess.ReadWrite))
                 {
@@ -181,7 +181,7 @@ EndGlobal";
                 signatureValidationMode.Add(new XAttribute(XName.Get("value"), "require"));
                 config.Add(signatureValidationMode);
 
-                File.WriteAllText(pathContext.NuGetConfig, doc.ToString());
+                File.WriteAllText(Path.Combine(workingDirectory, "NuGet.Config"), doc.ToString());
 
                 var args = $"restore --source \"{pathContext.PackageSource}\" ";
 
@@ -209,7 +209,7 @@ EndGlobal";
                 var workingDirectory = Path.Combine(testDirectory, projectName);
                 var projectFile = Path.Combine(workingDirectory, $"{projectName}.csproj");
 
-                _msbuildFixture.CreateDotnetNewProject(testDirectory.Path, projectName, " classlib");
+                _msbuildFixture.CreateDotnetNewProject(testDirectory.Path, projectName, "classlib");
 
                 using (var stream = File.Open(projectFile, FileMode.Open, FileAccess.ReadWrite))
                 {

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
@@ -103,8 +103,6 @@ EndGlobal";
                 {
                     var xml = XDocument.Load(stream);
 
-                    ProjectFileUtils.SetTargetFrameworkForProject(xml, "TargetFrameworks", "net472");
-
                     var attributes = new Dictionary<string, string>() { { "Version", "1.0.0" } };
 
                     ProjectFileUtils.AddItem(
@@ -156,8 +154,6 @@ EndGlobal";
                 using (var stream = File.Open(projectFile, FileMode.Open, FileAccess.ReadWrite))
                 {
                     var xml = XDocument.Load(stream);
-
-                    //ProjectFileUtils.SetTargetFrameworkForProject(xml, "TargetFrameworks", "net472");
 
                     var attributes = new Dictionary<string, string>() { { "Version", "1.0.0" } };
 
@@ -218,8 +214,6 @@ EndGlobal";
                 using (var stream = File.Open(projectFile, FileMode.Open, FileAccess.ReadWrite))
                 {
                     var xml = XDocument.Load(stream);
-
-                    //ProjectFileUtils.SetTargetFrameworkForProject(xml, "TargetFrameworks", "net472");
 
                     var attributes = new Dictionary<string, string>() { { "Version", "1.0.0" } };
 


### PR DESCRIPTION
## Bug

Fixes: NuGet/Home#9287

Regression: No

## Fix

Details: Added `dotnet` integration tests that run cross platform for below scenarios
- `dotnet` restore with unsigned package and `signatureValidationMode` set to `require`
- `dotnet` restore with author signed package and `signatureValidationMode` set to `require`
- `DotnetRestore_WithAuthorSignedPackage_Succeeds` enabled this existing test to run cross platform

## Testing/Validation

Tests Added: Yes/No  
Reason for not adding tests:  
Validation:  
