### PR TITLE
Rearrange tasks in Build_and_UnitTest, to make mac/e2e/apex tests depend on nonRTM only, and start earlier

### DIFF
--- a/build/templates/Build_and_UnitTest.yml
+++ b/build/templates/Build_and_UnitTest.yml
@@ -228,7 +228,7 @@ steps:
     solution: "build\\build.proj"
     msbuildVersion: "16.0"
     configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/t:BuildVSIX /p:BuildRTM=$(BuildRTM) /p:ExcludeTestProjects=$(BuildRTM) /p:IsCIBuild=true"
+    msbuildArguments: "/t:BuildVSIX /p:BuildRTM=$(BuildRTM) /p:ExcludeTestProjects=$(BuildRTM) /p:IsCIBuild=$(IsOfficialBuild)"
   condition: "and(succeeded(),eq(variables['BuildRTM'], 'false'))"
 
 - task: MSBuild@1

--- a/build/templates/Build_and_UnitTest.yml
+++ b/build/templates/Build_and_UnitTest.yml
@@ -253,13 +253,13 @@ steps:
   inputs:
     command: "custom"
     arguments: "verify -Signatures $(Build.Repository.LocalPath)\\artifacts\\$(NupkgOutputDir)\\*.nupkg"
-  contidion: or(eq(variables['IsOfficialBuild'], 'true'), eq(variables['BuildRTM'], 'true'))  #skip this task for nonRTM in private build
+  condition: or(eq(variables['IsOfficialBuild'], 'true'), eq(variables['BuildRTM'], 'true'))  #skip this task for nonRTM in private build
 
 - task: ms-vseng.MicroBuildShipTasks.7c429315-71ba-4cb3-94bb-f829c95f7915.MicroBuildCodesignVerify@1
   displayName: Verify Assembly Signatures and StrongName for the nupkgs
   inputs:
     TargetFolder: '$(Build.Repository.LocalPath)\\artifacts\\$(NupkgOutputDir)'
-  contidion: or(eq(variables['IsOfficialBuild'], 'true'), eq(variables['BuildRTM'], 'true'))  #skip this task for nonRTM in private build
+  condition: or(eq(variables['IsOfficialBuild'], 'true'), eq(variables['BuildRTM'], 'true'))  #skip this task for nonRTM in private build
 
 - task: ms-vseng.MicroBuildShipTasks.7c429315-71ba-4cb3-94bb-f829c95f7915.MicroBuildCodesignVerify@1
   displayName: Verify Assembly Signatures and StrongName for the VSIX & exes
@@ -267,7 +267,7 @@ steps:
     TargetFolder: '$(Build.Repository.LocalPath)\\artifacts\\$(VsixPublishDir)'
     WhiteListPathForCerts: '$(Build.Repository.LocalPath)\\build\\ignorecodesign.csv'
     WhiteListPathForSigs: '$(Build.Repository.LocalPath)\\build\\ignorecodesign.csv'
-  contidion: or(eq(variables['IsOfficialBuild'], 'true'), eq(variables['BuildRTM'], 'true'))  #skip this task for nonRTM in private build
+  condition: or(eq(variables['IsOfficialBuild'], 'true'), eq(variables['BuildRTM'], 'true'))  #skip this task for nonRTM in private build
 
 - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
   displayName: 'Component Detection'

--- a/build/templates/Build_and_UnitTest.yml
+++ b/build/templates/Build_and_UnitTest.yml
@@ -152,7 +152,7 @@ steps:
     msbuildVersion: "16.0"
     configuration: "$(BuildConfiguration)"
     msbuildArguments: "/t:CopyFinalNuGetExeToOutputPath"
-  condition: "or(and(succeeded(),eq(variables['BuildRTM'], 'true')), and(succeeded(),eq(variables['BuildRTM'], 'false'),not(eq(variables['IsOfficialBuild'], 'true'))))"   #for private build, run this task for nonRTM instead of RTM
+  condition: "and(succeeded(),eq(variables['BuildRTM'], 'false'))"
 
 - task: MSBuild@1
   displayName: "Run unit tests (stop on error)"
@@ -201,7 +201,7 @@ steps:
     PathtoPublish: "$(Build.Repository.LocalPath)\\test\\NuGet.Clients.Tests\\NuGet.CommandLine.Test\\bin\\$(BuildConfiguration)\\net472"
     ArtifactName: "NuGet.CommandLine.Test"
     ArtifactType: "Container"
-  condition: "or(and(succeeded(),eq(variables['BuildRTM'], 'true')), and(succeeded(),eq(variables['BuildRTM'], 'false'),not(eq(variables['IsOfficialBuild'], 'true'))))"  #for private build, run this task for nonRTM instead of RTM
+  condition: "and(succeeded(),eq(variables['BuildRTM'], 'false'))"
 
 - task: MSBuild@1
   displayName: "Sign Assemblies"
@@ -277,6 +277,7 @@ steps:
     SourceFolder: "artifacts\\$(NupkgOutputDir)"
     Contents: "*.nupkg"
     TargetFolder: "$(BuildOutputTargetPath)\\artifacts\\$(VsixPublishDir)\\$(NupkgOutputDir)"
+  condition: or(eq(variables['IsOfficialBuild'], 'true'), eq(variables['BuildRTM'], 'true'))  #skip this task for nonRTM in private build
 
 - task: MSBuild@1
   displayName: "Generate VSMAN file for NuGet Core VSIX"

--- a/build/templates/Build_and_UnitTest.yml
+++ b/build/templates/Build_and_UnitTest.yml
@@ -67,6 +67,7 @@ steps:
     signType: "$(SigningType)"
     esrpSigning: "true"
   displayName: "Install Signing Plugin"
+  condition: or(eq(variables['IsOfficialBuild'], 'true'), eq(variables['BuildRTM'], 'true'))  #skip this task for nonRTM in private build
 
 - task: MicroBuildSwixPlugin@1
   displayName: "Install Swix Plugin"
@@ -210,6 +211,7 @@ steps:
     msbuildVersion: "16.0"
     configuration: "$(BuildConfiguration)"
     msbuildArguments: "/t:AfterBuild"
+  condition: or(eq(variables['IsOfficialBuild'], 'true'), eq(variables['BuildRTM'], 'true'))  #skip this task for nonRTM in private build
 
 - task: MSBuild@1
   displayName: "Pack Nupkgs"
@@ -245,6 +247,7 @@ steps:
     msbuildVersion: "16.0"
     configuration: "$(BuildConfiguration)"
     msbuildArguments: "/t:AfterBuild /p:SignPackages=true"
+  condition: or(eq(variables['IsOfficialBuild'], 'true'), eq(variables['BuildRTM'], 'true'))  #skip this task for nonRTM in private build
 
 - task: NuGetCommand@2
   displayName: "Verify Nupkg Signatures"

