### PR TITLE
uses different parsing logic for platform versions when dot is missing

### DIFF
--- a/src/NuGet.Core/NuGet.Frameworks/FrameworkNameProvider.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/FrameworkNameProvider.cs
@@ -167,6 +167,26 @@ namespace NuGet.Frameworks
             return false;
         }
 
+        public bool TryGetPlatformVersion(string versionString, out Version version)
+        {
+            version = null;
+
+            if (string.IsNullOrEmpty(versionString))
+            {
+                version = new Version(0, 0);
+            }
+            else
+            {
+                if (versionString.IndexOf('.') < 0)
+                {
+                    versionString += ".0";
+                }
+                return Version.TryParse(versionString, out version);
+            }
+
+            return false;
+        }
+
         public string GetVersionString(string framework, Version version)
         {
             var versionString = string.Empty;

--- a/src/NuGet.Core/NuGet.Frameworks/NuGetFrameworkFactory.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/NuGetFrameworkFactory.cs
@@ -370,7 +370,7 @@ namespace NuGet.Frameworks
 
                                     // Parse the version if it's there.
                                     Version platformVersion = FrameworkConstants.EmptyVersion;
-                                    if ((string.IsNullOrEmpty(platformVersionString) || mappings.TryGetVersion(platformVersionString, out platformVersion)))
+                                    if ((string.IsNullOrEmpty(platformVersionString) || mappings.TryGetPlatformVersion(platformVersionString, out platformVersion)))
                                     {
                                         result = new NuGetFramework(framework, version, platform ?? string.Empty, platformVersion ?? FrameworkConstants.EmptyVersion);
                                     }

--- a/src/NuGet.Core/NuGet.Frameworks/PublicAPI/net40/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Frameworks/PublicAPI/net40/PublicAPI.Unshipped.txt
@@ -1,2 +1,3 @@
 NuGet.Frameworks.FrameworkNameProvider.TryGetPlatformVersion(string versionString, out System.Version version) -> bool
+NuGet.Frameworks.IFrameworkNameProvider.TryGetPlatformVersion(string versionString, out System.Version version) -> bool
 static NuGet.Frameworks.NuGetFramework.ParseComponents(string targetFrameworkIdentifier, string targetFrameworkVersion, string targetFrameworkProfile, string targetPlatformIdentifier, string targetPlatformVersion) -> NuGet.Frameworks.NuGetFramework

--- a/src/NuGet.Core/NuGet.Frameworks/PublicAPI/net40/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Frameworks/PublicAPI/net40/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
+NuGet.Frameworks.FrameworkNameProvider.TryGetPlatformVersion(string versionString, out System.Version version) -> bool
 static NuGet.Frameworks.NuGetFramework.ParseComponents(string targetFrameworkIdentifier, string targetFrameworkVersion, string targetFrameworkProfile, string targetPlatformIdentifier, string targetPlatformVersion) -> NuGet.Frameworks.NuGetFramework

--- a/src/NuGet.Core/NuGet.Frameworks/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Frameworks/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -1,2 +1,3 @@
 NuGet.Frameworks.FrameworkNameProvider.TryGetPlatformVersion(string versionString, out System.Version version) -> bool
+NuGet.Frameworks.IFrameworkNameProvider.TryGetPlatformVersion(string versionString, out System.Version version) -> bool
 static NuGet.Frameworks.NuGetFramework.ParseComponents(string targetFrameworkIdentifier, string targetFrameworkVersion, string targetFrameworkProfile, string targetPlatformIdentifier, string targetPlatformVersion) -> NuGet.Frameworks.NuGetFramework

--- a/src/NuGet.Core/NuGet.Frameworks/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Frameworks/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
+NuGet.Frameworks.FrameworkNameProvider.TryGetPlatformVersion(string versionString, out System.Version version) -> bool
 static NuGet.Frameworks.NuGetFramework.ParseComponents(string targetFrameworkIdentifier, string targetFrameworkVersion, string targetFrameworkProfile, string targetPlatformIdentifier, string targetPlatformVersion) -> NuGet.Frameworks.NuGetFramework

--- a/src/NuGet.Core/NuGet.Frameworks/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Frameworks/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,2 +1,3 @@
 NuGet.Frameworks.FrameworkNameProvider.TryGetPlatformVersion(string versionString, out System.Version version) -> bool
+NuGet.Frameworks.IFrameworkNameProvider.TryGetPlatformVersion(string versionString, out System.Version version) -> bool
 static NuGet.Frameworks.NuGetFramework.ParseComponents(string targetFrameworkIdentifier, string targetFrameworkVersion, string targetFrameworkProfile, string targetPlatformIdentifier, string targetPlatformVersion) -> NuGet.Frameworks.NuGetFramework

--- a/src/NuGet.Core/NuGet.Frameworks/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Frameworks/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
+NuGet.Frameworks.FrameworkNameProvider.TryGetPlatformVersion(string versionString, out System.Version version) -> bool
 static NuGet.Frameworks.NuGetFramework.ParseComponents(string targetFrameworkIdentifier, string targetFrameworkVersion, string targetFrameworkProfile, string targetPlatformIdentifier, string targetPlatformVersion) -> NuGet.Frameworks.NuGetFramework

--- a/src/NuGet.Core/NuGet.Frameworks/def/IFrameworkNameProvider.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/def/IFrameworkNameProvider.cs
@@ -39,6 +39,12 @@ namespace NuGet.Frameworks
         bool TryGetVersion(string versionString, out Version version);
 
         /// <summary>
+        /// Parses a version string. If no dots exist, all digits are treated
+        /// as semver-major, instead of inserting dots.
+        /// </summary>
+        bool TryGetPlatformVersion(string versionString, out Version version);
+
+        /// <summary>
         /// Returns a shortened version. If all digits are single digits no dots will be used.
         /// </summary>
         string GetVersionString(string framework, Version version);

--- a/test/NuGet.Core.Tests/NuGet.Frameworks.Test/NuGetFrameworkParseTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Frameworks.Test/NuGetFrameworkParseTests.cs
@@ -228,6 +228,7 @@ namespace NuGet.Test
         [InlineData("netcoreapp3.0", ".NetCoreApp,Version=v3.0")]
         [InlineData("net5.0-android", "net5.0-android")]
         [InlineData("net5.0-android", "net5.0-android0.0")]
+        [InlineData("net5.0-android10.0", "net5.0-android10")]
         [InlineData("net5.0-ios14.0", "net5.0-ios14.0")]
         [InlineData("net5.0-macos10.0", "net5.0-macos10.0")]
         [InlineData("net5.0-watchos1.0", "net5.0-watchos1.0")]


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Home/issues/9842
