### PR TITLE
Remove temp patching for deps.json

### DIFF
--- a/build/config.props
+++ b/build/config.props
@@ -37,8 +37,8 @@
     <!--TODO: remove temporary workaround of using LockSDKVersion. Tracking issue: https://github.com/NuGet/Home/issues/9712 -->
     <LockSDKVersion>true</LockSDKVersion>
     <OverrideCliBranchForTesting Condition="'$(LockSDKVersion)' == 'false'"></OverrideCliBranchForTesting>
-    <OverrideCliBranchForTesting Condition="'$(LockSDKVersion)' == 'true'">master 5.0.100-preview.7.20319.6</OverrideCliBranchForTesting>
-    <CliVersionForBuilding>"master 5.0.100-preview.4.20258.7"</CliVersionForBuilding>
+    <OverrideCliBranchForTesting Condition="'$(LockSDKVersion)' == 'true'">master 5.0.100-preview.7.20366.6;3.1</OverrideCliBranchForTesting>
+    <CliVersionForBuilding>"master 5.0.100-preview.7.20366.6"</CliVersionForBuilding>
     <CliBranchForTesting Condition="'$(OverrideCliBranchForTesting)' != ''">$(OverrideCliBranchForTesting)</CliBranchForTesting>
     <CliBranchForTesting Condition="'$(OverrideCliBranchForTesting)' == ''">master</CliBranchForTesting>
     <CliTargetBranches Condition="'$(OverrideCliTargetBranches)' != ''">$(OverrideCliTargetBranches)</CliTargetBranches>

--- a/build/config.props
+++ b/build/config.props
@@ -37,7 +37,7 @@
     <!--TODO: remove temporary workaround of using LockSDKVersion. Tracking issue: https://github.com/NuGet/Home/issues/9712 -->
     <LockSDKVersion>true</LockSDKVersion>
     <OverrideCliBranchForTesting Condition="'$(LockSDKVersion)' == 'false'"></OverrideCliBranchForTesting>
-    <OverrideCliBranchForTesting Condition="'$(LockSDKVersion)' == 'true'">master 5.0.100-preview.7.20366.6;3.1</OverrideCliBranchForTesting>
+    <OverrideCliBranchForTesting Condition="'$(LockSDKVersion)' == 'true'">master 5.0.100-preview.7.20366.6</OverrideCliBranchForTesting>
     <CliVersionForBuilding>"master 5.0.100-preview.7.20366.6"</CliVersionForBuilding>
     <CliBranchForTesting Condition="'$(OverrideCliBranchForTesting)' != ''">$(OverrideCliBranchForTesting)</CliBranchForTesting>
     <CliBranchForTesting Condition="'$(OverrideCliBranchForTesting)' == ''">master</CliBranchForTesting>

--- a/build/packages.targets
+++ b/build/packages.targets
@@ -7,7 +7,6 @@
         <VSFrameworkVersion>16.6.30107.105</VSFrameworkVersion>
         <VSServicesVersion>16.153.0</VSServicesVersion>
         <VSThreadingVersion>16.7.54</VSThreadingVersion>
-        <!-- TODO - remove this when temporary patching is no longer necessary. See https://github.com/nuget/home/issues/8952 -->
         <PatchedSystemPackagesVersion>5.0.0-preview.3.20214.6</PatchedSystemPackagesVersion>
     </PropertyGroup>
 

--- a/build/packages.targets
+++ b/build/packages.targets
@@ -7,7 +7,7 @@
         <VSFrameworkVersion>16.6.30107.105</VSFrameworkVersion>
         <VSServicesVersion>16.153.0</VSServicesVersion>
         <VSThreadingVersion>16.7.54</VSThreadingVersion>
-        <PatchedSystemPackagesVersion>5.0.0-preview.3.20214.6</PatchedSystemPackagesVersion>
+        <CryptographyPackagesVersion>5.0.0-preview.3.20214.6</CryptographyPackagesVersion>
     </PropertyGroup>
 
     <!-- Test and package versions -->
@@ -63,8 +63,8 @@
         <PackageReference Update="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
         <PackageReference Update="System.Collections.Immutable" Version="1.5.0" />
         <PackageReference Update="System.Diagnostics.Debug" Version="$(SystemPackagesVersion)" />
-        <PackageReference Update="System.Security.Cryptography.Pkcs" Version="$(PatchedSystemPackagesVersion)" />
-        <PackageReference Update="System.Security.Cryptography.Cng" Version="$(PatchedSystemPackagesVersion)" />
+        <PackageReference Update="System.Security.Cryptography.Pkcs" Version="$(CryptographyPackagesVersion)" />
+        <PackageReference Update="System.Security.Cryptography.Cng" Version="$(CryptographyPackagesVersion)" />
         <PackageReference Update="System.Security.Cryptography.ProtectedData" Version="4.4.0" />
         <PackageReference Update="System.Threading.Tasks.Dataflow" Version="4.9.0" />
         <PackageReference Update="VSLangProj" Version="7.0.3300" />

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/MsbuildIntegrationTestFixture.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/MsbuildIntegrationTestFixture.cs
@@ -41,9 +41,6 @@ namespace Dotnet.Integration.Test
 
             var sdkPath = Directory.EnumerateDirectories(Path.Combine(_cliDirectory, "sdk")).Single();
 
-            // TODO - remove when shipping. See https://github.com/NuGet/Home/issues/8952
-            PatchSDKWithCryptographyDlls(sdkPath);
-
             MsBuildSdksPath = Path.Combine(sdkPath, "Sdks");
 
             _templateDirectory = new SimpleTestPathContext();
