### PR TITLE
Enable the partial restore optimization for legacy package reference projects

### DIFF
--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/ISolutionRestoreChecker.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/ISolutionRestoreChecker.cs
@@ -36,7 +36,7 @@ namespace NuGet.SolutionRestoreManager
         /// <remarks>Note that this call is stateful. This method may end up caching the dependency graph spec, so do not invoke multiple times.
         ///  Ideally <see cref="PerformUpToDateCheck(DependencyGraphSpec)"/> call should be followed by a <see cref="ReportStatus(IReadOnlyList{RestoreSummary})"/> call.
         /// </remarks>
-        void ReportStatus(IReadOnlyList<RestoreSummary> restoreSummaries);
+        void SaveRestoreStatus(IReadOnlyList<RestoreSummary> restoreSummaries);
 
         /// <summary>
         /// Clears any cached values. This is meant to mimic restores that overwrite the incremental restore optimizations.

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/ISolutionRestoreChecker.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/ISolutionRestoreChecker.cs
@@ -18,14 +18,14 @@ namespace NuGet.SolutionRestoreManager
         /// The checker itself caches the DependencyGraphSpec it is provided and the last restore status, reported through <see cref="ReportStatus(IReadOnlyList{RestoreSummary})"/>.
         /// Accounts for changes in the PackageSpec and marks all the parent projects as dirty as well.
         /// Additionally, ensures that the expected output files have the same timestamps as the last reported status
-        /// <see cref="ReportStatus(IReadOnlyList{RestoreSummary})"/>.\
+        /// <see cref="ReportStatus(IReadOnlyList{RestoreSummary})"/>
         /// Finally we will use the logger provided to replay any warnings necessary. Whether warnings are replayed in conditional on the <see cref="ProjectRestoreSettings"/> in the <see cref="PackageSpec"/>.
         /// </summary>
         /// <param name="dependencyGraphSpec">The current dependency graph spec.</param>
         /// <param name="logger">A logger that will be used to replay warnings for projects that no-op if necessary.</param>
         /// <returns>Unique ids of the dirty projects</returns>
         /// <remarks>Note that this call is stateful. This method may end up caching the dependency graph spec, so do not invoke multiple times. 
-        /// Ideally <see cref="PerformUpToDateCheck(DependencyGraphSpec)"/> call should be followed by a <see cref="ReportStatus(IReadOnlyList{RestoreSummary})"/> call.
+        /// Ideally each <see cref="PerformUpToDateCheck(DependencyGraphSpec, ILogger)"/> call should be followed by a <see cref="ReportStatus(IReadOnlyList{RestoreSummary})"/> call.
         /// </remarks>
         IEnumerable<string> PerformUpToDateCheck(DependencyGraphSpec dependencyGraphSpec, ILogger logger);
 
@@ -41,7 +41,6 @@ namespace NuGet.SolutionRestoreManager
         /// <summary>
         /// Clears any cached values. This is meant to mimic restores that overwrite the incremental restore optimizations.
         /// </summary>
-        /// <returns></returns>
         void CleanCache();
     }
 }

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/ISolutionRestoreChecker.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/ISolutionRestoreChecker.cs
@@ -2,9 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using System.Threading.Tasks;
-
 using NuGet.Commands;
+using NuGet.Common;
 using NuGet.ProjectModel;
 
 namespace NuGet.SolutionRestoreManager
@@ -19,14 +18,16 @@ namespace NuGet.SolutionRestoreManager
         /// The checker itself caches the DependencyGraphSpec it is provided and the last restore status, reported through <see cref="ReportStatus(IReadOnlyList{RestoreSummary})"/>.
         /// Accounts for changes in the PackageSpec and marks all the parent projects as dirty as well.
         /// Additionally, ensures that the expected output files have the same timestamps as the last reported status
-        /// <see cref="ReportStatus(IReadOnlyList{RestoreSummary})"/>.
+        /// <see cref="ReportStatus(IReadOnlyList{RestoreSummary})"/>.\
+        /// Finally we will use the logger provided to replay any warnings necessary. Whether warnings are replayed in conditional on the <see cref="ProjectRestoreSettings"/> in the <see cref="PackageSpec"/>.
         /// </summary>
         /// <param name="dependencyGraphSpec">The current dependency graph spec.</param>
+        /// <param name="logger">A logger that will be used to replay warnings for projects that no-op if necessary.</param>
         /// <returns>Unique ids of the dirty projects</returns>
         /// <remarks>Note that this call is stateful. This method may end up caching the dependency graph spec, so do not invoke multiple times. 
         /// Ideally <see cref="PerformUpToDateCheck(DependencyGraphSpec)"/> call should be followed by a <see cref="ReportStatus(IReadOnlyList{RestoreSummary})"/> call.
         /// </remarks>
-        IEnumerable<string> PerformUpToDateCheck(DependencyGraphSpec dependencyGraphSpec);
+        IEnumerable<string> PerformUpToDateCheck(DependencyGraphSpec dependencyGraphSpec, ILogger logger);
 
         /// <summary>
         /// Report the status of all the projects restored. 

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreJob.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreJob.cs
@@ -412,7 +412,7 @@ namespace NuGet.SolutionRestoreManager
                                 _packageCount += restoreSummaries.Select(summary => summary.InstallCount).Sum();
                                 var isRestoreFailed = restoreSummaries.Any(summary => summary.Success == false);
                                 _noOpProjectsCount += restoreSummaries.Where(summary => summary.NoOpRestore == true).Count();
