### PR TITLE
obsolete PackageSource related types from earlier in 5.8

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/PackageSourcesOptionsControl.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/PackageSourcesOptionsControl.cs
@@ -254,7 +254,9 @@ namespace NuGet.Options
             {
                 if (SourcesChanged(_originalPackageSources, packageSources))
                 {
+#pragma warning disable CS0618 // Type or member is obsolete
                     await _nugetSourcesService.SavePackageSourcesAsync(packageSources, new PackageSourceUpdateOptions(updateCredentials: false, updateEnabled: true), cancellationToken);
+#pragma warning restore CS0618 // Type or member is obsolete
                 }
             }
             // Thrown during creating or saving NuGet.Config.

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetSourcesService.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetSourcesService.cs
@@ -38,12 +38,16 @@ namespace NuGet.PackageManagement.VisualStudio
             return packageSources.PackageSourceProvider.LoadPackageSources().ToList();
         }
 
+#pragma warning disable CS0618 // Type or member is obsolete
         public async ValueTask SavePackageSourcesAsync(IReadOnlyList<PackageSource> sources, PackageSourceUpdateOptions packageSourceUpdateOptions, CancellationToken cancellationToken)
+#pragma warning restore CS0618 // Type or member is obsolete
         {
             var packageSources = await ServiceLocator.GetInstanceAsync<ISourceRepositoryProvider>();
             Assumes.NotNull(packageSources);
 
+#pragma warning disable CS0618 // Type or member is obsolete
             var packageSources2 = packageSources.PackageSourceProvider as IPackageSourceProvider2;
+#pragma warning restore CS0618 // Type or member is obsolete
             if (packageSources2 != null)
             {
                 packageSources2.SavePackageSources(sources, packageSourceUpdateOptions);

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/PackageSourceUpdateOptionsFormatter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/PackageSourceUpdateOptionsFormatter.cs
@@ -9,18 +9,24 @@ using NuGet.Configuration;
 
 namespace NuGet.VisualStudio.Internal.Contracts
 {
+#pragma warning disable CS0618 // Type or member is obsolete
     internal class PackageSourceUpdateOptionsFormatter : IMessagePackFormatter<PackageSourceUpdateOptions?>
+#pragma warning restore CS0618 // Type or member is obsolete
     {
         private const string UpdateCredentialsPropertyName = "updatecredentials";
         private const string UpdateEnabledPropertyName = "updateenabled";
 
+#pragma warning disable CS0618 // Type or member is obsolete
         internal static readonly IMessagePackFormatter<PackageSourceUpdateOptions?> Instance = new PackageSourceUpdateOptionsFormatter();
+#pragma warning restore CS0618 // Type or member is obsolete
 
         private PackageSourceUpdateOptionsFormatter()
         {
         }
 
+#pragma warning disable CS0618 // Type or member is obsolete
         public PackageSourceUpdateOptions? Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
+#pragma warning restore CS0618 // Type or member is obsolete
         {
             if (reader.TryReadNil())
             {
@@ -52,7 +58,9 @@ namespace NuGet.VisualStudio.Internal.Contracts
                     }
                 }
 
+#pragma warning disable CS0618 // Type or member is obsolete
                 return new PackageSourceUpdateOptions(updateCredentials, updateEnabled);
+#pragma warning restore CS0618 // Type or member is obsolete
             }
             finally
             {
@@ -61,7 +69,9 @@ namespace NuGet.VisualStudio.Internal.Contracts
             }
         }
 
+#pragma warning disable CS0618 // Type or member is obsolete
         public void Serialize(ref MessagePackWriter writer, PackageSourceUpdateOptions? value, MessagePackSerializerOptions options)
+#pragma warning restore CS0618 // Type or member is obsolete
         {
             if (value == null)
             {

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/INuGetSourcesService.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/INuGetSourcesService.cs
@@ -14,6 +14,8 @@ namespace NuGet.VisualStudio.Internal.Contracts
     public interface INuGetSourcesService : IDisposable
     {
         ValueTask<IReadOnlyList<PackageSource>> GetPackageSourcesAsync(CancellationToken cancellationToken);
+#pragma warning disable CS0618 // Type or member is obsolete
         ValueTask SavePackageSourcesAsync(IReadOnlyList<PackageSource> sources, PackageSourceUpdateOptions packageSourceUpdateOptions, CancellationToken cancellationToken);
+#pragma warning restore CS0618 // Type or member is obsolete
     }
 }

--- a/src/NuGet.Core/NuGet.Configuration/PackageSource/IPackageSourceProvider2.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSource/IPackageSourceProvider2.cs
@@ -1,10 +1,12 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 
 namespace NuGet.Configuration
 {
+    [Obsolete("https://github.com/NuGet/Home/issues/10098")]
     public interface IPackageSourceProvider2 : IPackageSourceProvider
     {
         /// <summary>

--- a/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceProvider.cs
@@ -9,7 +9,9 @@ using NuGet.Common;
 
 namespace NuGet.Configuration
 {
+#pragma warning disable CS0618 // Type or member is obsolete
     public class PackageSourceProvider : IPackageSourceProvider, IPackageSourceProvider2
+#pragma warning restore CS0618 // Type or member is obsolete
     {
         public ISettings Settings { get; private set; }
 
@@ -748,8 +750,9 @@ namespace NuGet.Configuration
             {
                 throw new ArgumentNullException(nameof(sources));
             }
-
+#pragma warning disable CS0618 // Type or member is obsolete
             SavePackageSources(sources, PackageSourceUpdateOptions.Default);
+#pragma warning restore CS0618 // Type or member is obsolete
         }
 
         private Dictionary<string, SourceItem> GetExistingSettingsLookup()

--- a/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceProvider.cs
@@ -652,6 +652,7 @@ namespace NuGet.Configuration
             }
         }
 
+        [Obsolete("https://github.com/NuGet/Home/issues/10098")]
         public void SavePackageSources(IEnumerable<PackageSource> sources, PackageSourceUpdateOptions sourceUpdateSettings)
         {
             if (sources == null)

--- a/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceUpdateOptions.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceUpdateOptions.cs
@@ -1,8 +1,11 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+
 namespace NuGet.Configuration
 {
+    [Obsolete("https://github.com/NuGet/Home/issues/10098")]
     public sealed class PackageSourceUpdateOptions
     {
         public readonly static PackageSourceUpdateOptions Default = new PackageSourceUpdateOptions(true, true);

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/Formatters/PackageSourceUpdateOptionsFormatterTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/Formatters/PackageSourceUpdateOptionsFormatterTests.cs
@@ -10,6 +10,8 @@ namespace NuGet.VisualStudio.Internal.Contracts.Test
     {
         [Theory]
         [MemberData(nameof(PackageSourceUpdateOptions))]
+#pragma warning disable CS0618 // Type or member is obsolete
+
         public void SerializeThenDeserialize_WithValidArguments_RoundTrips(PackageSourceUpdateOptions expectedResult)
         {
             PackageSourceUpdateOptions actualResult = SerializeThenDeserialize(PackageSourceUpdateOptionsFormatter.Instance, expectedResult);
@@ -23,5 +25,6 @@ namespace NuGet.VisualStudio.Internal.Contracts.Test
                 { new PackageSourceUpdateOptions(updateCredentials: true, updateEnabled: false) },
                 { new PackageSourceUpdateOptions(updateCredentials: false, updateEnabled: true) },
             };
+#pragma warning restore CS0618 // Type or member is obsolete
     }
 }


### PR DESCRIPTION
## Bug

related to https://github.com/NuGet/Home/issues/10098
Regression: No  

## Fix

Details: Obsolete a few apis that were added earlier in 5.8, to avoid customers from using them.

## Testing/Validation

Tests Added: No  
Validation:  will validate insertion build to ensure tools/options/package sources still works in codespaces and non-codespaces.
