### PR TITLE
don't inherit nuget.config fallback folders

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -14,4 +14,7 @@
   <disabledPackageSources>
     <clear />
   </disabledPackageSources>
+  <fallbackPackageFolders>
+    <clear />
+  </fallbackPackageFolders>
 </configuration>

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/FallbackFolderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/FallbackFolderTests.cs
@@ -172,13 +172,11 @@ namespace NuGet.Configuration.Test
                 SettingsTestUtils.CreateConfigurationFile(nugetConfigPath, mockBaseDirectory, configB);
                 SettingsTestUtils.CreateConfigurationFile(nugetConfigPath, machineWide, configC);
 
-                var machineWiderFolderSettings = new Settings(machineWide);
-                var machineWideSettings = new TestMachineWideSettings(machineWiderFolderSettings);
-
-                var settings = Settings.LoadDefaultSettings(
-                    subFolder,
-                    configFileName: null,
-                    machineWideSettings: machineWideSettings);
+                var settings = Settings.LoadSettingsGivenConfigPaths(new[] {
+                    Path.Combine(subFolder, nugetConfigPath),
+                    Path.Combine(mockBaseDirectory, nugetConfigPath),
+                    Path.Combine(machineWide, nugetConfigPath)
+                });
 
                 // Act
                 var actual = SettingsUtility
@@ -232,13 +230,11 @@ namespace NuGet.Configuration.Test
                 SettingsTestUtils.CreateConfigurationFile(nugetConfigPath, mockBaseDirectory, configB);
                 SettingsTestUtils.CreateConfigurationFile(nugetConfigPath, machineWide, configC);
 
-                var machineWiderFolderSettings = new Settings(machineWide);
-                var machineWideSettings = new TestMachineWideSettings(machineWiderFolderSettings);
-
-                var settings = Settings.LoadDefaultSettings(
-                    subFolder,
-                    configFileName: null,
-                    machineWideSettings: machineWideSettings);
+                var settings = Settings.LoadSettingsGivenConfigPaths(new[] {
+                    Path.Combine(subFolder, nugetConfigPath),
+                    Path.Combine(mockBaseDirectory, nugetConfigPath),
+                    Path.Combine(machineWide, nugetConfigPath)
+                });
 
                 // Act
                 var paths = SettingsUtility.GetFallbackPackageFolders(settings).ToArray();


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Client.Engineering/issues/368
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: Clear the fallback folders list in nuget.config

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  build configuration change
Validation:  