-                                _solutionUpToDateChecker.ReportStatus(restoreSummaries);
+                                _solutionUpToDateChecker.SaveRestoreStatus(restoreSummaries);
                                 
                                 if (isRestoreFailed)
                                 {

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreJob.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreJob.cs
@@ -355,8 +355,7 @@ namespace NuGet.SolutionRestoreManager
                 using (intervalTracker.Start(RestoreTelemetryEvent.SolutionUpToDateCheck))
                 {
                     // Run solution based up to date check.
-                    var projectsNeedingRestore = _solutionUpToDateChecker.PerformUpToDateCheck(originalDgSpec).AsList();
-
+                    var projectsNeedingRestore = _solutionUpToDateChecker.PerformUpToDateCheck(originalDgSpec, _logger).AsList();
                     dgSpec = originalDgSpec;
                     // Only use the optimization results if the restore is not `force`.
                     // Still run the optimization check anyways to prep the cache.
@@ -368,12 +367,6 @@ namespace NuGet.SolutionRestoreManager
                         {
                             dgSpec.AddRestore(uniqueProjectId);
                         }
-                        // loop through all legacy PackageReference projects. We don't know how to replay their warnings & errors yet. TODO: https://github.com/NuGet/Home/issues/9565
-                        foreach(var project in (await _solutionManager.GetNuGetProjectsAsync()).Where(e => e is LegacyPackageReferenceProject).Select(e => e as LegacyPackageReferenceProject))
-                        {
-                            dgSpec.AddRestore(project.MSBuildProjectPath);
-                        }
-
                         // recorded the number of up to date projects
                         _upToDateProjectCount = originalDgSpec.Restore.Count - projectsNeedingRestore.Count;
                         _noOpProjectsCount = _upToDateProjectCount;

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionUpToDateChecker.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionUpToDateChecker.cs
@@ -20,7 +20,7 @@ namespace NuGet.SolutionRestoreManager
         private DependencyGraphSpec _cachedDependencyGraphSpec;
         private Dictionary<string, RestoreData> _restoreData = new Dictionary<string, RestoreData>();
 
-        public void ReportStatus(IReadOnlyList<RestoreSummary> restoreSummaries)
+        public void SaveRestoreStatus(IReadOnlyList<RestoreSummary> restoreSummaries)
         {
             if (restoreSummaries == null)
             {

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionUpToDateChecker.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionUpToDateChecker.cs
@@ -129,6 +129,7 @@ namespace NuGet.SolutionRestoreManager
                 {
                     _restoreData.Remove(project);
                 }
+
                 // Fast path. Skip Pass #2
                 if (dirtySpecs.Count == 0 && dirtyOutputs.Count == 0)
                 {

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreSummary.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreSummary.cs
@@ -26,6 +26,9 @@ namespace NuGet.Commands
 
         public int InstallCount { get; }
 
+        /// <summary>
+        /// All the warnings and errors that were produced as a result of the restore.
+        /// </summary>
         public IReadOnlyList<IRestoreLogMessage> Errors { get; }
 
         public RestoreSummary(bool success)

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/SolutionUpToDateCheckerTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/SolutionUpToDateCheckerTests.cs
@@ -272,7 +272,7 @@ namespace NuGet.SolutionRestoreManager.Test
 
             // Now we run 
             var results = RunRestore(failedProjects: new HashSet<string>(), projectsWithWarnings: new HashSet<string>(), projectA, projectB, projectC, projectD, projectE);
-            checker.ReportStatus(results);
+            checker.SaveRestoreStatus(results);
 
             // Prepare the new DG Spec:
             // Make projectE dirty by setting a random value that's usually not there :)
@@ -315,7 +315,7 @@ namespace NuGet.SolutionRestoreManager.Test
                 var expected = GetUniqueNames(projectA, projectB, projectC);
                 actual.Should().BeEquivalentTo(expected);
                 var results = RunRestore(failedProjects: new HashSet<string>(), projectsWithWarnings: new HashSet<string>(), projectA, projectB, projectC);
-                checker.ReportStatus(results);
+                checker.SaveRestoreStatus(results);
 
                 // Act & Asset.
                 actual = checker.PerformUpToDateCheck(dgSpec, NullLogger.Instance);
@@ -349,7 +349,7 @@ namespace NuGet.SolutionRestoreManager.Test
                 var expected = GetUniqueNames(projectA, projectB, projectC, projectD);
                 actual.Should().BeEquivalentTo(expected);
                 var results = RunRestore(failedProjects: new HashSet<string>(), projectsWithWarnings: new HashSet<string>(), projectA, projectB, projectC, projectD);
-                checker.ReportStatus(results);
+                checker.SaveRestoreStatus(results);
 
                 // Set-up, B => D
                 projectB = projectB.WithTestProjectReference(projectD);
@@ -386,7 +386,7 @@ namespace NuGet.SolutionRestoreManager.Test
                 var expected = GetUniqueNames(projectA, projectB, projectC);
                 actual.Should().BeEquivalentTo(expected);
                 var results = RunRestore(failedProjects: new HashSet<string>(), projectsWithWarnings: new HashSet<string>(), projectA, projectB, projectC);
-                checker.ReportStatus(results);
+                checker.SaveRestoreStatus(results);
 
                 // Set-up, delete C's outputs
                 SolutionUpToDateChecker.GetOutputFilePaths(projectC, out string assetsFilePath, out string _, out string _, out string _, out string _);
@@ -423,7 +423,7 @@ namespace NuGet.SolutionRestoreManager.Test
                 var expected = GetUniqueNames(projectA, projectB, projectC);
                 actual.Should().BeEquivalentTo(expected);
                 var results = RunRestore(failedProjects: new HashSet<string>(), projectsWithWarnings: new HashSet<string>(), projectA, projectB, projectC);
-                checker.ReportStatus(results);
+                checker.SaveRestoreStatus(results);
 
                 // Set-up, delete C's outputs
                 SolutionUpToDateChecker.GetOutputFilePaths(projectC, out string _, out string cacheFilePath, out string _, out string _, out string _);
@@ -462,7 +462,7 @@ namespace NuGet.SolutionRestoreManager.Test
                 var expected = GetUniqueNames(projectA, projectB, projectC, projectD);
                 actual.Should().BeEquivalentTo(expected);
                 var results = RunRestore(failedProjects: new HashSet<string>(), projectsWithWarnings: new HashSet<string>(), projectA, projectB, projectC, projectD);
-                checker.ReportStatus(results);
+                checker.SaveRestoreStatus(results);
 
                 // Set-up, make C dirty.
                 projectC = projectC.Clone();
@@ -499,7 +499,7 @@ namespace NuGet.SolutionRestoreManager.Test
 
                 // Set-up, ensure the last status for projectC is a failure.
                 var results = RunRestore(failedProjects: new HashSet<string>() { projectC.RestoreMetadata.ProjectUniqueName }, projectsWithWarnings: new HashSet<string>(), projectA, projectB, projectC);
-                checker.ReportStatus(results);
+                checker.SaveRestoreStatus(results);
 
                 // Act & Assert
                 actual = checker.PerformUpToDateCheck(dgSpec, NullLogger.Instance);
@@ -532,7 +532,7 @@ namespace NuGet.SolutionRestoreManager.Test
                 var expected = GetUniqueNames(projectA, projectB, projectC);
                 actual.Should().BeEquivalentTo(expected);
                 var results = RunRestore(failedProjects: new HashSet<string>(), projectsWithWarnings: new HashSet<string>(), projectA, projectB, projectC);
-                checker.ReportStatus(results);
+                checker.SaveRestoreStatus(results);
 
                 // Set-up, delete C's outputs
                 Directory.Delete(projectC.RestoreMetadata.PackagesPath, recursive: true);
@@ -579,7 +579,7 @@ namespace NuGet.SolutionRestoreManager.Test
                 var results = RunRestore(failedProjects: new HashSet<string>(), projectsWithWarnings: new HashSet<string>() { projectC.RestoreMetadata.ProjectUniqueName }, projectA, projectB, projectC);
                 // The test logger will not contain any messages because we are not running actual restore.
                 testLogger.WarningMessages.Should().BeEmpty();
-                checker.ReportStatus(results);
+                checker.SaveRestoreStatus(results);
 
                 // Act & Asset.
                 testLogger = new TestLogger();
@@ -622,7 +622,7 @@ namespace NuGet.SolutionRestoreManager.Test
                 var results = RunRestore(failedProjects: new HashSet<string>(), projectsWithWarnings: new HashSet<string>() { projectC.RestoreMetadata.ProjectUniqueName }, projectA, projectB, projectC);
                 // The test logger will not contain any messages because we are not running actual restore.
                 testLogger.WarningMessages.Should().BeEmpty();
-                checker.ReportStatus(results);
+                checker.SaveRestoreStatus(results);
 
                 // Act & Assert.
                 testLogger = new TestLogger();
@@ -667,14 +667,14 @@ namespace NuGet.SolutionRestoreManager.Test
                 var results = RunRestore(failedProjects: new HashSet<string>(), projectsWithWarnings: new HashSet<string>() { projectC.RestoreMetadata.ProjectUniqueName }, projectA, projectB, projectC);
                 // The test logger will not contain any messages because we are not running actual restore.
                 testLogger.WarningMessages.Should().BeEmpty();
-                checker.ReportStatus(results);
+                checker.SaveRestoreStatus(results);
 
                 // Run again to verify the warning is replayed once!
                 testLogger = new TestLogger();
                 actual = checker.PerformUpToDateCheck(dgSpec, testLogger);
                 testLogger.WarningMessages.Should().HaveCount(1);
                 actual.Should().BeEmpty();
-                checker.ReportStatus(new RestoreSummary[] { });
+                checker.SaveRestoreStatus(new RestoreSummary[] { });
 
                 // Pretend project C has been unloaded
                 dgSpec = new DependencyGraphSpec();
@@ -724,7 +724,7 @@ namespace NuGet.SolutionRestoreManager.Test
                 var expected = GetUniqueNames(projectA, projectB, projectC, projectD, projectE);
                 actual.Should().BeEquivalentTo(expected);
                 var results = RunRestore(failedProjects: new HashSet<string>(), projectsWithWarnings: new HashSet<string>(), projectA, projectB, projectC, projectD, projectE);
-                checker.ReportStatus(results);
+                checker.SaveRestoreStatus(results);
 
                 // D => E
                 projectD = projectD.WithTestProjectReference(projectE);
@@ -736,7 +736,7 @@ namespace NuGet.SolutionRestoreManager.Test
                 expected = GetUniqueNames(projectA, projectD);
                 actual.Should().BeEquivalentTo(expected);
                 results = RunRestore(failedProjects: new HashSet<string>(), projectsWithWarnings: new HashSet<string>(), projectA, projectD);
-                checker.ReportStatus(results);
+                checker.SaveRestoreStatus(results);
 
                 // Finally, last check. Run for a 3rd time. Everything should be up to date
                 actual = checker.PerformUpToDateCheck(dgSpec, NullLogger.Instance);

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/SolutionUpToDateCheckerTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/SolutionUpToDateCheckerTests.cs
@@ -266,12 +266,12 @@ namespace NuGet.SolutionRestoreManager.Test
 
             var checker = new SolutionUpToDateChecker();
 
-            var actual = checker.PerformUpToDateCheck(dgSpec);
+            var actual = checker.PerformUpToDateCheck(dgSpec, NullLogger.Instance);
             var expected = GetUniqueNames(projectA, projectB, projectC, projectD, projectE);
             actual.Should().BeEquivalentTo(expected);
 
             // Now we run 
-            var results = RunRestore(failedProjects: new HashSet<string>(), projectA, projectB, projectC, projectD, projectE);
+            var results = RunRestore(failedProjects: new HashSet<string>(), projectsWithWarnings: new HashSet<string>(), projectA, projectB, projectC, projectD, projectE);
             checker.ReportStatus(results);
 
             // Prepare the new DG Spec:
@@ -282,7 +282,7 @@ namespace NuGet.SolutionRestoreManager.Test
 
             // Act & Assert.
             expected = GetUniqueNames(projectA, projectE);
-            actual = checker.PerformUpToDateCheck(dgSpec);
+            actual = checker.PerformUpToDateCheck(dgSpec, NullLogger.Instance);
             actual.Should().BeEquivalentTo(expected);
         }
 
@@ -311,14 +311,14 @@ namespace NuGet.SolutionRestoreManager.Test
                 var checker = new SolutionUpToDateChecker();
 
                 // Preconditions, run 1st check
-                var actual = checker.PerformUpToDateCheck(dgSpec);
+                var actual = checker.PerformUpToDateCheck(dgSpec, NullLogger.Instance);
                 var expected = GetUniqueNames(projectA, projectB, projectC);
                 actual.Should().BeEquivalentTo(expected);
-                var results = RunRestore(failedProjects: new HashSet<string>(), projectA, projectB, projectC);
+                var results = RunRestore(failedProjects: new HashSet<string>(), projectsWithWarnings: new HashSet<string>(), projectA, projectB, projectC);
                 checker.ReportStatus(results);
 
                 // Act & Asset.
-                actual = checker.PerformUpToDateCheck(dgSpec);
+                actual = checker.PerformUpToDateCheck(dgSpec, NullLogger.Instance);
                 actual.Should().BeEmpty();
             }
         }
@@ -345,10 +345,10 @@ namespace NuGet.SolutionRestoreManager.Test
                 var checker = new SolutionUpToDateChecker();
 
                 // Preconditions, run 1st check
-                var actual = checker.PerformUpToDateCheck(dgSpec);
+                var actual = checker.PerformUpToDateCheck(dgSpec, NullLogger.Instance);
                 var expected = GetUniqueNames(projectA, projectB, projectC, projectD);
                 actual.Should().BeEquivalentTo(expected);
-                var results = RunRestore(failedProjects: new HashSet<string>(), projectA, projectB, projectC, projectD);
+                var results = RunRestore(failedProjects: new HashSet<string>(), projectsWithWarnings: new HashSet<string>(), projectA, projectB, projectC, projectD);
                 checker.ReportStatus(results);
 
                 // Set-up, B => D
@@ -356,7 +356,7 @@ namespace NuGet.SolutionRestoreManager.Test
                 dgSpec = ProjectJsonTestHelpers.GetDGSpecFromPackageSpecs(projectA, projectB, projectC, projectD);
 
                 // Act & Assert
-                actual = checker.PerformUpToDateCheck(dgSpec);
+                actual = checker.PerformUpToDateCheck(dgSpec, NullLogger.Instance);
                 expected = GetUniqueNames(projectA, projectB);
                 actual.Should().BeEquivalentTo(expected);
             }
@@ -382,10 +382,10 @@ namespace NuGet.SolutionRestoreManager.Test
                 var checker = new SolutionUpToDateChecker();
 
                 // Preconditions, run 1st check
-                var actual = checker.PerformUpToDateCheck(dgSpec);
+                var actual = checker.PerformUpToDateCheck(dgSpec, NullLogger.Instance);
                 var expected = GetUniqueNames(projectA, projectB, projectC);
                 actual.Should().BeEquivalentTo(expected);
-                var results = RunRestore(failedProjects: new HashSet<string>(), projectA, projectB, projectC);
+                var results = RunRestore(failedProjects: new HashSet<string>(), projectsWithWarnings: new HashSet<string>(), projectA, projectB, projectC);
                 checker.ReportStatus(results);
 
                 // Set-up, delete C's outputs
@@ -393,7 +393,7 @@ namespace NuGet.SolutionRestoreManager.Test
                 File.Delete(assetsFilePath);
 
                 // Act & Assert
-                actual = checker.PerformUpToDateCheck(dgSpec);
+                actual = checker.PerformUpToDateCheck(dgSpec, NullLogger.Instance);
                 expected = GetUniqueNames(projectC);
                 actual.Should().BeEquivalentTo(expected);
             }
