### PR TITLE
ignore case when populating solution explorer dependencies tree

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Properties/AssemblyInfo.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Properties/AssemblyInfo.cs
@@ -1,0 +1,10 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Runtime.CompilerServices;
+
+#if SIGNED_BUILD
+[assembly: InternalsVisibleTo("NuGet.VisualStudio.Implementation.Test, PublicKey=002400000480000094000000060200000024000052534131000400000100010007d1fa57c4aed9f0a32e84aa0faefd0de9e8fd6aec8f87fb03766c834c99921eb23be79ad9d5dcc1dd9ad236132102900b723cf980957fc4e177108fc607774f29e8320e92ea05ece4e821c0a5efe8f1645c4c0c93c1ab99285d622caa652c1dfad63d745d6f2de5f17e5eaf0fc4963d261c8a12436518206dc093344d5ad293")]
+#else
+[assembly: InternalsVisibleTo("NuGet.VisualStudio.Implementation.Test")]
+#endif

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/Models/AssetsFileDependenciesSnapshot.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/Models/AssetsFileDependenciesSnapshot.cs
@@ -139,7 +139,7 @@ namespace NuGet.VisualStudio.SolutionExplorer.Models
 
             static ImmutableDictionary<string, AssetsFileTargetLibrary> ParseLibraries(LockFileTarget lockFileTarget)
             {
-                ImmutableDictionary<string, AssetsFileTargetLibrary>.Builder builder = ImmutableDictionary.CreateBuilder<string, AssetsFileTargetLibrary>(StringComparer.Ordinal);
+                ImmutableDictionary<string, AssetsFileTargetLibrary>.Builder builder = ImmutableDictionary.CreateBuilder<string, AssetsFileTargetLibrary>(StringComparer.OrdinalIgnoreCase);
 
                 foreach (LockFileTargetLibrary lockFileLibrary in lockFileTarget.Libraries)
                 {

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/Models/AssetsFileDependenciesSnapshot.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/Models/AssetsFileDependenciesSnapshot.cs
@@ -136,21 +136,21 @@ namespace NuGet.VisualStudio.SolutionExplorer.Models
 
                 return builder.ToImmutable();
             }
+        }
 
-            static ImmutableDictionary<string, AssetsFileTargetLibrary> ParseLibraries(LockFileTarget lockFileTarget)
+        internal static ImmutableDictionary<string, AssetsFileTargetLibrary> ParseLibraries(LockFileTarget lockFileTarget)
+        {
+            ImmutableDictionary<string, AssetsFileTargetLibrary>.Builder builder = ImmutableDictionary.CreateBuilder<string, AssetsFileTargetLibrary>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (LockFileTargetLibrary lockFileLibrary in lockFileTarget.Libraries)
             {
-                ImmutableDictionary<string, AssetsFileTargetLibrary>.Builder builder = ImmutableDictionary.CreateBuilder<string, AssetsFileTargetLibrary>(StringComparer.OrdinalIgnoreCase);
-
-                foreach (LockFileTargetLibrary lockFileLibrary in lockFileTarget.Libraries)
+                if (AssetsFileTargetLibrary.TryCreate(lockFileLibrary, out AssetsFileTargetLibrary? library))
                 {
-                    if (AssetsFileTargetLibrary.TryCreate(lockFileLibrary, out AssetsFileTargetLibrary? library))
-                    {
-                        builder.Add(library.Name, library);
-                    }
+                    builder.Add(library.Name, library);
                 }
-
-                return builder.ToImmutable();
             }
+
+            return builder.ToImmutable();
         }
 
         public bool TryGetTarget(string? target, [NotNullWhen(returnValue: true)] out AssetsFileTarget? targetData)

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/NuGet.VisualStudio.Implementation.Test.csproj
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/NuGet.VisualStudio.Implementation.Test.csproj
@@ -57,6 +57,6 @@
     <PackageReference Include="Microsoft.ServiceHub.Framework" />
 </ItemGroup>
 
-  <Import Project="$(BuildCommonDirectory)common.targets"/>
+  <Import Project="$(BuildCommonDirectory)common.targets" />
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 </Project>

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/NuGet.VisualStudio.Implementation.Test.csproj
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/NuGet.VisualStudio.Implementation.Test.csproj
@@ -57,6 +57,6 @@
     <PackageReference Include="Microsoft.ServiceHub.Framework" />
 </ItemGroup>
 
