### PR TITLE
Remove unnecessary NuGet package references.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -197,3 +197,6 @@ launchSettings.json
 # include the test packages
 !test/EndToEnd/Packages/**/*
 !test/EndToEnd/ProjectTemplates/**/*.pfx
+
+.idea
+.ionide

--- a/build/packages.targets
+++ b/build/packages.targets
@@ -1,7 +1,7 @@
 <Project>
     <PropertyGroup>
         <MicrosoftBuildPackageVersion Condition="'$(MicrosoftBuildPackageVersion)' == ''">16.5.0-preview-19606-01</MicrosoftBuildPackageVersion>
-        <NewtonsoftJsonPackageVersion Condition="$(NewtonsoftJsonPackageVersion) == ''">12.0.3</NewtonsoftJsonPackageVersion>
+        <NewtonsoftJsonPackageVersion Condition="$(NewtonsoftJsonPackageVersion) == ''">9.0.1</NewtonsoftJsonPackageVersion>
         <SystemPackagesVersion>4.3.0</SystemPackagesVersion>
         <VSComponentsVersion>16.4.280</VSComponentsVersion>
         <VSFrameworkVersion>16.6.30107.105</VSFrameworkVersion>

--- a/build/packages.targets
+++ b/build/packages.targets
@@ -1,7 +1,7 @@
 <Project>
     <PropertyGroup>
         <MicrosoftBuildPackageVersion Condition="'$(MicrosoftBuildPackageVersion)' == ''">16.5.0-preview-19606-01</MicrosoftBuildPackageVersion>
-        <NewtonsoftJsonPackageVersion Condition="$(NewtonsoftJsonPackageVersion) == ''">9.0.1</NewtonsoftJsonPackageVersion>
+        <NewtonsoftJsonPackageVersion Condition="$(NewtonsoftJsonPackageVersion) == ''">12.0.3</NewtonsoftJsonPackageVersion>
         <SystemPackagesVersion>4.3.0</SystemPackagesVersion>
         <VSComponentsVersion>16.4.280</VSComponentsVersion>
         <VSFrameworkVersion>16.6.30107.105</VSFrameworkVersion>
@@ -66,15 +66,12 @@
         <PackageReference Update="Microsoft.Web.Xdt" Version="2.1.2" />
         <PackageReference Update="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
         <PackageReference Update="System.Collections.Immutable" Version="1.5.0" />
-        <PackageReference Update="System.Diagnostics.Process" Version="$(SystemPackagesVersion)" />
-        <PackageReference Update="System.Dynamic.Runtime" Version="$(SystemPackagesVersion)" /> 
         <PackageReference Update="System.Runtime.Serialization.Formatters" Version="$(SystemPackagesVersion)" />
         <PackageReference Update="System.Runtime.Serialization.Primitives" Version="$(SystemPackagesVersion)" />
         <PackageReference Update="System.Security.Cryptography.Pkcs" Version="$(PatchedSystemPackagesVersion)" />
         <PackageReference Update="System.Security.Cryptography.Cng" Version="$(PatchedSystemPackagesVersion)" />
         <PackageReference Update="System.Security.Cryptography.ProtectedData" Version="$(SystemPackagesVersion)" />
         <PackageReference Update="System.Threading.Tasks.Dataflow" Version="4.9.0" />
-        <PackageReference Update="System.Threading.Thread" Version="$(SystemPackagesVersion)" />
         <PackageReference Update="VSLangProj" Version="7.0.3300" />
         <PackageReference Update="VSLangProj110" Version="11.0.61030" />
         <PackageReference Update="VSLangProj157" Version="15.7.0" />
@@ -102,10 +99,6 @@
         <PackageReference Update="Moq" Version="$(MoqVersion)" />
         <PackageReference Update="NuGet.Core" Version="2.14.0-rtm-832" />
         <PackageReference Update="Portable.BouncyCastle" Version="1.8.1.3" />
