### PR TITLE
FileAndForget replacement which logs same fault event for every failure.

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageItemListViewModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageItemListViewModel.cs
@@ -7,7 +7,6 @@ using System.ComponentModel;
 using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.VisualStudio.Shell;
 using NuGet.Common;
 using NuGet.PackageManagement.VisualStudio;
 using NuGet.Packaging;
@@ -308,10 +307,7 @@ namespace NuGet.PackageManagement.UI
                     _providersLoaderStarted = true;
                     NuGetUIThreadHelper.JoinableTaskFactory
                         .RunAsync(ReloadProvidersAsync)
-                        .FileAndForget(
-                            TelemetryUtility.CreateFileAndForgetEventName(
-                                nameof(PackageItemListViewModel),
-                                nameof(ReloadProvidersAsync)));
+                        .PostOnFailure(nameof(PackageItemListViewModel), nameof(ReloadProvidersAsync));
                 }
 
                 return _providers;
@@ -390,10 +386,7 @@ namespace NuGet.PackageManagement.UI
             {
                 NuGetUIThreadHelper.JoinableTaskFactory
                     .RunAsync(ReloadPackageVersionsAsync)
-                    .FileAndForget(
-                        TelemetryUtility.CreateFileAndForgetEventName(
-                            nameof(PackageItemListViewModel),
-                            nameof(ReloadPackageVersionsAsync)));
+                    .PostOnFailure(nameof(PackageItemListViewModel), nameof(ReloadPackageVersionsAsync));
             }
 
 
@@ -401,10 +394,7 @@ namespace NuGet.PackageManagement.UI
             {
                 NuGetUIThreadHelper.JoinableTaskFactory
                     .RunAsync(ReloadPackageDeprecationAsync)
-                    .FileAndForget(
-                        TelemetryUtility.CreateFileAndForgetEventName(
-                            nameof(PackageItemListViewModel),
-                            nameof(ReloadPackageDeprecationAsync)));
+                    .PostOnFailure(nameof(PackageItemListViewModel), nameof(ReloadPackageDeprecationAsync));
             }
         }
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -8,9 +8,12 @@ using System.Globalization;
 using System.Linq;
 using System.Security;
 using System.Threading;
+using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
+using Microsoft.VisualStudio.Experimentation;
+using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Threading;
 using NuGet.Common;
@@ -19,17 +22,15 @@ using NuGet.PackageManagement.Telemetry;
 using NuGet.PackageManagement.VisualStudio;
 using NuGet.Packaging.Core;
 using NuGet.ProjectManagement;
+using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
 using NuGet.Resolver;
 using NuGet.Versioning;
 using NuGet.VisualStudio;
 using NuGet.VisualStudio.Telemetry;
 using Resx = NuGet.PackageManagement.UI;
-using VSThreadHelper = Microsoft.VisualStudio.Shell.ThreadHelper;
 using Task = System.Threading.Tasks.Task;
-using System.Threading.Tasks;
-using Microsoft.VisualStudio.Shell;
-using NuGet.Protocol;
+using VSThreadHelper = Microsoft.VisualStudio.Shell.ThreadHelper;
 
 namespace NuGet.PackageManagement.UI
 {
@@ -744,7 +745,7 @@ namespace NuGet.PackageManagement.UI
                     pSearchCallback: null,
                     searchTask: null);
             })
-            .FileAndForget(TelemetryUtility.CreateFileAndForgetEventName(nameof(PackageManagerControl), nameof(SearchPackagesAndRefreshUpdateCount)));
+            .PostOnFailure(nameof(PackageManagerControl), nameof(SearchPackagesAndRefreshUpdateCount));
         }
 
         // Enable if environment variable RecommendNuGetPackages is set to 1.
@@ -932,7 +933,7 @@ namespace NuGet.PackageManagement.UI
 
                 _topPanel.UpdateCountOnUpdatesTab(Model.CachedUpdates.Packages.Count);
             })
-            .FileAndForget(TelemetryUtility.CreateFileAndForgetEventName(nameof(PackageManagerControl), nameof(RefreshInstalledAndUpdatesTabs)));
+            .PostOnFailure(nameof(PackageManagerControl), nameof(RefreshInstalledAndUpdatesTabs));
         }
 
         private static async Task<int> GetInstalledDeprecatedPackagesCountAsync(PackageLoadContext loadContext, IPackageMetadataProvider metadataProvider, CancellationToken token)
