### PR TITLE
Defer PMC power shell load DLL until user start typing

### DIFF
--- a/src/NuGet.Clients/NuGet.Console/Console/ConsoleDispatcher.cs
+++ b/src/NuGet.Clients/NuGet.Console/Console/ConsoleDispatcher.cs
@@ -264,6 +264,8 @@ namespace NuGetConsole.Implementation.Console
 
             private bool _isExecuting;
 
+            private int _runCount;
+
             public bool IsExecuting
             {
                 get { return _isExecuting; }
@@ -317,7 +319,18 @@ namespace NuGetConsole.Implementation.Console
             [SuppressMessage("Microsoft.Globalization", "CA1303")]
             protected void PromptNewLine()
             {
-                NuGetUIThreadHelper.JoinableTaskFactory.Run(() => WpfConsole.WriteAsync(WpfConsole.Host.Prompt + ' '));
+                var input = WpfConsole.Host.Prompt;
+                if (_runCount == 1)
+                {
+                    input = "";
+                }
+                else
+                {
+                    input += ' ';
+                }
+                _runCount++;
+
+                NuGetUIThreadHelper.JoinableTaskFactory.Run(() => WpfConsole.WriteAsync(input));
                 WpfConsole.BeginInputLine();
             }
 

--- a/src/NuGet.Clients/NuGet.Console/Console/ConsoleDispatcher.cs
+++ b/src/NuGet.Clients/NuGet.Console/Console/ConsoleDispatcher.cs
@@ -320,6 +320,9 @@ namespace NuGetConsole.Implementation.Console
             protected void PromptNewLine()
             {
                 var input = WpfConsole.Host.Prompt;
+
+                // 1st run shows PM> ready to to enter command.
+                // Then this 2nd run(0 based index) is fake only to kick start actual Powershell when user start typing.
                 if (_runCount == 1)
                 {
                     input = "";
@@ -328,6 +331,7 @@ namespace NuGetConsole.Implementation.Console
                 {
                     input += ' ';
                 }
+
                 _runCount++;
 
                 NuGetUIThreadHelper.JoinableTaskFactory.Run(() => WpfConsole.WriteAsync(input));

--- a/src/NuGet.Clients/NuGet.Console/WpfConsole/WpfConsoleKeyProcessor.cs
+++ b/src/NuGet.Clients/NuGet.Console/WpfConsole/WpfConsoleKeyProcessor.cs
@@ -29,7 +29,7 @@ namespace NuGetConsole.Implementation.Console
         private const string TabExpansionTimeoutKey = @"TabExpansionTimeout"; // in seconds
         private const int DefaultTabExpansionTimeout = 3; // in seconds
         private readonly Lazy<IntPtr> _pKeybLayout = new Lazy<IntPtr>(() => NativeMethods.GetKeyboardLayout(0));
-        private bool _notFirstInput;
+        private bool _isFirstCommand;
         private WpfConsole WpfConsole { get; }
         private IWpfTextView WpfTextView { get; }
 
@@ -186,9 +186,9 @@ namespace NuGetConsole.Implementation.Console
                 //Debug.Print("Exec: GUID_VSStandardCommandSet97: {0}", (VSConstants.VSStd97CmdID)nCmdID);
                 var commandID = (VSConstants.VSStd97CmdID)nCmdID;
                 // User pasted command here, kick off loading Powershell.
-                if (commandID == VSConstants.VSStd97CmdID.Paste && !_notFirstInput)
+                if (commandID == VSConstants.VSStd97CmdID.Paste && !_isFirstCommand)
                 {
-                    _notFirstInput = true;
+                    _isFirstCommand = true;
                     WpfConsole.EndInputLine();
                 }
 
@@ -213,9 +213,9 @@ namespace NuGetConsole.Implementation.Console
                 var commandID = (VSConstants.VSStd2KCmdID)nCmdID;
 
                 // User start typing command here, kick off loading Powershell.
-                if (commandID != VSConstants.VSStd2KCmdID.SolutionPlatform && !_notFirstInput)
+                if (commandID != VSConstants.VSStd2KCmdID.SolutionPlatform && !_isFirstCommand)
                 {
-                    _notFirstInput = true;
+                    _isFirstCommand = true;
                     WpfConsole.EndInputLine();
                 }
 

--- a/src/NuGet.Clients/NuGet.Console/WpfConsole/WpfConsoleKeyProcessor.cs
+++ b/src/NuGet.Clients/NuGet.Console/WpfConsole/WpfConsoleKeyProcessor.cs
@@ -29,7 +29,7 @@ namespace NuGetConsole.Implementation.Console
         private const string TabExpansionTimeoutKey = @"TabExpansionTimeout"; // in seconds
         private const int DefaultTabExpansionTimeout = 3; // in seconds
         private readonly Lazy<IntPtr> _pKeybLayout = new Lazy<IntPtr>(() => NativeMethods.GetKeyboardLayout(0));
-        private bool _firstInput;
+        private bool _notFirstInput;
         private WpfConsole WpfConsole { get; }
         private IWpfTextView WpfTextView { get; }
 
@@ -184,9 +184,9 @@ namespace NuGetConsole.Implementation.Console
             if (pguidCmdGroup == VSConstants.GUID_VSStandardCommandSet97)
             {
                 //Debug.Print("Exec: GUID_VSStandardCommandSet97: {0}", (VSConstants.VSStd97CmdID)nCmdID);
-                if (!_firstInput)
+                if (!_notFirstInput)
                 {
-                    _firstInput = true;
+                    _notFirstInput = true;
                     WpfConsole.EndInputLine();
                 }
 
@@ -210,9 +210,9 @@ namespace NuGetConsole.Implementation.Console
 
                 var commandID = (VSConstants.VSStd2KCmdID)nCmdID;
 
-                if (commandID != VSConstants.VSStd2KCmdID.SolutionPlatform && !_firstInput)
+                if (commandID != VSConstants.VSStd2KCmdID.SolutionPlatform && !_notFirstInput)
                 {
-                    _firstInput = true;
+                    _notFirstInput = true;
                     WpfConsole.EndInputLine();
                 }
 

--- a/src/NuGet.Clients/NuGet.Console/WpfConsole/WpfConsoleKeyProcessor.cs
+++ b/src/NuGet.Clients/NuGet.Console/WpfConsole/WpfConsoleKeyProcessor.cs
@@ -183,7 +183,6 @@ namespace NuGetConsole.Implementation.Console
 
             if (pguidCmdGroup == VSConstants.GUID_VSStandardCommandSet97)
             {
-                //Debug.Print("Exec: GUID_VSStandardCommandSet97: {0}", (VSConstants.VSStd97CmdID)nCmdID);
                 var commandID = (VSConstants.VSStd97CmdID)nCmdID;
                 // User pasted command here, kick off loading Powershell.
                 if (commandID == VSConstants.VSStd97CmdID.Paste && !_isFirstCommand)
@@ -208,8 +207,6 @@ namespace NuGetConsole.Implementation.Console
             }
             else if (pguidCmdGroup == VSConstants.VSStd2K)
             {
-                //Debug.Print("Exec: VSStd2K: {0}", (VSConstants.VSStd2KCmdID)nCmdID);
-
                 var commandID = (VSConstants.VSStd2KCmdID)nCmdID;
 
                 // User start typing command here, kick off loading Powershell.

--- a/src/NuGet.Clients/NuGet.Console/WpfConsole/WpfConsoleKeyProcessor.cs
+++ b/src/NuGet.Clients/NuGet.Console/WpfConsole/WpfConsoleKeyProcessor.cs
@@ -184,6 +184,11 @@ namespace NuGetConsole.Implementation.Console
             if (pguidCmdGroup == VSConstants.GUID_VSStandardCommandSet97)
             {
                 //Debug.Print("Exec: GUID_VSStandardCommandSet97: {0}", (VSConstants.VSStd97CmdID)nCmdID);
+                if (!_firstInput)
+                {
+                    _firstInput = true;
+                    WpfConsole.EndInputLine();
+                }
 
                 switch ((VSConstants.VSStd97CmdID)nCmdID)
                 {

--- a/src/NuGet.Clients/NuGet.Console/WpfConsole/WpfConsoleKeyProcessor.cs
+++ b/src/NuGet.Clients/NuGet.Console/WpfConsole/WpfConsoleKeyProcessor.cs
@@ -29,6 +29,7 @@ namespace NuGetConsole.Implementation.Console
         private const string TabExpansionTimeoutKey = @"TabExpansionTimeout"; // in seconds
         private const int DefaultTabExpansionTimeout = 3; // in seconds
         private readonly Lazy<IntPtr> _pKeybLayout = new Lazy<IntPtr>(() => NativeMethods.GetKeyboardLayout(0));
+        private bool _firstInput;
         private WpfConsole WpfConsole { get; }
         private IWpfTextView WpfTextView { get; }
 
@@ -203,6 +204,12 @@ namespace NuGetConsole.Implementation.Console
                 //Debug.Print("Exec: VSStd2K: {0}", (VSConstants.VSStd2KCmdID)nCmdID);
 
                 var commandID = (VSConstants.VSStd2KCmdID)nCmdID;
+
+                if (commandID != VSConstants.VSStd2KCmdID.SolutionPlatform && !_firstInput)
+                {
+                    _firstInput = true;
+                    WpfConsole.EndInputLine();
+                }
 
                 if (WpfConsole.Dispatcher.IsExecutingReadKey)
                 {

--- a/src/NuGet.Clients/NuGet.Console/WpfConsole/WpfConsoleKeyProcessor.cs
+++ b/src/NuGet.Clients/NuGet.Console/WpfConsole/WpfConsoleKeyProcessor.cs
@@ -184,6 +184,8 @@ namespace NuGetConsole.Implementation.Console
             if (pguidCmdGroup == VSConstants.GUID_VSStandardCommandSet97)
             {
                 //Debug.Print("Exec: GUID_VSStandardCommandSet97: {0}", (VSConstants.VSStd97CmdID)nCmdID);
+
+                // User pasted command here, kick off loading Powershell.
                 if (!_notFirstInput)
                 {
                     _notFirstInput = true;
@@ -210,6 +212,7 @@ namespace NuGetConsole.Implementation.Console
 
                 var commandID = (VSConstants.VSStd2KCmdID)nCmdID;
 
+                // User start typing command here, kick off loading Powershell.
                 if (commandID != VSConstants.VSStd2KCmdID.SolutionPlatform && !_notFirstInput)
                 {
                     _notFirstInput = true;

--- a/src/NuGet.Clients/NuGet.Console/WpfConsole/WpfConsoleKeyProcessor.cs
+++ b/src/NuGet.Clients/NuGet.Console/WpfConsole/WpfConsoleKeyProcessor.cs
@@ -184,9 +184,9 @@ namespace NuGetConsole.Implementation.Console
             if (pguidCmdGroup == VSConstants.GUID_VSStandardCommandSet97)
             {
                 //Debug.Print("Exec: GUID_VSStandardCommandSet97: {0}", (VSConstants.VSStd97CmdID)nCmdID);
-
+                var commandID = (VSConstants.VSStd97CmdID)nCmdID;
                 // User pasted command here, kick off loading Powershell.
-                if (!_notFirstInput)
+                if (commandID == VSConstants.VSStd97CmdID.Paste && !_notFirstInput)
                 {
                     _notFirstInput = true;
                     WpfConsole.EndInputLine();

--- a/src/NuGet.Clients/NuGetConsole.Host.PowerShell/PowerShellHost.cs
+++ b/src/NuGet.Clients/NuGetConsole.Host.PowerShell/PowerShellHost.cs
@@ -339,7 +339,7 @@ namespace NuGetConsole.Host.PowerShell.Implementation
             });
         }
 
-        private void GetRunspaceAsync(IConsole console)
+        private async Task GetRunspaceAsync(IConsole console)
         {
             var result = _runspaceManager.GetRunspace(console, _name);
             Runspace = result.Item1;
@@ -347,10 +347,7 @@ namespace NuGetConsole.Host.PowerShell.Implementation
 
             UpdateWorkingDirectory();
 
-            NuGetUIThreadHelper.JoinableTaskFactory.Run(async delegate 
-            {
-                await ExecuteInitScriptsAsync();
-            });
+            await ExecuteInitScriptsAsync();
 
             // check if PMC console is actually opened, then only hook to solution load/close events.
             if (console is IWpfConsole)
@@ -563,10 +560,7 @@ namespace NuGetConsole.Host.PowerShell.Implementation
 
                 if (Runspace == null)
                 {
-#pragma warning disable VSTHRD110 // Observe result of async calls
-                    Task.Run(() => GetRunspaceAsync(console));
-#pragma warning restore VSTHRD110 // Observe result of async calls
-
+                    NuGetUIThreadHelper.JoinableTaskFactory.Run(() => GetRunspaceAsync(console));
                 }
                 else
                 {

--- a/src/NuGet.Clients/NuGetConsole.Host.PowerShell/PowerShellHost.cs
+++ b/src/NuGet.Clients/NuGetConsole.Host.PowerShell/PowerShellHost.cs
@@ -66,9 +66,7 @@ namespace NuGetConsole.Host.PowerShell.Implementation
         private uint _solutionExistsCookie;
 
         private IConsole _activeConsole;
-#pragma warning disable IDE1006 // Naming Styles
-        protected NuGetPSHost _nugetHost { get; private set; }
-#pragma warning restore IDE1006 // Naming Styles
+        private NuGetPSHost _nugetHost;
         // indicates whether this host has been initialized.
         // null = not initilized, true = initialized successfully, false = initialized unsuccessfully
         private bool? _initialized;
@@ -266,7 +264,7 @@ namespace NuGetConsole.Host.PowerShell.Implementation
                             return prompt;
                         }
 
-                        return "";
+                        return string.Empty;
                     }
 
                     // Execute the prompt function from a worker thread, so that the UI thread is not blocked waiting
@@ -337,7 +335,6 @@ namespace NuGetConsole.Host.PowerShell.Implementation
 
         private async Task GetRunspaceAsync(IConsole console)
         {
-            //await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
             var result = _runspaceManager.GetRunspace(console, _name);
             Runspace = result.Item1;
             _nugetHost = result.Item2;
@@ -560,6 +557,7 @@ namespace NuGetConsole.Host.PowerShell.Implementation
             if (Runspace == null)
             {
                 var result = Task.Run(async () => await GetRunspaceAsync(console));
+                System.Threading.Thread.Sleep(50);
             }
             else
             {

--- a/src/NuGet.Clients/NuGetConsole.Host.PowerShell/PowerShellHost.cs
+++ b/src/NuGet.Clients/NuGetConsole.Host.PowerShell/PowerShellHost.cs
@@ -557,7 +557,7 @@ namespace NuGetConsole.Host.PowerShell.Implementation
                 throw new ArgumentNullException(nameof(command));
             }
 
-            
+
             if (Runspace == null)
             {
                 NuGetUIThreadHelper.JoinableTaskFactory.Run(() => GetRunspaceAsync(console));

--- a/src/NuGet.Clients/NuGetConsole.Host.PowerShell/PowerShellHost.cs
+++ b/src/NuGet.Clients/NuGetConsole.Host.PowerShell/PowerShellHost.cs
@@ -73,7 +73,6 @@ namespace NuGetConsole.Host.PowerShell.Implementation
         // null = not initilized, true = initialized successfully, false = initialized unsuccessfully
         private bool? _initialized;
         public bool IsInitializedSuccessfully => _initialized.HasValue && _initialized.Value;
-        private bool _notFirstRun;
 
         // store the current (non-truncated) project names displayed in the project name combobox
         private string[] _projectSafeNames;
@@ -259,7 +258,7 @@ namespace NuGetConsole.Host.PowerShell.Implementation
             {
                 try
                 {
-                    lock(_lockObj)
+                    lock (_lockObj)
                     {
                         if (Runspace == null)
                         {
@@ -280,15 +279,8 @@ namespace NuGetConsole.Host.PowerShell.Implementation
                         if (!string.IsNullOrEmpty(result))
                         {
                             prompt = result;
-
-                            if (!_notFirstRun && result == "PM>")
-                            {
-                                prompt = string.Empty;
-                            }
                         }
                     }
-
-                    _notFirstRun = true;
                 }
                 catch (Exception ex)
                 {
@@ -305,7 +297,7 @@ namespace NuGetConsole.Host.PowerShell.Implementation
         public void Initialize(IConsole console)
         {
             NuGetUIThreadHelper.JoinableTaskFactory.Run(() =>
-            { 
+            {
                 ActiveConsole = console;
                 if (_initialized.HasValue)
                 {
@@ -549,7 +541,7 @@ namespace NuGetConsole.Host.PowerShell.Implementation
 
         public bool Execute(IConsole console, string command, params object[] inputs)
         {
-            lock(_lockObj)
+            lock (_lockObj)
             {
                 if (console == null)
                 {

--- a/src/NuGet.Clients/NuGetConsole.Host.PowerShell/RunspaceManager.cs
+++ b/src/NuGet.Clients/NuGetConsole.Host.PowerShell/RunspaceManager.cs
@@ -37,7 +37,8 @@ namespace NuGetConsole.Host.PowerShell.Implementation
             Justification = "We can't dispose it if we want to return it.")]
         private static Tuple<RunspaceDispatcher, NuGetPSHost> CreateAndSetupRunspace(IConsole console, string hostName)
         {
-            return NuGetUIThreadHelper.JoinableTaskFactory.Run(async () => {
+            return NuGetUIThreadHelper.JoinableTaskFactory.Run(async () =>
+            {
                 Tuple<RunspaceDispatcher, NuGetPSHost> runspace = CreateRunspace(console, hostName);
                 await TaskScheduler.Default;
                 SetupExecutionPolicy(runspace.Item1);


### PR DESCRIPTION
## Fix

Details: [Issue#9988](https://github.com/NuGet/Home/issues/9988)
Child of https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1167790.
To goal is to figure out there is a quick win as far as assembly loading goes.

Most of assembly load comes from Powershell about 40MB, but actual Nuget is just 5MB.
Below line of code is loading Poweshell Dll, so I deferred this load until user start typing something or paste.
https://github.com/NuGet/NuGet.Client/blob/14fa722fbfeb9b485e86dac5c20e589de9138bf5/src/NuGet.Clients/NuGetConsole.Host.PowerShell/PowerShellHost.cs#L303

I installed Vsix into public instance of VS and did following measurement.

1. No solution loaded: **_25Mb(deferred Powershell)_**

           PMC not focused-386Mb,     PMC opened-404Mb,        PMC+Powershloaded-429Mb
   			               		              
            Here  18mb(PMC overhead) + 25Mb(deferred Powershell) =   43MB (Total memory difference due to PMC+powershell)

2. Vidly(simple MVC+EF6) solution loaded:  **_32Mb (deferred Powershell)_** 

           PMC not focused-691Mb ,     PMC opened-709Mb,        PMC+Powershloaded-741MB
    		        		
           Here 18Mb(PMC overhead)  +32Mb (deferred Powershell) =   50MB (Total memory difference due to PMC+powershell)

3. Orchard(90 projects) solution loaded:  **_52Mb (deferred Powershell)_** 

           PMC not focused-878Mb ,     PMC opened-905Mb,        PMC+Powershloaded-957MB
    		        		
           Here 27Mb(PMC overhead)  +52Mb (deferred Powershell) =   74MB (Total memory difference due to PMC+powershell)
 
Maybe my code change is not really ideal one since this is my first PR regarding UI of VS, but can be improved, please advise. 
## Testing/Validation

Tests Added: Yes/No  
Reason for not adding tests:  
Validation:  Manual testing on MVC application with EF6, I did migration on it. Not sure which other package uses powershell.