-        <PackageReference Update="System.Diagnostics.TraceSource" Version="$(SystemPackagesVersion)" />
-        <PackageReference Update="System.IO.Compression.ZipFile" Version="$(SystemPackagesVersion)" />
-        <PackageReference Update="System.Runtime.Loader" Version="$(SystemPackagesVersion)" />
-        <PackageReference Update="System.Threading.Tasks.Parallel" Version="$(SystemPackagesVersion)" />
         <PackageReference Update="Xunit.StaFact" Version="0.2.9" />
         <PackageReference Update="xunit" Version="$(XunitVersion)" />
         <PackageReference Update="xunit.runner.visualstudio" Version="$(XunitVersion)" />

--- a/build/packages.targets
+++ b/build/packages.targets
@@ -66,8 +66,6 @@
         <PackageReference Update="Microsoft.Web.Xdt" Version="2.1.2" />
         <PackageReference Update="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
         <PackageReference Update="System.Collections.Immutable" Version="1.5.0" />
-        <PackageReference Update="System.Runtime.Serialization.Formatters" Version="$(SystemPackagesVersion)" />
-        <PackageReference Update="System.Runtime.Serialization.Primitives" Version="$(SystemPackagesVersion)" />
         <PackageReference Update="System.Security.Cryptography.Pkcs" Version="$(PatchedSystemPackagesVersion)" />
         <PackageReference Update="System.Security.Cryptography.Cng" Version="$(PatchedSystemPackagesVersion)" />
         <PackageReference Update="System.Security.Cryptography.ProtectedData" Version="$(SystemPackagesVersion)" />

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/NuGet.CommandLine.XPlat.csproj
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/NuGet.CommandLine.XPlat.csproj
@@ -23,7 +23,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.CommandLineUtils" />
-    <PackageReference Include="System.Runtime.Serialization.Primitives" />
   </ItemGroup>
 
   <!-- Microsoft.Build.Locator is needed when debugging, but should not be used in the assemblies we insert.

--- a/src/NuGet.Core/NuGet.Common/NuGet.Common.csproj
+++ b/src/NuGet.Core/NuGet.Common/NuGet.Common.csproj
@@ -23,11 +23,6 @@
     <Reference Include="System.IO.Compression" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == '$(NetStandardVersion)' ">
-    <PackageReference Include="System.Diagnostics.Process" />
-    <PackageReference Include="System.Threading.Thread" />
-  </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\NuGet.Frameworks\NuGet.Frameworks.csproj" />
   </ItemGroup>

--- a/src/NuGet.Core/NuGet.Credentials/NuGet.Credentials.csproj
+++ b/src/NuGet.Core/NuGet.Credentials/NuGet.Credentials.csproj
@@ -35,7 +35,6 @@
 
   <ItemGroup>
     <ProjectReference Include="$(NuGetCoreSrcDirectory)\NuGet.Protocol\NuGet.Protocol.csproj" />
-    <PackageReference Include="System.Runtime.Serialization.Formatters" Condition=" '$(IsCore)' == 'true' " />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NuGet.Core/NuGet.Packaging/NuGet.Packaging.csproj
+++ b/src/NuGet.Core/NuGet.Packaging/NuGet.Packaging.csproj
@@ -47,13 +47,6 @@
     <PackageReference Include="Newtonsoft.Json" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(IsCore)' == 'true' ">
-    <PackageReference Include="System.Dynamic.Runtime" />
-    <!-- TODO - remove this when temporary patching is no longer necessary. See https://github.com/nuget/home/issues/8952 -->
-    <PackageReference Include="System.Security.Cryptography.Pkcs" />
-    <PackageReference Include="System.Security.Cryptography.Cng" />
-  </ItemGroup>
-
   <ItemGroup>
     <Compile Update="Signing\DerEncoding\SR.Designer.cs">
       <DesignTime>True</DesignTime>
@@ -95,7 +88,7 @@
       <LastGenOutput>NuGetResources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
   </ItemGroup>
-  
+
   <Import Project="$(BuildCommonDirectory)common.targets" />
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 </Project>