@@ -419,10 +419,10 @@ namespace NuGet.SolutionRestoreManager.Test
                 var checker = new SolutionUpToDateChecker();
 
                 // Preconditions, run 1st check
-                var actual = checker.PerformUpToDateCheck(dgSpec);
+                var actual = checker.PerformUpToDateCheck(dgSpec, NullLogger.Instance);
                 var expected = GetUniqueNames(projectA, projectB, projectC);
                 actual.Should().BeEquivalentTo(expected);
-                var results = RunRestore(failedProjects: new HashSet<string>(), projectA, projectB, projectC);
+                var results = RunRestore(failedProjects: new HashSet<string>(), projectsWithWarnings: new HashSet<string>(), projectA, projectB, projectC);
                 checker.ReportStatus(results);
 
                 // Set-up, delete C's outputs
@@ -430,7 +430,7 @@ namespace NuGet.SolutionRestoreManager.Test
                 File.Delete(cacheFilePath);
 
                 // Act & Assert
-                actual = checker.PerformUpToDateCheck(dgSpec);
+                actual = checker.PerformUpToDateCheck(dgSpec, NullLogger.Instance);
                 expected = GetUniqueNames(projectC);
                 actual.Should().BeEquivalentTo(expected);
             }
@@ -458,10 +458,10 @@ namespace NuGet.SolutionRestoreManager.Test
                 var checker = new SolutionUpToDateChecker();
 
                 // Preconditions, run 1st check