--- a/build/templates/Build_and_UnitTest.yml
+++ b/build/templates/Build_and_UnitTest.yml
@@ -1,0 +1,499 @@
+steps:
+- task: PowerShell@1
+  inputs:
+    scriptName: "$(Build.Repository.LocalPath)\\scripts\\utils\\InstallCLIforBuild.ps1"
+    arguments: '$(SDKVersionForBuild)'
+  displayName: "Install .NET 5.0 for build"
+
+- task: PowerShell@1
+  displayName: "Update Build Number"
+  inputs:
+    scriptType: "inlineScript"
+    inlineScript: |
+      Write-Host "##vso[build.updatebuildnumber]$env:FullVstsBuildNumber"
+      Get-ChildItem Env: | Sort-Object Name | Format-Table -Wrap -AutoSize
+
+- task: PowerShell@1
+  displayName: "Define variables"
+  inputs:
+    scriptType: "inlineScript"
+    inlineScript: |
+      Write-Host "##vso[task.setvariable variable=Path]${env:AGENT_TEMPDIRECTORY}\dotnet\;${env:Path}"
+
+- task: NuGetToolInstaller@0
+  displayName: "Use NuGet 5.0.0"
+  inputs:
+    versionSpec: "5.0.0"
+
+- task: PowerShell@1
+  inputs:
+    scriptName: "$(Build.Repository.LocalPath)\\configure.ps1"
+    arguments: "-Force"
+  displayName: "Run Configure.ps1"
+
+- task: PowerShell@1
+  inputs:
+    scriptName: "$(Build.Repository.LocalPath)\\scripts\\cibuild\\ConfigureVstsBuild.ps1"
+    arguments: "-BuildCounterFile $(BuildCounterFile) -BuildInfoJsonFile $(BuildInfoJsonFile) -BuildRTM $(BuildRTM) -SkipUpdateBuildNumber"
+  displayName: "Configure VSTS CI Environment"
+
+- task: PublishBuildArtifacts@1
+  displayName: 'Publish buildinfo.json as an artifact'
+  inputs:
+    ArtifactName: 'BuildInfo'
+    ArtifactType: 'Container'
+    PathToPublish: '$(Build.Repository.LocalPath)\artifacts\buildinfo.json'
+  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
+
+- task: PowerShell@1
+  displayName: "Print Environment Variables"
+  inputs:
+    scriptType: "inlineScript"
+    inlineScript: |
+      Get-ChildItem Env: | Sort-Object Name | Format-Table -Wrap -AutoSize
+
+- task: NuGetCommand@2
+  displayName: 'MicroBuild:  install core package'
+  inputs:
+    command: 'custom'
+    arguments: 'install Microsoft.VisualStudioEng.MicroBuild.Core -Version 0.4.1 -ConfigFile $(System.DefaultWorkingDirectory)\NuGet.config -OutputDirectory $(System.DefaultWorkingDirectory)\packages'
+  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
+
+- task: MicroBuildLocalizationPlugin@1
+  displayName: "Install Localization Plugin"
+
+- task: MicroBuildSigningPlugin@1
+  inputs:
+    signType: "$(SigningType)"
+    esrpSigning: "true"
+  displayName: "Install Signing Plugin"
+
+- task: MicroBuildSwixPlugin@1
+  displayName: "Install Swix Plugin"
+
+- task: ms-vseng.MicroBuildTasks.965C8DC6-1483-45C9-B384-5AC75DA1F1A4.MicroBuildOptProfPlugin@4
+  displayName: 'OptProfV2:  install the plugin'
+  inputs:
+    getDropNameByDrop: true
+    optimizationInputsDropNamePrefix: OptimizationInputs/$(System.TeamProject)/$(Build.Repository.Name)
+  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
+
+- task: PowerShell@1
+  displayName: "Restore dotnet tools"
+  inputs:
+    scriptType: "inlineScript"
+    inlineScript: |
+      dotnet tool restore
+  condition: "not(eq(variables['IsOfficialBuild'], 'true'))"
+
+- task: PowerShell@1
+  displayName: "Check source file format"
+  inputs:
+    scriptType: "inlineScript"
+    inlineScript: |
+      dotnet format --check --exclude submodules --verbosity diagnostic
+  condition: "and(succeeded(), not(eq(variables['IsOfficialBuild'], 'true')))"
+
+- task: MSBuild@1
+  displayName: "Restore for VS2019"
+  inputs:
+    solution: "build\\build.proj"
+    msbuildVersion: "16.0"
+    configuration: "$(BuildConfiguration)"
+    msbuildArguments: "/t:RestoreVS /p:BuildNumber=$(BuildNumber) /p:BuildRTM=$(BuildRTM) /v:m"
+
+- task: MSBuild@1
+  displayName: "Build for VS2019"
+  inputs:
+    solution: "build\\build.proj"
+    msbuildVersion: "16.0"
+    configuration: "$(BuildConfiguration)"
+    msbuildArguments: "/t:BuildNoVSIX /p:BuildRTM=$(BuildRTM) /p:BuildNumber=$(BuildNumber) /p:SkipILMergeOfNuGetExe=true"
+
+- task: MSBuild@1
+  displayName: "Ensure msbuild.exe can parse nuget.sln"
+  continueOnError: "false"
+  inputs:
+    solution: "nuget.sln"
+    msbuildVersion: "16.0"
+    msbuildArguments: "/t:EnsureNewtonsoftJsonVersion"
+  condition: "succeeded()"
+
+- task: MSBuild@1
+  displayName: "Ensure package versions are declared in packages.targets"
+  continueOnError: "false"
+  inputs:
+    solution: "build\\build.proj"
+    msbuildVersion: "16.0"
+    msbuildArguments: "/t:EnsurePackageReferenceVersionsInSolution"
+  condition: "succeeded()"
+
+
+- task: MSBuild@1
+  displayName: "Localize Assemblies"
+  inputs:
+    solution: "build\\loc.proj"
+    msbuildVersion: "16.0"
+    configuration: "$(BuildConfiguration)"
+    msbuildArguments: "/t:AfterBuild"
+
+- task: MSBuild@1
+  displayName: "Build Final NuGet.exe (via ILMerge)"
+  inputs:
+    solution: "src\\NuGet.Clients\\NuGet.CommandLine\\NuGet.CommandLine.csproj"
+    msbuildVersion: "16.0"
+    configuration: "$(BuildConfiguration)"
+    msbuildArguments: "/t:ILMergeNuGetExe /p:ExpectedLocalizedArtifactCount=$(LocalizedLanguageCount)"
+
+- task: MSBuild@1
+  displayName: "Publish NuGet.exe (ILMerged) into NuGet.CommandLine.Test (Mac tests use this)"
+  inputs:
+    solution: "test\\NuGet.Clients.Tests\\NuGet.CommandLine.Test\\NuGet.CommandLine.Test.csproj"
+    msbuildVersion: "16.0"
+    configuration: "$(BuildConfiguration)"
+    msbuildArguments: "/t:CopyFinalNuGetExeToOutputPath"
+  condition: "and(succeeded(),eq(variables['BuildRTM'], 'true'))"
+
+- task: MSBuild@1
+  displayName: "Run unit tests (stop on error)"
+  continueOnError: "false"
+  inputs:
+    solution: "build\\build.proj"
+    msbuildVersion: "16.0"
+    configuration: "$(BuildConfiguration)"
+    msbuildArguments: "/t:CoreUnitTests;UnitTestsVS /p:BuildRTM=$(BuildRTM) /p:BuildNumber=$(BuildNumber) /p:TestResultOutputFormat=xml /p:SkipILMergeOfNuGetExe=true"
+  condition: "and(succeeded(), eq(variables['BuildRTM'], 'true'), not(eq(variables['IsOfficialBuild'], 'true')))"
+
+- task: MSBuild@1
+  displayName: "Run unit tests (continue on error)"
+  continueOnError: "true"
+  inputs:
+    solution: "build\\build.proj"
+    msbuildVersion: "16.0"
+    configuration: "$(BuildConfiguration)"
+    msbuildArguments: "/t:CoreUnitTests;UnitTestsVS /p:BuildRTM=$(BuildRTM) /p:BuildNumber=$(BuildNumber) /p:TestResultOutputFormat=xml /p:SkipILMergeOfNuGetExe=true"
+  condition: "and(succeeded(), eq(variables['BuildRTM'], 'true'), eq(variables['IsOfficialBuild'], 'true'))"
+
+- task: PublishTestResults@2
+  displayName: "Publish Test Results"
+  inputs:
+    testRunner: "XUnit"
+    testResultsFiles: "*.xml"
+    testRunTitle: "NuGet.Client Unit Tests On Windows"
+    searchFolder: "$(Build.Repository.LocalPath)\\build\\TestResults"
+    mergeTestResults: "true"
+    publishRunAttachments: "false"
+  condition: "and(succeededOrFailed(),eq(variables['BuildRTM'], 'true'))"
+
+- task: PowerShell@1
+  displayName: "Initialize Git Commit Status on GitHub"
+  inputs:
+    scriptType: "inlineScript"
+    arguments: "-VstsPersonalAccessToken $(VstsPersonalAccessToken)"
+    inlineScript: |
+      . $(Build.Repository.LocalPath)\\scripts\\utils\\PostGitCommitStatus.ps1
+      SetCommitStatusForTestResult -PersonalAccessToken $(NuGetLurkerPersonalAccessToken) -VstsPersonalAccessToken $(VstsPersonalAccessToken) -CommitSha $(Build.SourceVersion) -TestName "Unit Tests On Windows"
+  condition: "and(always(),eq(variables['BuildRTM'], 'true'))"
+
+- task: PublishBuildArtifacts@1
+  displayName: "Publish NuGet.CommandLine.Test as artifact"
+  inputs:
+    PathtoPublish: "$(Build.Repository.LocalPath)\\test\\NuGet.Clients.Tests\\NuGet.CommandLine.Test\\bin\\$(BuildConfiguration)\\net472"
+    ArtifactName: "NuGet.CommandLine.Test"
+    ArtifactType: "Container"
+  condition: "and(succeeded(),eq(variables['BuildRTM'], 'true'))"
+
+- task: MSBuild@1
+  displayName: "Sign Assemblies"
+  inputs:
+    solution: "build\\sign.proj"
+    msbuildVersion: "16.0"
+    configuration: "$(BuildConfiguration)"
+    msbuildArguments: "/t:AfterBuild"
+
+- task: MSBuild@1
+  displayName: "Pack Nupkgs"
+  inputs:
+    solution: "build\\build.proj"
+    msbuildVersion: "16.0"
+    configuration: "$(BuildConfiguration)"
+    msbuildArguments: "/t:Pack /p:BuildRTM=$(BuildRTM) /p:ExcludeTestProjects=$(BuildRTM) /p:BuildNumber=$(BuildNumber)"
+
+- task: MSBuild@1
+  displayName: "Pack VSIX"
+  inputs:
+    solution: "build\\build.proj"
+    msbuildVersion: "16.0"
+    configuration: "$(BuildConfiguration)"
+    msbuildArguments: "/t:BuildVSIX /p:BuildRTM=$(BuildRTM) /p:ExcludeTestProjects=$(BuildRTM) /p:IsCIBuild=true"
+  condition: "and(succeeded(),eq(variables['BuildRTM'], 'false'))"
+
+- task: MSBuild@1
+  displayName: "Generate Build Tools package"
+  inputs:
+    solution: "setup/Microsoft.VisualStudio.NuGet.BuildTools.vsmanproj"
+    msbuildVersion: "16.0"
+    configuration: "$(BuildConfiguration)"
+    msbuildArguments: "/p:BuildNumber=$(BuildNumber) /p:IsVsixBuild=true"
+  condition: " and(succeeded(), eq(variables['BuildRTM'], 'false'))"
+
+- task: MSBuild@1
+  displayName: "Sign Nupkgs and VSIX"
+  inputs:
+    solution: "build\\sign.proj"
+    msbuildVersion: "16.0"
+    configuration: "$(BuildConfiguration)"
+    msbuildArguments: "/t:AfterBuild /p:SignPackages=true"
+
+- task: NuGetCommand@2
+  displayName: "Verify Nupkg Signatures"
+  inputs:
+    command: "custom"
+    arguments: "verify -Signatures $(Build.Repository.LocalPath)\\artifacts\\$(NupkgOutputDir)\\*.nupkg"
+
+- task: ms-vseng.MicroBuildShipTasks.7c429315-71ba-4cb3-94bb-f829c95f7915.MicroBuildCodesignVerify@1
+  displayName: Verify Assembly Signatures and StrongName for the nupkgs
+  inputs:
+    TargetFolder: '$(Build.Repository.LocalPath)\\artifacts\\$(NupkgOutputDir)'
+
+- task: ms-vseng.MicroBuildShipTasks.7c429315-71ba-4cb3-94bb-f829c95f7915.MicroBuildCodesignVerify@1
+  displayName: Verify Assembly Signatures and StrongName for the VSIX & exes
+  inputs:
+    TargetFolder: '$(Build.Repository.LocalPath)\\artifacts\\$(VsixPublishDir)'
+    WhiteListPathForCerts: '$(Build.Repository.LocalPath)\\build\\ignorecodesign.csv'
+    WhiteListPathForSigs: '$(Build.Repository.LocalPath)\\build\\ignorecodesign.csv'
+
+- task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
+  displayName: 'Component Detection'
+  condition: "and(succeeded(),eq(variables['BuildRTM'], 'true'))"
+
+- task: CopyFiles@2
+  displayName: "Copy Nupkgs"
+  inputs:
+    SourceFolder: "artifacts\\$(NupkgOutputDir)"
+    Contents: "*.nupkg"
+    TargetFolder: "$(BuildOutputTargetPath)\\artifacts\\$(VsixPublishDir)\\$(NupkgOutputDir)"
+
+- task: MSBuild@1
+  displayName: "Generate VSMAN file for NuGet Core VSIX"
+  inputs:
+    solution: "setup\\Microsoft.VisualStudio.NuGet.Core.vsmanproj"
+    msbuildVersion: "16.0"
+    configuration: "$(BuildConfiguration)"
+  condition: " and(succeeded(),eq(variables['BuildRTM'], 'false')) "
+
+- task: MSBuild@1
+  displayName: "Generate VSMAN file for Build Tools VSIX"
+  inputs:
+    solution: "setup\\Microsoft.VisualStudio.NuGet.BuildTools.vsmanproj"
+    msbuildVersion: "16.0"
+    configuration: "$(BuildConfiguration)"
+  condition: " and(succeeded(),eq(variables['BuildRTM'], 'false')) "
+
+- task: PowerShell@1
+  displayName: "Create EndToEnd Test Package"
+  inputs:
+    scriptName: "$(Build.Repository.LocalPath)\\scripts\\cibuild\\CreateEndToEndTestPackage.ps1"
+    arguments: "-c $(BuildConfiguration) -tv 16 -out $(Build.Repository.LocalPath)\\artifacts\\$(VsixPublishDir)"
+    failOnStandardError: "true"
+  condition: " and(succeeded(),eq(variables['BuildRTM'], 'false')) "
+
+- task: CopyFiles@2
+  displayName: "Copy NuGet.exe, VSIX and EndToEnd"
+  inputs:
+    SourceFolder: "artifacts"
+    Contents: |
+      $(VsixPublishDir)\\NuGet.exe
+      $(VsixPublishDir)\\NuGet.pdb
+      $(VsixPublishDir)\\NuGet.Mssign.exe
+      $(VsixPublishDir)\\NuGet.Mssign.pdb
+      $(VsixPublishDir)\\Microsoft.VisualStudio.NuGet.Core.json
+      $(VsixPublishDir)\\NuGet.Tools.vsix
+      $(VsixPublishDir)\\Microsoft.VisualStudio.NuGet.BuildTools.vsix
+      $(VsixPublishDir)\\Microsoft.VisualStudio.NuGet.BuildTools.json
+      $(VsixPublishDir)\\EndToEnd.zip
+    TargetFolder: "$(BuildOutputTargetPath)\\artifacts"
+
+- task: NuGetCommand@2
+  displayName: 'OptProfV2:  add the NuGet package source'
+  inputs:
+    command: 'custom'
+    arguments: 'sources add -Name VS -Source $(VsPackageFeedUrl) -UserName $(VsPackageFeedUsername) -Password $(VsPackageFeedPassword) -ConfigFile $(System.DefaultWorkingDirectory)\NuGet.config'
+  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
+
+- task: NuGetCommand@2
+  displayName: 'OptProfV2:  install the NuGet package for building .runsettingsproj file'
+  inputs:
+    command: 'custom'
+    arguments: 'install Microsoft.DevDiv.Validation.TestPlatform.Settings.Tasks -Version 1.0.308 -Source $(VsPackageFeedUrl) -ConfigFile $(System.DefaultWorkingDirectory)\NuGet.config -OutputDirectory $(System.DefaultWorkingDirectory)\packages'
+  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
+
+- task: ms-vseng.MicroBuildTasks.0e9d0d4d-71ec-4e4e-ae40-db9896f1ae74.MicroBuildBuildVSBootstrapper@2
+  displayName: 'OptProfV2:  build a Visual Studio bootstrapper'
+  inputs:
+    channelName: "$(VsTargetChannel)"
+    vsMajorVersion: "$(VsTargetMajorVersion)"
+    manifests: '$(Build.Repository.LocalPath)\artifacts\$(VsixPublishDir)\Microsoft.VisualStudio.NuGet.Core.vsman'
+    outputFolder: '$(Build.Repository.LocalPath)\artifacts\$(VsixPublishDir)'
+  continueOnError: true
+  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
+
+- task: PublishBuildArtifacts@1
+  displayName: 'OptProfV2:  publish BootstrapperInfo.json as a build artifact'
+  inputs:
+    PathtoPublish: $(Build.StagingDirectory)\MicroBuild\Output
+    ArtifactName: MicroBuildOutputs
+    ArtifactType: Container
+  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
+
+- task: PowerShell@1
+  displayName: 'OptProfV2:  set the TestDrop environment variable'
+  inputs:
+    scriptType: 'inlineScript'
+    inlineScript: |
+      [string] $bootstrapperInfoFilePath = "$Env:BUILD_STAGINGDIRECTORY\MicroBuild\Output\BootstrapperInfo.json"
+      $json = Get-Content $bootstrapperInfoFilePath | ConvertFrom-Json
+      [string] $buildDropPath = $json.BuildDrop
+      Write-Host "Build drop:  $buildDropPath"
+      [string] $testDropPath = $buildDropPath.Replace('/Products/', '/Tests/').Substring('https://vsdrop.corp.microsoft.com/file/v1/'.Length)
+      Write-Host "Test drop:  $testDropPath"
+      Write-Host "##vso[task.setvariable variable=TestDrop]$testDropPath"
+  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
+
+- task: MSBuild@1
+  displayName: 'OptProfV2:  generate a .runsettings file'
+  inputs:
+    solution: 'build\NuGet.OptProfV2.runsettingsproj'
+    msbuildVersion: '16.0'
+    msbuildArguments: '/p:OutputPath="$(Build.Repository.LocalPath)\artifacts\RunSettings" /p:TestDrop="$(TestDrop)" /p:ProfilingInputsDrop="ProfilingInputs/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildId)"'
+  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
+
+- task: ms-vscs-artifact.build-tasks.artifactDropTask-1.artifactDropTask@0
+  displayName: 'OptProfV2:  publish the .runsettings file to artifact services'
+  inputs:
+    dropServiceURI: 'https://devdiv.artifacts.visualstudio.com'
+    buildNumber: 'RunSettings/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildId)'
+    sourcePath: 'artifacts\RunSettings'
+    toLowerCase: false
+    usePat: false
+    dropMetadataContainerName: RunSettings
+  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
+
+- task: ms-vscs-artifact.build-tasks.artifactDropTask-1.artifactDropTask@0
+  displayName: 'OptProfV2:  publish profiling inputs to artifact services'
+  inputs:
+    dropServiceURI: 'https://devdiv.artifacts.visualstudio.com'
+    buildNumber: 'ProfilingInputs/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildId)'
+    sourcePath: '$(Build.ArtifactStagingDirectory)\OptProf\ProfilingInputs'
+    toLowerCase: false
+    usePat: false
+  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
+
+- task: PublishBuildArtifacts@1
+  displayName: "Publish NuGet.exe VSIX and EndToEnd.zip as artifact"
+  inputs:
+    PathtoPublish: "$(Build.Repository.LocalPath)\\artifacts\\$(VsixPublishDir)"
+    ArtifactName: "$(VsixPublishDir)"
+    ArtifactType: "Container"
+  condition: "and(succeeded(),eq(variables['BuildRTM'], 'false'))"
+
+- task: CopyFiles@2
+  displayName: "Copy LCG Files"
+  inputs:
+    SourceFolder: "artifacts\\"
+    Contents: "**\\*.lcg"
+    TargetFolder: "$(CIRoot)\\PLOC\\$(Build.SourceBranchName)\\$(Build.BuildNumber)"
+  condition: " and(succeeded(),eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true')) "
+
+- task: PowerShell@1
+  displayName: "Publish Artifacts to MyGet"
+  continueOnError: "true"
+  inputs:
+    scriptName: "$(Build.Repository.LocalPath)\\scripts\\cibuild\\PublishArtifactsFromVsts.ps1"
+    arguments: "-NuGetBuildFeedUrl $(NuGetBuildFeed) -NuGetBuildSymbolsFeedUrl $(NuGetBuildSymbolsFeed) -DotnetCoreFeedUrl $(DotnetCoreBuildFeed) -DotnetCoreSymbolsFeedUrl $(DotnetCoreSymbolsFeed) -NuGetBuildFeedApiKey $(NuGetBuildApiKey) -DotnetCoreFeedApiKey $(DotnetCoreFeedApiKey)"
+    failOnStandardError: "true"
+  condition: " and(succeeded(),eq(variables['PublishArtifactsToMyGet'], 'true'), eq(variables['BuildRTM'], 'false')) "
+
+- task: MSBuild@1
+  displayName: "Collect Build Symbols"
+  inputs:
+    solution: "build\\symbols.proj"
+    msbuildVersion: "16.0"
+    configuration: "$(BuildConfiguration)"
+    msbuildArguments: "/p:IsSymbolBuild=true"
+  condition: " and(succeeded(),eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true')) "
+
+- task: CopyFiles@2
+  displayName: "Copy Symbols"
+  inputs:
+    SourceFolder: "$(Build.Repository.LocalPath)\\artifacts\\symbolstoindex"
+    Contents: "**\\*"
+    TargetFolder: "$(BuildOutputTargetPath)\\symbols"
+  condition: " and(succeeded(),eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true')) "
+
+- task: ms-vscs-artifact.build-tasks.artifactSymbolTask-1.artifactSymbolTask@0
+  displayName: "Publish Symbols on Symweb"
+  inputs:
+    symbolServiceURI: "https://microsoft.artifacts.visualstudio.com/DefaultCollection"
+    requestName: "CollectionId/$(System.CollectionId)/ProjectId/$(System.TeamProjectId)/$(TeamName)/BuildId/$(Build.BuildId)"
+    sourcePath: "$(Build.Repository.LocalPath)\\artifacts\\symbolstoindex"
+    detailedLog: "true"
+    expirationInDays: "45"
+    usePat: "false"
+  condition: " and(succeeded(),eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true')) "
+
+- task: MicroBuildUploadVstsDropFolder@1
+  displayName: "Upload VSTS Drop"
+  inputs:
+    DropFolder: "$(Build.Repository.LocalPath)\\artifacts\\$(VsixPublishDir)"
+  condition: " and(succeeded(),eq(variables['BuildRTM'], 'false')) "
+
+- task: PowerShell@1
+  displayName: "LocValidation: Verify VSIX"
+  inputs:
+    scriptName: "$(Build.Repository.LocalPath)\\scripts\\cibuild\\BuildValidator.ps1"
+    arguments: "-BuildRTM $(BuildRTM) -RepoRoot $(Build.Repository.LocalPath) -OutputLogsBasePath $(Build.Repository.LocalPath)\\logs -TmpPath $(Agent.TempDirectory) -ValidateVsix"
+  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
+
+- task: PowerShell@1
+  displayName: "LocValidation: Verify Artifacts"
+  inputs:
+    scriptName: "$(Build.Repository.LocalPath)\\scripts\\cibuild\\BuildValidator.ps1"
+    arguments: "-BuildRTM $(BuildRTM) -RepoRoot $(Build.Repository.LocalPath) -OutputLogsBasePath $(Build.Repository.LocalPath)\\logs"
+  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
+
+- task: PublishPipelineArtifact@1
+  displayName: "LocValidation: Publish Logs as an artifact"
+  inputs:
+    artifactName: LocValidationLogs
+    targetPath: "$(Build.Repository.LocalPath)\\logs\\LocalizationValidation"
+  condition: "eq(variables['BuildRTM'], 'false')"
+
+  # Use dotnet msbuild instead of MSBuild CLI.
+  # Using MSBuild CLI results in an assembly binding failure for NuGet.Common.dll 4.4.0.3 because Microsoft.DotNet.Build.Tasks.Feed.dll references SleetLib.dll which references NuGet.Common 4.4.0.3.
+  # The Microsoft.DotNet.Build.Tasks.Feed package includes NuGet.Common 4.9.0.6 and a binding redirection in Microsoft.DotNet.Build.Tasks.Feed.dll.config but the binding redirection is not processed.
+  # This would probably solve it:  https://github.com/Microsoft/msbuild/issues/1309
+- task: CmdLine@2
+  displayName: "Publish to the .NET Core build asset registry (BAR)"
+  inputs:
+    script: dotnet msbuild $(Build.Repository.LocalPath)\build\publish.proj /t:PublishToBuildAssetRegistry /p:NuGetClientNupkgsDirectoryPath=$(Build.Repository.LocalPath)\artifacts\$(NupkgOutputDir) /p:BUILD_BUILDNUMBER=$(Build.BuildNumber) /p:BUILD_SOURCEBRANCH=$(Build.SourceBranchName) /p:BUILD_SOURCEVERSION=$(Build.SourceVersion) /p:BUILD_REPOSITORY_URI=$(Build.Repository.Uri) /p:ArtifactsLogDir=$(Build.Repository.LocalPath)\artifacts\manifests\ /p:MaestroApiEndpoint=$(MaestroApiEndpoint) /p:MaestroAccessToken=$(MaestroAccessToken)
+    workingDirectory: cli
+    failOnStderr: true
+  env:
+    DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+    DOTNET_MULTILEVEL_LOOKUP: true
+  condition: " and(succeeded(),eq(variables['PublishArtifactsToDotNetBuildAssetRegistry'], 'true'), eq(variables['BuildRTM'], 'false')) "
+
+- task: MicroBuildCleanup@1
+  displayName: "Perform Cleanup Tasks"
+
+- task: PowerShell@1
+  displayName: "Cleanup on Failure"
+  inputs:
+    scriptType: "inlineScript"
+    arguments: "-BuildOutputTargetPath $(BuildOutputTargetPath)"
+    inlineScript: |
+      param([string]$BuildOutputTargetPath)
+      Get-ChildItem $(BuildOutputTargetPath) -Recurse | Remove-Item -Force -Recurse -ErrorAction SilentlyContinue
+      Remove-Item -Path $(BuildOutputTargetPath) -Force -Recurse -ErrorAction SilentlyContinue
+  condition: "eq(variables['Agent.JobStatus'], 'Failed')"

