### PR TITLE
Replace the SHA1 instance

### DIFF
--- a/src/NuGet.Core/NuGet.Common/CryptoHashUtility.cs
+++ b/src/NuGet.Core/NuGet.Common/CryptoHashUtility.cs
@@ -203,22 +203,6 @@ namespace NuGet.Common
                 nameof(hashAlgorithmName));
         }
 
-        public static HashAlgorithm GetSha1HashProvider()
-        {
-#if !IS_CORECLR
-            if (AllowFipsAlgorithmsOnly.Value)
-            {
-                return new SHA1CryptoServiceProvider();
-            }
-            else
-            {
-                return new SHA1Managed();
-            }
-#else
-            return SHA1.Create();
-#endif
-        }
-
         // Read this value once.
         private static Lazy<bool> AllowFipsAlgorithmsOnly = new Lazy<bool>(() => ReadFipsConfigValue());
 

--- a/src/NuGet.Core/NuGet.Common/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Common/PublicAPI.Shipped.txt
@@ -496,7 +496,6 @@ static NuGet.Common.CryptoHashUtility.GetHashAlgorithm(NuGet.Common.HashAlgorith
 static NuGet.Common.CryptoHashUtility.GetHashAlgorithm(string hashAlgorithmName) -> System.Security.Cryptography.HashAlgorithm
 static NuGet.Common.CryptoHashUtility.GetHashAlgorithmName(string hashAlgorithm) -> NuGet.Common.HashAlgorithmName
 static NuGet.Common.CryptoHashUtility.GetHashProvider(this NuGet.Common.HashAlgorithmName hashAlgorithmName) -> System.Security.Cryptography.HashAlgorithm
-static NuGet.Common.CryptoHashUtility.GetSha1HashProvider() -> System.Security.Cryptography.HashAlgorithm
 static NuGet.Common.CryptoHashUtility.OidToHashAlgorithmName(string oid) -> NuGet.Common.HashAlgorithmName
 static NuGet.Common.CultureUtility.DisableLocalization() -> void
 static NuGet.Common.DatetimeUtility.ToReadableTimeFormat(System.TimeSpan time) -> string

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Utility/SignatureUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Utility/SignatureUtility.cs
@@ -581,7 +581,6 @@ namespace NuGet.Packaging.Signing
                 }
             }
 
-            //X509Certificate2.Thumbprint is dynamically generated using the SHA1 algorithm
             byte[] actualHash = FromHexStringToByteArray(certificate.Thumbprint);
 
             return essCertId.CertificateHash.SequenceEqual(actualHash);
@@ -652,22 +651,14 @@ namespace NuGet.Packaging.Signing
             return new DerSequenceReader(attribute.Values[0].RawData);
         }
 
-
         private static byte[] FromHexStringToByteArray(string thumbprint)
         {
             byte[] hash = new byte[thumbprint.Length / 2];
             for (int i = 0; i < hash.Length; i++)
             {
-                string byteString = thumbprint.Substring(i * 2, 2);
-                if (byte.TryParse(byteString, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out byte hashByte))
-                {
-                    hash[i] = hashByte;
-                }
-                else
-                {
-                    //If parsing fails, return the hash byte array. The mismatch will be processed by throwing SignatureException with SigningCertificateCertificateNotFound
-                    return hash;
-                }
+                string byteString = thumbprint.Substring(startIndex: i * 2, length: 2);
+
+                hash[i] = byte.Parse(byteString, NumberStyles.HexNumber, CultureInfo.InvariantCulture);
             }
             return hash;
         }

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/CryptoHashUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/CryptoHashUtilityTests.cs
@@ -107,47 +107,5 @@ namespace NuGet.Common.Test
             Assert.Equal("oid", exception.ParamName);
             Assert.StartsWith($"Hash algorithm '{Oids.Sha1}' is unsupported.", exception.Message);
         }
