### PR TITLE
Add a project framework inference/parsing utility

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -929,6 +929,7 @@ Copyright (c) .NET Foundation. All rights reserved.
         <TargetFrameworkIdentifier>$(TargetFrameworkIdentifier)</TargetFrameworkIdentifier>
         <TargetFrameworkVersion>$(TargetFrameworkVersion)</TargetFrameworkVersion>
         <TargetFrameworkMoniker>$(TargetFrameworkMoniker)</TargetFrameworkMoniker>
+        <TargetFrameworkProfile>$(TargetFrameworkProfile)</TargetFrameworkProfile>
         <TargetPlatformIdentifier>$(TargetPlatformIdentifier)</TargetPlatformIdentifier>
         <TargetPlatformVersion>$(TargetPlatformVersion)</TargetPlatformVersion>
         <TargetPlatformMinVersion>$(TargetPlatformMinVersion)</TargetPlatformMinVersion>

--- a/src/NuGet.Core/NuGet.Commands/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Commands/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+static NuGet.Commands.MSBuildProjectFrameworkUtility.GetProjectFramework(string projectFilePath, string targetFrameworkMoniker, string targetFrameworkIdentifier, string targetFrameworkVersion, string targetFrameworkProfile, string targetPlatformIdentifier, string targetPlatformVersion, string targetPlatformMinVersion) -> NuGet.Frameworks.NuGetFramework

--- a/src/NuGet.Core/NuGet.Commands/PublicAPI/netcoreapp5.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Commands/PublicAPI/netcoreapp5.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+static NuGet.Commands.MSBuildProjectFrameworkUtility.GetProjectFramework(string projectFilePath, string targetFrameworkMoniker, string targetFrameworkIdentifier, string targetFrameworkVersion, string targetFrameworkProfile, string targetPlatformIdentifier, string targetPlatformVersion, string targetPlatformMinVersion) -> NuGet.Frameworks.NuGetFramework

--- a/src/NuGet.Core/NuGet.Commands/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Commands/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+static NuGet.Commands.MSBuildProjectFrameworkUtility.GetProjectFramework(string projectFilePath, string targetFrameworkMoniker, string targetFrameworkIdentifier, string targetFrameworkVersion, string targetFrameworkProfile, string targetPlatformIdentifier, string targetPlatformVersion, string targetPlatformMinVersion) -> NuGet.Frameworks.NuGetFramework

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
@@ -423,6 +423,7 @@ namespace NuGet.Commands
                 var targetFrameworkIdentifier = item.GetProperty("TargetFrameworkIdentifier");
                 var targetFrameworkVersion = item.GetProperty("TargetFrameworkVersion");
                 var targetFrameworkMoniker = item.GetProperty("TargetFrameworkMoniker");
+                var targetFrameworkProfile = item.GetProperty("TargetFrameworkProfile");
                 var targetPlatformIdentifier = item.GetProperty("TargetPlatformIdentifier");
                 var targetPlatformVersion = item.GetProperty("TargetPlatformVersion");
                 var targetPlatformMinVersion = item.GetProperty("TargetPlatformMinVersion");
@@ -434,18 +435,19 @@ namespace NuGet.Commands
                 }
                 uniqueIds.Add(targetAlias);
 
-                IEnumerable<string> targetFramework = MSBuildProjectFrameworkUtility.GetProjectFrameworkStrings(
-                  projectFilePath: filePath,
-                  targetFrameworks: null,
-                  targetFramework: null,
-                  targetFrameworkMoniker: targetFrameworkMoniker,
-                  targetPlatformIdentifier: targetPlatformIdentifier,
-                  targetPlatformVersion: targetPlatformVersion,
-                  targetPlatformMinVersion: targetPlatformMinVersion);
+                NuGetFramework targetFramework = MSBuildProjectFrameworkUtility.GetProjectFramework(
+                    projectFilePath: filePath,
+                    targetFrameworkMoniker: targetFrameworkMoniker,
+                    targetFrameworkIdentifier: targetFrameworkIdentifier,
+                    targetFrameworkVersion: targetFrameworkVersion,
+                    targetFrameworkProfile: targetFrameworkProfile,
+                    targetPlatformIdentifier: targetPlatformIdentifier,
+                    targetPlatformVersion: targetPlatformVersion,
+                    targetPlatformMinVersion: targetPlatformMinVersion);
 
                 var targetFrameworkInfo = new TargetFrameworkInformation()
                 {
-                    FrameworkName = NuGetFramework.Parse(targetFramework.Single()),
+                    FrameworkName = targetFramework,
                     TargetAlias = targetAlias
                 };
                 if (restoreType == ProjectStyle.PackageReference ||

--- a/src/NuGet.Core/NuGet.Commands/Utility/MSBuildProjectFrameworkUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/Utility/MSBuildProjectFrameworkUtility.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using NuGet.Common;
 using NuGet.Frameworks;
 
@@ -35,6 +36,36 @@ namespace NuGet.Commands
         }
 
         /// <summary>
