### PR TITLE
Upgrade the VS/MSBuild dependencies, update the pack Sdk used

### DIFF
--- a/build/bootstrap.proj
+++ b/build/bootstrap.proj
@@ -23,7 +23,7 @@
         <PackageDownload Include="Microsoft.VisualStudio.ProjectSystem.Managed.VS" version="[16.7.0-beta1-65318-02]" />
         <PackageDownload Include="Microsoft.Web.Xdt" version="[2.1.2]" />
         <PackageDownload Include="Newtonsoft.Json" version="[9.0.1]" />
-        <PackageDownload Include="NuGet.Build.Tasks.Pack" version="[5.6.0]" />
+        <PackageDownload Include="NuGet.Build.Tasks.Pack" version="[5.7.0]" />
         <PackageDownload Include="NuGet.Client.EndToEnd.TestData" version="[1.0.0]" />
         <PackageDownload Include="NuGet.Core" version="[2.14.0-rtm-832]" />
         <PackageDownload Include="NuGetValidator" version="[2.0.3]" />

--- a/build/common.project.props
+++ b/build/common.project.props
@@ -39,7 +39,7 @@
     <XunitConsoleExePath>$(SolutionPackagesFolder)xunit.runner.console\2.4.1\tools\net472\xunit.console.x86.exe</XunitConsoleExePath>
     <ILMergeExePath>$(SolutionPackagesFolder)ilmerge\3.0.21\tools\net452\ILMerge.exe</ILMergeExePath>
     <XunitXmlLoggerDirectory>$(SolutionPackagesFolder)xunitxml.testlogger\2.0.0\build\_common</XunitXmlLoggerDirectory>
-    <NuGetBuildTasksPackTargets Condition="Exists('$(SolutionPackagesFolder)nuget.build.tasks.pack\5.6.0\build\NuGet.Build.Tasks.Pack.targets')">$(SolutionPackagesFolder)nuget.build.tasks.pack\5.6.0\build\NuGet.Build.Tasks.Pack.targets</NuGetBuildTasksPackTargets>
+    <NuGetBuildTasksPackTargets Condition="Exists('$(SolutionPackagesFolder)nuget.build.tasks.pack\5.7.0\build\NuGet.Build.Tasks.Pack.targets')">$(SolutionPackagesFolder)nuget.build.tasks.pack\5.7.0\build\NuGet.Build.Tasks.Pack.targets</NuGetBuildTasksPackTargets>
     <EnlistmentRoot>$(RepositoryRootDirectory)</EnlistmentRoot>
     <EnlistmentRootSrc>$(RepositoryRootDirectory)src</EnlistmentRootSrc>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">$(RepositoryRootDirectory)</SolutionDir>

--- a/build/packages.targets
+++ b/build/packages.targets
@@ -1,21 +1,18 @@
 <Project>
     <PropertyGroup>
-        <MicrosoftBuildPackageVersion Condition="'$(MicrosoftBuildPackageVersion)' == ''">16.5.0-preview-19606-01</MicrosoftBuildPackageVersion>
+        <MicrosoftBuildPackageVersion Condition="'$(MicrosoftBuildPackageVersion)' == ''">16.6.0</MicrosoftBuildPackageVersion>
         <NewtonsoftJsonPackageVersion Condition="$(NewtonsoftJsonPackageVersion) == ''">9.0.1</NewtonsoftJsonPackageVersion>
         <SystemPackagesVersion>4.3.0</SystemPackagesVersion>
-        <VSComponentsVersion>16.4.280</VSComponentsVersion>
+        <VSComponentsVersion>16.6.255</VSComponentsVersion>
         <VSFrameworkVersion>16.6.30107.105</VSFrameworkVersion>
         <VSServicesVersion>16.153.0</VSServicesVersion>
