### PR TITLE
Fix 'Directory.Packages.props' import logic

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.targets
@@ -11,12 +11,14 @@ Copyright (c) .NET Foundation. All rights reserved.
 ***********************************************************************************************
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
   <!-- Load NuGet.Build.Tasks.Pack.dll, this can be overridden to use a different version with $(NuGetPackTaskAssemblyFile) -->
   <PropertyGroup Condition="$(NuGetPackTaskAssemblyFile) == ''">
     <NuGetPackTaskAssemblyFile Condition="'$(MSBuildRuntimeType)' == 'Core'">..\CoreCLR\NuGet.Build.Tasks.Pack.dll</NuGetPackTaskAssemblyFile>
     <NuGetPackTaskAssemblyFile Condition="'$(MSBuildRuntimeType)' != 'Core'">..\Desktop\NuGet.Build.Tasks.Pack.dll</NuGetPackTaskAssemblyFile>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>
+
   <UsingTask TaskName="NuGet.Build.Tasks.Pack.PackTask" AssemblyFile="$(NuGetPackTaskAssemblyFile)" />
   <UsingTask TaskName="NuGet.Build.Tasks.Pack.GetPackOutputItemsTask" AssemblyFile="$(NuGetPackTaskAssemblyFile)" />
   <UsingTask TaskName="NuGet.Build.Tasks.GetProjectTargetFrameworksTask" AssemblyFile="$(NuGetPackTaskAssemblyFile)" />
@@ -48,15 +50,19 @@ Copyright (c) .NET Foundation. All rights reserved.
     <AllowedOutputExtensionsInSymbolsPackageBuildOutputFolder Condition="'$(SymbolPackageFormat)' == 'snupkg'">.pdb</AllowedOutputExtensionsInSymbolsPackageBuildOutputFolder>
     <SuppressDependenciesWhenPacking Condition="'$(SuppressDependenciesWhenPacking)' == ''">false</SuppressDependenciesWhenPacking>
   </PropertyGroup>
+
   <PropertyGroup Condition="'$(NoBuild)' == 'true' or '$(GeneratePackageOnBuild)' == 'true'">
     <GenerateNuspecDependsOn>$(GenerateNuspecDependsOn)</GenerateNuspecDependsOn>
   </PropertyGroup>
+
   <PropertyGroup Condition="'$(NoBuild)' != 'true' and '$(GeneratePackageOnBuild)' != 'true'">
     <GenerateNuspecDependsOn>Build;$(GenerateNuspecDependsOn)</GenerateNuspecDependsOn>
   </PropertyGroup>
+
   <ItemGroup>
     <ProjectCapability Include="Pack"/>
   </ItemGroup>
+
   <ItemDefinitionGroup>
     <BuildOutputInPackage>
       <TargetFramework>$(TargetFramework)</TargetFramework>
@@ -99,17 +105,17 @@ Copyright (c) .NET Foundation. All rights reserved.
     Returns="@(_TargetFrameworks)">
 
     <PropertyGroup>
-      <_ProjectFrameworks></_ProjectFrameworks>
+      <_ProjectFrameworks/>
     </PropertyGroup>
 
       <GetProjectTargetFrameworksTask
-      ProjectPath="$(MSBuildProjectFullPath)"
-      TargetFrameworks="$(TargetFrameworks)"
-      TargetFramework="$(TargetFramework)"
-      TargetFrameworkMoniker="$(TargetFrameworkMoniker)"
-      TargetPlatformIdentifier="$(TargetPlatformIdentifier)"
-      TargetPlatformVersion="$(TargetPlatformVersion)"
-      TargetPlatformMinVersion="$(TargetPlatformMinVersion)">
+        ProjectPath="$(MSBuildProjectFullPath)"
+        TargetFrameworks="$(TargetFrameworks)"
+        TargetFramework="$(TargetFramework)"
+        TargetFrameworkMoniker="$(TargetFrameworkMoniker)"
+        TargetPlatformIdentifier="$(TargetPlatformIdentifier)"
+        TargetPlatformVersion="$(TargetPlatformVersion)"
+        TargetPlatformMinVersion="$(TargetPlatformMinVersion)">
       <Output
         TaskParameter="ProjectTargetFrameworks"
         PropertyName="_ProjectFrameworks" />
