### PR TITLE
PM UI:  fix exception during package install to .NET Framework project with PackageReference

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/PackagesConfigToPackageReferenceMigrator.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/PackagesConfigToPackageReferenceMigrator.cs
@@ -160,7 +160,7 @@ namespace NuGet.PackageManagement.UI
                 }
                 finally
                 {
-                    IEnumerable<string> projectIds = await ProjectUtility.GetProjectIdsAsync(uiService.Projects, token);
+                    IEnumerable<string> projectIds = await ProjectUtility.GetSortedProjectIdsAsync(uiService.Projects, token);
 
                     upgradeInformationTelemetryEvent.SetResult(projectIds, status, packagesCount);
                 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Utility/ProjectUtility.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Utility/ProjectUtility.cs
@@ -12,7 +12,7 @@ namespace NuGet.PackageManagement.UI
 {
     internal static class ProjectUtility
     {
-        internal static async ValueTask<IEnumerable<string>> GetProjectIdsAsync(
+        internal static async ValueTask<IEnumerable<string>> GetSortedProjectIdsAsync(
             IEnumerable<IProjectContextInfo> projects,
             CancellationToken cancellationToken)
         {


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9995
Regression: Yes  
* Last working version:  previous build
* How are we preventing it in future:   dedupe project ID's

## Fix

Details: During the last rebase, I adapted to in incoming breaking change.  What I didn't realize is that when installing a package to a .NET Framework project the first time when PackageReference project style is enabled there is a brief moment during the upgrade process where 2 projects exist simultaneously for the same project.  One project is packages.config while the other project is PackageReference.  When we fetch install actions during this time we need to ensure that the set of project ID's has no duplicates.

The fix involves [adding a `.Distinct()` call](https://github.com/NuGet/NuGet.Client/pull/3643/files#diff-cf33c7d7a6896e312b8b86f1e05f557fR771).

This PR also removes a bunch of dead code and renames `ProjectUtility.GetProjectIdsAsync(...)` to better reflect what it really does, lest someone (like me) be inclined to simplify the code to use the already cached ID's in `IProjectContextInfo.ProjectId` and then lose sorting.

## Testing/Validation

Tests Added: No 
Reason for not adding tests:  already covered by manual test plan
Validation:  manual
