### PR TITLE
Disable cpvm transitive pinning.

### DIFF
--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpecReferenceDependencyProvider.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpecReferenceDependencyProvider.cs
@@ -326,6 +326,7 @@ namespace NuGet.ProjectModel
                 var targetFrameworkInfo = packageSpec.GetTargetFramework(targetFramework);
                 dependencies.AddRange(targetFrameworkInfo.Dependencies);
 
+#if enableCPVMTransitivePinning
                 if (packageSpec.RestoreMetadata?.CentralPackageVersionsEnabled == true)
                 {
                     var dependencyNamesSet = new HashSet<string>(targetFrameworkInfo.Dependencies.Select(d => d.Name), StringComparer.OrdinalIgnoreCase);
@@ -338,7 +339,7 @@ namespace NuGet.ProjectModel
                             ReferenceType = LibraryDependencyReferenceType.None,
                         }));
                 }
-
+#endif
                 // Remove all framework assemblies
                 dependencies.RemoveAll(d => d.LibraryRange.TypeConstraint == LibraryDependencyTarget.Reference);
 

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
@@ -10068,7 +10068,6 @@ namespace NuGet.CommandLine.Test
             {
                 // Set up solution, project, and packages
                 var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
-              
                 var packagesForSource = new List<SimpleTestPackageContext>();
                 var packagesForProject = new List<SimpleTestPackageContext>();
                 var framework = NuGetFramework.Parse("netcoreapp2.0");
@@ -10093,11 +10092,10 @@ namespace NuGet.CommandLine.Test
 
                 // the package references defined in the project should not have version
                 var packageBNoVersion = createTestPackage("B", null, packagesForProject);
-               
                 var packageB100 = createTestPackage("B", "1.0.0", packagesForSource);
                 var packageC100 = createTestPackage("C", "1.0.0", packagesForSource);
                 var packageC200 = createTestPackage("C", "2.0.0", packagesForSource);
-          
+
                 packageB100.Dependencies.Add(packageC100);
 
                 await SimpleTestPackageUtility.CreateFolderFeedV3Async(

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
@@ -9795,7 +9795,7 @@ namespace NuGet.CommandLine.Test
         ///  P will be accepted (because its parent B is Accepted)
         ///  S will be accepted (because its parent O 300 is Accepted)
         /// </summary>
-        [Fact]
+        [Fact(Skip = "Depends on cpvm transitive pinning")]
         public async Task RestoreNetCore_CPVMProject_MultipleLinkedCentralTransitiveDepenencies()
         {
             // Arrange
@@ -10057,6 +10057,82 @@ namespace NuGet.CommandLine.Test
 
                 Assert.Contains("'$(TargetFramework)' == 'net5.0-windows' AND '$(ExcludeRestorePackageImports)' != 'true'", propsItemGroups[1].Attribute(XName.Get("Condition")).Value.Trim());
                 Assert.Contains("'$(TargetFramework)' == 'net50-android' AND '$(ExcludeRestorePackageImports)' != 'true'", propsItemGroups[2].Attribute(XName.Get("Condition")).Value.Trim());
+            }
+        }
+
+        [Fact]
+        public async Task RestoreNetCore_CPVMProject_TransitiveDependenciesAreNotPinned()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Set up solution, project, and packages
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+              
+                var packagesForSource = new List<SimpleTestPackageContext>();
+                var packagesForProject = new List<SimpleTestPackageContext>();
+                var framework = NuGetFramework.Parse("netcoreapp2.0");
+
+                SimpleTestPackageContext createTestPackage(string name, string version, List<SimpleTestPackageContext> source)
+                {
+                    var result = new SimpleTestPackageContext()
+                    {
+                        Id = name,
+                        Version = version
+                    };
+                    result.Files.Clear();
+                    source.Add(result);
+                    return result;
+                };
+
+                var projectA = SimpleTestProjectContext.CreateNETCore(
+                   "projectA",
+                   pathContext.SolutionRoot,
+                   NuGetFramework.Parse("netcoreapp2.0"));
+                projectA.Properties.Add("ManagePackageVersionsCentrally", "true");
+
+                // the package references defined in the project should not have version
+                var packageBNoVersion = createTestPackage("B", null, packagesForProject);
+               
+                var packageB100 = createTestPackage("B", "1.0.0", packagesForSource);
+                var packageC100 = createTestPackage("C", "1.0.0", packagesForSource);
+                var packageC200 = createTestPackage("C", "2.0.0", packagesForSource);
+          
+                packageB100.Dependencies.Add(packageC100);
+
+                await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                   pathContext.PackageSource,
+                   packagesForSource.ToArray());
+
+                projectA.AddPackageToAllFrameworks(packagesForProject.ToArray());
+
+                var cpvmFile = CentralPackageVersionsManagementFile.Create(pathContext.SolutionRoot)
+                    .AddPackageVersion("B", "1.0.0")
+                    .AddPackageVersion("C", "2.0.0");
+
+                solution.Projects.Add(projectA);
+                solution.CentralPackageVersionsManagementFile = cpvmFile;
+                solution.Create(pathContext.SolutionRoot);
+
+                // Act
+                var r = Util.RestoreSolution(pathContext);
+
+                // Assert
+                r.Success.Should().BeTrue();
+                Assert.True(File.Exists(projectA.AssetsFileOutputPath));
+
+                var assetFileReader = new LockFileFormat();
+                var assetsFile = assetFileReader.Read(projectA.AssetsFileOutputPath);
+
+                var expectedLibraries = new List<string>() { "B.1.0.0", "C.1.0.0" };
+                var libraries = assetsFile.Libraries.Select(l => $"{l.Name}.{l.Version}").OrderBy(n => n).ToList();
+                Assert.Equal(expectedLibraries, libraries);
+
+                var centralfileDependencyGroups = assetsFile
+                    .CentralTransitiveDependencyGroups
+                    .SelectMany(g => g.TransitiveDependencies.Select(t => $"{g.FrameworkName}_{t.LibraryRange.Name}.{t.LibraryRange.VersionRange.OriginalString}")).ToList();
+
+                Assert.Equal(0, centralfileDependencyGroups.Count);
             }
         }
 

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
@@ -9795,7 +9795,7 @@ namespace NuGet.CommandLine.Test
         ///  P will be accepted (because its parent B is Accepted)
         ///  S will be accepted (because its parent O 300 is Accepted)
         /// </summary>
