### PR TITLE
In commandline restore, in multi targeting scenarios, read the target framework details from the inner build

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -507,7 +507,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <!-- For project.json projects target frameworks will be read from project.json. -->
     <GetProjectTargetFrameworksTask
-      Condition=" '$(RestoreProjectStyle)' != 'ProjectJson' "
+      Condition=" '$(RestoreProjectStyle)' != 'ProjectJson' OR '$(PackageReferenceCompatibleProjectStyle)' == 'true' "
       ProjectPath="$(MSBuildProjectFullPath)"
       TargetFrameworks="$(TargetFrameworks)"
       TargetFramework="$(TargetFramework)"
@@ -711,7 +711,6 @@ Copyright (c) .NET Foundation. All rights reserved.
         <PackagesPath>$(_OutputPackagesPath)</PackagesPath>
         <ProjectStyle>$(RestoreProjectStyle)</ProjectStyle>
         <OutputPath>$(RestoreOutputAbsolutePath)</OutputPath>
-        <TargetFrameworks>@(_RestoreTargetFrameworksOutputFiltered)</TargetFrameworks>
         <RuntimeIdentifiers>$(RuntimeIdentifiers);$(RuntimeIdentifier)</RuntimeIdentifiers>
         <RuntimeSupports>$(RuntimeSupports)</RuntimeSupports>
         <CrossTargeting>$(_RestoreCrossTargeting)</CrossTargeting>
@@ -754,7 +753,6 @@ Copyright (c) .NET Foundation. All rights reserved.
         <ProjectPath>$(MSBuildProjectFullPath)</ProjectPath>
         <ProjectName>$(_RestoreProjectName)</ProjectName>
         <ProjectStyle>$(RestoreProjectStyle)</ProjectStyle>
-        <TargetFrameworks>@(_RestoreTargetFrameworksOutputFiltered)</TargetFrameworks>
         <PackagesConfigPath Condition="Exists('$(MSBuildProjectDirectory)\packages.$(MSBuildProjectName).config')">$(MSBuildProjectDirectory)\packages.$(MSBuildProjectName).config</PackagesConfigPath>
         <PackagesConfigPath Condition="Exists('$(MSBuildProjectDirectory)\packages.config')">$(MSBuildProjectDirectory)\packages.config</PackagesConfigPath>
         <RestorePackagesWithLockFile>$(RestorePackagesWithLockFile)</RestorePackagesWithLockFile>
@@ -776,7 +774,7 @@ Copyright (c) .NET Foundation. All rights reserved.
         <ProjectPath>$(MSBuildProjectFullPath)</ProjectPath>
         <ProjectName>$(_RestoreProjectName)</ProjectName>
         <ProjectStyle>$(RestoreProjectStyle)</ProjectStyle>
-        <TargetFrameworks>@(_RestoreTargetFrameworksOutputFiltered)</TargetFrameworks>
+        <TargetFrameworks>@(_RestoreTargetFrameworksOutputFiltered)</TargetFrameworks>	
       </_RestoreGraphEntry>
     </ItemGroup>
   </Target>
@@ -790,7 +788,6 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Target Name="_GenerateProjectRestoreGraph"
       DependsOnTargets="
       _GetRestoreProjectStyle;
-      _GetRestoreTargetFrameworksOutput;
       _GenerateRestoreProjectSpec;
       _GenerateRestoreDependencies"
       Returns="@(_RestoreGraphEntry)">
@@ -931,18 +928,20 @@ Copyright (c) .NET Foundation. All rights reserved.
       </_RestoreGraphEntry>
     </ItemGroup>
 
-    <PropertyGroup>
-      <_CombinedFallbacks>$(PackageTargetFallback);$(AssetTargetFallback)</_CombinedFallbacks>
-    </PropertyGroup>
-
     <!-- Write out target framework information -->
-    <ItemGroup Condition="  '$(PackageReferenceCompatibleProjectStyle)' == 'true' AND '$(_CombinedFallbacks)' != '' ">
+    <ItemGroup Condition="  '$(PackageReferenceCompatibleProjectStyle)' == 'true'">
       <_RestoreGraphEntry Include="$([System.Guid]::NewGuid())">
         <Type>TargetFrameworkInformation</Type>
         <ProjectUniqueName>$(MSBuildProjectFullPath)</ProjectUniqueName>
         <PackageTargetFallback>$(PackageTargetFallback)</PackageTargetFallback>
         <AssetTargetFallback>$(AssetTargetFallback)</AssetTargetFallback>
         <TargetFramework>$(TargetFramework)</TargetFramework>
+        <TargetFrameworkIdentifier>$(TargetFrameworkIdentifier)</TargetFrameworkIdentifier>
+        <TargetFrameworkVersion>$(TargetFrameworkVersion)</TargetFrameworkVersion>
+        <TargetFrameworkMoniker>$(TargetFrameworkMoniker)</TargetFrameworkMoniker>
+        <TargetPlatformIdentifier>$(TargetPlatformIdentifier)</TargetPlatformIdentifier>
+        <TargetPlatformVersion>$(TargetPlatformVersion)</TargetPlatformVersion>
+        <TargetPlatformMinVersion>$(TargetPlatformMinVersion)</TargetPlatformMinVersion>
       </_RestoreGraphEntry>
     </ItemGroup>
   </Target>

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -774,7 +774,7 @@ Copyright (c) .NET Foundation. All rights reserved.
         <ProjectPath>$(MSBuildProjectFullPath)</ProjectPath>
         <ProjectName>$(_RestoreProjectName)</ProjectName>
         <ProjectStyle>$(RestoreProjectStyle)</ProjectStyle>
-        <TargetFrameworks>@(_RestoreTargetFrameworksOutputFiltered)</TargetFrameworks>	
+        <TargetFrameworks>@(_RestoreTargetFrameworksOutputFiltered)</TargetFrameworks>
       </_RestoreGraphEntry>
     </ItemGroup>
   </Target>

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
@@ -797,11 +797,12 @@ namespace NuGet.Commands
                 var tfmProperty = specItem.GetProperty("TargetFrameworks");
                 if (!string.IsNullOrEmpty(tfmProperty))
                 {
+                    var needsAlias = projectStyle == ProjectStyle.DotnetCliTool;
                     spec.TargetFrameworks.Add(
                         new TargetFrameworkInformation()
                         {
                             FrameworkName = NuGetFramework.Parse(tfmProperty),
-                            TargetAlias = tfmProperty
+                            TargetAlias = needsAlias ? tfmProperty : string.Empty
                         });
                 }
             }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
@@ -1034,10 +1034,10 @@ namespace NuGet.Commands
         private static void AddCentralPackageVersions(PackageSpec spec, IEnumerable<IMSBuildItem> items)
         {
             var centralVersionsDependencies = CreateCentralVersionDependencies(items, spec.TargetFrameworks);
-            foreach (var framework in centralVersionsDependencies.Keys)
+            foreach (var targetAlias in centralVersionsDependencies.Keys)
             {
-                var frameworkInfo = spec.GetTargetFramework(framework);
-                frameworkInfo.CentralPackageVersions.AddRange(centralVersionsDependencies[framework]);
+                var frameworkInfo = spec.TargetFrameworks.FirstOrDefault(f => targetAlias.Equals(f.TargetAlias, StringComparison.OrdinalIgnoreCase));
+                frameworkInfo.CentralPackageVersions.AddRange(centralVersionsDependencies[targetAlias]);
             }
         }
     }

--- a/src/NuGet.Core/NuGet.Commands/Utility/MSBuildProjectFrameworkUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/Utility/MSBuildProjectFrameworkUtility.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -138,6 +138,16 @@ namespace NuGet.Commands
                     && ".NETFramework,Version=v4.0".Equals(currentFrameworkString, StringComparison.OrdinalIgnoreCase))
                 {
                     currentFrameworkString = "Silverlight,Version=v4.0,Profile=WindowsPhone71";
+                }
+
+                if (!string.IsNullOrEmpty(platformVersion))
+                {
+                    // TODO NK - this is hacky :)
+                    var framework = NuGetFramework.Parse(currentFrameworkString);
+                    if (framework.Version.Major >= 5 && framework.Framework.Equals(FrameworkConstants.FrameworkIdentifiers.NetCoreApp, StringComparison.OrdinalIgnoreCase))
+                    {
+                        currentFrameworkString = framework.GetShortFolderName() + $"-{platformIdentifier}{platformVersion}";
+                    }
                 }
 
                 frameworks.Add(currentFrameworkString);

--- a/src/NuGet.Core/NuGet.Commands/Utility/MSBuildProjectFrameworkUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/Utility/MSBuildProjectFrameworkUtility.cs
@@ -140,9 +140,9 @@ namespace NuGet.Commands
                     currentFrameworkString = "Silverlight,Version=v4.0,Profile=WindowsPhone71";
                 }
 
+                // Workaround until https://github.com/NuGet/Home/issues/9871 is ready.
                 if (!string.IsNullOrEmpty(platformVersion))
                 {
-                    // TODO NK - this is hacky :)
                     var framework = NuGetFramework.Parse(currentFrameworkString);
                     if (framework.Version.Major >= 5 && framework.Framework.Equals(FrameworkConstants.FrameworkIdentifiers.NetCoreApp, StringComparison.OrdinalIgnoreCase))
                     {

--- a/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
@@ -1449,9 +1449,9 @@ namespace NuGet.ProjectModel
                 NuGetFramework framework = NuGetFramework.Parse(frameworkPropertyName);
                 var frameworkGroup = new ProjectRestoreMetadataFrameworkInfo(framework);
 
-                jsonReader.ReadObject(projectReferencesPropertyName =>
+                jsonReader.ReadObject(propertyName =>
                 {
-                    if (projectReferencesPropertyName == "projectReferences")
+                    if (propertyName == "projectReferences")
                     {
                         jsonReader.ReadObject(projectReferencePropertyName =>
                         {
@@ -1500,6 +1500,10 @@ namespace NuGet.ProjectModel
                                     defaultFlags: LibraryIncludeFlagUtils.DefaultSuppressParent),
                             });
                         });
+                    }
+                    else if(propertyName == "targetAlias")
+                    {
+                        frameworkGroup.TargetAlias = jsonReader.ReadNextTokenAsString();
                     }
                 });
 
@@ -1569,6 +1573,10 @@ namespace NuGet.ProjectModel
 
                     case "runtimeIdentifierGraphPath":
                         targetFrameworkInformation.RuntimeIdentifierGraphPath = jsonReader.ReadNextTokenAsString();
+                        break;
+
+                    case "targetAlias":
+                        targetFrameworkInformation.TargetAlias = jsonReader.ReadNextTokenAsString();
                         break;
 
                     case "warn":

--- a/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
@@ -1501,7 +1501,7 @@ namespace NuGet.ProjectModel
                             });
                         });
                     }
-                    else if(propertyName == "targetAlias")
+                    else if (propertyName == "targetAlias")
                     {
                         frameworkGroup.TargetAlias = jsonReader.ReadNextTokenAsString();
                     }

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpecExtensions.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpecExtensions.cs
@@ -1,6 +1,7 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Linq;
 using NuGet.Frameworks;
 
@@ -13,13 +14,20 @@ namespace NuGet.ProjectModel
         /// </summary>
         public static TargetFrameworkInformation GetTargetFramework(this PackageSpec project, NuGetFramework targetFramework)
         {
-            var frameworkInfo = project.TargetFrameworks.FirstOrDefault(f => NuGetFrameworkFullComparer.Equals(targetFramework, f));
+            var frameworkInfo = project.TargetFrameworks.FirstOrDefault(f => NuGetFramework.Comparer.Equals(targetFramework, f.FrameworkName));
             if (frameworkInfo == null)
             {
                 frameworkInfo = NuGetFrameworkUtility.GetNearest(project.TargetFrameworks,
                     targetFramework,
                     item => item.FrameworkName);
             }
+
+            return frameworkInfo ?? new TargetFrameworkInformation();
+        }
+
+        public static TargetFrameworkInformation GetTargetFramework(this PackageSpec project, string targetAlias)
+        {
+            var frameworkInfo = project.TargetFrameworks.FirstOrDefault(f => targetAlias.Equals(f.TargetAlias, StringComparison.OrdinalIgnoreCase));
 
             return frameworkInfo ?? new TargetFrameworkInformation();
         }

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpecExtensions.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpecExtensions.cs
@@ -25,13 +25,6 @@ namespace NuGet.ProjectModel
             return frameworkInfo ?? new TargetFrameworkInformation();
         }
 
-        public static TargetFrameworkInformation GetTargetFramework(this PackageSpec project, string targetAlias)
-        {
-            var frameworkInfo = project.TargetFrameworks.FirstOrDefault(f => targetAlias.Equals(f.TargetAlias, StringComparison.OrdinalIgnoreCase));
-
-            return frameworkInfo ?? new TargetFrameworkInformation();
-        }
-
         /// <summary>
         /// Get restore metadata framework. This is based on the project's target frameworks, then an 
         /// exact match is found under restore metadata.

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpecWriter.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpecWriter.cs
@@ -140,14 +140,8 @@ namespace NuGet.ProjectModel
 
             SetArrayValue(writer, "fallbackFolders", msbuildMetadata.FallbackFolders);
             SetArrayValue(writer, "configFilePaths", msbuildMetadata.ConfigFilePaths);
-            if (msbuildMetadata.CrossTargeting)
-            {
-                SetArrayValue(writer, "originalTargetFrameworks", msbuildMetadata.OriginalTargetFrameworks.OrderBy(c => c, StringComparer.Ordinal)); // This need to stay the original strings because the nuget.g.targets have conditional imports based on the original framework name
-            }
-            else
-            {
-                SetArrayValue(writer, "originalTargetFrameworks", msbuildMetadata.OriginalTargetFrameworks.Select(e => NuGetFramework.Parse(e).GetShortFolderName()).OrderBy(c => c, StringComparer.Ordinal));
-            }
+            // This need to stay the original strings because the nuget.g.targets have conditional imports based on the original framework name
+            SetArrayValue(writer, "originalTargetFrameworks", msbuildMetadata.OriginalTargetFrameworks.OrderBy(c => c, StringComparer.Ordinal));
 
             WriteMetadataSources(writer, msbuildMetadata);
             WriteMetadataFiles(writer, msbuildMetadata);
