### PR TITLE
Clarify Restore task differences in both IDE and CLI contexts

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/ProjectFactory.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/ProjectFactory.cs
@@ -354,7 +354,7 @@ namespace NuGet.CommandLine
             // resolved by name if the nuspec contains tokens
             _properties.Clear();
 
-            // Allow Id to be overriden by cmd line properties
+            // Allow Id to be overridden by cmd line properties
             if (ProjectProperties.ContainsKey("Id"))
             {
                 _properties.Add("Id", ProjectProperties["Id"]);
@@ -425,15 +425,13 @@ namespace NuGet.CommandLine
 
                 BuildProjectWithMsbuild();
             }
-            else
-            {
-                TargetPath = ResolveTargetPath();
 
-                // Make if the target path doesn't exist, fail
-                if (!Directory.Exists(TargetPath) && !File.Exists(TargetPath))
-                {
-                    throw new PackagingException(NuGetLogCode.NU5012, String.Format(CultureInfo.CurrentCulture, LocalizedResourceManager.GetString("UnableToFindBuildOutput"), TargetPath));
-                }
+            TargetPath = ResolveTargetPath();
+
+            // Make if the target path doesn't exist, fail
+            if (!Directory.Exists(TargetPath) && !File.Exists(TargetPath))
+            {
+                throw new PackagingException(NuGetLogCode.NU5012, String.Format(CultureInfo.CurrentCulture, LocalizedResourceManager.GetString("UnableToFindBuildOutput"), TargetPath));
             }
         }
 
@@ -454,8 +452,6 @@ namespace NuGet.CommandLine
                 var error = String.Format(CultureInfo.CurrentCulture, LocalizedResourceManager.GetString("FailedToBuildProject"), Path.GetFileName(_project.FullPath));
                 throw new PackagingException(NuGetLogCode.NU5013, error);
             }
-
-            TargetPath = ResolveTargetPath();
         }
 
         private string ResolveTargetPath()
@@ -482,9 +478,7 @@ namespace NuGet.CommandLine
             if (string.IsNullOrEmpty(targetPath))
             {
                 string outputPath = _project.GetPropertyValue("OutputPath");
-                string configuration = _project.GetPropertyValue("Configuration");
-                string projectName = Path.GetFileName(Path.GetDirectoryName(_project.FullPath));
-                targetPath = PathUtility.EnsureTrailingSlash(Path.Combine(outputPath, projectName, "bin", configuration));
+                targetPath = PathUtility.EnsureTrailingSlash(Path.Combine(_project.FullPath, outputPath));
             }
 
             return targetPath;

--- a/src/NuGet.Core/NuGet.Commands/CommandRunners/PackCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/CommandRunners/PackCommandRunner.cs
@@ -664,7 +664,7 @@ namespace NuGet.Commands
             if (_packArgs.InstallPackageToOutputPath)
             {
                 string outputPath = GetOutputPath(packageBuilder, _packArgs);
-                successful = BuildPackage(packageBuilder, outputPath: outputPath, symbolsPackage: false);
+                successful = BuildPackage(packageBuilder, outputPath, symbolsPackage: false);
             }
             else
             {
@@ -790,7 +790,7 @@ namespace NuGet.Commands
                 if (_packArgs.InstallPackageToOutputPath)
                 {
                     string outputPath = GetOutputPath(mainPackageBuilder, _packArgs);
-                    successful = BuildPackage(mainPackageBuilder, outputPath: outputPath, symbolsPackage: false);
+                    successful = BuildPackage(mainPackageBuilder, outputPath, symbolsPackage: false);
                 }
                 else
                 {

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/DependencyGraphSpecRequestProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/DependencyGraphSpecRequestProvider.cs
@@ -181,8 +181,8 @@ namespace NuGet.Commands
                 ProjectStyle = project.PackageSpec.RestoreMetadata.ProjectStyle,
                 //  Project.json is special cased to put assets file and generated .props and targets in the project folder
                 RestoreOutputPath = project.PackageSpec.RestoreMetadata.ProjectStyle == ProjectStyle.ProjectJson ? rootPath : project.PackageSpec.RestoreMetadata.OutputPath,
-                DependencyGraphSpec = projectDgSpec,
                 MSBuildProjectExtensionsPath = projectPackageSpec.RestoreMetadata.OutputPath,
+                DependencyGraphSpec = projectDgSpec,
                 AdditionalMessages = projectAdditionalMessages
             };
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/NoOpRestoreUtilities.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/NoOpRestoreUtilities.cs
@@ -30,7 +30,8 @@ namespace NuGet.Commands
         }
 
         /// <summary>
-        /// The cache file path is $(MSBuildProjectExtensionsPath)\$(project).nuget.cache
+        /// The cache file path will be $(RestoreOutputPath)\$(project).nuget.cache
+        /// or $(MSBuildProjectExtensionsPath)\$(project).nuget.cache depending on the Project Style.
         /// </summary>
         private static string GetBuildIntegratedProjectCacheFilePath(RestoreRequest request)
         {

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectStyle.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectStyle.cs
@@ -16,7 +16,7 @@ namespace NuGet.ProjectModel
         ProjectJson = 1,
 
         /// <summary>
-        /// MSBuild style, project.assets.json is generated in the RestoreOutputPath folder
+        /// MSBuild style, project.assets.json is generated in the RestoreOutputPath (aka MSBuildProjectExtensionsPath) folder
         /// </summary>
         PackageReference = 2,
 


### PR DESCRIPTION
## Bug

Fixes: **TBA**
Regression: No

## Fix

Details: These are some of the improvements separated from the PR #3270

* Clarify 'MSBuildProjectExtensionsPath' and 'RestoreOutputPath' differences
    - Remove redundant code paths in 'ProjectFactory'
    - Remove redundant parameter labels on call sites
    - Update comments to better reflect the behavior of Restore
* Miscellaneous refactors and whitespace fixes (**TBA**)

## Testing/Validation

Tests Added: No
Reason for not adding tests: Already present
Validation: Existing tests passes