### PR TITLE
Track background loading of PackageSearchMetadata

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageItemListViewModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageItemListViewModel.cs
@@ -237,10 +237,11 @@ namespace NuGet.PackageManagement.UI
                     OnPropertyChanged(nameof(IsUpdateAvailable));
                     OnPropertyChanged(nameof(IsUninstallable));
                     OnPropertyChanged(nameof(IsNotInstalled));
+                    OnPropertyChanged(nameof(HasPendingBackgroundWork));
                 }
             }
         }
-       
+
         // If the values that help calculate this property change, make sure you raise OnPropertyChanged for IsNotInstalled
         // in all those properties.
         public bool IsNotInstalled
@@ -395,7 +396,7 @@ namespace NuGet.PackageManagement.UI
         public int TaskCount
         {
             get { return _taskCount; }
-            set
+            private set
             {
                 _taskCount = value;
                 OnPropertyChanged(nameof(HasPendingBackgroundWork));
@@ -437,7 +438,7 @@ namespace NuGet.PackageManagement.UI
             }
         }
 
-        private async System.Threading.Tasks.Task ReloadPackageVersionsAsync()
+        public async System.Threading.Tasks.Task ReloadPackageVersionsAsync()
         {
             IncrementTask();
             var result = await _backgroundLatestVersionLoader.Value;
@@ -480,7 +481,6 @@ namespace NuGet.PackageManagement.UI
             _backgroundLatestVersionLoader = AsyncLazy.New(
                 async () =>
                 {
-                    await Task.Delay(3000);
                     var packageVersions = await GetVersionsAsync();
 
                     // filter package versions based on allowed versions in packages.config

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageItemListViewModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageItemListViewModel.cs
@@ -240,6 +240,7 @@ namespace NuGet.PackageManagement.UI
                 }
             }
         }
+        public bool HasPendingBackgroundWork { get; private set; } = true;
 
         // If the values that help calculate this property change, make sure you raise OnPropertyChanged for IsNotInstalled
         // in all those properties.
@@ -386,6 +387,7 @@ namespace NuGet.PackageManagement.UI
         {
             if (!_backgroundLatestVersionLoader.IsValueCreated)
             {
+                HasPendingBackgroundWork = true;
                 NuGetUIThreadHelper.JoinableTaskFactory
                     .RunAsync(ReloadPackageVersionsAsync)
                     .PostOnFailure(nameof(PackageItemListViewModel), nameof(ReloadPackageVersionsAsync));
@@ -408,6 +410,7 @@ namespace NuGet.PackageManagement.UI
 
             LatestVersion = result;
             Status = GetPackageStatus(LatestVersion, InstalledVersion, AutoReferenced);
+            HasPendingBackgroundWork = false;
         }
 
         private async System.Threading.Tasks.Task ReloadPackageDeprecationAsync()

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml
@@ -10,7 +10,12 @@
   d:DesignHeight="200"
   d:DesignWidth="500">
   <UserControl.Resources>
-    <nuget:InfiniteScrollListItemStyleSelector
+    <ResourceDictionary>
+      <ResourceDictionary.MergedDictionaries>
+        <nuget:SharedResources />
+      </ResourceDictionary.MergedDictionaries>
+
+      <nuget:InfiniteScrollListItemStyleSelector
       x:Key="itemStyleSelector" />
 
     <DataTemplate
@@ -268,7 +273,9 @@
           <ScrollBar x:Name="PART_HorizontalScrollBar" AutomationProperties.AutomationId="HorizontalScrollBar" Cursor="Arrow" Grid.Column="0" Maximum="{TemplateBinding ScrollableWidth}" Minimum="0" Orientation="Horizontal" Grid.Row="1" Visibility="{TemplateBinding ComputedHorizontalScrollBarVisibility}" Value="{Binding HorizontalOffset, Mode=OneWay, RelativeSource={RelativeSource TemplatedParent}}" ViewportSize="{TemplateBinding ViewportWidth}"/>
       </Grid>
     </ControlTemplate>
-  </UserControl.Resources>
+    </ResourceDictionary>
+  </UserControl.Resources>    
+    
   <DockPanel LastChildFill="True">
     <Border
       x:Name="_updateButtonContainer"
@@ -276,6 +283,7 @@
       BorderBrush="{DynamicResource {x:Static SystemColors.ActiveBorderBrushKey}}"
       BorderThickness="0,0,0,1"
       Background="{DynamicResource {x:Static nuget:Brushes.LegalMessageBackground}}"
+      IsEnabled="{Binding HasPendingBackgroundWork, RelativeSource={RelativeSource AncestorType={x:Type nuget:InfiniteScrollList}}, Converter={StaticResource InverseBooleanConverter}}"
       Visibility="Collapsed">
       <Grid>
         <Grid.ColumnDefinitions>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml
@@ -274,8 +274,8 @@
       </Grid>
     </ControlTemplate>
     </ResourceDictionary>
-  </UserControl.Resources>    
-    
+  </UserControl.Resources>
+
   <DockPanel LastChildFill="True">
     <Border
       x:Name="_updateButtonContainer"

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
@@ -13,6 +13,7 @@ using System.Windows.Controls;
 using System.Windows.Data;
 using System.Windows.Input;
 using System.Windows.Media;
+using Microsoft.TeamFoundation.Server;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Threading;
 using NuGet.Common;
@@ -29,8 +30,9 @@ namespace NuGet.PackageManagement.UI
     /// Interaction logic for InfiniteScrollList.xaml
     /// </summary>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1001")]
-    public partial class InfiniteScrollList : UserControl
+    public partial class InfiniteScrollList : UserControl, INotifyPropertyChanged
     {
+        public event PropertyChangedEventHandler PropertyChanged;
         private readonly LoadingStatusIndicator _loadingStatusIndicator = new LoadingStatusIndicator();
         private ScrollViewer _scrollViewer;
 
@@ -150,6 +152,14 @@ namespace NuGet.PackageManagement.UI
         public int SelectedIndex => _list.SelectedIndex;
 
         public Guid? OperationId => _loader?.State.OperationId;
+
+        public bool HasPendingBackgroundWork
+        {
+            get
+            {
+                return PackageItems.Any(p => p.HasPendingBackgroundWork);
+            }
+        }
 
         // Load items using the specified loader
         internal async Task LoadItemsAsync(
@@ -611,6 +621,19 @@ namespace NuGet.PackageManagement.UI
                 }
 
                 UpdateCheckBoxStatus();
+            }
+
+            if (e.PropertyName == nameof(package.HasPendingBackgroundWork))
+            {
+                OnPropertyChanged(nameof(HasPendingBackgroundWork));
+            }
+        }
+        protected void OnPropertyChanged(string propertyName)
+        {
+            if (PropertyChanged != null)
+            {
+                var e = new PropertyChangedEventArgs(propertyName);
+                PropertyChanged(this, e);
             }
         }
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
@@ -13,7 +13,6 @@ using System.Windows.Controls;
 using System.Windows.Data;
 using System.Windows.Input;
 using System.Windows.Media;