@@ -209,6 +203,8 @@ namespace NuGet.ProjectModel
                         frameworkNames.Add(frameworkName);
 
                         writer.WriteObjectStart(frameworkName);
+
+                        SetValueIfNotNull(writer, "targetAlias", framework.TargetAlias);
 
                         writer.WriteObjectStart("projectReferences");
 
@@ -494,12 +490,11 @@ namespace NuGet.ProjectModel
             if (frameworks.Any())
             {
                 writer.WriteObjectStart("frameworks");
-
                 var frameworkSorter = new NuGetFrameworkSorter();
                 foreach (var framework in frameworks.OrderBy(c => c.FrameworkName, frameworkSorter))
                 {
                     writer.WriteObjectStart(framework.FrameworkName.GetShortFolderName());
-
+                    SetValueIfNotNull(writer, "targetAlias", framework.TargetAlias);
                     SetDependencies(writer, framework.Dependencies);
                     SetCentralDependencies(writer, framework.CentralPackageVersions.Values);
                     SetImports(writer, framework.Imports);

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadataFrameworkInfo.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadataFrameworkInfo.cs
@@ -12,6 +12,8 @@ namespace NuGet.ProjectModel
 {
     public class ProjectRestoreMetadataFrameworkInfo : IEquatable<ProjectRestoreMetadataFrameworkInfo>
     {
+        public string TargetAlias { get; set; } = string.Empty;
+
         /// <summary>
         /// Target framework
         /// </summary>
@@ -41,6 +43,7 @@ namespace NuGet.ProjectModel
             var hashCode = new HashCodeCombiner();
 
             hashCode.AddObject(FrameworkName);
+            hashCode.AddObject(TargetAlias);
             hashCode.AddSequence(ProjectReferences);
 
             return hashCode.CombinedHash;
@@ -64,6 +67,7 @@ namespace NuGet.ProjectModel
             }
 
             return EqualityUtility.EqualsWithNullCheck(FrameworkName, other.FrameworkName) &&
+                   EqualityUtility.EqualsWithNullCheck(TargetAlias, other.TargetAlias) &&
                    ProjectReferences.OrderedEquals(other.ProjectReferences, e => e.ProjectPath, PathUtility.GetStringComparerBasedOnOS());
         }
 
@@ -71,6 +75,7 @@ namespace NuGet.ProjectModel
         {
             var clonedObject = new ProjectRestoreMetadataFrameworkInfo();
             clonedObject.FrameworkName = FrameworkName;
+            clonedObject.TargetAlias = TargetAlias;
             clonedObject.ProjectReferences = ProjectReferences?.Select(c => c.Clone()).ToList();
             return clonedObject;
         }

--- a/src/NuGet.Core/NuGet.ProjectModel/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.ProjectModel/PublicAPI.Unshipped.txt
@@ -1,0 +1,5 @@
+NuGet.ProjectModel.ProjectRestoreMetadataFrameworkInfo.TargetAlias.get -> string
+NuGet.ProjectModel.ProjectRestoreMetadataFrameworkInfo.TargetAlias.set -> void
+NuGet.ProjectModel.TargetFrameworkInformation.TargetAlias.get -> string
+NuGet.ProjectModel.TargetFrameworkInformation.TargetAlias.set -> void
+static NuGet.ProjectModel.PackageSpecExtensions.GetTargetFramework(this NuGet.ProjectModel.PackageSpec project, string targetAlias) -> NuGet.ProjectModel.TargetFrameworkInformation

--- a/src/NuGet.Core/NuGet.ProjectModel/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.ProjectModel/PublicAPI.Unshipped.txt
@@ -2,4 +2,3 @@ NuGet.ProjectModel.ProjectRestoreMetadataFrameworkInfo.TargetAlias.get -> string
 NuGet.ProjectModel.ProjectRestoreMetadataFrameworkInfo.TargetAlias.set -> void
 NuGet.ProjectModel.TargetFrameworkInformation.TargetAlias.get -> string
 NuGet.ProjectModel.TargetFrameworkInformation.TargetAlias.set -> void
-static NuGet.ProjectModel.PackageSpecExtensions.GetTargetFramework(this NuGet.ProjectModel.PackageSpec project, string targetAlias) -> NuGet.ProjectModel.TargetFrameworkInformation

--- a/src/NuGet.Core/NuGet.ProjectModel/TargetFrameworkInformation.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/TargetFrameworkInformation.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using NuGet.Frameworks;
 using NuGet.LibraryModel;
@@ -14,6 +13,8 @@ namespace NuGet.ProjectModel
 {
     public class TargetFrameworkInformation : IEquatable<TargetFrameworkInformation>
     {
+        public string TargetAlias { get; set; } = string.Empty;
+
         public NuGetFramework FrameworkName { get; set; }
 
         public IList<LibraryDependency> Dependencies { get; set; } = new List<LibraryDependency>();
@@ -71,6 +72,7 @@ namespace NuGet.ProjectModel
             hashCode.AddSequence(FrameworkReferences);
             hashCode.AddObject(RuntimeIdentifierGraphPath);
             hashCode.AddSequence(CentralPackageVersions);
+            hashCode.AddSequence(TargetAlias);
             return hashCode.CombinedHash;
         }
 
@@ -98,7 +100,8 @@ namespace NuGet.ProjectModel
                    DownloadDependencies.OrderedEquals(other.DownloadDependencies, dep => dep) &&
                    FrameworkReferences.OrderedEquals(other.FrameworkReferences, fr => fr) &&
                    CentralPackageVersions.Values.SequenceEqualWithNullCheck(other.CentralPackageVersions.Values) &&
-                   string.Equals(RuntimeIdentifierGraphPath, other.RuntimeIdentifierGraphPath);
+                   EqualityUtility.EqualsWithNullCheck(RuntimeIdentifierGraphPath, other.RuntimeIdentifierGraphPath) &&
+                   EqualityUtility.EqualsWithNullCheck(TargetAlias, other.TargetAlias);
         }
 
         public TargetFrameworkInformation Clone()
@@ -113,6 +116,7 @@ namespace NuGet.ProjectModel
             clonedObject.FrameworkReferences.AddRange(FrameworkReferences);
             clonedObject.RuntimeIdentifierGraphPath = RuntimeIdentifierGraphPath;
             clonedObject.CentralPackageVersions.AddRange(CentralPackageVersions.ToDictionary(item => item.Key, item => item.Value));
+            clonedObject.TargetAlias = TargetAlias;
             return clonedObject;
         }
     }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
@@ -1588,13 +1588,13 @@ namespace NuGet.CommandLine.Test
 
                 var projects = new List<SimpleTestProjectContext>();
 
-                var project = SimpleTestProjectContext.CreateNETCore(
+                var project = SimpleTestProjectContext.CreateNETCoreWithSDK(
                     "proj",
                     pathContext.SolutionRoot,
-                    NuGetFramework.Parse("netstandard1.3"),
-                    NuGetFramework.Parse("net4"));
+                    "net46",
+                    "net45");
 
-                project.OriginalFrameworkStrings = new List<string> { "netstandard1.3", "net4" };
+                project.OriginalFrameworkStrings = new List<string> { "net46", "net45" };
 
                 project.AddPackageToAllFrameworks(packageX);
                 solution.Projects.Add(project);
@@ -1614,8 +1614,8 @@ namespace NuGet.CommandLine.Test
 
                 var propsItemGroups = propsXML.Root.Elements().Where(e => e.Name.LocalName == "ItemGroup").ToList();
 
-                Assert.Equal("'$(TargetFramework)' == 'net4' AND '$(ExcludeRestorePackageImports)' != 'true'", propsItemGroups[1].Attribute(XName.Get("Condition")).Value.Trim());
-                Assert.Equal("'$(TargetFramework)' == 'netstandard1.3' AND '$(ExcludeRestorePackageImports)' != 'true'", propsItemGroups[2].Attribute(XName.Get("Condition")).Value.Trim());
+                Assert.Contains("'$(TargetFramework)' == 'net45' AND '$(ExcludeRestorePackageImports)' != 'true'", propsItemGroups[1].Attribute(XName.Get("Condition")).Value.Trim());
+                Assert.Contains("'$(TargetFramework)' == 'net46' AND '$(ExcludeRestorePackageImports)' != 'true'", propsItemGroups[2].Attribute(XName.Get("Condition")).Value.Trim());
             }
         }
 

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
@@ -14,6 +14,7 @@ using NuGet.Packaging;
 using NuGet.ProjectModel;
 using NuGet.Test.Utility;
 using Xunit;
+using static NuGet.Frameworks.FrameworkConstants;
 
 namespace Dotnet.Integration.Test
 {
@@ -828,6 +829,66 @@ EndGlobal";
 
                 // Assert
                 Assert.True(!result.Output.Contains($"The project {projectFile} is using CentralPackageVersionManagement, a NuGet preview feature."));
+            }
+        }
+
+        [PlatformFact(Platform.Windows)]
+        public async Task DotnetRestore_MultiTargettingWithAliases_Succeeds()
+        {
+            using (var pathContext = _msbuildFixture.CreateSimpleTestPathContext())
+            {
+                var testDirectory = pathContext.SolutionRoot;
+                var pkgX = new SimpleTestPackageContext("x", "1.0.0");
+                await SimpleTestPackageUtility.CreatePackagesAsync(pathContext.PackageSource, pkgX);
+
+                var latestNetFrameworkAlias = "latestnetframework";
+                var notLatestNetFrameworkAlias = "notlatestnetframework";
+                var projectName1 = "ClassLibrary1";
+                var workingDirectory1 = Path.Combine(testDirectory, projectName1);
+                var projectFile1 = Path.Combine(workingDirectory1, $"{projectName1}.csproj");
+                _msbuildFixture.CreateDotnetNewProject(testDirectory, projectName1, " classlib");
+
+                using (var stream = File.Open(projectFile1, FileMode.Open, FileAccess.ReadWrite))
+                {
+                    var xml = XDocument.Load(stream);
+                    ProjectFileUtils.SetTargetFrameworkForProject(xml, "TargetFrameworks", $"{latestNetFrameworkAlias};{notLatestNetFrameworkAlias}");
+
+                    var attributes = new Dictionary<string, string>() { { "Version", "1.0.0" } };
+
+                    ProjectFileUtils.AddItem(
+                        xml,
+                        "PackageReference",
+                        "x",
+                        notLatestNetFrameworkAlias,
+                        new Dictionary<string, string>(),
+                        attributes);
+
+                    var latestNetFrameworkProps = new Dictionary<string, string>();
+                    latestNetFrameworkProps.Add("TargetFrameworkIdentifier", ".NETFramework");
+                    latestNetFrameworkProps.Add("TargetFrameworkVersion", "v4.7.2");
+
+                    ProjectFileUtils.AddProperties(xml, latestNetFrameworkProps, $" '$(TargetFramework)' == '{latestNetFrameworkAlias}' ");
+
+                    var notLatestNetFrameworkProps = new Dictionary<string, string>();
+                    notLatestNetFrameworkProps.Add("TargetFrameworkIdentifier", ".NETFramework");
+                    notLatestNetFrameworkProps.Add("TargetFrameworkVersion", "v4.6.3");
+                    ProjectFileUtils.AddProperties(xml, notLatestNetFrameworkProps, $" '$(TargetFramework)' == '{notLatestNetFrameworkAlias}' ");
+
+                    ProjectFileUtils.WriteXmlToFile(xml, stream);
+                }
+
+                // Act
+                var result = _msbuildFixture.RunDotnet(pathContext.SolutionRoot, $"restore {projectFile1} {$"--source \"{pathContext.PackageSource}\" /p:AutomaticallyUseReferenceAssemblyPackages=false"}", ignoreExitCode: true);
+
+                // Assert
+                result.ExitCode.Should().Be(0, because: result.AllOutput);
+                var assetsFilePath = Path.Combine(workingDirectory1, "obj", "project.assets.json");
+                File.Exists(assetsFilePath).Should().BeTrue(because: "The assets file needs to exist");
+                var assetsFile = new LockFileFormat().Read(assetsFilePath);
+                LockFileTarget nonLatestTarget = assetsFile.Targets.Single(e => e.TargetFramework.Equals(CommonFrameworks.Net463) && string.IsNullOrEmpty(e.RuntimeIdentifier));
+                nonLatestTarget.Libraries.Should().ContainSingle(e => e.Name.Equals("x"));
+                LockFileTarget latestTarget = assetsFile.Targets.Single(e => e.TargetFramework.Equals(NuGetFramework.Parse("net472")) && string.IsNullOrEmpty(e.RuntimeIdentifier));
+                latestTarget.Libraries.Should().NotContain(e => e.Name.Equals("x"));
             }
         }
 

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/MsbuildIntegrationTestFixture.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/MsbuildIntegrationTestFixture.cs
@@ -136,8 +136,8 @@ namespace Dotnet.Integration.Test
             var projectFile = $@"<Project Sdk=""Microsoft.NET.Sdk"">
                 <PropertyGroup><RestoreProjectStyle>DotnetToolReference</RestoreProjectStyle>
                 <OutputType>Exe</OutputType>
-                <TargetFramework> {targetFramework} </TargetFramework>
-                <RuntimeIdentifier>{rid} </RuntimeIdentifier>
+                <TargetFramework>{targetFramework}</TargetFramework>
+                <RuntimeIdentifier>{rid}</RuntimeIdentifier>
                 <!-- Things that do change-->
                 <RestorePackagesPath>{restorePackagesPath}</RestorePackagesPath>
                 <RestoreSolutionDirectory>{restoreSolutionDirectory}</RestoreSolutionDirectory>

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/MSBuildRestoreUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/MSBuildRestoreUtilityTests.cs
@@ -69,12 +69,45 @@ namespace NuGet.Commands.Test
                     { "OutputPath", outputPath1 },
                     { "ProjectUniqueName", project1UniqueName },
                     { "ProjectPath", project1Path },