@@ -975,7 +976,7 @@ namespace NuGet.PackageManagement.UI
 
                     _topPanel.UpdateCountOnConsolidateTab(await loader.GetTotalCountAsync(maxCount: 100, CancellationToken.None));
                 })
-                .FileAndForget(TelemetryUtility.CreateFileAndForgetEventName(nameof(PackageManagerControl), nameof(RefreshConsolidatablePackagesCount)));
+                .PostOnFailure(nameof(PackageManagerControl), nameof(RefreshConsolidatablePackagesCount));
             }
         }
 
@@ -988,7 +989,7 @@ namespace NuGet.PackageManagement.UI
         {
             NuGetUIThreadHelper.JoinableTaskFactory
                 .RunAsync(UpdateDetailPaneAsync)
-                .FileAndForget(TelemetryUtility.CreateFileAndForgetEventName(nameof(PackageManagerControl), nameof(PackageList_SelectionChanged)));
+                .PostOnFailure(nameof(PackageManagerControl), nameof(PackageList_SelectionChanged));
         }
 
         /// <summary>
@@ -1210,7 +1211,7 @@ namespace NuGet.PackageManagement.UI
                         CancellationToken.None);
                     _packageList.UpdatePackageStatus(installedPackages.ToArray());
                 })
-                .FileAndForget(TelemetryUtility.CreateFileAndForgetEventName(nameof(PackageManagerControl), nameof(Refresh)));
+                .PostOnFailure(nameof(PackageManagerControl), nameof(Refresh));
 
                 RefreshInstalledAndUpdatesTabs();
             }
@@ -1326,7 +1327,7 @@ namespace NuGet.PackageManagement.UI
 
                 _windowSearchHost.Activate();
             })
-            .FileAndForget(TelemetryUtility.CreateFileAndForgetEventName(nameof(PackageManagerControl), nameof(FocusOnSearchBox_Executed)));
+            .PostOnFailure(nameof(PackageManagerControl), nameof(FocusOnSearchBox_Executed));
         }
 
         public void Search(string searchText)
@@ -1436,7 +1437,7 @@ namespace NuGet.PackageManagement.UI
                     }
                 }
             })
-            .FileAndForget(TelemetryUtility.CreateFileAndForgetEventName(nameof(PackageManagerControl), nameof(ExecuteAction)));
+            .PostOnFailure(nameof(PackageManagerControl), nameof(ExecuteAction));
         }
 
         private void ExecuteUninstallPackageCommand(object sender, ExecutedRoutedEventArgs e)
@@ -1554,10 +1555,7 @@ namespace NuGet.PackageManagement.UI
                 Debug.Assert(project != null);
                 await Model.Context.UIActionEngine.UpgradeNuGetProjectAsync(Model.UIController, project);
             })
-            .FileAndForget(
-                            TelemetryUtility.CreateFileAndForgetEventName(
-                                nameof(PackageManagerControl),
-                                nameof(UpgradeButton_Click)));
+            .PostOnFailure(nameof(PackageManagerControl), nameof(UpgradeButton_Click));
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSPackageRestoreManager.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSPackageRestoreManager.cs
@@ -48,7 +48,7 @@ namespace NuGet.PackageManagement.VisualStudio
                 await TaskScheduler.Default;
                 await RaisePackagesMissingEventForSolutionAsync(solutionDirectory, CancellationToken.None);
             })
-            .FileAndForget(TelemetryUtility.CreateFileAndForgetEventName(nameof(VSPackageRestoreManager), nameof(OnSolutionOpened)));
+            .PostOnFailure(nameof(VSPackageRestoreManager), nameof(OnSolutionOpened));
         }
 
         private void OnSolutionClosed(object sender, EventArgs e)
@@ -71,8 +71,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
                 await RaisePackagesMissingEventForSolutionAsync(solutionDirectory, CancellationToken.None);
             })
