### PR TITLE
Create actions in parallel before Preview.

### DIFF
--- a/src/NuGet.Core/NuGet.PackageManagement/NuGet.PackageManagement.csproj
+++ b/src/NuGet.Core/NuGet.PackageManagement/NuGet.PackageManagement.csproj
@@ -1,4 +1,4 @@
-﻿<Project>
+<Project>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common.props" />
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
@@ -26,6 +26,10 @@
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.Net.Http" />
     <Reference Include="Microsoft.CSharp" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.Threading.Tasks.Dataflow" Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' " />
   </ItemGroup>
   
   <ItemGroup>


### PR DESCRIPTION
## Bug

Fixes: [Issue#9955](https://github.com/NuGet/Home/issues/9955)
Regression: No  

## Fix

Details: Details_about_the_fix  
During my performance improvement effort Nikolche [pointed out](https://github.com/NuGet/NuGet.Client/pull/3559/files#r479564095) I can parallelize create actions before preview. Since I agree with him creating this follow up issue.
`I think this whole loop can be parallelized too. The bottleneck in particular is the LockFile.Read.
I don't think you should do it now do, I'd create a future task if you agree with my suggestion.`

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  
Validation:  
