### PR TITLE
warn on missing dots for net5.0+ TFMs

### DIFF
--- a/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
@@ -857,5 +857,10 @@ namespace NuGet.Common
         /// Undefined package warning
         /// </summary>
         NU5500 = 5500,
+
+        /// <summary>
+        /// InvalidUndottedFrameworkWarning
+        /// </summary>
+        NU5501 = 5501,
     }
 }

--- a/src/NuGet.Core/NuGet.Common/PublicAPI/net45/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Common/PublicAPI/net45/PublicAPI.Unshipped.txt
@@ -1,2 +1,3 @@
 NuGet.Common.NuGetLogCode.NU1010 = 1010 -> NuGet.Common.NuGetLogCode
 NuGet.Common.NuGetLogCode.NU1011 = 1011 -> NuGet.Common.NuGetLogCode
+NuGet.Common.NuGetLogCode.NU5501 = 5501 -> NuGet.Common.NuGetLogCode

--- a/src/NuGet.Core/NuGet.Common/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Common/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -1,3 +1,3 @@
 NuGet.Common.NuGetLogCode.NU1010 = 1010 -> NuGet.Common.NuGetLogCode
 NuGet.Common.NuGetLogCode.NU1011 = 1011 -> NuGet.Common.NuGetLogCode
-
+NuGet.Common.NuGetLogCode.NU5501 = 5501 -> NuGet.Common.NuGetLogCode

--- a/src/NuGet.Core/NuGet.Common/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Common/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,3 +1,3 @@
 NuGet.Common.NuGetLogCode.NU1010 = 1010 -> NuGet.Common.NuGetLogCode
 NuGet.Common.NuGetLogCode.NU1011 = 1011 -> NuGet.Common.NuGetLogCode
-
+NuGet.Common.NuGetLogCode.NU5501 = 5501 -> NuGet.Common.NuGetLogCode

--- a/src/NuGet.Core/NuGet.Packaging/ContentModel/ContentItemCollection.cs
+++ b/src/NuGet.Core/NuGet.Packaging/ContentModel/ContentItemCollection.cs
@@ -244,6 +244,10 @@ namespace NuGet.ContentModel
                 var hashCode = 0;
                 foreach (var property in obj.Properties)
                 {
+                    if (property.Key.EndsWith("_raw", StringComparison.OrdinalIgnoreCase))
+                    {
+                        continue;
+                    }
                     hashCode ^= property.Key.GetHashCode();
                     hashCode ^= property.Value.GetHashCode();
                 }
@@ -264,6 +268,12 @@ namespace NuGet.ContentModel
 
                 foreach (var xProperty in x.Properties)
                 {
+                    if (xProperty.Key.EndsWith("_raw", StringComparison.OrdinalIgnoreCase))
+                    {
+                        // We've started storing raw versions of each key, but
+                        // we don't want that to affect results.
+                        continue;
+                    }
                     object yValue;
                     if (!y.Properties.TryGetValue(xProperty.Key, out yValue))
                     {

--- a/src/NuGet.Core/NuGet.Packaging/ContentModel/Infrastructure/Parser.cs
+++ b/src/NuGet.Core/NuGet.Packaging/ContentModel/Infrastructure/Parser.cs
@@ -203,7 +203,7 @@ namespace NuGet.ContentModel.Infrastructure
                                     Path = path
                                 };
                             }
-
+                            item.Properties.Add(_token + "_raw", substring);
                             item.Properties.Add(_token, value);
                         }
                         endIndex = delimiterIndex;

--- a/src/NuGet.Core/NuGet.Packaging/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Packaging/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -1,0 +1,5 @@
+static NuGet.Packaging.Rules.AnalysisResources.InvalidUndottedFrameworkInDependencyGroupsWarning.get -> string
+static NuGet.Packaging.Rules.AnalysisResources.InvalidUndottedFrameworkInFilesWarning.get -> string
+static NuGet.Packaging.Rules.AnalysisResources.InvalidUndottedFrameworkInFrameworkAssemblyGroupsWarning.get -> string
+static NuGet.Packaging.Rules.AnalysisResources.InvalidUndottedFrameworkInReferenceGroupsWarning.get -> string
+static NuGet.Packaging.Rules.AnalysisResources.InvalidUndottedFrameworkWarning.get -> string

