### PR TITLE
OutputConsoleLogger: Avoid reentrancy when reporting an error.

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/OutputConsoleLogger.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/OutputConsoleLogger.cs
@@ -141,7 +141,7 @@ namespace NuGet.VisualStudio.Common
                     if (message.Level == LogLevel.Error ||
                         message.Level == LogLevel.Warning)
                     {
-                        ReportError(message);
+                        await ReportAsync(message);
                     }
                 }
             },
@@ -177,26 +177,20 @@ namespace NuGet.VisualStudio.Common
 
         public void ReportError(string message)
         {
-            Run(async () =>
-            {
-                await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-
-                var errorListEntry = new ErrorListTableEntry(message, LogLevel.Error);
-                ErrorListTableDataSource.Value.AddNuGetEntries(errorListEntry);
-            },
-            $"{nameof(ReportError)}/{nameof(String)}");
+            Run(() => ReportAsync(new LogMessage(LogLevel.Error, message)), $"{nameof(ReportError)}/{nameof(String)}");
         }
 
         public void ReportError(ILogMessage message)
         {
-            Run(async () =>
-            {
-                await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            Run(() => ReportAsync(message), $"{nameof(ReportError)}/{nameof(ILogMessage)}");
+        }
 
-                var errorListEntry = new ErrorListTableEntry(message);
-                ErrorListTableDataSource.Value.AddNuGetEntries(errorListEntry);
-            },
-            $"{nameof(ReportError)}/{nameof(ILogMessage)}");
+        private async Task ReportAsync(ILogMessage message)
+        {
+            await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+            var errorListEntry = new ErrorListTableEntry(message);
+            ErrorListTableDataSource.Value.AddNuGetEntries(errorListEntry);
         }
 
         private void Run(Func<Task> action, [CallerMemberName] string methodName = null)


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9798
Regression: Yes
* Last working version: Build 6704
* How are we preventing it in future: Manual test pass already covers the scenario. Filled https://github.com/NuGet/Home/issues/9815 to improve unit test coverage.

## Fix

Details: Refactored out core of ReportError to enable sharing same code both from Log(...) calls and direct ReportError(...) calls.

## Testing/Validation

Tests Added: No (filed https://github.com/NuGet/Home/issues/9815)
Reason for not adding tests: I feel that it would require potential refactorings to get it under test harness, more on a level of task.
Validation:  Tested changed code locally, verified that warning errors show up in the list as expected.
