### PR TITLE
ilmerge N.Packaging.Extraction.dll with its dependencies, to avoid co…

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging.Extraction/NuGet.Packaging.Extraction.csproj
+++ b/src/NuGet.Core/NuGet.Packaging.Extraction/NuGet.Packaging.Extraction.csproj
@@ -11,7 +11,7 @@
     <PackProject>true</PackProject>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <IncludeBuildOutput>false</IncludeBuildOutput>
-    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);CreateNupkgFromILMerge</TargetsForTfmSpecificContentInPackage>
+    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);ILMergeNPE;CreateNupkgFromILMerge</TargetsForTfmSpecificContentInPackage>
     <Shipping>true</Shipping>
     <IncludeInVSIX>false</IncludeInVSIX>
     <XPLATProject>false</XPLATProject>

--- a/src/NuGet.Core/NuGet.Packaging.Extraction/NuGet.Packaging.Extraction.csproj
+++ b/src/NuGet.Core/NuGet.Packaging.Extraction/NuGet.Packaging.Extraction.csproj
@@ -30,7 +30,7 @@
   </Target>
 
   <!--These targets help get all the DLLs that are packed in the nuspec to be sent for signing.-->
-  <Target Name="GetIlmergeBuildOutput" DependsOnTargets="_GetDllsInOutputDirectory" Returns="@(DllsToSign)">
+  <Target Name="GetIlmergeBuildOutput" DependsOnTargets="ILMergeNPE;_GetDllsInOutputDirectory" Returns="@(DllsToSign)">
     <ItemGroup>
       <DllsToSign Include="@(DllsInOutputDir)" KeepDuplicates="false" />
     </ItemGroup>

--- a/src/NuGet.Core/NuGet.Packaging.Extraction/NuGet.Packaging.Extraction.csproj
+++ b/src/NuGet.Core/NuGet.Packaging.Extraction/NuGet.Packaging.Extraction.csproj
@@ -30,7 +30,7 @@
   </Target>
 
   <!--These targets help get all the DLLs that are packed in the nuspec to be sent for signing.-->
-  <Target Name="GetIlmergeBuildOutput" DependsOnTargets="ILMergeNPE;_GetDllsInOutputDirectory" Returns="@(DllsToSign)">
+  <Target Name="GetIlmergeBuildOutput" DependsOnTargets="_GetDllsInOutputDirectory" Returns="@(DllsToSign)">
     <ItemGroup>
       <DllsToSign Include="@(DllsInOutputDir)" KeepDuplicates="false" />
     </ItemGroup>

--- a/src/NuGet.Core/NuGet.Packaging.Extraction/NuGet.Packaging.Extraction.csproj
+++ b/src/NuGet.Core/NuGet.Packaging.Extraction/NuGet.Packaging.Extraction.csproj
@@ -11,7 +11,7 @@
     <PackProject>true</PackProject>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <IncludeBuildOutput>false</IncludeBuildOutput>
-    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);ILMergeNPE;CreateNupkgFromILMerge</TargetsForTfmSpecificContentInPackage>
+    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);CreateNupkgFromILMerge</TargetsForTfmSpecificContentInPackage>
     <Shipping>true</Shipping>
     <IncludeInVSIX>false</IncludeInVSIX>
     <XPLATProject>false</XPLATProject>

--- a/src/NuGet.Core/NuGet.Packaging.Extraction/NuGet.Packaging.Extraction.csproj
+++ b/src/NuGet.Core/NuGet.Packaging.Extraction/NuGet.Packaging.Extraction.csproj
@@ -1,20 +1,76 @@
 ﻿<Project>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common.props" />
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
+  <Import Project="ilmerge.props" />
 
   <PropertyGroup>
     <Description>NuGet's understanding of packages. Reading nuspec, nupkgs and package signing.</Description>
     <TargetFrameworks>net45</TargetFrameworks>