--- a/src/NuGet.Core/NuGet.Packaging/PublicAPI/netcoreapp5.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Packaging/PublicAPI/netcoreapp5.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,5 @@
+static NuGet.Packaging.Rules.AnalysisResources.InvalidUndottedFrameworkInDependencyGroupsWarning.get -> string
+static NuGet.Packaging.Rules.AnalysisResources.InvalidUndottedFrameworkInFilesWarning.get -> string
+static NuGet.Packaging.Rules.AnalysisResources.InvalidUndottedFrameworkInFrameworkAssemblyGroupsWarning.get -> string
+static NuGet.Packaging.Rules.AnalysisResources.InvalidUndottedFrameworkInReferenceGroupsWarning.get -> string
+static NuGet.Packaging.Rules.AnalysisResources.InvalidUndottedFrameworkWarning.get -> string

--- a/src/NuGet.Core/NuGet.Packaging/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Packaging/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,5 @@
+static NuGet.Packaging.Rules.AnalysisResources.InvalidUndottedFrameworkInDependencyGroupsWarning.get -> string
+static NuGet.Packaging.Rules.AnalysisResources.InvalidUndottedFrameworkInFilesWarning.get -> string
+static NuGet.Packaging.Rules.AnalysisResources.InvalidUndottedFrameworkInFrameworkAssemblyGroupsWarning.get -> string
+static NuGet.Packaging.Rules.AnalysisResources.InvalidUndottedFrameworkInReferenceGroupsWarning.get -> string
+static NuGet.Packaging.Rules.AnalysisResources.InvalidUndottedFrameworkWarning.get -> string

