### PR TITLE
Installed/Updates/Consolidate tabs use Cached Installed Packages to simplify UIFiltering & improve perf

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageItemListViewModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageItemListViewModel.cs
@@ -237,10 +237,11 @@ namespace NuGet.PackageManagement.UI
                     OnPropertyChanged(nameof(IsUpdateAvailable));
                     OnPropertyChanged(nameof(IsUninstallable));
                     OnPropertyChanged(nameof(IsNotInstalled));
+                    OnPropertyChanged(nameof(HasPendingBackgroundWork));
                 }
             }
         }
-       
+
         // If the values that help calculate this property change, make sure you raise OnPropertyChanged for IsNotInstalled
         // in all those properties.
         public bool IsNotInstalled
@@ -395,7 +396,7 @@ namespace NuGet.PackageManagement.UI
         public int TaskCount
         {
             get { return _taskCount; }
-            set
+            private set
             {
                 _taskCount = value;
                 OnPropertyChanged(nameof(HasPendingBackgroundWork));
@@ -437,7 +438,7 @@ namespace NuGet.PackageManagement.UI
             }
         }
 
-        private async System.Threading.Tasks.Task ReloadPackageVersionsAsync()
+        public async System.Threading.Tasks.Task ReloadPackageVersionsAsync()
         {
             IncrementTask();
             var result = await _backgroundLatestVersionLoader.Value;
@@ -480,7 +481,6 @@ namespace NuGet.PackageManagement.UI
             _backgroundLatestVersionLoader = AsyncLazy.New(
                 async () =>
                 {
-                    await Task.Delay(3000);
                     var packageVersions = await GetVersionsAsync();
 
                     // filter package versions based on allowed versions in packages.config

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageItemListViewModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageItemListViewModel.cs
@@ -240,6 +240,7 @@ namespace NuGet.PackageManagement.UI
                 }
             }
         }
+        public bool HasPendingBackgroundWork { get; private set; } = true;
 
         // If the values that help calculate this property change, make sure you raise OnPropertyChanged for IsNotInstalled
         // in all those properties.
@@ -386,6 +387,7 @@ namespace NuGet.PackageManagement.UI
         {
             if (!_backgroundLatestVersionLoader.IsValueCreated)
             {
+                HasPendingBackgroundWork = true;
                 NuGetUIThreadHelper.JoinableTaskFactory
                     .RunAsync(ReloadPackageVersionsAsync)
                     .PostOnFailure(nameof(PackageItemListViewModel), nameof(ReloadPackageVersionsAsync));
@@ -408,6 +410,7 @@ namespace NuGet.PackageManagement.UI
 
             LatestVersion = result;
             Status = GetPackageStatus(LatestVersion, InstalledVersion, AutoReferenced);
+            HasPendingBackgroundWork = false;
         }
 
         private async System.Threading.Tasks.Task ReloadPackageDeprecationAsync()

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/PackageItemLoader.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/PackageItemLoader.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -37,6 +38,8 @@ namespace NuGet.PackageManagement.UI
         public IItemLoaderState State => _state;
 
         public bool IsMultiSource => _packageFeed.IsMultiSource;
+
+        internal ObservableCollection<PackageItemListViewModel> CachedInstalledItems { get; private set; }
 
         private class PackageFeedSearchState : IItemLoaderState
         {
@@ -327,6 +330,11 @@ namespace NuGet.PackageManagement.UI
 
                     return listItem;
                 });
+
+            if (_packageFeed is InstalledPackageFeed)
+            {
+                CachedInstalledItems = new ObservableCollection<PackageItemListViewModel>(listItems);
+            }
 
             return listItems.ToArray();
         }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml
@@ -10,7 +10,12 @@
   d:DesignHeight="200"
   d:DesignWidth="500">
   <UserControl.Resources>
-    <nuget:InfiniteScrollListItemStyleSelector
+    <ResourceDictionary>
+      <ResourceDictionary.MergedDictionaries>
+        <nuget:SharedResources />
+      </ResourceDictionary.MergedDictionaries>
+
+      <nuget:InfiniteScrollListItemStyleSelector
       x:Key="itemStyleSelector" />
 
     <DataTemplate