-                var actual = checker.PerformUpToDateCheck(dgSpec);
+                var actual = checker.PerformUpToDateCheck(dgSpec, NullLogger.Instance);
                 var expected = GetUniqueNames(projectA, projectB, projectC, projectD);
                 actual.Should().BeEquivalentTo(expected);
-                var results = RunRestore(failedProjects: new HashSet<string>(), projectA, projectB, projectC, projectD);
+                var results = RunRestore(failedProjects: new HashSet<string>(), projectsWithWarnings: new HashSet<string>(), projectA, projectB, projectC, projectD);
                 checker.ReportStatus(results);
 
                 // Set-up, make C dirty.
@@ -470,7 +470,7 @@ namespace NuGet.SolutionRestoreManager.Test
                 dgSpec = ProjectJsonTestHelpers.GetDGSpecFromPackageSpecs(projectA, projectB, projectC, projectD);
 
                 // Act & Assert
-                actual = checker.PerformUpToDateCheck(dgSpec);
+                actual = checker.PerformUpToDateCheck(dgSpec, NullLogger.Instance);
                 expected = GetUniqueNames(projectA, projectC);
                 actual.Should().BeEquivalentTo(expected);
             }
@@ -494,15 +494,15 @@ namespace NuGet.SolutionRestoreManager.Test
                 var checker = new SolutionUpToDateChecker();
 
                 // Preconditions, run 1st check
