### PR TITLE
VS nomination uses TFI/TFV/TFP/TPI/TPV properties to parse NuGetFramework

### DIFF
--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/VSNominationUtilities.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/VSNominationUtilities.cs
@@ -94,8 +94,9 @@ namespace NuGet.SolutionRestoreManager
         {
             var tfi = new TargetFrameworkInformation
             {
-                FrameworkName = NuGetFramework.Parse(targetFrameworkInfo.TargetFrameworkMoniker)
+                FrameworkName = GetTargetFramework(targetFrameworkInfo.Properties)
             };
+            tfi.TargetAlias = GetPropertyValueOrNull(targetFrameworkInfo.Properties, ProjectBuildProperties.TargetFramework) ?? tfi.FrameworkName.GetShortFolderName();
 
             var ptf = MSBuildStringUtility.Split(GetPropertyValueOrNull(targetFrameworkInfo.Properties, ProjectBuildProperties.PackageTargetFallback))
                                           .Select(NuGetFramework.Parse)
@@ -149,6 +150,17 @@ namespace NuGet.SolutionRestoreManager
             }
 
             return tfi;
+        }
+
+        internal static NuGetFramework GetTargetFramework(IVsProjectProperties properties)
+        {
+            var targetFrameworkIdentifier = GetPropertyValueOrNull(properties, ProjectBuildProperties.TargetFrameworkIdentifier) ?? string.Empty;
+            var targetFrameworkVersion = GetPropertyValueOrNull(properties, ProjectBuildProperties.TargetFrameworkVersion) ?? string.Empty;
+            var targetFrameworkProfile = GetPropertyValueOrNull(properties, ProjectBuildProperties.TargetFrameworkProfile) ?? string.Empty;
+            var targetPlatformIdentifier = GetPropertyValueOrNull(properties, ProjectBuildProperties.TargetPlatformIdentifier) ?? string.Empty;
+            var targetPlatformVersion = GetPropertyValueOrNull(properties, ProjectBuildProperties.TargetPlatformVersion) ?? string.Empty;
+
+            return NuGetFramework.ParseComponents(targetFrameworkIdentifier, targetFrameworkVersion, targetFrameworkProfile, targetPlatformIdentifier, targetPlatformVersion);
         }
 
         internal static ProjectRestoreMetadataFrameworkInfo ToProjectRestoreMetadataFrameworkInfo(

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/VSNominationUtilities.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/VSNominationUtilities.cs
@@ -94,9 +94,9 @@ namespace NuGet.SolutionRestoreManager
         {
             var tfi = new TargetFrameworkInformation
             {
-                FrameworkName = GetTargetFramework(targetFrameworkInfo.Properties)
+                FrameworkName = GetTargetFramework(targetFrameworkInfo.Properties),
+                TargetAlias = GetPropertyValueOrNull(targetFrameworkInfo.Properties, ProjectBuildProperties.TargetFramework)
             };
-            tfi.TargetAlias = GetPropertyValueOrNull(targetFrameworkInfo.Properties, ProjectBuildProperties.TargetFramework) ?? tfi.FrameworkName.GetShortFolderName();
 
             var ptf = MSBuildStringUtility.Split(GetPropertyValueOrNull(targetFrameworkInfo.Properties, ProjectBuildProperties.PackageTargetFallback))
                                           .Select(NuGetFramework.Parse)
@@ -154,11 +154,11 @@ namespace NuGet.SolutionRestoreManager
 
         internal static NuGetFramework GetTargetFramework(IVsProjectProperties properties)
         {
-            var targetFrameworkIdentifier = GetPropertyValueOrNull(properties, ProjectBuildProperties.TargetFrameworkIdentifier) ?? string.Empty;
-            var targetFrameworkVersion = GetPropertyValueOrNull(properties, ProjectBuildProperties.TargetFrameworkVersion) ?? string.Empty;
-            var targetFrameworkProfile = GetPropertyValueOrNull(properties, ProjectBuildProperties.TargetFrameworkProfile) ?? string.Empty;
-            var targetPlatformIdentifier = GetPropertyValueOrNull(properties, ProjectBuildProperties.TargetPlatformIdentifier) ?? string.Empty;
-            var targetPlatformVersion = GetPropertyValueOrNull(properties, ProjectBuildProperties.TargetPlatformVersion) ?? string.Empty;
+            var targetFrameworkIdentifier = GetPropertyValueOrNull(properties, ProjectBuildProperties.TargetFrameworkIdentifier);
+            var targetFrameworkVersion = GetPropertyValueOrNull(properties, ProjectBuildProperties.TargetFrameworkVersion);
+            var targetFrameworkProfile = GetPropertyValueOrNull(properties, ProjectBuildProperties.TargetFrameworkProfile);
+            var targetPlatformIdentifier = GetPropertyValueOrNull(properties, ProjectBuildProperties.TargetPlatformIdentifier);
+            var targetPlatformVersion = GetPropertyValueOrNull(properties, ProjectBuildProperties.TargetPlatformVersion);
 
             return NuGetFramework.ParseComponents(targetFrameworkIdentifier, targetFrameworkVersion, targetFrameworkProfile, targetPlatformIdentifier, targetPlatformVersion);
         }

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/VSNominationUtilities.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/VSNominationUtilities.cs
@@ -90,11 +90,11 @@ namespace NuGet.SolutionRestoreManager
         }
 
         internal static TargetFrameworkInformation ToTargetFrameworkInformation(
-            IVsTargetFrameworkInfo targetFrameworkInfo, bool cpvmEnabled)
+            IVsTargetFrameworkInfo targetFrameworkInfo, bool cpvmEnabled, string projectFullPath)
         {
             var tfi = new TargetFrameworkInformation
             {
-                FrameworkName = GetTargetFramework(targetFrameworkInfo.Properties),
+                FrameworkName = GetTargetFramework(targetFrameworkInfo.Properties, projectFullPath),
                 TargetAlias = GetPropertyValueOrNull(targetFrameworkInfo.Properties, ProjectBuildProperties.TargetFramework)
             };
 
@@ -152,24 +152,36 @@ namespace NuGet.SolutionRestoreManager
             return tfi;
         }
 
