### PR TITLE
Improve test fixtures and related code

### DIFF
--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
@@ -799,7 +799,7 @@ namespace NuGet.CommandLine.Test
                                                         'x': '1.0.0'
                                                     },
                                                     'frameworks': {
-                                                        'net45': { }                                                            
+                                                        'net45': { }
                                                     }
                                                   }");
 
@@ -5728,7 +5728,7 @@ namespace NuGet.CommandLine.Test
                 configuration.Add(disabledPackageSources);
                 File.WriteAllText(configPath, doc.ToString());
 
-                // Act 
+                // Act
                 var r2 = Util.RestoreSolution(pathContext);
 
                 // Assert
@@ -5817,7 +5817,7 @@ namespace NuGet.CommandLine.Test
 
                 File.WriteAllText(configPath2, doc2.ToString());
 
-                // Act 
+                // Act
                 var r2 = Util.RestoreSolution(pathContext);
 
                 // Assert
@@ -6484,7 +6484,7 @@ namespace NuGet.CommandLine.Test
             // Related issue: https://github.com/NuGet/Home/issues/7807
             // First senario : Enable RestorePackagesWithLockFile by only setting property.
             //     First restore should fail the No-op, generate the package lock file. After deleting the package lock file, run the second restore.
-            //     The second restore should fail the No-op, and generate the package lock file. 
+            //     The second restore should fail the No-op, and generate the package lock file.
 
             // Arrange
             using (var pathContext = new SimpleTestPathContext())
@@ -6521,7 +6521,7 @@ namespace NuGet.CommandLine.Test
                 var packageLockFileName = project.NuGetLockFileOutputPath;
                 var noOpFailedMsg = "The lock file for " + project.ProjectName + " at location " + packageLockFileName + " does not exist, no-op is not possible. Continuing restore.";
 
-                // Act  
+                // Act
                 var result1 = Util.Restore(pathContext, project.ProjectPath, additionalArgs: "-verbosity Detailed");
 
                 // Assert
@@ -6588,7 +6588,7 @@ namespace NuGet.CommandLine.Test
                 var noOpFailedMsg = "The lock file for " + project.ProjectName + " at location " + packageLockFileName + " does not exist, no-op is not possible. Continuing restore.";
                 var noOpSucceedMsg = "No-Op restore. The cache will not be updated.";
 
-                // Act  
+                // Act
                 var result1 = Util.Restore(pathContext, project.ProjectPath, additionalArgs: "-verbosity Detailed");
 
                 // Assert
@@ -6613,7 +6613,7 @@ namespace NuGet.CommandLine.Test
             // Related issue: https://github.com/NuGet/Home/issues/7807
             // Second senario : Enable RestorePackagesWithLockFile by only adding a lock file.
             //      First restore should fail the No-op, regenerate the package lock file. After deleting the package lock file, run the second restore.
-            //      The second restore: since there is no property set and no lock file exists, no lockfile will be generated. And no-op succeed. 
+            //      The second restore: since there is no property set and no lock file exists, no lockfile will be generated. And no-op succeed.
 
             // Arrange
             using (var pathContext = new SimpleTestPathContext())
@@ -7904,7 +7904,7 @@ namespace NuGet.CommandLine.Test
         public void RestoreNetCore_PackagesLockFile_ProjectReferenceChange_UpdatesLockFile()
         {
             // Arrange
-            // A -> B -> C and 
+            // A -> B -> C and
             // A -> B, A -> C
             // should have different lock files
             using (var pathContext = new SimpleTestPathContext())
@@ -8274,7 +8274,7 @@ namespace NuGet.CommandLine.Test
                 // Act
                 var result = Util.RestoreSolution(pathContext);
 
-                // Assert 
+                // Assert
                 result.Success.Should().BeTrue();
                 Assert.True(File.Exists(projectA.AssetsFileOutputPath));
                 Assert.True(File.Exists(projectB.AssetsFileOutputPath));
@@ -9121,14 +9121,14 @@ namespace NuGet.CommandLine.Test
                 Assert.True(File.Exists(projectA.AssetsFileOutputPath));
                 Assert.True(File.Exists(projectA.NuGetLockFileOutputPath));
                 Assert.Equal(expectedVersion, projectA.AssetsFile.Libraries.Single().Version.ToString());
-                // Set-up again. 
+                // Set-up again.
                 projectA.Properties.Add("RestoreLockedMode", "true");
                 projectA.Save();
 
                 // Act
                 result = Util.RestoreSolution(pathContext);
 
-                // Assert 
+                // Assert
                 result.Success.Should().BeTrue();
                 Assert.True(File.Exists(projectA.AssetsFileOutputPath));
                 Assert.True(File.Exists(projectA.NuGetLockFileOutputPath));
@@ -9335,7 +9335,7 @@ namespace NuGet.CommandLine.Test
 
                 Assert.True(File.Exists(projectA.NuGetLockFileOutputPath));
 
-                // Update the transitive dependency in cpvm 
+                // Update the transitive dependency in cpvm
                 cpvmFile.UpdatePackageVersion("y", "2.0.0");
                 cpvmFile.Save();
 
@@ -9665,8 +9665,8 @@ namespace NuGet.CommandLine.Test
         /// Project A -> PackageX 100
         ///           -> PackageY 200 -> PackageX 200
         ///            -> ProjectB -> ProjectC -> PackageX 100
-        ///  All projects CPVM enabled; PackageX 100 and PackageY 200 in cpvm file         
-        ///  Expected NU1605                     
+        ///  All projects CPVM enabled; PackageX 100 and PackageY 200 in cpvm file
+        ///  Expected NU1605
         /// </summary>
         [Fact]
         public async Task RestoreNetCore_CPVMProject_DowngradedByCentralDirectDependencyWithP2P_IsWarningNU1605()
@@ -9757,16 +9757,16 @@ namespace NuGet.CommandLine.Test
 
         /// <summary>
         /// A more complex graph with linked central transitive dependecies
-        /// 
+        ///
         /// A -> B 1.0.0 -> C 1.0.0 -> D 1.0.0 -> E 1.0.0
-        ///              -> P 2.0.0           
+        ///              -> P 2.0.0
         ///   -> F 1.0.0 -> C 2.0.0 -> H 2.0.0 -> M 2.0.0 -> N 2.0.0
         ///   -> G 1.0.0 -> H 1.0.0 -> D 1.0.0
         ///   -> X 1.0.0 -> Y 1.0.0 -> Z 1.0.0
         ///                         -> T 1.0.0
         ///   -> U 1.0.0 -> V 1.0.0
         ///              -> O 1.0.0 -> R 1.0.0 -> S 1.0.0 -> SS 1.0.0
-        ///   
+        ///
         ///         D has version defined centrally 2.0.0
         ///         E has version defined centrally 3.0.0
         ///         M has version defined centrally 2.0.0
@@ -9775,7 +9775,7 @@ namespace NuGet.CommandLine.Test
         ///         T has version defined centrally 3.0.0
         ///         R has version defined centrally 3.0.0
         ///         S has version defined centrally 3.0.0
-        /// 
+        ///
         ///  D 2.0.0 -> I 2.0.0 -> E 2.0.0
         ///  M 2.0.0 -> N 2.0.0
         ///  P 3.0.0 -> H 3.0.0
@@ -9785,15 +9785,15 @@ namespace NuGet.CommandLine.Test
         ///  T 3.0.0 -> W 3.0.0
         ///          -> C 1.0.0
         ///  S 3.0.0 -> SS 3.0.0
-        ///  
+        ///
         ///  D will be rejected (because its parents C 1.0.0, H 1.0.0 are rejected)
         ///  E will be rejected (because its parent D was rejected)
         ///  M will be rejected (because its parent lost the dispute with H 3.0.0)
         ///  T will be rejected (because its parent lost the dispute with Y 3.0.0)
         ///  Z will be rejected (because its parent lost the dispute with Y 3.0.0)
-        ///  
+        ///
         ///  P will be accepted (because its parent B is Accepted)
-        ///  S will be accepted (because its parent O 300 is Accepted) 
+        ///  S will be accepted (because its parent O 300 is Accepted)
         /// </summary>
         [Fact]
         public async Task RestoreNetCore_CPVMProject_MultipleLinkedCentralTransitiveDepenencies()
@@ -9829,7 +9829,7 @@ namespace NuGet.CommandLine.Test
                    NuGetFramework.Parse("netcoreapp2.0"));
                 projectA.Properties.Add("ManagePackageVersionsCentrally", "true");
 
