### PR TITLE
Make all NuGet.CommandLine.XPlat classes internal

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/CommandConstants.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/CommandConstants.cs
@@ -1,6 +1,6 @@
-﻿namespace NuGet.CommandLine.XPlat
+namespace NuGet.CommandLine.XPlat
 {
-    public static class CommandConstants
+    internal static class CommandConstants
     {
         public const string ForceEnglishOutputOption = "--force-english-output";
     }

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/CommandConstants.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/CommandConstants.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 namespace NuGet.CommandLine.XPlat
 {
     internal static class CommandConstants

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommand.cs
@@ -11,7 +11,7 @@ using NuGet.Versioning;
 
 namespace NuGet.CommandLine.XPlat
 {
-    public static class AddPackageReferenceCommand
+    internal static class AddPackageReferenceCommand
     {
         public static void Register(CommandLineApplication app, Func<ILogger> getLogger,
             Func<IPackageReferenceCommandRunner> getCommandRunner)

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommandRunner.cs
@@ -21,7 +21,7 @@ using NuGet.Versioning;
 
 namespace NuGet.CommandLine.XPlat
 {
-    public class AddPackageReferenceCommandRunner : IPackageReferenceCommandRunner
+    internal class AddPackageReferenceCommandRunner : IPackageReferenceCommandRunner
     {
         public async Task<int> ExecuteCommand(PackageReferenceArgs packageReferenceArgs, MSBuildAPIUtility msBuild)
         {

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/IPackageReferenceCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/IPackageReferenceCommandRunner.cs
@@ -1,11 +1,11 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
 
 namespace NuGet.CommandLine.XPlat
 {
-    public interface IPackageReferenceCommandRunner
+    internal interface IPackageReferenceCommandRunner
     {
         Task<int> ExecuteCommand(PackageReferenceArgs packageRefArgs, MSBuildAPIUtility msBuild);
     }

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackage/IListPackageCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackage/IListPackageCommandRunner.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 
 namespace NuGet.CommandLine.XPlat
 {
-    public interface IListPackageCommandRunner
+    internal interface IListPackageCommandRunner
     {
         Task ExecuteCommandAsync(ListPackageArgs packageRefArgs);
     }

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackage/ListPackageArgs.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackage/ListPackageArgs.cs
@@ -9,7 +9,7 @@ using NuGet.Configuration;
 
 namespace NuGet.CommandLine.XPlat
 {
-    public class ListPackageArgs
+    internal class ListPackageArgs
     {
         public ILogger Logger { get; }
         public string Path { get; }

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackage/ListPackageCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackage/ListPackageCommand.cs
@@ -15,7 +15,7 @@ using NuGet.Frameworks;
 
 namespace NuGet.CommandLine.XPlat
 {
-    public static class ListPackageCommand
+    internal static class ListPackageCommand
     {
         public static void Register(CommandLineApplication app, Func<ILogger> getLogger,
             Func<IListPackageCommandRunner> getCommandRunner)

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackage/ListPackageCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackage/ListPackageCommandRunner.cs
@@ -19,7 +19,7 @@ using NuGet.Versioning;
 
 namespace NuGet.CommandLine.XPlat
 {
-    public class ListPackageCommandRunner : IListPackageCommandRunner
+    internal class ListPackageCommandRunner : IListPackageCommandRunner
     {
         private const string ProjectAssetsFile = "ProjectAssetsFile";
         private const string ProjectName = "MSBuildProjectName";

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/PackageReferenceArgs.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/PackageReferenceArgs.cs
@@ -9,7 +9,7 @@ using NuGet.Packaging.Core;
 
 namespace NuGet.CommandLine.XPlat
 {
-    public class PackageReferenceArgs
+    internal class PackageReferenceArgs
     {
         public string ProjectPath { get; }
         public ILogger Logger { get; }

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/RemovePackageReferenceCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/RemovePackageReferenceCommand.cs
@@ -9,7 +9,7 @@ using NuGet.Common;
 
 namespace NuGet.CommandLine.XPlat
 {
-    public class RemovePackageReferenceCommand
+    internal class RemovePackageReferenceCommand
     {
         public static void Register(CommandLineApplication app, Func<ILogger> getLogger,
             Func<IPackageReferenceCommandRunner> getCommandRunner)

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/RemovePackageReferenceCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/RemovePackageReferenceCommandRunner.cs
@@ -9,7 +9,7 @@ using NuGet.LibraryModel;
 
 namespace NuGet.CommandLine.XPlat
 {
-    public class RemovePackageReferenceCommandRunner : IPackageReferenceCommandRunner
+    internal class RemovePackageReferenceCommandRunner : IPackageReferenceCommandRunner
     {
         public Task<int> ExecuteCommand(PackageReferenceArgs packageReferenceArgs, MSBuildAPIUtility msBuild)
         {

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Program.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Program.cs
@@ -16,7 +16,7 @@ using Microsoft.Build.Locator;
 
 namespace NuGet.CommandLine.XPlat
 {
-    public class Program
+    internal class Program
     {
 #if DEBUG
         private const string DebugOption = "--debug";

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Properties/AssemblyInfo.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Properties/AssemblyInfo.cs
@@ -1,0 +1,13 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Runtime.CompilerServices;
+
+#if SIGNED_BUILD
+[assembly: InternalsVisibleTo("NuGet.XPlat.FuncTest, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2, PublicKey=0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7")]
+#else
+[assembly: InternalsVisibleTo("NuGet.XPlat.Test")]
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
+#endif

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/CommandLineUtility.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/CommandLineUtility.cs
@@ -12,7 +12,7 @@ namespace NuGet.CommandLine.XPlat
     /// <summary>
     /// This class holds common commandline helper methods.
     /// </summary>
-    public static class CommandLineUtility
+    internal static class CommandLineUtility
     {
         /// <summary>
         /// Helper method to join across multiple values of a commandline option.

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/CommandOutputLogger.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/CommandOutputLogger.cs
@@ -12,7 +12,7 @@ namespace NuGet.CommandLine.XPlat
     /// <summary>
     /// Logger to print formatted command output.
     /// </summary>
-    public class CommandOutputLogger : LegacyLoggerAdapter, ILogger
+    internal class CommandOutputLogger : LegacyLoggerAdapter, ILogger
     {
         private static readonly bool _useConsoleColor = true;
         private LogLevel _logLevel;

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/MSBuildAPIUtility.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/MSBuildAPIUtility.cs
@@ -19,7 +19,7 @@ using NuGet.Protocol.Core.Types;
 
 namespace NuGet.CommandLine.XPlat
 {
-    public class MSBuildAPIUtility
+    internal class MSBuildAPIUtility
     {
         private const string PACKAGE_REFERENCE_TYPE_TAG = "PackageReference";
         private const string VERSION_TAG = "Version";

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/TableParser.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/TableParser.cs
@@ -9,7 +9,7 @@ using System.Threading.Tasks;
 
 namespace NuGet.CommandLine.XPlat.Utility
 {
-    public static class TableParser
+    internal static class TableParser
     {
         internal static Task<IEnumerable<string>> ToStringTableAsync<T>(
           this IEnumerable<T> values,

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/TestCommandOutputLogger.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/TestCommandOutputLogger.cs
@@ -9,7 +9,7 @@ using NuGet.Test.Utility;
 
 namespace NuGet.XPlat.FuncTest
 {
-    public class TestCommandOutputLogger : CommandOutputLogger
+    internal class TestCommandOutputLogger : CommandOutputLogger
     {
         private readonly bool _observeLogLevel;
 

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatTestUtils.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatTestUtils.cs
@@ -209,14 +209,14 @@ namespace NuGet.XPlat.FuncTest
             return package;
         }
 
-        public static PackageReferenceArgs GetPackageReferenceArgs(string packageId, SimpleTestProjectContext project)
+        internal static PackageReferenceArgs GetPackageReferenceArgs(string packageId, SimpleTestProjectContext project)
         {
             var logger = new TestCommandOutputLogger();
             var packageDependency = new PackageDependency(packageId);
             return new PackageReferenceArgs(project.ProjectPath, packageDependency, logger);
         }
 
-        public static PackageReferenceArgs GetPackageReferenceArgs(string packageId, string packageVersion, SimpleTestProjectContext project,
+        internal static PackageReferenceArgs GetPackageReferenceArgs(string packageId, string packageVersion, SimpleTestProjectContext project,
             string frameworks = "", string packageDirectory = "", string sources = "", bool noRestore = false, bool noVersion = false)
         {
             var logger = new TestCommandOutputLogger();


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9821
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: Changed all `public` classes to `internal`. Added `InternalsVisibleTo` to test projects as necessary.

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  No product change.
Validation:  
