### PR TITLE
Removed net40 from NuGet.Frameworks

### DIFF
--- a/src/NuGet.Core/NuGet.Frameworks/NuGet.Frameworks.csproj
+++ b/src/NuGet.Core/NuGet.Frameworks/NuGet.Frameworks.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <Description>NuGet's understanding of target frameworks.</Description>
-    <TargetFrameworks>$(TargetFrameworksLibrary);net40</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksLibrary)</TargetFrameworks>
     <TargetFramework />
     <NoWarn>$(NoWarn);CS1591;CS1574;CS1573</NoWarn>
     <LangVersion>5</LangVersion>


### PR DESCRIPTION
## Bug

Fixes: NuGet/Home#8416
Regression: No
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: Details_about_the_fix  

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  Build issue
Validation:  Green build (in progress)

## TODO:

- Check codepaths with IS_NET40_CLIENT constant, more info at NuGet.Frameworks.csproj
- Gather more context