@@ -282,8 +288,8 @@ Copyright (c) .NET Foundation. All rights reserved.
       <PackProjectInputFile>$(MSBuildProjectFullPath)</PackProjectInputFile>
     </PropertyGroup>
   </Target>
-  
-  <Target Name="_GetProjectReferenceVersions" 
+
+  <Target Name="_GetProjectReferenceVersions"
           Condition="'$(NuspecFile)' == ''"
           DependsOnTargets="_CalculateInputsOutputsForPack;$(GetPackageVersionDependsOn)">
     <ConvertToAbsolutePath Paths="$(RestoreOutputPath)">
@@ -302,7 +308,7 @@ Copyright (c) .NET Foundation. All rights reserved.
         ItemName="_ProjectReferencesFromAssetsFile" />
     </GetProjectReferencesFromAssetsFileTask>
 
-    <Msbuild
+    <MSBuild
       Projects="@(_ProjectReferencesFromAssetsFile)"
       Targets="_GetProjectVersion"
       SkipNonexistentTargets="true"
@@ -311,7 +317,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <Output
         TaskParameter="TargetOutputs"
         ItemName="_ProjectReferencesWithVersions"/>
-    </Msbuild>
+    </MSBuild>
   </Target>
 
   <Target Name="_GetProjectVersion" DependsOnTargets="$(GetPackageVersionDependsOn)"
@@ -402,12 +408,12 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Target Name ="_GetFrameworkAssemblyReferences" DependsOnTargets="ResolveReferences" Returns="@(TfmSpecificFrameworkAssemblyReferences)">
     <ItemGroup>
       <TfmSpecificFrameworkAssemblyReferences Include="@(ReferencePath->'%(OriginalItemSpec)')"
-      Condition="'%(ReferencePath.Pack)' != 'false' AND '%(ReferencePath.ResolvedFrom)' == '{TargetFrameworkDirectory}'">
+        Condition="'%(ReferencePath.Pack)' != 'false' AND '%(ReferencePath.ResolvedFrom)' == '{TargetFrameworkDirectory}'">
         <TargetFramework>$(TargetFramework)</TargetFramework>
       </TfmSpecificFrameworkAssemblyReferences>
     </ItemGroup>
   </Target>
-  
+
   <Target Name="_GetBuildOutputFilesWithTfm"
           DependsOnTargets="BuiltProjectOutputGroup;DocumentationProjectOutputGroup;SatelliteDllsProjectOutputGroup;_AddPriFileToPackBuildOutput;$(TargetsForTfmSpecificBuildOutput)"
           Returns="@(BuildOutputInPackage)">
@@ -468,47 +474,48 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- Include PackageFiles and Content of the project being packed -->
     <ItemGroup>
       <_PackageFiles Include="@(Content)" Condition=" %(Content.Pack) != 'false' ">
-        <BuildAction Condition = "'%(Content.BuildAction)' == ''">Content</BuildAction>
+        <BuildAction Condition="'%(Content.BuildAction)' == ''">Content</BuildAction>
       </_PackageFiles>
       <_PackageFiles Include="@(Compile)" Condition=" %(Compile.Pack) == 'true' ">
-        <BuildAction Condition = "'%(Compile.BuildAction)' == ''">Compile</BuildAction>
+        <BuildAction Condition="'%(Compile.BuildAction)' == ''">Compile</BuildAction>
       </_PackageFiles>
       <_PackageFiles Include="@(None)" Condition=" %(None.Pack) == 'true' ">
-        <BuildAction Condition = "'%(None.BuildAction)' == ''">None</BuildAction>
+        <BuildAction Condition="'%(None.BuildAction)' == ''">None</BuildAction>
       </_PackageFiles>
       <_PackageFiles Include="@(EmbeddedResource)" Condition=" %(EmbeddedResource.Pack) == 'true' ">
-        <BuildAction Condition = "'%(EmbeddedResource.BuildAction)' == ''">EmbeddedResource</BuildAction>
+        <BuildAction Condition="'%(EmbeddedResource.BuildAction)' == ''">EmbeddedResource</BuildAction>
       </_PackageFiles>
       <_PackageFiles Include="@(ApplicationDefinition)" Condition=" %(ApplicationDefinition.Pack) == 'true' ">