-            .FileAndForget(TelemetryUtility.CreateFileAndForgetEventName(nameof(VSPackageRestoreManager), nameof(OnNuGetProjectAdded)));
-
+            .PostOnFailure(nameof(VSPackageRestoreManager), nameof(OnNuGetProjectAdded));
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreBuildHandler.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreBuildHandler.cs
@@ -12,6 +12,7 @@ using Microsoft.VisualStudio.Threading;
 using NuGet.Configuration;
 using NuGet.PackageManagement;
 using NuGet.VisualStudio;
+using NuGet.VisualStudio.Telemetry;
 using SystemTask = System.Threading.Tasks.Task;
 using ThreadHelper = Microsoft.VisualStudio.Shell.ThreadHelper;
 
@@ -81,13 +82,16 @@ namespace NuGet.SolutionRestoreManager
 
         public void Dispose()
         {
-            ThreadHelper.ThrowIfNotOnUIThread();
-
-            if (_updateSolutionEventsCookieEx != VSCOOKIE_NIL)
+            NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async () =>
             {
-                ((IVsSolutionBuildManager)_solutionBuildManager).UnadviseUpdateSolutionEvents(_updateSolutionEventsCookieEx);
-                _updateSolutionEventsCookieEx = VSCOOKIE_NIL;
-            }
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+                if (_updateSolutionEventsCookieEx != VSCOOKIE_NIL)
+                {
+                    ((IVsSolutionBuildManager)_solutionBuildManager).UnadviseUpdateSolutionEvents(_updateSolutionEventsCookieEx);
+                    _updateSolutionEventsCookieEx = VSCOOKIE_NIL;
+                }
+            }).PostOnFailure(nameof(SolutionRestoreBuildHandler));
         }
 
         // A factory method invoked internally only

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
@@ -186,7 +186,7 @@ namespace NuGet.SolutionRestoreManager
             catch (Exception e)
             {
                 _logger.LogError(e.ToString());
-                TelemetryUtility.EmitException(nameof(VsSolutionRestoreService), nameof(NominateProjectAsync), e);
+                await TelemetryUtility.PostFaultAsync(e, nameof(VsSolutionRestoreService));
                 return false;
             }
         }

--- a/src/NuGet.Clients/NuGet.Tools/NuGetPackage.cs
+++ b/src/NuGet.Clients/NuGet.Tools/NuGetPackage.cs
@@ -29,7 +29,6 @@ using NuGet.VisualStudio.Implementation.Extensibility;
 using NuGet.VisualStudio.Telemetry;
 using NuGetConsole;
 using NuGetConsole.Implementation;
-using IAsyncServiceProvider = Microsoft.VisualStudio.Shell.IAsyncServiceProvider;
 using IBrokeredServiceContainer = Microsoft.VisualStudio.Shell.ServiceBroker.IBrokeredServiceContainer;
 using ISettings = NuGet.Configuration.ISettings;
 using Resx = NuGet.PackageManagement.UI.Resources;
@@ -548,11 +547,7 @@ namespace NuGetVSExtension
             {
                 await ExecuteUpgradeNuGetProjectCommandAsync(sender, e);
             })
-          .FileAndForget(
-                          TelemetryUtility.CreateFileAndForgetEventName(
-                              nameof(NuGetPackage),
-                              nameof(ExecuteUpgradeNuGetProjectCommand)));
-
+           .PostOnFailure(nameof(NuGetPackage), nameof(ExecuteUpgradeNuGetProjectCommand));
         }
 
         private async Task ExecuteUpgradeNuGetProjectCommandAsync(object sender, EventArgs e)
@@ -646,10 +641,7 @@ namespace NuGetVSExtension
 
                     MessageHelper.ShowWarningMessage(errorMessage, Resources.ErrorDialogBoxTitle);
                 }
-            }).FileAndForget(
-                          TelemetryUtility.CreateFileAndForgetEventName(
-                              nameof(NuGetPackage),
-                              nameof(ShowManageLibraryPackageDialog)));
+            }).PostOnFailure(nameof(NuGetPackage), nameof(ShowManageLibraryPackageDialog));
         }
 
         private async Task<IVsWindowFrame> FindExistingSolutionWindowFrameAsync()
@@ -823,10 +815,7 @@ namespace NuGetVSExtension
 
                     windowFrame.Show();
                 }
