### PR TITLE
Codespaces -  fix toolwindow api usage....start using findtoolwindowex, use correct values in createtoolwindow

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/PackageManagerToolWindowPane.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/PackageManagerToolWindowPane.cs
@@ -14,7 +14,6 @@ namespace NuGet.PackageManagement.UI
     public class PackageManagerToolWindowPane : ToolWindowPane, IVsWindowFrameNotify3
     {
         private PackageManagerControl _content;
-        private string _projectGuid;
 
         /// <summary>
         /// Initializes a new instance of the EditorPane class.
@@ -23,7 +22,7 @@ namespace NuGet.PackageManagement.UI
             : base(null)
         {
             _content = control;
-            _projectGuid = projectGuid;
+            ProjectGuid = projectGuid;
         }
 
         public PackageManagerModel Model
@@ -41,10 +40,7 @@ namespace NuGet.PackageManagement.UI
             get { return _content; }
         }
 
-        public string ProjectGuid
-        {
-            get { return _projectGuid; }
-        }
+        public string ProjectGuid { get; }
 
         private void CleanUp()
         {
@@ -84,7 +80,7 @@ namespace NuGet.PackageManagement.UI
 
             _content?.Model.Context.UserSettingsManager.PersistSettings();
 
-            Closed?.Invoke(this, new EventArgs());
+            Closed?.Invoke(this, EventArgs.Empty);
 
             pgrfSaveOptions = (uint)__FRAMECLOSE.FRAMECLOSE_NoSave;
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/PackageManagerToolWindowPane.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/PackageManagerToolWindowPane.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell;
@@ -13,14 +14,17 @@ namespace NuGet.PackageManagement.UI
     public class PackageManagerToolWindowPane : ToolWindowPane, IVsWindowFrameNotify3
     {
         private PackageManagerControl _content;
+        private string _projectGuid;
+        public event EventHandler<EventArgs> Closed;
 
         /// <summary>
         /// Initializes a new instance of the EditorPane class.
         /// </summary>
-        public PackageManagerToolWindowPane(PackageManagerControl control)
+        public PackageManagerToolWindowPane(PackageManagerControl control, string projectGuid)
             : base(null)
         {
             _content = control;
+            _projectGuid = projectGuid;
         }
 
         public PackageManagerModel Model
@@ -36,6 +40,11 @@ namespace NuGet.PackageManagement.UI
         public override object Content
         {
             get { return _content; }
+        }
+
+        public string ProjectGuid
+        {
+            get { return _projectGuid; }
         }
 
         private void CleanUp()
@@ -73,6 +82,8 @@ namespace NuGet.PackageManagement.UI
             });
 
             _content?.Model.Context.UserSettingsManager.PersistSettings();
+
+            Closed?.Invoke(this, new EventArgs());
 
             pgrfSaveOptions = (uint)__FRAMECLOSE.FRAMECLOSE_NoSave;
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/PackageManagerToolWindowPane.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/PackageManagerToolWindowPane.cs
@@ -15,7 +15,6 @@ namespace NuGet.PackageManagement.UI
     {
         private PackageManagerControl _content;
         private string _projectGuid;
-        public event EventHandler<EventArgs> Closed;
 
         /// <summary>
         /// Initializes a new instance of the EditorPane class.
@@ -73,6 +72,8 @@ namespace NuGet.PackageManagement.UI
                 base.Dispose(disposing);
             }
         }
