### PR TITLE
Add DontForceCreate option for PMC

### DIFF
--- a/src/NuGet.Clients/NuGet.Tools/NuGetPackage.cs
+++ b/src/NuGet.Clients/NuGet.Tools/NuGetPackage.cs
@@ -48,7 +48,8 @@ namespace NuGetVSExtension
     [ProvideToolWindow(typeof(PowerConsoleToolWindow),
         Style = VsDockStyle.Tabbed,
         Window = "{34E76E81-EE4A-11D0-AE2E-00A0C90FFFC3}", // this is the guid of the Output tool window, which is present in both VS and VWD
-        Orientation = ToolWindowOrientation.Right)]
+        Orientation = ToolWindowOrientation.Right,
+        Transient=true)]
     [ProvideOptionPage(typeof(PackageSourceOptionsPage), "NuGet Package Manager", "Package Sources", 113, 114, true)]
     [ProvideOptionPage(typeof(GeneralOptionPage), "NuGet Package Manager", "General", 113, 115, true)]
     [ProvideSearchProvider(typeof(NuGetSearchProvider), "NuGet Search")]

--- a/src/NuGet.Clients/NuGet.Tools/NuGetPackage.cs
+++ b/src/NuGet.Clients/NuGet.Tools/NuGetPackage.cs
@@ -49,7 +49,7 @@ namespace NuGetVSExtension
         Style = VsDockStyle.Tabbed,
         Window = "{34E76E81-EE4A-11D0-AE2E-00A0C90FFFC3}", // this is the guid of the Output tool window, which is present in both VS and VWD
         Orientation = ToolWindowOrientation.Right,
-        Transient=true)]
+        Transient = true)]
     [ProvideOptionPage(typeof(PackageSourceOptionsPage), "NuGet Package Manager", "Package Sources", 113, 114, true)]
     [ProvideOptionPage(typeof(GeneralOptionPage), "NuGet Package Manager", "General", 113, 115, true)]
     [ProvideSearchProvider(typeof(NuGetSearchProvider), "NuGet Search")]


### PR DESCRIPTION
## Bug

Fixes: [Issue #9987](https://github.com/NuGet/Home/issues/9987)
Regression: No  
* Last working version:   n/a
* How are we preventing it in future:   n/a

## Fix

Details:
Child of https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1167790. 

If the PMC is visible when VS shuts down, when VS starts, it's loaded even with no solution loaded. 
This 75 M memory penalty is incurred even if user never uses the PMC  in that session.
Please lazily initialize and DontForceCreate. This will reduce the penalty for many sessions with very little change.
I added `Transient=true` flag and now PMC window doesn't re-open automatically when we open next time even though it was open before we close the VS.

PMC: When PMC is loaded because the last time VS closed, PMC was open: 
https://docs.microsoft.com/en-us/visualstudio/extensibility/registering-a-tool-window?view=vs-2019

@aortiz-msft  @nkolev92 
This change makes PMC doesn't open when you re-open solution next time.
So it's change of user experience. What do you think should be go ahead with this one or not?

## Testing/Validation

Tests Added: No  
Reason for not adding tests: 
Validation:  Manual validation. I tested on both experimental instance and installed vsix into public instance.
Just in case I'have done actual EF6 migrations are MVC solution still working after this change. So far everything looks good EF6.
