### PR TITLE
Build NuGet.Client even if response file is detected

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -51,6 +51,9 @@ project.json text
 *.sql   text
 *.vb    text
 
+# Unix artifacts
+*.sh text eol=lf
+
 # Visual Studio artifacts
 *.csproj text eol=crlf
 *.dbproj text eol=crlf

--- a/build.sh
+++ b/build.sh
@@ -15,11 +15,21 @@ echo "Installing dotnet CLI"
 mkdir -p cli
 curl -o cli/dotnet-install.sh -L https://dot.net/v1/dotnet-install.sh
 
+if (( $? )); then
+	echo "Could not download 'dotnet-install.sh' script. Please check your network and try again!"
+	exit 1
+fi
+
 # Run install.sh for cli
 chmod +x cli/dotnet-install.sh
 
 # v1 needed for some test and bootstrapping testing version
 cli/dotnet-install.sh -i cli -c 1.0
+
+if (( $? )); then
+	echo "The .NET CLI Install failed!!"
+	exit 1
+fi
 
 DOTNET="$(pwd)/cli/dotnet"
 
@@ -32,8 +42,13 @@ DOTNET_BRANCH="$($DOTNET msbuild build/config.props /v:m /nologo /t:GetCliBranch
 echo $DOTNET_BRANCH
 cli/dotnet-install.sh -i cli -c $DOTNET_BRANCH
 
-# Display current version
-$DOTNET --version
+if (( $? )); then
+	echo "The .NET CLI Install failed!!"
+	exit 1
+fi
+
+# Display .NET CLI info
+$DOTNET --info
 
 echo "================="
 
@@ -54,6 +69,7 @@ fi
 # restore packages
 echo "$DOTNET msbuild build/build.proj /t:Restore /p:VisualStudioVersion=16.0 /p:Configuration=Release /p:BuildNumber=1 /p:ReleaseLabel=beta"
 $DOTNET msbuild build/build.proj /t:Restore /p:VisualStudioVersion=16.0 /p:Configuration=Release /p:BuildNumber=1 /p:ReleaseLabel=beta
+
 if [ $? -ne 0 ]; then
 	echo "Restore failed!!"
 	exit 1

--- a/build.sh
+++ b/build.sh
@@ -24,7 +24,7 @@ fi
 chmod +x cli/dotnet-install.sh
 
 # Get recommended version for bootstrapping testing version
-cli/dotnet-install.sh -i cli -c 1.0
+cli/dotnet-install.sh -i cli -c 2.2 -nopath
 
 if (( $? )); then
 	echo "The .NET CLI Install failed!!"
@@ -42,24 +42,34 @@ echo "dotnet msbuild build/config.props /v:m /nologo /t:GetCliBranchForTesting"
 IFS=$'\n'
 CMD_OUT_LINES=(`dotnet msbuild build/config.props /v:m /nologo /t:GetCliBranchForTesting`)
 # Take only last the line which has the version information and strip all the spaces