+
+        public event EventHandler<EventArgs> Closed;
 
         public int OnClose(ref uint pgrfSaveOptions)
         {

--- a/src/NuGet.Clients/NuGet.VisualStudio.OnlineEnvironment.Client/NuGetClientPackage.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.OnlineEnvironment.Client/NuGetClientPackage.cs
@@ -2,6 +2,7 @@ using System;
 using System.Runtime.InteropServices;
 using System.Threading;
 using Microsoft.VisualStudio.Shell;
+using NuGet.PackageManagement.UI;
 using Task = System.Threading.Tasks.Task;
 
 namespace NuGet.VisualStudio.OnlineEnvironment.Client
@@ -26,6 +27,10 @@ namespace NuGet.VisualStudio.OnlineEnvironment.Client
     [PackageRegistration(UseManagedResourcesOnly = true, AllowsBackgroundLoading = true)]
     [Guid(PackageGuidString)]
     [ProvideMenuResource("Menus.ctmenu", 1)]
+    [ProvideToolWindow(typeof(PackageManagerToolWindowPane),
+        Style = VsDockStyle.MDI,
+        MultiInstances = true,
+        DocumentLikeTool = true)]
     public sealed class NuGetClientPackage : AsyncPackage
     {
         /// <summary>

--- a/src/NuGet.Clients/NuGet.VisualStudio.OnlineEnvironment.Client/SolutionExplorer/PackageManagerUICommandHandler.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.OnlineEnvironment.Client/SolutionExplorer/PackageManagerUICommandHandler.cs
@@ -261,12 +261,14 @@ namespace NuGet.VisualStudio.OnlineEnvironment.Client
 
             if (foundToolWindowId)
             {
-                uiShell.FindToolWindowEx(
-                    FTW_none, //grfFTW - badly-documented enum value.
-                    typeof(PackageManagerToolWindowPane).GUID,    // rguidPersistenceSlot
-                    toolWindowId,   // dwToolWindowId
-                    out windowFrame);
-                ((IVsWindowFrame2)windowFrame).ActivateOwnerDockedWindow();
+                ErrorHandler.ThrowOnFailure(
+                    uiShell.FindToolWindowEx(
+                        FTW_none, //grfFTW - badly-documented enum value.
+                        typeof(PackageManagerToolWindowPane).GUID,    // rguidPersistenceSlot
+                        toolWindowId,   // dwToolWindowId
+                        out windowFrame));
+
+                ((IVsWindowFrame2)windowFrame)?.ActivateOwnerDockedWindow();
             }
 
             if (windowFrame == null)

--- a/src/NuGet.Clients/NuGet.VisualStudio.OnlineEnvironment.Client/SolutionExplorer/PackageManagerUICommandHandler.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.OnlineEnvironment.Client/SolutionExplorer/PackageManagerUICommandHandler.cs
@@ -268,7 +268,14 @@ namespace NuGet.VisualStudio.OnlineEnvironment.Client
                         toolWindowId,   // dwToolWindowId
                         out windowFrame));
 
-                ((IVsWindowFrame2)windowFrame)?.ActivateOwnerDockedWindow();
+                if (windowFrame != null)
+                {
+                    ((IVsWindowFrame2)windowFrame).ActivateOwnerDockedWindow();
+                }
+                else
+                {
+                    _projectGuidToToolWindowId.Remove(projectGuid.ToString());
+                }
             }
 
             if (windowFrame == null)

--- a/src/NuGet.Clients/NuGet.VisualStudio.OnlineEnvironment.Client/SolutionExplorer/PackageManagerUICommandHandler.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.OnlineEnvironment.Client/SolutionExplorer/PackageManagerUICommandHandler.cs
@@ -257,11 +257,12 @@ namespace NuGet.VisualStudio.OnlineEnvironment.Client
 
             uint toolWindowId;
             bool foundToolWindowId = _projectGuidToToolWindowId.TryGetValue(projectGuid.ToString(), out toolWindowId);
