### PR TITLE
remove ILmerge of newtonsoft.json

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging.Extraction/ilmerge.props
+++ b/src/NuGet.Core/NuGet.Packaging.Extraction/ilmerge.props
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0">
   <ItemGroup>
-    <MergeInclude Include="$(OutputPath)Newtonsoft.Json.dll"/>
     <MergeInclude Include="$(OutputPath)NuGet.Common.dll"/>
     <MergeInclude Include="$(OutputPath)NuGet.Configuration.dll"/>
     <MergeInclude Include="$(OutputPath)NuGet.Frameworks.dll"/>


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9966
Regression: No

## Fix

Details: remove newtonsoft.json from merged DLL

## Testing/Validation

Tests Added: No
Reason for not adding tests:  
Validation:  partner
