### PR TITLE
Fixed Bug in NuGet.CommandLine.Console's PrintJustified Method

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Common/Console.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Common/Console.cs
@@ -282,7 +282,7 @@ namespace NuGet.CommandLine
 
                     if (newLineIndex == 0)
                     {
-                        Out.WriteLine("");
+                        Out.WriteLine(string.Empty);
                         text = text.Substring(rn ? 2 : 1);
                         continue;
                     }

--- a/src/NuGet.Clients/NuGet.CommandLine/Common/Console.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Common/Console.cs
@@ -275,12 +275,12 @@ namespace NuGet.CommandLine
                     string content;
 
                     // Get the index of the newLine character upto 'length' characters
-                    (int newLineIndex, bool crlf) = NewLineIndex(text, length);
+                    (int newLineIndex, bool isCRLF) = NewLineIndex(text, length);
 
                     if (newLineIndex == 0)
                     {
                         Out.WriteLine(string.Empty);
-                        text = text.Substring(crlf ? 2 : 1);
+                        text = text.Substring(isCRLF ? 2 : 1);
                         continue;
                     }
                     else if (newLineIndex > -1)
@@ -303,48 +303,49 @@ namespace NuGet.CommandLine
                     }
 
                     // Get the next substring to be printed
-                    text = text.Substring(newLineIndex == -1 ? content.Length : crlf ? content.Length + 2 : content.Length + 1);
+                    text = text.Substring(newLineIndex == -1 ? content.Length : isCRLF ? content.Length + 2 : content.Length + 1);
                 }
             }
         }
 
-
+        // The input string to PrintJustified could use different newline variables than the
+        // client's environment does. The previous implementation used Environment.Newline
+        // to find the index of the newline character, but would fail to do so if there was
+        // a mismatch. This method returns the correct result regardless of the client's environment.
         private (int, bool) NewLineIndex(string text, int length)
         {
             int nIndex = text.IndexOf("\n", 0, length, StringComparison.OrdinalIgnoreCase);
             int rIndex = text.IndexOf("\r", 0, length, StringComparison.OrdinalIgnoreCase);
 
-            bool crlf = false; // \r\n
+            bool isCRLF = false; // \r\n
 
             if (nIndex == rIndex + 1 && nIndex > 0)
             {
-                crlf = true;
+                isCRLF = true;
             }
 
             if (nIndex == -1 && rIndex == -1)
             {
-                return (-1, crlf);
+                return (-1, isCRLF);
             }
             else if (nIndex > -1 && rIndex > -1)
             {
                 if (nIndex < rIndex)
                 {
-                    return (nIndex, crlf);
+                    return (nIndex, isCRLF);
                 }
 
-                return (rIndex, crlf);
+                return (rIndex, isCRLF);
             }
             else if (nIndex > -1)
             {
-                return (nIndex, crlf);
+                return (nIndex, isCRLF);
             }
             else
             {
-                return (rIndex, crlf);
+                return (rIndex, isCRLF);
             }
-            
         }
-
 
         public bool Confirm(string description)
         {

--- a/src/NuGet.Clients/NuGet.CommandLine/Common/Console.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Common/Console.cs
@@ -275,12 +275,12 @@ namespace NuGet.CommandLine
                     string content;
 
                     // Get the index of the newLine character upto 'length' characters
-                    (int newLineIndex, bool newLine) = NewLineIndex(text, length);
+                    (int newLineIndex, bool crlf) = NewLineIndex(text, length);
 
                     if (newLineIndex == 0)
                     {
                         Out.WriteLine(string.Empty);
-                        text = text.Substring(newLine ? 2 : 1);
+                        text = text.Substring(crlf ? 2 : 1);
                         continue;
                     }
                     else if (newLineIndex > -1)
@@ -303,7 +303,7 @@ namespace NuGet.CommandLine
                     }
 
                     // Get the next substring to be printed
-                    text = text.Substring(newLineIndex == -1 ? content.Length : newLine ? content.Length + 2 : content.Length + 1);
+                    text = text.Substring(newLineIndex == -1 ? content.Length : crlf ? content.Length + 2 : content.Length + 1);
                 }
             }
         }
