### PR TITLE
When installing a package in the global packages folder, enhance a verbose log statement to include the exact source a package is coming from

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/PackageExtractor.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageExtractor.cs
@@ -553,7 +553,7 @@ namespace NuGet.Packaging
 
                             File.Move(tempNupkgMetadataPath, nupkgMetadataFilePath);
 
-                            logger.LogVerbose($"Completed installation of {packageIdentity.Id} {packageIdentity.Version}");
+                            logger.LogVerbose($"Completed installation of {packageIdentity.Id} {packageIdentity.Version} from {source}");
 
                             packageExtractionTelemetryEvent.SetResult(NuGetOperationStatus.Succeeded);
                             return true;
@@ -825,7 +825,7 @@ namespace NuGet.Packaging
 
                             File.Move(tempNupkgMetadataFilePath, nupkgMetadataFilePath);
 
-                            logger.LogVerbose($"Completed installation of {packageIdentity.Id} {packageIdentity.Version}");
+                            logger.LogVerbose($"Completed installation of {packageIdentity.Id} {packageIdentity.Version} from {packageDownloader.Source}");
 
                             packageExtractionTelemetryEvent.SetResult(NuGetOperationStatus.Succeeded);
                             return true;

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageExtractorTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageExtractorTests.cs
@@ -3765,6 +3765,98 @@ namespace NuGet.Packaging.Test
             }
         }
 
