### PR TITLE
Updates Release label to 16.8 Preview 2

### DIFF
--- a/build/config.props
+++ b/build/config.props
@@ -24,7 +24,7 @@
     <!-- ** Increment each insertion, set to zero after incrementing Major/Minor or Patch version -->
     <!-- We need to update this netcoreassembly build number with EVERY insertion into VS to workaround any breaking api
     changes we might have made. -->
-    <NetCoreAssemblyBuildNumber Condition=" '$(NetCoreAssemblyBuildNumber)' == '' ">1</NetCoreAssemblyBuildNumber>
+    <NetCoreAssemblyBuildNumber Condition=" '$(NetCoreAssemblyBuildNumber)' == '' ">2</NetCoreAssemblyBuildNumber>
 
     <IsEscrowMode>false</IsEscrowMode>
 

--- a/build/config.props
+++ b/build/config.props
@@ -19,7 +19,7 @@
 
     <!-- ** Change for each new preview/rtm -->
     <!-- Check the VS schedule and manually enter a preview number here that makes sense. -->
-    <ReleaseLabel Condition=" '$(ReleaseLabel)' == '' ">preview.1</ReleaseLabel>
+    <ReleaseLabel Condition=" '$(ReleaseLabel)' == '' ">preview.2</ReleaseLabel>
 
     <!-- ** Increment each insertion, set to zero after incrementing Major/Minor or Patch version -->
     <!-- We need to update this netcoreassembly build number with EVERY insertion into VS to workaround any breaking api


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Client.Engineering/issues/436
Regression: No
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: Updates ReleaseLabel to preview.2

## Testing/Validation

Tests Added: No
Reason for not adding tests:  versioning change
Validation:  Successful CI run
