### PR TITLE
Revert "Enable re-running jobs with flaky tests for PR builds (#3660)"

### DIFF
--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -266,7 +266,7 @@ jobs:
 
   - task: MSBuild@1
     displayName: "Run unit tests"
-    continueOnError: ${{ eq(variables['IsOfficialBuild'], 'true') }}
+    continueOnError: "true"
     inputs:
       solution: "build\\build.proj"
       msbuildVersion: "16.0"
@@ -667,7 +667,7 @@ jobs:
 
   - task: MSBuild@1
     displayName: "Run Functional Tests"
-    continueOnError: ${{ eq(variables['IsOfficialBuild'], 'true') }}
+    continueOnError: "true"
     inputs:
       solution: "build\\build.proj"
       msbuildVersion: "16.0"
@@ -676,7 +676,7 @@ jobs:
 
   - task: PublishTestResults@2
     displayName: "Publish Test Results"
-    continueOnError: ${{ eq(variables['IsOfficialBuild'], 'true') }}
+    continueOnError: "true"
     inputs:
       testRunner: "XUnit"
       testResultsFiles: "*.xml"
@@ -736,7 +736,7 @@ jobs:
 
   - task: ShellScript@2
     displayName: "Run Tests"
-    continueOnError: ${{ eq(variables['IsOfficialBuild'], 'true') }}
+    continueOnError: "true"
     inputs:
       scriptPath: "scripts/funcTests/runFuncTests.sh"
       disableAutoCwd: "true"
@@ -750,7 +750,6 @@ jobs:
       testRunTitle: "NuGet.Client Tests On Linux"
       searchFolder: "$(Build.Repository.LocalPath)/build/TestResults"
       mergeTestResults: "true"
-    condition: "succeededOrFailed()"
 
   - task: PowerShell@2
     displayName: "Initialize Git Commit Status on GitHub"
@@ -809,7 +808,7 @@ jobs:
 
   - task: ShellScript@2
     displayName: "Run Tests"
-    continueOnError: ${{ eq(variables['IsOfficialBuild'], 'true') }}
+    continueOnError: "true"
     inputs:
       scriptPath: "scripts/funcTests/runFuncTests.sh"
       disableAutoCwd: "true"
@@ -914,7 +913,7 @@ jobs:
   - task: PowerShell@1
     displayName: "RunFunctionalTests.ps1"
     timeoutInMinutes: 75
-    continueOnError: ${{ eq(variables['IsOfficialBuild'], 'true') }}
+    continueOnError: "true"
     inputs:
       scriptName: "$(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\RunFunctionalTests.ps1"
       arguments: "-PMCCommand $(EndToEndTestCommandToRun) -PMCLaunchWaitTimeInSecs 30 -EachTestTimoutInSecs 600 -NuGetDropPath $(System.DefaultWorkingDirectory)\\artifacts -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts -RunCounter $(Build.BuildNumber) -VSVersion 16.0"
@@ -1058,7 +1057,7 @@ jobs:
   - task: MSBuild@1
     displayName: "Run Apex Tests"
     timeoutInMinutes: 45
-    continueOnError: ${{ eq(variables['IsOfficialBuild'], 'true') }}
+    continueOnError: "true"
     inputs:
       solution: "build\\build.proj"
       msbuildVersion: "16.0"


### PR DESCRIPTION
This reverts commit ab95cc903df00869fa08c696e805ce5aac61fa65.

## Bug

reverts: NuGet/Client.Engineering#411
Regression: yes
* Last working version:   well, it wasn't a product change
* How are we preventing it in future: build yaml changes can only be tested manually 😞 

## Fix

Details: revert commit causing problems with official builds

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  build yaml changes
Validation:  
