### PR TITLE
Change branding to rc, incase this is the last insertion

### DIFF
--- a/build/config.props
+++ b/build/config.props
@@ -19,7 +19,7 @@
 
     <!-- ** Change for each new preview/rc -->
     <!-- Check the VS schedule and manually enter a preview number here that makes sense. -->
-    <ReleaseLabel Condition=" '$(ReleaseLabel)' == '' ">preview.4</ReleaseLabel>
+    <ReleaseLabel Condition=" '$(ReleaseLabel)' == '' ">rc</ReleaseLabel>
 
     <IsEscrowMode>false</IsEscrowMode>
 


### PR DESCRIPTION
## Bug

Fixes: none - engineering/branding change
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: Change branding to rc, in case preview.4 is the last insertion and NuGet will ship with preview.4 branding when VS goes GA.

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  
Validation:  