-        <BuildAction Condition = "'%(ApplicationDefinition.BuildAction)' == ''">ApplicationDefinition</BuildAction>
+        <BuildAction Condition="'%(ApplicationDefinition.BuildAction)' == ''">ApplicationDefinition</BuildAction>
       </_PackageFiles>
       <_PackageFiles Include="@(Page)" Condition=" %(Page.Pack) == 'true' ">
-        <BuildAction Condition = "'%(Page.BuildAction)' == ''">Page</BuildAction>
+        <BuildAction Condition="'%(Page.BuildAction)' == ''">Page</BuildAction>
       </_PackageFiles>
       <_PackageFiles Include="@(Resource)" Condition=" %(Resource.Pack) == 'true' ">
-        <BuildAction Condition = "'%(Resource.BuildAction)' == ''">Resource</BuildAction>
+        <BuildAction Condition="'%(Resource.BuildAction)' == ''">Resource</BuildAction>
       </_PackageFiles>
       <_PackageFiles Include="@(SplashScreen)" Condition=" %(SplashScreen.Pack) == 'true' ">
-        <BuildAction Condition = "'%(SplashScreen.BuildAction)' == ''">SplashScreen</BuildAction>
+        <BuildAction Condition="'%(SplashScreen.BuildAction)' == ''">SplashScreen</BuildAction>
       </_PackageFiles>
       <_PackageFiles Include="@(DesignData)" Condition=" %(DesignData.Pack) == 'true' ">
-        <BuildAction Condition = "'%(DesignData.BuildAction)' == ''">DesignData</BuildAction>
+        <BuildAction Condition="'%(DesignData.BuildAction)' == ''">DesignData</BuildAction>
       </_PackageFiles>
       <_PackageFiles Include="@(DesignDataWithDesignTimeCreatableTypes)" Condition=" %(DesignDataWithDesignTimeCreatableTypes.Pack) == 'true' ">
-        <BuildAction Condition = "'%(DesignDataWithDesignTimeCreatableTypes.BuildAction)' == ''">DesignDataWithDesignTimeCreatableTypes</BuildAction>
+        <BuildAction Condition="'%(DesignDataWithDesignTimeCreatableTypes.BuildAction)' == ''">DesignDataWithDesignTimeCreatableTypes</BuildAction>
       </_PackageFiles>
       <_PackageFiles Include="@(CodeAnalysisDictionary)" Condition=" %(CodeAnalysisDictionary.Pack) == 'true' ">
-        <BuildAction Condition = "'%(CodeAnalysisDictionary.BuildAction)' == ''">CodeAnalysisDictionary</BuildAction>
+        <BuildAction Condition="'%(CodeAnalysisDictionary.BuildAction)' == ''">CodeAnalysisDictionary</BuildAction>
       </_PackageFiles>
       <_PackageFiles Include="@(AndroidAsset)" Condition=" %(AndroidAsset.Pack) == 'true' ">
-        <BuildAction Condition = "'%(AndroidAsset.BuildAction)' == ''">AndroidAsset</BuildAction>
+        <BuildAction Condition="'%(AndroidAsset.BuildAction)' == ''">AndroidAsset</BuildAction>
       </_PackageFiles>
       <_PackageFiles Include="@(AndroidResource)" Condition=" %(AndroidResource.Pack) == 'true' ">
-        <BuildAction Condition = "'%(AndroidResource.BuildAction)' == ''">AndroidResource</BuildAction>
+        <BuildAction Condition="'%(AndroidResource.BuildAction)' == ''">AndroidResource</BuildAction>
       </_PackageFiles>
       <_PackageFiles Include="@(BundleResource)" Condition=" %(BundleResource.Pack) == 'true' ">
-        <BuildAction Condition = "'%(BundleResource.BuildAction)' == ''">BundleResource</BuildAction>
+        <BuildAction Condition="'%(BundleResource.BuildAction)' == ''">BundleResource</BuildAction>
       </_PackageFiles>
     </ItemGroup>
   </Target>
+
 </Project>

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.targets
@@ -19,6 +19,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>
 
