### PR TITLE
move from dotnet.myget.com feeds to AzDO for Build (1/2)

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -4,12 +4,12 @@
     <clear />
     <add key="NuGet.org" value="https://api.nuget.org/v3/index.json" />
     <add key="nuget-build" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/nuget-build/nuget/v3/index.json" />
+    <add key="vside_vs-impl" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl/nuget/v3/index.json" />
+    <add key="vside_vssdk" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vssdk/nuget/v3/index.json" />
     <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
-    <add key="dotnet-buildtools" value="https://dotnet.myget.org/F/dotnet-buildtools/api/v3/index.json" />
+
+    <!-- Microsoft.VisualStudio.ProjectSystem.Managed* from roslyn. moving to vs-impl with new versions soon.  -->
     <add key="dotnet-roslyn" value="https://dotnet.myget.org/F/roslyn/api/v3/index.json" />
-    <add key="vside" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl/nuget/v3/index.json" />
-    <add key="dotnet-msbuild" value="https://dotnet.myget.org/F/msbuild/api/v3/index.json" />
-    <add key="vssdk" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vssdk/nuget/v3/index.json" />
   </packageSources>
   <disabledPackageSources>
     <clear />

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -3,7 +3,7 @@
   <packageSources>
     <clear />
     <add key="NuGet.org" value="https://api.nuget.org/v3/index.json" />
-    <add key="NuGetVolatile" value="https://dotnet.myget.org/F/nuget-volatile/api/v3/index.json" />
+    <add key="nuget-build" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/nuget-build/nuget/v3/index.json" />
     <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
     <add key="dotnet-buildtools" value="https://dotnet.myget.org/F/dotnet-buildtools/api/v3/index.json" />
     <add key="dotnet-roslyn" value="https://dotnet.myget.org/F/roslyn/api/v3/index.json" />

--- a/test/EndToEnd/tests/GetPackageTest.ps1
+++ b/test/EndToEnd/tests/GetPackageTest.ps1
@@ -508,7 +508,7 @@ function Test-GetPackageUpdatesAfterSwitchToSourceThatDoesNotContainInstalledPac
     $p | Install-Package antlr -Version '3.1.1' -Source $SourceNuGet
 
     # Act
-    $packages = @(Get-Package -updates -Source 'https://dotnet.myget.org/F/nuget-volatile/api/v3/index.json')
+    $packages = @(Get-Package -updates -Source 'https://pkgs.dev.azure.com/dnceng/public/_packaging/nuget-build/nuget/v3/index.json')
 
     # Assert
     Assert-AreEqual 0 $packages.Count

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/PackageItemLoaderTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/PackageItemLoaderTests.cs
@@ -36,7 +36,7 @@ namespace NuGet.PackageManagement.UI.Test
                 .Setup(x => x.SolutionManager)
                 .Returns(solutionManager);
 
-            var source1 = new PackageSource("https://dotnet.myget.org/F/nuget-volatile/api/v3/index.json", "NuGetVolatile");
+            var source1 = new PackageSource("https://pkgs.dev.azure.com/dnceng/public/_packaging/nuget-build/nuget/v3/index.json", "NuGetBuild");
             var source2 = new PackageSource("https://api.nuget.org/v3/index.json", "NuGet.org");
 
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateSourceRepositoryProvider(new[] { source1, source2 });
@@ -173,7 +173,7 @@ namespace NuGet.PackageManagement.UI.Test
                 .Setup(x => x.SolutionManager)
                 .Returns(solutionManager);
 
-            var source1 = new PackageSource("https://dotnet.myget.org/F/nuget-volatile/api/v3/index.json", "NuGetVolatile");
+            var source1 = new PackageSource("https://pkgs.dev.azure.com/dnceng/public/_packaging/nuget-build/nuget/v3/index.json", "NuGetBuild");
             var source2 = new PackageSource("https://api.nuget.org/v3/index.json", "NuGet.org");
 
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateSourceRepositoryProvider(new[] { source1, source2 });

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/FeedTypeUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/FeedTypeUtilityTests.cs
@@ -19,7 +19,6 @@ namespace NuGet.Protocol.Tests
         [InlineData("http://nuget.org")]
         [InlineData("http://")]
         [InlineData("http://nuget.org/index.xml")]
-        [InlineData("https://dotnet.myget.org/F/nuget-volatile/api/v2")]
         [InlineData("http://nuget.org/index.json.html")]
         [InlineData("http://tempuri.org/api/v2/")]
         public void GetFeedType_WithV2HttpSources_ReturnsHttpV2(string source)
@@ -31,7 +30,7 @@ namespace NuGet.Protocol.Tests
         [InlineData("https://api.nuget.org/v3/index.json")]
         [InlineData("http://api.nuget.org/v3/index.json")]
         [InlineData("https://api.nuget.org/v3/INDEX.JSON")]
-        [InlineData("https://dotnet.myget.org/F/nuget-volatile/api/v3/index.json")]
+        [InlineData("https://pkgs.dev.azure.com/dnceng/public/_packaging/nuget-build/nuget/v3/index.json")]
         public void GetFeedType_WithV3HttpSources_ReturnsHttpV3(string source)
         {
             Assert.Equal(FeedType.HttpV3, FeedTypeUtility.GetFeedType(new PackageSource(source)));


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Client.Engineering/issues/489
Regression: No

## Fix

Details: move from dotnet.myget.com feeds to AzDO

Will follow on with CI publishing of build to the new nuget-build AzDO feed...in a separate change.

## Testing/Validation

Tests Added: No
Reason for not adding tests: not appropriate.
Validation:  local and CI builds.