-                    { "TargetFrameworks", "net46;netstandard1.6" },
                     { "CrossTargeting", "true" },
                 };
 
                 itemsWithSameCasings.Add(projectAItem);
                 itemsWithDifferentCasings.Add(WithUniqueName(projectAItem, project1UniqueNameCasings[0]));
+
+                var projectATfmInformationNetItem = new Dictionary<string, string>()
+                {
+                    { "Type", "TargetFrameworkInformation" },
+                    { "AssetTargetFallback", "" },
+                    { "PackageTargetFallback", "" },
+                    { "ProjectUniqueName", project1UniqueName },
+                    { "TargetFramework", "net46" },
+                    { "TargetFrameworkIdentifier", ".NETFramework" },
+                    { "TargetFrameworkVersion", "v4.6" },
+                    { "TargetFrameworkMoniker", ".NETFramework,Version=v4.6" },
+                    { "TargetPlatformIdentifier", "" },
+                    { "TargetPlatformVersion", "" },
+                };
+
+                itemsWithSameCasings.Add(projectATfmInformationNetItem);
+                itemsWithDifferentCasings.Add(WithUniqueName(projectATfmInformationNetItem, project1UniqueNameCasings[0]));
+
+                var projectATfmInformationNSItem = new Dictionary<string, string>()
+                {
+                    { "Type", "TargetFrameworkInformation" },
+                    { "AssetTargetFallback", "" },
+                    { "PackageTargetFallback", "" },
+                    { "ProjectUniqueName", project1UniqueName },
+                    { "TargetFramework", "netstandard1.6" },
+                    { "TargetFrameworkIdentifier", ".NETStandard" },
+                    { "TargetFrameworkVersion", "v1.6" },
+                    { "TargetFrameworkMoniker", ".NETStandard,Version=v1.6" },
+                    { "TargetPlatformIdentifier", "" },
+                    { "TargetPlatformVersion", "" },
+                };
+
+                itemsWithSameCasings.Add(projectATfmInformationNSItem);
+                itemsWithDifferentCasings.Add(WithUniqueName(projectATfmInformationNSItem, project1UniqueNameCasings[0]));
 
                 var projectBItem = new Dictionary<string, string>()
                 {
@@ -84,18 +117,51 @@ namespace NuGet.Commands.Test
                     { "OutputPath", outputPath2 },
                     { "ProjectUniqueName", project2UniqueName },
                     { "ProjectPath", project2Path },
-                    { "TargetFrameworks", "net45;netstandard1.0" },
                     { "CrossTargeting", "true" },
                 };
 
                 itemsWithSameCasings.Add(projectBItem);
                 itemsWithDifferentCasings.Add(WithUniqueName(projectBItem, project2UniqueNameCasings[0]));
 
+                var projectBTfmInformationNetItem = new Dictionary<string, string>()
+                {
+                    { "Type", "TargetFrameworkInformation" },
+                    { "AssetTargetFallback", "" },
+                    { "PackageTargetFallback", "" },
+                    { "ProjectUniqueName", project2UniqueName },
+                    { "TargetFramework", "net45" },
+                    { "TargetFrameworkIdentifier", ".NETFramework" },
+                    { "TargetFrameworkVersion", "v4.5" },
+                    { "TargetFrameworkMoniker", ".NETFramework,Version=v4.5" },
+                    { "TargetPlatformIdentifier", "" },
+                    { "TargetPlatformVersion", "" },
+                };
+
+                itemsWithSameCasings.Add(projectBTfmInformationNetItem);
+                itemsWithDifferentCasings.Add(WithUniqueName(projectBTfmInformationNetItem, project2UniqueNameCasings[0]));
+
+                var projectBTfmInformationNSItem = new Dictionary<string, string>()
+                {
+                    { "Type", "TargetFrameworkInformation" },
+                    { "AssetTargetFallback", "" },
+                    { "PackageTargetFallback", "" },
+                    { "ProjectUniqueName", project2UniqueName },
+                    { "TargetFramework", "netstandard1.0" },
+                    { "TargetFrameworkIdentifier", ".NETStandard" },
+                    { "TargetFrameworkVersion", "v1.0" },
+                    { "TargetFrameworkMoniker", ".NETStandard,Version=v1.0" },
+                    { "TargetPlatformIdentifier", "" },
+                    { "TargetPlatformVersion", "" },
+                };
+
+                itemsWithSameCasings.Add(projectBTfmInformationNSItem);
+                itemsWithDifferentCasings.Add(WithUniqueName(projectBTfmInformationNSItem, project2UniqueNameCasings[0]));
+
                 // A -> B
                 var projectReference = new Dictionary<string, string>()
                 {
                     { "Type", "ProjectReference" },
-                    { "ProjectUniqueName", project1UniqueName },
+                    { "ProjectUniqueName", project2UniqueName },
                     { "ProjectReferenceUniqueName", project2UniqueName },
                     { "ProjectPath", project2Path },
                     { "TargetFrameworks", "netstandard1.6" },
@@ -208,10 +274,39 @@ namespace NuGet.Commands.Test
                     { "OutputPath", outputPath1 },
                     { "ProjectUniqueName", project1UniqueName },
                     { "ProjectPath", project1Path },
-                    { "TargetFrameworks", "net46;netstandard1.6" },
                     { "CrossTargeting", "true" },
                 };
                 items.Add(projectAItem);
+
+                var projectATfmInformationNetItem = new Dictionary<string, string>()
+                {
+                    { "Type", "TargetFrameworkInformation" },
+                    { "AssetTargetFallback", "" },
+                    { "PackageTargetFallback", "" },
+                    { "ProjectUniqueName", project1UniqueName },
+                    { "TargetFramework", "net46" },
+                    { "TargetFrameworkIdentifier", ".NETFramework" },
+                    { "TargetFrameworkVersion", "v4.6" },
+                    { "TargetFrameworkMoniker", ".NETFramework,Version=v4.6" },
+                    { "TargetPlatformIdentifier", "" },
+                    { "TargetPlatformVersion", "" },
+                };
+                items.Add(projectATfmInformationNetItem);
+
+                var projectATfmInformationNSItem = new Dictionary<string, string>()
+                {
+                    { "Type", "TargetFrameworkInformation" },
+                    { "AssetTargetFallback", "" },
+                    { "PackageTargetFallback", "" },
+                    { "ProjectUniqueName", project1UniqueName },
+                    { "TargetFramework", "netstandard1.6" },
+                    { "TargetFrameworkIdentifier", ".NETStandard" },
+                    { "TargetFrameworkVersion", "v1.6" },
+                    { "TargetFrameworkMoniker", ".NETStandard,Version=v1.6" },
+                    { "TargetPlatformIdentifier", "" },
+                    { "TargetPlatformVersion", "" },
+                };
+                items.Add(projectATfmInformationNSItem);
 
                 var projectA2Item = new Dictionary<string, string>()
                 {
@@ -221,10 +316,39 @@ namespace NuGet.Commands.Test
                     { "OutputPath", outputPath2 },
                     { "ProjectUniqueName", project2UniqueName },
                     { "ProjectPath", project2Path },
-                    { "TargetFrameworks", "net46;netstandard1.6" },
                     { "CrossTargeting", "true" },
                 };
                 items.Add(projectA2Item);
+
+                var project2TfmInformationNetItem = new Dictionary<string, string>()
+                {
+                    { "Type", "TargetFrameworkInformation" },
+                    { "AssetTargetFallback", "" },
+                    { "PackageTargetFallback", "" },
+                    { "ProjectUniqueName", project2UniqueName },
+                    { "TargetFramework", "net46" },
+                    { "TargetFrameworkIdentifier", ".NETFramework" },
+                    { "TargetFrameworkVersion", "v4.6" },
+                    { "TargetFrameworkMoniker", ".NETFramework,Version=v4.6" },
+                    { "TargetPlatformIdentifier", "" },
+                    { "TargetPlatformVersion", "" },
+                };
+                items.Add(project2TfmInformationNetItem);
+
+                var project2TfmInformationNSItem = new Dictionary<string, string>()
+                {
+                    { "Type", "TargetFrameworkInformation" },
+                    { "AssetTargetFallback", "" },
+                    { "PackageTargetFallback", "" },
+                    { "ProjectUniqueName", project2UniqueName },
+                    { "TargetFramework", "netstandard1.6" },
+                    { "TargetFrameworkIdentifier", ".NETStandard" },
+                    { "TargetFrameworkVersion", "v1.6" },
+                    { "TargetFrameworkMoniker", ".NETStandard,Version=v1.6" },
+                    { "TargetPlatformIdentifier", "" },
+                    { "TargetPlatformVersion", "" },
+                };
+                items.Add(project2TfmInformationNSItem);
 
                 // Package references
                 // A net46 -> X
@@ -296,10 +420,24 @@ namespace NuGet.Commands.Test
                     { "OutputPath", outputPath1 },
                     { "ProjectUniqueName", project1UniqueName },
                     { "ProjectPath", project1Path },
-                    { "TargetFrameworks", "net46" },
                     { "CrossTargeting", "true" },
                 };
                 items.Add(projectAItem);
+
+                var project1TfmInformationItem = new Dictionary<string, string>()
+                {
+                    { "Type", "TargetFrameworkInformation" },
+                    { "AssetTargetFallback", "" },
+                    { "PackageTargetFallback", "" },
+                    { "ProjectUniqueName", project1UniqueName },
+                    { "TargetFramework", "net46" },
+                    { "TargetFrameworkIdentifier", ".NETFramework" },
+                    { "TargetFrameworkVersion", "v4.6" },
+                    { "TargetFrameworkMoniker", ".NETFramework,Version=4.6" },
+                    { "TargetPlatformIdentifier", "" },
+                    { "TargetPlatformVersion", "" },
+                };
+                items.Add(project1TfmInformationItem);
 
                 var projectBItem = new Dictionary<string, string>()
                 {
@@ -313,6 +451,21 @@ namespace NuGet.Commands.Test
                     { "CrossTargeting", "true" },
                 };
                 items.Add(projectBItem);
+
+                var project2TfmInformationItem = new Dictionary<string, string>()
+                {
+                    { "Type", "TargetFrameworkInformation" },
+                    { "AssetTargetFallback", "" },
+                    { "PackageTargetFallback", "" },
+                    { "ProjectUniqueName", project2UniqueName },
+                    { "TargetFramework", "net46" },
+                    { "TargetFrameworkIdentifier", ".NETFramework" },
+                    { "TargetFrameworkVersion", "v4.6" },
+                    { "TargetFrameworkMoniker", ".NETFramework,Version=4.6" },
+                    { "TargetPlatformIdentifier", "" },
+                    { "TargetPlatformVersion", "" },
+                };
+                items.Add(project2TfmInformationItem);
 
                 // A -> B
                 items.Add(new Dictionary<string, string>()
@@ -368,7 +521,6 @@ namespace NuGet.Commands.Test
                     { "OutputPath", outputPath1 },
                     { "ProjectUniqueName", project1UniqueName },
                     { "ProjectPath", project1Path },
-                    { "TargetFrameworks", "net46" },
                     { "CrossTargeting", "true" },
                 };
                 items.Add(projectAItem);
@@ -381,10 +533,37 @@ namespace NuGet.Commands.Test
                     { "OutputPath", outputPath2 },
                     { "ProjectUniqueName", project2UniqueName },
                     { "ProjectPath", project2Path },
-                    { "TargetFrameworks", "net46" },
                     { "CrossTargeting", "true" },
                 };
                 items.Add(projectBItem);
+
+                items.Add(new Dictionary<string, string>()
+                {
+                    { "Type", "TargetFrameworkInformation" },
+                    { "AssetTargetFallback", "" },
+                    { "PackageTargetFallback", "" },
+                    { "ProjectUniqueName", project1UniqueName },
+                    { "TargetFramework", "net46" },
+                    { "TargetFrameworkIdentifier", ".NETFramework" },
+                    { "TargetFrameworkVersion", "v4.6" },
+                    { "TargetFrameworkMoniker", ".NETFramework,Version=4.6" },
+                    { "TargetPlatformIdentifier", "" },
+                    { "TargetPlatformVersion", "" },
+                });
+
+                items.Add(new Dictionary<string, string>()
+                {
+                    { "Type", "TargetFrameworkInformation" },
+                    { "AssetTargetFallback", "" },
+                    { "PackageTargetFallback", "" },
+                    { "ProjectUniqueName", project2UniqueName },
+                    { "TargetFramework", "net46" },
+                    { "TargetFrameworkIdentifier", ".NETFramework" },
+                    { "TargetFrameworkVersion", "v4.6" },
+                    { "TargetFrameworkMoniker", ".NETFramework,Version=4.6" },
+                    { "TargetPlatformIdentifier", "" },
+                    { "TargetPlatformVersion", "" },
+                });
 
                 // A -> B
                 items.Add(new Dictionary<string, string>()
@@ -439,7 +618,6 @@ namespace NuGet.Commands.Test
                     { "OutputPath", outputPath1 },
                     { "ProjectUniqueName", project1UniqueName },
                     { "ProjectPath", project1Path },
-                    { "TargetFrameworks", "net46" },
                     { "CrossTargeting", "true" },
                 };
                 items.Add(projectAItem);
@@ -452,10 +630,37 @@ namespace NuGet.Commands.Test
                     { "OutputPath", outputPath2 },
                     { "ProjectUniqueName", project2UniqueName },
                     { "ProjectPath", project2Path },
-                    { "TargetFrameworks", "net46" },
                     { "CrossTargeting", "true" },
                 };
                 items.Add(projectBItem);
