### PR TITLE
Set 5.6.0-preview.3 branding

### DIFF
--- a/build/config.props
+++ b/build/config.props
@@ -19,7 +19,7 @@
     
     <!-- ** Change for each new preview/rtm -->
     <!-- Check the VS schedule and manually enter a preview number here that makes sense. -->
-    <ReleaseLabel Condition=" '$(ReleaseLabel)' == '' ">preview.2</ReleaseLabel>
+    <ReleaseLabel Condition=" '$(ReleaseLabel)' == '' ">preview.3</ReleaseLabel>
     
     <!-- ** Increment each insertion, set to zero after incrementing Major/Minor or Patch version -->
     <!-- We need to update this netcoreassembly build number with EVERY insertion into VS to workaround any breaking api


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Client.Engineering/issues/340
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: Update version config

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  version number change
Validation:  
