### PR TITLE
Construct OutputWindowTextWriter on main thread.

### DIFF
--- a/src/NuGet.Clients/NuGet.Console/OutputConsole/BuildOutputConsole.cs
+++ b/src/NuGet.Clients/NuGet.Console/OutputConsole/BuildOutputConsole.cs
@@ -46,6 +46,7 @@ namespace NuGetConsole
                 var outputWindowPane = await _outputWindowPane.GetValueAsync();
                 if (outputWindowPane != null)
                 {
+                    await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
                     return new OutputWindowTextWriter(outputWindowPane);
                 }
                 else

--- a/src/NuGet.Clients/NuGet.Console/OutputConsole/OutputConsole.cs
+++ b/src/NuGet.Clients/NuGet.Console/OutputConsole/OutputConsole.cs
@@ -66,6 +66,7 @@ namespace NuGetConsole
             _outputWindowTextWriter = new AsyncLazy<OutputWindowTextWriter>(async () =>
             {
                 var outputWindowPane = await _outputWindowPane.GetValueAsync();
+                await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
                 return new OutputWindowTextWriter(outputWindowPane);
             },
             NuGetUIThreadHelper.JoinableTaskFactory);


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9764
Regression: Yes
* Last working version: Yesterday.
* How are we preventing it in future:  Better manual testing,

## Fix

OutputWindowTextWriter constructor must be called on UI thread.

## Testing/Validation

Tests Added: No 
Reason for not adding tests: Situation which does not lend for easy unit testing.
Validation: Manual validation of package UI.
