### PR TITLE
Allow CI jobs to be rerunnable on PR (Private) builds

### DIFF
--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -265,14 +265,24 @@ jobs:
     condition: "and(succeeded(),eq(variables['BuildRTM'], 'true'))"
 
   - task: MSBuild@1
-    displayName: "Run unit tests"
+    displayName: "Run unit tests (stop on error)"
+    continueOnError: "false"
+    inputs:
+      solution: "build\\build.proj"
+      msbuildVersion: "16.0"
+      configuration: "$(BuildConfiguration)"
+      msbuildArguments: "/t:CoreUnitTests;UnitTestsVS /p:BuildRTM=$(BuildRTM) /p:BuildNumber=$(BuildNumber) /p:TestResultOutputFormat=xml /p:SkipILMergeOfNuGetExe=true"
+    condition: "and(succeeded(), eq(variables['BuildRTM'], 'true'), not(eq(variables['IsOfficialBuild'], 'true')))"
+
+  - task: MSBuild@1
+    displayName: "Run unit tests (continue on error)"
     continueOnError: "true"
     inputs:
       solution: "build\\build.proj"
       msbuildVersion: "16.0"
       configuration: "$(BuildConfiguration)"
       msbuildArguments: "/t:CoreUnitTests;UnitTestsVS /p:BuildRTM=$(BuildRTM) /p:BuildNumber=$(BuildNumber) /p:TestResultOutputFormat=xml /p:SkipILMergeOfNuGetExe=true"
-    condition: "and(succeeded(),eq(variables['BuildRTM'], 'true'))"
+    condition: "and(succeeded(), eq(variables['BuildRTM'], 'true'), eq(variables['IsOfficialBuild'], 'true'))"
 
   - task: PublishTestResults@2
     displayName: "Publish Test Results"
@@ -666,13 +676,24 @@ jobs:
       msbuildArguments: "/t:RestoreVS /p:BuildNumber=$(BuildNumber) /p:BuildRTM=false /v:m"
 
   - task: MSBuild@1
-    displayName: "Run Functional Tests"
+    displayName: "Run Functional Tests (continue on error)"
     continueOnError: "true"
     inputs:
       solution: "build\\build.proj"
       msbuildVersion: "16.0"
       configuration: "$(BuildConfiguration)"
       msbuildArguments: "/t:CoreFuncTests /p:BuildRTM=false /p:BuildNumber=$(BuildNumber) /p:TestResultOutputFormat=xml /p:SkipDesktopAssemblies=$(SkipDesktopAssemblies) /p:SkipCoreAssemblies=$(SkipCoreAssemblies)"
+    condition: "eq(variables['IsOfficialBuild'], 'true')"
+
+  - task: MSBuild@1
+    displayName: "Run Functional Tests (stop on error)"
+    continueOnError: "false"
+    inputs:
+      solution: "build\\build.proj"
+      msbuildVersion: "16.0"
+      configuration: "$(BuildConfiguration)"
+      msbuildArguments: "/t:CoreFuncTests /p:BuildRTM=false /p:BuildNumber=$(BuildNumber) /p:TestResultOutputFormat=xml /p:SkipDesktopAssemblies=$(SkipDesktopAssemblies) /p:SkipCoreAssemblies=$(SkipCoreAssemblies)"
+    condition: "not(eq(variables['IsOfficialBuild'], 'true'))"
 
   - task: PublishTestResults@2
     displayName: "Publish Test Results"
@@ -735,12 +756,22 @@ jobs:
     condition: "always()"
 
   - task: ShellScript@2
-    displayName: "Run Tests"
+    displayName: "Run Tests (continue on error)"
     continueOnError: "true"
     inputs:
       scriptPath: "scripts/funcTests/runFuncTests.sh"
       disableAutoCwd: "true"
       cwd: "$(Build.Repository.LocalPath)"
+    condition: "eq(variables['IsOfficialBuild'], 'true')"
+
+  - task: ShellScript@2
+    displayName: "Run Tests (stop on error)"
+    continueOnError: "false"
+    inputs:
+      scriptPath: "scripts/funcTests/runFuncTests.sh"
+      disableAutoCwd: "true"
+      cwd: "$(Build.Repository.LocalPath)"
+    condition: "not(eq(variables['IsOfficialBuild'], 'true'))"
 
   - task: PublishTestResults@2
     displayName: "Publish Test Results"
@@ -750,6 +781,7 @@ jobs:
       testRunTitle: "NuGet.Client Tests On Linux"
       searchFolder: "$(Build.Repository.LocalPath)/build/TestResults"
       mergeTestResults: "true"
+    condition: "succeededOrFailed()"
 
   - task: PowerShell@2
     displayName: "Initialize Git Commit Status on GitHub"
