### PR TITLE
Removes Localization Validation dependency from build share

### DIFF
--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -541,12 +541,11 @@ jobs:
       arguments: "-BuildRTM $(BuildRTM) -RepoRoot $(Build.Repository.LocalPath) -OutputLogsBasePath $(Build.Repository.LocalPath)\\logs"
     condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
 
-  - task: CopyFiles@2
-    displayName: "LocValidation: Copy Logs"
+  - task: PublishPipelineArtifact@1
+    displayName: "LocValidation: Publish Logs as an artifact"
     inputs:
-      SourceFolder: "$(Build.Repository.LocalPath)\\logs"
-      Contents: "**"
-      TargetFolder: "$(Build.Repository.LocalPath)\\artifacts"
+      artifactName: LocValidationLogs
+      targetPath: "$(Build.Repository.LocalPath)\\logs\\LocalizationValidation"
     condition: "eq(variables['BuildRTM'], 'false')"
 
     # Use dotnet msbuild instead of MSBuild CLI.

--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -531,15 +531,23 @@ jobs:
     displayName: "Validate VSIX Localization"
     inputs:
       scriptName: "$(Build.Repository.LocalPath)\\scripts\\cibuild\\BuildValidator.ps1"
-      arguments: "-BuildRTM $(BuildRTM) -BuildOutputTargetPath $(BuildOutputTargetPath) -ValidateVsix"
-    condition: "succeeded()"
+      arguments: "-BuildRTM $(BuildRTM) -RepoRoot $(Build.Repository.LocalPath) -OutputLogsBasePath $(Build.Repository.LocalPath)\\LocalizationValidation -TmpPath $(Agent.TempDirectory) -ValidateVsix"
+    condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
 
   - task: PowerShell@1
-    displayName: "Validate Repository Artifacts Localization"
+    displayName: "Validate Artifacts Localization"
     inputs:
       scriptName: "$(Build.Repository.LocalPath)\\scripts\\cibuild\\BuildValidator.ps1"
-      arguments: "-BuildRTM $(BuildRTM) -BuildOutputTargetPath $(BuildOutputTargetPath)"
-    condition: "succeeded()"
+      arguments: "-BuildRTM $(BuildRTM) -RepoRoot $(Build.Repository.LocalPath) -OutputLogsBasePath $(Build.Repository.LocalPath)\\LocalizationValidation -TmpPath $(Agent.TempDirectory)"
+    condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
+
+  - task: CopyFiles@2
+    displayName: "Copy LocValidalidation logs to artifacts"
+    inputs:
+      SourceFolder: "$(Build.Repository.LocalPath)\\LocalizationValidation"
+      Contents: "**"
+      TargetFolder: "$(BuildOutputTargetPath)\\artifactsLocalizationValidation"
+    condition: "and(eq(variables['BuildRTM'], 'false'))"
 
     # Use dotnet msbuild instead of MSBuild CLI.
     # Using MSBuild CLI results in an assembly binding failure for NuGet.Common.dll 4.4.0.3 because Microsoft.DotNet.Build.Tasks.Feed.dll references SleetLib.dll which references NuGet.Common 4.4.0.3.

--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -547,7 +547,7 @@ jobs:
       SourceFolder: "$(Build.Repository.LocalPath)\\LocalizationValidation"
       Contents: "**"
       TargetFolder: "$(BuildOutputTargetPath)\\artifactsLocalizationValidation"
-    condition: "and(eq(variables['BuildRTM'], 'false')"
+    condition: "eq(variables['BuildRTM'], 'false')"
 
     # Use dotnet msbuild instead of MSBuild CLI.
     # Using MSBuild CLI results in an assembly binding failure for NuGet.Common.dll 4.4.0.3 because Microsoft.DotNet.Build.Tasks.Feed.dll references SleetLib.dll which references NuGet.Common 4.4.0.3.

--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -547,7 +547,7 @@ jobs:
       SourceFolder: "$(Build.Repository.LocalPath)\\LocalizationValidation"
       Contents: "**"
       TargetFolder: "$(BuildOutputTargetPath)\\artifactsLocalizationValidation"
