### PR TITLE
Use the original TargetFramework string for conditions in nuget.g.* for frameworks with platforms (such as net5.0-windows)

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommandRunner.cs
@@ -209,9 +209,9 @@ namespace NuGet.CommandLine.XPlat
                     packageReferenceArgs.PackageId,
                     packageReferenceArgs.ProjectPath));
 
-                var compatibleOriginalFrameworks = originalPackageSpec.RestoreMetadata
-                    .OriginalTargetFrameworks
-                    .Where(s => compatibleFrameworks.Contains(NuGetFramework.Parse(s)));
+                var compatibleOriginalFrameworks = compatibleFrameworks
+                    .Select(e => GetAliasForFramework(originalPackageSpec, e))
+                    .Where(originalFramework => originalFramework != null);
 
                 // generate a library dependency with all the metadata like Include, Exlude and SuppressParent
                 var libraryDependency = GenerateLibraryDependency(updatedPackageSpec, packageReferenceArgs, restorePreviewResult, userSpecifiedFrameworks, packageDependency);
@@ -225,6 +225,11 @@ namespace NuGet.CommandLine.XPlat
             await RestoreRunner.CommitAsync(restorePreviewResult, CancellationToken.None);
 
             return 0;
+        }
+
+        private static string GetAliasForFramework(PackageSpec spec, NuGetFramework framework)
+        {
+            return spec.TargetFrameworks.Where(e => e.FrameworkName.Equals(framework)).FirstOrDefault()?.TargetAlias;
         }
 
         public static async Task<NuGetVersion> GetLatestVersionAsync(PackageSpec originalPackageSpec, string packageId, ILogger logger, bool prerelease)

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
@@ -472,7 +472,7 @@ namespace NuGet.Commands
                         CultureInfo.InvariantCulture,
                         TargetFrameworkCondition,
                         GetMatchingFrameworkStrings(project, ridlessTarget.TargetFramework));
-                
+
                 // Find matching target in the original target graphs.
                 var targetGraph = targetGraphs.FirstOrDefault(e =>
                     string.IsNullOrEmpty(e.RuntimeIdentifier)
@@ -750,7 +750,7 @@ namespace NuGet.Commands
         }
 
         private static string GetMatchingFrameworkStrings(PackageSpec spec, NuGetFramework framework)
-        {           
+        {
             var frameworkString = spec.TargetFrameworks.Where(e => e.FrameworkName.Equals(framework)).FirstOrDefault()?.TargetAlias;
 
             // If there were no matches, use the generated name

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/SpecValidationUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/SpecValidationUtility.cs
@@ -5,8 +5,10 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using NuGet.Frameworks;
 using NuGet.LibraryModel;
 using NuGet.ProjectModel;
+using NuGet.Shared;
 
 namespace NuGet.Commands
 {
@@ -161,7 +163,8 @@ namespace NuGet.Commands
             }
 
             // Duplicate frameworks may not exist
-            if (frameworks.Length != frameworks.Distinct().Count())
+            // Change in ATF should *not* affect our duplicate check, so we use the full framework comparer.
+            if (frameworks.Length != frameworks.Distinct(new NuGetFrameworkFullComparer()).Count())
             {
                 var message = string.Format(
                     CultureInfo.CurrentCulture,
@@ -211,6 +214,23 @@ namespace NuGet.Commands
                     ProjectStyle.PackageReference.ToString());
 
                 throw RestoreSpecException.Create(message, files);
+            }
+
+            //OriginalTargetFrameworks must match the aliases.
+            if (spec.RestoreMetadata.TargetFrameworks.Count > 1)
+            {
+                var aliases = spec.TargetFrameworks.Select(e => e.TargetAlias);
+
+                if (!EqualityUtility.OrderedEquals(aliases, spec.RestoreMetadata.OriginalTargetFrameworks, e => e, StringComparer.OrdinalIgnoreCase, StringComparer.OrdinalIgnoreCase))
+                {
+                    var message = string.Format(
+                        CultureInfo.CurrentCulture,
+                        Strings.SpecValidation_OriginalTargetFrameworksMustMatchAliases,
+                        string.Join(";", spec.RestoreMetadata.OriginalTargetFrameworks),
+                        string.Join(";", aliases)
+                        );
+                    throw RestoreSpecException.Create(message, files);
+                }
             }
         }
 

--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -2249,6 +2249,15 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The original target frameworks value must match the aliases. Original target frameworks: {0}, aliases: {1}..
+        /// </summary>
+        internal static string SpecValidation_OriginalTargetFrameworksMustMatchAliases {
+            get {
+                return ResourceManager.GetString("SpecValidation_OriginalTargetFrameworksMustMatchAliases", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Duplicate frameworks found: &apos;{0}&apos;..
         /// </summary>
         internal static string SpecValidationDuplicateFrameworks {

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -1105,4 +1105,7 @@ For more information, visit https://docs.nuget.org/docs/reference/command-line-r
   <data name="Error_CentralPackageVersions_FloatingVersionsAreNotAllowed" xml:space="preserve">
     <value>Centrally defined floating package versions are not allowed.</value>
   </data>
+  <data name="SpecValidation_OriginalTargetFrameworksMustMatchAliases" xml:space="preserve">
+    <value>The original target frameworks value must match the aliases. Original target frameworks: {0}, aliases: {1}.</value>
+  </data>
 </root>

--- a/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
@@ -2646,10 +2646,9 @@ namespace NuGet.PackageManagement
 
             // Build the installation context
             var originalFrameworks = updatedPackageSpec
-                .RestoreMetadata
-                .OriginalTargetFrameworks
-                .GroupBy(x => NuGetFramework.Parse(x))
-                .ToDictionary(x => x.Key, x => x.First());
+                .TargetFrameworks
+                .ToDictionary(x => x.FrameworkName, x => x.TargetAlias);
+
             var installationContext = new BuildIntegratedInstallationContext(
                 successfulFrameworks,
                 unsuccessfulFrameworks,

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/ProjectRestoreInfoBuilder.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/ProjectRestoreInfoBuilder.cs
@@ -146,14 +146,15 @@ namespace NuGet.SolutionRestoreManager.Test
                 {
                     "PackageTargetFallback",
                     string.Join(";", tfm.Imports.Select(x => x.GetShortFolderName()))
-                }
+                },
             };
 
             return new VsTargetFrameworkInfo(
                 tfm.FrameworkName.ToString(),
                 packageReferences,
                 projectReferences,
-                projectProperties.Concat(globalProperties));
+                projectProperties.Concat(globalProperties),
+                originalTargetFramework: tfm.TargetAlias);
         }
 
         private static VsTargetFrameworkInfo2 ToTargetFrameworkInfo2(
@@ -190,7 +191,8 @@ namespace NuGet.SolutionRestoreManager.Test
                 projectReferences,
                 packageDownloads,
                 frameworkReferences,
-                projectProperties.Concat(globalProperties));
+                projectProperties.Concat(globalProperties),
+                originalTargetFramework: tfm.TargetAlias);
         }
 
         public static IEnumerable<IVsProjectProperty> GetTargetFrameworkProperties(NuGetFramework framework, string originalString = null)
