### PR TITLE
Optimize IsMono check for non-Windows platforms

### DIFF
--- a/src/NuGet.Core/NuGet.Common/RuntimeEnvironmentHelper.cs
+++ b/src/NuGet.Core/NuGet.Common/RuntimeEnvironmentHelper.cs
@@ -59,7 +59,7 @@ namespace NuGet.Common
         {
             get
             {
-                if (IsRunningInVisualStudio)
+                if (IsWindows && IsRunningInVisualStudio)
                 {
                     // skip Mono type check if current process is Devenv
                     return false;

--- a/src/NuGet.Core/NuGet.Common/RuntimeEnvironmentHelper.cs
+++ b/src/NuGet.Core/NuGet.Common/RuntimeEnvironmentHelper.cs
@@ -23,6 +23,11 @@ namespace NuGet.Common
 
         private static Lazy<bool> _isRunningInVisualStudio = new Lazy<bool>(() =>
         {
+            if (!IsWindows)
+            {
+                return false;
+            }
+
             var currentProcessName = Path.GetFileNameWithoutExtension(GetCurrentProcessFilePath());
 
             return VisualStudioProcesses.Any(
@@ -59,7 +64,7 @@ namespace NuGet.Common
         {
             get
             {
-                if (IsWindows && IsRunningInVisualStudio)
+                if (IsRunningInVisualStudio)
                 {
                     // skip Mono type check if current process is Devenv
                     return false;


### PR DESCRIPTION
This should improve the performance of showing the IDE shell when a solution is being loaded.
https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1155582

## Bug

Fixes: https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1155582
Fixes: https://github.com/NuGet/Home/issues/9989
Regression: No

## Fix

DEVENV and BLEND are the Windows-only process names for Visual Studio.

Avoid triggering expensive runtime initialization of Process modules when querying GetCurrentProcess, by simply not querying IsRunningInVisualStudio on non-Windows platforms.

Sample trace:
https://gist.github.com/Therzok/9b2e09655e75aa0c4eeec25cc8df2123

## Testing/Validation

I'm not sure how this could be tested, as it is a performance issue that exhibits on mono/macOS in VSMac.

cc @marshall-lerner