--- a/build/templates/Build_and_UnitTest.yml
+++ b/build/templates/Build_and_UnitTest.yml
@@ -61,6 +61,7 @@ steps:
 
 - task: MicroBuildLocalizationPlugin@1
   displayName: "Install Localization Plugin"
+  condition: or(eq(variables['IsOfficialBuild'], 'true'), eq(variables['BuildRTM'], 'true'))  #skip this task for nonRTM in private build
 
 - task: MicroBuildSigningPlugin@1
   inputs:
@@ -84,7 +85,7 @@ steps:
     scriptType: "inlineScript"
     inlineScript: |
       dotnet tool restore
-  condition: "not(eq(variables['IsOfficialBuild'], 'true'))"
+  condition: "and(not(eq(variables['IsOfficialBuild'], 'true')), eq(variables['BuildRTM'], 'true'))"   #skip this task for nonRTM in private build
 
 - task: PowerShell@1
   displayName: "Check source file format"
@@ -92,7 +93,7 @@ steps:
     scriptType: "inlineScript"
     inlineScript: |
       dotnet format --check --exclude submodules --verbosity diagnostic
-  condition: "and(succeeded(), not(eq(variables['IsOfficialBuild'], 'true')))"
+  condition: "and(succeeded(), not(eq(variables['IsOfficialBuild'], 'true')), eq(variables['BuildRTM'], 'true'))"   #skip this task for nonRTM in private build
 
 - task: MSBuild@1
   displayName: "Restore for VS2019"