--- a/src/NuGet.Core/NuGet.Packaging/NuGet.Packaging.csproj
+++ b/src/NuGet.Core/NuGet.Packaging/NuGet.Packaging.csproj
@@ -1,4 +1,4 @@
-﻿<Project>
+<Project>
   <PropertyGroup>
     <RequiresSigningXplatAPIs>true</RequiresSigningXplatAPIs>
   </PropertyGroup>
@@ -45,6 +45,11 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(IsCore)' == 'true' ">
+    <PackageReference Include="System.Security.Cryptography.Pkcs" />
+    <PackageReference Include="System.Security.Cryptography.Cng" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NuGet.Core/NuGet.ProjectModel/NuGet.ProjectModel.csproj
+++ b/src/NuGet.Core/NuGet.ProjectModel/NuGet.ProjectModel.csproj
@@ -26,11 +26,6 @@
     <ProjectReference Include="..\NuGet.DependencyResolver.Core\NuGet.DependencyResolver.Core.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(IsCore)' == 'true' ">
-    <PackageReference Include="System.Dynamic.Runtime" />
-    <PackageReference Include="System.Threading.Thread" />
-  </ItemGroup>
-
   <ItemGroup>
     <Compile Update="Strings.Designer.cs">
       <DesignTime>True</DesignTime>
@@ -38,7 +33,7 @@
       <DependentUpon>Strings.resx</DependentUpon>
     </Compile>
   </ItemGroup>
-  
+
   <ItemGroup>
     <EmbeddedResource Update="Strings.resx">
       <Generator>ResXFileCodeGenerator</Generator>

--- a/src/NuGet.Core/NuGet.Protocol/NuGet.Protocol.csproj
+++ b/src/NuGet.Core/NuGet.Protocol/NuGet.Protocol.csproj
@@ -34,7 +34,7 @@
       <DependentUpon>Strings.resx</DependentUpon>
     </Compile>
   </ItemGroup>
-  
+
   <ItemGroup>
     <EmbeddedResource Update="Strings.resx">
       <Generator>ResXFileCodeGenerator</Generator>
@@ -48,10 +48,6 @@
     <Reference Include="System.Net.Http.WebRequest" />
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.IO.Compression" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(IsCore)' == 'true' ">
-    <PackageReference Include="System.Dynamic.Runtime" />
   </ItemGroup>
 
   <Import Project="$(BuildCommonDirectory)common.targets" />

--- a/test/NuGet.Core.FuncTests/NuGet.Core.FuncTest/NuGet.Core.FuncTest.csproj
+++ b/test/NuGet.Core.FuncTests/NuGet.Core.FuncTest/NuGet.Core.FuncTest.csproj
@@ -1,4 +1,4 @@
-﻿<Project>
+<Project>
   <PropertyGroup>
     <RequiresSigningXplatAPIs>true</RequiresSigningXplatAPIs>
   </PropertyGroup>
@@ -21,10 +21,6 @@
 
   <ItemGroup>
     <ProjectReference Include="$(TestUtilitiesDirectory)Test.Utility\Test.Utility.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(IsCore)' == 'true' ">
-    <PackageReference Include="System.Diagnostics.TraceSource" Version="$(SystemPackagesVersion)" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == '$(NETFXTargetFramework)' ">

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Pack.Test/NuGet.Build.Tasks.Pack.Test.csproj
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Pack.Test/NuGet.Build.Tasks.Pack.Test.csproj
@@ -5,7 +5,7 @@
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common.test.props" />
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
-  
+
   <PropertyGroup>
     <TargetFrameworks>$(TargetFrameworksExe)</TargetFrameworks>
     <TargetFrameworks Condition=" '$(IsXPlat)' == 'true' ">$(NETCoreTargetFrameworks)</TargetFrameworks>
