### PR TITLE
Fix error when a project doesn't not specify a restore output path

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs
@@ -424,21 +424,12 @@ namespace NuGet.Build.Tasks.Console
         /// Gets the restore output path for the specified project.
         /// </summary>
         /// <param name="project">The <see cref="IMSBuildItem" /> representing the project.</param>
-        /// <returns>The full path to the restore output directory for the specified project.</returns>
-        internal string GetRestoreOutputPath(IMSBuildProject project)
+        /// <returns>The full path to the restore output directory for the specified project if a value is specified, otherwise <code>null</code>.</returns>
+        internal static string GetRestoreOutputPath(IMSBuildProject project)
         {
             string outputPath = project.GetProperty("RestoreOutputPath") ?? project.GetProperty("MSBuildProjectExtensionsPath");
 
-            if (string.IsNullOrWhiteSpace(outputPath))
-            {
-                // If the project doesn't supply a restore output path, it doesn't support restore.  The properties above are defined in the .NET SDK and if a project does not have them set then the project
-                // author isn't importing something from the SDK which is not supported.
-                MSBuildLogger.LogVerbose($"The project '{project.FullPath}' does not specify a value for the properties 'RestoreOutputPath' or 'MSBuildProjectExtensionsPath' and will not be restored.");
-
-                return null;
-            }
-
-            return Path.GetFullPath(Path.Combine(project.Directory, outputPath));
+            return outputPath == null ? null : Path.GetFullPath(Path.Combine(project.Directory, outputPath));
         }
 
         /// <summary>
@@ -738,11 +729,6 @@ namespace NuGet.Build.Tasks.Console
             var projectName = GetProjectName(project);
 
             var outputPath = GetRestoreOutputPath(project);
-
-            if (outputPath == null)
-            {
-                return (null, null);
-            }
 
             var projectStyleOrNull = BuildTasksUtility.GetProjectRestoreStyleFromProjectProperty(project.GetProperty("RestoreProjectStyle"));
             var isCpvmEnabled = IsCentralVersionsManagementEnabled(project, projectStyleOrNull);

--- a/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs
@@ -699,7 +699,7 @@ namespace NuGet.Build.Tasks.Console
 
             (ProjectRestoreMetadata restoreMetadata, List<TargetFrameworkInformation> targetFrameworkInfos) = GetProjectRestoreMetadataAndTargetFrameworkInformation(project, projectsByTargetFramework, settings);
 
-            if(restoreMetadata == null || targetFrameworkInfos == null)
+            if (restoreMetadata == null || targetFrameworkInfos == null)
             {
                 return null;
             }
@@ -739,7 +739,7 @@ namespace NuGet.Build.Tasks.Console
 
             var outputPath = GetRestoreOutputPath(project);
 
-            if(outputPath == null)
+            if (outputPath == null)
             {
                 return (null, null);
             }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/NoOpRestoreUtilities.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/NoOpRestoreUtilities.cs
@@ -53,7 +53,7 @@ namespace NuGet.Commands
 
         public static string GetProjectCacheFilePath(string cacheRoot)
         {
-            return Path.Combine(cacheRoot, NoOpCacheFileName);
+            return cacheRoot == null ? null : Path.Combine(cacheRoot, NoOpCacheFileName);
         }
 
         internal static string GetToolCacheFilePath(RestoreRequest request, LockFile lockFile)

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Console.Test/MSBuildStaticGraphRestoreTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Console.Test/MSBuildStaticGraphRestoreTests.cs
@@ -546,9 +546,7 @@ namespace NuGet.Build.Tasks.Console.Test
                     ["MSBuildProjectExtensionsPath"] = msbuildProjectExtensionsPath
                 });
 
-                MSBuildStaticGraphRestore msBuildStaticGraphRestore = new MSBuildStaticGraphRestore();
-
-                var actual = msBuildStaticGraphRestore.GetRestoreOutputPath(project);
+                var actual = MSBuildStaticGraphRestore.GetRestoreOutputPath(project);
 
                 if (expected == null)
                 {

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Console.Test/MSBuildStaticGraphRestoreTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Console.Test/MSBuildStaticGraphRestoreTests.cs
@@ -535,6 +535,7 @@ namespace NuGet.Build.Tasks.Console.Test
         [InlineData(@"custom\", null, @"custom\")]
         [InlineData(null, @"obj2\", @"obj2\")]
         [InlineData(null, @"obj3", "obj3")]
+        [InlineData(null, null, null)]
         public void GetRestoreOutputPath_WhenOutputPathOrMSBuildProjectExtensionsPathSpecified_CorrectPathDetected(string restoreOutputPath, string msbuildProjectExtensionsPath, string expected)
         {
             using (var testDirectory = TestDirectory.Create())
@@ -545,11 +546,20 @@ namespace NuGet.Build.Tasks.Console.Test
                     ["MSBuildProjectExtensionsPath"] = msbuildProjectExtensionsPath
                 });
 
-                var actual = MSBuildStaticGraphRestore.GetRestoreOutputPath(project);
+                MSBuildStaticGraphRestore msBuildStaticGraphRestore = new MSBuildStaticGraphRestore();
 
-                expected = Path.Combine(testDirectory, expected);
+                var actual = msBuildStaticGraphRestore.GetRestoreOutputPath(project);
 
-                actual.Should().Be(expected);
+                if (expected == null)
+                {
+                    actual.Should().BeNull();
+                }
+                else
+                {
+                    expected = Path.Combine(testDirectory, expected);
+
+                    actual.Should().Be(expected);
+                }
             }
         }
 


### PR DESCRIPTION
If a project does not import Microsoft.Common.props, it won't have the properties set to determine the restore output path.  This can cause us to crash when we call `Path.Combine()` with a null value.

## Bug

Fixes: https://github.com/NuGet/Home/issues/9280
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

This fix checks for the condition when the necessary properties are not defined, logs a message, and leaves the project out of restore.

## Testing/Validation

Tests Added: Yes
Reason for not adding tests:  
Validation:  
