### PR TITLE
Updating NuGet.Build.Tasks.Console.exe.config with binding redirects

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Console/App.config
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Console/App.config
@@ -43,7 +43,8 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Numerics.Vectors" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
-        <codeBase version="4.1.3.0" href="..\..\..\..\..\MSBuild\Current\Bin\System.Numerics.Vectors.dll" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.4.0" newVersion="4.1.4.0" />
+        <codeBase version="4.1.4.0" href="..\..\..\..\..\MSBuild\Current\Bin\System.Numerics.Vectors.dll" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Resources.Extensions" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
@@ -51,7 +52,8 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
-        <codeBase version="4.0.4.1" href="..\..\..\..\..\MSBuild\Current\Bin\System.Runtime.CompilerServices.Unsafe.dll" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.6.0" newVersion="4.0.6.0" />
+        <codeBase version="4.0.6.0" href="..\..\..\..\..\MSBuild\Current\Bin\System.Runtime.CompilerServices.Unsafe.dll" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Threading.Tasks.Dataflow" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />

--- a/src/NuGet.Core/NuGet.Build.Tasks.Console/App.config
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Console/App.config
@@ -32,7 +32,7 @@
       <dependentAssembly>
         <assemblyIdentity name="System.Buffers" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
-        <codeBase version="4.0.2.0" href="..\..\..\..\..\MSBuild\Current\Bin\System.Buffers.dll" />
+        <codeBase version="4.0.3.0" href="..\..\..\..\..\MSBuild\Current\Bin\System.Buffers.dll" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Collections.Immutable" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />

--- a/src/NuGet.Core/NuGet.Build.Tasks.Console/App.config
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Console/App.config
@@ -31,6 +31,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Buffers" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
         <codeBase version="4.0.2.0" href="..\..\..\..\..\MSBuild\Current\Bin\System.Buffers.dll" />
       </dependentAssembly>
       <dependentAssembly>
@@ -58,6 +59,11 @@
       <dependentAssembly>
         <assemblyIdentity name="System.Threading.Tasks.Dataflow" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
         <codeBase version="4.6.3.0" href="..\..\..\..\..\MSBuild\Current\Bin\System.Threading.Tasks.Dataflow.dll" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.ValueTuple" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+        <codeBase version="4.0.3.0" href="..\..\..\..\..\MSBuild\Current\Bin\System.ValueTuple.dll" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildRestoreTaskTests.cs
+++ b/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildRestoreTaskTests.cs
@@ -420,7 +420,7 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
             }
         }
 
-        [PlatformTheory(Platform.Windows)]
+        [PlatformTheory(Platform.Windows, Skip="https://github.com/NuGet/Home/issues/9674")]
         [InlineData(true)]
         [InlineData(false)]
         public async Task MsbuildRestore_StaticGraphEvaluation_CleanupAssetsForUnsupportedProjectsAsync(bool cleanupAssetsForUnsupportedProjects)


### PR DESCRIPTION
MSBuild added binding redirects for some of its dependencies because of a mismatch which means this app.config needs to have them as well.

## Bug

Fixes: https://github.com/NuGet/Home/issues/9665
Regression: Yes  
* Last working version:   5.6
* How are we preventing it in future:   Looking into VS setup automation to generate these binding redirects at install time.

## Fix

Details: Match the binding redirects from MSBuild.exe.config for 16.7

## Testing/Validation

Tests Added: No
Reason for not adding tests:  Not possible
Validation:  Set these binding redirects for my local config and verified that the restore works.