-        internal static NuGetFramework GetTargetFramework(IVsProjectProperties properties)
+        internal static NuGetFramework GetTargetFramework(IVsProjectProperties properties, string projectFullPath)
         {
+            var targetFrameworkMoniker = GetPropertyValueOrNull(properties, ProjectBuildProperties.TargetFrameworkMoniker);
             var targetFrameworkIdentifier = GetPropertyValueOrNull(properties, ProjectBuildProperties.TargetFrameworkIdentifier);
             var targetFrameworkVersion = GetPropertyValueOrNull(properties, ProjectBuildProperties.TargetFrameworkVersion);
             var targetFrameworkProfile = GetPropertyValueOrNull(properties, ProjectBuildProperties.TargetFrameworkProfile);
             var targetPlatformIdentifier = GetPropertyValueOrNull(properties, ProjectBuildProperties.TargetPlatformIdentifier);
             var targetPlatformVersion = GetPropertyValueOrNull(properties, ProjectBuildProperties.TargetPlatformVersion);
+            var targetPlatformMinVersion = GetPropertyValueOrNull(properties, ProjectBuildProperties.TargetPlatformMinVersion);
 
-            return NuGetFramework.ParseComponents(targetFrameworkIdentifier, targetFrameworkVersion, targetFrameworkProfile, targetPlatformIdentifier, targetPlatformVersion);
+            return MSBuildProjectFrameworkUtility.GetProjectFramework(
+                projectFullPath,
+                targetFrameworkMoniker,
+                targetFrameworkIdentifier,
+                targetFrameworkVersion,
+                targetFrameworkProfile,
+                targetPlatformIdentifier,
+                targetPlatformVersion,
+                targetPlatformMinVersion);
         }
 
         internal static ProjectRestoreMetadataFrameworkInfo ToProjectRestoreMetadataFrameworkInfo(
             IVsTargetFrameworkInfo targetFrameworkInfo,
-            string projectDirectory)
+            string projectDirectory,
+            string projectFullPath)
         {
             var tfi = new ProjectRestoreMetadataFrameworkInfo
             {
-                FrameworkName = NuGetFramework.Parse(targetFrameworkInfo.TargetFrameworkMoniker)
+                FrameworkName = GetTargetFramework(targetFrameworkInfo.Properties, projectFullPath),
+                TargetAlias = GetPropertyValueOrNull(targetFrameworkInfo.Properties, ProjectBuildProperties.TargetFramework)
             };
 
             if (targetFrameworkInfo.ProjectReferences != null)

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
@@ -220,7 +220,7 @@ namespace NuGet.SolutionRestoreManager
 
             var tfis = TargetFrameworks
                 .Cast<IVsTargetFrameworkInfo>()
-                .Select(tfi => VSNominationUtilities.ToTargetFrameworkInformation(tfi, cpvmEnabled))
+                .Select(tfi => VSNominationUtilities.ToTargetFrameworkInformation(tfi, cpvmEnabled, projectNames.FullName))
                 .ToArray();
 
             var projectFullPath = Path.GetFullPath(projectNames.FullName);
@@ -259,7 +259,7 @@ namespace NuGet.SolutionRestoreManager
                     ProjectStyle = ProjectStyle.PackageReference,
                     TargetFrameworks = TargetFrameworks
                         .Cast<IVsTargetFrameworkInfo>()
-                        .Select(item => VSNominationUtilities.ToProjectRestoreMetadataFrameworkInfo(item, projectDirectory))
+                        .Select(item => VSNominationUtilities.ToProjectRestoreMetadataFrameworkInfo(item, projectDirectory, projectFullPath))
                         .ToList(),
                     OriginalTargetFrameworks = originalTargetFrameworks,
                     CrossTargeting = crossTargeting,

--- a/src/NuGet.Core/NuGet.PackageManagement/Projects/ProjectBuildProperties.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Projects/ProjectBuildProperties.cs
@@ -18,7 +18,10 @@ namespace NuGet.ProjectManagement
         public const string RuntimeIdentifiers = nameof(RuntimeIdentifiers);
         public const string RuntimeSupports = nameof(RuntimeSupports);
         public const string TargetFramework = nameof(TargetFramework);
+        public const string TargetFrameworkIdentifier = nameof(TargetFrameworkIdentifier);
         public const string TargetFrameworkMoniker = nameof(TargetFrameworkMoniker);
+        public const string TargetFrameworkProfile = nameof(TargetFrameworkProfile);
+        public const string TargetFrameworkVersion = nameof(TargetFrameworkVersion);
         public const string TargetFrameworks = nameof(TargetFrameworks);
         public const string TargetPlatformIdentifier = nameof(TargetPlatformIdentifier);
         public const string TargetPlatformMinVersion = nameof(TargetPlatformMinVersion);

--- a/src/NuGet.Core/NuGet.PackageManagement/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.PackageManagement/PublicAPI.Unshipped.txt
@@ -1,2 +1,5 @@
 NuGet.ProjectManagement.MessageLevelExtensions
+const NuGet.ProjectManagement.ProjectBuildProperties.TargetFrameworkIdentifier = "TargetFrameworkIdentifier" -> string
+const NuGet.ProjectManagement.ProjectBuildProperties.TargetFrameworkProfile = "TargetFrameworkProfile" -> string
+const NuGet.ProjectManagement.ProjectBuildProperties.TargetFrameworkVersion = "TargetFrameworkVersion" -> string
 static NuGet.ProjectManagement.MessageLevelExtensions.ToLogLevel(this NuGet.ProjectManagement.MessageLevel messageLevel) -> NuGet.Common.LogLevel

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/ProjectRestoreInfoBuilder.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/ProjectRestoreInfoBuilder.cs
@@ -4,7 +4,9 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using NuGet.Frameworks;
 using NuGet.LibraryModel;
+using NuGet.ProjectManagement;
 using NuGet.ProjectModel;
 
 namespace NuGet.SolutionRestoreManager.Test
@@ -187,6 +189,25 @@ namespace NuGet.SolutionRestoreManager.Test
                 packageDownloads,
                 frameworkReferences,
                 projectProperties.Concat(globalProperties));
