### PR TITLE
When latest dotnet is unavailable, use specific version as a workaround

### DIFF
--- a/build/config.props
+++ b/build/config.props
@@ -39,6 +39,10 @@
 
     <!-- .NET Core SDK Insertion Logic -->
     <!--We don't have .NET5 installed on CI, so we need to get version from CliVersionForBuilding and install it-->
+    <!--TODO: remove temporary workaround of using LockSDKVersion. Tracking issue: https://github.com/NuGet/Home/issues/9712 -->
+    <LockSDKVersion>true</LockSDKVersion>
+    <OverrideCliBranchForTesting Condition="'$(LockSDKVersion)' == 'false'"></OverrideCliBranchForTesting>
+    <OverrideCliBranchForTesting Condition="'$(LockSDKVersion)' == 'true'">master 5.0.100-preview.7.20319.6;3.1</OverrideCliBranchForTesting>
     <CliVersionForBuilding>"master 5.0.100-preview.4.20258.7"</CliVersionForBuilding>
     <CliBranchForTesting Condition="'$(OverrideCliBranchForTesting)' != ''">$(OverrideCliBranchForTesting)</CliBranchForTesting>
     <CliBranchForTesting Condition="'$(OverrideCliBranchForTesting)' == ''">master;3.1</CliBranchForTesting>


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9713
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: 
Use specific version of dotnet for testing

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  
Validation:  
