### PR TITLE
Use "PackageReferences" to determine applicability

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/VsHierarchyUtility.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/VsHierarchyUtility.cs
@@ -77,7 +77,9 @@ namespace NuGet.VisualStudio
         {
             ThreadHelper.ThrowIfNotOnUIThread();
 
-            return hierarchy.IsCapabilityMatch("AssemblyReferences + DeclaredSourceItems + UserSourceItems");
+            // NOTE: (AssemblyReferences + DeclaredSourceItems + UserSourceItems) exists solely for compatibility reasons
+            // with existing custom CPS-based projects that existed before "PackageReferences" capability was introduced.
+            return hierarchy.IsCapabilityMatch("(AssemblyReferences + DeclaredSourceItems + UserSourceItems) | PackageReferences");
         }
 
         public static bool HasUnsupportedProjectCapability(IVsHierarchy hierarchy)


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Home/issues/9957

## Fix

Restore uses a variety of things to opt projects into restore operations. One is a list of hardcoded project types "guids", and the other is a set of [project capabilities](https://github.com/microsoft/VSProjectSystem/blob/master/doc/overview/project_capabilities.md). Across VS we're moved away from hardcoding project types to capabilities as a better way of representing the set of features a given project supports. In the past before "PackageReferences" existed, NuGet used the presence of `AssemblyReferences + DeclaredSourceItems + UserSourceItem` as indicator that a project supports restore. Since then we've added a new capability; `PackageReferences`. CPS-based package-related features have been tied behind it, including the code that nominates for restore, and watches the project assets file for changes. This code can be found here: https://github.com/dotnet/project-system/tree/master/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore.

This change lets a custom CPS-based project type, including C++ and MSIX projects to opt into the _PackageReferences_ capability and have end-to-end just work.

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  There is no obvious way to test this in the code base.
Validation:  

I've verified that this doesn't break existing restore for existing projects. Only two project types are currently using `PackageReferences` project capability and both already defined `AssemblyReferences + DeclaredSourceItems + UserSourceItem`, so this change by itself does not opt anymore projects into restore without corresponding project system changes.
I've verified in a custom project type (based on CPS) that this "lights" up Package Manager support including restore, and package manager. It does not, however, cause the assets file to be written whcih needs investigation. I think we should enable this anyway, as it lets us iterate with MSIX/C++ without needing custom builds of NuGet.
