### PR TITLE
PM UI:  propagate ISolutionManager.ActionsExecuted event

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/UIActionEngine.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/UIActionEngine.cs
@@ -434,7 +434,12 @@ namespace NuGet.PackageManagement.UI
                             actions,
                             cancellationToken);
 
-                        uiService.UIContext.RaiseProjectActionsExecuted(actions);
+                        string[] projectIds = actions
+                            .Select(action => action.ProjectId)
+                            .Distinct()
+                            .ToArray();
+
+                        uiService.UIContext.RaiseProjectActionsExecuted(projectIds);
                     }
                     else
                     {

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/UserInterfaceService/INuGetUIContext.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/UserInterfaceService/INuGetUIContext.cs
@@ -14,7 +14,7 @@ namespace NuGet.PackageManagement.UI
 {
     public interface INuGetUIContext : IDisposable
     {
-        event EventHandler<IReadOnlyCollection<ProjectAction>> ProjectActionsExecuted;
+        event EventHandler<IReadOnlyCollection<string>> ProjectActionsExecuted;
 
         ISourceRepositoryProvider SourceProvider { get; }
 
@@ -40,6 +40,6 @@ namespace NuGet.PackageManagement.UI
 
         Task<IModalProgressDialogSession> StartModalProgressDialogAsync(string caption, ProgressDialogData initialData, INuGetUI uiService);
 
-        void RaiseProjectActionsExecuted(IReadOnlyCollection<ProjectAction> projectActions);
+        void RaiseProjectActionsExecuted(IReadOnlyCollection<string> projectIds);
     }
 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -258,7 +258,7 @@ namespace NuGet.PackageManagement.UI
             }
         }
 
-        private void OnProjectActionsExecuted(object sender, IReadOnlyCollection<ProjectAction> actions)
+        private void OnProjectActionsExecuted(object sender, IReadOnlyCollection<string> projectIds)
         {
             var timeSpan = GetTimeSinceLastRefreshAndRestart();
             // Do not refresh if the UI is not visible. It will be refreshed later when the loaded event is called.
@@ -270,8 +270,6 @@ namespace NuGet.PackageManagement.UI
                 }
                 else
                 {
-                    string[] projectIds = actions.Select(action => action.ProjectId).ToArray();
-
                     RefreshProjectAfterAction(timeSpan, projectIds);
                 }
             }

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/NuGet.PackageManagement.UI.Test.csproj
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/NuGet.PackageManagement.UI.Test.csproj
@@ -53,6 +53,7 @@
     <Compile Include="TestNuGetUILogger.cs" />
     <Compile Include="TestPackageManagerProviders.cs" />
     <Compile Include="TestPackageSearchMetadata.cs" />
