### PR TITLE
INuGetUILogger: Simplify by removing redundant APIs.

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/GeneralOptionControl.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/GeneralOptionControl.cs
@@ -7,10 +7,10 @@ using System.Diagnostics;
 using System.Windows.Forms;
 using Microsoft.VisualStudio.Shell;
 using NuGet.Commands;
+using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.PackageManagement.UI;
 using NuGet.PackageManagement.VisualStudio;
-using NuGet.ProjectManagement;
 using NuGet.VisualStudio;
 
 namespace NuGet.Options
@@ -190,12 +190,12 @@ namespace NuGet.Options
 
         private void LogError(string message)
         {
-            _outputConsoleLogger.Log(MessageLevel.Error, message);
+            _outputConsoleLogger.Log(new LogMessage(LogLevel.Error, message));
         }
 
         private void LogInformation(string message)
         {
-            _outputConsoleLogger.Log(MessageLevel.Info, message);
+            _outputConsoleLogger.Log(new LogMessage(LogLevel.Information, message));
         }
 
         private void OnLocalsCommandStatusTextLinkClicked(object sender, LinkClickedEventArgs e)

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/UserInterfaceService/NuGetUI.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/UserInterfaceService/NuGetUI.cs
@@ -353,7 +353,7 @@ namespace NuGet.PackageManagement.UI
                     ProjectContext.Log(MessageLevel.Error, ex.ToString());
                 }
 
-                UILogger.ReportError(ExceptionUtilities.DisplayMessage(ex, indent: false));
+                UILogger.ReportError(new LogMessage(LogLevel.Error, ExceptionUtilities.DisplayMessage(ex, indent: false)));
             }
         }
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/UserInterfaceService/NuGetUIProjectContext.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/UserInterfaceService/NuGetUIProjectContext.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Globalization;
 using System.Xml.Linq;
 using NuGet.Common;
 using NuGet.PackageManagement.VisualStudio;
@@ -43,9 +44,8 @@ namespace NuGet.PackageManagement.UI
 
         public void Log(ProjectManagement.MessageLevel level, string message, params object[] args)
         {
-            _logger.Log(level, message, args);
+            _logger.Log(new LogMessage(level.ToLogLevel(), string.Format(CultureInfo.CurrentCulture, message, args)));
         }
-
 
         public FileConflictAction ShowFileConflictResolution(string message)
         {
@@ -95,7 +95,7 @@ namespace NuGet.PackageManagement.UI
 
         public void ReportError(string message)
         {
-            _logger.ReportError(message);
+            _logger.ReportError(new LogMessage(LogLevel.Error, message));
         }
 
         public void Log(ILogMessage message)

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
@@ -19,7 +19,6 @@ using NuGet.Common;
 using NuGet.PackageManagement.VisualStudio;
 using NuGet.Protocol.Core.Types;
 using NuGet.VisualStudio;
-using NuGet.VisualStudio.Telemetry;
 using Mvs = Microsoft.VisualStudio.Shell;
 using Resx = NuGet.PackageManagement.UI;
 using Task = System.Threading.Tasks.Task;
@@ -263,7 +262,7 @@ namespace NuGet.PackageManagement.UI
                 // The user cancelled the login, but treat as a load error in UI
                 // So the retry button and message is displayed
                 // Do not log to the activity log, since it is not a NuGet error
-                _logger.Log(ProjectManagement.MessageLevel.Error, Resx.Resources.Text_UserCanceled);
+                _logger.Log(new LogMessage(LogLevel.Error, Resx.Resources.Text_UserCanceled));
 
                 _loadingStatusIndicator.SetError(Resx.Resources.Text_UserCanceled);
 
@@ -282,7 +281,7 @@ namespace NuGet.PackageManagement.UI
                 await _joinableTaskFactory.Value.SwitchToMainThreadAsync();
 
                 var errorMessage = ExceptionUtilities.DisplayMessage(ex);
-                _logger.Log(ProjectManagement.MessageLevel.Error, errorMessage);
+                _logger.Log(new LogMessage(LogLevel.Error, errorMessage));
 
                 _loadingStatusIndicator.SetError(errorMessage);
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/DefaultVSCredentialServiceProvider.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/DefaultVSCredentialServiceProvider.cs
@@ -11,7 +11,6 @@ using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using NuGet.Common;
 using NuGet.Credentials;
-using NuGet.ProjectManagement;
 using NuGet.Protocol.Plugins;
 using NuGet.VisualStudio;
 using IAsyncServiceProvider = Microsoft.VisualStudio.Shell.IAsyncServiceProvider;
@@ -144,10 +143,11 @@ namespace NuGet.PackageManagement.VisualStudio
         {
             // Log the user-friendly message to the output console (no stack trace).
             _outputConsoleLogger.Value.Log(
-                MessageLevel.Error,
-                failureMessage +
-                Environment.NewLine +
-                ExceptionUtilities.DisplayMessage(exception));
+                new LogMessage(
+                    LogLevel.Error,
+                    failureMessage +
+                    Environment.NewLine +
+                    ExceptionUtilities.DisplayMessage(exception)));
 
             // Write the stack trace to the activity log.
             ActivityLog.LogWarning(

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/PackageFeeds/MultiSourcePackageFeed.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/PackageFeeds/MultiSourcePackageFeed.cs
@@ -373,8 +373,9 @@ namespace NuGet.PackageManagement.VisualStudio
 
                 var errorMessage = ExceptionUtilities.DisplayMessage(task.Exception);
                 _logger.Log(
-                    ProjectManagement.MessageLevel.Error,
-                    $"[{state.ToString()}] {errorMessage}");
+                    new LogMessage(
+                        LogLevel.Error,
+                        $"[{state.ToString()}] {errorMessage}"));
             });
         }
     }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/OutputConsoleLogger.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/OutputConsoleLogger.cs
