### PR TITLE
change VS target branch for QB approval mode 5.8.0.preview3

### DIFF
--- a/build/config.props
+++ b/build/config.props
@@ -21,11 +21,11 @@
     <!-- Check the VS schedule and manually enter a preview number here that makes sense. -->
     <ReleaseLabel Condition=" '$(ReleaseLabel)' == '' ">preview.3</ReleaseLabel>
 
-    <IsEscrowMode>false</IsEscrowMode>
+    <IsEscrowMode>true</IsEscrowMode>
 
     <!-- Visual Studio Insertion Logic -->
     <VsTargetMajorVersion>$([MSBuild]::Add(11, $(MajorNuGetVersion)))</VsTargetMajorVersion>
-    <VsTargetBranch>d16.8</VsTargetBranch>
+    <VsTargetBranch>main</VsTargetBranch>
     <VsTargetChannel>int.$(VsTargetBranch)</VsTargetChannel>
 
     <!-- This branches are used for creating insertion PRs -->

--- a/build/config.props
+++ b/build/config.props
@@ -25,7 +25,7 @@
 
     <!-- Visual Studio Insertion Logic -->
     <VsTargetMajorVersion>$([MSBuild]::Add(11, $(MajorNuGetVersion)))</VsTargetMajorVersion>
-    <VsTargetBranch>main</VsTargetBranch>
+    <VsTargetBranch>d16.8</VsTargetBranch>
     <VsTargetChannel>int.$(VsTargetBranch)</VsTargetChannel>
 
     <!-- This branches are used for creating insertion PRs -->


### PR DESCRIPTION
## Bug

Fixes:  none - engineering/branding change
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: change the IsEscrowMode to true, so that changes VS target branch from main to d16.8, for branch release-5.8.0-preview.3, according to the schedule.
## Testing/Validation

Tests Added: No  
Reason for not adding tests:  
Validation:  
