### PR TITLE
Improve Auth Error Messages and Ux

### DIFF
--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/Resources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/Resources.Designer.cs
@@ -189,7 +189,7 @@ namespace NuGet.SolutionRestoreManager {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to NuGet package restore failed. Please see Error List window for detailed warnings and errors..
+        ///   Looks up a localized string similar to NuGet package restore failed. See the Error List window for detailed warnings and errors..
         /// </summary>
         internal static string PackageRestoreFinishedWithError {
             get {

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/Resources.resx
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/Resources.resx
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -165,7 +165,7 @@ Missing packages: {0}</value>
     <value>NuGet Package restore finished for project '{0}'.</value>
   </data>
   <data name="PackageRestoreFinishedWithError" xml:space="preserve">
-    <value>NuGet package restore failed. Please see Error List window for detailed warnings and errors.</value>
+    <value>NuGet package restore failed. See the Error List window for detailed warnings and errors.</value>
   </data>
   <data name="PackageRestoreOptOutMessage" xml:space="preserve">
     <value>Restoring NuGet packages...

--- a/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
@@ -4,18 +4,18 @@
 namespace NuGet.Common
 {
     /// <summary>
-    /// This enum is used to quantify NuGet error and warning codes. 
+    /// This enum is used to quantify NuGet error and warning codes.
     /// Format - NUxyzw where NU is the prefix indicating NuGet and xyzw is a 4 digit code
     ///
     /// Numbers - xyzw
     ///     x - 'x' is the largest digit and should be used to quantify a set of errors.
     ///         For example 1yzw are set of restore related errors and no other code path should use the range 1000 to 1999 for errors or warnings.
-    ///         
+    ///
     ///     y - 'y' is the second largest digit and should be used for sub sections withing a broad category.
-    ///     
+    ///
     ///         For example 12zw cvould be http related errors.
     ///         Further 'y' = 0-4 should be used for errors and 'y' = 5-9 should be warnings.
-    ///         
+    ///
     ///     zw - 'zw' are the least two digit.
     ///         These could be used for different errors or warnings within the broad categories set by digits 'xy'.
     ///
@@ -31,9 +31,9 @@ namespace NuGet.Common
     /// 1200/1700     - Compat
     /// 1300/1800     - Feed
     /// 1400/1900     - Package
-    /// 
+    ///
     /// All new codes need a corresponding MarkDown file under https://github.com/NuGet/docs.microsoft.com-nuget/tree/master/docs/reference/errors-and-warnings.
-    /// 
+    ///
     /// </summary>
     public enum NuGetLogCode
     {
@@ -161,7 +161,7 @@ namespace NuGet.Common
         /// <summary>
         /// Invalid package types
         /// </summary>
-        NU1204 = 1204, 
+        NU1204 = 1204,
 
         /// <summary>
         /// Project has an invalid dependency count
@@ -177,6 +177,36 @@ namespace NuGet.Common
         /// Incompatible package type
         /// </summary>
         NU1213 = 1213,
+
+        /// <summary>
+        /// Uncategorized FatalProtocolException
+        /// </summary>
+        NU1300 = 1300,
+
+        /// <summary>
+        /// Feed was Unauthorized (HTTP 401)
+        /// </summary>
+        NU1301 = 1301,
+
+        /// <summary>
+        /// Fallback folder or local feed folder does not exist
+        /// </summary>
+        NU1302 = 1302,
+
+        /// <summary>
+        /// Feed was Forbidden (HTTP 403)
+        /// </summary>
+        NU1303 = 1303,
+
+        /// <summary>
+        /// Url was Not Found, server exists (HTTP 404)
+        /// </summary>
+        NU1304 = 1304,
+
+        /// <summary>
+        /// Feed needs Proxy Authentication (HTTP 407)
+        /// </summary>
+        NU1307 = 1307,
 
         /// <summary>
         /// Package MinClientVersion did not match.

--- a/src/NuGet.Core/NuGet.Common/PublicAPI/net45/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Common/PublicAPI/net45/PublicAPI.Unshipped.txt
@@ -1,0 +1,6 @@
+NuGet.Common.NuGetLogCode.NU1300 = 1300 -> NuGet.Common.NuGetLogCode
+NuGet.Common.NuGetLogCode.NU1301 = 1301 -> NuGet.Common.NuGetLogCode
+NuGet.Common.NuGetLogCode.NU1302 = 1302 -> NuGet.Common.NuGetLogCode
+NuGet.Common.NuGetLogCode.NU1303 = 1303 -> NuGet.Common.NuGetLogCode
+NuGet.Common.NuGetLogCode.NU1304 = 1304 -> NuGet.Common.NuGetLogCode
+NuGet.Common.NuGetLogCode.NU1307 = 1307 -> NuGet.Common.NuGetLogCode

--- a/src/NuGet.Core/NuGet.Common/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Common/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -1,0 +1,6 @@
+NuGet.Common.NuGetLogCode.NU1300 = 1300 -> NuGet.Common.NuGetLogCode
+NuGet.Common.NuGetLogCode.NU1301 = 1301 -> NuGet.Common.NuGetLogCode
+NuGet.Common.NuGetLogCode.NU1302 = 1302 -> NuGet.Common.NuGetLogCode
+NuGet.Common.NuGetLogCode.NU1303 = 1303 -> NuGet.Common.NuGetLogCode
+NuGet.Common.NuGetLogCode.NU1304 = 1304 -> NuGet.Common.NuGetLogCode
+NuGet.Common.NuGetLogCode.NU1307 = 1307 -> NuGet.Common.NuGetLogCode

--- a/src/NuGet.Core/NuGet.Common/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Common/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,6 @@
+NuGet.Common.NuGetLogCode.NU1300 = 1300 -> NuGet.Common.NuGetLogCode
+NuGet.Common.NuGetLogCode.NU1301 = 1301 -> NuGet.Common.NuGetLogCode
+NuGet.Common.NuGetLogCode.NU1302 = 1302 -> NuGet.Common.NuGetLogCode
+NuGet.Common.NuGetLogCode.NU1303 = 1303 -> NuGet.Common.NuGetLogCode
+NuGet.Common.NuGetLogCode.NU1304 = 1304 -> NuGet.Common.NuGetLogCode
+NuGet.Common.NuGetLogCode.NU1307 = 1307 -> NuGet.Common.NuGetLogCode

--- a/src/NuGet.Core/NuGet.Protocol/Exceptions/FatalProtocolException.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Exceptions/FatalProtocolException.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -15,5 +15,17 @@ namespace NuGet.Protocol.Core.Types
         public FatalProtocolException(string message, Exception innerException) : base(message, innerException)
         {
         }
+
+        public FatalProtocolException(string message, NuGetLogCode logCode) : base(message)
+        {
+            LogCode = logCode;
+        }
+
+        public FatalProtocolException(string message, Exception innerException, NuGetLogCode logCode) : base(message, innerException)
+        {
+            LogCode = logCode;
+        }
+
+        public NuGetLogCode LogCode { get; } = NuGetLogCode.NU1300;
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpSource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpSource.cs
@@ -151,7 +151,7 @@ namespace NuGet.Protocol
                             return await processAsync(httpSourceResult);
                         }
 
-                        throttledResponse.Response.EnsureSuccessStatusCode();
+                        EnsureSuccessStatusCode(throttledResponse.Response);
 
                         if (!request.CacheContext.DirectDownload)
                         {
@@ -214,13 +214,24 @@ namespace NuGet.Protocol
                         return await processAsync(null);
                     }
 
-                    response.EnsureSuccessStatusCode();
+                    EnsureSuccessStatusCode(response);
 
                     return await processAsync(response);
                 },
                 cacheContext : null,
                 log,
                 token);
+        }
+
+        /// <summary>
+        /// Wraps the call to response EnsureSuccessStatusCode and adds status code data to the exception, to work well pre .NET 5.0
+        /// </summary>
+        /// <param name="response"></param>
+        /// <returns>Response StatusCode</returns>
+        private static HttpStatusCode EnsureSuccessStatusCode(HttpResponseMessage response)
+        {
+            HttpRequestExceptionUtility.EnsureSuccessAndStashStatusCodeIfThrows(response);
+            return response.StatusCode;
         }
 
         public async Task<T> ProcessStreamAsync<T>(
@@ -240,7 +251,7 @@ namespace NuGet.Protocol
                         return await processAsync(null);
                     }
 
-                    response.EnsureSuccessStatusCode();
+                    EnsureSuccessStatusCode(response);
 
                     var networkStream = await response.Content.ReadAsStreamAsync();
                     return await processAsync(networkStream);

--- a/src/NuGet.Core/NuGet.Protocol/LegacyFeed/ODataServiceDocumentUtils.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LegacyFeed/ODataServiceDocumentUtils.cs
@@ -40,8 +40,13 @@ static internal class ODataServiceDocumentUtils
         }
         catch (Exception ex) when (!(ex is FatalProtocolException) && (!(ex is OperationCanceledException)))
         {
-            string message = String.Format(CultureInfo.CurrentCulture, Strings.Log_FailedToReadServiceIndex, url);
+            HttpRequestException httpEx = ex as HttpRequestException;
+            if (httpEx != null)
+            {
+                HttpRequestExceptionUtility.ThrowFatalProtocolExceptionIfCritical(httpEx, url);
+            }
 
+            string message = string.Format(CultureInfo.CurrentCulture, Strings.Log_FailedToReadServiceIndex, url);
             throw new FatalProtocolException(message, ex);
         }
 