@@ -4,14 +4,12 @@
 using System;
 using System.ComponentModel.Composition;
 using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Threading;
 using NuGet.Common;
 using NuGet.PackageManagement.VisualStudio;
-using NuGet.ProjectManagement;
 using NuGet.VisualStudio.Telemetry;
 using Task = System.Threading.Tasks.Task;
 
@@ -107,26 +105,6 @@ namespace NuGet.VisualStudio.Common
             });
         }
 
-        public void Log(MessageLevel level, string message, params object[] args)
-        {
-            Run(async () =>
-            {
-                if (level == MessageLevel.Info
-                    || level == MessageLevel.Error
-                    || level == MessageLevel.Warning
-                    || _verbosityLevel > DefaultVerbosityLevel)
-                {
-                    if (args.Length > 0)
-                    {
-                        message = string.Format(CultureInfo.CurrentCulture, message, args);
-                    }
-
-                    await OutputConsole.WriteLineAsync(message);
-                }
-            },
-            $"{nameof(Log)}/{nameof(String)}");
-        }
-
         public void Log(ILogMessage message)
         {
             Run(async () =>
@@ -144,8 +122,7 @@ namespace NuGet.VisualStudio.Common
                         await ReportAsync(message);
                     }
                 }
-            },
-            $"{nameof(Log)}/{nameof(ILogMessage)}");
+            });
         }
 
         public void Start()
@@ -175,14 +152,9 @@ namespace NuGet.VisualStudio.Common
             return DefaultVerbosityLevel;
         }
 
-        public void ReportError(string message)
-        {
-            Run(() => ReportAsync(new LogMessage(LogLevel.Error, message)), $"{nameof(ReportError)}/{nameof(String)}");
-        }
-
         public void ReportError(ILogMessage message)
         {
-            Run(() => ReportAsync(message), $"{nameof(ReportError)}/{nameof(ILogMessage)}");
+            Run(() => ReportAsync(message));
         }
 
         private async Task ReportAsync(ILogMessage message)

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/UserInterfaceService/INuGetUILogger.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/UserInterfaceService/INuGetUILogger.cs
@@ -5,18 +5,21 @@ using NuGet.Common;
 
 namespace NuGet.PackageManagement.VisualStudio
 {
+    /// <summary> UI logger abstraction. </summary>
     public interface INuGetUILogger
     {
-        void Log(ProjectManagement.MessageLevel level, string message, params object[] args);
-
+        /// <summary> Log a message. </summary>
+        /// <param name="message"> Log message. </param>
         void Log(ILogMessage message);
 
-        void ReportError(string message);
-
+        /// <summary> Report an error or warning. </summary>
+        /// <param name="message"> Error or warning log message. </param>
         void ReportError(ILogMessage message);
 
+        /// <summary> Start the logging. </summary>
         void Start();
 
+        /// <summary> End the logging. </summary>
         void End();
     }
 }