-        <VSThreadingVersion>16.6.13</VSThreadingVersion>
+        <VSThreadingVersion>16.7.54</VSThreadingVersion>
         <!-- TODO - remove this when temporary patching is no longer necessary. See https://github.com/nuget/home/issues/8952 -->
         <PatchedSystemPackagesVersion>5.0.0-preview.3.20214.6</PatchedSystemPackagesVersion>
     </PropertyGroup>
 
     <!-- Test and package versions -->
     <PropertyGroup>
-        <FluentAssertionsVersion>4.19.4</FluentAssertionsVersion>
-        <MoqVersion>4.14.1</MoqVersion>
-        <TestSDKVersion>15.5.0</TestSDKVersion>
         <XunitVersion>2.4.1</XunitVersion>
     </PropertyGroup>
 
@@ -24,7 +21,7 @@
         <PackageReference Update="Lucene.Net" Version="3.0.3" />
         <PackageReference Update="Microsoft.Build" Version="$(MicrosoftBuildPackageVersion)" />
         <PackageReference Update="Microsoft.Build.Framework" Version="$(MicrosoftBuildPackageVersion)" />
-        <PackageReference Update="Microsoft.Build.Locator" Version="1.2.2" />
+        <PackageReference Update="Microsoft.Build.Locator" Version="1.2.6" />
         <PackageReference Update="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildPackageVersion)" />
         <PackageReference Update="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildPackageVersion)" />
         <PackageReference Update="Microsoft.DataAI.NuGetRecommender.Contracts" Version="2.1.0" />
@@ -33,7 +30,7 @@
         <PackageReference Update="Microsoft.ServiceHub.Framework" Version="2.4.227" />
         <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.0.0" />
         <PackageReference Update="Microsoft.TeamFoundationServer.ExtendedClient" Version="$(VSServicesVersion)" />
-        <PackageReference Update="Microsoft.VSSDK.BuildTools" Version="16.7.11" />
+        <PackageReference Update="Microsoft.VSSDK.BuildTools" Version="16.7.3069" />
         <PackageReference Update="Microsoft.VisualStudio.ComponentModelHost" Version="$(VSComponentsVersion)" />
         <PackageReference Update="Microsoft.VisualStudio.CoreUtility" Version="$(VSComponentsVersion)" />
         <PackageReference Update="Microsoft.VisualStudio.Editor" Version="$(VSComponentsVersion)" />
@@ -66,6 +63,7 @@
         <PackageReference Update="Microsoft.Web.Xdt" Version="2.1.2" />
         <PackageReference Update="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
         <PackageReference Update="System.Collections.Immutable" Version="1.5.0" />
+        <PackageReference Update="System.Diagnostics.Debug" Version="$(SystemPackagesVersion)" />
         <PackageReference Update="System.Security.Cryptography.Pkcs" Version="$(PatchedSystemPackagesVersion)" />
         <PackageReference Update="System.Security.Cryptography.Cng" Version="$(PatchedSystemPackagesVersion)" />
         <PackageReference Update="System.Security.Cryptography.ProtectedData" Version="4.4.0" />
@@ -81,21 +79,21 @@
     <!-- Test and utility packages -->
     <ItemGroup>
         <PackageReference Update="EnvDTE" Version="8.0.1" />
-        <PackageReference Update="FluentAssertions" Version="$(FluentAssertionsVersion)" />
+        <PackageReference Update="FluentAssertions" Version="4.19.4" />
         <PackageReference Update="Microsoft.Build.Runtime" Version="$(MicrosoftBuildPackageVersion)" />
         <PackageReference Update="Microsoft.CSharp" Version="$(SystemPackagesVersion)" />
         <PackageReference Update="Microsoft.CodeAnalysis" Version="3.0.0" />
         <PackageReference Update="Microsoft.CodeAnalysis.Build.Tasks" Version="3.0.0-dev-61717-03" />
         <PackageReference Update="Microsoft.CodeAnalysis.CSharp" Version="3.0.0-dev-61717-03" />
         <PackageReference Update="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.0.0" />