--- a/src/NuGet.Core/NuGet.Protocol/LocalRepositories/LocalV3FindPackageByIdResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LocalRepositories/LocalV3FindPackageByIdResource.cs
@@ -528,7 +528,7 @@ namespace NuGet.Protocol
                     Strings.Log_LocalSourceNotExist,
                     _source);
 
-                throw new FatalProtocolException(message);
+                throw new FatalProtocolException(message, NuGetLogCode.NU1302);
             }
 
             return versions;

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -1,0 +1,3 @@
+NuGet.Protocol.Core.Types.FatalProtocolException.FatalProtocolException(string message, NuGet.Common.NuGetLogCode logCode) -> void
+NuGet.Protocol.Core.Types.FatalProtocolException.FatalProtocolException(string message, System.Exception innerException, NuGet.Common.NuGetLogCode logCode) -> void
+NuGet.Protocol.Core.Types.FatalProtocolException.LogCode.get -> NuGet.Common.NuGetLogCode

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/netcoreapp5.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/netcoreapp5.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,3 @@
+NuGet.Protocol.Core.Types.FatalProtocolException.FatalProtocolException(string message, NuGet.Common.NuGetLogCode logCode) -> void
+NuGet.Protocol.Core.Types.FatalProtocolException.FatalProtocolException(string message, System.Exception innerException, NuGet.Common.NuGetLogCode logCode) -> void
+NuGet.Protocol.Core.Types.FatalProtocolException.LogCode.get -> NuGet.Common.NuGetLogCode

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,3 @@
+NuGet.Protocol.Core.Types.FatalProtocolException.FatalProtocolException(string message, NuGet.Common.NuGetLogCode logCode) -> void
+NuGet.Protocol.Core.Types.FatalProtocolException.FatalProtocolException(string message, System.Exception innerException, NuGet.Common.NuGetLogCode logCode) -> void
+NuGet.Protocol.Core.Types.FatalProtocolException.LogCode.get -> NuGet.Common.NuGetLogCode

