### PR TITLE
Fix the race condition leading to an outdated version in PM UI when installing/update a package

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/NetCorePackageReferenceProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/NetCorePackageReferenceProject.cs
@@ -242,13 +242,15 @@ namespace NuGet.PackageManagement.VisualStudio
             PackageSpec lastPackageSpec = default;
             _lastPackageSpec?.TryGetTarget(out lastPackageSpec);
 
-            if (fileInfo.Exists && fileInfo.LastWriteTimeUtc > _lastTimeAssetsModified && !ReferenceEquals(lastPackageSpec, packageSpec))
+            if ((fileInfo.Exists && fileInfo.LastWriteTimeUtc > _lastTimeAssetsModified) || !ReferenceEquals(lastPackageSpec, packageSpec))
             {
                 await TaskScheduler.Default;
-                var lockFile = new LockFileFormat().Read(assetsFilePath);
-                assetsPackageSpec = lockFile.PackageSpec;
-                targets = lockFile.Targets;
-
+                if (fileInfo.Exists)
+                {
+                    var lockFile = new LockFileFormat().Read(assetsFilePath);
+                    assetsPackageSpec = lockFile.PackageSpec;
+                    targets = lockFile.Targets;
+                }
                 _lastTimeAssetsModified = fileInfo.LastWriteTimeUtc;
                 _lastPackageSpec = new WeakReference<PackageSpec>(packageSpec);
             }

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/NetCorePackageReferenceProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/NetCorePackageReferenceProject.cs
@@ -46,6 +46,7 @@ namespace NuGet.PackageManagement.VisualStudio
         private readonly UnconfiguredProject _unconfiguredProject;
         private List<(NuGetFramework, Dictionary<string, ProjectInstalledPackage>)> _installedPackages = new List<(NuGetFramework, Dictionary<string, ProjectInstalledPackage>)>();
         private DateTime _lastTimeAssetsModified;
+        private WeakReference<PackageSpec> _lastPackageSpec;
 
         public NetCorePackageReferenceProject(
             string projectName,
@@ -238,8 +239,10 @@ namespace NuGet.PackageManagement.VisualStudio
             var fileInfo = new FileInfo(assetsFilePath);
             PackageSpec assetsPackageSpec = default;
             IList<LockFileTarget> targets = default;
+            PackageSpec lastPackageSpec = default;
+            _lastPackageSpec?.TryGetTarget(out lastPackageSpec);
 
-            if (fileInfo.Exists && fileInfo.LastWriteTimeUtc > _lastTimeAssetsModified)
+            if (fileInfo.Exists && fileInfo.LastWriteTimeUtc > _lastTimeAssetsModified && !ReferenceEquals(lastPackageSpec, packageSpec))
             {
                 await TaskScheduler.Default;
                 var lockFile = new LockFileFormat().Read(assetsFilePath);
@@ -247,6 +250,7 @@ namespace NuGet.PackageManagement.VisualStudio
                 targets = lockFile.Targets;
 
                 _lastTimeAssetsModified = fileInfo.LastWriteTimeUtc;
+                _lastPackageSpec = new WeakReference<PackageSpec>(packageSpec);
             }
 
             return packageSpec


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9952
Regression: Yes 
* Last working version: 5.7
* How are we preventing it in future: We can't guarantee it won't happen, but we will have a test for this particular race condition

## Fix

Details: 

When determining which version should we displayed, we use the assets file and the package spec. The rest is always a combination of both. We do have a way if the assets file was changed last time, but we're not doing that for the package spec. 

## Testing/Validation

Tests Added: Yes  
Reason for not adding tests:  
Validation:  Manual
