### PR TITLE
Fix missing runtime config file for net5.0, supress 2 warns

### DIFF
--- a/build/common.project.props
+++ b/build/common.project.props
@@ -49,7 +49,7 @@
     <IsBuildOnlyXPLATProjects>$(DotNetBuildFromSource)</IsBuildOnlyXPLATProjects>
     <MicrosoftDotNetBuildTasksFeedFilePath>$(SolutionPackagesFolder)microsoft.dotnet.build.tasks.feed\5.0.0-beta.20159.1\tools\netcoreapp2.1\Microsoft.DotNet.Build.Tasks.Feed.dll</MicrosoftDotNetBuildTasksFeedFilePath>
     <MicrosoftDotNetMaestroTasksFilePath>$(SolutionPackagesFolder)microsoft.dotnet.maestro.tasks\1.1.0-beta.20065.7\tools\netcoreapp2.1\Microsoft.DotNet.Maestro.Tasks.dll</MicrosoftDotNetMaestroTasksFilePath>
-    <NoWarn>$(NoWarn);NU5105;NU5048;NU5128;NU5104</NoWarn>
+    <NoWarn>$(NoWarn);NU5105;NU5048</NoWarn>
   </PropertyGroup>
 
   <!-- Defaults -->

--- a/build/common.project.props
+++ b/build/common.project.props
@@ -49,7 +49,7 @@
     <IsBuildOnlyXPLATProjects>$(DotNetBuildFromSource)</IsBuildOnlyXPLATProjects>
     <MicrosoftDotNetBuildTasksFeedFilePath>$(SolutionPackagesFolder)microsoft.dotnet.build.tasks.feed\5.0.0-beta.20159.1\tools\netcoreapp2.1\Microsoft.DotNet.Build.Tasks.Feed.dll</MicrosoftDotNetBuildTasksFeedFilePath>
     <MicrosoftDotNetMaestroTasksFilePath>$(SolutionPackagesFolder)microsoft.dotnet.maestro.tasks\1.1.0-beta.20065.7\tools\netcoreapp2.1\Microsoft.DotNet.Maestro.Tasks.dll</MicrosoftDotNetMaestroTasksFilePath>
-    <NoWarn>$(NoWarn);NU5105;NU5048</NoWarn>
+    <NoWarn>$(NoWarn);NU5105;NU5048;NU5128;NU5104</NoWarn>
   </PropertyGroup>
 
   <!-- Defaults -->

--- a/src/NuGet.Core/NuGet.Build.Tasks.Console/NuGet.Build.Tasks.Console.csproj
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Console/NuGet.Build.Tasks.Console.csproj
@@ -14,7 +14,7 @@
     <PackProject>true</PackProject>
     <SkipShared>true</SkipShared>
     <Description>NuGet Build tasks for MSBuild and dotnet restore. Contains restore logic using the MSBuild static graph functionality.</Description>
-    <NoWarn>$(NoWarn);CS1591;NU5100</NoWarn>
+    <NoWarn>$(NoWarn);CS1591;NU5100;NU5128;NU5104</NoWarn>
     <XPLATProject>true</XPLATProject>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);PackBuildOutputs</TargetsForTfmSpecificContentInPackage>

--- a/src/NuGet.Core/NuGet.Build.Tasks.Console/NuGet.Build.Tasks.Console.csproj
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Console/NuGet.Build.Tasks.Console.csproj
@@ -65,7 +65,7 @@
   <Target Name="PackBuildOutputs">
     <ItemGroup>
       <TfmSpecificPackageFile Include="$(TargetPath)" PackagePath="contentFiles\any\$(TargetFramework)\" PackageCopyToOutput="true" />
-      <TfmSpecificPackageFile Include="$(ProjectRuntimeConfigFilePath)" Condition="'$(TargetFramework)' == '$(NetCoreTargetFramework)'" PackagePath="contentFiles\any\$(TargetFramework)\" PackageCopyToOutput="true" />
+      <TfmSpecificPackageFile Include="$(ProjectRuntimeConfigFilePath)" Condition=" '$(IsCore)' == 'true' " PackagePath="contentFiles\any\$(TargetFramework)\" PackageCopyToOutput="true" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9710
Regression: No
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: 
1.Add NuGet.Build.Tasks.Console.runtimeconfig.json during packing for net5.0
2.Supress 2 warns
NU5104: A stable release of a package should not have a prerelease dependency. Either modify the version spec of dependency
NU5128: Some target frameworks declared in the dependencies group of the nuspec and the lib/ref folder do not have exact matc
hes in the other location.
## Testing/Validation

Tests Added: Yes/No  
Reason for not adding tests:  
Validation:  