+
+                items.Add(new Dictionary<string, string>()
+                {
+                    { "Type", "TargetFrameworkInformation" },
+                    { "AssetTargetFallback", "" },
+                    { "PackageTargetFallback", "" },
+                    { "ProjectUniqueName", project1UniqueName },
+                    { "TargetFramework", "net46" },
+                    { "TargetFrameworkIdentifier", ".NETFramework" },
+                    { "TargetFrameworkVersion", "v4.6" },
+                    { "TargetFrameworkMoniker", ".NETFramework,Version=4.6" },
+                    { "TargetPlatformIdentifier", "" },
+                    { "TargetPlatformVersion", "" },
+                });
+
+                items.Add(new Dictionary<string, string>()
+                {
+                    { "Type", "TargetFrameworkInformation" },
+                    { "AssetTargetFallback", "" },
+                    { "PackageTargetFallback", "" },
+                    { "ProjectUniqueName", project2UniqueName },
+                    { "TargetFramework", "net46" },
+                    { "TargetFrameworkIdentifier", ".NETFramework" },
+                    { "TargetFrameworkVersion", "v4.6" },
+                    { "TargetFrameworkMoniker", ".NETFramework,Version=4.6" },
+                    { "TargetPlatformIdentifier", "" },
+                    { "TargetPlatformVersion", "" },
+                });
 
                 // A -> B
                 items.Add(new Dictionary<string, string>()
@@ -511,7 +716,8 @@ namespace NuGet.Commands.Test
                 var project3Root = Path.Combine(workingDir, "c");
                 var project3Path = Path.Combine(project3Root, "c.csproj");
                 var outputPath3 = Path.Combine(project3Root, "obj");
-
+                var project1UniqueName = "482C20DE-DFF9-4BD0-B90A-BD3201AA351A";
+                var project2UniqueName = "C82C20DE-DFF9-4BD0-B90A-BD3201AA351A";
                 var items = new List<IDictionary<string, string>>();
 
                 items.Add(new Dictionary<string, string>()
@@ -521,8 +727,52 @@ namespace NuGet.Commands.Test
                     { "ProjectName", "a" },
                     { "ProjectStyle", "PackageReference" },
                     { "OutputPath", outputPath1 },
-                    { "ProjectUniqueName", "482C20DE-DFF9-4BD0-B90A-BD3201AA351A" },
+                    { "ProjectUniqueName", project1UniqueName },
                     { "ProjectPath", project1Path },
+                    { "Sources", "https://nuget.org/a/index.json;https://nuget.org/b/index.json" },
+                    { "FallbackFolders", fallbackFolder },
+                    { "PackagesPath", packagesFolder },
+                    { "CrossTargeting", "true" },
+                    { "RestoreLegacyPackagesDirectory", "true" }
+                });
+
+                items.Add(new Dictionary<string, string>()
+                {
+                    { "Type", "TargetFrameworkInformation" },
+                    { "AssetTargetFallback", "" },
+                    { "PackageTargetFallback", "" },
+                    { "ProjectUniqueName", project1UniqueName },
+                    { "TargetFramework", "net46" },
+                    { "TargetFrameworkIdentifier", ".NETFramework" },
+                    { "TargetFrameworkVersion", "v4.6" },
+                    { "TargetFrameworkMoniker", ".NETFramework,Version=4.6" },
+                    { "TargetPlatformIdentifier", "" },
+                    { "TargetPlatformVersion", "" },
+                });
+
+                items.Add(new Dictionary<string, string>()
+                {
+                    { "Type", "TargetFrameworkInformation" },
+                    { "AssetTargetFallback", "" },
+                    { "PackageTargetFallback", "" },
+                    { "ProjectUniqueName", project1UniqueName },
+                    { "TargetFramework", "netstandard1.6" },
+                    { "TargetFrameworkIdentifier", ".NETStandard" },
+                    { "TargetFrameworkVersion", "v1.6" },
+                    { "TargetFrameworkMoniker", ".NETStandard,Version=v1.6" },
+                    { "TargetPlatformIdentifier", "" },
+                    { "TargetPlatformVersion", "" },
+                });
+
+                items.Add(new Dictionary<string, string>()
+                {
+                    { "Type", "ProjectSpec" },
+                    { "Version", "2.0.0-rc.2+a.b.c" },
+                    { "ProjectName", "c" },
+                    { "ProjectStyle", "PackageReference" },
+                    { "OutputPath", outputPath3 },
+                    { "ProjectUniqueName", project2UniqueName },
+                    { "ProjectPath", project3Path },
                     { "TargetFrameworks", "net46;netstandard16" },
                     { "Sources", "https://nuget.org/a/index.json;https://nuget.org/b/index.json" },
                     { "FallbackFolders", fallbackFolder },
@@ -533,19 +783,30 @@ namespace NuGet.Commands.Test
 
                 items.Add(new Dictionary<string, string>()
                 {
-                    { "Type", "ProjectSpec" },
-                    { "Version", "2.0.0-rc.2+a.b.c" },
-                    { "ProjectName", "c" },
-                    { "ProjectStyle", "PackageReference" },
-                    { "OutputPath", outputPath3 },
-                    { "ProjectUniqueName", "C82C20DE-DFF9-4BD0-B90A-BD3201AA351A" },
-                    { "ProjectPath", project3Path },
-                    { "TargetFrameworks", "net46;netstandard16" },
-                    { "Sources", "https://nuget.org/a/index.json;https://nuget.org/b/index.json" },
-                    { "FallbackFolders", fallbackFolder },
-                    { "PackagesPath", packagesFolder },
-                    { "CrossTargeting", "true" },
-                    { "RestoreLegacyPackagesDirectory", "true" }
+                    { "Type", "TargetFrameworkInformation" },
+                    { "AssetTargetFallback", "" },
+                    { "PackageTargetFallback", "" },
+                    { "ProjectUniqueName", project2UniqueName },
+                    { "TargetFramework", "net46" },
+                    { "TargetFrameworkIdentifier", ".NETFramework" },
+                    { "TargetFrameworkVersion", "v4.6" },
+                    { "TargetFrameworkMoniker", ".NETFramework,Version=4.6" },
+                    { "TargetPlatformIdentifier", "" },
+                    { "TargetPlatformVersion", "" },
+                });
+
+                items.Add(new Dictionary<string, string>()
+                {
+                    { "Type", "TargetFrameworkInformation" },
+                    { "AssetTargetFallback", "" },
+                    { "PackageTargetFallback", "" },
+                    { "ProjectUniqueName", project2UniqueName },
+                    { "TargetFramework", "netstandard1.6" },
+                    { "TargetFrameworkIdentifier", ".NETStandard" },
+                    { "TargetFrameworkVersion", "v1.6" },
+                    { "TargetFrameworkMoniker", ".NETStandard,Version=v1.6" },
+                    { "TargetPlatformIdentifier", "" },
+                    { "TargetPlatformVersion", "" },
                 });
 
                 // A -> B
@@ -695,7 +956,7 @@ namespace NuGet.Commands.Test
                 var project1Root = Path.Combine(workingDir, "a");
                 var project1Path = Path.Combine(project1Root, "a.csproj");
                 var outputPath1 = Path.Combine(project1Root, "obj");
-
+                var project1UniqueName = "482C20DE-DFF9-4BD0-B90A-BD3201AA351A";
                 var items = new List<IDictionary<string, string>>();
 
                 items.Add(new Dictionary<string, string>()
@@ -704,10 +965,23 @@ namespace NuGet.Commands.Test
                     { "ProjectName", "a" },
                     { "ProjectStyle", "PackageReference" },
                     { "OutputPath", outputPath1 },
-                    { "ProjectUniqueName", "482C20DE-DFF9-4BD0-B90A-BD3201AA351A" },
+                    { "ProjectUniqueName", project1UniqueName },
                     { "ProjectPath", project1Path },
-                    { "TargetFrameworks", "net46" },
                     { "CrossTargeting", "true" },
+                });
+
+                items.Add(new Dictionary<string, string>()
+                {
+                    { "Type", "TargetFrameworkInformation" },
+                    { "AssetTargetFallback", "" },
+                    { "PackageTargetFallback", "" },
+                    { "ProjectUniqueName", project1UniqueName },
+                    { "TargetFramework", "net46" },
+                    { "TargetFrameworkIdentifier", ".NETFramework" },
+                    { "TargetFrameworkVersion", "v4.6" },
+                    { "TargetFrameworkMoniker", ".NETFramework,Version=4.6" },
+                    { "TargetPlatformIdentifier", "" },
+                    { "TargetPlatformVersion", "" },
                 });
 
                 // Package references
@@ -781,7 +1055,7 @@ namespace NuGet.Commands.Test
                 var fallbackFolder = Path.Combine(project1Root, "fallback");
                 var packagesFolder = Path.Combine(project1Root, "packages");
                 var configFilePath = Path.Combine(project1Root, "nuget.config");
-
+                var project1UniqueName = "482C20DE-DFF9-4BD0-B90A-BD3201AA351A";
                 var items = new List<IDictionary<string, string>>();
 
                 items.Add(new Dictionary<string, string>()
@@ -791,15 +1065,42 @@ namespace NuGet.Commands.Test
                     { "ProjectName", "a" },
                     { "ProjectStyle", "PackageReference" },
                     { "OutputPath", outputPath1 },
-                    { "ProjectUniqueName", "482C20DE-DFF9-4BD0-B90A-BD3201AA351A" },
+                    { "ProjectUniqueName", project1UniqueName },
                     { "ProjectPath", project1Path },
-                    { "TargetFrameworks", "net46;netstandard16" },
                     { "Sources", "https://nuget.org/a/index.json;https://nuget.org/b/index.json" },
                     { "FallbackFolders", fallbackFolder },
                     { "PackagesPath", packagesFolder },
                     { "ConfigFilePaths", configFilePath },
                     { "CrossTargeting", "true" },
                     { "RestoreLegacyPackagesDirectory", "true" }
+                });
+
+                items.Add(new Dictionary<string, string>()
+                {
+                    { "Type", "TargetFrameworkInformation" },
+                    { "AssetTargetFallback", "" },
+                    { "PackageTargetFallback", "" },
+                    { "ProjectUniqueName", project1UniqueName },
+                    { "TargetFramework", "net46" },
+                    { "TargetFrameworkIdentifier", ".NETFramework" },
+                    { "TargetFrameworkVersion", "v4.6" },
+                    { "TargetFrameworkMoniker", ".NETFramework,Version=4.6" },
+                    { "TargetPlatformIdentifier", "" },
+                    { "TargetPlatformVersion", "" },
+                });
+
+                items.Add(new Dictionary<string, string>()
+                {
+                    { "Type", "TargetFrameworkInformation" },
+                    { "AssetTargetFallback", "" },
+                    { "PackageTargetFallback", "" },
+                    { "ProjectUniqueName", project1UniqueName },
+                    { "TargetFramework", "netstandard16" },
+                    { "TargetFrameworkIdentifier", ".NETStandard" },
+                    { "TargetFrameworkVersion", "v1.6" },
+                    { "TargetFrameworkMoniker", ".NETStandard,Version=v1.6" },
+                    { "TargetPlatformIdentifier", "" },
+                    { "TargetPlatformVersion", "" },
                 });
 
                 var wrappedItems = items.Select(CreateItems).ToList();
@@ -813,7 +1114,7 @@ namespace NuGet.Commands.Test
                 Assert.Equal("a", project1Spec.Name);
                 Assert.Equal("2.0.0-rc.2+a.b.c", project1Spec.Version.ToFullString());
                 Assert.Equal(ProjectStyle.PackageReference, project1Spec.RestoreMetadata.ProjectStyle);
-                Assert.Equal("482C20DE-DFF9-4BD0-B90A-BD3201AA351A", project1Spec.RestoreMetadata.ProjectUniqueName);
+                Assert.Equal(project1UniqueName, project1Spec.RestoreMetadata.ProjectUniqueName);
                 Assert.Equal(project1Path, project1Spec.RestoreMetadata.ProjectPath);
                 Assert.Equal(0, project1Spec.RestoreMetadata.TargetFrameworks.SelectMany(e => e.ProjectReferences).Count());
                 Assert.Null(project1Spec.RestoreMetadata.ProjectJsonPath);
@@ -843,7 +1144,7 @@ namespace NuGet.Commands.Test
                 var fallbackFolder = Path.Combine(project1Root, "fallback");
                 var packagesFolder = Path.Combine(project1Root, "packages");
                 var configFilePath = Path.Combine(project1Root, "nuget.config");
-
+                var project1UniqueName = "482C20DE-DFF9-4BD0-B90A-BD3201AA351A";
                 var items = new List<IDictionary<string, string>>();
 
                 items.Add(new Dictionary<string, string>()
@@ -852,15 +1153,42 @@ namespace NuGet.Commands.Test
                     { "ProjectName", "a" },
                     { "ProjectStyle", "PackageReference" },
                     { "OutputPath", outputPath1 },
-                    { "ProjectUniqueName", "482C20DE-DFF9-4BD0-B90A-BD3201AA351A" },
+                    { "ProjectUniqueName", project1UniqueName },
                     { "ProjectPath", project1Path },
-                    { "TargetFrameworks", "net46;netstandard16" },
                     { "Sources", "https://nuget.org/a/index.json;https://nuget.org/b/index.json" },
                     { "FallbackFolders", fallbackFolder },
                     { "ConfigFilePaths", configFilePath },
                     { "PackagesPath", packagesFolder },
                     { "CrossTargeting", "true" },
                     { "RestoreLegacyPackagesDirectory", "true" }
+                });
+
+                items.Add(new Dictionary<string, string>()
+                {
+                    { "Type", "TargetFrameworkInformation" },
+                    { "AssetTargetFallback", "" },
+                    { "PackageTargetFallback", "" },
+                    { "ProjectUniqueName", project1UniqueName },
+                    { "TargetFramework", "net46" },
+                    { "TargetFrameworkIdentifier", ".NETFramework" },
+                    { "TargetFrameworkVersion", "v4.6" },
+                    { "TargetFrameworkMoniker", ".NETFramework,Version=4.6" },
+                    { "TargetPlatformIdentifier", "" },
+                    { "TargetPlatformVersion", "" },
+                });
+
+                items.Add(new Dictionary<string, string>()
+                {
+                    { "Type", "TargetFrameworkInformation" },
+                    { "AssetTargetFallback", "" },
+                    { "PackageTargetFallback", "" },
+                    { "ProjectUniqueName", project1UniqueName },
+                    { "TargetFramework", "netstandard16" },
+                    { "TargetFrameworkIdentifier", ".NETStandard" },
+                    { "TargetFrameworkVersion", "v1.6" },
+                    { "TargetFrameworkMoniker", ".NETStandard,Version=v1.6" },
+                    { "TargetPlatformIdentifier", "" },
+                    { "TargetPlatformVersion", "" },
                 });
 
                 var wrappedItems = items.Select(CreateItems).ToList();
