### PR TITLE
Add metadata to filter MEF exports until needed

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/PackageReferenceAttachedCollectionSourceProvider.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/PackageReferenceAttachedCollectionSourceProvider.cs
@@ -14,6 +14,7 @@ using NuGet.VisualStudio.SolutionExplorer.Models;
 
 namespace NuGet.VisualStudio.SolutionExplorer
 {
+    [AppliesToProject(ProjectCapability.DependenciesTree)]
     [Export(typeof(IAttachedCollectionSourceProvider))]
     [Name(nameof(PackageReferenceAttachedCollectionSourceProvider))]
     [Order(Before = HierarchyItemsProviderNames.Contains)]

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/ProjectReferenceAttachedCollectionSourceProvider.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/ProjectReferenceAttachedCollectionSourceProvider.cs
@@ -14,6 +14,7 @@ using NuGet.VisualStudio.SolutionExplorer.Models;
 
 namespace NuGet.VisualStudio.SolutionExplorer
 {
+    [AppliesToProject(ProjectCapability.DependenciesTree)]
     [Export(typeof(IAttachedCollectionSourceProvider))]
     [Name(nameof(ProjectReferenceAttachedCollectionSourceProvider))]
     [Order(Before = HierarchyItemsProviderNames.Contains)]


### PR DESCRIPTION
Fixes https://github.com/NuGet/Home/issues/10044

Previously the import of `IAttachedCollectionSourceProvider` parts did not filter exports based on metadata. This meant that all exports were loaded, which resulted in DLLs such as `NuGet.Client` being loaded even when the dependencies tree was unused.

This filtering is now supported by Solution Explorer, and this commit adds the relevant condition to ensure DLLs are not loaded unnecessarily.