-
-        [Fact]
-        public void GetSha1HashProvider_ReturnsCorrectImplementation()
-        {
-            using (var hashAlgorithm = CryptoHashUtility.GetSha1HashProvider())
-            {
-                Assert.True(hashAlgorithm is SHA1);
-
-#if !IS_CORECLR
-                if (AllowOnlyFipsAlgorithms())
-                {
-                    Assert.IsType<SHA1CryptoServiceProvider>(hashAlgorithm);
-                }
-                else
-                {
-                    Assert.IsType<SHA1Managed>(hashAlgorithm);
-                }
-#endif
-            }
-        }
-
-        private static bool AllowOnlyFipsAlgorithms()
-        {
-#if !IS_CORECLR
-            // Mono does not currently support this method. Have this in a separate method to avoid JITing exceptions.
-            var cryptoConfig = typeof(CryptoConfig);
-
-            if (cryptoConfig != null)
-            {
-                var allowOnlyFipsAlgorithmsProperty = cryptoConfig.GetProperty("AllowOnlyFipsAlgorithms", BindingFlags.Public | BindingFlags.Static);
-
-                if (allowOnlyFipsAlgorithmsProperty != null)
-                {
-                    return (bool)allowOnlyFipsAlgorithmsProperty.GetValue(null, null);
-                }
-            }
-
-            return false;
-#else
-            return false;
-#endif
-        }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/SigningCertificateTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/SigningCertificateTests.cs
@@ -77,7 +77,7 @@ namespace NuGet.Packaging.Test
 
         private static BcEssCertId CreateBcEssCertId(string text)
         {
-            using (var hashAlgorithm = SigningTestUtility.GetSha1HashProvider())
+            using (var hashAlgorithm = SHA1.Create())
             {
                 var hash = hashAlgorithm.ComputeHash(Encoding.UTF8.GetBytes(text));
 

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/SigningCertificateTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/SigningCertificateTests.cs
@@ -77,7 +77,7 @@ namespace NuGet.Packaging.Test
 
         private static BcEssCertId CreateBcEssCertId(string text)
         {
-            using (var hashAlgorithm = CryptoHashUtility.GetSha1HashProvider())
+            using (var hashAlgorithm = SigningTestUtility.GetSha1HashProvider())
             {
                 var hash = hashAlgorithm.ComputeHash(Encoding.UTF8.GetBytes(text));
 

--- a/test/TestUtilities/Test.Utility/Signing/CertificateUtilities.cs
+++ b/test/TestUtilities/Test.Utility/Signing/CertificateUtilities.cs
@@ -27,7 +27,7 @@ namespace Test.Utility.Signing
 
         internal static string GenerateFingerprint(X509Certificate certificate)
         {
-            using (var hashAlgorithm = SigningTestUtility.GetSha1HashProvider())
+            using (var hashAlgorithm = SHA1.Create())
             {
                 var hash = hashAlgorithm.ComputeHash(certificate.GetEncoded());
 

--- a/test/TestUtilities/Test.Utility/Signing/CertificateUtilities.cs
+++ b/test/TestUtilities/Test.Utility/Signing/CertificateUtilities.cs
@@ -27,7 +27,7 @@ namespace Test.Utility.Signing
 
         internal static string GenerateFingerprint(X509Certificate certificate)
         {
-            using (var hashAlgorithm = CryptoHashUtility.GetSha1HashProvider())
+            using (var hashAlgorithm = SigningTestUtility.GetSha1HashProvider())
             {
                 var hash = hashAlgorithm.ComputeHash(certificate.GetEncoded());
 

--- a/test/TestUtilities/Test.Utility/Signing/SigningTestUtility.cs
+++ b/test/TestUtilities/Test.Utility/Signing/SigningTestUtility.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using System.Security.Cryptography;
 using System.Security.Cryptography.Pkcs;
 using System.Security.Cryptography.X509Certificates;
@@ -753,50 +752,6 @@ namespace Test.Utility.Signing
         public static string AddSignatureLogPrefix(string log, PackageIdentity package, string source)
         {
             return $"{string.Format(_signatureLogPrefix, package.Id, package.Version, source)} {log}";
-        }
-
-        public static HashAlgorithm GetSha1HashProvider()
-        {
-#if !IS_CORECLR
-            if (AllowFipsAlgorithmsOnly())
-            {
-                return new SHA1CryptoServiceProvider();
-            }
-            else
-            {
-                return new SHA1Managed();
-            }
-#else
-            return SHA1.Create();
-#endif
-        }
-
-        /// <summary>
-        /// Determines if we are to only allow Fips compliant algorithms.
-        /// </summary>
-        /// <remarks>
-        /// CryptoConfig.AllowOnlyFipsAlgorithm does not exist in Mono.
-        /// </remarks>
-        private static bool AllowFipsAlgorithmsOnly()
-        {
-#if !IS_CORECLR
-            // Mono does not currently support this method. Have this in a separate method to avoid JITing exceptions.
-            var cryptoConfig = typeof(CryptoConfig);
-
-            if (cryptoConfig != null)
-            {
-                var allowOnlyFipsAlgorithmsProperty = cryptoConfig.GetProperty("AllowOnlyFipsAlgorithms", BindingFlags.Public | BindingFlags.Static);
-
-                if (allowOnlyFipsAlgorithmsProperty != null)
-                {
-                    return (bool)allowOnlyFipsAlgorithmsProperty.GetValue(null, null);
-                }
-            }
-
-            return false;
-#else
-            return false;
-#endif
         }
     }
 }

--- a/test/TestUtilities/Test.Utility/Signing/SigningTestUtility.cs
+++ b/test/TestUtilities/Test.Utility/Signing/SigningTestUtility.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Security.Cryptography;
 using System.Security.Cryptography.Pkcs;
 using System.Security.Cryptography.X509Certificates;
@@ -752,6 +753,52 @@ namespace Test.Utility.Signing
         public static string AddSignatureLogPrefix(string log, PackageIdentity package, string source)
         {
             return $"{string.Format(_signatureLogPrefix, package.Id, package.Version, source)} {log}";
+        }
+
+        public static HashAlgorithm GetSha1HashProvider()
+        {
+#if !IS_CORECLR
+            if (AllowFipsAlgorithmsOnly.Value)
+            {
+                return new SHA1CryptoServiceProvider();
+            }
+            else
+            {
+                return new SHA1Managed();
+            }
+#else
+            return SHA1.Create();
+#endif
+        }
+
+        private static Lazy<bool> AllowFipsAlgorithmsOnly = new Lazy<bool>(() => ReadFipsConfigValue());
+
+        /// <summary>
+        /// Determines if we are to only allow Fips compliant algorithms.
+        /// </summary>
+        /// <remarks>
+        /// CryptoConfig.AllowOnlyFipsAlgorithm does not exist in Mono.
+        /// </remarks>
+        private static bool ReadFipsConfigValue()
+        {
+#if !IS_CORECLR
+            // Mono does not currently support this method. Have this in a separate method to avoid JITing exceptions.
+            var cryptoConfig = typeof(CryptoConfig);
+
+            if (cryptoConfig != null)
+            {
+                var allowOnlyFipsAlgorithmsProperty = cryptoConfig.GetProperty("AllowOnlyFipsAlgorithms", BindingFlags.Public | BindingFlags.Static);
+
+                if (allowOnlyFipsAlgorithmsProperty != null)
+                {
+                    return (bool)allowOnlyFipsAlgorithmsProperty.GetValue(null, null);
+                }
+            }
+
+            return false;
+#else
+            return false;
+#endif
         }
     }
 }

--- a/test/TestUtilities/Test.Utility/Signing/SigningTestUtility.cs
+++ b/test/TestUtilities/Test.Utility/Signing/SigningTestUtility.cs
@@ -758,7 +758,7 @@ namespace Test.Utility.Signing
         public static HashAlgorithm GetSha1HashProvider()
         {
 #if !IS_CORECLR
-            if (AllowFipsAlgorithmsOnly.Value)
+            if (AllowFipsAlgorithmsOnly())
             {
                 return new SHA1CryptoServiceProvider();
             }
@@ -771,15 +771,13 @@ namespace Test.Utility.Signing
 #endif
         }
 
-        private static Lazy<bool> AllowFipsAlgorithmsOnly = new Lazy<bool>(() => ReadFipsConfigValue());
-
         /// <summary>
         /// Determines if we are to only allow Fips compliant algorithms.
         /// </summary>
         /// <remarks>
         /// CryptoConfig.AllowOnlyFipsAlgorithm does not exist in Mono.
         /// </remarks>
-        private static bool ReadFipsConfigValue()
+        private static bool AllowFipsAlgorithmsOnly()
         {
 #if !IS_CORECLR
             // Mono does not currently support this method. Have this in a separate method to avoid JITing exceptions.


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Client.Engineering/issues/449
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: 
Replace the SHA1 instance usage with thumbprint in product code.
The X509Certificate2.Thumbprint property is dynamically generated using the SHA1 algorithm. 

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  
Validation:  
Tested `FromHexStringToByteArray` for the following senarios, both of them returned an mismatched byte array as expected: 
1. odd length of thumbprint string.
2.unexpected character in thumbprint string (like, "G").
