### PR TITLE
Make the build script run on PowerShell Core without errors

### DIFF
--- a/build/common.ps1
+++ b/build/common.ps1
@@ -12,8 +12,6 @@ $ILMerge = Join-Path $NuGetClientRoot 'packages\ilmerge\2.14.1208\tools\ILMerge.
 Set-Alias dotnet $DotNetExe
 Set-Alias ilmerge $ILMerge
 
-[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-
 Function Read-PackageSources {
     param($NuGetConfig)
     $xml = New-Object xml
@@ -192,7 +190,7 @@ Function Install-DotnetCLI {
             Version = $Version
             Channel = $Channel
         }
-    
+
         $DotNetExe = Join-Path $cli.Root 'dotnet.exe';
 
         if ([Environment]::Is64BitOperatingSystem) {
@@ -222,14 +220,14 @@ Function Install-DotnetCLI {
         else {
             $specificVersion = $Version
         }
-        
+
         Trace-Log "The version of SDK should be installed is : $specificVersion"
 
         $probeDotnetPath = Join-Path (Join-Path $cli.Root sdk)  $specificVersion
 
         Trace-Log "Probing folder : $probeDotnetPath"
 
-        #If "-force" is specified, or folder with specific version doesn't exist, the download command will run" 
+        #If "-force" is specified, or folder with specific version doesn't exist, the download command will run"
         if ($Force -or -not (Test-Path $probeDotnetPath)) {
             & $DotNetInstall -Channel $cli.Channel -i $cli.Root -Version $cli.Version -Architecture $arch -NoPath
         }

--- a/build/common.ps1
+++ b/build/common.ps1
@@ -14,12 +14,6 @@ Set-Alias ilmerge $ILMerge
 
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
-$Version = New-Object -TypeName System.Version -ArgumentList "4.0"
-
-if ($PSVersionTable.PSVersion.CompareTo($Version) -lt 0) {
-    Set-Alias wget Invoke-WebRequest
-}
-
 Function Read-PackageSources {
     param($NuGetConfig)
     $xml = New-Object xml

--- a/test/EndToEnd/NuGet.Tests.psm1
+++ b/test/EndToEnd/NuGet.Tests.psm1
@@ -22,7 +22,7 @@ if ((Test-Path $nugetExePath) -eq $False)
 {
     Write-Host -BackgroundColor Yellow -ForegroundColor Black 'nuget.exe cannot be found at' $nugetExePath
     Write-Host "Downloading nuget.exe"
-    wget https://dist.nuget.org/win-x86-commandline/latest-prerelease/nuget.exe -OutFile $nugetExePath
+    Invoke-WebRequest https://dist.nuget.org/win-x86-commandline/latest-prerelease/nuget.exe -OutFile $nugetExePath
 }
 
 # Enable NuGet Test Mode


### PR DESCRIPTION
## Bug

Fixes: NuGet/Home#9673
Regression: No
* Last working version: N/A
* How are we preventing it in future: Run the CI on PowerShell Core/PowerShell 7+.

## Fix details

`build/common.ps1` was aliasing the `Invoke-WebRequest` command to `wget` only if the shell's version was less than 4.0. The way the version was compared seems to not work with `pwsh`. Instead of fixing the comparison, this PR entirely removed the aliasing (thankfully it was used only once).

Moreover, it caught my eye that `common.ps1` was explicitly setting the TLS version -something there is no reason to do- and it was removed.

## Testing/Validation

Tests Added: No
Reason for not adding tests: The changes are trivial and no source code changed.
Validation: N/A
