### PR TITLE
Add back VS experimentation service call after partner bug fix (AB Test)

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -748,10 +748,10 @@ namespace NuGet.PackageManagement.UI
             .PostOnFailure(nameof(PackageManagerControl), nameof(SearchPackagesAndRefreshUpdateCount));
         }
 
-        // Enable if environment variable RecommendNuGetPackages is set to 1.
+        // Check if user has environment variable of RecommendNuGetPackages set to 1 or is in A/B experiment.
         public bool IsRecommenderFlightEnabled()
         {
-            return _forceRecommender;
+            return _forceRecommender | ExperimentationService.Default.IsCachedFlightEnabled("nugetrecommendpkgs");
         }
 
         private async Task<(IPackageFeed mainFeed, IPackageFeed recommenderFeed)> GetPackageFeedsAsync(string searchText, PackageLoadContext loadContext)

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -751,7 +751,7 @@ namespace NuGet.PackageManagement.UI
         // Check if user has environment variable of RecommendNuGetPackages set to 1 or is in A/B experiment.
         public bool IsRecommenderFlightEnabled()
         {
-            return _forceRecommender | ExperimentationService.Default.IsCachedFlightEnabled("nugetrecommendpkgs");
+            return _forceRecommender || ExperimentationService.Default.IsCachedFlightEnabled("nugetrecommendpkgs");
         }
 
         private async Task<(IPackageFeed mainFeed, IPackageFeed recommenderFeed)> GetPackageFeedsAsync(string searchText, PackageLoadContext loadContext)


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9845
Regression: No

## Fix

Details: reenable a call we almost shipped in 5.7...VS partner team fixed bugs in 16.8 that we helped find.  

## Testing/Validation

Tests Added: No
Reason for not adding tests: this is the on/off switch for the experimental feature. 
Validation:  manual testing by @birgithi 