+        /// Given the properties from an msbuild project file and a the file path, infer the target framework.
+        /// This method prioritizes projects without a framework, such as vcxproj and accounts for the mismatching arguments in UAP projects, where the TFI and TFV are set but should be ignored.
+        /// Likewise, this method will *ignore* unnecessary properties, such as TPI and TPV when profiles are used, and frameworks that do not support platforms have some default values.
+        /// </summary>
+        /// <returns>The inferred framework. Unsupported otherwise.</returns>
+        public static NuGetFramework GetProjectFramework(
+            string projectFilePath,
+            string targetFrameworkMoniker,
+            string targetFrameworkIdentifier,
+            string targetFrameworkVersion,
+            string targetFrameworkProfile,
+            string targetPlatformIdentifier,
+            string targetPlatformVersion,
+            string targetPlatformMinVersion)
+        {
+            return GetProjectFramework(
+                projectFilePath,
+                targetFrameworkMoniker,
+                targetFrameworkIdentifier,
+                targetFrameworkVersion,
+                targetFrameworkProfile,
+                targetPlatformIdentifier,
+                targetPlatformVersion,
+                targetPlatformMinVersion,
+                isXnaWindowsPhoneProject: false,
+                isManagementPackProject: false,
+                GetAsNuGetFramework);
+        }
+
+        /// <summary>
         /// Determine the target framework of an msbuild project.
         /// </summary>
         public static IEnumerable<string> GetProjectFrameworkStrings(
@@ -48,6 +79,37 @@ namespace NuGet.Commands
             bool isXnaWindowsPhoneProject,
             bool isManagementPackProject)
         {
+            return GetProjectFrameworks(
+                projectFilePath,
+                targetFrameworks,
+                targetFramework,
+                targetFrameworkMoniker,
+                targetFrameworkIdentifier: null,
+                targetFrameworkVersion: null,
+                targetFrameworkProfile: null,
+                targetPlatformIdentifier,
+                targetPlatformVersion,
+                targetPlatformMinVersion,
+                isXnaWindowsPhoneProject,
+                isManagementPackProject,
+                GetAsFrameworkString);
+        }
+
+        internal static IEnumerable<T> GetProjectFrameworks<T>(
+            string projectFilePath,
+            string targetFrameworks,
+            string targetFramework,
+            string targetFrameworkMoniker,
+            string targetFrameworkIdentifier,
+            string targetFrameworkVersion,
+            string targetFrameworkProfile,
+            string targetPlatformIdentifier,
+            string targetPlatformVersion,
+            string targetPlatformMinVersion,
+            bool isXnaWindowsPhoneProject,
+            bool isManagementPackProject,
+            Func<object, T> valueFactory)
+        {
             var frameworks = new SortedSet<string>(StringComparer.OrdinalIgnoreCase);
 
             // TargetFrameworks property
@@ -55,7 +117,7 @@ namespace NuGet.Commands
 
             if (frameworks.Count > 0)
             {
-                return frameworks;
+                return frameworks.Select(e => valueFactory(e));
             }
 
             // TargetFramework property
@@ -65,26 +127,49 @@ namespace NuGet.Commands
             {
                 frameworks.Add(currentFrameworkString);
 
-                return frameworks;
+                return frameworks.Select(e => valueFactory(e));
             }
 
+            return new T[] { GetProjectFramework(
+                projectFilePath,
+                targetFrameworkMoniker,
+                targetFrameworkIdentifier,
+                targetFrameworkVersion,
+                targetFrameworkProfile,
+                targetPlatformIdentifier,
+                targetPlatformVersion,
+                targetPlatformMinVersion,
+                isXnaWindowsPhoneProject,
+                isManagementPackProject,
+                valueFactory) };
+        }
+
+        internal static T GetProjectFramework<T>(
+            string projectFilePath,
+            string targetFrameworkMoniker,
+            string targetFrameworkIdentifier,
+            string targetFrameworkVersion,
+            string targetFrameworkProfile,
+            string targetPlatformIdentifier,
+            string targetPlatformVersion,
+            string targetPlatformMinVersion,
+            bool isXnaWindowsPhoneProject,
+            bool isManagementPackProject,
+            Func<object, T> valueFactory)
+        {
             // C++ check
             if (projectFilePath?.EndsWith(".vcxproj", StringComparison.OrdinalIgnoreCase) == true)
             {
                 // The C++ project does not have a TargetFrameworkMoniker property set. 
                 // We hard-code the return value to Native.
-                frameworks.Add("Native, Version=0.0");
-
-                return frameworks;
+                return valueFactory("Native, Version=0.0");
             }
 
             // The MP project does not have a TargetFrameworkMoniker property set. 
             // We hard-code the return value to SCMPInfra.
             if (isManagementPackProject)
             {
-                frameworks.Add("SCMPInfra, Version=0.0");
-
-                return frameworks;
+                return valueFactory("SCMPInfra, Version=0.0");
             }
 
             // UAP/Windows store projects
@@ -113,24 +198,23 @@ namespace NuGet.Commands
                     platformIdentifier = FrameworkConstants.FrameworkIdentifiers.Windows;
                 }
 
