### PR TITLE
PM UI: propagate remote exceptions with custom error type

### DIFF
--- a/build/packages.targets
+++ b/build/packages.targets
@@ -6,7 +6,7 @@
         <VSComponentsVersion>16.6.255</VSComponentsVersion>
         <VSFrameworkVersion>16.6.30107.105</VSFrameworkVersion>
         <VSServicesVersion>16.153.0</VSServicesVersion>
-        <VSThreadingVersion>16.7.54</VSThreadingVersion>
+        <VSThreadingVersion>16.7.56</VSThreadingVersion>
         <!-- TODO - remove this when temporary patching is no longer necessary. See https://github.com/nuget/home/issues/8952 -->
         <PatchedSystemPackagesVersion>5.0.0-preview.3.20214.6</PatchedSystemPackagesVersion>
     </PropertyGroup>
@@ -27,7 +27,7 @@
         <PackageReference Update="Microsoft.DataAI.NuGetRecommender.Contracts" Version="2.1.0" />
         <PackageReference Update="Microsoft.Extensions.CommandLineUtils" Version="1.0.1" />
         <PackageReference Update="Microsoft.Internal.VisualStudio.Shell.Embeddable" Version="16.4.29305.180" />
-        <PackageReference Update="Microsoft.ServiceHub.Framework" Version="2.4.227" />
+        <PackageReference Update="Microsoft.ServiceHub.Framework" Version="2.7.96" />
         <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.0.0" />
         <PackageReference Update="Microsoft.TeamFoundationServer.ExtendedClient" Version="$(VSServicesVersion)" />
         <PackageReference Update="Microsoft.VSSDK.BuildTools" Version="16.7.3069" />
@@ -62,7 +62,7 @@
         <PackageReference Update="Microsoft.VisualStudio.Utilities" Version="$(VSFrameworkVersion)" />
         <PackageReference Update="Microsoft.Web.Xdt" Version="2.1.2" />
         <PackageReference Update="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
-        <PackageReference Update="System.Collections.Immutable" Version="1.5.0" />
+        <PackageReference Update="System.Collections.Immutable" Version="1.7.1" />
         <PackageReference Update="System.Diagnostics.Debug" Version="$(SystemPackagesVersion)" />
         <PackageReference Update="System.Security.Cryptography.Pkcs" Version="$(PatchedSystemPackagesVersion)" />
         <PackageReference Update="System.Security.Cryptography.Cng" Version="$(PatchedSystemPackagesVersion)" />

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetProjectManagerService.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetProjectManagerService.cs
@@ -15,11 +15,13 @@ using Microsoft.ServiceHub.Framework.Services;
 using Microsoft.VisualStudio.Threading;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
+using NuGet.Packaging.Signing;
 using NuGet.ProjectManagement;
 using NuGet.Protocol.Core.Types;
 using NuGet.Resolver;
 using NuGet.VisualStudio;
 using NuGet.VisualStudio.Internal.Contracts;
