### PR TITLE
Temp HttpRequestMessage workaround until net5 is GA

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/CommandRunners/PackCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/CommandRunners/PackCommandRunner.cs
@@ -794,7 +794,7 @@ namespace NuGet.Commands
                 }
                 else
                 {
-                    successful= BuildPackage(mainPackageBuilder, symbolsPackage: false);
+                    successful = BuildPackage(mainPackageBuilder, symbolsPackage: false);
                 }
 
                 // If we're excluding symbols then do nothing else

--- a/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpRequestMessageExtensions.cs
+++ b/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpRequestMessageExtensions.cs
@@ -34,17 +34,20 @@ namespace NuGet.Protocol
                 clone.Headers.TryAddWithoutValidation(header.Key, header.Value);
             }
 
-#if NET5_0
+#if USE_HTTPREQUESTMESSAGE_OPTIONS
             var clonedOptions = (IDictionary<string, object>)clone.Options;
             foreach (var option in request.Options)
             {
                 clonedOptions.Add(option.Key, option.Value);
             }
 #else
+            // stop ignoring CS0618 when fixing https://github.com/NuGet/Home/issues/9981
+#pragma warning disable CS0618
             foreach (var property in request.Properties)
             {
                 clone.Properties.Add(property);
             }
+#pragma warning restore CS0618
 #endif
             return clone;
         }
@@ -118,21 +121,27 @@ namespace NuGet.Protocol
                 throw new ArgumentNullException(nameof(configuration));
             }
 
-#if NET5_0
+#if USE_HTTPREQUESTMESSAGE_OPTIONS
             request.Options.Set(new HttpRequestOptionsKey<HttpRequestMessageConfiguration>(NuGetConfigurationKey), configuration);
 #else
+            // stop ignoring CS0618 when fixing https://github.com/NuGet/Home/issues/9981
+#pragma warning disable CS0618
             request.Properties[NuGetConfigurationKey] = configuration;
