### PR TITLE
Stop reading the lock file during no-op

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/NoOpRestoreResult.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/NoOpRestoreResult.cs
@@ -23,6 +23,7 @@ namespace NuGet.Commands
                 cacheFile: cacheFile, cacheFilePath: cacheFilePath, packagesLockFilePath:null, packagesLockFile:null, dependencyGraphSpecFilePath: null, dependencyGraphSpec: null, projectStyle: projectStyle, elapsedTime: elapsedTime)
         {
             _lockFileLazy = lockFileLazy ?? throw new ArgumentNullException(nameof(lockFileLazy));
+            LogMessages = cacheFile?.LogMessages;
         }
 
         public override LockFile LockFile => _lockFileLazy.Value;

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/NoOpRestoreResult.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/NoOpRestoreResult.cs
@@ -23,7 +23,7 @@ namespace NuGet.Commands
                 cacheFile: cacheFile, cacheFilePath: cacheFilePath, packagesLockFilePath:null, packagesLockFile:null, dependencyGraphSpecFilePath: null, dependencyGraphSpec: null, projectStyle: projectStyle, elapsedTime: elapsedTime)
         {
             _lockFileLazy = lockFileLazy ?? throw new ArgumentNullException(nameof(lockFileLazy));
-            LogMessages = cacheFile?.LogMessages;
+            LogMessages = cacheFile?.LogMessages ?? new List<IAssetsLogMessage>();
         }
 
         public override LockFile LockFile => _lockFileLazy.Value;

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreResult.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreResult.cs
@@ -57,6 +57,12 @@ namespace NuGet.Commands
         public TimeSpan ElapsedTime { get; }
 
         /// <summary>
+        /// The log messages raised during this restore operation
+        /// </summary>
+        /// <remarks>The messages here are usually sources from the <see cref="LockFile"/> in full restores or <see cref="CacheFile"/> for no-op restores.</remarks>
+        public virtual IList<IAssetsLogMessage> LogMessages { get; internal set; }
+
+        /// <summary>
         ///  Cache File. The previous cache file for this project
         /// </summary>
         private CacheFile CacheFile { get; }
@@ -113,6 +119,7 @@ namespace NuGet.Commands
             _dependencyGraphSpec = dependencyGraphSpec;
             ProjectStyle = projectStyle;
             ElapsedTime = elapsedTime;
+            LogMessages = lockFile.LogMessages;
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreResult.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreResult.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -11,6 +12,7 @@ using System.Threading.Tasks;
 using NuGet.Common;
 using NuGet.LibraryModel;
 using NuGet.ProjectModel;
+using NuGet.Shared;
 
 namespace NuGet.Commands
 {
@@ -119,7 +121,7 @@ namespace NuGet.Commands
             _dependencyGraphSpec = dependencyGraphSpec;
             ProjectStyle = projectStyle;
             ElapsedTime = elapsedTime;
-            LogMessages = lockFile.LogMessages;
+            LogMessages = lockFile?.LogMessages ?? new List<IAssetsLogMessage>();
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRunner.cs
@@ -286,8 +286,8 @@ namespace NuGet.Commands
                     summaryRequest.InputPath,
                     DatetimeUtility.ToReadableTimeFormat(result.ElapsedTime)));
             }
-            // Remote the summary messages from the assets file. This will be removed later.
-            var messages = restoreResult.Result.LockFile?.LogMessages
+            // Remote the summary messages from the assets file.
+            var messages = restoreResult.Result.LogMessages
                 .Select(e => new RestoreLogMessage(e.Level, e.Code, e.Message)) ?? Enumerable.Empty<RestoreLogMessage>();
 
             // Build the summary

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRunner.cs
@@ -286,6 +286,8 @@ namespace NuGet.Commands
                     summaryRequest.InputPath,
                     DatetimeUtility.ToReadableTimeFormat(result.ElapsedTime)));
             }
+            // TODO NK - This is dumb. We read the assets file for no good reason here.
+            // Even if we actually don't need these errors in Visual Studio. We should use the messages from the cache file.
 
             // Remote the summary messages from the assets file. This will be removed later.
             var messages = restoreResult.Result.LockFile?.LogMessages

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRunner.cs
@@ -286,9 +286,6 @@ namespace NuGet.Commands
                     summaryRequest.InputPath,
                     DatetimeUtility.ToReadableTimeFormat(result.ElapsedTime)));
             }
-            // TODO NK - This is dumb. We read the assets file for no good reason here.
-            // Even if we actually don't need these errors in Visual Studio. We should use the messages from the cache file.
-
             // Remote the summary messages from the assets file. This will be removed later.
             var messages = restoreResult.Result.LockFile?.LogMessages
                 .Select(e => new RestoreLogMessage(e.Level, e.Code, e.Message)) ?? Enumerable.Empty<RestoreLogMessage>();