@@ -117,7 +118,7 @@ steps:
     solution: "nuget.sln"
     msbuildVersion: "16.0"
     msbuildArguments: "/t:EnsureNewtonsoftJsonVersion"
-  condition: "succeeded()"
+  condition: "and(succeeded(), or(eq(variables['IsOfficialBuild'], 'true'), eq(variables['BuildRTM'], 'true')))"  #skip this task for nonRTM in private build
 
 - task: MSBuild@1
   displayName: "Ensure package versions are declared in packages.targets"
@@ -126,7 +127,7 @@ steps:
     solution: "build\\build.proj"
     msbuildVersion: "16.0"
     msbuildArguments: "/t:EnsurePackageReferenceVersionsInSolution"
-  condition: "succeeded()"
+  condition: "and(succeeded(), or(eq(variables['IsOfficialBuild'], 'true'), eq(variables['BuildRTM'], 'true')))"  #skip this task for nonRTM in private build
 
 
 - task: MSBuild@1
@@ -136,6 +137,7 @@ steps:
     msbuildVersion: "16.0"
     configuration: "$(BuildConfiguration)"
     msbuildArguments: "/t:AfterBuild"
+  condition: or(eq(variables['IsOfficialBuild'], 'true'), eq(variables['BuildRTM'], 'true'))  #skip this task for nonRTM in private build
 
 - task: MSBuild@1
   displayName: "Build Final NuGet.exe (via ILMerge)"
@@ -152,7 +154,7 @@ steps:
     msbuildVersion: "16.0"
     configuration: "$(BuildConfiguration)"
     msbuildArguments: "/t:CopyFinalNuGetExeToOutputPath"
-  condition: "and(succeeded(),eq(variables['BuildRTM'], 'true'))"
+  condition: "or(and(succeeded(),eq(variables['BuildRTM'], 'true')), and(succeeded(),eq(variables['BuildRTM'], 'false'),not(eq(variables['IsOfficialBuild'], 'true'))))"   #for private build, run this task for nonRTM instead of RTM
 
 - task: MSBuild@1
   displayName: "Run unit tests (stop on error)"
@@ -201,7 +203,7 @@ steps:
     PathtoPublish: "$(Build.Repository.LocalPath)\\test\\NuGet.Clients.Tests\\NuGet.CommandLine.Test\\bin\\$(BuildConfiguration)\\net472"
     ArtifactName: "NuGet.CommandLine.Test"
     ArtifactType: "Container"
-  condition: "and(succeeded(),eq(variables['BuildRTM'], 'true'))"
+  condition: "or(and(succeeded(),eq(variables['BuildRTM'], 'true')), and(succeeded(),eq(variables['BuildRTM'], 'false'),not(eq(variables['IsOfficialBuild'], 'true'))))"  #for private build, run this task for nonRTM instead of RTM
 
 - task: MSBuild@1
   displayName: "Sign Assemblies"
@@ -218,6 +220,7 @@ steps:
     msbuildVersion: "16.0"
     configuration: "$(BuildConfiguration)"
     msbuildArguments: "/t:Pack /p:BuildRTM=$(BuildRTM) /p:ExcludeTestProjects=$(BuildRTM) /p:BuildNumber=$(BuildNumber)"
+  condition: or(eq(variables['IsOfficialBuild'], 'true'), eq(variables['BuildRTM'], 'true'))  #skip this task for nonRTM in private build
 
 - task: MSBuild@1
   displayName: "Pack VSIX"
@@ -250,11 +253,13 @@ steps:
   inputs:
     command: "custom"
     arguments: "verify -Signatures $(Build.Repository.LocalPath)\\artifacts\\$(NupkgOutputDir)\\*.nupkg"
+  contidion: or(eq(variables['IsOfficialBuild'], 'true'), eq(variables['BuildRTM'], 'true'))  #skip this task for nonRTM in private build
 
 - task: ms-vseng.MicroBuildShipTasks.7c429315-71ba-4cb3-94bb-f829c95f7915.MicroBuildCodesignVerify@1
   displayName: Verify Assembly Signatures and StrongName for the nupkgs
   inputs:
     TargetFolder: '$(Build.Repository.LocalPath)\\artifacts\\$(NupkgOutputDir)'
