### PR TITLE
Improve the debugging docs - Add info about the nomination env var

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -57,6 +57,11 @@ Some of the other points are summarized below:
 
 * Package Manager Console operations - The PowerShell cmdlets are defined in the [NuGet.PackageManagement.Cmdlets](..\src\NuGet.Clients\NuGet.PackageManagement.PowerShellCmdlets\NuGet.PackageManagement.PowerShellCmdlets.csproj) project, more specifically in the [cmdlets](..\src\NuGet.Clients\NuGet.PackageManagement.PowerShellCmdlets\Cmdlets) folder.
 
+#### Investigating NuGet and project-system interactions
+
+When investigating Visual Studio PackageReference restore with SDK-based projects, you can set an environment variable respected by the [project-system](https://github.com/dotnet/project-system/pull/3027) that would dump the nomination data each time a project is nominated.
+Set `PROJECTSYSTEM_PROJECTOUTPUTPANEENABLED=1` and look for a new category enabled in the Output window.
+
 ## Debugging and testing the NuGet MSBuild functionality
 
 Exactly two NuGet functionalities are available in MSBuild, `restore` and `pack`.


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Client.Engineering/issues/351
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: 

Just porting more of our internal debugging docs.

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  Only docs change
Validation:  
