### PR TITLE
PM UI:  do not display dependency information in preview results when updating package

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/UIActionEngine.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/UIActionEngine.cs
@@ -802,7 +802,8 @@ namespace NuGet.PackageManagement.UI
             return results;
         }
 
-        private static async ValueTask<IReadOnlyList<PreviewResult>> GetPreviewResultsAsync(
+        // Non-private only to facilitate testing.
+        internal static async ValueTask<IReadOnlyList<PreviewResult>> GetPreviewResultsAsync(
             INuGetProjectManagerService projectManagerService,
             IReadOnlyList<ProjectAction> projectActions,
             CancellationToken cancellationToken)
@@ -845,11 +846,11 @@ namespace NuGet.PackageManagement.UI
 
                 foreach (ProjectAction action in actions)
                 {
-                    PackageIdentity packageIdentity = action.PackageIdentity;
+                    // Create new identities without the dependency graph
+                    var packageIdentity = new PackageIdentity(action.PackageIdentity.Id, action.PackageIdentity.Version);
 
                     packageIds.Add(packageIdentity.Id);
 
-                    // Create new identities without the dependency graph
                     if (action.ProjectActionType == NuGetProjectActionType.Install)
                     {
                         installed[packageIdentity.Id] = packageIdentity;

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Actions/UIActionEngineTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Actions/UIActionEngineTests.cs
@@ -1,0 +1,87 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using NuGet.Packaging.Core;
+using NuGet.Versioning;
+using NuGet.VisualStudio.Internal.Contracts;
+using Xunit;
+
+namespace NuGet.PackageManagement.UI.Test
+{
+    public class UIActionEngineTests
+    {
+        [Fact]
+        public async Task GetPreviewResultsAsync_WhenPackageIdentityIsSubclass_ItIsReplacedWithNewPackageIdentity()
+        {
+            string projectId = Guid.NewGuid().ToString();
+            var packageIdentityA1 = new PackageIdentitySubclass(id: "a", NuGetVersion.Parse("1.0.0"));
+            var packageIdentityA2 = new PackageIdentitySubclass(id: "a", NuGetVersion.Parse("2.0.0"));
+            var packageIdentityB1 = new PackageIdentitySubclass(id: "b", NuGetVersion.Parse("3.0.0"));
+            var packageIdentityB2 = new PackageIdentitySubclass(id: "b", NuGetVersion.Parse("4.0.0"));
+            var uninstallAction = new ProjectAction(
+                id: Guid.NewGuid().ToString(),
+                projectId,
+                packageIdentityA1,
+                NuGetProjectActionType.Uninstall,
+                implicitActions: new[]
+                {
+                    new ImplicitProjectAction(
+                        id: Guid.NewGuid().ToString(),
+                        packageIdentityB1,
+                        NuGetProjectActionType.Uninstall)
+                });
+            var installAction = new ProjectAction(
+                id: Guid.NewGuid().ToString(),
+                projectId,
+                packageIdentityA2,
+                NuGetProjectActionType.Install,
+                implicitActions: new[]
+                {
+                    new ImplicitProjectAction(
+                        id: Guid.NewGuid().ToString(),
+                        packageIdentityB2,
+                        NuGetProjectActionType.Install)
+                });
+            IReadOnlyList<PreviewResult> previewResults = await UIActionEngine.GetPreviewResultsAsync(
+                Mock.Of<INuGetProjectManagerService>(),
+                new[] { uninstallAction, installAction },
+                CancellationToken.None);
+
+            Assert.Equal(1, previewResults.Count);
+            UpdatePreviewResult[] updatedResults = previewResults[0].Updated.ToArray();
+
+            Assert.Equal(2, updatedResults.Length);
+
+            UpdatePreviewResult updatedResult = updatedResults[0];
+
+            Assert.False(updatedResult.Old.GetType().IsSubclassOf(typeof(PackageIdentity)));
+            Assert.False(updatedResult.New.GetType().IsSubclassOf(typeof(PackageIdentity)));
+            Assert.Equal("a.1.0.0 -> a.2.0.0", updatedResult.ToString());
+
+            updatedResult = updatedResults[1];
+
+            Assert.False(updatedResult.Old.GetType().IsSubclassOf(typeof(PackageIdentity)));
+            Assert.False(updatedResult.New.GetType().IsSubclassOf(typeof(PackageIdentity)));
+            Assert.Equal("b.3.0.0 -> b.4.0.0", updatedResult.ToString());
+        }
+
+        private sealed class PackageIdentitySubclass : PackageIdentity
+        {
+            public PackageIdentitySubclass(string id, NuGetVersion version)
+                : base(id, version)
+            {
+            }
+
+            public override string ToString()
+            {
+                return "If this displays, it is a bug";
+            }
+        }
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/NuGet.PackageManagement.UI.Test.csproj
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/NuGet.PackageManagement.UI.Test.csproj
@@ -30,6 +30,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Actions\AccessiblePackageIdentityTests.cs" />
+    <Compile Include="Actions\UIActionEngineTests.cs" />
     <Compile Include="Actions\UpdatePreviewResultTests.cs" />
     <Compile Include="Converters\IconUrlToImageCacheConverterTests.cs" />
     <Compile Include="Converters\DateTimeConverterTests.cs" />


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/10013
Regression: Yes  
* Last working version:   any dev branch build
* How are we preventing it in future:   adding a test

## Fix

Details:  Before displaying preview results for an update package operation, package identities must be simplified --- subclasses of `PackageIdentity` should be disallowed.

## Testing/Validation

Tests Added: Yes