### PR TITLE
Remove validation on TSA response headers for net5.0

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/Rfc3161TimestampRequestNetstandard21Wrapper.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/Rfc3161TimestampRequestNetstandard21Wrapper.cs
@@ -70,11 +70,6 @@ namespace NuGet.Packaging.Signing
                                 httpResponse.ReasonPhrase));
                     }
 
-                    if (!string.Equals(httpResponse.Content.Headers.ContentType.MediaType, "application/timestamp-response", StringComparison.OrdinalIgnoreCase))
-                    {
-                        throw new CryptographicException(Strings.TimestampServiceRespondedInvalidFormat);
-                    }
-
                     var data = await httpResponse.Content.ReadAsByteArrayAsync();
 
                     System.Security.Cryptography.Pkcs.Rfc3161TimestampToken response = _rfc3161TimestampRequest.ProcessResponse(data, out var _);

--- a/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
@@ -1600,15 +1600,6 @@ namespace NuGet.Packaging {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The reply from the timestamp server was invalid..
-        /// </summary>
-        internal static string TimestampServiceRespondedInvalidFormat {
-            get {
-                return ResourceManager.GetString("TimestampServiceRespondedInvalidFormat", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to The timestamp signature has an unsupported digest algorithm ({0}). The following algorithms are supported: {1}..
         /// </summary>
         internal static string TimestampSignatureUnsupportedDigestAlgorithm {

--- a/src/NuGet.Core/NuGet.Packaging/Strings.resx
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.resx
@@ -839,7 +839,4 @@ Valid from:</comment>
     <value>The timestamp service responded with HTTP status code '{0}' ('{1}').</value>
     <comment>{0} is the httpResponse.StatusCode, {1} is the httpResponse.ReasonPhrase.</comment>
   </data>
-  <data name="TimestampServiceRespondedInvalidFormat" xml:space="preserve">
-    <value>The reply from the timestamp server was invalid.</value>
-  </data>
 </root>


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9725
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: 
Remove the validation on TSA response headers for net5.0. As there is no such validation for net472 code path.

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  
Validation:  