-    condition: "and(eq(variables['BuildRTM'], 'false'))"
+    condition: "and(eq(variables['BuildRTM'], 'false')"
 
     # Use dotnet msbuild instead of MSBuild CLI.
     # Using MSBuild CLI results in an assembly binding failure for NuGet.Common.dll 4.4.0.3 because Microsoft.DotNet.Build.Tasks.Feed.dll references SleetLib.dll which references NuGet.Common 4.4.0.3.

--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -528,25 +528,25 @@ jobs:
     condition: " and(succeeded(),eq(variables['BuildRTM'], 'false')) "
 
   - task: PowerShell@1
-    displayName: "Validate VSIX Localization"
+    displayName: "LocValidation: Verify VSIX"
     inputs:
       scriptName: "$(Build.Repository.LocalPath)\\scripts\\cibuild\\BuildValidator.ps1"
-      arguments: "-BuildRTM $(BuildRTM) -RepoRoot $(Build.Repository.LocalPath) -OutputLogsBasePath $(Build.Repository.LocalPath)\\LocalizationValidation -TmpPath $(Agent.TempDirectory) -ValidateVsix"
+      arguments: "-BuildRTM $(BuildRTM) -RepoRoot $(Build.Repository.LocalPath) -OutputLogsBasePath $(Build.Repository.LocalPath)\\logs -TmpPath $(Agent.TempDirectory) -ValidateVsix"
     condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
 
   - task: PowerShell@1
-    displayName: "Validate Artifacts Localization"
+    displayName: "LocValidation: Verify Artifacts"
     inputs:
       scriptName: "$(Build.Repository.LocalPath)\\scripts\\cibuild\\BuildValidator.ps1"
-      arguments: "-BuildRTM $(BuildRTM) -RepoRoot $(Build.Repository.LocalPath) -OutputLogsBasePath $(Build.Repository.LocalPath)\\LocalizationValidation -TmpPath $(Agent.TempDirectory)"
+      arguments: "-BuildRTM $(BuildRTM) -RepoRoot $(Build.Repository.LocalPath) -OutputLogsBasePath $(Build.Repository.LocalPath)\\logs"
     condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
 
   - task: CopyFiles@2
-    displayName: "Copy LocValidalidation logs to artifacts"
+    displayName: "LocValidation: Copy Logs"
     inputs:
-      SourceFolder: "$(Build.Repository.LocalPath)\\LocalizationValidation"
+      SourceFolder: "$(Build.Repository.LocalPath)\\logs"
       Contents: "**"
-      TargetFolder: "$(BuildOutputTargetPath)\\artifactsLocalizationValidation"
+      TargetFolder: "$(Build.Repository.LocalPath)\\artifacts"
     condition: "eq(variables['BuildRTM'], 'false')"
 
     # Use dotnet msbuild instead of MSBuild CLI.

--- a/scripts/cibuild/BuildValidator.ps1
+++ b/scripts/cibuild/BuildValidator.ps1
@@ -3,52 +3,59 @@
 Validates the result of the localization process
 
 .DESCRIPTION
-This script is used to validate the results of localization.
+Runs NuGetValidator.exe over localized artifact binaries to count validation mismatchs between binaries and localization inputs
 
 .PARAMETER RepoRoot
-Path to NuGet.Client repo root folfer
+Path to NuGet.Client repo root folder
 
 .PARAMETER OutputLogsBasePath
-Path to the location where the build artifacts are output
+Path to logs output folder
 
 .PARAMETER BuildRTM
-True/false depending on whether nupkgs are being with or without the release labels.
+true/false depending on whether nupkgs are being with or without the release labels.
 
 .PARAMETER ValidateVsix