@@ -268,7 +273,9 @@
           <ScrollBar x:Name="PART_HorizontalScrollBar" AutomationProperties.AutomationId="HorizontalScrollBar" Cursor="Arrow" Grid.Column="0" Maximum="{TemplateBinding ScrollableWidth}" Minimum="0" Orientation="Horizontal" Grid.Row="1" Visibility="{TemplateBinding ComputedHorizontalScrollBarVisibility}" Value="{Binding HorizontalOffset, Mode=OneWay, RelativeSource={RelativeSource TemplatedParent}}" ViewportSize="{TemplateBinding ViewportWidth}"/>
       </Grid>
     </ControlTemplate>
-  </UserControl.Resources>
+    </ResourceDictionary>
+  </UserControl.Resources>    
+    
   <DockPanel LastChildFill="True">
     <Border
       x:Name="_updateButtonContainer"
@@ -276,6 +283,7 @@
       BorderBrush="{DynamicResource {x:Static SystemColors.ActiveBorderBrushKey}}"
       BorderThickness="0,0,0,1"
       Background="{DynamicResource {x:Static nuget:Brushes.LegalMessageBackground}}"
+      IsEnabled="{Binding HasPendingBackgroundWork, RelativeSource={RelativeSource AncestorType={x:Type nuget:InfiniteScrollList}}, Converter={StaticResource InverseBooleanConverter}}"
       Visibility="Collapsed">
       <Grid>
         <Grid.ColumnDefinitions>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml
@@ -274,8 +274,8 @@
       </Grid>
     </ControlTemplate>
     </ResourceDictionary>
-  </UserControl.Resources>    
-    
+  </UserControl.Resources>
+
   <DockPanel LastChildFill="True">
     <Border
       x:Name="_updateButtonContainer"

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
@@ -13,6 +13,7 @@ using System.Windows.Controls;
 using System.Windows.Data;
 using System.Windows.Input;
 using System.Windows.Media;
+using Microsoft.TeamFoundation.Server;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Threading;
 using NuGet.Common;
@@ -29,8 +30,9 @@ namespace NuGet.PackageManagement.UI
     /// Interaction logic for InfiniteScrollList.xaml
     /// </summary>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1001")]
-    public partial class InfiniteScrollList : UserControl
+    public partial class InfiniteScrollList : UserControl, INotifyPropertyChanged
     {
+        public event PropertyChangedEventHandler PropertyChanged;
         private readonly LoadingStatusIndicator _loadingStatusIndicator = new LoadingStatusIndicator();
         private ScrollViewer _scrollViewer;
 
@@ -150,6 +152,14 @@ namespace NuGet.PackageManagement.UI
         public int SelectedIndex => _list.SelectedIndex;
 
         public Guid? OperationId => _loader?.State.OperationId;
+
+        public bool HasPendingBackgroundWork
+        {
+            get
+            {
+                return PackageItems.Any(p => p.HasPendingBackgroundWork);
+            }
+        }
 
         // Load items using the specified loader
         internal async Task LoadItemsAsync(
@@ -611,6 +621,19 @@ namespace NuGet.PackageManagement.UI
                 }
 
                 UpdateCheckBoxStatus();
+            }
+
+            if (e.PropertyName == nameof(package.HasPendingBackgroundWork))
+            {
+                OnPropertyChanged(nameof(HasPendingBackgroundWork));
+            }
+        }
+        protected void OnPropertyChanged(string propertyName)
+        {
+            if (PropertyChanged != null)
+            {
+                var e = new PropertyChangedEventArgs(propertyName);
+                PropertyChanged(this, e);
             }
         }
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
@@ -13,7 +13,6 @@ using System.Windows.Controls;
 using System.Windows.Data;
 using System.Windows.Input;
 using System.Windows.Media;
-using Microsoft.TeamFoundation.Server;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Threading;
 using NuGet.Common;
@@ -83,6 +82,13 @@ namespace NuGet.PackageManagement.UI
 
             DataContext = Items;
             CheckBoxesEnabled = false;
