### PR TITLE
Update Package Link to stable version

### DIFF
--- a/build/packages.targets
+++ b/build/packages.targets
@@ -29,7 +29,7 @@
         <PackageReference Update="Microsoft.Extensions.CommandLineUtils" Version="1.0.1" />
         <PackageReference Update="Microsoft.Internal.VisualStudio.Shell.Embeddable" Version="16.4.29305.180" />
         <PackageReference Update="Microsoft.ServiceHub.Framework" Version="2.4.227" />
-        <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19351-01" />
+        <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.0.0" />
         <PackageReference Update="Microsoft.TeamFoundationServer.ExtendedClient" Version="$(VSServicesVersion)" />
         <PackageReference Update="Microsoft.VSSDK.BuildTools" Version="16.7.11" />
         <PackageReference Update="Microsoft.VisualStudio.ComponentModelHost" Version="$(VSComponentsVersion)" />


### PR DESCRIPTION
Update Source Link package version to stable

## Bug

Fixes: https://github.com/NuGet/Home/issues/9695
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: Building the solution locally found the next error 

```
C:\Users\t-marui\.nuget\packages\microsoft.build.tasks.git\1.0.0-beta2-19351-01\build\Microsoft.Build.Tasks.Git.targets(24,5): error MSB4018: The "Microsoft.Build.Tasks.Git.LocateRepository" task failed unexp
ectedly. [C:\Users\t-marui\Documents\GitHub\NuGet.Client\src\NuGet.Core\NuGet.Frameworks\NuGet.Frameworks.csproj]
C:\Users\t-marui\.nuget\packages\microsoft.build.tasks.git\1.0.0-beta2-19351-01\build\Microsoft.Build.Tasks.Git.targets(24,5): error MSB4018: System.ArgumentNullException: Value cannot be null. [C:\Users\t-ma
rui\Documents\GitHub\NuGet.Client\src\NuGet.Core\NuGet.Frameworks\NuGet.Frameworks.csproj]
C:\Users\t-marui\.nuget\packages\microsoft.build.tasks.git\1.0.0-beta2-19351-01\build\Microsoft.Build.Tasks.Git.targets(24,5): error MSB4018: Parameter name: path1 [C:\Users\t-marui\Documents\GitHub\NuGet.Cli
ent\src\NuGet.Core\NuGet.Frameworks\NuGet.Frameworks.csproj]
C:\Users\t-marui\.nuget\packages\microsoft.build.tasks.git\1.0.0-beta2-19351-01\build\Microsoft.Build.Tasks.Git.targets(24,5): error MSB4018:    at System.IO.Path.Combine(String path1, String path2) [C:\Users
\t-marui\Documents\GitHub\NuGet.Client\src\NuGet.Core\NuGet.Frameworks\NuGet.Frameworks.csproj]
```

Upgrading the package to 1.0.0 fixes the problem

## Testing/Validation

Tests Added: No  
Reason for not adding tests: Infrastructure  
Validation:  Manual
