### PR TITLE
Skip flaky test TestPacMan_PreviewInstallPackage_BuildIntegrated_RaiseTelemetryEventsWithWarningCode

### DIFF
--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests.cs
@@ -6321,7 +6321,7 @@ namespace NuGet.Test
         }
 
 
-        [Fact]
+        [Fact(Skip = "https://github.com/NuGet/Home/issues/10093")]
         public async Task TestPacMan_PreviewInstallPackage_BuildIntegrated_RaiseTelemetryEventsWithWarningCode()
         {
             // Arrange


### PR DESCRIPTION
tracking issue: https://github.com/NuGet/Home/issues/10093