### PR TITLE
Static graph restore should read the target framework information and alias. 

### DIFF
--- a/scripts/nuget-debug-helpers.ps1
+++ b/scripts/nuget-debug-helpers.ps1
@@ -19,8 +19,9 @@ Function Invoke-NuGetCustom()
     $packTargetsPath = Join-Path $NuGetClientRoot "src\NuGet.Core\NuGet.Build.Tasks.Pack\NuGet.Build.Tasks.Pack.targets"
     $restoreDllPath = Join-Path $NuGetClientRoot "artifacts\NuGet.Build.Tasks\$VSVersion\bin\$Configuration\$NETFramework\NuGet.Build.Tasks.dll"
     $nugetRestoreTargetsPath = Join-Path $NuGetClientRoot "src\NuGet.Core\NuGet.Build.Tasks\NuGet.targets"
-    Write-Host "msbuild /p:NuGetRestoreTargets=$nugetRestoreTargetsPath /p:RestoreTaskAssemblyFile=$restoreDllPath /p:NuGetBuildTasksPackTargets=$packTargetsPath /p:ImportNuGetBuildTasksPackTargetsFromSdk=true /p:NuGetPackTaskAssemblyFile=$packDllPath $($args[0..$args.Count])" 
-    & msbuild /p:NuGetRestoreTargets=$nugetRestoreTargetsPath /p:RestoreTaskAssemblyFile=$restoreDllPath /p:NuGetBuildTasksPackTargets=$packTargetsPath /p:ImportNuGetBuildTasksPackTargetsFromSdk=true /p:NuGetPackTaskAssemblyFile=$packDllPath $args[0..$args.Count]
+    $consoleExePath = Join-Path $NuGetClientRoot "artifacts\NuGet.Build.Tasks.Console\$VSVersion\bin\$Configuration\$NETFramework\NuGet.Build.Tasks.Console.exe"
+    Write-Host "msbuild /p:NuGetRestoreTargets=$nugetRestoreTargetsPath /p:RestoreTaskAssemblyFile=$restoreDllPath /p:NuGetBuildTasksPackTargets=$packTargetsPath /p:NuGetConsoleProcessFileName=$consoleExePath /p:ImportNuGetBuildTasksPackTargetsFromSdk=true /p:NuGetPackTaskAssemblyFile=$packDllPath $($args[0..$args.Count])" 
+    & msbuild /p:NuGetRestoreTargets=$nugetRestoreTargetsPath /p:RestoreTaskAssemblyFile=$restoreDllPath /p:NuGetBuildTasksPackTargets=$packTargetsPath /p:NuGetConsoleProcessFileName=$consoleExePath /p:ImportNuGetBuildTasksPackTargetsFromSdk=true /p:NuGetPackTaskAssemblyFile=$packDllPath $args[0..$args.Count]
 }
 
 <#
@@ -33,8 +34,9 @@ Function Invoke-NuGetRestoreCustom()
 {
     $restoreDllPath = Join-Path $NuGetClientRoot "artifacts\NuGet.Build.Tasks\$VSVersion\bin\$Configuration\$NETFramework\NuGet.Build.Tasks.dll"
     $nugetRestoreTargetsPath = Join-Path $NuGetClientRoot "src\NuGet.Core\NuGet.Build.Tasks\NuGet.targets"
-    Write-Host "msbuild /p:NuGetRestoreTargets=$nugetRestoreTargetsPath /p:RestoreTaskAssemblyFile=$restoreDllPath $($args[0..$args.Count])" 
-    & msbuild /p:NuGetRestoreTargets=$nugetRestoreTargetsPath /p:RestoreTaskAssemblyFile=$restoreDllPath $args[0..$args.Count]
+    $consoleExePath = Join-Path $NuGetClientRoot "artifacts\NuGet.Build.Tasks.Console\$VSVersion\bin\$Configuration\$NETFramework\NuGet.Build.Console.exe"
+    Write-Host "msbuild /p:NuGetRestoreTargets=$nugetRestoreTargetsPath /p:RestoreTaskAssemblyFile=$restoreDllPath /p:NuGetConsoleProcessFileName=$consoleExePath $($args[0..$args.Count])" 
+    & msbuild /p:NuGetRestoreTargets=$nugetRestoreTargetsPath /p:RestoreTaskAssemblyFile=$restoreDllPath /p:NuGetConsoleProcessFileName=$consoleExePath $args[0..$args.Count]
 }
 
 <#

--- a/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs
@@ -527,27 +527,21 @@ namespace NuGet.Build.Tasks.Console
             foreach (var projectInnerNode in projectInnerNodes)
             {
                 var msBuildProjectInstance = projectInnerNode.Value;
-
-                var targetFrameworkIdentifier = msBuildProjectInstance.GetProperty("TargetFrameworkIdentifier");
-                var targetFrameworkVersion = msBuildProjectInstance.GetProperty("TargetFrameworkVersion");
-                var targetFrameworkMoniker = msBuildProjectInstance.GetProperty("TargetFrameworkMoniker");
-                var targetPlatformIdentifier = msBuildProjectInstance.GetProperty("TargetPlatformIdentifier");
-                var targetPlatformVersion = msBuildProjectInstance.GetProperty("TargetPlatformVersion");
-                var targetPlatformMinVersion = msBuildProjectInstance.GetProperty("TargetPlatformMinVersion");
                 var targetAlias = string.IsNullOrEmpty(projectInnerNode.Key) ? string.Empty : projectInnerNode.Key;
 
-                IEnumerable<string> targetFramework = MSBuildProjectFrameworkUtility.GetProjectFrameworkStrings(
-                  projectFilePath: projectInnerNode.Value.FullPath,
-                  targetFrameworks: null,
-                  targetFramework: null,
-                  targetFrameworkMoniker: targetFrameworkMoniker,
-                  targetPlatformIdentifier: targetPlatformIdentifier,
-                  targetPlatformVersion: targetPlatformVersion,
-                  targetPlatformMinVersion: targetPlatformMinVersion);
+                NuGetFramework targetFramework = MSBuildProjectFrameworkUtility.GetProjectFramework(
+                    projectFilePath: projectInnerNode.Value.FullPath,
+                    targetFrameworkMoniker: msBuildProjectInstance.GetProperty("TargetFrameworkMoniker"),
+                    targetFrameworkIdentifier: msBuildProjectInstance.GetProperty("TargetFrameworkIdentifier"),
+                    targetFrameworkVersion: msBuildProjectInstance.GetProperty("TargetFrameworkVersion"),
+                    targetFrameworkProfile: msBuildProjectInstance.GetProperty("TargetFrameworkProfile"),
+                    targetPlatformIdentifier: msBuildProjectInstance.GetProperty("TargetPlatformIdentifier"),
+                    targetPlatformVersion: msBuildProjectInstance.GetProperty("TargetPlatformVersion"),
+                    targetPlatformMinVersion: msBuildProjectInstance.GetProperty("TargetPlatformMinVersion"));
 
                 var targetFrameworkInformation = new TargetFrameworkInformation()
                 {
-                    FrameworkName = NuGetFramework.Parse(targetFramework.Single()),
+                    FrameworkName = targetFramework,
                     TargetAlias = targetAlias,
                     RuntimeIdentifierGraphPath = msBuildProjectInstance.GetProperty(nameof(TargetFrameworkInformation.RuntimeIdentifierGraphPath))
                 };

--- a/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs
@@ -154,33 +154,6 @@ namespace NuGet.Build.Tasks.Console
         }
 
         /// <summary>