+  <!-- Tasks -->
   <UsingTask TaskName="NuGet.Build.Tasks.Pack.PackTask" AssemblyFile="$(NuGetPackTaskAssemblyFile)" />
   <UsingTask TaskName="NuGet.Build.Tasks.Pack.GetPackOutputItemsTask" AssemblyFile="$(NuGetPackTaskAssemblyFile)" />
   <UsingTask TaskName="NuGet.Build.Tasks.GetProjectTargetFrameworksTask" AssemblyFile="$(NuGetPackTaskAssemblyFile)" />

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.RestoreEx.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.RestoreEx.targets
@@ -1,5 +1,11 @@
 <!--
 ***********************************************************************************************
+NuGet.RestoreEx.targets
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
 Copyright (c) .NET Foundation. All rights reserved.
 ***********************************************************************************************
 -->
@@ -9,6 +15,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <UsingTask TaskName="NuGet.Build.Tasks.RestoreTaskEx" AssemblyFile="$(RestoreTaskAssemblyFile)" />
 
   <Target Name="Restore">
+    <!-- Restore using MSBuild's Static Graph Evaluation -->
     <RestoreTaskEx
         CleanupAssetsForUnsupportedProjects="$([MSBuild]::ValueOrDefault('$(RestoreCleanupAssetsForUnsupportedProjects)', 'true'))"
         DisableParallel="$(RestoreDisableParallel)"

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.RestoreEx.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.RestoreEx.targets
@@ -3,7 +3,9 @@
 Copyright (c) .NET Foundation. All rights reserved.
 ***********************************************************************************************
 -->
+
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
   <UsingTask TaskName="NuGet.Build.Tasks.RestoreTaskEx" AssemblyFile="$(RestoreTaskAssemblyFile)" />
 
   <Target Name="Restore">
@@ -22,4 +24,5 @@ Copyright (c) .NET Foundation. All rights reserved.
         RestorePackagesConfig="$(RestorePackagesConfig)"
         SolutionPath="$(SolutionPath)" />
   </Target>
+
 </Project>

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.props
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.props
@@ -10,22 +10,26 @@ Copyright (c) .NET Foundation. All rights reserved.
 ***********************************************************************************************
 -->
 
-<Project>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <!--
+      Import 'Directory.Packages.props'
+  -->
+
   <PropertyGroup>
     <ImportDirectoryPackagesProps Condition="'$(ImportDirectoryPackagesProps)' == ''">true</ImportDirectoryPackagesProps>
   </PropertyGroup>
-  <!-- 
-        Import Directory.Packages.props.
-    -->
+
   <PropertyGroup Condition="'$(ImportDirectoryPackagesProps)' == 'true' and '$(DirectoryPackagesPropsPath)' == ''">
     <_DirectoryPackagesPropsFile Condition="'$(_DirectoryPackagesPropsFile)' == ''">Directory.Packages.props</_DirectoryPackagesPropsFile>
     <_DirectoryPackagesPropsBasePath Condition="'$(_DirectoryPackagesPropsBasePath)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), '$(_DirectoryPackagesPropsFile)'))</_DirectoryPackagesPropsBasePath>
     <DirectoryPackagesPropsPath Condition="'$(_DirectoryPackagesPropsBasePath)' != '' and '$(_DirectoryPackagesPropsFile)' != ''">$([MSBuild]::GetPathOfFileAbove('$(_DirectoryPackagesPropsFile)', '$(MSBuildProjectDirectory)'))</DirectoryPackagesPropsPath>
   </PropertyGroup>
 
-  <Import Project="$(DirectoryPackagesPropsPath)" Condition="'$(ImportDirectoryPackagesProps)' == 'true' and '$(DirectoryPackagesPropsPath)' != '' and exists('$(DirectoryPackagesPropsPath)')"/>
+  <Import Project="$(DirectoryPackagesPropsPath)" Condition="'$(ImportDirectoryPackagesProps)' == 'true' and '$(DirectoryPackagesPropsPath)' != '' and Exists('$(DirectoryPackagesPropsPath)')"/>
 
-  <PropertyGroup Condition="'$(ImportDirectoryPackagesProps)' == 'true' and '$(DirectoryPackagesPropsPath)' != '' and exists('$(DirectoryPackagesPropsPath)')">
+  <PropertyGroup Condition="'$(ImportDirectoryPackagesProps)' == 'true' and '$(DirectoryPackagesPropsPath)' != '' and Exists('$(DirectoryPackagesPropsPath)')">
     <CentralPackageVersionsFileImported>true</CentralPackageVersionsFileImported>
   </PropertyGroup>
