### PR TITLE
Skip QueryDelayBuildAction_CleanBuild and UninstallPackageFromUI tests as flakyness

### DIFF
--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/SolutionRestoreBuildHandlerTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/SolutionRestoreBuildHandlerTests.cs
@@ -26,7 +26,7 @@ namespace NuGet.SolutionRestoreManager.Test
             _jtf = fixture.JoinableTaskFactory;
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/NuGet/Home/issues/9701")]
         public async Task QueryDelayBuildAction_CleanBuild()
         {
             var settings = Mock.Of<ISettings>();
@@ -53,7 +53,7 @@ namespace NuGet.SolutionRestoreManager.Test
                 .Verify(x => x.ScheduleRestoreAsync(It.IsAny<SolutionRestoreRequest>(), It.IsAny<CancellationToken>()), Times.Never);
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/NuGet/Home/issues/9701")]
         public async Task QueryDelayBuildAction_ShouldNotRestoreOnBuild_NoOps()
         {
             var settings = Mock.Of<ISettings>();
@@ -81,7 +81,7 @@ namespace NuGet.SolutionRestoreManager.Test
                 .Verify(x => x.ScheduleRestoreAsync(It.IsAny<SolutionRestoreRequest>(), It.IsAny<CancellationToken>()), Times.Never);
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/NuGet/Home/issues/9701")]
         public async Task QueryDelayBuildAction_ShouldNotRestoreOnBuild_ProjectUpToDateMark()
         {
             var settings = Mock.Of<ISettings>();
@@ -109,7 +109,7 @@ namespace NuGet.SolutionRestoreManager.Test
                 .Verify(x => x.ScheduleRestoreAsync(It.IsAny<SolutionRestoreRequest>(), It.IsAny<CancellationToken>()), Times.Never);
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/NuGet/Home/issues/9701")]
         public async Task QueryDelayBuildAction_ShouldRestoreOnBuild()
         {
             var settings = Mock.Of<ISettings>();

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetUITestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetUITestCase.cs
@@ -123,7 +123,7 @@ namespace NuGet.Tests.Apex
             CommonUtility.AssertPackageNotInPackagesConfig(VisualStudio, project, "newtonsoft.json", XunitLogger);
         }
 
-        [StaFact]
+        [StaFact(Skip = "https://github.com/NuGet/Home/issues/9701")]
         public void UpdatePackageFromUI()
         {
             // Arrange

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetUITestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetUITestCase.cs
@@ -65,7 +65,7 @@ namespace NuGet.Tests.Apex
             CommonUtility.AssertPackageInPackagesConfig(VisualStudio, project, "newtonsoft.json", "9.0.1", XunitLogger);
         }
 
-        [StaFact]
+        [StaFact(Skip = "https://github.com/NuGet/Home/issues/9701")]
         public void InstallPackageToProjectsFromUI()
         {
             // Arrange

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetUITestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetUITestCase.cs
@@ -94,7 +94,7 @@ namespace NuGet.Tests.Apex
             CommonUtility.AssertPackageInPackagesConfig(VisualStudio, nuProject, "newtonsoft.json", "9.0.1", XunitLogger);
         }
 
-        [StaFact]
+        [StaFact(Skip = "https://github.com/NuGet/Home/issues/9701")]
         public void UninstallPackageFromUI()
         {
             // Arrange
@@ -123,7 +123,7 @@ namespace NuGet.Tests.Apex
             CommonUtility.AssertPackageNotInPackagesConfig(VisualStudio, project, "newtonsoft.json", XunitLogger);
         }
 
-        [StaFact(Skip = "https://github.com/NuGet/Home/issues/9701")]
+        [StaFact]
         public void UpdatePackageFromUI()
         {
             // Arrange


### PR DESCRIPTION
tracking issue: https://github.com/NuGet/Home/issues/9701
