### PR TITLE
Save RTM build symbols for publishing

### DIFF
--- a/build/symbols.proj
+++ b/build/symbols.proj
@@ -15,7 +15,8 @@
   <Target Name="GetSymbolsAndAssembliesToIndex">
     <MSBuild
       Projects="@(SolutionProjectsWithoutVSIX)"
-      Targets="GetSymbolsToIndex">
+      Targets="GetSymbolsToIndex"
+      Properties="NoBuild=true;">
 
       <Output
           TaskParameter="TargetOutputs"

--- a/build/templates/Build_and_UnitTest.yml
+++ b/build/templates/Build_and_UnitTest.yml
@@ -428,16 +428,24 @@ steps:
     solution: "build\\symbols.proj"
     msbuildVersion: "16.0"
     configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/p:IsSymbolBuild=true"
-  condition: " and(succeeded(),eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true')) "
+    msbuildArguments: "/p:IsSymbolBuild=true /p:BuildRTM=$(BuildRTM)"
+  condition: " succeeded() "
 
 - task: CopyFiles@2
-  displayName: "Copy Symbols"
+  displayName: "Copy Symbols (non-rtm)"
   inputs:
     SourceFolder: "$(Build.Repository.LocalPath)\\artifacts\\symbolstoindex"
     Contents: "**\\*"
     TargetFolder: "$(BuildOutputTargetPath)\\symbols"
-  condition: " and(succeeded(),eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true')) "
+  condition: " and(succeeded(), eq(variables['BuildRTM'], 'false')) "
+
+- task: CopyFiles@2
+  displayName: "Copy Symbols (rtm)"
+  inputs:
+    SourceFolder: "$(Build.Repository.LocalPath)\\artifacts\\symbolstoindex"
+    Contents: "**\\*"
+    TargetFolder: "$(BuildOutputTargetPath)\\symbols-rtm"
+  condition: " and(succeeded(), not(eq(variables['BuildRTM'], 'false')) "
 
 - task: ms-vscs-artifact.build-tasks.artifactSymbolTask-1.artifactSymbolTask@0
   displayName: "Publish Symbols on Symweb"

--- a/build/templates/Build_and_UnitTest.yml
+++ b/build/templates/Build_and_UnitTest.yml
@@ -445,7 +445,7 @@ steps:
     SourceFolder: "$(Build.Repository.LocalPath)\\artifacts\\symbolstoindex"
     Contents: "**\\*"
     TargetFolder: "$(BuildOutputTargetPath)\\symbols-rtm"
-  condition: " and(succeeded(), not(eq(variables['BuildRTM'], 'false')) "
+  condition: " and(succeeded(), not(eq(variables['BuildRTM'], 'false'))) "
 
 - task: ms-vscs-artifact.build-tasks.artifactSymbolTask-1.artifactSymbolTask@0
   displayName: "Publish Symbols on Symweb"

--- a/build/templates/Build_and_UnitTest.yml
+++ b/build/templates/Build_and_UnitTest.yml
@@ -429,7 +429,7 @@ steps:
     msbuildVersion: "16.0"
     configuration: "$(BuildConfiguration)"
     msbuildArguments: "/p:IsSymbolBuild=true /p:BuildRTM=$(BuildRTM)"
-  condition: " succeeded() "
+  condition: " and(succeeded(), eq(variables['IsOfficialBuild'], 'true')) "
 
 - task: CopyFiles@2
   displayName: "Copy Symbols (non-rtm)"
@@ -437,7 +437,7 @@ steps:
     SourceFolder: "$(Build.Repository.LocalPath)\\artifacts\\symbolstoindex"
     Contents: "**\\*"
     TargetFolder: "$(BuildOutputTargetPath)\\symbols"
-  condition: " and(succeeded(), eq(variables['BuildRTM'], 'false')) "
+  condition: " and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true')) "
 
 - task: CopyFiles@2
   displayName: "Copy Symbols (rtm)"
@@ -445,7 +445,7 @@ steps:
     SourceFolder: "$(Build.Repository.LocalPath)\\artifacts\\symbolstoindex"
     Contents: "**\\*"
     TargetFolder: "$(BuildOutputTargetPath)\\symbols-rtm"
-  condition: " and(succeeded(), not(eq(variables['BuildRTM'], 'false'))) "
+  condition: " and(succeeded(), not(eq(variables['BuildRTM'], 'false')), eq(variables['IsOfficialBuild'], 'true')) "
 
 - task: ms-vscs-artifact.build-tasks.artifactSymbolTask-1.artifactSymbolTask@0
   displayName: "Publish Symbols on Symweb"


### PR DESCRIPTION
## Bug

Related: https://github.com/nuget/client.engineering/issues/338
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: Save RTM symbols on file share, so they can be published during the release process.

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  CI build script change
Validation:  
