### PR TITLE
Add license header template to editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -56,6 +56,9 @@ dotnet_style_explicit_tuple_names = true:suggestion
 dotnet_style_coalesce_expression = true:suggestion
 dotnet_style_null_propagation = true:suggestion
 
+; Licence header
+file_header_template = Copyright (c) .NET Foundation. All rights reserved.\nLicensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 ; CSharp code style settings
 [*.cs]
 ; IDE0007 'var' preferences


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9862
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: Add `file_header_template` to `.editorconfig`.

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  no code changes
Validation:  