-        [Fact(Skip = "Depends on cpvm transitive pinning")]
+        [Fact(Skip = "https://github.com/NuGet/Home/issues/10133")]
         public async Task RestoreNetCore_CPVMProject_MultipleLinkedCentralTransitiveDepenencies()
         {
             // Arrange
@@ -10070,7 +10070,7 @@ namespace NuGet.CommandLine.Test
                 var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
                 var packagesForSource = new List<SimpleTestPackageContext>();
                 var packagesForProject = new List<SimpleTestPackageContext>();
-                var framework = NuGetFramework.Parse("netcoreapp2.0");
+                var framework = FrameworkConstants.CommonFrameworks.NetCoreApp20;
 
                 SimpleTestPackageContext createTestPackage(string name, string version, List<SimpleTestPackageContext> source)
                 {
@@ -10087,7 +10087,7 @@ namespace NuGet.CommandLine.Test
                 var projectA = SimpleTestProjectContext.CreateNETCore(
                    "projectA",
                    pathContext.SolutionRoot,
-                   NuGetFramework.Parse("netcoreapp2.0"));
+                   framework);
                 projectA.Properties.Add("ManagePackageVersionsCentrally", "true");
 
                 // the package references defined in the project should not have version

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
@@ -4425,7 +4425,7 @@ namespace ClassLibrary
             }
         }
 
-        [PlatformFact(Platform.Windows, Skip = "Depends on cpvm transitive pinning")]
+        [PlatformFact(Platform.Windows, Skip = "https://github.com/NuGet/Home/issues/10133")]
         public void PackCommand_PackProjectWithCentralTransitiveDependencies()
         {
             using (var testDirectory = msbuildFixture.CreateTestDirectory())

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
@@ -4425,7 +4425,7 @@ namespace ClassLibrary
             }
         }
 