@@ -249,10 +251,26 @@ namespace NuGet.SolutionRestoreManager.Test
             return sb.ToString();
         }
 
-        public static IEnumerable<IVsProjectProperty> GetTargetFrameworkProperties(string shortFrameworkName)
+        public static IEnumerable<IVsProjectProperty> GetTargetFrameworkProperties(string targetFrameworkMoniker, string originalFrameworkName = null)
         {
-            var framework = NuGetFramework.Parse(shortFrameworkName);
-            return GetTargetFrameworkProperties(framework, shortFrameworkName);
+            var framework = NuGetFramework.Parse(targetFrameworkMoniker);
+            var originalTFM = !string.IsNullOrEmpty(originalFrameworkName) ?
+                            originalFrameworkName :
+                            GetTargetFramework(framework, targetFrameworkMoniker);
+
+            return GetTargetFrameworkProperties(framework, originalTFM);
+        }
+
+        private static string GetTargetFramework(NuGetFramework framework, string targetFrameworkMoniker)
+        {
+            try
+            {
+                return framework.GetShortFolderName();
+            }
+            catch
+            {
+                return targetFrameworkMoniker;
+            }
         }
 
         private static IVsReferenceItem ToFrameworkReference(FrameworkDependency frameworkDependency)

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsSolutionRestoreServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsSolutionRestoreServiceTests.cs
@@ -271,8 +271,12 @@ namespace NuGet.SolutionRestoreManager.Test
         [InlineData(
 @"{
     ""frameworks"": {
-        ""netstandard1.4"": { },
-        ""net46"": { }
+        ""netstandard1.4"": {
+            ""targetAlias"": ""netstandard1.4""
+        },
+        ""net46"": {
+            ""targetAlias"": ""net46""
+        }
     }
 }", "netstandard1.4;net46", "netstandard1.4;net46")]
         [InlineData(
@@ -291,8 +295,12 @@ namespace NuGet.SolutionRestoreManager.Test
         [InlineData(
 @"{
     ""frameworks"": {
-        ""netstandard1.4"": { },
-        ""net46"": { }
+        ""netstandard1.4"": {
+            ""targetAlias"": ""netstandard1.4""
+        },
+        ""net46"": {
+            ""targetAlias"": ""net46""
+        }
     }
 }", "netstandard1.4;net46", "netstandard1.4;net46", false)]
         [InlineData(

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsTargetFrameworkInfo.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsTargetFrameworkInfo.cs
@@ -22,6 +22,7 @@ namespace NuGet.SolutionRestoreManager.Test
             IEnumerable<IVsReferenceItem> packageReferences,
             IEnumerable<IVsReferenceItem> projectReferences,
             IEnumerable<IVsProjectProperty> projectProperties,
+            string originalTargetFramework = null,
             bool addTargetFrameworkProperties = true)
         {
             if (string.IsNullOrEmpty(targetFrameworkMoniker))
@@ -49,7 +50,7 @@ namespace NuGet.SolutionRestoreManager.Test
             ProjectReferences = new VsReferenceItems(projectReferences);
             Properties =
                 addTargetFrameworkProperties
-                ? new VsProjectProperties(ProjectRestoreInfoBuilder.GetTargetFrameworkProperties(targetFrameworkMoniker).Concat(projectProperties))
+                ? new VsProjectProperties(ProjectRestoreInfoBuilder.GetTargetFrameworkProperties(targetFrameworkMoniker, originalTargetFramework).Concat(projectProperties))
                 : new VsProjectProperties(projectProperties);
         }
     }

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsTargetFrameworkInfo2.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsTargetFrameworkInfo2.cs
@@ -28,6 +28,7 @@ namespace NuGet.SolutionRestoreManager.Test
             IEnumerable<IVsReferenceItem> packageDownloads,
             IEnumerable<IVsReferenceItem> frameworkReferences,
             IEnumerable<IVsProjectProperty> projectProperties,
+            string originalTargetFramework = null,
             bool addTargetFrameworkProperties = true)
         {
             if (string.IsNullOrEmpty(targetFrameworkMoniker))
@@ -67,7 +68,7 @@ namespace NuGet.SolutionRestoreManager.Test
             FrameworkReferences = new VsReferenceItems(frameworkReferences);
             Properties =
                 addTargetFrameworkProperties
-                ? new VsProjectProperties(ProjectRestoreInfoBuilder.GetTargetFrameworkProperties(targetFrameworkMoniker).Concat(projectProperties))
+                ? new VsProjectProperties(ProjectRestoreInfoBuilder.GetTargetFrameworkProperties(targetFrameworkMoniker, originalTargetFramework).Concat(projectProperties))
                 : new VsProjectProperties(projectProperties);
         }
 

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatAddPkgTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatAddPkgTests.cs
@@ -13,6 +13,7 @@ using NuGet.CommandLine.XPlat;
 using NuGet.CommandLine.XPlat.Utility;
 using NuGet.Commands;
 using NuGet.Common;
+using NuGet.Configuration;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
 using NuGet.Test.Utility;
@@ -676,6 +677,71 @@ namespace NuGet.XPlat.FuncTest
                 Assert.Equal(0, result);
                 Assert.NotNull(itemGroup);
                 Assert.True(XPlatTestUtils.ValidateReference(itemGroup, packageX.Id, packageX.Version));
+            }
+        }
+
+        [Theory]
+        [InlineData("net46", "net46; netcoreapp1.0", ".NETFramework,Version=v4.7.2;NetCoreApp,Version=v1.0", "Windows,Version=7.0;,Version=", "net46")]
+        [InlineData("netcoreapp2.0", "net46;netcoreapp20;net50", ".NETFramework,Version=v4.6;NetCoreApp,Version=v2.0;NetCoreApp,Version=v5.0", "Windows,Version=7.0;,Version=;,Version=", "netcoreapp20;net50")]
+        public async Task AddPkg_ConditionalWithAlias_Success(
+            string packageFrameworks,
+            string projectFrameworks,
+            string projectTargetFrameworkMonikers,
+            string projectTargetPlatforMonikers,
+            string expectedConditions)
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                var userInputVersion = "1.0.0";
+                var actualProjectFrameworks = MSBuildStringUtility.Split(projectFrameworks);
+                var actualProjectTargetFrameworkMonikers = MSBuildStringUtility.Split(projectTargetFrameworkMonikers);
+                var actualProjectTargetPlatforMonikers = MSBuildStringUtility.Split(projectTargetPlatforMonikers);
+                var settings = Settings.LoadDefaultSettings(Path.GetDirectoryName(pathContext.NuGetConfig), Path.GetFileName(pathContext.NuGetConfig), null);
+                var project = SimpleTestProjectContext.CreateNETCoreWithSDK(
+                        projectName: ProjectName,
+                        solutionRoot: pathContext.SolutionRoot,
+                        frameworks: MSBuildStringUtility.Split(projectFrameworks));
+
+                for (int i = 0; i < actualProjectFrameworks.Length; i++)
+                {
+                    var framework = project.Frameworks.Single(e => e.TargetAlias.Equals(actualProjectFrameworks[i]));
+                    framework.Properties.Add("TargetFrameworkMoniker", actualProjectTargetFrameworkMonikers[i]);
+                    framework.Properties.Add("TargetPlatformMoniker", actualProjectTargetPlatforMonikers[i]);
+                }
+
+                project.FallbackFolders = (IList<string>)SettingsUtility.GetFallbackPackageFolders(settings);
+                project.GlobalPackagesFolder = SettingsUtility.GetGlobalPackagesFolder(settings);
+                var packageSourceProvider = new PackageSourceProvider(settings);
+                project.Sources = packageSourceProvider.LoadPackageSources();
+
+                project.Save();
+
+                var packageX = XPlatTestUtils.CreatePackage(frameworkString: packageFrameworks);
+
+                // Generate Package
+                await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                    pathContext.PackageSource,
+                    PackageSaveMode.Defaultv3,
+                    packageX);
+
+                var packageArgs = XPlatTestUtils.GetPackageReferenceArgs(packageX.Id, userInputVersion, project);
+                var commandRunner = new AddPackageReferenceCommandRunner();
+
+                // Act
+                var result = commandRunner.ExecuteCommand(packageArgs, MsBuild)
+                    .Result;
+                var projectXmlRoot = XPlatTestUtils.LoadCSProj(project.ProjectPath).Root;
+
+                // Assert
+                Assert.Equal(0, result);
+
+                foreach (var framework in MSBuildStringUtility.Split(expectedConditions))
+                {
+                    var itemGroup = XPlatTestUtils.GetItemGroupForFramework(projectXmlRoot, framework);
+                    Assert.NotNull(itemGroup);
+                    Assert.True(XPlatTestUtils.ValidateReference(itemGroup, packageX.Id, userInputVersion));
+                }
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/NETCoreRestoreTestUtility.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/NETCoreRestoreTestUtility.cs
@@ -76,7 +76,7 @@ namespace NuGet.CommandLine.XPlat.Tests
             spec.RestoreMetadata.ProjectStyle = ProjectStyle.PackageReference;
             spec.RestoreMetadata.OriginalTargetFrameworks.Add(framework);
             spec.Name = projectName;
