### PR TITLE
Search Command for NuGet.exe

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/SearchCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/SearchCommand.cs
@@ -72,7 +72,7 @@ namespace NuGet.CommandLine
 
         public override async Task ExecuteCommandAsync()
         {
-            ILogger logger = NullLogger.Instance;
+            ILogger logger = Console;
             CancellationToken cancellationToken = CancellationToken.None;
 
             SearchFilter searchFilter = new SearchFilter(includePrerelease: PreRelease);
@@ -132,8 +132,17 @@ namespace NuGet.CommandLine
 
                 string printBasicInfo = $"> {result.Identity.Id} | {result.Identity.Version.ToNormalizedString()}";
 
-                string downloads = string.Format(culture, "{0:N}", result.DownloadCount);
-                string printDownloads = $" | Downloads: {downloads.Substring(0, downloads.Length - 3)}";
+                string downloads, printDownloads;
+
+                if (result.DownloadCount != null)
+                {
+                    downloads = string.Format(culture, "{0:N}", result.DownloadCount);
+                    printDownloads = $" | Downloads: {downloads.Substring(0, downloads.Length - 3)}";
+                }
+                else
+                {
+                    printDownloads = "0";
+                }
 
                 System.Console.WriteLine(Verbosity != Verbosity.Quiet ? printBasicInfo + printDownloads : printBasicInfo); // System.Console is used so that output is not suppressed by Verbosity.Quiet
 

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/SearchCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/SearchCommand.cs
@@ -141,12 +141,12 @@ namespace NuGet.CommandLine
                 }
                 else
                 {
-                    printDownloads = "0";
+                    printDownloads = " | Downloads: N/A";
                 }
 
                 System.Console.WriteLine(Verbosity != Verbosity.Quiet ? printBasicInfo + printDownloads : printBasicInfo); // System.Console is used so that output is not suppressed by Verbosity.Quiet
 
-                if (Verbosity != Verbosity.Quiet)
+                if (Verbosity != Verbosity.Quiet && result.Description != null)
                 {
                     string description = result.Description;
 
@@ -157,7 +157,6 @@ namespace NuGet.CommandLine
                             description = description.Substring(0, 100) + "...";
                         }
                     }
-
                     Console.PrintJustified(2, description);
                 }
             }
@@ -165,7 +164,6 @@ namespace NuGet.CommandLine
             Console.WriteLine(new string('-', 20));
             System.Console.WriteLine("");
         }
-
 
         public override bool IncludedInHelp(string optionName)
         {

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/SearchCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/SearchCommand.cs
@@ -52,7 +52,7 @@ namespace NuGet.CommandLine
 
         private IList<PackageSource> GetEndpointsAsync()
         {
-            var configurationSources = SourceProvider.LoadPackageSources()
+            List<PackageSource> configurationSources = SourceProvider.LoadPackageSources()
                 .Where(p => p.IsEnabled)
                 .ToList();
 
@@ -77,12 +77,12 @@ namespace NuGet.CommandLine
 
             SearchFilter searchFilter = new SearchFilter(includePrerelease: PreRelease);
 
-            var listEndpoints = GetEndpointsAsync();
+            IList<PackageSource> listEndpoints = GetEndpointsAsync();
 
-            foreach (var source in listEndpoints)
+            foreach (PackageSource source in listEndpoints)
             {
-                var target = source.Source;
-                var name = source.Name;
+                string target = source.Source;
+                string name = source.Name;
 
                 SourceRepository repository = Repository.Factory.GetCoreV3(target);
                 PackageSearchResource resource = await repository.GetResourceAsync<PackageSearchResource>();
@@ -93,7 +93,8 @@ namespace NuGet.CommandLine
                 }
 
                 IEnumerable<IPackageSearchMetadata> results = await resource.SearchAsync(
-                    string.Join("+", Arguments).Trim().Replace(' ', '+'),
+                    string.Join("+", Arguments).Trim().Replace(' ', '+'), // The arguments (query strings) are joined with '+' so that the queries are passed to the
+                                                                          // search query url with the correct format (eg. "logging extensions" --> "logging+extensions")
                     searchFilter,
                     skip: 0,
                     take: Take,
@@ -120,7 +121,6 @@ namespace NuGet.CommandLine
                 }
             }
         }
-
 
         private void PrintResults(IEnumerable<IPackageSearchMetadata> results)
         {

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/SearchCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/SearchCommand.cs
@@ -9,6 +9,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
+using System.Resources;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
@@ -83,6 +84,12 @@ namespace NuGet.CommandLine
 
                 if (resource is null)
                 {
+                    Console.WriteLine(sourceSeparator);
+                    System.Console.WriteLine($"Source: {source.Name}");
+                    System.Console.WriteLine(packageSeparator);
+                    System.Console.WriteLine("Failed to obtain a search resource.");
+                    Console.WriteLine(packageSeparator);
+                    System.Console.WriteLine();
                     continue;
                 }
 

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/SearchCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/SearchCommand.cs
@@ -95,13 +95,12 @@ namespace NuGet.CommandLine
                     cancellationToken);
 
                 Console.WriteLine(sourceSeparator);