-                frameworks.Add($"{platformIdentifier}, Version={platformVersion}");
-
-                return frameworks;
+                return valueFactory($"{platformIdentifier}, Version={platformVersion}");
             }
 
             if (!string.IsNullOrEmpty(platformVersion)
                 && StringComparer.OrdinalIgnoreCase.Equals(platformIdentifier, "UAP"))
             {
                 // Use the platform id and versions, this is done for UAP projects
-                frameworks.Add($"{platformIdentifier}, Version={platformVersion}");
-
-                return frameworks;
+                return valueFactory($"{platformIdentifier}, Version={platformVersion}");
             }
 
             // TargetFrameworkMoniker
-            currentFrameworkString = MSBuildStringUtility.TrimAndGetNullForEmpty(targetFrameworkMoniker);
+            var currentFrameworkString = MSBuildStringUtility.TrimAndGetNullForEmpty(targetFrameworkMoniker);
+            var trimmedTargetFrameworkIdentifier = MSBuildStringUtility.TrimAndGetNullForEmpty(targetFrameworkIdentifier);
+            var trimmedTargetFrameworkVersion = MSBuildStringUtility.TrimAndGetNullForEmpty(targetFrameworkVersion);
+            var hasTFIandTFV = !string.IsNullOrEmpty(trimmedTargetFrameworkIdentifier) && !string.IsNullOrEmpty(trimmedTargetFrameworkVersion);
 
-            if (!string.IsNullOrEmpty(currentFrameworkString))
+            if (!string.IsNullOrEmpty(currentFrameworkString) || hasTFIandTFV)
             {
                 // XNA project lies about its true identity, reporting itself as a normal .NET 4.0 project.
                 // We detect it and changes its target framework to Silverlight4-WindowsPhone71
@@ -138,30 +222,23 @@ namespace NuGet.Commands
                     && ".NETFramework,Version=v4.0".Equals(currentFrameworkString, StringComparison.OrdinalIgnoreCase))
                 {
                     currentFrameworkString = "Silverlight,Version=v4.0,Profile=WindowsPhone71";
+                    return valueFactory(currentFrameworkString);
                 }
 
