### PR TITLE
Reduce resource contention at solution load time cause by not blocking the threadpool thread

### DIFF
--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreWorker.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreWorker.cs
@@ -30,6 +30,7 @@ namespace NuGet.SolutionRestoreManager
     internal sealed class SolutionRestoreWorker : SolutionEventsListener, ISolutionRestoreWorker, IDisposable
     {
         private const int IdleTimeoutMs = 400;
+        private const int RequestQueueLimit = 150;
         private const int PromoteAttemptsLimit = 150;
         private const int DelayAutoRestoreRetries = 50;
         private const int DelaySolutionLoadRetry = 100;
@@ -45,7 +46,7 @@ namespace NuGet.SolutionRestoreManager
         private EnvDTE.SolutionEvents _solutionEvents;
         private CancellationTokenSource _workerCts;
         private AsyncLazy<bool> _backgroundJobRunner;
-        private AsyncQueue<SolutionRestoreRequest> _pendingRequests;
+        private Lazy<BlockingCollection<SolutionRestoreRequest>> _pendingRequests;
         private BackgroundRestoreOperation _pendingRestore;
         private Task<bool> _activeRestoreTask;
         private int _initialized;
@@ -244,13 +245,20 @@ namespace NuGet.SolutionRestoreManager
             _pendingRestore?.Dispose();
             _workerCts?.Dispose();
 
+            if (_pendingRequests?.IsValueCreated == true)
+            {
+                _pendingRequests.Value.Dispose();
+            }
+
             if (!isDisposing)
             {
                 _solutionLoadedEvent.Reset();
 
                 _workerCts = new CancellationTokenSource();
 
-                _pendingRequests = new AsyncQueue<SolutionRestoreRequest>();
+                _pendingRequests = new Lazy<BlockingCollection<SolutionRestoreRequest>>(
+                    () => new BlockingCollection<SolutionRestoreRequest>(RequestQueueLimit));
+
                 _pendingRestore = new BackgroundRestoreOperation();
                 _activeRestoreTask = Task.FromResult(true);
                 _restoreJobContext = new SolutionRestoreJobContext();
@@ -303,7 +311,7 @@ namespace NuGet.SolutionRestoreManager
 
                     // check if there are already pending restore request or active restore task
                     // then don't initiate a new background job runner.
-                    if (_pendingRequests.Count > 0 || IsBusy)
+                    if (_pendingRequests.Value.Count > 0 || IsBusy)
                     {
                         shouldStartNewBGJobRunner = false;
                     }
@@ -332,7 +340,7 @@ namespace NuGet.SolutionRestoreManager
                     }
 
                     // on-board request onto pending restore operation
-                    _pendingRequests.Enqueue(request);
+                    _pendingRequests.Value.TryAdd(request);
 
                     // When there is no current background restore job running, then start a new one.
                     // Otherwise, the current request will await the existing job to be completed.
@@ -446,7 +454,7 @@ namespace NuGet.SolutionRestoreManager
                 lock (_lockPendingRequestsObj)
                 {
                     // if no pending restore requests then shut down the restore job runner.
-                    if (_pendingRequests.Count == 0)
+                    if (_pendingRequests.Value.Count == 0)
                     {
                         break;
                     }
@@ -459,7 +467,7 @@ namespace NuGet.SolutionRestoreManager
                     {
                         // Blocks the execution until first request is scheduled
                         // Monitors the cancelllation token as well.
-                        var request = await _pendingRequests.DequeueAsync(token);
+                        var request = _pendingRequests.Value.Take(token);
 
                         token.ThrowIfCancellationRequested();
 
@@ -472,19 +480,21 @@ namespace NuGet.SolutionRestoreManager
                         var retries = 0;
 
                         // Drains the queue
-                        while (!_pendingRequests.IsCompleted
+                        while (!_pendingRequests.Value.IsCompleted
                             && !token.IsCancellationRequested)
                         {
+                            SolutionRestoreRequest next;
+
                             // check if there are pending nominations
                             var isAllProjectsNominated = await _solutionManager.Value.IsAllProjectsNominatedAsync();
 
-                            SolutionRestoreRequest next = await _pendingRequests.DequeueAsync()
-                                            .WithTimeout(TimeSpan.FromMilliseconds(IdleTimeoutMs))
-                                            .WithCancellation(token);
-                            if (next != null && isAllProjectsNominated)
+                            if (!_pendingRequests.Value.TryTake(out next, IdleTimeoutMs, token))
                             {
-                                // if we've got all the nominations then continue with the auto restore
-                                break;
+                                if (isAllProjectsNominated)
+                                {
+                                    // if we've got all the nominations then continue with the auto restore
+                                    break;
+                                }
                             }
 
                             // Upgrade request if necessary

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreWorker.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreWorker.cs
@@ -511,7 +511,7 @@ namespace NuGet.SolutionRestoreManager
                                 break;
                             }
 
-                            await Task.Delay(IdleTimeoutMs);
+                            await Task.Delay(IdleTimeoutMs, token);
 
                             if (!isAllProjectsNominated)
                             {

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreWorker.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreWorker.cs
@@ -488,7 +488,8 @@ namespace NuGet.SolutionRestoreManager
                             // check if there are pending nominations
                             var isAllProjectsNominated = await _solutionManager.Value.IsAllProjectsNominatedAsync();
 
-                            if (!_pendingRequests.Value.TryTake(out next, IdleTimeoutMs, token))
+                            // Try to get a request without a timeout. We don't want to *block* the threadpool thread.
+                            if (!_pendingRequests.Value.TryTake(out next, millisecondsTimeout: 0, token))
                             {
                                 if (isAllProjectsNominated)
                                 {
@@ -509,6 +510,8 @@ namespace NuGet.SolutionRestoreManager
                                 // we don't want to delay explicit solution restore request so just break at this time.
                                 break;
                             }
+
+                            await Task.Delay(IdleTimeoutMs);
 
                             if (!isAllProjectsNominated)
                             {


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9822
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: At solution load time, we listen for nominations and we try to batch as many of them into one restore operation.

We either wait for all projects to get nominated or for 20s.

Trick is we are waiting by blocking a threadpool thread: https://github.com/NuGet/NuGet.Client/blob/4a02c08cb2cfb87c77f0d378e361052944b8f3aa/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreWorker.cs#L491.

The fix is to check without a timeout so we don't block synchronously. 
This gives the other components in VS an extra thread to process things. 

On my home machine, this led from 1 failed restore at solution load time, to no failed restores due to missing nominations. 

This likely won't lead to a measurable improvement in *every* scenario, likely in large slns only, but threadpool threads are precious, so we shouldn't block them :) 

## Testing/Validation

Tests Added: No  
Reason for not adding tests: The infrastructure does not lend itself to easy testing.
Validation:  Lots of manual validation. 