@@ -927,7 +1255,7 @@ namespace NuGet.Commands.Test
                 var fallbackFolder = Path.Combine(project1Root, "fallback");
                 var packagesFolder = Path.Combine(project1Root, "packages");
                 var configFilePath = Path.Combine(project1Root, "nuget.config");
-
+                var project1UniqueName = "482C20DE-DFF9-4BD0-B90A-BD3201AA351A";
                 var items = new List<IDictionary<string, string>>();
 
                 items.Add(new Dictionary<string, string>()
@@ -936,13 +1264,27 @@ namespace NuGet.Commands.Test
                     { "ProjectName", "a" },
                     { "ProjectStyle", "PackageReference" },
                     { "OutputPath", outputPath1 },
-                    { "ProjectUniqueName", "482C20DE-DFF9-4BD0-B90A-BD3201AA351A" },
+                    { "ProjectUniqueName",  project1UniqueName },
                     { "ProjectPath", project1Path },
                     { "TargetFrameworks", "netstandard16" },
                     { "Sources", "https://nuget.org/a/index.json;https://nuget.org/b/index.json" },
                     { "FallbackFolders", fallbackFolder },
                     { "PackagesPath", packagesFolder },
                     { "ConfigFilePaths", configFilePath },
+                });
+
+                items.Add(new Dictionary<string, string>()
+                {
+                    { "Type", "TargetFrameworkInformation" },
+                    { "AssetTargetFallback", "" },
+                    { "PackageTargetFallback", "" },
+                    { "ProjectUniqueName", project1UniqueName },
+                    { "TargetFramework", "netstandard16" },
+                    { "TargetFrameworkIdentifier", ".NETStandard" },
+                    { "TargetFrameworkVersion", "v1.6" },
+                    { "TargetFrameworkMoniker", ".NETStandard,Version=v1.6" },
+                    { "TargetPlatformIdentifier", "" },
+                    { "TargetPlatformVersion", "" },
                 });
 
                 var wrappedItems = items.Select(CreateItems).ToList();
@@ -972,6 +1314,7 @@ namespace NuGet.Commands.Test
                 var outputPath1 = Path.Combine(project1Root, "obj");
                 var fallbackFolder = Path.Combine(project1Root, "fallback");
                 var packagesFolder = Path.Combine(project1Root, "packages");
+                var project1UniqueName = "482C20DE-DFF9-4BD0-B90A-BD3201AA351A";
 
                 var items = new List<IDictionary<string, string>>();
 
@@ -981,12 +1324,26 @@ namespace NuGet.Commands.Test
                     { "ProjectName", "a" },
                     { "ProjectStyle", "PackageReference" },
                     { "OutputPath", outputPath1 },
-                    { "ProjectUniqueName", "482C20DE-DFF9-4BD0-B90A-BD3201AA351A" },
+                    { "ProjectUniqueName", project1UniqueName },
                     { "ProjectPath", project1Path },
                     { "TargetFrameworks", "netstandard16" },
                     { "Sources", "https://nuget.org/a/index.json;https://nuget.org/b/index.json" },
                     { "FallbackFolders", fallbackFolder },
                     { "PackagesPath", packagesFolder },
+                });
+
+                items.Add(new Dictionary<string, string>()
+                {
+                    { "Type", "TargetFrameworkInformation" },
+                    { "AssetTargetFallback", "" },
+                    { "PackageTargetFallback", "" },
+                    { "ProjectUniqueName", project1UniqueName },
+                    { "TargetFramework", "netstandard16" },
+                    { "TargetFrameworkIdentifier", ".NETStandard" },
+                    { "TargetFrameworkVersion", "v1.6" },
+                    { "TargetFrameworkMoniker", ".NETStandard,Version=v1.6" },
+                    { "TargetPlatformIdentifier", "" },
+                    { "TargetPlatformVersion", "" },
                 });
 
                 var wrappedItems = items.Select(CreateItems).ToList();
@@ -1016,7 +1373,7 @@ namespace NuGet.Commands.Test
                 var outputPath1 = Path.Combine(project1Root, "obj");
                 var fallbackFolder = Path.Combine(project1Root, "fallback");
                 var packagesFolder = Path.Combine(project1Root, "packages");
-
+                var project1UniqueName = "482C20DE-DFF9-4BD0-B90A-BD3201AA351A";
                 var items = new List<IDictionary<string, string>>();
 
                 items.Add(new Dictionary<string, string>()
@@ -1025,9 +1382,8 @@ namespace NuGet.Commands.Test
                     { "ProjectName", "a" },
                     { "ProjectStyle", "PackageReference" },
                     { "OutputPath", outputPath1 },
-                    { "ProjectUniqueName", "482C20DE-DFF9-4BD0-B90A-BD3201AA351A" },
+                    { "ProjectUniqueName", project1UniqueName },
                     { "ProjectPath", project1Path },
-                    { "TargetFrameworks", "net46;netstandard16" },
                     { "Sources", "https://nuget.org/a/index.json;https://nuget.org/b/index.json" },
                     { "FallbackFolders", fallbackFolder },
                     { "PackagesPath", packagesFolder },
@@ -1037,9 +1393,28 @@ namespace NuGet.Commands.Test
                 items.Add(new Dictionary<string, string>()
                 {
                     { "Type", "TargetFrameworkInformation" },
-                    { "ProjectUniqueName", "482C20DE-DFF9-4BD0-B90A-BD3201AA351A" },
+                    { "ProjectUniqueName", project1UniqueName },
                     { "PackageTargetFallback", "portable-net45+win8;dnxcore50;;" },
-                    { "TargetFramework", "netstandard16" }
+                    { "TargetFramework", "netstandard16" },
+                    { "TargetFrameworkIdentifier", ".NETStandard" },
+                    { "TargetFrameworkVersion", "v1.6" },
+                    { "TargetFrameworkMoniker", ".NETStandard,Version=v1.6" },
+                    { "TargetPlatformIdentifier", "" },
+                    { "TargetPlatformVersion", "" },
+                });
+
+                items.Add(new Dictionary<string, string>()
+                {
+                    { "Type", "TargetFrameworkInformation" },
+                    { "AssetTargetFallback", "" },
+                    { "PackageTargetFallback", "" },
+                    { "ProjectUniqueName", project1UniqueName },
+                    { "TargetFramework", "net46" },
+                    { "TargetFrameworkIdentifier", ".NETFramework" },
+                    { "TargetFrameworkVersion", "v4.6" },
+                    { "TargetFrameworkMoniker", ".NETFramework,Version=4.6" },
+                    { "TargetPlatformIdentifier", "" },
+                    { "TargetPlatformVersion", "" },
                 });
 
                 var wrappedItems = items.Select(CreateItems).ToList();
@@ -1087,6 +1462,7 @@ namespace NuGet.Commands.Test
                 var outputPath1 = Path.Combine(project1Root, "obj");
                 var fallbackFolder = Path.Combine(project1Root, "fallback");
                 var packagesFolder = Path.Combine(project1Root, "packages");
+                var project1UniqueName = "482C20DE-DFF9-4BD0-B90A-BD3201AA351A";
 
                 var items = new List<IDictionary<string, string>>();
 
@@ -1096,9 +1472,8 @@ namespace NuGet.Commands.Test
                     { "ProjectName", "a" },
                     { "ProjectStyle", "PackageReference" },
                     { "OutputPath", outputPath1 },
-                    { "ProjectUniqueName", "482C20DE-DFF9-4BD0-B90A-BD3201AA351A" },
+                    { "ProjectUniqueName", project1UniqueName },
                     { "ProjectPath", project1Path },
-                    { "TargetFrameworks", "net46;netstandard16" },
                     { "Sources", "https://nuget.org/a/index.json;https://nuget.org/b/index.json" },
                     { "FallbackFolders", fallbackFolder },
                     { "PackagesPath", packagesFolder },
@@ -1108,9 +1483,28 @@ namespace NuGet.Commands.Test
                 items.Add(new Dictionary<string, string>()
                 {
                     { "Type", "TargetFrameworkInformation" },
-                    { "ProjectUniqueName", "482C20DE-DFF9-4BD0-B90A-BD3201AA351A" },
+                    { "ProjectUniqueName", project1UniqueName },
                     { "PackageTargetFallback", "" },
-                    { "TargetFramework", "netstandard16" }
+                    { "TargetFramework", "netstandard16" },
+                    { "TargetFrameworkIdentifier", ".NETStandard" },
+                    { "TargetFrameworkVersion", "v1.6" },
+                    { "TargetFrameworkMoniker", ".NETStandard,Version=v1.6" },
+                    { "TargetPlatformIdentifier", "" },
+                    { "TargetPlatformVersion", "" },
+                });
+
+                items.Add(new Dictionary<string, string>()
+                {
+                    { "Type", "TargetFrameworkInformation" },
+                    { "AssetTargetFallback", "" },
+                    { "PackageTargetFallback", "" },
+                    { "ProjectUniqueName", project1UniqueName },
+                    { "TargetFramework", "net46" },
+                    { "TargetFrameworkIdentifier", ".NETFramework" },
+                    { "TargetFrameworkVersion", "v4.6" },
+                    { "TargetFrameworkMoniker", ".NETFramework,Version=4.6" },
+                    { "TargetPlatformIdentifier", "" },
+                    { "TargetPlatformVersion", "" },
                 });
 
                 var wrappedItems = items.Select(CreateItems).ToList();
@@ -1143,6 +1537,7 @@ namespace NuGet.Commands.Test
                 var outputPath1 = Path.Combine(project1Root, "obj");
                 var fallbackFolder = Path.Combine(project1Root, "fallback");
                 var packagesFolder = Path.Combine(project1Root, "packages");
+                var project1UniqueName = "482C20DE-DFF9-4BD0-B90A-BD3201AA351A";
 
                 var items = new List<IDictionary<string, string>>();
 
@@ -1152,9 +1547,8 @@ namespace NuGet.Commands.Test
                     { "ProjectName", "  a\n  " },
                     { "ProjectStyle", "PackageReference" },
                     { "OutputPath", outputPath1 },
-                    { "ProjectUniqueName", "482C20DE-DFF9-4BD0-B90A-BD3201AA351A" },
+                    { "ProjectUniqueName", project1UniqueName },
                     { "ProjectPath", project1Path },
-                    { "TargetFrameworks", "  net46  ;   netstandard16\n  " },
                     { "Sources", "https://nuget.org/a/index.json; https://nuget.org/b/index.json\n" },
                     { "FallbackFolders", fallbackFolder },
                     { "PackagesPath", packagesFolder },
@@ -1164,9 +1558,28 @@ namespace NuGet.Commands.Test
                 items.Add(new Dictionary<string, string>()
                 {
                     { "Type", "TargetFrameworkInformation" },
-                    { "ProjectUniqueName", "482C20DE-DFF9-4BD0-B90A-BD3201AA351A" },
+                    { "AssetTargetFallback", "" },
+                    { "PackageTargetFallback", "" },
+                    { "ProjectUniqueName", project1UniqueName },
+                    { "TargetFramework", "net46\n" },
+                    { "TargetFrameworkIdentifier", ".NETFramework\n" },
+                    { "TargetFrameworkVersion", "v4.6\n" },
+                    { "TargetFrameworkMoniker", ".NETFramework,Version=4.6\n" },
+                    { "TargetPlatformIdentifier", "" },
+                    { "TargetPlatformVersion", "" },
+                });
+
+                items.Add(new Dictionary<string, string>()
+                {
+                    { "Type", "TargetFrameworkInformation" },
+                    { "ProjectUniqueName", project1UniqueName },
                     { "PackageTargetFallback", "   portable-net45+win8  ;   dnxcore50\n   ; ;  " },
-                    { "TargetFramework", " netstandard16\n  " }
+                    { "TargetFramework", " netstandard16\n  " },
+                    { "TargetFrameworkIdentifier", ".NETStandard\n" },
+                    { "TargetFrameworkVersion", "v1.6\n" },
+                    { "TargetFrameworkMoniker", ".NETStandard,Version=v1.6\n" },
+                    { "TargetPlatformIdentifier", "" },
+                    { "TargetPlatformVersion", "" },
                 });
 
                 var wrappedItems = items.Select(CreateItems).ToList();
@@ -1219,7 +1632,7 @@ namespace NuGet.Commands.Test
                 var outputPath1 = Path.Combine(project1Root, "obj");
                 var fallbackFolder = Path.Combine(project1Root, "fallback");
                 var packagesFolder = Path.Combine(project1Root, "packages");
-
+                var project1UniqueName = "482C20DE-DFF9-4BD0-B90A-BD3201AA351A";
                 var items = new List<IDictionary<string, string>>();
 
                 items.Add(new Dictionary<string, string>()
@@ -1228,12 +1641,38 @@ namespace NuGet.Commands.Test
                     { "ProjectName", "a" },
                     { "ProjectStyle", "PackageReference" },
                     { "OutputPath", outputPath1 },
-                    { "ProjectUniqueName", "482C20DE-DFF9-4BD0-B90A-BD3201AA351A" },
+                    { "ProjectUniqueName", project1UniqueName },
                     { "ProjectPath", project1Path },
-                    { "TargetFrameworks", "net46;netstandard16" },
                     { "RuntimeIdentifiers", "win7-x86;linux-x64" },
                     { "RuntimeSupports", "net46.app;win8.app" },
                     { "CrossTargeting", "true" },
+                });
+
+                items.Add(new Dictionary<string, string>()
+                {
+                    { "Type", "TargetFrameworkInformation" },
+                    { "ProjectUniqueName", project1UniqueName },
+                    { "PackageTargetFallback", "" },
+                    { "TargetFramework", "netstandard16" },
+                    { "TargetFrameworkIdentifier", ".NETStandard" },
+                    { "TargetFrameworkVersion", "v1.6" },
+                    { "TargetFrameworkMoniker", ".NETStandard,Version=v1.6" },
+                    { "TargetPlatformIdentifier", "" },
+                    { "TargetPlatformVersion", "" },
+                });
+
+                items.Add(new Dictionary<string, string>()
+                {
+                    { "Type", "TargetFrameworkInformation" },
+                    { "AssetTargetFallback", "" },
+                    { "PackageTargetFallback", "" },
+                    { "ProjectUniqueName", project1UniqueName },
+                    { "TargetFramework", "net46" },
+                    { "TargetFrameworkIdentifier", ".NETFramework" },
+                    { "TargetFrameworkVersion", "v4.6" },
+                    { "TargetFrameworkMoniker", ".NETFramework,Version=4.6" },
+                    { "TargetPlatformIdentifier", "" },
+                    { "TargetPlatformVersion", "" },
                 });
 
                 var wrappedItems = items.Select(CreateItems).ToList();
