### PR TITLE
MSBuild should hard link files, instead of copy, to reduce disk space

### DIFF
--- a/build/common.project.props
+++ b/build/common.project.props
@@ -55,6 +55,7 @@
   <!-- Defaults -->
   <PropertyGroup>
     <TreatWarningsAsErrors Condition=" '$(TreatWarningsAsErrors)' == '' ">true</TreatWarningsAsErrors>
+    <CreateHardLinksForCopyLocalIfPossible>true</CreateHardLinksForCopyLocalIfPossible>
   </PropertyGroup>
 
   <!-- Default project configuration -->


### PR DESCRIPTION

## Bug

Fixes: https://github.com/NuGet/Client.Engineering/issues/416
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: Use `CreateHardLinksForCopyLocalIfPossible` to tell MSBuild to prefer hard links over copying files.

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  build script change
Validation:  
