### PR TITLE
When restoring, resolve commandline passed sources against the current working directory

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Console/ExtensionMethods.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Console/ExtensionMethods.cs
@@ -38,6 +38,19 @@ namespace NuGet.Build.Tasks.Console
         }
 
         /// <summary>
+        /// Splits the value of the specified property and returns an array if the property has a value, otherwise returns <code>null</code>.
+        /// </summary>
+        /// <param name="item">The <see cref="IMSBuildItem" /> to get the property value from.</param>
+        /// <param name="name">The name of the property to get the value of and split.</param>
+        /// <returns>A <see cref="T:string[]" /> containing the split value of the property if the property had a value, otherwise <code>null</code>.</returns>
+        public static string[] SplitGlobalPropertyValueOrNull(this IMSBuildProject item, string name)
+        {
+            string value = item.GetGlobalProperty(name);
+
+            return value == null ? null : MSBuildStringUtility.Split(value);
+        }
+
+        /// <summary>
         /// Determines if the specified value is equal to <see cref="bool.TrueString" />.
         /// </summary>
         /// <param name="value">The value to compare to <see cref="bool.TrueString" />.</param>

--- a/src/NuGet.Core/NuGet.Build.Tasks.Console/IMSBuildProject.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Console/IMSBuildProject.cs
@@ -22,6 +22,13 @@ namespace NuGet.Build.Tasks.Console
         string FullPath { get; }
 
         /// <summary>
+        /// Retrieve global property value and trim.
+        /// </summary>
+        /// <param name="property"></param>
+        /// <returns>Trimmed global property value</returns>
+        string GetGlobalProperty(string property);
+
+        /// <summary>
         /// Gets items in the project with the specified name.
         /// </summary>
         /// <param name="name">The name of the item to get.</param>

--- a/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildProjectInstance.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildProjectInstance.cs
@@ -50,5 +50,17 @@ namespace NuGet.Build.Tasks.Console
 
         /// <inheritdoc cref="MSBuildItemBase.GetPropertyValue(string)" />
         protected override string GetPropertyValue(string name) => _projectInstance.GetPropertyValue(name);
+
+        public string GetGlobalProperty(string property)
+        {
+            string value = GetPropertyValue(property).Trim();
+
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return null;
+            }
+
+            return value;
+        }
     }
 }