+
 </Project>

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.props
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.props
@@ -13,17 +13,23 @@ Copyright (c) .NET Foundation. All rights reserved.
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <!--
-      Import 'Directory.Packages.props'
+      Import 'Directory.Packages.props' which will contain centralized packages for all the projects and solutions under
+      the directory in which the file is present. This is similar to 'Directory.Build.props/targets' logic which is present
+      in the common props/targets which serve a similar purpose.
   -->
 
   <PropertyGroup>
     <ImportDirectoryPackagesProps Condition="'$(ImportDirectoryPackagesProps)' == ''">true</ImportDirectoryPackagesProps>
   </PropertyGroup>
 
+  <!--
+      Determine the path to the 'Directory.Packages.props' file, if the user did not disable $(ImportDirectoryPackagesProps) and
+      they did not already specify an absolute path to use via $(DirectoryPackagesPropsPath)
+  -->
   <PropertyGroup Condition="'$(ImportDirectoryPackagesProps)' == 'true' and '$(DirectoryPackagesPropsPath)' == ''">
     <_DirectoryPackagesPropsFile Condition="'$(_DirectoryPackagesPropsFile)' == ''">Directory.Packages.props</_DirectoryPackagesPropsFile>
-    <_DirectoryPackagesPropsBasePath Condition="'$(_DirectoryPackagesPropsBasePath)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), '$(_DirectoryPackagesPropsFile)'))</_DirectoryPackagesPropsBasePath>
-    <DirectoryPackagesPropsPath Condition="'$(_DirectoryPackagesPropsBasePath)' != '' and '$(_DirectoryPackagesPropsFile)' != ''">$([MSBuild]::GetPathOfFileAbove('$(_DirectoryPackagesPropsFile)', '$(MSBuildProjectDirectory)'))</DirectoryPackagesPropsPath>
+    <_DirectoryPackagesPropsBasePath Condition="'$(_DirectoryPackagesPropsBasePath)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove('$(MSBuildProjectDirectory)', '$(_DirectoryPackagesPropsFile)'))</_DirectoryPackagesPropsBasePath>
+    <DirectoryPackagesPropsPath Condition="'$(_DirectoryPackagesPropsBasePath)' != '' and '$(_DirectoryPackagesPropsFile)' != ''">$([MSBuild]::NormalizePath('$(_DirectoryPackagesPropsBasePath)', '$(_DirectoryPackagesPropsFile)'))</DirectoryPackagesPropsPath>
   </PropertyGroup>
 
   <Import Project="$(DirectoryPackagesPropsPath)" Condition="'$(ImportDirectoryPackagesProps)' == 'true' and '$(DirectoryPackagesPropsPath)' != '' and Exists('$(DirectoryPackagesPropsPath)')"/>

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -33,6 +33,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   4. DotnetCliTool references
   -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
   <PropertyGroup>
     <!-- Mark that this target file has been loaded.  -->
     <IsRestoreTargetsFileLoaded>true</IsRestoreTargetsFileLoaded>
@@ -52,7 +53,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <RestoreBuildInParallel Condition=" '$(BuildInParallel)' != '' ">$(BuildInParallel)</RestoreBuildInParallel>
     <RestoreBuildInParallel Condition=" '$(RestoreBuildInParallel)' == '' ">true</RestoreBuildInParallel>
     <!-- Check if the restore target was executed on a sln file -->
-    <_RestoreSolutionFileUsed Condition=" '$(_RestoreSolutionFileUsed)' == '' AND '$(SolutionDir)' != '' AND $(MSBuildProjectFullPath.EndsWith('.metaproj')) == 'true' " >true</_RestoreSolutionFileUsed>
+    <_RestoreSolutionFileUsed Condition=" '$(_RestoreSolutionFileUsed)' == '' AND '$(SolutionDir)' != '' AND $(MSBuildProjectFullPath.EndsWith('.metaproj')) == 'true' ">true</_RestoreSolutionFileUsed>
     <!-- We default to MSBuildInteractive. -->
     <NuGetInteractive Condition=" '$(NuGetInteractive)' == '' ">$(MSBuildInteractive)</NuGetInteractive>
     <!-- Mark that this targets file supports package download. -->