@@ -1263,6 +1702,7 @@ namespace NuGet.Commands.Test
                 var outputPath1 = Path.Combine(project1Root, "obj");
                 var fallbackFolder = Path.Combine(project1Root, "fallback");
                 var packagesFolder = Path.Combine(project1Root, "packages");
+                var project1UniqueName = "482C20DE-DFF9-4BD0-B90A-BD3201AA351A";
 
                 var items = new List<IDictionary<string, string>>();
 
@@ -1272,12 +1712,38 @@ namespace NuGet.Commands.Test
                     { "ProjectName", "a" },
                     { "ProjectStyle", "PackageReference" },
                     { "OutputPath", outputPath1 },
-                    { "ProjectUniqueName", "482C20DE-DFF9-4BD0-B90A-BD3201AA351A" },
+                    { "ProjectUniqueName", project1UniqueName },
                     { "ProjectPath", project1Path },
-                    { "TargetFrameworks", "net46;netstandard16" },
                     { "RuntimeIdentifiers", "win7-x86;linux-x64;win7-x86;linux-x64" },
                     { "RuntimeSupports", "net46.app;win8.app;net46.app;win8.app" },
                     { "CrossTargeting", "true" },
+                });
+
+                items.Add(new Dictionary<string, string>()
+                {
+                    { "Type", "TargetFrameworkInformation" },
+                    { "ProjectUniqueName", project1UniqueName },
+                    { "PackageTargetFallback", "" },
+                    { "TargetFramework", "netstandard16" },
+                    { "TargetFrameworkIdentifier", ".NETStandard" },
+                    { "TargetFrameworkVersion", "v1.6" },
+                    { "TargetFrameworkMoniker", ".NETStandard,Version=v1.6" },
+                    { "TargetPlatformIdentifier", "" },
+                    { "TargetPlatformVersion", "" },
+                });
+
+                items.Add(new Dictionary<string, string>()
+                {
+                    { "Type", "TargetFrameworkInformation" },
+                    { "AssetTargetFallback", "" },
+                    { "PackageTargetFallback", "" },
+                    { "ProjectUniqueName", project1UniqueName },
+                    { "TargetFramework", "net46" },
+                    { "TargetFrameworkIdentifier", ".NETFramework" },
+                    { "TargetFrameworkVersion", "v4.6" },
+                    { "TargetFrameworkMoniker", ".NETFramework,Version=4.6" },
+                    { "TargetPlatformIdentifier", "" },
+                    { "TargetPlatformVersion", "" },
                 });
 
                 var wrappedItems = items.Select(CreateItems).ToList();
@@ -1311,6 +1777,9 @@ namespace NuGet.Commands.Test
                 var outputPath1 = Path.Combine(project1Root, "obj");
                 var outputPath2 = Path.Combine(project2Root, "obj");
 
+                var project1UniqueName = "482C20DE-DFF9-4BD0-B90A-BD3201AA351A";
+                var project2UniqueName = "AA2C20DE-DFF9-4BD0-B90A-BD3201AA351A";
+
                 var items = new List<IDictionary<string, string>>();
 
                 items.Add(new Dictionary<string, string>()
@@ -1319,10 +1788,36 @@ namespace NuGet.Commands.Test
                     { "ProjectName", "a" },
                     { "ProjectStyle", "PackageReference" },
                     { "OutputPath", outputPath1 },
-                    { "ProjectUniqueName", "482C20DE-DFF9-4BD0-B90A-BD3201AA351A" },
+                    { "ProjectUniqueName", project1UniqueName },
                     { "ProjectPath", project1Path },
-                    { "TargetFrameworks", "net46;netstandard1.6" },
                     { "CrossTargeting", "true" },
+                });
+
+                items.Add(new Dictionary<string, string>()
+                {
+                    { "Type", "TargetFrameworkInformation" },
+                    { "ProjectUniqueName", project1UniqueName },
+                    { "PackageTargetFallback", "" },
+                    { "TargetFramework", "netstandard1.6" },
+                    { "TargetFrameworkIdentifier", ".NETStandard" },
+                    { "TargetFrameworkVersion", "v1.6" },
+                    { "TargetFrameworkMoniker", ".NETStandard,Version=v1.6" },
+                    { "TargetPlatformIdentifier", "" },
+                    { "TargetPlatformVersion", "" },
+                });
+
+                items.Add(new Dictionary<string, string>()
+                {
+                    { "Type", "TargetFrameworkInformation" },
+                    { "AssetTargetFallback", "" },
+                    { "PackageTargetFallback", "" },
+                    { "ProjectUniqueName", project1UniqueName },
+                    { "TargetFramework", "net46" },
+                    { "TargetFrameworkIdentifier", ".NETFramework" },
+                    { "TargetFrameworkVersion", "v4.6" },
+                    { "TargetFrameworkMoniker", ".NETFramework,Version=4.6" },
+                    { "TargetPlatformIdentifier", "" },
+                    { "TargetPlatformVersion", "" },
                 });
 
                 items.Add(new Dictionary<string, string>()
@@ -1331,10 +1826,36 @@ namespace NuGet.Commands.Test
                     { "ProjectName", "b" },
                     { "ProjectStyle", "PackageReference" },
                     { "OutputPath", outputPath2 },
-                    { "ProjectUniqueName", "AA2C20DE-DFF9-4BD0-B90A-BD3201AA351A" },
+                    { "ProjectUniqueName", project2UniqueName },
                     { "ProjectPath", project2Path },
-                    { "TargetFrameworks", "net45;netstandard1.0" },
                     { "CrossTargeting", "true" },
+                });
+
+                items.Add(new Dictionary<string, string>()
+                {
+                    { "Type", "TargetFrameworkInformation" },
+                    { "ProjectUniqueName", project2UniqueName },
+                    { "PackageTargetFallback", "" },
+                    { "TargetFramework", "netstandard1.0" },
+                    { "TargetFrameworkIdentifier", ".NETStandard" },
+                    { "TargetFrameworkVersion", "v1.0" },
+                    { "TargetFrameworkMoniker", ".NETStandard,Version=v1.0" },
+                    { "TargetPlatformIdentifier", "" },
+                    { "TargetPlatformVersion", "" },
+                });
+
+                items.Add(new Dictionary<string, string>()
+                {
+                    { "Type", "TargetFrameworkInformation" },
+                    { "AssetTargetFallback", "" },
+                    { "PackageTargetFallback", "" },
+                    { "ProjectUniqueName", project2UniqueName },
+                    { "TargetFramework", "net45" },
+                    { "TargetFrameworkIdentifier", ".NETFramework" },
+                    { "TargetFrameworkVersion", "v4.5" },
+                    { "TargetFrameworkMoniker", ".NETFramework,Version=4.5" },
+                    { "TargetPlatformIdentifier", "" },
+                    { "TargetPlatformVersion", "" },
                 });
 
                 // A -> B
@@ -1454,7 +1975,7 @@ namespace NuGet.Commands.Test
                 var projectRoot = Path.Combine(workingDir, "a");
                 var projectPath = Path.Combine(projectRoot, "a.csproj");
                 var outputPath = Path.Combine(projectRoot, "obj");
-
+                var project1UniqueName = "482C20DE-DFF9-4BD0-B90A-BD3201AA351A";
                 var items = new List<IDictionary<string, string>>();
 
                 var specItem = new Dictionary<string, string>()
@@ -1463,9 +1984,8 @@ namespace NuGet.Commands.Test
                     { "ProjectName", "a" },
                     { "ProjectStyle", "PackageReference" },
                     { "OutputPath", outputPath },
-                    { "ProjectUniqueName", "482C20DE-DFF9-4BD0-B90A-BD3201AA351A" },
+                    { "ProjectUniqueName", project1UniqueName },
                     { "ProjectPath", projectPath },
-                    { "TargetFrameworks", "net46;netstandard1.6" },
                     { "CrossTargeting", "true" },
                 };
 