-Flag to indicate validation on VSIX artifact. Otherwise, validates binaries under $RepoRoot\artifacts folder (default)
+Flag to verify VSIX artifact. Otherwise, verifies binaries under $RepoRoot\artifacts folder (default)
+
+.PARAMETER TmpPath
+Path to a temporary folder to extract the VSIX artifact.
 #>
 param
 (
     [Parameter(Mandatory=$True)]
     [string]$RepoRoot,
+    
     [Parameter(Mandatory=$True)]
     [string]$OutputLogsBasePath,
+    
     [Parameter(Mandatory=$True)]
     [string]$BuildRTM,
-    [string]$TmpPath = $Env:TEMP,
-    [switch]$ValidateVsix
+    
+    [switch]$ValidateVsix,
+    
+    [string]$TmpPath = $Env:TEMP
 )
 
 if ($BuildRTM -eq 'false')
-{   
+{
     $NuGetValidator = [System.IO.Path]::Combine($RepoRoot, 'packages', 'nugetvalidator', '2.0.2', 'tools', 'NuGetValidator.exe')
     $LocalizationRepository = [System.IO.Path]::Combine($RepoRoot, 'submodules', 'NuGet.Build.Localization', 'localize', 'comments', '15')
 
-    if ($ValidateVsix) 
+    if ($ValidateVsix)
     {
-        $VsixLocation = [System.IO.Path]::Combine($RepoRoot, 'artifacts', 'VS15', 'NuGet.Tools.vsix' )
+        $VsixLocation = [System.IO.Path]::Combine($RepoRoot, 'artifacts', 'VS15', 'NuGet.Tools.vsix')
         $VsixExtractLocation = [System.IO.Path]::Combine($TmpPath, 'extractedVsix')
-        $VsixLogOutputDir = [System.IO.Path]::Combine($OutputLogsBasePath, 'LocalizationValidation', 'vsix' )
+        $VsixLogOutputDir = [System.IO.Path]::Combine($OutputLogsBasePath, 'LocalizationValidation', 'vsix')
 
         Write-Host "Validating NuGet.Tools.Vsix localization..."
         Write-Host "Running: $NuGetValidator localization --vsix --vsix-path $VsixLocation --vsix-extract-path $VsixExtractLocation --output-path $VsixLogOutputDir --comments-path $LocalizationRepository"
         & $NuGetValidator localization --vsix --vsix-path $VsixLocation --vsix-extract-path $VsixExtractLocation --output-path $VsixLogOutputDir --comments-path $LocalizationRepository
     }
-    else 
+    else
     {
         $ArtifactsLocation = [System.IO.Path]::Combine($RepoRoot, 'artifacts')
-        $ArtifactsLogOutputDir = [System.IO.Path]::Combine($OutputLogsBasePath, 'LocalizationValidation', 'artifacts' )
-    
+        $ArtifactsLogOutputDir = [System.IO.Path]::Combine($OutputLogsBasePath, 'LocalizationValidation', 'artifacts')
+
         Write-Host "Validating NuGet.Client repository localization..."
         Write-Host "Running: $NuGetValidator localization --artifacts-path $ArtifactsLocation --output-path $ArtifactsLogOutputDir --comments-path $LocalizationRepository"
         & $NuGetValidator localization --artifacts-path $ArtifactsLocation --output-path $ArtifactsLogOutputDir --comments-path $LocalizationRepository

--- a/scripts/cibuild/BuildValidator.ps1
+++ b/scripts/cibuild/BuildValidator.ps1
@@ -5,37 +5,40 @@ Validates the result of the localization process
 .DESCRIPTION
 This script is used to validate the results of localization.
 
-.PARAMETER BuildOutputTargetPath
+.PARAMETER RepoRoot
+Path to NuGet.Client repo root folfer
+
+.PARAMETER OutputLogsBasePath
 Path to the location where the build artifacts are output
 
 .PARAMETER BuildRTM
 True/false depending on whether nupkgs are being with or without the release labels.
 
+.PARAMETER ValidateVsix
+Flag to indicate validation on VSIX artifact. Otherwise, validates binaries under $RepoRoot\artifacts folder (default)
 #>
-
 param
 (
     [Parameter(Mandatory=$True)]
-    [string]$BuildOutputTargetPath,
+    [string]$RepoRoot,
+    [Parameter(Mandatory=$True)]
+    [string]$OutputLogsBasePath,
     [Parameter(Mandatory=$True)]
     [string]$BuildRTM,
+    [string]$TmpPath = $Env:TEMP,
     [switch]$ValidateVsix
 )
 
-
 if ($BuildRTM -eq 'false')
 {   
+    $NuGetValidator = [System.IO.Path]::Combine($RepoRoot, 'packages', 'nugetvalidator', '2.0.2', 'tools', 'NuGetValidator.exe')
+    $LocalizationRepository = [System.IO.Path]::Combine($RepoRoot, 'submodules', 'NuGet.Build.Localization', 'localize', 'comments', '15')
 
-    $NuGetClientRoot = $env:BUILD_REPOSITORY_LOCALPATH
-    $NuGetValidator = [System.IO.Path]::Combine($NuGetClientRoot, 'packages', 'nugetvalidator', '2.0.2', 'tools', 'NuGetValidator.exe')
-    $VsixLogOutputDir = [System.IO.Path]::Combine($BuildOutputTargetPath, 'LocalizationValidation', 'vsix' )
-    $LocalizationRepository = [System.IO.Path]::Combine($NuGetClientRoot, 'submodules', 'NuGet.Build.Localization', 'localize', 'comments', '15')
-    
     if ($ValidateVsix) 
     {
-        $VsixLocation = [System.IO.Path]::Combine($BuildOutputTargetPath, 'artifacts', 'VS15', 'NuGet.Tools.vsix' )
-        $VsixExtractLocation = [System.IO.Path]::Combine($env:SYSTEM_DEFAULTWORKINGDIRECTORY, 'extractedVsix' ) 
-        $VsixLogOutputDir = [System.IO.Path]::Combine($BuildOutputTargetPath, 'LocalizationValidation', 'vsix' )
+        $VsixLocation = [System.IO.Path]::Combine($RepoRoot, 'artifacts', 'VS15', 'NuGet.Tools.vsix' )
+        $VsixExtractLocation = [System.IO.Path]::Combine($TmpPath, 'extractedVsix')
+        $VsixLogOutputDir = [System.IO.Path]::Combine($OutputLogsBasePath, 'LocalizationValidation', 'vsix' )
 
         Write-Host "Validating NuGet.Tools.Vsix localization..."
         Write-Host "Running: $NuGetValidator localization --vsix --vsix-path $VsixLocation --vsix-extract-path $VsixExtractLocation --output-path $VsixLogOutputDir --comments-path $LocalizationRepository"
@@ -43,9 +46,9 @@ if ($BuildRTM -eq 'false')
     }
     else 
     {
-        $ArtifactsLocation = [System.IO.Path]::Combine($NuGetClientRoot, 'artifacts')
-        $ArtifactsLogOutputDir = [System.IO.Path]::Combine($BuildOutputTargetPath, 'LocalizationValidation', 'artifacts' )
-
+        $ArtifactsLocation = [System.IO.Path]::Combine($RepoRoot, 'artifacts')
+        $ArtifactsLogOutputDir = [System.IO.Path]::Combine($OutputLogsBasePath, 'LocalizationValidation', 'artifacts' )
+    
         Write-Host "Validating NuGet.Client repository localization..."
         Write-Host "Running: $NuGetValidator localization --artifacts-path $ArtifactsLocation --output-path $ArtifactsLogOutputDir --comments-path $LocalizationRepository"
         & $NuGetValidator localization --artifacts-path $ArtifactsLocation --output-path $ArtifactsLogOutputDir --comments-path $LocalizationRepository


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Client.Engineering/issues/396
Regression: No
* Last working version:   
* How are we preventing it in future: Not using build share as an scratch/temp folder for CI

## Fix

- Temporally store localization validation logs on the CI machine. Then, upload logs as a pipeline artifact.
- Added documentation to the localization validation script (BuildValidator.ps1)

## Testing/Validation

Tests Added: No
Reason for not adding tests: CI infrastructure
Validation:  Green CI build (in progress)