-        /// Gets the original target frameworks for the specified project.
-        /// </summary>
-        /// <param name="project">An <see cref="IMSBuildItem" /> representing the project.</param>
-        /// <param name="frameworks">An <see cref="IReadOnlyCollection{NuGetFrameowrk}" /> object containing the frameworks that were parsed from the outer project.</param>
-        /// <returns>A <see cref="List{String}" /> containing the original target frameworks of the project.</returns>
-        internal static List<string> GetOriginalTargetFrameworks(IMSBuildProject project, IReadOnlyCollection<NuGetFramework> frameworks)
-        {
-            // If the project specified the TargetFrameworks property, just return that list
-            var projectTargetFrameworks = project.SplitPropertyValueOrNull("TargetFrameworks");
-
-            if (projectTargetFrameworks != null)
-            {
-                return projectTargetFrameworks.ToList();
-            }
-
-            // If the project did not specify a value for TargetFrameworks, return the short folder name of the frameworks which where parsed via other properties
-            var targetFrameworks = new List<string>(frameworks.Count);
-
-            foreach (var framework in frameworks)
-            {
-                targetFrameworks.Add(framework.GetShortFolderName());
-            }
-
-            return targetFrameworks;
-        }
-
-        /// <summary>
         /// Gets the package downloads for the specified project.
         /// </summary>
         /// <param name="project">The <see cref="ProjectInstance" /> to get package downloads for.</param>
@@ -343,15 +316,17 @@ namespace NuGet.Build.Tasks.Console
         /// </summary>
         /// <param name="projects">A <see cref="IReadOnlyDictionary{NuGetFramework,ProjectInstance}" /> representing the target frameworks and their corresponding projects.</param>
         /// <returns>A <see cref="List{ProjectRestoreMetadataFrameworkInfo}" /> containing the restore metadata framework information for the specified project.</returns>