-                // the package references defined in the project should not have version 
+                // the package references defined in the project should not have version
                 var packageBNoVersion = createTestPackage("B", null, packagesForProject);
                 var packageFNoVersion = createTestPackage("F", null, packagesForProject);
                 var packageGNoVersion = createTestPackage("G", null, packagesForProject);

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
@@ -8840,12 +8840,11 @@ namespace NuGet.CommandLine.Test
             {
                 // Set up solution, project, and packages
                 var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
-                var netcoreapp20 = mainProjectFramework;
 
                 var projectA = SimpleTestProjectContext.CreateNETCore(
                    "a",
                    pathContext.SolutionRoot,
-                   NuGetFramework.Parse(netcoreapp20));
+                   NuGetFramework.Parse(mainProjectFramework));
 
                 projectA.Properties.Add("RestorePackagesWithLockFile", "true");
 
@@ -8897,12 +8896,11 @@ namespace NuGet.CommandLine.Test
             {
                 // Set up solution, project, and packages
                 var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
-                var netcoreapp20 = mainProjectFramework;
 
                 var projectA = SimpleTestProjectContext.CreateNETCore(
                    "a",
                    pathContext.SolutionRoot,
-                   NuGetFramework.Parse(netcoreapp20));
+                   NuGetFramework.Parse(mainProjectFramework));
 
                 projectA.Properties.Add("RestorePackagesWithLockFile", "true");
 

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Util.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Util.cs
@@ -861,7 +861,7 @@ EndProject";
 
         /// <summary>
         /// Utility for asserting faulty executions of nuget.exe
-        /// 
+        ///
         /// Asserts a non-zero status code and a message on stderr.
         /// </summary>
         /// <param name="result">An instance of <see cref="CommandRunnerResult"/> with command execution results</param>

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetToolTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetToolTests.cs
@@ -34,13 +34,10 @@ namespace Dotnet.Integration.Test
                 var tfm = "netcoreapp2.0";
                 var projectName = "ToolRestoreProject";
                 var workingDirectory = Path.Combine(testDirectory, projectName);
-                var source = workingDirectory;
                 var rid = "win-x86";
-                var packages = new List<PackageIdentity>();
 
-                _msbuildFixture.CreateDotnetToolProject(solutionRoot: testDirectory.Path,
-                    projectName: projectName, targetFramework: tfm, rid: rid,
-                    source: workingDirectory, packages: packages);
+                _msbuildFixture.CreateDotnetToolProject(testDirectory.Path, projectName, tfm, rid);
+
                 // Act
                 var result = _msbuildFixture.RestoreToolProject(workingDirectory, projectName, string.Empty);
 
@@ -58,13 +55,11 @@ namespace Dotnet.Integration.Test
                 var tfm = "netcoreapp2.0";
                 var projectName = "ToolRestoreProject";
                 var workingDirectory = Path.Combine(testDirectory, projectName);
-                var source = "https://api.nuget.org/v3/index.json";
+                var packageSource = "https://api.nuget.org/v3/index.json";
                 var rid = "win-x86";
                 var packages = new List<PackageIdentity>() { new PackageIdentity("Newtonsoft.Json", NuGetVersion.Parse("10.0.3")) };
 
-                _msbuildFixture.CreateDotnetToolProject(solutionRoot: testDirectory.Path,
-                    projectName: projectName, targetFramework: tfm, rid: rid,
-                    source: source, packages: packages);
+                _msbuildFixture.CreateDotnetToolProject(testDirectory.Path, projectName, tfm, rid, packageSource, packages);
 
                 // Act
                 var result = _msbuildFixture.RestoreToolProject(workingDirectory, projectName, string.Empty);
@@ -84,7 +79,7 @@ namespace Dotnet.Integration.Test
                 var tfm = "netcoreapp2.0";
                 var projectName = "ToolRestoreProject";
                 var workingDirectory = Path.Combine(testDirectory, projectName);
-                var source = Path.Combine(testDirectory, "packageSource");
+                var packageSource = Path.Combine(testDirectory, "packageSource");
                 var rid = "win-x64";
                 var packageName = string.Join("ToolPackage-", tfm, rid);
                 var packageVersion = NuGetVersion.Parse("1.0.0");
@@ -96,11 +91,9 @@ namespace Dotnet.Integration.Test
                 package.PackageType = PackageType.DotnetTool;
                 package.UseDefaultRuntimeAssemblies = false;
                 package.PackageTypes.Add(PackageType.DotnetTool);
-                await SimpleTestPackageUtility.CreatePackagesAsync(source, package);
+                await SimpleTestPackageUtility.CreatePackagesAsync(packageSource, package);
 
-                _msbuildFixture.CreateDotnetToolProject(solutionRoot: testDirectory.Path,
-                    projectName: projectName, targetFramework: tfm, rid: rid,
-                    source: source, packages: packages);
+                _msbuildFixture.CreateDotnetToolProject(testDirectory.Path, projectName, tfm, rid, packageSource, packages);
 
                 // Act
                 var result = _msbuildFixture.RestoreToolProject(workingDirectory, projectName, string.Empty);
@@ -128,7 +121,7 @@ namespace Dotnet.Integration.Test
                 var tfm = "netcoreapp2.0";
                 var projectName = "ToolRestoreProject";
                 var workingDirectory = Path.Combine(testDirectory, projectName);
-                var source = Path.Combine(testDirectory, "packageSource");
+                var packageSource = Path.Combine(testDirectory, "packageSource");
                 var projectRID = "win-x64";
                 var packageRID = "win-x86";
 
@@ -141,11 +134,9 @@ namespace Dotnet.Integration.Test
                 package.PackageType = PackageType.DotnetTool;
                 package.UseDefaultRuntimeAssemblies = false;
                 package.PackageTypes.Add(PackageType.DotnetTool);
-                await SimpleTestPackageUtility.CreatePackagesAsync(source, package);
+                await SimpleTestPackageUtility.CreatePackagesAsync(packageSource, package);
 
-                _msbuildFixture.CreateDotnetToolProject(solutionRoot: testDirectory.Path,
-                    projectName: projectName, targetFramework: tfm, rid: projectRID,
-                    source: source, packages: packages);
+                _msbuildFixture.CreateDotnetToolProject(testDirectory.Path, projectName, tfm, projectRID, packageSource, packages);
 
                 // Act
                 var result = _msbuildFixture.RestoreToolProject(workingDirectory, projectName, string.Empty);
@@ -164,7 +155,7 @@ namespace Dotnet.Integration.Test
                 var tfm = "netcoreapp2.0";
                 var projectName = "ToolRestoreProject";
                 var workingDirectory = Path.Combine(testDirectory, projectName);
-                var source = Path.Combine(testDirectory, "packageSource");
+                var packageSource = Path.Combine(testDirectory, "packageSource");
                 var rid = "win-x64";
                 var packageName = string.Join("ToolPackage-", tfm, rid);
                 var packageVersion = NuGetVersion.Parse("1.0.0");
@@ -178,11 +169,9 @@ namespace Dotnet.Integration.Test
                 package.PackageType = PackageType.DotnetTool;
                 package.UseDefaultRuntimeAssemblies = false;
                 package.PackageTypes.Add(PackageType.DotnetTool);
-                await SimpleTestPackageUtility.CreatePackagesAsync(source, package);
+                await SimpleTestPackageUtility.CreatePackagesAsync(packageSource, package);
 
-                _msbuildFixture.CreateDotnetToolProject(solutionRoot: testDirectory.Path,
-                    projectName: projectName, targetFramework: tfm, rid: rid,
-                    source: source, packages: packages);
+                _msbuildFixture.CreateDotnetToolProject(testDirectory.Path, projectName, tfm, rid, packageSource, packages);
 
                 // Act
                 var result = _msbuildFixture.RestoreToolProject(workingDirectory, projectName, string.Empty);