-                Console.WriteLine($"Source: {source.Name}");
+                System.Console.WriteLine($"Source: {source.Name}"); // System.Console is used so that output is not suppressed by Verbosity.Quiet
 
                 if (results.Any())
                 {
                     if (Verbosity == Verbosity.Quiet)
                     {
-                        System.Console.WriteLine($"Source: {source.Name}"); // Would not have printed using Console.WriteLine if Verbosity == quiet
                         System.Console.WriteLine(packageSeparator);
                     }
 
@@ -109,9 +108,10 @@ namespace NuGet.CommandLine
                 }
                 else
                 {
+                    System.Console.WriteLine(packageSeparator);
+                    System.Console.WriteLine("No results found.");
                     Console.WriteLine(packageSeparator);
-                    Console.WriteLine("No results found.");
-                    Console.WriteLine(packageSeparator + Environment.NewLine);
+                    System.Console.WriteLine();
                 }
             }
         }

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/SearchCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/SearchCommand.cs
@@ -62,7 +62,7 @@ namespace NuGet.CommandLine
             {
                 using (Process myProcess = new Process())
                 {
-                    myProcess.StartInfo.FileName = "cmd";
+                    myProcess.StartInfo.FileName = "cmd"; // TODO: Move outside the loop
                     myProcess.StartInfo.Arguments = "/c more";
                     myProcess.StartInfo.UseShellExecute = false;
                     myProcess.StartInfo.RedirectStandardInput = true;

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/SearchCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/SearchCommand.cs
@@ -89,8 +89,7 @@ namespace NuGet.CommandLine
                 }
 
                 IEnumerable<IPackageSearchMetadata> results = await resource.SearchAsync(
-                    string.Join("+", Arguments).Trim().Replace(' ', '+'), // The arguments (query strings) are joined with '+' so that the queries are passed to the
-                                                                          // search query url with the correct format (eg. "logging extensions" --> "logging+extensions")
+                    string.Join(" ", Arguments).Trim(), // The arguments are joined with spaces to form a single query string
                     searchFilter,
                     skip: 0,
                     take: Take,

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/SearchCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/SearchCommand.cs
@@ -63,7 +63,7 @@ namespace NuGet.CommandLine
                     continue;
                 }
 
-                SearchFilter searchFilter = new SearchFilter(includePrerelease: true);
+                SearchFilter searchFilter = new SearchFilter(includePrerelease: false);
 
                 IEnumerable<IPackageSearchMetadata> results = await resource.SearchAsync(
                     Arguments[0],

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/SearchCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/SearchCommand.cs
@@ -1,0 +1,166 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using System.Threading;
+using Newtonsoft.Json;
+using NuGet.Common;
+using NuGet.Configuration;
+using NuGet.Frameworks;
+using NuGet.Packaging;
+using NuGet.Packaging.Core;
+using NuGet.Packaging.Licenses;
+using NuGet.Protocol;
+using NuGet.Protocol.Core.Types;
+using NuGet.Versioning;
+
+
+namespace NuGet.CommandLine
+{
+
+    [Command(typeof(NuGetCommand), "search", "SearchCommandDescription", MaxArgs = 1,
+            UsageSummaryResourceName = "SearchCommandUsageSummary", UsageExampleResourceName = "SearchCommandUsageExamples")]
+    public class SearchCommand : Command
+    {
+        [Option(typeof(NuGetCommand), "SearchCommandAssemblyPathDescription")]
+        public string AssemblyPath
+        {
+            get;
+            set;
+        }
+
+        [Option(typeof(NuGetCommand), "SearchCommandForceDescription")]
+        public bool Force
+        {
+            get;
+            set;
+        }
+
+        //private static string BoldStart = "\x1B[1m";
+        //private static string BoldEnd = "\x1B[22m";
+
+        //private string Bold(string text)
+        //{
+        //    return BoldStart + text + BoldEnd;
+        //}
+
+        public override async Task ExecuteCommandAsync()
+        {
+
+            ILogger logger = NullLogger.Instance;
+            CancellationToken cancellationToken = CancellationToken.None;
+
+            foreach (var source in SourceProvider.LoadPackageSources())
+            {
+                using (Process myProcess = new Process())
+                {
+                    myProcess.StartInfo.FileName = "cmd";
+                    myProcess.StartInfo.Arguments = "/c more";
+                    myProcess.StartInfo.UseShellExecute = false;
+                    myProcess.StartInfo.RedirectStandardInput = true;
+
+                    myProcess.Start();
+
+                    StreamWriter myStreamWriter = myProcess.StandardInput;
+
+                    var target = source.Source;
+                    var name = source.Name;
+
+                    SourceRepository repository = Repository.Factory.GetCoreV3(target);
+                    PackageSearchResource resource = await repository.GetResourceAsync<PackageSearchResource>();
+
+                    if (resource is null)
+                    {
+                        continue;
+                    }
+
+                    SearchFilter searchFilter = new SearchFilter(includePrerelease: true);
+
+                    IEnumerable<IPackageSearchMetadata> results = await resource.SearchAsync(
+                        Arguments[0],
+                        searchFilter,
+                        skip: 0,
+                        take: 20,
+                        logger,
+                        cancellationToken);
+
+
+                    myStreamWriter.WriteLine(new string('=', 20));
+                    myStreamWriter.WriteLine($"Source: {source.Name}");
+
+                    if (!results.Any())
+                    {
+                        myStreamWriter.WriteLine(new string('-', 20));
+                        myStreamWriter.WriteLine("No results found.");
+                    }
+
+
+                    foreach (IPackageSearchMetadata result in results)
+                    {
+                        myStreamWriter.WriteLine(new string('-', 20));
+                        myStreamWriter.WriteLine($"> {result.Identity.Id} | v{result.Identity.Version} | DLs: {result.DownloadCount}"); // TODO: '>' and 'v' necessary or not?
+                        myStreamWriter.WriteLine($"{result.Description}\n");
+
+                    }
+
+                    myStreamWriter.Close();
+
+                    // Wait for the sort process to write the sorted text lines.
+                    myProcess.WaitForExit();
+                }
+
+            }
+
+            Thread.Sleep(5000);
+        }
+
+
+        public override bool IncludedInHelp(string optionName)
+        {
+            if (string.Equals(optionName, "ConfigFile", StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            return base.IncludedInHelp(optionName);
+        }
+        
+        private static string RemoveSchemaNamespace(string content)
+        {
+            // This seems to be the only way to clear out xml namespaces.
+            return Regex.Replace(content, @"(xmlns:?[^=]*=[""][^""]*[""])", string.Empty, RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.CultureInvariant);
+        }
+
+        private static IList<Resource> Deserialize(string value)
+        {
+            return JsonConvert.DeserializeObject<IndexJson>(value).Resources;
+        }
+
+        private sealed class IndexJson
+        {
+            [JsonProperty("resources")]
+            public IList<Resource> Resources { get; set; }
+        }
+
+        private sealed class Resource
+        {
+            [JsonProperty("@type")]
+            public string Type { get; set; }
+
+            [JsonProperty("@id")]
+            public string Id { get; set; }
+        }
+
+
+    }
+
+    
+}

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.resx
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.resx
@@ -351,6 +351,33 @@ nuget push foo.nupkg -Timeout 360</value>
   <data name="PushCommandUsageSummary" xml:space="preserve">
     <value>&lt;package path&gt; [API key] [options]</value>
   </data>
+  <data name="SearchCommandDescription" xml:space="preserve">
+    <value>Searches a given source using the query string provided. If no sources are specified, all sources defined in %AppData%\NuGet\NuGet.config are used. If NuGet.config specifies no sources, uses the default NuGet feed.</value>
+    <comment>Please don't localize "%AppData%\NuGet\NuGet.config", "NuGet.config".</comment>
+  </data>
+  <data name="SearchCommandPreRelease" xml:space="preserve">
+    <value>Allow prerelease packages to be shown.</value>
+  </data>
+  <data name="SearchCommandSourceDescription" xml:space="preserve">
+    <value>A list of packages sources to search.</value>
+  </data>
+  <data name="SearchCommandTake" xml:space="preserve">
+    <value>Number of results to display.</value>
+  </data>
+  <data name="SearchCommandUsageDescription" xml:space="preserve">
+    <value>Specify search terms.</value>
+  </data>
+  <data name="SearchCommandUsageExamples" xml:space="preserve">
+    <value>nuget search foo
+
+nuget search foo -Verbosity detailed
+
+nuget search foo -PreRelease -Take 5</value>
+    <comment>Please don't localize this string</comment>
+  </data>
+  <data name="SearchCommandUsageSummary" xml:space="preserve">
+    <value>[search terms] [options]</value>
+  </data>
   <data name="SetApiKeyCommandDescription" xml:space="preserve">
     <value>Saves an API key for a given server URL. When no URL is provided API key is saved for the NuGet gallery.</value>
   </data>

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.resx
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.resx
@@ -359,7 +359,7 @@ nuget push foo.nupkg -Timeout 360</value>
     <value>Include prerelease packages.</value>
   </data>
   <data name="SearchCommandSourceDescription" xml:space="preserve">
-    <value>A list of package sources to search.</value>
+    <value>The package source to search. You can pass multiple -Source options to search multiple package sources.</value>
   </data>
   <data name="SearchCommandTake" xml:space="preserve">
     <value>The number of results to return. The default value is 20.</value>

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.resx
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.resx
@@ -352,17 +352,17 @@ nuget push foo.nupkg -Timeout 360</value>
     <value>&lt;package path&gt; [API key] [options]</value>
   </data>
   <data name="SearchCommandDescription" xml:space="preserve">
-    <value>Searches a given source using the query string provided. If no sources are specified, all sources defined in %AppData%\NuGet\NuGet.config are used. If NuGet.config specifies no sources, uses the default NuGet feed.</value>
+    <value>Searches a given source using the query string provided. If no sources are specified, all sources defined in %AppData%\NuGet\NuGet.config are used.</value>
     <comment>Please don't localize "%AppData%\NuGet\NuGet.config", "NuGet.config".</comment>
   </data>
   <data name="SearchCommandPreRelease" xml:space="preserve">
-    <value>Allow prerelease packages to be shown.</value>
+    <value>Include prerelease packages.</value>
   </data>
   <data name="SearchCommandSourceDescription" xml:space="preserve">
-    <value>A list of packages sources to search.</value>
+    <value>A list of package sources to search.</value>
   </data>
   <data name="SearchCommandTake" xml:space="preserve">
-    <value>Number of results to display.</value>
+    <value>The number of results to return. The default value is 20.</value>
   </data>
   <data name="SearchCommandUsageDescription" xml:space="preserve">
     <value>Specify search terms.</value>

--- a/src/NuGet.Core/NuGet.Protocol/Resources/PackageSearchResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/PackageSearchResourceV3.cs
@@ -108,7 +108,6 @@ namespace NuGet.Protocol
                     Common.ILogger log,
                     CancellationToken cancellationToken)
         {
-            //Console.Error.WriteLine($"Found {_searchEndpoints.Length} search endpoints.");
             log.LogVerbose($"Found {_searchEndpoints.Length} search endpoints.");
 
             for (var i = 0; i < _searchEndpoints.Length; i++)
@@ -154,7 +153,6 @@ namespace NuGet.Protocol
                 var searchResult = default(T);
                 try
                 {
-                    // Console.Error.WriteLine($"Querying {queryUrl.Uri}");
                     log.LogVerbose($"Querying {queryUrl.Uri}");
 
                     searchResult = await getResultAsync(queryUrl.Uri);

--- a/src/NuGet.Core/NuGet.Protocol/Resources/PackageSearchResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/PackageSearchResourceV3.cs
@@ -61,7 +61,7 @@ namespace NuGet.Protocol
                     filter,
                     skip,
                     take,
-                    Common.NullLogger.Instance,
+                    log,
                     cancellationToken);
             }
             else
@@ -108,7 +108,9 @@ namespace NuGet.Protocol
                     Common.ILogger log,
                     CancellationToken cancellationToken)
         {
-            Console.Error.WriteLine($"Found {_searchEndpoints.Length} search endpoints.");
+            //Console.Error.WriteLine($"Found {_searchEndpoints.Length} search endpoints.");
+            log.LogVerbose($"Found {_searchEndpoints.Length} search endpoints.");
+
             for (var i = 0; i < _searchEndpoints.Length; i++)
             {
                 var endpoint = _searchEndpoints[i];
@@ -152,7 +154,9 @@ namespace NuGet.Protocol
                 var searchResult = default(T);
                 try
                 {
-                    Console.Error.WriteLine($"Querying {queryUrl.Uri}");
+                    // Console.Error.WriteLine($"Querying {queryUrl.Uri}");
+                    log.LogVerbose($"Querying {queryUrl.Uri}");
+
                     searchResult = await getResultAsync(queryUrl.Uri);
                 }
                 catch (OperationCanceledException)
@@ -224,7 +228,7 @@ namespace NuGet.Protocol
                 (httpSource, uri) => httpSource.ProcessHttpStreamAsync(
                     new HttpSourceRequest(uri, Common.NullLogger.Instance),
                     s => ProcessHttpStreamTakeCountedItemAsync(s, take, cancellationToken),
-                    log,
+                    Common.NullLogger.Instance,
                     cancellationToken),
                 searchTerm,
                 filters,

--- a/src/NuGet.Core/NuGet.Protocol/Resources/PackageSearchResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/PackageSearchResourceV3.cs
@@ -108,6 +108,7 @@ namespace NuGet.Protocol
                     Common.ILogger log,
                     CancellationToken cancellationToken)
         {
+            Console.Error.WriteLine($"Found {_searchEndpoints.Length} search endpoints.");
             for (var i = 0; i < _searchEndpoints.Length; i++)
             {
                 var endpoint = _searchEndpoints[i];
@@ -151,6 +152,7 @@ namespace NuGet.Protocol
                 var searchResult = default(T);
                 try
                 {
+                    Console.Error.WriteLine($"Querying {queryUrl.Uri}");
                     searchResult = await getResultAsync(queryUrl.Uri);
                 }
                 catch (OperationCanceledException)

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SearchCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SearchCommandTests.cs
@@ -58,44 +58,55 @@ namespace NuGet.CommandLine.FuncTest.Commands
 
 
 
-                string queryResult = $@"{{
-""@context"": {{
-""@vocab"": ""http://schema.nuget.org/schema#"",
-""@base"": ""https://api.nuget.org/v3/registration5-semver1/""
-}},
-""totalHits"": 396,
-""data"": [
-{{
-""@id"": ""https://api.nuget.org/v3/registration5-semver1/newtonsoft.json/index.json"",
-""@type"": ""Package"",
-""registration"": ""https://api.nuget.org/v3/registration5-semver1/newtonsoft.json/index.json"",
-""id"": ""Newtonsoft.Json"",
-""version"": ""12.0.3"",
-""description"": ""Json.NET is a popular high-performance JSON framework for .NET"",
-""summary"": """",
-""title"": ""Json.NET"",
-""iconUrl"": ""https://api.nuget.org/v3-flatcontainer/newtonsoft.json/12.0.3/icon"",
-""licenseUrl"": ""https://www.nuget.org/packages/Newtonsoft.Json/12.0.3/license"",
-""projectUrl"": ""https://www.newtonsoft.com/json"",
-""tags"": [
-""json""
-],
-""authors"": [
-""James Newton-King""
-],
-""totalDownloads"": 531607259,
-""verified"": true,
-""packageTypes"": [
-{{
-""name"": ""Dependency""
-}}
-],
-""versions"": [{{
-""version"": ""3.5.8"",
-""downloads"": 461992,
-""@id"": ""https://api.nuget.org/v3/registration5-semver1/newtonsoft.json/3.5.8.json""
-}}]
-}}";
+                string queryResult = $@"
+                {{
+                    ""@context"":
+                    {{
+                        ""@vocab"": ""http://schema.nuget.org/schema#"",
+                        ""@base"": ""https://api.nuget.org/v3/registration5-semver1/""
+                    }},
+                    ""totalHits"": 396,
+                    ""data"": [
+                    {{
+                        ""@id"": ""https://api.nuget.org/v3/registration5-semver1/newtonsoft.json/index.json"",
+                        ""@type"": ""Package"",
+                        ""registration"": ""https://api.nuget.org/v3/registration5-semver1/newtonsoft.json/index.json"",
+                        ""id"": ""Newtonsoft.Json"",
+                        ""version"": ""12.0.3"",
+                        ""description"": ""Json.NET is a popular high-performance JSON framework for .NET"",
+                        ""summary"": """",
+                        ""title"": ""Json.NET"",
+                        ""iconUrl"": ""https://api.nuget.org/v3-flatcontainer/newtonsoft.json/12.0.3/icon"",
+                        ""licenseUrl"": ""https://www.nuget.org/packages/Newtonsoft.Json/12.0.3/license"",
+                        ""projectUrl"": ""https://www.newtonsoft.com/json"",
+
+                        ""tags"": [
+                            ""json""
+                        ],
+
+                        ""authors"": [
+                        ""James Newton-King""
+                        ],
+
+                        ""totalDownloads"": 531607259,
+                        ""verified"": true,
+
+                        ""packageTypes"": [
+                        {{
+                            ""name"": ""Dependency""
+                        }}
+                        ],
+
+                        ""versions"": [
+                        {{
+                            ""version"": ""3.5.8"",
+                            ""downloads"": 461992,
+                            ""@id"": ""https://api.nuget.org/v3/registration5-semver1/newtonsoft.json/3.5.8.json""
+                        }}
+                        ]
+                    }}
+                    ]
+                }}";
 
                 server.Get.Add("/search/query?q=logging&skip=0&take=20&prerelease=true&semVerLevel=2.0.0", r => queryResult);
 

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SearchCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SearchCommandTests.cs
@@ -29,7 +29,15 @@ namespace NuGet.CommandLine.FuncTest.Commands
             var nugetexe = Util.GetNuGetExePath();
 
             using (var server = new MockServer())
+            using (var config = new SimpleTestPathContext())
             {
+
+                CommandRunner.Run(
+                    nugetexe,
+                    config.WorkingDirectory,
+                    $"source add -name mockSource -source {server.Uri}v3/index.json -configfile {config.NuGetConfig}",
+                    waitForExit: true);
+
                 string index = $@"
 {{""version"": ""3.0.0"",
   ""resources"": [
@@ -89,9 +97,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
 }}]
 }}";
 
-
-                server.Get.Add("/search/query?q=logging&skip=0&take=20&prerelease=false&semVerLevel=2.0.0", r => queryResult
-                );
+                server.Get.Add("/search/query?q=logging&skip=0&take=20&prerelease=false&semverLevel=2.0.0", r => queryResult);
 
 
                 server.Start();
@@ -105,7 +111,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
 
                 var result = CommandRunner.Run(
                     nugetexe,
-                    Directory.GetCurrentDirectory(),
+                    config.WorkingDirectory,
                     string.Join(" ", args),
                     waitForExit: true);
 
@@ -113,7 +119,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
 
                 // Assert
                 Assert.True(0 == result.Item1, $"{result.Item2} {result.Item3}");
-                Assert.Contains("foo", result.Item2);
+                Assert.Contains("foo", $"{result.Item2} {result.Item3}");
             }
         }
 

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SearchCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SearchCommandTests.cs
@@ -39,20 +39,23 @@ namespace NuGet.CommandLine.FuncTest.Commands
                     waitForExit: true);
 
                 string index = $@"
