### PR TITLE
BugFix (Central package management throws errors about duplicate dictionary keys when attempting to create the lock file)

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/LockFileBuilder.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/LockFileBuilder.cs
@@ -59,7 +59,7 @@ namespace NuGet.Commands
             var libraryItems = targetGraphs
                 .SelectMany(g => g.Flattened) // All GraphItem<RemoteResolveResult> resolved in the graph.
                 .Distinct(GraphItemKeyComparer<RemoteResolveResult>.Instance) // Distinct list of GraphItems. Two items are equal only if the itmes' Keys are equal.
-                .OrderBy(x => x.Data.Match.Library); 
+                .OrderBy(x => x.Data.Match.Library);
             foreach (var item in libraryItems)
             {
                 var library = item.Data.Match.Library;

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/LockFileBuilder.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/LockFileBuilder.cs
@@ -56,8 +56,11 @@ namespace NuGet.Commands
             }
 
             // Record all libraries used
-            foreach (var item in targetGraphs.SelectMany(g => g.Flattened).Distinct(GraphItemKeyComparer<RemoteResolveResult>.Instance)
-                .OrderBy(x => x.Data.Match.Library))
+            var libraryItems = targetGraphs
+                .SelectMany(g => g.Flattened) // All GraphItem<RemoteResolveResult> resolved in the graph.
+                .Distinct(GraphItemKeyComparer<RemoteResolveResult>.Instance) // Distinct list of GraphItems. Two items are equal only if the itmes' Keys are equal.
+                .OrderBy(x => x.Data.Match.Library); 
+            foreach (var item in libraryItems)
             {
                 var library = item.Data.Match.Library;
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/LockFileBuilder.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/LockFileBuilder.cs
@@ -56,7 +56,7 @@ namespace NuGet.Commands
             }
 
             // Record all libraries used