+            const uint FTW_none = 0;
 
             if (foundToolWindowId)
             {
                 uiShell.FindToolWindowEx(
-                    (uint)__VSFINDTOOLWIN.FTW_fFindFirst,
+                    FTW_none, //grfFTW - non-documented enum value I learned from API owner.
                     typeof(PackageManagerToolWindowPane).GUID,    // rguidPersistenceSlot
                     toolWindowId,   // dwToolWindowId
                     out windowFrame);

--- a/src/NuGet.Clients/NuGet.VisualStudio.OnlineEnvironment.Client/SolutionExplorer/PackageManagerUICommandHandler.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.OnlineEnvironment.Client/SolutionExplorer/PackageManagerUICommandHandler.cs
@@ -271,8 +271,8 @@ namespace NuGet.VisualStudio.OnlineEnvironment.Client
 
             if (windowFrame == null)
             {
-                var projectContextInfo = await ProjectContextInfo.CreateAsync(projectGuid.ToString(), CancellationToken.None);
-                var uiController = UIFactory.Value.Create(projectContextInfo);
+                IProjectContextInfo projectContextInfo = await ProjectContextInfo.CreateAsync(projectGuid.ToString(), CancellationToken.None);
+                INuGetUI uiController = UIFactory.Value.Create(projectContextInfo);
                 var model = new PackageManagerModel(uiController, isSolution: false, editorFactoryGuid: GuidList.NuGetEditorType);
                 var control = await PackageManagerControl.CreateAsync(model, OutputConsoleLogger.Value);
                 var caption = string.Format(CultureInfo.CurrentCulture, Resx.Label_NuGetWindowCaption, Path.GetFileNameWithoutExtension(workspaceVisualNodeBase.NodeMoniker));

--- a/src/NuGet.Clients/NuGet.VisualStudio.OnlineEnvironment.Client/SolutionExplorer/PackageManagerUICommandHandler.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.OnlineEnvironment.Client/SolutionExplorer/PackageManagerUICommandHandler.cs
@@ -265,7 +265,7 @@ namespace NuGet.VisualStudio.OnlineEnvironment.Client
                     0,              // dwToolWindowId - singleInstance = 0
                     windowPane,     // ToolWindowPane
                     Guid.Empty,     // rclsidTool = GUID_NULL
-                    projectGuid,
+                    Guid.NewGuid(), // rguidPersistenceSlot
                     Guid.Empty,     // reserved - do not use - GUID_NULL
                     null,           // IServiceProvider
                     caption,

--- a/src/NuGet.Clients/NuGet.VisualStudio.OnlineEnvironment.Client/SolutionExplorer/PackageManagerUICommandHandler.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.OnlineEnvironment.Client/SolutionExplorer/PackageManagerUICommandHandler.cs
@@ -262,7 +262,7 @@ namespace NuGet.VisualStudio.OnlineEnvironment.Client
             if (foundToolWindowId)
             {
                 uiShell.FindToolWindowEx(
-                    FTW_none, //grfFTW - non-documented enum value I learned from API owner.
+                    FTW_none, //grfFTW - badly-documented enum value.
                     typeof(PackageManagerToolWindowPane).GUID,    // rguidPersistenceSlot
                     toolWindowId,   // dwToolWindowId
                     out windowFrame);

--- a/src/NuGet.Clients/NuGet.VisualStudio.OnlineEnvironment.Client/SolutionExplorer/PackageManagerUICommandHandler.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.OnlineEnvironment.Client/SolutionExplorer/PackageManagerUICommandHandler.cs
@@ -46,6 +46,8 @@ namespace NuGet.VisualStudio.OnlineEnvironment.Client
         private uint _solutionExistsAndFullyLoadedContextCookie;
         private uint _solutionNotBuildingAndNotDebuggingContextCookie;
         private uint _solutionExistsCookie;
+        private uint _maxToolWindowId = 0;
+        private Dictionary<string, uint> _projectGuidToToolWindowId;
 
         private bool _initialized;
 
@@ -117,6 +119,7 @@ namespace NuGet.VisualStudio.OnlineEnvironment.Client
                     return vsMonitorSelection;
                 },
                 ThreadHelper.JoinableTaskFactory);
+            _projectGuidToToolWindowId = new Dictionary<string, uint>();
         }
 
         public bool IsPackageManagerUISupported(WorkspaceVisualNodeBase workspaceVisualNodeBase)
@@ -247,39 +250,66 @@ namespace NuGet.VisualStudio.OnlineEnvironment.Client
                 throw new InvalidOperationException();
             }
 
-            var projectContextInfo = await ProjectContextInfo.CreateAsync(projectGuid.ToString(), CancellationToken.None);
-            var uiController = UIFactory.Value.Create(projectContextInfo);
-            var model = new PackageManagerModel(uiController, isSolution: false, editorFactoryGuid: GuidList.NuGetEditorType);
-            var control = await PackageManagerControl.CreateAsync(model, OutputConsoleLogger.Value);
-            var caption = string.Format(CultureInfo.CurrentCulture, Resx.Label_NuGetWindowCaption, Path.GetFileNameWithoutExtension(workspaceVisualNodeBase.NodeMoniker));
+            IVsWindowFrame windowFrame = null;
 
             var uiShell = await _asyncServiceProvider.GetServiceAsync(typeof(SVsUIShell)) as IVsUIShell;
             Assumes.Present(uiShell);
 