--- a/src/NuGet.Core/NuGet.PackageManagement/INuGetProjectContext.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/INuGetProjectContext.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Xml.Linq;
 using NuGet.Common;
 using NuGet.Packaging;
@@ -54,62 +53,5 @@ namespace NuGet.ProjectManagement
         NuGetActionType ActionType { get; set; }
 
         Guid OperationId { get; set; }
-    }
-
-    /// <summary>
-    /// MessageLevel
-    /// </summary>
-    public enum MessageLevel
-    {
-        /// <summary>
-        /// Information
-        /// </summary>
-        Info,
-
-        /// <summary>
-        /// Warning
-        /// </summary>
-        Warning,
-
-        /// <summary>
-        /// Debug only
-        /// </summary>
-        Debug,
-
-        /// <summary>
-        /// Error
-        /// </summary>
-        Error
-    }
-
-    /// <summary>
-    /// Enum for the type of NuGetAction
-    /// </summary>
-    public enum NuGetActionType
-    {
-        /// <summary>
-        /// Install
-        /// </summary>
-        Install,
-
-        /// <summary>
-        /// Uninstall
-        /// </summary>
-        Uninstall,
-        
-        /// <summary>
-        /// Reinstall
-        /// </summary>
-        Reinstall,
-        
-        /// <summary>
-        /// Update
-        /// </summary>
-        Update,
-        
-        /// <summary>
-        /// UpdateAll
-        /// </summary>
-        UpdateAll
     }
 }

--- a/src/NuGet.Core/NuGet.PackageManagement/MessageLevel.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/MessageLevel.cs
@@ -1,0 +1,31 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGet.ProjectManagement
+{
+    /// <summary>
+    /// MessageLevel
+    /// </summary>
+    public enum MessageLevel
+    {
+        /// <summary>
+        /// Information
+        /// </summary>
+        Info,
+
+        /// <summary>
+        /// Warning
+        /// </summary>
+        Warning,
+
+        /// <summary>
+        /// Debug only
+        /// </summary>
+        Debug,
+
+        /// <summary>
+        /// Error
+        /// </summary>
+        Error
+    }
+}

--- a/src/NuGet.Core/NuGet.PackageManagement/MessageLevelExtensions.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/MessageLevelExtensions.cs
@@ -1,0 +1,26 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using NuGet.Common;
+
+namespace NuGet.ProjectManagement
+{
+    /// <summary> Extension methods for <see cref="MessageLevel"/>. </summary>
+    public static class MessageLevelExtensions
+    {
+        /// <summary> Convert <see cref="MessageLevel"/> to <see cref="LogLevel"/>. </summary>
+        /// <param name="messageLevel"> Message level. </param>
+        /// <returns> Corresponding log level. </returns>
+        public static LogLevel ToLogLevel(this MessageLevel messageLevel)
+        {
+            switch (messageLevel)
+            {
+                case MessageLevel.Error: return LogLevel.Error;
+                case MessageLevel.Warning: return LogLevel.Warning;
+                case MessageLevel.Info: return LogLevel.Information;
+                case MessageLevel.Debug: return LogLevel.Debug;
+                default: return LogLevel.Minimal;
+            }
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.PackageManagement/NuGetActionType.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/NuGetActionType.cs
@@ -1,0 +1,36 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGet.ProjectManagement
+{
+    /// <summary>
+    /// Enum for the type of NuGetAction
+    /// </summary>
+    public enum NuGetActionType
+    {
+        /// <summary>
+        /// Install
+        /// </summary>
+        Install,
+
+        /// <summary>
+        /// Uninstall
+        /// </summary>
+        Uninstall,
+        
+        /// <summary>
+        /// Reinstall
+        /// </summary>
+        Reinstall,
+        
+        /// <summary>
+        /// Update
+        /// </summary>
+        Update,
+        
+        /// <summary>
+        /// UpdateAll
+        /// </summary>
+        UpdateAll
+    }
+}


### PR DESCRIPTION
## Bug

Fixes: Part of https://github.com/NuGet/Home/issues/9815
Regression: No 

## Fix

Details: INuGetUILogger has pairs of similar APIs (`Log` and `ReportError`) which can be trivially replaced with just one of them accepting ILogMessage. That will help with unit testing of OutputConsoleLogger.

## Testing/Validation

Tests Added: No
Reason for not adding tests: Simple refactoring to eliminate redundant APIs.