--- a/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs
@@ -442,7 +442,7 @@ namespace NuGet.Build.Tasks.Console
         internal static List<PackageSource> GetSources(IMSBuildProject project, IReadOnlyCollection<IMSBuildProject> innerNodes, ISettings settings)
         {
             return BuildTasksUtility.GetSources(
-                project.GetProperty("MSBuildStartupDirectory"),
+                project.GetGlobalProperty("OriginalMSBuildStartupDirectory"),
                 project.Directory,
                 project.SplitPropertyValueOrNull("RestoreSources"),
                 project.SplitGlobalPropertyValueOrNull("RestoreSources"),
@@ -607,6 +607,8 @@ namespace NuGet.Build.Tasks.Console
                     // Get the PackageSpecs in parallel because creating each one is relatively expensive so parallelism speeds things up
                     Parallel.ForEach(projects, new ParallelOptions { MaxDegreeOfParallelism = Environment.ProcessorCount }, project =>
                     {
+                        MSBuildLogger.LogMinimal($"For {project.OuterProject.FullPath}," +
+                            $" the value of MSBuildStartupDirectory:{project.OuterProject.GetProperty("MSBuildStartupDirectory")}");
                         var packageSpec = GetPackageSpec(project.OuterProject, project);
 
                         if (packageSpec != null)

--- a/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs
@@ -247,7 +247,7 @@ namespace NuGet.Build.Tasks.Console
         internal static string GetPackagesPath(IMSBuildProject project, ISettings settings)
         {
             return RestoreSettingsUtils.GetValue(
-                () => UriUtility.GetAbsolutePath(project.Directory, project.GetProperty("RestorePackagesPathOverride")),
+                () => UriUtility.GetAbsolutePath(project.Directory, project.GetGlobalProperty("RestorePackagesPath")),
                 () => UriUtility.GetAbsolutePath(project.Directory, project.GetProperty("RestorePackagesPath")),
                 () => SettingsUtility.GetGlobalPackagesFolder(settings));
         }
@@ -405,7 +405,7 @@ namespace NuGet.Build.Tasks.Console
         internal static string GetRepositoryPath(IMSBuildProject project, ISettings settings)
         {
             return RestoreSettingsUtils.GetValue(
-                () => UriUtility.GetAbsolutePath(project.Directory, project.GetProperty("RestoreRepositoryPathOverride")),
+                () => UriUtility.GetAbsolutePath(project.Directory, project.GetGlobalProperty("RestoreRepositoryPath")),
                 () => UriUtility.GetAbsolutePath(project.Directory, project.GetProperty("RestoreRepositoryPath")),
                 () => SettingsUtility.GetRepositoryPath(settings),
                 () =>
@@ -442,9 +442,10 @@ namespace NuGet.Build.Tasks.Console
         internal static List<PackageSource> GetSources(IMSBuildProject project, IReadOnlyCollection<IMSBuildProject> innerNodes, ISettings settings)
         {
             return BuildTasksUtility.GetSources(
+                project.GetProperty("MSBuildStartupDirectory"),
                 project.Directory,
                 project.SplitPropertyValueOrNull("RestoreSources"),
-                project.SplitPropertyValueOrNull("RestoreSourcesOverride"),
+                project.SplitGlobalPropertyValueOrNull("RestoreSources"),
                 innerNodes.SelectMany(i => MSBuildStringUtility.Split(i.GetProperty("RestoreAdditionalProjectSources"))),
                 settings)
                 .Select(i => new PackageSource(i))
@@ -623,7 +624,6 @@ namespace NuGet.Build.Tasks.Console
                                 projectPathLookup.TryAdd(projectPath, projectPath);
                             }
 
-                            // TODO: Remove this lock once https://github.com/NuGet/Home/issues/9002 is fixed
                             lock (dependencyGraphSpec)
                             {
                                 dependencyGraphSpec.AddProject(packageSpec);
@@ -765,9 +765,10 @@ namespace NuGet.Build.Tasks.Console
                     CrossTargeting = (projectStyle == ProjectStyle.PackageReference || projectStyle == ProjectStyle.DotnetToolReference) && (
                         projectsByTargetFramework.Count > 1 || !string.IsNullOrWhiteSpace(project.GetProperty("TargetFrameworks"))),
                     FallbackFolders = BuildTasksUtility.GetFallbackFolders(
+                        project.GetProperty("MSBuildStartupDirectory"),
                         project.Directory,
                         project.SplitPropertyValueOrNull("RestoreFallbackFolders"),
-                        project.SplitPropertyValueOrNull("RestoreFallbackFoldersOverride"),
+                        project.SplitGlobalPropertyValueOrNull("RestoreFallbackFolders"),
                         innerNodes.SelectMany(i => MSBuildStringUtility.Split(i.GetProperty("RestoreAdditionalProjectFallbackFolders"))),
                         innerNodes.SelectMany(i => MSBuildStringUtility.Split(i.GetProperty("RestoreAdditionalProjectFallbackFoldersExcludes"))),
                         settings),

--- a/src/NuGet.Core/NuGet.Build.Tasks/BuildTasksUtility.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/BuildTasksUtility.cs
@@ -677,6 +677,7 @@ namespace NuGet.Build.Tasks
         /// <param name="additionalProjectFallbackFoldersExcludes">An <see cref="IEnumerable{String}" /> containing fallback folders to exclude.</param>
         /// <param name="settings">An <see cref="ISettings" /> object containing settings for the project.</param>
         /// <returns>A <see cref="T:string[]" /> containing the package fallback folders for the project.</returns>
+        [Obsolete("This method calculates the source overrides incorrectly and will be removed in a future release")]
         public static string[] GetFallbackFolders(string projectDirectory, string[] fallbackFolders, string[] fallbackFoldersOverride, IEnumerable<string> additionalProjectFallbackFolders, IEnumerable<string> additionalProjectFallbackFoldersExcludes, ISettings settings)
         {
             // Fallback folders
@@ -695,6 +696,7 @@ namespace NuGet.Build.Tasks
             return AppendItems(projectDirectory, currentFallbackFolders, filteredAdditionalProjectFallbackFolders);
         }
 
+        [Obsolete("This method calculates the source overrides incorrectly and will be removed in a future release")]
         public static string[] GetSources(string projectDirectory, string[] sources, string[] sourcesOverride, IEnumerable<string> additionalProjectSources, ISettings settings)
         {
             // Sources

--- a/src/NuGet.Core/NuGet.Build.Tasks/BuildTasksUtility.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/BuildTasksUtility.cs
@@ -715,6 +715,55 @@ namespace NuGet.Build.Tasks
             return AppendItems(projectDirectory, currentSources, filteredAdditionalProjectSources);
         }
 
+        public static string[] GetSources(string startupDirectory, string projectDirectory, string[] sources, string[] sourcesOverride, IEnumerable<string> additionalProjectSources, ISettings settings)
+        {
+            // Sources
+            var currentSources = RestoreSettingsUtils.GetValue(
+                () => sourcesOverride?.Select(MSBuildRestoreUtility.FixSourcePath).Select(e => UriUtility.GetAbsolutePath(startupDirectory, e)).ToArray(),
+                () => MSBuildRestoreUtility.ContainsClearKeyword(sources) ? Array.Empty<string>() : null,
+                () => sources?.Select(MSBuildRestoreUtility.FixSourcePath).Select(e => UriUtility.GetAbsolutePath(projectDirectory, e)).ToArray(),
+                () => (PackageSourceProvider.LoadPackageSources(settings)).Where(e => e.IsEnabled).Select(e => e.Source).ToArray());
+
+            // Append additional sources
+            // Escape strings to avoid xplat path issues with msbuild.
+            var filteredAdditionalProjectSources = MSBuildRestoreUtility.AggregateSources(
+                    values: additionalProjectSources,
+                    excludeValues: Enumerable.Empty<string>())
+                .Select(MSBuildRestoreUtility.FixSourcePath)
+                .ToArray();
+
+            return AppendItems(projectDirectory, currentSources, filteredAdditionalProjectSources);
+        }
+
+        /// <summary>
+        /// Gets the package fallback folders for a project.
+        /// </summary>
+        /// <param name="startupDirectory">The start-up directory of the tool.</param>
+        /// <param name="projectDirectory">The full path to the directory of the project.</param>
+        /// <param name="fallbackFolders">A <see cref="T:string[]" /> containing the fallback folders for the project.</param>
+        /// <param name="fallbackFoldersOverride">A <see cref="T:string[]" /> containing overrides for the fallback folders for the project.</param>
+        /// <param name="additionalProjectFallbackFolders">An <see cref="IEnumerable{String}" /> containing additional fallback folders for the project.</param>
+        /// <param name="additionalProjectFallbackFoldersExcludes">An <see cref="IEnumerable{String}" /> containing fallback folders to exclude.</param>
+        /// <param name="settings">An <see cref="ISettings" /> object containing settings for the project.</param>
+        /// <returns>A <see cref="T:string[]" /> containing the package fallback folders for the project.</returns>
+        public static string[] GetFallbackFolders(string startupDirectory, string projectDirectory, string[] fallbackFolders, string[] fallbackFoldersOverride, IEnumerable<string> additionalProjectFallbackFolders, IEnumerable<string> additionalProjectFallbackFoldersExcludes, ISettings settings)
+        {
+            // Fallback folders
+            var currentFallbackFolders = RestoreSettingsUtils.GetValue(
+                () => fallbackFoldersOverride?.Select(e => UriUtility.GetAbsolutePath(startupDirectory, e)).ToArray(),
+                () => MSBuildRestoreUtility.ContainsClearKeyword(fallbackFolders) ? Array.Empty<string>() : null,
+                () => fallbackFolders?.Select(e => UriUtility.GetAbsolutePath(projectDirectory, e)).ToArray(),
+                () => SettingsUtility.GetFallbackPackageFolders(settings).ToArray());
+
+            // Append additional fallback folders after removing excluded folders
+            var filteredAdditionalProjectFallbackFolders = MSBuildRestoreUtility.AggregateSources(
+                    values: additionalProjectFallbackFolders,
+                    excludeValues: additionalProjectFallbackFoldersExcludes)
+                .ToArray();
+
+            return AppendItems(projectDirectory, currentFallbackFolders, filteredAdditionalProjectFallbackFolders);
+        }
+
         private static string[] AppendItems(string projectDirectory, string[] current, string[] additional)
         {
             if (additional == null || additional.Length == 0)

--- a/src/NuGet.Core/NuGet.Build.Tasks/BuildTasksUtility.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/BuildTasksUtility.cs
@@ -690,8 +690,7 @@ namespace NuGet.Build.Tasks
             // Append additional fallback folders after removing excluded folders
             var filteredAdditionalProjectFallbackFolders = MSBuildRestoreUtility.AggregateSources(
                     values: additionalProjectFallbackFolders,
-                    excludeValues: additionalProjectFallbackFoldersExcludes)
-                .ToArray();
+                    excludeValues: additionalProjectFallbackFoldersExcludes);
 
             return AppendItems(projectDirectory, currentFallbackFolders, filteredAdditionalProjectFallbackFolders);
         }
@@ -711,8 +710,7 @@ namespace NuGet.Build.Tasks
             var filteredAdditionalProjectSources = MSBuildRestoreUtility.AggregateSources(
                     values: additionalProjectSources,
                     excludeValues: Enumerable.Empty<string>())
-                .Select(MSBuildRestoreUtility.FixSourcePath)
-                .ToArray();
+                .Select(MSBuildRestoreUtility.FixSourcePath);
 
             return AppendItems(projectDirectory, currentSources, filteredAdditionalProjectSources);
         }
@@ -731,8 +729,7 @@ namespace NuGet.Build.Tasks
             var filteredAdditionalProjectSources = MSBuildRestoreUtility.AggregateSources(
                     values: additionalProjectSources,
                     excludeValues: Enumerable.Empty<string>())
-                .Select(MSBuildRestoreUtility.FixSourcePath)
-                .ToArray();
+                .Select(MSBuildRestoreUtility.FixSourcePath);
 
             return AppendItems(projectDirectory, currentSources, filteredAdditionalProjectSources);
         }
@@ -760,15 +757,14 @@ namespace NuGet.Build.Tasks
             // Append additional fallback folders after removing excluded folders
             var filteredAdditionalProjectFallbackFolders = MSBuildRestoreUtility.AggregateSources(
                     values: additionalProjectFallbackFolders,
-                    excludeValues: additionalProjectFallbackFoldersExcludes)
-                .ToArray();
+                    excludeValues: additionalProjectFallbackFoldersExcludes);
 
             return AppendItems(projectDirectory, currentFallbackFolders, filteredAdditionalProjectFallbackFolders);
         }
 
-        private static string[] AppendItems(string projectDirectory, string[] current, string[] additional)
+        private static string[] AppendItems(string projectDirectory, string[] current, IEnumerable<string> additional)
         {
-            if (additional == null || additional.Length == 0)
+            if (additional == null || !additional.Any())
             {
                 // noop
                 return current;

--- a/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreSettingsTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreSettingsTask.cs
@@ -94,6 +94,13 @@ namespace NuGet.Build.Tasks
 
         public override bool Execute()
         {
+#if DEBUG
+            var debugRestoreTask = Environment.GetEnvironmentVariable("DEBUG_RESTORE_TASK");
+            if (!string.IsNullOrEmpty(debugRestoreTask) && debugRestoreTask.Equals(bool.TrueString, StringComparison.OrdinalIgnoreCase))
+            {
+                System.Diagnostics.Debugger.Launch();
+            }
+#endif
             var log = new MSBuildLogger(Log);
 
             // Log Inputs
@@ -159,6 +166,7 @@ namespace NuGet.Build.Tasks
 
                 // Sources
                 OutputSources = BuildTasksUtility.GetSources(
+                    MSBuildStartupDirectory,
                     Path.GetDirectoryName(ProjectUniqueName),
                     RestoreSources,
                     RestoreSourcesOverride,
@@ -167,6 +175,7 @@ namespace NuGet.Build.Tasks
 
                 // Fallback folders
                 OutputFallbackFolders = BuildTasksUtility.GetFallbackFolders(
+                    MSBuildStartupDirectory,
                     Path.GetDirectoryName(ProjectUniqueName),
                     RestoreFallbackFolders, RestoreFallbackFoldersOverride,
                     GetPropertyValues(RestoreSettingsPerFramework, "RestoreAdditionalProjectFallbackFolders"),

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.RestoreEx.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.RestoreEx.targets
@@ -31,6 +31,7 @@ Copyright (c) .NET Foundation. All rights reserved.
         RestorePackagesConfig="$(RestorePackagesConfig)"
         SolutionPath="$(SolutionPath)"
         ProcessFileName="$(NuGetConsoleProcessFileName)"
+        MSBuildStartupDirectory="$(MSBuildStartupDirectory)"
         />
   </Target>
 

--- a/src/NuGet.Core/NuGet.Build.Tasks/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Build.Tasks/PublicAPI.Unshipped.txt
@@ -2,3 +2,5 @@ NuGet.Build.Tasks.GetReferenceNearestTargetFrameworkTask.CurrentProjectTargetPla
 NuGet.Build.Tasks.GetReferenceNearestTargetFrameworkTask.CurrentProjectTargetPlatform.set -> void
 NuGet.Build.Tasks.RestoreTaskEx.ProcessFileName.get -> string
 NuGet.Build.Tasks.RestoreTaskEx.ProcessFileName.set -> void
+static NuGet.Build.Tasks.BuildTasksUtility.GetFallbackFolders(string startupDirectory, string projectDirectory, string[] fallbackFolders, string[] fallbackFoldersOverride, System.Collections.Generic.IEnumerable<string> additionalProjectFallbackFolders, System.Collections.Generic.IEnumerable<string> additionalProjectFallbackFoldersExcludes, NuGet.Configuration.ISettings settings) -> string[]
+static NuGet.Build.Tasks.BuildTasksUtility.GetSources(string startupDirectory, string projectDirectory, string[] sources, string[] sourcesOverride, System.Collections.Generic.IEnumerable<string> additionalProjectSources, NuGet.Configuration.ISettings settings) -> string[]

--- a/src/NuGet.Core/NuGet.Build.Tasks/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Build.Tasks/PublicAPI.Unshipped.txt
@@ -1,5 +1,7 @@
 NuGet.Build.Tasks.GetReferenceNearestTargetFrameworkTask.CurrentProjectTargetPlatform.get -> string
 NuGet.Build.Tasks.GetReferenceNearestTargetFrameworkTask.CurrentProjectTargetPlatform.set -> void
+NuGet.Build.Tasks.RestoreTaskEx.MSBuildStartupDirectory.get -> string
+NuGet.Build.Tasks.RestoreTaskEx.MSBuildStartupDirectory.set -> void
 NuGet.Build.Tasks.RestoreTaskEx.ProcessFileName.get -> string
 NuGet.Build.Tasks.RestoreTaskEx.ProcessFileName.set -> void
 static NuGet.Build.Tasks.BuildTasksUtility.GetFallbackFolders(string startupDirectory, string projectDirectory, string[] fallbackFolders, string[] fallbackFoldersOverride, System.Collections.Generic.IEnumerable<string> additionalProjectFallbackFolders, System.Collections.Generic.IEnumerable<string> additionalProjectFallbackFoldersExcludes, NuGet.Configuration.ISettings settings) -> string[]

--- a/src/NuGet.Core/NuGet.Build.Tasks/RestoreTaskEx.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/RestoreTaskEx.cs
@@ -106,6 +106,11 @@ namespace NuGet.Build.Tasks
         /// </summary>
         public string ProcessFileName { get; set; }
 
+        /// <summary>
+        /// MSBuildStartupDirectory - Used to calculate relative paths
+        /// </summary>
+        public string MSBuildStartupDirectory { get; set; }
+
         /// <inheritdoc cref="ICancelableTask.Cancel" />
         public void Cancel() => _cancellationTokenSource.Cancel();
 
@@ -206,9 +211,8 @@ namespace NuGet.Build.Tasks
                 [nameof(Interactive)] = Interactive,
                 [nameof(NoCache)] = NoCache,
                 [nameof(Recursive)] = Recursive,
-                [nameof(RestorePackagesConfig)] = RestorePackagesConfig
+                [nameof(RestorePackagesConfig)] = RestorePackagesConfig,
             };
-
             // Semicolon delimited list of options
             yield return string.Join(";", options.Where(i => i.Value).Select(i => $"{i.Key}={i.Value}"));
 
@@ -226,7 +230,9 @@ namespace NuGet.Build.Tasks
                     : ProjectFullPath;
 
             // Semicolon delimited list of MSBuild global properties
-            yield return string.Join(";", GetGlobalProperties().Select(i => $"{i.Key}={i.Value}"));
+            var globalProperties = GetGlobalProperties().Select(i => $"{i.Key}={i.Value}").Concat(new string[] { $"OriginalMSBuildStartupDirectory={MSBuildStartupDirectory}" });
+
+            yield return string.Join(";", globalProperties);
         }
 
         /// <summary>

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
@@ -5603,7 +5603,8 @@ namespace NuGet.CommandLine.Test
                 solution.Projects.Add(projectA);
                 solution.Create(pathContext.SolutionRoot);
 
-                var source = Path.Combine(pathContext.WorkingDirectory, "valid");
+                var relativeSourceName = "valid";
+                var source = Path.Combine(pathContext.WorkingDirectory, relativeSourceName);
 
                 // X is only in the source
                 await SimpleTestPackageUtility.CreateFolderFeedV3Async(
@@ -5612,7 +5613,7 @@ namespace NuGet.CommandLine.Test
                     packageX);
 
                 // Act
-                var r = Util.RestoreSolution(pathContext, 0, "-Source", source);
+                var r = Util.RestoreSolution(pathContext, 0, "-Source", relativeSourceName);
 
                 // Assert
                 r.Success.Should().BeTrue();

--- a/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildRestoreTaskTests.cs
+++ b/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildRestoreTaskTests.cs
@@ -638,7 +638,7 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
 
         [PlatformTheory(Platform.Windows)]
         [InlineData(true)]
-        //[InlineData(false)]
+        [InlineData(false)]
         public async Task MsbuildRestore_WithRelativeSource_ResolvesAgainstCurrentWorkingDirectory(bool isStaticGraphRestore)
         {
             // Arrange

--- a/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildRestoreTaskTests.cs
+++ b/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildRestoreTaskTests.cs
@@ -683,7 +683,7 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
 
                 // Restore the project with a PackageReference which generates assets
                 var result = _msbuildFixture.RunMsBuild(pathContext.WorkingDirectory, $"/t:restore {project.ProjectPath} /p:RestoreSources=\"{relativePath}\"" +
-                    (isStaticGraphRestore ? "/p:RestoreUseStaticGraphEvaluation=true" : string.Empty),
+                    (isStaticGraphRestore ? " /p:RestoreUseStaticGraphEvaluation=true" : string.Empty),
                     ignoreExitCode: true);
                 result.Success.Should().BeTrue(because: result.AllOutput);
 

--- a/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildRestoreTaskTests.cs
+++ b/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildRestoreTaskTests.cs
@@ -635,5 +635,63 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
                 result.AllOutput.Should().Contain($"error : Invalid restore input. Missing required property 'OutputPath' for project type 'PackageReference'. Input files: {project.ProjectPath}.");
             }
         }
+
+        [PlatformTheory(Platform.Windows)]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task MsbuildRestore_WithRelativeSource_ResolvesAgainstCurrentWorkingDirectory(bool isStaticGraphRestore)
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Set up solution, project, and packages
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+
+                var net461 = NuGetFramework.Parse("net461");
+
+                var project = SimpleTestProjectContext.CreateLegacyPackageReference(
+                    "a",
+                    pathContext.SolutionRoot,
+                    net461);
+
+                var packageX = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.0"
+                };
+
+                packageX.Files.Clear();
+                project.AddPackageToAllFrameworks(packageX);
+                packageX.AddFile("lib/net461/a.dll");
+
+                solution.Projects.Add(project);
+                solution.Create(pathContext.SolutionRoot);
+                var relativePath = "relativeSource";
+                var relativeSource = Path.Combine(pathContext.WorkingDirectory, relativePath);
+
+                await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                    relativeSource,
+                    packageX);
+
+                var projectOutputPaths = new[]
+                {
+                    project.AssetsFileOutputPath,
+                    project.PropsOutput,
+                    project.TargetsOutput,
+                    project.CacheFileOutputPath,
+                };
+
+                // Restore the project with a PackageReference which generates assets
+                var result = _msbuildFixture.RunMsBuild(pathContext.WorkingDirectory, $"/t:restore {project.ProjectPath} /p:RestoreSources=\"{relativePath}\"" +
+                    (isStaticGraphRestore ? "/p:RestoreUseStaticGraphEvaluation=true" : string.Empty),
+                    ignoreExitCode: true);
+                result.Success.Should().BeTrue(because: result.AllOutput);
+
+                foreach (var asset in projectOutputPaths)
+                {
+                    new FileInfo(asset).Exists.Should().BeTrue(because: result.AllOutput);
+                }
+            }
+        }
     }
 }