@@ -1477,7 +1997,7 @@ namespace NuGet.Commands.Test
                 var projectRef = new Dictionary<string, string>()
                 {
                     { "Type", "ProjectReference" },
-                    { "ProjectUniqueName", "482C20DE-DFF9-4BD0-B90A-BD3201AA351A" },
+                    { "ProjectUniqueName", project1UniqueName },
                     { "ProjectReferenceUniqueName", "AA2C20DE-DFF9-4BD0-B90A-BD3201AA351A" },
                     { "ProjectPath", "otherProjectPath.csproj" },
                     { "TargetFrameworks", "netstandard1.6" },
@@ -1492,7 +2012,7 @@ namespace NuGet.Commands.Test
                 var packageRef1 = new Dictionary<string, string>()
                 {
                     { "Type", "Dependency" },
-                    { "ProjectUniqueName", "482C20DE-DFF9-4BD0-B90A-BD3201AA351A" },
+                    { "ProjectUniqueName", project1UniqueName },
                     { "Id", "z" },
                     { "VersionRange", "2.0.0" },
                     { "TargetFrameworks", "netstandard1.6" },
@@ -1506,7 +2026,7 @@ namespace NuGet.Commands.Test
                 var packageRef2 = new Dictionary<string, string>()
                 {
                     { "Type", "Dependency" },
-                    { "ProjectUniqueName", "482C20DE-DFF9-4BD0-B90A-BD3201AA351A" },
+                    { "ProjectUniqueName", project1UniqueName },
                     { "Id", "y" },
                     { "VersionRange", "[1.0.0]" },
                     { "TargetFrameworks", "netstandard1.6;net46" },
@@ -1517,16 +2037,38 @@ namespace NuGet.Commands.Test
                 items.Add(packageRef2);
 
                 // TFM info
-                var tfmInfo = new Dictionary<string, string>()
+                var tfmInfoNS = new Dictionary<string, string>()
                 {
                     { "Type", "TargetFrameworkInformation" },
-                    { "ProjectUniqueName", "482C20DE-DFF9-4BD0-B90A-BD3201AA351A" },
+                    { "ProjectUniqueName", project1UniqueName },
                     { "PackageTargetFallback", "portable-net45+win8;dnxcore50;;" },
-                    { "TargetFramework", "netstandard16" }
+                    { "TargetFramework", "netstandard1.6" },
+                    { "TargetFrameworkIdentifier", ".NETStandard" },
+                    { "TargetFrameworkVersion", "v1.6" },
+                    { "TargetFrameworkMoniker", ".NETStandard,Version=v1.6" },
+                    { "TargetPlatformIdentifier", "" },
+                    { "TargetPlatformVersion", "" },
                 };
 
-                items.Add(tfmInfo);
-                items.Add(tfmInfo);
+                items.Add(tfmInfoNS);
+                items.Add(tfmInfoNS);
+
+                var tfmInfoNet = new Dictionary<string, string>()
+                {
+                    { "Type", "TargetFrameworkInformation" },
+                    { "AssetTargetFallback", "" },
+                    { "PackageTargetFallback", "" },
+                    { "ProjectUniqueName", project1UniqueName },
+                    { "TargetFramework", "net46" },
+                    { "TargetFrameworkIdentifier", ".NETFramework" },
+                    { "TargetFrameworkVersion", "v4.6" },
+                    { "TargetFrameworkMoniker", ".NETFramework,Version=4.6" },
+                    { "TargetPlatformIdentifier", "" },
+                    { "TargetPlatformVersion", "" },
+                };
+
+                items.Add(tfmInfoNet);
+                items.Add(tfmInfoNet);
 
                 var wrappedItems = items.Select(CreateItems).ToList();
 
@@ -1554,14 +2096,14 @@ namespace NuGet.Commands.Test
                 var outputPath = Path.Combine(projectRoot, "obj");
 
                 var items = new List<IDictionary<string, string>>();
-
+                var project1UniqueName = "AA2C20DE-DFF9-4BD0-B90A-BD3201AA351A";
                 var specItem = new Dictionary<string, string>()
                 {
                     { "Type", "ProjectSpec" },
                     { "ProjectName", "a" },
                     { "ProjectStyle", "PackageReference" },
                     { "OutputPath", outputPath },
-                    { "ProjectUniqueName", "AA2C20DE-DFF9-4BD0-B90A-BD3201AA351A" },
+                    { "ProjectUniqueName", project1UniqueName },
                     { "ProjectPath", projectPath },
                     { "TargetFrameworks", "net46;netstandard1.6" },
                     { "CrossTargeting", "true" },
@@ -1569,11 +2111,37 @@ namespace NuGet.Commands.Test
 
                 items.Add(specItem);
 
+                items.Add(new Dictionary<string, string>()
+                {
+                    { "Type", "TargetFrameworkInformation" },
+                    { "ProjectUniqueName", project1UniqueName },
+                    { "PackageTargetFallback", "" },
+                    { "TargetFramework", "netstandard1.6" },
+                    { "TargetFrameworkIdentifier", ".NETStandard" },
+                    { "TargetFrameworkVersion", "v1.6" },
+                    { "TargetFrameworkMoniker", ".NETStandard,Version=v1.6" },
+                    { "TargetPlatformIdentifier", "" },
+                    { "TargetPlatformVersion", "" },
+                });
+
+                items.Add(new Dictionary<string, string>()
+                {
+                    { "Type", "TargetFrameworkInformation" },
+                    { "AssetTargetFallback", "" },
+                    { "PackageTargetFallback", "" },
+                    { "ProjectUniqueName", project1UniqueName },
+                    { "TargetFramework", "net46" },
+                    { "TargetFrameworkIdentifier", ".NETFramework" },
+                    { "TargetFrameworkVersion", "v4.6" },
+                    { "TargetFrameworkMoniker", ".NETFramework,Version=4.6" },
+                    { "TargetPlatformIdentifier", "" },
+                    { "TargetPlatformVersion", "" },
+                });
+
                 // A -> B
                 var projectRef = new Dictionary<string, string>()
                 {
                     { "Type", "ProjectReference" },
-
                     // This ID does not match the project!
                     { "ProjectUniqueName", "BB2C20DE-DFF9-4BD0-B90A-BD3201AA351A" },
                     { "ProjectReferenceUniqueName", "CC2C20DE-DFF9-4BD0-B90A-BD3201AA351A" },
@@ -1884,7 +2452,7 @@ namespace NuGet.Commands.Test
                 var outputPath1 = Path.Combine(project1Root, "obj");
                 var fallbackFolder = Path.Combine(project1Root, "fallback");
                 var packagesFolder = Path.Combine(project1Root, "packages");
-
+                var project1UniqueName = "482C20DE-DFF9-4BD0-B90A-BD3201AA351A";
                 var items = new List<IDictionary<string, string>>();
 
                 items.Add(new Dictionary<string, string>()
@@ -1893,19 +2461,31 @@ namespace NuGet.Commands.Test
                     { "ProjectName", "a" },
                     { "ProjectStyle", "PackageReference" },
                     { "OutputPath", outputPath1 },
-                    { "ProjectUniqueName", "482C20DE-DFF9-4BD0-B90A-BD3201AA351A" },
+                    { "ProjectUniqueName", project1UniqueName },
                     { "ProjectPath", project1Path },
-                    { "TargetFrameworks", "net46" },
                     { "Sources", "https://nuget.org/a/index.json;https://nuget.org/b/index.json" },
                     { "FallbackFolders", fallbackFolder },
                     { "PackagesPath", packagesFolder },
                 });
 
+                items.Add(new Dictionary<string, string>()
+                {
+                    { "Type", "TargetFrameworkInformation" },
+                    { "AssetTargetFallback", "" },
+                    { "PackageTargetFallback", "" },
+                    { "ProjectUniqueName", project1UniqueName },
+                    { "TargetFramework", "net46" },
+                    { "TargetFrameworkIdentifier", ".NETFramework" },
+                    { "TargetFrameworkVersion", "v4.6" },
+                    { "TargetFrameworkMoniker", ".NETFramework,Version=4.6" },
+                    { "TargetPlatformIdentifier", "" },
+                    { "TargetPlatformVersion", "" },
+                });
 
                 items.Add(new Dictionary<string, string>()
                 {
                     { "Type", "Dependency" },
-                    { "ProjectUniqueName", "482C20DE-DFF9-4BD0-B90A-BD3201AA351A" },
+                    { "ProjectUniqueName", project1UniqueName },
                     { "Id", "x" },
                     { "VersionRange", "1.0.0" },
                     { "IncludeAssets", "build;compile" },
@@ -2016,7 +2596,7 @@ namespace NuGet.Commands.Test
                 var fallbackFolder = Path.Combine(project1Root, "fallback");
                 var packagesFolder = Path.Combine(project1Root, "packages");
                 var configFilePath = Path.Combine(project1Root, "nuget.config");
-
+                var project1UniqueName = "482C20DE-DFF9-4BD0-B90A-BD3201AA351A";
                 var items = new List<IDictionary<string, string>>();
 
 
@@ -2027,9 +2607,8 @@ namespace NuGet.Commands.Test
                     { "ProjectName", "a" },
                     { "ProjectStyle", "PackageReference" },
                     { "OutputPath", outputPath1 },
-                    { "ProjectUniqueName", "482C20DE-DFF9-4BD0-B90A-BD3201AA351A" },
+                    { "ProjectUniqueName", project1UniqueName },
                     { "ProjectPath", project1Path },
-                    { "TargetFrameworks", "net46" },
                     { "Sources", "https://nuget.org/a/index.json;https://nuget.org/b/index.json" },
                     { "FallbackFolders", fallbackFolder },
                     { "PackagesPath", packagesFolder },
@@ -2037,6 +2616,20 @@ namespace NuGet.Commands.Test
                     { "TreatWarningsAsErrors", "true" },
                     { "WarningsAsErrors", "NU1001;NU1002" },
                     { "NoWarn", "NU1100;NU1101" },
+                });
+
+                items.Add(new Dictionary<string, string>()
+                {
+                    { "Type", "TargetFrameworkInformation" },
+                    { "AssetTargetFallback", "" },
+                    { "PackageTargetFallback", "" },
+                    { "ProjectUniqueName", project1UniqueName },
+                    { "TargetFramework", "net46" },
+                    { "TargetFrameworkIdentifier", ".NETFramework" },
+                    { "TargetFrameworkVersion", "v4.6" },
+                    { "TargetFrameworkMoniker", ".NETFramework,Version=4.6" },
+                    { "TargetPlatformIdentifier", "" },
+                    { "TargetPlatformVersion", "" },
                 });
 
                 var wrappedItems = items.Select(CreateItems).ToList();
@@ -2065,7 +2658,7 @@ namespace NuGet.Commands.Test
                 var fallbackFolder = Path.Combine(project1Root, "fallback");
                 var packagesFolder = Path.Combine(project1Root, "packages");
                 var configFilePath = Path.Combine(project1Root, "nuget.config");
-
+                var project1UniqueName = "482C20DE-DFF9-4BD0-B90A-BD3201AA351A";
                 var items = new List<IDictionary<string, string>>();
 
 
@@ -2076,9 +2669,8 @@ namespace NuGet.Commands.Test
                     { "ProjectName", "a" },
                     { "ProjectStyle", "PackageReference" },
                     { "OutputPath", outputPath1 },
-                    { "ProjectUniqueName", "482C20DE-DFF9-4BD0-B90A-BD3201AA351A" },
+                    { "ProjectUniqueName", project1UniqueName },
                     { "ProjectPath", project1Path },
-                    { "TargetFrameworks", "net46" },
                     { "Sources", "https://nuget.org/a/index.json;https://nuget.org/b/index.json" },
                     { "FallbackFolders", fallbackFolder },
                     { "PackagesPath", packagesFolder },
@@ -2086,6 +2678,20 @@ namespace NuGet.Commands.Test
                     { "TreatWarningsAsErrors", "" },
                     { "WarningsAsErrors", "" },
                     { "NoWarn", "" },
+                });
+
+                items.Add(new Dictionary<string, string>()
+                {
+                    { "Type", "TargetFrameworkInformation" },
+                    { "AssetTargetFallback", "" },
+                    { "PackageTargetFallback", "" },
+                    { "ProjectUniqueName", project1UniqueName },
+                    { "TargetFramework", "net46" },
+                    { "TargetFrameworkIdentifier", ".NETFramework" },
+                    { "TargetFrameworkVersion", "v4.6" },
+                    { "TargetFrameworkMoniker", ".NETFramework,Version=4.6" },
+                    { "TargetPlatformIdentifier", "" },
+                    { "TargetPlatformVersion", "" },
                 });
 
                 var wrappedItems = items.Select(CreateItems).ToList();
@@ -2122,9 +2728,22 @@ namespace NuGet.Commands.Test
                     { "ProjectUniqueName", uniqueName },
                     { "Id", "x" },
                     { "VersionRange", "1.0.0" },
-                    { "TargetFrameworks", "net46" },
                     { "CrossTargeting", "true" },
                     { "NoWarn", "NU1001;NU1002" },
+                });
+
+                items.Add(new Dictionary<string, string>()
+                {
+                    { "Type", "TargetFrameworkInformation" },
+                    { "AssetTargetFallback", "" },
+                    { "PackageTargetFallback", "" },
+                    { "ProjectUniqueName", uniqueName },
+                    { "TargetFramework", "net46" },
+                    { "TargetFrameworkIdentifier", ".NETFramework" },
+                    { "TargetFrameworkVersion", "v4.6" },
+                    { "TargetFrameworkMoniker", ".NETFramework,Version=4.6" },
+                    { "TargetPlatformIdentifier", "" },
+                    { "TargetPlatformVersion", "" },
                 });
 
                 var wrappedItems = items.Select(CreateItems).ToList();
@@ -2159,8 +2778,21 @@ namespace NuGet.Commands.Test
                     { "ProjectUniqueName", uniqueName },
                     { "Id", "x" },
                     { "VersionRange", "1.0.0" },
-                    { "TargetFrameworks", "net46" },
                     { "CrossTargeting", "true" },
+                });
+
+                items.Add(new Dictionary<string, string>()
+                {
+                    { "Type", "TargetFrameworkInformation" },
+                    { "AssetTargetFallback", "" },
+                    { "PackageTargetFallback", "" },
+                    { "ProjectUniqueName", uniqueName },
+                    { "TargetFramework", "net46" },
+                    { "TargetFrameworkIdentifier", ".NETFramework" },
+                    { "TargetFrameworkVersion", "v4.6" },
+                    { "TargetFrameworkMoniker", ".NETFramework,Version=4.6" },
+                    { "TargetPlatformIdentifier", "" },
+                    { "TargetPlatformVersion", "" },
                 });
 
                 var wrappedItems = items.Select(CreateItems).ToList();
@@ -2195,8 +2827,21 @@ namespace NuGet.Commands.Test
                     { "ProjectUniqueName", uniqueName },
                     { "Id", "x" },
                     { "VersionRange", "1.0.0" },
-                    { "TargetFrameworks", "net46" },
                     { "IsImplicitlyDefined", "true" },
+                });
+
+                items.Add(new Dictionary<string, string>()
+                {
+                    { "Type", "TargetFrameworkInformation" },
+                    { "AssetTargetFallback", "" },
+                    { "PackageTargetFallback", "" },
+                    { "ProjectUniqueName", uniqueName },
+                    { "TargetFramework", "net46" },
+                    { "TargetFrameworkIdentifier", ".NETFramework" },
+                    { "TargetFrameworkVersion", "v4.6" },
+                    { "TargetFrameworkMoniker", ".NETFramework,Version=4.6" },
+                    { "TargetPlatformIdentifier", "" },
+                    { "TargetPlatformVersion", "" },
                 });
 
                 var wrappedItems = items.Select(CreateItems).ToList();
@@ -2537,19 +3182,33 @@ namespace NuGet.Commands.Test
         {
             // Arrange
             var targetFramework = FrameworkConstants.CommonFrameworks.NetStandard20;
-
+            var alias = "netstandard2.0";
             var spec = MSBuildRestoreUtility.GetPackageSpec(new[]
             {
+                CreateItems(
+                    new Dictionary<string, string>()
+                    {
+                        { "Type", "ProjectSpec" },
+                        { "ProjectName", "a" },
+                        { "ProjectStyle", "PackageReference" },
+                        { "ProjectUniqueName", "a" },
+                        { "TargetFrameworks", alias },
+                        { "CrossTargeting", "true" },
+                    }),
                 CreateItems(new Dictionary<string, string>()
-                {
-                    { "Type", "ProjectSpec" },
-                    { "ProjectName", "a" },
-                    { "ProjectStyle", "PackageReference" },
-                    { "ProjectUniqueName", "a" },
-                    { "TargetFrameworks", targetFramework.GetShortFolderName() },
-                    { "CrossTargeting", "true" },
-                })
-                });
+                    {
+                        { "Type", "TargetFrameworkInformation" },
+                        { "AssetTargetFallback", "" },
+                        { "PackageTargetFallback", "" },
+                        { "ProjectUniqueName", "a" },
+                        { "TargetFramework", alias },
+                        { "TargetFrameworkIdentifier", targetFramework.Framework },
+                        { "TargetFrameworkVersion", $"v{targetFramework.Version.ToString(2)}" },
+                        { "TargetFrameworkMoniker", $"{targetFramework.Framework},Version={targetFramework.Version.ToString(2)}" },
+                        { "TargetPlatformIdentifier", "" },
+                        { "TargetPlatformVersion", "" },
+                    })
+            });
 
             var packageX = new Mock<IMSBuildItem>();
             packageX.Setup(p => p.GetProperty("Type")).Returns("DownloadDependency");
@@ -2579,7 +3238,7 @@ namespace NuGet.Commands.Test
         {
             // Arrange
             var targetFramework = FrameworkConstants.CommonFrameworks.NetStandard20;
-
+            var alias = "netstandard2.0";
             var spec = MSBuildRestoreUtility.GetPackageSpec(new[]
             {
                 CreateItems(new Dictionary<string, string>()
@@ -2588,9 +3247,22 @@ namespace NuGet.Commands.Test
                     { "ProjectName", "a" },
                     { "ProjectStyle", "PackageReference" },
                     { "ProjectUniqueName", "a" },
-                    { "TargetFrameworks", targetFramework.GetShortFolderName() },
+                    { "TargetFrameworks", alias },
                     { "CrossTargeting", "true" },
-                })
+                }),
+                CreateItems(new Dictionary<string, string>()
+                    {
+                        { "Type", "TargetFrameworkInformation" },
+                        { "AssetTargetFallback", "" },
+                        { "PackageTargetFallback", "" },
+                        { "ProjectUniqueName", "a" },
+                        { "TargetFramework", alias },
+                        { "TargetFrameworkIdentifier", targetFramework.Framework },
+                        { "TargetFrameworkVersion", $"v{targetFramework.Version.ToString(2)}" },
+                        { "TargetFrameworkMoniker", $"{targetFramework.Framework},Version={targetFramework.Version.ToString(2)}" },
+                        { "TargetPlatformIdentifier", "" },
+                        { "TargetPlatformVersion", "" },
+                    })
                 });
 
             var packageX = new Mock<IMSBuildItem>();
