### PR TITLE
Set IsEscrow to true for the 5.8.0 branch

### DIFF
--- a/build/config.props
+++ b/build/config.props
@@ -21,7 +21,7 @@
     <!-- Check the VS schedule and manually enter a preview number here that makes sense. -->
     <ReleaseLabel Condition=" '$(ReleaseLabel)' == '' ">rc</ReleaseLabel>
 
-    <IsEscrowMode>false</IsEscrowMode>
+    <IsEscrowMode>true</IsEscrowMode>
 
     <!-- Visual Studio Insertion Logic -->
     <VsTargetMajorVersion>$([MSBuild]::Add(11, $(MajorNuGetVersion)))</VsTargetMajorVersion>


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Client.Engineering/issues/569
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: The 5.8.0 release is in permanent escrow. Fixing the IsEscrow property to make the automation target the rel branch.

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  
Validation:  
