### PR TITLE
Update CODEOWNERS, use team instead of individual assignment

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # the repo. Unless a later match takes precedence,
 # review when someone opens a pull request.
 # For more on how to customize the CODEOWNERS file - https://help.github.com/en/articles/about-code-owners
-*       @aortiz-msft @cristinamanum @donnie-msft @dominoFire @dtivel @heng-liu @kartheekp-ms @nkolev92 @rrelyea @zivkan @zkat
+*       @NuGet/nuget-client


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Client.Engineering/issues/337
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: Make code-owners use the team. 
Last time I tried this we had *notification* issues but those can be resolved by making the team public, which I've done. 

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  
Validation:  
