### PR TITLE
Use new NuGet.Build.Tasks.Pack(5.6.0) containing the right logic treating net5.0

### DIFF
--- a/build/bootstrap.proj
+++ b/build/bootstrap.proj
@@ -23,7 +23,7 @@
         <PackageDownload Include="Microsoft.VisualStudio.ProjectSystem.Managed.VS" version="[16.7.0-beta1-65318-02]" />
         <PackageDownload Include="Microsoft.Web.Xdt" version="[2.1.2]" />
         <PackageDownload Include="Newtonsoft.Json" version="[9.0.1]" />
-        <PackageDownload Include="NuGet.Build.Tasks.Pack" version="[4.9.2]" />
+        <PackageDownload Include="NuGet.Build.Tasks.Pack" version="[5.6.0]" />
         <PackageDownload Include="NuGet.Client.EndToEnd.TestData" version="[1.0.0]" />
         <PackageDownload Include="NuGet.Core" version="[2.14.0-rtm-832]" />
         <PackageDownload Include="NuGetValidator" version="[2.0.2]" />

--- a/build/common.project.props
+++ b/build/common.project.props
@@ -36,7 +36,7 @@
     <XunitConsoleExePath>$(SolutionPackagesFolder)xunit.runner.console\2.4.1\tools\net472\xunit.console.x86.exe</XunitConsoleExePath>
     <ILMergeExePath>$(SolutionPackagesFolder)ilmerge\3.0.21\tools\net452\ILMerge.exe</ILMergeExePath>
     <XunitXmlLoggerDirectory>$(SolutionPackagesFolder)xunitxml.testlogger\2.0.0\build\_common</XunitXmlLoggerDirectory>
-    <NuGetBuildTasksPackTargets Condition="Exists('$(SolutionPackagesFolder)nuget.build.tasks.pack\4.9.2\build\NuGet.Build.Tasks.Pack.targets')">$(SolutionPackagesFolder)nuget.build.tasks.pack\4.9.2\build\NuGet.Build.Tasks.Pack.targets</NuGetBuildTasksPackTargets>
+    <NuGetBuildTasksPackTargets Condition="Exists('$(SolutionPackagesFolder)nuget.build.tasks.pack\5.6.0\build\NuGet.Build.Tasks.Pack.targets')">$(SolutionPackagesFolder)nuget.build.tasks.pack\5.6.0\build\NuGet.Build.Tasks.Pack.targets</NuGetBuildTasksPackTargets>
     <EnlistmentRoot>$(RepositoryRootDirectory)</EnlistmentRoot>
     <EnlistmentRootSrc>$(RepositoryRootDirectory)src</EnlistmentRootSrc>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">$(RepositoryRootDirectory)</SolutionDir>
@@ -49,7 +49,7 @@
     <IsBuildOnlyXPLATProjects>$(DotNetBuildFromSource)</IsBuildOnlyXPLATProjects>
     <MicrosoftDotNetBuildTasksFeedFilePath>$(SolutionPackagesFolder)microsoft.dotnet.build.tasks.feed\5.0.0-beta.20159.1\tools\netcoreapp2.1\Microsoft.DotNet.Build.Tasks.Feed.dll</MicrosoftDotNetBuildTasksFeedFilePath>
     <MicrosoftDotNetMaestroTasksFilePath>$(SolutionPackagesFolder)microsoft.dotnet.maestro.tasks\1.1.0-beta.20065.7\tools\netcoreapp2.1\Microsoft.DotNet.Maestro.Tasks.dll</MicrosoftDotNetMaestroTasksFilePath>
-    <NoWarn>$(NoWarn);NU5105</NoWarn>
+    <NoWarn>$(NoWarn);NU5105;NU5048</NoWarn>
   </PropertyGroup>
 
   <!-- Defaults -->


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9707
Regression: Yes  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: 
1.Upgrade package version of NuGet.Build.Tasks.Pack from 4.9.2 to 5.6.0.
2.Supress error NU5048 temporally.
```
The 'PackageIconUrl'/'iconUrl' element is deprecated. Consider using the 'PackageIcon'/'icon' element instead. Learn
more at https://aka.ms/deprecateIconUrl
```

## Testing/Validation

Tests Added: Yes/No  
Reason for not adding tests:  
Validation:  
