### PR TITLE
env vars to control showing dialogs for PluginCredentialProviders

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/Command.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/Command.cs
@@ -216,7 +216,7 @@ namespace NuGet.CommandLine
 
             // environment variables control showing dialogs
             bool cannotShowDialog = string.Equals(Environment.GetEnvironmentVariable("CODESPACES"), bool.TrueString, StringComparison.OrdinalIgnoreCase)
-                || string.Equals(Environment.GetEnvironmentVariable("NUGET_CANNOT_SHOW_DIALOG"), bool.TrueString, StringComparison.OrdinalIgnoreCase);
+                || string.Equals(Environment.GetEnvironmentVariable("NUGET_EXE_NO_DIALOG"), bool.TrueString, StringComparison.OrdinalIgnoreCase);
 
             var securePluginProviders = await (new SecurePluginCredentialProviderBuilder(PluginManager.Instance, canShowDialog: !cannotShowDialog, logger: Console)).BuildAllAsync();
 

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/Command.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/Command.cs
@@ -216,7 +216,7 @@ namespace NuGet.CommandLine
 
             // environment variables control showing dialogs
             bool cannotShowDialog = string.Equals(Environment.GetEnvironmentVariable("CODESPACES"), bool.TrueString, StringComparison.OrdinalIgnoreCase)
-                || string.Equals(Environment.GetEnvironmentVariable("NUGET_EXE_NO_DIALOG"), bool.TrueString, StringComparison.OrdinalIgnoreCase);
+                || string.Equals(Environment.GetEnvironmentVariable("NUGET_NO_DIALOG"), bool.TrueString, StringComparison.OrdinalIgnoreCase);
 
             var securePluginProviders = await (new SecurePluginCredentialProviderBuilder(PluginManager.Instance, canShowDialog: !cannotShowDialog, logger: Console)).BuildAllAsync();
 

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/Command.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/Command.cs
@@ -213,7 +213,12 @@ namespace NuGet.CommandLine
             var pluginProviders = new PluginCredentialProviderBuilder(extensionLocator, Settings, Console)
                 .BuildAll(Verbosity.ToString())
                 .ToList();
-            var securePluginProviders = await (new SecurePluginCredentialProviderBuilder(PluginManager.Instance, canShowDialog: true, logger: Console)).BuildAllAsync();
+
+            // environment variables control showing dialogs
+            bool cannotShowDialog = string.Equals(Environment.GetEnvironmentVariable("CODESPACES"), bool.TrueString, StringComparison.OrdinalIgnoreCase)
+                || string.Equals(Environment.GetEnvironmentVariable("NUGET_CANNOT_SHOW_DIALOG"), bool.TrueString, StringComparison.OrdinalIgnoreCase);
+
+            var securePluginProviders = await (new SecurePluginCredentialProviderBuilder(PluginManager.Instance, canShowDialog: !cannotShowDialog, logger: Console)).BuildAllAsync();
 
             providers.Add(new CredentialProviderAdapter(new SettingsCredentialProvider(SourceProvider, Console)));
             providers.AddRange(securePluginProviders);


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9687
Regression: No

## Fix

Details: look for two env vars
if ($env:NUGET_EXE_NO_DIALOG == "true" || $env:CODESPACES == "true")
   create PluginCredentialProvider with canShowDialog: false

## Testing/Validation

Tests Added: In Progress
Validation:  
