### PR TITLE
Skip ClientCert test that is probably causing hangs on Mac

### DIFF
--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatClientCertTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatClientCertTests.cs
@@ -124,6 +124,7 @@ namespace NuGet.XPlat.FuncTest
             Assert.Equal(1, exitCode);
         }
 
+        // https://github.com/NuGet/Home/issues/9684
         [PlatformFact(Platform.Windows, Platform.Linux, SkipMono = true)]
         public void ClientCertAddCommand_Fail_StoreCertificateNotExist()
         {
@@ -154,6 +155,7 @@ namespace NuGet.XPlat.FuncTest
             }
         }
 
+        // https://github.com/NuGet/Home/issues/9684
         [PlatformFact(Platform.Windows, SkipMono = true)]
         public void ClientCertAddCommand_Success_FileCertificateAbsolute()
         {
@@ -190,6 +192,7 @@ namespace NuGet.XPlat.FuncTest
             }
         }
 
+        // https://github.com/NuGet/Home/issues/9684
         [PlatformFact(Platform.Windows, SkipMono = true)]
         public void ClientCertAddCommand_Success_FileCertificateNotExistForce()
         {
@@ -229,6 +232,7 @@ namespace NuGet.XPlat.FuncTest
             }
         }
 
+        // https://github.com/NuGet/Home/issues/9684
         [PlatformFact(Platform.Windows, SkipMono = true)]
         public void ClientCertAddCommand_Success_FileCertificateRelative()
         {
@@ -269,6 +273,7 @@ namespace NuGet.XPlat.FuncTest
             }
         }
 
+        // https://github.com/NuGet/Home/issues/9684
         [PlatformFact(Platform.Windows, Platform.Linux, SkipMono = true)]
         public void ClientCertAddCommand_Success_StoreCertificate()
         {
@@ -382,6 +387,7 @@ namespace NuGet.XPlat.FuncTest
             }
         }
 
+        // https://github.com/NuGet/Home/issues/9684
         [PlatformFact(Platform.Windows, SkipMono = true)]
         public void ClientCertListCommand_Success_NotEmptyList()
         {
@@ -451,6 +457,7 @@ namespace NuGet.XPlat.FuncTest
             }
         }
 
+        // https://github.com/NuGet/Home/issues/9684
         [PlatformFact(Platform.Windows, SkipMono = true)]
         public void ClientCertRemoveCommand_Success_ItemCertificate()
         {
@@ -578,6 +585,7 @@ namespace NuGet.XPlat.FuncTest
             }
         }
 
+        // https://github.com/NuGet/Home/issues/9684
         [PlatformFact(Platform.Windows, SkipMono = true)]
         public void ClientCertUpdateCommand_Success_FileCertificateForce()
         {
@@ -678,6 +686,7 @@ namespace NuGet.XPlat.FuncTest
             }
         }
 
+        // https://github.com/NuGet/Home/issues/9684
         [PlatformFact(Platform.Windows, SkipMono = true)]
         public void ClientCertUpdatedCommand_Fail_FileCertificateNotExist()
         {
@@ -754,6 +763,7 @@ namespace NuGet.XPlat.FuncTest
             }
         }
 
+        // https://github.com/NuGet/Home/issues/9684
         [PlatformFact(Platform.Windows, Platform.Linux, SkipMono = true)]
         public void ClientCertUpdatedCommand_Fail_StoreCertificateNotExist()
         {

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatClientCertTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatClientCertTests.cs
@@ -124,7 +124,7 @@ namespace NuGet.XPlat.FuncTest
             Assert.Equal(1, exitCode);
         }
 