--- a/src/NuGet.Core/NuGet.Protocol/Resources/PackageUpdateResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/PackageUpdateResource.cs
@@ -75,9 +75,9 @@ namespace NuGet.Protocol.Core.Types
                 var apiKey = getApiKey(_source);
 
                 bool explicitSnupkgPush = true;
-                
+
                 if (!packagePath.EndsWith(NuGetConstants.SnupkgExtension, StringComparison.OrdinalIgnoreCase))
-                {   
+                {
                     await PushPackage(packagePath, _source, apiKey, noServiceEndpoint, skipDuplicate,
                                       requestTimeout, log, tokenSource.Token);
 
@@ -358,7 +358,7 @@ namespace NuGet.Protocol.Core.Types
                                 response =>
                                 {
                                     var responseStatusCode = EnsureSuccessStatusCode(response, codeNotToThrow, logger);
-                                    
+
                                     var logOccurred = DetectAndLogSkippedErrorOccurrence(responseStatusCode, source, pathToPackage, response.ReasonPhrase, logger);
                                     showPushCommandPackagePushed = !logOccurred;
 
@@ -430,11 +430,12 @@ namespace NuGet.Protocol.Core.Types
             }
             else
             {
-                 AdvertiseAvailableOptionToIgnore(response.StatusCode, logger);
+                AdvertiseAvailableOptionToIgnore(response.StatusCode, logger);
             }
 
             //No exception to the rule specified.
-            response.EnsureSuccessStatusCode();
+
+            HttpRequestExceptionUtility.EnsureSuccessAndStashStatusCodeIfThrows(response);
             return null;
         }
 
@@ -453,11 +454,11 @@ namespace NuGet.Protocol.Core.Types
             {
                 string messageToLog = null;
                 string messageToLogVerbose = null;
-                
+
                 switch (skippedErrorStatusCode.Value)
                 {
                     case HttpStatusCode.Conflict:
-                        
+
                         messageToLog = string.Format(
                                    CultureInfo.CurrentCulture,
                                    Strings.AddPackage_PackageAlreadyExists,
@@ -603,7 +604,7 @@ namespace NuGet.Protocol.Core.Types
                     throwIfPackageExistsAndInvalid: !skipDuplicate,
                     throwIfPackageExists: !skipDuplicate,
                     extractionContext: packageExtractionContext);
-                
+
                 await OfflineFeedUtility.AddPackageToSource(context, token);
             }
         }
@@ -664,7 +665,7 @@ namespace NuGet.Protocol.Core.Types
                     }),
                 response =>
                 {
-                    response.EnsureSuccessStatusCode();
+                    EnsureSuccessStatusCode(response, codeNotToThrow: null, logger);
 
                     return Task.FromResult(0);
                 },
