### PR TITLE
Add the "PackageReference with version defined" error in the asset files.

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/LockFileBuilder.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/LockFileBuilder.cs
@@ -330,8 +330,6 @@ namespace NuGet.Commands
                     .Flattened
                     .SingleOrDefault(library => library.Key.Name.Equals(project.Name, StringComparison.OrdinalIgnoreCase));
 
-                Debug.Assert(resolvedEntry != null, "Unable to find project entry in target graph, project references will not be added");
-
                 // In some failure cases where there is a conflict the root level project cannot be resolved, this should be handled gracefully
                 if (resolvedEntry != null)
                 {

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -177,25 +177,8 @@ namespace NuGet.Commands
 
                 if (isCpvmEnabled && !await AreCentralVersionRequirementsSatisfiedAsync())
                 {
-                    restoreTime.Stop();
+                    // the errors will be added to the assets file
                     _success = false;
-
-                    return new RestoreResult(
-                        success: _success,
-                        restoreGraphs: Enumerable.Empty<RestoreTargetGraph>(),
-                        compatibilityCheckResults: Enumerable.Empty<CompatibilityCheckResult>(),
-                        msbuildFiles: Enumerable.Empty<MSBuildOutputFile>(),
-                        lockFile: _request.ExistingLockFile,
-                        previousLockFile: _request.ExistingLockFile,
-                        lockFilePath: _request.ExistingLockFile?.Path,
-                        cacheFile: null,
-                        cacheFilePath: _request.Project.RestoreMetadata.CacheFilePath,
-                        packagesLockFilePath: null,
-                        packagesLockFile: null,
-                        projectStyle: _request.ProjectStyle,
-                        dependencyGraphSpecFilePath: NoOpRestoreUtilities.GetPersistedDGSpecFilePath(_request),
-                        dependencyGraphSpec: _request.DependencyGraphSpec,
-                        elapsedTime: restoreTime.Elapsed);
                 }
 
                 // evaluate packages.lock.json file
@@ -428,7 +411,6 @@ namespace NuGet.Commands
             if (dependenciesWithDefinedVersion.Any())
             {
                 await _logger.LogAsync(RestoreLogMessage.CreateError(NuGetLogCode.NU1008, string.Format(CultureInfo.CurrentCulture, Strings.Error_CentralPackageVersions_VersionsNotAllowed, string.Join(";", dependenciesWithDefinedVersion.Select(d => d.Name)))));
-
                 return false;
             }
             IEnumerable<LibraryDependency> autoReferencedAndDefinedInCentralFile = _request.Project.TargetFrameworks.SelectMany(tfm => tfm.Dependencies.Where(d => d.AutoReferenced && tfm.CentralPackageVersions.ContainsKey(d.Name)));


### PR DESCRIPTION
## Bug

Fixes: [Improve the CPVM Visual Studio experience for the case when PackageReference items have version](https://github.com/NuGet/Home/issues/9507)

The error will be displayed in Visual Studio like below:

![image](https://user-images.githubusercontent.com/16580006/87090979-bb2e3900-c1ed-11ea-8108-0c9782b79735.png)


Regression: No  

## Fix

Let the error propagate to the assets file.

## Testing/Validation

Tests Added: Yes 
Reason for not adding tests:  
Validation:  Unit tests and manual testing. 