-            foreach (var item in targetGraphs.SelectMany(g => g.Flattened).Distinct()
+            foreach (var item in targetGraphs.SelectMany(g => g.Flattened).Distinct(GraphItemKeyComparer<RemoteResolveResult>.Instance)
                 .OrderBy(x => x.Data.Match.Library))
             {
                 var library = item.Data.Match.Library;

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/GraphItemKeyComparer.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/GraphItemKeyComparer.cs
@@ -1,0 +1,51 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace NuGet.DependencyResolver
+{
+    public sealed class GraphItemKeyComparer<T> : IEqualityComparer<GraphItem<T>>
+    {
+#pragma warning disable IDE1006 // Naming Styles
+        private static readonly Lazy<GraphItemKeyComparer<T>> _defaultComparer = new Lazy<GraphItemKeyComparer<T>>(() => new GraphItemKeyComparer<T>());
+#pragma warning restore IDE1006 // Naming Styles
+
+        /// <summary>
+        /// Returns a singleton instance for the <see cref="GraphItemKeyComparer"/>.
+        /// </summary>
+        public static GraphItemKeyComparer<T> Instance
+        {
+            get
+            {
+                return _defaultComparer.Value;
+            }
+        }
+
+        /// <summary>
+        /// Get a singleton instance only through the <see cref="GraphItemKeyComparer.Instance"/>.
+        /// </summary>
+        private GraphItemKeyComparer()
+        {
+        }
+
+        public bool Equals(GraphItem<T> x, GraphItem<T> y)
+        {
+            if (x == null)
+            {
+                return y == null;
+            }
+            return x.Key.Equals(y.Key);
+        }
+
+        public int GetHashCode(GraphItem<T> obj)
+        {
+            if (obj == null)
+            {
+                throw new ArgumentNullException(nameof(obj));
+            }
+            return obj.Key.GetHashCode();
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/GraphItemKeyComparer.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/GraphItemKeyComparer.cs
@@ -11,9 +11,7 @@ namespace NuGet.DependencyResolver
     /// </summary>
     public sealed class GraphItemKeyComparer<T> : IEqualityComparer<GraphItem<T>>
     {
-#pragma warning disable IDE1006 // Naming Styles
-        private static readonly Lazy<GraphItemKeyComparer<T>> _defaultComparer = new Lazy<GraphItemKeyComparer<T>>(() => new GraphItemKeyComparer<T>());
-#pragma warning restore IDE1006 // Naming Styles
+        private static readonly Lazy<GraphItemKeyComparer<T>> DefaultComparer = new Lazy<GraphItemKeyComparer<T>>(() => new GraphItemKeyComparer<T>());
 
         /// <summary>
         /// Returns a singleton instance for the <see cref="GraphItemKeyComparer"/>.
@@ -22,7 +20,7 @@ namespace NuGet.DependencyResolver
         {
             get
             {
-                return _defaultComparer.Value;
+                return DefaultComparer.Value;
             }
         }
 

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/GraphItemKeyComparer.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/GraphItemKeyComparer.cs
@@ -6,6 +6,9 @@ using System.Collections.Generic;
 
 namespace NuGet.DependencyResolver
 {
+    /// <summary>
+    /// A <see cref="GraphItem{T}"/> Key based comparer. Two instances are equal only if the Keys are equal.
+    /// </summary>
     public sealed class GraphItemKeyComparer<T> : IEqualityComparer<GraphItem<T>>
     {
 #pragma warning disable IDE1006 // Naming Styles

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/PublicAPI.Unshipped.txt
@@ -1,0 +1,4 @@
+NuGet.DependencyResolver.GraphItemKeyComparer<T>
+NuGet.DependencyResolver.GraphItemKeyComparer<T>.Equals(NuGet.DependencyResolver.GraphItem<T> x, NuGet.DependencyResolver.GraphItem<T> y) -> bool
+NuGet.DependencyResolver.GraphItemKeyComparer<T>.GetHashCode(NuGet.DependencyResolver.GraphItem<T> obj) -> int
+static NuGet.DependencyResolver.GraphItemKeyComparer<T>.Instance.get -> NuGet.DependencyResolver.GraphItemKeyComparer<T>

--- a/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests/GraphItemKeyComparerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests/GraphItemKeyComparerTests.cs
@@ -11,60 +11,33 @@ namespace NuGet.DependencyResolver.Core.Tests
 {
     public class GraphItemKeyComparerTests
     {
-        [Fact]
-        public void DistinctListOfObjects()
+        [Theory]
+        [MemberData(nameof(Data))]
+        public void Equals_GraphItemsAreEqualOnlyIfKeysAreEqual(GraphItem<string> item1, GraphItem<string> item2, bool expectedResult)
         {
-            // Arrange
-            var lib1Version1 = new LibraryIdentity("lib1", NuGetVersion.Parse("1.0.0"), LibraryType.Package);
-            var lib1Version1Duplicate = new LibraryIdentity("lib1", NuGetVersion.Parse("1.0.0"), LibraryType.Package);
-            var lib2Version1 = new LibraryIdentity("lib2", NuGetVersion.Parse("1.0.0"), LibraryType.Package);
-            var lib1Version2 = new LibraryIdentity("lib1", NuGetVersion.Parse("2.0.0"), LibraryType.Package);
-
-            var graphItem1 = new GraphItem<string>(lib1Version1);
-            var graphItem2 = new GraphItem<string>(lib1Version1Duplicate);
-            var graphItem3 = new GraphItem<string>(lib2Version1);
-            var graphItem4 = new GraphItem<string>(lib1Version2);
-            var graphItem5 = new GraphItem<string>(lib1Version1) { IsCentralTransitive = true };
-
-            var list = new List<GraphItem<string>>() { graphItem1, graphItem2, graphItem3, graphItem4, graphItem5 };
-
-            // Act
-            var distinctElements = list.Distinct(GraphItemKeyComparer<string>.Instance).ToList();
-
             // Assert
-            // There should be three elements distinct
-            // These should be graphItem1, graphItem3, graphItem4
-            Assert.Equal(3, distinctElements.Count);
-            Assert.Equal(graphItem1.Key.Name, distinctElements[0].Key.Name);
-            Assert.Equal(graphItem3.Key.Name, distinctElements[1].Key.Name);
-            Assert.Equal(graphItem4.Key.Name, distinctElements[2].Key.Name);
+            if(expectedResult)
+            {
+                Assert.True(GraphItemKeyComparer<string>.Instance.Equals(item1, item2));
+                Assert.Equal(GraphItemKeyComparer<string>.Instance.GetHashCode(item1), GraphItemKeyComparer<string>.Instance.GetHashCode(item2));
+            }
+            else
+            {
+                Assert.False(GraphItemKeyComparer<string>.Instance.Equals(item1, item2));
+                Assert.NotEqual(GraphItemKeyComparer<string>.Instance.GetHashCode(item1), GraphItemKeyComparer<string>.Instance.GetHashCode(item2));
+            }
         }
 
-        [Fact]
-        public void ObjectAreEqualsOnlyWhenGetHashAreEquals()
-        {
-            // Arrange
-            var lib1Version1 = new LibraryIdentity("lib1", NuGetVersion.Parse("1.0.0"), LibraryType.Package);
-            var lib1Version1Duplicate = new LibraryIdentity("lib1", NuGetVersion.Parse("1.0.0"), LibraryType.Package);
-            var lib2Version1 = new LibraryIdentity("lib2", NuGetVersion.Parse("1.0.0"), LibraryType.Package);
-            var lib1Version2 = new LibraryIdentity("lib1", NuGetVersion.Parse("2.0.0"), LibraryType.Package);
+        public static IEnumerable<object[]> Data =>
+           new List<object[]>
+           {
+                new object[] {new GraphItem<string>(new LibraryIdentity("lib1", NuGetVersion.Parse("1.0.0"), LibraryType.Package)), new GraphItem<string>(new LibraryIdentity("lib1", NuGetVersion.Parse("1.0.0"), LibraryType.Package)), true },
+                new object[] {new GraphItem<string>(new LibraryIdentity("lib1", NuGetVersion.Parse("1.0.0"), LibraryType.Package)), new GraphItem<string>(new LibraryIdentity("lib1", NuGetVersion.Parse("1.0.0"), LibraryType.ExternalProject)), false },
+                new object[] {new GraphItem<string>(new LibraryIdentity("lib1", NuGetVersion.Parse("1.0.0"), LibraryType.Package)), new GraphItem<string>(new LibraryIdentity("lib2", NuGetVersion.Parse("1.0.0"), LibraryType.Package)), false },
+                new object[] {new GraphItem<string>(new LibraryIdentity("lib1", NuGetVersion.Parse("1.0.0"), LibraryType.Package)), new GraphItem<string>(new LibraryIdentity("lib1", NuGetVersion.Parse("2.0.0"), LibraryType.Package)), false },
+                new object[] {new GraphItem<string>(new LibraryIdentity("lib1", NuGetVersion.Parse("1.0.0"), LibraryType.Package)), new GraphItem<string>(new LibraryIdentity("lib1", NuGetVersion.Parse("1.0.0"), LibraryType.Package)){ IsCentralTransitive = true }, true },
+                new object[] {new GraphItem<string>(new LibraryIdentity("lib1", NuGetVersion.Parse("1.0.0"), LibraryType.Package)), new GraphItem<string>(new LibraryIdentity("lib1", NuGetVersion.Parse("1.0.0"), LibraryType.Package)){ Data = "foo" }, true },
+           };
 
-            var graphItem1 = new GraphItem<string>(lib1Version1);
-            var graphItem2 = new GraphItem<string>(lib1Version1Duplicate);
-            var graphItem3 = new GraphItem<string>(lib2Version1);
-            var graphItem4 = new GraphItem<string>(lib1Version2);
-            var graphItem5 = new GraphItem<string>(lib1Version1) { IsCentralTransitive = true };
-
-            // Assert
-            Assert.True(GraphItemKeyComparer<string>.Instance.Equals(graphItem1, graphItem2));
-            Assert.True(GraphItemKeyComparer<string>.Instance.Equals(graphItem1, graphItem5));
-            Assert.False(GraphItemKeyComparer<string>.Instance.Equals(graphItem1, graphItem3));
-            Assert.False(GraphItemKeyComparer<string>.Instance.Equals(graphItem1, graphItem4));
-
-            Assert.Equal(GraphItemKeyComparer<string>.Instance.GetHashCode(graphItem1), GraphItemKeyComparer<string>.Instance.GetHashCode(graphItem2));
-            Assert.Equal(GraphItemKeyComparer<string>.Instance.GetHashCode(graphItem1), GraphItemKeyComparer<string>.Instance.GetHashCode(graphItem5));
-            Assert.NotEqual(GraphItemKeyComparer<string>.Instance.GetHashCode(graphItem1), GraphItemKeyComparer<string>.Instance.GetHashCode(graphItem3));
-            Assert.NotEqual(GraphItemKeyComparer<string>.Instance.GetHashCode(graphItem1), GraphItemKeyComparer<string>.Instance.GetHashCode(graphItem4));
-        }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests/GraphItemKeyComparerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests/GraphItemKeyComparerTests.cs
@@ -1,0 +1,70 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using NuGet.LibraryModel;
+using NuGet.Versioning;
+using Xunit;
+
+namespace NuGet.DependencyResolver.Core.Tests
+{
+    public class GraphItemKeyComparerTests
+    {
+        [Fact]
+        public void DistinctListOfObjects()
+        {
+            // Arrange
+            var lib1Version1 = new LibraryIdentity("lib1", NuGetVersion.Parse("1.0.0"), LibraryType.Package);
+            var lib1Version1Duplicate = new LibraryIdentity("lib1", NuGetVersion.Parse("1.0.0"), LibraryType.Package);
+            var lib2Version1 = new LibraryIdentity("lib2", NuGetVersion.Parse("1.0.0"), LibraryType.Package);
+            var lib1Version2 = new LibraryIdentity("lib1", NuGetVersion.Parse("2.0.0"), LibraryType.Package);
+
+            var graphItem1 = new GraphItem<string>(lib1Version1);
+            var graphItem2 = new GraphItem<string>(lib1Version1Duplicate);
+            var graphItem3 = new GraphItem<string>(lib2Version1);
+            var graphItem4 = new GraphItem<string>(lib1Version2);
+            var graphItem5 = new GraphItem<string>(lib1Version1) { IsCentralTransitive = true };
+
+            var list = new List<GraphItem<string>>() { graphItem1, graphItem2, graphItem3, graphItem4, graphItem5 };
+
+            // Act
+            var distinctElements = list.Distinct(GraphItemKeyComparer<string>.Instance).ToList();
+
+            // Assert
+            // There should be three elements distinct
+            // These should be graphItem1, graphItem3, graphItem4
+            Assert.Equal(3, distinctElements.Count);
+            Assert.Equal(graphItem1.Key.Name, distinctElements[0].Key.Name);
+            Assert.Equal(graphItem3.Key.Name, distinctElements[1].Key.Name);
+            Assert.Equal(graphItem4.Key.Name, distinctElements[2].Key.Name);
+        }
+
+        [Fact]
+        public void ObjectAreEqualsOnlyWhenGetHashAreEquals()
+        {
+            // Arrange
+            var lib1Version1 = new LibraryIdentity("lib1", NuGetVersion.Parse("1.0.0"), LibraryType.Package);
+            var lib1Version1Duplicate = new LibraryIdentity("lib1", NuGetVersion.Parse("1.0.0"), LibraryType.Package);
+            var lib2Version1 = new LibraryIdentity("lib2", NuGetVersion.Parse("1.0.0"), LibraryType.Package);
+            var lib1Version2 = new LibraryIdentity("lib1", NuGetVersion.Parse("2.0.0"), LibraryType.Package);
+
+            var graphItem1 = new GraphItem<string>(lib1Version1);
+            var graphItem2 = new GraphItem<string>(lib1Version1Duplicate);
+            var graphItem3 = new GraphItem<string>(lib2Version1);
+            var graphItem4 = new GraphItem<string>(lib1Version2);
+            var graphItem5 = new GraphItem<string>(lib1Version1) { IsCentralTransitive = true };
+
+            // Assert
+            Assert.True(GraphItemKeyComparer<string>.Instance.Equals(graphItem1, graphItem2));
+            Assert.True(GraphItemKeyComparer<string>.Instance.Equals(graphItem1, graphItem5));
+            Assert.False(GraphItemKeyComparer<string>.Instance.Equals(graphItem1, graphItem3));
+            Assert.False(GraphItemKeyComparer<string>.Instance.Equals(graphItem1, graphItem4));
+
+            Assert.Equal(GraphItemKeyComparer<string>.Instance.GetHashCode(graphItem1), GraphItemKeyComparer<string>.Instance.GetHashCode(graphItem2));
+            Assert.Equal(GraphItemKeyComparer<string>.Instance.GetHashCode(graphItem1), GraphItemKeyComparer<string>.Instance.GetHashCode(graphItem5));
+            Assert.NotEqual(GraphItemKeyComparer<string>.Instance.GetHashCode(graphItem1), GraphItemKeyComparer<string>.Instance.GetHashCode(graphItem3));
+            Assert.NotEqual(GraphItemKeyComparer<string>.Instance.GetHashCode(graphItem1), GraphItemKeyComparer<string>.Instance.GetHashCode(graphItem4));
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests/GraphItemKeyComparerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests/GraphItemKeyComparerTests.cs
@@ -16,7 +16,7 @@ namespace NuGet.DependencyResolver.Core.Tests
         public void Equals_GraphItemsAreEqualOnlyIfKeysAreEqual(GraphItem<string> item1, GraphItem<string> item2, bool expectedResult)
         {
             // Assert
-            if(expectedResult)
+            if (expectedResult)
             {
                 Assert.True(GraphItemKeyComparer<string>.Instance.Equals(item1, item2));
                 Assert.Equal(GraphItemKeyComparer<string>.Instance.GetHashCode(item1), GraphItemKeyComparer<string>.Instance.GetHashCode(item2));


### PR DESCRIPTION
## Bug

Fixes: [Central package management throws errors about duplicate dictionary keys when attempting to create the lock file](https://github.com/NuGet/Home/issues/9965)

Regression: No  

## Fix

When a project targets two (or more ) TFMs and for one TFM a central package version is direct dependency and in the other it is transitive an exception is raised due to the fact that the two library objects are different. 
The fix will add a KeyComparer that will identify two GraphNodes as equal only if the Key (LibraryIdentity) are equal.  

## Testing/Validation

Tests Added: Yes
Validation:  Unit tests and manual testing. 
