### PR TITLE
Make package recommendations when package source is 'All' and includes nuget.org

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -778,11 +778,11 @@ namespace NuGet.PackageManagement.UI
             if (IsRecommenderFlightEnabled())
             {
                 packageFeeds = await CreatePackageFeedAsync(loadContext, _topPanel.Filter, _uiLogger, _recommendPackages);
+                _recommenderVersion = ((RecommenderPackageFeed)packageFeeds.recommenderFeed)?.VersionInfo;
             }
             else
             {
                 packageFeeds = await CreatePackageFeedAsync(loadContext, _topPanel.Filter, _uiLogger, recommendPackages: false);
-                _recommenderVersion = ((RecommenderPackageFeed)packageFeeds.recommenderFeed)?.VersionInfo;
             }
 
             return packageFeeds;

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -782,6 +782,7 @@ namespace NuGet.PackageManagement.UI
             else
             {
                 packageFeeds = await CreatePackageFeedAsync(loadContext, _topPanel.Filter, _uiLogger, recommendPackages: false);
+                _recommenderVersion = ((RecommenderPackageFeed)packageFeeds.recommenderFeed)?.VersionInfo;
             }
 
             return packageFeeds;
@@ -832,9 +833,6 @@ namespace NuGet.PackageManagement.UI
                     var searchResult = await searchResultTask;
                     pSearchCallback.ReportComplete(searchTask, (uint)searchResult.RawItemsCount);
                 }
-
-                // get the version info from the recommender
-                _recommenderVersion = ((RecommenderPackageFeed)packageFeeds.recommenderFeed)?.VersionInfo;
 
                 // When not using Cache, refresh all Counts.
                 if (!useCachedPackageMetadata)

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -748,7 +748,7 @@ namespace NuGet.PackageManagement.UI
             .PostOnFailure(nameof(PackageManagerControl), nameof(SearchPackagesAndRefreshUpdateCount));
         }
 
-        // Check if user has environment variable of RecommendNuGetPackages set to 1 or is in A/B experiment.
+        // Check if user has environment variable of NUGET_RECOMMEND_PACKAGES set to 1 or is in A/B experiment.
         public bool IsRecommenderFlightEnabled()
         {
             return _forceRecommender || ExperimentationService.Default.IsCachedFlightEnabled("nugetrecommendpkgs");


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9872
Regression: No  

## Fix

Instead of checking that there is only one source and it is nuget.org, check that any one of the sources is nuget.org.

## Testing/Validation

Tests Added: Yes/No  
Reason for not adding tests:  
Validation:  
