### PR TITLE
OutputConsoleLogger: Avoid waiting on any main thread work.

### DIFF
--- a/src/NuGet.Clients/NuGet.Console/OutputConsole/OutputConsole.cs
+++ b/src/NuGet.Clients/NuGet.Console/OutputConsole/OutputConsole.cs
@@ -104,6 +104,9 @@ namespace NuGetConsole
         {
             Start();
 
+            var outputWindowTextWriter = await _outputWindowTextWriter.GetValueAsync();
+            await outputWindowTextWriter.FlushAsync();
+
             await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
             VsOutputWindowPane.Activate();

--- a/src/NuGet.Clients/NuGet.Tools/NuGetPackage.cs
+++ b/src/NuGet.Clients/NuGet.Tools/NuGetPackage.cs
@@ -578,7 +578,7 @@ namespace NuGetVSExtension
             windowFrame?.CloseFrame((uint)__FRAMECLOSE.FRAMECLOSE_SaveIfDirty);
 
             var nuGetProject = await SolutionManager.Value.GetNuGetProjectAsync(uniqueName);
-            var uiController = ServiceLocator.GetInstance<INuGetUIFactory>().Create(nuGetProject);
+            var uiController = UIFactory.Value.Create(nuGetProject);
             var settings = uiController.UIContext.UserSettingsManager.GetSettings(GetProjectSettingsKey(nuGetProject));
 
             await uiController.UIContext.UIActionEngine.UpgradeNuGetProjectAsync(uiController, nuGetProject);

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/OutputConsoleLogger.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/OutputConsoleLogger.cs
@@ -36,7 +36,7 @@ namespace NuGet.VisualStudio.Common
         private EnvDTE.SolutionEvents _solutionEvents;
 
         [SuppressMessage("Build", "CA2213:'OutputConsoleLogger' contains field '_semaphore' that is of IDisposable type 'ReentrantSemaphore', but it is never disposed. Change the Dispose method on 'OutputConsoleLogger' to call Close or Dispose on this field.", Justification = "Field is disposed from async task invoked from Dispose.")]
-        private readonly ReentrantSemaphore _semaphore = ReentrantSemaphore.Create(0, NuGetUIThreadHelper.JoinableTaskFactory.Context, ReentrantSemaphore.ReentrancyMode.NotAllowed);
+        private readonly ReentrantSemaphore _semaphore = ReentrantSemaphore.Create(1, NuGetUIThreadHelper.JoinableTaskFactory.Context, ReentrantSemaphore.ReentrancyMode.NotAllowed);
 
         public IOutputConsole OutputConsole { get; private set; }
 


### PR DESCRIPTION
## Bug

**Fixes:** https://github.com/NuGet/Home/issues/9591
**Regression:** No, but Yes -- it seems that enough code moved around that this issue now causes deadlocks frequently enough to raise in ranks on Watson). 

## Fix

**Details:** Every operation requiring main thread is offloaded to async method which we do not wait to return.

## Testing/Validation

**Tests Added:** No  
**Reason for not adding tests:** Plenty of coverage from existing tests, hard to test for race conditions.
**Validation:** Running automates suite of tests
