### PR TITLE
add TFM netcoreapp5.0 to N.B.T.Console and N.P.Core projects

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Console/NuGet.Build.Tasks.Console.csproj
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Console/NuGet.Build.Tasks.Console.csproj
@@ -1,4 +1,8 @@
 <Project>
+  <PropertyGroup>
+  <RequiresSigningXplatAPIs>true</RequiresSigningXplatAPIs>
+  </PropertyGroup>
+  
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common.props" />
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 

--- a/src/NuGet.Core/NuGet.Build.Tasks.Console/NuGet.Build.Tasks.Console.csproj
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Console/NuGet.Build.Tasks.Console.csproj
@@ -1,8 +1,8 @@
 <Project>
   <PropertyGroup>
-  <RequiresSigningXplatAPIs>true</RequiresSigningXplatAPIs>
+    <RequiresSigningXplatAPIs>true</RequiresSigningXplatAPIs>
   </PropertyGroup>
-  
+
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common.props" />
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 

--- a/src/NuGet.Core/NuGet.Packaging.Core/NuGet.Packaging.Core.csproj
+++ b/src/NuGet.Core/NuGet.Packaging.Core/NuGet.Packaging.Core.csproj
@@ -1,4 +1,8 @@
 <Project>
+  <PropertyGroup>
+  <RequiresSigningXplatAPIs>true</RequiresSigningXplatAPIs>
+  </PropertyGroup>
+  
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common.props" />
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 

--- a/src/NuGet.Core/NuGet.Packaging.Core/NuGet.Packaging.Core.csproj
+++ b/src/NuGet.Core/NuGet.Packaging.Core/NuGet.Packaging.Core.csproj
@@ -1,8 +1,8 @@
 <Project>
   <PropertyGroup>
-  <RequiresSigningXplatAPIs>true</RequiresSigningXplatAPIs>
+    <RequiresSigningXplatAPIs>true</RequiresSigningXplatAPIs>
   </PropertyGroup>
-  
+
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common.props" />
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9605
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: 
The code map changed a little bit after we adding netstandard2.1(now netcoreapp5.0) to NuGet.Packaging related projects.
So adding netcoreapp5.0 TFM for NuGet.Build.Tasks.Console and NuGet.Packaging.Core projects

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  
Validation:  
