### PR TITLE
avoid appdomain for markup compilation for PM.UI.dll to work around MSB3061

### DIFF
--- a/src/NuGet.Clients/NuGet.Console/NuGet.Console.csproj
+++ b/src/NuGet.Clients/NuGet.Console/NuGet.Console.csproj
@@ -13,6 +13,7 @@
     <Description>Package Manager PowerShell Console implementation.</Description>
     <TargetFrameworkProfile />
     <TargetFrameworkVersion>$(NETFXTargetFrameworkVersion)</TargetFrameworkVersion>
+    <AlwaysCompileMarkupFilesInSeparateDomain>false</AlwaysCompileMarkupFilesInSeparateDomain>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/NuGet.PackageManagement.UI.csproj
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/NuGet.PackageManagement.UI.csproj
@@ -21,6 +21,7 @@
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>3b445626</NuGetPackageImportStamp>
     <TargetFrameworkVersion>$(NETFXTargetFrameworkVersion)</TargetFrameworkVersion>
+    <AlwaysCompileMarkupFilesInSeparateDomain>false</AlwaysCompileMarkupFilesInSeparateDomain>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
     <DefineConstants>TRACE;DEBUG;VS15</DefineConstants>


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Client.Engineering/issues/311
Regression: No, but it has gotten worse lately

## Fix

Details: 
Deletion of a temp copy of NuGet.PackageManagement.UI.dll fails sometimes...and recently more often.

Related Forum post: https://social.msdn.microsoft.com/Forums/en-US/6360a1e3-a269-457c-a763-fb415b8bbf14/quotbecause-it-is-being-used-by-another-processquot-error-has-me-dead-in-the-water?forum=msbuild

The markup compiler will optionally use that appdomain to isolate reference assemblies.
Tearing down an appdomain may change timing, which may block deletion of the dll shortly thereafter by CleanupTemporaryTargetAssembly target from Microsoft.winfx.targets.

This workaround, sets AlwaysCompileMarkupFilesInSeparateDomain to false.

## Testing/Validation

Tests Added: No
Validation:  CI build succeeded