@@ -2626,6 +3298,7 @@ namespace NuGet.Commands.Test
         {
             // Arrange
             var targetFramework = FrameworkConstants.CommonFrameworks.NetStandard20;
+            var alias = "netstandard2.0";
 
             var spec = MSBuildRestoreUtility.GetPackageSpec(new[]
             {
@@ -2635,9 +3308,22 @@ namespace NuGet.Commands.Test
                     { "ProjectName", "a" },
                     { "ProjectStyle", "PackageReference" },
                     { "ProjectUniqueName", "a" },
-                    { "TargetFrameworks", targetFramework.GetShortFolderName() },
+                    { "TargetFrameworks", alias },
                     { "CrossTargeting", "true" },
-                })
+                }),
+                CreateItems(new Dictionary<string, string>()
+                    {
+                        { "Type", "TargetFrameworkInformation" },
+                        { "AssetTargetFallback", "" },
+                        { "PackageTargetFallback", "" },
+                        { "ProjectUniqueName", "a" },
+                        { "TargetFramework", alias },
+                        { "TargetFrameworkIdentifier", targetFramework.Framework },
+                        { "TargetFrameworkVersion", $"v{targetFramework.Version.ToString(2)}" },
+                        { "TargetFrameworkMoniker", $"{targetFramework.Framework},Version={targetFramework.Version.ToString(2)}" },
+                        { "TargetPlatformIdentifier", "" },
+                        { "TargetPlatformVersion", "" },
+                    })
                 });
 
             var packageX = new Mock<IMSBuildItem>();
@@ -2655,6 +3341,7 @@ namespace NuGet.Commands.Test
             var exception = Assert.Throws<ArgumentException>(() => MSBuildRestoreUtility.AddPackageDownloads(spec, msbuildItems));
         }
 
+        // TODO NK - Continue here.
         [Fact]
         public void MSBuildRestoreUtility_GetDependencySpec_CentralVersionIsMergedWhenCPVMEnabled()
         {
@@ -2675,9 +3362,22 @@ namespace NuGet.Commands.Test
                     { "ProjectStyle", "PackageReference" },
                     { "ProjectUniqueName", projectUniqueName },
                     { "ProjectPath", project1Path },
-                    { "TargetFrameworks", "netcoreapp3.0" },
                     { "CrossTargeting", "true" },
                     { "_CentralPackageVersionsEnabled", "true"}
+                });
+
+                items.Add(new Dictionary<string, string>()
+                {
+                    { "Type", "TargetFrameworkInformation" },
+                    { "AssetTargetFallback", "" },
+                    { "PackageTargetFallback", "" },
+                    { "ProjectUniqueName", projectUniqueName },
+                    { "TargetFramework", "netcoreapp3.0" },
+                    { "TargetFrameworkIdentifier", ".NETCoreApp" },
+                    { "TargetFrameworkVersion", "v3.0" },
+                    { "TargetFrameworkMoniker", "NETCoreApp,Version=3.0" },
+                    { "TargetPlatformIdentifier", "" },
+                    { "TargetPlatformVersion", "" },
                 });
 
                 // Package reference
@@ -2783,8 +3483,21 @@ namespace NuGet.Commands.Test
                     { "ProjectStyle", "PackageReference" },
                     { "ProjectUniqueName", projectUniqueName },
                     { "ProjectPath", project1Path },
-                    { "TargetFrameworks", ".NETFramework,Version=v4.7.2" },
                     { "_CentralPackageVersionsEnabled", "true"}
+                });
+
+                items.Add(new Dictionary<string, string>()
+                {
+                    { "Type", "TargetFrameworkInformation" },
+                    { "AssetTargetFallback", "" },
+                    { "PackageTargetFallback", "" },
+                    { "ProjectUniqueName", projectUniqueName },
+                    { "TargetFramework", "net472" },
+                    { "TargetFrameworkIdentifier", ".NETFramework" },
+                    { "TargetFrameworkVersion", "v4.7.2" },
+                    { "TargetFrameworkMoniker", ".NETFramework,Version=v4.7.2" },
+                    { "TargetPlatformIdentifier", "" },
+                    { "TargetPlatformVersion", "" },
                 });
 
                 // Package reference
@@ -2862,7 +3575,6 @@ namespace NuGet.Commands.Test
                     { "ProjectStyle", projectStyle.ToString() },
                     { "ProjectUniqueName", projectUniqueName },
                     { "ProjectPath", project1Path },
-                    { "TargetFrameworks", "netcoreapp3.0" },
                     { "CrossTargeting", "true" },
                     { "_CentralPackageVersionsEnabled", "true"}
                 });
@@ -2895,6 +3607,20 @@ namespace NuGet.Commands.Test
                     { "TargetFrameworks", "netcoreapp3.0" },
                     { "CrossTargeting", "true" },
                     { "_CentralPackageVersionsEnabled", "false"}
+                });
+
+                items.Add(new Dictionary<string, string>()
+                {
+                    { "Type", "TargetFrameworkInformation" },
+                    { "AssetTargetFallback", "" },
+                    { "PackageTargetFallback", "" },
+                    { "ProjectUniqueName", projectUniqueName },
+                    { "TargetFramework", "netcoreapp3.0" },
+                    { "TargetFrameworkIdentifier", ".NETCoreApp" },
+                    { "TargetFrameworkVersion", "v3.0" },
+                    { "TargetFrameworkMoniker", "NETCoreApp,Version=3.0" },
+                    { "TargetPlatformIdentifier", "" },
+                    { "TargetPlatformVersion", "" },
                 });
 
                 // Package reference
@@ -2964,6 +3690,20 @@ namespace NuGet.Commands.Test
                     { "TargetFrameworks", "netcoreapp3.0" },
                     { "CrossTargeting", "true" },
                     { "_CentralPackageVersionsEnabled", "true"}
+                });
+
+                items.Add(new Dictionary<string, string>()
+                {
+                    { "Type", "TargetFrameworkInformation" },
+                    { "AssetTargetFallback", "" },
+                    { "PackageTargetFallback", "" },
+                    { "ProjectUniqueName", projectUniqueName },
+                    { "TargetFramework", "netcoreapp3.0" },
+                    { "TargetFrameworkIdentifier", ".NETCoreApp" },
+                    { "TargetFrameworkVersion", "v3.0" },
+                    { "TargetFrameworkMoniker", "NETCoreApp,Version=3.0" },
+                    { "TargetPlatformIdentifier", "" },
+                    { "TargetPlatformVersion", "" },
                 });
 
                 // Package reference

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/JsonPackageSpecReaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/JsonPackageSpecReaderTests.cs
@@ -3507,6 +3507,49 @@ namespace NuGet.ProjectModel.Test
             Assert.Equal(expectedResult, packageSpec.FilePath);
         }
 
+        [Fact]
+        public void GetTargetFrameworkInformation_WithAnAlias()
+        {
+            TargetFrameworkInformation framework = GetFramework("{\"frameworks\":{\"net46\":{ \"targetAlias\" : \"alias\"}}}");
+
+            Assert.Equal("alias", framework.TargetAlias);
+        }
+
+        [Fact]
+        public void PackageSpecReader_ReadsRestoreMetadataWithAliases()
+        {
+            // Arrange
+            var json = @"{  
+                            ""restore"": {
+    ""projectUniqueName"": ""projectUniqueName"",
+    ""projectName"": ""projectName"",
+    ""projectPath"": ""projectPath"",
+    ""projectJsonPath"": ""projectJsonPath"",
+    ""packagesPath"": ""packagesPath"",
+    ""outputPath"": ""outputPath"",
+    ""projectStyle"": ""PackageReference"",
+    ""crossTargeting"": true,
+    ""frameworks"": {
+      ""frameworkidentifier123-frameworkprofile"": {
+        ""targetAlias"" : ""alias"",
+        ""projectReferences"": {}
+      }
+    },
+    ""warningProperties"": {
+    }
+  }
+}";
+
+            var actual = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json");
+
+            // Assert
+            var metadata = actual.RestoreMetadata;
+            var warningProperties = actual.RestoreMetadata.ProjectWideWarningProperties;
+
+            Assert.NotNull(metadata);
+            Assert.Equal("alias", metadata.TargetFrameworks.Single().TargetAlias);
+        }
+
         private static PackageSpec GetPackageSpec(string json)
         {
             using (var stream = new MemoryStream(Encoding.UTF8.GetBytes(json)))

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/LockFileFormatTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/LockFileFormatTests.cs
@@ -15,8 +15,6 @@ using static NuGet.Test.Utility.TestPackagesCore;
 
 namespace NuGet.ProjectModel.Test
 {
-    // This project can output the Class library as a NuGet Package.
-    // To enable this option, right-click on the project and select the Properties menu item. In the Build tab select "Produce outputs on build".
     public class LockFileFormatTests
     {
         // Verify the value of locked has no impact on the parsed lock file

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecCloningTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecCloningTests.cs
@@ -349,6 +349,7 @@ namespace NuGet.ProjectModel.Test
             projectReference.PrivateAssets = LibraryIncludeFlags.Build;
             var nugetFramework = NuGetFramework.Parse("net461");
             var originalPRMFI = new ProjectRestoreMetadataFrameworkInfo(nugetFramework);
+            originalPRMFI.TargetAlias = Guid.NewGuid().ToString();
             originalPRMFI.ProjectReferences = new List<ProjectRestoreReference>() { projectReference };
             var targetframeworks = new List<ProjectRestoreMetadataFrameworkInfo>() { originalPRMFI };
 
@@ -610,6 +611,7 @@ namespace NuGet.ProjectModel.Test
             var imports = NuGetFramework.Parse("net45"); // This makes no sense in the context of fallback, just for testing :)
 
             var originalTargetFrameworkInformation = new TargetFrameworkInformation();
+            originalTargetFrameworkInformation.TargetAlias = Guid.NewGuid().ToString();
             originalTargetFrameworkInformation.FrameworkName = framework;
             originalTargetFrameworkInformation.Dependencies = new List<LibraryDependency>() { dependency };
             originalTargetFrameworkInformation.AssetTargetFallback = false;

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecWriterTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecWriterTests.cs
@@ -625,6 +625,43 @@ namespace NuGet.ProjectModel.Test
             VerifyJsonPackageSpecRoundTrip(json);
         }
 
+        [Fact]
+        public void RoundTripTargetFrameworkAliases()
+        {
+            var json = @"{  
+                        ""restore"": {
+                        ""projectUniqueName"": ""projectUniqueName"",
+                        ""projectName"": ""projectName"",
+                        ""projectPath"": ""projectPath"",
+                        ""projectJsonPath"": ""projectJsonPath"",
+                        ""packagesPath"": ""packagesPath"",
+                        ""outputPath"": ""outputPath"",
+                        ""projectStyle"": ""PackageReference"",
+                        ""frameworks"": {
+                          ""net45"": {
+                            ""targetAlias"" : ""minNetVersion"",
+                            ""projectReferences"": {}
+                          }
+                        }
+                      },
+                  ""frameworks"": {
+                    ""net46"": {
+                        ""targetAlias"" : ""minNetVersion"",
+                        ""dependencies"": {
+                            ""a"": {
+                                ""version"": ""[1.0.0, )"",
+                                ""aliases"": ""yay""
+                            }
+                        }
+                    }
+                }
+            }";
+            // Arrange
+
+            // Act & Assert
+            VerifyJsonPackageSpecRoundTrip(json);
+        }
+
         private static string GetJsonString(PackageSpec packageSpec)
         {
             JObject jObject = packageSpec.ToJObject();


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9869
Regression: No 
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: 
Currently in command line scenarios NuGet reads the target framework information in the outer build. 
That is incorrect because the the contract is that we should depend on on TargetFrameworkIdentifier and the like properties. 
We do that here: https://github.com/NuGet/NuGet.Client/blob/bd482514a87a0085f8eb8603842ee1cb3ca5f277/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets#L500-L526

This issue covers  commandline restore (nuget.exe, msbuild.exe dotnet.exe).

Roughly some more important notes about the changes: 

* We *do not* parse the `TargetFramework` property any more.
* When grouping the dependencies, we group them over the TargetFramework alias. 
* Added a TargetAlias in each of the models containing pivots for dependencies such as `TargetFrameworkInformation` & `ProjectRestoreMetadataFrameworkInfo`. The first one contains the package refs, the latter one contains the project refs.
* When setting conditions, we'll retain the original value of `TargetFramework`. This is normal, but think it's worth calling it out. 
* We read the tfm information through a bunch of props. The item we define for this information will remain the one that was used for AssetTargetFallback (which was already being read from the inner build). 

* The target framework generation scenarios are hacky. Those changes are going to be replaced with whatever comes out of https://github.com/NuGet/NuGet.Client/pull/3549 + https://github.com/nuget/home/issues/9871.
* When I generate the dg spec for the NuGet.sln, there are 2 differences:
  * Each frameworks setting has a "targetAlias" value. 
  * net5.0 is getting parsed as `net5.0-windows7.0` because the SDK 5.0.100 P7 reports default TargetPlatformIdentifier and related.

**Note that this change is time critical. Any cosmetic suggestions, I'll be happy to address, but in a future PR**. 

## Testing/Validation

Tests Added: Yes  
Reason for not adding tests:  
Validation:  