-                var actual = checker.PerformUpToDateCheck(dgSpec);
+                var actual = checker.PerformUpToDateCheck(dgSpec, NullLogger.Instance);
                 new List<string>() { projectA.RestoreMetadata.ProjectUniqueName, projectB.RestoreMetadata.ProjectUniqueName, projectC.RestoreMetadata.ProjectUniqueName }.Should().BeEquivalentTo(actual);
 
                 // Set-up, ensure the last status for projectC is a failure.
-                var results = RunRestore(failedProjects: new HashSet<string>() { projectC.RestoreMetadata.ProjectUniqueName }, projectA, projectB, projectC);
+                var results = RunRestore(failedProjects: new HashSet<string>() { projectC.RestoreMetadata.ProjectUniqueName }, projectsWithWarnings: new HashSet<string>(), projectA, projectB, projectC);
                 checker.ReportStatus(results);
 
                 // Act & Assert
-                actual = checker.PerformUpToDateCheck(dgSpec);
+                actual = checker.PerformUpToDateCheck(dgSpec, NullLogger.Instance);
                 var expected = new List<string>() { projectC.RestoreMetadata.ProjectUniqueName };
                 actual.Should().BeEquivalentTo(expected);
             }
@@ -528,19 +528,166 @@ namespace NuGet.SolutionRestoreManager.Test
                 var checker = new SolutionUpToDateChecker();
 
                 // Preconditions, run 1st check
-                var actual = checker.PerformUpToDateCheck(dgSpec);
+                var actual = checker.PerformUpToDateCheck(dgSpec, NullLogger.Instance);
                 var expected = GetUniqueNames(projectA, projectB, projectC);
                 actual.Should().BeEquivalentTo(expected);