@@ -314,33 +314,33 @@ namespace NuGet.CommandLine
             int nIndex = text.IndexOf("\n", 0, length, StringComparison.OrdinalIgnoreCase);
             int rIndex = text.IndexOf("\r", 0, length, StringComparison.OrdinalIgnoreCase);
 
-            bool newLine = false; // \r\n
+            bool crlf = false; // \r\n
 
             if (nIndex == rIndex + 1 && nIndex > 0)
             {
-                newLine = true;
+                crlf = true;
             }
 
             if (nIndex == -1 && rIndex == -1)
             {
-                return (-1, newLine);
+                return (-1, crlf);
             }
             else if (nIndex > -1 && rIndex > -1)
             {
                 if (nIndex < rIndex)
                 {
-                    return (nIndex, newLine);
+                    return (nIndex, crlf);
                 }
 
-                return (rIndex, newLine);
+                return (rIndex, crlf);
             }
             else if (nIndex > -1)
             {
-                return (nIndex, newLine);
+                return (nIndex, crlf);
             }
             else
             {
-                return (rIndex, newLine);
+                return (rIndex, crlf);
             }
             
         }

--- a/src/NuGet.Clients/NuGet.CommandLine/Common/Console.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Common/Console.cs
@@ -88,10 +88,7 @@ namespace NuGet.CommandLine
         }
 
 
-        internal int? MockWindowWidth
-        {
-            get; set;
-        }
+        internal int? MockWindowWidth { get; set; }
 
         private Verbosity _verbosity;
 
@@ -278,12 +275,12 @@ namespace NuGet.CommandLine
                     string content;
 
                     // Get the index of the newLine character upto 'length' characters
-                    (int newLineIndex, bool rn) = NewLineIndex(text, length);
+                    (int newLineIndex, bool newLine) = NewLineIndex(text, length);
 
                     if (newLineIndex == 0)
                     {
                         Out.WriteLine(string.Empty);
-                        text = text.Substring(rn ? 2 : 1);
+                        text = text.Substring(newLine ? 2 : 1);
                         continue;
                     }
                     else if (newLineIndex > -1)
@@ -306,7 +303,7 @@ namespace NuGet.CommandLine
                     }
 
                     // Get the next substring to be printed
-                    text = text.Substring(newLineIndex == -1 ? content.Length : rn ? content.Length + 2 : content.Length + 1);
+                    text = text.Substring(newLineIndex == -1 ? content.Length : newLine ? content.Length + 2 : content.Length + 1);
                 }
             }
         }
@@ -317,33 +314,33 @@ namespace NuGet.CommandLine
             int nIndex = text.IndexOf("\n", 0, length, StringComparison.OrdinalIgnoreCase);
             int rIndex = text.IndexOf("\r", 0, length, StringComparison.OrdinalIgnoreCase);
 
-            bool rn = false;
+            bool newLine = false; // \r\n
 
             if (nIndex == rIndex + 1 && nIndex > 0)
             {
-                rn = true;
+                newLine = true;
             }
 
             if (nIndex == -1 && rIndex == -1)
             {
-                return (-1, rn);
+                return (-1, newLine);
             }
             else if (nIndex > -1 && rIndex > -1)
             {
                 if (nIndex < rIndex)
                 {
-                    return (nIndex, rn);
+                    return (nIndex, newLine);
                 }
 
-                return (rIndex, rn);
+                return (rIndex, newLine);
             }
             else if (nIndex > -1)
             {
-                return (nIndex, rn);
+                return (nIndex, newLine);
             }
             else
             {
-                return (rIndex, rn);
+                return (rIndex, newLine);
             }
             
         }

--- a/src/NuGet.Clients/NuGet.CommandLine/Common/Console.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Common/Console.cs
@@ -277,9 +277,7 @@ namespace NuGet.CommandLine
 
                     string content;
 
-                    // Text we can print without overflowing the System.Console, excluding new line characters.
-                    //int newLineIndex = text.IndexOf(Environment.NewLine, 0, length, StringComparison.OrdinalIgnoreCase);
-
+                    // Get the index of the newLine character upto 'length' characters
                     (int newLineIndex, bool rn) = NewLineIndex(text, length);
 
                     if (newLineIndex == 0)
@@ -292,7 +290,6 @@ namespace NuGet.CommandLine
                     {
                         content = text.Substring(0, newLineIndex);
                     }
