### PR TITLE
Placeholder text to use https for new package sources

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/PackageSourcesOptionsControl.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/PackageSourcesOptionsControl.cs
@@ -347,7 +347,7 @@ namespace NuGet.Options
             for (int i = 0; ; i++)
             {
                 var newName = i == 0 ? "Package source" : "Package source " + i;
-                var newSource = i == 0 ? "http://packagesource" : "http://packagesource" + i;
+                var newSource = i == 0 ? "https://packagesource" : "https://packagesource" + i;
                 var packageSource = new Configuration.PackageSource(newSource, newName);
                 if (sourcesList.All(ps => !ps.Equals(packageSource)))
                 {


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9974
Regression: No  

## Fix

Most prominent package sources now use https. This changes the placeholder text which is used when adding a new package source to minimise overtyping needed for the most common case.

## Testing/Validation

Tests Added: No  
Reason for not adding tests: Trvial change
Validation:  



