### PR TITLE
In PackageReference projects, the actual installed package versions are now read from the assets file. This allows the resolved version to be displayed in the PM UI.

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/NuGet.PackageManagement.VisualStudio.csproj
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/NuGet.PackageManagement.VisualStudio.csproj
@@ -171,6 +171,8 @@
     <Compile Include="Utility\EnvDTESolutionUtility.cs" />
     <Compile Include="Utility\FrameworkAssembly.cs" />
     <Compile Include="Utility\FrameworkAssemblyResolver.cs" />
+    <Compile Include="Utility\GetPackageReferenceUtility.cs" />
+    <Compile Include="Utility\ProjectInstalledPackage.cs" />
     <Compile Include="Utility\NativeMethods.cs" />
     <Compile Include="Utility\NuGetProjectUpgradeUtility.cs" />
     <Compile Include="Utility\ProjectRetargetingUtility.cs" />

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Utility/GetPackageReferenceUtility.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Utility/GetPackageReferenceUtility.cs
@@ -1,0 +1,76 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NuGet.Frameworks;
+using NuGet.LibraryModel;
+using NuGet.ProjectModel;
+using NuGet.Packaging.Core;
+using NuGet.Versioning;
+
+namespace NuGet.PackageManagement.VisualStudio.Utility
+{
+    internal static class GetPackageReferenceUtility
+    {
+        /// <summary>
+        /// Compares the project and the assets files returning the installed package.
+        /// Assets information can be null and returns the package from the project files.
+        /// Checks if package already exists in the project and return it, otherwise update the project installed packages.
+        /// </summary>
+        /// <param name="projectLibrary">Library from the project file.</param>
+        /// <param name="targetFramework">Target framework from the project file.</param>
+        /// <param name="assetsTargetFrameworkInformation">Target framework information from the assets file.</param>
+        /// <param name="targets">Target assets file with the package information.</param>
+        /// <param name="installedPackages">Installed packages information from the project.</param>
+        internal static PackageIdentity UpdateResolvedVersion(LibraryDependency projectLibrary, NuGetFramework targetFramework, TargetFrameworkInformation assetsTargetFrameworkInformation, IEnumerable<LockFileTarget> targets, Dictionary<string, ProjectInstalledPackage> installedPackages)
+        {
+            NuGetVersion resolvedVersion = default;
+
+            // Returns the installed version if the package:
+            // 1. Already exists in the installedPackages
+            // 2. The range is the same as the installed one
+            // 3. There are no changes in the assets file
+            if (installedPackages.TryGetValue(projectLibrary.Name, out ProjectInstalledPackage installedVersion) && installedVersion.AllowedVersions.Equals(projectLibrary.LibraryRange.VersionRange) && targets == null)
+            {
+                return installedVersion.InstalledPackage;
+            }
+
+            resolvedVersion = GetInstalledVersion(projectLibrary, targetFramework, assetsTargetFrameworkInformation, targets);
+
+            if (resolvedVersion == null)
+            {
+                resolvedVersion = projectLibrary.LibraryRange?.VersionRange?.MinVersion ?? new NuGetVersion(0, 0, 0);
+            }
+
+            // Add or update the the version of the package in the project
+            if (installedPackages.TryGetValue(projectLibrary.Name, out ProjectInstalledPackage installedPackage))
+            {
+                installedPackages[projectLibrary.Name] = new ProjectInstalledPackage(projectLibrary.LibraryRange.VersionRange, new PackageIdentity(projectLibrary.Name, resolvedVersion));
+            }
+            else
+            {
+                ProjectInstalledPackage newInstalledPackage = new ProjectInstalledPackage(projectLibrary.LibraryRange.VersionRange, new PackageIdentity(projectLibrary.Name, resolvedVersion));
+                installedPackages.Add(projectLibrary.Name, newInstalledPackage);
+            }
+
+            return new PackageIdentity(projectLibrary.Name, resolvedVersion);
+        }
+
+        private static NuGetVersion GetInstalledVersion(LibraryDependency libraryProjectFile, NuGetFramework targetFramework, TargetFrameworkInformation assetsTargetFrameworkInformation, IEnumerable<LockFileTarget> targets)
+        {
+            LibraryDependency libraryAsset = assetsTargetFrameworkInformation?.Dependencies.FirstOrDefault(e => e.Name.Equals(libraryProjectFile.Name, StringComparison.OrdinalIgnoreCase));
+
+            if (libraryAsset == null)
+            {
+                return null;
+            }
+
+            return targets
+                .FirstOrDefault(t => t.TargetFramework.Equals(targetFramework) && string.IsNullOrEmpty(t.RuntimeIdentifier))
+                ?.Libraries
+                .FirstOrDefault(a => a.Name.Equals(libraryAsset.Name, StringComparison.OrdinalIgnoreCase))?.Version;
+        }
+    }
+}

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Utility/ProjectInstalledPackage.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Utility/ProjectInstalledPackage.cs
@@ -1,0 +1,31 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using NuGet.Packaging.Core;
+using NuGet.Versioning;
+
+namespace NuGet.PackageManagement.VisualStudio.Utility
+{
+    internal class ProjectInstalledPackage
+    {
+        public VersionRange AllowedVersions { get; }
+        public PackageIdentity InstalledPackage { get; }
+
+        public ProjectInstalledPackage(VersionRange versionRange, PackageIdentity installedPackage)
+        {
+            if (versionRange == null)
+            {
+                throw new ArgumentNullException(nameof(versionRange));
+            }
+
+            if (installedPackage == null)
+            {
+                throw new ArgumentNullException(nameof(installedPackage));
+            }
+
+            AllowedVersions = versionRange;
+            InstalledPackage = installedPackage;
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.PackageManagement/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.PackageManagement/PublicAPI.Unshipped.txt
@@ -1,3 +1,4 @@
+NuGet.ProjectManagement.BuildIntegratedPackageReference.BuildIntegratedPackageReference(NuGet.LibraryModel.LibraryDependency dependency, NuGet.Frameworks.NuGetFramework projectFramework, NuGet.Packaging.Core.PackageIdentity installedVersion) -> void
 NuGet.ProjectManagement.MessageLevelExtensions
 const NuGet.ProjectManagement.ProjectBuildProperties.TargetFrameworkIdentifier = "TargetFrameworkIdentifier" -> string
 const NuGet.ProjectManagement.ProjectBuildProperties.TargetFrameworkProfile = "TargetFrameworkProfile" -> string

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/NetCorePackageReferenceProjectTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/NetCorePackageReferenceProjectTests.cs
@@ -1,0 +1,538 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+using NuGet.VisualStudio;
+using NuGet.Test.Utility;
+using System.Threading;
+using System.IO;
+using Moq;
+using FluentAssertions;
+using NuGet.ProjectModel;
+using NuGet.Commands.Test;
+using NuGet.Commands;
+using NuGet.Configuration;
+using NuGet.Packaging.Core;
+using NuGet.Versioning;
+
+namespace NuGet.PackageManagement.VisualStudio.Test
+{
+    public class NetCorePackageReferenceProjectTests
+    {
+        [Fact]
+        public async Task GetInstalledVersion_WithAssetsFile_ReturnsVersionsFromAssetsSpecs()
+        {
+            using (var testDirectory = TestDirectory.Create())
+            {
+                // Setup
+                var projectName = "project1";
+                var projectFullPath = Path.Combine(testDirectory.Path, projectName + ".csproj");
+
+                // Project
+                var projectCache = new ProjectSystemCache();
+                IVsProjectAdapter projectAdapter = (new Mock<IVsProjectAdapter>()).Object;
+                var project = CreateNetCorePackageReferenceProject(projectName, projectFullPath, projectCache);
+
+                var projectNames = GetTestProjectNames(projectFullPath, projectName);
+                var packageSpec = GetPackageSpec(projectName, projectFullPath, "[2.0.0, )");
+
+                // Restore info
+                var projectRestoreInfo = ProjectJsonTestHelpers.GetDGSpecFromPackageSpecs(packageSpec);
+                projectCache.AddProjectRestoreInfo(projectNames, projectRestoreInfo, new List<IAssetsLogMessage>());
+                projectCache.AddProject(projectNames, projectAdapter, project).Should().BeTrue();
+
+                // Package directories
+                var sources = new List<PackageSource>();
+                var packagesDir = new DirectoryInfo(Path.Combine(testDirectory, "globalPackages"));
+                var packageSource = new DirectoryInfo(Path.Combine(testDirectory, "packageSource"));
+                packagesDir.Create();
+                packageSource.Create();
+                sources.Add(new PackageSource(packageSource.FullName));
+
+                var logger = new TestLogger();
+                var request = new TestRestoreRequest(packageSpec, sources, packagesDir.FullName, logger)
+                {
+                    LockFilePath = Path.Combine(testDirectory, "project.assets.json")
+                };
+
+                await SimpleTestPackageUtility.CreateFullPackageAsync(packageSource.FullName, "packageA", "3.0.0");
+
+                // Act
+                var command = new RestoreCommand(request);
+                var result = await command.ExecuteAsync();
+                await result.CommitAsync(logger, CancellationToken.None);
+                var packages = await project.GetInstalledPackagesAsync(CancellationToken.None);
+
+                // Asert
+                Assert.True(result.Success);
+                packages.Should().Contain(a => a.PackageIdentity.Equals(new PackageIdentity("packageA", new NuGetVersion("3.0.0"))));
+            }
+        }
+
+        [Fact]
+        public async Task GetInstalledVersion_WithFloating_WithAssetsFile_ReturnsVersionsFromAssetsSpecs()
+        {
+            using (var testDirectory = TestDirectory.Create())
+            {
+                // Setup
+                var projectName = "project1";
+                var projectFullPath = Path.Combine(testDirectory.Path, projectName + ".csproj");
+
+                // Project
+                var projectCache = new ProjectSystemCache();
+                IVsProjectAdapter projectAdapter = (new Mock<IVsProjectAdapter>()).Object;
+                var project = CreateNetCorePackageReferenceProject(projectName, projectFullPath, projectCache);
+
+                var projectNames = GetTestProjectNames(projectFullPath, projectName);
+                var packageSpec = GetPackageSpec(projectName, projectFullPath, "[*, )");
+
+                // Restore info
+                var projectRestoreInfo = ProjectJsonTestHelpers.GetDGSpecFromPackageSpecs(packageSpec);
+                projectCache.AddProjectRestoreInfo(projectNames, projectRestoreInfo, new List<IAssetsLogMessage>());
+                projectCache.AddProject(projectNames, projectAdapter, project).Should().BeTrue();
+
+                // Package directories
+                var sources = new List<PackageSource>();
+                var packagesDir = new DirectoryInfo(Path.Combine(testDirectory, "globalPackages"));
+                var packageSource = new DirectoryInfo(Path.Combine(testDirectory, "packageSource"));
+                packagesDir.Create();
+                packageSource.Create();
+                sources.Add(new PackageSource(packageSource.FullName));
+
+                var logger = new TestLogger();
+                var request = new TestRestoreRequest(packageSpec, sources, packagesDir.FullName, logger)
+                {
+                    LockFilePath = Path.Combine(testDirectory, "project.assets.json")
+                };
+
+                await SimpleTestPackageUtility.CreateFullPackageAsync(packageSource.FullName, "packageA", "4.0.0");
+
+                // Act
+                var command = new RestoreCommand(request);
+                var result = await command.ExecuteAsync();
+                await result.CommitAsync(logger, CancellationToken.None);
+                var packages = await project.GetInstalledPackagesAsync(CancellationToken.None);
+
+                // Asert
+                Assert.True(result.Success);
+                packages.Should().Contain(a => a.PackageIdentity.Equals(new PackageIdentity("packageA", new NuGetVersion("4.0.0"))));
+
+                var cache_packages = await project.GetInstalledPackagesAsync(CancellationToken.None);
+                cache_packages.Should().Contain(a => a.PackageIdentity.Equals(new PackageIdentity("packageA", new NuGetVersion("4.0.0"))));
+            }
+        }
+
+        [Fact]
+        public async Task GetInstalledVersion_WithoutAssetsFile_ReturnsVersionsFromPackageSpecs()
+        {
+            using (var testDirectory = TestDirectory.Create())
+            {
+                // Setup
+                var projectName = "project1";
+                var projectFullPath = Path.Combine(testDirectory.Path, projectName + ".csproj");
+
+                // Project
+                var projectCache = new ProjectSystemCache();
+                IVsProjectAdapter projectAdapter = (new Mock<IVsProjectAdapter>()).Object;
+                var project = CreateNetCorePackageReferenceProject(projectName, projectFullPath, projectCache);
+
+                var projectNames = GetTestProjectNames(projectFullPath, projectName);
+                var packageSpec = GetPackageSpec(projectName, projectFullPath, "[2.0.0, )");
+
+                // Restore info
+                var projectRestoreInfo = ProjectJsonTestHelpers.GetDGSpecFromPackageSpecs(packageSpec);
+                projectCache.AddProjectRestoreInfo(projectNames, projectRestoreInfo, new List<IAssetsLogMessage>());
+                projectCache.AddProject(projectNames, projectAdapter, project).Should().BeTrue();
+
+                // Package directories
+                var sources = new List<PackageSource>();
+                var packagesDir = new DirectoryInfo(Path.Combine(testDirectory, "globalPackages"));
+                var packageSource = new DirectoryInfo(Path.Combine(testDirectory, "packageSource"));
+                packagesDir.Create();
+                packageSource.Create();
+                sources.Add(new PackageSource(packageSource.FullName));
+
+                var logger = new TestLogger();
+
+                // Act
+                var packages = await project.GetInstalledPackagesAsync(CancellationToken.None);
+
+                // Asert
+                packages.Should().Contain(a => a.PackageIdentity.Equals(new PackageIdentity("packageA", new NuGetVersion("2.0.0"))));
+
+                var cache_packages = await project.GetInstalledPackagesAsync(CancellationToken.None);
+                cache_packages.Should().Contain(a => a.PackageIdentity.Equals(new PackageIdentity("packageA", new NuGetVersion("2.0.0"))));
+            }
+        }
+
+        [Fact]
+        public async Task GetInstalledVersion_WithoutPackages_ReturnsEmpty()
+        {
+            using (var testDirectory = TestDirectory.Create())
+            {
+                // Setup
+                var projectName = "project1";
+                var projectFullPath = Path.Combine(testDirectory.Path, projectName + ".csproj");
+
+                // Project
+                var projectCache = new ProjectSystemCache();
+                IVsProjectAdapter projectAdapter = (new Mock<IVsProjectAdapter>()).Object;
+                var project = CreateNetCorePackageReferenceProject(projectName, projectFullPath, projectCache);
+
+                var projectNames = GetTestProjectNames(projectFullPath, projectName);
+                var packageSpec = GetPackageSpecNoPackages(projectName, projectFullPath);
+
+                // Restore info
+                var projectRestoreInfo = ProjectJsonTestHelpers.GetDGSpecFromPackageSpecs(packageSpec);
+                projectCache.AddProjectRestoreInfo(projectNames, projectRestoreInfo, new List<IAssetsLogMessage>());
+                projectCache.AddProject(projectNames, projectAdapter, project).Should().BeTrue();
+
+                // Package directories
+                var sources = new List<PackageSource>();
+                var packagesDir = new DirectoryInfo(Path.Combine(testDirectory, "globalPackages"));
+                var packageSource = new DirectoryInfo(Path.Combine(testDirectory, "packageSource"));
+                packagesDir.Create();
+                packageSource.Create();
+                sources.Add(new PackageSource(packageSource.FullName));
+
+                var logger = new TestLogger();
+                var request = new TestRestoreRequest(packageSpec, sources, packagesDir.FullName, logger);
+
+                // Act
+                var command = new RestoreCommand(request);
+                var result = await command.ExecuteAsync();
+                await result.CommitAsync(logger, CancellationToken.None);
+                var packages = await project.GetInstalledPackagesAsync(CancellationToken.None);
+
+                // Asert
+                packages.Should().BeEmpty();
+            }
+        }
+
+        [Fact]
+        public async Task GetInstalledVersion_WithASpecificVersionLowerThanAvailableOne_ReturnsVersionFromAssetsFile()
+        {
+            using (var testDirectory = TestDirectory.Create())
+            {
+                // Setup
+                var projectName = "project1";
+                var projectFullPath = Path.Combine(testDirectory.Path, projectName + ".csproj");
+
+                // Project
+                var projectCache = new ProjectSystemCache();
+                IVsProjectAdapter projectAdapter = (new Mock<IVsProjectAdapter>()).Object;
+                var project = CreateNetCorePackageReferenceProject(projectName, projectFullPath, projectCache);
+
+                var projectNames = GetTestProjectNames(projectFullPath, projectName);
+                var packageSpec = GetPackageSpec(projectName, projectFullPath, "[2.0.0, )");
+
+                // Restore info
+                var projectRestoreInfo = ProjectJsonTestHelpers.GetDGSpecFromPackageSpecs(packageSpec);
+                projectCache.AddProjectRestoreInfo(projectNames, projectRestoreInfo, new List<IAssetsLogMessage>());
+                projectCache.AddProject(projectNames, projectAdapter, project).Should().BeTrue();
+
+                // Package directories
+                var sources = new List<PackageSource>();
+                var packagesDir = new DirectoryInfo(Path.Combine(testDirectory, "globalPackages"));
+                var packageSource = new DirectoryInfo(Path.Combine(testDirectory, "packageSource"));
+                packagesDir.Create();
+                packageSource.Create();
+                sources.Add(new PackageSource(packageSource.FullName));
+
+                var logger = new TestLogger();
+                var request = new TestRestoreRequest(packageSpec, sources, packagesDir.FullName, logger)
+                {
+                    LockFilePath = Path.Combine(testDirectory, "project.assets.json")
+                };
+
+                await SimpleTestPackageUtility.CreateFullPackageAsync(packageSource.FullName, "packageA", "4.0.0");
+
+                // Act
+                var command = new RestoreCommand(request);
+                var result = await command.ExecuteAsync();
+                await result.CommitAsync(logger, CancellationToken.None);
+                var packages = await project.GetInstalledPackagesAsync(CancellationToken.None);
+
+                // Asert
+                var exists = packages.Where(a => a.PackageIdentity.Equals(new PackageIdentity("packageA", new NuGetVersion("4.0.0"))));
+                Assert.True(exists.Count() == 1);
+            }
+        }
+
+        [Fact]
+        public async Task GetInstalledVersion_WithoutPackages_WithAssets_ReturnsEmpty()
+        {
+            using (var testDirectory = TestDirectory.Create())
+            {
+                // Setup
+                var projectName = "project1";
+                var projectFullPath = Path.Combine(testDirectory.Path, projectName + ".csproj");
+
+                // Project
+                var projectCache = new ProjectSystemCache();
+                IVsProjectAdapter projectAdapter = (new Mock<IVsProjectAdapter>()).Object;
+                var project = CreateNetCorePackageReferenceProject(projectName, projectFullPath, projectCache);
+
+                var projectNames = GetTestProjectNames(projectFullPath, projectName);
+                var packageSpec = GetPackageSpecNoPackages(projectName, projectFullPath);
+
+                // Restore info
+                var projectRestoreInfo = ProjectJsonTestHelpers.GetDGSpecFromPackageSpecs(packageSpec);
+                projectCache.AddProjectRestoreInfo(projectNames, projectRestoreInfo, new List<IAssetsLogMessage>());
+                projectCache.AddProject(projectNames, projectAdapter, project).Should().BeTrue();
+
+                // Package directories
+                var sources = new List<PackageSource>();
+                var packagesDir = new DirectoryInfo(Path.Combine(testDirectory, "globalPackages"));
+                var packageSource = new DirectoryInfo(Path.Combine(testDirectory, "packageSource"));
+                packagesDir.Create();
+                packageSource.Create();
+                sources.Add(new PackageSource(packageSource.FullName));
+
+                var logger = new TestLogger();
+                var request = new TestRestoreRequest(packageSpec, sources, packagesDir.FullName, logger)
+                {
+                    LockFilePath = Path.Combine(testDirectory, "project.assets.json")
+                };
+
+                await SimpleTestPackageUtility.CreateFullPackageAsync(packageSource.FullName, "packageA", "1.0.0");
+
+                // Act
+                var command = new RestoreCommand(request);
+                var result = await command.ExecuteAsync();
+                await result.CommitAsync(logger, CancellationToken.None);
+                var packages = await project.GetInstalledPackagesAsync(CancellationToken.None);
+
+                // Asert
+                packages.Should().BeEmpty();
+            }
+        }
+
+        [Fact]
+        public async Task GetInstalledVersions_WhenCalledMultipleTimes_ReturnsSameResult()
+        {
+            using (var testDirectory = TestDirectory.Create())
+            {
+                // Setup
+                var projectName = "project1";
+                var projectFullPath = Path.Combine(testDirectory.Path, projectName + ".csproj");
+
+                // Project
+                var projectCache = new ProjectSystemCache();
+                IVsProjectAdapter projectAdapter = (new Mock<IVsProjectAdapter>()).Object;
+                var project = CreateNetCorePackageReferenceProject(projectName, projectFullPath, projectCache);
+
+                var projectNames = GetTestProjectNames(projectFullPath, projectName);
+                var packageSpec = GetPackageSpecMultipleVersions(projectName, projectFullPath);
+
+                // Restore info
+                var projectRestoreInfo = ProjectJsonTestHelpers.GetDGSpecFromPackageSpecs(packageSpec);
+                projectCache.AddProjectRestoreInfo(projectNames, projectRestoreInfo, new List<IAssetsLogMessage>());
+                projectCache.AddProject(projectNames, projectAdapter, project).Should().BeTrue();
+
+                // Package directories
+                var sources = new List<PackageSource>();
+                var packagesDir = new DirectoryInfo(Path.Combine(testDirectory, "globalPackages"));
+                var packageSource = new DirectoryInfo(Path.Combine(testDirectory, "packageSource"));
+                packagesDir.Create();
+                packageSource.Create();
+                sources.Add(new PackageSource(packageSource.FullName));
+
+                var logger = new TestLogger();
+                var request = new TestRestoreRequest(packageSpec, sources, packagesDir.FullName, logger)
+                {
+                    LockFilePath = Path.Combine(testDirectory, "project.assets.json")
+                };
+
+                await SimpleTestPackageUtility.CreateFullPackageAsync(packageSource.FullName, "packageA", "3.0.0");
+                await SimpleTestPackageUtility.CreateFullPackageAsync(packageSource.FullName, "packageB", "4.0.0");
+                await SimpleTestPackageUtility.CreateFullPackageAsync(packageSource.FullName, "packageC", "1.0.0");
+
+                // Act
+                var command = new RestoreCommand(request);
+                var result = await command.ExecuteAsync();
+                await result.CommitAsync(logger, CancellationToken.None);
+                var packages = await project.GetInstalledPackagesAsync(CancellationToken.None);
+
+                // Asert
+                Assert.True(result.Success);
+                packages.Should().Contain(a => a.PackageIdentity.Equals(new PackageIdentity("packageA", new NuGetVersion("3.0.0"))));
+                packages.Should().Contain(a => a.PackageIdentity.Equals(new PackageIdentity("packageB", new NuGetVersion("4.0.0"))));
+                packages.Should().Contain(a => a.PackageIdentity.Equals(new PackageIdentity("packageC", new NuGetVersion("1.0.0"))));
+
+                var cache_packages = await project.GetInstalledPackagesAsync(CancellationToken.None);
+                cache_packages.Should().Contain(a => a.PackageIdentity.Equals(new PackageIdentity("packageA", new NuGetVersion("3.0.0"))));
+                cache_packages = await project.GetInstalledPackagesAsync(CancellationToken.None);
+                cache_packages.Should().Contain(a => a.PackageIdentity.Equals(new PackageIdentity("packageB", new NuGetVersion("4.0.0"))));
+                cache_packages = await project.GetInstalledPackagesAsync(CancellationToken.None);
+                cache_packages.Should().Contain(a => a.PackageIdentity.Equals(new PackageIdentity("packageC", new NuGetVersion("1.0.0"))));
+            }
+        }
+
+        [Fact]
+        public async Task GetInstalledVersion_WithAssetsFile_ChangingPackageSpec_ReturnsVersionsFromAssetsSpecs()
+        {
+            using (var testDirectory = TestDirectory.Create())
+            {
+                // Setup
+                var projectName = "project1";
+                var projectFullPath = Path.Combine(testDirectory.Path, projectName + ".csproj");
+
+                // Project
+                var projectCache = new ProjectSystemCache();
+                IVsProjectAdapter projectAdapter = (new Mock<IVsProjectAdapter>()).Object;
+                var project = CreateNetCorePackageReferenceProject(projectName, projectFullPath, projectCache);
+
+                var projectNames = GetTestProjectNames(projectFullPath, projectName);
+                var packageSpec = GetPackageSpec(projectName, projectFullPath, "[2.0.0, )");
+
+                // Restore info
+                var projectRestoreInfo = ProjectJsonTestHelpers.GetDGSpecFromPackageSpecs(packageSpec);
+                projectCache.AddProjectRestoreInfo(projectNames, projectRestoreInfo, new List<IAssetsLogMessage>());
+                projectCache.AddProject(projectNames, projectAdapter, project).Should().BeTrue();
+
+                // Package directories
+                var sources = new List<PackageSource>();
+                var packagesDir = new DirectoryInfo(Path.Combine(testDirectory, "globalPackages"));
+                var packageSource = new DirectoryInfo(Path.Combine(testDirectory, "packageSource"));
+                packagesDir.Create();
+                packageSource.Create();
+                sources.Add(new PackageSource(packageSource.FullName));
+
+                var logger = new TestLogger();
+                var request = new TestRestoreRequest(packageSpec, sources, packagesDir.FullName, logger)
+                {
+                    LockFilePath = Path.Combine(testDirectory, "project.assets.json")
+                };
+
+                await SimpleTestPackageUtility.CreateFullPackageAsync(packageSource.FullName, "packageA", "2.0.0");
+                await SimpleTestPackageUtility.CreateFullPackageAsync(packageSource.FullName, "packageA", "3.0.0");
+
+                // Act
+                var command = new RestoreCommand(request);
+                var result = await command.ExecuteAsync();
+                await result.CommitAsync(logger, CancellationToken.None);
+                var packages = await project.GetInstalledPackagesAsync(CancellationToken.None);
+
+                // Asert
+                Assert.True(result.Success);
+                packages.Should().Contain(a => a.PackageIdentity.Equals(new PackageIdentity("packageA", new NuGetVersion("2.0.0"))));
+
+                // Setup
+                packageSpec = GetPackageSpec(projectName, projectFullPath, "[3.0.0, )");
+
+                // Restore info
+                projectRestoreInfo = ProjectJsonTestHelpers.GetDGSpecFromPackageSpecs(packageSpec);
+                projectCache.AddProjectRestoreInfo(projectNames, projectRestoreInfo, new List<IAssetsLogMessage>());
+                projectCache.AddProject(projectNames, projectAdapter, project).Should().BeTrue();
+
+                request = new TestRestoreRequest(packageSpec, sources, packagesDir.FullName, logger)
+                {
+                    LockFilePath = Path.Combine(testDirectory, "project.assets.json")
+                };
+
+                // Act
+                command = new RestoreCommand(request);
+                result = await command.ExecuteAsync();
+                await result.CommitAsync(logger, CancellationToken.None);
+                packages = await project.GetInstalledPackagesAsync(CancellationToken.None);
+
+                // Asert
+                Assert.True(result.Success);
+                packages.Should().Contain(a => a.PackageIdentity.Equals(new PackageIdentity("packageA", new NuGetVersion("3.0.0"))));
+            }
+        }
+
+        private NetCorePackageReferenceProject CreateNetCorePackageReferenceProject(string projectName, string projectFullPath, ProjectSystemCache projectSystemCache)
+        {
+            var projectServices = new TestProjectSystemServices();
+
+            return new NetCorePackageReferenceProject(
+                    projectName: projectName,
+                    projectUniqueName: projectName,
+                    projectFullPath: projectFullPath,
+                    projectSystemCache: projectSystemCache,
+                    unconfiguredProject: null,
+                    projectServices: projectServices,
+                    projectId: projectName);
+        }
+
+        private ProjectNames GetTestProjectNames(string projectPath, string projectUniqueName)
+        {
+            var projectNames = new ProjectNames(
+            fullName: projectPath,
+            uniqueName: projectUniqueName,
+            shortName: projectUniqueName,
+            customUniqueName: projectUniqueName,
+            projectId: Guid.NewGuid().ToString());
+            return projectNames;
+        }
+
+        private static PackageSpec GetPackageSpec(string projectName, string testDirectory, string version)
+        {
+            string referenceSpec = $@"
+                {{
+                    ""frameworks"":
+                    {{
+                        ""net5.0"":
+                        {{
+                            ""dependencies"":
+                            {{
+                                ""packageA"":
+                                {{
+                                    ""version"": ""{version}"",
+                                    ""target"": ""Package""
+                                }},
+                            }}
+                        }}
+                    }}
+                }}";
+            return JsonPackageSpecReader.GetPackageSpec(referenceSpec, projectName, testDirectory).WithTestRestoreMetadata();
+        }
+
+        private static PackageSpec GetPackageSpecNoPackages(string projectName, string testDirectory)
+        {
+            const string referenceSpec = @"
+                {
+                    ""frameworks"": {
+                        ""net5.0"": {
+                            ""dependencies"": {
+                                }
+                            }
+                        }
+                    }
+                }";
+            return JsonPackageSpecReader.GetPackageSpec(referenceSpec, projectName, testDirectory).WithTestRestoreMetadata();
+        }
+
+        private static PackageSpec GetPackageSpecMultipleVersions(string projectName, string testDirectory)
+        {
+            const string referenceSpec = @"
+                {
+                    ""frameworks"": {
+                        ""net5.0"": {
+                            ""dependencies"": {
+                                    ""packageA"": {
+                                    ""version"": ""[*, )"",
+                                    ""target"": ""Package""
+                                },
+                                    ""packageB"": {
+                                    ""version"": ""[1.0.0, )"",
+                                    ""target"": ""Package""
+                                },
+                                    ""packageC"": {
+                                    ""version"": ""[1.0.0, )"",
+                                    ""target"": ""Package""
+                                }
+                            }
+                        }
+                    }
+                }";
+            return JsonPackageSpecReader.GetPackageSpec(referenceSpec, projectName, testDirectory).WithTestRestoreMetadata();
+        }
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/NuGet.PackageManagement.VisualStudio.Test.csproj
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/NuGet.PackageManagement.VisualStudio.Test.csproj
@@ -25,6 +25,7 @@
   <ItemGroup>
     <Compile Include="Feeds\SourceRepositoryCreator.cs" />
     <Compile Include="Feeds\SourceRepositoryExtensionsTests.cs" />
+    <Compile Include="NetCorePackageReferenceProjectTests.cs" />
     <Compile Include="ProjectSystems\LegacyPackageReferenceProjectTests.cs" />
     <Compile Include="DispatcherThreadCollection.cs" />
     <Compile Include="Feeds\MultiSourcePackageMetadataProviderTests.cs" />
@@ -72,6 +73,9 @@
     <Reference Include="VSLangProj150">
       <HintPath>$(SolutionPackagesFolder)vslangproj150\1.0.0\lib\net46\VSLangProj150.dll</HintPath>
       <EmbedInteropTypes>True</EmbedInteropTypes>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.ProjectSystem">
+      <HintPath>$(SolutionPackagesFolder)microsoft.visualstudio.projectsystem\16.7.156-pre\lib\net472\Microsoft.VisualStudio.ProjectSystem.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
## Bug

Fixes: [Display the resolved version in the PMUI](https://github.com/NuGet/Home/issues/9826)
Regression: Yes/No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: Getting the resolved version 

## Testing/Validation

Tests Added: Yes 
Reason for not adding tests:  
Validation:  