-                    
                     else
                     {
                         content = text.Substring(0, length);
@@ -307,6 +304,7 @@ namespace NuGet.CommandLine
                     {
                         break;
                     }
+
                     // Get the next substring to be printed
                     text = text.Substring(newLineIndex == -1 ? content.Length : rn ? content.Length + 2 : content.Length + 1);
                 }
@@ -316,8 +314,6 @@ namespace NuGet.CommandLine
 
         private (int, bool) NewLineIndex(string text, int length)
         {
-
-            //int rnIndex = text.IndexOf("\r\n", 0, length, StringComparison.OrdinalIgnoreCase);
             int nIndex = text.IndexOf("\n", 0, length, StringComparison.OrdinalIgnoreCase);
             int rIndex = text.IndexOf("\r", 0, length, StringComparison.OrdinalIgnoreCase);
 
@@ -328,12 +324,10 @@ namespace NuGet.CommandLine
                 rn = true;
             }
 
-
             if (nIndex == -1 && rIndex == -1)
             {
                 return (-1, rn);
             }
-
             else if (nIndex > -1 && rIndex > -1)
             {
                 if (nIndex < rIndex)
@@ -343,15 +337,16 @@ namespace NuGet.CommandLine
 
                 return (rIndex, rn);
             }
-
             else if (nIndex > -1)
             {
                 return (nIndex, rn);
             }
-
-            return (rIndex, rn);
+            else
+            {
+                return (rIndex, rn);
+            }
+            
         }
-
 
 
         public bool Confirm(string description)

--- a/src/NuGet.Clients/NuGet.CommandLine/Common/Console.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Common/Console.cs
@@ -37,6 +37,11 @@ namespace NuGet.CommandLine
         {
             get
             {
+                if (MockCursorLeft != null)
+                {
+                    return (int)MockCursorLeft;
+                }
+
                 try
                 {
                     return System.Console.CursorLeft;
@@ -89,6 +94,8 @@ namespace NuGet.CommandLine
 
 
         internal int? MockWindowWidth { get; set; }
+
+        internal int? MockCursorLeft { get; set; }
 
         private Verbosity _verbosity;
 
@@ -270,6 +277,9 @@ namespace NuGet.CommandLine
                     string line;
                     while ((line = stringReader.ReadLine()) != null)
                     {
+                        // Trim extra whitespace at the beginning and end of the line
+                        line = line.Trim();
+
                         if (line == string.Empty)
                         {
                             Out.WriteLine();
@@ -278,8 +288,6 @@ namespace NuGet.CommandLine
 
                         while (true)
                         {
-                            // Trim whitespace at the beginning
-                            line = line.TrimStart();
                             // Calculate the number of chars to print based on the width of the System.Console
                             int length = Math.Min(line.Length, maxWidth);
 
@@ -291,12 +299,12 @@ namespace NuGet.CommandLine
                             // Print it with the correct padding
                             Out.WriteLine((leftPadding > 0) ? content.PadLeft(leftPadding) : content);
 
-                            if (content.Length == line.Length)
+                            line = line.Substring(content.Length).Trim();
+
+                            if (line.Trim() == string.Empty)
                             {
                                 break;
                             }
-
-                            line = line.Substring(content.Length);
                         }
                     }
                 }

--- a/src/NuGet.Clients/NuGet.CommandLine/Common/Console.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Common/Console.cs
@@ -308,10 +308,10 @@ namespace NuGet.CommandLine
             }
         }
 
-        // The input string to PrintJustified could use different newline variables than the
-        // client's environment does. The previous implementation used Environment.Newline
-        // to find the index of the newline character, but would fail to do so if there was
-        // a mismatch. This method returns the correct result regardless of the client's environment.
+        /// The input string to PrintJustified could use different newline variables than the
+        /// client's environment does. The previous implementation used Environment.Newline
+        /// to find the index of the newline character, but would fail to do so if there was
+        /// a mismatch. This method returns the correct result regardless of the client's environment.
         private (int, bool) NewLineIndex(string text, int length)
         {
             int nIndex = text.IndexOf("\n", 0, length, StringComparison.OrdinalIgnoreCase);

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/ConsoleTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/ConsoleTest.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.IO;
 using NuGet.Test.Utility;

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/ConsoleTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/ConsoleTest.cs
@@ -24,6 +24,11 @@ namespace NuGet.CommandLine.Test
         [InlineData(2, "abcde\rwcjb", "  abcdeXXX  wcjbXXX", 10)]
         [InlineData(2, "abcdefghijk\nAB", "  abcdeXXX  fghijXXX  kXXX  ABXXX", 7)]
         [InlineData(2, "ab  cd", "  abXXX  cdXXX", 6)]
+        [InlineData(2, "  abcd    ", "  abcdXXX", 10)]
+        [InlineData(2, "  abcd\t", "  abcdXXX", 10)]
+        [InlineData(2, "  abcd\n", "  abcdXXX", 10)]
+        [InlineData(2, "  abcd\n\n", "  abcdXXXXXX", 10)]
+        [InlineData(2, "\t\nabcd\n\n", "XXX  abcdXXXXXX", 10)]
         public void TestPrintJustified(int indent, string input, string expected, int width)
         {
             var sw = new StringWriter();

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/ConsoleTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/ConsoleTest.cs
@@ -18,10 +18,12 @@ namespace NuGet.CommandLine.Test
 
         [Theory]
         [InlineData(2, "abcd\nwxyz", "  abcdXXX  wxyzXXX", 10)]
+        [InlineData(2, "abcd\rwxyz", "  abcdXXX  wxyzXXX", 10)]
         [InlineData(3, "abcde\n\nwcjb", "   abcdeXXXXXX   wcjbXXX", 10)]
         [InlineData(2, "abcde\r\nwcjb", "  abcdeXXX  wcjbXXX", 10)]
         [InlineData(2, "abcde\rwcjb", "  abcdeXXX  wcjbXXX", 10)]
         [InlineData(2, "abcdefghijk\nAB", "  abcdeXXX  fghijXXX  kXXX  ABXXX", 7)]
+        [InlineData(2, "ab  cd", "  abXXX  cdXXX", 6)]
         public void TestPrintJustified(int indent, string input, string expected, int width)
         {
             var sw = new StringWriter();

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/ConsoleTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/ConsoleTest.cs
@@ -16,7 +16,6 @@ namespace NuGet.CommandLine.Test
             Assert.NotEqual(0, new Console().WindowWidth);
         }
 
-
         [Theory]
         [InlineData(2, "abcd\nwxyz", "  abcdXXX  wxyzXXX", 10)]
         [InlineData(3, "abcde\n\nwcjb", "   abcdeXXXXXX   wcjbXXX", 10)]
@@ -34,6 +33,5 @@ namespace NuGet.CommandLine.Test
 
             Assert.Equal(expected.Replace("XXX", Environment.NewLine), sw.ToString());
         }
-
     }
 }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/ConsoleTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/ConsoleTest.cs
