### PR TITLE
Adds forceRestore flag to restore telemetry events

### DIFF
--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreJob.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreJob.cs
@@ -257,6 +257,7 @@ namespace NuGet.SolutionRestoreManager
                     // Emit telemetry event for restore operation
                     EmitRestoreTelemetryEvent(
                         projects,
+                        forceRestore,
                         restoreSource,
                         startTime,
                         duration.TotalSeconds,
@@ -267,6 +268,7 @@ namespace NuGet.SolutionRestoreManager
         }
 
         private void EmitRestoreTelemetryEvent(IEnumerable<NuGetProject> projects,
+            bool forceRestore,
             RestoreOperationSource source,
             DateTimeOffset startTime,
             double duration,
@@ -281,6 +283,7 @@ namespace NuGet.SolutionRestoreManager
             var restoreTelemetryEvent = new RestoreTelemetryEvent(
                 _nuGetProjectContext.OperationId.ToString(),
                 projectIds,
+                forceRestore,
                 source,
                 startTime,
                 _status,

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/RestoreTelemetryEvent.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/RestoreTelemetryEvent.cs
@@ -22,6 +22,7 @@ namespace NuGet.VisualStudio
         public RestoreTelemetryEvent(
             string operationId,
             string[] projectIds,
+            bool forceRestore,
             RestoreOperationSource source,
             DateTimeOffset startTime,
             NuGetOperationStatus status,
@@ -35,6 +36,7 @@ namespace NuGet.VisualStudio
             base[nameof(OperationSource)] = source;
             base[nameof(NoOpProjectsCount)] = noOpProjectsCount;
             base[UpToDateProjectCount] = upToDateProjectsCount;
+            base[nameof(ForceRestore)] = forceRestore;
 
             foreach (var (intervalName, intervalDuration) in intervalTimingTracker.GetIntervals())
             {
@@ -47,5 +49,7 @@ namespace NuGet.VisualStudio
         public RestoreOperationSource OperationSource => (RestoreOperationSource)base[nameof(OperationSource)];
 
         public int NoOpProjectsCount => (int)base[nameof(NoOpProjectsCount)];
+
+        public bool ForceRestore => (bool)base[nameof(ForceRestore)];
     }
 }

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Telemetry/RestoreTelemetryServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Telemetry/RestoreTelemetryServiceTests.cs
@@ -12,13 +12,19 @@ namespace NuGet.PackageManagement.VisualStudio.Test
     public class RestoreTelemetryServiceTests
     {
         [Theory]
-        [InlineData(RestoreOperationSource.OnBuild, NuGetOperationStatus.Succeeded)]
-        [InlineData(RestoreOperationSource.Explicit, NuGetOperationStatus.Succeeded)]
-        [InlineData(RestoreOperationSource.OnBuild, NuGetOperationStatus.NoOp)]
-        [InlineData(RestoreOperationSource.Explicit, NuGetOperationStatus.NoOp)]
-        [InlineData(RestoreOperationSource.OnBuild, NuGetOperationStatus.Failed)]
-        [InlineData(RestoreOperationSource.Explicit, NuGetOperationStatus.Failed)]
-        public void RestoreTelemetryService_EmitRestoreEvent_OperationSucceed(RestoreOperationSource source, NuGetOperationStatus status)
+        [InlineData(false, RestoreOperationSource.OnBuild, NuGetOperationStatus.Succeeded)]
+        [InlineData(false, RestoreOperationSource.Explicit, NuGetOperationStatus.Succeeded)]
+        [InlineData(false, RestoreOperationSource.OnBuild, NuGetOperationStatus.NoOp)]
+        [InlineData(false, RestoreOperationSource.Explicit, NuGetOperationStatus.NoOp)]
+        [InlineData(false, RestoreOperationSource.OnBuild, NuGetOperationStatus.Failed)]
+        [InlineData(false, RestoreOperationSource.Explicit, NuGetOperationStatus.Failed)]
+        [InlineData(true, RestoreOperationSource.OnBuild, NuGetOperationStatus.Succeeded)]
+        [InlineData(true, RestoreOperationSource.Explicit, NuGetOperationStatus.Succeeded)]
+        [InlineData(true, RestoreOperationSource.OnBuild, NuGetOperationStatus.NoOp)]
+        [InlineData(true, RestoreOperationSource.Explicit, NuGetOperationStatus.NoOp)]
+        [InlineData(true, RestoreOperationSource.OnBuild, NuGetOperationStatus.Failed)]
+        [InlineData(true, RestoreOperationSource.Explicit, NuGetOperationStatus.Failed)]
+        public void RestoreTelemetryService_EmitRestoreEvent_OperationSucceed(bool forceRestore, RestoreOperationSource source, NuGetOperationStatus status)
         {
             // Arrange
             var telemetrySession = new Mock<ITelemetrySession>();
@@ -41,6 +47,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             var restoreTelemetryData = new RestoreTelemetryEvent(
                 operationId,
                 projectIds: new[] { Guid.NewGuid().ToString() },
+                forceRestore: forceRestore,
                 source: source,
                 startTime: DateTimeOffset.Now.AddSeconds(-3),
                 status: status,
@@ -85,6 +92,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             var restoreTelemetryData = new RestoreTelemetryEvent(
                 operationId,
                 projectIds: new[] { Guid.NewGuid().ToString() },
+                forceRestore: false,
                 source: RestoreOperationSource.OnBuild,
                 startTime: DateTimeOffset.Now.AddSeconds(-3),
                 status: NuGetOperationStatus.Succeeded,
@@ -104,7 +112,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
             Assert.NotNull(lastTelemetryEvent);
             Assert.Equal(RestoreTelemetryEvent.RestoreActionEventName, lastTelemetryEvent.Name);
-            Assert.Equal(13, lastTelemetryEvent.Count);
+            Assert.Equal(14, lastTelemetryEvent.Count);
 
             Assert.Equal(restoreTelemetryData.OperationSource.ToString(), lastTelemetryEvent["OperationSource"].ToString());
 
@@ -117,11 +125,12 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         {
             Assert.NotNull(actual);
             Assert.Equal(RestoreTelemetryEvent.RestoreActionEventName, actual.Name);
-            Assert.Equal(11, actual.Count);
+            Assert.Equal(12, actual.Count);
 
             Assert.Equal(expected.OperationSource.ToString(), actual["OperationSource"].ToString());
 
             Assert.Equal(expected.NoOpProjectsCount, (int)actual["NoOpProjectsCount"]);
+            Assert.Equal(expected.ForceRestore, (bool)actual["ForceRestore"]);
 
             TestTelemetryUtility.VerifyTelemetryEventData(operationId, expected, actual);
         }


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9569
Regression: No
* Last working version:   
* How are we preventing it in future:   

## Fix

Adds `forceRestore` flag parameter to a RestoreTelemetryEvent

## Testing/Validation

Tests Added: No
Reason for not adding tests:  Modified existing tests 
Validation:  Via Telemetry tool
- When you open a project in VS, a restore event is triggered  with the flag on false 
- When you click on Build > Rebuild Solution or Build > Rebuild Project, a restore event is triggered with the flag is set to true
- When you right-click in a project and select Build in a project with no assets an NuGet automatic restore is enabled, an event is triggered with the flag set on false.

The flag that indicates when a rebuild is requested is `VSSOLNBUILDUPDATEFLAGS.SBF_OPERATION_FORCE_UPDATE` as shown below:

https://github.com/NuGet/NuGet.Client/blob/dev/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreBuildHandler.cs#L156
