### PR TITLE
Stop testing 3.1.xxx SDK as it's not the main development target anymore

### DIFF
--- a/build/common.project.props
+++ b/build/common.project.props
@@ -18,6 +18,7 @@
     <NETCoreTargetFrameworks Condition=" '$(RequiresSigningXplatAPIs)' != 'true' ">netcoreapp2.1</NETCoreTargetFrameworks>
     <NETCoreTargetFrameworks Condition=" '$(RequiresSigningXplatAPIs)' == 'true' ">netcoreapp2.1;netcoreapp5.0</NETCoreTargetFrameworks>
     <NETCoreTestTargetFrameworks>netcoreapp3.1;netcoreapp5.0</NETCoreTestTargetFrameworks>
+    <NETCoreTestTargetFramework>netcoreapp5.0</NETCoreTestTargetFramework>
     <NetStandardVersion>netstandard2.0</NetStandardVersion>
     <TargetFrameworksExe>$(NETFXTargetFramework);$(NETCoreTargetFrameworks)</TargetFrameworksExe>
     <TargetFrameworksExe Condition="'$(IsBuildOnlyXPLATProjects)' == 'true'">$(NETCoreTargetFramework)</TargetFrameworksExe>

--- a/build/config.props
+++ b/build/config.props
@@ -43,7 +43,7 @@
     <LockSDKVersion>true</LockSDKVersion>
     <OverrideCliBranchForTesting Condition="'$(LockSDKVersion)' == 'false'"></OverrideCliBranchForTesting>
     <OverrideCliBranchForTesting Condition="'$(LockSDKVersion)' == 'true'">master 5.0.100-preview.7.20319.6</OverrideCliBranchForTesting>
-    <CliVersionForBuilding>master 5.0.100-preview.4.20258.7</CliVersionForBuilding>
+    <CliVersionForBuilding>"master 5.0.100-preview.4.20258.7"</CliVersionForBuilding>
     <CliBranchForTesting Condition="'$(OverrideCliBranchForTesting)' != ''">$(OverrideCliBranchForTesting)</CliBranchForTesting>
     <CliBranchForTesting Condition="'$(OverrideCliBranchForTesting)' == ''">master</CliBranchForTesting>
     <CliTargetBranches Condition="'$(OverrideCliTargetBranches)' != ''">$(OverrideCliTargetBranches)</CliTargetBranches>

--- a/build/config.props
+++ b/build/config.props
@@ -42,16 +42,12 @@
     <!--TODO: remove temporary workaround of using LockSDKVersion. Tracking issue: https://github.com/NuGet/Home/issues/9712 -->
     <LockSDKVersion>true</LockSDKVersion>
     <OverrideCliBranchForTesting Condition="'$(LockSDKVersion)' == 'false'"></OverrideCliBranchForTesting>
-    <OverrideCliBranchForTesting Condition="'$(LockSDKVersion)' == 'true'">master 5.0.100-preview.7.20319.6;3.1</OverrideCliBranchForTesting>
-    <CliVersionForBuilding>"master 5.0.100-preview.4.20258.7"</CliVersionForBuilding>
+    <OverrideCliBranchForTesting Condition="'$(LockSDKVersion)' == 'true'">master 5.0.100-preview.7.20319.6</OverrideCliBranchForTesting>
+    <CliVersionForBuilding>master 5.0.100-preview.4.20258.7</CliVersionForBuilding>
     <CliBranchForTesting Condition="'$(OverrideCliBranchForTesting)' != ''">$(OverrideCliBranchForTesting)</CliBranchForTesting>
-    <CliBranchForTesting Condition="'$(OverrideCliBranchForTesting)' == ''">master;3.1</CliBranchForTesting>
+    <CliBranchForTesting Condition="'$(OverrideCliBranchForTesting)' == ''">master</CliBranchForTesting>
     <CliTargetBranches Condition="'$(OverrideCliTargetBranches)' != ''">$(OverrideCliTargetBranches)</CliTargetBranches>
     <CliTargetBranches Condition="'$(OverrideCliTargetBranches)' == ''">master</CliTargetBranches>
-    <SdkTargetBranches Condition="'$(OverrideCliTargetBranches)' != ''">$(OverrideCliTargetBranches)</SdkTargetBranches>
-    <SdkTargetBranches Condition="'$(OverrideCliTargetBranches)' == ''">master</SdkTargetBranches>
-    <ToolsetTargetBranches Condition="'$(OverrideToolsetTargetBranches)' != ''">$(OverrideToolsetTargetBranches)</ToolsetTargetBranches>
-    <ToolsetTargetBranches Condition="'$(OverrideToolsetTargetBranches)' == ''">master</ToolsetTargetBranches>
   </PropertyGroup>
 
   <!-- Config -->
@@ -93,12 +89,6 @@
   </Target>
   <Target Name="GetCliTargetBranches">
     <Message Text="$(CliTargetBranches)" Importance="High"/>
-  </Target>
-  <Target Name="GetSdkTargetBranches">
-    <Message Text="$(SdkTargetBranches)" Importance="High"/>
-  </Target>
-  <Target Name="GetToolsetTargetBranches">
-    <Message Text="$(ToolsetTargetBranches)" Importance="High"/>
   </Target>
   <Target Name="GetCliBranchForTesting">
       <Message Text="$(CliBranchForTesting)" Importance="High"/>

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/Dotnet.Integration.Test.csproj
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/Dotnet.Integration.Test.csproj
@@ -7,7 +7,7 @@
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
   
   <PropertyGroup>
-    <TargetFrameworks>$(NETCoreTestTargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks>$(NETCoreTestTargetFramework)</TargetFrameworks>
     <TestProject>true</TestProject>
     <Description>Integration tests for NuGet-powered dotnet CLI commands such as pack/restore/list package and dotnet nuget.</Description>
   </PropertyGroup>

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/MsbuildIntegrationTestFixture.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/MsbuildIntegrationTestFixture.cs
@@ -41,10 +41,8 @@ namespace Dotnet.Integration.Test
 
             var sdkPath = Directory.EnumerateDirectories(Path.Combine(_cliDirectory, "sdk")).Single();
 
-#if NETCOREAPP5_0
             // TODO - remove when shipping. See https://github.com/NuGet/Home/issues/8952
             PatchSDKWithCryptographyDlls(sdkPath);
-#endif
 
             MsBuildSdksPath = Path.Combine(sdkPath, "Sdks");
 


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Client.Engineering/issues/455
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: 

3.1.xxx is not under active development, it's moving into servicing mode. It is still supported ofc.
My suggestion is that we remove 3.1.xxx tests in dev because we don't insert into 3.1.xxx anymore. dev = active development, release-5.7.x = servicing mode.
If we need to service 3.1.xxx, we'll use the corresponding branch from which we were inserting in the first place.

This should save us ~15 mins of build time. cc @zivkan 

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  Infra, removing tests! :)
Validation:  