-{{""version"": ""3.0.0"",
-  ""resources"": [
-    {{
-      ""@id"": ""{server.Uri + "search/query"}"",
-      ""@type"": ""SearchQueryService/Versioned"",
-      ""comment"": ""Query endpoint of NuGet Search service (primary)""
-    }}
-    ],
-    ""@context"": {{
-    ""@vocab"": ""http://schema.nuget.org/services#"",
-    ""comment"": ""http://www.w3.org/2000/01/rdf-schema#comment""
-  }}
-        }}
-            ";
+                {{
+                    ""version"": ""3.0.0"",
+
+                    ""resources"": [
+                    {{
+                        ""@id"": ""{server.Uri + "search/query"}"",
+                        ""@type"": ""SearchQueryService/Versioned"",
+                        ""comment"": ""Query endpoint of NuGet Search service (primary)""
+                    }}
+                    ],
+
+                    ""@context"":
+                    {{
+                        ""@vocab"": ""http://schema.nuget.org/services#"",
+                        ""comment"": ""http://www.w3.org/2000/01/rdf-schema#comment""
+                    }}
+                }}";
 
                 server.Get.Add("/v3/index.json", r => index);
 

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SearchCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SearchCommandTests.cs
@@ -371,12 +371,11 @@ namespace NuGet.CommandLine.FuncTest.Commands
         public void SearchCommand_VerbosityQuietTest()
         {
             // Arrange
-            var nugetexe = Util.GetNuGetExePath();
+            string nugetexe = Util.GetNuGetExePath();
 
-            using (var server = new MockServer())
-            using (var config = new SimpleTestPathContext())
+            using (MockServer server = new MockServer())
+            using (SimpleTestPathContext config = new SimpleTestPathContext())
             {
-
                 CommandRunner.Run(
                     nugetexe,
                     config.WorkingDirectory,
@@ -456,11 +455,10 @@ namespace NuGet.CommandLine.FuncTest.Commands
 
                 server.Get.Add("/search/query?q=json&skip=0&take=20&prerelease=false&semVerLevel=2.0.0", r => queryResult);
 
-
                 server.Start();
 
                 // Act
-                var args = new[]
+                string[] args = new[]
                 {
                     "search",
                     "json",
@@ -468,7 +466,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
                     "quiet",
                 };
 
-                var result = CommandRunner.Run(
+                CommandRunnerResult result = CommandRunner.Run(
                     nugetexe,
                     config.WorkingDirectory,
                     string.Join(" ", args),
@@ -648,6 +646,119 @@ namespace NuGet.CommandLine.FuncTest.Commands
                 // Assert
                 Assert.True(0 == result.Item1, $"{result.Item2} {result.Item3}");
                 Assert.Contains("Fake.Newtonsoft.Json - Correct result", $"{result.Item2} {result.Item3}");
+            }
+        }
+
+        [Fact]
+        public void SearchCommand_SourceOptionTest()
+        {
+            // Arrange
+            string nugetexe = Util.GetNuGetExePath();
+
+            using (MockServer server = new MockServer())
+            using (SimpleTestPathContext config = new SimpleTestPathContext())
+            {
+                CommandRunner.Run(
+                    nugetexe,
+                    config.WorkingDirectory,
+                    $"source add -name mockSource -source {server.Uri}v3/index.json -configfile {config.NuGetConfig}",
+                    waitForExit: true);
+
+                string index = $@"
+                {{
+                    ""version"": ""3.0.0"",
+
+                    ""resources"": [
+                    {{
+                        ""@id"": ""{server.Uri + "search/query"}"",
+                        ""@type"": ""SearchQueryService/Versioned"",
+                        ""comment"": ""Query endpoint of NuGet Search service (primary)""
+                    }}
+                    ],
+
+                    ""@context"":
+                    {{
+                        ""@vocab"": ""http://schema.nuget.org/services#"",
+                        ""comment"": ""http://www.w3.org/2000/01/rdf-schema#comment""
+                    }}
+                }}";
+
+                server.Get.Add("/v3/index.json", r => index);
+
+                string queryResult = $@"
+                {{
+                    ""@context"":
+                    {{
+                        ""@vocab"": ""http://schema.nuget.org/schema#"",
+                        ""@base"": ""https://api.nuget.org/v3/registration5-semver1/""
+                    }},
+                    ""totalHits"": 396,
+                    ""data"": [
+                    {{
+                        ""@id"": ""https://api.nuget.org/v3/registration5-semver1/newtonsoft.json/index.json"",
+                        ""@type"": ""Package"",
+                        ""registration"": ""https://api.nuget.org/v3/registration5-semver1/newtonsoft.json/index.json"",
+                        ""id"": ""Fake.Newtonsoft.Json"",
+                        ""version"": ""12.0.3"",
+                        ""description"": ""Json.NET is a popular high-performance JSON framework for .NET, plus more detailed description so that we can test -Verbosity normal and -Verbosity detailed properly."",
+                        ""summary"": """",
+                        ""title"": ""Json.NET"",
+                        ""iconUrl"": ""https://api.nuget.org/v3-flatcontainer/newtonsoft.json/12.0.3/icon"",
+                        ""licenseUrl"": ""https://www.nuget.org/packages/Newtonsoft.Json/12.0.3/license"",
+                        ""projectUrl"": ""https://www.newtonsoft.com/json"",
+
+                        ""tags"": [
+                            ""json""
+                        ],
+
+                        ""authors"": [
+                        ""James Newton-King""
+                        ],
+
+                        ""totalDownloads"": 531607259,
+                        ""verified"": true,
+
+                        ""packageTypes"": [
+                        {{
+                            ""name"": ""Dependency""
+                        }}
+                        ],
+
+                        ""versions"": [
+                        {{
+                            ""version"": ""3.5.8"",
+                            ""downloads"": 461992,
+                            ""@id"": ""https://api.nuget.org/v3/registration5-semver1/newtonsoft.json/3.5.8.json""
+                        }}
+                        ]
+                    }}
+                    ]
+                }}";
+
+                server.Get.Add("/search/query?q=json&skip=0&take=20&prerelease=false&semVerLevel=2.0.0", r => queryResult);
+
+                server.Start();
+
+                // Act
+                string[] args = new[]
+                {
+                    "search",
+                    "json",
+                    "-Source",
+                    "mockSource",
+                };
+
+                CommandRunnerResult result = CommandRunner.Run(
+                    nugetexe,
+                    config.WorkingDirectory,
+                    string.Join(" ", args),
+                    waitForExit: true);
+
+                server.Stop();
+
+                // Assert
+                Assert.True(0 == result.Item1, $"{result.Item2} {result.Item3}");
+                Assert.Contains("Source: mockSource", $"{result.Item2} {result.Item3}");
             }
         }
     }

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SearchCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SearchCommandTests.cs
@@ -43,7 +43,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
   ""resources"": [
     {{
       ""@id"": ""{server.Uri + "search/query"}"",
-      ""@type"": ""SearchQueryService"",
+      ""@type"": ""SearchQueryService/Versioned"",
       ""comment"": ""Query endpoint of NuGet Search service (primary)""
     }}
     ],
@@ -97,7 +97,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
 }}]
 }}";
 
-                server.Get.Add("/search/query?q=logging&skip=0&take=20&prerelease=false&semverLevel=2.0.0", r => queryResult);
+                server.Get.Add("/search/query?q=logging&skip=0&take=20&prerelease=true&semVerLevel=2.0.0", r => queryResult);
 
 
                 server.Start();

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SearchCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SearchCommandTests.cs
@@ -128,8 +128,8 @@ namespace NuGet.CommandLine.FuncTest.Commands
                 server.Stop();
 
                 // Assert
-                Assert.True(result.Success, $"{result.Output} {result.Errors}");
-                Assert.Contains("Fake.Newtonsoft.Json", $"{result.Output} {result.Errors}");
+                Assert.True(result.Success, $"{result.AllOutput}");
+                Assert.Contains("Fake.Newtonsoft.Json", $"{result.AllOutput}");
             }
         }
 
@@ -241,12 +241,12 @@ namespace NuGet.CommandLine.FuncTest.Commands
                 server.Stop();
 
                 // Assert
-                Assert.True(result.Success, $"{result.Output} {result.Errors}");
-                Assert.Contains("Fake.Newtonsoft.Json", $"{result.Output} {result.Errors}");
-                Assert.Contains("Downloads", $"{result.Output} {result.Errors}");
-                Assert.Contains("detailed properly.", $"{result.Output} {result.Errors}");
-                Assert.DoesNotContain("...", $"{result.Output} {result.Errors}");
-                Assert.Contains("Querying", $"{result.Output} {result.Errors}");
+                Assert.True(result.Success, $"{result.AllOutput}");
+                Assert.Contains("Fake.Newtonsoft.Json", $"{result.AllOutput}");
+                Assert.Contains("Downloads", $"{result.AllOutput}");
+                Assert.Contains("detailed properly.", $"{result.AllOutput}");
+                Assert.DoesNotContain("...", $"{result.AllOutput}");
+                Assert.Contains("Querying", $"{result.AllOutput}");
             }
         }
 
@@ -358,12 +358,12 @@ namespace NuGet.CommandLine.FuncTest.Commands
                 server.Stop();
 
                 // Assert
-                Assert.True(result.Success, $"{result.Output} {result.Errors}");
-                Assert.Contains("Fake.Newtonsoft.Json", $"{result.Output} {result.Errors}");
-                Assert.Contains("Downloads", $"{result.Output} {result.Errors}");
-                Assert.DoesNotContain("detailed properly.", $"{result.Output} {result.Errors}");
-                Assert.Contains("...", $"{result.Output} {result.Errors}");
-                Assert.DoesNotContain("Querying", $"{result.Output} {result.Errors}");
+                Assert.True(result.Success, $"{result.AllOutput}");
+                Assert.Contains("Fake.Newtonsoft.Json", $"{result.AllOutput}");
+                Assert.Contains("Downloads", $"{result.AllOutput}");
+                Assert.DoesNotContain("detailed properly.", $"{result.AllOutput}");
+                Assert.Contains("...", $"{result.AllOutput}");
+                Assert.DoesNotContain("Querying", $"{result.AllOutput}");
             }
         }
 
@@ -475,12 +475,12 @@ namespace NuGet.CommandLine.FuncTest.Commands
                 server.Stop();
 
                 // Assert
-                Assert.True(result.Success, $"{result.Output} {result.Errors}");
-                Assert.Contains("Fake.Newtonsoft.Json", $"{result.Output} {result.Errors}");
-                Assert.DoesNotContain("Downloads", $"{result.Output} {result.Errors}");
-                Assert.DoesNotContain("detailed properly.", $"{result.Output} {result.Errors}");
-                Assert.DoesNotContain("...", $"{result.Output} {result.Errors}");
-                Assert.DoesNotContain("Querying", $"{result.Output} {result.Errors}");
+                Assert.True(result.Success, $"{result.AllOutput}");
+                Assert.Contains("Fake.Newtonsoft.Json", $"{result.AllOutput}");
+                Assert.DoesNotContain("Downloads", $"{result.AllOutput}");
+                Assert.DoesNotContain("detailed properly.", $"{result.AllOutput}");
+                Assert.DoesNotContain("...", $"{result.AllOutput}");
+                Assert.DoesNotContain("Querying", $"{result.AllOutput}");
             }
         }
 
@@ -644,8 +644,8 @@ namespace NuGet.CommandLine.FuncTest.Commands
                 server.Stop();
 
                 // Assert
-                Assert.True(result.Success, $"{result.Output} {result.Errors}");
-                Assert.Contains("Fake.Newtonsoft.Json - Correct result", $"{result.Output} {result.Errors}");
+                Assert.True(result.Success, $"{result.AllOutput}");
+                Assert.Contains("Fake.Newtonsoft.Json - Correct result", $"{result.AllOutput}");
             }
         }
 
@@ -757,8 +757,8 @@ namespace NuGet.CommandLine.FuncTest.Commands
                 server.Stop();
 
                 // Assert
-                Assert.True(result.Success, $"{result.Output} {result.Errors}");
-                Assert.Contains("Source: mockSource", $"{result.Output} {result.Errors}");
+                Assert.True(result.Success, $"{result.AllOutput}");
+                Assert.Contains("Source: mockSource", $"{result.AllOutput}");
             }
         }
 
@@ -870,8 +870,8 @@ namespace NuGet.CommandLine.FuncTest.Commands
                 server.Stop();
 
                 // Assert
-                Assert.True(result.Success, $"{result.Output} {result.Errors}");
-                Assert.Contains("Fake.Newtonsoft.Json", $"{result.Output} {result.Errors}");
+                Assert.True(result.Success, $"{result.AllOutput}");
+                Assert.Contains("Fake.Newtonsoft.Json", $"{result.AllOutput}");
             }
         }
 
@@ -942,9 +942,9 @@ namespace NuGet.CommandLine.FuncTest.Commands
                 server.Stop();
 
                 // Assert
-                Assert.True(result.Success, $"{result.Output} {result.Errors}");
-                Assert.Contains("No results found.", $"{result.Output} {result.Errors}");
-                Assert.DoesNotContain(">", $"{result.Output} {result.Errors}");
+                Assert.True(result.Success, $"{result.AllOutput}");
+                Assert.Contains("No results found.", $"{result.AllOutput}");
+                Assert.DoesNotContain(">", $"{result.AllOutput}");
             }
         }
     }

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SearchCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SearchCommandTests.cs
@@ -110,7 +110,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
                     ]
                 }}";
 
-                server.Get.Add("/search/query?q=json&skip=0&take=20&prerelease=true&semVerLevel=2.0.0", r => queryResult);
+                server.Get.Add("/search/query?q=json&skip=0&take=20&prerelease=false&semVerLevel=2.0.0", r => queryResult);
 
 
                 server.Start();
@@ -223,7 +223,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
                     ]
                 }}";
 
-                server.Get.Add("/search/query?q=json&skip=0&take=20&prerelease=true&semVerLevel=2.0.0", r => queryResult);
+                server.Get.Add("/search/query?q=json&skip=0&take=20&prerelease=false&semVerLevel=2.0.0", r => queryResult);
 
 
                 server.Start();
@@ -248,8 +248,8 @@ namespace NuGet.CommandLine.FuncTest.Commands
                 // Assert
                 Assert.True(0 == result.Item1, $"{result.Item2} {result.Item3}");
                 Assert.Contains("Fake.Newtonsoft.Json", $"{result.Item2} {result.Item3}");
-                Assert.Contains("531607259", $"{result.Item2} {result.Item3}");
-                Assert.Contains("detailed", $"{result.Item2} {result.Item3}");
+                Assert.Contains("Downloads", $"{result.Item2} {result.Item3}");
+                Assert.Contains("detailed properly.", $"{result.Item2} {result.Item3}");
                 Assert.DoesNotContain("...", $"{result.Item2} {result.Item3}");
                 Assert.Contains("Querying", $"{result.Item2} {result.Item3}");
             }

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SearchCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SearchCommandTests.cs
@@ -1,0 +1,121 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Threading;
+using FluentAssertions;
+using NuGet.CommandLine.Test;
+using NuGet.Commands;
+using NuGet.Configuration;
+using NuGet.Packaging;
+using NuGet.Protocol;
+using NuGet.Protocol.Core.Types;
+using NuGet.Test.Utility;
+using Test.Utility;
+using Xunit;
+
+namespace NuGet.CommandLine.FuncTest.Commands
+{
+    public class SearchCommandTest
+    {
+        [Fact]
+        public void SearchCommand_BasicTest()
+        {
+            // Arrange
+            var nugetexe = Util.GetNuGetExePath();
+
+            using (var server = new MockServer())
+            {
+                string index = $@"
+{{""version"": ""3.0.0"",
+  ""resources"": [
+    {{
+      ""@id"": ""{server.Uri + "search/query"}"",
+      ""@type"": ""SearchQueryService"",
+      ""comment"": ""Query endpoint of NuGet Search service (primary)""
+    }}
+    ],
+    ""@context"": {{
+    ""@vocab"": ""http://schema.nuget.org/services#"",
+    ""comment"": ""http://www.w3.org/2000/01/rdf-schema#comment""
+  }}
+        }}
+            ";
+
+                server.Get.Add("/v3/index.json", r => index);
+
+
+
+                string queryResult = $@"{{
+""@context"": {{
+""@vocab"": ""http://schema.nuget.org/schema#"",
+""@base"": ""https://api.nuget.org/v3/registration5-semver1/""
+}},
+""totalHits"": 396,
+""data"": [
+{{
+""@id"": ""https://api.nuget.org/v3/registration5-semver1/newtonsoft.json/index.json"",
+""@type"": ""Package"",
+""registration"": ""https://api.nuget.org/v3/registration5-semver1/newtonsoft.json/index.json"",
+""id"": ""Newtonsoft.Json"",
+""version"": ""12.0.3"",
+""description"": ""Json.NET is a popular high-performance JSON framework for .NET"",
+""summary"": """",
+""title"": ""Json.NET"",
+""iconUrl"": ""https://api.nuget.org/v3-flatcontainer/newtonsoft.json/12.0.3/icon"",
+""licenseUrl"": ""https://www.nuget.org/packages/Newtonsoft.Json/12.0.3/license"",
+""projectUrl"": ""https://www.newtonsoft.com/json"",
+""tags"": [
+""json""
+],
+""authors"": [
+""James Newton-King""
+],
+""totalDownloads"": 531607259,
+""verified"": true,
+""packageTypes"": [
+{{
+""name"": ""Dependency""
+}}
+],
+""versions"": [{{
+""version"": ""3.5.8"",
+""downloads"": 461992,
+""@id"": ""https://api.nuget.org/v3/registration5-semver1/newtonsoft.json/3.5.8.json""
+}}]
+}}";
+
+
+                server.Get.Add("/search/query?q=logging&skip=0&take=20&prerelease=false&semVerLevel=2.0.0", r => queryResult
+                );
+
+
+                server.Start();
+
+                // Act
+                var args = new[]
+                {
+                    "search",
+                    "logging",
+                };
+
+                var result = CommandRunner.Run(
+                    nugetexe,
+                    Directory.GetCurrentDirectory(),
+                    string.Join(" ", args),
+                    waitForExit: true);
+
+                server.Stop();
+
+                // Assert
+                Assert.True(0 == result.Item1, $"{result.Item2} {result.Item3}");
+                Assert.Contains("foo", result.Item2);
+            }
+        }
+
+    }
+}

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SearchCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SearchCommandTests.cs
@@ -128,8 +128,8 @@ namespace NuGet.CommandLine.FuncTest.Commands
                 server.Stop();
 
                 // Assert
-                Assert.True(0 == result.Item1, $"{result.Item2} {result.Item3}");
-                Assert.Contains("Fake.Newtonsoft.Json", $"{result.Item2} {result.Item3}");
+                Assert.True(result.Success, $"{result.Output} {result.Errors}");
+                Assert.Contains("Fake.Newtonsoft.Json", $"{result.Output} {result.Errors}");
             }
         }
 
@@ -241,12 +241,12 @@ namespace NuGet.CommandLine.FuncTest.Commands
                 server.Stop();
 
                 // Assert
-                Assert.True(0 == result.Item1, $"{result.Item2} {result.Item3}");
-                Assert.Contains("Fake.Newtonsoft.Json", $"{result.Item2} {result.Item3}");
-                Assert.Contains("Downloads", $"{result.Item2} {result.Item3}");
-                Assert.Contains("detailed properly.", $"{result.Item2} {result.Item3}");
-                Assert.DoesNotContain("...", $"{result.Item2} {result.Item3}");
-                Assert.Contains("Querying", $"{result.Item2} {result.Item3}");
+                Assert.True(result.Success, $"{result.Output} {result.Errors}");
+                Assert.Contains("Fake.Newtonsoft.Json", $"{result.Output} {result.Errors}");
+                Assert.Contains("Downloads", $"{result.Output} {result.Errors}");
+                Assert.Contains("detailed properly.", $"{result.Output} {result.Errors}");
+                Assert.DoesNotContain("...", $"{result.Output} {result.Errors}");
+                Assert.Contains("Querying", $"{result.Output} {result.Errors}");
             }
         }
 
