### PR TITLE
Cleanup the MSBuildProjectFrameworkUtility, use NuGetFramework wherever possible instead of strings

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/Utility/MSBuildProjectFrameworkUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/Utility/MSBuildProjectFrameworkUtility.cs
@@ -90,11 +90,10 @@ namespace NuGet.Commands
                 targetPlatformVersion,
                 targetPlatformMinVersion,
                 isXnaWindowsPhoneProject,
-                isManagementPackProject)
-                .Select(e => e.DotNetFrameworkName);
+                isManagementPackProject);
         }
 
-        internal static IEnumerable<NuGetFramework> GetProjectFrameworks(
+        internal static IEnumerable<string> GetProjectFrameworks(
             string projectFilePath,
             string targetFrameworks,
             string targetFramework,
@@ -113,7 +112,7 @@ namespace NuGet.Commands
 
             if (frameworks.Count > 0)
             {
-                return frameworks.Select(e => NuGetFramework.Parse(e));
+                return frameworks;
             }
 
             // TargetFramework property
@@ -123,10 +122,10 @@ namespace NuGet.Commands
             {
                 frameworks.Add(currentFrameworkString);
 
-                return frameworks.Select(e => NuGetFramework.Parse(e));
+                return frameworks;
             }
 
-            return new NuGetFramework[] { GetProjectFramework(
+            return new string[] { GetProjectFramework(
                 projectFilePath,
                 targetFrameworkMoniker,
                 targetPlatformMoniker,
@@ -134,7 +133,7 @@ namespace NuGet.Commands
                 targetPlatformVersion,
                 targetPlatformMinVersion,
                 isXnaWindowsPhoneProject,
-                isManagementPackProject) };
+                isManagementPackProject).DotNetFrameworkName };
         }
 
         internal static NuGetFramework GetProjectFramework(


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9878
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: When https://github.com/NuGet/NuGet.Client/pull/3562 was done, @zivkan was not a fan of the whole casting approach, so I have removed that. Note that I am returning DotnetFrameworkName because the codepaths that rely on this are legacy PR & packages.config. 

Now there's a further cleanup, that I did not do. 
I did *not* replace to calls to strings with ones where NuGetFramework is returned.

The reason for that is because we *do not* have an API to get a NuGetFramework out of the same parameters as the currently use string versions. 

Specifically, many places use TargetPlatformIdentifier and TargetPlatformVersion and not TargetPlatformMoniker. 
I'd be hesitant to change that now, but I think the risk is lower if we did. 

Right now, I have not done that. 

Would be happy to answer to feedback and do a different refactoring if necessary @zivkan 

## Testing/Validation

Tests Added: Yes/No  
Reason for not adding tests:  
Validation:  