-    <TargetFramework />
-    <NoWarn>$(NoWarn);CS1591;CS1574;CS1573;CS1572</NoWarn>
+    <TargetFramework></TargetFramework>
+    <NoWarn>$(NoWarn);CS1591;CS1574;CS1573;CS1572;NU5128</NoWarn>
     <PackProject>true</PackProject>
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);CreateNupkgFromILMerge</TargetsForTfmSpecificContentInPackage>
     <Shipping>true</Shipping>
     <IncludeInVSIX>false</IncludeInVSIX>
     <XPLATProject>false</XPLATProject>
     <UsePublicApiAnalyzer>false</UsePublicApiAnalyzer>
     <DefineConstants>$(DefineConstants);IS_DESKTOP</DefineConstants>
     <IsDesktop>true</IsDesktop>
+    <ILMergeDirectory Condition=" '$(OutputPath)' != '' ">$(OutputPath)$(TargetFramework)\ilmerge\</ILMergeDirectory>
+    <ILMergeDirectory Condition=" '$(OutputPath)' == '' ">$(ArtifactsDirectory)$(MSBuildProjectName)\$(BuildVariationFolder)\bin\$(Configuration)\$(TargetFramework)\ilmerge\</ILMergeDirectory>
   </PropertyGroup>
+
+  <Target
+    Name="PublishAndMergePackNupkg"
+    AfterTargets="AfterBuild"
+    Condition="'$(TargetFramework)' != '' AND '$(IsXPlat)' != 'true' AND '$(IsBuildOnlyXPLATProjects)' != 'true' AND '$(BuildingInsideVisualStudio)' != 'true'">
+    <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="Publish;ILMergeNPE" />
+  </Target>
+
+  <!--These targets help get all the DLLs that are packed in the nuspec to be sent for signing.-->
+  <Target Name="GetIlmergeBuildOutput" DependsOnTargets="_GetDllsInOutputDirectory" Returns="@(DllsToSign)">
+    <ItemGroup>
+      <DllsToSign Include="@(DllsInOutputDir)" KeepDuplicates="false" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="_GetDllsInOutputDirectory" Returns="@(DllsInOutputDir)">
+    <ItemGroup>
+      <DllsInOutputDir Include="$(ILMergeDirectory)*.dll" KeepDuplicates="false">
+        <StrongName>MsSharedLib72</StrongName>
+        <Authenticode>Microsoft400</Authenticode>
+      </DllsInOutputDir>
+      <DllsInOutputDir Include="$(ILMergeDirectory)*.xml" KeepDuplicates="false">
+        <Authenticode>MicrosoftXmlSHA2</Authenticode>
+      </DllsInOutputDir>
+    </ItemGroup>
+  </Target>
+
+  <!--These targets help get all the DLLs that are packed in the nuspec to be sent for signing.-->
+  <Target Name="GetIlmergeSymbolOutput" Returns="@(SymbolsToIndex)">
+    <ItemGroup>
+      <SymbolsToIndex Include="$(ILMergeDirectory)*.pdb" KeepDuplicates="false" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="GetFinalBuildOutput" Returns="@(DllsToIndex)">
+    <ItemGroup>
+      <DllsToIndex Include="$(ILMergeDirectory)*.dll"/>
+    </ItemGroup>
+  </Target>
+
+  <Target Name="CreateNupkgFromILMerge">
+    <ItemGroup>
+      <TfmSpecificPackageFile Include="$(ILMergeDirectory)NuGet.Packaging.Extraction.dll">
+        <PackagePath>lib/net45/</PackagePath>
+      </TfmSpecificPackageFile>
+      <TfmSpecificPackageFile Include="$(ILMergeDirectory)NuGet.Packaging.Extraction.pdb">
+        <PackagePath>lib/net45/</PackagePath>
+      </TfmSpecificPackageFile>
+    </ItemGroup>
+  </Target>
 
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -307,6 +363,26 @@
     </EmbeddedResource>
   </ItemGroup>
 