+using StreamJsonRpc;
 
 namespace NuGet.PackageManagement.VisualStudio
 {
@@ -218,38 +220,51 @@ namespace NuGet.PackageManagement.VisualStudio
 
             cancellationToken.ThrowIfCancellationRequested();
 
-            INuGetProjectContext projectContext = await ServiceLocator.GetInstanceAsync<INuGetProjectContext>();
-
-            Assumes.NotNull(projectContext);
-
-            if (IsDirectInstall(actions))
+            await CatchAndRethrowExceptionAsync(async () =>
             {
-                NuGetPackageManager.SetDirectInstall(_state.PackageIdentity, projectContext);
-            }
+                INuGetProjectContext? projectContext = null;
 
-            var nugetProjectActions = new List<NuGetProjectAction>();
-
-            foreach (ProjectAction action in actions)
-            {
-                if (_state.ResolvedActions.TryGetValue(action.Id, out ResolvedAction resolvedAction))
+                try
                 {
-                    nugetProjectActions.Add(resolvedAction.Action);
+                    projectContext = await ServiceLocator.GetInstanceAsync<INuGetProjectContext>();
+
+                    Assumes.NotNull(projectContext);
+
+                    if (IsDirectInstall(actions))
+                    {
+                        NuGetPackageManager.SetDirectInstall(_state.PackageIdentity, projectContext);
+                    }
+
+                    var nugetProjectActions = new List<NuGetProjectAction>();
+
+                    foreach (ProjectAction action in actions)
+                    {
+                        if (_state.ResolvedActions.TryGetValue(action.Id, out ResolvedAction resolvedAction))
+                        {
+                            nugetProjectActions.Add(resolvedAction.Action);
+                        }
+                    }
+
+                    Assumes.NotNullOrEmpty(nugetProjectActions);
+
+                    NuGetPackageManager packageManager = await _sharedState.PackageManager.GetValueAsync(cancellationToken);
+                    IEnumerable<NuGetProject> projects = nugetProjectActions.Select(action => action.Project);
+
+                    await packageManager.ExecuteNuGetProjectActionsAsync(
+                        projects,
+                        nugetProjectActions,
+                        projectContext,
+                        _state.SourceCacheContext,
+                        cancellationToken);
                 }
-            }
-
-            Assumes.NotNullOrEmpty(nugetProjectActions);
-
-            NuGetPackageManager packageManager = await _sharedState.PackageManager.GetValueAsync(cancellationToken);
-            IEnumerable<NuGetProject> projects = nugetProjectActions.Select(action => action.Project);
-
-            await packageManager.ExecuteNuGetProjectActionsAsync(
-                projects,
-                nugetProjectActions,
-                projectContext,
-                _state.SourceCacheContext,
-                cancellationToken);
-
-            NuGetPackageManager.ClearDirectInstall(projectContext);
+                finally
+                {
+                    if (projectContext != null)
+                    {
+                        NuGetPackageManager.ClearDirectInstall(projectContext);
+                    }
+                }
+            });
         }
 
         public async ValueTask<IReadOnlyList<ProjectAction>> GetInstallActionsAsync(
@@ -270,69 +285,72 @@ namespace NuGet.PackageManagement.VisualStudio
 
             cancellationToken.ThrowIfCancellationRequested();
 
-            _state.PackageIdentity = packageIdentity;
-
-            IReadOnlyList<SourceRepository> sourceRepositories = await GetSourceRepositoriesAsync(
-                packageSourceNames,
-                cancellationToken);
-
-            Assumes.NotNullOrEmpty(sourceRepositories);
-
-            INuGetProjectContext projectContext = await ServiceLocator.GetInstanceAsync<INuGetProjectContext>();
-            IReadOnlyList<NuGetProject> projects = await GetProjectsAsync(projectIds, cancellationToken);
-
-            var resolutionContext = new ResolutionContext(
-                dependencyBehavior,
-                includePrelease,
-                includeUnlisted: false,
-                versionConstraints,
-                new GatherCache(),
-                _state.SourceCacheContext);
-
-            NuGetPackageManager packageManager = await _sharedState.PackageManager.GetValueAsync(cancellationToken);
-            IEnumerable<ResolvedAction> resolvedActions = await packageManager.PreviewProjectsInstallPackageAsync(
-                projects,
-                _state.PackageIdentity,
-                resolutionContext,
-                projectContext,
-                sourceRepositories,
-                cancellationToken);
-
-            var projectActions = new List<ProjectAction>();
-
-            foreach (ResolvedAction resolvedAction in resolvedActions)
+            return await CatchAndRethrowExceptionAsync(async () =>
             {
-                List<ImplicitProjectAction>? implicitActions = null;
+                _state.PackageIdentity = packageIdentity;
 
-                if (resolvedAction.Action is BuildIntegratedProjectAction buildIntegratedAction)
+                IReadOnlyList<SourceRepository> sourceRepositories = await GetSourceRepositoriesAsync(
+                    packageSourceNames,
+                    cancellationToken);
+
+                Assumes.NotNullOrEmpty(sourceRepositories);
+
+                INuGetProjectContext projectContext = await ServiceLocator.GetInstanceAsync<INuGetProjectContext>();
+                IReadOnlyList<NuGetProject> projects = await GetProjectsAsync(projectIds, cancellationToken);
+
+                var resolutionContext = new ResolutionContext(
+                    dependencyBehavior,
+                    includePrelease,
+                    includeUnlisted: false,
+                    versionConstraints,
+                    new GatherCache(),
+                    _state.SourceCacheContext);
+
+                NuGetPackageManager packageManager = await _sharedState.PackageManager.GetValueAsync(cancellationToken);
+                IEnumerable<ResolvedAction> resolvedActions = await packageManager.PreviewProjectsInstallPackageAsync(
+                    projects,
+                    _state.PackageIdentity,
+                    resolutionContext,
+                    projectContext,
+                    sourceRepositories,
+                    cancellationToken);
+
+                var projectActions = new List<ProjectAction>();
+
+                foreach (ResolvedAction resolvedAction in resolvedActions)
                 {
-                    implicitActions = new List<ImplicitProjectAction>();
+                    List<ImplicitProjectAction>? implicitActions = null;
 
-                    foreach (NuGetProjectAction? buildAction in buildIntegratedAction.GetProjectActions())
+                    if (resolvedAction.Action is BuildIntegratedProjectAction buildIntegratedAction)
                     {
-                        var implicitAction = new ImplicitProjectAction(
-                            CreateProjectActionId(),
-                            buildAction.PackageIdentity,
-                            buildAction.NuGetProjectActionType);
+                        implicitActions = new List<ImplicitProjectAction>();
 
-                        implicitActions.Add(implicitAction);
+                        foreach (NuGetProjectAction? buildAction in buildIntegratedAction.GetProjectActions())
+                        {
+                            var implicitAction = new ImplicitProjectAction(
+                                CreateProjectActionId(),
+                                buildAction.PackageIdentity,
+                                buildAction.NuGetProjectActionType);
+
+                            implicitActions.Add(implicitAction);
+                        }
                     }
+
+                    string projectId = resolvedAction.Project.GetMetadata<string>(NuGetProjectMetadataKeys.ProjectId);
+                    var projectAction = new ProjectAction(
+                        CreateProjectActionId(),
+                        projectId,
+                        resolvedAction.Action.PackageIdentity,
+                        resolvedAction.Action.NuGetProjectActionType,
+                        implicitActions);
+
+                    _state.ResolvedActions[projectAction.Id] = resolvedAction;
+
+                    projectActions.Add(projectAction);
                 }
 
-                string projectId = resolvedAction.Project.GetMetadata<string>(NuGetProjectMetadataKeys.ProjectId);
-                var projectAction = new ProjectAction(
-                    CreateProjectActionId(),
-                    projectId,
-                    resolvedAction.Action.PackageIdentity,
-                    resolvedAction.Action.NuGetProjectActionType,
-                    implicitActions);
-
-                _state.ResolvedActions[projectAction.Id] = resolvedAction;
-
-                projectActions.Add(projectAction);
-            }
-
-            return projectActions;
+                return projectActions;
+            });
         }
 
         public async ValueTask<IReadOnlyList<ProjectAction>> GetUninstallActionsAsync(
@@ -351,39 +369,43 @@ namespace NuGet.PackageManagement.VisualStudio
 
             cancellationToken.ThrowIfCancellationRequested();
 
-            INuGetProjectContext projectContext = await ServiceLocator.GetInstanceAsync<INuGetProjectContext>();
-            (bool success, NuGetProject? project) = await TryGetNuGetProjectMatchingProjectIdAsync(projectId);
-
-            Assumes.True(success);
-            Assumes.NotNull(project);
-
-            var projectActions = new List<ProjectAction>();
-            var uninstallationContext = new UninstallationContext(removeDependencies, forceRemove);
-
-            NuGetPackageManager packageManager = await _sharedState.PackageManager.GetValueAsync(cancellationToken);
-            IEnumerable<NuGetProjectAction> actions = await packageManager.PreviewUninstallPackageAsync(
-                project,
-                packageIdentity.Id,
-                uninstallationContext,
-                projectContext,
-                cancellationToken);
-
-            foreach (NuGetProjectAction action in actions)
+            return await CatchAndRethrowExceptionAsync(async () =>
             {
-                var resolvedAction = new ResolvedAction(project, action);
-                var projectAction = new ProjectAction(
-                    CreateProjectActionId(),
-                    projectId,
-                    action.PackageIdentity,
-                    action.NuGetProjectActionType,
-                    implicitActions: null);
 
-                _state.ResolvedActions[projectAction.Id] = resolvedAction;
+                INuGetProjectContext projectContext = await ServiceLocator.GetInstanceAsync<INuGetProjectContext>();
+                (bool success, NuGetProject? project) = await TryGetNuGetProjectMatchingProjectIdAsync(projectId);
 
-                projectActions.Add(projectAction);
-            }
+                Assumes.True(success);
+                Assumes.NotNull(project);
 
-            return projectActions;
+                var projectActions = new List<ProjectAction>();
+                var uninstallationContext = new UninstallationContext(removeDependencies, forceRemove);
+
+                NuGetPackageManager packageManager = await _sharedState.PackageManager.GetValueAsync(cancellationToken);
+                IEnumerable<NuGetProjectAction> actions = await packageManager.PreviewUninstallPackageAsync(
+                    project,
+                    packageIdentity.Id,
+                    uninstallationContext,
+                    projectContext,
+                    cancellationToken);
+
+                foreach (NuGetProjectAction action in actions)
+                {
+                    var resolvedAction = new ResolvedAction(project, action);
+                    var projectAction = new ProjectAction(
+                        CreateProjectActionId(),
+                        projectId,
+                        action.PackageIdentity,
+                        action.NuGetProjectActionType,
+                        implicitActions: null);
+
+                    _state.ResolvedActions[projectAction.Id] = resolvedAction;
+
+                    projectActions.Add(projectAction);
+                }
+
+                return projectActions;
+            });
         }
 
         public async ValueTask<IReadOnlyList<ProjectAction>> GetUpdateActionsAsync(
@@ -402,76 +424,79 @@ namespace NuGet.PackageManagement.VisualStudio
             Assumes.NotNull(_state.ResolvedActions);
             Assumes.Null(_state.PackageIdentity);
 
-            var primarySources = new List<SourceRepository>();
-            var secondarySources = new List<SourceRepository>();
-
-            ISourceRepositoryProvider sourceRepositoryProvider = await _sharedState.SourceRepositoryProvider.GetValueAsync(cancellationToken);
-            IEnumerable<SourceRepository> sourceRepositories = sourceRepositoryProvider.GetRepositories();
-            var packageSourceNamesSet = new HashSet<string>(packageSourceNames, StringComparer.OrdinalIgnoreCase);
-
-            foreach (SourceRepository sourceRepository in sourceRepositories)
+            return await CatchAndRethrowExceptionAsync(async () =>
             {
-                if (packageSourceNamesSet.Contains(sourceRepository.PackageSource.Name))
+                var primarySources = new List<SourceRepository>();
+                var secondarySources = new List<SourceRepository>();
+
+                ISourceRepositoryProvider sourceRepositoryProvider = await _sharedState.SourceRepositoryProvider.GetValueAsync(cancellationToken);
+                IEnumerable<SourceRepository> sourceRepositories = sourceRepositoryProvider.GetRepositories();
+                var packageSourceNamesSet = new HashSet<string>(packageSourceNames, StringComparer.OrdinalIgnoreCase);
+
+                foreach (SourceRepository sourceRepository in sourceRepositories)
                 {
-                    primarySources.Add(sourceRepository);
+                    if (packageSourceNamesSet.Contains(sourceRepository.PackageSource.Name))
+                    {
+                        primarySources.Add(sourceRepository);
+                    }
+
+                    if (sourceRepository.PackageSource.IsEnabled)
+                    {
+                        secondarySources.Add(sourceRepository);
+                    }
                 }
 
-                if (sourceRepository.PackageSource.IsEnabled)
+                INuGetProjectContext projectContext = await ServiceLocator.GetInstanceAsync<INuGetProjectContext>();
+                var projects = new List<NuGetProject>();
+
+                foreach (string projectId in projectIds)
                 {
-                    secondarySources.Add(sourceRepository);
+                    (bool success, NuGetProject? project) = await TryGetNuGetProjectMatchingProjectIdAsync(projectId);
+
+                    Assumes.True(success);
+                    Assumes.NotNull(project);
+
+                    projects.Add(project);
                 }
-            }
 
-            INuGetProjectContext projectContext = await ServiceLocator.GetInstanceAsync<INuGetProjectContext>();
-            var projects = new List<NuGetProject>();
+                var resolutionContext = new ResolutionContext(
+                    dependencyBehavior,
+                    includePrelease,
+                    includeUnlisted: true,
+                    versionConstraints,
+                    new GatherCache(),
+                    _state.SourceCacheContext);
 
-            foreach (string projectId in projectIds)
-            {
-                (bool success, NuGetProject? project) = await TryGetNuGetProjectMatchingProjectIdAsync(projectId);
+                NuGetPackageManager packageManager = await _sharedState.PackageManager.GetValueAsync(cancellationToken);
+                IEnumerable<NuGetProjectAction> actions = await packageManager.PreviewUpdatePackagesAsync(
+                      packageIdentities.ToList(),
+                      projects,
+                      resolutionContext,
+                      projectContext,
+                      primarySources,
+                      secondarySources,
+                      cancellationToken);
 
-                Assumes.True(success);
-                Assumes.NotNull(project);
+                var projectActions = new List<ProjectAction>();
 
-                projects.Add(project);
-            }
+                foreach (NuGetProjectAction action in actions)
+                {
+                    string projectId = action.Project.GetMetadata<string>(NuGetProjectMetadataKeys.ProjectId);
+                    var resolvedAction = new ResolvedAction(action.Project, action);
+                    var projectAction = new ProjectAction(
+                        CreateProjectActionId(),
+                        projectId,
+                        action.PackageIdentity,
+                        action.NuGetProjectActionType,
+                        implicitActions: null);
 
-            var resolutionContext = new ResolutionContext(
-                dependencyBehavior,
-                includePrelease,
-                includeUnlisted: true,
-                versionConstraints,
-                new GatherCache(),
-                _state.SourceCacheContext);
+                    _state.ResolvedActions[projectAction.Id] = resolvedAction;
 
-            NuGetPackageManager packageManager = await _sharedState.PackageManager.GetValueAsync(cancellationToken);
-            IEnumerable<NuGetProjectAction> actions = await packageManager.PreviewUpdatePackagesAsync(
-                  packageIdentities.ToList(),
-                  projects,
-                  resolutionContext,
-                  projectContext,
-                  primarySources,
-                  secondarySources,
-                  cancellationToken);
+                    projectActions.Add(projectAction);
+                }
 
-            var projectActions = new List<ProjectAction>();
-
-            foreach (NuGetProjectAction action in actions)
-            {
-                string projectId = action.Project.GetMetadata<string>(NuGetProjectMetadataKeys.ProjectId);
-                var resolvedAction = new ResolvedAction(action.Project, action);
-                var projectAction = new ProjectAction(
-                    CreateProjectActionId(),
-                    projectId,
-                    action.PackageIdentity,
-                    action.NuGetProjectActionType,
-                    implicitActions: null);
-
-                _state.ResolvedActions[projectAction.Id] = resolvedAction;
-
-                projectActions.Add(projectAction);
-            }
-
-            return projectActions;
+                return projectActions;
+            });
         }
 
         public async ValueTask<IReadOnlyCollection<IProjectContextInfo>> GetProjectsWithDeprecatedDotnetFrameworkAsync(CancellationToken cancellationToken)
