### PR TITLE
Adds icon filename extension validation

### DIFF
--- a/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
@@ -880,6 +880,6 @@ namespace NuGet.Common
         /// <summary>
         /// InvalidUndottedFrameworkWarning
         /// </summary>
-        NU5501 = 5501,
+        NU5502 = 5502,
     }
 }

--- a/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
@@ -880,6 +880,6 @@ namespace NuGet.Common
         /// <summary>
         /// InvalidUndottedFrameworkWarning
         /// </summary>
-        NU5502 = 5502,
+        NU5501 = 5501,
     }
 }

--- a/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
@@ -5,8 +5,12 @@ namespace NuGet.Common
 {
     /// <summary>
     /// This enum is used to quantify NuGet error and warning codes.
+    /// </summary>
+    /// <remarks>
+    /// <para>
     /// Format - NUxyzw where NU is the prefix indicating NuGet and xyzw is a 4 digit code
-    ///
+    /// </para>
+    /// 
     /// Numbers - xyzw
     ///     x - 'x' is the largest digit and should be used to quantify a set of errors.
     ///         For example 1yzw are set of restore related errors and no other code path should use the range 1000 to 1999 for errors or warnings.
@@ -18,12 +22,15 @@ namespace NuGet.Common
     ///
     ///     zw - 'zw' are the least two digit.
     ///         These could be used for different errors or warnings within the broad categories set by digits 'xy'.
-    ///
+    /// 
+    /// <para>
     /// Groups:
     /// 1000-1999 - Restore
     /// 3000-3999 - Signing
     /// 5000-5999 - Packaging
+    /// </para>
     ///
+    /// <para>
     /// Sub groups for Restore:
     /// error/warning - Reason
     /// 1000/1500     - Input
@@ -31,10 +38,12 @@ namespace NuGet.Common
     /// 1200/1700     - Compat
     /// 1300/1800     - Feed
     /// 1400/1900     - Package
+    /// </para>
     ///
+    /// <para>
     /// All new codes need a corresponding MarkDown file under https://github.com/NuGet/docs.microsoft.com-nuget/tree/master/docs/reference/errors-and-warnings.
-    ///
-    /// </summary>
+    /// </para>
+    /// </remarks>
     public enum NuGetLogCode
     {
         /// <summary>
@@ -682,6 +691,11 @@ namespace NuGet.Common
         /// Error_MissingNuspecFile
         /// </summary>
         NU5037 = 5037,
+
+        /// <summary>
+        /// Invalid icon extension error
+        /// </summary>
+        NU5045 = 5045,
 
         /// <summary>
         /// Error_Manifest_IconCannotOpenFile

--- a/src/NuGet.Core/NuGet.Common/PublicAPI/net45/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Common/PublicAPI/net45/PublicAPI.Unshipped.txt
@@ -1,2 +1,3 @@
 NuGet.Common.NuGetLogCode.NU5501 = 5501 -> NuGet.Common.NuGetLogCode
 NuGet.Common.NuGetLogCode.NU1012 = 1012 -> NuGet.Common.NuGetLogCode
+NuGet.Common.NuGetLogCode.NU5045 = 5045 -> NuGet.Common.NuGetLogCode

--- a/src/NuGet.Core/NuGet.Common/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Common/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -1,2 +1,3 @@
 NuGet.Common.NuGetLogCode.NU5501 = 5501 -> NuGet.Common.NuGetLogCode
 NuGet.Common.NuGetLogCode.NU1012 = 1012 -> NuGet.Common.NuGetLogCode
+NuGet.Common.NuGetLogCode.NU5045 = 5045 -> NuGet.Common.NuGetLogCode

--- a/src/NuGet.Core/NuGet.Common/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Common/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,2 +1,3 @@
 NuGet.Common.NuGetLogCode.NU5501 = 5501 -> NuGet.Common.NuGetLogCode
 NuGet.Common.NuGetLogCode.NU1012 = 1012 -> NuGet.Common.NuGetLogCode
+NuGet.Common.NuGetLogCode.NU5045 = 5045 -> NuGet.Common.NuGetLogCode

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PackageBuilder.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PackageBuilder.cs
@@ -314,7 +314,7 @@ namespace NuGet.Packaging
         {
             get
             {
-                return String.Join(" ", Tags);
+                return string.Join(" ", Tags);
             }
         }
 
@@ -580,7 +580,7 @@ namespace NuGet.Packaging
             }
 
             var libFiles = new HashSet<string>(from file in files
-                                               where !String.IsNullOrEmpty(file.Path) && file.Path.StartsWith("lib", StringComparison.OrdinalIgnoreCase)
+                                               where !string.IsNullOrEmpty(file.Path) && file.Path.StartsWith("lib", StringComparison.OrdinalIgnoreCase)
                                                select Path.GetFileName(file.Path), StringComparer.OrdinalIgnoreCase);
 
             foreach (var reference in packageAssemblyReferences.SelectMany(p => p.References))
@@ -590,7 +590,7 @@ namespace NuGet.Packaging
                     !libFiles.Contains(reference + ".exe") &&
                     !libFiles.Contains(reference + ".winmd"))
                 {
-                    throw new PackagingException(NuGetLogCode.NU5018, String.Format(CultureInfo.CurrentCulture, NuGetResources.Manifest_InvalidReference, reference));
+                    throw new PackagingException(NuGetLogCode.NU5018, string.Format(CultureInfo.CurrentCulture, NuGetResources.Manifest_InvalidReference, reference));
                 }
             }
         }