-        internal static List<ProjectRestoreMetadataFrameworkInfo> GetProjectRestoreMetadataFrameworkInfos(IReadOnlyDictionary<NuGetFramework, IMSBuildProject> projects)
+        internal static List<ProjectRestoreMetadataFrameworkInfo> GetProjectRestoreMetadataFrameworkInfos(List<TargetFrameworkInformation> targetFrameworkInfos, IReadOnlyDictionary<string, IMSBuildProject> projects)
         {
             var projectRestoreMetadataFrameworkInfos = new List<ProjectRestoreMetadataFrameworkInfo>(projects.Count);
 
-            foreach (var project in projects)
+            foreach (var targetFrameworkInfo in targetFrameworkInfos)
             {
-                projectRestoreMetadataFrameworkInfos.Add(new ProjectRestoreMetadataFrameworkInfo(project.Key)
+                var project = projects[targetFrameworkInfo.TargetAlias];
+                projectRestoreMetadataFrameworkInfos.Add(new ProjectRestoreMetadataFrameworkInfo(targetFrameworkInfo.FrameworkName)
                 {
-                    ProjectReferences = GetProjectReferences(project.Value)
+                    TargetAlias = targetFrameworkInfo.TargetAlias,
+                    ProjectReferences = GetProjectReferences(project)
                 });
             }
 
@@ -364,31 +339,35 @@ namespace NuGet.Build.Tasks.Console
         /// <param name="project">An <see cref="IMSBuildProject" /> representing the main project.</param>
         /// <param name="innerNodes">An <see cref="IReadOnlyDictionary{String,IMSBuildProject}" /> representing all inner projects by their target framework.</param>
         /// <returns></returns>
-        internal static IReadOnlyDictionary<NuGetFramework, IMSBuildProject> GetProjectTargetFrameworks(IMSBuildProject project, IReadOnlyDictionary<string, IMSBuildProject> innerNodes)
+        internal static IReadOnlyDictionary<string, IMSBuildProject> GetProjectTargetFrameworks(IMSBuildProject project, IReadOnlyDictionary<string, IMSBuildProject> innerNodes)
         {
-            // Get the raw list of target frameworks that the project specifies
-            var projectFrameworkStrings = MSBuildProjectFrameworkUtility.GetProjectFrameworkStrings(
-                projectFilePath: project.FullPath,
-                targetFrameworks: project.GetProperty("TargetFrameworks"),
-                targetFramework: project.GetProperty("TargetFramework"),
-                targetFrameworkMoniker: project.GetProperty("TargetFrameworkMoniker"),
-                targetPlatformIdentifier: project.GetProperty("TargetPlatformIdentifier"),
-                targetPlatformVersion: project.GetProperty("TargetPlatformVersion"),
-                targetPlatformMinVersion: project.GetProperty("TargetPlatformMinVersion")).ToList();
+            var targetFrameworks = project.GetProperty("TargetFrameworks");
+            if (string.IsNullOrEmpty(targetFrameworks))
+            {
+                targetFrameworks = project.GetProperty("TargetFramework");
+            }
+            var projectFrameworkStrings = MSBuildStringUtility.Split(targetFrameworks);
+            var projectTargetFrameworks = new Dictionary<string, IMSBuildProject>();
 
-            var projectTargetFrameworks = new Dictionary<NuGetFramework, IMSBuildProject>();
-
-            foreach (var projectTargetFramework in projectFrameworkStrings)
+            if (projectFrameworkStrings.Length > 0)
+            {
+                foreach (var projectTargetFramework in projectFrameworkStrings)
+                {
+                    // Attempt to get the corresponding project instance for the target framework.  If one is not found, then the project must not target multiple frameworks
+                    // and the main project should be used
+                    if (!innerNodes.TryGetValue(projectTargetFramework, out IMSBuildProject innerNode))
+                    {
+                        innerNode = project;
+                    }
+                    // Add the target framework and associate it with the project instance to be used for gathering details
+                    projectTargetFrameworks[projectTargetFramework] = innerNode;
+                }
+            }
+            else
             {
                 // Attempt to get the corresponding project instance for the target framework.  If one is not found, then the project must not target multiple frameworks
                 // and the main project should be used
-                if (!innerNodes.TryGetValue(projectTargetFramework, out IMSBuildProject innerNode))
-                {
-                    innerNode = project;
-                }
-
-                // Add the target framework and associate it with the project instance to be used for gathering details
-                projectTargetFrameworks[NuGetFramework.Parse(projectTargetFramework)] = innerNode;
+                projectTargetFrameworks[string.Empty] = project;
             }
 
             return projectTargetFrameworks;
@@ -535,7 +514,7 @@ namespace NuGet.Build.Tasks.Console
         /// <param name="projectInnerNodes">An <see cref="IReadOnlyDictionary{NuGetFramework,ProjectInstance} "/> containing the projects by their target framework.</param>
         /// <param name="isCpvmEnabled">A flag that is true if the Central Package Management was enabled.</param>
         /// <returns>A <see cref="List{TargetFrameworkInformation}" /> containing the target framework information for the specified project.</returns>
-        internal static List<TargetFrameworkInformation> GetTargetFrameworkInfos(IReadOnlyDictionary<NuGetFramework, IMSBuildProject> projectInnerNodes, bool isCpvmEnabled)
+        internal static List<TargetFrameworkInformation> GetTargetFrameworkInfos(IReadOnlyDictionary<string, IMSBuildProject> projectInnerNodes, bool isCpvmEnabled)
         {
             var targetFrameworkInfos = new List<TargetFrameworkInformation>(projectInnerNodes.Count);
 
@@ -543,9 +522,27 @@ namespace NuGet.Build.Tasks.Console
             {
                 var msBuildProjectInstance = projectInnerNode.Value;
 
-                var targetFrameworkInformation = new TargetFrameworkInformation
+                var targetFrameworkIdentifier = msBuildProjectInstance.GetProperty("TargetFrameworkIdentifier");
+                var targetFrameworkVersion = msBuildProjectInstance.GetProperty("TargetFrameworkVersion");
+                var targetFrameworkMoniker = msBuildProjectInstance.GetProperty("TargetFrameworkMoniker");
+                var targetPlatformIdentifier = msBuildProjectInstance.GetProperty("TargetPlatformIdentifier");
+                var targetPlatformVersion = msBuildProjectInstance.GetProperty("TargetPlatformVersion");
+                var targetPlatformMinVersion = msBuildProjectInstance.GetProperty("TargetPlatformMinVersion");
+                var targetAlias = string.IsNullOrEmpty(projectInnerNode.Key) ? string.Empty : projectInnerNode.Key;
+
+                IEnumerable<string> targetFramework = MSBuildProjectFrameworkUtility.GetProjectFrameworkStrings(
+                  projectFilePath: null, // TODO NK - This needs fixed.
+                  targetFrameworks: null,
+                  targetFramework: null,
+                  targetFrameworkMoniker: targetFrameworkMoniker,
+                  targetPlatformIdentifier: targetPlatformIdentifier,
+                  targetPlatformVersion: targetPlatformVersion,
+                  targetPlatformMinVersion: targetPlatformMinVersion);
+
+                var targetFrameworkInformation = new TargetFrameworkInformation()
                 {
-                    FrameworkName = projectInnerNode.Key,
+                    FrameworkName = NuGetFramework.Parse(targetFramework.Single()),
+                    TargetAlias = targetAlias,
                     RuntimeIdentifierGraphPath = msBuildProjectInstance.GetProperty(nameof(TargetFrameworkInformation.RuntimeIdentifierGraphPath))
                 };
 
@@ -726,7 +723,7 @@ namespace NuGet.Build.Tasks.Console
         /// <param name="projectsByTargetFramework">A <see cref="IReadOnlyDictionary{NuGetFramework,IMSBuildProject}" /> containing the inner nodes by target framework.</param>
         /// <param name="settings">The <see cref="ISettings" /> of the specified project.</param>
         /// <returns>A <see cref="Tuple" /> containing the <see cref="ProjectRestoreMetadata" /> and <see cref="List{TargetFrameworkInformation}" /> for the specified project.</returns>
-        private (ProjectRestoreMetadata RestoreMetadata, List<TargetFrameworkInformation> TargetFrameworkInfos) GetProjectRestoreMetadataAndTargetFrameworkInformation(IMSBuildProject project, IReadOnlyDictionary<NuGetFramework, IMSBuildProject> projectsByTargetFramework, ISettings settings)
+        private (ProjectRestoreMetadata RestoreMetadata, List<TargetFrameworkInformation> TargetFrameworkInfos) GetProjectRestoreMetadataAndTargetFrameworkInformation(IMSBuildProject project, IReadOnlyDictionary<string, IMSBuildProject> projectsByTargetFramework, ISettings settings)
         {
             var projectName = GetProjectName(project);
 
@@ -779,7 +776,7 @@ namespace NuGet.Build.Tasks.Console
             restoreMetadata.CacheFilePath = NoOpRestoreUtilities.GetProjectCacheFilePath(outputPath, project.FullPath);
             restoreMetadata.ConfigFilePaths = settings.GetConfigFilePaths();
             restoreMetadata.OutputPath = outputPath;
-            restoreMetadata.OriginalTargetFrameworks = GetOriginalTargetFrameworks(project, projectsByTargetFramework.Keys.ToList());
+            restoreMetadata.OriginalTargetFrameworks.AddRange(targetFrameworkInfos.Select(e => e.TargetAlias));
             restoreMetadata.PackagesPath = GetPackagesPath(project, settings);
             restoreMetadata.ProjectName = projectName;
             restoreMetadata.ProjectPath = project.FullPath;
@@ -788,7 +785,7 @@ namespace NuGet.Build.Tasks.Console
             restoreMetadata.ProjectWideWarningProperties = WarningProperties.GetWarningProperties(project.GetProperty("TreatWarningsAsErrors"), project.GetProperty("WarningsAsErrors"), project.GetProperty("NoWarn"));
             restoreMetadata.RestoreLockProperties = new RestoreLockProperties(project.GetProperty("RestorePackagesWithLockFile"), project.GetProperty("NuGetLockFilePath"), project.IsPropertyTrue("RestoreLockedMode"));
             restoreMetadata.Sources = GetSources(project, innerNodes, settings);
-            restoreMetadata.TargetFrameworks = GetProjectRestoreMetadataFrameworkInfos(projectsByTargetFramework);
+            restoreMetadata.TargetFrameworks = GetProjectRestoreMetadataFrameworkInfos(targetFrameworkInfos, projectsByTargetFramework);
 
             return (restoreMetadata, targetFrameworkInfos);
         }

--- a/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs
@@ -341,12 +341,7 @@ namespace NuGet.Build.Tasks.Console
         /// <returns></returns>
         internal static IReadOnlyDictionary<string, IMSBuildProject> GetProjectTargetFrameworks(IMSBuildProject project, IReadOnlyDictionary<string, IMSBuildProject> innerNodes)
         {
-            var targetFrameworks = project.GetProperty("TargetFrameworks");
-            if (string.IsNullOrEmpty(targetFrameworks))
-            {
-                targetFrameworks = project.GetProperty("TargetFramework");
-            }
-            var projectFrameworkStrings = MSBuildStringUtility.Split(targetFrameworks);
+            var projectFrameworkStrings = GetTargetFrameworkStrings(project);
             var projectTargetFrameworks = new Dictionary<string, IMSBuildProject>();
 
             if (projectFrameworkStrings.Length > 0)
@@ -371,6 +366,17 @@ namespace NuGet.Build.Tasks.Console
             }
 
             return projectTargetFrameworks;
+        }
+
+        internal static string[] GetTargetFrameworkStrings(IMSBuildProject project)
+        {
+            var targetFrameworks = project.GetProperty("TargetFrameworks");
+            if (string.IsNullOrEmpty(targetFrameworks))
+            {
+                targetFrameworks = project.GetProperty("TargetFramework");
+            }
+            var projectFrameworkStrings = MSBuildStringUtility.Split(targetFrameworks);
+            return projectFrameworkStrings;
         }
 
         /// <summary>
@@ -531,7 +537,7 @@ namespace NuGet.Build.Tasks.Console
                 var targetAlias = string.IsNullOrEmpty(projectInnerNode.Key) ? string.Empty : projectInnerNode.Key;
 
                 IEnumerable<string> targetFramework = MSBuildProjectFrameworkUtility.GetProjectFrameworkStrings(
-                  projectFilePath: null, // TODO NK - This needs fixed.
+                  projectFilePath: projectInnerNode.Value.FullPath,
                   targetFrameworks: null,
                   targetFramework: null,
                   targetFrameworkMoniker: targetFrameworkMoniker,

--- a/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs
@@ -759,7 +759,9 @@ namespace NuGet.Build.Tasks.Console
             {
                 restoreMetadata = new ProjectRestoreMetadata
                 {
-                    CrossTargeting = (projectStyle == ProjectStyle.PackageReference || projectStyle == ProjectStyle.DotnetToolReference) && projectsByTargetFramework.Count > 1,
+                    // CrossTargeting is on, even if the TargetFrameworks property has only 1 tfm.
+                    CrossTargeting = (projectStyle == ProjectStyle.PackageReference || projectStyle == ProjectStyle.DotnetToolReference) && (
+                        projectsByTargetFramework.Count > 1 || !string.IsNullOrWhiteSpace(project.GetProperty("TargetFrameworks"))),
                     FallbackFolders = BuildTasksUtility.GetFallbackFolders(
                         project.Directory,
                         project.SplitPropertyValueOrNull("RestoreFallbackFolders"),

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.RestoreEx.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.RestoreEx.targets
@@ -20,6 +20,8 @@ Copyright (c) .NET Foundation. All rights reserved.
         ProjectFullPath="$(MSBuildProjectFullPath)"
         Recursive="$([MSBuild]::ValueOrDefault('$(RestoreRecursive)', 'true'))"
         RestorePackagesConfig="$(RestorePackagesConfig)"
-        SolutionPath="$(SolutionPath)" />
+        SolutionPath="$(SolutionPath)"
+        ProcessFileName="$(NuGetConsoleProcessFileName)"
+        />
   </Target>
 </Project>

--- a/src/NuGet.Core/NuGet.Build.Tasks/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Build.Tasks/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+NuGet.Build.Tasks.RestoreTaskEx.ProcessFileName.get -> string
+NuGet.Build.Tasks.RestoreTaskEx.ProcessFileName.set -> void

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
@@ -892,7 +892,7 @@ EndGlobal";
             }
         }
 
-        [PlatformFact(Platform.Windows)]
+        [Fact]
         public async Task DotnetRestore_WithTargetFrameworksProperty_StaticGraphAndRegularRestore_AreEquivalent()
         {
             using (var pathContext = _msbuildFixture.CreateSimpleTestPathContext())

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
@@ -892,6 +892,7 @@ EndGlobal";
             }
         }
 
+#if NET5_0
         [Fact]
         public async Task DotnetRestore_WithTargetFrameworksProperty_StaticGraphAndRegularRestore_AreEquivalent()
         {
@@ -941,7 +942,7 @@ EndGlobal";
                 result.AllOutput.Should().Contain("All projects are up-to-date for restore.");
             }
         }
-
+#endif
         private static byte[] GetResource(string name)
         {
             return ResourceTestUtility.GetResourceBytes(

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
@@ -892,6 +892,56 @@ EndGlobal";
             }
         }
 
+        [PlatformFact(Platform.Windows)]
+        public async Task DotnetRestore_WithTargetFrameworksProperty_StaticGraphAndRegularRestore_AreEquivalent()
+        {
+            using (var pathContext = _msbuildFixture.CreateSimpleTestPathContext())
+            {
+                var testDirectory = pathContext.SolutionRoot;
+                var pkgX = new SimpleTestPackageContext("x", "1.0.0");
+                await SimpleTestPackageUtility.CreatePackagesAsync(pathContext.PackageSource, pkgX);
+
+                var projectName1 = "ClassLibrary1";
+                var workingDirectory1 = Path.Combine(testDirectory, projectName1);
+                var projectFile1 = Path.Combine(workingDirectory1, $"{projectName1}.csproj");
+                _msbuildFixture.CreateDotnetNewProject(testDirectory, projectName1, " classlib");
+
+                using (var stream = File.Open(projectFile1, FileMode.Open, FileAccess.ReadWrite))
+                {
+                    var xml = XDocument.Load(stream);
+                    ProjectFileUtils.SetTargetFrameworkForProject(xml, "TargetFrameworks", "net472");
+
+                    ProjectFileUtils.AddItem(
+                        xml,
+                        "PackageReference",
+                        "x",
+                        framework: "net472",
+                        new Dictionary<string, string>(),
+                        new Dictionary<string, string>() { { "Version", "1.0.0" } });
+
+                    ProjectFileUtils.WriteXmlToFile(xml, stream);
+                }
+
+                // Preconditions
+                var command = $"restore {projectFile1} {$"--source \"{pathContext.PackageSource}\" /p:AutomaticallyUseReferenceAssemblyPackages=false"}";
+                var result = _msbuildFixture.RunDotnet(pathContext.SolutionRoot, command, ignoreExitCode: true);
+
+                result.ExitCode.Should().Be(0, because: result.AllOutput);
+                var assetsFilePath = Path.Combine(workingDirectory1, "obj", "project.assets.json");
+                File.Exists(assetsFilePath).Should().BeTrue(because: "The assets file needs to exist");
+                var assetsFile = new LockFileFormat().Read(assetsFilePath);
+                LockFileTarget target = assetsFile.Targets.Single(e => e.TargetFramework.Equals(NuGetFramework.Parse("net472")) && string.IsNullOrEmpty(e.RuntimeIdentifier));
+                target.Libraries.Should().ContainSingle(e => e.Name.Equals("x"));
+
+                // Act static graph restore
+                result = _msbuildFixture.RunDotnet(pathContext.SolutionRoot, command + " /p:RestoreUseStaticGraphEvaluation=true", ignoreExitCode: true);
+
+                // Ensure static graph restore no-ops
+                result.ExitCode.Should().Be(0, because: result.AllOutput);
+                result.AllOutput.Should().Contain("All projects are up-to-date for restore.");
+            }
+        }
+
         private static byte[] GetResource(string name)
         {
             return ResourceTestUtility.GetResourceBytes(

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/MsbuildIntegrationTestFixture.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/MsbuildIntegrationTestFixture.cs
@@ -423,7 +423,9 @@ SDKs found: {string.Join(", ", Directory.EnumerateDirectories(sdkDir).Select(Pat
         {
             const string restoreProjectName = "NuGet.Build.Tasks";
             const string restoreTargetsName = "NuGet.targets";
-            var sdkDependencies = new List<string> { restoreProjectName, "NuGet.Versioning", "NuGet.Protocol", "NuGet.ProjectModel", "NuGet.Packaging", "NuGet.LibraryModel", "NuGet.Frameworks", "NuGet.DependencyResolver.Core", "NuGet.Configuration", "NuGet.Common", "NuGet.Commands", "NuGet.CommandLine.XPlat", "NuGet.Credentials" };
+            const string restoreTargetsExtName = "NuGet.RestoreEx.targets";
+
+            var sdkDependencies = new List<string> { restoreProjectName, "NuGet.Versioning", "NuGet.Protocol", "NuGet.ProjectModel", "NuGet.Packaging", "NuGet.LibraryModel", "NuGet.Frameworks", "NuGet.DependencyResolver.Core", "NuGet.Configuration", "NuGet.Common", "NuGet.Commands", "NuGet.CommandLine.XPlat", "NuGet.Credentials", "NuGet.Build.Tasks.Console" };
 
             var sdkTfm = AssemblyReader.GetTargetFramework(Path.Combine(pathToSdkInCli, "dotnet.dll"));
 
@@ -446,6 +448,10 @@ SDKs found: {string.Join(", ", Directory.EnumerateDirectories(sdkDir).Select(Pat
                     File.Copy(
                         sourceFileName: Path.Combine(frameworkArtifactsFolder.FullName, restoreTargetsName),
                         destFileName: Path.Combine(pathToSdkInCli, restoreTargetsName),
+                        overwrite: true);
+                    File.Copy(
+                        sourceFileName: Path.Combine(frameworkArtifactsFolder.FullName, restoreTargetsExtName),
+                        destFileName: Path.Combine(pathToSdkInCli, restoreTargetsExtName),
                         overwrite: true);
                 }
             }

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Console.Test/MSBuildStaticGraphRestoreTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Console.Test/MSBuildStaticGraphRestoreTests.cs
@@ -845,7 +845,7 @@ namespace NuGet.Build.Tasks.Console.Test
                         { "PackageTargetFallback", "" },
                         { "TargetFramework", latestCore },
                         { "TargetFrameworkIdentifier", FrameworkConstants.FrameworkIdentifiers.NetCoreApp },
-                        { "TargetFrameworkVersion", "v3.0" },
+                        { "TargetFrameworkVersion", "v5.0" },
                         { "TargetFrameworkMoniker", $"{FrameworkConstants.FrameworkIdentifiers.NetCoreApp},Version=5.0" },
                         { "TargetPlatformIdentifier", "android" },
                         { "TargetPlatformVersion", "21.0" },

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Console.Test/MSBuildStaticGraphRestoreTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Console.Test/MSBuildStaticGraphRestoreTests.cs
@@ -15,7 +15,6 @@ using NuGet.ProjectModel;
 using NuGet.Test.Utility;
 using NuGet.Versioning;
 using Test.Utility;
-using Moq;
 using Xunit;
 
 namespace NuGet.Build.Tasks.Console.Test
@@ -59,22 +58,6 @@ namespace NuGet.Build.Tasks.Console.Test
         [Theory]
         [InlineData("net45", new[] { "net45" })]
         [InlineData("net40;net45", new[] { "net40", "net45" })]
-        [InlineData("net40;net45;netstandard2.0", new[] { "net40", "net45", "netstandard2.0" })]
-        public void GetOriginalTargetFrameworks_WhenTargetFrameworksNotSpecified_HasCorrectTargetFramework(string targetFrameworks, string[] expected)
-        {
-            var project = new MockMSBuildProject(new Dictionary<string, string>
-            {
-                ["TargetFrameworks"] = null
-            });
-
-            var actual = MSBuildStaticGraphRestore.GetOriginalTargetFrameworks(project, targetFrameworks.Split(';').Select(NuGetFramework.Parse).ToList());
-
-            actual.ShouldBeEquivalentTo(expected);
-        }
-
-        [Theory]
-        [InlineData("net45", new[] { "net45" })]
-        [InlineData("net40;net45", new[] { "net40", "net45" })]
         [InlineData("net40;net45 ; netstandard2.0 ", new[] { "net40", "net45", "netstandard2.0" })]
         public void GetOriginalTargetFrameworks_WhenTargetFramworksSpecified_HasCorrectTargetFramework(string targetFrameworks, string[] expected)
         {
@@ -83,7 +66,7 @@ namespace NuGet.Build.Tasks.Console.Test
                 ["TargetFrameworks"] = targetFrameworks
             });
 
-            var actual = MSBuildStaticGraphRestore.GetOriginalTargetFrameworks(project, new List<NuGetFramework>());
+            var actual = MSBuildStaticGraphRestore.GetTargetFrameworkStrings(project);
 
             actual.ShouldBeEquivalentTo(expected);
         }
@@ -337,16 +320,18 @@ namespace NuGet.Build.Tasks.Console.Test
         }
 
         [Fact]
-        public void GetProjectRestoreMetadataFrameworkInfos_WhenProjectReferenceSpecified_CorrectTargetFrameworkDetected()
+        public void GetProjectRestoreMetadataFrameworkInfos_WhenProjectReferenceSpecified_UsesFrameworkFromTargetFrameworkInformation()
         {
             using (var testDirectory = TestDirectory.Create())
             {
                 var projectA = new MockMSBuildProject(Path.Combine(testDirectory, "ProjectA", "ProjectA.csproj"));
                 var projectB = new MockMSBuildProject(Path.Combine(testDirectory, "ProjectB", "ProjectB.csproj"));
+                var net45Alias = "net45";
+                var netstandard20Alias = "netstandard2.0";
 
-                var projects = new Dictionary<NuGetFramework, IMSBuildProject>
+                var projects = new Dictionary<string, IMSBuildProject>
                 {
-                    [FrameworkConstants.CommonFrameworks.Net45] = new MockMSBuildProject(testDirectory)
+                    [net45Alias] = new MockMSBuildProject(testDirectory)
                     {
                         Items = new Dictionary<string, IList<IMSBuildItem>>
                         {
@@ -357,7 +342,7 @@ namespace NuGet.Build.Tasks.Console.Test
                             }
                         }
                     },
-                    [FrameworkConstants.CommonFrameworks.NetStandard20] = new MockMSBuildProject(testDirectory)
+                    [netstandard20Alias] = new MockMSBuildProject(testDirectory)
                     {
                         Items = new Dictionary<string, IList<IMSBuildItem>>
                         {
@@ -369,12 +354,17 @@ namespace NuGet.Build.Tasks.Console.Test
                     }
                 };
 
-                var actual = MSBuildStaticGraphRestore.GetProjectRestoreMetadataFrameworkInfos(projects);
+                var targetFrameworkInfos = new List<TargetFrameworkInformation>();
+                targetFrameworkInfos.Add(new TargetFrameworkInformation { TargetAlias = net45Alias, FrameworkName = FrameworkConstants.CommonFrameworks.Net45 });
+                targetFrameworkInfos.Add(new TargetFrameworkInformation { TargetAlias = netstandard20Alias, FrameworkName = FrameworkConstants.CommonFrameworks.NetStandard20 });
+
+                var actual = MSBuildStaticGraphRestore.GetProjectRestoreMetadataFrameworkInfos(targetFrameworkInfos, projects);
 
                 actual.ShouldBeEquivalentTo(new[]
                 {
                     new ProjectRestoreMetadataFrameworkInfo(FrameworkConstants.CommonFrameworks.Net45)
                     {
+                        TargetAlias = net45Alias,
                         ProjectReferences = new List<ProjectRestoreReference>
                         {
                             new ProjectRestoreReference
@@ -391,6 +381,7 @@ namespace NuGet.Build.Tasks.Console.Test
                     },
                     new ProjectRestoreMetadataFrameworkInfo(FrameworkConstants.CommonFrameworks.NetStandard20)
                     {
+                        TargetAlias = netstandard20Alias,
                         ProjectReferences = new List<ProjectRestoreReference>
                         {
                             new ProjectRestoreReference
@@ -419,8 +410,7 @@ namespace NuGet.Build.Tasks.Console.Test
                 var actual = MSBuildStaticGraphRestore.GetProjectTargetFrameworks(project, innerNodes)
                     .Should().ContainSingle();
 
-                actual.Subject.Key.Should().Be(FrameworkConstants.CommonFrameworks.Net461);
-
+                actual.Subject.Key.Should().Be(string.Empty);
                 actual.Subject.Value.FullPath.Should().Be(project.FullPath);
             }
         }
@@ -447,8 +437,8 @@ namespace NuGet.Build.Tasks.Console.Test
                 actual.Keys.ShouldBeEquivalentTo(
                     new[]
                     {
-                        FrameworkConstants.CommonFrameworks.Net45,
-                        FrameworkConstants.CommonFrameworks.NetStandard20
+                        "net45",
+                        "netstandard2.0"
                     });
 
                 actual.Values.Select(i => i.FullPath).ShouldBeEquivalentTo(
@@ -733,10 +723,10 @@ namespace NuGet.Build.Tasks.Console.Test
         public void GetTargetFrameworkInfos_TheCentralVersionInformationIsAdded()
         {
             // Arrange
-            NuGetFramework netstandard22 = new NuGetFramework("netstandard2.2");
-            NuGetFramework netstandard20 = new NuGetFramework("netstandard2.0");
+            string netstandard22 = "netstandard2.2";
+            string netstandard20 = "netstandard2.0";
 
-            var innerNodes = new Dictionary<NuGetFramework, IMSBuildProject>
+            var innerNodes = new Dictionary<string, IMSBuildProject>
             {
                 [netstandard20] = new MockMSBuildProject("Project-netstandard2.0",
                     new Dictionary<string, string>(),
@@ -772,26 +762,148 @@ namespace NuGet.Build.Tasks.Console.Test
 
             // Assert
             Assert.Equal(2, targetFrameworkInfos.Count);
-            var framework20 = targetFrameworkInfos.Where(f => f.FrameworkName.DotNetFrameworkName == "netstandard2.0,Version=v0.0").ToList();
-            var framework22 = targetFrameworkInfos.Where(f => f.FrameworkName.DotNetFrameworkName == "netstandard2.2,Version=v0.0").ToList();
+            var framework20 = targetFrameworkInfos.Single(f => f.TargetAlias == netstandard20);
+            var framework22 = targetFrameworkInfos.Single(f => f.TargetAlias == netstandard22);
 
-            Assert.Equal(1, framework20.Count);
-            Assert.Equal(1, framework20.First().Dependencies.Count);
-            Assert.Equal("PackageA", framework20.First().Dependencies.First().Name);
-            Assert.Null(framework20.First().Dependencies.First().LibraryRange.VersionRange);
+            Assert.Equal(1, framework20.Dependencies.Count);
+            Assert.Equal("PackageA", framework20.Dependencies.First().Name);
+            Assert.Null(framework20.Dependencies.First().LibraryRange.VersionRange);
 
-            Assert.Equal(2, framework20.First().CentralPackageVersions.Count);
-            Assert.Equal("2.0.0", framework20.First().CentralPackageVersions["PackageA"].VersionRange.OriginalString);
-            Assert.Equal("3.0.0", framework20.First().CentralPackageVersions["PackageB"].VersionRange.OriginalString);
+            Assert.Equal(2, framework20.CentralPackageVersions.Count);
+            Assert.Equal("2.0.0", framework20.CentralPackageVersions["PackageA"].VersionRange.OriginalString);
+            Assert.Equal("3.0.0", framework20.CentralPackageVersions["PackageB"].VersionRange.OriginalString);
 
-            Assert.Equal(1, framework22.Count);
-            Assert.Equal(1, framework22.First().Dependencies.Count);
-            Assert.Equal("PackageA", framework22.First().Dependencies.First().Name);
-            Assert.Equal("11.0.0", framework22.First().Dependencies.First().LibraryRange.VersionRange.OriginalString);
+            Assert.Equal(1, framework22.Dependencies.Count);
+            Assert.Equal("PackageA", framework22.Dependencies.First().Name);
+            Assert.Equal("11.0.0", framework22.Dependencies.First().LibraryRange.VersionRange.OriginalString);
 
-            Assert.Equal(2, framework22.First().CentralPackageVersions.Count);
-            Assert.Equal("2.2.2", framework22.First().CentralPackageVersions["PackageA"].VersionRange.OriginalString);
-            Assert.Equal("3.2.0", framework22.First().CentralPackageVersions["PackageB"].VersionRange.OriginalString);
+            Assert.Equal(2, framework22.CentralPackageVersions.Count);
+            Assert.Equal("2.2.2", framework22.CentralPackageVersions["PackageA"].VersionRange.OriginalString);
+            Assert.Equal("3.2.0", framework22.CentralPackageVersions["PackageB"].VersionRange.OriginalString);
+        }
+
+        [Fact]
+        public void GetTargetFrameworkInfos_WithUAPProject_InfersUAPTargetFramework()
+        {
+            // Arrange
+            string key = string.Empty;
+            var runtimeIdentifierGraphPath = Path.Combine(Path.GetTempPath(), "runtime.json");
+
+            var project = new MockMSBuildProject("Project-core",
+                    new Dictionary<string, string>
+                    {
+                        { "AssetTargetFallback", "" },
+                        { "PackageTargetFallback", "" },
+                        { "TargetFramework", key },
+                        { "TargetFrameworkIdentifier", FrameworkConstants.FrameworkIdentifiers.NetCore },
+                        { "TargetFrameworkVersion", "v5.0" },
+                        { "TargetFrameworkMoniker", $"{FrameworkConstants.FrameworkIdentifiers.NetCore},Version=5.0" },
+                        { "TargetPlatformIdentifier", "UAP" },
+                        { "TargetPlatformVersion", "10.1608.1" }
+                    },
+                    new Dictionary<string, IList<IMSBuildItem>>
+                    {
+                        ["PackageReference"] = new List<IMSBuildItem>
+                        {
+                            new MSBuildItem("PackageA", new Dictionary<string, string> { ["Version"] = "2.0.0" }),
+                        }
+                    });
+
+            // Act
+            List<TargetFrameworkInformation> targetFrameworkInfos = MSBuildStaticGraphRestore.GetTargetFrameworkInfos(
+                    new Dictionary<string, IMSBuildProject>() {
+                        { string.Empty, project }
+                    },
+                    isCpvmEnabled: false);
+
+            // Assert
+            targetFrameworkInfos.Should().HaveCount(1);
+            TargetFrameworkInformation targetFrameworkInformation = targetFrameworkInfos.Single(f => f.TargetAlias == key);
+
+            targetFrameworkInformation.Dependencies.Should().HaveCount(1);
+            targetFrameworkInformation.Dependencies.Single().Name.Should().Be("PackageA");
+            targetFrameworkInformation.Dependencies.Single().LibraryRange.VersionRange.OriginalString.Should().Be("2.0.0");
+            targetFrameworkInformation.FrameworkName.GetShortFolderName().Should().Be("uap10.1608.1");
+            targetFrameworkInformation.AssetTargetFallback.Should().BeFalse();
+        }
+
+        [Fact]
+        public void GetTargetFrameworkInfos_WithCustomAliases_InfersCorrectTargetFramework()
+        {
+            // Arrange
+            string latestNet = "latestNet";
+            string latestCore = "latestCore";
+            var atf = "net472";
+            var runtimeIdentifierGraphPath = Path.Combine(Path.GetTempPath(), "runtime.json");
+
+            var innerNodes = new Dictionary<string, IMSBuildProject>
+            {
+                [latestCore] = new MockMSBuildProject("Project-core",
+                    new Dictionary<string, string>
+                    {
+                        { "AssetTargetFallback", atf },
+                        { "PackageTargetFallback", "" },
+                        { "TargetFramework", latestCore },
+                        { "TargetFrameworkIdentifier", FrameworkConstants.FrameworkIdentifiers.NetCoreApp },
+                        { "TargetFrameworkVersion", "v3.0" },
+                        { "TargetFrameworkMoniker", $"{FrameworkConstants.FrameworkIdentifiers.NetCoreApp},Version=5.0" },
+                        { "TargetPlatformIdentifier", "android" },
+                        { "TargetPlatformVersion", "21.0" },
+                        { "RuntimeIdentifierGraphPath", runtimeIdentifierGraphPath }
+                    },
+                    new Dictionary<string, IList<IMSBuildItem>>
+                    {
+                        ["PackageReference"] = new List<IMSBuildItem>
+                        {
+                            new MSBuildItem("PackageA", new Dictionary<string, string> { ["Version"] = "2.0.0" }),
+                        }
+                    }),
+                [latestNet] = new MockMSBuildProject("Project-net",
+                    new Dictionary<string, string>
+                    {
+                        { "AssetTargetFallback", "" },
+                        { "PackageTargetFallback", "" },
+                        { "TargetFramework", latestNet },
+                        { "TargetFrameworkIdentifier", FrameworkConstants.FrameworkIdentifiers.Net },
+                        { "TargetFrameworkVersion", "v4.6.1" },
+                        { "TargetFrameworkMoniker", $"{FrameworkConstants.FrameworkIdentifiers.Net},Version=4.6.1" },
+                        { "TargetPlatformIdentifier", "" },
+                        { "TargetPlatformVersion", "" },
+                        { "RuntimeIdentifierGraphPath", runtimeIdentifierGraphPath }
+                    },
+                    new Dictionary<string, IList<IMSBuildItem>>
+                    {
+                        ["PackageReference"] = new List<IMSBuildItem>
+                        {
+                            new MSBuildItem("PackageB", new Dictionary<string, string> { ["Version"] = "2.1.0" }),
+                        },
+                    }),
+            };
+
+            // Act
+            List<TargetFrameworkInformation> targetFrameworkInfos = MSBuildStaticGraphRestore.GetTargetFrameworkInfos(innerNodes, isCpvmEnabled: false);
+
+            // Assert
+            targetFrameworkInfos.Should().HaveCount(2);
+            TargetFrameworkInformation coreTFI = targetFrameworkInfos.Single(f => f.TargetAlias == latestCore);
+            TargetFrameworkInformation netTFI = targetFrameworkInfos.Single(f => f.TargetAlias == latestNet);
+
+            coreTFI.Dependencies.Should().HaveCount(1);
+            coreTFI.Dependencies.Single().Name.Should().Be("PackageA");
+            coreTFI.Dependencies.Single().LibraryRange.VersionRange.OriginalString.Should().Be("2.0.0");
+            coreTFI.RuntimeIdentifierGraphPath.Should().Be(runtimeIdentifierGraphPath);
+            coreTFI.FrameworkName.GetShortFolderName().Should().Be("net5.0-android21.0");
+            coreTFI.AssetTargetFallback.Should().BeTrue();
+            AssetTargetFallbackFramework assetTargetFallbackFramework = (AssetTargetFallbackFramework)coreTFI.FrameworkName;
+            assetTargetFallbackFramework.Fallback.Should().HaveCount(1);
+            assetTargetFallbackFramework.Fallback.Single().GetShortFolderName().Should().Be("net472");
+
+            netTFI.Dependencies.Should().HaveCount(1);
+            netTFI.Dependencies.Single().Name.Should().Be("PackageB");
+            netTFI.Dependencies.Single().LibraryRange.VersionRange.OriginalString.Should().Be("2.1.0");
+            netTFI.RuntimeIdentifierGraphPath.Should().Be(runtimeIdentifierGraphPath);
+            netTFI.FrameworkName.Should().Be(FrameworkConstants.CommonFrameworks.Net461);
+            netTFI.AssetTargetFallback.Should().BeFalse();
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/RestoreTaskExTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/RestoreTaskExTests.cs
@@ -84,10 +84,28 @@ namespace NuGet.Build.Tasks.Test
                 })
                 {
 #if IS_CORECLR
-                    task.GetProcessFileName().Should().Be(Path.Combine(testDirectory, "MSBuild", "dotnet"));
+                    task.GetProcessFileName(null).Should().Be(Path.Combine(testDirectory, "MSBuild", "dotnet"));
 #else
-                    task.GetProcessFileName().Should().Be(Path.ChangeExtension(typeof(RestoreTaskEx).Assembly.Location, ".Console.exe"));
+                    task.GetProcessFileName(null).Should().Be(Path.ChangeExtension(typeof(RestoreTaskEx).Assembly.Location, ".Console.exe"));
 #endif
+                }
+            }
+        }
+
+        [Fact]
+        public void GetProcessFileName_WithExePathParameter_ReturnsCorrectValue()
+        {
+            using (var testDirectory = TestDirectory.Create())
+            {
+                string msbuildBinPath = Path.Combine(testDirectory, "MSBuild", "Current", "Bin");
+                string exePath = Path.Combine(testDirectory, "override.exe");
+
+                using (var task = new RestoreTaskEx
+                {
+                    MSBuildBinPath = msbuildBinPath
+                })
+                {
+                    task.GetProcessFileName(exePath).Should().Be(exePath);
                 }
             }
         }


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9870
Fixes: https://github.com/NuGet/Home/issues/9881
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: 

Currently in command line scenarios NuGet reads the target framework information in the outer build.
That is incorrect because the the contract is that we should depend on on TargetFrameworkIdentifier and the like properties.
We do that here: https://github.com/NuGet/NuGet.Client/blob/bd482514a87a0085f8eb8603842ee1cb3ca5f277/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets#L500-L526

This task covers, the static graph restore changes.

Note that I will rebase this PR when https://github.com/NuGet/NuGet.Client/pull/3562 is merged. 

**Note**

As part of this PR I have made some additional changes that will allow us to test static graph restore better/faster/easier. 
If you prefer, I can move those changes to a different PR if necessary. 

## Testing/Validation

Tests Added: Yes 
Reason for not adding tests:  
Validation:  
