### PR TITLE
Use HttpRequestMessage.Options instead of Properties on net5.0

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpRetryHandler.cs
+++ b/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpRetryHandler.cs
@@ -81,7 +81,11 @@ namespace NuGet.Protocol
                         headerStopwatch = new Stopwatch();
                         stopwatches.Add(headerStopwatch);
                     }
+#if NET5_0
+                    requestMessage.Options.Set(new HttpRequestOptionsKey<List<Stopwatch>>(StopwatchPropertyName), stopwatches);
+#else
                     requestMessage.Properties[StopwatchPropertyName] = stopwatches;
+#endif
                     var requestUri = requestMessage.RequestUri;
 
                     try

--- a/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpSourceAuthenticationHandler.cs
+++ b/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpSourceAuthenticationHandler.cs
@@ -96,11 +96,18 @@ namespace NuGet.Protocol
                 if (response.StatusCode == HttpStatusCode.Unauthorized ||
                     (configuration.PromptOn403 && response.StatusCode == HttpStatusCode.Forbidden))
                 {
-                    IList<Stopwatch> stopwatches = null;
+                    List<Stopwatch> stopwatches = null;
 
+#if NET5_0
+                    if (request.Options.TryGetValue(
+                        new HttpRequestOptionsKey<List<Stopwatch>>(HttpRetryHandler.StopwatchPropertyName),
+                        out stopwatches))
+                    {
+#else
                     if (request.Properties.TryGetValue(HttpRetryHandler.StopwatchPropertyName, out var value))
                     {
-                        stopwatches = value as IList<Stopwatch>;
+                        stopwatches = value as List<Stopwatch>;
+#endif
                         if (stopwatches != null)
                         {
                             foreach (var stopwatch in stopwatches)


### PR DESCRIPTION
This dotnet/runtime PR marked Properties as obsolete:
https://github.com/dotnet/runtime/pull/39182

Since we use warnings as errors, we have to change our code.

## Bug

Fixes: https://github.com/NuGet/Home/issues/9964
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: Add some `#if NET5_0` that will cause problems when we eventually move to NET6.0, but we can deal with this later.

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  I expect existing tests to cover it. This change did not change any APIs or expected behaviour.
Validation:  
