### PR TITLE
RestoreNetCore_MultipleProjects_SameToolDifferentVersionsAsync: Add -DisableParallelProcessing.

### DIFF
--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
@@ -1791,7 +1791,7 @@ namespace NuGet.CommandLine.Test
                 var zPath = Path.Combine(pathContext.UserPackagesFolder, ".tools", "z");
 
                 // Act
-                var r = Util.RestoreSolution(pathContext);
+                var r = Util.RestoreSolution(pathContext, expectedExitCode: 0, "-DisableParallelProcessing");
 
                 // Assert
                 Assert.True(File.Exists(path), r.Item2);


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/10075
Regression: No

## Fix

Details: Adding -DisableParallelProcessing flag to build in this test.

## Testing/Validation

Tests Added: No
Reason for not adding tests: Just attempting to fix flaky test.
Validation: Automated.
