### PR TITLE
Make two newly added dotnet integration tests be able to run on multiple TFMs

### DIFF
--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
@@ -764,7 +764,7 @@ EndGlobal";
         [PlatformFact(Platform.Windows)]
         public void RestoreCommand_DisplaysCPVMInPreviewMessageIfCPVMEnabled()
         {
-            using (var testDirectory = TestDirectory.Create())
+            using (var testDirectory = _msbuildFixture.CreateTestDirectory())
             {
                 // Arrange
                 var projectName = "ClassLibrary1";
@@ -805,7 +805,7 @@ EndGlobal";
         [PlatformFact(Platform.Windows)]
         public void RestoreCommand_DoesNotDisplayCPVMInPreviewMessageIfCPVMNotEnabled()
         {
-            using (var testDirectory = TestDirectory.Create())
+            using (var testDirectory = _msbuildFixture.CreateTestDirectory())
             {
                 // Arrange
                 var projectName = "ClassLibrary1";


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9681
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: 
We implemented "Run dotnet nuget tests on multiple TFMs" in https://github.com/NuGet/NuGet.Client/pull/3387 in xplat feature branch.
There're two newly added dotnet integration tests in dev branch, which are not able to generate temporary global.json to run on multiple TFMs.
So adapt the two tests, make them able to run on multiple TFMs. 

## Testing/Validation

Tests Added: Yes/No  
Reason for not adding tests:  
Validation:  
