### PR TITLE
Change PackageReference to use PackageReferenceContextInfo

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageSolutionDetailControlModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageSolutionDetailControlModel.cs
@@ -123,12 +123,12 @@ namespace NuGet.PackageManagement.UI
             {
                 try
                 {
-                    PackageReference installedVersion = await GetInstalledPackageAsync(project.NuGetProject, Id, cancellationToken);
+                    IPackageReferenceContextInfo installedVersion = await GetInstalledPackageAsync(project.NuGetProject, Id, cancellationToken);
                     if (installedVersion != null)
                     {
-                        project.InstalledVersion = installedVersion.PackageIdentity.Version;
-                        hash.Add(installedVersion.PackageIdentity.Version);
-                        project.AutoReferenced = (installedVersion as BuildIntegratedPackageReference)?.Dependency?.AutoReferenced == true;
+                        project.InstalledVersion = installedVersion.Identity.Version;
+                        hash.Add(installedVersion.Identity.Version);
+                        project.AutoReferenced = installedVersion.IsAutoReferenced;
                     }
                     else
                     {
@@ -173,11 +173,11 @@ namespace NuGet.PackageManagement.UI
         /// This method is called from several methods that are called from properties and LINQ queries
         /// It is likely not called more than once in an action.
         /// </summary>
-        private static async Task<Packaging.PackageReference> GetInstalledPackageAsync(IProjectContextInfo project, string id, CancellationToken cancellationToken)
+        private static async Task<IPackageReferenceContextInfo> GetInstalledPackageAsync(IProjectContextInfo project, string id, CancellationToken cancellationToken)
         {
-            IEnumerable<PackageReference> installedPackages = await project.GetInstalledPackagesAsync(cancellationToken);
-            PackageReference installedPackage = installedPackages
-                .Where(p => StringComparer.OrdinalIgnoreCase.Equals(p.PackageIdentity.Id, id))
+            IEnumerable<IPackageReferenceContextInfo> installedPackages = await project.GetInstalledPackagesAsync(cancellationToken);
+            IPackageReferenceContextInfo installedPackage = installedPackages
+                .Where(p => StringComparer.OrdinalIgnoreCase.Equals(p.Identity.Id, id))
                 .FirstOrDefault();
             return installedPackage;
         }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/PackageItemLoader.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/PackageItemLoader.cs
@@ -11,6 +11,7 @@ using NuGet.Common;
 using NuGet.PackageManagement.VisualStudio;
 using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
+using NuGet.VisualStudio.Internal.Contracts;
 
 namespace NuGet.PackageManagement.UI
 {
@@ -24,7 +25,7 @@ namespace NuGet.PackageManagement.UI
         private readonly IPackageFeed _recommenderPackageFeed;
         private PackageCollection _installedPackages;
         private int _recommendedCount;
-        private IEnumerable<Packaging.PackageReference> _packageReferences;
+        private IEnumerable<IPackageReferenceContextInfo> _packageReferences;
 
         // Never null
         private PackageFeedSearchState _state = new PackageFeedSearchState();
@@ -287,7 +288,7 @@ namespace NuGet.PackageManagement.UI
                     // get the allowed version range and pass it to package item view model to choose the latest version based on that
                     if (_packageReferences != null)
                     {
-                        var matchedPackageReferences = _packageReferences.Where(r => StringComparer.OrdinalIgnoreCase.Equals(r.PackageIdentity.Id, metadata.Identity.Id));
+                        var matchedPackageReferences = _packageReferences.Where(r => StringComparer.OrdinalIgnoreCase.Equals(r.Identity.Id, metadata.Identity.Id));
                         var allowedVersionsRange = matchedPackageReferences.Select(r => r.AllowedVersions).Where(v => v != null).ToArray();
 
                         if (allowedVersionsRange.Length > 0)

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -383,7 +383,6 @@ namespace NuGet.PackageManagement.UI
 
         private void PackageManagerLoaded(object sender, RoutedEventArgs e)
         {
-            Loaded -= PackageManagerLoaded;
             var timeSpan = GetTimeSinceLastRefreshAndRestart();
             // Do not trigger a refresh if the browse tab is open and this is not the first load of the control.
             // The loaded event is triggered once all the data binding has occurred, which effectively means we'll just display what was loaded earlier and not trigger another search

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -383,6 +383,7 @@ namespace NuGet.PackageManagement.UI
 
         private void PackageManagerLoaded(object sender, RoutedEventArgs e)
         {
+            Loaded -= PackageManagerLoaded;
             var timeSpan = GetTimeSinceLastRefreshAndRestart();
             // Do not trigger a refresh if the browse tab is open and this is not the first load of the control.
             // The loaded event is triggered once all the data binding has occurred, which effectively means we'll just display what was loaded earlier and not trigger another search

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Common/PackageCollection.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Common/PackageCollection.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -47,7 +49,7 @@ namespace NuGet.PackageManagement.VisualStudio
             // Group all package references for an id/version into a single item.
             var packages = packageReferences
                     .SelectMany(e => e)
-                    .GroupBy(e => e.PackageIdentity, (key, group) => new PackageCollectionItem(key.Id, key.Version, group))
+                    .GroupBy(e => e.Identity, (key, group) => new PackageCollectionItem(key.Id, key.Version, group))
                     .ToArray();
 
             return new PackageCollection(packages);

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Common/PackageCollectionItem.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Common/PackageCollectionItem.cs
@@ -1,11 +1,13 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#nullable enable
 
 using System.Collections.Generic;
 using System.Linq;
-using NuGet.Packaging;
 using NuGet.Packaging.Core;
 using NuGet.Versioning;
+using NuGet.VisualStudio.Internal.Contracts;
 
 namespace NuGet.PackageManagement.VisualStudio
 {
@@ -17,12 +19,12 @@ namespace NuGet.PackageManagement.VisualStudio
         /// <summary>
         /// Installed package references.
         /// </summary>
-        public List<PackageReference> PackageReferences { get; }
+        public List<IPackageReferenceContextInfo> PackageReferences { get; }
 
-        public PackageCollectionItem(string id, NuGetVersion version, IEnumerable<PackageReference> installedReferences)
+        public PackageCollectionItem(string id, NuGetVersion version, IEnumerable<IPackageReferenceContextInfo> installedReferences)
             : base(id, version)
         {
-            PackageReferences = installedReferences?.ToList() ?? new List<PackageReference>();
+            PackageReferences = installedReferences?.ToList() ?? new List<IPackageReferenceContextInfo>();
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Common/PackageCollectionItemExtensions.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Common/PackageCollectionItemExtensions.cs
@@ -1,8 +1,9 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+#nullable enable
+
 using System.Linq;
-using NuGet.ProjectManagement;
 
 namespace NuGet.PackageManagement.VisualStudio
 {
@@ -13,9 +14,7 @@ namespace NuGet.PackageManagement.VisualStudio
     {
         public static bool IsAutoReferenced(this PackageCollectionItem package)
         {
-            return package.PackageReferences
-                .Select(e => e as BuildIntegratedPackageReference)
-                .Any(e => e?.Dependency?.AutoReferenced == true);
+            return package.PackageReferences.Any(e => e.IsAutoReferenced);
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/PackageFeeds/UpdatePackageFeed.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/PackageFeeds/UpdatePackageFeed.cs
@@ -123,14 +123,14 @@ namespace NuGet.PackageManagement.VisualStudio
                 var installed = await project.GetInstalledPackagesAsync(cancellationToken);
                 foreach (var installedPackage in installed)
                 {
-                    var installedVersion = installedPackage.PackageIdentity.Version;
+                    var installedVersion = installedPackage.Identity.Version;
                     var allowedVersions = installedPackage.AllowedVersions ?? VersionRange.All;
 
                     // filter packages based on current package identity
                     var allPackages = prefetchedPackages
                         .Where(p => StringComparer.OrdinalIgnoreCase.Equals(
                             p.Identity.Id,
-                            installedPackage.PackageIdentity.Id))
+                            installedPackage.Identity.Id))
                         .ToArray();
 
                     // and allowed versions

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetProjectManagerService.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetProjectManagerService.cs
@@ -57,7 +57,7 @@ namespace NuGet.PackageManagement.VisualStudio
             return await ProjectContextInfo.CreateAsync(project, cancellationToken);
         }
 
-        public async ValueTask<IReadOnlyCollection<PackageReference>> GetInstalledPackagesAsync(IReadOnlyCollection<string> projectGuids, CancellationToken cancellationToken)
+        public async ValueTask<IReadOnlyCollection<IPackageReferenceContextInfo>> GetInstalledPackagesAsync(IReadOnlyCollection<string> projectGuids, CancellationToken cancellationToken)
         {
             var solutionManager = await ServiceLocator.GetInstanceAsync<IVsSolutionManager>();
             Assumes.NotNull(solutionManager);
@@ -70,7 +70,7 @@ namespace NuGet.PackageManagement.VisualStudio
             IEnumerable<Task<IEnumerable<PackageReference>>> tasks = projects.Select(project => project.GetInstalledPackagesAsync(cancellationToken));
             IEnumerable<PackageReference>[] packageReferences = await Task.WhenAll(tasks);
 
-            return packageReferences.SelectMany(e => e).ToArray();
+            return packageReferences.SelectMany(e => e).Select(pr => PackageReferenceContextInfo.Create(pr)).ToArray();
         }
 
         public async ValueTask<object> GetMetadataAsync(string projectGuid, string key, CancellationToken cancellationToken)

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/IPackageReferenceContextInfoFormatter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/IPackageReferenceContextInfoFormatter.cs
@@ -1,14 +1,14 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 #nullable enable
 
 using MessagePack;
+using MessagePack.Formatters;
 using Microsoft;
 using NuGet.Frameworks;
 using NuGet.Packaging.Core;
 using NuGet.Versioning;
-using MessagePack.Formatters;
 
 namespace NuGet.VisualStudio.Internal.Contracts
 {
@@ -67,7 +67,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
                             isDevelopmentDependency = reader.ReadBoolean();
                             break;
                         case AllowedVersionsPropertyName:
-                            if(!reader.TryReadNil()) // Advances beyond the current value if the current value is nil and returns true; otherwise leaves the reader's position unchanged and returns false.
+                            if (!reader.TryReadNil()) // Advances beyond the current value if the current value is nil and returns true; otherwise leaves the reader's position unchanged and returns false.
                             {
                                 allowedVersions = reader.ReadString();
                             }
@@ -88,7 +88,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
                     IsDevelopmentDependency = isDevelopmentDependency
                 };
 
-                if(!string.IsNullOrWhiteSpace(allowedVersions) && VersionRange.TryParse(allowedVersions, out VersionRange versionRange))
+                if (!string.IsNullOrWhiteSpace(allowedVersions) && VersionRange.TryParse(allowedVersions, out VersionRange versionRange))
                 {
                     packageReferenceContextInfo.AllowedVersions = versionRange;
                 }
@@ -122,13 +122,13 @@ namespace NuGet.VisualStudio.Internal.Contracts
             writer.Write(IsDevelopmentDependencyPropertyName);
             writer.Write(value.IsDevelopmentDependency);
             writer.Write(AllowedVersionsPropertyName);
-            if(value.AllowedVersions != null)
+            if (value.AllowedVersions == null)
             {
-                writer.Write(value.AllowedVersions.ToString());
+                writer.WriteNil();
             }
             else
             {
-                writer.WriteNil();
+                writer.Write(value.AllowedVersions.ToString());
             }
         }
     }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/IPackageReferenceContextInfoFormatter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/IPackageReferenceContextInfoFormatter.cs
@@ -1,0 +1,135 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#nullable enable
+
+using MessagePack;
+using Microsoft;
+using NuGet.Frameworks;
+using NuGet.Packaging.Core;
+using NuGet.Versioning;
+using MessagePack.Formatters;
+
+namespace NuGet.VisualStudio.Internal.Contracts
+{
+    internal class IPackageReferenceContextInfoFormatter : IMessagePackFormatter<IPackageReferenceContextInfo?>
+    {
+        private const string IdentityPropertyName = "identity";
+        private const string FrameworkPropertyName = "framework";
+        private const string IsUserInstalledPropertyName = "isuserinstalled";
+        private const string IsAutoReferencedPropertyName = "isautoreferenced";
+        private const string IsDevelopmentDependencyPropertyName = "isdevelopmentdependency";
+        private const string AllowedVersionsPropertyName = "allowedversions";
+
+        internal static readonly IMessagePackFormatter<IPackageReferenceContextInfo?> Instance = new IPackageReferenceContextInfoFormatter();
+
+        private IPackageReferenceContextInfoFormatter()
+        {
+        }
+
+        public IPackageReferenceContextInfo? Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
+        {
+            if (reader.TryReadNil())
+            {
+                return null;
+            }
+
+            // stack overflow mitigation - see https://github.com/neuecc/MessagePack-CSharp/security/advisories/GHSA-7q36-4xx7-xcxf
+            options.Security.DepthStep(ref reader);
+
+            try
+            {
+                PackageIdentity? identity = null;
+                NuGetFramework? framework = null;
+                bool isUserInstalled = false;
+                bool isAutoReferenced = false;
+                bool isDevelopmentDependency = false;
+                string? allowedVersions = null;
+
+                int propertyCount = reader.ReadMapHeader();
+                for (int propertyIndex = 0; propertyIndex < propertyCount; propertyIndex++)
+                {
+                    switch (reader.ReadString())
+                    {
+                        case IdentityPropertyName:
+                            identity = PackageIdentityFormatter.Instance.Deserialize(ref reader, options);
+                            break;
+                        case FrameworkPropertyName:
+                            framework = NuGetFrameworkFormatter.Instance.Deserialize(ref reader, options);
+                            break;
+                        case IsUserInstalledPropertyName:
+                            isUserInstalled = reader.ReadBoolean();
+                            break;
+                        case IsAutoReferencedPropertyName:
+                            isAutoReferenced = reader.ReadBoolean();
+                            break;
+                        case IsDevelopmentDependencyPropertyName:
+                            isDevelopmentDependency = reader.ReadBoolean();
+                            break;
+                        case AllowedVersionsPropertyName:
+                            if(!reader.TryReadNil()) // Advances beyond the current value if the current value is nil and returns true; otherwise leaves the reader's position unchanged and returns false.
+                            {
+                                allowedVersions = reader.ReadString();
+                            }
+                            break;
+                        default:
+                            reader.Skip();
+                            break;
+                    }
+                }
+
+                Assumes.NotNull(identity);
+                Assumes.NotNull(framework);
+
+                var packageReferenceContextInfo = new PackageReferenceContextInfo(identity, framework)
+                {
+                    IsUserInstalled = isUserInstalled,
+                    IsAutoReferenced = isAutoReferenced,
+                    IsDevelopmentDependency = isDevelopmentDependency
+                };
+
+                if(!string.IsNullOrWhiteSpace(allowedVersions) && VersionRange.TryParse(allowedVersions, out VersionRange versionRange))
+                {
+                    packageReferenceContextInfo.AllowedVersions = versionRange;
+                }
+
+                return packageReferenceContextInfo;
+            }
+            finally
+            {
+                // stack overflow mitigation - see https://github.com/neuecc/MessagePack-CSharp/security/advisories/GHSA-7q36-4xx7-xcxf
+                reader.Depth--;
+            }
+        }
+
+        public void Serialize(ref MessagePackWriter writer, IPackageReferenceContextInfo? value, MessagePackSerializerOptions options)
+        {
+            if (value == null)
+            {
+                writer.WriteNil();
+                return;
+            }
+
+            writer.WriteMapHeader(count: 6);
+            writer.Write(IdentityPropertyName);
+            PackageIdentityFormatter.Instance.Serialize(ref writer, value.Identity, options);
+            writer.Write(FrameworkPropertyName);
+            NuGetFrameworkFormatter.Instance.Serialize(ref writer, value.Framework, options);
+            writer.Write(IsUserInstalledPropertyName);
+            writer.Write(value.IsUserInstalled);
+            writer.Write(IsAutoReferencedPropertyName);
+            writer.Write(value.IsAutoReferenced);
+            writer.Write(IsDevelopmentDependencyPropertyName);
+            writer.Write(value.IsDevelopmentDependency);
+            writer.Write(AllowedVersionsPropertyName);
+            if(value.AllowedVersions != null)
+            {
+                writer.Write(value.AllowedVersions.ToString());
+            }
+            else
+            {
+                writer.WriteNil();
+            }
+        }
+    }
+}

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/INuGetProjectManagerService.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/INuGetProjectManagerService.cs
@@ -13,7 +13,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
 {
     public interface INuGetProjectManagerService : IDisposable
     {
-        ValueTask<IReadOnlyCollection<PackageReference>> GetInstalledPackagesAsync(IReadOnlyCollection<string> projectGuids, CancellationToken cancellationToken);
+        ValueTask<IReadOnlyCollection<IPackageReferenceContextInfo>> GetInstalledPackagesAsync(IReadOnlyCollection<string> projectGuids, CancellationToken cancellationToken);
         ValueTask<object> GetMetadataAsync(string projectGuid, string key, CancellationToken cancellationToken);
         ValueTask<(bool, object)> TryGetMetadataAsync(string projectGuid, string key, CancellationToken cancellationToken);
         ValueTask<IProjectContextInfo> GetProjectAsync(string projectGuid, CancellationToken cancellationToken);

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/IPackageReferenceContextInfo.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/IPackageReferenceContextInfo.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#nullable enable
+
+using NuGet.Frameworks;
+using NuGet.Packaging.Core;
+using NuGet.Versioning;
+
+namespace NuGet.VisualStudio.Internal.Contracts
+{
+    public interface IPackageReferenceContextInfo
+    {
+        PackageIdentity Identity { get; }
+        NuGetFramework Framework { get; }
+        VersionRange? AllowedVersions { get; }
+        bool IsAutoReferenced { get; }
+        bool IsUserInstalled { get; }
+        bool IsDevelopmentDependency { get; }
+    }
+}

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/IProjectContextInfo.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/IProjectContextInfo.cs
@@ -6,7 +6,6 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using NuGet.Packaging;
 using NuGet.ProjectModel;
 
 namespace NuGet.VisualStudio.Internal.Contracts
@@ -20,7 +19,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
         ProjectStyle ProjectStyle { get; }
         NuGetProjectKind ProjectKind { get; }
         ValueTask<bool> IsUpgradeableAsync(CancellationToken cancellationToken);
-        Task<IEnumerable<PackageReference>> GetInstalledPackagesAsync(CancellationToken cancellationToken);
+        Task<IEnumerable<IPackageReferenceContextInfo>> GetInstalledPackagesAsync(CancellationToken cancellationToken);
         ValueTask<(bool, T)> TryGetMetadataAsync<T>(string key, CancellationToken cancellationToken);
         ValueTask<T> GetMetadataAsync<T>(string key, CancellationToken cancellationToken);
         ValueTask<string> GetUniqueNameOrNameAsync(CancellationToken cancellationToken);

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/NuGetServiceMessagePackRpcDescriptor.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/NuGetServiceMessagePackRpcDescriptor.cs
@@ -27,7 +27,8 @@ namespace NuGet.VisualStudio.Internal.Contracts
                 PackageIdentityFormatter.Instance,
                 PackageReferenceFormatter.Instance,
                 NuGetFrameworkFormatter.Instance,
-                IProjectContextInfoFormatter.Instance
+                IProjectContextInfoFormatter.Instance,
+                IPackageReferenceContextInfoFormatter.Instance
             };
             var resolvers = new IFormatterResolver[] { MessagePackSerializerOptions.Standard.Resolver };
 

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/PackageReferenceContextInfo.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/PackageReferenceContextInfo.cs
@@ -46,7 +46,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
         public PackageIdentity Identity { get; internal set; }
         public NuGetFramework Framework { get; internal set; }
         public VersionRange? AllowedVersions { get; internal set; }
-        public bool IsAutoReferenced { get; internal set; } // Property is determined by (packageReference as BuildIntegratedPackageReference)?.Dependency?.AutoReferenced
+        public bool IsAutoReferenced { get; internal set; }
         public bool IsUserInstalled { get; internal set; }
         public bool IsDevelopmentDependency { get; internal set; }
     }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/PackageReferenceContextInfo.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/PackageReferenceContextInfo.cs
@@ -1,0 +1,53 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#nullable enable
+
+using Microsoft;
+using NuGet.Frameworks;
+using NuGet.Packaging;
+using NuGet.Packaging.Core;
+using NuGet.ProjectManagement;
+using NuGet.Versioning;
+
+namespace NuGet.VisualStudio.Internal.Contracts
+{
+    public sealed class PackageReferenceContextInfo : IPackageReferenceContextInfo
+    {
+        public PackageReferenceContextInfo(PackageIdentity identity, NuGetFramework framework)
+        {
+            Assumes.NotNull(identity);
+            Assumes.NotNull(framework);
+
+            Identity = identity;
+            Framework = framework;
+        }
+
+        public static PackageReferenceContextInfo Create(PackageIdentity identity, NuGetFramework framework)
+        {
+            return new PackageReferenceContextInfo(identity, framework);
+        }
+
+        public static PackageReferenceContextInfo Create(PackageReference packageReference)
+        {
+            Assumes.NotNull(packageReference);
+
+            var packageReferenceContextInfo = new PackageReferenceContextInfo(packageReference.PackageIdentity, packageReference.TargetFramework)
+            {
+                IsAutoReferenced = (packageReference as BuildIntegratedPackageReference)?.Dependency?.AutoReferenced == true,
+                AllowedVersions = packageReference.AllowedVersions,
+                IsUserInstalled = packageReference.IsUserInstalled,
+                IsDevelopmentDependency = packageReference.IsDevelopmentDependency
+            };
+
+            return packageReferenceContextInfo;
+        }
+
+        public PackageIdentity Identity { get; internal set; }
+        public NuGetFramework Framework { get; internal set; }
+        public VersionRange? AllowedVersions { get; internal set; }
+        public bool IsAutoReferenced { get; internal set; } // Property is determined by (packageReference as BuildIntegratedPackageReference)?.Dependency?.AutoReferenced
+        public bool IsUserInstalled { get; internal set; }
+        public bool IsDevelopmentDependency { get; internal set; }
+    }
+}

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/ProjectContextInfo.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/ProjectContextInfo.cs
@@ -11,7 +11,6 @@ using Microsoft;
 using Microsoft.ServiceHub.Framework;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.ServiceBroker;
-using NuGet.Packaging;
 using NuGet.ProjectManagement;
 using NuGet.ProjectManagement.Projects;
 using NuGet.ProjectModel;
@@ -44,7 +43,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
             }
         }
 
-        public async Task<IEnumerable<PackageReference>> GetInstalledPackagesAsync(CancellationToken cancellationToken)
+        public async Task<IEnumerable<IPackageReferenceContextInfo>> GetInstalledPackagesAsync(CancellationToken cancellationToken)
         {
             IServiceBroker remoteBroker = await GetRemoteServiceBrokerAsync();
             using (var nugetProjectManagerService = await remoteBroker.GetProxyAsync<INuGetProjectManagerService>(NuGetServices.ProjectManagerService, cancellationToken: cancellationToken))
@@ -118,10 +117,11 @@ namespace NuGet.VisualStudio.Internal.Contracts
 
         internal static NuGetProjectKind GetProjectKind(NuGetProject nugetProject)
         {
+            // Order matters
             NuGetProjectKind projectKind = NuGetProjectKind.Unknown;
-            if (nugetProject is INuGetIntegratedProject)
+            if (nugetProject is BuildIntegratedNuGetProject)
             {
-                projectKind = NuGetProjectKind.Classic;
+                projectKind = NuGetProjectKind.BuildIntegrated;
             }
             else if (nugetProject is ProjectKNuGetProjectBase)
             {
@@ -131,9 +131,9 @@ namespace NuGet.VisualStudio.Internal.Contracts
             {
                 projectKind = NuGetProjectKind.MSBuild;
             }
-            else if (nugetProject is BuildIntegratedNuGetProject)
+            else if (nugetProject is INuGetIntegratedProject)
             {
-                projectKind = NuGetProjectKind.BuildIntegrated;
+                projectKind = NuGetProjectKind.Classic;
             }
 
             return projectKind;

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Feeds/UpdatePackageFeedTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Feeds/UpdatePackageFeedTests.cs
@@ -259,19 +259,20 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
             var installedPackages = new[]
             {
-                new PackageReference(
-                    packageIdentity,
-                    NuGetFramework.Parse("net45"),
-                    userInstalled: true,
-                    developmentDependency: false,
-                    requireReinstallation: false,
-                    allowedVersions: allowedVersions != null ? VersionRange.Parse(allowedVersions) : null)
+                PackageReferenceContextInfo.Create(
+                    new PackageReference(
+                        packageIdentity,
+                        NuGetFramework.Parse("net45"),
+                        userInstalled: true,
+                        developmentDependency: false,
+                        requireReinstallation: false,
+                        allowedVersions: allowedVersions != null ? VersionRange.Parse(allowedVersions) : null))
             };
 
             var project = Mock.Of<IProjectContextInfo>();
             Mock.Get(project)
                 .Setup(x => x.GetInstalledPackagesAsync(It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult<IEnumerable<PackageReference>>(installedPackages));
+                .Returns(Task.FromResult<IEnumerable<IPackageReferenceContextInfo>>(installedPackages));
             return project;
         }
 


### PR DESCRIPTION
## Bug

Fixes: https://github.com/nuget/home/issues/9907
Regression: No  

## Fix

Details: Create a new type that is serializable and we can map to a PackageRef on the server side 

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  Covered by existing tests
