### PR TITLE
Fix bug #9960 The SVsNuGetRecommenderService service is unavailable

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/PackageFeeds/RecommenderPackageFeed.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/PackageFeeds/RecommenderPackageFeed.cs
@@ -90,7 +90,14 @@ namespace NuGet.PackageManagement.VisualStudio
             // get recommender service and version info
             if (NuGetRecommender == null)
             {
-                NuGetRecommender = await _nuGetRecommender.GetValueAsync();
+                try
+                {
+                    NuGetRecommender = await _nuGetRecommender.GetValueAsync();
+                }
+                catch(ServiceUnavailableException)
+                {
+                    // if the recommender service is not available, NuGetRecommender remains null and we show only the default package list
+                }
                 if (NuGetRecommender != null)
                 {
                     var VersionDict = NuGetRecommender.GetVersionInfo();

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/PackageFeeds/RecommenderPackageFeed.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/PackageFeeds/RecommenderPackageFeed.cs
@@ -94,7 +94,7 @@ namespace NuGet.PackageManagement.VisualStudio
                 {
                     NuGetRecommender = await _nuGetRecommender.GetValueAsync(cancellationToken);
                 }
-                catch(ServiceUnavailableException)
+                catch (ServiceUnavailableException)
                 {
                     // if the recommender service is not available, NuGetRecommender remains null and we show only the default package list
                 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/PackageFeeds/RecommenderPackageFeed.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/PackageFeeds/RecommenderPackageFeed.cs
@@ -92,7 +92,7 @@ namespace NuGet.PackageManagement.VisualStudio
             {
                 try
                 {
-                    NuGetRecommender = await _nuGetRecommender.GetValueAsync();
+                    NuGetRecommender = await _nuGetRecommender.GetValueAsync(cancellationToken);
                 }
                 catch(ServiceUnavailableException)
                 {


### PR DESCRIPTION
## Bug 9960

Fixes: https://github.com/NuGet/Home/issues/9960
Regression: Yes  
* Last working version:  16.8.30403.00 
* How are we preventing it in future: If the recommender service is unavailable, we will continue without it.   

## Fix
In Blend, when the NuGet Package Manager Browse tab is opened "The SVsNuGetRecommenderService service is unavailable" appears instead of the expected package list. This is because the package manager is not able to load the recommender service, since the NuGetRecommender extension is not installed in Blend.
The fix is to check for ServiceUnavailableException when getting the recommender service. If it's not found, users will see the default list of packages without recommendations.

## Testing/Validation
Tests Added: No  
Reason for not adding tests:  
Validation:  Manual test
