### PR TITLE
added a unit test to solution explorer dependencies tree generation logic

### DIFF
--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/SolutionExplorer/Models/AssetsFileDependenciesSnapshotTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/SolutionExplorer/Models/AssetsFileDependenciesSnapshotTests.cs
@@ -65,6 +65,32 @@ namespace NuGet.VisualStudio.Implementation.Test.SolutionExplorer.Models
         }
 
         [Fact]
+        public void ParseLibraries_LockFileTargetLibrariesWithDifferentCase_Throws()
+        {
+            // Arrange
+            LockFileTarget lockFileTarget = new LockFileTarget();
+            lockFileTarget.Libraries = new List<LockFileTargetLibrary>
+            {
+                new LockFileTargetLibrary()
+                {
+                    Name = "packageA",
+                    Type = "package",
+                    Version = NuGetVersion.Parse("1.0.0")
+                },
+                new LockFileTargetLibrary()
+                {
+                    Name = "PackageA",
+                    Type = "package",
+                    Version = NuGetVersion.Parse("1.0.0")
+                }
+            };
+
+            var exception = Assert.Throws<ArgumentException>(() => AssetsFileDependenciesSnapshot.ParseLibraries(lockFileTarget));
+
+            Assert.Equal("An element with the same key but a different value already exists. Key: PackageA", exception.Message);
+        }
+
+        [Fact]
         public void ParseLibraries_LockFileTargetLibrariesMatchesDependencies_Succeeds()
         {
             // Arrange

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/SolutionExplorer/Models/AssetsFileDependenciesSnapshotTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/SolutionExplorer/Models/AssetsFileDependenciesSnapshotTests.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using NuGet.LibraryModel;
 using NuGet.ProjectModel;
 using NuGet.Versioning;
 using NuGet.VisualStudio.SolutionExplorer.Models;

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/SolutionExplorer/Models/AssetsFileDependenciesSnapshotTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/SolutionExplorer/Models/AssetsFileDependenciesSnapshotTests.cs
@@ -1,5 +1,12 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
 using System.Linq;
+using NuGet.LibraryModel;
 using NuGet.ProjectModel;
+using NuGet.Versioning;
 using NuGet.VisualStudio.SolutionExplorer.Models;
 using Xunit;
 
@@ -56,6 +63,57 @@ namespace NuGet.VisualStudio.Implementation.Test.SolutionExplorer.Models
 
             Assert.Equal(1, dependencies.Count);
             Assert.True(dependencies.ContainsKey("system.runtime"));
+        }
+
+        [Fact]
+        public void ParseLibraries_LockFileTargetLibrariesMatchesDependencies_Succeeds()
+        {
+            // Arrange
+            LockFileTarget lockFileTarget = new LockFileTarget();
+            lockFileTarget.Libraries = new List<LockFileTargetLibrary>
+            {
+                new LockFileTargetLibrary()
+                {
+                    Name = "packageA",
+                    Type = "package",
+                    Version = NuGetVersion.Parse("1.0.0")
+                },
+                new LockFileTargetLibrary()
+                {
+                    Name = "packageB",
+                    Type = "package",
+                    Version = NuGetVersion.Parse("1.0.0")
+                },
+                new LockFileTargetLibrary()
+                {
+                    Name = "projectA",
+                    Type = "project",
+                    Version = NuGetVersion.Parse("1.0.0")
+                },
+                new LockFileTargetLibrary()
+                {
+                    Name = "projectB",
+                    Type = "project",
+                    Version = NuGetVersion.Parse("1.0.0")
+                }
+            };
+
+            var dependencies = AssetsFileDependenciesSnapshot.ParseLibraries(lockFileTarget);
+
+            Assert.Equal(lockFileTarget.Libraries.Count, dependencies.Count);
+            Assert.All<LockFileTargetLibrary>(lockFileTarget.Libraries,
+                source =>
+                {
+                    Assert.True(dependencies.ContainsKey(source.Name));
+
+                    var target = dependencies[source.Name];
+                    Assert.Equal(source.Name, target.Name);
+                    Assert.Equal(source.Version.ToNormalizedString(), target.Version);
+
+                    AssetsFileLibraryType sourceType;
+                    Assert.True(Enum.TryParse<AssetsFileLibraryType>(source.Type, ignoreCase: true, out sourceType));
+                    Assert.Equal(sourceType, target.Type);
+                });
         }
     }
 }

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/SolutionExplorer/Models/AssetsFileDependenciesSnapshotTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/SolutionExplorer/Models/AssetsFileDependenciesSnapshotTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using NuGet.ProjectModel;
 using NuGet.Versioning;
@@ -68,7 +69,7 @@ namespace NuGet.VisualStudio.Implementation.Test.SolutionExplorer.Models
         public void ParseLibraries_LockFileTargetLibrariesWithDifferentCase_Throws()
         {
             // Arrange
-            LockFileTarget lockFileTarget = new LockFileTarget();
+            var lockFileTarget = new LockFileTarget();
             lockFileTarget.Libraries = new List<LockFileTargetLibrary>
             {
                 new LockFileTargetLibrary()
@@ -87,14 +88,14 @@ namespace NuGet.VisualStudio.Implementation.Test.SolutionExplorer.Models
 
             var exception = Assert.Throws<ArgumentException>(() => AssetsFileDependenciesSnapshot.ParseLibraries(lockFileTarget));
 
-            Assert.Equal("An element with the same key but a different value already exists. Key: PackageA", exception.Message);
+            Assert.Contains("PackageA", exception.Message);
         }
 
         [Fact]
         public void ParseLibraries_LockFileTargetLibrariesMatchesDependencies_Succeeds()
         {
             // Arrange
-            LockFileTarget lockFileTarget = new LockFileTarget();
+            var lockFileTarget = new LockFileTarget();
             lockFileTarget.Libraries = new List<LockFileTargetLibrary>
             {
                 new LockFileTargetLibrary()
@@ -123,7 +124,7 @@ namespace NuGet.VisualStudio.Implementation.Test.SolutionExplorer.Models
                 }
             };
 
-            var dependencies = AssetsFileDependenciesSnapshot.ParseLibraries(lockFileTarget);
+            ImmutableDictionary<string, AssetsFileTargetLibrary> dependencies = AssetsFileDependenciesSnapshot.ParseLibraries(lockFileTarget);
 
             Assert.Equal(lockFileTarget.Libraries.Count, dependencies.Count);
             Assert.All<LockFileTargetLibrary>(lockFileTarget.Libraries,
@@ -131,7 +132,7 @@ namespace NuGet.VisualStudio.Implementation.Test.SolutionExplorer.Models
                 {
                     Assert.True(dependencies.ContainsKey(source.Name));
 
-                    var target = dependencies[source.Name];
+                    AssetsFileTargetLibrary target = dependencies[source.Name];
                     Assert.Equal(source.Name, target.Name);
                     Assert.Equal(source.Version.ToNormalizedString(), target.Version);
 


### PR DESCRIPTION
## Bug

Fixes: NuGet/Home#9971
Regression: No

## Fix

Details: Added a unit test to to compare lock file target libraries in `project.assets.json` file with the libraries in the Dependencies tree.

## Testing/Validation

Tests Added: Yes  
Reason for not adding tests:  
Validation:  
