### PR TITLE
Return empty result for packages that are not available on the feed.

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/Resources/PackageMetadataResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/PackageMetadataResourceV3.cs
@@ -149,6 +149,11 @@ namespace NuGet.Protocol
         {
             token.ThrowIfCancellationRequested();
 
+            if (stream == null)
+            {
+                return default(T);
+            }
+
             using (var streamReader = new StreamReader(stream))
             using (var jsonReader = new JsonTextReader(streamReader))
             {

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/PackageMetadataResourceV3Tests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/PackageMetadataResourceV3Tests.cs
@@ -36,7 +36,7 @@ namespace NuGet.Protocol.Tests
             // Act
             using (var sourceCacheContext = new SourceCacheContext())
             {
-                var result = (PackageSearchMetadataRegistration) await resource.GetMetadataAsync(package, sourceCacheContext, Common.NullLogger.Instance, CancellationToken.None);
+                var result = (PackageSearchMetadataRegistration)await resource.GetMetadataAsync(package, sourceCacheContext, Common.NullLogger.Instance, CancellationToken.None);
 
                 // Assert
                 Assert.Equal("deepequal", result.Identity.Id, StringComparer.OrdinalIgnoreCase);
@@ -46,7 +46,8 @@ namespace NuGet.Protocol.Tests
                 Assert.Null(result.IconUrl);
                 Assert.Null(result.LicenseUrl);
                 Assert.Equal("http://github.com/jamesfoster/DeepEqual", result.ProjectUrl.ToString());
-                Assert.Equal("https://api.nuget.org/v3/catalog0/data/2015.02.03.18.34.51/deepequal.0.9.0.json", result.CatalogUri.ToString());
+                Assert.Equal("https://api.nuget.org/v3/catalog0/data/2015.02.03.18.34.51/deepequal.0.9.0.json",
+                    result.CatalogUri.ToString());
                 Assert.Equal(DateTimeOffset.Parse("2013-08-28T09:19:10.013Z"), result.Published);
                 Assert.False(result.RequireLicenseAcceptance);
                 Assert.Equal(result.Description, result.Summary);
@@ -72,7 +73,7 @@ namespace NuGet.Protocol.Tests
             // Act
             using (var sourceCacheContext = new SourceCacheContext())
             {
-                var result = (PackageSearchMetadataRegistration) await resource.GetMetadataAsync(package, sourceCacheContext, Common.NullLogger.Instance, CancellationToken.None);
+                var result = (PackageSearchMetadataRegistration)await resource.GetMetadataAsync(package, sourceCacheContext, Common.NullLogger.Instance, CancellationToken.None);
 
                 // Assert
                 Assert.False(result.IsListed);
@@ -94,8 +95,7 @@ namespace NuGet.Protocol.Tests
             // Act
             using (var sourceCacheContext = new SourceCacheContext())
             {
-                var result = (IEnumerable<PackageSearchMetadataRegistration>) await resource.GetMetadataAsync("afine", true, true, sourceCacheContext, Common.NullLogger.Instance,
-                    CancellationToken.None);
+                var result = (IEnumerable<PackageSearchMetadataRegistration>)await resource.GetMetadataAsync("afine", true, true, sourceCacheContext, Common.NullLogger.Instance, CancellationToken.None);
 
                 var first = result.ElementAt(0);
                 var second = result.ElementAt(1);
@@ -139,7 +139,8 @@ namespace NuGet.Protocol.Tests
         public async Task PackageMetadataResourceV3_GetMetadataAsync_ParsesLicenseExpression(string expression, string version)
         {
 
-            var licenseData = $@"""{JsonProperties.LicenseExpression}"": ""{expression}""," + (version != null ? $@"""{JsonProperties.LicenseExpressionVersion}"": ""{version}""," : "");
+            var licenseData = $@"""{JsonProperties.LicenseExpression}"": ""{expression}""," +
+                              (version != null ? $@"""{JsonProperties.LicenseExpressionVersion}"": ""{version}""," : "");
 
             var sourceName = $"http://{Guid.NewGuid().ToString()}.com/v3/index.json";
 
@@ -187,7 +188,8 @@ namespace NuGet.Protocol.Tests
         public async Task PackageMetadataResourceV3_GetMetadataAsync_ParsesLicenseExpressionWithWarnings(string expression, string version, int errorCount, string errorMessage)
         {
 
-            var licenseData = $@"""{JsonProperties.LicenseExpression}"": ""{expression}""," + (version != null ? $@"""{JsonProperties.LicenseExpressionVersion}"": ""{version}""," : "");
+            var licenseData = $@"""{JsonProperties.LicenseExpression}"": ""{expression}""," +
+                              (version != null ? $@"""{JsonProperties.LicenseExpressionVersion}"": ""{version}""," : "");
 
             var sourceName = $"http://{Guid.NewGuid().ToString()}.com/v3/index.json";
 

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/PackageMetadataResourceV3Tests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/PackageMetadataResourceV3Tests.cs
@@ -263,5 +263,41 @@ namespace NuGet.Protocol.Tests
                 Assert.Null(metadata);
             }
         }
+
+        [Fact]
+        public async Task PackageMetadataResourceV3_GetMetadataAsync_NoContentHandleNullStream()
+        {
+            // Arrange
+            var noContentPackage = "NoContentPackage";
+            var package = new PackageIdentity(noContentPackage, NuGetVersion.Parse("1.0.0"));
+            var source = "http://testsource.com/v3/index.json";
+
+            var responses = new Dictionary<string, Func<HttpRequestMessage, Task<HttpResponseMessage>>>
+            {
+                {
+                    source,
+                    _ => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new TestContent(JsonData.IndexWithoutFlatContainer)
+                    })
+                },
+                {
+                    $"https://api.nuget.org/v3/registration0/{noContentPackage.ToLowerInvariant()}/index.json",
+                    _ => Task.FromResult(new HttpResponseMessage(HttpStatusCode.NoContent))
+                }
+            };
+
+            var repo = StaticHttpHandler.CreateSource(source, Repository.Provider.GetCoreV3(), responses);
+            var resource = await repo.GetResourceAsync<PackageMetadataResource>();
+
+            //Act
+            using (var sourceCacheContext = new SourceCacheContext())
+            {
+                var metadata = await resource.GetMetadataAsync(package, sourceCacheContext, Common.NullLogger.Instance, CancellationToken.None);
+
+                //Assert
+                Assert.Null(metadata);
+            }
+        }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/PackageMetadataResourceV3Tests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/PackageMetadataResourceV3Tests.cs
@@ -231,7 +231,7 @@ namespace NuGet.Protocol.Tests
         }
 
         [Fact]
-        public async Task PackageMetadataResourceV3_GetMetadataAsync_NothingMatchesHandleNullStream()
+        public async Task PackageMetadataResourceV3_GetMetadataAsync_NotFoundHandleNullStream()
         {
             // Arrange
             var notExistPackage = "NotExistPackage";


### PR DESCRIPTION
## Bug
Signed packages return null stream, instead of try to process just return default empty value.
Fixes: https://github.com/NuGet/Home/issues/9728
Regression: Yes/No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: Details_about_the_fix  

## Testing/Validation

Tests Added: Yes/No  
Reason for not adding tests:  
Validation:  