@@ -358,12 +358,12 @@ namespace NuGet.CommandLine.FuncTest.Commands
                 server.Stop();
 
                 // Assert
-                Assert.True(0 == result.Item1, $"{result.Item2} {result.Item3}");
-                Assert.Contains("Fake.Newtonsoft.Json", $"{result.Item2} {result.Item3}");
-                Assert.Contains("Downloads", $"{result.Item2} {result.Item3}");
-                Assert.DoesNotContain("detailed properly.", $"{result.Item2} {result.Item3}");
-                Assert.Contains("...", $"{result.Item2} {result.Item3}");
-                Assert.DoesNotContain("Querying", $"{result.Item2} {result.Item3}");
+                Assert.True(result.Success, $"{result.Output} {result.Errors}");
+                Assert.Contains("Fake.Newtonsoft.Json", $"{result.Output} {result.Errors}");
+                Assert.Contains("Downloads", $"{result.Output} {result.Errors}");
+                Assert.DoesNotContain("detailed properly.", $"{result.Output} {result.Errors}");
+                Assert.Contains("...", $"{result.Output} {result.Errors}");
+                Assert.DoesNotContain("Querying", $"{result.Output} {result.Errors}");
             }
         }
 
@@ -475,12 +475,12 @@ namespace NuGet.CommandLine.FuncTest.Commands
                 server.Stop();
 
                 // Assert
