### PR TITLE
Fix NuGetFramework copy constructor to avoid creating incorrect frameworks (frameworks with platform are affected)

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks/WriteRestoreGraphTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/WriteRestoreGraphTask.cs
@@ -1,12 +1,14 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.IO;
+using System.Diagnostics;
 using System.Linq;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using Newtonsoft.Json;
 using NuGet.Commands;
+using System;
 
 namespace NuGet.Build.Tasks
 {
@@ -31,6 +33,14 @@ namespace NuGet.Build.Tasks
 
         public override bool Execute()
         {
+#if DEBUG
+            var debugRestoreTask = Environment.GetEnvironmentVariable("DEBUG_RESTORE_GRAPH_TASK");
+            if (!string.IsNullOrEmpty(debugRestoreTask) && debugRestoreTask.Equals(bool.TrueString, StringComparison.OrdinalIgnoreCase))
+            {
+                Debugger.Launch();
+            }
+#endif
+
             if (RestoreGraphItems.Length < 1)
             {
                 Log.LogWarning("Unable to find a project to restore!");

--- a/src/NuGet.Core/NuGet.Frameworks/AssetTargetFallbackFramework.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/AssetTargetFallbackFramework.cs
@@ -49,13 +49,8 @@ namespace NuGet.Frameworks
         }
 
         public AssetTargetFallbackFramework(NuGetFramework framework, FallbackList fallbackFrameworks)
-            : base(framework)
+            : base(ValidateFrameworkArgument(framework))
         {
-            if (framework == null)
-            {
-                throw new ArgumentNullException("framework");
-            }
-
             if (fallbackFrameworks == null)
             {
                 throw new ArgumentNullException("fallbackFrameworks");
@@ -68,6 +63,16 @@ namespace NuGet.Frameworks
 
             _fallback = fallbackFrameworks;
             _rootFramework = framework;
+        }
+
+
+        private static NuGetFramework ValidateFrameworkArgument(NuGetFramework framework)
+        {
+            if (framework == null)
+            {
+                throw new ArgumentNullException("framework");
+            }
+            return framework;
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Frameworks/NuGetFramework.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/NuGetFramework.cs
@@ -27,7 +27,7 @@ namespace NuGet.Frameworks
         private int? _hashCode;
 
         public NuGetFramework(NuGetFramework framework)
-            : this(framework.Framework, framework.Version, framework.Profile)
+            : this(framework.Framework, framework.Version, framework.Profile, framework.Platform, framework.PlatformVersion)
         {
         }
 
@@ -93,6 +93,18 @@ namespace NuGet.Frameworks
                 throw new ArgumentNullException("platformVersion");
             }
 
+            _frameworkIdentifier = frameworkIdentifier;
+            _frameworkVersion = NormalizeVersion(frameworkVersion);
+            _frameworkProfile = string.Empty;
+
+            IsNet5Era = (_frameworkVersion.Major >= Version5 && StringComparer.OrdinalIgnoreCase.Equals(FrameworkConstants.FrameworkIdentifiers.NetCoreApp, _frameworkIdentifier));
+
+            Platform = IsNet5Era ? platform : string.Empty;
+            PlatformVersion = IsNet5Era ? NormalizeVersion(platformVersion) : FrameworkConstants.EmptyVersion;
+        }
+
+        internal NuGetFramework(string frameworkIdentifier, Version frameworkVersion, string profile, string platform, Version platformVersion) : this(frameworkIdentifier, frameworkVersion, profile)
+        {
             _frameworkIdentifier = frameworkIdentifier;
             _frameworkVersion = NormalizeVersion(frameworkVersion);
             _frameworkProfile = string.Empty;

--- a/src/NuGet.Core/NuGet.Frameworks/NuGetFramework.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/NuGetFramework.cs
@@ -46,7 +46,7 @@ namespace NuGet.Frameworks
         /// Creates a new NuGetFramework instance, with an optional profile (only available for netframework)
         /// </summary>
         public NuGetFramework(string frameworkIdentifier, Version frameworkVersion, string profile)
-            : this(frameworkIdentifier, frameworkVersion, profile: string.Empty, platform: string.Empty, platformVersion: FrameworkConstants.EmptyVersion)
+            : this(frameworkIdentifier, frameworkVersion, profile: profile, platform: string.Empty, platformVersion: FrameworkConstants.EmptyVersion)
 
         {
         }

--- a/src/NuGet.Core/NuGet.Frameworks/NuGetFramework.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/NuGetFramework.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Text;
-using NuGet.Shared;
 
 namespace NuGet.Frameworks
 {
@@ -27,7 +26,7 @@ namespace NuGet.Frameworks
         private int? _hashCode;
 
         public NuGetFramework(NuGetFramework framework)
-            : this(framework.Framework, framework.Version, framework.Profile)
+            : this(framework.Framework, framework.Version, framework.Profile, framework.Platform, framework.PlatformVersion)
         {
         }
 
@@ -47,31 +46,20 @@ namespace NuGet.Frameworks
         /// Creates a new NuGetFramework instance, with an optional profile (only available for netframework)
         /// </summary>
         public NuGetFramework(string frameworkIdentifier, Version frameworkVersion, string profile)
+            : this(frameworkIdentifier, frameworkVersion, profile: string.Empty, platform: string.Empty, platformVersion: FrameworkConstants.EmptyVersion)
+
         {
-            if (frameworkIdentifier == null)
-            {
-                throw new ArgumentNullException("frameworkIdentifier");
-            }
-
-            if (frameworkVersion == null)
-            {
-                throw new ArgumentNullException("frameworkVersion");
-            }
-
-            _frameworkIdentifier = frameworkIdentifier;
-            _frameworkVersion = NormalizeVersion(frameworkVersion);
-
-            IsNet5Era = (_frameworkVersion.Major >= Version5 && StringComparer.OrdinalIgnoreCase.Equals(FrameworkConstants.FrameworkIdentifiers.NetCoreApp, _frameworkIdentifier));
-
-            _frameworkProfile = profile ?? string.Empty;
-            Platform = string.Empty;
-            PlatformVersion = FrameworkConstants.EmptyVersion;
         }
 
         /// <summary>
         /// Creates a new NuGetFramework instance, with an optional platform and platformVersion (only available for net5.0+)
         /// </summary>
         public NuGetFramework(string frameworkIdentifier, Version frameworkVersion, string platform, Version platformVersion)
+            : this(frameworkIdentifier, frameworkVersion, profile: string.Empty, platform: platform, platformVersion: platformVersion)
+        {
+        }
+
+        internal NuGetFramework(string frameworkIdentifier, Version frameworkVersion, string profile, string platform, Version platformVersion)
         {
             if (frameworkIdentifier == null)
             {
@@ -95,22 +83,9 @@ namespace NuGet.Frameworks
 
             _frameworkIdentifier = frameworkIdentifier;
             _frameworkVersion = NormalizeVersion(frameworkVersion);
-            _frameworkProfile = string.Empty;
+            _frameworkProfile = profile;
 
             IsNet5Era = (_frameworkVersion.Major >= Version5 && StringComparer.OrdinalIgnoreCase.Equals(FrameworkConstants.FrameworkIdentifiers.NetCoreApp, _frameworkIdentifier));
-
-            Platform = IsNet5Era ? platform : string.Empty;
-            PlatformVersion = IsNet5Era ? NormalizeVersion(platformVersion) : FrameworkConstants.EmptyVersion;
-        }
-
-        internal NuGetFramework(string frameworkIdentifier, Version frameworkVersion, string profile, string platform, Version platformVersion) : this(frameworkIdentifier, frameworkVersion, profile)
-        {
-            _frameworkIdentifier = frameworkIdentifier;
-            _frameworkVersion = NormalizeVersion(frameworkVersion);
-            _frameworkProfile = string.Empty;
-
-            IsNet5Era = (_frameworkVersion.Major >= Version5 && StringComparer.OrdinalIgnoreCase.Equals(FrameworkConstants.FrameworkIdentifiers.NetCoreApp, _frameworkIdentifier));
-
             Platform = IsNet5Era ? platform : string.Empty;
             PlatformVersion = IsNet5Era ? NormalizeVersion(platformVersion) : FrameworkConstants.EmptyVersion;
         }

--- a/src/NuGet.Core/NuGet.Frameworks/NuGetFramework.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/NuGetFramework.cs
@@ -27,7 +27,7 @@ namespace NuGet.Frameworks
         private int? _hashCode;
 
         public NuGetFramework(NuGetFramework framework)
-            : this(framework.Framework, framework.Version, framework.Profile, framework.Platform, framework.PlatformVersion)
+            : this(framework.Framework, framework.Version, framework.Profile)
         {
         }
 

--- a/src/NuGet.Core/NuGet.Frameworks/NuGetFramework.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/NuGetFramework.cs
@@ -46,9 +46,14 @@ namespace NuGet.Frameworks
         /// Creates a new NuGetFramework instance, with an optional profile (only available for netframework)
         /// </summary>
         public NuGetFramework(string frameworkIdentifier, Version frameworkVersion, string profile)
-            : this(frameworkIdentifier, frameworkVersion, profile: profile, platform: string.Empty, platformVersion: FrameworkConstants.EmptyVersion)
+            : this(frameworkIdentifier, frameworkVersion, profile: ProcessProfile(profile), platform: string.Empty, platformVersion: FrameworkConstants.EmptyVersion)
 
         {
+        }
+
+        private static string ProcessProfile(string profile)
+        {
+            return profile ?? string.Empty;
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpecExtensions.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpecExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Linq;
@@ -13,7 +13,7 @@ namespace NuGet.ProjectModel
         /// </summary>
         public static TargetFrameworkInformation GetTargetFramework(this PackageSpec project, NuGetFramework targetFramework)
         {
-            var frameworkInfo = project.TargetFrameworks.FirstOrDefault(f => NuGetFrameworkFullComparer.Equals(targetFramework, f));
+            var frameworkInfo = project.TargetFrameworks.FirstOrDefault(f => targetFramework.Equals(f.FrameworkName));
             if (frameworkInfo == null)
             {
                 frameworkInfo = NuGetFrameworkUtility.GetNearest(project.TargetFrameworks,

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpecExtensions.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpecExtensions.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Linq;
@@ -13,7 +13,7 @@ namespace NuGet.ProjectModel
         /// </summary>
         public static TargetFrameworkInformation GetTargetFramework(this PackageSpec project, NuGetFramework targetFramework)
         {
-            var frameworkInfo = project.TargetFrameworks.FirstOrDefault(f => targetFramework.Equals(f.FrameworkName));
+            var frameworkInfo = project.TargetFrameworks.FirstOrDefault(f => NuGetFrameworkFullComparer.Equals(targetFramework, f));
             if (frameworkInfo == null)
             {
                 frameworkInfo = NuGetFrameworkUtility.GetNearest(project.TargetFrameworks,

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
@@ -9967,7 +9967,7 @@ namespace NuGet.CommandLine.Test
         }
 
         [PlatformFact(Platform.Windows)]
-        public void RestoreNetCore_WithMultipleFrameworksWithPlatform_Suceeds()
+        public void RestoreNetCore_WithMultipleFrameworksWithPlatformAndAssetTargetFallback_Succeeds()
         {
             // Arrange
             using (var pathContext = new SimpleTestPathContext())
@@ -9986,6 +9986,8 @@ namespace NuGet.CommandLine.Test
                     pathContext.SolutionRoot,
                     frameworks
                     );
+
+                projectA.Properties.Add("AssetTargetFallback", "net472");
 
                 solution.Projects.Add(projectA);
                 solution.Create(pathContext.SolutionRoot);

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
@@ -9966,6 +9966,44 @@ namespace NuGet.CommandLine.Test
             }
         }
 
+        [PlatformFact(Platform.Windows)]
+        public void RestoreNetCore_WithMultipleFrameworksWithPlatform_Suceeds()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Set up solution, project, and packages
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+
+                var frameworks = new NuGetFramework[]
+                {
+                    NuGetFramework.Parse("net5.0-windows10.0.10000.1"),
+                    NuGetFramework.Parse("net5.0-android21")
+                };
+
+                var projectA = SimpleTestProjectContext.CreateNETCore(
+                    "a",
+                    pathContext.SolutionRoot,
+                    frameworks
+                    );
+
+                solution.Projects.Add(projectA);
+                solution.Create(pathContext.SolutionRoot);
+
+                // Act
+                var r = Util.RestoreSolution(pathContext);
+
+                // Assert
+                r.Success.Should().BeTrue();
+                var targets = projectA.AssetsFile.Targets.Where(e => string.IsNullOrEmpty(e.RuntimeIdentifier)).Select(e => e);
+                targets.Should().HaveCount(2);
+                foreach (var framework in frameworks)
+                {
+                    targets.Select(e => e.TargetFramework).Should().Contain(framework);
+                }
+            }
+        }
+
         private static byte[] GetTestUtilityResource(string name)
         {
             return ResourceTestUtility.GetResourceBytes(

--- a/test/NuGet.Core.Tests/NuGet.Frameworks.Test/AssetTargetFallbackTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Frameworks.Test/AssetTargetFallbackTests.cs
@@ -1,0 +1,68 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using FluentAssertions;
+using Xunit;
+
+namespace NuGet.Frameworks.Test
+{
+    public class AssetTargetFallbackTests
+    {
+        private static readonly IReadOnlyList<NuGetFramework> SampleFrameworkList = new NuGetFramework[] { new NuGetFramework(".NETCoreApp") };
+
+        [Fact]
+        public void Constructor_WithNullFramework_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() => new AssetTargetFallbackFramework(framework: null, fallbackFrameworks: SampleFrameworkList));
+        }
+
+        [Fact]
+        public void Constructor_WithNullFallbacks_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() => new AssetTargetFallbackFramework(framework: NuGetFramework.AnyFramework, fallbackFrameworks: null));
+        }
+
+        [Fact]
+        public void Constructor_WithEmptyFallbacks_Throws()
+        {
+            Assert.Throws<ArgumentException>(() => new AssetTargetFallbackFramework(framework: NuGetFramework.AnyFramework, fallbackFrameworks: new NuGetFramework[] { }));
+        }
+
+        [Theory]
+        [InlineData("net5.0")]
+        [InlineData("net45")]
+        [InlineData("net5.0-windows10.0.6508.1")]
+        public void NuGetFrameworkFullComparer_WithAssetTargetFallback_Succeeds(string shortFrameworkName)
+        {
+            var nugetFramework = NuGetFramework.Parse(shortFrameworkName);
+            var assetTargetFallback = new AssetTargetFallbackFramework(nugetFramework, fallbackFrameworks: SampleFrameworkList);
+            var comparer = new NuGetFrameworkFullComparer();
+            Assert.True(comparer.Equals(nugetFramework, assetTargetFallback));
+        }
+
+        [Theory]
+        [InlineData("net5.0", "net5.0", true)]
+        [InlineData("net45", "net45", true)]
+        [InlineData("net5.0-windows10.0.6508.1", "net5.0-windows10.0.6508.1", true)]
+        [InlineData("net5.0-windows10.0.6508.1", "net5.0-windows10.0.6508.2", false)]
+        public void NuGetFrameworkEquals_WithAssetTargetFallback_Succeeds(string shortFrameworkName, string atfRootFrameworkName, bool equals)
+        {
+            var nugetFramework = NuGetFramework.Parse(shortFrameworkName);
+            var assetTargetFallback = new AssetTargetFallbackFramework(NuGetFramework.Parse(atfRootFrameworkName), fallbackFrameworks: SampleFrameworkList);
+            nugetFramework.Equals(assetTargetFallback).Should().Be(equals);
+        }
+
+        [Theory]
+        [InlineData("net5.0")]
+        [InlineData("net45")]
+        [InlineData("net5.0-windows10.0.6508.1")]
+        public void AssetTargetFrameworkEquals_WithNonAssetTargetFallbackFramework_Succeeds(string shortFrameworkName)
+        {
+            var nugetFramework = NuGetFramework.Parse(shortFrameworkName);
+            var assetTargetFallback = new AssetTargetFallbackFramework(nugetFramework, fallbackFrameworks: SampleFrameworkList);
+            Assert.False(assetTargetFallback.Equals((object)nugetFramework));
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Frameworks.Test/NuGetFrameworkTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Frameworks.Test/NuGetFrameworkTests.cs
@@ -358,5 +358,18 @@ namespace NuGet.Test
                 "A hyphen may not be in any of the portable framework names.",
                 ex.Message);
         }
+
+        [Theory]
+        [InlineData("netcoreapp5.0")]
+        [InlineData("net45")]
+        [InlineData("net5.0-windows10.0.16000.1")]
+        public void NuGetFramework_WithCopyConstructor_CreatesEquivalentFrameworks(string frameworkName)
+        {
+            var originalFramework = NuGetFramework.Parse(frameworkName);
+
+            var copiedFramework = new NuGetFramework(originalFramework);
+
+            Assert.Equal(originalFramework, copiedFramework);
+        }
     }
 }


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9849
Regression: Yes  
* Last working version:   
* How are we preventing it in future: Better tests :) 

## Fix

Details: NuGetFramework copy constructor does not create an equivalent frameworks. This leads to ATF getting created with the wrong base framework and to an incorrect framework being used forrestore.
https://github.com/NuGet/NuGet.Client/blob/e09cdc8a877737addb01eeb90d5ea2bd9433ac52/src/NuGet.Core/NuGet.Frameworks/AssetTargetFallbackFramework.cs#L52
Repros anytime you use ATF + framework with a platform.

## Testing/Validation

Tests Added: Yes  
Reason for not adding tests:  
Validation:  Manual + tests. 