@@ -180,7 +181,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     ============================================================
   -->
   <Target Name="CollectCentralPackageVersions" Returns="@(PackageVersion)" />
-  
+
   <!--
     ============================================================
     CollectPackageDownloads
@@ -279,7 +280,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <!-- Remove projects that do not support restore. -->
     <!-- With SkipNonexistentTargets support -->
-    <MsBuild Condition=" '$(RestoreUseSkipNonexistentTargets)' == 'true' "
+    <MSBuild Condition=" '$(RestoreUseSkipNonexistentTargets)' == 'true' "
         BuildInParallel="$(RestoreBuildInParallel)"
         Projects="@(FilteredRestoreGraphProjectInputItemsWithoutDuplicates)"
         Targets="_IsProjectRestoreSupported"
@@ -289,10 +290,10 @@ Copyright (c) .NET Foundation. All rights reserved.
       <Output
           TaskParameter="TargetOutputs"
           ItemName="FilteredRestoreGraphProjectInputItems" />
-    </MsBuild>
+    </MSBuild>
 
     <!-- Without SkipNonexistentTargets support -->
-    <MsBuild Condition=" '$(RestoreUseSkipNonexistentTargets)' != 'true' "
+    <MSBuild Condition=" '$(RestoreUseSkipNonexistentTargets)' != 'true' "
       Projects="@(FilteredRestoreGraphProjectInputItemsWithoutDuplicates)"
       Targets="_IsProjectRestoreSupported"
       ContinueOnError="$(RestoreContinueOnError)"
@@ -301,7 +302,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <Output
           TaskParameter="TargetOutputs"
           ItemName="FilteredRestoreGraphProjectInputItems" />
-    </MsBuild>
+    </MSBuild>
 
     <!-- Warn for projects that do not support restore. -->
     <WarnForInvalidProjectsTask
@@ -329,7 +330,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     </ItemGroup>
 
     <!-- Add top level entries to the direct restore list. These projects will also restore tools. -->
-    <MsBuild
+    <MSBuild
         BuildInParallel="$(RestoreBuildInParallel)"
         Projects="@(_GenerateRestoreGraphProjectEntryInput)"
         Targets="_GenerateRestoreGraphProjectEntry"
@@ -338,10 +339,10 @@ Copyright (c) .NET Foundation. All rights reserved.
       <Output
           TaskParameter="TargetOutputs"
           ItemName="_RestoreGraphEntry" />
-    </MsBuild>
+    </MSBuild>
 
     <!-- Generate a spec for every project including dependencies. -->
-    <MsBuild
+    <MSBuild
         BuildInParallel="$(RestoreBuildInParallel)"
         Projects="@(_RestoreProjectPathItems)"
         Targets="_GenerateProjectRestoreGraph"
@@ -350,7 +351,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <Output
           TaskParameter="TargetOutputs"
           ItemName="_RestoreGraphEntry" />
-    </MsBuild>
+    </MSBuild>
   </Target>
 
   <!--
@@ -502,7 +503,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     Returns="@(_RestoreTargetFrameworksOutputFiltered)">
 
     <PropertyGroup>
-      <_RestoreProjectFramework></_RestoreProjectFramework>
+      <_RestoreProjectFramework/>
     </PropertyGroup>
 
     <!-- For project.json projects target frameworks will be read from project.json. -->
@@ -555,21 +556,21 @@ Copyright (c) .NET Foundation. All rights reserved.
     </PropertyGroup>
     <!-- For transitive project styles, we rely on evaluating all the settings and including them in the dg spec to faciliate no-op restore-->
     <GetRestoreSettingsTask