-                Assert.True(0 == result.Item1, $"{result.Item2} {result.Item3}");
-                Assert.Contains("Fake.Newtonsoft.Json", $"{result.Item2} {result.Item3}");
-                Assert.DoesNotContain("Downloads", $"{result.Item2} {result.Item3}");
-                Assert.DoesNotContain("detailed properly.", $"{result.Item2} {result.Item3}");
-                Assert.DoesNotContain("...", $"{result.Item2} {result.Item3}");
-                Assert.DoesNotContain("Querying", $"{result.Item2} {result.Item3}");
+                Assert.True(result.Success, $"{result.Output} {result.Errors}");
+                Assert.Contains("Fake.Newtonsoft.Json", $"{result.Output} {result.Errors}");
+                Assert.DoesNotContain("Downloads", $"{result.Output} {result.Errors}");
+                Assert.DoesNotContain("detailed properly.", $"{result.Output} {result.Errors}");
+                Assert.DoesNotContain("...", $"{result.Output} {result.Errors}");
+                Assert.DoesNotContain("Querying", $"{result.Output} {result.Errors}");
             }
         }
 
@@ -644,8 +644,8 @@ namespace NuGet.CommandLine.FuncTest.Commands
                 server.Stop();
 
                 // Assert
-                Assert.True(0 == result.Item1, $"{result.Item2} {result.Item3}");
-                Assert.Contains("Fake.Newtonsoft.Json - Correct result", $"{result.Item2} {result.Item3}");
+                Assert.True(result.Success, $"{result.Output} {result.Errors}");
+                Assert.Contains("Fake.Newtonsoft.Json - Correct result", $"{result.Output} {result.Errors}");
             }
         }
 
