### PR TITLE
Fail CI set build number step on errors

### DIFF
--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -44,23 +44,28 @@ jobs:
     inputs:
       scriptType: "inlineScript"
       inlineScript: |
-        $revision = Get-Content $env:BUILDCOUNTERFILE
-        $newBuildCounter = [System.Decimal]::Parse($revision)
-        $newBuildCounter++
-        Set-Content $env:BUILDCOUNTERFILE $newBuildCounter
-        $msbuildExe = 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\bin\msbuild.exe'
-        $productVersion = & $msbuildExe $env:BUILD_REPOSITORY_LOCALPATH\build\config.props /v:m /nologo /t:GetSemanticVersion
-        $productVersion = $productVersion.Trim()
-        $FullBuildNumber = "$productVersion.$newBuildCounter"
-        $targetChannel = & $msbuildExe $env:BUILD_REPOSITORY_LOCALPATH\build\config.props /v:m /nologo /t:GetVsTargetChannel
-        $targetChannel = $targetChannel.Trim()
-        $targetMajorVersion = & $msbuildExe $env:BUILD_REPOSITORY_LOCALPATH\build\config.props /v:m /nologo /t:GetVsTargetMajorVersion
-        $targetMajorVersion = $targetMajorVersion.Trim()
-        Write-Host "##vso[task.setvariable variable=VsTargetChannel;isOutput=true]$targetChannel"
-        Write-Host "##vso[task.setvariable variable=VsTargetMajorVersion;isOutput=true]$targetMajorVersion"
-        Write-Host "##vso[build.updatebuildnumber]$FullBuildNumber"
-        Write-Host "##vso[task.setvariable variable=BuildNumber;isOutput=true]$newBuildCounter"
-        Write-Host "##vso[task.setvariable variable=FullVstsBuildNumber;isOutput=true]$FullBuildNumber"
+        try {
+          $revision = Get-Content $env:BUILDCOUNTERFILE
+          $newBuildCounter = [System.Decimal]::Parse($revision)
+          $newBuildCounter++
+          Set-Content $env:BUILDCOUNTERFILE $newBuildCounter
+          $msbuildExe = 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\bin\msbuild.exe'
+          $productVersion = & $msbuildExe $env:BUILD_REPOSITORY_LOCALPATH\build\config.props /v:m /nologo /t:GetSemanticVersion
+          $productVersion = $productVersion.Trim()
+          $FullBuildNumber = "$productVersion.$newBuildCounter"
+          $targetChannel = & $msbuildExe $env:BUILD_REPOSITORY_LOCALPATH\build\config.props /v:m /nologo /t:GetVsTargetChannel
+          $targetChannel = $targetChannel.Trim()
+          $targetMajorVersion = & $msbuildExe $env:BUILD_REPOSITORY_LOCALPATH\build\config.props /v:m /nologo /t:GetVsTargetMajorVersion
+          $targetMajorVersion = $targetMajorVersion.Trim()
+          Write-Host "##vso[task.setvariable variable=VsTargetChannel;isOutput=true]$targetChannel"
+          Write-Host "##vso[task.setvariable variable=VsTargetMajorVersion;isOutput=true]$targetMajorVersion"
+          Write-Host "##vso[build.updatebuildnumber]$FullBuildNumber"
+          Write-Host "##vso[task.setvariable variable=BuildNumber;isOutput=true]$newBuildCounter"
+          Write-Host "##vso[task.setvariable variable=FullVstsBuildNumber;isOutput=true]$FullBuildNumber"
+        } catch {
+          Write-Host "##vso[task.LogIssue type=error;]Unable to set build number"
+          exit 1
+        }
 
   - task: PowerShell@1
     displayName: "Get SDK Version For Build"


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Client.Engineering/issues/492
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: catch errors and throw exception to fail step, rather than ignoring errors.

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  CI build script change.
Validation:  