@@ -807,12 +839,22 @@ jobs:
       downloadPath: "$(Build.Repository.LocalPath)/artifacts"
 
   - task: ShellScript@2
-    displayName: "Run Tests"
+    displayName: "Run Tests (continue on error)"
     continueOnError: "true"
     inputs:
       scriptPath: "scripts/funcTests/runFuncTests.sh"
       disableAutoCwd: "true"
       cwd: "$(Build.Repository.LocalPath)"
+    condition: "eq(variables['IsOfficialBuild'], 'true')"
+
+  - task: ShellScript@2
+    displayName: "Run Tests (stop on error)"
+    continueOnError: "false"
+    inputs:
+      scriptPath: "scripts/funcTests/runFuncTests.sh"
+      disableAutoCwd: "true"
+      cwd: "$(Build.Repository.LocalPath)"
+    condition: "not(eq(variables['IsOfficialBuild'], 'true'))"
 
   - task: PublishTestResults@2
     displayName: "Publish Test Results"
@@ -911,12 +953,22 @@ jobs:
     condition: "failed()"
 
   - task: PowerShell@1
-    displayName: "RunFunctionalTests.ps1"
+    displayName: "RunFunctionalTests.ps1 (continue on error)"
     timeoutInMinutes: 75
     continueOnError: "true"
     inputs:
       scriptName: "$(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\RunFunctionalTests.ps1"
       arguments: "-PMCCommand $(EndToEndTestCommandToRun) -PMCLaunchWaitTimeInSecs 30 -EachTestTimoutInSecs 600 -NuGetDropPath $(System.DefaultWorkingDirectory)\\artifacts -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts -RunCounter $(Build.BuildNumber) -VSVersion 16.0"
+    condition: "eq(variables['IsOfficialBuild'], 'true')"
+
+  - task: PowerShell@1
+    displayName: "RunFunctionalTests.ps1 (stop on error)"
+    timeoutInMinutes: 75
+    continueOnError: "false"
+    inputs:
+      scriptName: "$(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\RunFunctionalTests.ps1"
+      arguments: "-PMCCommand $(EndToEndTestCommandToRun) -PMCLaunchWaitTimeInSecs 30 -EachTestTimoutInSecs 600 -NuGetDropPath $(System.DefaultWorkingDirectory)\\artifacts -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts -RunCounter $(Build.BuildNumber) -VSVersion 16.0"
+    condition: "not(eq(variables['IsOfficialBuild'], 'true'))"
 
   - task: PublishTestResults@2
     displayName: "Publish Test Results"
@@ -1055,7 +1107,7 @@ jobs:
       msbuildArguments: "/t:RestoreApex /p:BuildNumber=$(BuildNumber)"
 
   - task: MSBuild@1
-    displayName: "Run Apex Tests"
+    displayName: "Run Apex Tests (continue on error)"
     timeoutInMinutes: 45
     continueOnError: "true"
     inputs:
@@ -1063,6 +1115,18 @@ jobs:
       msbuildVersion: "16.0"
       configuration: "$(BuildConfiguration)"
       msbuildArguments: "/t:ApexTestsStandalone /p:TestResultOutputFormat=xml /p:BuildNumber=$(BuildNumber)"
+    condition: "eq(variables['IsOfficialBuild'], 'true')"
+
+  - task: MSBuild@1
+    displayName: "Run Apex Tests (stop on error)"
+    timeoutInMinutes: 45
+    continueOnError: "false"
+    inputs:
+      solution: "build\\build.proj"
+      msbuildVersion: "16.0"
+      configuration: "$(BuildConfiguration)"
+      msbuildArguments: "/t:ApexTestsStandalone /p:TestResultOutputFormat=xml /p:BuildNumber=$(BuildNumber)"
+    condition: "not(eq(variables['IsOfficialBuild'], 'true'))"
 
   - task: PublishTestResults@2
     displayName: "Publish Test Results"

--- a/test/EndToEnd/tests/FindPackageTest.ps1
+++ b/test/EndToEnd/tests/FindPackageTest.ps1
@@ -63,7 +63,10 @@ function Test-FindPackageByIdAndPrereleaseVersion {
 }
 
 function Test-FindPackageByIdExactMatch {
-    # Act 
+    [SkipTest('https://github.com/NuGet/Home/issues/10066')]
+    param()
+
+   # Act 
     $packages = Find-Package TestPackage.OverwriteTest -ExactMatch
     
     # Assert 


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Client.Engineering/issues/411
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: Duplicate every "run test" step. One of them is only used on official builds, and uses `continueOnError: true`, the other duplicate uses `continueOnError: false`, so that flaky tests cause the job to fail, and AzDO provides the "rerun failed jobs" button.

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  CI build script.
Validation:  