-            spec.RestoreMetadata.TargetFrameworks.Add(new ProjectRestoreMetadataFrameworkInfo(targetFrameworkInfo.FrameworkName));
+            spec.RestoreMetadata.TargetFrameworks.Add(new ProjectRestoreMetadataFrameworkInfo(targetFrameworkInfo.FrameworkName) { TargetAlias = framework });
 
             return spec;
         }

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/MSBuildRestoreUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/MSBuildRestoreUtilityTests.cs
@@ -1140,6 +1140,7 @@ namespace NuGet.Commands.Test
                 Assert.Equal(0, project1Spec.RestoreMetadata.TargetFrameworks.SelectMany(e => e.ProjectReferences).Count());
                 Assert.Null(project1Spec.RestoreMetadata.ProjectJsonPath);
                 Assert.Equal("net46|netstandard1.6", string.Join("|", project1Spec.TargetFrameworks.Select(e => e.FrameworkName.GetShortFolderName())));
+                Assert.Equal("net46|netstandard16", string.Join("|", project1Spec.TargetFrameworks.Select(e => e.TargetAlias)));
                 Assert.Equal("net46|netstandard16", string.Join("|", project1Spec.RestoreMetadata.OriginalTargetFrameworks));
                 Assert.Equal(outputPath1, project1Spec.RestoreMetadata.OutputPath);
                 Assert.Equal("https://nuget.org/a/index.json|https://nuget.org/b/index.json", string.Join("|", project1Spec.RestoreMetadata.Sources.Select(s => s.Source)));
