### PR TITLE
Use microsoft400 instead of microsoft402 authenticode cert

### DIFF
--- a/src/NuGet.Clients/NuGetConsole.Host.PowerShell/NuGetConsole.Host.PowerShell.csproj
+++ b/src/NuGet.Clients/NuGetConsole.Host.PowerShell/NuGetConsole.Host.PowerShell.csproj
@@ -164,7 +164,7 @@
   <Target Name="GetScriptsForSigning" Returns="@(ScriptsToSign)">
     <ItemGroup>
       <ScriptsToSign Include="$(ArtifactsDirectory)Scripts\*.ps*">
-        <Authenticode>Microsoft402</Authenticode>
+        <Authenticode>Microsoft400</Authenticode>
       </ScriptsToSign>
     </ItemGroup>
   </Target>


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Client.Engineering/issues/430
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: Change authenticode cert, as requested by MicroBuild.

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  no code/product change.
Validation:  