+  contidion: or(eq(variables['IsOfficialBuild'], 'true'), eq(variables['BuildRTM'], 'true'))  #skip this task for nonRTM in private build
 
 - task: ms-vseng.MicroBuildShipTasks.7c429315-71ba-4cb3-94bb-f829c95f7915.MicroBuildCodesignVerify@1
   displayName: Verify Assembly Signatures and StrongName for the VSIX & exes
@@ -262,6 +267,7 @@ steps:
     TargetFolder: '$(Build.Repository.LocalPath)\\artifacts\\$(VsixPublishDir)'
     WhiteListPathForCerts: '$(Build.Repository.LocalPath)\\build\\ignorecodesign.csv'
     WhiteListPathForSigs: '$(Build.Repository.LocalPath)\\build\\ignorecodesign.csv'
+  contidion: or(eq(variables['IsOfficialBuild'], 'true'), eq(variables['BuildRTM'], 'true'))  #skip this task for nonRTM in private build
 
 - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
   displayName: 'Component Detection'

--- a/build/templates/Build_and_UnitTest.yml
+++ b/build/templates/Build_and_UnitTest.yml
@@ -61,7 +61,6 @@ steps:
 
 - task: MicroBuildLocalizationPlugin@1
   displayName: "Install Localization Plugin"
-  condition: or(eq(variables['IsOfficialBuild'], 'true'), eq(variables['BuildRTM'], 'true'))  #skip this task for nonRTM in private build
 
 - task: MicroBuildSigningPlugin@1
   inputs:
@@ -137,7 +136,6 @@ steps:
     msbuildVersion: "16.0"
     configuration: "$(BuildConfiguration)"
     msbuildArguments: "/t:AfterBuild"
-  condition: or(eq(variables['IsOfficialBuild'], 'true'), eq(variables['BuildRTM'], 'true'))  #skip this task for nonRTM in private build
 
 - task: MSBuild@1
   displayName: "Build Final NuGet.exe (via ILMerge)"
@@ -228,7 +226,7 @@ steps:
     solution: "build\\build.proj"
     msbuildVersion: "16.0"
     configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/t:BuildVSIX /p:BuildRTM=$(BuildRTM) /p:ExcludeTestProjects=$(BuildRTM) /p:IsCIBuild=$(IsOfficialBuild)"
+    msbuildArguments: "/t:BuildVSIX /p:BuildRTM=$(BuildRTM) /p:ExcludeTestProjects=$(BuildRTM) /p:IsCIBuild=true"
   condition: "and(succeeded(),eq(variables['BuildRTM'], 'false'))"
 
 - task: MSBuild@1

--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -85,7 +85,7 @@ jobs:
         Write-Host "##vso[build.addbuildtag]${env:BUILD_SOURCEVERSIONAUTHOR}"
         Write-Host "##vso[build.addbuildtag]${env:BUILD_SOURCEBRANCHNAME}"
 
-- job: Build_and_UnitTest
+- job: Build_and_UnitTest_RTM
   dependsOn: Initialize_Build
   timeoutInMinutes: 170
   variables:
@@ -95,518 +95,37 @@ jobs:
     VsTargetMajorVersion: $[dependencies.Initialize_Build.outputs['updatebuildnumber.VsTargetMajorVersion']]
     SDKVersionForBuild: $[dependencies.Initialize_Build.outputs['getSDKVersionForBuild.SDKVersionForBuild']]
     LocalizedLanguageCount: "13"
+    BuildRTM: "true"
 
   pool:
     name: VSEng-MicroBuildVS2019
     demands:
       - DotNetFramework
       - msbuild
-  strategy:
-    matrix:
-      RTM:
-        BuildRTM: "true"
-      NonRTM:
-        BuildRTM: "false"
 
   steps:
-  - task: PowerShell@1
-    inputs:
-      scriptName: "$(Build.Repository.LocalPath)\\scripts\\utils\\InstallCLIforBuild.ps1"
-      arguments: '$(SDKVersionForBuild)'
-    displayName: "Install .NET 5.0 for build"
+  - template: templates/Build_and_UnitTest.yml  
 
-  - task: PowerShell@1
-    displayName: "Update Build Number"
-    inputs:
-      scriptType: "inlineScript"
-      inlineScript: |
-        Write-Host "##vso[build.updatebuildnumber]$env:FullVstsBuildNumber"
-        Get-ChildItem Env: | Sort-Object Name | Format-Table -Wrap -AutoSize
+- job: Build_and_UnitTest_NonRTM
+  dependsOn: Initialize_Build
+  timeoutInMinutes: 170
+  variables:
+    BuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.BuildNumber']]
+    FullVstsBuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
+    VsTargetChannel: $[dependencies.Initialize_Build.outputs['updatebuildnumber.VsTargetChannel']]
+    VsTargetMajorVersion: $[dependencies.Initialize_Build.outputs['updatebuildnumber.VsTargetMajorVersion']]
+    SDKVersionForBuild: $[dependencies.Initialize_Build.outputs['getSDKVersionForBuild.SDKVersionForBuild']]
+    LocalizedLanguageCount: "13"
+    BuildRTM: "false"
 
-  - task: PowerShell@1
-    displayName: "Define variables"
-    inputs:
-      scriptType: "inlineScript"
-      inlineScript: |
-        Write-Host "##vso[task.setvariable variable=Path]${env:AGENT_TEMPDIRECTORY}\dotnet\;${env:Path}"
+  pool:
+    name: VSEng-MicroBuildVS2019
+    demands:
+      - DotNetFramework
+      - msbuild
 
