### PR TITLE
Populate the original target frameworks field for legacy package reference projects in commandline restore

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs
@@ -774,7 +774,11 @@ namespace NuGet.Build.Tasks.Console
             restoreMetadata.CacheFilePath = NoOpRestoreUtilities.GetProjectCacheFilePath(outputPath, project.FullPath);
             restoreMetadata.ConfigFilePaths = settings.GetConfigFilePaths();
             restoreMetadata.OutputPath = outputPath;
-            restoreMetadata.OriginalTargetFrameworks.AddRange(targetFrameworkInfos.Select(e => e.TargetAlias));
+            targetFrameworkInfos.ForEach(tfi =>
+                restoreMetadata.OriginalTargetFrameworks.Add(
+                        !string.IsNullOrEmpty(tfi.TargetAlias) ?
+                            tfi.TargetAlias :
+                            tfi.FrameworkName.GetShortFolderName()));
             restoreMetadata.PackagesPath = GetPackagesPath(project, settings);
             restoreMetadata.ProjectName = projectName;
             restoreMetadata.ProjectPath = project.FullPath;

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
@@ -14,6 +14,7 @@ using NuGet.LibraryModel;
 using NuGet.Packaging;
 using NuGet.ProjectModel;
 using NuGet.RuntimeModel;
+using NuGet.Shared;
 using NuGet.Versioning;
 
 namespace NuGet.Commands
@@ -227,10 +228,11 @@ namespace NuGet.Commands
                     AddFrameworkReferences(result, items);
 
                     // Store the original framework strings for msbuild conditionals