@@ -823,9 +824,9 @@ namespace NuGet.Protocol.Core.Types
                    logger,
                    token);
 
-                return result.Value<string>("Key")?? InvalidApiKey;
+                return result.Value<string>("Key") ?? InvalidApiKey;
             }
-            catch(HttpRequestException ex)
+            catch (HttpRequestException ex)
             {
 #if NETCOREAPP
                 if (ex.Message.Contains("Response status code does not indicate success: 403 (Forbidden).", StringComparison.OrdinalIgnoreCase))

--- a/src/NuGet.Core/NuGet.Protocol/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Strings.Designer.cs
@@ -268,6 +268,15 @@ namespace NuGet.Protocol {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The server responded with HTTP &apos;404 Not Found&apos; when accessing the source &apos;{0}&apos;. Change the URL to a resource that exists..
+        /// </summary>
+        internal static string Http_UrlNotFound {
+            get {
+                return ResourceManager.GetString("Http_UrlNotFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The folder &apos;{0}&apos; contains an invalid version..
         /// </summary>
         internal static string InvalidVersionFolder {
@@ -385,7 +394,7 @@ namespace NuGet.Protocol {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Unable to load the service index for source {0}..
+        ///   Looks up a localized string similar to Unable to load the service index for source &apos;{0}&apos;..
         /// </summary>
         internal static string Log_FailedToReadServiceIndex {
             get {
@@ -448,7 +457,7 @@ namespace NuGet.Protocol {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The local source &apos;{0}&apos; doesn&apos;t exist..
+        ///   Looks up a localized string similar to The local source or fallback folder &apos;{0}&apos; doesn&apos;t exist. Create the directory or fix packageSource/fallbackPackageFolder declarations..
         /// </summary>
         internal static string Log_LocalSourceNotExist {
             get {

--- a/src/NuGet.Core/NuGet.Protocol/Strings.resx
+++ b/src/NuGet.Core/NuGet.Protocol/Strings.resx
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -265,7 +265,7 @@ The "ms" should be localized to the abbreviation for milliseconds.</comment>
     <value>The nupkg at '{0}' is not valid.</value>
   </data>
   <data name="Log_FailedToReadServiceIndex" xml:space="preserve">
-    <value>Unable to load the service index for source {0}.</value>
+    <value>Unable to load the service index for source '{0}'.</value>
   </data>
   <data name="Log_RetryingServiceIndex" xml:space="preserve">
     <value>Retrying service index request for source '{0}'.</value>
@@ -331,6 +331,10 @@ The "ms" should be localized to the abbreviation for milliseconds.</comment>
   </data>
   <data name="Http_CredentialsForForbidden" xml:space="preserve">
     <value>The server responded with HTTP '403 Forbidden' when accessing the source '{0}'. This suggests that the server has authenticated your identity but has not permitted you to access the requested resource. Provide credentials that have permissions to view this resource.</value>
+    <comment>{0} is the source that needs credentials to be accessed.</comment>
+  </data>
+  <data name="Http_UrlNotFound" xml:space="preserve">
+    <value>The server responded with HTTP '404 Not Found' when accessing the source '{0}'. Change the URL to a resource that exists.</value>
     <comment>{0} is the source that needs credentials to be accessed.</comment>
   </data>
   <data name="Http_CredentialsForProxy" xml:space="preserve">
@@ -467,7 +471,7 @@ The "ms" should be localized to the abbreviation for milliseconds.</comment>
 {1} is the exception ToString() result</comment>
   </data>
   <data name="Log_LocalSourceNotExist" xml:space="preserve">
-    <value>The local source '{0}' doesn't exist.</value>
+    <value>The local source or fallback folder '{0}' doesn't exist. Create the directory or fix packageSource/fallbackPackageFolder declarations.</value>
   </data>
   <data name="Log_FailedToFetchV2FeedHttp" xml:space="preserve">
     <value>Failed to fetch results from V2 feed at '{0}' with following message : {1}</value>
@@ -484,7 +488,7 @@ The "ms" should be localized to the abbreviation for milliseconds.</comment>
   </data>
   <data name="Log_FailedToParseRepoSignInfor" xml:space="preserve">
     <value>Unable to parse {0} information from {1}. </value>
-    <comment>{0} is the information name that needs to be parsed. 
+    <comment>{0} is the information name that needs to be parsed.
 {1} is the repository signature information endpoint.</comment>
   </data>
   <data name="RepositoryContentUrlMustBeHttps" xml:space="preserve">

--- a/src/NuGet.Core/NuGet.Protocol/Utility/HttpRequestExceptionUtility.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Utility/HttpRequestExceptionUtility.cs
@@ -1,0 +1,89 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Globalization;
+using System.Net;
+using System.Net.Http;
+using NuGet.Common;
+using NuGet.Protocol.Core.Types;
+
+namespace NuGet.Protocol
+{
+    internal static class HttpRequestExceptionUtility
+    {
+        internal static HttpStatusCode? GetHttpStatusCode(HttpRequestException ex)
+        {
+            HttpStatusCode? statusCode = null;
+
+#if NETCOREAPP5_0
+            statusCode = ex.StatusCode;
+#else
+            // All places which might raise an HttpRequestException need to put StatusCode in exception object.
+            if (ex.Data.Contains(StatusCode))
+            {
+                statusCode = (HttpStatusCode)ex.Data[StatusCode];
+            }
+#endif
+
+            return statusCode;
+        }
+
+        internal static void ThrowFatalProtocolExceptionIfCritical(HttpRequestException ex, string url)
+        {
+            HttpStatusCode? statusCode = GetHttpStatusCode(ex);
+            NuGetLogCode? logCode = null;
+            string message = null;
+
+            // For these status codes, we throw exception.
+            // Ideally, we add more status codes to this switch statement as we run into other codes that
+            // will benefit with a better error experience.
+            switch (statusCode)
+            {
+                case HttpStatusCode.Unauthorized:
+                    message = string.Format(CultureInfo.CurrentCulture, Strings.Http_CredentialsForUnauthorized, url);
+                    logCode = NuGetLogCode.NU1301;
+                    break;
+                case HttpStatusCode.Forbidden:
+                    message = string.Format(CultureInfo.CurrentCulture, Strings.Http_CredentialsForForbidden, url);
+                    logCode = NuGetLogCode.NU1303;
+                    break;
+                case HttpStatusCode.NotFound:
+                    message = string.Format(CultureInfo.CurrentCulture, Strings.Http_UrlNotFound, url);
+                    logCode = NuGetLogCode.NU1304;
+                    break;
+                case HttpStatusCode.ProxyAuthenticationRequired:
+                    message = string.Format(CultureInfo.CurrentCulture, Strings.Http_CredentialsForProxy, url);
+                    logCode = NuGetLogCode.NU1307;
+                    break;
+            }
+
+            if (message != null)
+            {
+                throw new FatalProtocolException(message, ex, logCode.Value);
+            }
+        }
+
+        internal static void EnsureSuccessAndStashStatusCodeIfThrows(HttpResponseMessage response)
+        {
+#if !NETCOREAPP5_0
+            // Before calling EnsureSuccessStatusCode(), squirrel away statuscode, in order to add it to exception.
+            HttpStatusCode statusCode = response.StatusCode;
+            try
+            {
+#endif
+                response.EnsureSuccessStatusCode();
+#if !NETCOREAPP5_0
+            }
+            catch (HttpRequestException ex)
+            {
+                ex.Data[StatusCode] = statusCode;
+                throw;
+            }
+#endif
+        }
+
+#if !NETCOREAPP5_0
+        private const string StatusCode = "StatusCode";
+#endif
+    }
+}

--- a/test/EndToEnd/tests/ServicesTest.ps1
+++ b/test/EndToEnd/tests/ServicesTest.ps1
@@ -15,7 +15,7 @@ function Test-PackageManagerServicesAreAvailableThroughMEF {
 
 # If this test fails with the cryptic error:
 #
-#    Exception calling "NewProject" with "5" argument(s): "The method or operation is not implemented." 
+#    Exception calling "NewProject" with "5" argument(s): "The method or operation is not implemented."
 #
 # ...it is because the specific Windows 10 SDK build indicated by the <TargetPlatformVersion /> element in the test's
 # project file (test\EndToEnd\ProjectTemplates\UwpClassLibraryProjectJson.zip\ClassLibrary6.csproj) is not installed.
@@ -92,7 +92,7 @@ function Test-GetInstalledPackagesWithCustomRestorePackagesPath {
     # Act
     $packages = @($installerServices.GetInstalledPackages())
 
-    # Assert    
+    # Assert
     Assert-NotNull $packages
     $package = $packages | where Id -eq NuGet.Versioning
     Assert-NotNull $package.InstallPath
@@ -116,7 +116,7 @@ function Test-GetInstalledPackagesForProjectWithCustomRestorePackagesPath {
     # Act
     $packages = @($installerServices.GetInstalledPackages($p))
 
-    # Assert    
+    # Assert
     Assert-NotNull $packages
     $package = $packages | where Id -eq NuGet.Versioning
     Assert-NotNull $package.InstallPath
@@ -423,7 +423,7 @@ function Test-InstallPackageAPIUnreachableSource
     # Act&Assert
     Assert-Throws {
         [API.Test.InternalAPITestHook]::InstallPackageApi("http://packagesource", "owin", "1.0.0", $false)
-    } "Exception calling `"InstallPackageApi`" with `"4`" argument(s): `"Unable to load the service index for source http://packagesource.`""
+    } "Exception calling `"InstallPackageApi`" with `"4`" argument(s): `"Unable to load the service index for source 'http://packagesource'.`""
     Assert-NoPackage $p "owin"
 }
 
@@ -1005,6 +1005,6 @@ function Test-InstallPackageAsyncWithPackageReferenceFormat {
 	# Assert
     $packageRefs = @(Get-MsBuildItems $p 'PackageReference')
     Assert-AreEqual 1 $packageRefs.Count
-    Assert-AreEqual $packageRefs[0].GetMetadataValue("Identity") 'owin' 
+    Assert-AreEqual $packageRefs[0].GetMetadataValue("Identity") 'owin'
     Assert-AreEqual $packageRefs[0].GetMetadataValue("Version") '1.0.0'
 }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetListCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetListCommandTest.cs
@@ -22,8 +22,7 @@ namespace NuGet.CommandLine.Test
             var nugetexe = Util.GetNuGetExePath();
             var hostName = Guid.NewGuid().ToString();
             var fullHostName = "https://" + hostName + "/";
-            var expected = "NuGet.Protocol.Core.Types.FatalProtocolException: Unable to load the service index for source " +
-                           $"{fullHostName}";
+            var expected = "Unable to load the service index for source";
 
             var args = new[] { "list", "-Source", fullHostName };
 
@@ -850,7 +849,7 @@ namespace NuGet.CommandLine.Test
                 result.Item1 != 0,
                 "The run did not fail as desired. Simply got this output:" + result.Item2);
 
-                Assert.Contains($"Unable to load the service index for source {invalidInput}.", result.Item3);
+                Assert.Contains($"Unable to load the service index for source", result.AllOutput);
         }
 
         [Theory]
@@ -901,10 +900,7 @@ namespace NuGet.CommandLine.Test
                 result.Item1 != 0,
                 "The run did not fail as desired. Simply got this output:" + result.Item2);
 
-            Assert.True(
-                result.Item3.Contains($"Unable to load the service index for source {invalidInput}."),
-                "Expected error message not found in " + result.Item3
-                );
+            Assert.Contains($"Unable to load the service index for source '{invalidInput}'.", result.AllOutput);
         }
 
         [Theory]

--- a/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/DownloadResourceV2FeedTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/DownloadResourceV2FeedTests.cs
@@ -89,7 +89,7 @@ namespace NuGet.Protocol.FuncTest
                 packagesFolder,
                 NullLogger.Instance,
                 CancellationToken.None))
-            { 
+            {
                 // Assert
                 Assert.NotNull(actual);
                 Assert.Equal(DownloadResourceResultStatus.NotFound, actual.Status);
@@ -104,10 +104,10 @@ namespace NuGet.Protocol.FuncTest
             var repo = Repository.Factory.GetCoreV3($"https://www.{randomName}.org/api/v2/");
 
             // Act & Assert
-            Exception ex = await Assert.ThrowsAsync<FatalProtocolException>(async () => await repo.GetResourceAsync<DownloadResource>());
+            FatalProtocolException ex = await Assert.ThrowsAsync<FatalProtocolException>(async () => await repo.GetResourceAsync<DownloadResource>());
 
             Assert.NotNull(ex);
-            Assert.Equal($"Unable to load the service index for source https://www.{randomName}.org/api/v2/.", ex.Message);
+            Assert.Equal(NuGetLogCode.NU1300, ex.LogCode);
         }
 
         [Fact]

--- a/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/ODataServiceDocumentResourceV2Tests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/ODataServiceDocumentResourceV2Tests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -25,7 +25,7 @@ namespace NuGet.Protocol.FuncTest
             // Arrange
             var repo = Repository.Factory.GetCoreV3(TestSources.NuGetV2Uri);
 
-            // Act 
+            // Act
             var resource = await repo.GetResourceAsync<ODataServiceDocumentResourceV2>();
 
             // Assert
@@ -39,7 +39,7 @@ namespace NuGet.Protocol.FuncTest
             // Arrange
             var repo = Repository.Factory.GetCoreV3("https://www.nuget.org/api/v99///");
 
-            // Act 
+            // Act
             var resource = await repo.GetResourceAsync<ODataServiceDocumentResourceV2>();
 
             // Assert
@@ -55,12 +55,11 @@ namespace NuGet.Protocol.FuncTest
             var repo = Repository.Factory.GetCoreV3($"https://www.{randomName}.org/api/v2");
 
             // Act & Assert
-            Exception ex = await Assert.ThrowsAsync<FatalProtocolException>(async () =>
+            FatalProtocolException ex = await Assert.ThrowsAsync<FatalProtocolException>(async () =>
                 await repo.GetResourceAsync<ODataServiceDocumentResourceV2>());
 
-            Assert.Equal(
-                $"Unable to load the service index for source https://www.{randomName}.org/api/v2.",
-                ex.Message);
+            Assert.NotNull(ex);
+            Assert.Equal(NuGetLogCode.NU1300, ex.LogCode);
             Assert.NotNull(ex.InnerException);
             Assert.IsType<HttpRequestException>(ex.InnerException);
         }

--- a/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/V2FeedParserTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/V2FeedParserTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Linq;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Common;
@@ -28,11 +29,11 @@ namespace NuGet.Protocol.FuncTest
 
             var parser = new V2FeedParser(httpSource, TestSources.NuGetV2Uri);
 
-            // Act 
+            // Act
             using (var packagesFolder = TestDirectory.Create())
             using (var cacheContext = new SourceCacheContext())
             {
-                Exception ex = await Assert.ThrowsAsync<FatalProtocolException>(
+                FatalProtocolException ex = await Assert.ThrowsAsync<FatalProtocolException>(
                     async () => await parser.DownloadFromUrl(
                         new PackageIdentity("not-found", new NuGetVersion("6.2.0")),
                         new Uri($"https://www.{randomName}.org/api/v2/"),
@@ -44,6 +45,9 @@ namespace NuGet.Protocol.FuncTest
                 // Assert
                 Assert.NotNull(ex);
                 Assert.Equal($"Error downloading 'not-found.6.2.0' from 'https://www.{randomName}.org/api/v2/'.", ex.Message);
+                Assert.Equal(ex.LogCode, NuGetLogCode.NU1300);
+                Assert.NotNull(ex.InnerException);
+                Assert.IsType<HttpRequestException>(ex.InnerException);
             }
         }
 
@@ -57,7 +61,7 @@ namespace NuGet.Protocol.FuncTest
 
             var parser = new V2FeedParser(httpSource, TestSources.NuGetV2Uri);
 
-            // Act 
+            // Act
             using (var packagesFolder = TestDirectory.Create())
             using (var cacheContext = new SourceCacheContext())
             {

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommand/FallbackFolderRestoreTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommand/FallbackFolderRestoreTests.cs
@@ -9,7 +9,6 @@ using System.Threading.Tasks;
 using NuGet.Configuration;
 using NuGet.Packaging;
 using NuGet.ProjectModel;
-using NuGet.Protocol.Core.Types;
 using NuGet.Test.Utility;
 using Xunit;
 
@@ -90,7 +89,7 @@ namespace NuGet.Commands.Test
 
                 // Act
                 var command = new RestoreCommand(request);
-                var result = await command.ExecuteAsync();
+                RestoreResult result = await command.ExecuteAsync();
                 var lockFile = result.LockFile;
                 await result.CommitAsync(logger, CancellationToken.None);
 
@@ -187,7 +186,7 @@ namespace NuGet.Commands.Test
 
                 // Act
                 var command = new RestoreCommand(request);
-                var result = await command.ExecuteAsync();
+                RestoreResult result = await command.ExecuteAsync();
                 var lockFile = result.LockFile;
                 await result.CommitAsync(logger, CancellationToken.None);
 
@@ -277,7 +276,7 @@ namespace NuGet.Commands.Test
 
                 // Act
                 var command = new RestoreCommand(request);
-                var result = await command.ExecuteAsync();
+                RestoreResult result = await command.ExecuteAsync();
                 var lockFile = result.LockFile;
                 await result.CommitAsync(logger, CancellationToken.None);
 
@@ -365,7 +364,7 @@ namespace NuGet.Commands.Test
 
                 // Act
                 var command = new RestoreCommand(request);
-                var result = await command.ExecuteAsync();
+                RestoreResult result = await command.ExecuteAsync();
                 var lockFile = result.LockFile;
                 await result.CommitAsync(logger, CancellationToken.None);
 
@@ -450,7 +449,15 @@ namespace NuGet.Commands.Test
 
                 // Act & Assert
                 var command = new RestoreCommand(request);
-                await Assert.ThrowsAsync<FatalProtocolException>(async () => await command.ExecuteAsync());
+                RestoreResult result = await command.ExecuteAsync();
+                await result.CommitAsync(logger, CancellationToken.None);
+
+                Assert.False(result.Success);
+                // ideally, this error wouldn't repeat itself in the same project.
+                Assert.Equal(2, logger.ErrorMessages.Count());
+                string[] errors = logger.ErrorMessages.ToArray();
+                Assert.StartsWith("NU1302", errors[0]);
+                Assert.StartsWith("NU1302", errors[1]);
             }
         }
     }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/ServiceIndexResourceV3ProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/ServiceIndexResourceV3ProviderTests.cs
@@ -10,6 +10,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
@@ -76,6 +77,7 @@ namespace NuGet.Protocol.Tests
             });
 
             Assert.IsType<HttpRequestException>(exception.InnerException);
+            Assert.Equal(exception.LogCode, NuGetLogCode.NU1304);
         }
 
         [Theory]

--- a/test/TestUtilities/Test.Utility/TestLogger.cs
+++ b/test/TestUtilities/Test.Utility/TestLogger.cs
@@ -178,7 +178,7 @@ namespace NuGet.Test.Utility
         {
             LogMessages.Enqueue(message);
 
-            await LogAsync(message.Level, message.Message);
+            await LogAsync(message.Level, message.FormatWithCode());
         }
     }
 }


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9688
Regression: No

## Fix

Details: When attempting to authenticate to an v3 feed, like Azure Artifacts, currently if not authenticated (via 401, 403, or 404):
- the restore won't complete, but will fail due to an exception
- the error message won't be a NUXXXX message, and thus will have no help page in the docs
- the message isn't customized for those 3 different scenarios

This fix should fix all those things. NU1301, NU1303, and NU1304 have customized messages, they won't end the restore, but will be one of many errors/warnings written to the assets file.

Trying to figure out how to best complete test coverage additions here. Would love pointers...but will be figuring that out.

## Testing/Validation

Tests Added: No
Reason for not adding tests:  Modified test for 404. Need to brainstorm more test coverage to add
Validation:  nuget.exe and devenv.exe validation against:
- feeds that don't exist on servers that i'm validated for - 403
- servers that i can't authenticate with - 401 
- and a 404 too.