### PR TITLE
Fix formatting error

### DIFF
--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
@@ -1781,14 +1781,14 @@ namespace NuGet.Commands.Test
                 // Package Bar does not have a corresponding PackageVersion 
                 var packageRefDependecyBar = new LibraryDependency()
                 {
-                    LibraryRange = new LibraryRange("bar", versionRange: null, typeConstraint: LibraryDependencyTarget.Package) ,
+                    LibraryRange = new LibraryRange("bar", versionRange: null, typeConstraint: LibraryDependencyTarget.Package),
                 };
 
                 var centralVersionFoo = new CentralPackageVersion("foo", VersionRange.Parse("1.0.0"));
 
                 var tfi = CreateTargetFrameworkInformation(
                     new List<LibraryDependency>() { packageRefDependecyBar },
-                    new List<CentralPackageVersion>() { centralVersionFoo});
+                    new List<CentralPackageVersion>() { centralVersionFoo });
 
                 var packageSpec = new PackageSpec(new List<TargetFrameworkInformation>() { tfi });
                 packageSpec.RestoreMetadata = new ProjectRestoreMetadata()


### PR DESCRIPTION
@cristinamanum merged https://github.com/NuGet/NuGet.Client/pull/3574 after the PR that added `dotnet-format --check` was merged (https://github.com/NuGet/NuGet.Client/pull/3587). The PR did not meet formatting requirements, and as a result, CI builds are failing for anyone who creates a branch from the latest dev commit.  This PR fixes that.