### PR TITLE
improve the debugging of the CLIs

### DIFF
--- a/scripts/nuget-debug-helpers.ps1
+++ b/scripts/nuget-debug-helpers.ps1
@@ -79,7 +79,8 @@ Function Add-NuGetToCLI {
     $sdk_path = $sdkLocation
     
     $nugetXplatArtifactsPath = [System.IO.Path]::Combine($NuGetClientRoot, 'artifacts', 'NuGet.CommandLine.XPlat', $VSVersion, 'bin', $Configuration, $NETCoreApp)
-    $nugetBuildTasks = [System.IO.Path]::Combine($NuGetClientRoot, 'artifacts', 'NuGet.Build.Tasks.Console', $VSVersion, 'bin', $Configuration, $NETCoreApp, 'NuGet.Build.Tasks.Console.dll')
+    $nugetBuildTasks = [System.IO.Path]::Combine($NuGetClientRoot, 'artifacts', 'NuGet.Build.Tasks', $VSVersion, 'bin', $Configuration, $NETStandard, 'NuGet.Build.Tasks.dll')
+    $nugetBuildTasksConsole = [System.IO.Path]::Combine($NuGetClientRoot, 'artifacts', 'NuGet.Build.Tasks.Console', $VSVersion, 'bin', $Configuration, $NETCoreApp, 'NuGet.Build.Tasks.Console.dll')
     $nugetTargets = [System.IO.Path]::Combine($NuGetClientRoot, 'src', 'NuGet.Core', 'NuGet.Build.Tasks', 'NuGet.targets')
     $nugetExTargets = [System.IO.Path]::Combine($NuGetClientRoot, 'src', 'NuGet.Core', 'NuGet.Build.Tasks', 'NuGet.RestoreEx.targets')
     $ilmergedCorePackTasks = [System.IO.Path]::Combine($NuGetClientRoot, 'artifacts', 'NuGet.Build.Tasks.Pack', $VSVersion, 'bin', $Configuration, $NETStandard, "ilmerge", "NuGet.Build.Tasks.Pack.dll")
@@ -95,6 +96,11 @@ Function Add-NuGetToCLI {
 
     if (-Not (Test-Path $nugetBuildTasks)) {
         Write-Error "$nugetBuildTasks not found!"
+        return;
+    }
+
+    if (-Not (Test-Path $nugetBuildTasksConsole)) {
+        Write-Error "$nugetBuildTasksConsole not found!"
         return;
     }
 
@@ -148,6 +154,10 @@ Function Add-NuGetToCLI {
     $buildTasksDest = "$($sdk_path)\NuGet.Build.Tasks.dll" 
     Write-Host "Moving to - $($buildTasksDest)"
     Copy-Item $nugetBuildTasks $buildTasksDest
+
+    $buildTasksConsoleDest = "$($sdk_path)\NuGet.Build.Tasks.Console.dll" 
+    Write-Host "Moving to - $($buildTasksConsoleDest)"
+    Copy-Item $nugetBuildTasksConsole $buildTasksConsoleDest
 
     $nugetTargetsDest = "$($sdk_path)\NuGet.targets" 
     Write-Host "Moving to - $($nugetTargetsDest)"

--- a/src/NuGet.Core/NuGet.Build.Tasks.Console/Program.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Console/Program.cs
@@ -37,18 +37,7 @@ namespace NuGet.Build.Tasks.Console
 
             if (debug)
             {
-#if IS_CORECLR
-                System.Console.WriteLine($"Waiting for debugger to attach to Process ID: {Process.GetCurrentProcess().Id}");
-
-                while (!Debugger.IsAttached)
-                {
-                    System.Threading.Thread.Sleep(100);
-                }
-
-                Debugger.Break();
-#else
                 Debugger.Launch();
-#endif
             }
 
             // Parse command-line arguments

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTask.cs
@@ -107,18 +107,7 @@ namespace NuGet.Build.Tasks.Pack
                 var debugPackTask = Environment.GetEnvironmentVariable("DEBUG_PACK_TASK");
                 if (!string.IsNullOrEmpty(debugPackTask) && debugPackTask.Equals(bool.TrueString, StringComparison.OrdinalIgnoreCase))
                 {
-#if IS_CORECLR
-                    Console.WriteLine("Waiting for debugger to attach.");
-                    Console.WriteLine($"Process ID: {Process.GetCurrentProcess().Id}");
-
-                    while (!Debugger.IsAttached)
-                    {
-                        System.Threading.Thread.Sleep(100);
-                    }
-                    Debugger.Break();
-#else
-            Debugger.Launch();
-#endif
+                    Debugger.Launch();
                 }
 #endif
 

--- a/src/NuGet.Core/NuGet.Build.Tasks/RestoreTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/RestoreTask.cs
@@ -78,18 +78,7 @@ namespace NuGet.Build.Tasks
             var debugRestoreTask = Environment.GetEnvironmentVariable("DEBUG_RESTORE_TASK");
             if (!string.IsNullOrEmpty(debugRestoreTask) && debugRestoreTask.Equals(bool.TrueString, StringComparison.OrdinalIgnoreCase))
             {
-#if IS_CORECLR
-                Console.WriteLine("Waiting for debugger to attach.");
-                Console.WriteLine($"Process ID: {Process.GetCurrentProcess().Id}");
-
-                while (!Debugger.IsAttached)
-                {
-                    System.Threading.Thread.Sleep(100);
-                }
-                Debugger.Break();
-#else
                 Debugger.Launch();
-#endif
             }
 #endif
             var log = new MSBuildLogger(Log);

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Program.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Program.cs
@@ -54,16 +54,7 @@ namespace NuGet.CommandLine.XPlat
             if (args.Contains(DebugOption) || string.Equals(bool.TrueString, debugNuGetXPlat, StringComparison.OrdinalIgnoreCase))
             {
                 args = args.Where(arg => !StringComparer.OrdinalIgnoreCase.Equals(arg, DebugOption)).ToArray();
-
-                Console.WriteLine("Waiting for debugger to attach.");
-                Console.WriteLine($"Process ID: {Process.GetCurrentProcess().Id}");
-
-                while (!Debugger.IsAttached)
-                {
-                    System.Threading.Thread.Sleep(100);
-                }
-
-                Debugger.Break();
+                Debugger.Launch();
             }
 #endif
 


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Client.Engineering/issues/373
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: Fix the dotnet debugging scripts + replace every mention of wait for debugger to debugger.launch in the .NET Core codepaths. Debugger.Launch now correctly launches the debugger.

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  
Validation:  
