### PR TITLE
Disable verification during extraction for Mono, disable a test on Mono

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs
@@ -381,7 +381,7 @@ namespace NuGet.Packaging
         public override bool CanVerifySignedPackages(SignedPackageVerifierSettings verifierSettings)
         {
 #if IS_SIGNING_SUPPORTED
-            // Mono support has been deprioritized, so verification on Mono is not enabled
+            // Mono support has been deprioritized, so verification on Mono is not enabled, tracking issue: https://github.com/NuGet/Home/issues/9027
             if (RuntimeEnvironmentHelper.IsMono)
             {
                 return false;

--- a/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs
@@ -381,7 +381,16 @@ namespace NuGet.Packaging
         public override bool CanVerifySignedPackages(SignedPackageVerifierSettings verifierSettings)
         {
 #if IS_SIGNING_SUPPORTED
-            return true;
+            // Mono support has been deprioritized, so verification on Mono is not enabled
+            if (RuntimeEnvironmentHelper.IsMono)
+            {
+                return false;
+            }
+            else
+            {
+                return true;
+            }
+            
 #else
             return false;
 #endif

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetVerifyCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetVerifyCommandTest.cs
@@ -58,7 +58,7 @@ namespace NuGet.CommandLine.Test
             }
         }
 
-        [Fact]
+        [PlatformFact(Platform.Windows)]
         public void VerifyCommand_WithAuthorSignedPackage_FailsGracefully()
         {
             var nugetExe = Util.GetNuGetExePath();

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetVerifyCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetVerifyCommandTest.cs
@@ -58,7 +58,7 @@ namespace NuGet.CommandLine.Test
             }
         }
 
-        [PlatformFact(Platform.Windows)]
+        [PlatformFact(Platform.Windows, SkipMono = true)]
         public void VerifyCommand_WithAuthorSignedPackage_FailsGracefully()
         {
             var nugetExe = Util.GetNuGetExePath();


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/8940
Regression: Yes/No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: 
1.disable the verification during extraction for Mono
2.disable a test, which failed differently when verifying the signed package on Mono.

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  
Validation:  
