### PR TITLE
Catch ProjectException when querying properties

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/PackageReferenceAttachedCollectionSourceProvider.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/PackageReferenceAttachedCollectionSourceProvider.cs
@@ -26,13 +26,21 @@ namespace NuGet.VisualStudio.SolutionExplorer
 
         protected override bool TryGetIdentity(Properties properties, out (string Name, string Version) identity)
         {
-            if (properties.Item("Name")?.Value is string name &&
-                properties.Item("Version")?.Value is string version &&
-                !string.IsNullOrEmpty(name) &&
-                !string.IsNullOrEmpty(version))
+            try
             {
-                identity = (name, version);
-                return true;
+                if (properties.Item("Name")?.Value is string name &&
+                    properties.Item("Version")?.Value is string version &&
+                    !string.IsNullOrEmpty(name) &&
+                    !string.IsNullOrEmpty(version))
+                {
+                    identity = (name, version);
+                    return true;
+                }
+            }
+            catch (Microsoft.VisualStudio.ProjectSystem.ProjectException)
+            {
+                // Work around https://github.com/dotnet/project-system/issues/6311
+                // "Could not find project item with item type 'PackageReference' and include value '...'.
             }
 
             identity = default;

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/ProjectReferenceAttachedCollectionSourceProvider.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/ProjectReferenceAttachedCollectionSourceProvider.cs
@@ -26,10 +26,18 @@ namespace NuGet.VisualStudio.SolutionExplorer
 
         protected override bool TryGetIdentity(Properties properties, out string identity)
         {
-            if (properties.Item("Identity")?.Value is string identityString)
+            try
             {
-                identity = identityString;
-                return true;
+                if (properties.Item("Identity")?.Value is string identityString)
+                {
+                    identity = identityString;
+                    return true;
+                }
+            }
+            catch (Microsoft.VisualStudio.ProjectSystem.ProjectException)
+            {
+                // Work around https://github.com/dotnet/project-system/issues/6311
+                // "Could not find project item with item type 'ProjectReference' and include value '...'.
             }
 
             identity = null!;


### PR DESCRIPTION
## Bug

Relates to dotnet/project-system#6311
Fixes NuGet/Home#9741
Regression: No  

## Fix

Under a rare set of circumstances where a project multi-targets and a given reference is not defined in the active configuration (described in dotnet/project-system#6311) it's possible that an item is not known by the project.

This change catches the exception to prevent larger failures in the tree. Without this, the node appears expanded (its triangle points down) but no children are displayed beneath.

## Testing/Validation

Tests Added: No
Reason for not adding tests: No existing tests to extend.
Validation: Yes, validated manually.