-  - task: NuGetToolInstaller@0
-    displayName: "Use NuGet 5.0.0"
-    inputs:
-      versionSpec: "5.0.0"
-
-  - task: PowerShell@1
-    inputs:
-      scriptName: "$(Build.Repository.LocalPath)\\configure.ps1"
-      arguments: "-Force"
-    displayName: "Run Configure.ps1"
-
-  - task: PowerShell@1
-    inputs:
-      scriptName: "$(Build.Repository.LocalPath)\\scripts\\cibuild\\ConfigureVstsBuild.ps1"
-      arguments: "-BuildCounterFile $(BuildCounterFile) -BuildInfoJsonFile $(BuildInfoJsonFile) -BuildRTM $(BuildRTM) -SkipUpdateBuildNumber"
-    displayName: "Configure VSTS CI Environment"
-
-  - task: PublishBuildArtifacts@1
-    displayName: 'Publish buildinfo.json as an artifact'
-    inputs:
-      ArtifactName: 'BuildInfo'
-      ArtifactType: 'Container'
-      PathToPublish: '$(Build.Repository.LocalPath)\artifacts\buildinfo.json'
-    condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
-
-  - task: PowerShell@1
-    displayName: "Print Environment Variables"
-    inputs:
-      scriptType: "inlineScript"
-      inlineScript: |
-        Get-ChildItem Env: | Sort-Object Name | Format-Table -Wrap -AutoSize
-
-  - task: NuGetCommand@2
-    displayName: 'MicroBuild:  install core package'
-    inputs:
-      command: 'custom'
-      arguments: 'install Microsoft.VisualStudioEng.MicroBuild.Core -Version 0.4.1 -ConfigFile $(System.DefaultWorkingDirectory)\NuGet.config -OutputDirectory $(System.DefaultWorkingDirectory)\packages'
-    condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
-
-  - task: MicroBuildLocalizationPlugin@1
-    displayName: "Install Localization Plugin"
-
-  - task: MicroBuildSigningPlugin@1
-    inputs:
-      signType: "$(SigningType)"
-      esrpSigning: "true"
-    displayName: "Install Signing Plugin"
-
-  - task: MicroBuildSwixPlugin@1
-    displayName: "Install Swix Plugin"
-
-  - task: ms-vseng.MicroBuildTasks.965C8DC6-1483-45C9-B384-5AC75DA1F1A4.MicroBuildOptProfPlugin@4
-    displayName: 'OptProfV2:  install the plugin'
-    inputs:
-      getDropNameByDrop: true
-      optimizationInputsDropNamePrefix: OptimizationInputs/$(System.TeamProject)/$(Build.Repository.Name)
-    condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
-
-  - task: PowerShell@1
-    displayName: "Restore dotnet tools"
-    inputs:
-      scriptType: "inlineScript"
-      inlineScript: |
-        dotnet tool restore
-    condition: "not(eq(variables['IsOfficialBuild'], 'true'))"
-
-  - task: PowerShell@1
-    displayName: "Check source file format"
-    inputs:
-      scriptType: "inlineScript"
-      inlineScript: |
-        dotnet format --check --exclude submodules --verbosity diagnostic
-    condition: "and(succeeded(), not(eq(variables['IsOfficialBuild'], 'true')))"
-
-  - task: MSBuild@1
-    displayName: "Restore for VS2019"
-    inputs:
-      solution: "build\\build.proj"
-      msbuildVersion: "16.0"
-      configuration: "$(BuildConfiguration)"
-      msbuildArguments: "/t:RestoreVS /p:BuildNumber=$(BuildNumber) /p:BuildRTM=$(BuildRTM) /v:m"
-
-  - task: MSBuild@1
-    displayName: "Build for VS2019"
-    inputs:
-      solution: "build\\build.proj"
-      msbuildVersion: "16.0"
-      configuration: "$(BuildConfiguration)"
-      msbuildArguments: "/t:BuildNoVSIX /p:BuildRTM=$(BuildRTM) /p:BuildNumber=$(BuildNumber) /p:SkipILMergeOfNuGetExe=true"
-
-  - task: MSBuild@1
-    displayName: "Ensure msbuild.exe can parse nuget.sln"
-    continueOnError: "false"
-    inputs:
-      solution: "nuget.sln"
-      msbuildVersion: "16.0"
-      msbuildArguments: "/t:EnsureNewtonsoftJsonVersion"
-    condition: "succeeded()"
-
-  - task: MSBuild@1
-    displayName: "Ensure package versions are declared in packages.targets"
-    continueOnError: "false"
-    inputs:
-      solution: "build\\build.proj"
-      msbuildVersion: "16.0"
-      msbuildArguments: "/t:EnsurePackageReferenceVersionsInSolution"
-    condition: "succeeded()"
-
-
-  - task: MSBuild@1
-    displayName: "Localize Assemblies"
-    inputs:
-      solution: "build\\loc.proj"
-      msbuildVersion: "16.0"
-      configuration: "$(BuildConfiguration)"
-      msbuildArguments: "/t:AfterBuild"
-
-  - task: MSBuild@1
-    displayName: "Build Final NuGet.exe (via ILMerge)"
-    inputs:
-      solution: "src\\NuGet.Clients\\NuGet.CommandLine\\NuGet.CommandLine.csproj"
-      msbuildVersion: "16.0"
-      configuration: "$(BuildConfiguration)"
-      msbuildArguments: "/t:ILMergeNuGetExe /p:ExpectedLocalizedArtifactCount=$(LocalizedLanguageCount)"
-
-  - task: MSBuild@1
-    displayName: "Publish NuGet.exe (ILMerged) into NuGet.CommandLine.Test (Mac tests use this)"
-    inputs:
-      solution: "test\\NuGet.Clients.Tests\\NuGet.CommandLine.Test\\NuGet.CommandLine.Test.csproj"
-      msbuildVersion: "16.0"
-      configuration: "$(BuildConfiguration)"
-      msbuildArguments: "/t:CopyFinalNuGetExeToOutputPath"
-    condition: "and(succeeded(),eq(variables['BuildRTM'], 'true'))"
-
-  - task: MSBuild@1
-    displayName: "Run unit tests (stop on error)"
-    continueOnError: "false"
-    inputs:
-      solution: "build\\build.proj"
-      msbuildVersion: "16.0"
-      configuration: "$(BuildConfiguration)"
-      msbuildArguments: "/t:CoreUnitTests;UnitTestsVS /p:BuildRTM=$(BuildRTM) /p:BuildNumber=$(BuildNumber) /p:TestResultOutputFormat=xml /p:SkipILMergeOfNuGetExe=true"
-    condition: "and(succeeded(), eq(variables['BuildRTM'], 'true'), not(eq(variables['IsOfficialBuild'], 'true')))"
-
-  - task: MSBuild@1
-    displayName: "Run unit tests (continue on error)"
-    continueOnError: "true"
-    inputs:
-      solution: "build\\build.proj"
-      msbuildVersion: "16.0"
-      configuration: "$(BuildConfiguration)"
-      msbuildArguments: "/t:CoreUnitTests;UnitTestsVS /p:BuildRTM=$(BuildRTM) /p:BuildNumber=$(BuildNumber) /p:TestResultOutputFormat=xml /p:SkipILMergeOfNuGetExe=true"
-    condition: "and(succeeded(), eq(variables['BuildRTM'], 'true'), eq(variables['IsOfficialBuild'], 'true'))"
-
-  - task: PublishTestResults@2
-    displayName: "Publish Test Results"
-    inputs:
-      testRunner: "XUnit"
-      testResultsFiles: "*.xml"
-      testRunTitle: "NuGet.Client Unit Tests On Windows"
-      searchFolder: "$(Build.Repository.LocalPath)\\build\\TestResults"
-      mergeTestResults: "true"
-      publishRunAttachments: "false"
-    condition: "and(succeededOrFailed(),eq(variables['BuildRTM'], 'true'))"
-
-  - task: PowerShell@1
-    displayName: "Initialize Git Commit Status on GitHub"
-    inputs:
-      scriptType: "inlineScript"
-      arguments: "-VstsPersonalAccessToken $(VstsPersonalAccessToken)"
-      inlineScript: |
-        . $(Build.Repository.LocalPath)\\scripts\\utils\\PostGitCommitStatus.ps1
-        SetCommitStatusForTestResult -PersonalAccessToken $(NuGetLurkerPersonalAccessToken) -VstsPersonalAccessToken $(VstsPersonalAccessToken) -CommitSha $(Build.SourceVersion) -TestName "Unit Tests On Windows"
-    condition: "and(always(),eq(variables['BuildRTM'], 'true'))"
-
-  - task: PublishBuildArtifacts@1
-    displayName: "Publish NuGet.CommandLine.Test as artifact"
-    inputs:
-      PathtoPublish: "$(Build.Repository.LocalPath)\\test\\NuGet.Clients.Tests\\NuGet.CommandLine.Test\\bin\\$(BuildConfiguration)\\net472"
-      ArtifactName: "NuGet.CommandLine.Test"
-      ArtifactType: "Container"
-    condition: "and(succeeded(),eq(variables['BuildRTM'], 'true'))"
-
-  - task: MSBuild@1
-    displayName: "Sign Assemblies"
-    inputs:
-      solution: "build\\sign.proj"
-      msbuildVersion: "16.0"
-      configuration: "$(BuildConfiguration)"
-      msbuildArguments: "/t:AfterBuild"
-
-  - task: MSBuild@1
-    displayName: "Pack Nupkgs"
-    inputs:
-      solution: "build\\build.proj"
-      msbuildVersion: "16.0"
-      configuration: "$(BuildConfiguration)"
-      msbuildArguments: "/t:Pack /p:BuildRTM=$(BuildRTM) /p:ExcludeTestProjects=$(BuildRTM) /p:BuildNumber=$(BuildNumber)"
-
-  - task: MSBuild@1
-    displayName: "Pack VSIX"
-    inputs:
-      solution: "build\\build.proj"
-      msbuildVersion: "16.0"
-      configuration: "$(BuildConfiguration)"
-      msbuildArguments: "/t:BuildVSIX /p:BuildRTM=$(BuildRTM) /p:ExcludeTestProjects=$(BuildRTM) /p:IsCIBuild=true"
-    condition: "and(succeeded(),eq(variables['BuildRTM'], 'false'))"
-
-  - task: MSBuild@1
-    displayName: "Generate Build Tools package"
-    inputs:
-      solution: "setup/Microsoft.VisualStudio.NuGet.BuildTools.vsmanproj"
-      msbuildVersion: "16.0"
-      configuration: "$(BuildConfiguration)"
-      msbuildArguments: "/p:BuildNumber=$(BuildNumber) /p:IsVsixBuild=true"
-    condition: " and(succeeded(), eq(variables['BuildRTM'], 'false'))"
-
-  - task: MSBuild@1
-    displayName: "Sign Nupkgs and VSIX"
-    inputs:
-      solution: "build\\sign.proj"
-      msbuildVersion: "16.0"
-      configuration: "$(BuildConfiguration)"
-      msbuildArguments: "/t:AfterBuild /p:SignPackages=true"
-
-  - task: NuGetCommand@2
-    displayName: "Verify Nupkg Signatures"
-    inputs:
-      command: "custom"
-      arguments: "verify -Signatures $(Build.Repository.LocalPath)\\artifacts\\$(NupkgOutputDir)\\*.nupkg"
-
-  - task: ms-vseng.MicroBuildShipTasks.7c429315-71ba-4cb3-94bb-f829c95f7915.MicroBuildCodesignVerify@1
-    displayName: Verify Assembly Signatures and StrongName for the nupkgs
-    inputs:
-      TargetFolder: '$(Build.Repository.LocalPath)\\artifacts\\$(NupkgOutputDir)'
-
-  - task: ms-vseng.MicroBuildShipTasks.7c429315-71ba-4cb3-94bb-f829c95f7915.MicroBuildCodesignVerify@1
-    displayName: Verify Assembly Signatures and StrongName for the VSIX & exes
-    inputs:
-      TargetFolder: '$(Build.Repository.LocalPath)\\artifacts\\$(VsixPublishDir)'
-      WhiteListPathForCerts: '$(Build.Repository.LocalPath)\\build\\ignorecodesign.csv'
-      WhiteListPathForSigs: '$(Build.Repository.LocalPath)\\build\\ignorecodesign.csv'
-
-  - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
-    displayName: 'Component Detection'
-    condition: "and(succeeded(),eq(variables['BuildRTM'], 'true'))"
-
-  - task: CopyFiles@2
-    displayName: "Copy Nupkgs"
-    inputs:
-      SourceFolder: "artifacts\\$(NupkgOutputDir)"
-      Contents: "*.nupkg"
-      TargetFolder: "$(BuildOutputTargetPath)\\artifacts\\$(VsixPublishDir)\\$(NupkgOutputDir)"
-
-  - task: MSBuild@1
-    displayName: "Generate VSMAN file for NuGet Core VSIX"
-    inputs:
-      solution: "setup\\Microsoft.VisualStudio.NuGet.Core.vsmanproj"
-      msbuildVersion: "16.0"
-      configuration: "$(BuildConfiguration)"
-    condition: " and(succeeded(),eq(variables['BuildRTM'], 'false')) "
-
-  - task: MSBuild@1
-    displayName: "Generate VSMAN file for Build Tools VSIX"
-    inputs:
-      solution: "setup\\Microsoft.VisualStudio.NuGet.BuildTools.vsmanproj"
-      msbuildVersion: "16.0"
-      configuration: "$(BuildConfiguration)"
-    condition: " and(succeeded(),eq(variables['BuildRTM'], 'false')) "
-
-  - task: PowerShell@1
-    displayName: "Create EndToEnd Test Package"
-    inputs:
-      scriptName: "$(Build.Repository.LocalPath)\\scripts\\cibuild\\CreateEndToEndTestPackage.ps1"
-      arguments: "-c $(BuildConfiguration) -tv 16 -out $(Build.Repository.LocalPath)\\artifacts\\$(VsixPublishDir)"
-      failOnStandardError: "true"
-    condition: " and(succeeded(),eq(variables['BuildRTM'], 'false')) "
-
-  - task: CopyFiles@2
-    displayName: "Copy NuGet.exe, VSIX and EndToEnd"
-    inputs:
-      SourceFolder: "artifacts"
-      Contents: |
-        $(VsixPublishDir)\\NuGet.exe
-        $(VsixPublishDir)\\NuGet.pdb
-        $(VsixPublishDir)\\NuGet.Mssign.exe
-        $(VsixPublishDir)\\NuGet.Mssign.pdb
-        $(VsixPublishDir)\\Microsoft.VisualStudio.NuGet.Core.json
-        $(VsixPublishDir)\\NuGet.Tools.vsix
-        $(VsixPublishDir)\\Microsoft.VisualStudio.NuGet.BuildTools.vsix
-        $(VsixPublishDir)\\Microsoft.VisualStudio.NuGet.BuildTools.json
-        $(VsixPublishDir)\\EndToEnd.zip
-      TargetFolder: "$(BuildOutputTargetPath)\\artifacts"
-
-  - task: NuGetCommand@2
-    displayName: 'OptProfV2:  add the NuGet package source'
-    inputs:
-      command: 'custom'
-      arguments: 'sources add -Name VS -Source $(VsPackageFeedUrl) -UserName $(VsPackageFeedUsername) -Password $(VsPackageFeedPassword) -ConfigFile $(System.DefaultWorkingDirectory)\NuGet.config'
-    condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
-
-  - task: NuGetCommand@2
-    displayName: 'OptProfV2:  install the NuGet package for building .runsettingsproj file'
-    inputs:
-      command: 'custom'
-      arguments: 'install Microsoft.DevDiv.Validation.TestPlatform.Settings.Tasks -Version 1.0.308 -Source $(VsPackageFeedUrl) -ConfigFile $(System.DefaultWorkingDirectory)\NuGet.config -OutputDirectory $(System.DefaultWorkingDirectory)\packages'
-    condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
-
-  - task: ms-vseng.MicroBuildTasks.0e9d0d4d-71ec-4e4e-ae40-db9896f1ae74.MicroBuildBuildVSBootstrapper@2
-    displayName: 'OptProfV2:  build a Visual Studio bootstrapper'
-    inputs:
-      channelName: "$(VsTargetChannel)"
-      vsMajorVersion: "$(VsTargetMajorVersion)"
-      manifests: '$(Build.Repository.LocalPath)\artifacts\$(VsixPublishDir)\Microsoft.VisualStudio.NuGet.Core.vsman'
-      outputFolder: '$(Build.Repository.LocalPath)\artifacts\$(VsixPublishDir)'
-    continueOnError: true
-    condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
-
-  - task: PublishBuildArtifacts@1
-    displayName: 'OptProfV2:  publish BootstrapperInfo.json as a build artifact'
-    inputs:
-      PathtoPublish: $(Build.StagingDirectory)\MicroBuild\Output
-      ArtifactName: MicroBuildOutputs
-      ArtifactType: Container
-    condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
-
-  - task: PowerShell@1
-    displayName: 'OptProfV2:  set the TestDrop environment variable'
-    inputs:
-      scriptType: 'inlineScript'
-      inlineScript: |
-        [string] $bootstrapperInfoFilePath = "$Env:BUILD_STAGINGDIRECTORY\MicroBuild\Output\BootstrapperInfo.json"
-        $json = Get-Content $bootstrapperInfoFilePath | ConvertFrom-Json
-        [string] $buildDropPath = $json.BuildDrop
-        Write-Host "Build drop:  $buildDropPath"
-        [string] $testDropPath = $buildDropPath.Replace('/Products/', '/Tests/').Substring('https://vsdrop.corp.microsoft.com/file/v1/'.Length)
-        Write-Host "Test drop:  $testDropPath"
-        Write-Host "##vso[task.setvariable variable=TestDrop]$testDropPath"
-    condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
-
-  - task: MSBuild@1
-    displayName: 'OptProfV2:  generate a .runsettings file'
-    inputs:
-      solution: 'build\NuGet.OptProfV2.runsettingsproj'
-      msbuildVersion: '16.0'
-      msbuildArguments: '/p:OutputPath="$(Build.Repository.LocalPath)\artifacts\RunSettings" /p:TestDrop="$(TestDrop)" /p:ProfilingInputsDrop="ProfilingInputs/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildId)"'
-    condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
-
-  - task: ms-vscs-artifact.build-tasks.artifactDropTask-1.artifactDropTask@0
-    displayName: 'OptProfV2:  publish the .runsettings file to artifact services'
-    inputs:
-      dropServiceURI: 'https://devdiv.artifacts.visualstudio.com'
-      buildNumber: 'RunSettings/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildId)'
-      sourcePath: 'artifacts\RunSettings'
-      toLowerCase: false
-      usePat: false
-      dropMetadataContainerName: RunSettings
-    condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
-
-  - task: ms-vscs-artifact.build-tasks.artifactDropTask-1.artifactDropTask@0
-    displayName: 'OptProfV2:  publish profiling inputs to artifact services'
-    inputs:
-      dropServiceURI: 'https://devdiv.artifacts.visualstudio.com'
-      buildNumber: 'ProfilingInputs/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildId)'
-      sourcePath: '$(Build.ArtifactStagingDirectory)\OptProf\ProfilingInputs'
-      toLowerCase: false
-      usePat: false
-    condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
-
-  - task: PublishBuildArtifacts@1
-    displayName: "Publish NuGet.exe VSIX and EndToEnd.zip as artifact"
-    inputs:
-      PathtoPublish: "$(Build.Repository.LocalPath)\\artifacts\\$(VsixPublishDir)"
-      ArtifactName: "$(VsixPublishDir)"
-      ArtifactType: "Container"
-    condition: "and(succeeded(),eq(variables['BuildRTM'], 'false'))"
-
-  - task: CopyFiles@2
-    displayName: "Copy LCG Files"
-    inputs:
-      SourceFolder: "artifacts\\"
-      Contents: "**\\*.lcg"
-      TargetFolder: "$(CIRoot)\\PLOC\\$(Build.SourceBranchName)\\$(Build.BuildNumber)"
-    condition: " and(succeeded(),eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true')) "
-
-  - task: PowerShell@1
-    displayName: "Publish Artifacts to MyGet"
-    continueOnError: "true"
-    inputs:
-      scriptName: "$(Build.Repository.LocalPath)\\scripts\\cibuild\\PublishArtifactsFromVsts.ps1"
-      arguments: "-NuGetBuildFeedUrl $(NuGetBuildFeed) -NuGetBuildSymbolsFeedUrl $(NuGetBuildSymbolsFeed) -DotnetCoreFeedUrl $(DotnetCoreBuildFeed) -DotnetCoreSymbolsFeedUrl $(DotnetCoreSymbolsFeed) -NuGetBuildFeedApiKey $(NuGetBuildApiKey) -DotnetCoreFeedApiKey $(DotnetCoreFeedApiKey)"
-      failOnStandardError: "true"
-    condition: " and(succeeded(),eq(variables['PublishArtifactsToMyGet'], 'true'), eq(variables['BuildRTM'], 'false')) "
-
-  - task: MSBuild@1
-    displayName: "Collect Build Symbols"
-    inputs:
-      solution: "build\\symbols.proj"
-      msbuildVersion: "16.0"
-      configuration: "$(BuildConfiguration)"
-      msbuildArguments: "/p:IsSymbolBuild=true"
-    condition: " and(succeeded(),eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true')) "
-
-  - task: CopyFiles@2
-    displayName: "Copy Symbols"
-    inputs:
-      SourceFolder: "$(Build.Repository.LocalPath)\\artifacts\\symbolstoindex"
-      Contents: "**\\*"
-      TargetFolder: "$(BuildOutputTargetPath)\\symbols"
-    condition: " and(succeeded(),eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true')) "
-
-  - task: ms-vscs-artifact.build-tasks.artifactSymbolTask-1.artifactSymbolTask@0
-    displayName: "Publish Symbols on Symweb"
-    inputs:
-      symbolServiceURI: "https://microsoft.artifacts.visualstudio.com/DefaultCollection"
-      requestName: "CollectionId/$(System.CollectionId)/ProjectId/$(System.TeamProjectId)/$(TeamName)/BuildId/$(Build.BuildId)"
-      sourcePath: "$(Build.Repository.LocalPath)\\artifacts\\symbolstoindex"
-      detailedLog: "true"
-      expirationInDays: "45"
-      usePat: "false"
-    condition: " and(succeeded(),eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true')) "
-
-  - task: MicroBuildUploadVstsDropFolder@1
-    displayName: "Upload VSTS Drop"
-    inputs:
-      DropFolder: "$(Build.Repository.LocalPath)\\artifacts\\$(VsixPublishDir)"
-    condition: " and(succeeded(),eq(variables['BuildRTM'], 'false')) "
-
-  - task: PowerShell@1
-    displayName: "LocValidation: Verify VSIX"
-    inputs:
-      scriptName: "$(Build.Repository.LocalPath)\\scripts\\cibuild\\BuildValidator.ps1"
-      arguments: "-BuildRTM $(BuildRTM) -RepoRoot $(Build.Repository.LocalPath) -OutputLogsBasePath $(Build.Repository.LocalPath)\\logs -TmpPath $(Agent.TempDirectory) -ValidateVsix"
-    condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
-
-  - task: PowerShell@1
-    displayName: "LocValidation: Verify Artifacts"
-    inputs:
-      scriptName: "$(Build.Repository.LocalPath)\\scripts\\cibuild\\BuildValidator.ps1"
-      arguments: "-BuildRTM $(BuildRTM) -RepoRoot $(Build.Repository.LocalPath) -OutputLogsBasePath $(Build.Repository.LocalPath)\\logs"
-    condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
-
-  - task: PublishPipelineArtifact@1
-    displayName: "LocValidation: Publish Logs as an artifact"
-    inputs:
-      artifactName: LocValidationLogs
-      targetPath: "$(Build.Repository.LocalPath)\\logs\\LocalizationValidation"
-    condition: "eq(variables['BuildRTM'], 'false')"
-
-    # Use dotnet msbuild instead of MSBuild CLI.
-    # Using MSBuild CLI results in an assembly binding failure for NuGet.Common.dll 4.4.0.3 because Microsoft.DotNet.Build.Tasks.Feed.dll references SleetLib.dll which references NuGet.Common 4.4.0.3.
-    # The Microsoft.DotNet.Build.Tasks.Feed package includes NuGet.Common 4.9.0.6 and a binding redirection in Microsoft.DotNet.Build.Tasks.Feed.dll.config but the binding redirection is not processed.
-    # This would probably solve it:  https://github.com/Microsoft/msbuild/issues/1309
-  - task: CmdLine@2
-    displayName: "Publish to the .NET Core build asset registry (BAR)"
-    inputs:
-      script: dotnet msbuild $(Build.Repository.LocalPath)\build\publish.proj /t:PublishToBuildAssetRegistry /p:NuGetClientNupkgsDirectoryPath=$(Build.Repository.LocalPath)\artifacts\$(NupkgOutputDir) /p:BUILD_BUILDNUMBER=$(Build.BuildNumber) /p:BUILD_SOURCEBRANCH=$(Build.SourceBranchName) /p:BUILD_SOURCEVERSION=$(Build.SourceVersion) /p:BUILD_REPOSITORY_URI=$(Build.Repository.Uri) /p:ArtifactsLogDir=$(Build.Repository.LocalPath)\artifacts\manifests\ /p:MaestroApiEndpoint=$(MaestroApiEndpoint) /p:MaestroAccessToken=$(MaestroAccessToken)
-      workingDirectory: cli
-      failOnStderr: true
-    env:
-      DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
-      DOTNET_MULTILEVEL_LOOKUP: true
-    condition: " and(succeeded(),eq(variables['PublishArtifactsToDotNetBuildAssetRegistry'], 'true'), eq(variables['BuildRTM'], 'false')) "
-
-  - task: MicroBuildCleanup@1
-    displayName: "Perform Cleanup Tasks"
-
-  - task: PowerShell@1
-    displayName: "Cleanup on Failure"
-    inputs:
-      scriptType: "inlineScript"
-      arguments: "-BuildOutputTargetPath $(BuildOutputTargetPath)"
-      inlineScript: |
-        param([string]$BuildOutputTargetPath)
-        Get-ChildItem $(BuildOutputTargetPath) -Recurse | Remove-Item -Force -Recurse -ErrorAction SilentlyContinue
-        Remove-Item -Path $(BuildOutputTargetPath) -Force -Recurse -ErrorAction SilentlyContinue
-    condition: "eq(variables['Agent.JobStatus'], 'Failed')"
+  steps:
+  - template: templates/Build_and_UnitTest.yml  
 
 - job: Functional_Tests_On_Windows
   dependsOn: Initialize_Build
