### PR TITLE
Add SourceRoot item in the generated props to integrate with deterministic source paths

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
@@ -154,6 +154,7 @@ namespace NuGet.Commands
 
         /// <summary>
         /// Apply standard properties in a property group.
+        /// Additionally add a SourceRoot item to point to the package folders.
         /// </summary>
         public static void AddNuGetProperties(
             XDocument doc,
@@ -172,7 +173,10 @@ namespace NuGet.Commands
                             GenerateProperty("NuGetPackageRoot", ReplacePathsWithMacros(repositoryRoot)),
                             GenerateProperty("NuGetPackageFolders", string.Join(";", packageFolders)),
                             GenerateProperty("NuGetProjectStyle", projectStyle.ToString()),
-                            GenerateProperty("NuGetToolVersion", MinClientVersionUtility.GetNuGetClientVersion().ToFullString())));
+                            GenerateProperty("NuGetToolVersion", MinClientVersionUtility.GetNuGetClientVersion().ToFullString())),
+                new XElement(Namespace + "ItemGroup",
+                            new XAttribute("Condition", $" {ExcludeAllCondition} "),
+                            GenerateItem("SourceRoot", "$(NuGetPackageFolders)")));
         }
 
         /// <summary>
@@ -197,6 +201,11 @@ namespace NuGet.Commands
             return new XElement(Namespace + propertyName,
                             new XAttribute("Condition", $" '$({propertyName})' == '' "),
                             content);
+        }
+
+        internal static XElement GenerateItem(string itemName, string path)
+        {
+            return new XElement(Namespace + itemName, new XAttribute("Include", path));
         }
 
         public static XElement GenerateImport(string path)

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
@@ -176,7 +176,7 @@ namespace NuGet.Commands
                             GenerateProperty("NuGetToolVersion", MinClientVersionUtility.GetNuGetClientVersion().ToFullString())),
                 new XElement(Namespace + "ItemGroup",
                             new XAttribute("Condition", $" {ExcludeAllCondition} "),
-                            GenerateItem("SourceRoot", "$(NuGetPackageFolders)")));
+                            GenerateItem("SourceRoot", "$([MSBuild]::EnsureTrailingSlash($(NuGetPackageFolders)))")));
         }
 
         /// <summary>

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/RestoreCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/RestoreCommandTests.cs
@@ -4,7 +4,6 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using System.Threading.Tasks;
 using NuGet.CommandLine.Test;
 using NuGet.Frameworks;

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
@@ -1617,8 +1617,8 @@ namespace NuGet.CommandLine.Test
 
                 var propsItemGroups = propsXML.Root.Elements().Where(e => e.Name.LocalName == "ItemGroup").ToList();
 
-                Assert.Equal("'$(TargetFramework)' == 'net4' AND '$(ExcludeRestorePackageImports)' != 'true'", propsItemGroups[0].Attribute(XName.Get("Condition")).Value.Trim());
-                Assert.Equal("'$(TargetFramework)' == 'netstandard1.3' AND '$(ExcludeRestorePackageImports)' != 'true'", propsItemGroups[1].Attribute(XName.Get("Condition")).Value.Trim());
+                Assert.Equal("'$(TargetFramework)' == 'net4' AND '$(ExcludeRestorePackageImports)' != 'true'", propsItemGroups[1].Attribute(XName.Get("Condition")).Value.Trim());
+                Assert.Equal("'$(TargetFramework)' == 'netstandard1.3' AND '$(ExcludeRestorePackageImports)' != 'true'", propsItemGroups[2].Attribute(XName.Get("Condition")).Value.Trim());
             }
         }
 

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
@@ -8,10 +8,8 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Xml.Linq;
-
 using FluentAssertions;
 using Newtonsoft.Json.Linq;
-
 using NuGet.Common;
 using NuGet.Frameworks;
 using NuGet.LibraryModel;
@@ -20,7 +18,6 @@ using NuGet.Packaging.Core;
 using NuGet.ProjectModel;
 using NuGet.Test.Utility;
 using NuGet.Versioning;
-
 using Xunit;
 using Xunit.Abstractions;
 

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/BuildAssetsUtilsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/BuildAssetsUtilsTests.cs
@@ -79,7 +79,7 @@ namespace NuGet.Commands.Test
             // Assert
             Assert.Equal(packageFolders, props["NuGetPackageFolders"]);
             Assert.Equal(1, items.Count);
-            Assert.Equal("$(NuGetPackageFolders)", items["SourceRoot"]["Include"]);
+            Assert.Equal("$([MSBuild]::EnsureTrailingSlash($(NuGetPackageFolders)))", items["SourceRoot"]["Include"]);
         }
 
         [Fact]

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/BuildAssetsUtilsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/BuildAssetsUtilsTests.cs
@@ -57,6 +57,32 @@ namespace NuGet.Commands.Test
         }
 
         [Fact]