@@ -1322,6 +1323,7 @@ namespace NuGet.Commands.Test
                 Assert.Equal("a", project1Spec.Name);
                 Assert.Equal(ProjectStyle.PackageReference, project1Spec.RestoreMetadata.ProjectStyle);
                 Assert.Equal("netstandard1.6", string.Join("|", project1Spec.TargetFrameworks.Select(e => e.FrameworkName.GetShortFolderName())));
+                Assert.Equal("netstandard16", string.Join("|", project1Spec.TargetFrameworks.Select(e => e.TargetAlias)));
                 Assert.Equal("netstandard16", string.Join("|", project1Spec.RestoreMetadata.OriginalTargetFrameworks));
                 Assert.False(project1Spec.RestoreMetadata.CrossTargeting);
             }
@@ -1383,6 +1385,7 @@ namespace NuGet.Commands.Test
                 Assert.Equal(ProjectStyle.PackageReference, project1Spec.RestoreMetadata.ProjectStyle);
                 Assert.Equal("netstandard1.6", string.Join("|", project1Spec.TargetFrameworks.Select(e => e.FrameworkName.GetShortFolderName())));
                 Assert.Equal("netstandard16", string.Join("|", project1Spec.RestoreMetadata.OriginalTargetFrameworks));
+                Assert.Equal("netstandard16", string.Join("|", project1Spec.TargetFrameworks.Select(e => e.TargetAlias)));
                 Assert.False(project1Spec.RestoreMetadata.LegacyPackagesDirectory);
             }
         }
