### PR TITLE
VS OE:  add IProjectMetadataContextInfo formatter

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetProjectManagerService.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetProjectManagerService.cs
@@ -142,7 +142,7 @@ namespace NuGet.PackageManagement.VisualStudio
             return results.ToArray();
         }
 
-        public async ValueTask<ProjectMetadataContextInfo> GetMetadataAsync(string projectId, CancellationToken cancellationToken)
+        public async ValueTask<IProjectMetadataContextInfo> GetMetadataAsync(string projectId, CancellationToken cancellationToken)
         {
             Assumes.NotNullOrEmpty(projectId);
 

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/IProjectMetadataContextInfoFormatter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/IProjectMetadataContextInfoFormatter.cs
@@ -1,0 +1,151 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#nullable enable
+
+using MessagePack;
+using MessagePack.Formatters;
+using Microsoft;
+using NuGet.Frameworks;
+
+namespace NuGet.VisualStudio.Internal.Contracts
+{
+    internal sealed class IProjectMetadataContextInfoFormatter : IMessagePackFormatter<IProjectMetadataContextInfo?>
+    {
+        private const string FullPathPropertyName = "fullpath";
+        private const string NamePropertyName = "name";
+        private const string ProjectIdPropertyName = "projectid";
+        private const string SupportedFrameworksPropertyName = "supportedframeworks";
+        private const string TargetFrameworkPropertyName = "targetframework";
+        private const string UniqueNamePropertyName = "uniquename";
+
+        internal static readonly IMessagePackFormatter<IProjectMetadataContextInfo?> Instance = new IProjectMetadataContextInfoFormatter();
+
+        private IProjectMetadataContextInfoFormatter()
+        {
+        }
+
+        public IProjectMetadataContextInfo? Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
+        {
+            if (reader.TryReadNil())
+            {
+                return null;
+            }
+
+            // stack overflow mitigation - see https://github.com/neuecc/MessagePack-CSharp/security/advisories/GHSA-7q36-4xx7-xcxf
+            options.Security.DepthStep(ref reader);
+
+            try
+            {
+                string? fullPath = null;
+                string? name = null;
+                string? projectId = null;
+                NuGetFramework[]? supportedFrameworks = null;
+                NuGetFramework? targetFramework = null;
+                string? uniqueName = null;
+
+                int propertyCount = reader.ReadMapHeader();
+
+                for (var propertyIndex = 0; propertyIndex < propertyCount; ++propertyIndex)
+                {
+                    switch (reader.ReadString())
+                    {
+                        case FullPathPropertyName:
+                            fullPath = reader.ReadString();
+                            break;
+
+                        case NamePropertyName:
+                            name = reader.ReadString();
+                            break;
+
+                        case ProjectIdPropertyName:
+                            projectId = reader.ReadString();
+                            break;
+
+                        case SupportedFrameworksPropertyName:
+                            if (!reader.TryReadNil())
+                            {
+                                int elementCount = reader.ReadArrayHeader();
+                                supportedFrameworks = new NuGetFramework[elementCount];
+
+                                for (var i = 0; i < elementCount; ++i)
+                                {
+                                    NuGetFramework? framework = NuGetFrameworkFormatter.Instance.Deserialize(ref reader, options);
+
+                                    Assumes.NotNull(framework);
+
+                                    supportedFrameworks[i] = framework;
+                                }
+                            }
+                            break;
+
+                        case TargetFrameworkPropertyName:
+                            targetFramework = NuGetFrameworkFormatter.Instance.Deserialize(ref reader, options);
+                            break;
+
+                        case UniqueNamePropertyName:
+                            uniqueName = reader.ReadString();
+                            break;
+
+                        default:
+                            reader.Skip();
+                            break;
+                    }
+                }
+
+                return new ProjectMetadataContextInfo(fullPath, name, projectId, supportedFrameworks, targetFramework, uniqueName);
+            }
+            finally
+            {
+                // stack overflow mitigation - see https://github.com/neuecc/MessagePack-CSharp/security/advisories/GHSA-7q36-4xx7-xcxf
+                reader.Depth--;
+            }
+        }
+
+        public void Serialize(ref MessagePackWriter writer, IProjectMetadataContextInfo? value, MessagePackSerializerOptions options)
+        {
+            if (value == null)
+            {
+                writer.WriteNil();
+                return;
+            }
+
+            writer.WriteMapHeader(count: 6);
+            writer.Write(FullPathPropertyName);
+            writer.Write(value.FullPath);
+            writer.Write(NamePropertyName);
+            writer.Write(value.Name);
+            writer.Write(ProjectIdPropertyName);
+            writer.Write(value.ProjectId);
+            writer.Write(SupportedFrameworksPropertyName);
+
+            if (value.SupportedFrameworks is null)
+            {
+                writer.WriteNil();
+            }
+            else
+            {
+                writer.WriteArrayHeader(value.SupportedFrameworks.Count);
+
+                foreach (NuGetFramework framework in value.SupportedFrameworks)
+                {
+                    NuGetFrameworkFormatter.Instance.Serialize(ref writer, framework, options);
+                }
+            }
+
+            writer.Write(TargetFrameworkPropertyName);
+
+            if (value.TargetFramework is null)
+            {
+                writer.WriteNil();
+            }
+            else
+            {
+                NuGetFrameworkFormatter.Instance.Serialize(ref writer, value.TargetFramework, options);
+            }
+
+            writer.Write(UniqueNamePropertyName);
+            writer.Write(value.UniqueName);
+        }
+    }
+}

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/INuGetProjectManagerService.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/INuGetProjectManagerService.cs
@@ -22,7 +22,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
             string projectId,
             bool includeUnresolved,
             CancellationToken cancellationToken);
