### PR TITLE
restore: trying out mmap-based file extraction

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs
@@ -166,6 +166,8 @@ namespace NuGet.Packaging
 
             private readonly long _size;
 
+            private bool _isDisposed;
+
             public SizedArchiveEntryStream(Stream inner, long size)
             {
                 _inner = inner;
@@ -206,8 +208,6 @@ namespace NuGet.Packaging
             {
                 _inner.Write(buffer, offset, count);
             }
-
-            private bool _isDisposed;
 
             protected override void Dispose(bool disposing)
             {
@@ -259,7 +259,7 @@ namespace NuGet.Packaging
                 using (var stream = entry.Open())
                 using (var sizedStream = new SizedArchiveEntryStream(stream, entry.Length))
                 {
-                    var copiedFile = extractFile(packageFileName, targetFilePath, sizedStream);
+                    string copiedFile = extractFile(packageFileName, targetFilePath, sizedStream);
                     if (copiedFile != null)
                     {
                         entry.UpdateFileTimeFromEntry(copiedFile, logger);

--- a/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs
@@ -160,11 +160,11 @@ namespace NuGet.Packaging
         /// <summary>
         /// This class literally just exists so CopyToFile gets a file size
         /// </summary>
-        private class SizedArchiveEntryStream : Stream
+        private sealed class SizedArchiveEntryStream : Stream
         {
-            Stream _inner;
+            private readonly Stream _inner;
 
-            long _size;
+            private readonly long _size;
 
             public SizedArchiveEntryStream(Stream inner, long size)
             {
@@ -172,7 +172,7 @@ namespace NuGet.Packaging
                 _size = size;
             }
 
-            public override long Length { get { return _size; } }
+            public override long Length { get => _size; }
 
             public override bool CanRead => _inner.CanRead;
 
@@ -207,6 +207,20 @@ namespace NuGet.Packaging
                 _inner.Write(buffer, offset, count);
             }
 
+            private bool _isDisposed;
+
+            protected override void Dispose(bool disposing)
+            {
+                if (!_isDisposed)
+                {
+                    if (disposing)
+                    {
+                        _inner.Dispose();
+                    }
+
+                    _isDisposed = true;
+                }
+            }
         }
 
         public override IEnumerable<string> CopyFiles(

--- a/src/NuGet.Core/NuGet.Packaging/PackageExtraction/StreamExtensions.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageExtraction/StreamExtensions.cs
@@ -56,10 +56,10 @@ namespace NuGet.Packaging
                         outputStream,
                         mapName: null,
                         capacity: (long)size,
-                        MemoryMappedFileAccess.ReadWriteExecute,
+                        MemoryMappedFileAccess.ReadWrite,
                         HandleInheritability.None,
                         leaveOpen: false))
-                    using (MemoryMappedViewStream mmstream = mmf.CreateViewStream())
+                    using (MemoryMappedViewStream mmstream = mmf.CreateViewStream(0, (long)size))
                     {
                         inputStream.CopyTo(mmstream);
                     }

--- a/src/NuGet.Core/NuGet.Packaging/PackageExtraction/StreamExtensions.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageExtraction/StreamExtensions.cs
@@ -1,12 +1,20 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.IO;
+using System.IO.MemoryMappedFiles;
 
 namespace NuGet.Packaging
 {
     public static class StreamExtensions
     {
+
+        /**
+        Only files smaller than this value will be mmap'ed
+        */
+        private const long MAX_MMAP_SIZE = 10 * 1024 * 1024;
+
         public static string CopyToFile(this Stream inputStream, string fileFullPath)
         {
             if (Path.GetFileName(fileFullPath).Length == 0)
@@ -27,11 +35,40 @@ namespace NuGet.Packaging
                 return fileFullPath;
             }
 
+            // For files of a certain size, we can do some Cleverness and mmap
+            // them instead of writing directly to disk. This can improve
+            // performance by a lot on some operating systems and hardware,
+            // particularly Windows
+            long? size = null;
+            try
+            {
+                size = inputStream.Length;
+            }
+            catch (NotSupportedException)
+            {
+                // If we can't get Length, just move on.
+            }
             using (var outputStream = NuGetExtractionFileIO.CreateFile(fileFullPath))
             {
-                inputStream.CopyTo(outputStream);
+                if (size > 0 && size <= MAX_MMAP_SIZE)
+                {
+                    using (MemoryMappedFile mmf = MemoryMappedFile.CreateFromFile(
+                        outputStream,
+                        mapName: null,
+                        capacity: (long)size,
+                        MemoryMappedFileAccess.ReadWrite,
+                        HandleInheritability.None,
+                        leaveOpen: false))
+                    using (MemoryMappedViewStream mmstream = mmf.CreateViewStream())
+                    {
+                        inputStream.CopyTo(mmstream);
+                    }
+                }
+                else
+                {
+                    inputStream.CopyTo(outputStream);
+                }
             }
-
             return fileFullPath;
         }
     }

--- a/src/NuGet.Core/NuGet.Packaging/PackageExtraction/StreamExtensions.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageExtraction/StreamExtensions.cs
@@ -56,7 +56,7 @@ namespace NuGet.Packaging
                         outputStream,
                         mapName: null,
                         capacity: (long)size,
-                        MemoryMappedFileAccess.ReadWrite,
+                        MemoryMappedFileAccess.ReadWriteExecute,
                         HandleInheritability.None,
                         leaveOpen: false))
                     using (MemoryMappedViewStream mmstream = mmf.CreateViewStream())