-                var results = RunRestore(failedProjects: new HashSet<string>(), projectA, projectB, projectC);
+                var results = RunRestore(failedProjects: new HashSet<string>(), projectsWithWarnings: new HashSet<string>(), projectA, projectB, projectC);
                 checker.ReportStatus(results);
 
                 // Set-up, delete C's outputs
                 Directory.Delete(projectC.RestoreMetadata.PackagesPath, recursive: true);
 
                 // Act & Assert
-                actual = checker.PerformUpToDateCheck(dgSpec);
+                actual = checker.PerformUpToDateCheck(dgSpec, NullLogger.Instance);
                 expected = GetUniqueNames(projectC);
                 actual.Should().BeEquivalentTo(expected);
+            }
+        }
+
+        [Fact]
+        public void PerformUpToDateCheck_WithNoChanges_ReplaysWarningsForProjectsWithoutSuppressedWarnings()
+        {
+            using (var testDirectory = TestDirectory.Create())
+            {
+                var projectA = GetPackageSpec("A", testDirectory.Path);
+                var projectB = GetPackageSpec("B", testDirectory.Path);
+                var projectC = GetPackageSpec("C", testDirectory.Path);
+
+                // Pretend C is a legacy package reference projects, so we manage it's error list.
+                projectC.RestoreSettings = new ProjectRestoreSettings { HideWarningsAndErrors = false };
+
+                // A => B
+                projectA = projectA.WithTestProjectReference(projectB);
+                // B => C
+                projectB = projectB.WithTestProjectReference(projectC);
+
+                var dgSpec = new DependencyGraphSpec();
+                dgSpec.AddProject(projectA);
+                dgSpec.AddRestore(projectA.RestoreMetadata.ProjectUniqueName);
+                dgSpec.AddProject(projectB);
+                dgSpec.AddRestore(projectB.RestoreMetadata.ProjectUniqueName);
+                dgSpec.AddProject(projectC);
+                dgSpec.AddRestore(projectC.RestoreMetadata.ProjectUniqueName);
+
+                var checker = new SolutionUpToDateChecker();
+
+                // Preconditions, run 1st check
+                var testLogger = new TestLogger();
+                var actual = checker.PerformUpToDateCheck(dgSpec, testLogger);
+                var expected = GetUniqueNames(projectA, projectB, projectC);
+                actual.Should().BeEquivalentTo(expected);
+                var results = RunRestore(failedProjects: new HashSet<string>(), projectsWithWarnings: new HashSet<string>() { projectC.RestoreMetadata.ProjectUniqueName }, projectA, projectB, projectC);
+                // The test logger will not contain any messages because we are not running actual restore.
+                testLogger.WarningMessages.Should().BeEmpty();
+                checker.ReportStatus(results);
+
+                // Act & Asset.
+                testLogger = new TestLogger();
+                actual = checker.PerformUpToDateCheck(dgSpec, testLogger);
+                testLogger.WarningMessages.Should().HaveCount(1);
+                actual.Should().BeEmpty();
+            }
+        }
+
+        [Fact]
+        public void PerformUpToDateCheck_WithNoChanges_DoesNotReplayWarningsForProjectsWithSuppressedWarnings()
+        {
+            using (var testDirectory = TestDirectory.Create())
+            {
+                var projectA = GetPackageSpec("A", testDirectory.Path);
+                var projectB = GetPackageSpec("B", testDirectory.Path);
+                var projectC = GetPackageSpec("C", testDirectory.Path);
+
+                // A => B
+                projectA = projectA.WithTestProjectReference(projectB);
+                // B => C
+                projectB = projectB.WithTestProjectReference(projectC);
+
+                var dgSpec = new DependencyGraphSpec();
+                dgSpec.AddProject(projectA);
+                dgSpec.AddRestore(projectA.RestoreMetadata.ProjectUniqueName);
+                dgSpec.AddProject(projectB);
+                dgSpec.AddRestore(projectB.RestoreMetadata.ProjectUniqueName);
+                dgSpec.AddProject(projectC);
+                dgSpec.AddRestore(projectC.RestoreMetadata.ProjectUniqueName);
+
+                var checker = new SolutionUpToDateChecker();
+
+                // Preconditions, run 1st check
+                var testLogger = new TestLogger();
+                var actual = checker.PerformUpToDateCheck(dgSpec, testLogger);
+                var expected = GetUniqueNames(projectA, projectB, projectC);
+                actual.Should().BeEquivalentTo(expected);
+                // ProjectC will have a warning, but these warnings are not cached because they are from projects that have their warnings/errors suppressed.
+                var results = RunRestore(failedProjects: new HashSet<string>(), projectsWithWarnings: new HashSet<string>() { projectC.RestoreMetadata.ProjectUniqueName }, projectA, projectB, projectC);
+                // The test logger will not contain any messages because we are not running actual restore.
+                testLogger.WarningMessages.Should().BeEmpty();
+                checker.ReportStatus(results);
+
+                // Act & Assert.
+                testLogger = new TestLogger();
+                actual = checker.PerformUpToDateCheck(dgSpec, testLogger);
+                testLogger.WarningMessages.Should().BeEmpty();
+                actual.Should().BeEmpty();
+            }
+        }
+
+        [Fact]
+        public void PerformUpToDateCheck_WhenAProjectIsUnloaded_ItsWarningsAreNotReplayed()
+        {
+            using (var testDirectory = TestDirectory.Create())
+            {
+                var projectA = GetPackageSpec("A", testDirectory.Path);
+                var projectB = GetPackageSpec("B", testDirectory.Path);
+                var projectC = GetPackageSpec("C", testDirectory.Path);
+
+                projectC.RestoreSettings.HideWarningsAndErrors = false;
+
+                // A => B
+                projectA = projectA.WithTestProjectReference(projectB);
+                // B => C
+                projectB = projectB.WithTestProjectReference(projectC);
+
+                var dgSpec = new DependencyGraphSpec();
+                dgSpec.AddProject(projectA);
+                dgSpec.AddRestore(projectA.RestoreMetadata.ProjectUniqueName);
+                dgSpec.AddProject(projectB);
+                dgSpec.AddRestore(projectB.RestoreMetadata.ProjectUniqueName);
+                dgSpec.AddProject(projectC);
+                dgSpec.AddRestore(projectC.RestoreMetadata.ProjectUniqueName);
+
+                var checker = new SolutionUpToDateChecker();
+
+                // Preconditions, run 1st check
+                var testLogger = new TestLogger();
+                var actual = checker.PerformUpToDateCheck(dgSpec, testLogger);
+                var expected = GetUniqueNames(projectA, projectB, projectC);
+                actual.Should().BeEquivalentTo(expected);
+                // ProjectC will have a warning
+                var results = RunRestore(failedProjects: new HashSet<string>(), projectsWithWarnings: new HashSet<string>() { projectC.RestoreMetadata.ProjectUniqueName }, projectA, projectB, projectC);
+                // The test logger will not contain any messages because we are not running actual restore.
+                testLogger.WarningMessages.Should().BeEmpty();
+                checker.ReportStatus(results);
+
+                // Run again to verify the warning is replayed once!
+                testLogger = new TestLogger();
+                actual = checker.PerformUpToDateCheck(dgSpec, testLogger);
+                testLogger.WarningMessages.Should().HaveCount(1);
+                actual.Should().BeEmpty();
+                checker.ReportStatus(new RestoreSummary[] { });
+
+                // Pretend project C has been unloaded
+                dgSpec = new DependencyGraphSpec();
+                dgSpec.AddProject(projectA);
+                dgSpec.AddRestore(projectA.RestoreMetadata.ProjectUniqueName);
+                dgSpec.AddProject(projectB);
+                dgSpec.AddRestore(projectB.RestoreMetadata.ProjectUniqueName);
+
+                // Act & Assert.
+                testLogger = new TestLogger();
+                actual = checker.PerformUpToDateCheck(dgSpec, testLogger);
+                testLogger.WarningMessages.Should().BeEmpty();
+                actual.Should().BeEmpty();
             }
         }
 