@@ -796,7 +315,8 @@ jobs:
 
 - job: Tests_On_Mac
   dependsOn:
-  - Build_and_UnitTest
+  - Build_and_UnitTest_RTM
+  - Build_and_UnitTest_NonRTM
   - Initialize_Build
   timeoutInMinutes: 75
   variables:
@@ -879,7 +399,8 @@ jobs:
 
 - job: End_To_End_Tests_On_Windows
   dependsOn:
-  - Build_and_UnitTest
+  - Build_and_UnitTest_RTM
+  - Build_and_UnitTest_NonRTM
   - Initialize_Build
   timeoutInMinutes: 150
   variables:
@@ -1001,7 +522,8 @@ jobs:
 
 - job: Apex_Tests_On_Windows
   dependsOn:
-  - Build_and_UnitTest
+  - Build_and_UnitTest_RTM
+  - Build_and_UnitTest_NonRTM
   - Initialize_Build
   timeoutInMinutes: 120
   variables:

--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -85,27 +85,6 @@ jobs:
         Write-Host "##vso[build.addbuildtag]${env:BUILD_SOURCEVERSIONAUTHOR}"
         Write-Host "##vso[build.addbuildtag]${env:BUILD_SOURCEBRANCHNAME}"
 
-- job: Build_and_UnitTest_RTM
-  dependsOn: Initialize_Build
-  timeoutInMinutes: 170
-  variables:
-    BuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.BuildNumber']]
-    FullVstsBuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
-    VsTargetChannel: $[dependencies.Initialize_Build.outputs['updatebuildnumber.VsTargetChannel']]
-    VsTargetMajorVersion: $[dependencies.Initialize_Build.outputs['updatebuildnumber.VsTargetMajorVersion']]
-    SDKVersionForBuild: $[dependencies.Initialize_Build.outputs['getSDKVersionForBuild.SDKVersionForBuild']]
-    LocalizedLanguageCount: "13"
-    BuildRTM: "true"
-
-  pool:
-    name: VSEng-MicroBuildVS2019
-    demands:
-      - DotNetFramework
-      - msbuild
-
-  steps:
-  - template: templates/Build_and_UnitTest.yml  
-
 - job: Build_and_UnitTest_NonRTM
   dependsOn: Initialize_Build
   timeoutInMinutes: 170