+#pragma warning restore CS0618
 #endif
         }
 
         private static T GetProperty<T>(this HttpRequestMessage request, string key)
         {
 
-#if NET5_0
+#if USE_HTTPREQUESTMESSAGE_OPTIONS
             if (request.Options.TryGetValue<T>(new HttpRequestOptionsKey<T>(key), out T result))
 #else
+            // stop ignoring CS0618 when fixing https://github.com/NuGet/Home/issues/9981
+#pragma warning disable CS0618
             object result;
             if (request.Properties.TryGetValue(key, out result) && result is T)
+#pragma warning restore CS0618
 #endif
             {
                 return (T)result;

--- a/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpRetryHandler.cs
+++ b/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpRetryHandler.cs
@@ -81,10 +81,13 @@ namespace NuGet.Protocol
                         headerStopwatch = new Stopwatch();
                         stopwatches.Add(headerStopwatch);
                     }
-#if NET5_0
+#if USE_HTTPREQUESTMESSAGE_OPTIONS
                     requestMessage.Options.Set(new HttpRequestOptionsKey<List<Stopwatch>>(StopwatchPropertyName), stopwatches);
 #else
+                    // stop ignoring CS0618 when fixing https://github.com/NuGet/Home/issues/9981
+#pragma warning disable CS0618
                     requestMessage.Properties[StopwatchPropertyName] = stopwatches;
+#pragma warning restore CS0618
 #endif
                     var requestUri = requestMessage.RequestUri;
 

--- a/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpSourceAuthenticationHandler.cs
+++ b/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpSourceAuthenticationHandler.cs
@@ -105,9 +105,11 @@ namespace NuGet.Protocol
                     {
 #else
                     // stop ignoring CS0618 when fixing https://github.com/NuGet/Home/issues/9981
+#pragma warning disable CS0618
                     if (request.Properties.TryGetValue(HttpRetryHandler.StopwatchPropertyName, out var value))
                     {
                         stopwatches = value as List<Stopwatch>;
+#pragma warning restore CS0618
 #endif
                         if (stopwatches != null)
                         {

--- a/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpSourceAuthenticationHandler.cs
+++ b/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpSourceAuthenticationHandler.cs
@@ -105,11 +105,9 @@ namespace NuGet.Protocol
                     {
 #else
                     // stop ignoring CS0618 when fixing https://github.com/NuGet/Home/issues/9981
-#pragma warning disable CS0618
                     if (request.Properties.TryGetValue(HttpRetryHandler.StopwatchPropertyName, out var value))
                     {
                         stopwatches = value as List<Stopwatch>;
-#pragma warning restore CS0618
 #endif
                         if (stopwatches != null)
                         {

--- a/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpSourceAuthenticationHandler.cs
+++ b/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpSourceAuthenticationHandler.cs
@@ -98,15 +98,18 @@ namespace NuGet.Protocol
                 {
                     List<Stopwatch> stopwatches = null;
 
-#if NET5_0
+#if USE_HTTPREQUESTMESSAGE_OPTIONS
                     if (request.Options.TryGetValue(
                         new HttpRequestOptionsKey<List<Stopwatch>>(HttpRetryHandler.StopwatchPropertyName),
                         out stopwatches))
                     {
 #else
+                    // stop ignoring CS0618 when fixing https://github.com/NuGet/Home/issues/9981
+#pragma warning disable CS0618
                     if (request.Properties.TryGetValue(HttpRetryHandler.StopwatchPropertyName, out var value))
                     {
                         stopwatches = value as List<Stopwatch>;
+#pragma warning restore CS0618
 #endif
                         if (stopwatches != null)
                         {

--- a/src/NuGet.Core/NuGet.Protocol/NuGet.Protocol.csproj
+++ b/src/NuGet.Core/NuGet.Protocol/NuGet.Protocol.csproj
@@ -1,4 +1,4 @@
-<Project>
+﻿<Project>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common.props" />
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
@@ -13,6 +13,9 @@
     <XPLATProject>true</XPLATProject>
     <Description>NuGet's implementation for interacting with feeds. Contains functionality for all feed types.</Description>
     <UsePublicApiAnalyzer>perTfm</UsePublicApiAnalyzer>
+    <!-- Uncomment when fixing https://github.com/NuGet/Home/issues/9981.  Also, try to make it check TFI = netcoreapp and TFV >= 5.0, so this doesn't break when net6 comes around
+    <DefineConstants Condition =" '$(TargetFameworkMoniker)' == '.NETCoreApp,Version=v5.0' ">$(DefineConstants);USE_HTTPREQUESTMESSAGE_OPTIONS</DefineConstants>
+    -->
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(IsVsixBuild)' == 'true' ">

--- a/src/NuGet.Core/NuGet.Protocol/NuGet.Protocol.csproj
+++ b/src/NuGet.Core/NuGet.Protocol/NuGet.Protocol.csproj
@@ -1,4 +1,4 @@
-﻿<Project>
+<Project>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common.props" />
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
@@ -13,10 +13,16 @@
     <XPLATProject>true</XPLATProject>
     <Description>NuGet's implementation for interacting with feeds. Contains functionality for all feed types.</Description>
     <UsePublicApiAnalyzer>perTfm</UsePublicApiAnalyzer>
-    <!-- Uncomment when fixing https://github.com/NuGet/Home/issues/9981.  Also, try to make it check TFI = netcoreapp and TFV >= 5.0, so this doesn't break when net6 comes around
-    <DefineConstants Condition =" '$(TargetFameworkMoniker)' == '.NETCoreApp,Version=v5.0' ">$(DefineConstants);USE_HTTPREQUESTMESSAGE_OPTIONS</DefineConstants>
+    <!-- Uncomment when fixing https://github.com/NuGet/Home/issues/9981
+    <CoreCompileDependsOn>$(CoreCompileDependsOn);DefineHttpRequestMessageOptions</CoreCompileDependsOn>
     -->
   </PropertyGroup>
+
+  <Target Name="DefineHttpRequestMessageOptions">
+    <PropertyGroup Condition =" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionGreaterThanOrEquals('$(TargetFrameworkVersion)', '5.0')) ">
+      <DefineConstants >$(DefineConstants);USE_HTTPREQUESTMESSAGE_OPTIONS</DefineConstants>
+    </PropertyGroup>
+  </Target>
 
   <PropertyGroup Condition=" '$(IsVsixBuild)' == 'true' ">
     <TargetFrameworks />


### PR DESCRIPTION
## Bug

Tracking issue: https://github.com/NuGet/Home/issues/9981
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: Ignore CS0618 (obsolete method), so using .NET 5 SDK rc.1  or above doesn't fail, but don't use Options just yet, so that using preview 8 or earlier doesn't fail. Added comments to remove workaround once .NET 5 goes GA.

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  existing tests cover it.
Validation:  