@@ -556,6 +581,42 @@ namespace NuGet.PackageManagement.VisualStudio
                 .FirstOrDefault(p => projectId.Equals(p.GetMetadata<string>(NuGetProjectMetadataKeys.ProjectId), StringComparison.OrdinalIgnoreCase));
 
             return (project != null, project);
+        }
+
+        private async ValueTask CatchAndRethrowExceptionAsync(Func<Task> taskFunc)
+        {
+            try
+            {
+                await taskFunc();
+            }
+            catch (Exception ex)
+            {
+                var exception = new LocalRpcException(ex.Message, ex)
+                {
+                    ErrorCode = (int)RemoteErrorCode.RemoteError,
+                    ErrorData = RemoteErrorUtility.ToRemoteError(ex)
+                };
+
+                throw exception;
+            }
+        }
+
+        private async ValueTask<T> CatchAndRethrowExceptionAsync<T>(Func<Task<T>> taskFunc)
+        {
+            try
+            {
+                return await taskFunc();
+            }
+            catch (Exception ex)
+            {
+                var exception = new LocalRpcException(ex.Message, ex)
+                {
+                    ErrorCode = (int)RemoteErrorCode.RemoteError,
+                    ErrorData = RemoteErrorUtility.ToRemoteError(ex)
+                };
+
+                throw exception;
+            }
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/ILogMessageFormatter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/ILogMessageFormatter.cs
@@ -1,0 +1,371 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using MessagePack;
+using MessagePack.Formatters;
+using Microsoft;
+using NuGet.Common;
+using NuGet.Packaging.Signing;
+
+namespace NuGet.VisualStudio.Internal.Contracts
+{
+    internal sealed class ILogMessageFormatter : IMessagePackFormatter<ILogMessage?>
+    {
+        private const string CodePropertyName = "code";
+        private const string EndColumnNumberPropertyName = "endcolumnnumber";
+        private const string EndLineNumberPropertyName = "endlinenumber";
+        private const string FilePathPropertyName = "filepath";
+        private const string LevelPropertyName = "level";
+        private const string LibraryIdPropertyName = "libraryid";
+        private const string MessagePropertyName = "message";
+        private const string ProjectPathPropertyName = "projectpath";
+        private const string ShouldDisplayPropertyName = "shoulddisplay";
+        private const string StartColumnNumberPropertyName = "startcolumnnumber";
+        private const string StartLineNumberPropertyName = "startlinenumber";
+        private const string TargetGraphsPropertyName = "targetgraphs";
+        private const string TimePropertyName = "time";
+        private const string TypeNamePropertyName = "typename";
+        private const string WarningLevelPropertyName = "warninglevel";
+
+        private static readonly string LogMessageTypeName = typeof(LogMessage).Name;
+        private static readonly string PackagingLogMessageTypeName = typeof(PackagingLogMessage).Name;
+        private static readonly string RestoreLogMessageTypeName = typeof(RestoreLogMessage).Name;
+        private static readonly string SignatureLogTypeName = typeof(SignatureLog).Name;
+
+        internal static readonly IMessagePackFormatter<ILogMessage?> Instance = new ILogMessageFormatter();
+
+        private ILogMessageFormatter()
+        {
+        }
+
+        public ILogMessage? Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
+        {
+            if (reader.TryReadNil())
+            {
+                return null;
+            }
+
+            // stack overflow mitigation - see https://github.com/neuecc/MessagePack-CSharp/security/advisories/GHSA-7q36-4xx7-xcxf
+            options.Security.DepthStep(ref reader);
+
+            try
+            {
+                NuGetLogCode? code = null;
+                int? endColumnNumber = null;
+                int? endLineNumber = null;
+                string? filePath = null;
+                string? libraryId = null;
+                LogLevel? logLevel = null;
+                string? message = null;
+                string? projectPath = null;
+                bool? shouldDisplay = null;
+                int? startColumnNumber = null;
+                int? startLineNumber = null;
+                List<string>? targetGraphs = null;
+                DateTimeOffset? time = null;
+                string? typeName = null;
+                WarningLevel? warningLevel = null;
+
+                int propertyCount = reader.ReadMapHeader();
+
+                for (var propertyIndex = 0; propertyIndex < propertyCount; ++propertyIndex)
+                {
+                    switch (reader.ReadString())
+                    {
+                        case CodePropertyName:
+                            code = options.Resolver.GetFormatter<NuGetLogCode>().Deserialize(ref reader, options);
+                            break;
+
+                        case EndColumnNumberPropertyName:
+                            endColumnNumber = reader.ReadInt32();
+                            break;
+
+                        case EndLineNumberPropertyName:
+                            endLineNumber = reader.ReadInt32();
+                            break;
+
+                        case FilePathPropertyName:
+                            filePath = reader.ReadString();
+                            break;
+
+                        case LevelPropertyName:
+                            logLevel = options.Resolver.GetFormatter<LogLevel>().Deserialize(ref reader, options);
+                            break;
+
+                        case LibraryIdPropertyName:
+                            libraryId = reader.ReadString();
+                            break;
+
+                        case MessagePropertyName:
+                            message = reader.ReadString();
+                            break;
+
+                        case ProjectPathPropertyName:
+                            projectPath = reader.ReadString();
+                            break;
+
+                        case ShouldDisplayPropertyName:
+                            shouldDisplay = reader.ReadBoolean();
+                            break;
+
+                        case StartColumnNumberPropertyName:
+                            startColumnNumber = reader.ReadInt32();
+                            break;
+
+                        case StartLineNumberPropertyName:
+                            startLineNumber = reader.ReadInt32();
+                            break;
+
+                        case TargetGraphsPropertyName:
+                            if (!reader.TryReadNil())
+                            {
+                                targetGraphs = new List<string>();
+
+                                int targetGraphsCount = reader.ReadArrayHeader();
+
+                                for (var i = 0; i < targetGraphsCount; ++i)
+                                {
+                                    string targetGraph = reader.ReadString();
+
+                                    targetGraphs.Add(targetGraph);
+                                }
+                            }
+                            break;
+
+                        case TimePropertyName:
+                            time = options.Resolver.GetFormatter<DateTimeOffset>().Deserialize(ref reader, options);
+                            break;
+
+                        case TypeNamePropertyName:
+                            typeName = reader.ReadString();
+                            break;
+
+                        case WarningLevelPropertyName:
+                            warningLevel = options.Resolver.GetFormatter<WarningLevel>().Deserialize(ref reader, options);
+                            break;
+
+                        default:
+                            reader.Skip();
+                            break;
+                    }
+                }
+
+                Assumes.NotNullOrEmpty(typeName);
+                Assumes.True(code.HasValue);
+                Assumes.True(logLevel.HasValue);
+                Assumes.NotNull(message);
+                Assumes.True(time.HasValue);
+                Assumes.True(warningLevel.HasValue);
+
+                ILogMessage? logMessage = null;
+
+                if (typeName == LogMessageTypeName)
+                {
+                    logMessage = new LogMessage(logLevel.Value, message)
+                    {
+                        Code = code.Value,
+                        ProjectPath = projectPath,
+                        Time = time.Value,
+                        WarningLevel = warningLevel.Value
+                    };
+                }
+                else if (typeName == PackagingLogMessageTypeName)
+                {
+                    Assumes.True(endColumnNumber.HasValue);
+                    Assumes.True(endLineNumber.HasValue);
+                    Assumes.True(startColumnNumber.HasValue);
+                    Assumes.True(startLineNumber.HasValue);
+
+                    PackagingLogMessage packagingLogMessage = PackagingLogMessage.CreateError(message, code.Value);
+
+                    packagingLogMessage.Code = code.Value;
+                    packagingLogMessage.EndColumnNumber = endColumnNumber.Value;
+                    packagingLogMessage.EndLineNumber = endLineNumber.Value;
+                    packagingLogMessage.FilePath = filePath;
+                    packagingLogMessage.Level = logLevel.Value;
+                    packagingLogMessage.ProjectPath = projectPath;
+                    packagingLogMessage.StartColumnNumber = startColumnNumber.Value;
+                    packagingLogMessage.StartLineNumber = startLineNumber.Value;
+                    packagingLogMessage.Time = time.Value;
+                    packagingLogMessage.WarningLevel = warningLevel.Value;
+
+                    logMessage = packagingLogMessage;
+                }
+                else if (typeName == RestoreLogMessageTypeName)
+                {
+                    Assumes.True(endColumnNumber.HasValue);
+                    Assumes.True(endLineNumber.HasValue);
+                    Assumes.True(shouldDisplay.HasValue);
+                    Assumes.True(startColumnNumber.HasValue);
+                    Assumes.True(startLineNumber.HasValue);
+
+                    logMessage = new RestoreLogMessage(logLevel.Value, message)
+                    {
+                        Code = code.Value,
+                        EndColumnNumber = endColumnNumber.Value,
+                        EndLineNumber = endLineNumber.Value,
+                        FilePath = filePath,
+                        Level = logLevel.Value,
+                        LibraryId = libraryId,
+                        Message = message,
+                        ProjectPath = projectPath,
+                        ShouldDisplay = shouldDisplay.Value,
+                        StartColumnNumber = startColumnNumber.Value,
+                        StartLineNumber = startLineNumber.Value,
+                        TargetGraphs = targetGraphs,
+                        Time = time.Value,
+                        WarningLevel = warningLevel.Value
+                    };
+                }
+                else if (typeName == SignatureLogTypeName)
+                {
+                    SignatureLog signatureLog = SignatureLog.Error(code.Value, message);
+
+                    signatureLog.Code = code.Value;
+                    signatureLog.Level = logLevel.Value;
+                    signatureLog.LibraryId = libraryId;
+                    signatureLog.ProjectPath = projectPath;
+                    signatureLog.Time = time.Value;
+                    signatureLog.WarningLevel = warningLevel.Value;
+
+                    logMessage = signatureLog;
+                }
+                else
+                {
+                    throw new InvalidOperationException();
+                }
+
+                return logMessage;
+            }
+            finally
+            {
+                // stack overflow mitigation - see https://github.com/neuecc/MessagePack-CSharp/security/advisories/GHSA-7q36-4xx7-xcxf
+                reader.Depth--;
+            }
+        }
+
+        public void Serialize(ref MessagePackWriter writer, ILogMessage? value, MessagePackSerializerOptions options)
+        {
+            if (value == null)
+            {
+                writer.WriteNil();
+                return;
+            }
+
+            if (value is LogMessage logMessage)
+            {
+                Serialize(ref writer, logMessage, options);
+            }
+            else if (value is RestoreLogMessage restoreLogMessage)
+            {
+                Serialize(ref writer, restoreLogMessage, options);
+            }
+            else if (value is SignatureLog signatureLogMessage)
+            {
+                Serialize(ref writer, signatureLogMessage, options);
+            }
+            else if (value is PackagingLogMessage packagingLogMessage)
+            {
+                Serialize(ref writer, packagingLogMessage, options);
+            }
+            else
+            {
+                throw new InvalidOperationException();
+            }
+        }
+
+        private void SerializeCommonProperties(ref MessagePackWriter writer, ILogMessage value, MessagePackSerializerOptions options)
+        {
+            writer.Write(TypeNamePropertyName);
+            writer.Write(value.GetType().Name);
+            writer.Write(CodePropertyName);
+            options.Resolver.GetFormatter<NuGetLogCode>().Serialize(ref writer, value.Code, options);
+            writer.Write(LevelPropertyName);
+            options.Resolver.GetFormatter<LogLevel>().Serialize(ref writer, value.Level, options);
+            writer.Write(MessagePropertyName);
+            writer.Write(value.Message);
+            writer.Write(ProjectPathPropertyName);
+            writer.Write(value.ProjectPath);
+            writer.Write(TimePropertyName);
+            options.Resolver.GetFormatter<DateTimeOffset>().Serialize(ref writer, value.Time, options);
+            writer.Write(WarningLevelPropertyName);
+            options.Resolver.GetFormatter<WarningLevel>().Serialize(ref writer, value.WarningLevel, options);
+        }
+
+        private void Serialize(ref MessagePackWriter writer, LogMessage logMessage, MessagePackSerializerOptions options)
+        {
+            writer.WriteMapHeader(count: 7);
+
+            SerializeCommonProperties(ref writer, logMessage, options);
+        }
+
+        private void Serialize(ref MessagePackWriter writer, PackagingLogMessage logMessage, MessagePackSerializerOptions options)
+        {
+            writer.WriteMapHeader(count: 12);
+
+            SerializeCommonProperties(ref writer, logMessage, options);
+
+            writer.Write(EndColumnNumberPropertyName);
+            writer.Write(logMessage.EndColumnNumber);
+            writer.Write(EndLineNumberPropertyName);
+            writer.Write(logMessage.EndLineNumber);
+            writer.Write(FilePathPropertyName);
+            writer.Write(logMessage.FilePath);
+            writer.Write(StartColumnNumberPropertyName);
+            writer.Write(logMessage.StartColumnNumber);
+            writer.Write(StartLineNumberPropertyName);
+            writer.Write(logMessage.StartLineNumber);
+        }
+
+        private void Serialize(ref MessagePackWriter writer, RestoreLogMessage logMessage, MessagePackSerializerOptions options)
+        {
+            writer.WriteMapHeader(count: 15);
+
+            SerializeCommonProperties(ref writer, logMessage, options);
+
+            writer.Write(EndColumnNumberPropertyName);
+            writer.Write(logMessage.EndColumnNumber);
+            writer.Write(EndLineNumberPropertyName);
+            writer.Write(logMessage.EndLineNumber);
+            writer.Write(FilePathPropertyName);
+            writer.Write(logMessage.FilePath);
+            writer.Write(LibraryIdPropertyName);
+            writer.Write(logMessage.LibraryId);
+            writer.Write(ShouldDisplayPropertyName);
+            writer.Write(logMessage.ShouldDisplay);
+            writer.Write(StartColumnNumberPropertyName);
+            writer.Write(logMessage.StartColumnNumber);
+            writer.Write(StartLineNumberPropertyName);
+            writer.Write(logMessage.StartLineNumber);
+            writer.Write(TargetGraphsPropertyName);
+
+            if (logMessage.TargetGraphs is null)
+            {
+                writer.WriteNil();
+            }
+            else
+            {
+                writer.WriteArrayHeader(logMessage.TargetGraphs.Count);
+
+                foreach (string targetGraph in logMessage.TargetGraphs)
+                {
+                    writer.Write(targetGraph);
+                }
+            }
+        }
+
+        private void Serialize(ref MessagePackWriter writer, SignatureLog logMessage, MessagePackSerializerOptions options)
+        {
+            writer.WriteMapHeader(count: 8);
+
+            SerializeCommonProperties(ref writer, logMessage, options);
+
+            writer.Write(LibraryIdPropertyName);
+            writer.Write(logMessage.LibraryId);
+        }
+    }
+}

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/RemoteErrorFormatter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/RemoteErrorFormatter.cs
@@ -1,0 +1,140 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#nullable enable
+
+using System.Collections.Generic;
+using MessagePack;
+using MessagePack.Formatters;
+using Microsoft;
+using NuGet.Common;
+
+namespace NuGet.VisualStudio.Internal.Contracts
+{
+    internal sealed class RemoteErrorFormatter : IMessagePackFormatter<RemoteError?>
+    {
+        private const string ActivityLogMessagePropertyName = "activitylog";
+        private const string LogMessagePropertyName = "logmessage";
+        private const string LogMessagesPropertyName = "logmessages";
+        private const string ProjectContextLogMessagePropertyName = "projectcontextlogmessage";
+        private const string TypeNamePropertyName = "typename";
+
+        internal static readonly IMessagePackFormatter<RemoteError?> Instance = new RemoteErrorFormatter();
+
+        private RemoteErrorFormatter()
+        {
+        }
+
+        public RemoteError? Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
+        {
+            if (reader.TryReadNil())
+            {
+                return null;
+            }
+
+            // stack overflow mitigation - see https://github.com/neuecc/MessagePack-CSharp/security/advisories/GHSA-7q36-4xx7-xcxf
+            options.Security.DepthStep(ref reader);
+
+            try
+            {
+                string? activityLogMessage = null;
+                ILogMessage? logMessage = null;
+                List<ILogMessage>? logMessages = null;
+                string? projectContextLogMessage = null;
+                string? typeName = null;
+
+                int propertyCount = reader.ReadMapHeader();
+
+                for (var propertyIndex = 0; propertyIndex < propertyCount; ++propertyIndex)
+                {
+                    switch (reader.ReadString())
+                    {
+                        case ActivityLogMessagePropertyName:
+                            activityLogMessage = reader.ReadString();
+                            break;
+
+                        case LogMessagePropertyName:
+                            logMessage = ILogMessageFormatter.Instance.Deserialize(ref reader, options);
+                            break;
+
+                        case LogMessagesPropertyName:
+                            if (!reader.TryReadNil())
+                            {
+                                logMessages = new List<ILogMessage>();
+
+                                int logMessagesCount = reader.ReadArrayHeader();
+
+                                for (var i = 0; i < logMessagesCount; ++i)
+                                {
+                                    ILogMessage? lm = ILogMessageFormatter.Instance.Deserialize(ref reader, options);
+
+                                    Assumes.NotNull(lm);
+
+                                    logMessages.Add(lm);
+                                }
+                            }
+                            break;
+
+                        case ProjectContextLogMessagePropertyName:
+                            projectContextLogMessage = reader.ReadString();
+                            break;
+
+                        case TypeNamePropertyName:
+                            typeName = reader.ReadString();
+                            break;
+
+                        default:
+                            reader.Skip();
+                            break;
+                    }
+                }
+
+                Assumes.NotNullOrEmpty(typeName);
+                Assumes.NotNull(logMessage);
+
+                return new RemoteError(typeName, logMessage, logMessages, projectContextLogMessage, activityLogMessage);
+            }
+            finally
+            {
+                // stack overflow mitigation - see https://github.com/neuecc/MessagePack-CSharp/security/advisories/GHSA-7q36-4xx7-xcxf
+                reader.Depth--;
+            }
+        }
+
+        public void Serialize(ref MessagePackWriter writer, RemoteError? value, MessagePackSerializerOptions options)
+        {
+            if (value == null)
+            {
+                writer.WriteNil();
+                return;
+            }
+
+            writer.WriteMapHeader(count: 5);
+            writer.Write(ActivityLogMessagePropertyName);
+            writer.Write(value.ActivityLogMessage);
+            writer.Write(LogMessagePropertyName);
+            ILogMessageFormatter.Instance.Serialize(ref writer, value.LogMessage, options);
+
+            writer.Write(LogMessagesPropertyName);
+
+            if (value.LogMessages is null)
+            {
+                writer.WriteNil();
+            }
+            else
+            {
+                writer.WriteArrayHeader(value.LogMessages.Count);
+
+                foreach (ILogMessage logMessage in value.LogMessages)
+                {
+                    ILogMessageFormatter.Instance.Serialize(ref writer, logMessage, options);
+                }
+            }
+
+            writer.Write(ProjectContextLogMessagePropertyName);
+            writer.Write(value.ProjectContextLogMessage);
+            writer.Write(TypeNamePropertyName);
+            writer.Write(value.TypeName);
+        }
+    }
+}

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/NuGetJsonRpc.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/NuGetJsonRpc.cs
@@ -1,0 +1,30 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using StreamJsonRpc;
+using StreamJsonRpc.Protocol;
+
+namespace NuGet.VisualStudio.Internal.Contracts
+{
+    // Unsealed only to facilitate testing.
+    internal class NuGetJsonRpc : JsonRpc
+    {
+        internal NuGetJsonRpc(IJsonRpcMessageHandler messageHandler)
+            : base(messageHandler)
+        {
+        }
+
+        protected override Type GetErrorDetailsDataType(JsonRpcError error)
+        {
+            if (error is object
+                && error.Error is object
+                && (int)error.Error.Code == (int)RemoteErrorCode.RemoteError)
+            {
+                return typeof(RemoteError);
+            }
+
+            return base.GetErrorDetailsDataType(error);
+        }
+    }
+}

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/NuGetServiceMessagePackRpcDescriptor.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/NuGetServiceMessagePackRpcDescriptor.cs
@@ -34,11 +34,14 @@ namespace NuGet.VisualStudio.Internal.Contracts
                 PackageSourceFormatter.Instance,
                 PackageSourceUpdateOptionsFormatter.Instance,
                 ProjectActionFormatter.Instance,
+                RemoteErrorFormatter.Instance,
                 VersionRangeFormatter.Instance
             };
             var resolvers = new IFormatterResolver[] { MessagePackSerializerOptions.Standard.Resolver };
 