--- a/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileUtilities.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileUtilities.cs
@@ -1,10 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
 using NuGet.Common;
 
 namespace NuGet.ProjectModel

--- a/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileUtilities.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileUtilities.cs
@@ -1,7 +1,10 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
 using NuGet.Common;
 
 namespace NuGet.ProjectModel

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
@@ -2900,6 +2900,87 @@ namespace NuGet.Commands.FuncTest
             }
         }
 
+        [Fact]
+        public async Task RestoreCommand_WhenRestoreNoOps_TheAssetsFileIsNotRead()
+        {
+            using (var pathContext = new SimpleTestPathContext())
+            using (var context = new SourceCacheContext())
+            {
+                var configJson = JObject.Parse(@"
+                {
+                    ""frameworks"": {
+                        ""net5.0"": {
+                            ""dependencies"": {
+                                ""A"": {
+                                    ""version"" : ""1.0.0"",
+                                }
+                            }
+                        }
+                    }
+                }");
+
+                // Arrange
+                var packageA = new SimpleTestPackageContext("a", "1.0.0");
+                packageA.Files.Clear();
+                packageA.AddFile("lib/net5.0/a.dll");
+
+                await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                    pathContext.PackageSource,
+                    PackageSaveMode.Defaultv3,
+                    packageA);
+
+                var sources = new List<PackageSource>
+                {
+                    new PackageSource(pathContext.PackageSource)
+                };
+                var logger = new TestLogger();
+
+                var projectDirectory = Path.Combine(pathContext.SolutionRoot, "TestProject");
+                var cachingSourceProvider = new CachingSourceProvider(new PackageSourceProvider(NullSettings.Instance));
+
+                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", Path.Combine(projectDirectory, "project.csproj")).WithTestRestoreMetadata();
+                var dgSpec = new DependencyGraphSpec();
+                dgSpec.AddProject(spec);
+                dgSpec.AddRestore(spec.Name);
+
+                var request = new TestRestoreRequest(spec, sources, pathContext.UserPackagesFolder, logger)
+                {
+                    ProjectStyle = ProjectStyle.PackageReference,
+                    DependencyGraphSpec = dgSpec,
+                    AllowNoOp = true,
+                };
+                var command = new RestoreCommand(request);
+
+                // Preconditions
+                var result = await command.ExecuteAsync();
+                await result.CommitAsync(logger, CancellationToken.None);
+                result.Success.Should().BeTrue(because: logger.ShowMessages());
+
+                // Modify the assets file. No-op restore should not read the assets file, if it does, it will throw.
+                File.WriteAllText(Path.Combine(spec.RestoreMetadata.OutputPath, "project.assets.json"), "<xml> </xml>");
+                var newSpec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", Path.Combine(projectDirectory, "project.csproj")).WithTestRestoreMetadata();
+                var newDgSpec = new DependencyGraphSpec();
+                newDgSpec.AddProject(newSpec);
+                newDgSpec.AddRestore(newSpec.Name);
+
+                var newRequest = new TestRestoreRequest(spec, sources, pathContext.UserPackagesFolder, logger)
+                {
+                    ProjectStyle = ProjectStyle.PackageReference,
+                    DependencyGraphSpec = dgSpec,
+                    AllowNoOp = true,
+                };
+                var newCommand = new RestoreCommand(newRequest);
+
+                // Act
+                result = await newCommand.ExecuteAsync();
+                // Assert
+
+                await result.CommitAsync(logger, CancellationToken.None);
+                result.Success.Should().BeTrue(because: logger.ShowMessages());
+                result.Should().BeAssignableTo<NoOpRestoreResult>(because: "This should be a no-op restore.");
+            }
+        }
+
         private static byte[] GetTestUtilityResource(string name)
         {
             return ResourceTestUtility.GetResourceBytes(


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9693
Regression: No  
* Last working version:   Never worked
* How are we preventing it in future:   

## Fix

Details: 

Follow up to https://github.com/NuGet/NuGet.Client/pull/3104. 

Despite removing the reading of the assets file before restore, the assets file was actually being read at the end of the operation, in order to determine whether the operation is failure or not (in commandline & for no great reason in VS). 

Impact of this:

* Unnecessary reads of n assets files in NuGet.exe restore to get the status.
* Unnecessary reads in msbuild.exe restore to get the status

This improved restore performance (with static graph enabled), by 8%. 

When it comes to NuGet only restore stuff (so no msbuild), it's 20% of out of the 100% spent in the actual restore task. 

So 8% out of 40% if you are looking at the below image.
![perfimprovement](https://user-images.githubusercontent.com/2878341/84848073-4eb58500-b007-11ea-88a7-41259e895728.png)
 

## Testing/Validation

Tests Added: Yes  
Reason for not adding tests:  
Validation:  