+        }
+
+        public static IEnumerable<IVsProjectProperty> GetTargetFrameworkProperties(NuGetFramework framework, string originalString = null)
+        {
+            return new IVsProjectProperty[]
+            {
+                new VsProjectProperty(ProjectBuildProperties.TargetFrameworkIdentifier, framework.Framework),
+                new VsProjectProperty(ProjectBuildProperties.TargetFrameworkVersion, "v" + framework.Version),
+                new VsProjectProperty(ProjectBuildProperties.TargetFrameworkProfile, framework.Profile),
+                new VsProjectProperty(ProjectBuildProperties.TargetPlatformIdentifier, framework.Platform),
+                new VsProjectProperty(ProjectBuildProperties.TargetPlatformVersion, framework.PlatformVersion.ToString()),
+                new VsProjectProperty(ProjectBuildProperties.TargetFramework, originalString ?? framework.GetShortFolderName())
+            };
+        }
+
+        public static IEnumerable<IVsProjectProperty> GetTargetFrameworkProperties(string shortFrameworkName)
+        {
+            var framework = NuGetFramework.Parse(shortFrameworkName);
+            return GetTargetFrameworkProperties(framework, shortFrameworkName);
         }
 
         private static IVsReferenceItem ToFrameworkReference(FrameworkDependency frameworkDependency)

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsTargetFrameworkInfo.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsTargetFrameworkInfo.cs
@@ -1,8 +1,9 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace NuGet.SolutionRestoreManager.Test
 {
@@ -20,7 +21,8 @@ namespace NuGet.SolutionRestoreManager.Test
             string targetFrameworkMoniker,
             IEnumerable<IVsReferenceItem> packageReferences,
             IEnumerable<IVsReferenceItem> projectReferences,
-            IEnumerable<IVsProjectProperty> projectProperties)
+            IEnumerable<IVsProjectProperty> projectProperties,
+            bool addTargetFrameworkProperties = true)
         {
             if (string.IsNullOrEmpty(targetFrameworkMoniker))
             {
@@ -45,7 +47,10 @@ namespace NuGet.SolutionRestoreManager.Test
             TargetFrameworkMoniker = targetFrameworkMoniker;
             PackageReferences = new VsReferenceItems(packageReferences);
             ProjectReferences = new VsReferenceItems(projectReferences);
-            Properties = new VsProjectProperties(projectProperties);
+            Properties =
+                addTargetFrameworkProperties
+                ? new VsProjectProperties(ProjectRestoreInfoBuilder.GetTargetFrameworkProperties(targetFrameworkMoniker).Concat(projectProperties))
+                : new VsProjectProperties(projectProperties);
         }
     }
 }

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsTargetFrameworkInfo2.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsTargetFrameworkInfo2.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace NuGet.SolutionRestoreManager.Test
 {
@@ -26,7 +27,8 @@ namespace NuGet.SolutionRestoreManager.Test
             IEnumerable<IVsReferenceItem> projectReferences,
             IEnumerable<IVsReferenceItem> packageDownloads,
             IEnumerable<IVsReferenceItem> frameworkReferences,
-            IEnumerable<IVsProjectProperty> projectProperties)
+            IEnumerable<IVsProjectProperty> projectProperties,
+            bool addTargetFrameworkProperties = true)
         {
             if (string.IsNullOrEmpty(targetFrameworkMoniker))
             {
@@ -63,7 +65,10 @@ namespace NuGet.SolutionRestoreManager.Test
             ProjectReferences = new VsReferenceItems(projectReferences);
             PackageDownloads = new VsReferenceItems(packageDownloads);
             FrameworkReferences = new VsReferenceItems(frameworkReferences);
-            Properties = new VsProjectProperties(projectProperties);
+            Properties =
+                addTargetFrameworkProperties
+                ? new VsProjectProperties(ProjectRestoreInfoBuilder.GetTargetFrameworkProperties(targetFrameworkMoniker).Concat(projectProperties))
+                : new VsProjectProperties(projectProperties);
         }
 
     }


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9863
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: Load the 5 target framework properties to parse `NuGetFramework`, rather than parsing the `TargetFrameworkMoniker` directly (it comes from `FrameworkName`, which doesn't contain the 2 platform properties).

## Testing/Validation

Tests Added: Yes (one new test added, otherwise existing tests modified)
Reason for not adding tests:  
Validation:  
