### PR TITLE
Detect zip file central directory on big and little endian hardware

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/Signing/Archive/EndOfCentralDirectoryRecord.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Archive/EndOfCentralDirectoryRecord.cs
@@ -2,8 +2,10 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 
 // ZIP specification: http://www.pkware.com/documents/casestudies/APPNOTE.TXT
 
@@ -11,7 +13,7 @@ namespace NuGet.Packaging.Signing
 {
     internal sealed class EndOfCentralDirectoryRecord
     {
-        internal const uint Signature = 0x06054b50;
+        private static readonly IReadOnlyList<byte> Signature = new byte[4] { 0x50, 0x4b, 0x05, 0x06 };
 
         internal ushort NumberOfThisDisk { get; private set; }
         internal ushort NumberOfTheDiskWithTheStartOfTheCentralDirectory { get; private set; }
@@ -49,12 +51,11 @@ namespace NuGet.Packaging.Signing
 
         private static void SeekToEndOfCentralDirectoryRecord(BinaryReader reader)
         {
-            var byteSignature = BitConverter.GetBytes(Signature);
             var length = reader.BaseStream.Length;
 
-            if (length < byteSignature.Length)
+            if (length < Signature.Count)
             {
-                ThrowByteSignatureNotFoundException(byteSignature);
+                ThrowByteSignatureNotFoundException(Signature);
             }
 
             const int DefaultBufferSize = 4096;
@@ -73,11 +74,11 @@ namespace NuGet.Packaging.Signing
 
                 for (var i = buffer.Length - 1; i >= 0; --i)
                 {
-                    if (buffer[i] == byteSignature[byteSignature.Length - matchingByteCount - 1])
+                    if (buffer[i] == Signature[Signature.Count - matchingByteCount - 1])
                     {
                         ++matchingByteCount;
 
-                        if (matchingByteCount == byteSignature.Length)
+                        if (matchingByteCount == Signature.Count)
                         {
                             reader.BaseStream.Position = position + i;
 
@@ -98,18 +99,18 @@ namespace NuGet.Packaging.Signing
                 }
             }
 
-            ThrowByteSignatureNotFoundException(byteSignature);
+            ThrowByteSignatureNotFoundException(Signature);
         }
 
-        private static void ThrowByteSignatureNotFoundException(byte[] signature)
+        private static void ThrowByteSignatureNotFoundException(IReadOnlyList<byte> signature)
         {
             throw new InvalidDataException(
                 string.Format(CultureInfo.CurrentCulture,
                 Strings.ErrorByteSignatureNotFound,
 #if NETCOREAPP
-                BitConverter.ToString(signature).Replace("-", "", StringComparison.Ordinal)));
+                BitConverter.ToString(signature.ToArray()).Replace("-", "", StringComparison.Ordinal)));
 #else
-                BitConverter.ToString(signature).Replace("-", "")));
+                BitConverter.ToString(signature.ToArray()).Replace("-", "")));
 #endif
         }
     }


### PR DESCRIPTION
inspired by @nealef's patch in https://github.com/NuGet/Home/issues/9547

## Bug

Fixes: https://github.com/NuGet/Home/issues/9547
Regression: Yes
* Last working version:   4.5
* How are we preventing it in future:  We're reliant on the community testing and providing feedback

## Fix

Details: Different CPUs might have different [endianness](https://en.wikipedia.org/wiki/Endianness). The zip file end of directory signature is serialized in little-endian order. Therefore it is not safe to assume that all machines natural conversion from an int to a byte array will match the same order that the file itself uses.

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  All tests that run the modified method already test this.
Validation:  @nealef did some [manual tests](https://github.com/NuGet/Home/issues/9547#issuecomment-654761984)
