### PR TITLE
Add support for multiple config files in the %APPDATA%\NuGet\config directory

### DIFF
--- a/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceProvider.cs
@@ -745,7 +745,9 @@ namespace NuGet.Configuration
         private Dictionary<string, SourceItem> GetExistingSettingsLookup()
         {
             var sourcesSection = Settings.GetSection(ConfigurationConstants.PackageSources);
-            var existingSettings = sourcesSection?.Items.OfType<SourceItem>().Where(c => !c.Origin?.IsMachineWide ?? true).ToList();
+            var existingSettings = sourcesSection?.Items.OfType<SourceItem>().Where(
+                c => !(c.Origin == null || c.Origin.IsReadOnly || c.Origin.IsMachineWide))
+                .ToList();
 
             var existingSettingsLookup = new Dictionary<string, SourceItem>(StringComparer.OrdinalIgnoreCase);
             if (existingSettings != null)

--- a/src/NuGet.Core/NuGet.Configuration/Resources.Designer.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Resources.Designer.cs
@@ -124,7 +124,16 @@ namespace NuGet.Configuration {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to There are several client certificate configurations associated to same package source(s): {0}.
+        ///   Looks up a localized string similar to Unable to update setting since it is in uneditable configuration..
+        /// </summary>
+        internal static string CannotUpdateReadOnlyConfig {
+            get {
+                return ResourceManager.GetString("CannotUpdateReadOnlyConfig", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to There are multiple client certificate configurations associated with the same package source(s): {0}.
         /// </summary>
         internal static string ClientCertificateDuplicateConfiguration {
             get {
@@ -205,7 +214,7 @@ namespace NuGet.Configuration {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Certificate for &apos;{0}&apos; package source was not found in &apos;{1}.{2}&apos; storage by &apos;{3}&apos; criteria with &apos;{4}&apos; value..
+        ///   Looks up a localized string similar to Certificate for the package source &apos;{0}&apos; was not found in &apos;{1}.{2}&apos; storage by &apos;{3}&apos; criteria with &apos;{4}&apos; value..
         /// </summary>
         internal static string Error_StoreCertCertificateNotFound {
             get {
@@ -214,7 +223,7 @@ namespace NuGet.Configuration {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to It is denied to use password and clearTextPassword at the same time..
+        ///   Looks up a localized string similar to Password and ClearTextPassword cannot be used at the same time..
         /// </summary>
         internal static string FileCertItemPasswordAndClearTextPasswordAtSameTime {
             get {
@@ -223,7 +232,7 @@ namespace NuGet.Configuration {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to From file client certificate configuration password for &apos;{0}&apos; package source cannot be decrypted.
+        ///   Looks up a localized string similar to Client certificate configuration password for the package source &apos;{0}&apos; cannot be decrypted.
         /// </summary>
         internal static string FileCertItemPasswordCannotBeDecrypted {
             get {
@@ -232,7 +241,7 @@ namespace NuGet.Configuration {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to A fileCert path attribute points on non existing file..
+        ///   Looks up a localized string similar to A fileCert path specified a file that does not exist..
         /// </summary>
         internal static string FileCertItemPathFileNotExist {
             get {
@@ -241,7 +250,7 @@ namespace NuGet.Configuration {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to A fileCert item path not set..
+        ///   Looks up a localized string similar to A fileCert item path was not set..
         /// </summary>
         internal static string FileCertItemPathFileNotSet {
             get {

--- a/src/NuGet.Core/NuGet.Configuration/Resources.Designer.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Resources.Designer.cs
@@ -124,7 +124,7 @@ namespace NuGet.Configuration {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Unable to update setting since it is in uneditable configuration..
+        ///   Looks up a localized string similar to Unable to update setting since it is in an uneditable config file..
         /// </summary>
         internal static string CannotUpdateReadOnlyConfig {
             get {

--- a/src/NuGet.Core/NuGet.Configuration/Resources.resx
+++ b/src/NuGet.Core/NuGet.Configuration/Resources.resx
@@ -297,6 +297,6 @@
     <comment>0 - Package name</comment>
   </data>
   <data name="CannotUpdateReadOnlyConfig" xml:space="preserve">
-    <value>Unable to update setting since it is in uneditable configuration.</value>
+    <value>Unable to update setting since it is in an uneditable config file.</value>
   </data>
 </root>

--- a/src/NuGet.Core/NuGet.Configuration/Resources.resx
+++ b/src/NuGet.Core/NuGet.Configuration/Resources.resx
@@ -296,4 +296,7 @@
     <value>Client certificate configuration password for the package source '{0}' cannot be decrypted</value>
     <comment>0 - Package name</comment>
   </data>
+  <data name="CannotUpdateReadOnlyConfig" xml:space="preserve">
+    <value>Unable to update setting since it is in uneditable configuration.</value>
+  </data>
 </root>

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Items/AddItem.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Items/AddItem.cs
@@ -77,7 +77,7 @@ namespace NuGet.Configuration
 
         public void AddOrUpdateAdditionalAttribute(string attributeName, string value)
         {
-            if (Origin != null && Origin.IsMachineWide)
+            if (Origin != null && Origin.IsReadOnly)
             {
                 return;
             }

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Items/FileClientCertItem.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Items/FileClientCertItem.cs
@@ -26,8 +26,8 @@ namespace NuGet.Configuration
                    password,
                    storePasswordInClearText,
                    string.IsNullOrWhiteSpace(settingsFilePath)
-                       ? null
-                       : new SettingsFile(Path.GetDirectoryName(settingsFilePath), Path.GetFileName(settingsFilePath), false))
+                       ? null // TODO NK - Do we know this?
+                       : new SettingsFile(Path.GetDirectoryName(settingsFilePath), Path.GetFileName(settingsFilePath), isMachineWide: false, isReadOnly: false))
         {
         }
 

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Items/FileClientCertItem.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Items/FileClientCertItem.cs
@@ -26,7 +26,7 @@ namespace NuGet.Configuration
                    password,
                    storePasswordInClearText,
                    string.IsNullOrWhiteSpace(settingsFilePath)
-                       ? null // TODO NK - Do we know this?
+                       ? null
                        : new SettingsFile(Path.GetDirectoryName(settingsFilePath), Path.GetFileName(settingsFilePath), isMachineWide: false, isReadOnly: false))
         {
         }

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Items/UnknownItem.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Items/UnknownItem.cs
@@ -85,6 +85,12 @@ namespace NuGet.Configuration
                 throw new InvalidOperationException(Resources.CannotUpdateMachineWide);
             }
 
+            if (Origin != null && Origin.IsReadOnly)
+            {
+                throw new InvalidOperationException(Resources.CannotUpdateReadOnlyConfig);
+            }
+
+
             if (!_mutableChildren.ContainsKey(setting) && !setting.IsEmpty())
             {
                 _mutableChildren.Add(setting, setting);
@@ -125,6 +131,11 @@ namespace NuGet.Configuration
             if (Origin != null && Origin.IsMachineWide)
             {
                 throw new InvalidOperationException(Resources.CannotUpdateMachineWide);
+            }
+
+            if (Origin != null && Origin.IsReadOnly)
+            {
+                throw new InvalidOperationException(Resources.CannotUpdateReadOnlyConfig);
             }
 
             if (_mutableChildren.TryGetValue(setting, out var currentSetting) && _mutableChildren.Remove(currentSetting))

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Items/UnknownItem.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Items/UnknownItem.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Xml.Linq;
-using NuGet.Shared;
 
 namespace NuGet.Configuration
 {
@@ -89,7 +88,6 @@ namespace NuGet.Configuration
             {
                 throw new InvalidOperationException(Resources.CannotUpdateReadOnlyConfig);
             }
-
 
             if (!_mutableChildren.ContainsKey(setting) && !setting.IsEmpty())
             {

--- a/src/NuGet.Core/NuGet.Configuration/Settings/SettingItem.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/SettingItem.cs
@@ -51,6 +51,11 @@ namespace NuGet.Configuration
                 throw new InvalidOperationException(Resources.CannotUpdateMachineWide);
             }
 
+            if (Origin != null && Origin.IsReadOnly)
+            {
+                throw new InvalidOperationException(Resources.CannotUpdateReadOnlyConfig);
+            }
+
             if (setting.GetType() != GetType())
             {
                 throw new InvalidOperationException(Resources.CannotUpdateDifferentItems);

--- a/src/NuGet.Core/NuGet.Configuration/Settings/SettingSection.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/SettingSection.cs
@@ -54,14 +54,14 @@ namespace NuGet.Configuration
 
         internal bool Update(SettingItem item)
         {
-            if (item == null || (Origin != null && Origin.IsMachineWide))
+            if (item == null || (Origin != null && Origin.IsReadOnly))
             {
                 return false;
             }
 
             if (TryGetChild(item, out var currentChild))
             {
-                if (currentChild.Origin != null && currentChild.Origin.IsMachineWide)
+                if (currentChild.Origin != null && currentChild.Origin.IsReadOnly)
                 {
                     return false;
                 }

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
@@ -564,14 +564,15 @@ namespace NuGet.Configuration
 
                 yield return userSpecificSettings;
 
-                // For backwards compatibility, we first return default user specific the non-default configs and then the additional files from the directory
+                // For backwards compatibility, we first return default user specific the non-default configs and then the additional files from the nested `config` directory
+                var additionalConfigurationPath = GetAdditionalUserWideConfigurationDirectory(userSettingsDir);
                 foreach (var file in FileSystemUtility
-                    .GetFilesRelativeToRoot(root: userSettingsDir, filters: SupportedMachineWideConfigExtension, searchOption: SearchOption.TopDirectoryOnly)
+                    .GetFilesRelativeToRoot(root: additionalConfigurationPath, filters: SupportedMachineWideConfigExtension, searchOption: SearchOption.TopDirectoryOnly)
                     .OrderBy(e => e, PathUtility.GetStringComparerBasedOnOS()))
                 {
                     if (!PathUtility.GetStringComparerBasedOnOS().Equals(DefaultSettingsFileName, file))
                     {
-                        var settings = ReadSettings(userSettingsDir, file, isMachineWideSettings: false, isAdditionalUserWideConfig: true);
+                        var settings = ReadSettings(additionalConfigurationPath, file, isMachineWideSettings: false, isAdditionalUserWideConfig: true);
                         if (settings != null)
                         {
                             yield return settings;
@@ -598,6 +599,11 @@ namespace NuGet.Configuration
             return useTestingGlobalPath
                 ? Path.Combine(rootDirectory, "TestingGlobalPath")
                 : NuGetEnvironment.GetFolderPath(NuGetFolderPath.UserSettingsDirectory);
+        }
+
+        private static string GetAdditionalUserWideConfigurationDirectory(string userSettingsDirectory)
+        {
+            return Path.Combine(userSettingsDirectory, "config");
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
@@ -560,7 +560,9 @@ namespace NuGet.Configuration
                 yield return userSpecificSettings;
 
                 // For backwards compatibility, we first return default user specific the non-default configs and then the additional files from the directory
-                foreach (var file in FileSystemUtility.GetFilesRelativeToRoot(root: userSettingsDir, filters: SupportedMachineWideConfigExtension, searchOption: SearchOption.TopDirectoryOnly))
+                foreach (var file in FileSystemUtility
+                    .GetFilesRelativeToRoot(root: userSettingsDir, filters: SupportedMachineWideConfigExtension, searchOption: SearchOption.TopDirectoryOnly)
+                    .OrderBy(e => e, PathUtility.GetStringComparerBasedOnOS()))
                 {
                     if (!PathUtility.GetStringComparerBasedOnOS().Equals(DefaultSettingsFileName, file))
                     {

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
@@ -603,7 +603,7 @@ namespace NuGet.Configuration
 
         private static string GetAdditionalUserWideConfigurationDirectory(string userSettingsDirectory)
         {
-            return Path.Combine(userSettingsDirectory, "config");
+            return Path.Combine(userSettingsDirectory, ConfigurationConstants.Config);
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Configuration/Settings/SettingsFile.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/SettingsFile.cs
@@ -43,7 +43,7 @@ namespace NuGet.Configuration
         /// Determines if the settings file is read only. 
         /// </summary>
         /// <remarks>User-wide configuration files imported from non-default locations are not considered editable.
-        /// Note that this is different from <see cref="IsMachineWide"/>. Every machine-wide config will return `true`. </remarks>
+        /// Note that this is different from <see cref="IsMachineWide"/>. <see cref="IsReadOnly"/> will return <see langword="true"/> for every machine-wide config. </remarks>
         internal bool IsReadOnly { get; }
 
         /// <summary>
@@ -83,8 +83,8 @@ namespace NuGet.Configuration
         /// if it doesn't exist it will create one with the default configuration.</remarks>
         /// <param name="directoryPath">path to the directory where the file is</param>
         /// <param name="fileName">name of config file</param>
-        /// <param name="isMachineWide">specifies if the SettingsFile is machine wide</param>
-        /// <param name="isReadOnly">specifies if the SettingsFile is from the additional user wide configuration path.</param>
+        /// <param name="isMachineWide">specifies if the SettingsFile is machine wide.</param>
+        /// <param name="isReadOnly">specifies if the SettingsFile is read only. If the config is machine wide, the value passed here is irrelevant. <see cref="IsReadOnly"/> will return <see langword="true"/> for every machine-wide config.</param>
         public SettingsFile(string directoryPath, string fileName, bool isMachineWide, bool isReadOnly)
         {
             if (string.IsNullOrEmpty(directoryPath))

--- a/src/NuGet.Core/NuGet.Configuration/Settings/SettingsFile.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/SettingsFile.cs
@@ -36,11 +36,11 @@ namespace NuGet.Configuration
         /// <summary>
         /// Defines if the settings file is considered a machine wide settings file
         /// </summary>
-        /// <remarks>Machine wide settings files cannot be eddited.</remarks>
+        /// <remarks>Machine wide settings files cannot be edited.</remarks>
         internal bool IsMachineWide { get; }
 
         /// <summary>
-        /// Determines if the settings file is read only. 
+        /// Determines if the settings file is considered read-only from NuGet perspective.
         /// </summary>
         /// <remarks>User-wide configuration files imported from non-default locations are not considered editable.
         /// Note that this is different from <see cref="IsMachineWide"/>. <see cref="IsReadOnly"/> will return <see langword="true"/> for every machine-wide config. </remarks>

--- a/src/NuGet.Core/NuGet.Configuration/Settings/SettingsFile.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/SettingsFile.cs
@@ -40,6 +40,13 @@ namespace NuGet.Configuration
         internal bool IsMachineWide { get; }
 
         /// <summary>
+        /// Determines if the settings file is read only. 
+        /// </summary>
+        /// <remarks>User-wide configuration files imported from non-default locations are not considered editable.
+        /// Note that this is different from <see cref="IsMachineWide"/>. Every machine-wide config will return `true`. </remarks>
+        internal bool IsReadOnly { get; }
+
+        /// <summary>
         /// XML element for settings file
         /// </summary>
         private readonly XDocument _xDocument;
@@ -55,7 +62,7 @@ namespace NuGet.Configuration
         /// </summary>
         /// <param name="directoryPath">path to the directory where the file is</param>
         public SettingsFile(string directoryPath)
-            : this(directoryPath, Settings.DefaultSettingsFileName, isMachineWide: false)
+            : this(directoryPath, Settings.DefaultSettingsFileName, isMachineWide: false, isReadOnly: false)
         {
         }
 
@@ -65,7 +72,7 @@ namespace NuGet.Configuration
         /// <param name="directoryPath">path to the directory where the file is</param>
         /// <param name="fileName">name of config file</param>
         public SettingsFile(string directoryPath, string fileName)
-            : this(directoryPath, fileName, isMachineWide: false)
+            : this(directoryPath, fileName, isMachineWide: false, isReadOnly: false)
         {
         }
 
@@ -77,7 +84,8 @@ namespace NuGet.Configuration
         /// <param name="directoryPath">path to the directory where the file is</param>
         /// <param name="fileName">name of config file</param>
         /// <param name="isMachineWide">specifies if the SettingsFile is machine wide</param>
-        public SettingsFile(string directoryPath, string fileName, bool isMachineWide)
+        /// <param name="isReadOnly">specifies if the SettingsFile is from the additional user wide configuration path.</param>
+        public SettingsFile(string directoryPath, string fileName, bool isMachineWide, bool isReadOnly)
         {
             if (string.IsNullOrEmpty(directoryPath))
             {
@@ -98,6 +106,7 @@ namespace NuGet.Configuration
             FileName = fileName;
             ConfigFilePath = Path.GetFullPath(Path.Combine(DirectoryPath, FileName));
             IsMachineWide = isMachineWide;
+            IsReadOnly = IsMachineWide || isReadOnly;
 
             XDocument config = null;
             ExecuteSynchronized(() =>

--- a/src/NuGet.Core/NuGet.Configuration/Settings/SettingsGroup.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/SettingsGroup.cs
@@ -97,6 +97,11 @@ namespace NuGet.Configuration
                 throw new InvalidOperationException(Resources.CannotUpdateMachineWide);
             }
 
+            if (Origin.IsReadOnly)
+            {
+                throw new InvalidOperationException(Resources.CannotUpdateReadOnlyConfig);
+            }
+
             if (!Children.Contains(setting) && !setting.IsEmpty())
             {
                 Children.Add(setting);
@@ -125,6 +130,11 @@ namespace NuGet.Configuration
             if (Origin != null && Origin.IsMachineWide)
             {
                 throw new InvalidOperationException(Resources.CannotUpdateMachineWide);
+            }
+
+            if (Origin != null && Origin.IsReadOnly)
+            {
+                throw new InvalidOperationException(Resources.CannotUpdateReadOnlyConfig);
             }
 
             if (TryGetChild(setting, out var currentSetting) && Children.Remove(currentSetting))

--- a/src/NuGet.Core/NuGet.Configuration/Settings/SettingsLoadingContext.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/SettingsLoadingContext.cs
@@ -21,7 +21,7 @@ namespace NuGet.Configuration
             _semaphore = new SemaphoreSlim(initialCount: 1, maxCount: 1);
         }
 
-        internal SettingsFile GetOrCreateSettingsFile(string filePath, bool isMachineWide = false)
+        internal SettingsFile GetOrCreateSettingsFile(string filePath, bool isMachineWide = false, bool isReadOnly = false)
         {
             if (_isDisposed)
             {
@@ -47,7 +47,7 @@ namespace NuGet.Configuration
                 }
 
                 var file = new FileInfo(filePath);
-                settingsFile = new Lazy<SettingsFile>(() => new SettingsFile(file.DirectoryName, file.Name, isMachineWide));
+                settingsFile = new Lazy<SettingsFile>(() => new SettingsFile(file.DirectoryName, file.Name, isMachineWide, isReadOnly));
                 _settingsFiles.Add(settingsFile);
             }
             finally

--- a/src/NuGet.Core/NuGet.Configuration/Settings/VirtualSettingSection.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/VirtualSettingSection.cs
@@ -99,6 +99,11 @@ namespace NuGet.Configuration
                     throw new InvalidOperationException(Resources.CannotUpdateMachineWide);
                 }
 
+                if (currentSetting.Origin != null && currentSetting.Origin.IsReadOnly)
+                {
+                    throw new InvalidOperationException(Resources.CannotUpdateReadOnlyConfig);
+                }
+
                 if (Children.Remove(currentSetting))
                 {
                     // Remove it from the appropriate config

--- a/src/NuGet.Core/NuGet.Configuration/Utility/FileSystemUtility.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Utility/FileSystemUtility.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -29,7 +29,7 @@ namespace NuGet.Configuration
             return File.Exists(Path.Combine(root, file));
         }
 
-        internal static IEnumerable<string> GetFilesRelativeToRoot(string root, string path, string[] filters = null, SearchOption searchOption = SearchOption.TopDirectoryOnly)
+        internal static IEnumerable<string> GetFilesRelativeToRoot(string root, string path = "", string[] filters = null, SearchOption searchOption = SearchOption.TopDirectoryOnly)
         {
             path = EnsureTrailingSlash(Path.Combine(root, path));
             if (filters == null || !filters.Any())

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
@@ -1763,7 +1763,7 @@ namespace NuGet.Configuration.Test
 ";
 
                 File.WriteAllText(Path.Combine(directory.Path, "machinewide.config"), machineWideContents);
-                var additionalConfigPath = Path.Combine(directory.Path, "TestingGlobalPath", "contoso.nuget.config");
+                var additionalConfigPath = Path.Combine(directory.Path, "TestingGlobalPath", "config", "contoso.nuget.config");
                 Directory.CreateDirectory(Path.GetDirectoryName(additionalConfigPath));
                 File.WriteAllText(additionalConfigPath, additionalConfigContents);
 

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/CredentialsItemTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/CredentialsItemTests.cs
@@ -301,7 +301,7 @@ namespace NuGet.Configuration.Test
                 // Assert
                 ex.Should().NotBeNull();
                 ex.Should().BeOfType<InvalidOperationException>();
-                ex.Message.Should().Be("Unable to update setting since it is in an uneditable config file.");
+                ex.Message.Should().Be(Resources.CannotUpdateReadOnlyConfig);
 
                 credentials.Password.Should().Be("pass");
             }

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/CredentialsItemTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/CredentialsItemTests.cs
@@ -281,6 +281,33 @@ namespace NuGet.Configuration.Test
         }
 
         [Fact]
+        public void CredentialsItem_Update_WhenOriginIsReadOnly_Throws()
+        {
+            // Arrange
+            using (var mockBaseDirectory = TestDirectory.Create())
+            {
+                var origin = new SettingsFile(mockBaseDirectory, fileName: Settings.DefaultSettingsFileName, isMachineWide: false, isReadOnly: true);
+
+                var xelement = new XElement("name",
+                                new XElement("add", new XAttribute("key", "Username"), new XAttribute("value", "user")),
+                                new XElement("add", new XAttribute("key", "Password"), new XAttribute("value", "pass")));
+
+                var credentials = new CredentialsItem(xelement, origin);
+
+                // Act
+                var ex = Record.Exception(() =>
+                    credentials.Update(new CredentialsItem("name", "user", "notpass", isPasswordClearText: true, validAuthenticationTypes: null)));
+
+                // Assert
+                ex.Should().NotBeNull();
+                ex.Should().BeOfType<InvalidOperationException>();
+                ex.Message.Should().Be("Unable to update setting since it is in uneditable configuration.");
+
+                credentials.Password.Should().Be("pass");
+            }
+        }
+
+        [Fact]
         public void CredentialsItem_Update_ChangeUsername_UpdatesObjectAndXNode()
         {
             // Arrange

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/CredentialsItemTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/CredentialsItemTests.cs
@@ -301,7 +301,7 @@ namespace NuGet.Configuration.Test
                 // Assert
                 ex.Should().NotBeNull();
                 ex.Should().BeOfType<InvalidOperationException>();
-                ex.Message.Should().Be("Unable to update setting since it is in uneditable configuration.");
+                ex.Message.Should().Be("Unable to update setting since it is in an uneditable config file.");
 
                 credentials.Password.Should().Be("pass");
             }

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/CredentialsItemTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/CredentialsItemTests.cs
@@ -259,7 +259,7 @@ namespace NuGet.Configuration.Test
             // Arrange
             using (var mockBaseDirectory = TestDirectory.Create())
             {
-                var origin = new SettingsFile(mockBaseDirectory, fileName: Settings.DefaultSettingsFileName, isMachineWide: true);
+                var origin = new SettingsFile(mockBaseDirectory, fileName: Settings.DefaultSettingsFileName, isMachineWide: true, isReadOnly: false);
 
                 var xelement = new XElement("name",
                                 new XElement("add", new XAttribute("key", "Username"), new XAttribute("value", "user")),

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/SettingSectionTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/SettingSectionTests.cs
@@ -237,6 +237,47 @@ namespace NuGet.Configuration.Test
         }
 
         [Fact]
+        public void SettingSection_AddOrUpdate_ToReadOnly_Throws()
+        {
+            // Arrange
+            var nugetConfigPath = "NuGet.Config";
+            var config = @"
+<configuration>
+    <Section>
+        <add key='key0' value='value0' />
+        <add key='key1' value='value1' meta1='data1' meta2='data2'/>
+    </Section>
+</configuration>";
+
+            using (var mockBaseDirectory = TestDirectory.Create())
+            {
+                SettingsTestUtils.CreateConfigurationFile(nugetConfigPath, mockBaseDirectory, config);
+                var configFileHash = SettingsTestUtils.GetFileHash(Path.Combine(mockBaseDirectory, nugetConfigPath));
+
+                var settingsFile = new SettingsFile(mockBaseDirectory, nugetConfigPath, isMachineWide: false, isReadOnly: true);
+
+                // Act
+                var section = settingsFile.GetSection("Section");
+                section.Should().NotBeNull();
+                section.Items.Count.Should().Be(2);
+
+                var ex = Record.Exception(() => settingsFile.AddOrUpdate("Section", new AddItem("key2", "value2")));
+                ex.Should().NotBeNull();
+                ex.Should().BeOfType<InvalidOperationException>();
+                ex.Message.Should().Be("Unable to update setting since it is in uneditable configuration.");
+
+                section = settingsFile.GetSection("Section");
+                section.Should().NotBeNull();
+                section.Items.Count.Should().Be(2);
+
+                settingsFile.SaveToDisk();
+
+                var updatedFileHash = SettingsTestUtils.GetFileHash(Path.Combine(mockBaseDirectory, nugetConfigPath));
+                updatedFileHash.Should().BeEquivalentTo(configFileHash);
+            }
+        }
+
+        [Fact]
         public void SettingSection_Remove_Succeeds()
         {
             // Arrange
@@ -315,6 +356,44 @@ namespace NuGet.Configuration.Test
             }
         }
 
+        [Fact]
+        public void SettingSection_Remove_ToReadOnly_Throws()
+        {
+            // Arrange
+            var nugetConfigPath = "NuGet.Config";
+            var config = @"
+<configuration>
+    <Section>
+        <add key='key0' value='value0' />
+        <add key='key1' value='value1' meta1='data1' meta2='data2'/>
+    </Section>
+</configuration>";
+
+            using (var mockBaseDirectory = TestDirectory.Create())
+            {
+                SettingsTestUtils.CreateConfigurationFile(nugetConfigPath, mockBaseDirectory, config);
+                var configFileHash = SettingsTestUtils.GetFileHash(Path.Combine(mockBaseDirectory, nugetConfigPath));
+
+                var settingsFile = new SettingsFile(mockBaseDirectory, nugetConfigPath, isMachineWide: false, isReadOnly: true);
+
+                // Act
+                var section = settingsFile.GetSection("Section");
+                section.Should().NotBeNull();
+
+                var child = section.GetFirstItemWithAttribute<AddItem>("key", "key0");
+                child.Should().NotBeNull();
+
+                var ex = Record.Exception(() => settingsFile.Remove("Section", child));
+                ex.Should().NotBeNull();
+                ex.Should().BeOfType<InvalidOperationException>();
+                ex.Message.Should().Be("Unable to update setting since it is in uneditable configuration.");
+
+                settingsFile.SaveToDisk();
+
+                var updatedFileHash = SettingsTestUtils.GetFileHash(Path.Combine(mockBaseDirectory, nugetConfigPath));
+                updatedFileHash.Should().BeEquivalentTo(configFileHash);
+            }
+        }
 
         [Fact]
         public void SettingSection_Remove_OnlyOneChild_SucceedsAndRemovesSection()

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/SettingSectionTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/SettingSectionTests.cs
@@ -264,7 +264,7 @@ namespace NuGet.Configuration.Test
                 var ex = Record.Exception(() => settingsFile.AddOrUpdate("Section", new AddItem("key2", "value2")));
                 ex.Should().NotBeNull();
                 ex.Should().BeOfType<InvalidOperationException>();
-                ex.Message.Should().Be("Unable to update setting since it is in an uneditable config file.");
+                ex.Message.Should().Be(Resources.CannotUpdateReadOnlyConfig);
 
                 section = settingsFile.GetSection("Section");
                 section.Should().NotBeNull();
@@ -386,7 +386,7 @@ namespace NuGet.Configuration.Test
                 var ex = Record.Exception(() => settingsFile.Remove("Section", child));
                 ex.Should().NotBeNull();
                 ex.Should().BeOfType<InvalidOperationException>();
-                ex.Message.Should().Be("Unable to update setting since it is in an uneditable config file.");
+                ex.Message.Should().Be(Resources.CannotUpdateReadOnlyConfig);
 
                 settingsFile.SaveToDisk();
 

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/SettingSectionTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/SettingSectionTests.cs
@@ -213,7 +213,7 @@ namespace NuGet.Configuration.Test
                 SettingsTestUtils.CreateConfigurationFile(nugetConfigPath, mockBaseDirectory, config);
                 var configFileHash = SettingsTestUtils.GetFileHash(Path.Combine(mockBaseDirectory, nugetConfigPath));
 
-                var settingsFile = new SettingsFile(mockBaseDirectory, nugetConfigPath, isMachineWide: true);
+                var settingsFile = new SettingsFile(mockBaseDirectory, nugetConfigPath, isMachineWide: true, isReadOnly: false);
 
                 // Act
                 var section = settingsFile.GetSection("Section");
@@ -294,7 +294,7 @@ namespace NuGet.Configuration.Test
                 SettingsTestUtils.CreateConfigurationFile(nugetConfigPath, mockBaseDirectory, config);
                 var configFileHash = SettingsTestUtils.GetFileHash(Path.Combine(mockBaseDirectory, nugetConfigPath));
 
-                var settingsFile = new SettingsFile(mockBaseDirectory, nugetConfigPath, isMachineWide: true);
+                var settingsFile = new SettingsFile(mockBaseDirectory, nugetConfigPath, isMachineWide: true, isReadOnly: false);
 
                 // Act
                 var section = settingsFile.GetSection("Section");

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/SettingSectionTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/SettingSectionTests.cs
@@ -264,7 +264,7 @@ namespace NuGet.Configuration.Test
                 var ex = Record.Exception(() => settingsFile.AddOrUpdate("Section", new AddItem("key2", "value2")));
                 ex.Should().NotBeNull();
                 ex.Should().BeOfType<InvalidOperationException>();
-                ex.Message.Should().Be("Unable to update setting since it is in uneditable configuration.");
+                ex.Message.Should().Be("Unable to update setting since it is in an uneditable config file.");
 
                 section = settingsFile.GetSection("Section");
                 section.Should().NotBeNull();
@@ -386,7 +386,7 @@ namespace NuGet.Configuration.Test
                 var ex = Record.Exception(() => settingsFile.Remove("Section", child));
                 ex.Should().NotBeNull();
                 ex.Should().BeOfType<InvalidOperationException>();
-                ex.Message.Should().Be("Unable to update setting since it is in uneditable configuration.");
+                ex.Message.Should().Be("Unable to update setting since it is in an uneditable config file.");
 
                 settingsFile.SaveToDisk();
 

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/SettingsFileTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/SettingsFileTests.cs
@@ -317,7 +317,7 @@ namespace NuGet.Configuration.Test
                 var ex = Record.Exception(() => settingsFile.AddOrUpdate("section", new AddItem("SomeKey", "SomeValue")));
                 ex.Should().NotBeNull();
                 ex.Should().BeOfType<InvalidOperationException>();
-                ex.Message.Should().Be("Unable to update setting since it is in uneditable configuration.");
+                ex.Message.Should().Be("Unable to update setting since it is in an uneditable config file.");
 
                 settingsFile.SaveToDisk();
 
@@ -623,7 +623,7 @@ namespace NuGet.Configuration.Test
                 var ex = Record.Exception(() => settingsFile.Remove("Section", item));
                 ex.Should().NotBeNull();
                 ex.Should().BeOfType<InvalidOperationException>();
-                ex.Message.Should().Be("Unable to update setting since it is in uneditable configuration.");
+                ex.Message.Should().Be("Unable to update setting since it is in an uneditable config file.");
 
                 settingsFile.SaveToDisk();
 

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/SettingsFileTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/SettingsFileTests.cs
@@ -282,7 +282,7 @@ namespace NuGet.Configuration.Test
                 var ex = Record.Exception(() => settingsFile.AddOrUpdate("section", new AddItem("SomeKey", "SomeValue")));
                 ex.Should().NotBeNull();
                 ex.Should().BeOfType<InvalidOperationException>();
-                ex.Message.Should().Be("Unable to update setting since it is in a machine-wide NuGet.Config.");
+                ex.Message.Should().Be(Resources.CannotUpdateMachineWide);
 
                 settingsFile.SaveToDisk();
 
@@ -317,7 +317,7 @@ namespace NuGet.Configuration.Test
                 var ex = Record.Exception(() => settingsFile.AddOrUpdate("section", new AddItem("SomeKey", "SomeValue")));
                 ex.Should().NotBeNull();
                 ex.Should().BeOfType<InvalidOperationException>();
-                ex.Message.Should().Be("Unable to update setting since it is in an uneditable config file.");
+                ex.Message.Should().Be(Resources.CannotUpdateReadOnlyConfig);
 
                 settingsFile.SaveToDisk();
 
@@ -623,7 +623,7 @@ namespace NuGet.Configuration.Test
                 var ex = Record.Exception(() => settingsFile.Remove("Section", item));
                 ex.Should().NotBeNull();
                 ex.Should().BeOfType<InvalidOperationException>();
-                ex.Message.Should().Be("Unable to update setting since it is in an uneditable config file.");
+                ex.Message.Should().Be(Resources.CannotUpdateReadOnlyConfig);
 
                 settingsFile.SaveToDisk();
 
@@ -1064,7 +1064,6 @@ namespace NuGet.Configuration.Test
 
             using (var mockBaseDirectory = TestDirectory.Create())
             {
-
                 // Set-up and Act
                 SettingsTestUtils.CreateConfigurationFile(nugetConfigPath, mockBaseDirectory, config);
                 var settingsFile = new SettingsFile(mockBaseDirectory, nugetConfigPath, isMachineWide: isMachineWide, isReadOnly: isReadOnlyInput);

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/SettingsFileTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/SettingsFileTests.cs
@@ -276,7 +276,7 @@ namespace NuGet.Configuration.Test
                 SettingsTestUtils.CreateConfigurationFile(nugetConfigPath, mockBaseDirectory, config);
                 var configFileHash = SettingsTestUtils.GetFileHash(Path.Combine(mockBaseDirectory, nugetConfigPath));
 
-                var settingsFile = new SettingsFile(mockBaseDirectory, nugetConfigPath, isMachineWide: true);
+                var settingsFile = new SettingsFile(mockBaseDirectory, nugetConfigPath, isMachineWide: true, isReadOnly: false);
 
                 // Act
                 var ex = Record.Exception(() => settingsFile.AddOrUpdate("section", new AddItem("SomeKey", "SomeValue")));
@@ -533,7 +533,7 @@ namespace NuGet.Configuration.Test
                 SettingsTestUtils.CreateConfigurationFile(nugetConfigPath, mockBaseDirectory, config);
                 var configFileHash = SettingsTestUtils.GetFileHash(Path.Combine(mockBaseDirectory, nugetConfigPath));
 
-                var settingsFile = new SettingsFile(mockBaseDirectory, nugetConfigPath, isMachineWide: true);
+                var settingsFile = new SettingsFile(mockBaseDirectory, nugetConfigPath, isMachineWide: true, isReadOnly: false);
 
                 // Act & Assert
                 var section = settingsFile.GetSection("Section");

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/SettingsFileTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/SettingsFileTests.cs
@@ -295,6 +295,41 @@ namespace NuGet.Configuration.Test
         }
 
         [Fact]
+        public void SettingsFile_AddOrUpdate_WithReadOnlySettings_Throws()
+        {
+            // Arrange
+            var nugetConfigPath = "NuGet.Config";
+            var config = @"
+<configuration>
+    <Section>
+        <add key='key0' value='value0' />
+    </Section>
+</configuration>";
+
+            using (var mockBaseDirectory = TestDirectory.Create())
+            {
+                SettingsTestUtils.CreateConfigurationFile(nugetConfigPath, mockBaseDirectory, config);
+                var configFileHash = SettingsTestUtils.GetFileHash(Path.Combine(mockBaseDirectory, nugetConfigPath));
+
+                var settingsFile = new SettingsFile(mockBaseDirectory, nugetConfigPath, isMachineWide: false, isReadOnly: true);
+
+                // Act
+                var ex = Record.Exception(() => settingsFile.AddOrUpdate("section", new AddItem("SomeKey", "SomeValue")));
+                ex.Should().NotBeNull();
+                ex.Should().BeOfType<InvalidOperationException>();
+                ex.Message.Should().Be("Unable to update setting since it is in uneditable configuration.");
+
+                settingsFile.SaveToDisk();
+
+                var section = settingsFile.GetSection("Section");
+                section.Items.Count.Should().Be(1);
+
+                var updatedFileHash = SettingsTestUtils.GetFileHash(Path.Combine(mockBaseDirectory, nugetConfigPath));
+                updatedFileHash.Should().BeEquivalentTo(configFileHash);
+            }
+        }
+
+        [Fact]
         public void SettingsFile_AddOrUpdate_SectionThatDoesntExist_WillAddSection()
         {
             // Arrange
@@ -547,6 +582,48 @@ namespace NuGet.Configuration.Test
                 ex.Should().NotBeNull();
                 ex.Should().BeOfType<InvalidOperationException>();
                 ex.Message.Should().Be("Unable to update setting since it is in a machine-wide NuGet.Config.");
+
+                settingsFile.SaveToDisk();
+
+                var section1 = settingsFile.GetSection("Section");
+                section1.Items.Count.Should().Be(1);
+
+                var updatedFileHash = SettingsTestUtils.GetFileHash(Path.Combine(mockBaseDirectory, nugetConfigPath));
+                updatedFileHash.Should().BeEquivalentTo(configFileHash);
+            }
+        }
+
+        [Fact]
+        public void SettingsFile_Remove_WithReadOnlySettings_Throws()
+        {
+            // Arrange
+            var nugetConfigPath = "NuGet.Config";
+            var config = @"
+<configuration>
+    <Section>
+        <add key='key0' value='value0' />
+    </Section>
+</configuration>";
+
+            using (var mockBaseDirectory = TestDirectory.Create())
+            {
+                SettingsTestUtils.CreateConfigurationFile(nugetConfigPath, mockBaseDirectory, config);
+                var configFileHash = SettingsTestUtils.GetFileHash(Path.Combine(mockBaseDirectory, nugetConfigPath));
+
+                var settingsFile = new SettingsFile(mockBaseDirectory, nugetConfigPath, isMachineWide: false, isReadOnly: true);
+
+                // Act & Assert
+                var section = settingsFile.GetSection("Section");
+                section.Should().NotBeNull();
+
+                var item = section.GetFirstItemWithAttribute<AddItem>("key", "key0");
+                item.Should().NotBeNull();
+                item.Value.Should().Be("value0");
+
+                var ex = Record.Exception(() => settingsFile.Remove("Section", item));
+                ex.Should().NotBeNull();
+                ex.Should().BeOfType<InvalidOperationException>();
+                ex.Message.Should().Be("Unable to update setting since it is in uneditable configuration.");
 
                 settingsFile.SaveToDisk();
 

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/SettingsFileTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/SettingsFileTests.cs
@@ -1045,5 +1045,34 @@ namespace NuGet.Configuration.Test
                 expectedSettingsDict.Should().BeEmpty();
             }
         }
+
+        [Theory]
+        [InlineData(false, false, false)]
+        [InlineData(false, true, true)]
+        [InlineData(true, false, true)]
+        [InlineData(true, true, true)]
+        public void SettingsFile_Constructor_MachineWideConfigsAreReadOnly(bool isMachineWide, bool isReadOnlyInput, bool expected)
+        {
+            // Arrange
+            var nugetConfigPath = "NuGet.Config";
+            var config = @"
+<configuration>
+    <Section>
+        <add key='key0' value='value0' />
+    </Section>
+</configuration>";
+
+            using (var mockBaseDirectory = TestDirectory.Create())
+            {
+
+                // Set-up and Act
+                SettingsTestUtils.CreateConfigurationFile(nugetConfigPath, mockBaseDirectory, config);
+                var settingsFile = new SettingsFile(mockBaseDirectory, nugetConfigPath, isMachineWide: isMachineWide, isReadOnly: isReadOnlyInput);
+
+                // Assert
+                settingsFile.IsReadOnly.Should().Be(expected);
+                settingsFile.IsMachineWide.Should().Be(isMachineWide);
+            }
+        }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/UnknownItemTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/UnknownItemTests.cs
@@ -204,7 +204,7 @@ namespace NuGet.Configuration.Test
             using (var mockBaseDirectory = TestDirectory.Create())
             {
                 SettingsTestUtils.CreateConfigurationFile(nugetConfigPath, mockBaseDirectory, config);
-                var settingsFile = new SettingsFile(mockBaseDirectory, nugetConfigPath, isMachineWide: true);
+                var settingsFile = new SettingsFile(mockBaseDirectory, nugetConfigPath, isMachineWide: true, isReadOnly: false);
 
                 // Act
                 var section = settingsFile.GetSection("Section");
@@ -306,7 +306,7 @@ namespace NuGet.Configuration.Test
             using (var mockBaseDirectory = TestDirectory.Create())
             {
                 SettingsTestUtils.CreateConfigurationFile(nugetConfigPath, mockBaseDirectory, config);
-                var settingsFile = new SettingsFile(mockBaseDirectory, nugetConfigPath, isMachineWide: true);
+                var settingsFile = new SettingsFile(mockBaseDirectory, nugetConfigPath, isMachineWide: true, isReadOnly: false);
 
                 // Act
                 var section = settingsFile.GetSection("Section");

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/UnknownItemTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/UnknownItemTests.cs
@@ -221,6 +221,37 @@ namespace NuGet.Configuration.Test
         }
 
         [Fact]
+        public void UnknownItem_Add_ToReadOnly_Throws()
+        {
+            // Arrange
+            var nugetConfigPath = "NuGet.Config";
+            var config = @"
+<configuration>
+    <Section>
+        <Unknown />
+    </Section>
+</configuration>";
+
+            using (var mockBaseDirectory = TestDirectory.Create())
+            {
+                SettingsTestUtils.CreateConfigurationFile(nugetConfigPath, mockBaseDirectory, config);
+                var settingsFile = new SettingsFile(mockBaseDirectory, nugetConfigPath, isMachineWide: false, isReadOnly: true);
+
+                // Act
+                var section = settingsFile.GetSection("Section");
+                section.Should().NotBeNull();
+
+                var element = section.Items.FirstOrDefault() as UnknownItem;
+                element.Should().NotBeNull();
+
+                // Assert
+                var ex = Record.Exception(() => element.Add(new SettingText("test")));
+                ex.Should().NotBeNull();
+                ex.Should().BeOfType<InvalidOperationException>();
+            }
+        }
+
+        [Fact]
         public void UnknownItem_Add_Item_WorksSuccessfully()
         {
             // Arrange
@@ -322,6 +353,38 @@ namespace NuGet.Configuration.Test
             }
         }
 
+        [Fact]
+        public void UnknownItem_Remove_ToReadOnly_Throws()
+        {
+            // Arrange
+            var nugetConfigPath = "NuGet.Config";
+            var config = @"
+<configuration>
+    <Section>
+        <Unknown>
+            <Unknown2 />
+        </Unknown>
+    </Section>
+</configuration>";
+
+            using (var mockBaseDirectory = TestDirectory.Create())
+            {
+                SettingsTestUtils.CreateConfigurationFile(nugetConfigPath, mockBaseDirectory, config);
+                var settingsFile = new SettingsFile(mockBaseDirectory, nugetConfigPath, isMachineWide: false, isReadOnly: true);
+
+                // Act
+                var section = settingsFile.GetSection("Section");
+                section.Should().NotBeNull();
+
+                var element = section.Items.FirstOrDefault() as UnknownItem;
+                element.Should().NotBeNull();
+
+                // Assert
+                var ex = Record.Exception(() => element.Remove(element.Children.First()));
+                ex.Should().NotBeNull();
+                ex.Should().BeOfType<InvalidOperationException>();
+            }
+        }
 
         [Fact]
         public void UnknownItem_Remove_UnexistingChild_DoesNotRemoveAnything()

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsTests.cs
@@ -2559,7 +2559,7 @@ namespace NuGet.Configuration.Test
     </SectionName>
 </configuration>";
 
-                SettingsTestUtils.CreateConfigurationFile("NuGet.Contoso.Config", Path.Combine(mockBaseDirectory, "TestingGlobalPath"), additionalUserConfig);
+                SettingsTestUtils.CreateConfigurationFile("NuGet.Contoso.Config", Path.Combine(mockBaseDirectory, "TestingGlobalPath", "config"), additionalUserConfig);
 
                 // Act
                 var settings = Settings.LoadSettings(
@@ -2620,7 +2620,7 @@ namespace NuGet.Configuration.Test
     </SectionName>
 </configuration>";
 
-                SettingsTestUtils.CreateConfigurationFile("NuGet.Contoso.Config", Path.Combine(mockBaseDirectory, "TestingGlobalPath"), additionalUserConfig);
+                SettingsTestUtils.CreateConfigurationFile("NuGet.Contoso.Config", Path.Combine(mockBaseDirectory, "TestingGlobalPath", "config"), additionalUserConfig);
 
                 // Act
                 var settings = Settings.LoadSettings(

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsTests.cs
@@ -1111,7 +1111,7 @@ namespace NuGet.Configuration.Test
             using (var mockBaseDirectory = TestDirectory.Create())
             {
                 SettingsTestUtils.CreateConfigurationFile("a1.config", Path.Combine(mockBaseDirectory, "nuget", "Config"), @"<configuration></configuration>");
-                var settingsFile = new SettingsFile(Path.Combine(mockBaseDirectory, "nuget", "Config"), "a1.config", isMachineWide: true);
+                var settingsFile = new SettingsFile(Path.Combine(mockBaseDirectory, "nuget", "Config"), "a1.config", isMachineWide: true, isReadOnly: false);
                 var settings = new Settings(new SettingsFile[] { settingsFile });
 
                 // Act
@@ -2658,7 +2658,7 @@ namespace NuGet.Configuration.Test
 
         /// <summary>
         /// We have 3 configs, one in the working directory, 2 in the user directory.
-        /// We always write to the furthest compatible config. In this case that means the additional config.
+        /// We always write to the furthest compatible write-able config. While the additional config is further, it's also not write-able.
         /// </summary>
         [Fact]
         public void AddOrUpdate_WithAdditionalUserSpecificConfigs_AddsToFurthestUserWideConfig()
@@ -2709,13 +2709,13 @@ namespace NuGet.Configuration.Test
                 settings.SaveToDisk();
 
                 // Assert
-                var expectedPath = Path.Combine(mockBaseDirectory, "TestingGlobalPath", "NuGet.Contoso.Config");
+                var expectedPath = Path.Combine(mockBaseDirectory, "TestingGlobalPath", "NuGet.Config");
 
                 var result = SettingsTestUtils.RemoveWhitespace(@"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
     <SectionName>
-        <add key=""key3"" value=""additional"" />
-        <add key=""key4"" value=""additional"" />
+        <add key=""key2"" value=""user"" />
+        <add key=""key3"" value=""user"" />
         <add key=""newKey"" value=""newValue"" />
     </SectionName>
 </configuration>");


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9394
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: 

Add the ability to detect additional configs in the user specific directory similar to the machine wide one as described in the issue. 

Given that these are additional configs, they are merged with lower priority than the default user specific config. The rest are merged deterministically in alphabetical order because they are not expected to confict. 
The determinism allows an out in case something really goes wrong. 

There is one concern here, which is what happens if someone already had a config in that folder, but NuGet was never reading them before. 
The answer is we read it. This is a NuGet specific folder so it's extremely unlikely that additional/unrelated configs are found there.

## Testing/Validation

Tests Added: Yes  
Reason for not adding tests:  
Validation:  