-  <Import Project="$(BuildCommonDirectory)common.targets" />
+  <Import Project="$(BuildCommonDirectory)common.targets"/>
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 </Project>

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/SolutionExplorer/Models/AssetsFileDependenciesSnapshotTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/SolutionExplorer/Models/AssetsFileDependenciesSnapshotTests.cs
@@ -7,7 +7,7 @@ using NuGet.ProjectModel;
 using NuGet.VisualStudio.SolutionExplorer.Models;
 using Xunit;
 
-namespace NuGet.VisualStudio.Implementation.Test
+namespace NuGet.VisualStudio.Implementation.Test.SolutionExplorer.Models
 {
    public class AssetsFileDependenciesSnapshotTests
     {

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/SolutionExplorer/Models/AssetsFileDependenciesSnapshotTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/SolutionExplorer/Models/AssetsFileDependenciesSnapshotTests.cs
@@ -1,15 +1,11 @@
-using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using NuGet.ProjectModel;
 using NuGet.VisualStudio.SolutionExplorer.Models;
 using Xunit;
 
 namespace NuGet.VisualStudio.Implementation.Test.SolutionExplorer.Models
 {
-   public class AssetsFileDependenciesSnapshotTests
+    public class AssetsFileDependenciesSnapshotTests
     {
         [Fact]
         public void ParseLibraries_IgnoreCaseInDependenciesTree_Succeeds()

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/SolutionExplorer/Models/AssetsFileDependenciesSnapshotTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/SolutionExplorer/Models/AssetsFileDependenciesSnapshotTests.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NuGet.ProjectModel;
+using NuGet.VisualStudio.SolutionExplorer.Models;
+using Xunit;
+
+namespace NuGet.VisualStudio.Implementation.Test
+{
+   public class AssetsFileDependenciesSnapshotTests
+    {
+        [Fact]
+        public void ParseLibraries_IgnoreCaseInDependenciesTree_Succeeds()
+        {
+            // Arrange
+            var lockFileContent = @"{
+  ""version"": 3,
+  ""targets"": {
+    ""net5.0"": {
+      ""System.Runtime/4.0.20-beta-22927"": {
+        ""type"": ""package"",
+        ""dependencies"": {
+          ""Frob"": ""4.0.20""
+        },
+        ""compile"": {
+          ""ref/dotnet/System.Runtime.dll"": {}
+        }
+      }
+    }
+  },
+  ""libraries"": {
+    ""System.Runtime/4.0.20-beta-22927"": {
+      ""sha512"": ""sup3rs3cur3"",
+      ""type"": ""package"",
+      ""files"": [
+        ""System.Runtime.nuspec""
+      ]
+    }
+  },
+  ""projectFileDependencyGroups"": {
+    """": [
+      ""System.Runtime [4.0.10-beta-*, )""
+    ],
+    ""net5.0"": []
+  },
+  ""logs"": [
+    {
+      ""code"": ""NU1000"",
+      ""level"": ""Error"",
+      ""message"": ""test log message""
+    }
+  ]
+}";
+            var lockFileFormat = new LockFileFormat();
+            var lockFile = lockFileFormat.Parse(lockFileContent, "In Memory");
+
+            var dependencies = AssetsFileDependenciesSnapshot.ParseLibraries(lockFile.Targets.First());
+
+            Assert.Equal(1, dependencies.Count);
+            Assert.True(dependencies.ContainsKey("system.runtime"));
+        }
+    }
+}


### PR DESCRIPTION
## Bug

Fixes: NuGet/Home#9898
Regression: Yes  
* Last working version:  VS 16.6
* How are we preventing it in future:  Added a unit test

## Fix

Details: `Dependencies` node in `Solution Explorer` for projects and packages is populated from assets file. This change was recently implemented in [this](https://github.com/NuGet/NuGet.Client/pull/3392) PR. In the `NuGet` side, all the dependencies per target framework are populated into dictionary and returned to project system layer for further rendering in the VS. If the customer specifies package dependencies in a different case than the actual NuGet package itself, the current implementation didn't display them in the `Dependencies` node due to case mismatch. Hence modified `KeyComparer` argument to ignore case so that dictionary returns `true` when looked up for a key whose case is different from the actual key.

## Testing/Validation

Tests Added: Yes  
Reason for not adding tests:  
Validation:  Performed manual validation in VS

![Capture](https://user-images.githubusercontent.com/52756182/90858130-6cbaa100-e33a-11ea-98ec-46aa5e4e1452.PNG)