--- a/src/NuGet.Core/NuGet.Packaging/PackageExtraction/StreamExtensions.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageExtraction/StreamExtensions.cs
@@ -59,7 +59,7 @@ namespace NuGet.Packaging
                         MemoryMappedFileAccess.ReadWrite,
                         HandleInheritability.None,
                         leaveOpen: false))
-                    using (MemoryMappedViewStream mmstream = mmf.CreateViewStream(0, (long)size))
+                    using (MemoryMappedViewStream mmstream = mmf.CreateViewStream(0, (long)size, MemoryMappedFileAccess.ReadWrite))
                     {
                         inputStream.CopyTo(mmstream);
                     }

--- a/src/NuGet.Core/NuGet.Packaging/PackageExtraction/StreamExtensions.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageExtraction/StreamExtensions.cs
@@ -59,7 +59,7 @@ namespace NuGet.Packaging
                         MemoryMappedFileAccess.ReadWrite,
                         HandleInheritability.None,
                         leaveOpen: false))
-                    using (MemoryMappedViewStream mmstream = mmf.CreateViewStream(0, 0, MemoryMappedFileAccess.ReadWrite))
+                    using (MemoryMappedViewStream mmstream = mmf.CreateViewStream(0, (long)size, MemoryMappedFileAccess.ReadWrite))
                     {
                         inputStream.CopyTo(mmstream);
                     }

--- a/src/NuGet.Core/NuGet.Packaging/PackageExtraction/StreamExtensions.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageExtraction/StreamExtensions.cs
@@ -59,7 +59,7 @@ namespace NuGet.Packaging
                         MemoryMappedFileAccess.ReadWrite,
                         HandleInheritability.None,
                         leaveOpen: false))
-                    using (MemoryMappedViewStream mmstream = mmf.CreateViewStream(0, (long)size, MemoryMappedFileAccess.ReadWrite))
+                    using (MemoryMappedViewStream mmstream = mmf.CreateViewStream(0, 0, MemoryMappedFileAccess.ReadWrite))
                     {
                         inputStream.CopyTo(mmstream);
                     }


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Home/issues/9807

Results are promising:
<details>
<summary>Benchmark results from one of our test benchmark projects (the Orchard example)</summary>
<img src="https://user-images.githubusercontent.com/17535/87737215-344e0300-c78f-11ea-95c2-fe37be5e7e50.png"></img>
</details>

Note: I couldn't get the NuGet.Client-based benchmarks to work, but the other two worked fine.

## TODO

- [x] (**SOLVED**) You'll notice a bunch of "file already in use" errors in the test failures in CI. These seem to be spurious/random and I'm not sure _exactly_ what's triggering them but I can probably work around it with a `try{}` around the mmap code that falls through to a regular write. These are rare enough that it shouldn't affect performance, and if we catch the right exception, won't affect correctness (because the incoming stream won't have been consumed at all).
- [ ] Have a conversation about max file size to mmap: I'm not sure how many of these extractions we're doing in parallel, but my assumption is "not many, if any at all", so I'm inclined to just... leave it at the current 10mb setting (files smaller than 10mb will be fully slurped into RAM)
- [x] Should we bother flushing? Basically none of our code flushes streams to disk, and a process crash won't prevent mmapped files from being persisted, so I'm inclined to not take the (relatively small) perf hit, and just go "don't power off your computer :)", which is what we're saying already, anyway, for these extractions.