@@ -573,10 +720,10 @@ namespace NuGet.SolutionRestoreManager.Test
                 var checker = new SolutionUpToDateChecker();
 
                 // Preconditions, run 1st check
-                var actual = checker.PerformUpToDateCheck(dgSpec);
+                var actual = checker.PerformUpToDateCheck(dgSpec, NullLogger.Instance);
                 var expected = GetUniqueNames(projectA, projectB, projectC, projectD, projectE);
                 actual.Should().BeEquivalentTo(expected);
-                var results = RunRestore(failedProjects: new HashSet<string>(), projectA, projectB, projectC, projectD, projectE);
+                var results = RunRestore(failedProjects: new HashSet<string>(), projectsWithWarnings: new HashSet<string>(), projectA, projectB, projectC, projectD, projectE);
                 checker.ReportStatus(results);
 
                 // D => E
@@ -585,14 +732,14 @@ namespace NuGet.SolutionRestoreManager.Test
                 // Set-up dg spec
                 dgSpec = ProjectJsonTestHelpers.GetDGSpecFromPackageSpecs(projectA, projectB, projectC, projectD, projectE);
                 // 2nd check
-                actual = checker.PerformUpToDateCheck(dgSpec);
+                actual = checker.PerformUpToDateCheck(dgSpec, NullLogger.Instance);
                 expected = GetUniqueNames(projectA, projectD);
                 actual.Should().BeEquivalentTo(expected);
-                results = RunRestore(failedProjects: new HashSet<string>(), projectA, projectD);
+                results = RunRestore(failedProjects: new HashSet<string>(), projectsWithWarnings: new HashSet<string>(), projectA, projectD);
                 checker.ReportStatus(results);
 
                 // Finally, last check. Run for a 3rd time. Everything should be up to date
-                actual = checker.PerformUpToDateCheck(dgSpec);
+                actual = checker.PerformUpToDateCheck(dgSpec, NullLogger.Instance);
                 expected = GetUniqueNames();
                 actual.Should().BeEquivalentTo(expected);
             }
@@ -633,7 +780,9 @@ namespace NuGet.SolutionRestoreManager.Test
                         }
                     }
                 }";
