### PR TITLE
Remove missing global.json file reference from solution

### DIFF
--- a/NuGet.sln
+++ b/NuGet.sln
@@ -11,7 +11,6 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{4A4623E9-CE1F-4DF2-A4C2-513CE8377D2A}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
-		src\NuGet.Core\global.json = src\NuGet.Core\global.json
 		build\NuGet.ruleset = build\NuGet.ruleset
 	EndProjectSection
 EndProject


### PR DESCRIPTION
## Bug

Fixes: [here](https://github.com/nuget/home/issues/9645)
Regression: Yes/No  
* Last working version:   N/A
* How are we preventing it in future:   

## Fix

Details: 
It seems this global.json reference is remnant from old .Net Core implementation which no longer need according to this [doc](https://docs.microsoft.com/en-us/dotnet/core/tools/global-json?tabs=netcore3x)
In general, you want to use the latest version of the SDK tools, so no global.json file is needed.

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  
Validation:  Trigged manual build to make sure this change don't break anything.
