### PR TITLE
Use thread-free OutputWindowsTextWriter instead of writting directly to output pane.

### DIFF
--- a/src/NuGet.Clients/NuGet.Console/OutputConsole/BuildOutputConsole.cs
+++ b/src/NuGet.Clients/NuGet.Console/OutputConsole/BuildOutputConsole.cs
@@ -2,10 +2,12 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Threading.Tasks;
 using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.Threading;
 using NuGet.VisualStudio;
+using Task = System.Threading.Tasks.Task;
 
 namespace NuGetConsole
 {
@@ -19,7 +21,8 @@ namespace NuGetConsole
         private static Guid BuildWindowPaneGuid = VSConstants.BuildOutput;
 
         private readonly IVsOutputWindow _vsOutputWindow;
-        private IVsOutputWindowPane _outputWindowPane;
+        private readonly AsyncLazy<IVsOutputWindowPane> _outputWindowPane;
+        private readonly AsyncLazy<OutputWindowTextWriter> _outputWindowTextWriter;
 
         public BuildOutputConsole(IVsOutputWindow vsOutputWindow)
         {
@@ -29,18 +32,35 @@ namespace NuGetConsole
             }
 
             _vsOutputWindow = vsOutputWindow;
+
+            _outputWindowPane = new AsyncLazy<IVsOutputWindowPane>(async () =>
+            {
+                await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                _vsOutputWindow.GetPane(ref BuildWindowPaneGuid, out var outputWindowPane);
+                return outputWindowPane;
+            },
+            NuGetUIThreadHelper.JoinableTaskFactory);
+
+            _outputWindowTextWriter = new AsyncLazy<OutputWindowTextWriter>(async () =>
+            {
+                var outputWindowPane = await _outputWindowPane.GetValueAsync();
+                if (outputWindowPane != null)
+                {
+                    return new OutputWindowTextWriter(outputWindowPane);
+                }
+                else
+                {
+                    return null;
+                }
+            },
+            NuGetUIThreadHelper.JoinableTaskFactory);
         }
 
         public override async Task ActivateAsync()
         {
+            var outputWindowPane = await _outputWindowPane.GetValueAsync();
             await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-
-            if (_outputWindowPane == null)
-            {
-                _vsOutputWindow.GetPane(ref BuildWindowPaneGuid, out _outputWindowPane);
-            }
-
-            _outputWindowPane?.Activate();
+            outputWindowPane?.Activate();
         }
 
         public override Task ClearAsync()
@@ -51,12 +71,8 @@ namespace NuGetConsole
 
         public override async Task WriteAsync(string text)
         {
-            if (_outputWindowPane != null)
-            {
-                await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-
-                _outputWindowPane.OutputStringThreadSafe(text);
-            }
+            var outputWindowTextWriter = await _outputWindowTextWriter.GetValueAsync();
+            await outputWindowTextWriter?.WriteAsync(text);
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.Console/OutputConsole/OutputConsole.cs
+++ b/src/NuGet.Clients/NuGet.Console/OutputConsole/OutputConsole.cs
@@ -2,11 +2,12 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Threading.Tasks;
 using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Threading;
 using NuGet.VisualStudio;
+using Task = System.Threading.Tasks.Task;
 
 namespace NuGetConsole
 {
@@ -19,6 +20,7 @@ namespace NuGetConsole
         private readonly IVsOutputWindow _vsOutputWindow;
         private readonly IVsUIShell _vsUiShell;
         private readonly AsyncLazy<IVsOutputWindowPane> _outputWindowPane;
+        private readonly AsyncLazy<OutputWindowTextWriter> _outputWindowTextWriter;
 
         private IVsOutputWindowPane VsOutputWindowPane => NuGetUIThreadHelper.JoinableTaskFactory.Run(_outputWindowPane.GetValueAsync);
 
@@ -60,6 +62,13 @@ namespace NuGetConsole
                 return pane;
 
             }, NuGetUIThreadHelper.JoinableTaskFactory);
+
+            _outputWindowTextWriter = new AsyncLazy<OutputWindowTextWriter>(async () =>
+            {
+                var outputWindowPane = await _outputWindowPane.GetValueAsync();
+                return new OutputWindowTextWriter(outputWindowPane);
+            },
+            NuGetUIThreadHelper.JoinableTaskFactory);
         }
 
         public override async Task WriteAsync(string text)
@@ -71,12 +80,15 @@ namespace NuGetConsole
 
             Start();
 
-            await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-            VsOutputWindowPane.OutputStringThreadSafe(text);
+            var outputWindowTextWriter = await _outputWindowTextWriter.GetValueAsync();
+            await outputWindowTextWriter.WriteAsync(text);
         }
 
         public override async Task ActivateAsync()
         {
+            var outputWindowTextWriter = await _outputWindowTextWriter.GetValueAsync();
+            await outputWindowTextWriter.FlushAsync();
+
             await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
             _vsUiShell.FindToolWindow(0,


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9591 (partially)
Regression: No

## Fix

Details: As a part of https://github.com/NuGet/NuGet.Client/pull/3484, I have implemented changes suggested by @AArnott to use thread-free OutputWindowsTextWritter. As pull request 3484 is failing e2e tests, I am trying to extract those changes unrelated to base fix in other PR, so that we can see if this has anything to do with e2e failures. If this PR comes clean, it is still worthwhile to be included, as it is still good change on its own.

## Testing/Validation

Tests Added: No  
Reason for not adding tests: Existing coverage seems good enough.
Validation:  e2e test pass. Manual testing through experimental instance.
