### PR TITLE
Enable test GetCertificateChain_WithUntrustedRoot_Throws on Mac

### DIFF
--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -738,7 +738,7 @@ jobs:
   dependsOn:
   - Build_and_UnitTest
   - Initialize_Build
-  timeoutInMinutes: 75
+  timeoutInMinutes: 120
   variables:
     FULLVSTSBUILDNUMBER: $[dependencies.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
     SDKVersionForBuild: $[dependencies.Initialize_Build.outputs['getSDKVersionForBuild.SDKVersionForBuild']]

--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -738,7 +738,7 @@ jobs:
   dependsOn:
   - Build_and_UnitTest
   - Initialize_Build
-  timeoutInMinutes: 120
+  timeoutInMinutes: 75
   variables:
     FULLVSTSBUILDNUMBER: $[dependencies.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
     SDKVersionForBuild: $[dependencies.Initialize_Build.outputs['getSDKVersionForBuild.SDKVersionForBuild']]

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/CertificateChainUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/CertificateChainUtilityTests.cs
@@ -98,7 +98,7 @@ namespace NuGet.Packaging.Test
                 Assert.Equal(1, logger.Errors);
                 SigningTestUtility.AssertUntrustedRoot(logger.LogMessages, LogLevel.Error);
 
-                if (RuntimeEnvironmentHelper.IsWindows || RuntimeEnvironmentHelper.IsLinux)
+                //if (RuntimeEnvironmentHelper.IsWindows || RuntimeEnvironmentHelper.IsLinux)
                 {
 #if NETCORE5_0
                     Assert.Equal(2, logger.Warnings);

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/CertificateChainUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/CertificateChainUtilityTests.cs
@@ -98,23 +98,24 @@ namespace NuGet.Packaging.Test
                 Assert.Equal(1, logger.Errors);
                 SigningTestUtility.AssertUntrustedRoot(logger.LogMessages, LogLevel.Error);
 
-                //if (RuntimeEnvironmentHelper.IsWindows || RuntimeEnvironmentHelper.IsLinux)
+                SigningTestUtility.AssertOfflineRevocation(logger.LogMessages, LogLevel.Warning);
+                if (RuntimeEnvironmentHelper.IsWindows)
+                {
+                    Assert.Equal(2, logger.Warnings);
+                    SigningTestUtility.AssertRevocationStatusUnknown(logger.LogMessages, LogLevel.Warning);
+                }
+                else if (RuntimeEnvironmentHelper.IsLinux)
                 {
 #if NETCORE5_0
                     Assert.Equal(2, logger.Warnings);
-#else
-                    Assert.Equal(RuntimeEnvironmentHelper.IsWindows ? 2 : 1, logger.Warnings);
-#endif
-                    SigningTestUtility.AssertOfflineRevocation(logger.LogMessages, LogLevel.Warning);
-
-#if NETCORE5_0
                     SigningTestUtility.AssertRevocationStatusUnknown(logger.LogMessages, LogLevel.Warning);
 #else
-                    if (RuntimeEnvironmentHelper.IsWindows)
-                    {
-                        SigningTestUtility.AssertRevocationStatusUnknown(logger.LogMessages, LogLevel.Warning);
-                    }
+                    Assert.Equal(1, logger.Warnings);
 #endif
+                }
+                else
+                {
+                    Assert.Equal(1, logger.Warnings);
                 }
             }
         }


### PR DESCRIPTION
## Bug

Fixes: NuGet/Home#9495
Regression: No

## Fix

Details: Enabled `GetCertificateChain_WithUntrustedRoot_Throws` test on Mac and modified assert statements accordingly.

## Testing/Validation

Tests Added: No. Fixed existing test 
Reason for not adding tests:  
Validation: `GetCertificateChain_WithUntrustedRoot_Throws` test passed on all combinations of `tfms` and `platforms` in [build](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=3775965&view=ms.vss-test-web.build-test-results-tab).