-CMD_LAST_LINE=${CMD_OUT_LINES[-1]//[[:space:]]}
+DOTNET_BRANCHES=${CMD_OUT_LINES[-1]//[[:space:]]}
 unset IFS
 
 IFS=$';'
-DOTNET_BRANCHES=(${CMD_LAST_LINE})
-unset IFS
+for DOTNET_BRANCH in ${DOTNET_BRANCHES[@]}
+do
+	echo $DOTNET_BRANCH
 
-IFS=$':'
-DOTNET_BRANCH=(${DOTNET_BRANCHES[0]})
-unset IFS
+	IFS=$':'
+	ChannelAndVersion=($DOTNET_BRANCH)
+	Channel=${ChannelAndVersion[0]}
+	if [ ${#ChannelAndVersion[@]} -eq 1 ]
+	then
+		Version="latest"
+	else
+		Version=${ChannelAndVersion[1]}
+	fi
+	unset IFS
 
-echo $DOTNET_BRANCH
-cli/dotnet-install.sh -i cli -c $DOTNET_BRANCH
+	echo "Channel is: $Channel"
+	echo "Version is: $Version"
+	cli/dotnet-install.sh -i cli -c $Channel -v $Version -nopath
 
-if (( $? )); then
-	echo "The .NET CLI Install failed!!"
-	exit 1
-fi
+	if (( $? )); then
+		echo "The .NET CLI Install for $DOTNET_BRANCH failed!!"
+		exit 1
+	fi
+done
 
 # Display .NET CLI info
 $DOTNET --info

--- a/build.sh
+++ b/build.sh
@@ -31,6 +31,9 @@ if (( $? )); then
 	exit 1
 fi
 
+# Disable .NET CLI Install Lookup
+DOTNET_MULTILEVEL_LOOKUP=0
+
 DOTNET="$(pwd)/cli/dotnet"
 
 # Let the dotnet cli expand and decompress first if it's a first-run

--- a/build/common.ps1
+++ b/build/common.ps1
@@ -155,8 +155,10 @@ Function Install-DotnetCLI {
     )
     $vsMajorVersion = Get-VSMajorVersion
     $MSBuildExe = Get-MSBuildExe $vsMajorVersion
-    $CliBranchListForTesting = & $msbuildExe $NuGetClientRoot\build\config.props /v:m /nologo /t:GetCliBranchForTesting
-    $CliBranchList = $CliBranchListForTesting.Trim().Split(';');
+
+    $CmdOutLines = ((& $msbuildExe $NuGetClientRoot\build\config.props /v:m /nologo /t:GetCliBranchForTesting) | Out-String).Trim()
+    $CliBranchListForTesting = ($CmdOutLines -split [Environment]::NewLine)[-1]
+    $CliBranchList = $CliBranchListForTesting -split ';'
 
     $DotNetInstall = Join-Path $CLIRoot 'dotnet-install.ps1'
 
@@ -171,7 +173,7 @@ Function Install-DotnetCLI {
 
     ForEach ($CliBranch in $CliBranchList) {
         $CliBranch = $CliBranch.trim()
-        $CliChannelAndVersion = $CliBranch -split "\s+"
+        $CliChannelAndVersion = $CliBranch -split ":"
 
         $Channel = $CliChannelAndVersion[0].trim()
         if ($CliChannelAndVersion.count -eq 1) {

--- a/build/config.props
+++ b/build/config.props
@@ -34,7 +34,7 @@
     <!-- Specifies the SDK version to download to use for testing. The first value represents the channel, the second value represents the exact SDK version to be download. If a version is not specified, the latest version from the channel will be downloaded. 
     Note that multiple SDKs can be downloaded by using `;` as a separator.
     -->
-    <CliBranchForTesting Condition="'$(CliBranchForTesting)' == ''">release/5.0.2xx 5.0.200-servicing.21120.4</CliBranchForTesting>
+    <CliBranchForTesting Condition="'$(CliBranchForTesting)' == ''">release/5.0.2xx:5.0.200-servicing.21120.4</CliBranchForTesting>
   </PropertyGroup>
 
   <!-- Config -->

--- a/scripts/funcTests/runFuncTests.sh
+++ b/scripts/funcTests/runFuncTests.sh
@@ -59,7 +59,8 @@ echo "dotnet msbuild build/config.props /v:m /nologo /t:GetCliBranchForTesting"
 IFS=$'\n'
 CMD_OUT_LINES=(`dotnet msbuild build/config.props /v:m /nologo /t:GetCliBranchForTesting`)
 # Take only last the line which has the version information and strip all the spaces
-DOTNET_BRANCHES=${CMD_OUT_LINES[-1]//[[:space:]]}
+CMD_LAST_LINE=${CMD_OUT_LINES[@]:(-1)}
+DOTNET_BRANCHES=${CMD_LAST_LINE//[[:space:]]}
 unset IFS
 
 IFS=$';'

--- a/scripts/funcTests/runFuncTests.sh
+++ b/scripts/funcTests/runFuncTests.sh
@@ -25,6 +25,8 @@ pushd $DIR/
 
 mono --version
 
+dotnet --info
+
 # Download the CLI install script to cli
 echo "Installing dotnet CLI"
 mkdir -p cli
@@ -36,7 +38,12 @@ chmod +x scripts/funcTests/dotnet-install.sh
 
 # Get recommended version for bootstrapping testing version
 # Issue 8936 - DISABLED TEMPORARILY cli/dotnet-install.sh -i cli -c 2.2
-scripts/funcTests/dotnet-install.sh -i cli -c 2.2 -NoPath
+scripts/funcTests/dotnet-install.sh -i cli -c 2.2 -nopath
+
+if (( $? )); then
+	echo "The .NET CLI Install failed!!"
+	exit 1
+fi
 
 DOTNET="$(pwd)/cli/dotnet"
 
@@ -60,10 +67,14 @@ do
 	echo "Version is: $Version"
 	scripts/funcTests/dotnet-install.sh -i cli -c $Channel -v $Version -nopath
 
-	# Display current version
-	$DOTNET --version
-	dotnet --info
+	if (( $? )); then
+		echo "The .NET CLI Install for $DOTNET_BRANCH failed!!"
+		exit 1
+	fi
 done
+
+# Display .NET CLI info
+$DOTNET --info
 
 echo "initial dotnet cli install finished at `date -u +"%Y-%m-%dT%H:%M:%S"`"
 
@@ -104,6 +115,7 @@ fi
 # restore packages
 echo "dotnet msbuild build/build.proj /t:Restore /p:VisualStudioVersion=16.0 /p:Configuration=Release /p:BuildNumber=1 /p:ReleaseLabel=beta"
 dotnet msbuild build/build.proj /t:Restore /p:VisualStudioVersion=16.0 /p:Configuration=Release /p:BuildNumber=1 /p:ReleaseLabel=beta
+
 if [ $? -ne 0 ]; then
 	echo "Restore failed!!"
 	exit 1

--- a/scripts/funcTests/runFuncTests.sh
+++ b/scripts/funcTests/runFuncTests.sh
@@ -45,6 +45,9 @@ if (( $? )); then
 	exit 1
 fi
 
+# Disable .NET CLI Install Lookup
+DOTNET_MULTILEVEL_LOOKUP=0
+
 DOTNET="$(pwd)/cli/dotnet"
 
 # Let the dotnet cli expand and decompress first if it's a first-run

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/MsbuildIntegrationTestFixture.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/MsbuildIntegrationTestFixture.cs
@@ -39,7 +39,9 @@ namespace Dotnet.Integration.Test
             var dotnetExecutableName = RuntimeEnvironmentHelper.IsWindows ? "dotnet.exe" : "dotnet";
             TestDotnetCli = Path.Combine(_cliDirectory, dotnetExecutableName);
 
-            var sdkPath = Directory.EnumerateDirectories(Path.Combine(_cliDirectory, "sdk")).Single();
+            var sdkPath = Directory.EnumerateDirectories(Path.Combine(_cliDirectory, "sdk"))
+                            .Where(d => !string.Equals(Path.GetFileName(d), "NuGetFallbackFolder", StringComparison.OrdinalIgnoreCase))
+                            .Single();
 
             MsBuildSdksPath = Path.Combine(sdkPath, "Sdks");
 
@@ -442,6 +444,7 @@ SDKs found: {string.Join(", ", Directory.EnumerateDirectories(sdkDir).Select(Pat
             var artifactsDirectory = DotnetCliUtil.GetArtifactsDirectoryInRepo();
             var pathToSdkInCli = Path.Combine(
                     Directory.EnumerateDirectories(Path.Combine(cliDirectory, "sdk"))
+                        .Where(d => !string.Equals(Path.GetFileName(d), "NuGetFallbackFolder", StringComparison.OrdinalIgnoreCase))
                         .First());
             const string configuration =
 #if DEBUG


### PR DESCRIPTION
## Bug

Fixes: NuGet/Home#9973
Fixes: NuGet/Home#10139
Regression: No

## Fix

Details:

 - Checkout bash script files with Unix line ending (only LF) even on Windows. This makes sure that we can use the repo in WSL also.

 - MSBuild picks up response files automatically, which messes up the version logic reading from standard output. Adding `-noAutoRsp` to it is one solution but you have to add it to every MSBuild call to get 
   uniform behavior. So, I have refactored the logic to work without needing it.

 - Also, `build.sh` currently downloads dotnet cli v1.0 for bootstrapping and runs MSBuild to get the dotnet cli version to build and test against. Since, v1 is out of support, the Sdk is not available to download. We 
   have to update the version to 2.2, similar to what is specified in `runFuncTests.sh`. Because of the nature of the change in the POSIX scripts, we can no longer depend on `space` character for splitting the branch 
   and version string in the `CliBranchForTesting` property in `build\config.props`. Instead, I have used colon `:` as a separator.

   For Example:
   ```xml
   <CliBranchForTesting Condition="'$(CliBranchForTesting)' == ''">release/5.0.2xx:5.0.202</CliBranchForTesting>
   ```

**NOTE:** This patch was separated from #3270.

## Testing/Validation

Tests Added: No
Reason for not adding tests: Build Infra changes only
Validation: Through successful CI