+
+            var lcv = CollectionView as ListCollectionView;
+            lcv.IsLiveFiltering = true;
+            lcv.LiveFilteringProperties.Add(nameof(PackageItemListViewModel.IsUpdateAvailable));
+            lcv.LiveFilteringProperties.Add(nameof(PackageItemListViewModel.Status));
+            lcv.LiveFilteringProperties.Add(nameof(PackageItemListViewModel.HasPendingBackgroundWork));
+            lcv.LiveFilteringProperties.Add(nameof(HasPendingBackgroundWork));
 
             _loadingStatusIndicator.PropertyChanged += LoadingStatusIndicator_PropertyChanged;
         }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
@@ -366,6 +366,8 @@ namespace NuGet.PackageManagement.UI
                     {
                         Items.Remove(_loadingStatusIndicator);
                     }
+
+                    _loadingStatusIndicator.Status = LoadingStatus.NoMoreItems;
                 }
             }
 
@@ -555,7 +557,7 @@ namespace NuGet.PackageManagement.UI
         /// </summary>
         /// <param name="packages">Packages collection to add</param>
         /// <param name="refresh">Clears <see cref="Items"> list if set to <c>true</c></param>
-        private void UpdatePackageList(IEnumerable<PackageItemListViewModel> packages, bool refresh)
+        internal void UpdatePackageList(IEnumerable<PackageItemListViewModel> packages, bool refresh)
         {
             _joinableTaskFactory.Value.Run(async () =>
             {
@@ -600,6 +602,14 @@ namespace NuGet.PackageManagement.UI
 
             Items.Clear();
             _loadingStatusBar.ItemsLoaded = 0;
+        }
+
+        internal void CleanupPackages(IEnumerable<PackageItemListViewModel> packages)
+        {
+            foreach (var package in packages)
+            {
+                package.PropertyChanged -= Package_PropertyChanged;
+            }
         }
 
         public void UpdatePackageStatus(PackageCollectionItem[] installedPackages)

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageItemControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageItemControl.xaml
@@ -149,9 +149,6 @@
         <StackPanel
                       Grid.Row="0"
                       Orientation="Horizontal">
-          <TextBlock Width="75" Visibility="{Binding HasPendingBackgroundWork,Converter={StaticResource BooleanToVisibilityConverter}}" Background="LightPink">
-            LOADING!!!!!!!!
-          </TextBlock>
           <TextBlock
                         FontWeight="Bold"
                         FontSize="{Binding ElementName=_self,Path=FontSize,Converter={StaticResource Font122PercentSizeConverter}}"

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageItemControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageItemControl.xaml
@@ -149,6 +149,9 @@
         <StackPanel
                       Grid.Row="0"
                       Orientation="Horizontal">
+          <TextBlock Width="75" Visibility="{Binding HasPendingBackgroundWork,Converter={StaticResource BooleanToVisibilityConverter}}" Background="LightPink">
+            LOADING!!!!!!!!
+          </TextBlock>
           <TextBlock
                         FontWeight="Bold"
                         FontSize="{Binding ElementName=_self,Path=FontSize,Converter={StaticResource Font122PercentSizeConverter}}"

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -821,10 +821,6 @@ namespace NuGet.PackageManagement.UI
                     ? Resx.Resources.Text_Loading
                     : string.Format(CultureInfo.CurrentCulture, Resx.Resources.Text_Searching, searchText);
 
-                // Set a new cancellation token source which will be used to cancel this task in case
-                // new loading task starts or manager ui is closed while loading packages.
-                _loadCts = new CancellationTokenSource();
-
                 // start SearchAsync task for initial loading of packages
                 var searchResultTask = loader.SearchAsync(continuationToken: null, cancellationToken: _loadCts.Token);
                 // this will wait for searchResultTask to complete instead of creating a new task

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -1482,7 +1482,7 @@ namespace NuGet.PackageManagement.UI
         private void PackageList_UpdateButtonClicked(PackageItemListViewModel[] selectedPackages)
         {
             var packagesToUpdate = selectedPackages
-                .Select(package => new PackageIdentity(package.Id, package.LatestVersion))
+                .Select(package => new PackageIdentity(package.Id, package.Version)) //LatestVersion
                 .ToList();
 
             UpdatePackage(packagesToUpdate);

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -293,6 +293,8 @@ namespace NuGet.PackageManagement.UI
             // Do not refresh if the UI is not visible. It will be refreshed later when the loaded event is called.
             if (IsVisible)
             {
+                ResetTabDataLoadFlags();
+
                 if (Model.IsSolution)
                 {
                     RefreshWhenNotExecutingAction(RefreshOperationSource.CacheUpdated, timeSpan);
@@ -903,8 +905,11 @@ namespace NuGet.PackageManagement.UI
 
         private void ResetTabDataLoadFlags()
         {
-            _installedTabDataIsLoaded = false;
-            _updatesTabDataIsLoaded = false;
+            lock (_tabDataLock)
+            {
+                _installedTabDataIsLoaded = false;
+                _updatesTabDataIsLoaded = false;
+            }
         }
 
         private void RefreshInstalledAndUpdatesTabs()
@@ -1496,8 +1501,9 @@ namespace NuGet.PackageManagement.UI
 
         private void PackageList_UpdateButtonClicked(PackageItemListViewModel[] selectedPackages)
         {
+            ResetTabDataLoadFlags();
             var packagesToUpdate = selectedPackages
-                .Select(package => new PackageIdentity(package.Id, package.Version)) //LatestVersion
+                .Select(package => new PackageIdentity(package.Id, package.LatestVersion))
                 .ToList();
 
             UpdatePackage(packagesToUpdate);

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -840,6 +840,9 @@ namespace NuGet.PackageManagement.UI
             else
             {
                 await LoadInstalledData(searchText, useCachedPackageMetadata, pSearchCallback, searchTask, filterToRender, loadContext);
+
+                //Filter installed packages based on Tab and user selections.
+                _packageList.FilterItems(_topPanel.Filter, _loadCts.Token);
             }
         }
 
@@ -1253,7 +1256,7 @@ namespace NuGet.PackageManagement.UI
                     //First time loading the Installed packages.
                     if (CachedInstalledItems == null)
                     {
-                        //Load Installed packages from feed, UpdatePackageList, and store into cache.
+                        //Load Installed packages from feed and store into cache, clear and UpdatePackageList, and Filter based on Tab and user selections.
                         SearchPackagesAndRefreshUpdateCount(useCacheForUpdates: true);
                     }
                     else
@@ -1266,10 +1269,10 @@ namespace NuGet.PackageManagement.UI
                             //Repopulate with Installed package data.
                             _packageList.UpdatePackageList(packages: CachedInstalledItems, refresh: true);
                         }
-                    }
 
-                    //Filter installed packages based on Tab and user selections.
-                    _packageList.FilterItems(_topPanel.Filter, _loadCts.Token);
+                        //Filter installed packages based on Tab and user selections.
+                        _packageList.FilterItems(_topPanel.Filter, _loadCts.Token);
+                    }                    
                 }
 
                 EmitRefreshEvent(timeSpan, RefreshOperationSource.FilterSelectionChanged, RefreshOperationStatus.Success, isUIFiltering);


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9804 (builds upon https://github.com/NuGet/NuGet.Client/pull/3612)
Fixes: https://github.com/nuget/home/issues/8290
Progress towards Fixing: https://github.com/nuget/home/issues/9675

Regression: No (https://github.com/NuGet/NuGet.Client/pull/3612 should fix the regression; this PR should improve UX)

## DRAFT Details
Similar issues persist as they do in https://github.com/NuGet/NuGet.Client/pull/3612 where it's difficult to cleanly interrupt a Loading routine when a user tab-switches. Since we are using 1 ListBox control, I either need more threading logic, or we have to evolve the XAML a bit.

Browse tab, scrolling down to trigger ScrollViewChanged, then quickly switching to Installed tab: you end up with partially Installed packages, and partially the next Page of data from the Browse tab.

## Fix

Details: Building upon https://github.com/NuGet/NuGet.Client/pull/3612, the next step is to stop throwing away packages for Installed/Updates/Consolidate tabs. I've plumbed a property from `PackageItemLoader` up to the `PackageManagerControl` which can intelligently restore those packages to the `InfiniteScrollList` depending on tab selection. A UI Filter handles tab-dependent filtering (ie, Updates Available, Consolidate applicability)

First advantage here is that we don't need to handle tab-switch interruption of an in-progress Loading.
Second advantage is we avoid unnecessary rebuilding of Installed package metadata. Existing external events will rebuild the cache as usual, and that should be adequate.

## Testing/Validation

Tests Added: Yes/No  
Reason for not adding tests:  
Validation:  