-            int[] pfDefaultPosition = null;
-            IVsWindowFrame windowFrame;
-            var windowPane = new PackageManagerToolWindowPane(control);
-            ErrorHandler.ThrowOnFailure(
-                uiShell.CreateToolWindow(
-                    (uint)__VSCREATETOOLWIN.CTW_fInitNew,
-                    0,              // dwToolWindowId - singleInstance = 0
-                    windowPane,     // ToolWindowPane
-                    Guid.Empty,     // rclsidTool = GUID_NULL
-                    Guid.NewGuid(), // rguidPersistenceSlot
-                    Guid.Empty,     // reserved - do not use - GUID_NULL
-                    null,           // IServiceProvider
-                    caption,
-                    pfDefaultPosition,
-                    out windowFrame));
+            uint toolWindowId;
+            bool foundToolWindowId = _projectGuidToToolWindowId.TryGetValue(projectGuid.ToString(), out toolWindowId);
 
-            if (windowFrame != null)
+            if (foundToolWindowId)
             {
-                WindowFrameHelper.AddF1HelpKeyword(windowFrame, keywordValue: F1KeywordValuePmUI);
-                WindowFrameHelper.DisableWindowAutoReopen(windowFrame);
-                WindowFrameHelper.DockToolWindow(windowFrame);
+                uiShell.FindToolWindowEx(
+                    (uint)__VSFINDTOOLWIN.FTW_fFindFirst,
+                    typeof(PackageManagerToolWindowPane).GUID,    // rguidPersistenceSlot
+                    toolWindowId,   // dwToolWindowId
+                    out windowFrame);
+                ((IVsWindowFrame2)windowFrame).ActivateOwnerDockedWindow();
+            }
+
+            if (windowFrame == null)
+            {
+                var projectContextInfo = await ProjectContextInfo.CreateAsync(projectGuid.ToString(), CancellationToken.None);
+                var uiController = UIFactory.Value.Create(projectContextInfo);
+                var model = new PackageManagerModel(uiController, isSolution: false, editorFactoryGuid: GuidList.NuGetEditorType);
+                var control = await PackageManagerControl.CreateAsync(model, OutputConsoleLogger.Value);
+                var caption = string.Format(CultureInfo.CurrentCulture, Resx.Label_NuGetWindowCaption, Path.GetFileNameWithoutExtension(workspaceVisualNodeBase.NodeMoniker));
+
+                int[] pfDefaultPosition = null;
+
+                var windowPane = new PackageManagerToolWindowPane(control, projectGuid.ToString());
+                ErrorHandler.ThrowOnFailure(
+                    uiShell.CreateToolWindow(
+                        (uint)__VSCREATETOOLWIN.CTW_fInitNew,
+                        ++_maxToolWindowId,    // dwToolWindowId
+                        windowPane,     // ToolWindowPane
+                        Guid.Empty,     // rclsidTool = GUID_NULL
+                        typeof(PackageManagerToolWindowPane).GUID,    // rguidPersistenceSlot
+                        Guid.Empty,     // reserved - do not use - GUID_NULL
+                        null,           // IServiceProvider
+                        caption,
+                        pfDefaultPosition,
+                        out windowFrame));
+                _projectGuidToToolWindowId.Add(projectGuid.ToString(), _maxToolWindowId);
+                windowPane.Closed += WindowPane_Closed;
+
+                if (windowFrame != null)
+                {
+                    WindowFrameHelper.AddF1HelpKeyword(windowFrame, keywordValue: F1KeywordValuePmUI);
+                    WindowFrameHelper.DisableWindowAutoReopen(windowFrame);
+                    WindowFrameHelper.DockToolWindow(windowFrame);
+                }
             }
 
             return windowFrame;
+        }
+
+        private void WindowPane_Closed(object sender, EventArgs e)
+        {
+            var windowPane = (PackageManagerToolWindowPane)sender;
+            _projectGuidToToolWindowId.Remove(windowPane.ProjectGuid);
+            windowPane.Closed -= WindowPane_Closed;
         }
 
         private async Task<IVsWindowFrame> FindExistingSolutionWindowFrameAsync()


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9905
Regression: No
* Last working version:   never working in codespaces code base.

## Fix

Details: fix toolwindow api usage....start using findtoolwindowex, use correct values in createtoolwindow

Also, treats the windowing behavior of these toolwindows closer to documentwindows.
We don't use DocumentWindows in the codespaces codepath because we can't get a VSUIHierarchy, which is necessary.

## Testing/Validation

Tests Added: No
Reason for not adding tests: manual tests will cover. 
Validation:  manual, and asking experts on vs team.
