### PR TITLE
Use normalized nonce from Rfc3161TimestampRequest for comparison 

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/IRfc3161TimestampRequest.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/IRfc3161TimestampRequest.cs
@@ -9,5 +9,11 @@ namespace NuGet.Packaging.Signing
     internal interface IRfc3161TimestampRequest
     {
         Task<IRfc3161TimestampToken> SubmitRequestAsync(Uri timestampUri, TimeSpan timeout);
+
+        /// <summary>
+        /// Gets the nonce for this timestamp request.
+        /// </summary>
+        /// <returns>The nonce for this timestamp request as byte[], if one was present; otherwise, null</returns>
+        byte[] GetNonce();
     }
 }

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/Rfc3161TimestampProvider.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/Rfc3161TimestampProvider.cs
@@ -103,7 +103,8 @@ namespace NuGet.Packaging.Signing
                 RequestTimeout);
 
             // quick check for response validity
-            ValidateTimestampResponse(nonce, request.HashedMessage, timestampToken);
+            var normalizedNonce = rfc3161TimestampRequest.GetNonce();
+            ValidateTimestampResponse(normalizedNonce, request.HashedMessage, timestampToken);
 
             var timestampCms = timestampToken.AsSignedCms();
             ValidateTimestampCms(request.SigningSpecifications, timestampCms, timestampToken);

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/Rfc3161TimestampRequestNet472Wrapper.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/Rfc3161TimestampRequestNet472Wrapper.cs
@@ -34,6 +34,11 @@ namespace NuGet.Packaging.Signing
         {
             return Task.FromResult(_rfc3161TimestampRequest.SubmitRequest(timestampUri, timeout));
         }
+
+        public byte[] GetNonce()
+        {
+            return _rfc3161TimestampRequest.GetNonce();
+        }
     }
 #endif
 }

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/Rfc3161TimestampRequestNetstandard21Wrapper.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/Rfc3161TimestampRequestNetstandard21Wrapper.cs
@@ -85,6 +85,12 @@ namespace NuGet.Packaging.Signing
                 }
             }
         }
+
+        public byte[] GetNonce()
+        {
+            ReadOnlyMemory<byte>? normalizedNonce = _rfc3161TimestampRequest.GetNonce();
+            return normalizedNonce.HasValue ? normalizedNonce.Value.ToArray() : null;
+        }
     }
 #endif
 }


### PR DESCRIPTION
## Bug

Fixes: NuGet/Home#9536
Regression: No  

## Fix

Details: As per [comment](https://github.com/NuGet/Home/issues/9536#issuecomment-625924126), invoked `Rfc3161TimestampRequest.GetNonce()` API to obtain normalized `Nonce` for comparison purposes as recommended by `dotnet/runtime` team.

## Testing/Validation

Tests Added: No
Reason for not adding tests:  This PR is to fix flaky test.
Validation:  `TimestampSignatureAsync_TimestampingCountersignature_SucceedsAsync ` Test passed in the [build](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=3775068&view=ms.vss-test-web.build-test-results-tab).