@@ -1649,6 +1652,7 @@ namespace NuGet.Commands.Test
                 // Verify original frameworks are trimmed
                 Assert.Equal("net46", project1Spec.RestoreMetadata.OriginalTargetFrameworks[0]);
                 Assert.Equal("netstandard16", project1Spec.RestoreMetadata.OriginalTargetFrameworks[1]);
+                Assert.Equal("net46|netstandard16", string.Join("|", project1Spec.TargetFrameworks.Select(e => e.TargetAlias)));
             }
         }
 
@@ -2548,6 +2552,7 @@ namespace NuGet.Commands.Test
                 Assert.Equal(ProjectStyle.PackageReference, project1Spec.RestoreMetadata.ProjectStyle);
                 Assert.Equal("net46", string.Join("|", project1Spec.TargetFrameworks.Select(e => e.FrameworkName.GetShortFolderName())));
                 Assert.Equal("net46", string.Join("|", project1Spec.RestoreMetadata.OriginalTargetFrameworks));
+                Assert.Equal("net46", string.Join("|", project1Spec.TargetFrameworks.Select(e => e.TargetAlias)));
                 Assert.Equal("x", project1Spec.GetTargetFramework(NuGetFramework.Parse("net46")).Dependencies.SingleOrDefault().Name);
                 Assert.Empty(project1Spec.Dependencies);
             }

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/NETCoreRestoreTestUtility.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/NETCoreRestoreTestUtility.cs
@@ -74,7 +74,7 @@ namespace NuGet.Commands.Test
             spec.RestoreMetadata.ProjectStyle = ProjectStyle.PackageReference;
             spec.RestoreMetadata.OriginalTargetFrameworks.Add(framework);
             spec.Name = projectName;
-            spec.RestoreMetadata.TargetFrameworks.Add(new ProjectRestoreMetadataFrameworkInfo(targetFrameworkInfo.FrameworkName));
+            spec.RestoreMetadata.TargetFrameworks.Add(new ProjectRestoreMetadataFrameworkInfo(targetFrameworkInfo.FrameworkName) { TargetAlias = framework });
 
             return spec;
         }

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreBuildTargetsAndPropsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreBuildTargetsAndPropsTests.cs
@@ -461,7 +461,8 @@ namespace NuGet.Commands.Test
             var frameworkGroups = frameworks.Select(s =>
                 new TargetFrameworkInformation()
                 {
-                    FrameworkName = NuGetFramework.Parse(s)
+                    FrameworkName = NuGetFramework.Parse(s),
+                    TargetAlias = s,
                 })
                 .ToList();
 
@@ -485,7 +486,7 @@ namespace NuGet.Commands.Test
             foreach (var frameworkInfo in frameworkGroups)
             {
                 spec.RestoreMetadata.TargetFrameworks.Add(
-                    new ProjectRestoreMetadataFrameworkInfo(frameworkInfo.FrameworkName));
+                    new ProjectRestoreMetadataFrameworkInfo(frameworkInfo.FrameworkName) { TargetAlias = frameworkInfo.TargetAlias });
             }
 
             return spec;

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreRunnerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreRunnerTests.cs
@@ -242,6 +242,7 @@ namespace NuGet.Commands.Test
 
                 var specPath1 = Path.Combine(project1.FullName, "project.json");
                 var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
+                spec1.TargetFrameworks.Single().TargetAlias = "net45";
                 spec1.RestoreMetadata = new ProjectRestoreMetadata
                 {
                     OutputPath = Path.Combine(project1.FullName, "obj"),
@@ -250,7 +251,7 @@ namespace NuGet.Commands.Test
                     ProjectPath = Path.Combine(project1.FullName, "project1.csproj")
                 };
                 spec1.RestoreMetadata.ProjectUniqueName = spec1.RestoreMetadata.ProjectPath;
-                spec1.RestoreMetadata.TargetFrameworks.Add(new ProjectRestoreMetadataFrameworkInfo(NuGetFramework.Parse("net45")));
+                spec1.RestoreMetadata.TargetFrameworks.Add(new ProjectRestoreMetadataFrameworkInfo(NuGetFramework.Parse("net45")) { TargetAlias = "net45" });
                 spec1.RestoreMetadata.OriginalTargetFrameworks.Add("net45");
                 spec1.FilePath = spec1.RestoreMetadata.ProjectPath;
 
