### PR TITLE
Skip SendAsync_RetryWithClonedPostRequest which is flaky

### DIFF
--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/HttpSource/HttpSourceAuthenticationHandlerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/HttpSource/HttpSourceAuthenticationHandlerTests.cs
@@ -492,7 +492,7 @@ namespace NuGet.Protocol.Tests
             yield return new object[] { multipartFormDataContent };
         }
 
-        [Theory]
+        [Theory(Skip = "https://github.com/NuGet/Home/issues/9685")]
         [MemberData(nameof(GetHttpContent))]
         public async Task SendAsync_RetryWithClonedPostRequest(HttpContent httpContent)
         {

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/HttpSource/HttpSourceAuthenticationHandlerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/HttpSource/HttpSourceAuthenticationHandlerTests.cs
@@ -492,7 +492,7 @@ namespace NuGet.Protocol.Tests
             yield return new object[] { multipartFormDataContent };
         }
 
-        [Theory(Skip = "https://github.com/NuGet/Home/issues/9685")]
+        [PlatformTheory(SkipPlatform = Platform.Linux, Skip = "https://github.com/NuGet/Home/issues/9685")]
         [MemberData(nameof(GetHttpContent))]
         public async Task SendAsync_RetryWithClonedPostRequest(HttpContent httpContent)
         {

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/HttpSource/HttpSourceAuthenticationHandlerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/HttpSource/HttpSourceAuthenticationHandlerTests.cs
@@ -13,6 +13,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Moq;
 using NuGet.Configuration;
+using NuGet.Test.Utility;
 using Xunit;
 
 namespace NuGet.Protocol.Tests
@@ -493,7 +494,7 @@ namespace NuGet.Protocol.Tests
         }
 
         //Skipped Linux: https://github.com/NuGet/Home/issues/9685
-        [PlatformTheory(platforms: new string[] { Platform.Windows, Platform.Darwin })]
+        [PlatformTheory(Platform.Windows, Platform.Darwin)]
         [MemberData(nameof(GetHttpContent))]
         public async Task SendAsync_RetryWithClonedPostRequest(HttpContent httpContent)
         {

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/HttpSource/HttpSourceAuthenticationHandlerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/HttpSource/HttpSourceAuthenticationHandlerTests.cs
@@ -492,7 +492,8 @@ namespace NuGet.Protocol.Tests
             yield return new object[] { multipartFormDataContent };
         }
 
-        [PlatformTheory(SkipPlatform = Platform.Linux, Skip = "https://github.com/NuGet/Home/issues/9685")]
+        //Skipped Linux: https://github.com/NuGet/Home/issues/9685
+        [PlatformTheory(platforms: new string[] { Platform.Windows, Platform.Darwin })]
         [MemberData(nameof(GetHttpContent))]
         public async Task SendAsync_RetryWithClonedPostRequest(HttpContent httpContent)
         {


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Client.Engineering/issues/307
See if this test is responsible for these Linux failures: https://github.com/NuGet/Client.Engineering/issues/307#issuecomment-644459133