### PR TITLE
Downgraded the Nuget.Packaging project to net46

### DIFF
--- a/build/common.targets
+++ b/build/common.targets
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0">
   <!-- Compiler flags -->
-  <PropertyGroup Condition=" '$(TargetFramework)' == '$(NETFXTargetFramework)' ">
+  <PropertyGroup Condition=" ('$(TargetFramework)' == '$(NETFXTargetFramework)' OR  '$(TargetFramework)' == 'net46') ">
     <DefineConstants>$(DefineConstants);IS_DESKTOP</DefineConstants>
     <IsDesktop>true</IsDesktop>
   </PropertyGroup>
@@ -37,7 +37,7 @@
   <ImportGroup Condition=" '$(SkipSigning)' != 'true' ">
     <Import Project="sign.targets" />
   </ImportGroup>
-  
+
   <PropertyGroup Condition="'$(Shipping)' == 'true'">
     <SignTargetsForRealSigning>GetBuildOutputWithSigningMetadata</SignTargetsForRealSigning>
     <SymbolTargetsToGetPdbs>GetDebugSymbolsProjectOutput</SymbolTargetsToGetPdbs>
@@ -72,7 +72,7 @@
     <OutputPath>bin\$(VisualStudioVersion)\$(Configuration)</OutputPath>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
-    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath> 
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
   </PropertyGroup>
 
@@ -119,7 +119,7 @@
 
   <!--
     ============================================================
-    GetSymbolsToIndex - gets the list of DLLs,EXEs and PDBs that 
+    GetSymbolsToIndex - gets the list of DLLs,EXEs and PDBs that
     need to be indexed on the symbol server
     ============================================================
   -->
@@ -135,7 +135,7 @@
           ItemName="SymbolFilesToIndex" />
     </MSBuild>
   </Target>
-  
+
   <!--
     ============================================================
     GetSigningInputs - gets the list of DLLs that need to
@@ -255,7 +255,7 @@
 
   <!--
     ============================================================
-    GetLocalizedFilesForVsix - gathers the list of localized DLLs 
+    GetLocalizedFilesForVsix - gathers the list of localized DLLs
     from each project
     ============================================================
   -->

--- a/src/NuGet.Core/NuGet.Common/NuGet.Common.csproj
+++ b/src/NuGet.Core/NuGet.Common/NuGet.Common.csproj
@@ -1,10 +1,10 @@
-<Project>
+﻿<Project>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common.props" />
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
   <PropertyGroup>
     <Description>Common utilities and interfaces for all NuGet libraries.</Description>
-    <TargetFrameworks>$(TargetFrameworksLibrary)</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksLibrary);net46</TargetFrameworks>
     <TargetFramework />
     <NoWarn>$(NoWarn);CS1591;CS1574</NoWarn>
     <PackProject>true</PackProject>
@@ -21,6 +21,10 @@
   <ItemGroup Condition=" '$(TargetFramework)' == '$(NETFXTargetFramework)' ">
     <Reference Include="System.Core" />
     <Reference Include="System.IO.Compression" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.IO.Compression" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -42,6 +46,6 @@
     </EmbeddedResource>
   </ItemGroup>
 
-  <Import Project="$(BuildCommonDirectory)common.targets"/>
+  <Import Project="$(BuildCommonDirectory)common.targets" />
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 </Project>

--- a/src/NuGet.Core/NuGet.Configuration/NuGet.Configuration.csproj
+++ b/src/NuGet.Core/NuGet.Configuration/NuGet.Configuration.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <Description>NuGet's configuration settings implementation.</Description>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
-    <TargetFrameworks>$(TargetFrameworksLibrary)</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksLibrary);net46</TargetFrameworks>
     <TargetFramework />
     <PackProject>true</PackProject>
     <Shipping>true</Shipping>
@@ -17,7 +17,7 @@
     <TargetFrameworks />
     <TargetFramework>$(NETFXTargetFramework)</TargetFramework>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <ProjectReference Include="$(NuGetCoreSrcDirectory)NuGet.Common\NuGet.Common.csproj" />
   </ItemGroup>
@@ -28,10 +28,10 @@
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == '$(NetStandardVersion)' ">
+  <ItemGroup Condition=" ('$(TargetFramework)' == '$(NetStandardVersion)' OR '$(TargetFramework)' == 'net46') ">
     <PackageReference Include="System.Security.Cryptography.ProtectedData" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <Compile Update="Resources.Designer.cs">
       <DesignTime>True</DesignTime>
@@ -47,6 +47,6 @@
     </EmbeddedResource>
   </ItemGroup>
 
-  <Import Project="$(BuildCommonDirectory)common.targets"/>
+  <Import Project="$(BuildCommonDirectory)common.targets" />
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 </Project>

--- a/src/NuGet.Core/NuGet.Packaging/NuGet.Packaging.csproj
+++ b/src/NuGet.Core/NuGet.Packaging/NuGet.Packaging.csproj
@@ -8,7 +8,7 @@
 
   <PropertyGroup>
     <Description>NuGet's understanding of packages. Reading nuspec, nupkgs and package signing.</Description>
-    <TargetFrameworks>$(TargetFrameworksLibrary)</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksLibrary);net46</TargetFrameworks>
     <TargetFramework />
     <NoWarn>$(NoWarn);CS1591;CS1574;CS1573;CS1572</NoWarn>
     <NoWarn Condition=" $(TargetFramework.StartsWith('netstandard')) OR $(TargetFramework.StartsWith('netcoreapp'))">$(NoWarn);CS0414</NoWarn>
@@ -45,6 +45,12 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="System.IO.Compression" Version="4.3.0" />
+    <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.1" />
+    <PackageReference Include="System.Security.Cryptography.Encoding" Version="4.3.0" />
+    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="4.5.2" />
+    <PackageReference Include="System.Security.Cryptography.X509Certificates" Version="4.3.2" />
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(IsCore)' == 'true' ">

--- a/src/NuGet.Core/NuGet.Packaging/NuGet.Packaging.csproj
+++ b/src/NuGet.Core/NuGet.Packaging/NuGet.Packaging.csproj
@@ -45,6 +45,9 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
     <PackageReference Include="System.IO.Compression" Version="4.3.0" />
     <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.1" />
     <PackageReference Include="System.Security.Cryptography.Encoding" Version="4.3.0" />

--- a/src/NuGet.Core/NuGet.Versioning/NuGet.Versioning.csproj
+++ b/src/NuGet.Core/NuGet.Versioning/NuGet.Versioning.csproj
@@ -3,7 +3,7 @@
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksLibrary)</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksLibrary);net46</TargetFrameworks>
     <TargetFramework />
     <Description>NuGet's implementation of Semantic Versioning.</Description>
     <PackageTags>semver;semantic versioning</PackageTags>


### PR DESCRIPTION
Teams within Visual Studio have a need to bring down and install Nuget Packages during VS installation to increase "first run" performance and support offline scenarios.  Currently, however, Nuget packages are not considered first-class objects within Visual Studio. 

To make Nuget packages first-class objects, we are adding Nupkg extraction support in the VS Installer, allowing VS teams to author SWR files to pull down NuGet Packages during VS install time where they will be extracted by the VS Setup engine and installed into a centralized, Visual Studio owned fallback folder to pre-seed dependencies for performance and offline scenarios.

In order to make this work, Visual Studio Installer will reference the Nuget.Packaging project.  However, this project currently targets net472 while VS Installer targets 4.5.  Our proposal is to add support for 4.6 in both projects.   VS Installer will upgrade to 4.6 while Nuget Packaging will add down level support for 4.6.

## Testing/Validation

In Progress.