-using Microsoft.TeamFoundation.Server;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Threading;
 using NuGet.Common;
@@ -83,6 +82,13 @@ namespace NuGet.PackageManagement.UI
 
             DataContext = Items;
             CheckBoxesEnabled = false;
+
+            var lcv = CollectionView as ListCollectionView;
+            lcv.IsLiveFiltering = true;
+            lcv.LiveFilteringProperties.Add(nameof(PackageItemListViewModel.IsUpdateAvailable));
+            lcv.LiveFilteringProperties.Add(nameof(PackageItemListViewModel.Status));
+            lcv.LiveFilteringProperties.Add(nameof(PackageItemListViewModel.HasPendingBackgroundWork));
+            lcv.LiveFilteringProperties.Add(nameof(HasPendingBackgroundWork));
 
             _loadingStatusIndicator.PropertyChanged += LoadingStatusIndicator_PropertyChanged;
         }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageItemControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageItemControl.xaml
@@ -149,9 +149,6 @@
         <StackPanel
                       Grid.Row="0"
                       Orientation="Horizontal">
-          <TextBlock Width="75" Visibility="{Binding HasPendingBackgroundWork,Converter={StaticResource BooleanToVisibilityConverter}}" Background="LightPink">
-            LOADING!!!!!!!!
-          </TextBlock>
           <TextBlock
                         FontWeight="Bold"
                         FontSize="{Binding ElementName=_self,Path=FontSize,Converter={StaticResource Font122PercentSizeConverter}}"

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageItemControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageItemControl.xaml
@@ -149,6 +149,9 @@
         <StackPanel
                       Grid.Row="0"
                       Orientation="Horizontal">
+          <TextBlock Width="75" Visibility="{Binding HasPendingBackgroundWork,Converter={StaticResource BooleanToVisibilityConverter}}" Background="LightPink">
+            LOADING!!!!!!!!
+          </TextBlock>
           <TextBlock
                         FontWeight="Bold"
                         FontSize="{Binding ElementName=_self,Path=FontSize,Converter={StaticResource Font122PercentSizeConverter}}"

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -821,10 +821,6 @@ namespace NuGet.PackageManagement.UI
                     ? Resx.Resources.Text_Loading
                     : string.Format(CultureInfo.CurrentCulture, Resx.Resources.Text_Searching, searchText);
 