-                // Workaround until https://github.com/NuGet/Home/issues/9871 is ready.
-                if (!string.IsNullOrEmpty(platformVersion))
-                {
-                    var framework = NuGetFramework.Parse(currentFrameworkString);
-                    if (framework.Version.Major >= 5 && framework.Framework.Equals(FrameworkConstants.FrameworkIdentifiers.NetCoreApp, StringComparison.OrdinalIgnoreCase))
-                    {
-                        currentFrameworkString = framework.GetShortFolderName() + $"-{platformIdentifier}{platformVersion}";
-                    }
-                }
+                NuGetFramework framework = hasTFIandTFV ?
+                    NuGetFramework.ParseComponents(
+                           trimmedTargetFrameworkIdentifier,
+                           trimmedTargetFrameworkVersion,
+                           MSBuildStringUtility.TrimAndGetNullForEmpty(targetFrameworkProfile),
+                           MSBuildStringUtility.TrimAndGetNullForEmpty(targetPlatformIdentifier),
+                           MSBuildStringUtility.TrimAndGetNullForEmpty(targetPlatformVersion)) :
+                    NuGetFramework.Parse(currentFrameworkString);
 
-                frameworks.Add(currentFrameworkString);
-
-                return frameworks;
+                return valueFactory(framework);
             }
 
-            // Default to unsupported it no framework can be found.
-            if (frameworks.Count < 1)
-            {
-                frameworks.Add(NuGetFramework.UnsupportedFramework.ToString());
-            }
-
-            return frameworks;
+            // Default to unsupported it no framework was found.
+            return valueFactory(NuGetFramework.UnsupportedFramework);
         }
 
         /// <summary>
@@ -221,16 +298,37 @@ namespace NuGet.Commands
             return framework;
         }
 
-        private static string GetPropertyOrNull(string propertyName, IDictionary<string, string> projectProperties)
+        /// <summary>
+        /// Get a NuGetFramework out of the passed object. The argument is expected to either be a <see cref="NuGetFramework"/> or <see cref="string"/>.
+        /// </summary>
+        private static NuGetFramework GetAsNuGetFramework(object arg)
         {
-            string value;
-            if (projectProperties.TryGetValue(propertyName, out value)
-                && !string.IsNullOrEmpty(value))
+            if (arg is NuGetFramework)
             {
-                return value;
+                return (NuGetFramework)arg;
+            }
+            if (arg is string frameworkString)
+            {
+                return NuGetFramework.Parse(frameworkString);
+            }
+            throw new ArgumentException("Unexpected object type");
+        }
+
+        /// <summary>
+        /// Get a roundtrippable framework string out of the passed object. The argument is expected to either be a <see cref="NuGetFramework"/> or <see cref="string"/>.
+        /// </summary>
+        private static string GetAsFrameworkString(object arg)
+        {
+            if (arg is string)
+            {
+                return (string)arg;
+            }
+            if (arg is NuGetFramework framework)
+            {
+                return framework.DotNetFrameworkName;
             }
 
-            return null;
+            throw new ArgumentException("Unexpected object type");
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Commands/Utility/MSBuildProjectFrameworkUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/Utility/MSBuildProjectFrameworkUtility.cs
@@ -212,7 +212,7 @@ namespace NuGet.Commands
             var currentFrameworkString = MSBuildStringUtility.TrimAndGetNullForEmpty(targetFrameworkMoniker);
             var trimmedTargetFrameworkIdentifier = MSBuildStringUtility.TrimAndGetNullForEmpty(targetFrameworkIdentifier);
             var trimmedTargetFrameworkVersion = MSBuildStringUtility.TrimAndGetNullForEmpty(targetFrameworkVersion);
-            var hasTFIandTFV = !string.IsNullOrEmpty(trimmedTargetFrameworkIdentifier) && !string.IsNullOrEmpty(trimmedTargetFrameworkVersion);
+            var hasTFIandTFV = trimmedTargetFrameworkIdentifier != null && trimmedTargetFrameworkVersion != null;
 
             if (!string.IsNullOrEmpty(currentFrameworkString) || hasTFIandTFV)
             {
@@ -230,8 +230,8 @@ namespace NuGet.Commands
                            trimmedTargetFrameworkIdentifier,
                            trimmedTargetFrameworkVersion,
                            MSBuildStringUtility.TrimAndGetNullForEmpty(targetFrameworkProfile),
-                           MSBuildStringUtility.TrimAndGetNullForEmpty(targetPlatformIdentifier),
-                           MSBuildStringUtility.TrimAndGetNullForEmpty(targetPlatformVersion)) :
+                           platformIdentifier,
+                           platformVersion) :
                     NuGetFramework.Parse(currentFrameworkString);
 
                 return valueFactory(framework);