@@ -607,113 +604,6 @@ project TFMs found: {string.Join(", ", compiledTfms.Keys.Select(k => k.ToString(
             {
 
             }
-        }
-
-        // Temporary added methods for processing deps.json files for patching
-
-        /// <summary>
-        /// Temporary patching process to bring in Cryptography DLLs for testing while SDK gets around to including them in 5.0.
-        /// See also: https://github.com/NuGet/Home/issues/8508
-        /// </summary>
-        private void PatchSDKWithCryptographyDlls(string sdkPath)
-        {
-            var assemblyNames = new string[1] { "System.Security.Cryptography.Pkcs.dll" };
-            PatchDepsJsonFiles(assemblyNames, sdkPath);
-
-            string userProfilePath = Environment.GetEnvironmentVariable(RuntimeEnvironmentHelper.IsWindows ? "USERPROFILE" : "HOME");
-            string globalPackagesPath = Path.Combine(userProfilePath, ".nuget", "packages");
-
-            CopyNewlyAddedDlls(assemblyNames, Directory.GetCurrentDirectory(), sdkPath);
-        }
-
-        private void PatchDepsJsonFiles(string[] assemblyNames, string patchDir)
-        {
-            string[] fileNames = new string[3] { "dotnet.deps.json", "MSBuild.deps.json", "NuGet.CommandLine.XPlat.deps.json" };
-            string[] fullNames = fileNames.Select(filename => Path.Combine(patchDir, filename)).ToArray();
-            PatchDepsJsonWithNewlyAddedDlls(assemblyNames, fullNames);
-        }
-
-        private void CopyNewlyAddedDlls(string[] assemblyNames, string copyFromPath, string copyToPath)
-        {
-            foreach (var assemblyName in assemblyNames)
-            {
-                File.Copy(
-                    Path.Combine(copyFromPath, assemblyName),
-                    Path.Combine(copyToPath, assemblyName)
-                );
-            }
-        }
-
-        private void PatchDepsJsonWithNewlyAddedDlls(string[] assemblyNames, string[] filePaths)
-        {
-            foreach (string assemblyName in assemblyNames)
-            {
-                foreach (string filePath in filePaths)
-                {
-                    JObject jsonFile = GetJson(filePath);
-
-                    JObject targets = jsonFile.GetJObjectProperty<JObject>("targets");
-
-                    JObject netcoreapp50 = targets.GetJObjectProperty<JObject>(".NETCoreApp,Version=v5.0");
-
-                    JProperty nugetBuildTasksProperty = netcoreapp50.Properties().
-                        FirstOrDefault(prop => prop.Name.StartsWith("NuGet.Build.Tasks/", StringComparison.OrdinalIgnoreCase));
-
-                    JObject nugetBuildTasks = nugetBuildTasksProperty.Value.FromJToken<JObject>();
-
-                    JObject runtime = nugetBuildTasks.GetJObjectProperty<JObject>("runtime");
-
-                    var assemblyPath = Path.Combine(Directory.GetCurrentDirectory(), assemblyName);
-                    var assemblyVersion = Assembly.LoadFile(assemblyPath).GetName().Version.ToString();
-                    var assemblyFileVersion = FileVersionInfo.GetVersionInfo(assemblyPath).FileVersion;
-                    var jproperty = new JProperty("lib/netcoreapp5.0/" + assemblyName,
-                        new JObject
-                        {
-                            new JProperty("assemblyVersion", assemblyVersion),
-                            new JProperty("fileVersion", assemblyFileVersion),
-                        }
-                    );
-                    runtime.Add(jproperty);
-                    nugetBuildTasks["runtime"] = runtime;
-                    netcoreapp50[nugetBuildTasksProperty.Name] = nugetBuildTasks;
-                    targets[".NETCoreApp,Version=v5.0"] = netcoreapp50;
-                    jsonFile["targets"] = targets;
-                    SaveJson(jsonFile, filePath);
-                }
-            }
-        }
-
-        private JObject GetJson(string jsonFilePath)
-        {
-            try
-            {
-                return FileUtility.SafeRead(jsonFilePath, (stream, filePath) =>
-                {
-                    using (var reader = new StreamReader(stream))
-                    {
-                        return JObject.Parse(reader.ReadToEnd());
-                    }
-                });
-            }
-            catch (Exception ex)
-            {
-                throw new InvalidOperationException(
-                    string.Format("Failed to read json file at {0}: {1}", jsonFilePath, ex.Message),
-                    ex
-                );
-            }
-        }
-
-        private void SaveJson(JObject json, string jsonFilePath)
-        {
-            FileUtility.Replace((outputPath) =>
-            {
-                using (var writer = new StreamWriter(outputPath, append: false, encoding: Encoding.UTF8))
-                {
-                    writer.Write(json.ToString());
-                }
-            },
-            jsonFilePath);
         }
     }
 }


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/8952 and https://github.com/NuGet/Client.Engineering/issues/367
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: 
Remove the patching on deps.json files in Dotnet.Integration.Test.
Remove the comments as we need package referrenc of System.Security.Cryptography.Pkcs/Cng as they're not part of the .NET 5 Base Class Libraries (BCL)   
Update the version of dotnet sdk for testing to a newer version, as the old one doesn't have Pkcs.dll.
Update the version of dotnet sdk for building to the latest public version(preview7).

## Testing/Validation

Tests Added: No  
Reason for not adding tests: 
Validation:  