+  <Target Name="ILMergeNPE" Condition="'$(BuildingInsideVisualStudio)' != 'true' and '$(SkipILMergeOfNPE)' != 'true'" >
+    <ItemGroup>
+      <BuildArtifacts Include="$(OutputPath)\*.dll" Exclude="@(MergeExclude)" />
+    </ItemGroup>
+    <PropertyGroup>
+      <PathToBuiltNPE>$(OutputPath)NuGet.Packaging.Extraction.dll</PathToBuiltNPE>
+      <IlmergeCommand>$(ILMergeExePath) /lib:$(OutputPath) /t:library /out:$(ILMergeDirectory)NuGet.Packaging.Extraction.dll @(MergeAllowDup -> '/allowdup:%(Identity)', ' ')</IlmergeCommand>
+      <IlmergeCommand Condition="Exists($(MS_PFX_PATH))">$(IlmergeCommand) /delaysign /keyfile:$(MS_PFX_PATH)</IlmergeCommand>
+      <IlmergeCommand>$(IlmergeCommand) $(PathToBuiltNPE) @(MergeInclude->'%(fullpath)', ' ')</IlmergeCommand>
+    </PropertyGroup>
+    <MakeDir Directories="$(ILMergeDirectory)" />
+    <Exec Command="$(IlmergeCommand)" ContinueOnError="false" StandardOutputImportance="High" StandardErrorImportance="High" />
+  </Target>
+
   <Import Project="$(BuildCommonDirectory)common.targets" />
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
+
+  <PropertyGroup>
+    <SignTargetsForRealSigning Condition="'$(IsSymbolsBuild)' != 'true'">GetIlmergeBuildOutput</SignTargetsForRealSigning>
+    <SymbolTargetsToGetPdbs>GetIlmergeSymbolOutput;GetFinalBuildOutput</SymbolTargetsToGetPdbs>
+  </PropertyGroup>
+
 </Project>

--- a/src/NuGet.Core/NuGet.Packaging.Extraction/ilmerge.props
+++ b/src/NuGet.Core/NuGet.Packaging.Extraction/ilmerge.props
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0">
+  <ItemGroup>
+    <MergeInclude Include="$(OutputPath)Newtonsoft.Json.dll"/>
+    <MergeInclude Include="$(OutputPath)NuGet.Common.dll"/>
+    <MergeInclude Include="$(OutputPath)NuGet.Configuration.dll"/>
+    <MergeInclude Include="$(OutputPath)NuGet.Frameworks.dll"/>
+    <MergeInclude Include="$(OutputPath)NuGet.Versioning.dll"/>
+
+    <MergeAllowdup Include="Strings"/>
+    <MergeAllowdup Include="EncodingUtility"/>
+    <MergeAllowdup Include="EqualityUtility"/>
+    <MergeAllowdup Include="HashCodeCombiner"/>
+    <MergeAllowdup Include="Extensions"/>
+  </ItemGroup>
+</Project>

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
@@ -1781,14 +1781,14 @@ namespace NuGet.Commands.Test
                 // Package Bar does not have a corresponding PackageVersion 
                 var packageRefDependecyBar = new LibraryDependency()
                 {
-                    LibraryRange = new LibraryRange("bar", versionRange: null, typeConstraint: LibraryDependencyTarget.Package) ,
+                    LibraryRange = new LibraryRange("bar", versionRange: null, typeConstraint: LibraryDependencyTarget.Package),
                 };
 
                 var centralVersionFoo = new CentralPackageVersion("foo", VersionRange.Parse("1.0.0"));
 
                 var tfi = CreateTargetFrameworkInformation(
                     new List<LibraryDependency>() { packageRefDependecyBar },
-                    new List<CentralPackageVersion>() { centralVersionFoo});
+                    new List<CentralPackageVersion>() { centralVersionFoo });
 
                 var packageSpec = new PackageSpec(new List<TargetFrameworkInformation>() { tfi });
                 packageSpec.RestoreMetadata = new ProjectRestoreMetadata()


### PR DESCRIPTION
…nflicts with other NuGet assemblies in VS

## Bug

Fixes: https://github.com/NuGet/Client.Engineering/issues/461
Regression: no

## Fix

Details: IL Merge Nuget.Packaging.Extraction.dll with all of its dependencies

## Testing/Validation

Tests Added: No
Reason for not adding tests: Will go through acceptance testing from vs setup team. 