@@ -757,8 +757,8 @@ namespace NuGet.CommandLine.FuncTest.Commands
                 server.Stop();
 
                 // Assert
-                Assert.True(0 == result.Item1, $"{result.Item2} {result.Item3}");
-                Assert.Contains("Source: mockSource", $"{result.Item2} {result.Item3}");
+                Assert.True(result.Success, $"{result.Output} {result.Errors}");
+                Assert.Contains("Source: mockSource", $"{result.Output} {result.Errors}");
             }
         }
 
@@ -870,8 +870,8 @@ namespace NuGet.CommandLine.FuncTest.Commands
                 server.Stop();
 
                 // Assert
-                Assert.True(0 == result.Item1, $"{result.Item2} {result.Item3}");
-                Assert.Contains("Fake.Newtonsoft.Json", $"{result.Item2} {result.Item3}");
+                Assert.True(result.Success, $"{result.Output} {result.Errors}");
+                Assert.Contains("Fake.Newtonsoft.Json", $"{result.Output} {result.Errors}");
             }
         }
 
@@ -942,9 +942,9 @@ namespace NuGet.CommandLine.FuncTest.Commands
                 server.Stop();
 
                 // Assert
-                Assert.True(0 == result.Item1, $"{result.Item2} {result.Item3}");
-                Assert.Contains("No results found.", $"{result.Item2} {result.Item3}");
-                Assert.DoesNotContain(">", $"{result.Item2} {result.Item3}");
+                Assert.True(result.Success, $"{result.Output} {result.Errors}");
+                Assert.Contains("No results found.", $"{result.Output} {result.Errors}");
+                Assert.DoesNotContain(">", $"{result.Output} {result.Errors}");
             }
         }
     }

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SearchCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SearchCommandTests.cs
@@ -22,17 +22,15 @@ namespace NuGet.CommandLine.FuncTest.Commands
 {
     public class SearchCommandTest
     {
-        
         [Fact]
         public void SearchCommand_TargetEndpointTest()
         {
             // Arrange
-            var nugetexe = Util.GetNuGetExePath();
+            string nugetexe = Util.GetNuGetExePath();
 
-            using (var server = new MockServer())
-            using (var config = new SimpleTestPathContext())
+            using (MockServer server = new MockServer())
+            using (SimpleTestPathContext config = new SimpleTestPathContext())
             {
-
                 CommandRunner.Run(
                     nugetexe,
                     config.WorkingDirectory,
@@ -112,17 +110,16 @@ namespace NuGet.CommandLine.FuncTest.Commands
 
                 server.Get.Add("/search/query?q=json&skip=0&take=20&prerelease=false&semVerLevel=2.0.0", r => queryResult);
 
-
                 server.Start();
 
                 // Act
-                var args = new[]
+                string[] args = new[]
                 {
                     "search",
                     "json",
                 };
 
-                var result = CommandRunner.Run(
+                CommandRunnerResult result = CommandRunner.Run(
                     nugetexe,
                     config.WorkingDirectory,
                     string.Join(" ", args),
@@ -137,7 +134,241 @@ namespace NuGet.CommandLine.FuncTest.Commands
         }
 
         [Fact]
-        public void SearchCommand_ResultOutputTest()
+        public void SearchCommand_VerbosityDetailedTest()
+        {
+            // Arrange
+            string nugetexe = Util.GetNuGetExePath();
+
+            using (MockServer server = new MockServer())
+            using (SimpleTestPathContext config = new SimpleTestPathContext())
+            {
+                CommandRunner.Run(
+                    nugetexe,
+                    config.WorkingDirectory,
+                    $"source add -name mockSource -source {server.Uri}v3/index.json -configfile {config.NuGetConfig}",
+                    waitForExit: true);
+
+                string index = $@"
+                {{
+                    ""version"": ""3.0.0"",
+
+                    ""resources"": [
+                    {{
+                        ""@id"": ""{server.Uri + "search/query"}"",
+                        ""@type"": ""SearchQueryService/Versioned"",
+                        ""comment"": ""Query endpoint of NuGet Search service (primary)""
+                    }}
+                    ],
+
+                    ""@context"":
+                    {{
+                        ""@vocab"": ""http://schema.nuget.org/services#"",
+                        ""comment"": ""http://www.w3.org/2000/01/rdf-schema#comment""
+                    }}
+                }}";
+
+                server.Get.Add("/v3/index.json", r => index);
+
+                string queryResult = $@"
+                {{
+                    ""@context"":
+                    {{
+                        ""@vocab"": ""http://schema.nuget.org/schema#"",
+                        ""@base"": ""https://api.nuget.org/v3/registration5-semver1/""
+                    }},
+                    ""totalHits"": 396,
+                    ""data"": [
+                    {{
+                        ""@id"": ""https://api.nuget.org/v3/registration5-semver1/newtonsoft.json/index.json"",
+                        ""@type"": ""Package"",
+                        ""registration"": ""https://api.nuget.org/v3/registration5-semver1/newtonsoft.json/index.json"",
+                        ""id"": ""Fake.Newtonsoft.Json"",
+                        ""version"": ""12.0.3"",
+                        ""description"": ""Json.NET is a popular high-performance JSON framework for .NET, plus more detailed description so that we can test -Verbosity normal and -Verbosity detailed properly."",
+                        ""summary"": """",
+                        ""title"": ""Json.NET"",
+                        ""iconUrl"": ""https://api.nuget.org/v3-flatcontainer/newtonsoft.json/12.0.3/icon"",
+                        ""licenseUrl"": ""https://www.nuget.org/packages/Newtonsoft.Json/12.0.3/license"",
+                        ""projectUrl"": ""https://www.newtonsoft.com/json"",
+
+                        ""tags"": [
+                            ""json""
+                        ],
+
+                        ""authors"": [
+                        ""James Newton-King""
+                        ],
+
+                        ""totalDownloads"": 531607259,
+                        ""verified"": true,
+
+                        ""packageTypes"": [
+                        {{
+                            ""name"": ""Dependency""
+                        }}
+                        ],
+
+                        ""versions"": [
+                        {{
+                            ""version"": ""3.5.8"",
+                            ""downloads"": 461992,
+                            ""@id"": ""https://api.nuget.org/v3/registration5-semver1/newtonsoft.json/3.5.8.json""
+                        }}
+                        ]
+                    }}
+                    ]
+                }}";
+
+                server.Get.Add("/search/query?q=json&skip=0&take=20&prerelease=false&semVerLevel=2.0.0", r => queryResult);
+
+                server.Start();
+
+                // Act
+                string[] args = new[]
+                {
+                    "search",
+                    "json",
+                    "-Verbosity",
+                    "detailed",
+                };
+
+                CommandRunnerResult result = CommandRunner.Run(
+                    nugetexe,
+                    config.WorkingDirectory,
+                    string.Join(" ", args),
+                    waitForExit: true);
+
+                server.Stop();
+
+                // Assert
+                Assert.True(0 == result.Item1, $"{result.Item2} {result.Item3}");
+                Assert.Contains("Fake.Newtonsoft.Json", $"{result.Item2} {result.Item3}");
+                Assert.Contains("Downloads", $"{result.Item2} {result.Item3}");
+                Assert.Contains("detailed properly.", $"{result.Item2} {result.Item3}");
+                Assert.DoesNotContain("...", $"{result.Item2} {result.Item3}");
+                Assert.Contains("Querying", $"{result.Item2} {result.Item3}");
+            }
+        }
+
+        [Fact]
+        public void SearchCommand_VerbosityNormalTest()
+        {
+            // Arrange
+            string nugetexe = Util.GetNuGetExePath();
+
+            using (MockServer server = new MockServer())
+            using (SimpleTestPathContext config = new SimpleTestPathContext())
+            {
+                CommandRunner.Run(
+                    nugetexe,
+                    config.WorkingDirectory,
+                    $"source add -name mockSource -source {server.Uri}v3/index.json -configfile {config.NuGetConfig}",
+                    waitForExit: true);
+
+                string index = $@"
+                {{
+                    ""version"": ""3.0.0"",
+
+                    ""resources"": [
+                    {{
+                        ""@id"": ""{server.Uri + "search/query"}"",
+                        ""@type"": ""SearchQueryService/Versioned"",
+                        ""comment"": ""Query endpoint of NuGet Search service (primary)""
+                    }}
+                    ],
+
+                    ""@context"":
+                    {{
+                        ""@vocab"": ""http://schema.nuget.org/services#"",
+                        ""comment"": ""http://www.w3.org/2000/01/rdf-schema#comment""
+                    }}
+                }}";
+
+                server.Get.Add("/v3/index.json", r => index);
+
+                string queryResult = $@"
+                {{
+                    ""@context"":
+                    {{
+                        ""@vocab"": ""http://schema.nuget.org/schema#"",
+                        ""@base"": ""https://api.nuget.org/v3/registration5-semver1/""
+                    }},
+                    ""totalHits"": 396,
+                    ""data"": [
+                    {{
+                        ""@id"": ""https://api.nuget.org/v3/registration5-semver1/newtonsoft.json/index.json"",
+                        ""@type"": ""Package"",
+                        ""registration"": ""https://api.nuget.org/v3/registration5-semver1/newtonsoft.json/index.json"",
+                        ""id"": ""Fake.Newtonsoft.Json"",
+                        ""version"": ""12.0.3"",
+                        ""description"": ""Json.NET is a popular high-performance JSON framework for .NET, plus more detailed description so that we can test -Verbosity normal and -Verbosity detailed properly."",
+                        ""summary"": """",
+                        ""title"": ""Json.NET"",
+                        ""iconUrl"": ""https://api.nuget.org/v3-flatcontainer/newtonsoft.json/12.0.3/icon"",
+                        ""licenseUrl"": ""https://www.nuget.org/packages/Newtonsoft.Json/12.0.3/license"",
+                        ""projectUrl"": ""https://www.newtonsoft.com/json"",
+
+                        ""tags"": [
+                            ""json""
+                        ],
+
+                        ""authors"": [
+                        ""James Newton-King""
+                        ],
+
+                        ""totalDownloads"": 531607259,
+                        ""verified"": true,
+
+                        ""packageTypes"": [
+                        {{
+                            ""name"": ""Dependency""
+                        }}
+                        ],
+
+                        ""versions"": [
+                        {{
+                            ""version"": ""3.5.8"",
+                            ""downloads"": 461992,
+                            ""@id"": ""https://api.nuget.org/v3/registration5-semver1/newtonsoft.json/3.5.8.json""
+                        }}
+                        ]
+                    }}
+                    ]
+                }}";
+
+                server.Get.Add("/search/query?q=json&skip=0&take=20&prerelease=false&semVerLevel=2.0.0", r => queryResult);
+
+                server.Start();
+
+                // Act
+                string[] args = new[]
+                {
+                    "search",
+                    "json",
+                    "-Verbosity",
+                    "normal",
+                };
+
+                CommandRunnerResult result = CommandRunner.Run(
+                    nugetexe,
+                    config.WorkingDirectory,
+                    string.Join(" ", args),
+                    waitForExit: true);
+
+                server.Stop();
+
+                // Assert
+                Assert.True(0 == result.Item1, $"{result.Item2} {result.Item3}");
+                Assert.Contains("Fake.Newtonsoft.Json", $"{result.Item2} {result.Item3}");
+                Assert.Contains("Downloads", $"{result.Item2} {result.Item3}");
+                Assert.DoesNotContain("detailed properly.", $"{result.Item2} {result.Item3}");
+                Assert.Contains("...", $"{result.Item2} {result.Item3}");
+                Assert.DoesNotContain("Querying", $"{result.Item2} {result.Item3}");
+            }
+        }
+
+        [Fact]
+        public void SearchCommand_VerbosityQuietTest()
         {
             // Arrange
             var nugetexe = Util.GetNuGetExePath();
@@ -234,7 +465,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
                     "search",
                     "json",
                     "-Verbosity",
-                    "detailed",
+                    "quiet",
                 };
 
                 var result = CommandRunner.Run(
@@ -248,49 +479,176 @@ namespace NuGet.CommandLine.FuncTest.Commands
                 // Assert
                 Assert.True(0 == result.Item1, $"{result.Item2} {result.Item3}");
                 Assert.Contains("Fake.Newtonsoft.Json", $"{result.Item2} {result.Item3}");
-                Assert.Contains("Downloads", $"{result.Item2} {result.Item3}");
-                Assert.Contains("detailed properly.", $"{result.Item2} {result.Item3}");
+                Assert.DoesNotContain("Downloads", $"{result.Item2} {result.Item3}");
+                Assert.DoesNotContain("detailed properly.", $"{result.Item2} {result.Item3}");
                 Assert.DoesNotContain("...", $"{result.Item2} {result.Item3}");
-                Assert.Contains("Querying", $"{result.Item2} {result.Item3}");
+                Assert.DoesNotContain("Querying", $"{result.Item2} {result.Item3}");
             }
         }
 
-        //[Fact]
-        //public void SearchCommand_WrongSourceTest()
-        //{
-        //    // Arrange
-        //    var nugetexe = Util.GetNuGetExePath();
+        [Fact]
+        public void SearchCommand_TakeOptionTest()
+        {
+            // Arrange
+            string nugetexe = Util.GetNuGetExePath();
 
-        //    using (var server = new MockServer())
-        //    using (var config = new SimpleTestPathContext())
-        //    {
-        //        server.Start();
+            using (MockServer server = new MockServer())
+            using (SimpleTestPathContext config = new SimpleTestPathContext())
+            {
+                CommandRunner.Run(
+                    nugetexe,
+                    config.WorkingDirectory,
+                    $"source add -name mockSource -source {server.Uri}v3/index.json -configfile {config.NuGetConfig}",
+                    waitForExit: true);
 
-        //        // Act
-        //        var args = new[]
-        //        {
-        //            "search",
-        //            "json",
-        //            "-Take",
-        //            "5",
-        //        };
+                string index = $@"
+                {{
+                    ""version"": ""3.0.0"",
 
-        //        var result = CommandRunner.Run(
-        //            nugetexe,
-        //            config.WorkingDirectory,
-        //            string.Join(" ", args),
-        //            waitForExit: true);
+                    ""resources"": [
+                    {{
+                        ""@id"": ""{server.Uri + "search/query"}"",
+                        ""@type"": ""SearchQueryService/Versioned"",
+                        ""comment"": ""Query endpoint of NuGet Search service (primary)""
+                    }}
+                    ],
 
-        //        server.Stop();
+                    ""@context"":
+                    {{
+                        ""@vocab"": ""http://schema.nuget.org/services#"",
+                        ""comment"": ""http://www.w3.org/2000/01/rdf-schema#comment""
+                    }}
+                }}";
 
-        //        // Assert
-        //        Assert.True(0 == result.Item1, $"{result.Item2} {result.Item3}");
-        //        Assert.Contains("Fake.Newtonsoft.Json", $"{result.Item2} {result.Item3}");
-        //        Assert.Contains("531607259", $"{result.Item2} {result.Item3}");
-        //        Assert.Contains("detailed", $"{result.Item2} {result.Item3}");
-        //        Assert.DoesNotContain("...", $"{result.Item2} {result.Item3}");
-        //        Assert.Contains("Querying", $"{result.Item2} {result.Item3}");
-        //    }
-        //}
+                server.Get.Add("/v3/index.json", r => index);
+
+                string incorrectQueryResult = $@"
+                {{
+                    ""@context"":
+                    {{
+                        ""@vocab"": ""http://schema.nuget.org/schema#"",
+                        ""@base"": ""https://api.nuget.org/v3/registration5-semver1/""
+                    }},
+                    ""totalHits"": 396,
+                    ""data"": [
+                    {{
+                        ""@id"": ""https://api.nuget.org/v3/registration5-semver1/newtonsoft.json/index.json"",
+                        ""@type"": ""Package"",
+                        ""registration"": ""https://api.nuget.org/v3/registration5-semver1/newtonsoft.json/index.json"",
+                        ""id"": ""Fake.Newtonsoft.Json - Incorrect result"",
+                        ""version"": ""12.0.3"",
+                        ""description"": ""Json.NET is a popular high-performance JSON framework for .NET, plus more detailed description so that we can test -Verbosity normal and -Verbosity detailed properly."",
+                        ""summary"": """",
+                        ""title"": ""Json.NET"",
+                        ""iconUrl"": ""https://api.nuget.org/v3-flatcontainer/newtonsoft.json/12.0.3/icon"",
+                        ""licenseUrl"": ""https://www.nuget.org/packages/Newtonsoft.Json/12.0.3/license"",
+                        ""projectUrl"": ""https://www.newtonsoft.com/json"",
+
+                        ""tags"": [
+                            ""json""
+                        ],
+
+                        ""authors"": [
+                        ""James Newton-King""
+                        ],
+
+                        ""totalDownloads"": 531607259,
+                        ""verified"": true,
+
+                        ""packageTypes"": [
+                        {{
+                            ""name"": ""Dependency""
+                        }}
+                        ],
+
+                        ""versions"": [
+                        {{
+                            ""version"": ""3.5.8"",
+                            ""downloads"": 461992,
+                            ""@id"": ""https://api.nuget.org/v3/registration5-semver1/newtonsoft.json/3.5.8.json""
+                        }}
+                        ]
+                    }}
+                    ]
+                }}";
+
+                server.Get.Add("/search/query?q=json&skip=0&take=20&prerelease=false&semVerLevel=2.0.0", r => incorrectQueryResult);
+
+                string correctQueryResult = $@"
+                {{
+                    ""@context"":
+                    {{
+                        ""@vocab"": ""http://schema.nuget.org/schema#"",
+                        ""@base"": ""https://api.nuget.org/v3/registration5-semver1/""
+                    }},
+                    ""totalHits"": 396,
+                    ""data"": [
+                    {{
+                        ""@id"": ""https://api.nuget.org/v3/registration5-semver1/newtonsoft.json/index.json"",
+                        ""@type"": ""Package"",
+                        ""registration"": ""https://api.nuget.org/v3/registration5-semver1/newtonsoft.json/index.json"",
+                        ""id"": ""Fake.Newtonsoft.Json - Correct result"",
+                        ""version"": ""12.0.3"",
+                        ""description"": ""Json.NET is a popular high-performance JSON framework for .NET, plus more detailed description so that we can test -Verbosity normal and -Verbosity detailed properly."",
+                        ""summary"": """",
+                        ""title"": ""Json.NET"",
+                        ""iconUrl"": ""https://api.nuget.org/v3-flatcontainer/newtonsoft.json/12.0.3/icon"",
+                        ""licenseUrl"": ""https://www.nuget.org/packages/Newtonsoft.Json/12.0.3/license"",
+                        ""projectUrl"": ""https://www.newtonsoft.com/json"",
+
+                        ""tags"": [
+                            ""json""
+                        ],
+
+                        ""authors"": [
+                        ""James Newton-King""
+                        ],
+
+                        ""totalDownloads"": 531607259,
+                        ""verified"": true,
+
+                        ""packageTypes"": [
+                        {{
+                            ""name"": ""Dependency""
+                        }}
+                        ],
+
+                        ""versions"": [
+                        {{
+                            ""version"": ""3.5.8"",
+                            ""downloads"": 461992,
+                            ""@id"": ""https://api.nuget.org/v3/registration5-semver1/newtonsoft.json/3.5.8.json""
+                        }}
+                        ]
+                    }}
+                    ]
+                }}";
+
+                server.Get.Add("/search/query?q=json&skip=0&take=5&prerelease=false&semVerLevel=2.0.0", r => correctQueryResult);
+
+                server.Start();
+
+                // Act
+                string[] args = new[]
+                {
+                    "search",
+                    "json",
+                    "-Take",
+                    "5",
+                };
+
+                CommandRunnerResult result = CommandRunner.Run(
+                    nugetexe,
+                    config.WorkingDirectory,
+                    string.Join(" ", args),
+                    waitForExit: true);
+
+                server.Stop();
+
+                // Assert
+                Assert.True(0 == result.Item1, $"{result.Item2} {result.Item3}");
+                Assert.Contains("Fake.Newtonsoft.Json - Correct result", $"{result.Item2} {result.Item3}");
+            }
+        }
     }
 }


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9704
Regression: No  

## Fix

This adds a `search` command to NuGet.exe that allows users to search for packages through the command line. The design spec for this feature is [here](https://github.com/NuGet/Home/blob/dev/designs/SearchCommandSpec.md).

## Testing/Validation

Tests Added: Yes