-     ProjectUniqueName="$(MSBuildProjectFullPath)"
-     RestoreSources="$(RestoreSources)"
-     RestorePackagesPath="$(RestorePackagesPath)"
-     RestoreRepositoryPath="$(RestoreRepositoryPath)"
-     RestoreFallbackFolders="$(RestoreFallbackFolders)"
-     RestoreConfigFile="$(RestoreConfigFile)"
-     RestoreRootConfigDirectory="$(RestoreRootConfigDirectory)"
-     RestoreSolutionDirectory="$(RestoreSolutionDirectory)"
-     RestoreSettingsPerFramework="@(_RestoreSettingsPerFramework)"
-     RestorePackagesPathOverride="$(_RestorePackagesPathOverride)"
-     RestoreRepositoryPathOverride="$(_RestoreRepositoryPathOverride)"
-     RestoreSourcesOverride="$(_RestoreSourcesOverride)"
-     RestoreFallbackFoldersOverride="$(_RestoreFallbackFoldersOverride)"
-     RestoreProjectStyle="$(RestoreProjectStyle)"
-     MSBuildStartupDirectory="$(MSBuildStartupDirectory)">
+      ProjectUniqueName="$(MSBuildProjectFullPath)"
+      RestoreSources="$(RestoreSources)"
+      RestorePackagesPath="$(RestorePackagesPath)"
+      RestoreRepositoryPath="$(RestoreRepositoryPath)"
+      RestoreFallbackFolders="$(RestoreFallbackFolders)"
+      RestoreConfigFile="$(RestoreConfigFile)"
+      RestoreRootConfigDirectory="$(RestoreRootConfigDirectory)"
+      RestoreSolutionDirectory="$(RestoreSolutionDirectory)"
+      RestoreSettingsPerFramework="@(_RestoreSettingsPerFramework)"
+      RestorePackagesPathOverride="$(_RestorePackagesPathOverride)"
+      RestoreRepositoryPathOverride="$(_RestoreRepositoryPathOverride)"
+      RestoreSourcesOverride="$(_RestoreSourcesOverride)"
+      RestoreFallbackFoldersOverride="$(_RestoreFallbackFoldersOverride)"
+      RestoreProjectStyle="$(RestoreProjectStyle)"
+      MSBuildStartupDirectory="$(MSBuildStartupDirectory)">
       <Output
         TaskParameter="OutputSources"
         PropertyName="_OutputSources" />
@@ -655,7 +656,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <!-- Determine the restore output path -->
     <PropertyGroup Condition=" '$(PackageReferenceCompatibleProjectStyle)' == 'true' OR '$(RestoreProjectStyle)' == 'ProjectJson' ">
-      <RestoreOutputPath Condition=" '$(RestoreOutputPath)' == '' " >$(MSBuildProjectExtensionsPath)</RestoreOutputPath>
+      <RestoreOutputPath Condition=" '$(RestoreOutputPath)' == '' ">$(MSBuildProjectExtensionsPath)</RestoreOutputPath>
     </PropertyGroup>
 
     <ConvertToAbsolutePath Paths="$(RestoreOutputPath)" Condition=" '$(PackageReferenceCompatibleProjectStyle)' == 'true' OR '$(RestoreProjectStyle)' == 'ProjectJson'">
@@ -1107,7 +1108,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <!-- Walk projects -->
     <!-- With SkipNonexistentTargets -->
-    <MsBuild
+    <MSBuild
         Condition=" '$(RestoreUseSkipNonexistentTargets)' == 'true' "
         BuildInParallel="$(RestoreBuildInParallel)"
         Projects="@(FilteredRestoreGraphProjectInputItems)"
@@ -1119,10 +1120,10 @@ Copyright (c) .NET Foundation. All rights reserved.
       <Output
           TaskParameter="TargetOutputs"
           ItemName="_RestoreProjectPathItemsOutputs" />
-    </MsBuild>
+    </MSBuild>
 
     <!-- Without SkipNonexistentTargets -->
-    <MsBuild
+    <MSBuild
       Condition=" '$(RestoreUseSkipNonexistentTargets)' != 'true' "
       Projects="@(FilteredRestoreGraphProjectInputItems)"
       Targets="_GenerateRestoreProjectPathWalk"
@@ -1132,7 +1133,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <Output
           TaskParameter="TargetOutputs"
           ItemName="_RestoreProjectPathItemsOutputs" />
-    </MsBuild>
+    </MSBuild>
 
     <!-- Remove duplicates -->
     <RemoveDuplicates
@@ -1144,7 +1145,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <!-- Remove projects that do not support restore. -->
     <!-- With SkipNonexistentTargets -->
-    <MsBuild
+    <MSBuild
         Condition=" '$(RestoreUseSkipNonexistentTargets)' == 'true' "
         BuildInParallel="$(RestoreBuildInParallel)"
         Projects="@(_RestoreProjectPathItemsWithoutDupes)"
