### PR TITLE
Increment NetCoreAssemblyBuildNumber after Insertion

### DIFF
--- a/build/config.props
+++ b/build/config.props
@@ -24,7 +24,7 @@
     <!-- ** Increment each insertion, set to zero after incrementing Major/Minor or Patch version -->
     <!-- We need to update this netcoreassembly build number with EVERY insertion into VS to workaround any breaking api
     changes we might have made. -->
-    <NetCoreAssemblyBuildNumber Condition=" '$(NetCoreAssemblyBuildNumber)' == '' ">4</NetCoreAssemblyBuildNumber>
+    <NetCoreAssemblyBuildNumber Condition=" '$(NetCoreAssemblyBuildNumber)' == '' ">5</NetCoreAssemblyBuildNumber>
 
     <IsEscrowMode>false</IsEscrowMode>
 


### PR DESCRIPTION
## Bug

Fixes: NuGet/Client.Engineering/issues/500
Regression: No

Last working version: N/A
How are we preventing it in future: N/A
Fix
Details: Increment NetCoreAssemblyBuildNumber after Insertion

Testing/Validation
Tests Added: No
Reason for not adding tests: Does not add new code.
Validation: Successful CI run
