### PR TITLE
removed NetworkProtocolUtility.ConfigureSupportedSslProtocols() method from net472 code path

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Program.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Program.cs
@@ -99,8 +99,6 @@ namespace NuGet.CommandLine
                 ServicePointManager.DefaultConnectionLimit = 1;
             }
 
-            NetworkProtocolUtility.ConfigureSupportedSslProtocols();
-
             var console = new Console();
             var fileSystem = new CoreV2.NuGet.PhysicalFileSystem(workingDirectory);
 

--- a/src/NuGet.Core/NuGet.Build.Tasks/BuildTasksUtility.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/BuildTasksUtility.cs
@@ -191,9 +191,6 @@ namespace NuGet.Build.Tasks
                 UserAgent.SetUserAgentString(new UserAgentStringBuilder("NuGet Desktop MSBuild Task"));
 #endif
 
-                // This method has no effect on .NET Core.
-                NetworkProtocolUtility.ConfigureSupportedSslProtocols();
-
                 var restoreSummaries = new List<RestoreSummary>();
                 var providerCache = new RestoreCommandProvidersCache();
 

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Program.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Program.cs
@@ -91,9 +91,6 @@ namespace NuGet.CommandLine.XPlat
 
             XPlatUtility.SetUserAgent();
 
-            // This method has no effect on .NET Core.
-            NetworkProtocolUtility.ConfigureSupportedSslProtocols();
-
             app.OnExecute(() =>
             {
                 app.ShowHelp();

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/XPlatUtility.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/XPlatUtility.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -35,9 +35,6 @@ namespace NuGet.CommandLine.XPlat
 
             // Set user agent string used for network calls
             SetUserAgent();
-
-            // This method has no effect on .NET Core.
-            NetworkProtocolUtility.ConfigureSupportedSslProtocols();
         }
 
         public static void SetUserAgent()

--- a/src/NuGet.Core/NuGet.Common/NetworkProtocolUtility.cs
+++ b/src/NuGet.Core/NuGet.Common/NetworkProtocolUtility.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Net;
@@ -7,21 +7,6 @@ namespace NuGet.Common
 {
     public static class NetworkProtocolUtility
     {
-        /// <summary>
-        /// This only has effect on .NET Framework (desktop). On .NET Core,
-        /// <see cref="ServicePointManager"/> is not available. Additionally,
-        /// no API is available to configure the supported SSL protocols.
-        /// </summary>
-        public static void ConfigureSupportedSslProtocols()
-        {
-#if !IS_CORECLR
-            ServicePointManager.SecurityProtocol =
-                SecurityProtocolType.Tls |
-                SecurityProtocolType.Tls11 |
-                SecurityProtocolType.Tls12;
-#endif
-        }
-
         /// <summary>
         /// Set ServicePointManager.DefaultConnectionLimit
         /// </summary>


### PR DESCRIPTION
## Bug

Fixes: NuGet/Client.Engineering#341
Regression: No   

## Fix

Details:  As per [doc](https://docs.microsoft.com/en-us/dotnet/api/system.net.servicepointmanager.securityprotocol?view=netcore-3.1#remarks), Starting with the .NET Framework 4.7, the default value of `ServicePointManager.SecurityProtocol` property is [SecurityProtocolType.SystemDefault](https://docs.microsoft.com/en-us/dotnet/api/system.net.securityprotocoltype?view=netcore-3.1#System_Net_SecurityProtocolType_SystemDefault) that allows the operating system to choose the best protocol to use, and to block protocols that are not secure. Since our `DESKTOP` code targets `net472`, I think we can safely remove the [`NetworkProtocolUtility.ConfigureSupportedSslProtocols()`](https://github.com/NuGet/NuGet.Client/blob/dev/src/NuGet.Core/NuGet.Common/NetworkProtocolUtility.cs#L15-L23) method and allow the operating system to choose the best protocol to use. This logic in this method is only executed on `net472` platform which is no longer required as per above explanation.

## Testing/Validation

Tests Added: No.  
Reason for not adding tests:  No new code is added to the product.
Validation:  No test failures due to this change in the [CI build](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=3779345&view=results).