-                    foreach(var tfi in result.TargetFrameworks)
-                    { 
-                        result.RestoreMetadata.OriginalTargetFrameworks.Add(tfi.TargetAlias);
-                    }
+                   result.TargetFrameworks.ForEach(tfi =>
+                       result.RestoreMetadata.OriginalTargetFrameworks.Add(
+                               !string.IsNullOrEmpty(tfi.TargetAlias) ?
+                                   tfi.TargetAlias :
+                                   tfi.FrameworkName.GetShortFolderName()));
                 }
 
                 if (restoreType == ProjectStyle.PackageReference

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/ToolRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/ToolRestoreUtility.cs
@@ -34,6 +34,7 @@ namespace NuGet.Commands
                 {
                     new TargetFrameworkInformation
                     {
+                        TargetAlias = frameworkShortFolderName,
                         FrameworkName = framework,
                         Dependencies = new List<LibraryDependency>
                         {
@@ -60,6 +61,7 @@ namespace NuGet.Commands
                     {
                         new ProjectRestoreMetadataFrameworkInfo
                         {
+                            TargetAlias = frameworkShortFolderName,
                             FrameworkName = framework,
                             ProjectReferences = { }
                         }

--- a/test/EndToEnd/tests/BuildIntegratedTest.ps1
+++ b/test/EndToEnd/tests/BuildIntegratedTest.ps1
@@ -647,7 +647,8 @@ function Test-BuildIntegratedVSandMSBuildNoOp {
     
     $MSBuildExe = Get-MSBuildExe
 
-    & "$MSBuildExe" /t:restore
+    & "$MSBuildExe" /t:restore $project.FullName
+    Assert-True ($LASTEXITCODE -eq 0)
 
     $MsBuildRestoreTimestamp =( [datetime](Get-ItemProperty -Path $cacheFile -Name LastWriteTime).lastwritetime).Ticks
 

--- a/test/EndToEnd/tests/NetCoreProjectTest.ps1
+++ b/test/EndToEnd/tests/NetCoreProjectTest.ps1
@@ -153,7 +153,8 @@ function Test-NetCoreVSandMSBuildNoOp {
     
     $MSBuildExe = Get-MSBuildExe
     
-    & "$MSBuildExe" /t:restore
+    & "$MSBuildExe" /t:restore  $project.FullName
+    Assert-True ($LASTEXITCODE -eq 0)
 
     $MsBuildRestoreTimestamp =( [datetime](Get-ItemProperty -Path $cacheFile -Name LastWriteTime).lastwritetime).Ticks
 
@@ -175,8 +176,9 @@ function Test-NetCoreTargetFrameworksVSandMSBuildNoOp {
     $VSRestoreTimestamp =( [datetime](Get-ItemProperty -Path $cacheFile -Name LastWriteTime).lastwritetime).Ticks
     
     $MSBuildExe = Get-MSBuildExe
-    
-    & "$MSBuildExe" /t:restore
+
+    & "$MSBuildExe" /t:restore  $project.FullName
+    Assert-True ($LASTEXITCODE -eq 0)
 
     $MsBuildRestoreTimestamp =( [datetime](Get-ItemProperty -Path $cacheFile -Name LastWriteTime).lastwritetime).Ticks
 
@@ -199,7 +201,8 @@ function Test-NetCoreMultipleTargetFrameworksVSandMSBuildNoOp {
     
     $MSBuildExe = Get-MSBuildExe
     
-    & "$MSBuildExe" /t:restore
+    & "$MSBuildExe" /t:restore  $project.FullName
+    Assert-True ($LASTEXITCODE -eq 0)
 
     $MsBuildRestoreTimestamp =( [datetime](Get-ItemProperty -Path $cacheFile -Name LastWriteTime).lastwritetime).Ticks
 
@@ -220,7 +223,8 @@ function Test-NetCoreToolsVSandMSBuildNoOp {
     
     $MSBuildExe = Get-MSBuildExe
     
-    & "$MSBuildExe" /t:restore
+    & "$MSBuildExe" /t:restore  $project.FullName
+    Assert-True ($LASTEXITCODE -eq 0)
 
     $MsBuildRestoreTimestamp =( [datetime](Get-ItemProperty -Path $ToolsCacheFile -Name LastWriteTime).lastwritetime).Ticks
 

--- a/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildRestoreTaskTests.cs
+++ b/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildRestoreTaskTests.cs
@@ -7,11 +7,11 @@ using System.Threading.Tasks;
 using System.Linq;
 using System.Xml.Linq;
 using FluentAssertions;
-using NuGet.Common;
 using NuGet.Frameworks;
 using NuGet.Test.Utility;
 using NuGet.ProjectModel;
 using Xunit;
+using System.Collections.Generic;
 
 namespace Msbuild.Integration.Test
 {
@@ -512,6 +512,74 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
                     {
                         Assert.True(File.Exists(asset), result.AllOutput);
                     }
+                }
+            }
+        }
+
+        [PlatformFact(Platform.Windows)]
+        public async Task MsbuildRestore_WithLegacyPackageReferenceProject_BothStaticGraphAndRegularRestoreNoOp()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Set up solution, project, and packages
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+
+                var net461 = NuGetFramework.Parse("net461");
+
+                var project = SimpleTestProjectContext.CreateLegacyPackageReference(
+                    "a",
+                    pathContext.SolutionRoot,
+                    net461);
+
+                var packageX = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.0"
+                };
+
+                packageX.Files.Clear();
+                project.AddPackageToAllFrameworks(packageX);
+                packageX.AddFile("lib/net461/a.dll");
+
+                solution.Projects.Add(project);
+                solution.Create(pathContext.SolutionRoot);
+
+                await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                    pathContext.PackageSource,
+                    packageX);
+
+                var projectOutputPaths = new[]
+                {
+                    project.AssetsFileOutputPath,
+                    project.PropsOutput,
+                    project.TargetsOutput,
+                    project.CacheFileOutputPath,
+                };
+
+                var projectOutputTimestamps = new Dictionary<string, DateTime>();
+
+                // Restore the project with a PackageReference which generates assets
+                var result = _msbuildFixture.RunMsBuild(pathContext.WorkingDirectory, $"/t:restore {project.ProjectPath}", ignoreExitCode: true);
+                result.Success.Should().BeTrue(because: result.AllOutput);
+
+                foreach (var asset in projectOutputPaths)
+                {
+                    var fileInfo = new FileInfo(asset);
+                    fileInfo.Exists.Should().BeTrue(because: result.AllOutput);
+                    projectOutputTimestamps.Add(asset, fileInfo.LastWriteTimeUtc);
+                }
+
+                // Restore the project with a PackageReference which generates assets
+                result = _msbuildFixture.RunMsBuild(pathContext.WorkingDirectory, $"/t:restore /p:RestoreUseStaticGraphEvaluation=true {project.ProjectPath}", ignoreExitCode: true);
+
+                result.Success.Should().BeTrue(because: result.AllOutput);
+
+                foreach (var asset in projectOutputPaths)
+                {
+                    var fileInfo = new FileInfo(asset);
+                    fileInfo.Exists.Should().BeTrue(because: result.AllOutput);
+                    fileInfo.LastWriteTimeUtc.Should().Be(projectOutputTimestamps[asset]);
                 }
             }
         }


### PR DESCRIPTION

## Bug

Fixes: https://github.com/NuGet/Home/issues/9924
Regression: Yes 
* Last working version: 5.8.0.6760
* How are we preventing it in future: Re-enabling the existing tests for this. For whatever reason the tests for this scenario broke (likely in 16.0). 

## Fix

Details: Populate the original target frameworks field for legacy package reference projects in commandline restore. 
The difference between cmd + VS restore was that in VS the OTF was populated with the short folder name: https://github.com/NuGet/NuGet.Client/blob/3501ddedc274ac10d4b135856b7593a6bb8a72f1/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyPackageReferenceProject.cs#L443.

Given that this is the old behavior and allows us to no-op across tools and versions, I've decided to preserve it.

## Testing/Validation

Tests Added: Yes  
Reason for not adding tests:  
Validation:  
