### PR TITLE
Increment NetCoreAssemblyBuildNumber after insertion

### DIFF
--- a/build/config.props
+++ b/build/config.props
@@ -24,7 +24,7 @@
     <!-- ** Increment each insertion, set to zero after incrementing Major/Minor or Patch version -->
     <!-- We need to update this netcoreassembly build number with EVERY insertion into VS to workaround any breaking api
     changes we might have made. -->
-    <NetCoreAssemblyBuildNumber Condition=" '$(NetCoreAssemblyBuildNumber)' == '' ">3</NetCoreAssemblyBuildNumber>
+    <NetCoreAssemblyBuildNumber Condition=" '$(NetCoreAssemblyBuildNumber)' == '' ">4</NetCoreAssemblyBuildNumber>
 
     <IsEscrowMode>false</IsEscrowMode>
 


### PR DESCRIPTION
## Bug

Insertion: https://github.com/NuGet/Client.Engineering/issues/462
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: increment build number

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  no product changes
Validation:  
