### PR TITLE
Add allowPrerelease to global.json

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,5 +1,7 @@
 {
   "sdk": {
-    "version": "5.0.100-preview"
+    "version": "5.0.100-preview",
+    "allowPrerelease": true,
+    "rollForward": "major"
   }
 }


### PR DESCRIPTION
Since 5.0.100-preview SDK is preview, we need allowPrerelease. Also adding rollForward while I'm here to allow using of newer SDKs without updating this file every time.