### PR TITLE
PM UI:  fix potential NullReferenceException

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/Cmdlets/InstallPackageCommand.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/Cmdlets/InstallPackageCommand.cs
@@ -13,7 +13,6 @@ using System.Text;
 using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.PackageManagement.Telemetry;
-using NuGet.PackageManagement.VisualStudio;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
 using NuGet.Packaging.Signing;
@@ -136,9 +135,12 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
                     Log(ex.AsLogMessage());
                 }
 
-                var logMessages = ex.Results.SelectMany(p => p.Issues).ToList();
+                if (ex.Results != null)
+                {
+                    var logMessages = ex.Results.SelectMany(p => p.Issues).ToList();
 
-                logMessages.ForEach(p => Log(ex.AsLogMessage()));
+                    logMessages.ForEach(p => Log(ex.AsLogMessage()));
+                }
             }
             catch (Exception ex)
             {
@@ -194,9 +196,12 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
                     Log(ex.AsLogMessage());
                 }
 
-                var logMessages = ex.Results.SelectMany(p => p.Issues).ToList();
+                if (ex.Results != null)
+                {
+                    var logMessages = ex.Results.SelectMany(p => p.Issues).ToList();
 
-                logMessages.ForEach(p => Log(p));
+                    logMessages.ForEach(p => Log(p));
+                }
             }
             catch (Exception ex)
             {

--- a/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/Cmdlets/UpdatePackageCommand.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/Cmdlets/UpdatePackageCommand.cs
@@ -9,12 +9,10 @@ using System.Management.Automation;
 using System.Threading.Tasks;
 using NuGet.Common;
 using NuGet.PackageManagement.Telemetry;
-using NuGet.PackageManagement.VisualStudio;
 using NuGet.Packaging.Core;
 using NuGet.Packaging.Signing;
 using NuGet.ProjectManagement;
 using NuGet.ProjectManagement.Projects;
-using NuGet.ProjectModel;
 using NuGet.Protocol.Core.Types;
 using NuGet.Resolver;
 using NuGet.Versioning;
@@ -215,9 +213,12 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
                     Log(ex.AsLogMessage());
                 }
 
-                var logMessages = ex.Results.SelectMany(p => p.Issues).ToList();
+                if (ex.Results != null)
+                {
+                    var logMessages = ex.Results.SelectMany(p => p.Issues).ToList();
 
-                logMessages.ForEach(p => Log(ex.AsLogMessage()));
+                    logMessages.ForEach(p => Log(ex.AsLogMessage()));
+                }
             }
             catch (Exception ex)
             {
@@ -262,9 +263,12 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
                     Log(ex.AsLogMessage());
                 }
 
-                var logMessages = ex.Results.SelectMany(p => p.Issues).ToList();
+                if (ex.Results != null)
+                {
+                    var logMessages = ex.Results.SelectMany(p => p.Issues).ToList();
 
-                logMessages.ForEach(p => Log(p));
+                    logMessages.ForEach(p => Log(p));
+                }
             }
             catch (Exception ex)
             {

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/UserInterfaceService/NuGetUI.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/UserInterfaceService/NuGetUI.cs
@@ -52,6 +52,17 @@ namespace NuGet.PackageManagement.UI
             DisplayDeprecatedFrameworkWindow = true;
         }
 
+        // For testing purposes only.
+        internal NuGetUI(
+            ICommonOperations commonOperations,
+            NuGetUIProjectContext projectContext,
+            INuGetUILogger logger,
+            NuGetUIContext uiContext)
+            : this(commonOperations, projectContext, logger)
+        {
+            UIContext = uiContext;
+        }
+
         public static async Task<NuGetUI> CreateAsync(
             ICommonOperations commonOperations,
             NuGetUIProjectContext projectContext,
@@ -406,6 +417,11 @@ namespace NuGet.PackageManagement.UI
             {
                 UILogger.ReportError(ex.AsLogMessage());
                 ProjectContext.Log(ex.AsLogMessage());
+            }
+
+            if (ex.Results is null)
+            {
+                return;
             }
 
             foreach (var result in ex.Results)

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreJob.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreJob.cs
@@ -472,18 +472,19 @@ namespace NuGet.SolutionRestoreManager
                 return;
             }
 
-            if (args.Exception is SignatureException)
+            if (args.Exception is SignatureException ex)
             {
                 _status = NuGetOperationStatus.Failed;
-
-                var ex = args.Exception as SignatureException;
 
                 if (!string.IsNullOrEmpty(ex.Message))
                 {
                     _logger.Log(ex.AsLogMessage());
                 }
 
-                ex.Results.SelectMany(p => p.Issues).ToList().ForEach(p => _logger.Log(p));
+                if (ex.Results != null)
+                {
+                    ex.Results.SelectMany(p => p.Issues).ToList().ForEach(p => _logger.Log(p));
+                }
 
                 return;
             }

--- a/src/NuGet.Core/NuGet.Build.Tasks/BuildTasksUtility.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/BuildTasksUtility.cs
@@ -599,7 +599,7 @@ namespace NuGet.Build.Tasks
                     }
                     else
                     {
-                        string message = String.Format(
+                        string message = string.Format(
                             Strings.Warning_InvalidPackageSaveMode,
                             v);
 
@@ -636,7 +636,7 @@ namespace NuGet.Build.Tasks
                 }
             }
 
-            return Enumerable.Empty<Packaging.PackageReference>();
+            return Enumerable.Empty<PackageReference>();
         }
 
         private static IEnumerable<RestoreLogMessage> ProcessFailedEventsIntoRestoreLogs(ConcurrentQueue<PackageRestoreFailedEventArgs> failedEvents)