--- a/src/NuGet.Core/NuGet.Commands/Utility/MSBuildProjectFrameworkUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/Utility/MSBuildProjectFrameworkUtility.cs
@@ -303,9 +303,9 @@ namespace NuGet.Commands
         /// </summary>
         private static NuGetFramework GetAsNuGetFramework(object arg)
         {
-            if (arg is NuGetFramework)
+            if (arg is NuGetFramework nugetFramework)
             {
-                return (NuGetFramework)arg;
+                return nugetFramework;
             }
             if (arg is string frameworkString)
             {
@@ -319,9 +319,9 @@ namespace NuGet.Commands
         /// </summary>
         private static string GetAsFrameworkString(object arg)
         {
-            if (arg is string)
+            if (arg is string str)
             {
-                return (string)arg;
+                return str;
             }
             if (arg is NuGetFramework framework)
             {

--- a/src/NuGet.Core/NuGet.Frameworks/NuGetFrameworkFactory.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/NuGetFrameworkFactory.cs
@@ -79,8 +79,15 @@ namespace NuGet.Frameworks
         }
 
         /// <summary>
-        /// Creates a NuGetFramework from individual components, using the given mappings
+        /// Creates a NuGetFramework from individual components, using the given mappings.
+        /// This method may have individual component preference, as described in the remarks.
         /// </summary>
+        /// <remarks>
+        /// Profiles and TargetPlatforms can't mix. As such the precedence order is profile over target platforms (TPI, TPV).
+        /// .NETCoreApp,Version=v5.0 and later do not support profiles.
+        /// Target Platforms are ignored for any frameworks not supporting them.
+        /// This allows to handle the old project scenarios where the TargetPlatformIdentifier and TargetPlatformVersion may be set to Windows and v7.0 respectively.
+        /// </remarks>
         internal static NuGetFramework ParseComponents(string targetFrameworkIdentifier, string targetFrameworkVersion, string targetFrameworkProfile, string targetPlatformIdentifier, string targetPlatformVersion, IFrameworkNameProvider mappings)
         {
             if (string.IsNullOrEmpty(targetFrameworkIdentifier))
@@ -166,27 +173,39 @@ namespace NuGet.Frameworks
                 }
             }
 
-            if (!string.IsNullOrEmpty(targetPlatformVersion))
+            // Profiles take precedence over TPI/TPV
+            if (string.IsNullOrEmpty(profile))
             {
-                targetPlatformVersion = targetPlatformVersion.TrimStart('v');
-                if (targetPlatformVersion.IndexOf('.') < 0)
+                if (version.Major >= 5 &&
+                    StringComparer.OrdinalIgnoreCase.Equals(FrameworkConstants.FrameworkIdentifiers.NetCoreApp, framework))
                 {
-                    targetPlatformVersion += ".0";
-                }
+                    if (!string.IsNullOrEmpty(targetPlatformVersion))
+                    {
+                        targetPlatformVersion = targetPlatformVersion.TrimStart('v');
+                        if (targetPlatformVersion.IndexOf('.') < 0)
+                        {
+                            targetPlatformVersion += ".0";
+                        }
 
-                if (!Version.TryParse(targetPlatformVersion, out platformVersion))
+                        if (!Version.TryParse(targetPlatformVersion, out platformVersion))
+                        {
+                            throw new ArgumentException(string.Format(
+                                CultureInfo.CurrentCulture,
+                                Strings.InvalidPlatformVersion,
+                                targetPlatformVersion));
+                        }
+                    }
+                    result = new NuGetFramework(framework, version, targetPlatformIdentifier ?? string.Empty, platformVersion);
+                }
+                else
                 {
-                    throw new ArgumentException(string.Format(
-                        CultureInfo.CurrentCulture,
-                        Strings.InvalidPlatformVersion,
-                        targetPlatformVersion));
+                    result = new NuGetFramework(framework, version);
                 }
             }
-
-            if (version.Major >= 5
-                && StringComparer.OrdinalIgnoreCase.Equals(FrameworkConstants.FrameworkIdentifiers.NetCoreApp, framework))
+            else
             {
-                if (!string.IsNullOrEmpty(profile))
+                if (version.Major >= 5 &&
+                    StringComparer.OrdinalIgnoreCase.Equals(FrameworkConstants.FrameworkIdentifiers.NetCoreApp, framework))
                 {
                     throw new ArgumentException(string.Format(
                         CultureInfo.CurrentCulture,
@@ -194,20 +213,6 @@ namespace NuGet.Frameworks
                         profile
                     ));
                 }
-
-                result = new NuGetFramework(framework, version, targetPlatformIdentifier ?? string.Empty, platformVersion);
-            }
-            else
-            {
-                if (!string.IsNullOrEmpty(targetPlatformIdentifier))
-                {
-                    throw new ArgumentException(string.Format(
-                        CultureInfo.CurrentCulture,
-                        Strings.FrameworkDoesNotSupportPlatforms,
-                        targetPlatformIdentifier
-                    ));
-                }
-
                 result = new NuGetFramework(framework, version, profile);
             }
 

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/MSBuildProjectFrameworkUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/MSBuildProjectFrameworkUtilityTests.cs
@@ -1,10 +1,9 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
 using NuGet.Frameworks;
 using Xunit;
 
@@ -225,6 +224,68 @@ namespace NuGet.Commands.Test
             // Assert
             Assert.Equal(NuGetFramework.UnsupportedFramework, framework);
         }