@@ -388,13 +389,15 @@ namespace NuGet.Commands.Test
 
             var targetFrameworkInfo1 = new TargetFrameworkInformation
             {
-                FrameworkName = NuGetFramework.Parse("net45")
+                FrameworkName = NuGetFramework.Parse("net45"),
+                TargetAlias = "net45",
             };
             var frameworks1 = new[] { targetFrameworkInfo1 };
 
             var targetFrameworkInfo2 = new TargetFrameworkInformation
             {
-                FrameworkName = NuGetFramework.Parse("net45")
+                FrameworkName = NuGetFramework.Parse("net45"),
+                TargetAlias = "net45",
             };
             var frameworks2 = new[] { targetFrameworkInfo2 };
 
@@ -537,13 +540,15 @@ namespace NuGet.Commands.Test
 
             var targetFrameworkInfo1 = new TargetFrameworkInformation
             {
-                FrameworkName = NuGetFramework.Parse("net45")
+                FrameworkName = NuGetFramework.Parse("net45"),
+                TargetAlias = "net45",
             };
             var frameworks1 = new[] { targetFrameworkInfo1 };
 
             var targetFrameworkInfo2 = new TargetFrameworkInformation
             {
-                FrameworkName = NuGetFramework.Parse("net45")
+                FrameworkName = NuGetFramework.Parse("net45"),
+                TargetAlias = "net45",
             };
             var frameworks2 = new[] { targetFrameworkInfo2 };
 
@@ -619,7 +624,7 @@ namespace NuGet.Commands.Test
                     }
                 });
 
-                spec1.RestoreMetadata.TargetFrameworks.Add(new ProjectRestoreMetadataFrameworkInfo(NuGetFramework.Parse("net45")));
+                spec1.RestoreMetadata.TargetFrameworks.Add(new ProjectRestoreMetadataFrameworkInfo(NuGetFramework.Parse("net45")) { TargetAlias = "net45" });
                 spec1.RestoreMetadata.TargetFrameworks
                     .Single()
                     .ProjectReferences

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/SpecValidationUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/SpecValidationUtilityTests.cs
@@ -8,8 +8,8 @@ using NuGet.Frameworks;
 using NuGet.LibraryModel;
 using NuGet.ProjectModel;
 using NuGet.Versioning;
-using Test.Utility;
 using Xunit;