-        <PackageReference Update="Microsoft.NET.Test.Sdk" Version="$(TestSDKVersion)" />
+        <PackageReference Update="Microsoft.NET.Test.Sdk" Version="15.5.0" />
         <PackageReference Update="Microsoft.Net.Compilers.netcore" Version="3.0.0-dev-61717-03" />
         <PackageReference Update="Microsoft.PowerShell.3.ReferenceAssemblies" Version="1.0.0" />
         <PackageReference Update="Microsoft.Test.Apex.VisualStudio" Version="16.3.29131.53-pre" />
         <PackageReference Update="Microsoft.VisualStudio.ProjectSystem" Version="15.0.751" PrivateAssets="All" />
         <PackageReference Update="Microsoft.VisualStudio.Sdk.TestFramework" Version="16.5.4-beta" />
         <PackageReference Update="Microsoft.VisualStudio.Shell.Interop.15.0.DesignTime" Version="15.0.26932" />
-        <PackageReference Update="Moq" Version="$(MoqVersion)" />
+        <PackageReference Update="Moq" Version="4.14.5" />
         <PackageReference Update="NuGet.Core" Version="2.14.0-rtm-832" />
         <PackageReference Update="Portable.BouncyCastle" Version="1.8.1.3" />
         <PackageReference Update="Xunit.StaFact" Version="0.2.9" />

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/NuGet.PackageManagement.VisualStudio.csproj
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/NuGet.PackageManagement.VisualStudio.csproj
@@ -15,7 +15,6 @@
     <Description>NuGet's Visual Studio functionalities, integrations and utilities.</Description>
     <ResolveNuGetPackages>true</ResolveNuGetPackages>
     <TargetFrameworkVersion>$(NETFXTargetFrameworkVersion)</TargetFrameworkVersion>
-    <NoWarn>$(NoWarn);NU5104</NoWarn>
   </PropertyGroup>
   <ItemGroup Condition="'$(VisualStudioVersion)' == '16.0'">
     <Reference Include="Microsoft.VisualStudio.VCProjectEngine, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/NuGet.VisualStudio.Common.csproj
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/NuGet.VisualStudio.Common.csproj
@@ -7,7 +7,6 @@
     <Shipping>true</Shipping>
     <IncludeInVsix>true</IncludeInVsix>
     <RootNamespace>NuGet.VisualStudio</RootNamespace>
-    <NoWarn>$(NoWarn);NU5104</NoWarn>
     <Description>NuGet's Visual Studio common types and interfaces used for both Package Manager UI, Package Manager Console, restore and install functionalities.</Description>
   </PropertyGroup>
 

--- a/src/NuGet.Core/NuGet.Build.Tasks.Console/NuGet.Build.Tasks.Console.csproj
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Console/NuGet.Build.Tasks.Console.csproj
@@ -10,7 +10,7 @@
     <PackProject>true</PackProject>
     <SkipShared>true</SkipShared>
     <Description>NuGet Build tasks for MSBuild and dotnet restore. Contains restore logic using the MSBuild static graph functionality.</Description>
-    <NoWarn>$(NoWarn);CS1591;NU5100;NU5128;NU5104</NoWarn>
+    <NoWarn>$(NoWarn);CS1591;NU5100;NU5128</NoWarn>
     <XPLATProject>true</XPLATProject>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);PackBuildOutputs</TargetsForTfmSpecificContentInPackage>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/NuGet.CommandLine.XPlat.csproj
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/NuGet.CommandLine.XPlat.csproj
@@ -19,6 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.CommandLineUtils" />
+    <PackageReference Include="System.Diagnostics.Debug" />
   </ItemGroup>
 
   <!-- Microsoft.Build.Locator is needed when debugging, but should not be used in the assemblies we insert.


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9950
Regression: Yes/No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: It's good practice to keep our VS/MSBuild dependencies up to date.
This tasks covers moving from prerelease to stable versions for MSBUild and bringing the VS dependencies as close to current shipping as possible.

The biggest reason why I did this upgrade was moving to the latest 5.7.0 pack SDK. 

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  
Validation:  