-            MessagePackSerializerOptions = MessagePackSerializerOptions.Standard.WithSecurity(MessagePackSecurity.UntrustedData).WithResolver(CompositeResolver.Create(formatters, resolvers));
+            MessagePackSerializerOptions = MessagePackSerializerOptions.Standard
+                .WithSecurity(MessagePackSecurity.UntrustedData)
+                .WithResolver(CompositeResolver.Create(formatters, resolvers));
         }
 
         internal NuGetServiceMessagePackRpcDescriptor(ServiceMoniker serviceMoniker)
@@ -65,6 +68,11 @@ namespace NuGet.VisualStudio.Internal.Contracts
             MessagePackFormatter formatter = base.CreateFormatter() as MessagePackFormatter ?? new MessagePackFormatter();
             formatter.SetMessagePackSerializerOptions(MessagePackSerializerOptions);
             return formatter;
+        }
+
+        protected override JsonRpc CreateJsonRpc(IJsonRpcMessageHandler handler)
+        {
+            return new NuGetJsonRpc(handler);
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/RemoteErrorCode.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/RemoteErrorCode.cs
@@ -1,0 +1,16 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGet.VisualStudio.Internal.Contracts
+{
+    // Values -32768 to -32000 are reserved by the JSON-RPC protocol.  Do not use them!
+    // See https://www.jsonrpc.org/specification#error_object for details.
+    public enum RemoteErrorCode : int
+    {
+        /// <summary>
+        /// This code serves as a hint to clients on how to deserialize the error data.
+        /// It does not represent a unique error condition.
+        /// </summary>
+        RemoteError = -31999
+    }
+}

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Utility/RemoteError.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Utility/RemoteError.cs
@@ -1,0 +1,42 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using NuGet.Common;
+
+namespace NuGet.VisualStudio.Internal.Contracts
+{
+    public sealed class RemoteError
+    {
+        public ILogMessage LogMessage { get; }
+        public IReadOnlyList<ILogMessage> LogMessages { get; }
+        public string ProjectContextLogMessage { get; }
+        public string ActivityLogMessage { get; }
+        public string TypeName { get; }
+
+        public RemoteError(string typeName, ILogMessage logMessage, IReadOnlyList<ILogMessage> logMessages)
+        {
+            if (string.IsNullOrEmpty(typeName))
+            {
+                throw new ArgumentException(Resources.ArgumentCannotBeNullOrEmpty, nameof(typeName));
+            }
+
+            TypeName = typeName;
+            LogMessage = logMessage ?? throw new ArgumentNullException(nameof(logMessage));
+            LogMessages = logMessages;
+        }
+
+        public RemoteError(
+            string typeName,
+            ILogMessage logMessage,
+            IReadOnlyList<ILogMessage> logMessages,
+            string projectContextLogMessage,
+            string activityLogMessage)
+            : this(typeName, logMessage, logMessages)
+        {
+            ProjectContextLogMessage = projectContextLogMessage;
+            ActivityLogMessage = activityLogMessage;
+        }
+    }
+}

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Utility/RemoteErrorUtility.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Utility/RemoteErrorUtility.cs
@@ -1,0 +1,67 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NuGet.Common;
+using NuGet.Frameworks;
+using NuGet.PackageManagement;
+using NuGet.Packaging;
+using NuGet.Packaging.Core;
+using NuGet.Packaging.Signing;
+using NuGet.Protocol.Core.Types;
+using NuGet.Resolver;
+
+namespace NuGet.VisualStudio.Internal.Contracts
+{
+    public static class RemoteErrorUtility
+    {
+        public static RemoteError ToRemoteError(Exception exception)
+        {
+            if (exception is null)
+            {
+                throw new ArgumentNullException(nameof(exception));
+            }
+
+            ILogMessage logMessage;
+            IReadOnlyList<ILogMessage> logMessages = null;
+            string typeName = exception.GetType().FullName;
+
+            if (exception is SignatureException signatureException)
+            {
+                logMessage = signatureException.AsLogMessage();
+                IReadOnlyList<PackageVerificationResult> results = signatureException.Results ?? Array.Empty<PackageVerificationResult>();
+                logMessages = results.SelectMany(result => result.Issues).ToArray();
+
+                return new RemoteError(typeName, logMessage, logMessages);
+            }
+
+            logMessage = new LogMessage(LogLevel.Error, ExceptionUtilities.DisplayMessage(exception, indent: false));
+            string projectContextLogMessage = null;
+            string activityLogMessage = null;
+
+            if (exception is NuGetResolverConstraintException
+                || exception is PackageAlreadyInstalledException
+                || exception is MinClientVersionException
+                || exception is FrameworkException
+                || exception is NuGetProtocolException
+                || exception is PackagingException
+                || exception is InvalidOperationException
+                || exception is PackageReferenceRollbackException)
+            {
+                projectContextLogMessage = ExceptionUtilities.DisplayMessage(exception, indent: true);
+                activityLogMessage = exception.ToString();
+
+                if (exception is PackageReferenceRollbackException rollbackException)
+                {
+                    logMessages = rollbackException.LogMessages
+                        .Where(message => message.Level == LogLevel.Error || message.Level == LogLevel.Warning)
+                        .ToArray();
+                }
+            }
+
+            return new RemoteError(typeName, logMessage, logMessages, projectContextLogMessage, activityLogMessage);
+        }
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/Formatters/ILogMessageFormatterTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/Formatters/ILogMessageFormatterTests.cs
@@ -1,0 +1,96 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using NuGet.Common;
+using NuGet.Packaging.Signing;
+using Xunit;
+
+namespace NuGet.VisualStudio.Internal.Contracts.Test
+{
+    public sealed class ILogMessageFormatterTests : FormatterTests
+    {
+        private const string Message = "a";
+
+        [Theory]
+        [MemberData(nameof(ILogMessages))]
+        public void SerializeThenDeserialize_WithValidArguments_RoundTrips(ILogMessage expectedResult)
+        {
+            ILogMessage actualResult = SerializeThenDeserialize(ILogMessageFormatter.Instance, expectedResult);
+
+            TestUtility.AssertEqual(expectedResult, actualResult);
+        }
+
+        public static TheoryData ILogMessages => new TheoryData<ILogMessage>
+            {
+                { new LogMessage(LogLevel.Error, Message, NuGetLogCode.NU3000) },
+                {
+                    new LogMessage(LogLevel.Warning, Message, NuGetLogCode.NU3027)
+                    {
+                        ProjectPath = "b",
+                        WarningLevel = WarningLevel.Important
+                    }
+                },
+                { PackagingLogMessage.CreateError(Message, NuGetLogCode.NU1103) },
+                { PackagingLogMessage.CreateMessage(Message, LogLevel.Verbose) },
+                { PackagingLogMessage.CreateWarning(Message, NuGetLogCode.NU1103) },
+                { CreatePackagingLogMessage() },
+                { SignatureLog.DebugLog(Message) },
+                { SignatureLog.DetailedLog(Message) },
+                { SignatureLog.Error(NuGetLogCode.NU3014, Message) },
+                { SignatureLog.InformationLog(Message) },
+                { SignatureLog.Issue(fatal: true, NuGetLogCode.NU3030, Message) },
+                { CreateSignatureLog() },
+                {
+                    new RestoreLogMessage(LogLevel.Error, errorString: "a")
+                    {
+                        Code = NuGetLogCode.NU1605,
+                        EndColumnNumber = 1,
+                        EndLineNumber = 2,
+                        FilePath = "b",
+                        Level = LogLevel.Minimal,
+                        LibraryId = "c",
+                        ProjectPath = "d",
+                        ShouldDisplay = true,
+                        StartColumnNumber = 3,
+                        StartLineNumber = 4,
+                        TargetGraphs = new string[] { "e", "f" },
+                        Time = DateTimeOffset.UtcNow,
+                        WarningLevel = WarningLevel.Important
+                    }
+                }
+            };
+
+        private static PackagingLogMessage CreatePackagingLogMessage()
+        {
+            PackagingLogMessage packagingLogMessage = PackagingLogMessage.CreateError(Message, NuGetLogCode.NU3031);
+
+            packagingLogMessage.Code = NuGetLogCode.NU1103;
+            packagingLogMessage.EndColumnNumber = 1;
+            packagingLogMessage.EndLineNumber = 2;
+            packagingLogMessage.FilePath = "b";
+            packagingLogMessage.Level = LogLevel.Minimal;
+            packagingLogMessage.ProjectPath = "c";
+            packagingLogMessage.StartColumnNumber = 3;
+            packagingLogMessage.StartLineNumber = 4;
+            packagingLogMessage.Time = DateTimeOffset.UtcNow;
+            packagingLogMessage.WarningLevel = WarningLevel.Minimal;
+
+            return packagingLogMessage;
+        }
+
+        private static SignatureLog CreateSignatureLog()
+        {
+            SignatureLog signatureLog = SignatureLog.Error(NuGetLogCode.NU3031, Message);
+
+            signatureLog.Code = NuGetLogCode.NU3017;
+            signatureLog.Level = LogLevel.Verbose;
+            signatureLog.LibraryId = "b";
+            signatureLog.ProjectPath = "c";
+            signatureLog.Time = DateTimeOffset.UtcNow;
+            signatureLog.WarningLevel = WarningLevel.Important;
+
+            return signatureLog;
+        }
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/Formatters/RemoteErrorFormatterTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/Formatters/RemoteErrorFormatterTests.cs
@@ -1,0 +1,49 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using NuGet.Common;
+using Xunit;
+
+namespace NuGet.VisualStudio.Internal.Contracts.Test
+{
+    public sealed class RemoteErrorFormatterTests : FormatterTests
+    {
+        private static readonly LogMessage LogMessage = new LogMessage(LogLevel.Error, message: "a");
+        private static readonly IReadOnlyList<LogMessage> LogMessages = new[] { new LogMessage(LogLevel.Warning, message: "b") };
+        private const string TypeName = "c";
+
+        [Theory]
+        [MemberData(nameof(RemoteErrors))]
+        public void SerializeThenDeserialize_WithValidArguments_RoundTrips(RemoteError expectedResult)
+        {
+            RemoteError actualResult = SerializeThenDeserialize(RemoteErrorFormatter.Instance, expectedResult);
+
+            Assert.Equal(expectedResult.ActivityLogMessage, actualResult.ActivityLogMessage);
+            TestUtility.AssertEqual(expectedResult.LogMessage, actualResult.LogMessage);
+            TestUtility.AssertEqual(expectedResult.LogMessages, actualResult.LogMessages);
+            Assert.Equal(expectedResult.ProjectContextLogMessage, actualResult.ProjectContextLogMessage);
+            Assert.Equal(expectedResult.TypeName, actualResult.TypeName);
+        }
+
+        public static TheoryData RemoteErrors => new TheoryData<RemoteError>
+            {
+                {
+                    new RemoteError(
+                        TypeName,
+                        LogMessage,
+                        logMessages: null,
+                        projectContextLogMessage: null,
+                        activityLogMessage: null)
+                },
+                {
+                    new RemoteError(
+                        TypeName,
+                        LogMessage,
+                        LogMessages,
+                        projectContextLogMessage: "d",
+                        activityLogMessage: "e")
+                },
+            };
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/NuGetJsonRpcTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/NuGetJsonRpcTests.cs
@@ -1,0 +1,89 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Moq;
+using StreamJsonRpc;
+using StreamJsonRpc.Protocol;
+using Xunit;
+
+namespace NuGet.VisualStudio.Internal.Contracts.Test
+{
+    public class NuGetJsonRpcTests
+    {
+        [Fact]
+        public void GetErrorDetailsDataType_WhenErrorIsNull_CallsBase()
+        {
+            using (var rpc = new TestJsonRpc())
+            {
+                Type type = rpc.GetErrorDetailsDataTypeHelper(error: null);
+
+                Assert.Equal(typeof(CommonErrorData), type);
+            }
+        }
+
+        [Fact]
+        public void GetErrorDetailsDataType_WhenErrorPropertyIsNull_CallsBase()
+        {
+            using (var rpc = new TestJsonRpc())
+            {
+                Type type = rpc.GetErrorDetailsDataTypeHelper(
+                    new JsonRpcError()
+                    {
+                        Error = null
+                    });
+
+                Assert.Equal(typeof(CommonErrorData), type);
+            }
+        }
+
+        [Fact]
+        public void GetErrorDetailsDataType_WhenErrorCodePropertyIsNotAMatch_CallsBase()
+        {
+            using (var rpc = new TestJsonRpc())
+            {
+                Type type = rpc.GetErrorDetailsDataTypeHelper(
+                    new JsonRpcError()
+                    {
+                        Error = new JsonRpcError.ErrorDetail()
+                        {
+                            Code = (JsonRpcErrorCode)int.MinValue
+                        }
+                    });
+
+                Assert.Equal(typeof(CommonErrorData), type);
+            }
+        }
+
+        [Fact]
+        public void GetErrorDetailsDataType_WhenErrorCodePropertyIsAMatch_ReturnsRemoteErrorType()
+        {
+            using (var rpc = new TestJsonRpc())
+            {
+                Type type = rpc.GetErrorDetailsDataTypeHelper(
+                    new JsonRpcError()
+                    {
+                        Error = new JsonRpcError.ErrorDetail()
+                        {
+                            Code = (JsonRpcErrorCode)(int)RemoteErrorCode.RemoteError
+                        }
+                    });
+
+                Assert.Equal(typeof(RemoteError), type);
+            }
+        }
+
+        private sealed class TestJsonRpc : NuGetJsonRpc
+        {
+            internal TestJsonRpc()
+                : base(Mock.Of<IJsonRpcMessageHandler>())
+            {
+            }
+
+            internal Type GetErrorDetailsDataTypeHelper(JsonRpcError error)
+            {
+                return GetErrorDetailsDataType(error);
+            }
+        }
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/TestUtility.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/TestUtility.cs
@@ -1,0 +1,95 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using NuGet.Common;
+using NuGet.Packaging.Signing;
+using Xunit;
+
+namespace NuGet.VisualStudio.Internal.Contracts.Test
+{
+    internal static class TestUtility
+    {
+        internal static void AssertEqual(ILogMessage expectedResult, ILogMessage actualResult)
+        {
+            if (expectedResult is null)
+            {
+                Assert.Null(actualResult);
+
+                return;
+            }
+            else
+            {
+                Assert.NotNull(actualResult);
+            }
+
+            Assert.Equal(expectedResult.Code, actualResult.Code);
+            Assert.Equal(expectedResult.Level, actualResult.Level);
+            Assert.Equal(expectedResult.Message, actualResult.Message);
+            Assert.Equal(expectedResult.ProjectPath, actualResult.ProjectPath);
+            Assert.Equal(expectedResult.Time, actualResult.Time);
+            Assert.Equal(expectedResult.WarningLevel, actualResult.WarningLevel);
+
+            if (expectedResult is PackagingLogMessage expectedPackagingResult)
+            {
+                Assert.IsType<PackagingLogMessage>(actualResult);
+
+                var actualPackagingResult = (PackagingLogMessage)actualResult;
+
+                Assert.Equal(expectedPackagingResult.EndColumnNumber, actualPackagingResult.EndColumnNumber);
+                Assert.Equal(expectedPackagingResult.EndLineNumber, actualPackagingResult.EndLineNumber);
+                Assert.Equal(expectedPackagingResult.FilePath, actualPackagingResult.FilePath);
+                Assert.Equal(expectedPackagingResult.StartColumnNumber, actualPackagingResult.StartColumnNumber);
+                Assert.Equal(expectedPackagingResult.StartLineNumber, actualPackagingResult.StartLineNumber);
+            }
+            else if (expectedResult is RestoreLogMessage expectedRestoreResult)
+            {
+                Assert.IsType<RestoreLogMessage>(actualResult);
+
+                var actualRestoreResult = (RestoreLogMessage)actualResult;
+
+                Assert.Equal(expectedRestoreResult.EndColumnNumber, actualRestoreResult.EndColumnNumber);
+                Assert.Equal(expectedRestoreResult.EndLineNumber, actualRestoreResult.EndLineNumber);
+                Assert.Equal(expectedRestoreResult.FilePath, actualRestoreResult.FilePath);
+                Assert.Equal(expectedRestoreResult.LibraryId, actualRestoreResult.LibraryId);
+                Assert.Equal(expectedRestoreResult.ShouldDisplay, actualRestoreResult.ShouldDisplay);
+                Assert.Equal(expectedRestoreResult.StartColumnNumber, actualRestoreResult.StartColumnNumber);
+                Assert.Equal(expectedRestoreResult.StartLineNumber, actualRestoreResult.StartLineNumber);
+                Assert.Equal(expectedRestoreResult.TargetGraphs, actualRestoreResult.TargetGraphs);
+            }
+            else if (expectedResult is SignatureLog expectedSignatureResult)
+            {
+                Assert.IsType<SignatureLog>(actualResult);
+
+                var actualSignatureResult = (SignatureLog)actualResult;
+
+                Assert.Equal(expectedSignatureResult.LibraryId, actualSignatureResult.LibraryId);
+            }
+            else
+            {
+                Assert.IsType<LogMessage>(expectedResult);
+                Assert.IsType<LogMessage>(actualResult);
+            }
+        }
+
+        internal static void AssertEqual(
+            IReadOnlyList<ILogMessage> expectedResults,
+            IReadOnlyList<ILogMessage> actualResults)
+        {
+            if (expectedResults is null)
+            {
+                Assert.Null(actualResults);
+            }
+            else
+            {
+                Assert.NotNull(actualResults);
+                Assert.Equal(expectedResults.Count, actualResults.Count);
+
+                for (var i = 0; i < expectedResults.Count; ++i)
+                {
+                    TestUtility.AssertEqual(expectedResults[i], actualResults[i]);
+                }
+            }
+        }
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/Utility/RemoteErrorTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/Utility/RemoteErrorTests.cs
@@ -1,0 +1,87 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using NuGet.Common;
+using Xunit;
+
+namespace NuGet.VisualStudio.Internal.Contracts.Test
+{
+    public class RemoteErrorTests
+    {
+        private const string ActivityLogMessage = "a";
+        private static readonly LogMessage LogMessage = new LogMessage(LogLevel.Error, message: "b");
+        private static readonly IReadOnlyList<LogMessage> LogMessages = new[]
+            {
+                new LogMessage(LogLevel.Warning, message: "c")
+            };
+        private const string ProjectContextLogMessage = "d";
+        private const string TypeName = "e";
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void Constructor_WhenTypeNameIsNullOrEmpty_Throws(string typeName)
+        {
+            ArgumentException exception = Assert.Throws<ArgumentException>(
+                () => new RemoteError(
+                    typeName,
+                    LogMessage,
+                    LogMessages,
+                    ProjectContextLogMessage,
+                    ActivityLogMessage));
+
+            Assert.StartsWith("The argument cannot be null or empty.", exception.Message);
+            Assert.Equal("typeName", exception.ParamName);
+        }
+
+        [Fact]
+        public void Constructor_WhenLogMessageIsNull_Throws()
+        {
+            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
+                () => new RemoteError(
+                    TypeName,
+                    logMessage: null,
+                    LogMessages,
+                    ProjectContextLogMessage,
+                    ActivityLogMessage));
+
+            Assert.Equal("logMessage", exception.ParamName);
+        }
+
+        [Fact]
+        public void Constructor_WhenArgumentsAreValid_InitializesProperties()
+        {
+            var error = new RemoteError(
+                TypeName,
+                LogMessage,
+                LogMessages,
+                ProjectContextLogMessage,
+                ActivityLogMessage);
+
+            Assert.Equal(ActivityLogMessage, error.ActivityLogMessage);
+            TestUtility.AssertEqual(LogMessage, error.LogMessage);
+            TestUtility.AssertEqual(LogMessages, error.LogMessages);
+            Assert.Equal(ProjectContextLogMessage, error.ProjectContextLogMessage);
+            Assert.Equal(TypeName, error.TypeName);
+        }
+
+        [Fact]
+        public void Constructor_WhenNullableArgumentsAreNull_InitializesProperties()
+        {
+            var error = new RemoteError(
+                TypeName,
+                LogMessage,
+                logMessages: null,
+                projectContextLogMessage: null,
+                activityLogMessage: null);
+
+            Assert.Null(error.ActivityLogMessage);
+            TestUtility.AssertEqual(LogMessage, error.LogMessage);
+            Assert.Null(error.LogMessages);
+            Assert.Null(error.ProjectContextLogMessage);
+            Assert.Equal(TypeName, error.TypeName);
+        }
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/Utility/RemoteErrorUtilityTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/Utility/RemoteErrorUtilityTests.cs
@@ -1,0 +1,20 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Xunit;
+
+namespace NuGet.VisualStudio.Internal.Contracts.Test
+{
+    public class RemoteErrorUtilityTests
+    {
+        [Fact]
+        public void ToRemoteError_WhenExceptionIsNull_Throws()
+        {
+            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
+                () => RemoteErrorUtility.ToRemoteError(exception: null));
+
+            Assert.Equal("exception", exception.ParamName);
+        }
+    }
+}


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/10034
Regression: Yes  
* Last working version:  any dev branch build before CodeSpaces branch was merged
* How are we preventing it in future:   adding tests

## Fix

Details:  In 16.8, a bunch of code was moved behind remoteable services.  The goo between the client and the service catches service exceptions, and raises them on the client side as a [`RemoteInvocationException`](https://docs.microsoft.com/en-us/dotnet/api/streamjsonrpc.remoteinvocationexception?view=streamjsonrpc-2.3) with much of the original exception details lost on the service side.  This is true irrespective of where the service actually runs (i.e.:  locally in the same process, locally in a different process, or remotely).

PM UI displays exceptions in the Error List tool window with custom behavior depending on the exception type.  Because PM UI now catches 1 exception type (`RemoteInvocationException`) instead of one of many different types, PM UI started adding unexpected entries in the Error List.  Sometimes these entries appear as near duplicates of other entries with sometimes extra information, sometimes less.  For example, in addition to seeing an Error List entry with `Exception.Message` as the error text, you might see another error with `Exception.ToString()` as the text.  In some cases the NUxxxx `NuGetLogCode` was missing, which meant no hyperlink to follow for help.  The rich information in a NuGet exception thrown a service was not getting propagated to the client.

Even before 16.8 NuGet sometimes added duplicate entries to the Error List; however, the duplicates would never actually display in the Error List.  This is because the [Error List deduplicates entries based on `ITableEntry.Identity`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.visualstudio.shell.tablemanager.itableentry.identity?view=visualstudiosdk-2019#remarks) and [NuGet defines table entry identities with the message text](https://github.com/NuGet/NuGet.Client/blob/ac8727799b7eef0b02c5af9292844cae7c0984f8/src/NuGet.Clients/NuGet.VisualStudio.Common/ErrorListTableEntry.cs#L21).

Solving this problem was not simple, because there wasn't a general facility in the VS SDK for propagating exceptions from service to client.  Propagating a custom error type via `RemoteInvocationException.DeserializedErrorData` was the recommended approach.

This change targets limited scenarios for 16.8.  In a later release we would approach this problem differently with the goal of handling exceptions thrown from _any_ service _anywhere_ not just in PM UI package operation scenarios.

## Testing/Validation

Tests Added: Yes
Validation:  manually verified error cases as outlined in related bugs, manually verified basic VS OE and non-VS OE PM UI scenarios (install/uninstall).

CC @rrelyea, @sbanni, @aortiz-msft