-        // https://github.com/NuGet/Home/issues/9684
+        // Skip: https://github.com/NuGet/Home/issues/9684
         [PlatformFact(Platform.Windows, Platform.Linux, SkipMono = true)]
         public void ClientCertAddCommand_Fail_StoreCertificateNotExist()
         {
@@ -155,7 +155,7 @@ namespace NuGet.XPlat.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/9684
+        // Skip: https://github.com/NuGet/Home/issues/9684
         [PlatformFact(Platform.Windows, SkipMono = true)]
         public void ClientCertAddCommand_Success_FileCertificateAbsolute()
         {
@@ -192,7 +192,7 @@ namespace NuGet.XPlat.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/9684
+        // Skip: https://github.com/NuGet/Home/issues/9684
         [PlatformFact(Platform.Windows, SkipMono = true)]
         public void ClientCertAddCommand_Success_FileCertificateNotExistForce()
         {
@@ -232,7 +232,7 @@ namespace NuGet.XPlat.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/9684
+        // Skip: https://github.com/NuGet/Home/issues/9684
         [PlatformFact(Platform.Windows, SkipMono = true)]
         public void ClientCertAddCommand_Success_FileCertificateRelative()
         {
@@ -273,7 +273,7 @@ namespace NuGet.XPlat.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/9684
+        // Skip: https://github.com/NuGet/Home/issues/9684
         [PlatformFact(Platform.Windows, Platform.Linux, SkipMono = true)]
         public void ClientCertAddCommand_Success_StoreCertificate()
         {
@@ -387,7 +387,7 @@ namespace NuGet.XPlat.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/9684
+        // Skip: https://github.com/NuGet/Home/issues/9684
         [PlatformFact(Platform.Windows, SkipMono = true)]
         public void ClientCertListCommand_Success_NotEmptyList()
         {
@@ -457,7 +457,7 @@ namespace NuGet.XPlat.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/9684
+        // Skip: https://github.com/NuGet/Home/issues/9684
         [PlatformFact(Platform.Windows, SkipMono = true)]
         public void ClientCertRemoveCommand_Success_ItemCertificate()
         {
@@ -585,7 +585,7 @@ namespace NuGet.XPlat.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/9684
+        // Skip: https://github.com/NuGet/Home/issues/9684
         [PlatformFact(Platform.Windows, SkipMono = true)]
         public void ClientCertUpdateCommand_Success_FileCertificateForce()
         {
@@ -686,7 +686,7 @@ namespace NuGet.XPlat.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/9684
+        // Skip: https://github.com/NuGet/Home/issues/9684
         [PlatformFact(Platform.Windows, SkipMono = true)]
         public void ClientCertUpdatedCommand_Fail_FileCertificateNotExist()
         {
@@ -763,7 +763,7 @@ namespace NuGet.XPlat.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/9684
+        // Skip: https://github.com/NuGet/Home/issues/9684
         [PlatformFact(Platform.Windows, Platform.Linux, SkipMono = true)]
         public void ClientCertUpdatedCommand_Fail_StoreCertificateNotExist()
         {

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/HttpSource/ClientCertificatesTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/HttpSource/ClientCertificatesTests.cs
@@ -14,7 +14,7 @@ namespace NuGet.Protocol.Tests
 {
     public class ClientCertificatesTests
     {
-        // https://github.com/NuGet/Home/issues/9684
+        // Skip: https://github.com/NuGet/Home/issues/9684
         [PlatformFact(Platform.Windows, Platform.Linux)]
         public void EnsurePackageSourceClientCertificatesForwardedToV3HttpClientHandler()
         {

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/HttpSource/ClientCertificatesTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/HttpSource/ClientCertificatesTests.cs
@@ -7,13 +7,15 @@ using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using NuGet.Configuration;
 using NuGet.Protocol.Core.Types;
+using NuGet.Test.Utility;
 using Xunit;
 
 namespace NuGet.Protocol.Tests
 {
     public class ClientCertificatesTests
     {
-        [Fact]
+        // https://github.com/NuGet/Home/issues/9684
+        [PlatformFact(Platform.Windows, Platform.Linux)]
         public void EnsurePackageSourceClientCertificatesForwardedToV3HttpClientHandler()
         {
             // Arrange


### PR DESCRIPTION
tracking issue: https://github.com/NuGet/Home/issues/9684

fixes: https://github.com/NuGet/Client.Engineering/issues/329