+using static NuGet.Frameworks.FrameworkConstants;
 
 namespace NuGet.Commands.Test
 {
@@ -310,14 +310,13 @@ namespace NuGet.Commands.Test
         [Fact]
         public void SpecValidationUtility_UAP_VerifyOutputPath()
         {
-
             // Arrange
             var spec = new DependencyGraphSpec();
             spec.AddRestore("a");
 
             var targetFramework1 = new TargetFrameworkInformation()
             {
-                FrameworkName = NuGetFramework.Parse("net45")
+                FrameworkName = NuGetFramework.Parse("net45"),
             };
 
             var info = new[] { targetFramework1 };
@@ -468,11 +467,47 @@ namespace NuGet.Commands.Test
             AssertError(spec, "Property 'ProjectJsonPath' is not allowed for project type 'PackageReference'.", "a.csproj");
         }
 
+        [Fact]
+        public void SpecValidationUtility_VerifyFrameworks_WithSameBase_DifferentAssetTargetFallback_Duplicates()
+        {
+            // Arrange
+            var spec = new DependencyGraphSpec();
+            spec.AddRestore("a");
+
+            var targetFramework1 = new TargetFrameworkInformation()
+            {
+                FrameworkName = new AssetTargetFallbackFramework(CommonFrameworks.Net50, new List<NuGetFramework>() { CommonFrameworks.Net463 })
+            };
+
+            var targetFramework2 = new TargetFrameworkInformation()
+            {
+                FrameworkName = new AssetTargetFallbackFramework(CommonFrameworks.Net50, new List<NuGetFramework>() { CommonFrameworks.Net462 })
+            };
+
+            var info = new[] { targetFramework1, targetFramework2 };
+
+            var project = new PackageSpec(info);
+            project.RestoreMetadata = new ProjectRestoreMetadata();
+            project.Name = "a";
+            project.FilePath = Path.Combine(Directory.GetCurrentDirectory(), "a.csproj");
+            project.RestoreMetadata.ProjectUniqueName = "a";
+            project.RestoreMetadata.ProjectName = "a";
+            project.RestoreMetadata.ProjectPath = Path.Combine(Directory.GetCurrentDirectory(), "a.csproj");
+            project.RestoreMetadata.ProjectStyle = ProjectStyle.ProjectJson;
+            project.RestoreMetadata.ProjectJsonPath = Path.Combine(Directory.GetCurrentDirectory(), "project.json");
+
+            spec.AddProject(project);
+
+            // Act && Assert
+            AssertError(spec, "Duplicate frameworks found");
+        }
+
         private static PackageSpec GetProjectA()
         {
             var targetFramework1 = new TargetFrameworkInformation()
             {
-                FrameworkName = NuGetFramework.Parse("net45")
+                FrameworkName = NuGetFramework.Parse("net45"),
+                TargetAlias = "net45",
             };
 
             var info = new[] { targetFramework1 };

--- a/test/NuGet.Core.Tests/NuGet.Frameworks.Test/NuGetFrameworkTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Frameworks.Test/NuGetFrameworkTests.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
 using NuGet.Frameworks;
 using Xunit;
 
@@ -386,6 +388,28 @@ namespace NuGet.Test
             var copiedFramework = new NuGetFramework(originalFramework);
 
             Assert.Equal(originalFramework, copiedFramework);
+        }
+
+        [Fact]
+        public void NuGetFramework_Stuff()
+        {
+            var leftSide = NuGetFramework.ParseComponents(".NETCoreApp,Version=v5.0", "Windows,Version=7.0");
+            var rightSide = NuGetFramework.ParseComponents(".NETCoreApp,Version=v5.0", "Windows,Version=7.0");
+
+            leftSide.Should().Be(rightSide);
+            leftSide.Should().Be(rightSide);
+            leftSide.GetHashCode().Should().Be(rightSide.GetHashCode(), because: "Equivalent objects should have the same hash code.");
+            leftSide.GetHashCode().Should().Be(rightSide.GetHashCode(), because: "Equivalent objects should have the same hash code.");
+
+            var frameworks = new List<NuGetFramework> { leftSide, rightSide };
+
+            var distinctFrameworksWithComparer = frameworks.Distinct(new NuGetFrameworkFullComparer()).ToArray();
+            var distinctFrameworksWithoutComparer = frameworks.Distinct().ToArray();
+
+            distinctFrameworksWithComparer.Should().HaveCount(1);
+            distinctFrameworksWithoutComparer.Should().HaveCount(1);
+
+
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/LockFileFormatTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/LockFileFormatTests.cs
@@ -378,16 +378,18 @@ namespace NuGet.ProjectModel.Test
       ""outputPath"": ""X:\\ProjectPath\\obj\\"",
       ""projectStyle"": ""PackageReference"",
       ""originalTargetFrameworks"": [
-        ""netcoreapp1.0""
+        ""netcoreapp10""
       ],
       ""frameworks"": {
         ""netcoreapp1.0"": {
+          ""targetAlias"": ""netcoreapp10"",
           ""projectReferences"": {}
         }
       }
     },
     ""frameworks"": {
       ""netcoreapp1.0"": {
+        ""targetAlias"": ""netcoreapp10"",
         ""dependencies"": {
          ""Microsoft.NET.Sdk"": {
                 ""suppressParent"": ""All"",
@@ -412,6 +414,7 @@ namespace NuGet.ProjectModel.Test
                     new TargetFrameworkInformation
                     {
                         FrameworkName = FrameworkConstants.CommonFrameworks.NetCoreApp10,
+                        TargetAlias = "netcoreapp10",
                         Dependencies = new[]
                         {
                             new LibraryDependency
@@ -445,10 +448,13 @@ namespace NuGet.ProjectModel.Test
                         ProjectPath = @"X:\ProjectPath\ProjectPath.csproj",
                         OutputPath = @"X:\ProjectPath\obj\",
                         ProjectStyle = ProjectStyle.PackageReference,
-                        OriginalTargetFrameworks = new[] { "netcoreapp1.0" },
+                        OriginalTargetFrameworks = new[] { "netcoreapp10" },
                         TargetFrameworks = new List<ProjectRestoreMetadataFrameworkInfo>
                         {
                             new ProjectRestoreMetadataFrameworkInfo(NuGetFramework.Parse("netcoreapp1.0"))
+                            {
+                                TargetAlias = "netcoreapp10",
+                            }
                         }
                     }
                 }

--- a/test/TestUtilities/Test.Utility/Commands/ProjectJsonTestHelpers.cs
+++ b/test/TestUtilities/Test.Utility/Commands/ProjectJsonTestHelpers.cs
@@ -133,9 +133,17 @@ namespace NuGet.Commands.Test
             updated.RestoreMetadata.ConfigFilePaths = new List<string>();
             updated.RestoreMetadata.CentralPackageVersionsEnabled = spec.RestoreMetadata?.CentralPackageVersionsEnabled ?? false;
 
-            foreach (var framework in updated.TargetFrameworks.Select(e => e.FrameworkName))
+            // Update the Target Alias.
+            foreach (var framework in updated.TargetFrameworks)
             {
-                updated.RestoreMetadata.TargetFrameworks.Add(new ProjectRestoreMetadataFrameworkInfo(framework));
+                if (string.IsNullOrEmpty(framework.TargetAlias))
+                {
+                    framework.TargetAlias = framework.FrameworkName.GetShortFolderName();
+                }
+            }
+            foreach (var framework in updated.TargetFrameworks)
+            {
+                updated.RestoreMetadata.TargetFrameworks.Add(new ProjectRestoreMetadataFrameworkInfo(framework.FrameworkName) { TargetAlias = framework.TargetAlias });
             }
             return updated;
         }

--- a/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestProjectContext.cs
+++ b/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestProjectContext.cs
@@ -400,7 +400,7 @@ namespace NuGet.Test.Utility
             params string[] frameworks)
         {
             var context = new SimpleTestProjectContext(projectName, ProjectStyle.PackageReference, solutionRoot);
-            context.Frameworks.AddRange(frameworks.Select(f => new SimpleTestProjectFrameworkContext(NuGetFramework.Parse(f)) { TargetAlias = f}));
+            context.Frameworks.AddRange(frameworks.Select(f => new SimpleTestProjectFrameworkContext(NuGetFramework.Parse(f)) { TargetAlias = f }));
             context.ToolingVersion15 = true;
             context.Properties.Add("RestoreProjectStyle", "PackageReference");
             return context;

--- a/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestProjectContext.cs
+++ b/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestProjectContext.cs
@@ -74,11 +74,6 @@ namespace NuGet.Test.Utility
         public List<SimpleTestProjectFrameworkContext> Frameworks { get; set; } = new List<SimpleTestProjectFrameworkContext>();
 
         /// <summary>
-        /// Original Target framework strings.
-        /// </summary>
-        public List<string> OriginalFrameworkStrings { get; set; } = new List<string>();
-
-        /// <summary>
         /// Project type
         /// </summary>
         public ProjectStyle Type { get; set; }
@@ -239,7 +234,8 @@ namespace NuGet.Test.Utility
                     .Select(f => new TargetFrameworkInformation()
                     {
                         FrameworkName = f.Framework,
-                        Dependencies = f.PackageReferences.Select(e => new LibraryDependency() { LibraryRange = new LibraryRange(e.Id, VersionRange.Parse(e.Version), LibraryDependencyTarget.Package) }).ToList()
+                        Dependencies = f.PackageReferences.Select(e => new LibraryDependency() { LibraryRange = new LibraryRange(e.Id, VersionRange.Parse(e.Version), LibraryDependencyTarget.Package) }).ToList(),
+                        TargetAlias = f.TargetAlias,
                     }).ToList());
                 _packageSpec.RestoreMetadata = new ProjectRestoreMetadata();
                 _packageSpec.Name = ProjectName;
@@ -249,7 +245,7 @@ namespace NuGet.Test.Utility
                 _packageSpec.RestoreMetadata.ProjectPath = ProjectPath;
                 _packageSpec.RestoreMetadata.ProjectStyle = Type;
                 _packageSpec.RestoreMetadata.OutputPath = OutputPath;
-                _packageSpec.RestoreMetadata.OriginalTargetFrameworks = OriginalFrameworkStrings;
+                _packageSpec.RestoreMetadata.OriginalTargetFrameworks = _packageSpec.TargetFrameworks.Select(e => e.TargetAlias).ToList();
                 _packageSpec.RestoreMetadata.TargetFrameworks = Frameworks
                     .Select(f => new ProjectRestoreMetadataFrameworkInfo(f.Framework))
                     .ToList();
@@ -404,8 +400,7 @@ namespace NuGet.Test.Utility
             params string[] frameworks)
         {
             var context = new SimpleTestProjectContext(projectName, ProjectStyle.PackageReference, solutionRoot);
-            context.OriginalFrameworkStrings.AddRange(frameworks);
-            context.Frameworks.AddRange(frameworks.Select(f => new SimpleTestProjectFrameworkContext(NuGetFramework.Parse(f))));
+            context.Frameworks.AddRange(frameworks.Select(f => new SimpleTestProjectFrameworkContext(NuGetFramework.Parse(f)) { TargetAlias = f}));
             context.ToolingVersion15 = true;
             context.Properties.Add("RestoreProjectStyle", "PackageReference");
             return context;
@@ -482,8 +477,7 @@ namespace NuGet.Test.Utility
 
                     ProjectFileUtils.AddProperties(xml, new Dictionary<string, string>()
                     {
-                        { tfPropName, OriginalFrameworkStrings.Count != 0 ? string.Join(";", OriginalFrameworkStrings):
-                        string.Join(";", Frameworks.Select(f => f.TargetAlias)) },
+                        { tfPropName, string.Join(";", Frameworks.Select(f => f.TargetAlias)) },
                     });
                 }
 


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9914
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: 

This is a consequence of #9756.
The idea is simple, earlier we'd match based on which tfm string parses to the nugetframework, now we look at the alias of TargetFrameworkInformation.

## Testing/Validation

Tests Added: Yes  
Reason for not adding tests:  
Validation:  