+    <Compile Include="UserInterfaceService\NuGetUIContextTests.cs" />
     <Compile Include="WpfFactAttribute.cs" />
     <Compile Include="WpfFactDiscoverer.cs" />
     <Compile Include="WpfTestCase.cs" />

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/UserInterfaceService/NuGetUIContextTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/UserInterfaceService/NuGetUIContextTests.cs
@@ -1,0 +1,195 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.ServiceHub.Framework;
+using Moq;
+using NuGet.Configuration;
+using NuGet.PackageManagement.VisualStudio;
+using NuGet.Packaging;
+using NuGet.Packaging.Core;
+using NuGet.ProjectManagement;
+using NuGet.Protocol.Core.Types;
+using NuGet.Test.Utility;
+using NuGet.Versioning;
+using NuGet.VisualStudio;
+using Xunit;
+
+namespace NuGet.PackageManagement.UI.Test.UserInterfaceService
+{
+    public class NuGetUIContextTests : IDisposable
+    {
+        private static readonly PackageIdentity PackageIdentity = new PackageIdentity(id: "x", NuGetVersion.Parse("1.0.0"));
+
+        private readonly Mock<IVsSolutionManager> _solutionManager = new Mock<IVsSolutionManager>();
+        private readonly TestDirectory _testDirectory = TestDirectory.Create();
+
+        [Fact]
+        public void ProjectActionsExecuted_WhenSolutionManagerActionsExecutedEventRaisedWithNullEventArgs_Throws()
+        {
+            NuGetUIContext context = CreateNuGetUIContext();
+            var wasEventRaised = false;
+
+            context.ProjectActionsExecuted += (object sender, IReadOnlyCollection<string> actualProjectIds) =>
+            {
+                wasEventRaised = true;
+            };
+
+            Assert.ThrowsAny<Exception>(() => _solutionManager.Raise(s => s.ActionsExecuted += null, (EventArgs)null));
+
+            Assert.False(wasEventRaised);
+        }
+
+        [Fact]
+        public void ProjectActionsExecuted_WhenSolutionManagerActionsExecutedEventRaisedWithNoActions_IsNotRaised()
+        {
+            NuGetUIContext context = CreateNuGetUIContext();
+            var resolvedActions = Enumerable.Empty<ResolvedAction>();
+            var wasEventRaised = false;
+
+            context.ProjectActionsExecuted += (object sender, IReadOnlyCollection<string> actualProjectIds) =>
+            {
+                wasEventRaised = true;
+            };
+
+            _solutionManager.Raise(s => s.ActionsExecuted += null, new ActionsExecutedEventArgs(resolvedActions));
+
+            Assert.False(wasEventRaised);
+        }
+
+        [Fact]
+        public void ProjectActionsExecuted_WhenSolutionManagerActionsExecutedEventRaised_DistinctIdsReturned()
+        {
+            NuGetUIContext context = CreateNuGetUIContext();
+            var projectA = new TestNuGetProject();
+            var projectB = new TestNuGetProject();
+
+            var projectActionA1 = NuGetProjectAction.CreateInstallProjectAction(
+                PackageIdentity,
+                sourceRepository: null,
+                projectA);
+            var projectActionA2 = NuGetProjectAction.CreateInstallProjectAction(
+                PackageIdentity,
+                sourceRepository: null,
+                projectA);
+            var projectActionB = NuGetProjectAction.CreateInstallProjectAction(
+                PackageIdentity,
+                sourceRepository: null,
+                projectB);
+            var resolvedActions = new ResolvedAction[]
+            {
+                new ResolvedAction(projectA, projectActionA1),
+                new ResolvedAction(projectA, projectActionA2),
+                new ResolvedAction(projectB, projectActionB),
+            };
+            var wasEventRaised = false;
+            string[] expectedProjectIds = resolvedActions
+                .Select(resolvedAction => resolvedAction.Project.GetMetadata<string>(NuGetProjectMetadataKeys.ProjectId))
+                .Distinct()
+                .ToArray();
+
+            context.ProjectActionsExecuted += (object sender, IReadOnlyCollection<string> actualProjectIds) =>
+            {
+                wasEventRaised = true;
+
+                Assert.Equal(expectedProjectIds, actualProjectIds);
+            };
+
+            _solutionManager.Raise(s => s.ActionsExecuted += null, new ActionsExecutedEventArgs(resolvedActions));
+
+            Assert.True(wasEventRaised);
+        }
+
+        [Fact]
+        public void ProjectActionsExecuted_WhenSolutionManagerActionsExecutedEventRaised_IsRaised()
+        {
+            NuGetUIContext context = CreateNuGetUIContext();
+            var project = new TestNuGetProject();
+
+            var projectAction = NuGetProjectAction.CreateInstallProjectAction(
+                PackageIdentity,
+                sourceRepository: null,
+                project);
+            var resolvedActions = new ResolvedAction[] { new ResolvedAction(project, projectAction) };
+            var wasEventRaised = false;
+            string[] expectedProjectIds = resolvedActions
+                .Select(resolvedAction => resolvedAction.Project.GetMetadata<string>(NuGetProjectMetadataKeys.ProjectId))
+                .ToArray();
+
+            context.ProjectActionsExecuted += (object sender, IReadOnlyCollection<string> actualProjectIds) =>
+            {
+                wasEventRaised = true;
+
+                Assert.Equal(expectedProjectIds, actualProjectIds);
+            };
+
+            _solutionManager.Raise(s => s.ActionsExecuted += null, new ActionsExecutedEventArgs(resolvedActions));
+
+            Assert.True(wasEventRaised);
+        }
+
+        public void Dispose()
+        {
+            _testDirectory.Dispose();
+        }
+
+        private NuGetUIContext CreateNuGetUIContext()
+        {
+            var sourceRepositoryProvider = Mock.Of<ISourceRepositoryProvider>();
+            var packageManager = new NuGetPackageManager(
+                sourceRepositoryProvider,
+                Mock.Of<ISettings>(),
+                _testDirectory.Path);
+
+            return new NuGetUIContext(
+                sourceRepositoryProvider,
+                Mock.Of<IServiceBroker>(),
+                _solutionManager.Object,
+                new NuGetSolutionManagerServiceWrapper(),
+                packageManager,
+                new UIActionEngine(
+                    sourceRepositoryProvider,
+                    packageManager,
+                    Mock.Of<INuGetLockService>()),
+                Mock.Of<IPackageRestoreManager>(),
+                Mock.Of<IOptionsPageActivator>(),
+                Mock.Of<IUserSettingsManager>(),
+                Enumerable.Empty<IVsPackageManagerProvider>());
+        }
+
+        private sealed class TestNuGetProject : NuGetProject
+        {
+            internal TestNuGetProject()
+            {
+                InternalMetadata[NuGetProjectMetadataKeys.ProjectId] = Guid.NewGuid().ToString();
+            }
+
+            public override Task<IEnumerable<PackageReference>> GetInstalledPackagesAsync(
+                CancellationToken token)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override Task<bool> InstallPackageAsync(
+                PackageIdentity packageIdentity,
+                DownloadResourceResult downloadResourceResult,
+                INuGetProjectContext nuGetProjectContext,
+                CancellationToken token)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override Task<bool> UninstallPackageAsync(
+                PackageIdentity packageIdentity,
+                INuGetProjectContext nuGetProjectContext,
+                CancellationToken token)
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/10012
Regression: Yes
* Last working version:   any dev branch build
* How are we preventing it in future:   adding test

## Fix

Details:  Executing the `Update-Package` command (among others) in Package Manager Console (PMC) raises the `ISolutionManager.ActionsExecuted` event by [calling `ISolutionManager.OnActionsExecuted(...)`](https://github.com/NuGet/NuGet.Client/blob/d8b872af0ae231686dfe7ac62868dfe154d7f565/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/NuGetPowerShellBaseCommand.cs#L296).  With recent remoting work, this code path isn't used any more by PM UI (like when a package is installed/updated/uninstalled in PM UI).  Instead, a similar actions executed event is raised by [calling `INuGetUIContext.RaiseProjectActionsExecuted(...)`](https://github.com/NuGet/NuGet.Client/blob/2b2794a23cab2c42a1e14dc78895d4b4fac64b97/src/NuGet.Clients/NuGet.PackageManagement.UI/UserInterfaceService/INuGetUIContext.cs#L43).  Until PMC is made remoteable, `NuGetUIContext` will need to listen for the `ISolutionManager.ActionsExecuted` event and propagate the event as `INuGetUIContext.ProjectActionsExecuted`.  This change will not result in `INuGetUIContext.ProjectActionsExecuted` firing twice for one operation.

Because the lowest common parameter type for both of these events is a simple string (representing the project ID of the affected project), the new event (`INuGetUIContext.ProjectActionsExecuted`) has been updated to pass project ID's instead of executed actions.

## Testing/Validation

Tests Added: Yes