+        [Fact]
+        public async Task InstallFromSourceAsync_LogsSourceOnVerboseLevel()
+        {
+            // Arrange
+            using (var testDirectory = TestDirectory.Create())
+            {
+                var source = Path.Combine(testDirectory, "source");
+                Directory.CreateDirectory(source);
+                var resolver = new VersionFolderPathResolver(Path.Combine(testDirectory, "gpf"));
+                var identity = new PackageIdentity("A", new NuGetVersion("1.2.3"));
+                var testLogger = new TestLogger();
+
+                var packageFileInfo = await TestPackagesCore.GeneratePackageAsync(
+                   source,
+                   identity.Id,
+                   identity.Version.ToString(),
+                   DateTimeOffset.UtcNow.LocalDateTime,
+                   "content/A.nupkg");
+
+                using (var packageStream = File.OpenRead(packageFileInfo.FullName))
+                {
+                    var packageExtractionContext = new PackageExtractionContext(
+                        PackageSaveMode.Defaultv3,
+                        XmlDocFileSaveMode.None,
+                        clientPolicyContext: null,
+                        testLogger);
+
+                    // Act
+                    await PackageExtractor.InstallFromSourceAsync(
+                        source,
+                        identity,
+                        (stream) => packageStream.CopyToAsync(stream, 4096, CancellationToken.None),
+                        resolver,
+                        packageExtractionContext,
+                        CancellationToken.None);
+
+                    // Assert
+                    File.Exists(resolver.GetPackageFilePath(identity.Id, identity.Version)).Should().BeTrue();
+                    testLogger.VerboseMessages.Should().Contain($"Completed installation of {identity.Id} {identity.Version} from {source}");
+                }
+            }
+        }
+
+        [Fact]
+        public async Task InstallFromSourceAsync_WithPackageDownloader_LogsSourceOnVerboseLevel()
+        {
+            // Arrange
+            using (var testDirectory = TestDirectory.Create())
+            {
+                var source = Path.Combine(testDirectory, "source");
+                Directory.CreateDirectory(source);
+                var resolver = new VersionFolderPathResolver(Path.Combine(testDirectory, "gpf"));
+                var identity = new PackageIdentity("A", new NuGetVersion("1.2.3"));
+                var testLogger = new TestLogger();
+
+                var packageFileInfo = await TestPackagesCore.GeneratePackageAsync(
+                   source,
+                   identity.Id,
+                   identity.Version.ToString(),
+                   DateTimeOffset.UtcNow.LocalDateTime,
+                   "content/A.nupkg");
+
+                using (var packageStream = File.OpenRead(packageFileInfo.FullName))
+                {
+                    var packageExtractionContext = new PackageExtractionContext(
+                        PackageSaveMode.Defaultv3,
+                        XmlDocFileSaveMode.None,
+                        clientPolicyContext: null,
+                        testLogger);
+
+                    using (var packageDownloader = new LocalPackageArchiveDownloader(
+                        source,
+                        Path.Combine(source, $"{identity.Id}.{identity.Version}.nupkg"),
+                        identity,
+                        testLogger))
+                    {
+                        var installed = await PackageExtractor.InstallFromSourceAsync(
+                            identity,
+                            packageDownloader,
+                            resolver,
+                            packageExtractionContext,
+                            CancellationToken.None);
+
+                    }
+
+                    // Assert
+                    File.Exists(resolver.GetPackageFilePath(identity.Id, identity.Version)).Should().BeTrue();
+                    testLogger.VerboseMessages.Should().Contain($"Completed installation of {identity.Id} {identity.Version} from {source}");
+                }
+            }
+        }
+
         private static bool FileExistsRecursively(string directoryPath, string fileNamePattern)
         {
             return Directory.GetFiles(directoryPath, fileNamePattern, SearchOption.AllDirectories)


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/3055
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: The original issue talks about 2 things (3 bullet points yes), logging the root source and logging the configs.
At restore time the config are already logged so there's nothing to add here. 
This takes care of enhancing an existing log statement.

I considered adding this to a log statement such as `Installing package {id} {version}` but that one is on normal verbosity, so I decided against it, and chose a message that's similar but with a lower verbosity. 

**To our customers**
This doesn't mean that NuGet will never change this message and any parsing scripts will remain valid forever, it merely means this information will remain available. 

Example how this would look like with NuGet.exe

```
C:\Users\Roki2\Documents\Code\test\WhereDoesAPackageComeFrom [master]> ..\..\NuGet\NuGet.Client\artifacts\VS15\NuGet.exe restore -verbosity detailed                                                                                         NuGet Version: 5.9.0.0
Restoring NuGet packages for solution C:\Users\Roki2\Documents\Code\test\WhereDoesAPackageComeFrom\WhereDoesAPackageComeFrom.sln.
MSBuild auto-detection: using msbuild version '16.8.0.45203' from 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Preview\MSBuild\Current\Bin'. Use option -MSBuildVersion to force nuget to use a specific version of MSBuild.
MSBuild P2P timeout [ms]: 120000
C:\Program Files (x86)\Microsoft Visual Studio\2019\Preview\MSBuild\Current\Bin\msbuild.exe "C:\Users\Roki2\AppData\Local\Temp\NuGetScratch\j3qpbshs.tqv.nugetinputs.targets" /t:GenerateRestoreGraphFile /nologo /nr:false /v:q /p:NuGetRestoreTargets="C:\Users\Roki2\AppData\Local\Temp\NuGetScratch\3vndyb1s.fs5.nugetrestore.targets" /p:RestoreUseCustomAfterTargets="True" /p:RestoreTaskAssemblyFile="C:\Users\Roki2\Documents\Code\NuGet\NuGet.Client\artifacts\VS15\NuGet.exe" /p:RestoreSolutionDirectory="C:\Users\Roki2\Documents\Code\test\WhereDoesAPackageComeFrom\\" /p:SolutionDir="C:\Users\Roki2\Documents\Code\test\WhereDoesAPackageComeFrom\\" /p:SolutionName="WhereDoesAPackageComeFrom"

Running restore with 8 concurrent jobs.
Reading project file C:\Users\Roki2\Documents\Code\test\WhereDoesAPackageComeFrom\Project1\Project1.csproj.
Restoring packages for C:\Users\Roki2\Documents\Code\test\WhereDoesAPackageComeFrom\Project1\Project1.csproj...
Restoring packages for .NETCoreApp,Version=v5.0...
  CACHE https://api.nuget.org/v3-flatcontainer/newtonsoft.json/index.json
  GET https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/9d15d80a-6afc-4f7e-901b-9378146a4b8b/nuget/v3/flat2/newtonsoft.json/index.json
  CACHE https://api.nuget.org/v3-flatcontainer/newtonsoft.json/12.0.3/newtonsoft.json.12.0.3.nupkg
  CACHE https://api.nuget.org/v3-flatcontainer/nugetvalidator/index.json
  CACHE https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/9d15d80a-6afc-4f7e-901b-9378146a4b8b/nuget/v3/flat2/nugetvalidator/index.json
  CACHE https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/9d15d80a-6afc-4f7e-901b-9378146a4b8b/nuget/v3/flat2/nugetvalidator/2.0.3/nugetvalidator.2.0.3.nupkg
Resolving conflicts for net5.0...
Acquiring lock for the installation of NuGetValidator 2.0.3
Acquired lock for the installation of NuGetValidator 2.0.3
Installing NuGetValidator 2.0.3.
Acquiring lock for the installation of Newtonsoft.Json 12.0.3
Acquired lock for the installation of Newtonsoft.Json 12.0.3
Installing Newtonsoft.Json 12.0.3.
  NotFound https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/9d15d80a-6afc-4f7e-901b-9378146a4b8b/nuget/v3/flat2/newtonsoft.json/index.json 158ms
Completed installation of NuGetValidator 2.0.3 from https://pkgs.dev.azure.com/dnceng/public/_packaging/nuget-build/nuget/v3/index.json
PackageSignatureVerificationLog: PackageIdentity: Newtonsoft.Json.12.0.3 Source: https://api.nuget.org/v3/index.json PackageSignatureValidity: True
Completed installation of Newtonsoft.Json 12.0.3 from https://api.nuget.org/v3/index.json
Checking compatibility of packages on net5.0.
Checking compatibility for Project1 1.0.0 with net5.0.
Checking compatibility for Newtonsoft.Json 12.0.3 with net5.0.
Checking compatibility for NuGetValidator 2.0.3 with net5.0.
All packages and projects are compatible with net5.0.
Committing restore...
Generating MSBuild file C:\Users\Roki2\Documents\Code\test\WhereDoesAPackageComeFrom\Project1\obj\Project1.csproj.nuget.g.props.
Generating MSBuild file C:\Users\Roki2\Documents\Code\test\WhereDoesAPackageComeFrom\Project1\obj\Project1.csproj.nuget.g.targets.
Writing assets file to disk. Path: C:\Users\Roki2\Documents\Code\test\WhereDoesAPackageComeFrom\Project1\obj\project.assets.json
Writing cache file to disk. Path: C:\Users\Roki2\Documents\Code\test\WhereDoesAPackageComeFrom\Project1\obj\project.nuget.cache
Persisting dg to C:\Users\Roki2\Documents\Code\test\WhereDoesAPackageComeFrom\Project1\obj\Project1.csproj.nuget.dgspec.json
Restored C:\Users\Roki2\Documents\Code\test\WhereDoesAPackageComeFrom\Project1\Project1.csproj (in 779 ms).

NuGet Config files used:
    C:\Users\Roki2\Documents\Code\test\WhereDoesAPackageComeFrom\NuGet.Config
    C:\Users\Roki2\Documents\Code\NuGet.Config
    C:\Users\Roki2\AppData\Roaming\NuGet\NuGet.Config
    C:\Program Files (x86)\NuGet\Config\Microsoft.VisualStudio.Offline.config

Feeds used:
    https://api.nuget.org/v3/index.json
    https://pkgs.dev.azure.com/dnceng/public/_packaging/nuget-build/nuget/v3/index.json

Installed:
    2 package(s) to C:\Users\Roki2\Documents\Code\test\WhereDoesAPackageComeFrom\Project1\Project1.csproj
```

## Testing/Validation

Tests Added: Yes
Reason for not adding tests:  
Validation:  