@@ -25,7 +25,6 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(IsCore)' == 'true' ">
-    <PackageReference Include="System.Diagnostics.TraceSource" />
     <PackageReference Include="Microsoft.Build.Framework" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" PrivateAssets="All" />

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/NuGet.Build.Tasks.Test.csproj
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/NuGet.Build.Tasks.Test.csproj
@@ -27,7 +27,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Diagnostics.TraceSource" />
     <PackageReference Include="Microsoft.Build.Framework" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" PrivateAssets="All" />
@@ -55,7 +54,7 @@
       <LastGenOutput>TestStrings.Designer.cs</LastGenOutput>
     </EmbeddedResource>
   </ItemGroup>
-  
+
   <Import Project="$(BuildCommonDirectory)common.targets" />
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 </Project>

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/NuGet.Commands.Test.csproj
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/NuGet.Commands.Test.csproj
@@ -1,4 +1,4 @@
-﻿<Project>
+<Project>
   <PropertyGroup>
     <RequiresSigningXplatAPIs>true</RequiresSigningXplatAPIs>
   </PropertyGroup>
@@ -19,10 +19,6 @@
     <ProjectReference Include="..\NuGet.Configuration.Test\NuGet.Configuration.Test.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(IsCore)' == 'true' ">
-    <PackageReference Include="System.Diagnostics.TraceSource" />
-  </ItemGroup>
-
   <ItemGroup Condition=" '$(TargetFramework)' == '$(NETFXTargetFramework)' ">
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.Net.Http" />
@@ -36,7 +32,7 @@
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
- 
+
   <Import Project="$(BuildCommonDirectory)common.targets" />
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 </Project>

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/NuGet.Common.Test.csproj
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/NuGet.Common.Test.csproj
@@ -18,12 +18,6 @@
     <ProjectReference Include="$(TestUtilitiesDirectory)Test.Utility\Test.Utility.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(IsCore)' == 'true' ">
-    <PackageReference Include="System.Threading.Tasks.Parallel" />
-    <PackageReference Include="System.Threading.Thread" />
-    <PackageReference Include="System.Diagnostics.TraceSource" />
-  </ItemGroup>
-
   <ItemGroup Condition=" '$(TargetFramework)' == '$(NETFXTargetFramework)' ">
     <Reference Include="System.Net" />
     <Reference Include="System.Net.Http" />

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/NuGet.Configuration.Test.csproj
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/NuGet.Configuration.Test.csproj
@@ -19,9 +19,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(IsCore)' == 'true' ">
-    <PackageReference Include="System.Diagnostics.TraceSource" />
     <PackageReference Include="System.Security.Cryptography.ProtectedData" />
-    <PackageReference Include="System.Threading.Tasks.Parallel" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == '$(NETFXTargetFramework)' ">

--- a/test/NuGet.Core.Tests/NuGet.Frameworks.Test/NuGet.Frameworks.Test.csproj
+++ b/test/NuGet.Core.Tests/NuGet.Frameworks.Test/NuGet.Frameworks.Test.csproj
@@ -18,10 +18,6 @@
     <ProjectReference Include="$(TestUtilitiesDirectory)Test.Utility\Test.Utility.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(IsCore)' == 'true' ">
-    <PackageReference Include="System.Diagnostics.TraceSource" />
-  </ItemGroup>
-
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/NuGet.Packaging.Test.csproj
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/NuGet.Packaging.Test.csproj
@@ -19,10 +19,6 @@
     <ProjectReference Include="..\NuGet.Configuration.Test\NuGet.Configuration.Test.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(IsCore)' == 'true' ">
-    <PackageReference Include="System.Diagnostics.TraceSource" />
-  </ItemGroup>
-
   <ItemGroup Condition=" '$(TargetFramework)' == '$(NETFXTargetFramework)' ">
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.Security" />

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/NuGet.Protocol.Tests.csproj
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/NuGet.Protocol.Tests.csproj
@@ -29,15 +29,11 @@
     <ProjectReference Include="$(TestUtilitiesDirectory)Test.Utility\Test.Utility.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(IsCore)' == 'true' ">
