### PR TITLE
do not clear project cache until solution is closed, so that tabs close properly

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
@@ -491,18 +491,18 @@ namespace NuGet.PackageManagement.VisualStudio
 
         private void OnAfterClosing()
         {
-            SolutionClosed?.Invoke(this, EventArgs.Empty);
-        }
-
-        private void OnBeforeClosing()
-        {
             DefaultNuGetProjectName = null;
             _projectSystemCache.Clear();
             _cacheInitialized = false;
 
-            SolutionClosing?.Invoke(this, EventArgs.Empty);
+            SolutionClosed?.Invoke(this, EventArgs.Empty);
 
             _solutionOpenedRaised = false;
+        }
+
+        private void OnBeforeClosing()
+        {
+            SolutionClosing?.Invoke(this, EventArgs.Empty);
         }
 
         private void SolutionSaveAs_BeforeExecute(


### PR DESCRIPTION
Fixes: https://github.com/nuget/client.engineering/issues/471
Regression: Yes, but tests fail because of it
* Last working version:   dev branch
* How are we preventing it in future: running apex tests   

## Fix

Details: Don't clear the projectcache until the solution is closed.
As I mention in the issue, haven't debugged old vs new, let me know if you have concerns about this approach.

## Testing/Validation

Tests Added: No
Reason for not adding tests: apex tests cover this 
Validation:  manual, adhoc and apex test running.