@@ -117,6 +96,27 @@ jobs:
     SDKVersionForBuild: $[dependencies.Initialize_Build.outputs['getSDKVersionForBuild.SDKVersionForBuild']]
     LocalizedLanguageCount: "13"
     BuildRTM: "false"
+
+  pool:
+    name: VSEng-MicroBuildVS2019
+    demands:
+      - DotNetFramework
+      - msbuild
+
+  steps:
+  - template: templates/Build_and_UnitTest.yml  
+
+- job: Build_and_UnitTest_RTM
+  dependsOn: Initialize_Build
+  timeoutInMinutes: 170
+  variables:
+    BuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.BuildNumber']]
+    FullVstsBuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
+    VsTargetChannel: $[dependencies.Initialize_Build.outputs['updatebuildnumber.VsTargetChannel']]
+    VsTargetMajorVersion: $[dependencies.Initialize_Build.outputs['updatebuildnumber.VsTargetMajorVersion']]
+    SDKVersionForBuild: $[dependencies.Initialize_Build.outputs['getSDKVersionForBuild.SDKVersionForBuild']]
+    LocalizedLanguageCount: "13"
+    BuildRTM: "true"
 
   pool:
     name: VSEng-MicroBuildVS2019

--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -115,7 +115,7 @@ jobs:
     VsTargetChannel: $[dependencies.Initialize_Build.outputs['updatebuildnumber.VsTargetChannel']]
     VsTargetMajorVersion: $[dependencies.Initialize_Build.outputs['updatebuildnumber.VsTargetMajorVersion']]
     SDKVersionForBuild: $[dependencies.Initialize_Build.outputs['getSDKVersionForBuild.SDKVersionForBuild']]
-    LocalizedLanguageCount: "0"
+    LocalizedLanguageCount: "13"
     BuildRTM: "false"
 
   pool:

--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -115,7 +115,7 @@ jobs:
     VsTargetChannel: $[dependencies.Initialize_Build.outputs['updatebuildnumber.VsTargetChannel']]
     VsTargetMajorVersion: $[dependencies.Initialize_Build.outputs['updatebuildnumber.VsTargetMajorVersion']]
     SDKVersionForBuild: $[dependencies.Initialize_Build.outputs['getSDKVersionForBuild.SDKVersionForBuild']]
-    LocalizedLanguageCount: "13"
+    LocalizedLanguageCount: "0"
     BuildRTM: "false"
 
   pool:
@@ -315,7 +315,6 @@ jobs:
 
 - job: Tests_On_Mac
   dependsOn:
-  - Build_and_UnitTest_RTM
   - Build_and_UnitTest_NonRTM
   - Initialize_Build
   timeoutInMinutes: 75
@@ -399,7 +398,6 @@ jobs:
 
 - job: End_To_End_Tests_On_Windows
   dependsOn:
-  - Build_and_UnitTest_RTM
   - Build_and_UnitTest_NonRTM
   - Initialize_Build
   timeoutInMinutes: 150
@@ -522,7 +520,6 @@ jobs:
 
 - job: Apex_Tests_On_Windows
   dependsOn:
-  - Build_and_UnitTest_RTM
   - Build_and_UnitTest_NonRTM
   - Initialize_Build
   timeoutInMinutes: 120


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Client.Engineering/issues/523 and https://github.com/NuGet/Client.Engineering/issues/524
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: 
1. Change matrix Build_and_UnitTest into two jobs: Build_and_UnitTest_RTM and Build_and_UnitTest_NonRTM
2. Change dependency for mac /E2E/Apex tests from the matrix Build_and_UnitTest into Build_and_UnitTest_NonRTM only.
([setting dependency on a single job of a matrix is not supported](https://developercommunity.visualstudio.com/content/problem/1192764/unable-to-dependson-a-single-job-of-a-matrix.html))
3. Use template for the above two jobs to avoid duplicate code.
Create templates/Build_and_unitTest.yml, copy all the tasks under original Build_and_UnitTest job into the Build_and_unitTest.yml.
4. Move task 
`Publish NuGet.exe (ILMerged) into NuGet.CommandLine.Test (Mac tests use this)`  and `Publish NuGet.CommandLine.Test as artifact` 
from RTM to nonRTM for both private build and official build.
5. Skip the following tasks for private nonRTM job: (for official nonRTM job, the following tasks will not be skipped)
```
Install Signing Plugin
Restore dotnet tools
Check source file format
Ensure msbuild.exe can parse nuget.sln
Ensure package versions are declared in packages.targets
Sign Assemblies
Pack Nupkgs
Sign Nupkgs and VSIX
Verify Nupkg Signatures
Verify Assembly Signatures and StrongName for the nupkgs
Verify Assembly Signatures and StrongName for the VSIX & exes
Copy Nupkgs
```
You may check the tasks change from the list below:
[Build_and_UnitTest job.xlsx](https://github.com/NuGet/NuGet.Client/files/5302446/Build_and_UnitTest.job.xlsx)


## Testing/Validation

Tests Added: No  
Reason for not adding tests:  
Validation:  
