### PR TITLE
Add support for emitting ETW events from the current telemetry events.

### DIFF
--- a/src/NuGet.Core/NuGet.Common/NuGet.Common.csproj
+++ b/src/NuGet.Core/NuGet.Common/NuGet.Common.csproj
@@ -1,4 +1,4 @@
-<Project>
+﻿<Project>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common.props" />
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
@@ -41,7 +41,11 @@
       <LastGenOutput>Strings.Designer.cs</LastGenOutput>
     </EmbeddedResource>
   </ItemGroup>
-
+  
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" />
+  </ItemGroup>
+  
   <Import Project="$(BuildCommonDirectory)common.targets"/>
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 </Project>

--- a/src/NuGet.Core/NuGet.Common/Telemetry/NuGetETWProvider.cs
+++ b/src/NuGet.Core/NuGet.Common/Telemetry/NuGetETWProvider.cs
@@ -1,0 +1,34 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics.Tracing;
+
+namespace NuGet.Common
+{
+    [EventSource(Name = "NuGetETWProvider")]
+    internal sealed class NuGetETWProvider : EventSource
+    {
+        private static Lazy<NuGetETWProvider> LazyInstance = new Lazy<NuGetETWProvider>(() => new NuGetETWProvider());
+
+        private NuGetETWProvider()
+        {
+        }
+
+        internal static NuGetETWProvider Instance
+        {
+            get
+            {
+                return LazyInstance.Value;
+            }
+        }
+
+        internal void WriteEventData(string name, string eventJsonString)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(1, name, eventJsonString);
+            }
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Common/Telemetry/TelemetryActivity.cs
+++ b/src/NuGet.Core/NuGet.Common/Telemetry/TelemetryActivity.cs
@@ -108,6 +108,7 @@ namespace NuGet.Common
                 }
 
                 NuGetTelemetryService.EmitTelemetryEvent(TelemetryEvent);
+                NuGetETWProvider.Instance.WriteEventData(TelemetryEvent.Name, TelemetryEvent.PropertiesToJsonString());
             }
 
             _telemetryActivity?.Dispose();

--- a/src/NuGet.Core/NuGet.Common/Telemetry/TelemetryEvent.cs
+++ b/src/NuGet.Core/NuGet.Common/Telemetry/TelemetryEvent.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace NuGet.Common
 {
@@ -77,6 +78,11 @@ namespace NuGet.Common
         public IEnumerable<KeyValuePair<string, object>> GetPiiData()
         {
             return _piiProperties;
+        }
+
+        internal string PropertiesToJsonString()
+        {
+            return JsonConvert.SerializeObject(_properties);
         }
     }
 }


### PR DESCRIPTION
## Summary
NuGet restore has telemetry events that are activated only when running under devenv process. 
This makes difficult to get diagnostics information while running msbuild or nuget.exe restore. 
The proposed change addsan ETW provider that will not be activated without an active listener. While this will be noop for the majority of external users, any users  interested to get detailed restore information can implement listeners and consume the etw data. 

For example the resulted data can be easily exported in ( Kusto/AI , sql or other data storage) and queried with known tools. 

## Fix
Add an ETW provider. 

## Testing/Validation

Tests Added: Not yet. Will be added if the teams agrees that this is an useful feature to have. Currently it will be a draft PR. 
Reason for not adding tests:  above
Validation:  