@@ -1156,10 +1157,10 @@ Copyright (c) .NET Foundation. All rights reserved.
       <Output
           TaskParameter="TargetOutputs"
           ItemName="_RestoreProjectPathItems" />
-    </MsBuild>
+    </MSBuild>
 
     <!-- Without SkipNonexistentTargets -->
-    <MsBuild
+    <MSBuild
       Condition=" '$(RestoreUseSkipNonexistentTargets)' != 'true' "
       Projects="@(_RestoreProjectPathItemsWithoutDupes)"
       Targets="_IsProjectRestoreSupported"
@@ -1169,7 +1170,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <Output
           TaskParameter="TargetOutputs"
           ItemName="_RestoreProjectPathItems" />
-    </MsBuild>
+    </MSBuild>
   </Target>
 
   <!--
@@ -1185,7 +1186,7 @@ Copyright (c) .NET Foundation. All rights reserved.
           Returns="$(_RestorePackagesPathOverride);$(_RestoreRepositoryPathOverride);$(_RestoreSourcesOverride);$(_RestoreFallbackFoldersOverride)">
 
     <!-- RestorePackagesPathOverride -->
-    <MsBuild
+    <MSBuild
         BuildInParallel="$(RestoreBuildInParallel)"
         Condition=" '$(RestorePackagesPath)' != '' "
         Projects="$(MSBuildThisFileFullPath)"
@@ -1194,10 +1195,10 @@ Copyright (c) .NET Foundation. All rights reserved.
       <Output
           TaskParameter="TargetOutputs"
           PropertyName="_RestorePackagesPathOverride" />
-    </MsBuild>
+    </MSBuild>
 
     <!-- RestoreRepositoryPathOverride -->
-    <MsBuild
+    <MSBuild
       BuildInParallel="$(RestoreBuildInParallel)"
       Condition=" '$(RestoreRepositoryPathOverride)' != '' "
       Projects="$(MSBuildThisFileFullPath)"
@@ -1206,10 +1207,10 @@ Copyright (c) .NET Foundation. All rights reserved.
       <Output
         TaskParameter="TargetOutputs"
         PropertyName="_RestoreRepositoryPathOverride" />
-    </MsBuild>
+    </MSBuild>
 
     <!-- RestoreSourcesOverride -->
-    <MsBuild
+    <MSBuild
         BuildInParallel="$(RestoreBuildInParallel)"
         Condition=" '$(RestoreSources)' != '' "
         Projects="$(MSBuildThisFileFullPath)"
@@ -1218,10 +1219,10 @@ Copyright (c) .NET Foundation. All rights reserved.
       <Output
           TaskParameter="TargetOutputs"
           PropertyName="_RestoreSourcesOverride" />
-    </MsBuild>
+    </MSBuild>
 
     <!-- RestoreFallbackFoldersOverride -->
-    <MsBuild
+    <MSBuild
         BuildInParallel="$(RestoreBuildInParallel)"
         Condition=" '$(RestoreFallbackFolders)' != '' "
         Projects="$(MSBuildThisFileFullPath)"
@@ -1230,7 +1231,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <Output
           TaskParameter="TargetOutputs"
           PropertyName="_RestoreFallbackFoldersOverride" />
-    </MsBuild>
+    </MSBuild>
   </Target>
 
   <!--
@@ -1306,4 +1307,5 @@ Copyright (c) .NET Foundation. All rights reserved.
     ============================================================
   -->
   <Import Project="NuGet.RestoreEx.targets" Condition="'$(RestoreUseStaticGraphEvaluation)' == 'true' And Exists('NuGet.RestoreEx.targets')" />
+
 </Project>


### PR DESCRIPTION
## Bug

The '_DirectoryPackagesPropsBasePath' property is not used in the import logic. When we do override it, the property is not respected. Thus we can't import the packages file from a custom directory.

Fixes: NuGet/Home#9841
Regression: No

## Fix

Details: The import logic is same as the 'Directory.Build.props' logic present in the common props. The fix is to match their logic. That's all!

> I have also formatted the props/targets to follow EditorConfig rules. I've also made sure that `git blame` doesn't break with these changes.
> If you want to take the formatting changes into a separate PR or drop them, please let me know.

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  It's same as the `Directory.Build.props` logic. Will add if we need them.
Validation:  Refer MSBuild's Common props