-            }).FileAndForget(
-                          TelemetryUtility.CreateFileAndForgetEventName(
-                              nameof(NuGetPackage),
-                              nameof(ShowManageLibraryPackageForSolutionDialog)));
+            }).PostOnFailure(nameof(NuGetPackage), nameof(ShowManageLibraryPackageForSolutionDialog));
         }
 
         /// <summary>
@@ -875,7 +864,7 @@ namespace NuGetVSExtension
             {
                 if (ShouldMEFBeInitialized())
                 {
-                  await InitializeMEFAsync();
+                    await InitializeMEFAsync();
                 }
 
                 await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/OutputConsoleLogger.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/OutputConsoleLogger.cs
@@ -91,7 +91,7 @@ namespace NuGet.VisualStudio.Common
 
                 _semaphore.Dispose();
             }
-            ).FileAndForget(TelemetryUtility.CreateFileAndForgetEventName(nameof(OutputConsoleLogger), nameof(Dispose)));
+            ).PostOnFailure(nameof(OutputConsoleLogger), nameof(Dispose));
         }
 
         public void End()
@@ -197,7 +197,7 @@ namespace NuGet.VisualStudio.Common
         {
             NuGetUIThreadHelper.JoinableTaskFactory
                                .RunAsync(() => _semaphore.ExecuteAsync(action))
-                               .FileAndForget(TelemetryUtility.CreateFileAndForgetEventName(nameof(OutputConsoleLogger), methodName));
+                               .PostOnFailure(nameof(OutputConsoleLogger), methodName);
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/JoinableTaskExtensions.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/JoinableTaskExtensions.cs
@@ -1,0 +1,33 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using Microsoft.VisualStudio.Threading;
+
+namespace NuGet.VisualStudio.Telemetry
+{
+    public static class JoinableTaskExtensions
+    {
+        /// <summary> Records error information when the given task faults. </summary>
+        /// <param name="joinableTask"> Joinable task to execute. </param>
+        /// <param name="callerClassName"> Caller class name. </param>
+        /// <param name="callerMemberName"> Caller member name. </param>
+        public static void PostOnFailure(this JoinableTask joinableTask, string callerClassName, [CallerMemberName] string callerMemberName = null)
+        {
+            NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            {
+                try
+                {
+#pragma warning disable VSTHRD003 // Avoid awaiting foreign Tasks - As a fire-and-forget continuation, deadlocks can't happen.
+                    await joinableTask.Task.ConfigureAwait(false);
+#pragma warning restore VSTHRD003
+                }
+                catch (Exception e)
+                {
+                    await TelemetryUtility.PostFaultAsync(e, callerClassName, callerMemberName);
+                }
+            });
+        }
+    }
+}

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/TelemetryUtility.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/TelemetryUtility.cs
@@ -30,7 +30,10 @@ namespace NuGet.VisualStudio.Telemetry
             var description = $"{e.GetType().Name} - {e.Message}";
 
             await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-            TelemetryService.DefaultSession.PostFault($"{VSTelemetrySession.VSEventNamePrefix}Fault", $"{caller} : {e.GetType().Name} - {e.Message}", e);
+
+            var fault = new FaultEvent($"{VSTelemetrySession.VSEventNamePrefix}Fault", description, FaultSeverity.General, e, gatherEventDetails: null);
+            fault.Properties[$"{VSTelemetrySession.VSPropertyNamePrefix}Fault.Caller"] = caller;
+            TelemetryService.DefaultSession.PostEvent(fault);
 
             if (await IsShellAvailable.GetValueAsync())
             {

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/NuGetProjectService.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/NuGetProjectService.cs
@@ -152,7 +152,7 @@ namespace NuGet.VisualStudio.Implementation.Extensibility
             var status = InstalledPackageResultStatus.Unknown;
 
             var notImplementedException = new NotImplementedException($"Project type {project.GetType().Name} is not implemented");
-            TelemetryUtility.EmitException(nameof(NuGetProjectService), nameof(GetInstalledPackagesAsync), notImplementedException);
+            await TelemetryUtility.PostFaultAsync(notImplementedException, nameof(NuGetProjectService));
 
             IEnumerable<PackageReference> projectPackages = await project.GetInstalledPackagesAsync(cancellationToken);
 

--- a/src/NuGet.Clients/NuGetConsole.Host.PowerShell/PowerShellHost.cs
+++ b/src/NuGet.Clients/NuGetConsole.Host.PowerShell/PowerShellHost.cs
@@ -754,7 +754,7 @@ namespace NuGetConsole.Host.PowerShell.Implementation
                         await CommandUiUtilities.InvalidateDefaultProjectAsync();
                     }
                 })