+
+        [Theory]
+        [InlineData(".NETFramework,Version=v.4.5", ".NETFramework", "v4.5", "", "", "", "", "net45")]
+        [InlineData(null, ".NETFramework", "v4.5", "", "", "", "", "net45")]
+        [InlineData(".NETFramework,Version=v.4.5", ".NETFramework", "v4.5", "client", "", "", "", "net45-client")]
+        [InlineData(".NETCoreApp,Version=v.5.0", ".NETCoreApp", "v5.0", "", "android", "10", "", "net5.0-android10.0")]
+        [InlineData(".NETCoreApp,Version=v.5.0", ".NETCoreApp", "v5.0", "", "ios", "21.0", "", "net5.0-ios21.0")]
+        [InlineData(null, ".NETCoreApp", "v6.0", "", "ios", "21.0", "", "net6.0-ios21.0")]
+        [InlineData(null, ".NETCoreApp", "v6.0", "", "ios", "v21.0", "", "net6.0-ios21.0")]
+        [InlineData(null, null, null, "", "ios", "v21.0", "", "unsupported")]
+        [InlineData(null, ".NETCoreApp", "v6.0", "", "UAP", "10.0.1.2", "", "uap10.0.1.2")]
+        [InlineData(null, ".NETCoreApp", "v6.0", "", "UAP", "10.0.1.2", "10.0.1.3", "uap10.0.1.3")]
+        [InlineData(".NETCoreApp,Version=v3.0", ".NETCoreApp", "v3.0", "", "android", "10", "", "netcoreapp3.0")]
+        public void GetProjectFramework_WithCanonicalProperties_Succeeds(
+                string targetFrameworkMoniker,
+                string targetFrameworkIdentifier,
+                string targetFrameworkVersion,
+                string targetFrameworkProfile,
+                string targetPlatformIdentifier,
+                string targetPlatformVersion,
+                string targetPlatformMinVersion,
+                string expectedShortName)
+        {
+            var nugetFramework = MSBuildProjectFrameworkUtility.GetProjectFramework(
+
+                projectFilePath: @"C:\csproj",
+                targetFrameworkMoniker,
+
+                targetFrameworkIdentifier,
+                targetFrameworkVersion,
+                targetFrameworkProfile,
+                targetPlatformIdentifier,
+                targetPlatformVersion,
+                targetPlatformMinVersion);
+
+            Assert.Equal(expectedShortName, nugetFramework.GetShortFolderName());
+        }
+
+        [Theory]
+        [InlineData(null, ".NETCoreApp", "v6.0", "", "ios", "5.0-preview.3", "")]
+        [InlineData(null, ".NETCoreApp", "v6.0-preview.3", "", "ios", "5.0", "")]
+        [InlineData(".NETCoreApp,Version=v.5.0", ".NETCoreApp", "v5.0", "NET50CannotHaveProfiles", "android", "10", "")]
+        public void GetProjectFramework_WithInvalidInput_Throws(
+        string targetFrameworkMoniker,
+        string targetFrameworkIdentifier,
+        string targetFrameworkVersion,
+        string targetFrameworkProfile,
+        string targetPlatformIdentifier,
+        string targetPlatformVersion,
+        string targetPlatformMinVersion)
+        {
+            Assert.ThrowsAny<Exception>(() => MSBuildProjectFrameworkUtility.GetProjectFramework(
+               projectFilePath: @"C:\csproj",
+               targetFrameworkMoniker,
+               targetFrameworkIdentifier,
+               targetFrameworkVersion,
+               targetFrameworkProfile,
+               targetPlatformIdentifier,
+               targetPlatformVersion,
+               targetPlatformMinVersion));
+        }
+
 
         /// <summary>
         /// Test helper