-        [PlatformFact(Platform.Windows)]
+        [PlatformFact(Platform.Windows, Skip = "Depends on cpvm transitive pinning")]
         public void PackCommand_PackProjectWithCentralTransitiveDependencies()
         {
             using (var testDirectory = msbuildFixture.CreateTestDirectory())

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
@@ -1569,7 +1569,7 @@ namespace NuGet.Commands.Test
             Assert.Equal(NuGetLogCode.NU1109, logMessage.Code);
         }
 
-        [Fact]
+        [Fact(Skip = "Depends on cpvm transitive pinning")]
         public async Task RestoreCommand_DowngradeIsErrorWhen_DowngradedByCentralTransitiveDependency()
         {
             // Arrange
@@ -1983,6 +1983,7 @@ namespace NuGet.Commands.Test
                 Assert.True(targetLib.Dependencies.Where(d => d.Id == packageName).Any());
             }
         }
+
         private static TargetFrameworkInformation CreateTargetFrameworkInformation(List<LibraryDependency> dependencies, List<CentralPackageVersion> centralVersionsDependencies, NuGetFramework framework = null)
         {
             NuGetFramework nugetFramework = framework ?? new NuGetFramework("net40");

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
@@ -1569,7 +1569,7 @@ namespace NuGet.Commands.Test
             Assert.Equal(NuGetLogCode.NU1109, logMessage.Code);
         }
 
-        [Fact(Skip = "Depends on cpvm transitive pinning")]
+        [Fact(Skip = "https://github.com/NuGet/Home/issues/10133")]
         public async Task RestoreCommand_DowngradeIsErrorWhen_DowngradedByCentralTransitiveDependency()
         {
             // Arrange

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreRunnerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreRunnerTests.cs
@@ -1896,7 +1896,7 @@ namespace NuGet.Commands.Test
             }
         }
 
-        [Fact]
+        [Fact(Skip = "Depends on cpvm transitive pinning")]
         public async Task RestoreRunner_ExecuteAndCommit_ProjectAssetsIsNotCommitedIfNotChanged()
         {
             var assetsFileName = "project.assets.json";

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreRunnerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreRunnerTests.cs
@@ -1896,7 +1896,7 @@ namespace NuGet.Commands.Test
             }
         }
 
-        [Fact(Skip = "Depends on cpvm transitive pinning")]
+        [Fact(Skip = "https://github.com/NuGet/Home/issues/10133")]
         public async Task RestoreRunner_ExecuteAndCommit_ProjectAssetsIsNotCommitedIfNotChanged()
         {
             var assetsFileName = "project.assets.json";

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecReferenceDependencyProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecReferenceDependencyProviderTests.cs
@@ -13,7 +13,7 @@ namespace NuGet.ProjectModel.Test
 {
     public class PackageSpecReferenceDependencyProviderTests
     {
-        [Theory]
+        [Theory(Skip = "Depends on cpvm transitive pinning")]
         [InlineData(true)]
         [InlineData(false)]
         public void GetSpecDependencies_AddsCentralPackageVersionsIfDefined(bool cpvmEnabled)

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecReferenceDependencyProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecReferenceDependencyProviderTests.cs
@@ -13,7 +13,7 @@ namespace NuGet.ProjectModel.Test
 {
     public class PackageSpecReferenceDependencyProviderTests
     {
-        [Theory(Skip = "Depends on cpvm transitive pinning")]
+        [Theory(Skip = "https://github.com/NuGet/Home/issues/10133")]
         [InlineData(true)]
         [InlineData(false)]
         public void GetSpecDependencies_AddsCentralPackageVersionsIfDefined(bool cpvmEnabled)


### PR DESCRIPTION
## Bug

Fixes: This change disable the enforcing/pinning of package versions for transitive dependencies defined in the CentralManagement file.
https://github.com/NuGet/Home/issues/10132

Regression: No  
  
## Fix
Disable transitive dependency pinning.

## Testing/Validation

Tests Added: Yes
Validation:  Automated and manual tests. 