--- a/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildRestoreTaskTests.cs
+++ b/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildRestoreTaskTests.cs
@@ -638,7 +638,7 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
 
         [PlatformTheory(Platform.Windows)]
         [InlineData(true)]
-        [InlineData(false)]
+        //[InlineData(false)]
         public async Task MsbuildRestore_WithRelativeSource_ResolvesAgainstCurrentWorkingDirectory(bool isStaticGraphRestore)
         {
             // Arrange

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Console.Test/BuildTasksUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Console.Test/BuildTasksUtilityTests.cs
@@ -2,11 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using FluentAssertions;
 using NuGet.Configuration;
 using NuGet.Test.Utility;
@@ -22,7 +18,6 @@ namespace NuGet.Build.Tasks.Console.Test
             using (var testDir = TestDirectory.CreateInTemp())
             {
                 // Arrange
-
                 var startupDirectory = Path.Combine(testDir, "startup");
                 var projectDirectory = Path.Combine(testDir, "project");
                 var relativePath = "relativeSource";
@@ -33,7 +28,7 @@ namespace NuGet.Build.Tasks.Console.Test
                      projectDirectory: projectDirectory,
                      sources: new string[] { relativePath },
                      sourcesOverride: null,
-                     additionalProjectSources: new string[] { },
+                     additionalProjectSources: Array.Empty<string>(),
                      settings: NullSettings.Instance
                      );
 
@@ -48,7 +43,6 @@ namespace NuGet.Build.Tasks.Console.Test
             using (var testDir = TestDirectory.CreateInTemp())
             {
                 // Arrange
-
                 var startupDirectory = Path.Combine(testDir, "startup");
                 var projectDirectory = Path.Combine(testDir, "project");
                 var relativePath = "relativeSource";
@@ -59,7 +53,7 @@ namespace NuGet.Build.Tasks.Console.Test
                      projectDirectory: projectDirectory,
                      sources: new string[] { relativePath },
                      sourcesOverride: new string[] { relativePath },
-                     additionalProjectSources: new string[] { },
+                     additionalProjectSources: Array.Empty<string>(),
                      settings: NullSettings.Instance
                      );
 

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Console.Test/BuildTasksUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Console.Test/BuildTasksUtilityTests.cs
@@ -1,0 +1,71 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using NuGet.Configuration;
+using NuGet.Test.Utility;
+using Xunit;
+
+namespace NuGet.Build.Tasks.Console.Test
+{
+    public class BuildTasksUtilityTests
+    {
+        [Fact]
+        public void GetSources_WithRestoreSourcesProperty_ResolvesAgainstProjectDirectory()
+        {
+            using (var testDir = TestDirectory.CreateInTemp())
+            {
+                // Arrange
+
+                var startupDirectory = Path.Combine(testDir, "startup");
+                var projectDirectory = Path.Combine(testDir, "project");
+                var relativePath = "relativeSource";
+
+                // Act
+                var effectiveSources = BuildTasksUtility.GetSources(
+                     startupDirectory: startupDirectory,
+                     projectDirectory: projectDirectory,
+                     sources: new string[] { relativePath },
+                     sourcesOverride: null,
+                     additionalProjectSources: new string[] { },
+                     settings: NullSettings.Instance
+                     );
+
+                // Assert
+                effectiveSources.ShouldBeEquivalentTo(new[] { Path.Combine(projectDirectory, relativePath) });
+            }
+        }
+
+        [Fact]
+        public void GetSources_WithRestoreSourcesGlobal_Property_ResolvesAgainstWorkingDirectory()
+        {
+            using (var testDir = TestDirectory.CreateInTemp())
+            {
+                // Arrange
+
+                var startupDirectory = Path.Combine(testDir, "startup");
+                var projectDirectory = Path.Combine(testDir, "project");
+                var relativePath = "relativeSource";
+
+                // Act
+                var effectiveSources = BuildTasksUtility.GetSources(
+                     startupDirectory: startupDirectory,
+                     projectDirectory: projectDirectory,
+                     sources: new string[] { relativePath },
+                     sourcesOverride: new string[] { relativePath },
+                     additionalProjectSources: new string[] { },
+                     settings: NullSettings.Instance
+                     );
+
+                // Assert
+                effectiveSources.ShouldBeEquivalentTo(new[] { Path.Combine(startupDirectory, relativePath) });
+            }
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Console.Test/MSBuildStaticGraphRestoreTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Console.Test/MSBuildStaticGraphRestoreTests.cs
@@ -219,11 +219,12 @@ namespace NuGet.Build.Tasks.Console.Test
         {
             using (var testDirectory = TestDirectory.Create())
             {
-                var project = new MockMSBuildProject(testDirectory, new Dictionary<string, string>
+                var project = new MockMSBuildProject(testDirectory,
+                properties: new Dictionary<string, string>
                 {
                     ["RestorePackagesPath"] = packagesPath
                 },
-                new Dictionary<string, string>
+                globalProperties: new Dictionary<string, string>
                 {
                     ["RestorePackagesPath"] = packagesPathOverride,
                 });
@@ -505,12 +506,13 @@ namespace NuGet.Build.Tasks.Console.Test
         {
             using (var testDirectory = TestDirectory.Create())
             {
-                var project = new MockMSBuildProject(testDirectory, new Dictionary<string, string>
+                var project = new MockMSBuildProject(testDirectory,
+                properties: new Dictionary<string, string>
                 {
                     ["RestoreRepositoryPath"] = restoreRepositoryPath,
                     ["SolutionPath"] = solutionPath == null || solutionPath == "*Undefined*" ? solutionPath : UriUtility.GetAbsolutePath(testDirectory, solutionPath)
                 },
-                new Dictionary<string, string>
+                globalProperties: new Dictionary<string, string>
                 {
                     ["RestoreRepositoryPath"] = repositoryPathOverride,
                 });
@@ -610,11 +612,12 @@ namespace NuGet.Build.Tasks.Console.Test
         [Fact]
         public void GetSources_WhenRestoreSourcesAndRestoreSourcesOverrideSpecified_CorrectSourcesDetected()
         {
-            var project = new MockMSBuildProject(new Dictionary<string, string>
+            var project = new MockMSBuildProject(
+            properties: new Dictionary<string, string>
             {
                 ["RestoreSources"] = "https://source1;https://source2",
             },
-            new Dictionary<string, string>
+            globalProperties: new Dictionary<string, string>
             {
                 ["RestoreSources"] = "https://source3"
             });

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Console.Test/MSBuildStaticGraphRestoreTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Console.Test/MSBuildStaticGraphRestoreTests.cs
@@ -221,8 +221,11 @@ namespace NuGet.Build.Tasks.Console.Test
             {
                 var project = new MockMSBuildProject(testDirectory, new Dictionary<string, string>
                 {
-                    ["RestorePackagesPathOverride"] = packagesPathOverride,
                     ["RestorePackagesPath"] = packagesPath
+                },
+                new Dictionary<string, string>
+                {
+                    ["RestorePackagesPath"] = packagesPathOverride,
                 });
 
                 var settings = new MockSettings
@@ -505,8 +508,11 @@ namespace NuGet.Build.Tasks.Console.Test
                 var project = new MockMSBuildProject(testDirectory, new Dictionary<string, string>
                 {
                     ["RestoreRepositoryPath"] = restoreRepositoryPath,
-                    ["RestoreRepositoryPathOverride"] = repositoryPathOverride,
                     ["SolutionPath"] = solutionPath == null || solutionPath == "*Undefined*" ? solutionPath : UriUtility.GetAbsolutePath(testDirectory, solutionPath)
+                },
+                new Dictionary<string, string>
+                {
+                    ["RestoreRepositoryPath"] = repositoryPathOverride,
                 });
 
                 var settings = new MockSettings
@@ -607,7 +613,10 @@ namespace NuGet.Build.Tasks.Console.Test
             var project = new MockMSBuildProject(new Dictionary<string, string>
             {
                 ["RestoreSources"] = "https://source1;https://source2",
-                ["RestoreSourcesOverride"] = "https://source3"
+            },
+            new Dictionary<string, string>
+            {
+                ["RestoreSources"] = "https://source3"
             });
 
             var settings = new MockSettings

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Console.Test/MockMSBuildProject.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Console.Test/MockMSBuildProject.cs
@@ -20,6 +20,11 @@ namespace NuGet.Build.Tasks.Console.Test
         {
         }
 
+        public MockMSBuildProject(TestDirectory directory, IDictionary<string, string> properties, IDictionary<string, string> globalProperties)
+            : this(Path.Combine(directory, "ProjectA.csproj"), properties, new Dictionary<string, IList<IMSBuildItem>>(), globalProperties)
+        {
+        }
+
         public MockMSBuildProject(string fullPath)
             : this(fullPath, properties: null)
         {
@@ -30,12 +35,22 @@ namespace NuGet.Build.Tasks.Console.Test
         {
         }
 
+        public MockMSBuildProject(IDictionary<string, string> properties, IDictionary<string, string> globalProperties)
+            : this("ProjectA", properties, new Dictionary<string, IList<IMSBuildItem>>(), globalProperties)
+        {
+        }
+
         public MockMSBuildProject(string fullPath, IDictionary<string, string> properties)
             : this(fullPath, properties, items: null)
         {
         }
 
         public MockMSBuildProject(string fullPath, IDictionary<string, string> properties, IDictionary<string, IList<IMSBuildItem>> items)
+            : this(fullPath, properties, items, new Dictionary<string, string>())
+        {
+        }
+
+        public MockMSBuildProject(string fullPath, IDictionary<string, string> properties, IDictionary<string, IList<IMSBuildItem>> items, IDictionary<string, string> globalProperties)
             : base(Path.GetFileName(fullPath), properties ?? new Dictionary<string, string>())
         {
             Items = items ?? new Dictionary<string, IList<IMSBuildItem>>();
@@ -43,6 +58,8 @@ namespace NuGet.Build.Tasks.Console.Test
             Directory = Path.GetDirectoryName(fullPath);
 
             FullPath = fullPath;
+
+            GlobalProperties = globalProperties;
         }
 
         public string Directory { get; }
@@ -51,6 +68,8 @@ namespace NuGet.Build.Tasks.Console.Test
 
         public IDictionary<string, IList<IMSBuildItem>> Items { get; set; }
 
+        public IDictionary<string, string> GlobalProperties { get; set; }
+
         public IEnumerable<IMSBuildItem> GetItems(string name)
         {
             return Items.TryGetValue(name, out var items) ? items : null;
@@ -58,7 +77,8 @@ namespace NuGet.Build.Tasks.Console.Test
 
         public string GetGlobalProperty(string property)
         {
-            return string.Empty;
+            GlobalProperties.TryGetValue(property, out string value);
+            return value;
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Console.Test/MockMSBuildProject.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Console.Test/MockMSBuildProject.cs
@@ -55,5 +55,10 @@ namespace NuGet.Build.Tasks.Console.Test
         {
             return Items.TryGetValue(name, out var items) ? items : null;
         }
+
+        public string GetGlobalProperty(string property)
+        {
+            return string.Empty;
+        }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/GetRestoreSettingTaskTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/GetRestoreSettingTaskTests.cs
@@ -641,6 +641,76 @@ namespace NuGet.Build.Tasks.Test
             }
         }
 
+        [Fact]
+        public void GetRestoreSettingsTask_WithRestoreSourcesOverride_ResolvesAgainstWorkingDirectory()
+        {
+            using (var testDir = TestDirectory.CreateInTemp())
+            {
+                // Arrange
+                var buildEngine = new TestBuildEngine();
+                var testLogger = buildEngine.TestLogger;
+
+                var settingsPerFramework = new List<ITaskItem>();
+                var settings1 = new Mock<ITaskItem>();
+                settings1.SetupGet(e => e.ItemSpec).Returns("a");
+                settingsPerFramework.Add(settings1.Object);
+                var startupDirectory = Path.Combine(testDir, "innerPath");
+                var relativePath = "relativeSource";
+
+                var task = new GetRestoreSettingsTask()
+                {
+                    BuildEngine = buildEngine,
+                    MSBuildStartupDirectory = startupDirectory,
+                    ProjectUniqueName = Path.Combine(testDir, "a.csproj"),
+                    RestoreSources = new[] { Path.Combine(testDir, "sourceA"), Path.Combine(testDir, "sourceB") },
+                    RestoreSourcesOverride = new[] { relativePath },
+                    RestoreSettingsPerFramework = settingsPerFramework.ToArray()
+                };
+
+                // Act
+                var result = task.Execute();
+
+                // Assert
+                result.Should().BeTrue();
+                task.OutputSources.ShouldBeEquivalentTo(new[] { Path.Combine(startupDirectory, relativePath) });
+            }
+        }
+
+        [Fact]
+        public void GetRestoreSettingsTask_WithFallbackFoldersOverride_ResolvesAgainstWorkingDirectory()
+        {
+            using (var testDir = TestDirectory.CreateInTemp())
+            {
+                // Arrange
+                var buildEngine = new TestBuildEngine();
+                var testLogger = buildEngine.TestLogger;
+
+                var settingsPerFramework = new List<ITaskItem>();
+                var settings1 = new Mock<ITaskItem>();
+                settings1.SetupGet(e => e.ItemSpec).Returns("a");
+                settingsPerFramework.Add(settings1.Object);
+                var startupDirectory = Path.Combine(testDir, "innerPath");
+                var relativePath = "relativeSource";
+
+                var task = new GetRestoreSettingsTask()
+                {
+                    BuildEngine = buildEngine,
+                    MSBuildStartupDirectory = startupDirectory,
+                    ProjectUniqueName = Path.Combine(testDir, "a.csproj"),
+                    RestoreFallbackFolders = new[] { Path.Combine(testDir, "sourceA"), Path.Combine(testDir, "sourceB") },
+                    RestoreFallbackFoldersOverride = new[] { relativePath },
+                    RestoreSettingsPerFramework = settingsPerFramework.ToArray()
+                };
+
+                // Act
+                var result = task.Execute();
+
+                // Assert
+                result.Should().BeTrue();
+                task.OutputFallbackFolders.ShouldBeEquivalentTo(new[] { Path.Combine(startupDirectory, relativePath) });
+            }
+        }
+
         private static readonly string MachineWideSettingsConfig = @"<?xml version=""1.0"" encoding=""utf-8""?>
                 <configuration>
                 </configuration>";

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/RestoreTaskExTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/RestoreTaskExTests.cs
@@ -52,10 +52,12 @@ namespace NuGet.Build.Tasks.Test
                     NoCache = true,
                     ProjectFullPath = projectPath,
                     Recursive = true,
-                    RestorePackagesConfig = true
+                    RestorePackagesConfig = true,
+                    MSBuildStartupDirectory = testDirectory,
                 })
                 {
-                    task.GetCommandLineArguments().ToList().Should().BeEquivalentTo(
+                    var arguments = task.GetCommandLineArguments().ToList();
+                    arguments.Should().BeEquivalentTo(
 #if IS_CORECLR
                     Path.ChangeExtension(typeof(RestoreTaskEx).Assembly.Location, ".Console.dll"),
 #endif
@@ -66,7 +68,7 @@ namespace NuGet.Build.Tasks.Test
                     Path.Combine(msbuildBinPath, "MSBuild.exe"),
 #endif
                     projectPath,
-                        "Property1=Value1;Property2=  Value2  ;ExcludeRestorePackageImports=true");
+                        $"Property1=Value1;Property2=  Value2  ;ExcludeRestorePackageImports=true;OriginalMSBuildStartupDirectory={testDirectory}");
                 }
             }
         }


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9406
Regression: Yes  
* Last working version: 5.4 
* How are we preventing it in future: Better tests! Existing test was actually passing an absolute, not a relative path.

## Fix

Details: This got regressed when we did our static graph refactoring, where https://github.com/NuGet/NuGet.Client/blob/dev/src/NuGet.Core/NuGet.Build.Tasks/BuildTasksUtility.cs was added. 

In particular, in non-static graph restore, we had to differentiate between the global properties passed in cmd and the properties set in the project files. The reason is that the props set in the project files need to resolved relative to the project. The cmd passed in props need to be resolved relative to the working directory. 
The concept of "Override" property was added in https://github.com/NuGet/NuGet.Client/blob/dev/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreSettingsTask.cs. 

This just fixes that by explicitly referring to the global property in static graph and by passing the correct relative path in general. 

## Testing/Validation

Tests Added: Yes 
Reason for not adding tests:  
Validation:  