-                // Set a new cancellation token source which will be used to cancel this task in case
-                // new loading task starts or manager ui is closed while loading packages.
-                _loadCts = new CancellationTokenSource();
-
                 // start SearchAsync task for initial loading of packages
                 var searchResultTask = loader.SearchAsync(continuationToken: null, cancellationToken: _loadCts.Token);
                 // this will wait for searchResultTask to complete instead of creating a new task

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -1482,7 +1482,7 @@ namespace NuGet.PackageManagement.UI
         private void PackageList_UpdateButtonClicked(PackageItemListViewModel[] selectedPackages)
         {
             var packagesToUpdate = selectedPackages
-                .Select(package => new PackageIdentity(package.Id, package.LatestVersion))
+                .Select(package => new PackageIdentity(package.Id, package.Version)) //LatestVersion
                 .ToList();
 
             UpdatePackage(packagesToUpdate);

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -293,6 +293,8 @@ namespace NuGet.PackageManagement.UI
             // Do not refresh if the UI is not visible. It will be refreshed later when the loaded event is called.
             if (IsVisible)
             {
+                ResetTabDataLoadFlags();
+
                 if (Model.IsSolution)
                 {
                     RefreshWhenNotExecutingAction(RefreshOperationSource.CacheUpdated, timeSpan);
@@ -903,8 +905,11 @@ namespace NuGet.PackageManagement.UI
 
         private void ResetTabDataLoadFlags()
         {
-            _installedTabDataIsLoaded = false;
-            _updatesTabDataIsLoaded = false;
+            lock (_tabDataLock)
+            {
+                _installedTabDataIsLoaded = false;
+                _updatesTabDataIsLoaded = false;
+            }
         }
 
         private void RefreshInstalledAndUpdatesTabs()
@@ -1496,8 +1501,9 @@ namespace NuGet.PackageManagement.UI
 
         private void PackageList_UpdateButtonClicked(PackageItemListViewModel[] selectedPackages)
         {
+            ResetTabDataLoadFlags();
             var packagesToUpdate = selectedPackages
-                .Select(package => new PackageIdentity(package.Id, package.Version)) //LatestVersion
+                .Select(package => new PackageIdentity(package.Id, package.LatestVersion))
                 .ToList();
 
             UpdatePackage(packagesToUpdate);

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -845,12 +845,12 @@ namespace NuGet.PackageManagement.UI
                     {
                         await package.ReloadPackageVersionsAsync();
                     }
-                    FlagTabDataAsLoaded(filterToRender);
 
                     // Loading Data on Installed tab should also consider the Data on Updates tab as loaded to indicate
                     // UI filtering for Updates is ready.
                     if (filterToRender == ItemFilter.Installed)
                     {
+                        FlagTabDataAsLoaded(filterToRender);
                         FlagTabDataAsLoaded(ItemFilter.UpdatesAvailable);
                     }
                 }).PostOnFailure(nameof(PackageManagerControl), nameof(SearchPackagesAndRefreshUpdateCountAsync));


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9804
Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1157527
Regression: Yes
* Last working version:   16.6

## DRAFT details
Currently, quickly switching to Installed -> Updates -> Installed can result in too few packages shown. Basically, there's a coordination problem when flagging tabs as loaded:
1. Installed tab loading begins
2. Switching to Updates clears the InfiniteScrollList and begins populating packages from Updates Feed
3. Installed tab loading steps continue to set flag as loaded, but it actually got interrupted in step 2.
4. Now Installed/Updates tabs are UI filtering, but only the UpdatesAvailable packages are filtered upon (too few packages).

(Note: I'm currently attempting & seeking input on another PR that attempts to disconnect the loading from the InfiniteScrollList, to avoid the problem of sharing 1 control with 2 datasources.)

-Verify that https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1157527 is resolved
-Add tests

## Fix

Details: After packages are loaded from a feed, an async loading of Version metadata is triggered to load LatestVersion per the packages sources. We have not had (nor needed) a way to track when this completed. Now that we are sometimes caching packages and simply applying UI Filters, we need to ensure we finish loading them before aborting a tab's Loading routine.

Track loading using an Increment/Decrement pattern. A property on the ViewModel gets bubbled up to the PackageManagerControl to identify if it's waiting on *anything*. 
Don't enable UI filtering unless all the background tasks are complete, to avoid an erroneous UIFilter (Updates tab may have incorrect count of packages with available updates if we don't wait: https://github.com/NuGet/Home/issues/9804).

While waiting, disable the Update button on the Updates Tab. This should prevent a `null` LatestVersion, as was the cause of https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1157527.

## Testing/Validation

Tests Added: Yes/No  
Reason for not adding tests:  
Validation:  