--- a/src/NuGet.Core/NuGet.Packaging/Rules/AnalysisResources.Designer.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Rules/AnalysisResources.Designer.cs
@@ -196,6 +196,51 @@ namespace NuGet.Packaging.Rules {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The following dependency group(s) require(s) dots in the framework version: {0}.
+        /// </summary>
+        public static string InvalidUndottedFrameworkInDependencyGroupsWarning {
+            get {
+                return ResourceManager.GetString("InvalidUndottedFrameworkInDependencyGroupsWarning", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The following packaged file folder(s) require(s) dots in the framework version: {0}.
+        /// </summary>
+        public static string InvalidUndottedFrameworkInFilesWarning {
+            get {
+                return ResourceManager.GetString("InvalidUndottedFrameworkInFilesWarning", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The following framework assembly group(s) require(s) dots in the framework version: {0}.
+        /// </summary>
+        public static string InvalidUndottedFrameworkInFrameworkAssemblyGroupsWarning {
+            get {
+                return ResourceManager.GetString("InvalidUndottedFrameworkInFrameworkAssemblyGroupsWarning", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The following reference group(s) require(s) dots in the framework version: {0}.
+        /// </summary>
+        public static string InvalidUndottedFrameworkInReferenceGroupsWarning {
+            get {
+                return ResourceManager.GetString("InvalidUndottedFrameworkInReferenceGroupsWarning", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to One or more target framework specifiers in your package are missing required dots in their framework version numbers. This is required as of .NET5.0. Please rename them to include dots as needed (e.g. &apos;net50&apos; to &apos;net5.0&apos;)..
+        /// </summary>
+        public static string InvalidUndottedFrameworkWarning {
+            get {
+                return ResourceManager.GetString("InvalidUndottedFrameworkWarning", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The package version &apos;{0}&apos; uses SemVer 2.0.0 or components of SemVer 1.0.0 that are not supported on legacy clients. Change the package version to a SemVer 1.0.0 string. If the version contains a release label it must start with a letter. This message can be ignored if the package is not intended for older clients..
         /// </summary>
         public static string LegacyVersionWarning {

--- a/src/NuGet.Core/NuGet.Packaging/Rules/AnalysisResources.resx
+++ b/src/NuGet.Core/NuGet.Packaging/Rules/AnalysisResources.resx
@@ -169,6 +169,25 @@
   <data name="InvalidPrereleaseDependencyWarning" xml:space="preserve">
     <value>A stable release of a package should not have a prerelease dependency. Either modify the version spec of dependency "{0}" or update the version field in the nuspec.</value>
   </data>
+  <data name="InvalidUndottedFrameworkInDependencyGroupsWarning" xml:space="preserve">
+    <value>The following dependency group(s) require(s) dots in the framework version: {0}</value>
+    <comment>0 - comma-separated list of target frameworks</comment>
+  </data>
+  <data name="InvalidUndottedFrameworkInFilesWarning" xml:space="preserve">
+    <value>The following packaged file folder(s) require(s) dots in the framework version: {0}</value>
+    <comment>0 - comma-separated list of paths</comment>
+  </data>
+  <data name="InvalidUndottedFrameworkInFrameworkAssemblyGroupsWarning" xml:space="preserve">
+    <value>The following framework assembly group(s) require(s) dots in the framework version: {0}</value>
+    <comment>0 - comma-separated list of target frameworks</comment>
+  </data>
+  <data name="InvalidUndottedFrameworkInReferenceGroupsWarning" xml:space="preserve">
+    <value>The following reference group(s) require(s) dots in the framework version: {0}</value>
+    <comment>0 - comma-separated list of target frameworks</comment>
+  </data>
+  <data name="InvalidUndottedFrameworkWarning" xml:space="preserve">
+    <value>One or more target framework specifiers in your package are missing required dots in their framework version numbers. This is required as of .NET5.0. Please rename them to include dots as needed (e.g. 'net50' to 'net5.0').</value>
+  </data>
   <data name="LegacyVersionWarning" xml:space="preserve">
     <value>The package version '{0}' uses SemVer 2.0.0 or components of SemVer 1.0.0 that are not supported on legacy clients. Change the package version to a SemVer 1.0.0 string. If the version contains a release label it must start with a letter. This message can be ignored if the package is not intended for older clients.</value>
   </data>

--- a/src/NuGet.Core/NuGet.Packaging/Rules/InvalidUndottedFrameworkRule.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Rules/InvalidUndottedFrameworkRule.cs
@@ -1,0 +1,296 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Xml;
+using System.Xml.Linq;
+using NuGet.Client;
+using NuGet.Common;
+using NuGet.ContentModel;
+using NuGet.Frameworks;
+using NuGet.Packaging.Core;
+using NuGet.RuntimeModel;
+
+namespace NuGet.Packaging.Rules
+{
+    internal class InvalidUndottedFrameworkRule : IPackageRule
+    {
+        private const string TargetFramework = "targetFramework";
+
+        private const string Metadata = "metadata";
+
+        private const string Dependencies = "dependencies";
+
+        private const string Group = "group";
+
+        private const string References = "references";
+
+        private const string FrameworkAssemblies = "frameworkAssemblies";
+
+        private const string FrameworkAssembly = "frameworkAssembly";
+
+        private static readonly char[] CommaArray = new char[] { ',' };
+
+        // NOTE: We generate many different messages here, so we avoid using MessageFormat itself.
+        public string MessageFormat => "";
+
+        public InvalidUndottedFrameworkRule()
+        {
+        }
+
+        public IEnumerable<PackagingLogMessage> Validate(PackageArchiveReader builder)
+        {
+            return Validate(LoadXml(builder.GetNuspec()), builder.GetFiles());
+        }
+
+        internal static IEnumerable<PackagingLogMessage> Validate(XDocument xml, IEnumerable<string> files)
+        {
+            // NOTE: Most of these validators are partially extracted from
+            // NuspecReader, because we need the raw framework strings, not
+            // the frameworks themselves. That does end up with a bit of
+            // duplicate code, but the alternative is to expand the scope of
+            // NuspecReader by a lot.
+            var metadataNode = xml.Root.Elements().Where(e => StringComparer.Ordinal.Equals(e.Name.LocalName, Metadata)).FirstOrDefault();
+            if (metadataNode == null)
+            {
+                throw new PackagingException(string.Format(
+                    CultureInfo.CurrentCulture,
+                    Strings.MissingMetadataNode,
+                    Metadata));
+            }
+
+            var logMessages = ValidateDependencyGroups(metadataNode)
+                .Concat(ValidateReferenceGroups(metadataNode))
+                .Concat(ValidateFrameworkAssemblies(xml, metadataNode))
+                .Concat(ValidateFiles(files));
+
+            if (logMessages.Any())
+            {
+                return logMessages.Concat(new List<PackagingLogMessage>()
+                {
+                    PackagingLogMessage.CreateWarning(string.Format(CultureInfo.CurrentCulture, AnalysisResources.InvalidUndottedFrameworkWarning), NuGetLogCode.NU5501)
+                });
+            }
+            else
+            {
+                return logMessages;
+            }
+        }
+
+        internal static IEnumerable<PackagingLogMessage> ValidateDependencyGroups(XElement metadataNode)
+        {
+            var ns = metadataNode.GetDefaultNamespace().NamespaceName;
+            var dependencyNode = metadataNode
+                .Elements(XName.Get(Dependencies, ns));
+
+            var dependencyGroups = dependencyNode
+                .Elements(XName.Get(Group, ns));
+
+            var bads = new HashSet<string>();
+            foreach (var depGroup in dependencyGroups)
+            {
+                var groupFramework = GetAttributeValue(depGroup, TargetFramework);
+                if (!string.IsNullOrEmpty(groupFramework) && !FrameworkVersionHasDesiredDots(groupFramework))
+                {
+                    bads.Add(groupFramework.Trim());
+                }
+            }
+
+            var messages = new List<PackagingLogMessage>();
+
+            if (bads.Any())
+            {
+                messages.Add(
+                    PackagingLogMessage.CreateWarning(
+                        string.Format(CultureInfo.CurrentCulture, AnalysisResources.InvalidUndottedFrameworkInDependencyGroupsWarning, string.Join(", ", bads)),
+                        NuGetLogCode.NU5501
+                    )
+                );
+            }
+
+            return messages;
+        }
+
+        internal static IEnumerable<PackagingLogMessage> ValidateReferenceGroups(XElement metadataNode)
+        {
+            var ns = metadataNode.GetDefaultNamespace().NamespaceName;
+
+            var bads = new HashSet<string>();
+            foreach (var group in metadataNode.Elements(XName.Get(References, ns)).Elements(XName.Get(Group, ns)))
+            {
+                var groupFramework = GetAttributeValue(group, TargetFramework);
+                if (!string.IsNullOrEmpty(groupFramework) && !FrameworkVersionHasDesiredDots(groupFramework))
+                {
+                    bads.Add(groupFramework.Trim());
+                }
+            }
+
+            var messages = new List<PackagingLogMessage>();
+
+            if (bads.Any())
+            {
+                messages.Add(
+                    PackagingLogMessage.CreateWarning(
+                        string.Format(CultureInfo.CurrentCulture, AnalysisResources.InvalidUndottedFrameworkInReferenceGroupsWarning, string.Join(", ", bads)),
+                        NuGetLogCode.NU5501
+                    )
+                );
+            }
+
+            return messages;
+        }
+
+        internal static IEnumerable<PackagingLogMessage> ValidateFrameworkAssemblies(XDocument xml, XElement metadataNode)
+        {
+            var ns = xml.Root.GetDefaultNamespace().NamespaceName;
+
+            var frameworks = new HashSet<string>();
+
+            foreach (var group in metadataNode.Elements(XName.Get(FrameworkAssemblies, ns)).Elements(XName.Get(FrameworkAssembly, ns))
+                .GroupBy(n => GetAttributeValue(n, TargetFramework)))
+            {
+                // Framework references may have multiple comma delimited frameworks
+                if (!string.IsNullOrEmpty(group.Key))
+                {
+                    foreach (var fwString in group.Key.Split(CommaArray, StringSplitOptions.RemoveEmptyEntries))
+                    {
+                        if (!string.IsNullOrEmpty(fwString))
+                        {
+                            frameworks.Add(fwString.Trim());
+                        }
+                    }
+                }
+            }
+
+            var bads = new HashSet<string>();
+            foreach (var framework in frameworks)
+            {
+                if (!string.IsNullOrEmpty(framework) && !FrameworkVersionHasDesiredDots(framework))
+                {
+                    bads.Add(framework);
+                }
+
+            }
+
+            var messages = new List<PackagingLogMessage>();
+
+            if (bads.Any())
+            {
+                messages.Add(
+                    PackagingLogMessage.CreateWarning(
+                        string.Format(CultureInfo.CurrentCulture, AnalysisResources.InvalidUndottedFrameworkInFrameworkAssemblyGroupsWarning, string.Join(", ", bads)),
+                        NuGetLogCode.NU5501
+                    )
+                );
+            }
+
+            return messages;
+        }
+
+        internal static IEnumerable<PackagingLogMessage> ValidateFiles(IEnumerable<string> files)
+        {
+            var set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var file in files.Select(t => PathUtility.GetPathWithDirectorySeparator(t)))
+            {
+                set.Add(file);
+            }
+
+            var managedCodeConventions = new ManagedCodeConventions(new RuntimeGraph());
+            var collection = new ContentItemCollection();
+            collection.Load(set.Select(path => path.Replace('\\', '/')).ToArray());
+
+            var patterns = managedCodeConventions.Patterns;
+
+            var frameworkPatterns = new List<PatternSet>()
+            {
+                patterns.RuntimeAssemblies,
+                patterns.CompileRefAssemblies,
+                patterns.CompileLibAssemblies,
+                patterns.NativeLibraries,
+                patterns.ResourceAssemblies,
+                patterns.MSBuildFiles,
+                patterns.ContentFiles,
+                patterns.ToolsAssemblies,
+                patterns.EmbedAssemblies,
+                patterns.MSBuildTransitiveFiles
+            };
+            var warnPaths = new HashSet<string>();
+
+            foreach (var pattern in frameworkPatterns)
+            {
+                IEnumerable<ContentItemGroup> targetedItemGroups = ContentExtractor.GetContentForPattern(collection, pattern);
+                foreach (ContentItemGroup group in targetedItemGroups)
+                {
+                    foreach (ContentItem item in group.Items)
+                    {
+                        var frameworkString = (string)item.Properties["tfm_raw"];
+                        if (string.IsNullOrEmpty(frameworkString))
+                        {
+                            continue;
+                        }
+
+                        if (!FrameworkVersionHasDesiredDots(frameworkString))
+                        {
+                            warnPaths.Add(item.Path);
+                        }
+                    }
+                }
+            }
+
+            var messages = new List<PackagingLogMessage>();
+
+            if (warnPaths.Count > 0)
+            {
+                messages.Add(
+                    PackagingLogMessage.CreateWarning(
+                        string.Format(CultureInfo.CurrentCulture, AnalysisResources.InvalidUndottedFrameworkInFilesWarning, string.Join(", ", warnPaths)),
+                        NuGetLogCode.NU5501
+                    )
+                );
+            }
+
+            return messages;
+        }
+
+        private static XDocument LoadXml(Stream stream)
+        {
+            using (var xmlReader = XmlReader.Create(stream, new XmlReaderSettings
+            {
+                CloseInput = true,
+                IgnoreWhitespace = true,
+                IgnoreComments = true,
+                IgnoreProcessingInstructions = true
+            }))
+            {
+                return XDocument.Load(xmlReader, LoadOptions.None);
+            }
+        }
+
+        private static string GetAttributeValue(XElement element, string attributeName)
+        {
+            var attribute = element.Attribute(XName.Get(attributeName));
+            return attribute?.Value;
+        }
+
+        internal static bool FrameworkVersionHasDesiredDots(string frameworkString)
+        {
+            var framework = NuGetFramework.Parse(frameworkString);
+            if (framework.Version.Major >= 5 &&
+                StringComparer.OrdinalIgnoreCase.Equals(FrameworkConstants.FrameworkIdentifiers.NetCoreApp, framework.Framework))
+            {
+                var dotIndex = frameworkString.IndexOf(".", StringComparison.Ordinal);
+                var dashIndex = frameworkString.IndexOf("-", StringComparison.Ordinal);
+                return (dashIndex > -1 && dotIndex > -1 && dotIndex < dashIndex) || (dashIndex == -1 && dotIndex > -1);
+            }
+            else
+            {
+                return true;
+            }
+        }
+    }
+}
+

--- a/src/NuGet.Core/NuGet.Packaging/Rules/RuleSet.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Rules/RuleSet.cs
@@ -8,7 +8,7 @@ namespace NuGet.Packaging.Rules
 {
     public static class RuleSet
     {
-        private static readonly ReadOnlyCollection<IPackageRule> _packageCreationRules = new ReadOnlyCollection<IPackageRule>(
+        private static readonly ReadOnlyCollection<IPackageRule> PackageCreationRules = new ReadOnlyCollection<IPackageRule>(
             new IPackageRule[] {
                 new InvalidFrameworkFolderRule(AnalysisResources.InvalidFrameworkWarning),
                 new MisplacedAssemblyUnderLibRule(AnalysisResources.AssemblyDirectlyUnderLibWarning),
@@ -29,11 +29,12 @@ namespace NuGet.Packaging.Rules
                 new DependenciesGroupsForEachTFMRule(),
                 new UpholdBuildConventionRule(),
                 new ReferencesInNuspecMatchRefAssetsRule(),
+                new InvalidUndottedFrameworkRule(),
                 new IconUrlDeprecationWarning(AnalysisResources.IconUrlDeprecationWarning),
             }
         );
 
-        private static readonly ReadOnlyCollection<IPackageRule> _packagesConfigToPackageReferenceMigrationRuleSet = new ReadOnlyCollection<IPackageRule>(
+        private static readonly ReadOnlyCollection<IPackageRule> PackagesConfigToPackageReferenceMigrationRules = new ReadOnlyCollection<IPackageRule>(
             new IPackageRule[] {
                 new MisplacedAssemblyUnderLibRule(AnalysisResources.Migrator_AssemblyDirectlyUnderLibWarning),
                 new InstallScriptInPackageReferenceProjectRule(AnalysisResources.Migrator_PackageHasInstallScript),
@@ -46,7 +47,7 @@ namespace NuGet.Packaging.Rules
         {
             get
             {
-                return _packageCreationRules;
+                return PackageCreationRules;
             }
         }
 
@@ -54,7 +55,7 @@ namespace NuGet.Packaging.Rules
         {
             get
             {
-                return _packagesConfigToPackageReferenceMigrationRuleSet;
+                return PackagesConfigToPackageReferenceMigrationRules;
             }
         }
     }

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/InvalidUndottedFrameworkRuleTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/InvalidUndottedFrameworkRuleTests.cs
@@ -1,0 +1,157 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Xml;
+using System.Xml.Linq;
+using NuGet.Commands;
+using NuGet.Common;
+using NuGet.Packaging.Rules;
+using NuGet.Test.Utility;
+using Xunit;
+
+namespace NuGet.Packaging.Test
+{
+    public class InvalidUndottedFrameworkRuleTests
+    {
+        [Theory]
+        [InlineData("net50", false)]
+        [InlineData("net5.0", true)]
+        [InlineData("net5.0-windows7.0", true)]
+        [InlineData("net50-windows7.0", false)]
+        [InlineData("net472", true)]
+        public void FrameworkVersionHasRequiredDots_UnitTest(string frameworkString, bool expected)
+        {
+            Assert.Equal(expected, InvalidUndottedFrameworkRule.FrameworkVersionHasDesiredDots(frameworkString));
+        }
+
+        [Theory]
+        [InlineData("net50", true)]
+        [InlineData("net50-windows", true)]
+        [InlineData("net50-windows7.0", true)]
+        [InlineData("net5.0", false)]
+        [InlineData("net5.0-windows", false)]
+        [InlineData("net472", false)]
+        [InlineData("netcoreapp3.1", false)]
+        public void ValidateDependencyGroups(string frameworkString, bool shouldWarn)
+        {
+            string xmlString = $@"
+            <?xml version=""1.0"" encoding=""utf-8""?>
+            <package>
+                <metadata>
+                    <dependencies>
+                        <group targetFramework=""{frameworkString}"">
+                            <dependency id=""Newtonsoft.Json"" version=""1.0.0"" />
+                        </group>
+                    </dependencies>
+                </metadata>
+            </package>
+            ".Trim();
+            XDocument xml = XDocument.Parse(xmlString);
+            XElement metadataNode = xml.Root.Elements().Where(e => StringComparer.Ordinal.Equals(e.Name.LocalName, "metadata")).FirstOrDefault();
+            var results = new List<PackagingLogMessage>(InvalidUndottedFrameworkRule.ValidateDependencyGroups(metadataNode));
+            if (shouldWarn)
+            {
+                Assert.True(results.Any());
+                Assert.Equal(NuGetLogCode.NU5501, results[0].Code);
+                Assert.True(results[0].Message.Contains(frameworkString));
+            }
+            else
+            {
+                Assert.False(results.Any());
+            }
+        }
+
+        [Theory]
+        [InlineData("net50", true)]
+        [InlineData("net50-windows", true)]
+        [InlineData("net50-windows7.0", true)]
+        [InlineData("net5.0", false)]
+        [InlineData("net5.0-windows", false)]
+        [InlineData("net472", false)]
+        [InlineData("netcoreapp3.1", false)]
+        public void ValidateReferenceGroups(string frameworkString, bool shouldWarn)
+        {
+            string xmlString = $@"
+            <?xml version=""1.0"" encoding=""utf-8""?>
+            <package>
+                <metadata>
+                    <references>
+                        <group targetFramework=""{frameworkString}"">
+                            <reference file=""foo.dll"" />
+                        </group>
+                    </references>
+                </metadata>
+            </package>
+            ".Trim();
+            XDocument xml = XDocument.Parse(xmlString);
+            XElement metadataNode = xml.Root.Elements().Where(e => StringComparer.Ordinal.Equals(e.Name.LocalName, "metadata")).FirstOrDefault();
+            var results = new List<PackagingLogMessage>(InvalidUndottedFrameworkRule.ValidateReferenceGroups(metadataNode));
+            if (shouldWarn)
+            {
+                Assert.True(results.Any());
+                Assert.Equal(NuGetLogCode.NU5501, results[0].Code);
+                Assert.True(results[0].Message.Contains(frameworkString));
+            }
+            else
+            {
+                Assert.False(results.Any());
+            }
+        }
+
+        [Theory]
+        [InlineData("net50", true)]
+        [InlineData("net50-windows", true)]
+        [InlineData("net50-windows7.0", true)]
+        [InlineData("net5.0,net50-windows7.0", true)]
+        [InlineData("net5.0", false)]
+        [InlineData("net5.0-windows", false)]
+        [InlineData("net472", false)]
+        [InlineData("netcoreapp3.1", false)]
+        public void ValidateFrameworkAssemblies(string frameworkString, bool shouldWarn)
+        {
+            string xmlString = $@"
+            <?xml version=""1.0"" encoding=""utf-8""?>
+            <package>
+                <metadata>
+                    <frameworkAssemblies>
+                        <frameworkAssembly assemblyName=""System.Net"" targetFramework=""{frameworkString}"" />
+                    </frameworkAssemblies>
+                </metadata>
+            </package>
+            ".Trim();
+            XDocument xml = XDocument.Parse(xmlString);
+            XElement metadataNode = xml.Root.Elements().Where(e => StringComparer.Ordinal.Equals(e.Name.LocalName, "metadata")).FirstOrDefault();
+            var results = new List<PackagingLogMessage>(InvalidUndottedFrameworkRule.ValidateFrameworkAssemblies(xml, metadataNode));
+            if (shouldWarn)
+            {
+                Assert.True(results.Any());
+                Assert.Equal(NuGetLogCode.NU5501, results[0].Code);
+            }
+            else
+            {
+                Assert.False(results.Any());
+            }
+        }
+
+        [Fact]
+        public void ValidateFiles()
+        {
+            var files = new string[]
+            {
+                "lib/net472/a.dll",
+                "contentFiles/any/net50/b.csv",
+                "lib/net5.0/c.pdb",
+                "lib/net50-windows7.0/d.dll",
+            };
+            var results = new List<PackagingLogMessage>(InvalidUndottedFrameworkRule.ValidateFiles(files));
+            Assert.Equal(1, results.Count());
+            Assert.Equal(NuGetLogCode.NU5501, results[0].Code);
+            Assert.True(results[0].Message.Contains("contentFiles/any/net50/b.csv"));
+            Assert.True(results[0].Message.Contains("lib/net50-windows7.0/d.dll"));
+        }
+    }
+}


### PR DESCRIPTION
## Bug

Fixes: https://github.com/nuget/home/issues/9215
Regression:No  
* How are we preventing it in future:   tests added

## Fix

This makes it so we warn when a user uses something like `net50` instead of `net5.0`. We want customers to start getting used to (and will eventually enforce) including dots in .NET version numbers.

## Testing/Validation

Tests Added: Yes