+        public void AddNuGetProperty_WithPackageFolders_AddsSourceRootItem()
+        {
+            // Arrange
+            var packageFolders = @"/tmp/gpf;/tmp/fallbackFolder";
+
+            var doc = BuildAssetsUtils.GenerateEmptyImportsFile();
+
+            // Act
+            BuildAssetsUtils.AddNuGetProperties(
+                doc,
+                packageFolders: packageFolders.Split(';'),
+                string.Empty,
+                ProjectStyle.PackageReference,
+                "/tmp/test/project.assets.json",
+                success: true);
+
+            var props = TargetsUtility.GetMSBuildProperties(doc);
+            var items = TargetsUtility.GetMSBuildItems(doc);
+
+            // Assert
+            Assert.Equal(packageFolders, props["NuGetPackageFolders"]);
+            Assert.Equal(1, items.Count);
+            Assert.Equal("$(NuGetPackageFolders)", items["SourceRoot"]["Include"]);
+        }
+
+        [Fact]
         public void BuildAssetsUtils_GenerateContentFilesItem_CompileAsset()
         {
             // Arrange

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/ContentFilesMSBuildTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/ContentFilesMSBuildTests.cs
@@ -71,7 +71,7 @@ namespace NuGet.Commands.Test
 
                 // Assert
                 Assert.True(result.Success, logger.ShowErrors());
-                Assert.Equal(0, itemGroups.Length);
+                Assert.Equal(1, itemGroups.Length); // The SourceRoot is the only expected item group.
             }
         }
 
@@ -131,9 +131,9 @@ namespace NuGet.Commands.Test
 
                 // Assert
                 Assert.True(result.Success, logger.ShowErrors());
-                Assert.Equal(1, itemGroups.Length);
-                Assert.EndsWith("x.txt", Path.GetFileName(itemGroups[0].Elements().Single().Attribute(XName.Get("Include")).Value));
-                Assert.Equal(expected.Trim(), itemGroups[0].Attribute(XName.Get("Condition")).Value.Trim());
+                Assert.Equal(2, itemGroups.Length); // SourceRoot is the first item group.
+                Assert.EndsWith("x.txt", Path.GetFileName(itemGroups[1].Elements().Single().Attribute(XName.Get("Include")).Value));
+                Assert.Equal(expected.Trim(), itemGroups[1].Attribute(XName.Get("Condition")).Value.Trim());
             }
         }
 

--- a/test/TestUtilities/Test.Utility/TargetsUtility.cs
+++ b/test/TestUtilities/Test.Utility/TargetsUtility.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -44,6 +44,36 @@ namespace NuGet.Test.Utility
                     if (!result.ContainsKey(key))
                     {
                         result.Add(key, item.Value);
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Read a targets or props file and find all the items.
+        /// </summary>
+        public static Dictionary<string, Dictionary<string, string>> GetMSBuildItems(XDocument doc)
+        {
+            var result = new Dictionary<string, Dictionary<string, string>>(StringComparer.OrdinalIgnoreCase);
+
+            var itemGroupName = XName.Get("ItemGroup", "http://schemas.microsoft.com/developer/msbuild/2003");
+
+            foreach (var group in doc.Root.Elements(itemGroupName))
+            {
+                foreach (var item in group.Elements())
+                {
+                    var key = item.Name.LocalName;
+
+                    if (!result.ContainsKey(key))
+                    {
+                        var attributeValues = new Dictionary<string, string>();
+                        foreach(var attribute in item.Attributes())
+                        {
+                            attributeValues.Add(attribute.Name.LocalName, attribute.Value);
+                        }
+                        result.Add(key, attributeValues);
                     }
                 }
             }


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9431
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: 
As per the details in https://github.com/NuGet/Home/issues/9431, for deterministic source builds, roslyn needs to know where all the assets used might be coming from. 
The global packages folder and the fallback folders are NuGet's consumption dirs for packages.

This will be done in the nuget.g.props file. The top of the file will look something like:

```xml
<?xml version="1.0" encoding="utf-8" standalone="no"?>
<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
  <PropertyGroup Condition=" '$(ExcludeRestorePackageImports)' != 'true' ">
    <RestoreSuccess Condition=" '$(RestoreSuccess)' == '' ">True</RestoreSuccess>
    <RestoreTool Condition=" '$(RestoreTool)' == '' ">NuGet</RestoreTool>
    <ProjectAssetsFile Condition=" '$(ProjectAssetsFile)' == '' ">$(MSBuildThisFileDirectory)project.assets.json</ProjectAssetsFile>
    <NuGetPackageRoot Condition=" '$(NuGetPackageRoot)' == '' ">$(UserProfile)\.nuget\packages\</NuGetPackageRoot>
    <NuGetPackageFolders Condition=" '$(NuGetPackageFolders)' == '' ">C:\Users\nikolev\.nuget\packages\;C:\Program Files\dotnet\sdk\NuGetFallbackFolder</NuGetPackageFolders>
    <NuGetProjectStyle Condition=" '$(NuGetProjectStyle)' == '' ">PackageReference</NuGetProjectStyle>
    <NuGetToolVersion Condition=" '$(NuGetToolVersion)' == '' ">5.7.0</NuGetToolVersion>
  </PropertyGroup>
  <ItemGroup Condition=" '$(ExcludeRestorePackageImports)' != 'true' ">
    <SourceRoot Include="$(NuGetPackageFolders)" />
  </ItemGroup>
  <PropertyGroup>
    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
  </PropertyGroup>
```

cc @tmat @clairernovotny 

## Testing/Validation

Tests Added: Yes  
Reason for not adding tests:  
Validation:  