-        ValueTask<ProjectMetadataContextInfo> GetMetadataAsync(string projectId, CancellationToken cancellationToken);
+        ValueTask<IProjectMetadataContextInfo> GetMetadataAsync(string projectId, CancellationToken cancellationToken);
         ValueTask<IProjectContextInfo> GetProjectAsync(string projectId, CancellationToken cancellationToken);
         ValueTask<IReadOnlyCollection<IProjectContextInfo>> GetProjectsAsync(CancellationToken cancellationToken);
         ValueTask<(bool, string?)> TryGetInstalledPackageFilePathAsync(

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/NuGetServiceMessagePackRpcDescriptor.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/NuGetServiceMessagePackRpcDescriptor.cs
@@ -24,6 +24,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
                 FloatRangeFormatter.Instance,
                 IPackageReferenceContextInfoFormatter.Instance,
                 IProjectContextInfoFormatter.Instance,
+                IProjectMetadataContextInfoFormatter.Instance,
                 NuGetFrameworkFormatter.Instance,
                 NuGetVersionFormatter.Instance,
                 PackageDependencyFormatter.Instance,

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/ProjectMetadataContextInfo.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/ProjectMetadataContextInfo.cs
@@ -20,7 +20,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
         public NuGetFramework? TargetFramework { get; }
         public string? UniqueName { get; }
 
-        private ProjectMetadataContextInfo(
+        internal ProjectMetadataContextInfo(
             string? fullPath,
             string? name,
             string? projectId,

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTaskLogic.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTaskLogic.cs
@@ -488,7 +488,8 @@ namespace NuGet.Build.Tasks.Pack
             var nugetFrameworks = new HashSet<NuGetFramework>();
             if (request.TargetFrameworks != null)
             {
-                nugetFrameworks = new HashSet<NuGetFramework>(request.TargetFrameworks.Select(targetFramework => {
+                nugetFrameworks = new HashSet<NuGetFramework>(request.TargetFrameworks.Select(targetFramework =>
+                {
                     string translated = null;
                     var succeeded = aliases.TryGetValue(targetFramework, out translated);
                     if (succeeded)

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/Formatters/IProjectMetadataContextInfoFormatterTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/Formatters/IProjectMetadataContextInfoFormatterTests.cs
@@ -1,0 +1,57 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using NuGet.Frameworks;
+using Xunit;
+
+namespace NuGet.VisualStudio.Internal.Contracts.Test
+{
+    public class IProjectMetadataContextInfoFormatterTests : FormatterTests
+    {
+        [Theory]
+        [MemberData(nameof(IProjectMetadataContextInfos))]
+        public void SerializeThenDeserialize_WithValidArguments_RoundTrips(IProjectMetadataContextInfo expectedResult)
+        {
+            IProjectMetadataContextInfo actualResult = SerializeThenDeserialize(IProjectMetadataContextInfoFormatter.Instance, expectedResult);
+
+            Assert.Equal(expectedResult.FullPath, actualResult.FullPath);
+            Assert.Equal(expectedResult.Name, actualResult.Name);
+            Assert.Equal(expectedResult.ProjectId, actualResult.ProjectId);
+            Assert.Equal(expectedResult.SupportedFrameworks, actualResult.SupportedFrameworks);
+            Assert.Equal(expectedResult.TargetFramework, actualResult.TargetFramework);
+            Assert.Equal(expectedResult.UniqueName, actualResult.UniqueName);
+        }
+
+        public static TheoryData IProjectMetadataContextInfos => new TheoryData<IProjectMetadataContextInfo>
+            {
+                {
+                    new ProjectMetadataContextInfo(
+                        fullPath: null,
+                        name: null,
+                        projectId: null,
+                        supportedFrameworks: null,
+                        targetFramework: null,
+                        uniqueName: null)
+                },
+                {
+                    new ProjectMetadataContextInfo(
+                        fullPath: string.Empty,
+                        name: string.Empty,
+                        projectId: string.Empty,
+                        supportedFrameworks: Array.Empty<NuGetFramework>(),
+                        targetFramework: null,
+                        uniqueName: string.Empty)
+                },
+                {
+                    new ProjectMetadataContextInfo(
+                        fullPath: "a",
+                        name: "b",
+                        projectId: "c",
+                        supportedFrameworks: new[] { NuGetFramework.Parse("net472"), NuGetFramework.Parse("net48") },
+                        targetFramework: NuGetFramework.Parse("net50"),
+                        uniqueName: "d")
+                }
+            };
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Pack.Test/PackTaskLogicTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Pack.Test/PackTaskLogicTests.cs
@@ -740,12 +740,10 @@ namespace NuGet.Build.Tasks.Pack.Test
 
         private class TestContext
         {
-
             public TestContext(TestDirectory testDir)
                 : this(testDir, "net45")
-                {
-
-                }
+            {
+            }
 
             public TestContext(TestDirectory testDir, string tfm)
             {


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/10079
Regression: Yes  
* Last working version:   The dev build before https://github.com/NuGet/NuGet.Client/pull/3679 was merged.
* How are we preventing it in future:   Add tests

## Fix

Details:  Add a MessagePack formatter for serializing/deserializing the `IProjectMetadataContextInfo` type.

This PR also includes formatting changes to 2 files that had formatting errors introduced via https://github.com/NuGet/NuGet.Client/commit/0f052fe2fd6859a188cb4c7ecf198067e66e7856.  This was necessary to get a green private branch build.

## Testing/Validation

Tests Added: Yes
Validation:  Manually verified local and remote scenarios.