-                .FileAndForget(TelemetryUtility.CreateFileAndForgetEventName(nameof(PowerShellHost), nameof(StartAsyncDefaultProjectUpdate)));
+                .PostOnFailure(nameof(PowerShellHost), nameof(StartAsyncDefaultProjectUpdate));
         }
 
         public string[] GetAvailableProjects()

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/SolutionRestoreBuildHandlerTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/SolutionRestoreBuildHandlerTests.cs
@@ -24,6 +24,12 @@ namespace NuGet.SolutionRestoreManager.Test
             Assumes.Present(fixture);
 
             _jtf = fixture.JoinableTaskFactory;
+
+#pragma warning disable VSSDK005 // Avoid instantiating JoinableTaskContext
+            var joinableTaskContext = new JoinableTaskContext(Thread.CurrentThread, SynchronizationContext.Current);
+#pragma warning restore VSSDK005 // Avoid instantiating JoinableTaskContext
+
+            NuGetUIThreadHelper.SetCustomJoinableTaskFactory(_jtf);
         }
 
         [Fact]

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsSolutionRestoreServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsSolutionRestoreServiceTests.cs
@@ -34,6 +34,12 @@ namespace NuGet.SolutionRestoreManager.Test
         public VsSolutionRestoreServiceTests()
         {
             _testDirectory = TestDirectory.Create();
+
+#pragma warning disable VSSDK005 // Avoid instantiating JoinableTaskContext
+            var joinableTaskContext = new JoinableTaskContext(Thread.CurrentThread, SynchronizationContext.Current);
+#pragma warning restore VSSDK005 // Avoid instantiating JoinableTaskContext
+
+            NuGetUIThreadHelper.SetCustomJoinableTaskFactory(joinableTaskContext.Factory);
         }
 
         public void Dispose()

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Common.Test/Telemetry/TelemetryUtilityTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Common.Test/Telemetry/TelemetryUtilityTests.cs
@@ -10,34 +10,6 @@ namespace NuGet.VisualStudio.Common.Test.Telemetry
 {
     public class TelemetryUtilityTests
     {
-        [Theory]
-        [InlineData(null)]
-        [InlineData("")]
-        public void CreateFileAndForgetEventName_WhenTypeNameIsNullOrEmpty_Throws(string typeName)
-        {
-            ArgumentException exception = Assert.Throws<ArgumentException>(() => TelemetryUtility.CreateFileAndForgetEventName(typeName, "memberName"));
-
-            Assert.Equal("typeName", exception.ParamName);
-        }
-
-        [Theory]
-        [InlineData(null)]
-        [InlineData("")]
-        public void CreateFileAndForgetEventName_WhenMemberNameIsNullOrEmpty_Throws(string memberName)
-        {
-            ArgumentException exception = Assert.Throws<ArgumentException>(() => TelemetryUtility.CreateFileAndForgetEventName("typeName", memberName));
-
-            Assert.Equal("memberName", exception.ParamName);
-        }
-
-        [Fact]
-        public void CreateFileAndForgetEventName_WhenArgumentsAreValid_ReturnsString()
-        {
-            string actualResult = TelemetryUtility.CreateFileAndForgetEventName("a", "b");
-
-            Assert.Equal("VS/NuGet/fileandforget/a/b", actualResult);
-        }
-
         [Fact]
         public void IsHttpV3_WhenSourceIsNull_Throws()
         {


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9812
Regression: No

## Fix

Details: Implement a new extension method for JoinableTask, PostOnFailure, which will always post same-named fault event.

## Testing/Validation

Tests Added: No.
Reason for not adding tests: Hard to test for exceptional circumstances here.
Validation: Pending.