@@ -683,15 +683,26 @@ namespace NuGet.Packaging
 
         /// <summary>
         /// Given a list of resolved files,
-        /// determine which file will be used as the icon file and validate its size.
+        /// determine which file will be used as the icon file and validate its size and extension.
         /// </summary>
         /// <param name="files">Files resolved from the file entries in the nuspec</param>
-        /// <param name="iconPath">iconpath found in the .nuspec</param>
+        /// <param name="iconPath">icon entry found in the .nuspec</param>
         /// <exception cref="PackagingException">When a validation rule is not met</exception>
         private void ValidateIconFile(IEnumerable<IPackageFile> files, string iconPath)
         {
             if (!PackageTypes.Contains(PackageType.SymbolsPackage) && !string.IsNullOrEmpty(iconPath))
             {
+                var ext = Path.GetExtension(iconPath);
+                if (!string.IsNullOrEmpty(ext) &&
+                        !ext.Equals(".jpeg", StringComparison.OrdinalIgnoreCase) &&
+                        !ext.Equals(".jpg", StringComparison.OrdinalIgnoreCase) &&
+                        !ext.Equals(".png", StringComparison.OrdinalIgnoreCase))
+                {
+                    throw new PackagingException(
+                        NuGetLogCode.NU5045,
+                        string.Format(CultureInfo.CurrentCulture, NuGetResources.IconInvalidExtension, iconPath));
+                }
+
                 // Validate entry
                 IPackageFile iconFile = FindFileInPackage(iconPath, files, out var iconPathWithIncorrectCase);
 
@@ -963,7 +974,7 @@ namespace NuGet.Packaging
             if (!PathResolver.IsWildcardSearch(source) && !PathResolver.IsDirectoryPath(source) && !searchFiles.Any() && string.IsNullOrEmpty(exclude))
             {
                 throw new PackagingException(NuGetLogCode.NU5019,
-                    String.Format(CultureInfo.CurrentCulture, NuGetResources.PackageAuthoring_FileNotFound, source));
+                    string.Format(CultureInfo.CurrentCulture, NuGetResources.PackageAuthoring_FileNotFound, source));
             }
 
             Files.AddRange(searchFiles);
@@ -1017,7 +1028,7 @@ namespace NuGet.Packaging
             {
                 packagePath = Path.GetFileName(fullPath);
             }
-            return Path.Combine(targetPath ?? String.Empty, packagePath);
+            return Path.Combine(targetPath ?? string.Empty, packagePath);
         }
 
         /// <summary>