@@ -645,16 +645,17 @@ namespace NuGet.Build.Tasks
 
             foreach (var failedEvent in failedEvents)
             {
-                if (failedEvent.Exception is SignatureException)
+                if (failedEvent.Exception is SignatureException signatureException)
                 {
-                    var signatureException = failedEvent.Exception as SignatureException;
+                    if (signatureException.Results != null)
+                    {
+                        IEnumerable<RestoreLogMessage> errorsAndWarnings = signatureException.Results
+                            .SelectMany(r => r.Issues)
+                            .Where(i => i.Level == LogLevel.Error || i.Level == LogLevel.Warning)
+                            .Select(i => i.AsRestoreLogMessage());
 
-                    var errorsAndWarnings = signatureException
-                        .Results.SelectMany(r => r.Issues)
-                        .Where(i => i.Level == LogLevel.Error || i.Level == LogLevel.Warning)
-                        .Select(i => i.AsRestoreLogMessage());
-
-                    result.AddRange(errorsAndWarnings);
+                        result.AddRange(errorsAndWarnings);
+                    }
                 }
                 else
                 {

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/NuGet.PackageManagement.UI.Test.csproj
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/NuGet.PackageManagement.UI.Test.csproj
@@ -54,6 +54,7 @@
     <Compile Include="TestPackageManagerProviders.cs" />
     <Compile Include="TestPackageSearchMetadata.cs" />
     <Compile Include="UserInterfaceService\NuGetUIContextTests.cs" />
+    <Compile Include="UserInterfaceService\NuGetUITests.cs" />
     <Compile Include="WpfFactAttribute.cs" />
     <Compile Include="WpfFactDiscoverer.cs" />
     <Compile Include="WpfTestCase.cs" />

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/UserInterfaceService/NuGetUITests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/UserInterfaceService/NuGetUITests.cs
@@ -1,0 +1,95 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using System.Threading;
+using Microsoft.ServiceHub.Framework;
+using Microsoft.VisualStudio.Threading;
+using Moq;
+using NuGet.Configuration;
+using NuGet.PackageManagement.VisualStudio;
+using NuGet.Packaging.Signing;
+using NuGet.ProjectManagement;
+using NuGet.Protocol.Core.Types;
+using NuGet.Test.Utility;
+using NuGet.VisualStudio;
+using Xunit;
+
+namespace NuGet.PackageManagement.UI.Test
+{
+    [Collection(MockedVS.Collection)]
+    public class NuGetUITests : IDisposable
+    {
+        private readonly JoinableTaskContext _joinableTaskContext;
+        private readonly TestDirectory _testDirectory;
+
+        public NuGetUITests()
+        {
+#pragma warning disable VSSDK005 // Avoid instantiating JoinableTaskContext
+            _joinableTaskContext = new JoinableTaskContext(Thread.CurrentThread, SynchronizationContext.Current);
+#pragma warning restore VSSDK005 // Avoid instantiating JoinableTaskContext
+
+            NuGetUIThreadHelper.SetCustomJoinableTaskFactory(_joinableTaskContext.Factory);
+
+            _testDirectory = TestDirectory.Create();
+        }
+
+        public void Dispose()
+        {
+            _joinableTaskContext?.Dispose();
+            _testDirectory.Dispose();
+        }
+
+        [Fact]
+        public void ShowError_WhenArgumentIsSignatureExceptionWithNullResults_DoesNotThrow()
+        {
+            var exception = new SignatureException(message: "a");
+
+            Assert.Null(exception.Results);
+
+            using (NuGetUI ui = CreateNuGetUI())
+            {
+                ui.ShowError(exception);
+            }
+        }
+
+        private NuGetUI CreateNuGetUI()
+        {
+            var uiContext = CreateNuGetUIContext();
+
+            return new NuGetUI(
+                Mock.Of<ICommonOperations>(),
+                new NuGetUIProjectContext(
+                    Mock.Of<ICommonOperations>(),
+                    Mock.Of<INuGetUILogger>(),
+                    Mock.Of<ISourceControlManagerProvider>()),
+                Mock.Of<INuGetUILogger>(),
+                uiContext);
+        }
+
+        private NuGetUIContext CreateNuGetUIContext()
+        {
+            var sourceRepositoryProvider = Mock.Of<ISourceRepositoryProvider>();
+            var packageManager = new NuGetPackageManager(
+                sourceRepositoryProvider,
+                Mock.Of<ISettings>(),
+                _testDirectory.Path);
+
+            return new NuGetUIContext(
+                sourceRepositoryProvider,
+                Mock.Of<IServiceBroker>(),
+                Mock.Of<IVsSolutionManager>(),
+                new NuGetSolutionManagerServiceWrapper(),
+                packageManager,
+                new UIActionEngine(
+                    sourceRepositoryProvider,
+                    packageManager,
+                    Mock.Of<INuGetLockService>()),
+                Mock.Of<IPackageRestoreManager>(),
+                Mock.Of<IOptionsPageActivator>(),
+                Mock.Of<IUserSettingsManager>(),
+                Enumerable.Empty<IVsPackageManagerProvider>());
+        }
+    }
+}


### PR DESCRIPTION
## Bug

Fixes:  https://github.com/NuGet/Home/issues/10042
Regression:  No

## Fix

Details: `SignatureException.Results` can be `null`.  Many places null check the property before using it; however, a few places didn't.  While following the repro for https://github.com/NuGet/Home/issues/10034, I hit a `NullReferenceException` [here](https://github.com/NuGet/NuGet.Client/blob/14fa722fbfeb9b485e86dac5c20e589de9138bf5/src/NuGet.Clients/NuGet.PackageManagement.UI/UserInterfaceService/NuGetUI.cs#L411).

While I was at it I found and fixed a few other places where `Results` was not null checked.

## Testing/Validation

Tests Added: Yes