### PR TITLE
PM UI:  call correct PreviewUninstallPackageAsync(...) overload

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetProjectManagerService.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetProjectManagerService.cs
@@ -392,7 +392,7 @@ namespace NuGet.PackageManagement.VisualStudio
             NuGetPackageManager packageManager = await _sharedState.PackageManager.GetValueAsync(cancellationToken);
             IEnumerable<NuGetProjectAction> actions = await packageManager.PreviewUninstallPackageAsync(
                 project,
-                packageIdentity,
+                packageIdentity.Id,
                 uninstallationContext,
                 projectContext,
                 cancellationToken);
@@ -403,7 +403,7 @@ namespace NuGet.PackageManagement.VisualStudio
                 var projectAction = new ProjectAction(
                     CreateProjectActionId(),
                     projectId,
-                    packageIdentity,
+                    action.PackageIdentity,
                     action.NuGetProjectActionType,
                     implicitActions: null);
 


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9980
Regression: Yes

## Fix

Details: Call the correct overload of `NuGetPackageManager.PreviewUninstallPackageAsync(...)`.

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  
Validation:  
