### PR TITLE
Fix SolutionRestoreManager tests by using UI thread fixture

### DIFF
--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsSolutionRestoreServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsSolutionRestoreServiceTests.cs
@@ -26,6 +26,7 @@ using static NuGet.Frameworks.FrameworkConstants;
 
 namespace NuGet.SolutionRestoreManager.Test
 {
+    [Collection(DispatcherThreadCollection.CollectionName)]
     public class VsSolutionRestoreServiceTests : IDisposable
     {
         private readonly TestDirectory _testDirectory;


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9669
Regression: No
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: Run VsSolutionRestoreServiceTests in same collection as SolutionRestoreBuildHandlerTests. This prevents them running in parallel. Although `VsSolutionRestoreServiceTests` doesn't use the collection fixture, so I'm not sure why this work.

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  This is fixing tests.
Validation:  