-    <PackageReference Include="System.Diagnostics.TraceSource" />
-  </ItemGroup>
-
   <ItemGroup Condition=" '$(TargetFramework)' == '$(NETFXTargetFramework)' ">
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.Net.Http" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/test/TestExtensions/GenerateLicenseList/GenerateLicenseList.csproj
+++ b/test/TestExtensions/GenerateLicenseList/GenerateLicenseList.csproj
@@ -1,7 +1,7 @@
 ﻿<Project>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common.props" />
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
-  
+
   <PropertyGroup>
     <SkipShared>true</SkipShared>
     <OutputType>Exe</OutputType>
@@ -12,7 +12,6 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" />
-    <PackageReference Include="System.Runtime.Loader" />
     <PackageReference Include="Microsoft.CodeAnalysis" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
   </ItemGroup>

--- a/test/TestExtensions/TestablePlugin/TestablePlugin.csproj
+++ b/test/TestExtensions/TestablePlugin/TestablePlugin.csproj
@@ -21,6 +21,13 @@
     <ProjectReference Include="$(NuGetCoreSrcDirectory)NuGet.Versioning\NuGet.Versioning.csproj" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(IsCore)' == 'true'">
+    <PackageReference Include="System.Collections" Version="4.3.0" />
+    <PackageReference Include="System.Runtime.Extensions" Version="4.3.0" />
+    <PackageReference Include="System.Text.Encoding.Extensions" Version="4.3.0" />
+    <PackageReference Include="System.IO.FileSystem.Primitives" Version="4.3.0" />
+  </ItemGroup>
+
   <Import Project="$(BuildCommonDirectory)common.targets"/>
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 </Project>

--- a/test/TestExtensions/TestablePlugin/TestablePlugin.csproj
+++ b/test/TestExtensions/TestablePlugin/TestablePlugin.csproj
@@ -1,4 +1,4 @@
-﻿<Project>
+<Project>
   <PropertyGroup>
     <RequiresSigningXplatAPIs>true</RequiresSigningXplatAPIs>
   </PropertyGroup>
@@ -22,10 +22,10 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(IsCore)' == 'true'">
-    <PackageReference Include="System.Collections" Version="4.3.0" />
-    <PackageReference Include="System.Runtime.Extensions" Version="4.3.0" />
-    <PackageReference Include="System.Text.Encoding.Extensions" Version="4.3.0" />
-    <PackageReference Include="System.IO.FileSystem.Primitives" Version="4.3.0" />
+    <PackageReference Include="System.Collections" Version="$(SystemPackagesVersion)" />
+    <PackageReference Include="System.Runtime.Extensions" Version="$(SystemPackagesVersion)" />
+    <PackageReference Include="System.Text.Encoding.Extensions" Version="$(SystemPackagesVersion)" />
+    <PackageReference Include="System.IO.FileSystem.Primitives" Version="$(SystemPackagesVersion)" />
   </ItemGroup>
 
   <Import Project="$(BuildCommonDirectory)common.targets"/>

--- a/test/TestUtilities/Test.Utility/Test.Utility.csproj
+++ b/test/TestUtilities/Test.Utility/Test.Utility.csproj
@@ -69,8 +69,6 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(IsCore)' == 'true' ">
-    <PackageReference Include="System.Diagnostics.Process" />
-    <PackageReference Include="System.IO.Compression.ZipFile" />
     <PackageReference Include="System.Security.Cryptography.Pkcs" />
   </ItemGroup>
 


### PR DESCRIPTION
## Bug

* Fixes: NuGet/Home#9723
* Regression: _No_
* Last working version: _None_
* How are we preventing it in future: _Review the necessity of the package dependencies more carefuly. Do not reference `System.*` packages that do not target .NET Standard 2.0 and/or their version number is stuck at 4.3.0._

## Fix

Details: This PR removes packages that are not meant for .NET Standard 2.0, significantly trimming the dependency tree, in a similar way to microsoft/msbuild#5242.

## Testing/Validation

Tests Added: _No_
Reason for not adding tests: _No functionality changed_
Validation: _The CI builds still succeed_