### PR TITLE
Make timeoutInMinutes configurable

### DIFF
--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -82,7 +82,7 @@ jobs:
 
 - job: Build_and_UnitTest
   dependsOn: Initialize_Build
-  timeoutInMinutes: $(TimeoutInMinutesUnitTest)
+  timeoutInMinutes: $[ variables['TimeoutInMinutesUnitTest'] ]
   variables:
     BuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.BuildNumber']]
     FullVstsBuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]

--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -82,7 +82,7 @@ jobs:
 
 - job: Build_and_UnitTest
   dependsOn: Initialize_Build
-  timeoutInMinutes: 170
+  timeoutInMinutes: "$(TimeoutInMinutesUnitTest)"
   variables:
     BuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.BuildNumber']]
     FullVstsBuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]

--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -82,7 +82,7 @@ jobs:
 
 - job: Build_and_UnitTest
   dependsOn: Initialize_Build
-  timeoutInMinutes: $[ variables['timeoutlimit'] ]
+  timeoutInMinutes: $[variables['timeoutlimit']]
   variables:
     BuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.BuildNumber']]
     FullVstsBuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
@@ -90,10 +90,10 @@ jobs:
     VsTargetMajorVersion: $[dependencies.Initialize_Build.outputs['updatebuildnumber.VsTargetMajorVersion']]
     SDKVersionForBuild: $[dependencies.Initialize_Build.outputs['getSDKVersionForBuild.SDKVersionForBuild']]
     LocalizedLanguageCount: "13"
-    ${{ if eq(variables['TimeoutInMinutesUnitTest'], '') }}:  # if TimeoutInMinutesUnitTest is not defined in pipeline, use default timeoutlimit
+    ${{ if eq($(TimeoutInMinutesUnitTest), '') }}:  # if TimeoutInMinutesUnitTest is not defined in pipeline, use default timeoutlimit
       timeoutlimit: 10
-    ${{ if ne(variables['TimeoutInMinutesUnitTest'], '') }}:   # if TimeoutInMinutesUnitTest is defined in pipeline, use TimeoutInMinutesUnitTest
-      timeoutlimit: $['TimeoutInMinutesUnitTest']
+    ${{ if ne($(TimeoutInMinutesUnitTest), '') }}:   # if TimeoutInMinutesUnitTest is defined in pipeline, use TimeoutInMinutesUnitTest
+      timeoutlimit: $(TimeoutInMinutesUnitTest)
 
   pool:
     name: VSEng-MicroBuildVS2019

--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -92,7 +92,7 @@ jobs:
     LocalizedLanguageCount: "13"
     ${{ if eq(variables['TimeoutInMinutesUnitTest'], '') }}:  # if TimeoutInMinutesUnitTest is not defined in pipeline, use default timeoutlimit
       timeoutlimit: 10
-    ${{ if ne(variables['Build.SourceBranchName'], '') }}:   # if TimeoutInMinutesUnitTest is defined in pipeline, use TimeoutInMinutesUnitTest
+    ${{ if ne(variables['TimeoutInMinutesUnitTest'], '') }}:   # if TimeoutInMinutesUnitTest is defined in pipeline, use TimeoutInMinutesUnitTest
       timeoutlimit: $['TimeoutInMinutesUnitTest']
 
   pool:

--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -82,7 +82,7 @@ jobs:
 
 - job: Build_and_UnitTest
   dependsOn: Initialize_Build
-  timeoutInMinutes: "$(TimeoutInMinutesUnitTest)"
+  timeoutInMinutes: $(TimeoutInMinutesUnitTest)
   variables:
     BuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.BuildNumber']]
     FullVstsBuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]

--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -581,7 +581,7 @@ jobs:
     BuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.BuildNumber']]
     FullVstsBuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
     SDKVersionForBuild: $[dependencies.Initialize_Build.outputs['getSDKVersionForBuild.SDKVersionForBuild']]
-  condition: "and(succeeded(),eq(variables['RunFunctionalTestsOnWindows'], 'true')) "
+  condition: "failed() "
   pool:
     name: VSEng-MicroBuildVS2019
     demands:
@@ -678,7 +678,7 @@ jobs:
     FULLVSTSBUILDNUMBER: $[dependencies.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
     SDKVersionForBuild: $[dependencies.Initialize_Build.outputs['getSDKVersionForBuild.SDKVersionForBuild']]
     MSBUILDDISABLENODEREUSE: 1
-  condition: "and(succeeded(),eq(variables['RunTestsOnLinux'], 'true')) "
+  condition: "failed() "
   pool:
     vmImage: ubuntu-latest
     demands: sh
@@ -746,7 +746,7 @@ jobs:
   variables:
     FULLVSTSBUILDNUMBER: $[dependencies.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
     SDKVersionForBuild: $[dependencies.Initialize_Build.outputs['getSDKVersionForBuild.SDKVersionForBuild']]
-  condition: "and(succeeded(),eq(variables['RunTestsOnMac'], 'true')) "
+  condition: "failed() "
   pool:
     vmImage: macos-latest
 
@@ -819,7 +819,7 @@ jobs:
   variables:
     FullVstsBuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
     SDKVersionForBuild: $[dependencies.Initialize_Build.outputs['getSDKVersionForBuild.SDKVersionForBuild']]
-  condition: "and(succeeded(),eq(variables['RunEndToEndTests'], 'true')) "
+  condition: "failed() "
   pool:
     name: DDNuGet-Windows
     demands:
@@ -932,7 +932,7 @@ jobs:
     BuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.BuildNumber']]
     FullVstsBuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
     SDKVersionForBuild: $[dependencies.Initialize_Build.outputs['getSDKVersionForBuild.SDKVersionForBuild']]
-  condition: "and(succeeded(),eq(variables['RunApexTests'], 'true')) "
+  condition: "failed() "
   pool:
     name: DDNuGet-Windows
     demands:

--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -82,7 +82,7 @@ jobs:
 
 - job: Build_and_UnitTest
   dependsOn: Initialize_Build
-  timeoutInMinutes: $[ variables['TimeoutInMinutesUnitTest'] ]
+  timeoutInMinutes: $[ variables['timeoutlimit'] ]
   variables:
     BuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.BuildNumber']]
     FullVstsBuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
@@ -90,6 +90,10 @@ jobs:
     VsTargetMajorVersion: $[dependencies.Initialize_Build.outputs['updatebuildnumber.VsTargetMajorVersion']]
     SDKVersionForBuild: $[dependencies.Initialize_Build.outputs['getSDKVersionForBuild.SDKVersionForBuild']]
     LocalizedLanguageCount: "13"
+    ${{ if eq(variables['TimeoutInMinutesUnitTest'], '') }}:  # if TimeoutInMinutesUnitTest is not defined in pipeline, use default timeoutlimit
+      timeoutlimit: 10
+    ${{ if ne(variables['Build.SourceBranchName'], '') }}:   # if TimeoutInMinutesUnitTest is defined in pipeline, use TimeoutInMinutesUnitTest
+      timeoutlimit: $['TimeoutInMinutesUnitTest']
 
   pool:
     name: VSEng-MicroBuildVS2019


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Client.Engineering/issues/422
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: 
Make the `timeoutInMinutes` of `Build_and_UnitTest` configurable. 
So that when signing goes slowly, we don't have to change the code to extend the time limitation.

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  
Validation:  
