### PR TITLE
Add minimal .vsconfig

### DIFF
--- a/.vsconfig
+++ b/.vsconfig
@@ -1,0 +1,25 @@
+{
+  "version": "1.0",
+  "components": [
+    "Microsoft.VisualStudio.Component.CoreEditor",
+    "Microsoft.VisualStudio.Workload.CoreEditor",
+    "Microsoft.NetCore.Component.Runtime.3.1",
+    "Microsoft.NetCore.Component.SDK",
+    "Microsoft.VisualStudio.Component.NuGet",
+    "Microsoft.VisualStudio.Component.Roslyn.Compiler",
+    "Microsoft.VisualStudio.Component.Roslyn.LanguageServices",
+    "Microsoft.NetCore.Component.DevelopmentTools",
+    "Microsoft.Net.Component.4.7.2.TargetingPack",
+    "Microsoft.Net.ComponentGroup.DevelopmentPrerequisites",
+    "Microsoft.Component.MSBuild",
+    "Microsoft.VisualStudio.Component.TextTemplating",
+    "Microsoft.VisualStudio.Component.ManagedDesktop.Core",
+    "Microsoft.VisualStudio.Component.IntelliCode",
+    "Microsoft.VisualStudio.Component.ManagedDesktop.Prerequisites",
+    "Microsoft.VisualStudio.Workload.ManagedDesktop",
+    "Microsoft.VisualStudio.Component.VSSDK",
+    "Microsoft.VisualStudio.ComponentGroup.VisualStudioExtension.Prerequisites",
+    "Microsoft.VisualStudio.Workload.VisualStudioExtension",
+    "Microsoft.VisualStudio.Workload.NetCoreTools"
+  ]
+}


### PR DESCRIPTION
Contains the components necessary to build and debug, and run unit tests.
Does not contain components necessary to run E2E or Apex tests.

## Bug

Fixes: https://github.com/NuGet/Client.Engineering/issues/174
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: Created VM, installed minimal VS, kept adding components until build was successful and most unit/functional tests ran. Exported `.vsconfig`.

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  no code changes
Validation:  