@@ -32,6 +32,7 @@ namespace NuGet.CommandLine.Test
         [InlineData(2, "  abcd\n", "abcdXXX", 8, 2)]
         [InlineData(2, "  abcd\n\n", "  abcdXXXXXX", 10, 0)]
         [InlineData(2, "\t\nabcd\n\n", "XXX  abcdXXXXXX", 10, 0)]
+        [InlineData(0, "abcd e", "abcdXXXeXXX", 5, 0)]
         public void TestPrintJustified(int indent, string input, string expected, int width, int cursorLeft)
         {
             var sw = new StringWriter();

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/ConsoleTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/ConsoleTest.cs
@@ -17,25 +17,29 @@ namespace NuGet.CommandLine.Test
         }
 
         [Theory]
-        [InlineData(2, "abcd\nwxyz", "  abcdXXX  wxyzXXX", 10)]
-        [InlineData(2, "abcd\rwxyz", "  abcdXXX  wxyzXXX", 10)]
-        [InlineData(3, "abcde\n\nwcjb", "   abcdeXXXXXX   wcjbXXX", 10)]
-        [InlineData(2, "abcde\r\nwcjb", "  abcdeXXX  wcjbXXX", 10)]
-        [InlineData(2, "abcde\rwcjb", "  abcdeXXX  wcjbXXX", 10)]
-        [InlineData(2, "abcdefghijk\nAB", "  abcdeXXX  fghijXXX  kXXX  ABXXX", 7)]
-        [InlineData(2, "ab  cd", "  abXXX  cdXXX", 6)]
-        [InlineData(2, "  abcd    ", "  abcdXXX", 10)]
-        [InlineData(2, "  abcd\t", "  abcdXXX", 10)]
-        [InlineData(2, "  abcd\n", "  abcdXXX", 10)]
-        [InlineData(2, "  abcd\n\n", "  abcdXXXXXX", 10)]
-        [InlineData(2, "\t\nabcd\n\n", "XXX  abcdXXXXXX", 10)]
-        public void TestPrintJustified(int indent, string input, string expected, int width)
+        [InlineData(2, "abcd\nwxyz", "  abcdXXX  wxyzXXX", 10, 0)]
+        [InlineData(2, "abcd\nwxyz", " abcdXXX wxyzXXX", 9, 1)]
+        [InlineData(2, "abcd\rwxyz", "  abcdXXX  wxyzXXX", 10, 0)]
+        [InlineData(3, "abcde\n\nwcjb", "   abcdeXXXXXX   wcjbXXX", 10, 0)]
+        [InlineData(2, "abcde\r\nwcjb", "  abcdeXXX  wcjbXXX", 10, 0)]
+        [InlineData(2, "abcde\rwcjb", "  abcdeXXX  wcjbXXX", 10, 0)]
+        [InlineData(2, "abcdefghijk\nAB", "  abcdeXXX  fghijXXX  kXXX  ABXXX", 7, 0)]
+        [InlineData(2, "abcdefghijk\nAB", " abcdeXXX fghijXXX kXXX ABXXX", 7, 1)]
+        [InlineData(2, "ab  cd", "  abXXX  cdXXX", 6, 0)]
+        [InlineData(2, "  abcd    ", "  abcdXXX", 10, 0)]
+        [InlineData(2, "  abcd\t", "  abcdXXX", 10, 0)]
+        [InlineData(2, "  abcd\n", "  abcdXXX", 10, 0)]
+        [InlineData(2, "  abcd\n", "abcdXXX", 8, 2)]
+        [InlineData(2, "  abcd\n\n", "  abcdXXXXXX", 10, 0)]
+        [InlineData(2, "\t\nabcd\n\n", "XXX  abcdXXXXXX", 10, 0)]
+        public void TestPrintJustified(int indent, string input, string expected, int width, int cursorLeft)
         {
             var sw = new StringWriter();
             System.Console.SetOut(sw);
 
             var console = new Console();
             console.MockWindowWidth = width;
+            console.MockCursorLeft = cursorLeft;
             console.PrintJustified(indent, input);
 
             Assert.Equal(expected.Replace("XXX", Environment.NewLine), sw.ToString());

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/ConsoleTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/ConsoleTest.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using System;
+using System.IO;
 using NuGet.Test.Utility;
 using Xunit;
 
@@ -11,5 +12,25 @@ namespace NuGet.CommandLine.Test
         {
             Assert.NotEqual(0, new Console().WindowWidth);
         }
+
+
+        [Theory]
+        [InlineData(2, "abcd\nwxyz", "  abcdXXX  wxyzXXX", 10)]
+        [InlineData(3, "abcde\n\nwcjb", "   abcdeXXXXXX   wcjbXXX", 10)]
+        [InlineData(2, "abcde\r\nwcjb", "  abcdeXXX  wcjbXXX", 10)]
+        [InlineData(2, "abcde\rwcjb", "  abcdeXXX  wcjbXXX", 10)]
+        [InlineData(2, "abcdefghijk\nAB", "  abcdeXXX  fghijXXX  kXXX  ABXXX", 7)]
+        public void TestPrintJustified(int indent, string input, string expected, int width)
+        {
+            var sw = new StringWriter();
+            System.Console.SetOut(sw);
+
+            var console = new Console();
+            console.MockWindowWidth = width;
+            console.PrintJustified(indent, input);
+
+            Assert.Equal(expected.Replace("XXX", Environment.NewLine), sw.ToString());
+        }
+
     }
 }


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9737
Regression: No
* How are we preventing it in future:   Wrote detailed unit test for the method

## Fix

Details: Fixed how new lines are accounted for in PrintJustified, and ensured that lines are indented/wrapped correctly even when new line characters are present in the middle of the text.

## Testing/Validation

Tests Added: Yes