--- a/test/NuGet.Core.Tests/NuGet.Frameworks.Test/NuGetFrameworkParseComponentsTest.cs
+++ b/test/NuGet.Core.Tests/NuGet.Frameworks.Test/NuGetFrameworkParseComponentsTest.cs
@@ -64,6 +64,16 @@ namespace NuGet.Test
         [InlineData("net5.0-tvos1.0", ".NETCoreApp", "v5.0", null, "tvos", "1.0")]
         [InlineData("net5.0-windows10.0", ".NETCoreApp", "v5.0", null, "windows", "10.0")]
         [InlineData("net5.0-macos10.15.2.3", ".NETCoreApp", "v5.0", null, "macos", "10.15.2.3")]
+        [InlineData("unsupported", "unsupported", null, null, null, null)]
+        // Scenarios where certain properties are ignored.
+        [InlineData("netcoreapp3.0", ".NETCoreApp", "v3.0", null, "macos", "10.15.2.3")]
+        [InlineData("netcoreapp3.0", ".NETCoreApp", "v3.0", null, "macos", null)]
+        [InlineData("netcoreapp3.1", ".NETCoreApp", "v3.1", null, null, "10.15.2.3")]
+        [InlineData("netcoreapp3.1-client", ".NETCoreApp", "v3.1", "client", null, "10.15.2.3")]
+        [InlineData("netcoreapp3.1-client", ".NETCoreApp", "v3.1", "client", null, null)]
+        [InlineData("netcoreapp3.0-client", ".NETCoreApp", "v3.0", "client", "Windows", "7.0")]
+        [InlineData("netcoreapp3.0", ".NETCoreApp", "v3.0", null, "Windows", "7.0")]
+
         public void NuGetFramework_ParseToShortName(string expected, string tfi, string tfv, string tfp, string tpi, string tpv)
         {
             // Arrange
@@ -88,6 +98,7 @@ namespace NuGet.Test
         [InlineData("net", "472", null, "ios", "14.0", "net472.0-ios14.0")]
 
         // Pre-Net5.0 ERA
+        [InlineData(".NETCoreApp", "v3.0", null, "Windows", "7.0", ".NETCoreApp,Version=v3.0")]
         [InlineData(".NETFramework", "v4.5", null, null, null, ".NETFramework,Version=v4.5")]
         [InlineData(".NETFramework", "v2.0", null, null, null, ".NETFramework,Version=v2.0")]
         [InlineData(".NETFramework", "4.0", null, null, null, ".NETFramework,Version=v4.0")]
@@ -125,11 +136,28 @@ namespace NuGet.Test
         [InlineData(".NETCoreApp", "1.5", null, null, null, ".NETCoreApp,Version=v1.5")]
         [InlineData(".NETCoreApp", "2", null, null, null, ".NETCoreApp,Version=v2.0")]
         [InlineData(".NETCoreApp", "3", null, null, null, ".NETCoreApp,Version=v3.0")]
+        [InlineData("unsupported", null, null, null, null, "Unsupported,Version=v0.0")]
+        // Scenarios where certain properties are ignored.
+        [InlineData(".NETCoreApp", "v3.0", null, "macos", "10.15.2.3", ".NETCoreApp,Version=v3.0")]
+        [InlineData(".NETCoreApp", "v3.0", null, "macos", null, ".NETCoreApp,Version=v3.0")]
+        [InlineData(".NETCoreApp", "v3.1", null, null, "10.15.2.3", ".NETCoreApp,Version=v3.1")]
+        [InlineData(".NETCoreApp", "v3.1", "client", null, "10.15.2.3", ".NETCoreApp,Version=v3.1,Profile=Client")]
+        [InlineData(".NETCoreApp", "v3.1", "client", null, null, ".NETCoreApp,Version=v3.1,Profile=Client")]
+        [InlineData(".NETCoreApp", "v3.0", "client", "Windows", "7.0", ".NETCoreApp,Version=v3.0,Profile=Client")]
         public void NuGetFramework_Basic(string tfi, string tfv, string tfp, string tpi, string tpv, string fullName)
         {
             string output = NuGetFramework.ParseComponents(tfi, tfv, tfp, tpi, tpv).DotNetFrameworkName;
 
             Assert.Equal(fullName, output);
+        }
+
+        [Theory]
+        [InlineData(null, "v1.0", null, "android", "v21.0")]
+        [InlineData(".NETCoreApp", "vklmnfkjdfn5.0", null, null, null)]
+        [InlineData(".NETCoreApp", "v5.0", null, "plat", "badversion")]
+        public void NuGetFramework_WithInvalidProperties_Throws(string tfi, string tfv, string tfp, string tpi, string tpv)
+        {
+            Assert.ThrowsAny<Exception>(() => NuGetFramework.ParseComponents(tfi, tfv, tfp, tpi, tpv));
         }
     }
 }


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9871
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: In https://github.com/NuGet/NuGet.Client/commit/280abd3f8a7f2656246450d91fb33fc7262e6de0, NuGet started reading the platform information out of the internal properties. There is some inherent priority in those properties and they are not *always* perfect. For example, UWP projects will have a TargetFrameworkIdentifier of `.NETCoreApp`. NuGet has known how to interpret these for a while. Now we just need to incorporate, `TargetPlatformIdentifer` and `TargetPlatformVersion` into the mix.