@@ -211,7 +200,7 @@ namespace Dotnet.Integration.Test
             {
                 var projectName = "ToolRestoreProject";
                 var workingDirectory = Path.Combine(testDirectory, projectName);
-                var source = Path.Combine(testDirectory, "packageSource");
+                var packageSource = Path.Combine(testDirectory, "packageSource");
                 var packageName = string.Join("ToolPackage-", tfm, packageRID);
                 var packageVersion = NuGetVersion.Parse("1.0.0");
                 var packages = new List<PackageIdentity>() { new PackageIdentity(packageName, packageVersion) };
@@ -224,11 +213,9 @@ namespace Dotnet.Integration.Test
                 package.PackageType = PackageType.DotnetTool;
                 package.UseDefaultRuntimeAssemblies = false;
                 package.PackageTypes.Add(PackageType.DotnetTool);
-                await SimpleTestPackageUtility.CreatePackagesAsync(source, package);
+                await SimpleTestPackageUtility.CreatePackagesAsync(packageSource, package);
 
-                _msbuildFixture.CreateDotnetToolProject(solutionRoot: testDirectory.Path,
-                    projectName: projectName, targetFramework: tfm, rid: projectRID,
-                    source: source, packages: packages);
+                _msbuildFixture.CreateDotnetToolProject(testDirectory.Path, projectName, tfm, projectRID, packageSource, packages);
 
                 // Act
                 var result = _msbuildFixture.RestoreToolProject(workingDirectory, projectName, string.Empty);
@@ -256,8 +243,8 @@ namespace Dotnet.Integration.Test
                 var tfm = "netcoreapp2.0";
                 var projectName = "ToolRestoreProject";
                 var workingDirectory = Path.Combine(testDirectory, projectName);
-                var localSource = Path.Combine(testDirectory, "packageSource");
-                var source = "https://api.nuget.org/v3/index.json" + ";" + localSource;
+                var packageSource = Path.Combine(testDirectory, "packageSource");
+                var packageSources = "https://api.nuget.org/v3/index.json" + ";" + packageSource;
                 var rid = "win-x64";
                 var packageName = string.Join("ToolPackage-", tfm, rid);
                 var packageVersion = NuGetVersion.Parse("1.0.0");
@@ -270,16 +257,15 @@ namespace Dotnet.Integration.Test
                 package.PackageType = PackageType.DotnetTool;
                 package.UseDefaultRuntimeAssemblies = false;
                 package.PackageTypes.Add(PackageType.DotnetTool);
-                await SimpleTestPackageUtility.CreatePackagesAsync(localSource, package);
+                await SimpleTestPackageUtility.CreatePackagesAsync(packageSource, package);
 
-                var packages = new List<PackageIdentity>() {
+                var packages = new List<PackageIdentity>()
+                {
                     new PackageIdentity(packageName, packageVersion),
                     new PackageIdentity("Newtonsoft.Json", NuGetVersion.Parse("10.0.3"))
                 };
 
-                _msbuildFixture.CreateDotnetToolProject(solutionRoot: testDirectory.Path,
-                    projectName: projectName, targetFramework: tfm, rid: rid,
-                    source: source, packages: packages);
+                _msbuildFixture.CreateDotnetToolProject(testDirectory.Path, projectName, tfm, rid, packageSources, packages);
 
                 // Act
                 var result = _msbuildFixture.RestoreToolProject(workingDirectory, projectName, string.Empty);
@@ -300,7 +286,7 @@ namespace Dotnet.Integration.Test
             {
                 var projectName = "ToolRestoreProject";
                 var workingDirectory = Path.Combine(testDirectory, projectName);
-                var localSource = Path.Combine(testDirectory, "packageSource");
+                var packageSource = Path.Combine(testDirectory, "packageSource");
                 var packageName = string.Join("ToolPackage-", tfm, packageRid);
                 var platformsPackageName = "PlatformsPackage";
                 var packageVersion = NuGetVersion.Parse("1.0.0");
@@ -322,14 +308,14 @@ namespace Dotnet.Integration.Test
                 toolPackage.PackageTypes.Add(PackageType.DotnetTool);
                 toolPackage.Dependencies.Add(platformsPackage);
 
-                await SimpleTestPackageUtility.CreatePackagesAsync(localSource, toolPackage, platformsPackage);
+                await SimpleTestPackageUtility.CreatePackagesAsync(packageSource, toolPackage, platformsPackage);
 
-                var packages = new List<PackageIdentity>() {
+                var packages = new List<PackageIdentity>()
+                {
                     new PackageIdentity(packageName, packageVersion),
                 };
-                _msbuildFixture.CreateDotnetToolProject(solutionRoot: testDirectory.Path,
-                    projectName: projectName, targetFramework: tfm, rid: projectRid,
-                    source: localSource, packages: packages);
+
+                _msbuildFixture.CreateDotnetToolProject(testDirectory.Path, projectName, tfm, projectRid, packageSource, packages);
 
                 // Act
                 var result = _msbuildFixture.RestoreToolProject(workingDirectory, projectName, string.Empty);
@@ -355,7 +341,7 @@ namespace Dotnet.Integration.Test
                 var tfm = "netcoreapp2.0";
                 var projectName = "ToolRestoreProject";
                 var workingDirectory = Path.Combine(testDirectory, projectName);
-                var source = Path.Combine(testDirectory, "packageSource");
+                var packageSource = Path.Combine(testDirectory, "packageSource");
                 var rid = "win-x64";
                 var packageName = string.Join("ToolPackage-", tfm, rid);
                 var packageVersion = NuGetVersion.Parse("1.0.0");
@@ -371,11 +357,9 @@ namespace Dotnet.Integration.Test
                 package.PackageType = PackageType.DotnetTool;
                 package.UseDefaultRuntimeAssemblies = false;
                 package.PackageTypes.Add(PackageType.DotnetTool);
-                await SimpleTestPackageUtility.CreatePackagesAsync(source, package);
+                await SimpleTestPackageUtility.CreatePackagesAsync(packageSource, package);
 
-                _msbuildFixture.CreateDotnetToolProject(solutionRoot: testDirectory.Path,
-                    projectName: projectName, targetFramework: tfm, rid: rid,
-                    source: source, packages: packages);
+                _msbuildFixture.CreateDotnetToolProject(testDirectory.Path, projectName, tfm, rid, packageSource, packages);
 
                 // Act
                 var result = _msbuildFixture.RestoreToolProject(workingDirectory, projectName, string.Empty);
@@ -394,7 +378,7 @@ namespace Dotnet.Integration.Test
                 var tfm = "netcoreapp2.0";
                 var projectName = "ToolRestoreProject";
                 var workingDirectory = Path.Combine(testDirectory, projectName);
-                var source = Path.Combine(testDirectory, "packageSource");
+                var packageSource = Path.Combine(testDirectory, "packageSource");
                 var rid = "win-x64";
                 var packageName = string.Join("ToolPackage-", tfm, rid);
                 var packageVersion = NuGetVersion.Parse("1.0.0");
@@ -406,11 +390,9 @@ namespace Dotnet.Integration.Test
                 package.UseDefaultRuntimeAssemblies = false;
                 package.PackageTypes.Add(PackageType.DotnetTool);
                 package.PackageTypes.Add(PackageType.Dependency);
-                await SimpleTestPackageUtility.CreatePackagesAsync(source, package);
+                await SimpleTestPackageUtility.CreatePackagesAsync(packageSource, package);
 
-                _msbuildFixture.CreateDotnetToolProject(solutionRoot: testDirectory.Path,
-                    projectName: projectName, targetFramework: tfm, rid: rid,
-                    source: source, packages: packages);
+                _msbuildFixture.CreateDotnetToolProject(testDirectory.Path, projectName, tfm, rid, packageSource, packages);
 
                 // Act
                 var result = _msbuildFixture.RestoreToolProject(workingDirectory, projectName, string.Empty);
@@ -429,7 +411,7 @@ namespace Dotnet.Integration.Test
                 var tfm = "netcoreapp2.0";
                 var projectName = "ToolRestoreProject";
                 var workingDirectory = Path.Combine(testDirectory, projectName);
-                var source = Path.Combine(testDirectory, "packageSource");
+                var packageSource = Path.Combine(testDirectory, "packageSource");
                 var rid = "win-x64";
                 var packageName = string.Join("ToolPackage-", tfm, rid);
                 var packageVersion = NuGetVersion.Parse("1.0.0");
@@ -442,11 +424,9 @@ namespace Dotnet.Integration.Test
                 package.PackageType = PackageType.DotnetTool;
                 package.UseDefaultRuntimeAssemblies = false;
                 package.PackageTypes.Add(PackageType.DotnetTool);
-                await SimpleTestPackageUtility.CreatePackagesAsync(source, package);
+                await SimpleTestPackageUtility.CreatePackagesAsync(packageSource, package);
 
-                _msbuildFixture.CreateDotnetToolProject(solutionRoot: testDirectory.Path,
-                    projectName: projectName, targetFramework: tfm, rid: rid,
-                    source: source, packages: packages);
+                _msbuildFixture.CreateDotnetToolProject(testDirectory.Path, projectName, tfm, rid, packageSource, packages);
 
                 // Act
                 var result = _msbuildFixture.RestoreToolProject(workingDirectory, projectName, string.Empty);
@@ -475,8 +455,8 @@ namespace Dotnet.Integration.Test
                 var tfm = "netcoreapp2.0";
                 var projectName = "ToolRestoreProject";
                 var workingDirectory = Path.Combine(testDirectory, projectName);
-                var localSource = Path.Combine(testDirectory, "packageSource");
-                var source = "https://api.nuget.org/v3/index.json" + ";" + localSource;
+                var packageSource = Path.Combine(testDirectory, "packageSource");
+                var packageSources = "https://api.nuget.org/v3/index.json" + ";" + packageSource;
                 var rid = "win-x64";
                 var packageName = string.Join("ToolPackage-", tfm, rid);
                 var autoReferencePackageName = "Microsoft.NETCore.Platforms";
@@ -490,16 +470,15 @@ namespace Dotnet.Integration.Test
                 package.PackageType = PackageType.DotnetTool;
                 package.UseDefaultRuntimeAssemblies = false;
                 package.PackageTypes.Add(PackageType.DotnetTool);
-                await SimpleTestPackageUtility.CreatePackagesAsync(localSource, package);
+                await SimpleTestPackageUtility.CreatePackagesAsync(packageSource, package);
 
-                var packages = new List<PackageIdentity>() {
+                var packages = new List<PackageIdentity>()
+                {
                     new PackageIdentity(packageName, packageVersion),
                     new PackageIdentity(autoReferencePackageName, NuGetVersion.Parse("2.0.1"))
                 };
 
-                _msbuildFixture.CreateDotnetToolProject(solutionRoot: testDirectory.Path,
-                    projectName: projectName, targetFramework: tfm, rid: rid,
-                    source: source, packages: packages);
+                _msbuildFixture.CreateDotnetToolProject(testDirectory.Path, projectName, tfm, rid, packageSources, packages);
 
                 var fullProjectPath = Path.Combine(workingDirectory, $"{projectName}.csproj");
                 MakePackageReferenceImplicitlyDefined(fullProjectPath, autoReferencePackageName);
@@ -527,8 +506,8 @@ namespace Dotnet.Integration.Test
                 var tfm = "netcoreapp2.0";
                 var projectName = "ToolRestoreProject";
                 var workingDirectory = Path.Combine(testDirectory, projectName);
-                var localSource = Path.Combine(testDirectory, "packageSource");
-                var source = "https://api.nuget.org/v3/index.json" + ";" + localSource;
+                var packageSource = Path.Combine(testDirectory, "packageSource");
+                var packageSources = "https://api.nuget.org/v3/index.json" + ";" + packageSource;
                 var rid = "win-x64";
                 var packageName = string.Join("ToolPackage-", tfm, rid);
                 var autoReferencePackageName = "Microsoft.NETCore.Platforms";
@@ -542,17 +521,16 @@ namespace Dotnet.Integration.Test
                 package.PackageType = PackageType.DotnetTool;
                 package.UseDefaultRuntimeAssemblies = false;
                 package.PackageTypes.Add(PackageType.DotnetTool);
-                await SimpleTestPackageUtility.CreatePackagesAsync(localSource, package);
+                await SimpleTestPackageUtility.CreatePackagesAsync(packageSource, package);
 
-                var packages = new List<PackageIdentity>() {
+                var packages = new List<PackageIdentity>()
+                {
                     new PackageIdentity(packageName, packageVersion),
                     new PackageIdentity(autoReferencePackageName, NuGetVersion.Parse("2.0.1")),
                     new PackageIdentity("NuGet.Versioning", NuGetVersion.Parse("4.3.0"))
                 };
 
-                _msbuildFixture.CreateDotnetToolProject(solutionRoot: testDirectory.Path,
-                    projectName: projectName, targetFramework: tfm, rid: rid,
-                    source: source, packages: packages);
+                _msbuildFixture.CreateDotnetToolProject(testDirectory.Path, projectName, tfm, rid, packageSources, packages);
 
                 var fullProjectPath = Path.Combine(workingDirectory, $"{projectName}.csproj");
                 MakePackageReferenceImplicitlyDefined(fullProjectPath, autoReferencePackageName);
@@ -578,8 +556,8 @@ namespace Dotnet.Integration.Test
                 var tfm = "netcoreapp2.0";
                 var projectName = "ToolRestoreProject";
                 var workingDirectory = Path.Combine(testDirectory, projectName);
-                var localSource = Path.Combine(testDirectory, "packageSource");
-                var source = "https://api.nuget.org/v3/index.json" + ";" + localSource;
+                var packageSource = Path.Combine(testDirectory, "packageSource");
+                var packageSources = "https://api.nuget.org/v3/index.json" + ";" + packageSource;
                 var rid = "win-x64";
                 var packageRid = "any";
                 var packageName = string.Join("ToolPackage-", tfm, packageRid);
@@ -594,16 +572,15 @@ namespace Dotnet.Integration.Test
                 package.PackageType = PackageType.DotnetTool;
                 package.UseDefaultRuntimeAssemblies = false;
                 package.PackageTypes.Add(PackageType.DotnetTool);
-                await SimpleTestPackageUtility.CreatePackagesAsync(localSource, package);
+                await SimpleTestPackageUtility.CreatePackagesAsync(packageSource, package);
 
-                var packages = new List<PackageIdentity>() {
+                var packages = new List<PackageIdentity>()
+                {
                     new PackageIdentity(packageName, packageVersion),
                     new PackageIdentity(autoReferencePackageName, NuGetVersion.Parse("2.0.1")),
                 };
 
-                _msbuildFixture.CreateDotnetToolProject(solutionRoot: testDirectory.Path,
-                    projectName: projectName, targetFramework: tfm, rid: rid,
-                    source: source, packages: packages);
+                _msbuildFixture.CreateDotnetToolProject(testDirectory.Path, projectName, tfm, rid, packageSources, packages);
 
                 var fullProjectPath = Path.Combine(workingDirectory, $"{projectName}.csproj");
                 MakePackageReferenceImplicitlyDefined(fullProjectPath, autoReferencePackageName);
@@ -633,8 +610,8 @@ namespace Dotnet.Integration.Test
                 var rid = "win-x64";
                 var projectName = "ToolRestoreProject";
                 var workingDirectory = Path.Combine(testDirectory, projectName);
-                var localSource = Path.Combine(testDirectory, "packageSource");
-                var source = "https://api.nuget.org/v3/index.json" + ";" + localSource;
+                var packageSource = Path.Combine(testDirectory, "packageSource");
+                var packageSources = "https://api.nuget.org/v3/index.json" + ";" + packageSource;
                 var packageName = string.Join("ToolPackage-", tfm, rid);
                 var autoReferencePackageName = "Microsoft.NETCore.Platforms";
                 var packageVersion = NuGetVersion.Parse("1.0.0");
@@ -652,16 +629,15 @@ namespace Dotnet.Integration.Test
                 autorefPackage.AddFile($"lib/{incompatibletfm}/b.dll");
                 autorefPackage.UseDefaultRuntimeAssemblies = false;
 
-                await SimpleTestPackageUtility.CreatePackagesAsync(localSource, package, autorefPackage);
+                await SimpleTestPackageUtility.CreatePackagesAsync(packageSource, package, autorefPackage);
 
-                var packages = new List<PackageIdentity>() {
+                var packages = new List<PackageIdentity>()
+                {
                     new PackageIdentity(packageName, packageVersion),
                     new PackageIdentity(autoReferencePackageName, packageVersion)
                 };
 
-                _msbuildFixture.CreateDotnetToolProject(solutionRoot: testDirectory.Path,
-                    projectName: projectName, targetFramework: tfm, rid: rid,
-                    source: source, packages: packages);
+                _msbuildFixture.CreateDotnetToolProject(testDirectory.Path, projectName, tfm, rid, packageSources, packages);
 
                 var fullProjectPath = Path.Combine(workingDirectory, $"{projectName}.csproj");
                 MakePackageReferenceImplicitlyDefined(fullProjectPath, autoReferencePackageName);
@@ -691,7 +667,7 @@ namespace Dotnet.Integration.Test
                 var fallbackTfm = "net46";
                 var projectName = "ToolRestoreProject";
                 var workingDirectory = Path.Combine(testDirectory, projectName);
-                var source = Path.Combine(testDirectory, "packageSource");
+                var packageSource = Path.Combine(testDirectory, "packageSource");
                 var rid = "win-x64";
                 var packageName = string.Join("ToolPackage-", fallbackTfm, rid);
                 var packageVersion = NuGetVersion.Parse("1.0.0");
@@ -705,11 +681,9 @@ namespace Dotnet.Integration.Test
                 package.PackageType = PackageType.DotnetTool;
                 package.UseDefaultRuntimeAssemblies = false;
                 package.PackageTypes.Add(PackageType.DotnetTool);
-                await SimpleTestPackageUtility.CreatePackagesAsync(source, package);
+                await SimpleTestPackageUtility.CreatePackagesAsync(packageSource, package);
 
-                _msbuildFixture.CreateDotnetToolProject(solutionRoot: testDirectory.Path,
-                    projectName: projectName, targetFramework: actualTfm, rid: rid,
-                    source: source, packages: packages);
+                _msbuildFixture.CreateDotnetToolProject(testDirectory.Path, projectName, actualTfm, rid, packageSource, packages);
 
                 using (var stream = File.Open(Path.Combine(workingDirectory, projectName + ".csproj"), FileMode.Open, FileAccess.ReadWrite))
                 {
@@ -748,7 +722,7 @@ namespace Dotnet.Integration.Test
                 var tfm = "netcoreapp2.0";
                 var projectName = "ToolRestoreProject";
                 var workingDirectory = Path.Combine(testDirectory, projectName);
-                var source = Path.Combine(testDirectory, "packageSource");
+                var packageSource = Path.Combine(testDirectory, "packageSource");
                 var rid = "win-x64";
                 var packageRid = "win";
                 var packageName = string.Join("ToolPackage-", tfm, rid);
@@ -763,11 +737,9 @@ namespace Dotnet.Integration.Test
                 package.PackageType = PackageType.DotnetTool;
                 package.UseDefaultRuntimeAssemblies = false;
                 package.PackageTypes.Add(PackageType.DotnetTool);
-                await SimpleTestPackageUtility.CreatePackagesAsync(source, package);
+                await SimpleTestPackageUtility.CreatePackagesAsync(packageSource, package);
 
-                _msbuildFixture.CreateDotnetToolProject(solutionRoot: testDirectory.Path,
-                    projectName: projectName, targetFramework: tfm, rid: rid,
-                    source: source, packages: packages);
+                _msbuildFixture.CreateDotnetToolProject(testDirectory.Path, projectName, tfm, rid, packageSource, packages);
 
                 // set up rid graph
                 var ridGraphPath = Path.Combine(testDirectory.Path, "runtime.json");

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetToolTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetToolTests.cs
@@ -100,7 +100,7 @@ namespace Dotnet.Integration.Test
 
                 // Assert
                 Assert.True(result.Item1 == 0, result.AllOutput);
-                Assert.True(2 == result.AllOutput.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries).Count(), result.AllOutput);
+                Assert.True(2 == result.AllOutput.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries).Length, result.AllOutput);
                 // Verify the assets file
                 var lockFile = LockFileUtilities.GetLockFile(Path.Combine(testDirectory, projectName, "project.assets.json"), NullLogger.Instance);
                 Assert.NotNull(lockFile);
@@ -776,11 +776,11 @@ namespace Dotnet.Integration.Test
 
         private static void MakePackageReferenceImplicitlyDefined(string fullProjectPath, string packageName)
         {
-            var searchString = $"\"{packageName}\" ";
+            var searchString = $"'{packageName}' ";
             var text = File.ReadAllText(fullProjectPath);
 
             var referenceElement = text.IndexOf(searchString) + searchString.Length;
-            text = text.Substring(0, referenceElement) + " IsImplicitlyDefined=\"true\" " + text.Substring(referenceElement);
+            text = text.Substring(0, referenceElement) + " IsImplicitlyDefined='true' " + text.Substring(referenceElement);
             File.WriteAllText(fullProjectPath, text);
         }
 

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/MsbuildIntegrationTestFixture.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/MsbuildIntegrationTestFixture.cs
@@ -175,25 +175,25 @@ namespace Dotnet.Integration.Test
             return result;
         }
 
-        internal void RestoreProject(string workingDirectory, string projectName, string args)
-            => RestoreProjectOrSolution(workingDirectory, $"{projectName}.csproj", args);
+        internal void RestoreProject(string workingDirectory, string projectName, string args, bool validateSuccess = true)
+            => RestoreProjectOrSolution(workingDirectory, $"{projectName}.csproj", args, validateSuccess);
 
-        internal void RestoreSolution(string workingDirectory, string solutionName, string args)
-            => RestoreProjectOrSolution(workingDirectory, $"{solutionName}.sln", args);
+        internal void RestoreSolution(string workingDirectory, string solutionName, string args, bool validateSuccess = true)
+            => RestoreProjectOrSolution(workingDirectory, $"{solutionName}.sln", args, validateSuccess);
 
-        private void RestoreProjectOrSolution(string workingDirectory, string fileName, string args)
+        private void RestoreProjectOrSolution(string workingDirectory, string fileName, string args, bool validateSuccess)
         {
-
-            var envVar = new Dictionary<string, string>();
-            envVar.Add("MSBuildSDKsPath", MsBuildSdksPath);
 
             var result = CommandRunner.Run(TestDotnetCli,
                 workingDirectory,
                 $"restore {fileName} {args}",
                 waitForExit: true,
                 environmentVariables: _processEnvVars);
-            Assert.True(result.Item1 == 0, $"Restore failed with following log information :\n {result.AllOutput}");
-            Assert.True(result.Item3 == "", $"Restore failed with following message in error stream :\n {result.AllOutput}");
+            if (validateSuccess)
+            {
+                Assert.True(result.Item1 == 0, $"Restore failed with following log information :\n {result.AllOutput}");
+                Assert.True(result.Item3 == "", $"Restore failed with following message in error stream :\n {result.AllOutput}");
+            }
         }
 
         /// <summary>
@@ -235,17 +235,30 @@ namespace Dotnet.Integration.Test
         }
 
         internal CommandRunnerResult PackProject(string workingDirectory, string projectName, string args, string nuspecOutputPath = "obj", bool validateSuccess = true)
-            => PackProjectOrSolution(workingDirectory, $"{projectName}.csproj", args, nuspecOutputPath, validateSuccess);
+        {
+            // We can't provide empty or spaces as arguments if we used `string.IsNullOrEmpty` or `string.IsNullOrWhiteSpace`.
+            if (nuspecOutputPath != null)
+            {
+                args = $"{args} /p:NuspecOutputPath={nuspecOutputPath}";
+            }
+            return PackProjectOrSolution(workingDirectory, $"{projectName}.csproj", args, validateSuccess);
+        }
 
         internal CommandRunnerResult PackSolution(string workingDirectory, string solutionName, string args, string nuspecOutputPath = "obj", bool validateSuccess = true)
-            => PackProjectOrSolution(workingDirectory, $"{solutionName}.sln", args, nuspecOutputPath, validateSuccess);
+        {
+            if (nuspecOutputPath != null)
+            {
+                args = $"{args} /p:NuspecOutputPath={nuspecOutputPath}";
+            }
+            return PackProjectOrSolution(workingDirectory, $"{solutionName}.sln", args, validateSuccess);
+        }
 
-        private CommandRunnerResult PackProjectOrSolution(string workingDirectory, string file, string args, string nuspecOutputPath, bool validateSuccess)
+        private CommandRunnerResult PackProjectOrSolution(string workingDirectory, string file, string args, bool validateSuccess)
         {
 
             var result = CommandRunner.Run(TestDotnetCli,
                 workingDirectory,
-                $"pack {file} {args} /p:NuspecOutputPath={nuspecOutputPath}",
+                $"pack {file} {args}",
                 waitForExit: true,
                 environmentVariables: _processEnvVars);
             if (validateSuccess)
@@ -256,16 +269,37 @@ namespace Dotnet.Integration.Test
             return result;
         }
 
-        internal void BuildProject(string workingDirectory, string projectName, string args)
+        internal void BuildProject(string workingDirectory, string projectName, string args, bool? appendRidToOutputPath = false, bool validateSuccess = true)
+        {
+            if (appendRidToOutputPath != null)
+            {
+                args = $"{args} /p:AppendRuntimeIdentifierToOutputPath={appendRidToOutputPath}";
+            }
+            BuildProjectOrSolution(workingDirectory, $"{projectName}.csproj", args, validateSuccess);
+        }
+
+        internal void BuildSolution(string workingDirectory, string solutionName, string args, bool? appendRidToOutputPath = false, bool validateSuccess = true)
+        {
+            if (appendRidToOutputPath != null)
+            {
+                args = $"{args} /p:AppendRuntimeIdentifierToOutputPath={appendRidToOutputPath}";
+            }
+            BuildProjectOrSolution(workingDirectory, $"{solutionName}.sln", args, validateSuccess);
+        }
+
+        private void BuildProjectOrSolution(string workingDirectory, string file, string args, bool validateSuccess)
         {
 
             var result = CommandRunner.Run(TestDotnetCli,
                 workingDirectory,
-                $"msbuild {projectName}.csproj {args} /p:AppendRuntimeIdentifierToOutputPath=false",
+                $"msbuild {file} {args}",
                 waitForExit: true,
                 environmentVariables: _processEnvVars);
-            Assert.True(result.Item1 == 0, $"Build failed with following log information :\n {result.AllOutput}");
-            Assert.True(result.Item3 == "", $"Build failed with following message in error stream :\n {result.AllOutput}");
+            if (validateSuccess)
+            {
+                Assert.True(result.Item1 == 0, $"Build failed with following log information :\n {result.AllOutput}");
+                Assert.True(result.Item3 == "", $"Build failed with following message in error stream :\n {result.AllOutput}");
+            }
         }
 
         internal TestDirectory CreateTestDirectory()

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/MsbuildIntegrationTestFixture.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/MsbuildIntegrationTestFixture.cs
@@ -176,7 +176,6 @@ namespace Dotnet.Integration.Test
 
         internal CommandRunnerResult RestoreToolProject(string workingDirectory, string projectName, string args = "")
         {
-
             var result = CommandRunner.Run(TestDotnetCli,
                 workingDirectory,
                 $"restore {projectName}.csproj {args}",
@@ -193,7 +192,6 @@ namespace Dotnet.Integration.Test
 
         private void RestoreProjectOrSolution(string workingDirectory, string fileName, string args, bool validateSuccess)
         {
-
             var result = CommandRunner.Run(TestDotnetCli,
                 workingDirectory,
                 $"restore {fileName} {args}",
@@ -265,7 +263,6 @@ namespace Dotnet.Integration.Test
 
         private CommandRunnerResult PackProjectOrSolution(string workingDirectory, string file, string args, bool validateSuccess)
         {
-
             var result = CommandRunner.Run(TestDotnetCli,
                 workingDirectory,
                 $"pack {file} {args}",
@@ -299,7 +296,6 @@ namespace Dotnet.Integration.Test
 
         private void BuildProjectOrSolution(string workingDirectory, string file, string args, bool validateSuccess)
         {
-
             var result = CommandRunner.Run(TestDotnetCli,
                 workingDirectory,
                 $"msbuild {file} {args}",

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/MsbuildIntegrationTestFixture.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/MsbuildIntegrationTestFixture.cs
@@ -520,13 +520,17 @@ project TFMs found: {string.Join(", ", compiledTfms.Keys.Select(k => k.ToString(
 
             const string packProjectName = "NuGet.Build.Tasks.Pack";
             const string packTargetsName = "NuGet.Build.Tasks.Pack.targets";
-            // Copy the pack SDK.
 
+            // Copy the pack SDK.
             var packProjectBinDirectory = Path.Combine(artifactsDirectory, packProjectName, toolsetVersion, "bin", configuration);
             var tfmToCopy = GetTfmToCopy(sdkTfm, packProjectBinDirectory);
 
             var packProjectCoreArtifactsDirectory = new DirectoryInfo(Path.Combine(packProjectBinDirectory, tfmToCopy));
-            var packAssemblyDestinationDirectory = Path.Combine(pathToPackSdk, "CoreCLR");
+
+            // We are only copying the CoreCLR assets, since, we're testing only them under Core MSBuild.
+            var targetRuntimeType = "CoreCLR";
+
+            var packAssemblyDestinationDirectory = Path.Combine(pathToPackSdk, targetRuntimeType);
             // Be smart here so we don't have to call ILMerge in the VS build. It takes ~15s total.
             // In VisualStudio, simply use the non il merged version.
             var ilMergedPackDirectoryPath = Path.Combine(packProjectCoreArtifactsDirectory.FullName, "ilmerge");
@@ -542,23 +546,23 @@ project TFMs found: {string.Join(", ", compiledTfms.Keys.Select(k => k.ToString(
                         sourceFileName: Path.Combine(packProjectCoreArtifactsDirectory.FullName, "ilmerge", packFileName),
                         destFileName: Path.Combine(packAssemblyDestinationDirectory, packFileName));
                 }
-                else
-                {
-                    foreach (var assembly in packProjectCoreArtifactsDirectory.EnumerateFiles("*.dll"))
-                    {
-                        File.Copy(
-                            sourceFileName: assembly.FullName,
-                            destFileName: Path.Combine(packAssemblyDestinationDirectory, assembly.Name),
-                            overwrite: true);
-                    }
-                }
-                // Copy the pack targets
-                var packTargetsSource = Path.Combine(packProjectCoreArtifactsDirectory.FullName, packTargetsName);
-                var targetsDestination = Path.Combine(pathToPackSdk, "build", packTargetsName);
-                var targetsDestinationCrossTargeting = Path.Combine(pathToPackSdk, "buildCrossTargeting", packTargetsName);
-                File.Copy(packTargetsSource, targetsDestination, overwrite: true);
-                File.Copy(packTargetsSource, targetsDestinationCrossTargeting, overwrite: true);
             }
+            else
+            {
+                foreach (var assembly in packProjectCoreArtifactsDirectory.EnumerateFiles("*.dll"))
+                {
+                    File.Copy(
+                        sourceFileName: assembly.FullName,
+                        destFileName: Path.Combine(packAssemblyDestinationDirectory, assembly.Name),
+                        overwrite: true);
+                }
+            }
+            // Copy the pack targets
+            var packTargetsSource = Path.Combine(packProjectCoreArtifactsDirectory.FullName, packTargetsName);
+            var targetsDestination = Path.Combine(pathToPackSdk, "build", packTargetsName);
+            var targetsDestinationCrossTargeting = Path.Combine(pathToPackSdk, "buildCrossTargeting", packTargetsName);
+            File.Copy(packTargetsSource, targetsDestination, overwrite: true);
+            File.Copy(packTargetsSource, targetsDestinationCrossTargeting, overwrite: true);
         }
 
         public void Dispose()

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
@@ -188,11 +188,10 @@ namespace Dotnet.Integration.Test
                 var args = includeSymbols ? $"-o {workingDirectory} --include-symbols" : $"-o {workingDirectory}";
                 msbuildFixture.PackProject(workingDirectory, projectName, args);
 
-                var nupkgPath = includeSymbols
-                    ? Path.Combine(workingDirectory, $"{projectName}.1.0.0.symbols.nupkg")
-                    : Path.Combine(workingDirectory, $"{projectName}.1.0.0.nupkg");
+                var nupkgExtension = includeSymbols ? ".symbols.nupkg" : ".nupkg";
+                var nupkgPath = Path.Combine(workingDirectory, $"{projectName}.1.0.0{nupkgExtension}");
                 var nuspecPath = Path.Combine(workingDirectory, "obj", $"{projectName}.1.0.0.nuspec");
-                Assert.True(File.Exists(nupkgPath), "The output .nupkg is not in the expected place");
+                Assert.True(File.Exists(nupkgPath), $"The output {nupkgExtension} is not in the expected place");
                 Assert.True(File.Exists(nuspecPath), "The intermediate nuspec file is not in the expected place");
 
                 using (var nupkgReader = new PackageArchiveReader(nupkgPath))

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
@@ -180,7 +180,6 @@ namespace Dotnet.Integration.Test
                     var xml = XDocument.Load(stream);
                     ProjectFileUtils.ChangeProperty(xml, "TargetFramework", "netcoreapp2.1");
                     ProjectFileUtils.AddProperty(xml, "RuntimeIdentifier", "win7-x64");
-
                     ProjectFileUtils.WriteXmlToFile(xml, stream);
                 }
 
@@ -211,10 +210,11 @@ namespace Dotnet.Integration.Test
                     }
                     else
                     {
-                        Assert.Equal(
-                            new[]
-                            {"lib/netcoreapp2.1/ConsoleApp1.dll", "lib/netcoreapp2.1/ConsoleApp1.runtimeconfig.json"},
-                            libItems[0].Items);
+                        Assert.Equal(new[]
+                        {
+                            "lib/netcoreapp2.1/ConsoleApp1.dll",
+                            "lib/netcoreapp2.1/ConsoleApp1.runtimeconfig.json"
+                        }, libItems[0].Items);
                     }
                 }
 

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
@@ -2325,7 +2325,7 @@ namespace ClassLibrary
       </TfmSpecificPackageFile>
       <TfmSpecificPackageFile Include=""Extensions/**/ext.cs.txt"" Condition=""'$(TargetFramework)' == 'net46'"">
         <PackagePath>net46content</PackagePath>
-      </TfmSpecificPackageFile>  
+      </TfmSpecificPackageFile>
     </ItemGroup>
   </Target>";
                     ProjectFileUtils.SetTargetFrameworkForProject(xml, tfmProperty, tfmValue);
@@ -4086,7 +4086,7 @@ namespace ClassLibrary
 
                 using (var nupkgReader = new PackageArchiveReader(nupkgPath))
                 {
-                    // Validate Compile assets 
+                    // Validate Compile assets
                     foreach (var buildTargetFolder in buildTargetFolders.Split(';'))
                     {
                         var compileItems = nupkgReader.GetFiles(buildTargetFolder).ToList();
@@ -4460,7 +4460,7 @@ namespace ClassLibrary
                 // The test depends on the presence of these packages and their versions.
                 // Change to Directory.Packages.props when new cli that supports NuGet.props will be downloaded
                 var directoryPackagesPropsName = Path.Combine(workingDirectory, $"Directory.Build.props");
-                var directoryPackagesPropsContent = @"<Project>  
+                var directoryPackagesPropsContent = @"<Project>
                         <ItemGroup>
                             <PackageVersion Include = ""Moq"" Version = ""4.10.0""/>
                             <PackageVersion Include = ""Castle.Core"" Version = ""4.4.0""/>

--- a/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildIntegrationTestFixture.cs
+++ b/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildIntegrationTestFixture.cs
@@ -53,7 +53,7 @@ namespace Msbuild.Integration.Test
         }
 
         /// <summary>
-        /// Depth-first recursive delete, with handling for descendant 
+        /// Depth-first recursive delete, with handling for descendant
         /// directories open in Windows Explorer or used by another process
         /// </summary>
         private static void DeleteDirectory(string path)

--- a/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildIntegrationTestFixture.cs
+++ b/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildIntegrationTestFixture.cs
@@ -36,7 +36,7 @@ namespace Msbuild.Integration.Test
             _processEnvVars["UNIT_TEST_RESTORE_TASK"] = bool.TrueString;
             var result = CommandRunner.Run(msBuildExe,
                 workingDirectory,
-                $"/p:NuGetRestoreTargets={nugetRestoreTargetsPath} /p:RestoreTaskAssemblyFile={restoreDllPath} /p:ImportNuGetBuildTasksPackTargetsFromSdk=\"true\" {args}",
+                $"/p:NuGetRestoreTargets={nugetRestoreTargetsPath} /p:RestoreTaskAssemblyFile={restoreDllPath} /p:ImportNuGetBuildTasksPackTargetsFromSdk=true {args}",
                 waitForExit: true,
                 environmentVariables: _processEnvVars);
 

--- a/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildRestoreTaskTests.cs
+++ b/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildRestoreTaskTests.cs
@@ -597,7 +597,7 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
 
                 var project = new SimpleTestProjectContext("a", ProjectStyle.PackageReference, pathContext.SolutionRoot)
                 {
-                    OutputPath = string.Empty,
+                    ProjectExtensionsPath = string.Empty,
                     Properties =
                     {
                         // When these two properties are not defined, restore should fail with a clear error and not crash

--- a/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildRestoreTaskTests.cs
+++ b/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildRestoreTaskTests.cs
@@ -162,7 +162,7 @@ namespace Msbuild.Integration.Test
    <!ENTITY sayhello ""&greeting; &name;"">
 ]>
 <packages>
-    <package id=""&sayhello;"" version=""1.1.0"" targetFramework=""net45"" /> 
+    <package id=""&sayhello;"" version=""1.1.0"" targetFramework=""net45"" />
     <package id=""x"" version=""1.0.0"" targetFramework=""net45"" />
 </packages>");
                 }

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/NETCoreRestoreTestUtility.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/NETCoreRestoreTestUtility.cs
@@ -26,7 +26,7 @@ namespace NuGet.CommandLine.XPlat.Tests
 
                 // Set proj properties
                 spec.FilePath = project.ProjectPath;
-                spec.RestoreMetadata.OutputPath = project.OutputPath;
+                spec.RestoreMetadata.OutputPath = project.ProjectExtensionsPath;
                 spec.RestoreMetadata.ProjectPath = project.ProjectPath;
 
                 projects.Add(project);

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/NETCoreRestoreTestUtility.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/NETCoreRestoreTestUtility.cs
@@ -24,7 +24,7 @@ namespace NuGet.Commands.Test
 
                 // Set proj properties
                 spec.FilePath = project.ProjectPath;
-                spec.RestoreMetadata.OutputPath = project.OutputPath;
+                spec.RestoreMetadata.OutputPath = project.ProjectExtensionsPath;
                 spec.RestoreMetadata.ProjectPath = project.ProjectPath;
 
                 projects.Add(project);

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreBuildTargetsAndPropsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreBuildTargetsAndPropsTests.cs
@@ -419,7 +419,7 @@ namespace NuGet.Commands.Test
 
                 // Set proj properties
                 spec.FilePath = project.ProjectPath;
-                spec.RestoreMetadata.OutputPath = project.OutputPath;
+                spec.RestoreMetadata.OutputPath = project.ProjectExtensionsPath;
                 spec.RestoreMetadata.ProjectPath = project.ProjectPath;
 
                 projects.Add(project);

--- a/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestProjectContext.cs
+++ b/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestProjectContext.cs
@@ -35,7 +35,7 @@ namespace NuGet.Test.Utility
 
             ProjectName = projectName;
             ProjectPath = Path.Combine(solutionRoot, projectName, $"{projectName}{ProjectExt}");
-            OutputPath = Path.Combine(solutionRoot, projectName, "obj");
+            ProjectExtensionsPath = Path.Combine(solutionRoot, projectName, "obj");
             Type = type;
         }
 
@@ -61,7 +61,7 @@ namespace NuGet.Test.Utility
         /// <summary>
         /// MSBuildProjectExtensionsPath
         /// </summary>
-        public string OutputPath { get; set; }
+        public string ProjectExtensionsPath { get; set; }
 
         /// <summary>
         /// Additional MSBuild properties
@@ -130,7 +130,7 @@ namespace NuGet.Test.Utility
                 switch (Type)
                 {
                     case ProjectStyle.PackageReference:
-                        return Path.Combine(OutputPath, "project.assets.json");
+                        return Path.Combine(ProjectExtensionsPath, "project.assets.json");
 
                     case ProjectStyle.ProjectJson:
                         return Path.Combine(Path.GetDirectoryName(ProjectPath), "project.lock.json");
@@ -148,7 +148,7 @@ namespace NuGet.Test.Utility
                 switch (Type)
                 {
                     case ProjectStyle.PackageReference:
-                        return Path.Combine(OutputPath, NoOpRestoreUtilities.NoOpCacheFileName);
+                        return Path.Combine(ProjectExtensionsPath, NoOpRestoreUtilities.NoOpCacheFileName);
 
                     default:
                         return null;
@@ -181,7 +181,7 @@ namespace NuGet.Test.Utility
                 switch (Type)
                 {
                     case ProjectStyle.PackageReference:
-                        return Path.Combine(OutputPath, $"{Path.GetFileName(ProjectPath)}.nuget.g.targets");
+                        return Path.Combine(ProjectExtensionsPath, $"{Path.GetFileName(ProjectPath)}.nuget.g.targets");
 
                     case ProjectStyle.ProjectJson:
                         return Path.Combine(Path.GetDirectoryName(ProjectPath), $"{Path.GetFileNameWithoutExtension(ProjectPath)}.nuget.targets");
@@ -199,7 +199,7 @@ namespace NuGet.Test.Utility
                 switch (Type)
                 {
                     case ProjectStyle.PackageReference:
-                        return Path.Combine(OutputPath, $"{Path.GetFileName(ProjectPath)}.nuget.g.props");
+                        return Path.Combine(ProjectExtensionsPath, $"{Path.GetFileName(ProjectPath)}.nuget.g.props");
 
                     case ProjectStyle.ProjectJson:
                         return Path.Combine(Path.GetDirectoryName(ProjectPath), $"{Path.GetFileNameWithoutExtension(ProjectPath)}.nuget.props");
@@ -244,7 +244,7 @@ namespace NuGet.Test.Utility
                 _packageSpec.RestoreMetadata.ProjectName = ProjectName;
                 _packageSpec.RestoreMetadata.ProjectPath = ProjectPath;
                 _packageSpec.RestoreMetadata.ProjectStyle = Type;
-                _packageSpec.RestoreMetadata.OutputPath = OutputPath;
+                _packageSpec.RestoreMetadata.OutputPath = ProjectExtensionsPath;
                 _packageSpec.RestoreMetadata.OriginalTargetFrameworks = _packageSpec.TargetFrameworks.Select(e => e.TargetAlias).ToList();
                 _packageSpec.RestoreMetadata.TargetFrameworks = Frameworks
                     .Select(f => new ProjectRestoreMetadataFrameworkInfo(f.Framework))
@@ -443,7 +443,7 @@ namespace NuGet.Test.Utility
             if (SetMSBuildProjectExtensionsPath)
             {
                 var propertyGroup = new XElement(ns + "PropertyGroup");
-                propertyGroup.Add(new XElement(ns + "MSBuildProjectExtensionsPath", OutputPath));
+                propertyGroup.Add(new XElement(ns + "MSBuildProjectExtensionsPath", ProjectExtensionsPath));
                 xml.Root.AddFirst(propertyGroup);
             }
 
@@ -528,7 +528,7 @@ namespace NuGet.Test.Utility
                         var attributes = new Dictionary<string, string>();
 
                         // To support CPVM scenarios the Version can be null
-                        // In these cases do not write any version 
+                        // In these cases do not write any version
                         if (package.Version != null)
                         {
                             if (ToolingVersion15)

--- a/test/TestUtilities/Test.Utility/TestDirectory.cs
+++ b/test/TestUtilities/Test.Utility/TestDirectory.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.IO;
+using PathIO = System.IO.Path;
 
 namespace NuGet.Test.Utility
 {
@@ -21,6 +22,7 @@ namespace NuGet.Test.Utility
         }
 
         public string Path { get; }
+
         public DirectoryInfo Info { get; }
 
         public void Dispose()
@@ -48,7 +50,7 @@ namespace NuGet.Test.Utility
         /// </summary>
         public static TestDirectory CreateInTemp()
         {
-            var root = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "NuGetTestFolder");
+            var root = PathIO.Combine(PathIO.GetTempPath(), "NuGetTestFolder");
             Directory.CreateDirectory(root);
 
             return Create(root);
@@ -56,7 +58,7 @@ namespace NuGet.Test.Utility
 
         public static TestDirectory Create(string root)
         {
-            string parentPath = null;
+            string parentPath;
 
             // Loop until we find a directory that isn't taken (extremely unlikely this would need multiple guids).
             while (true)
@@ -64,12 +66,12 @@ namespace NuGet.Test.Utility
                 var guid = Guid.NewGuid().ToString();
 
                 // Use a shorter path to this easier when debugging
-                parentPath = System.IO.Path.Combine(root, guid.Split('-')[0]);
+                parentPath = PathIO.Combine(root, guid.Split('-')[0]);
 
                 if (Directory.Exists(parentPath))
                 {
                     // If a collision happens use the full guid
-                    parentPath = System.IO.Path.Combine(root, guid);
+                    parentPath = PathIO.Combine(root, guid);
 
                     if (!Directory.Exists(parentPath))
                     {
@@ -85,23 +87,17 @@ namespace NuGet.Test.Utility
             Directory.CreateDirectory(parentPath);
 
             // Record what created this folder in case there is a problem with clean up.
-            File.WriteAllText(System.IO.Path.Combine(parentPath, "testStack.txt"), Environment.StackTrace);
+            File.WriteAllText(PathIO.Combine(parentPath, "testStack.txt"), Environment.StackTrace);
 
             // Create a random sub folder to use, this keeps tests from relying on the folder name.
-            var path = System.IO.Path.Combine(parentPath, Guid.NewGuid().ToString().Split('-')[0]);
+            var path = PathIO.Combine(parentPath, Guid.NewGuid().ToString().Split('-')[0]);
             Directory.CreateDirectory(path);
 
             return new TestDirectory(path, parentPath);
         }
 
-        public static implicit operator string(TestDirectory directory)
-        {
-            return directory.Path;
-        }
+        public static implicit operator string(TestDirectory directory) => directory.Path;
 
-        public override string ToString()
-        {
-            return Path;
-        }
+        public override string ToString() => Path;
     }
 }


### PR DESCRIPTION
## Bug

Fixes: NuGet/Home#9996
Regression: No

## Fix

Details: These are some of the improvements separated from the PR #3270

* Consolidate Restore/Build/Pack methods in Tests
  - Test Fixture now has similar API surface across Restore/Build/Pack commands
* Fix 'dotnet pack' tests when testing under VS IDE
  - The NuGet Pack artifacts aren't being copied to the test SDK layout, when building/testing under VS IDE locally and not on CI/CLI.
* Rename 'OutputPath' to 'ProjectExtensionsPath' in 'SimpleTestProjectContext'
   - The 'OutputPath' property under 'SimpleTestProjectContext' is an alias of 'MSBuildProjectExtensionsPath', but there is an 'OutputPath' property already in MSBuild project system.
* Refactor 'CreateDotnetToolProject' method & calls in 'DotNetToolTests'
    - Rename 'source' param to 'packageSource'
    - Make 'packageSource' param to accept null
    - Fix template's 'MSBuildProjectExtensionsPath' with explicit Sdk import
    - Remove redundant parameter labels on 'CreateDotnetToolProject' in 'DotNetToolTests'
* Miscellaneous refactoring and whitespace fixes

## Testing/Validation

Tests Added: No  
Reason for not adding tests: These are tests themselves
Validation: As long as CI succeeds