@@ -1048,7 +1059,7 @@ namespace NuGet.Packaging
 
         private static void ExcludeFiles(List<PhysicalPackageFile> searchFiles, string basePath, string exclude)
         {
-            if (String.IsNullOrEmpty(exclude))
+            if (string.IsNullOrEmpty(exclude))
             {
                 return;
             }
@@ -1197,7 +1208,7 @@ namespace NuGet.Packaging
                     new XAttribute(XNamespace.Xmlns + "dc", dcText),
                     new XAttribute(XNamespace.Xmlns + "dcterms", dctermsText),
                     new XAttribute(XNamespace.Xmlns + "xsi", xsiText),
-                    new XElement(dc + "creator", String.Join(", ", Authors)),
+                    new XElement(dc + "creator", string.Join(", ", Authors)),
                     new XElement(dc + "description", Description),
                     new XElement(dc + "identifier", Id),
                     new XElement(core + "version", Version.ToString()),

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PackageBuilder.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PackageBuilder.cs
@@ -693,10 +693,10 @@ namespace NuGet.Packaging
             if (!PackageTypes.Contains(PackageType.SymbolsPackage) && !string.IsNullOrEmpty(iconPath))
             {
                 var ext = Path.GetExtension(iconPath);
-                if (!string.IsNullOrEmpty(ext) &&
+                if (string.IsNullOrEmpty(ext) || (
                         !ext.Equals(".jpeg", StringComparison.OrdinalIgnoreCase) &&
                         !ext.Equals(".jpg", StringComparison.OrdinalIgnoreCase) &&
-                        !ext.Equals(".png", StringComparison.OrdinalIgnoreCase))
+                        !ext.Equals(".png", StringComparison.OrdinalIgnoreCase)))
                 {
                     throw new PackagingException(
                         NuGetLogCode.NU5045,

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Resources/NuGetResources.Designer.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Resources/NuGetResources.Designer.cs
@@ -106,7 +106,7 @@ namespace NuGet.Packaging.PackageCreation.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The &apos;icon&apos; element {0} has an invalid file extension. Valid options are .png, .jpg or .jpeg..
+        ///   Looks up a localized string similar to The &apos;icon&apos; element &apos;{0}&apos; has an invalid file extension. Valid options are .png, .jpg or .jpeg..
         /// </summary>
         internal static string IconInvalidExtension {
             get {

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Resources/NuGetResources.Designer.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Resources/NuGetResources.Designer.cs
@@ -106,6 +106,15 @@ namespace NuGet.Packaging.PackageCreation.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The &apos;icon&apos; element {0} has an invalid file extension. Valid options are .png, .jpg or .jpeg..
+        /// </summary>
+        internal static string IconInvalidExtension {
+            get {
+                return ResourceManager.GetString("IconInvalidExtension", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The icon file size must not exceed 1 megabyte..
         /// </summary>
         internal static string IconMaxFileSizeExceeded {

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Resources/NuGetResources.resx
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Resources/NuGetResources.resx
@@ -221,7 +221,7 @@
     <comment>0 - the license file, 1 - hint to guessed licensed file</comment>
   </data>
   <data name="IconInvalidExtension" xml:space="preserve">
-    <value>The 'icon' element {0} has an invalid file extension. Valid options are .png, .jpg or .jpeg.</value>
+    <value>The 'icon' element '{0}' has an invalid file extension. Valid options are .png, .jpg or .jpeg.</value>
     <comment>0 - Icon entry in the nuspec</comment>
   </data>
 </root>

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Resources/NuGetResources.resx
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Resources/NuGetResources.resx
@@ -220,4 +220,8 @@
     <value>The license file '{0}' does not exist in the package. (Did you mean '{1}'?)</value>
     <comment>0 - the license file, 1 - hint to guessed licensed file</comment>
   </data>
+  <data name="IconInvalidExtension" xml:space="preserve">
+    <value>The 'icon' element {0} has an invalid file extension. Valid options are .png, .jpg or .jpeg.</value>
+    <comment>0 - Icon entry in the nuspec</comment>
+  </data>
 </root>

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
@@ -5985,6 +5985,42 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
         }
 
         [Theory]
+        [InlineData(".jpg", null)]
+        [InlineData(".png", null)]
+        [InlineData(".PnG", null)]
+        [InlineData(".jpeg", null)]
+        [InlineData(".JpEg", null)]
+        [InlineData("abc.JpEg", null)]
+        [InlineData(".x", NuGetLogCode.NU5045)]
+        [InlineData(".jpeg.x", NuGetLogCode.NU5045)]
+        [InlineData("", NuGetLogCode.NU5044)]
+        public void PackCommand_PackIcon_InvalidExtension_SucceedOrFail(string fileExtension, NuGetLogCode? logCode)
+        {
+            NuspecBuilder nuspecBuilder = NuspecBuilder.Create();
+            TestDirectoryBuilder testDirBuilder = TestDirectoryBuilder.Create();
+            var rng = new Random();
+
+            var iconFile = $"icon{fileExtension}";
+
+            nuspecBuilder
+                .WithFile(iconFile)
+                .WithIcon(iconFile);
+
+            testDirBuilder
+                .WithNuspec(nuspecBuilder)
+                .WithFile(iconFile, rng.Next(1, 1024));
+
+            if (logCode == null)
+            {
+                TestPackIconSuccess(testDirBuilder, iconFile);
+            }
+            else
+            {
+                TestPackIconFailure(testDirBuilder, logCode.ToString());
+            }
+        }
+
+        [Theory]
         [InlineData(SymbolPackageFormat.Snupkg)]
         [InlineData(SymbolPackageFormat.SymbolsNupkg)]
         public void PackCommand_PackIcon_SymbolsPackage_MustNotHaveIconInfo_Succeed(SymbolPackageFormat symbolPackageFormat)

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
@@ -5986,12 +5986,9 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
 
         [Theory]
         [InlineData(".jpg")]
-        [InlineData(".png")]
         [InlineData(".PnG")]
-        [InlineData(".jpeg")]
-        [InlineData(".JpEg")]
-        [InlineData("abc.JpEg")]
-        public void PackCommand_PackIcon_InvalidExtension_Succeeds(string fileExtension)
+        [InlineData(".jpEg")]
+        public void PackCommand_PackIcon_ValidExtension_Succeeds(string fileExtension)
         {
             NuspecBuilder nuspecBuilder = NuspecBuilder.Create();
             TestDirectoryBuilder testDirBuilder = TestDirectoryBuilder.Create();

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
@@ -5985,16 +5985,13 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
         }
 
         [Theory]
-        [InlineData(".jpg", null)]
-        [InlineData(".png", null)]
-        [InlineData(".PnG", null)]
-        [InlineData(".jpeg", null)]
-        [InlineData(".JpEg", null)]
-        [InlineData("abc.JpEg", null)]
-        [InlineData(".x", NuGetLogCode.NU5045)]
-        [InlineData(".jpeg.x", NuGetLogCode.NU5045)]
-        [InlineData("", NuGetLogCode.NU5045)]
-        public void PackCommand_PackIcon_InvalidExtension_SucceedOrFail(string fileExtension, NuGetLogCode? logCode)
+        [InlineData(".jpg")]
+        [InlineData(".png")]
+        [InlineData(".PnG")]
+        [InlineData(".jpeg")]
+        [InlineData(".JpEg")]
+        [InlineData("abc.JpEg")]
+        public void PackCommand_PackIcon_InvalidExtension_Succeeds(string fileExtension)
         {
             NuspecBuilder nuspecBuilder = NuspecBuilder.Create();
             TestDirectoryBuilder testDirBuilder = TestDirectoryBuilder.Create();
@@ -6010,14 +6007,30 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
                 .WithNuspec(nuspecBuilder)
                 .WithFile(iconFile, rng.Next(1, 1024));
 
-            if (logCode == null)
-            {
-                TestPackIconSuccess(testDirBuilder, iconFile);
-            }
-            else
-            {
-                TestPackIconFailure(testDirBuilder, logCode.ToString());
-            }
+            TestPackIconSuccess(testDirBuilder, iconFile);
+        }
+
+        [Theory]
+        [InlineData(".x")]
+        [InlineData(".jpeg.x")]
+        [InlineData("")]
+        public void PackCommand_PackIcon_InvalidExtension_Fails(string fileExtension)
+        {
+            NuspecBuilder nuspecBuilder = NuspecBuilder.Create();
+            TestDirectoryBuilder testDirBuilder = TestDirectoryBuilder.Create();
+            var rng = new Random();
+
+            var iconFile = $"icon{fileExtension}";
+
+            nuspecBuilder
+                .WithFile(iconFile)
+                .WithIcon(iconFile);
+
+            testDirBuilder
+                .WithNuspec(nuspecBuilder)
+                .WithFile(iconFile, rng.Next(1, 1024));
+
+            TestPackIconFailure(testDirBuilder, NuGetLogCode.NU5045.ToString());
         }
 
         [Theory]

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
@@ -5993,7 +5993,7 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
         [InlineData("abc.JpEg", null)]
         [InlineData(".x", NuGetLogCode.NU5045)]
         [InlineData(".jpeg.x", NuGetLogCode.NU5045)]
-        [InlineData("", NuGetLogCode.NU5044)]
+        [InlineData("", NuGetLogCode.NU5045)]
         public void PackCommand_PackIcon_InvalidExtension_SucceedOrFail(string fileExtension, NuGetLogCode? logCode)
         {
             NuspecBuilder nuspecBuilder = NuspecBuilder.Create();

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageBuilderTest.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageBuilderTest.cs
@@ -2626,6 +2626,36 @@ Enabling license acceptance requires a license or a licenseUrl to be specified. 
             }
         }
 
+        [Theory]
+        [InlineData(".txt", "The 'icon' element 'icon.txt' has an invalid file extension. Valid options are .png, .jpg or .jpeg.")]
+        [InlineData(".jpeg", null)]
+        [InlineData(".jpg", null)]
+        [InlineData(".png", null)]
+        [InlineData(".PnG", null)]
+        [InlineData(".jPG", null)]
+        [InlineData(".jpEG", null)]
+        [InlineData("", "The 'icon' element 'icon' has an invalid file extension. Valid options are .png, .jpg or .jpeg.")]
+        public void Icon_IconInvalidExtension_ThrowsException(string fileExtension, string message)
+        {
+            var testDirBuilder = TestDirectoryBuilder.Create();
+            var nuspecBuilder = NuspecBuilder.Create();
+            var rng = new Random();
+
+            var iconFile = $"icon{fileExtension}";
+
+            nuspecBuilder
+                .WithIcon(iconFile)
+                .WithFile(iconFile);
+
+            testDirBuilder
+                .WithFile(iconFile, rng.Next(1, PackageBuilder.MaxIconFileSize))
+                .WithNuspec(nuspecBuilder);
+
+            TestIconPackaging(
+                testDirBuilder: testDirBuilder,
+                exceptionMessage: message);
+        }
+
         [Fact]
         public void Icon_IconMaxFileSizeExceeded_ThrowsException()
         {

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageBuilderTest.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageBuilderTest.cs
@@ -2659,7 +2659,7 @@ Enabling license acceptance requires a license or a licenseUrl to be specified. 
         [InlineData(".PNG")]
         [InlineData(".jPG")]
         [InlineData(".jpEG")]
-        public void Icon_IconInvalidExtension_Suceeds(string fileExtension)
+        public void Icon_IconInvalidExtension_Succeeds(string fileExtension)
         {
             var testDirBuilder = TestDirectoryBuilder.Create();
             var nuspecBuilder = NuspecBuilder.Create();
@@ -2717,7 +2717,7 @@ Enabling license acceptance requires a license or a licenseUrl to be specified. 
         }
 
         [Fact]
-        public void Icon_HappyPath_Suceeds()
+        public void Icon_HappyPath_Succeeds()
         {
             var testDirBuilder = TestDirectoryBuilder.Create();
             var nuspecBuilder = NuspecBuilder.Create();


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9311
Regression: No
* Last working version:   
* How are we preventing it in future: Close parity with existing features

## Fix

- Adds extension validation at pack time.
- Modifies code to comply with analyzers.
- Add tests

## Testing/Validation

Tests Added: Yes
Reason for not adding tests:  
Validation:  CI run with new nuget.exe test