To do that, we'll introduce a new utility, `GetProjectFramework`, that takes *all* these values and spits out a `NuGetFramework`.
Internally the existing utility has been refactored so that the same codepaths are hit. The public API hit is minimal ;) 

**Caveats** 

There's a larger impact of this PR.

In new .NET 5 SDKs, think NET5.0 P8, from the 5 properties NuGet reads, the ones that are not necessary, are cleared, however in .NET 5 P7 and earlier (that includes the complete 3.0, 3.1 SDK line), the `TargetPlatformInformation` & `TargetPlatformVersion` *may* default to something like `Windows` and `v7.0` and we'd end up with a framework such as `net5.0-windows7.0` in .NET 5 cases (think NuGet.Client), or an exception (in netcoreapp3.1 cases) saying that `TargetPlatformIdentifier` is only allowed. Note that the last case can easily happen in commandline scenarios where the customer ends up with an upgrade nuget, but not sdk. 
While this scenario is not recommended, I imagine it'll be common enough where we have to handle it. 

After a discussion with @zivkan and @zkat we agreed to change ParseComponents to fit the requirements that we have. 
Specifically that it having a precedence order of the params.

Other options considered:
* Add a utility in NuGet.Commands. This *will* require some code duplication. Essentially copying https://github.com/NuGet/NuGet.Client/commit/b0130c82f84d39a8bd552a4a6bb0c3463440e14e into a different assembly.

Note that given that ParseComponents hasn't shipped, we can easily revert the API. 

## Testing/Validation

Tests Added: Yes  
Reason for not adding tests:  
Validation:  
