### PR TITLE
`build.ps1 -internal` will enable a private feed to work with daily b…

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
     <clear />
@@ -10,9 +10,12 @@
     <add key="vside" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl/nuget/v3/index.json" />
     <add key="dotnet-msbuild" value="https://dotnet.myget.org/F/msbuild/api/v3/index.json" />
     <add key="vssdk" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vssdk/nuget/v3/index.json" />
+    <!-- disabled by default, as this feed authenticates - and is needed for pre-release net5.0 packages to stay in sync with daily VS builds. -->
+    <add key="dotnet5-internal" value="https://dnceng.pkgs.visualstudio.com/internal/_packaging/dotnet5-internal/nuget/v3/index.json" />
   </packageSources>
   <disabledPackageSources>
     <clear />
+    <add key="dotnet5-internal" value="true" />
   </disabledPackageSources>
   <fallbackPackageFolders>
     <clear />

--- a/build.ps1
+++ b/build.ps1
@@ -56,7 +56,7 @@ param (
     [switch]$PackageEndToEnd,
     [switch]$SkipDelaySigning,
     [switch]$Binlog,
-    [switch]$internal
+    [switch]$Internal
 )
 
 . "$PSScriptRoot\build\common.ps1"

--- a/build.ps1
+++ b/build.ps1
@@ -110,6 +110,9 @@ else {
 Invoke-BuildStep 'Running Restore' {
 
     # Restore
+    Trace-Log ". dotnet nuget disable source dotnet5-internal"
+    & dotnet nuget disable source dotnet5-internal
+
     if ($Internal)
     {
         Trace-Log ". dotnet nuget enable source dotnet5-internal"


### PR DESCRIPTION
…uilds of net5.0 inserted into VS

## Bug

Fixes: https://github.com/NuGet/Client.Engineering/issues/490
Regression: yes

## Fix

Details: run `build.ps1 -internal` to enable the right package source from nuget.config (auth required...so only works internally)

## Testing/Validation

Tests Added: No
Reason for not adding tests: dev machine build script 
Validation:  tested locally.
