### PR TITLE
Remove RuntimeIdentifier for tests.

### DIFF
--- a/build/test.targets
+++ b/build/test.targets
@@ -1,9 +1,7 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
   <!-- Shared test project template -->
-  <PropertyGroup>
-    <RuntimeIdentifier Condition=" '$(IsXPlat)' != 'true' ">win7-x64</RuntimeIdentifier>
-  </PropertyGroup>
 
   <PropertyGroup>
     <NoWarn>$(NoWarn);CS1701;xUnit2013;xUnit2000;xUnit2017;xUnit2006;xUnit2009;xUnit2013;xUnit2014;xUnit2003;xUnit2010;xUnit2015;xUnit2007;xUnit1013;xUnit1014;xUnit2002;xUnit2012;xUnit2004</NoWarn>

--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -298,7 +298,7 @@ jobs:
   - task: PublishBuildArtifacts@1
     displayName: "Publish NuGet.CommandLine.Test as artifact"
     inputs:
-      PathtoPublish: "$(Build.Repository.LocalPath)\\test\\NuGet.Clients.Tests\\NuGet.CommandLine.Test\\bin\\$(BuildConfiguration)\\net472\\win7-x64"
+      PathtoPublish: "$(Build.Repository.LocalPath)\\test\\NuGet.Clients.Tests\\NuGet.CommandLine.Test\\bin\\$(BuildConfiguration)\\net472"
       ArtifactName: "NuGet.CommandLine.Test"
       ArtifactType: "Container"
     condition: "and(succeeded(),eq(variables['BuildRTM'], 'true'))"

--- a/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/NuGet.Protocol.FuncTest.csproj
+++ b/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/NuGet.Protocol.FuncTest.csproj
@@ -32,7 +32,7 @@
 
   <PropertyGroup>
     <PostBuildEvent Condition="'$(OS)' == 'Windows_NT'">
-      xcopy /diye $(ArtifactsDirectory)TestablePlugin\$(BuildVariationFolder)\bin\$(Configuration)\$(TargetFramework)\* $(MSBuildProjectDirectory)\bin\$(Configuration)\$(TargetFramework)\win7-x64\TestablePlugin\
+      xcopy /diye $(ArtifactsDirectory)TestablePlugin\$(BuildVariationFolder)\bin\$(Configuration)\$(TargetFramework)\* $(MSBuildProjectDirectory)\bin\$(Configuration)\$(TargetFramework)\TestablePlugin\
     </PostBuildEvent>
   </PropertyGroup>
   


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9976
Regression: ? 
* Last working version: ?
* How are we preventing it in future:  

## Fix

Details: Remove part of test.targets which sets RuntimeIdentifier

## Testing/Validation

Tests Added: No.
Reason for not adding tests: Changing build of tests. 
Validation:  `build.ps1` of clean repo. Everything builds cleanly and unit tests pass.