-            return JsonPackageSpecReader.GetPackageSpec(referenceSpec, projectName, Path.Combine(rootPath, projectName, projectName)).WithTestRestoreMetadata();
+            var packageSpec = JsonPackageSpecReader.GetPackageSpec(referenceSpec, projectName, Path.Combine(rootPath, projectName, projectName)).WithTestRestoreMetadata();
+            packageSpec.RestoreSettings.HideWarningsAndErrors = true; // Pretend this is running in VS and this is a .NET Core project.
+            return packageSpec;
         }
 
         private static PackageSpec GetProjectJsonPackageSpec(string projectName, string rootPath = @"C:\")
@@ -672,34 +821,39 @@ namespace NuGet.SolutionRestoreManager.Test
             return packageSpec;
         }
 
-        private static IReadOnlyList<RestoreSummary> RunRestore(HashSet<string> failedProjects, params PackageSpec[] packageSpecs)
+        private static IReadOnlyList<RestoreSummary> RunRestore(HashSet<string> failedProjects, HashSet<string> projectsWithWarnings, params PackageSpec[] packageSpecs)
         {
             foreach (var spec in packageSpecs)
             {
                 CreateDummyOutputFiles(spec);
             }
 
-            return CreateRestoreSummaries(failedProjects, packageSpecs).ToImmutableList();
+            return CreateRestoreSummaries(failedProjects, projectsWithWarnings, packageSpecs).ToImmutableList();
         }
 
-        private static IEnumerable<RestoreSummary> CreateRestoreSummaries(HashSet<string> failedProjects, params PackageSpec[] packageSpecs)
+        private static IEnumerable<RestoreSummary> CreateRestoreSummaries(HashSet<string> failedProjects, HashSet<string> projectsWithWarnings, params PackageSpec[] packageSpecs)
         {
             foreach (var spec in packageSpecs)
             {
                 var status = !failedProjects.Contains(spec.RestoreMetadata.ProjectUniqueName);
-                yield return CreateRestoreSummary(spec, success: status);
+                var warnings = projectsWithWarnings.Contains(spec.RestoreMetadata.ProjectUniqueName);
+                yield return CreateRestoreSummary(spec, warnings, success: status);
             }
         }
 
-        private static RestoreSummary CreateRestoreSummary(PackageSpec spec, bool success)
+        private static RestoreSummary CreateRestoreSummary(PackageSpec spec, bool warnings, bool success)
         {
+            var warningMessages = warnings ?
+                new IRestoreLogMessage[] { new RestoreLogMessage(LogLevel.Warning, "Warning, warning, warning!") } :
+                new IRestoreLogMessage[] { };
+
             return new RestoreSummary(
                 success: success,
                 inputPath: spec.RestoreMetadata.ProjectUniqueName,
                 configFiles: new ReadOnlyCollection<string>(new List<string>()),
                 feedsUsed: new ReadOnlyCollection<string>(new List<string>()),
                 installCount: 0,
-                errors: new ReadOnlyCollection<IRestoreLogMessage>(new List<IRestoreLogMessage>()));
+                errors: new ReadOnlyCollection<IRestoreLogMessage>(warningMessages));
         }
 
         internal static void CreateDummyOutputFiles(PackageSpec packageSpec)

--- a/test/TestUtilities/Test.Utility/Commands/ProjectJsonTestHelpers.cs
+++ b/test/TestUtilities/Test.Utility/Commands/ProjectJsonTestHelpers.cs
@@ -110,7 +110,8 @@ namespace NuGet.Commands.Test
         }
 
         /// <summary>
-        /// Add fake PackageReference restore metadata. 
+        /// Add fake PackageReference restore metadata.
+        /// This resembles the .NET Core based projects (<see cref="ProjectRestoreSettings"/>.
         /// </summary>
         public static PackageSpec WithTestRestoreMetadata(this PackageSpec spec)
         {
@@ -136,7 +137,6 @@ namespace NuGet.Commands.Test
             {
                 updated.RestoreMetadata.TargetFrameworks.Add(new ProjectRestoreMetadataFrameworkInfo(framework));
             }
-
             return updated;
         }
     }


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9565
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: 
The partial restore optimization was added in NuGet/NuGet.Client#3391
Spec: NuGet/Home#9564. 

The reason why it wasn't enabled for legacy projects was because NuGet in charge of handling the errors and warnings in the error list and there was no "cheap" way of getting those. 

Following https://github.com/NuGet/NuGet.Client/commit/3241f15cae5f58984a128b69cffd9aeaa2ea47fa#diff-e477fe4236d8ab10fbf3623131b38349, we can now preempt a cache for the warnings and errors cheaply.

The approach here is simple, cache the log messages only for the projects for which we are handling the error list. 
Then when running the check just add them to the logger if the project no-ops.

I'll get some numbers of how this affects the restore of the NuGet solution.

NuGet sln restore is as follows:

| | New | Old |
|-| - | - |
|AVG| 0.34819695 | 0.50029106 |
|STDEV| 0.140399613 |	0.04661873 |

These numbers are obviously noisy and not in a lag, but it should give you a general feel about the effect of this improvement given that we are enabled it for additional 9/82 projects. 

Lab numbers + client metrics will allow us to keep track of the progress better.

## Testing/Validation

Tests Added: Yes  
Reason for not adding tests:  
Validation:  
