### PR TITLE
VS OE:  cache and reuse IServiceBroker instance in the client

### DIFF
--- a/src/NuGet.Clients/NuGet.Console/Xamls/ConsoleContainer.xaml.cs
+++ b/src/NuGet.Clients/NuGet.Console/Xamls/ConsoleContainer.xaml.cs
@@ -11,8 +11,8 @@ using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using NuGet.PackageManagement;
 using NuGet.PackageManagement.UI;
-using NuGet.PackageManagement.VisualStudio;
 using NuGet.VisualStudio;
+using NuGet.VisualStudio.Common;
 using NuGet.VisualStudio.Internal.Contracts;
 
 namespace NuGetConsole
@@ -34,7 +34,8 @@ namespace NuGetConsole
                     await System.Threading.Tasks.Task.Run(
                         async () =>
                         {
-                            IServiceBroker serviceBroker = await BrokeredServicesUtilities.GetRemoteServiceBrokerAsync();
+                            IServiceBrokerProvider serviceBrokerProvider = await ServiceLocator.GetInstanceAsync<IServiceBrokerProvider>();
+                            IServiceBroker serviceBroker = await serviceBrokerProvider.GetAsync();
 
                             _solutionManager = await serviceBroker.GetProxyAsync<INuGetSolutionManagerService>(
                                 NuGetServices.SolutionManagerService,

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/PackagesConfigToPackageReferenceMigrator.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/PackagesConfigToPackageReferenceMigrator.cs
@@ -47,7 +47,7 @@ namespace NuGet.PackageManagement.UI
                         return null;
                     }
 
-                    IServiceBroker serviceBroker = await BrokeredServicesUtilities.GetRemoteServiceBrokerAsync();
+                    IServiceBroker serviceBroker = context.ServiceBroker;
 
                     using (INuGetProjectUpgraderService projectUpgrader = await serviceBroker.GetProxyAsync<INuGetProjectUpgraderService>(
                         NuGetServices.ProjectUpgraderService,
@@ -160,7 +160,10 @@ namespace NuGet.PackageManagement.UI
                 }
                 finally
                 {
-                    IEnumerable<string> projectIds = await ProjectUtility.GetSortedProjectIdsAsync(uiService.Projects, token);
+                    IEnumerable<string> projectIds = await ProjectUtility.GetSortedProjectIdsAsync(
+                        uiService.UIContext.ServiceBroker,
+                        uiService.Projects,
+                        token);
 
                     upgradeInformationTelemetryEvent.SetResult(projectIds, status, packagesCount);
                 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/UIActionEngine.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/UIActionEngine.cs
@@ -93,7 +93,7 @@ namespace NuGet.PackageManagement.UI
                 new LoggerAdapter(uiService.ProjectContext),
                 CancellationToken.None);
 
-            IServiceBroker serviceBroker = await BrokeredServicesUtilities.GetRemoteServiceBrokerAsync();
+            IServiceBroker serviceBroker = context.ServiceBroker;
             NuGetProjectUpgradeWindowModel upgradeInformationWindowModel;
 
             using (INuGetProjectManagerService projectManager = await serviceBroker.GetProxyAsync<INuGetProjectManagerService>(
@@ -108,6 +108,7 @@ namespace NuGet.PackageManagement.UI
                     CancellationToken.None);
 
                 upgradeInformationWindowModel = await NuGetProjectUpgradeWindowModel.CreateAsync(
+                    serviceBroker,
                     project,
                     packagesDependencyInfo.ToList(),
                     CancellationToken.None);
@@ -120,7 +121,10 @@ namespace NuGet.PackageManagement.UI
                 var packagesCount = upgradeInformationWindowModel.UpgradeDependencyItems.Count;
 
                 var upgradeTelemetryEvent = new UpgradeInformationTelemetryEvent();
-                IEnumerable<string> projectIds = await ProjectUtility.GetSortedProjectIdsAsync(uiService.Projects, CancellationToken.None);
+                IEnumerable<string> projectIds = await ProjectUtility.GetSortedProjectIdsAsync(
+                    uiService.UIContext.ServiceBroker,
+                    uiService.Projects,
+                    CancellationToken.None);
 
                 upgradeTelemetryEvent.SetResult(
                     projectIds,
@@ -133,7 +137,9 @@ namespace NuGet.PackageManagement.UI
             }
 
             var progressDialogData = new ProgressDialogData(Resources.NuGetUpgrade_WaitMessage);
-            string projectName = await project.GetUniqueNameOrNameAsync(CancellationToken.None);
+            string projectName = await project.GetUniqueNameOrNameAsync(
+                uiService.UIContext.ServiceBroker,
+                CancellationToken.None);
             string backupPath;
 
             var windowTitle = string.Format(
@@ -195,7 +201,7 @@ namespace NuGet.PackageManagement.UI
             List<PackageIdentity> packagesToUpdate,
             CancellationToken cancellationToken)
         {
-            IServiceBroker serviceBroker = await BrokeredServicesUtilities.GetRemoteServiceBrokerAsync();
+            IServiceBroker serviceBroker = uiService.UIContext.ServiceBroker;
 
             using (INuGetProjectManagerService projectManagerService = await serviceBroker.GetProxyAsync<INuGetProjectManagerService>(
                 NuGetServices.ProjectManagerService,
@@ -247,7 +253,7 @@ namespace NuGet.PackageManagement.UI
             ResolveActionsAsync resolveActionsAsync,
             CancellationToken cancellationToken)
         {
-            IServiceBroker serviceBroker = await BrokeredServicesUtilities.GetRemoteServiceBrokerAsync();
+            IServiceBroker serviceBroker = uiService.UIContext.ServiceBroker;
 
             using (INuGetProjectManagerService projectManagerService = await serviceBroker.GetProxyAsync<INuGetProjectManagerService>(
                 NuGetServices.ProjectManagerService,
@@ -307,7 +313,9 @@ namespace NuGet.PackageManagement.UI
                 // collect the install state of the existing packages
                 foreach (IProjectContextInfo project in uiService.Projects)
                 {
-                    IEnumerable<IPackageReferenceContextInfo> installedPackages = await project.GetInstalledPackagesAsync(cancellationToken);
+                    IEnumerable<IPackageReferenceContextInfo> installedPackages = await project.GetInstalledPackagesAsync(
+                        uiService.UIContext.ServiceBroker,
+                        cancellationToken);
 
                     foreach (IPackageReferenceContextInfo package in installedPackages)
                     {
@@ -485,7 +493,10 @@ namespace NuGet.PackageManagement.UI
 
                     PackageLoadContext plc = new PackageLoadContext(sourceRepositories: null, isSolution: false, uiService.UIContext);
                     var frameworks = (await plc.GetSupportedFrameworksAsync()).ToList();
-                    string[] projectIds = (await ProjectUtility.GetSortedProjectIdsAsync(uiService.Projects, cancellationToken)).ToArray();
+                    string[] projectIds = (await ProjectUtility.GetSortedProjectIdsAsync(
+                        uiService.UIContext.ServiceBroker,
+                        uiService.Projects,
+                        cancellationToken)).ToArray();
 
                     var actionTelemetryEvent = new VSActionsTelemetryEvent(
                         uiService.ProjectContext.OperationId.ToString(),
@@ -661,7 +672,10 @@ namespace NuGet.PackageManagement.UI
                 }
 
                 Task<IProjectMetadataContextInfo>[] tasks = upgradeableProjects
-                    .Select(project => project.GetMetadataAsync(cancellationToken).AsTask())
+                    .Select(project => project.GetMetadataAsync(
+                            uiService.UIContext.ServiceBroker,
+                            cancellationToken)
+                        .AsTask())
                     .ToArray();
 
                 IProjectMetadataContextInfo[] projectMetadatas = await Task.WhenAll(tasks);

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailControlModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailControlModel.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Media.Imaging;
+using Microsoft.ServiceHub.Framework;
 using NuGet.PackageManagement.VisualStudio;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
@@ -46,9 +47,12 @@ namespace NuGet.PackageManagement.UI
 
         private Dictionary<NuGetVersion, DetailedPackageMetadata> _metadataDict;
 
-        protected DetailControlModel(IEnumerable<IProjectContextInfo> projects)
+        protected DetailControlModel(
+            IServiceBroker serviceBroker,
+            IEnumerable<IProjectContextInfo> projects)
         {
             _nugetProjects = projects;
+            ServiceBroker = serviceBroker;
             _options = new Options();
 
             // Show dependency behavior and file conflict options if any of the projects are non-build integrated
@@ -72,6 +76,8 @@ namespace NuGet.PackageManagement.UI
         public int RecommendedCount { get; private set; }
         public bool RecommendPackages { get; private set; }
         public (string modelVersion, string vsixVersion)? RecommenderVersion { get; private set; }
+
+        protected IServiceBroker ServiceBroker { get; }
 
         /// <summary>
         /// Sets the current selection info
@@ -119,14 +125,19 @@ namespace NuGet.PackageManagement.UI
                 if (project.ProjectKind == NuGetProjectKind.PackagesConfig)
                 {
                     // cache allowed version range for each nuget project for current selected package
-                    var packageReference = (await project.GetInstalledPackagesAsync(CancellationToken.None))
+                    IReadOnlyCollection<IPackageReferenceContextInfo> installedPackages = await project.GetInstalledPackagesAsync(
+                        ServiceBroker,
+                        CancellationToken.None);
+                    IPackageReferenceContextInfo packageReference = installedPackages
                         .FirstOrDefault(r => StringComparer.OrdinalIgnoreCase.Equals(r.Identity.Id, searchResultPackage.Id));
 
                     var range = packageReference?.AllowedVersions;
 
                     if (range != null && !VersionRange.All.Equals(range))
                     {
-                        IProjectMetadataContextInfo projectMetadata = await project.GetMetadataAsync(CancellationToken.None);
+                        IProjectMetadataContextInfo projectMetadata = await project.GetMetadataAsync(
+                            ServiceBroker,
+                            CancellationToken.None);
                         var constraint = new ProjectVersionConstraint()
                         {
                             ProjectName = projectMetadata.Name,
@@ -139,18 +150,23 @@ namespace NuGet.PackageManagement.UI
                 }
                 else if (project.ProjectKind == NuGetProjectKind.PackageReference)
                 {
-                    var packageReferences = await project.GetInstalledPackagesAsync(CancellationToken.None);
+                    IReadOnlyCollection<IPackageReferenceContextInfo> packageReferences = await project.GetInstalledPackagesAsync(
+                        ServiceBroker,
+                        CancellationToken.None);
 
                     // First the lowest auto referenced version of this package.
-                    var autoReferenced = packageReferences.Where(e => StringComparer.OrdinalIgnoreCase.Equals(searchResultPackage.Id, e.Identity.Id)
-                                                                      && e.Identity.Version != null)
-                                                        .Where(e => e.IsAutoReferenced)
-                                                        .OrderBy(e => e.Identity.Version)
-                                                        .FirstOrDefault();
+                    IPackageReferenceContextInfo autoReferenced = packageReferences
+                        .Where(e => StringComparer.OrdinalIgnoreCase.Equals(searchResultPackage.Id, e.Identity.Id)
+                            && e.Identity.Version != null)
+                        .Where(e => e.IsAutoReferenced)
+                        .OrderBy(e => e.Identity.Version)
+                        .FirstOrDefault();
 
                     if (autoReferenced != null)
                     {
-                        IProjectMetadataContextInfo projectMetadata = await project.GetMetadataAsync(CancellationToken.None);
+                        IProjectMetadataContextInfo projectMetadata = await project.GetMetadataAsync(
+                            ServiceBroker,
+                            CancellationToken.None);
 
                         // Add constraint for auto referenced package.
                         var constraint = new ProjectVersionConstraint()
@@ -239,7 +255,10 @@ namespace NuGet.PackageManagement.UI
                         var installedPackages = new List<IPackageReferenceContextInfo>();
                         foreach (var project in _nugetProjects)
                         {
-                            var projectInstalledPackages = await project.GetInstalledPackagesAsync(CancellationToken.None);
+                            IReadOnlyCollection<IPackageReferenceContextInfo> projectInstalledPackages = await project.GetInstalledPackagesAsync(
+                                ServiceBroker,
+                                CancellationToken.None);
+
                             installedPackages.AddRange(projectInstalledPackages);
                         }
                         return installedPackages.Select(e => e.Identity).Distinct(PackageIdentity.Comparer);
@@ -268,13 +287,15 @@ namespace NuGet.PackageManagement.UI
             }
         }
 
-        private static async Task<IReadOnlyList<PackageDependency>> GetDependencies(IProjectContextInfo project)
+        private async Task<IReadOnlyList<PackageDependency>> GetDependencies(IProjectContextInfo project)
         {
             var results = new List<PackageDependency>();
 
-            var projectInstalledPackages = await project.GetInstalledPackagesAsync(CancellationToken.None);
+            IReadOnlyCollection<IPackageReferenceContextInfo> projectInstalledPackages = await project.GetInstalledPackagesAsync(
+                ServiceBroker,
+                CancellationToken.None);
 
-            foreach (var package in projectInstalledPackages)
+            foreach (IPackageReferenceContextInfo package in projectInstalledPackages)
             {
                 VersionRange range;
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/NuGetProjectUpgradeWindowModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/NuGetProjectUpgradeWindowModel.cs
@@ -9,7 +9,9 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft;
+using Microsoft.ServiceHub.Framework;
 using NuGet.Common;
+using NuGet.PackageManagement.VisualStudio;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
 using NuGet.Packaging.Rules;
@@ -49,6 +51,7 @@ namespace NuGet.PackageManagement.UI
         }
 
         public static async Task<NuGetProjectUpgradeWindowModel> CreateAsync(
+            IServiceBroker serviceBroker,
             IProjectContextInfo project,
             IList<PackageDependencyInfo> packageDependencyInfos,
             CancellationToken cancellationToken)
@@ -58,7 +61,7 @@ namespace NuGet.PackageManagement.UI
 
             cancellationToken.ThrowIfCancellationRequested();
 
-            string projectName = await project.GetUniqueNameOrNameAsync(CancellationToken.None);
+            string projectName = await project.GetUniqueNameOrNameAsync(serviceBroker, CancellationToken.None);
             string title = string.Format(CultureInfo.CurrentCulture, Resources.WindowTitle_NuGetMigrator, projectName);
             var notFoundPackages = new HashSet<PackageIdentity>();
             var hasIssues = false;
@@ -70,6 +73,7 @@ namespace NuGet.PackageManagement.UI
             foreach (NuGetProjectUpgradeDependencyItem dependencyItem in dependencyItems)
             {
                 (bool _, string packagePath) = await project.TryGetInstalledPackageFilePathAsync(
+                    serviceBroker,
                     dependencyItem.Identity,
                     cancellationToken);
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageDetailControlModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageDetailControlModel.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using Microsoft.ServiceHub.Framework;
 using NuGet.Packaging.Core;
 using NuGet.Versioning;
 using NuGet.VisualStudio.Internal.Contracts;
@@ -19,9 +20,10 @@ namespace NuGet.PackageManagement.UI
         private readonly INuGetSolutionManagerService _solutionManager;
 
         public PackageDetailControlModel(
+            IServiceBroker serviceBroker,
             INuGetSolutionManagerService solutionManager,
             IEnumerable<IProjectContextInfo> projects)
-            : base(projects)
+            : base(serviceBroker, projects)
         {
             _solutionManager = solutionManager;
             _solutionManager.ProjectUpdated += ProjectChanged;

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/PackageSourcesOptionsControl.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/PackageSourcesOptionsControl.cs
@@ -12,13 +12,14 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using Microsoft;
+using Microsoft.ServiceHub.Framework;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using NuGet.Configuration;
 using NuGet.PackageManagement.UI;
-using NuGet.PackageManagement.VisualStudio;
 using NuGet.VisualStudio;
+using NuGet.VisualStudio.Common;
 using NuGet.VisualStudio.Internal.Contracts;
 using Task = System.Threading.Tasks.Task;
 
@@ -154,9 +155,13 @@ namespace NuGet.Options
 
                 _initialized = true;
 
-                var remoteBroker = await BrokeredServicesUtilities.GetRemoteServiceBrokerAsync();
+                IServiceBrokerProvider serviceBrokerProvider = await ServiceLocator.GetInstanceAsync<IServiceBrokerProvider>();
+                IServiceBroker serviceBroker = await serviceBrokerProvider.GetAsync();
+
 #pragma warning disable ISB001 // Dispose of proxies, disposed in disposing event or in ClearSettings
-                _nugetSourcesService = await remoteBroker.GetProxyAsync<INuGetSourcesService>(NuGetServices.SourceProviderService, cancellationToken: cancellationToken);
+                _nugetSourcesService = await serviceBroker.GetProxyAsync<INuGetSourcesService>(
+                    NuGetServices.SourceProviderService,
+                    cancellationToken: cancellationToken);
 #pragma warning restore ISB001 // Dispose of proxies, disposed in disposing event or in ClearSettings
                 Assumes.NotNull(_nugetSourcesService);
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/PackageInstallationInfo.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/PackageInstallationInfo.cs
@@ -5,6 +5,7 @@ using System;
 using System.ComponentModel;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.ServiceHub.Framework;
 using NuGet.PackageManagement.VisualStudio;
 using NuGet.Versioning;
 using NuGet.VisualStudio.Internal.Contracts;
@@ -23,22 +24,27 @@ namespace NuGet.PackageManagement.UI
         private bool _isSelected;
         private string _projectName;
         private AlternativePackageManagerProviders _providers;
+        private readonly IServiceBroker _serviceBroker;
 
-        private PackageInstallationInfo(IProjectContextInfo project)
+        private PackageInstallationInfo(IServiceBroker serviceBroker, IProjectContextInfo project)
         {
+            _serviceBroker = serviceBroker;
             NuGetProject = project;
         }
 
-        public static async ValueTask<PackageInstallationInfo> CreateAsync(IProjectContextInfo project, CancellationToken cancellationToken)
+        public static async ValueTask<PackageInstallationInfo> CreateAsync(
+            IServiceBroker serviceBroker,
+            IProjectContextInfo project,
+            CancellationToken cancellationToken)
         {
-            var packageInstallationInfo = new PackageInstallationInfo(project);
+            var packageInstallationInfo = new PackageInstallationInfo(serviceBroker, project);
             await packageInstallationInfo.InitializeAsync(cancellationToken);
             return packageInstallationInfo;
         }
 
         private async ValueTask InitializeAsync(CancellationToken cancellationToken)
         {
-            _projectName = await NuGetProject.GetUniqueNameOrNameAsync(cancellationToken);
+            _projectName = await NuGetProject.GetUniqueNameOrNameAsync(_serviceBroker, cancellationToken);
         }
 
         private NuGetVersion _versionInstalled;

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/UserInterfaceService/INuGetUIContext.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/UserInterfaceService/INuGetUIContext.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.ServiceHub.Framework;
 using NuGet.PackageManagement.VisualStudio;
 using NuGet.Protocol.Core.Types;
 using NuGet.VisualStudio;
@@ -15,6 +16,8 @@ namespace NuGet.PackageManagement.UI
     public interface INuGetUIContext : IDisposable
     {
         event EventHandler<IReadOnlyCollection<string>> ProjectActionsExecuted;
+
+        IServiceBroker ServiceBroker { get; }
 
         ISourceRepositoryProvider SourceProvider { get; }
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/UserInterfaceService/NuGetUI.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/UserInterfaceService/NuGetUI.cs
@@ -64,6 +64,7 @@ namespace NuGet.PackageManagement.UI
         }
 
         public static async Task<NuGetUI> CreateAsync(
+            IServiceBroker serviceBroker,
             ICommonOperations commonOperations,
             NuGetUIProjectContext projectContext,
             ISourceRepositoryProvider sourceRepositoryProvider,
@@ -80,6 +81,7 @@ namespace NuGet.PackageManagement.UI
             CancellationToken cancellationToken,
             params IProjectContextInfo[] projects)
         {
+            Assumes.NotNull(serviceBroker);
             Assumes.NotNull(commonOperations);
             Assumes.NotNull(projectContext);
             Assumes.NotNull(sourceRepositoryProvider);
@@ -102,6 +104,7 @@ namespace NuGet.PackageManagement.UI
                 logger)
             {
                 UIContext = await NuGetUIContext.CreateAsync(
+                    serviceBroker,
                     sourceRepositoryProvider,
                     settings,
                     solutionManager,
@@ -123,7 +126,10 @@ namespace NuGet.PackageManagement.UI
         {
             var result = false;
 
-            DeprecatedFrameworkModel dataContext = await DotnetDeprecatedPrompt.GetDeprecatedFrameworkModelAsync(projects, cancellationToken);
+            DeprecatedFrameworkModel dataContext = await DotnetDeprecatedPrompt.GetDeprecatedFrameworkModelAsync(
+                UIContext.ServiceBroker,
+                projects,
+                cancellationToken);
 
             InvokeOnUIThread(() => { result = WarnAboutDotnetDeprecationImpl(dataContext); });
 
@@ -207,7 +213,7 @@ namespace NuGet.PackageManagement.UI
 
             List<IProjectContextInfo> projects = Projects.ToList();
 
-            IServiceBroker serviceBroker = await BrokeredServicesUtilities.GetRemoteServiceBrokerAsync();
+            IServiceBroker serviceBroker = UIContext.ServiceBroker;
 
             using (INuGetProjectUpgraderService projectUpgrader = await serviceBroker.GetProxyAsync<INuGetProjectUpgraderService>(
                 NuGetServices.ProjectUpgraderService,

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/UserInterfaceService/NuGetUIFactory.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/UserInterfaceService/NuGetUIFactory.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.ServiceHub.Framework;
 using Microsoft.VisualStudio.Utilities;
 using NuGet.Configuration;
 using NuGet.PackageManagement.VisualStudio;
@@ -73,8 +74,15 @@ namespace NuGet.PackageManagement.UI
         /// <summary>
         /// Returns the UI for the project or given set of projects.
         /// </summary>
-        public async ValueTask<INuGetUI> CreateAsync(params IProjectContextInfo[] projects)
+        public async ValueTask<INuGetUI> CreateAsync(
+            IServiceBroker serviceBroker,
+            params IProjectContextInfo[] projects)
         {
+            if (serviceBroker is null)
+            {
+                throw new ArgumentNullException(nameof(serviceBroker));
+            }
+
             var adapterLogger = new LoggerAdapter(ProjectContext);
 
             ProjectContext.PackageExtractionContext = new PackageExtractionContext(
@@ -89,6 +97,7 @@ namespace NuGet.PackageManagement.UI
                 PackageManagerProviders, MaxPackageManager);
 
             return await NuGetUI.CreateAsync(
+                serviceBroker,
                 CommonOperations,
                 ProjectContext,
                 SourceRepositoryProvider.Value,

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Utility/ProjectUtility.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Utility/ProjectUtility.cs
@@ -6,6 +6,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.ServiceHub.Framework;
+using NuGet.PackageManagement.VisualStudio;
 using NuGet.VisualStudio.Internal.Contracts;
 
 namespace NuGet.PackageManagement.UI
@@ -13,9 +15,15 @@ namespace NuGet.PackageManagement.UI
     internal static class ProjectUtility
     {
         internal static async ValueTask<IEnumerable<string>> GetSortedProjectIdsAsync(
+            IServiceBroker serviceBroker,
             IEnumerable<IProjectContextInfo> projects,
             CancellationToken cancellationToken)
         {
+            if (serviceBroker is null)
+            {
+                throw new ArgumentNullException(nameof(serviceBroker));
+            }
+
             if (projects is null)
             {
                 throw new ArgumentNullException(nameof(projects));
@@ -24,7 +32,7 @@ namespace NuGet.PackageManagement.UI
             cancellationToken.ThrowIfCancellationRequested();
 
             IEnumerable<Task<IProjectMetadataContextInfo>> tasks = projects.Select(
-                project => project.GetMetadataAsync(cancellationToken).AsTask());
+                project => project.GetMetadataAsync(serviceBroker, cancellationToken).AsTask());
 
             IProjectMetadataContextInfo[] projectMetadatas = await Task.WhenAll(tasks);
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Common/IProjectContextInfoExtensions.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Common/IProjectContextInfoExtensions.cs
@@ -1,0 +1,116 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#nullable enable
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft;
+using Microsoft.ServiceHub.Framework;
+using NuGet.Packaging.Core;
+using NuGet.VisualStudio.Internal.Contracts;
+
+namespace NuGet.PackageManagement.VisualStudio
+{
+    public static class IProjectContextInfoExtensions
+    {
+        public static async ValueTask<bool> IsUpgradeableAsync(
+            this IProjectContextInfo projectContextInfo,
+            IServiceBroker serviceBroker,
+            CancellationToken cancellationToken)
+        {
+            Assumes.NotNull(projectContextInfo);
+            Assumes.NotNull(serviceBroker);
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            using (INuGetProjectUpgraderService? projectUpgrader = await serviceBroker.GetProxyAsync<INuGetProjectUpgraderService>(
+                NuGetServices.ProjectUpgraderService,
+                cancellationToken: cancellationToken))
+            {
+                Assumes.NotNull(projectUpgrader);
+
+                return await projectUpgrader.IsProjectUpgradeableAsync(projectContextInfo.ProjectId, cancellationToken);
+            }
+        }
+
+        public static async ValueTask<IReadOnlyCollection<IPackageReferenceContextInfo>> GetInstalledPackagesAsync(
+            this IProjectContextInfo projectContextInfo,
+            IServiceBroker serviceBroker,
+            CancellationToken cancellationToken)
+        {
+            Assumes.NotNull(projectContextInfo);
+            Assumes.NotNull(serviceBroker);
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            using (INuGetProjectManagerService projectManager = await GetProjectManagerAsync(serviceBroker, cancellationToken))
+            {
+                return await projectManager.GetInstalledPackagesAsync(new string[] { projectContextInfo.ProjectId }, cancellationToken);
+            }
+        }
+
+        public static async ValueTask<IProjectMetadataContextInfo> GetMetadataAsync(
+            this IProjectContextInfo projectContextInfo,
+            IServiceBroker serviceBroker,
+            CancellationToken cancellationToken)
+        {
+            Assumes.NotNull(projectContextInfo);
+            Assumes.NotNull(serviceBroker);
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            using (INuGetProjectManagerService projectManager = await GetProjectManagerAsync(serviceBroker, cancellationToken))
+            {
+                return await projectManager.GetMetadataAsync(projectContextInfo.ProjectId, cancellationToken);
+            }
+        }
+
+        public static async ValueTask<string?> GetUniqueNameOrNameAsync(
+            this IProjectContextInfo projectContextInfo,
+            IServiceBroker serviceBroker,
+            CancellationToken cancellationToken)
+        {
+            IProjectMetadataContextInfo metadata = await GetMetadataAsync(projectContextInfo, serviceBroker, cancellationToken);
+
+            return metadata.UniqueName ?? metadata.Name;
+        }
+
+        public static async ValueTask<(bool, string?)> TryGetInstalledPackageFilePathAsync(
+            this IProjectContextInfo projectContextInfo,
+            IServiceBroker serviceBroker,
+            PackageIdentity packageIdentity,
+            CancellationToken cancellationToken)
+        {
+            Assumes.NotNull(projectContextInfo);
+            Assumes.NotNull(serviceBroker);
+            Assumes.NotNull(packageIdentity);
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            using (INuGetProjectManagerService projectManager = await GetProjectManagerAsync(serviceBroker, cancellationToken))
+            {
+                return await projectManager.TryGetInstalledPackageFilePathAsync(
+                    projectContextInfo.ProjectId,
+                    packageIdentity,
+                    cancellationToken);
+            }
+        }
+
+        private static async ValueTask<INuGetProjectManagerService> GetProjectManagerAsync(
+            IServiceBroker serviceBroker,
+            CancellationToken cancellationToken)
+        {
+#pragma warning disable ISB001 // Dispose of proxies
+            INuGetProjectManagerService? projectManager = await serviceBroker.GetProxyAsync<INuGetProjectManagerService>(
+                 NuGetServices.ProjectManagerService,
+                 cancellationToken: cancellationToken);
+#pragma warning restore ISB001 // Dispose of proxies
+
+            Assumes.NotNull(projectManager);
+
+            return projectManager;
+        }
+    }
+}

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Common/PackageCollection.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Common/PackageCollection.cs
@@ -9,6 +9,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft;
+using Microsoft.ServiceHub.Framework;
 using NuGet.VisualStudio.Internal.Contracts;
 
 namespace NuGet.PackageManagement.VisualStudio
@@ -39,11 +41,17 @@ namespace NuGet.PackageManagement.VisualStudio
 
         public bool ContainsId(string packageId) => _uniqueIds.Contains(packageId);
 
-        public static async Task<PackageCollection> FromProjectsAsync(IEnumerable<IProjectContextInfo> projects, CancellationToken cancellationToken)
+        public static async Task<PackageCollection> FromProjectsAsync(
+            IServiceBroker serviceBroker,
+            IEnumerable<IProjectContextInfo> projects,
+            CancellationToken cancellationToken)
         {
+            Assumes.NotNull(serviceBroker);
+            Assumes.NotNull(projects);
+
             // Read package references from all projects.
             IEnumerable<Task<IReadOnlyCollection<IPackageReferenceContextInfo>>>? tasks = projects
-                .Select(project => project.GetInstalledPackagesAsync(cancellationToken).AsTask());
+                .Select(project => project.GetInstalledPackagesAsync(serviceBroker, cancellationToken).AsTask());
             IEnumerable<IPackageReferenceContextInfo>[]? packageReferences = await Task.WhenAll(tasks);
 
             // Group all package references for an id/version into a single item.

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/NuGet.PackageManagement.VisualStudio.csproj
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/NuGet.PackageManagement.VisualStudio.csproj
@@ -69,6 +69,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Common\IProjectContextInfoExtensions.cs" />
     <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="PackageFeeds\PackageSourceMoniker.cs" />
     <Compile Include="PackageFeeds\RecommenderPackageFeed.cs" />
@@ -181,6 +182,7 @@
     <Compile Include="Utility\FrameworkAssembly.cs" />
     <Compile Include="Utility\FrameworkAssemblyResolver.cs" />
     <Compile Include="Utility\GetPackageReferenceUtility.cs" />
+    <Compile Include="Utility\IProjectContextInfoUtility.cs" />
     <Compile Include="Utility\ProjectInstalledPackage.cs" />
     <Compile Include="Utility\NativeMethods.cs" />
     <Compile Include="Utility\NuGetProjectUpgradeUtility.cs" />

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Prompts/DotnetDeprecatedPrompt.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Prompts/DotnetDeprecatedPrompt.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.ServiceHub.Framework;
 using NuGet.Frameworks;
 using NuGet.ProjectManagement;
 using NuGet.VisualStudio.Internal.Contracts;
@@ -35,11 +36,12 @@ namespace NuGet.PackageManagement.VisualStudio
         }
 
         public static async ValueTask<DeprecatedFrameworkModel> GetDeprecatedFrameworkModelAsync(
+            IServiceBroker serviceBroker,
             IEnumerable<IProjectContextInfo> affectedProjects,
             CancellationToken cancellationToken)
         {
             Task<string>[] tasks = affectedProjects
-                .Select(project => project.GetUniqueNameOrNameAsync(cancellationToken).AsTask())
+                .Select(project => project.GetUniqueNameOrNameAsync(serviceBroker, cancellationToken).AsTask())
                 .ToArray();
 
             string[] projectNames = await Task.WhenAll(tasks);

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Utility/IProjectContextInfoUtility.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Utility/IProjectContextInfoUtility.cs
@@ -1,0 +1,73 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.ServiceHub.Framework;
+using NuGet.VisualStudio.Internal.Contracts;
+
+namespace NuGet.PackageManagement.VisualStudio
+{
+    public static class IProjectContextInfoUtility
+    {
+        private const string LiveShareUriScheme = "vsls";
+        private const string ProjectGuidQueryString = "projectGuid";
+
+        public static async Task<IProjectContextInfo> CreateAsync(IServiceBroker serviceBroker, string projectId, CancellationToken cancellationToken)
+        {
+            using (INuGetProjectManagerService projectManager = await serviceBroker.GetProxyAsync<INuGetProjectManagerService>(
+                NuGetServices.ProjectManagerService,
+                CancellationToken.None))
+            {
+                return await projectManager.GetProjectAsync(projectId, cancellationToken);
+            }
+        }
+
+        public static string GetProjectGuidStringFromVslsQueryString(string queryString)
+        {
+            if (Uri.TryCreate(queryString, UriKind.Absolute, out Uri pathUri))
+            {
+                if (string.Equals(pathUri.Scheme, LiveShareUriScheme, StringComparison.OrdinalIgnoreCase))
+                {
+                    Dictionary<string, string> queryStrings = ParseQueryString(pathUri);
+                    if (queryStrings.TryGetValue(ProjectGuidQueryString, out var projectGuid) && Guid.TryParse(projectGuid, out Guid result))
+                    {
+                        return result.ToString();
+                    }
+                }
+            }
+
+            return Guid.Empty.ToString();
+        }
+
+        private static Dictionary<string, string> ParseQueryString(Uri uri)
+        {
+            var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            string queryString = uri.Query;
+
+            if (queryString.StartsWith("?", StringComparison.Ordinal))
+            {
+                queryString = queryString.Substring(1);
+            }
+
+            if (queryString.Length == 0)
+            {
+                return result;
+            }
+
+            var queries = queryString.Split(new char[] { '&' }, StringSplitOptions.RemoveEmptyEntries);
+            foreach (var query in queries)
+            {
+                var nameValue = query.Split(new char[] { '=' }, StringSplitOptions.RemoveEmptyEntries);
+                if (nameValue.Length == 2)
+                {
+                    result.Add(nameValue[0], nameValue[1]);
+                }
+            }
+
+            return result;
+        }
+    }
+}

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/IServiceBrokerProvider.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/IServiceBrokerProvider.cs
@@ -3,12 +3,11 @@
 
 using System.Threading.Tasks;
 using Microsoft.ServiceHub.Framework;
-using NuGet.VisualStudio.Internal.Contracts;
 
-namespace NuGet.PackageManagement.UI
+namespace NuGet.VisualStudio.Common
 {
-    public interface INuGetUIFactory
+    public interface IServiceBrokerProvider
     {
-        ValueTask<INuGetUI> CreateAsync(IServiceBroker serviceBroker, params IProjectContextInfo[] projects);
+        ValueTask<IServiceBroker> GetAsync();
     }
 }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/CachingIServiceBrokerProvider.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/CachingIServiceBrokerProvider.cs
@@ -1,0 +1,31 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.ComponentModel.Composition;
+using System.Threading.Tasks;
+using Microsoft.ServiceHub.Framework;
+using Microsoft.VisualStudio.Threading;
+using NuGet.PackageManagement.VisualStudio;
+using NuGet.VisualStudio.Common;
+
+namespace NuGet.VisualStudio.Implementation
+{
+    [Export(typeof(IServiceBrokerProvider))]
+    [PartCreationPolicy(CreationPolicy.Shared)]
+    internal sealed class CachingIServiceBrokerProvider : IServiceBrokerProvider
+    {
+        private readonly AsyncLazy<IServiceBroker> _serviceBroker;
+
+        internal CachingIServiceBrokerProvider()
+        {
+            _serviceBroker = new AsyncLazy<IServiceBroker>(
+                () => BrokeredServicesUtilities.GetRemoteServiceBrokerAsync().AsTask(),
+                NuGetUIThreadHelper.JoinableTaskFactory);
+        }
+
+        public async ValueTask<IServiceBroker> GetAsync()
+        {
+            return await _serviceBroker.GetValueAsync();
+        }
+    }
+}

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/IProjectContextInfo.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/IProjectContextInfo.cs
@@ -3,10 +3,6 @@
 
 #nullable enable
 
-using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
-using NuGet.Packaging.Core;
 using NuGet.ProjectModel;
 
 namespace NuGet.VisualStudio.Internal.Contracts
@@ -19,12 +15,5 @@ namespace NuGet.VisualStudio.Internal.Contracts
         string ProjectId { get; }
         ProjectStyle ProjectStyle { get; }
         NuGetProjectKind ProjectKind { get; }
-        ValueTask<bool> IsUpgradeableAsync(CancellationToken cancellationToken);
-        ValueTask<IReadOnlyCollection<IPackageReferenceContextInfo>> GetInstalledPackagesAsync(CancellationToken cancellationToken);
-        ValueTask<IProjectMetadataContextInfo> GetMetadataAsync(CancellationToken cancellationToken);
-        ValueTask<string?> GetUniqueNameOrNameAsync(CancellationToken cancellationToken);
-        ValueTask<(bool, string?)> TryGetInstalledPackageFilePathAsync(
-            PackageIdentity packageIdentity,
-            CancellationToken cancellationToken);
     }
 }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/ProjectContextInfo.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/ProjectContextInfo.cs
@@ -4,14 +4,9 @@
 #nullable enable
 
 using System;
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft;
-using Microsoft.ServiceHub.Framework;
-using Microsoft.VisualStudio.Shell;
-using Microsoft.VisualStudio.Shell.ServiceBroker;
-using NuGet.Packaging.Core;
 using NuGet.ProjectManagement;
 using NuGet.ProjectManagement.Projects;
 using NuGet.ProjectModel;
@@ -20,9 +15,6 @@ namespace NuGet.VisualStudio.Internal.Contracts
 {
     public sealed class ProjectContextInfo : IProjectContextInfo
     {
-        private const string LiveShareUriScheme = "vsls";
-        private const string ProjectGuidQueryString = "projectGuid";
-
         public ProjectContextInfo(string projectId, ProjectStyle projectStyle, NuGetProjectKind projectKind)
         {
             ProjectId = projectId;
@@ -33,59 +25,6 @@ namespace NuGet.VisualStudio.Internal.Contracts
         public string ProjectId { get; }
         public NuGetProjectKind ProjectKind { get; }
         public ProjectStyle ProjectStyle { get; }
-
-        public async ValueTask<bool> IsUpgradeableAsync(CancellationToken cancellationToken)
-        {
-            IServiceBroker remoteBroker = await GetRemoteServiceBrokerAsync();
-
-            using (INuGetProjectUpgraderService? projectUpgrader = await remoteBroker.GetProxyAsync<INuGetProjectUpgraderService>(
-                NuGetServices.ProjectUpgraderService,
-                cancellationToken: cancellationToken))
-            {
-                Assumes.NotNull(projectUpgrader);
-
-                return await projectUpgrader.IsProjectUpgradeableAsync(ProjectId, cancellationToken);
-            }
-        }
-
-        public async ValueTask<IReadOnlyCollection<IPackageReferenceContextInfo>> GetInstalledPackagesAsync(CancellationToken cancellationToken)
-        {
-            using (INuGetProjectManagerService projectManager = await GetProjectManagerAsync(cancellationToken))
-            {
-                return await projectManager.GetInstalledPackagesAsync(new string[] { ProjectId }, cancellationToken);
-            }
-        }
-
-        public async ValueTask<IProjectMetadataContextInfo> GetMetadataAsync(CancellationToken cancellationToken)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-
-            using (INuGetProjectManagerService projectManager = await GetProjectManagerAsync(cancellationToken))
-            {
-                return await projectManager.GetMetadataAsync(ProjectId, cancellationToken);
-            }
-        }
-
-        public async ValueTask<string?> GetUniqueNameOrNameAsync(CancellationToken cancellationToken)
-        {
-            IProjectMetadataContextInfo metadata = await GetMetadataAsync(cancellationToken);
-
-            return metadata.UniqueName ?? metadata.Name;
-        }
-
-        public async ValueTask<(bool, string?)> TryGetInstalledPackageFilePathAsync(
-            PackageIdentity packageIdentity,
-            CancellationToken cancellationToken)
-        {
-            Assumes.NotNull(packageIdentity);
-
-            cancellationToken.ThrowIfCancellationRequested();
-
-            using (INuGetProjectManagerService projectManager = await GetProjectManagerAsync(cancellationToken))
-            {
-                return await projectManager.TryGetInstalledPackageFilePathAsync(ProjectId, packageIdentity, cancellationToken);
-            }
-        }
 
         public static ValueTask<IProjectContextInfo> CreateAsync(NuGetProject nugetProject, CancellationToken cancellationToken)
         {
@@ -100,14 +39,6 @@ namespace NuGet.VisualStudio.Internal.Contracts
             ProjectStyle projectStyle = nugetProject.ProjectStyle;
 
             return new ValueTask<IProjectContextInfo>(new ProjectContextInfo(projectId, projectStyle, projectKind));
-        }
-
-        public static async ValueTask<IProjectContextInfo> CreateAsync(string projectId, CancellationToken cancellationToken)
-        {
-            using (INuGetProjectManagerService projectManager = await GetProjectManagerAsync(cancellationToken))
-            {
-                return await projectManager.GetProjectAsync(projectId, cancellationToken);
-            }
         }
 
         private static NuGetProjectKind GetProjectKind(NuGetProject nugetProject)
@@ -128,73 +59,6 @@ namespace NuGet.VisualStudio.Internal.Contracts
             }
 
             return projectKind;
-        }
-
-        public static string GetProjectGuidStringFromVslsQueryString(string queryString)
-        {
-            if (Uri.TryCreate(queryString, UriKind.Absolute, out Uri pathUri))
-            {
-                if (string.Equals(pathUri.Scheme, LiveShareUriScheme, StringComparison.OrdinalIgnoreCase))
-                {
-                    Dictionary<string, string> queryStrings = ParseQueryString(pathUri);
-                    if (queryStrings.TryGetValue(ProjectGuidQueryString, out var projectGuid) && Guid.TryParse(projectGuid, out Guid result))
-                    {
-                        return result.ToString();
-                    }
-                }
-            }
-
-            return Guid.Empty.ToString();
-        }
-
-        private static Dictionary<string, string> ParseQueryString(Uri uri)
-        {
-            var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-            string queryString = uri.Query;
-
-            if (queryString.StartsWith("?", StringComparison.Ordinal))
-            {
-                queryString = queryString.Substring(1);
-            }
-
-            if (queryString.Length == 0)
-            {
-                return result;
-            }
-
-            var queries = queryString.Split(new char[] { '&' }, StringSplitOptions.RemoveEmptyEntries);
-            foreach (var query in queries)
-            {
-                var nameValue = query.Split(new char[] { '=' }, StringSplitOptions.RemoveEmptyEntries);
-                if (nameValue.Length == 2)
-                {
-                    result.Add(nameValue[0], nameValue[1]);
-                }
-            }
-
-            return result;
-        }
-
-        private static async ValueTask<INuGetProjectManagerService> GetProjectManagerAsync(CancellationToken cancellationToken)
-        {
-            IServiceBroker serviceBroker = await GetRemoteServiceBrokerAsync();
-
-#pragma warning disable ISB001 // Dispose of proxies
-            INuGetProjectManagerService? projectManager = await serviceBroker.GetProxyAsync<INuGetProjectManagerService>(
-                 NuGetServices.ProjectManagerService,
-                 cancellationToken: cancellationToken);
-#pragma warning restore ISB001 // Dispose of proxies
-
-            Assumes.NotNull(projectManager);
-
-            return projectManager;
-        }
-
-        private static async ValueTask<IServiceBroker> GetRemoteServiceBrokerAsync()
-        {
-            var serviceBrokerContainer = await AsyncServiceProvider.GlobalProvider.GetServiceAsync<SVsBrokeredServiceContainer, IBrokeredServiceContainer>();
-            Assumes.NotNull(serviceBrokerContainer);
-            return serviceBrokerContainer.GetFullAccessServiceBroker();
         }
     }
 }

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/LocalDetailControlModelTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/LocalDetailControlModelTests.cs
@@ -72,6 +72,7 @@ namespace NuGet.PackageManagement.UI.Test.Models
         {
             var solMgr = new Mock<INuGetSolutionManagerService>();
             _testInstance = new PackageDetailControlModel(
+                Mock.Of<IServiceBroker>(),
                 solutionManager: solMgr.Object,
                 projects: new List<IProjectContextInfo>());
 
@@ -104,7 +105,8 @@ namespace NuGet.PackageManagement.UI.Test.Models
                 .Returns(projectKind);
 
             var model = new PackageDetailControlModel(
-                solutionManager: Mock.Of<INuGetSolutionManagerService>(),
+                Mock.Of<IServiceBroker>(),
+                Mock.Of<INuGetSolutionManagerService>(),
                 projects: new[] { project.Object });
 
             Assert.False(model.Options.ShowClassicOptions);
@@ -119,7 +121,8 @@ namespace NuGet.PackageManagement.UI.Test.Models
                 .Returns(NuGetProjectKind.PackagesConfig);
 
             var model = new PackageDetailControlModel(
-                solutionManager: Mock.Of<INuGetSolutionManagerService>(),
+                Mock.Of<IServiceBroker>(),
+                Mock.Of<INuGetSolutionManagerService>(),
                 projects: new[] { project.Object });
 
             Assert.True(model.Options.ShowClassicOptions);
@@ -129,6 +132,7 @@ namespace NuGet.PackageManagement.UI.Test.Models
         public void IsSelectedVersionInstalled_WhenSelectedVersionAndInstalledVersionAreNull_ReturnsFalse()
         {
             var model = new PackageDetailControlModel(
+                Mock.Of<IServiceBroker>(),
                 Mock.Of<INuGetSolutionManagerService>(),
                 Enumerable.Empty<IProjectContextInfo>());
 
@@ -141,6 +145,7 @@ namespace NuGet.PackageManagement.UI.Test.Models
         public async Task IsSelectedVersionInstalled_WhenSelectedVersionAndInstalledVersionAreNotEqual_ReturnsFalse()
         {
             var model = new PackageDetailControlModel(
+                Mock.Of<IServiceBroker>(),
                 Mock.Of<INuGetSolutionManagerService>(),
                 Enumerable.Empty<IProjectContextInfo>());
 
@@ -168,6 +173,7 @@ namespace NuGet.PackageManagement.UI.Test.Models
         public async Task IsSelectedVersionInstalled_WhenSelectedVersionAndInstalledVersionAreEqual_ReturnsTrue()
         {
             var model = new PackageDetailControlModel(
+                Mock.Of<IServiceBroker>(),
                 Mock.Of<INuGetSolutionManagerService>(),
                 Enumerable.Empty<IProjectContextInfo>());
 

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/V3DetailControlModelTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/V3DetailControlModelTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.ServiceHub.Framework;
 using Microsoft.VisualStudio.Threading;
 using Moq;
 using NuGet.Common;
@@ -96,6 +97,7 @@ namespace NuGet.PackageManagement.UI.Test.Models
         {
             var solMgr = new Mock<INuGetSolutionManagerService>();
             _testInstance = new PackageDetailControlModel(
+                Mock.Of<IServiceBroker>(),
                 solutionManager: solMgr.Object,
                 Array.Empty<IProjectContextInfo>());
             _testInstance.SetCurrentPackage(

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/PackageItemLoaderTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/PackageItemLoaderTests.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.ServiceHub.Framework;
 using Moq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -32,10 +33,13 @@ namespace NuGet.PackageManagement.UI.Test
         public async Task MultipleSources_Works()
         {
             var solutionManager = Mock.Of<INuGetSolutionManagerService>();
-            var uiContext = Mock.Of<INuGetUIContext>();
-            Mock.Get(uiContext)
-                .Setup(x => x.SolutionManagerService)
+            var uiContext = new Mock<INuGetUIContext>();
+
+            uiContext.Setup(x => x.SolutionManagerService)
                 .Returns(solutionManager);
+
+            uiContext.Setup(x => x.ServiceBroker)
+                .Returns(Mock.Of<IServiceBroker>());
 
             var source1 = new PackageSource("https://pkgs.dev.azure.com/dnceng/public/_packaging/nuget-build/nuget/v3/index.json", "NuGetBuild");
             var source2 = new PackageSource("https://api.nuget.org/v3/index.json", "NuGet.org");
@@ -43,7 +47,7 @@ namespace NuGet.PackageManagement.UI.Test
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateSourceRepositoryProvider(new[] { source1, source2 });
             var repositories = sourceRepositoryProvider.GetRepositories();
 
-            var context = new PackageLoadContext(repositories, false, uiContext);
+            var context = new PackageLoadContext(repositories, isSolution: false, uiContext.Object);
 
             var packageFeed = new MultiSourcePackageFeed(repositories, logger: null, telemetryService: null);
             var loader = new PackageItemLoader(context, packageFeed, "nuget");
@@ -55,7 +59,7 @@ namespace NuGet.PackageManagement.UI.Test
                 while (loader.State.LoadingStatus == LoadingStatus.Loading)
                 {
                     await Task.Delay(TimeSpan.FromSeconds(1));
-                    await loader.UpdateStateAsync(null, CancellationToken.None);
+                    await loader.UpdateStateAsync(progress: null, CancellationToken.None);
                 }
 
                 var items = loader.GetCurrent();
@@ -81,10 +85,13 @@ namespace NuGet.PackageManagement.UI.Test
         {
             // Arrange
             var solutionManager = Mock.Of<INuGetSolutionManagerService>();
-            var uiContext = Mock.Of<INuGetUIContext>();
-            Mock.Get(uiContext)
-                .Setup(x => x.SolutionManagerService)
+            var uiContext = new Mock<INuGetUIContext>();
+
+            uiContext.Setup(x => x.SolutionManagerService)
                 .Returns(solutionManager);
+
+            uiContext.Setup(x => x.ServiceBroker)
+                .Returns(Mock.Of<IServiceBroker>());
 
             var telemetryService = new Mock<INuGetTelemetryService>();
             var eventsQueue = new ConcurrentQueue<TelemetryEvent>();
@@ -119,14 +126,14 @@ namespace NuGet.PackageManagement.UI.Test
                 var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateSourceRepositoryProvider(new[] { new PackageSource(source) }, new Lazy<INuGetResourceProvider>[] { new Lazy<INuGetResourceProvider>(() => new TestHttpSourceResourceProvider(injectedHttpSources)) });
                 var repositories = sourceRepositoryProvider.GetRepositories();
 
-                var context = new PackageLoadContext(repositories, false, uiContext);
+                var context = new PackageLoadContext(repositories, isSolution: false, uiContext.Object);
 
                 var packageFeed = new MultiSourcePackageFeed(repositories, logger: null, telemetryService: telemetryService.Object);
 
                 // Act
                 var loader = new PackageItemLoader(context, packageFeed, searchText: "nuget", includePrerelease: true);
-                await loader.LoadNextAsync(null, CancellationToken.None);
-                await loader.LoadNextAsync(null, CancellationToken.None);
+                await loader.LoadNextAsync(progress: null, CancellationToken.None);
+                await loader.LoadNextAsync(progress: null, CancellationToken.None);
 
                 // Assert
                 var events = eventsQueue.ToArray();
@@ -194,14 +201,17 @@ namespace NuGet.PackageManagement.UI.Test
         public async Task LoadNextAsync_Works()
         {
             var solutionManager = Mock.Of<INuGetSolutionManagerService>();
-            var uiContext = Mock.Of<INuGetUIContext>();
-            Mock.Get(uiContext)
-                .Setup(x => x.SolutionManagerService)
+            var uiContext = new Mock<INuGetUIContext>();
+
+            uiContext.Setup(x => x.SolutionManagerService)
                 .Returns(solutionManager);
 
-            var context = new PackageLoadContext(null, false, uiContext);
+            uiContext.Setup(x => x.ServiceBroker)
+                .Returns(Mock.Of<IServiceBroker>());
+
+            var context = new PackageLoadContext(sourceRepositories: null, isSolution: false, uiContext.Object);
             var packageFeed = new TestPackageFeed();
-            var loader = new PackageItemLoader(context, packageFeed, TestSearchTerm, true);
+            var loader = new PackageItemLoader(context, packageFeed, TestSearchTerm, includePrerelease: true);
 
             Assert.Equal(LoadingStatus.Unknown, loader.State.LoadingStatus);
             var initial = loader.GetCurrent();
@@ -209,20 +219,20 @@ namespace NuGet.PackageManagement.UI.Test
 
             var loaded = new List<PackageItemListViewModel>();
 
-            await loader.LoadNextAsync(null, CancellationToken.None);
+            await loader.LoadNextAsync(progress: null, CancellationToken.None);
 
             Assert.Equal(LoadingStatus.Loading, loader.State.LoadingStatus);
             var partial = loader.GetCurrent();
             Assert.Empty(partial);
 
             await Task.Delay(TimeSpan.FromSeconds(1));
-            await loader.UpdateStateAsync(null, CancellationToken.None);
+            await loader.UpdateStateAsync(progress: null, CancellationToken.None);
 
             Assert.NotEqual(LoadingStatus.Loading, loader.State.LoadingStatus);
             loaded.AddRange(loader.GetCurrent());
 
             Assert.Equal(LoadingStatus.Ready, loader.State.LoadingStatus);
-            await loader.LoadNextAsync(null, CancellationToken.None);
+            await loader.LoadNextAsync(progress: null, CancellationToken.None);
 
             Assert.Equal(LoadingStatus.NoMoreItems, loader.State.LoadingStatus);
             loaded.AddRange(loader.GetCurrent());
@@ -235,10 +245,13 @@ namespace NuGet.PackageManagement.UI.Test
         {
             // Prepare
             var solutionManager = Mock.Of<INuGetSolutionManagerService>();
-            var uiContext = Mock.Of<INuGetUIContext>();
-            Mock.Get(uiContext)
-                .Setup(x => x.SolutionManagerService)
+            var uiContext = new Mock<INuGetUIContext>();
+
+            uiContext.Setup(x => x.SolutionManagerService)
                 .Returns(solutionManager);
+
+            uiContext.Setup(x => x.ServiceBroker)
+                .Returns(Mock.Of<IServiceBroker>());
 
             using (var localFeedDir = TestDirectory.Create()) // local feed
             {
@@ -254,13 +267,13 @@ namespace NuGet.PackageManagement.UI.Test
                 var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateSourceRepositoryProvider(new[] { localSource });
                 var repositories = sourceRepositoryProvider.GetRepositories();
 
-                var context = new PackageLoadContext(repositories, false, uiContext);
+                var context = new PackageLoadContext(repositories, isSolution: false, uiContext.Object);
 
                 var packageFeed = new MultiSourcePackageFeed(repositories, logger: null, telemetryService: null);
                 var loader = new PackageItemLoader(context, packageFeed, "nuget");
 
                 // Act
-                await loader.LoadNextAsync(null, CancellationToken.None);
+                await loader.LoadNextAsync(progress: null, CancellationToken.None);
                 var results = loader.GetCurrent();
 
                 // Assert

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Utility/ProjectUtilityTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Utility/ProjectUtilityTests.cs
@@ -6,7 +6,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.ServiceHub.Framework;
 using Moq;
+using NuGet.PackageManagement.VisualStudio;
 using NuGet.VisualStudio.Internal.Contracts;
 using Xunit;
 
@@ -15,10 +17,25 @@ namespace NuGet.PackageManagement.UI.Test
     public class ProjectUtilityTests
     {
         [Fact]
+        public async Task GetSortedProjectIdsAsync_WhenServiceBrokerIsNull_Throws()
+        {
+            ArgumentNullException exception = await Assert.ThrowsAsync<ArgumentNullException>(
+                () => ProjectUtility.GetSortedProjectIdsAsync(
+                    serviceBroker: null,
+                    projects: null,
+                    CancellationToken.None).AsTask());
+
+            Assert.Equal("serviceBroker", exception.ParamName);
+        }
+
+        [Fact]
         public async Task GetSortedProjectIdsAsync_WhenProjectsIsNull_Throws()
         {
             ArgumentNullException exception = await Assert.ThrowsAsync<ArgumentNullException>(
-                () => ProjectUtility.GetSortedProjectIdsAsync(projects: null, CancellationToken.None).AsTask());
+                () => ProjectUtility.GetSortedProjectIdsAsync(
+                    Mock.Of<IServiceBroker>(),
+                    projects: null,
+                    CancellationToken.None).AsTask());
 
             Assert.Equal("projects", exception.ParamName);
         }
@@ -28,6 +45,7 @@ namespace NuGet.PackageManagement.UI.Test
         {
             await Assert.ThrowsAsync<OperationCanceledException>(
                 () => ProjectUtility.GetSortedProjectIdsAsync(
+                    Mock.Of<IServiceBroker>(),
                     Enumerable.Empty<IProjectContextInfo>(),
                     new CancellationToken(canceled: true)).AsTask());
         }
@@ -35,19 +53,40 @@ namespace NuGet.PackageManagement.UI.Test
         [Fact]
         public async Task GetSortedProjectIdsAsync_WhenProjectsUnsorted_ReturnsSortedProjectIds()
         {
+            string projectIdA = Guid.NewGuid().ToString();
+            string projectIdB = Guid.NewGuid().ToString();
+            string projectIdC = Guid.NewGuid().ToString();
             var projectA = new Mock<IProjectContextInfo>();
             var projectB = new Mock<IProjectContextInfo>();
             var projectC = new Mock<IProjectContextInfo>();
             var projectAMetadata = new Mock<IProjectMetadataContextInfo>();
             var projectBMetadata = new Mock<IProjectMetadataContextInfo>();
             var projectCMetadata = new Mock<IProjectMetadataContextInfo>();
+            var serviceBroker = new Mock<IServiceBroker>();
+            Mock<INuGetProjectManagerService> projectManagerService = SetupProjectManagerService(serviceBroker);
 
-            projectA.Setup(x => x.GetMetadataAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(projectAMetadata.Object);
-            projectB.Setup(x => x.GetMetadataAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(projectBMetadata.Object);
-            projectC.Setup(x => x.GetMetadataAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(projectCMetadata.Object);
+            projectManagerService.Setup(
+                    x => x.GetMetadataAsync(
+                        It.Is<string>(projectId => projectId == projectIdA),
+                        It.IsAny<CancellationToken>()))
+                .Returns(new ValueTask<IProjectMetadataContextInfo>(projectAMetadata.Object));
+            projectManagerService.Setup(
+                    x => x.GetMetadataAsync(
+                        It.Is<string>(projectId => projectId == projectIdB),
+                        It.IsAny<CancellationToken>()))
+                .Returns(new ValueTask<IProjectMetadataContextInfo>(projectBMetadata.Object));
+            projectManagerService.Setup(
+                    x => x.GetMetadataAsync(
+                        It.Is<string>(projectId => projectId == projectIdC),
+                        It.IsAny<CancellationToken>()))
+                .Returns(new ValueTask<IProjectMetadataContextInfo>(projectCMetadata.Object));
+
+            projectA.SetupGet(x => x.ProjectId)
+                .Returns(projectIdA);
+            projectB.SetupGet(x => x.ProjectId)
+                .Returns(projectIdB);
+            projectC.SetupGet(x => x.ProjectId)
+                .Returns(projectIdC);
 
             projectAMetadata.SetupGet(x => x.UniqueName)
                 .Returns("a");
@@ -67,10 +106,27 @@ namespace NuGet.PackageManagement.UI.Test
                 .Returns(expectedResults[2]);
 
             IEnumerable<string> actualResults = await ProjectUtility.GetSortedProjectIdsAsync(
+                serviceBroker.Object,
                 new[] { projectB.Object, projectA.Object, projectC.Object },
                 CancellationToken.None);
 
             Assert.Equal(expectedResults, actualResults.ToArray());
+        }
+
+        private static Mock<INuGetProjectManagerService> SetupProjectManagerService(Mock<IServiceBroker> serviceBroker)
+        {
+            var projectManagerService = new Mock<INuGetProjectManagerService>();
+
+            serviceBroker.Setup(
+#pragma warning disable ISB001 // Dispose of proxies
+                    x => x.GetProxyAsync<INuGetProjectManagerService>(
+                        It.Is<ServiceRpcDescriptor>(s => s == NuGetServices.ProjectManagerService),
+                        It.IsAny<ServiceActivationOptions>(),
+                        It.IsAny<CancellationToken>()))
+#pragma warning restore ISB001 // Dispose of proxies
+                .Returns(new ValueTask<INuGetProjectManagerService>(projectManagerService.Object));
+
+            return projectManagerService;
         }
     }
 }

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Common/IProjectContextInfoExtensionsTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Common/IProjectContextInfoExtensionsTests.cs
@@ -1,0 +1,401 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.ServiceHub.Framework;
+using Moq;
+using NuGet.Packaging.Core;
+using NuGet.ProjectManagement;
+using NuGet.Versioning;
+using NuGet.VisualStudio.Internal.Contracts;
+using Xunit;
+
+namespace NuGet.PackageManagement.VisualStudio.Test
+{
+    public class IProjectContextInfoExtensionsTests
+    {
+        private static readonly PackageIdentity PackageIdentity = new PackageIdentity(id: "a", NuGetVersion.Parse("1.0.0"));
+
+        [Fact]
+        public async Task IsUpgradeableAsync_WhenProjectContextInfoIsNull_Throws()
+        {
+            await VerifyMicrosoftAssumesExceptionAsync(
+                () => IProjectContextInfoExtensions.IsUpgradeableAsync(
+                    projectContextInfo: null,
+                    Mock.Of<IServiceBroker>(),
+                    CancellationToken.None)
+                .AsTask());
+        }
+
+        [Fact]
+        public async Task IsUpgradeableAsync_WhenServiceBrokerIsNull_Throws()
+        {
+            await VerifyMicrosoftAssumesExceptionAsync(
+                () => IProjectContextInfoExtensions.IsUpgradeableAsync(
+                    Mock.Of<IProjectContextInfo>(),
+                    serviceBroker: null,
+                    CancellationToken.None)
+                .AsTask());
+        }
+
+        [Fact]
+        public async Task IsUpgradeableAsync_WhenCancellationTokenIsCancelled_Throws()
+        {
+            await Assert.ThrowsAsync<OperationCanceledException>(
+                () => IProjectContextInfoExtensions.IsUpgradeableAsync(
+                    Mock.Of<IProjectContextInfo>(),
+                    Mock.Of<IServiceBroker>(),
+                    new CancellationToken(canceled: true))
+                .AsTask());
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task IsUpgradeableAsync_WhenArgumentsAreValid_ReturnsBoolean(bool expectedResult)
+        {
+            var serviceBroker = new Mock<IServiceBroker>();
+            var projectUpgraderService = new Mock<INuGetProjectUpgraderService>();
+            var project = new Mock<IProjectContextInfo>();
+            string projectId = Guid.NewGuid().ToString();
+
+            project.SetupGet(x => x.ProjectId)
+                .Returns(projectId);
+
+            projectUpgraderService.Setup(
+                x => x.IsProjectUpgradeableAsync(
+                    It.Is<string>(id => string.Equals(projectId, id)),
+                    It.IsAny<CancellationToken>()))
+                .Returns(new ValueTask<bool>(expectedResult));
+
+            serviceBroker.Setup(
+#pragma warning disable ISB001 // Dispose of proxies
+                x => x.GetProxyAsync<INuGetProjectUpgraderService>(
+                    It.Is<ServiceRpcDescriptor>(descriptor => descriptor == NuGetServices.ProjectUpgraderService),
+                    It.IsAny<ServiceActivationOptions>(),
+                    It.IsAny<CancellationToken>()))
+#pragma warning restore ISB001 // Dispose of proxies
+                .Returns(new ValueTask<INuGetProjectUpgraderService>(projectUpgraderService.Object));
+
+            bool actualResult = await IProjectContextInfoExtensions.IsUpgradeableAsync(
+                project.Object,
+                serviceBroker.Object,
+                CancellationToken.None);
+
+            Assert.Equal(expectedResult, actualResult);
+        }
+
+        [Fact]
+        public async Task GetInstalledPackagesAsync_WhenProjectContextInfoIsNull_Throws()
+        {
+            await VerifyMicrosoftAssumesExceptionAsync(
+                () => IProjectContextInfoExtensions.GetInstalledPackagesAsync(
+                    projectContextInfo: null,
+                    Mock.Of<IServiceBroker>(),
+                    CancellationToken.None)
+                .AsTask());
+        }
+
+        [Fact]
+        public async Task GetInstalledPackagesAsync_WhenServiceBrokerIsNull_Throws()
+        {
+            await VerifyMicrosoftAssumesExceptionAsync(
+                () => IProjectContextInfoExtensions.GetInstalledPackagesAsync(
+                    Mock.Of<IProjectContextInfo>(),
+                    serviceBroker: null,
+                    CancellationToken.None)
+                .AsTask());
+        }
+
+        [Fact]
+        public async Task GetInstalledPackagesAsync_WhenCancellationTokenIsCancelled_Throws()
+        {
+            await Assert.ThrowsAsync<OperationCanceledException>(
+                () => IProjectContextInfoExtensions.GetInstalledPackagesAsync(
+                    Mock.Of<IProjectContextInfo>(),
+                    Mock.Of<IServiceBroker>(),
+                    new CancellationToken(canceled: true))
+                .AsTask());
+        }
+
+        [Fact]
+        public async Task GetInstalledPackagesAsync_WhenArgumentsAreValid_ReturnsInstalledPackages()
+        {
+            var serviceBroker = new Mock<IServiceBroker>();
+            var projectManagerService = new Mock<INuGetProjectManagerService>();
+            var project = new Mock<IProjectContextInfo>();
+            string projectId = Guid.NewGuid().ToString();
+            var expectedResult = new List<IPackageReferenceContextInfo>();
+
+            project.SetupGet(x => x.ProjectId)
+                .Returns(projectId);
+
+            projectManagerService.Setup(
+                x => x.GetInstalledPackagesAsync(
+                    It.Is<string[]>(projectIds => projectIds.Length == 1 && string.Equals(projectId, projectIds[0])),
+                    It.IsAny<CancellationToken>()))
+                .Returns(new ValueTask<IReadOnlyCollection<IPackageReferenceContextInfo>>(expectedResult));
+
+            serviceBroker.Setup(
+#pragma warning disable ISB001 // Dispose of proxies
+                x => x.GetProxyAsync<INuGetProjectManagerService>(
+                    It.Is<ServiceRpcDescriptor>(descriptor => descriptor == NuGetServices.ProjectManagerService),
+                    It.IsAny<ServiceActivationOptions>(),
+                    It.IsAny<CancellationToken>()))
+#pragma warning restore ISB001 // Dispose of proxies
+                .Returns(new ValueTask<INuGetProjectManagerService>(projectManagerService.Object));
+
+            IReadOnlyCollection<IPackageReferenceContextInfo> actualResult = await IProjectContextInfoExtensions.GetInstalledPackagesAsync(
+                project.Object,
+                serviceBroker.Object,
+                CancellationToken.None);
+
+            Assert.Same(expectedResult, actualResult);
+        }
+
+        [Fact]
+        public async Task GetMetadataAsync_WhenProjectContextInfoIsNull_Throws()
+        {
+            await VerifyMicrosoftAssumesExceptionAsync(
+                () => IProjectContextInfoExtensions.GetMetadataAsync(
+                    projectContextInfo: null,
+                    Mock.Of<IServiceBroker>(),
+                    CancellationToken.None)
+                .AsTask());
+        }
+
+        [Fact]
+        public async Task GetMetadataAsync_WhenServiceBrokerIsNull_Throws()
+        {
+            await VerifyMicrosoftAssumesExceptionAsync(
+                () => IProjectContextInfoExtensions.GetMetadataAsync(
+                    Mock.Of<IProjectContextInfo>(),
+                    serviceBroker: null,
+                    CancellationToken.None)
+                .AsTask());
+        }
+
+        [Fact]
+        public async Task GetMetadataAsync_WhenCancellationTokenIsCancelled_Throws()
+        {
+            await Assert.ThrowsAsync<OperationCanceledException>(
+                () => IProjectContextInfoExtensions.GetMetadataAsync(
+                    Mock.Of<IProjectContextInfo>(),
+                    Mock.Of<IServiceBroker>(),
+                    new CancellationToken(canceled: true))
+                .AsTask());
+        }
+
+        [Fact]
+        public async Task GetMetadataAsync_WhenArgumentsAreValid_ReturnsProjectMetadata()
+        {
+            var serviceBroker = new Mock<IServiceBroker>();
+            var projectManagerService = new Mock<INuGetProjectManagerService>();
+            var project = new Mock<IProjectContextInfo>();
+            string projectId = Guid.NewGuid().ToString();
+            var expectedResult = Mock.Of<IProjectMetadataContextInfo>();
+
+            project.SetupGet(x => x.ProjectId)
+                .Returns(projectId);
+
+            projectManagerService.Setup(
+                x => x.GetMetadataAsync(
+                    It.Is<string>(id => string.Equals(projectId, id)),
+                    It.IsAny<CancellationToken>()))
+                .Returns(new ValueTask<IProjectMetadataContextInfo>(expectedResult));
+
+            serviceBroker.Setup(
+#pragma warning disable ISB001 // Dispose of proxies
+                x => x.GetProxyAsync<INuGetProjectManagerService>(
+                    It.Is<ServiceRpcDescriptor>(descriptor => descriptor == NuGetServices.ProjectManagerService),
+                    It.IsAny<ServiceActivationOptions>(),
+                    It.IsAny<CancellationToken>()))
+#pragma warning restore ISB001 // Dispose of proxies
+                .Returns(new ValueTask<INuGetProjectManagerService>(projectManagerService.Object));
+
+            IProjectMetadataContextInfo actualResult = await IProjectContextInfoExtensions.GetMetadataAsync(
+                project.Object,
+                serviceBroker.Object,
+                CancellationToken.None);
+
+            Assert.Same(expectedResult, actualResult);
+        }
+
+        [Fact]
+        public async Task GetUniqueNameOrNameAsync_WhenProjectContextInfoIsNull_Throws()
+        {
+            await VerifyMicrosoftAssumesExceptionAsync(
+                () => IProjectContextInfoExtensions.GetUniqueNameOrNameAsync(
+                    projectContextInfo: null,
+                    Mock.Of<IServiceBroker>(),
+                    CancellationToken.None)
+                .AsTask());
+        }
+
+        [Fact]
+        public async Task GetUniqueNameOrNameAsync_WhenServiceBrokerIsNull_Throws()
+        {
+            await VerifyMicrosoftAssumesExceptionAsync(
+                () => IProjectContextInfoExtensions.GetUniqueNameOrNameAsync(
+                    Mock.Of<IProjectContextInfo>(),
+                    serviceBroker: null,
+                    CancellationToken.None)
+                .AsTask());
+        }
+
+        [Fact]
+        public async Task GetUniqueNameOrNameAsync_WhenCancellationTokenIsCancelled_Throws()
+        {
+            await Assert.ThrowsAsync<OperationCanceledException>(
+                () => IProjectContextInfoExtensions.GetUniqueNameOrNameAsync(
+                    Mock.Of<IProjectContextInfo>(),
+                    Mock.Of<IServiceBroker>(),
+                    new CancellationToken(canceled: true))
+                .AsTask());
+        }
+
+        [Theory]
+        [InlineData("unique", null)]
+        [InlineData(null, "name")]
+        [InlineData("unique", "name")]
+        public async Task GetUniqueNameOrNameAsync_WhenArgumentsAreValid_ReturnsString(
+            string uniqueName,
+            string name)
+        {
+            var serviceBroker = new Mock<IServiceBroker>();
+            var projectManagerService = new Mock<INuGetProjectManagerService>();
+            var project = new Mock<IProjectContextInfo>();
+            string projectId = Guid.NewGuid().ToString();
+            var projectMetadata = new Mock<IProjectMetadataContextInfo>();
+
+            projectMetadata.SetupGet(x => x.Name)
+                .Returns(name);
+
+            projectMetadata.SetupGet(x => x.UniqueName)
+                .Returns(uniqueName);
+
+            string expectedResult = uniqueName ?? name;
+
+            project.SetupGet(x => x.ProjectId)
+                .Returns(projectId);
+
+            projectManagerService.Setup(
+                x => x.GetMetadataAsync(
+                    It.Is<string>(id => string.Equals(projectId, id)),
+                    It.IsAny<CancellationToken>()))
+                .Returns(new ValueTask<IProjectMetadataContextInfo>(projectMetadata.Object));
+
+            serviceBroker.Setup(
+#pragma warning disable ISB001 // Dispose of proxies
+                x => x.GetProxyAsync<INuGetProjectManagerService>(
+                    It.Is<ServiceRpcDescriptor>(descriptor => descriptor == NuGetServices.ProjectManagerService),
+                    It.IsAny<ServiceActivationOptions>(),
+                    It.IsAny<CancellationToken>()))
+#pragma warning restore ISB001 // Dispose of proxies
+                .Returns(new ValueTask<INuGetProjectManagerService>(projectManagerService.Object));
+
+            string actualResult = await IProjectContextInfoExtensions.GetUniqueNameOrNameAsync(
+                project.Object,
+                serviceBroker.Object,
+                CancellationToken.None);
+
+            Assert.Equal(expectedResult, actualResult);
+        }
+
+        [Fact]
+        public async Task TryGetInstalledPackageFilePathAsync_WhenProjectContextInfoIsNull_Throws()
+        {
+            await VerifyMicrosoftAssumesExceptionAsync(
+                () => IProjectContextInfoExtensions.TryGetInstalledPackageFilePathAsync(
+                    projectContextInfo: null,
+                    Mock.Of<IServiceBroker>(),
+                    PackageIdentity,
+                    CancellationToken.None)
+                .AsTask());
+        }
+
+        [Fact]
+        public async Task TryGetInstalledPackageFilePathAsync_WhenServiceBrokerIsNull_Throws()
+        {
+            await VerifyMicrosoftAssumesExceptionAsync(
+                () => IProjectContextInfoExtensions.TryGetInstalledPackageFilePathAsync(
+                    Mock.Of<IProjectContextInfo>(),
+                    serviceBroker: null,
+                    PackageIdentity,
+                    CancellationToken.None)
+                .AsTask());
+        }
+
+        [Fact]
+        public async Task TryGetInstalledPackageFilePathAsync_WhenPackageIdentityIsNull_Throws()
+        {
+            await VerifyMicrosoftAssumesExceptionAsync(
+                () => IProjectContextInfoExtensions.TryGetInstalledPackageFilePathAsync(
+                    Mock.Of<IProjectContextInfo>(),
+                    Mock.Of<IServiceBroker>(),
+                    packageIdentity: null,
+                    CancellationToken.None)
+                .AsTask());
+        }
+
+        [Fact]
+        public async Task TryGetInstalledPackageFilePathAsync_WhenCancellationTokenIsCancelled_Throws()
+        {
+            await Assert.ThrowsAsync<OperationCanceledException>(
+                () => IProjectContextInfoExtensions.TryGetInstalledPackageFilePathAsync(
+                    Mock.Of<IProjectContextInfo>(),
+                    Mock.Of<IServiceBroker>(),
+                    PackageIdentity,
+                    new CancellationToken(canceled: true))
+                .AsTask());
+        }
+
+        [Fact]
+        public async Task TryGetInstalledPackageFilePathAsync_WhenArgumentsAreValid_ReturnsString()
+        {
+            var serviceBroker = new Mock<IServiceBroker>();
+            var projectManagerService = new Mock<INuGetProjectManagerService>();
+            var project = new Mock<IProjectContextInfo>();
+            string projectId = Guid.NewGuid().ToString();
+            (bool, string) expectedResult = (true, "a");
+
+            project.SetupGet(x => x.ProjectId)
+                .Returns(projectId);
+
+            projectManagerService.Setup(
+                x => x.TryGetInstalledPackageFilePathAsync(
+                    It.Is<string>(id => string.Equals(projectId, id)),
+                    It.Is<PackageIdentity>(pi => ReferenceEquals(PackageIdentity, pi)),
+                    It.IsAny<CancellationToken>()))
+                .Returns(new ValueTask<(bool, string)>(expectedResult));
+
+            serviceBroker.Setup(
+#pragma warning disable ISB001 // Dispose of proxies
+                x => x.GetProxyAsync<INuGetProjectManagerService>(
+                    It.Is<ServiceRpcDescriptor>(descriptor => descriptor == NuGetServices.ProjectManagerService),
+                    It.IsAny<ServiceActivationOptions>(),
+                    It.IsAny<CancellationToken>()))
+#pragma warning restore ISB001 // Dispose of proxies
+                .Returns(new ValueTask<INuGetProjectManagerService>(projectManagerService.Object));
+
+            (bool, string) actualResult = await IProjectContextInfoExtensions.TryGetInstalledPackageFilePathAsync(
+                project.Object,
+                serviceBroker.Object,
+                PackageIdentity,
+                CancellationToken.None);
+
+            Assert.Equal(expectedResult.Item1, actualResult.Item1);
+            Assert.Equal(expectedResult.Item2, actualResult.Item2);
+        }
+
+        private static async Task VerifyMicrosoftAssumesExceptionAsync(Func<Task> test)
+        {
+            Exception exception = await Assert.ThrowsAnyAsync<Exception>(test);
+
+            Assert.Equal(typeof(Microsoft.Assumes), exception.GetType().DeclaringType);
+        }
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Feeds/UpdatePackageFeedTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Feeds/UpdatePackageFeedTests.cs
@@ -6,12 +6,13 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.ServiceHub.Framework;
 using Moq;
+using NuGet.Common;
 using NuGet.Frameworks;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
 using NuGet.Protocol.Core.Types;
-using NuGet.Test.Utility;
 using NuGet.Versioning;
 using NuGet.VisualStudio.Internal.Contracts;
 using Xunit;
@@ -36,7 +37,6 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 .Setup(x => x.ResourceType)
                 .Returns(typeof(PackageMetadataResource));
 
-            var logger = new TestLogger();
             var packageSource = new Configuration.PackageSource("http://fake-source");
             var source = new SourceRepository(packageSource, new[] { provider });
 
@@ -45,7 +45,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 new[] { source },
                 optionalLocalRepository: null,
                 optionalGlobalLocalRepositories: null,
-                logger: logger);
+                logger: NullLogger.Instance);
         }
 
         [Fact]
@@ -53,22 +53,32 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         {
             // Arrange
             var testPackageIdentity = new PackageCollectionItem("FakePackage", new NuGetVersion("1.0.0"), null);
+            var serviceBroker = new Mock<IServiceBroker>();
+            Mock<INuGetProjectManagerService> projectManagerService = SetupProjectManagerService(serviceBroker);
 
-            var projectA = SetupProject("FakePackage", "1.0.0");
+            IProjectContextInfo projectA = SetupProject(projectManagerService, "FakePackage", "1.0.0");
             SetupRemotePackageMetadata("FakePackage", "0.0.1", "1.0.0", "2.0.1", "2.0.0", "1.0.1");
 
-            var _target = new UpdatePackageFeed(new[] { testPackageIdentity }, _metadataProvider, new[] { projectA }, null, new TestLogger());
+            var _target = new UpdatePackageFeed(
+                serviceBroker.Object,
+                new[] { testPackageIdentity },
+                _metadataProvider,
+                new[] { projectA },
+                optionalCachedUpdates: null,
+                NullLogger.Instance);
 
             // Act
-            var packages = await _target.GetPackagesWithUpdatesAsync(
-                "fake", new SearchFilter(includePrerelease: false), CancellationToken.None);
+            IEnumerable<IPackageSearchMetadata> packages = await _target.GetPackagesWithUpdatesAsync(
+                searchText: "fake",
+                new SearchFilter(includePrerelease: false),
+                CancellationToken.None);
 
             // Assert
             Assert.Single(packages);
-            var updateCandidate = packages.Single();
+            IPackageSearchMetadata updateCandidate = packages.Single();
             Assert.Equal("2.0.1", updateCandidate.Identity.Version.ToString());
 
-            var actualVersions = await updateCandidate.GetVersionsAsync();
+            IEnumerable<VersionInfo> actualVersions = await updateCandidate.GetVersionsAsync();
             Assert.NotEmpty(actualVersions);
             Assert.Equal(
                 new[] { "2.0.1", "2.0.0", "1.0.1", "1.0.0", "0.0.1" },
@@ -80,22 +90,32 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         {
             // Arrange
             var testPackageIdentity = new PackageCollectionItem("FakePackage", new NuGetVersion("1.0.0"), null);
+            var serviceBroker = new Mock<IServiceBroker>();
+            Mock<INuGetProjectManagerService> projectManagerService = SetupProjectManagerService(serviceBroker);
 
-            var projectA = SetupProject("FakePackage", "1.0.0", "[1,2)");
+            IProjectContextInfo projectA = SetupProject(projectManagerService, "FakePackage", "1.0.0", "[1,2)");
             SetupRemotePackageMetadata("FakePackage", "0.0.1", "1.0.0", "2.0.1", "2.0.0", "1.0.1");
 
-            var _target = new UpdatePackageFeed(new[] { testPackageIdentity }, _metadataProvider, new[] { projectA }, null, new TestLogger());
+            var _target = new UpdatePackageFeed(
+                serviceBroker.Object,
+                new[] { testPackageIdentity },
+                _metadataProvider,
+                new[] { projectA },
+                optionalCachedUpdates: null,
+                NullLogger.Instance);
 
             // Act
-            var packages = await _target.GetPackagesWithUpdatesAsync(
-                "fake", new SearchFilter(includePrerelease: false), CancellationToken.None);
+            IEnumerable<IPackageSearchMetadata> packages = await _target.GetPackagesWithUpdatesAsync(
+                searchText: "fake",
+                new SearchFilter(includePrerelease: false),
+                CancellationToken.None);
 
             // Assert
             Assert.Single(packages);
-            var updateCandidate = packages.Single();
+            IPackageSearchMetadata updateCandidate = packages.Single();
             Assert.Equal("1.0.1", updateCandidate.Identity.Version.ToString());
 
-            var actualVersions = await updateCandidate.GetVersionsAsync();
+            IEnumerable<VersionInfo> actualVersions = await updateCandidate.GetVersionsAsync();
             Assert.NotEmpty(actualVersions);
             Assert.Equal(
                 new[] { "2.0.1", "2.0.0", "1.0.1", "1.0.0", "0.0.1" },
@@ -107,27 +127,37 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         {
             // Arrange
             var testPackageIdentity = new PackageCollectionItem("FakePackage", new NuGetVersion("1.0.0"), null);
+            var serviceBroker = new Mock<IServiceBroker>();
+            Mock<INuGetProjectManagerService> projectManagerService = SetupProjectManagerService(serviceBroker);
 
             // Both projects need to be updated to different versions
             // projectA: 1.0.0 => 2.0.1
             // projectB: 1.0.0 => 1.0.1
-            var projectA = SetupProject("FakePackage", "1.0.0");
-            var projectB = SetupProject("FakePackage", "1.0.0", "[1,2)");
+            IProjectContextInfo projectA = SetupProject(projectManagerService, "FakePackage", "1.0.0");
+            IProjectContextInfo projectB = SetupProject(projectManagerService, "FakePackage", "1.0.0", "[1,2)");
             SetupRemotePackageMetadata("FakePackage", "0.0.1", "1.0.0", "2.0.1", "2.0.0", "1.0.1");
 
-            var _target = new UpdatePackageFeed(new[] { testPackageIdentity }, _metadataProvider, new[] { projectA, projectB }, null, new TestLogger());
+            var _target = new UpdatePackageFeed(
+                serviceBroker.Object,
+                new[] { testPackageIdentity },
+                _metadataProvider,
+                new[] { projectA, projectB },
+                optionalCachedUpdates: null,
+                NullLogger.Instance);
 
             // Act
-            var packages = await _target.GetPackagesWithUpdatesAsync(
-                "fake", new SearchFilter(includePrerelease: false), CancellationToken.None);
+            IEnumerable<IPackageSearchMetadata> packages = await _target.GetPackagesWithUpdatesAsync(
+                searchText: "fake",
+                new SearchFilter(includePrerelease: false),
+                CancellationToken.None);
 
             // Assert
             // Should retrieve a single update item with the lowest version and full list of available versions
             Assert.Single(packages);
-            var updateCandidate = packages.Single();
+            IPackageSearchMetadata updateCandidate = packages.Single();
             Assert.Equal("1.0.1", updateCandidate.Identity.Version.ToString());
 
-            var actualVersions = await updateCandidate.GetVersionsAsync();
+            IEnumerable<VersionInfo> actualVersions = await updateCandidate.GetVersionsAsync();
             Assert.NotEmpty(actualVersions);
             Assert.Equal(
                 new[] { "2.0.1", "2.0.0", "1.0.1", "1.0.0", "0.0.1" },
@@ -139,27 +169,37 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         {
             // Arrange
             var testPackageIdentity = new PackageCollectionItem("FakePackage", NuGetVersion.Parse("1.0.0"), null);
+            var serviceBroker = new Mock<IServiceBroker>();
+            Mock<INuGetProjectManagerService> projectManagerService = SetupProjectManagerService(serviceBroker);
 
             // Only one project needs to be updated
             // projectA: 2.0.0 => 2.0.1
             // projectB: 1.0.1 => None
-            var projectA = SetupProject("FakePackage", "2.0.0");
-            var projectB = SetupProject("FakePackage", "1.0.1", "[1,2)");
+            IProjectContextInfo projectA = SetupProject(projectManagerService, "FakePackage", "2.0.0");
+            IProjectContextInfo projectB = SetupProject(projectManagerService, "FakePackage", "1.0.1", "[1,2)");
             SetupRemotePackageMetadata("FakePackage", "0.0.1", "1.0.0", "2.0.1", "2.0.0", "1.0.1");
 
-            var _target = new UpdatePackageFeed(new[] { testPackageIdentity }, _metadataProvider, new[] { projectA, projectB }, null, new TestLogger());
+            var _target = new UpdatePackageFeed(
+                serviceBroker.Object,
+                new[] { testPackageIdentity },
+                _metadataProvider,
+                new[] { projectA, projectB },
+                optionalCachedUpdates: null,
+                NullLogger.Instance);
 
             // Act
-            var packages = await _target.GetPackagesWithUpdatesAsync(
-                "fake", new SearchFilter(includePrerelease: false), CancellationToken.None);
+            IEnumerable<IPackageSearchMetadata> packages = await _target.GetPackagesWithUpdatesAsync(
+                searchText: "fake",
+                new SearchFilter(includePrerelease: false),
+                CancellationToken.None);
 
             // Assert
             // Should retrieve a single update item with the lowest version and full list of available versions
             Assert.Single(packages);
-            var updateCandidate = packages.Single();
+            IPackageSearchMetadata updateCandidate = packages.Single();
             Assert.Equal("2.0.1", updateCandidate.Identity.Version.ToString());
 
-            var actualVersions = await updateCandidate.GetVersionsAsync();
+            IEnumerable<VersionInfo> actualVersions = await updateCandidate.GetVersionsAsync();
             Assert.NotEmpty(actualVersions);
             Assert.Equal(
                 new[] { "2.0.1", "2.0.0", "1.0.1", "1.0.0", "0.0.1" },
@@ -171,27 +211,37 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         {
             // Arrange
             var testPackageIdentity = new PackageCollectionItem("FakePackage", NuGetVersion.Parse("1.0.0"), null);
+            var serviceBroker = new Mock<IServiceBroker>();
+            Mock<INuGetProjectManagerService> projectManagerService = SetupProjectManagerService(serviceBroker);
 
             // Only one project needs to be updated
             // projectA: 2.0.1 => None
             // projectB: 1.0.0 => 1.0.1
-            var projectA = SetupProject("FakePackage", "2.0.1");
-            var projectB = SetupProject("FakePackage", "1.0.0", "[1,2)");
+            IProjectContextInfo projectA = SetupProject(projectManagerService, "FakePackage", "2.0.1");
+            IProjectContextInfo projectB = SetupProject(projectManagerService, "FakePackage", "1.0.0", "[1,2)");
             SetupRemotePackageMetadata("FakePackage", "0.0.1", "1.0.0", "2.0.1", "2.0.0", "1.0.1");
 
-            var _target = new UpdatePackageFeed(new[] { testPackageIdentity }, _metadataProvider, new[] { projectA, projectB }, null, new TestLogger());
+            var _target = new UpdatePackageFeed(
+                serviceBroker.Object,
+                new[] { testPackageIdentity },
+                _metadataProvider,
+                new[] { projectA, projectB },
+                optionalCachedUpdates: null,
+                NullLogger.Instance);
 
             // Act
-            var packages = await _target.GetPackagesWithUpdatesAsync(
-                "fake", new SearchFilter(includePrerelease: false), CancellationToken.None);
+            IEnumerable<IPackageSearchMetadata> packages = await _target.GetPackagesWithUpdatesAsync(
+                searchText: "fake",
+                new SearchFilter(includePrerelease: false),
+                CancellationToken.None);
 
             // Assert
             // Should retrieve a single update item with the lowest version and full list of available versions
             Assert.Single(packages);
-            var updateCandidate = packages.Single();
+            IPackageSearchMetadata updateCandidate = packages.Single();
             Assert.Equal("1.0.1", updateCandidate.Identity.Version.ToString());
 
-            var actualVersions = await updateCandidate.GetVersionsAsync();
+            IEnumerable<VersionInfo> actualVersions = await updateCandidate.GetVersionsAsync();
             Assert.NotEmpty(actualVersions);
             Assert.Equal(
                 new[] { "2.0.1", "2.0.0", "1.0.1", "1.0.0", "0.0.1" },
@@ -203,16 +253,26 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         {
             // Arrange
             var testPackageIdentity = new PackageCollectionItem("FakePackage", NuGetVersion.Parse("1.0.0"), null);
+            var serviceBroker = new Mock<IServiceBroker>();
+            Mock<INuGetProjectManagerService> projectManagerService = SetupProjectManagerService(serviceBroker);
 
-            var projectA = SetupProject("FakePackage", "2.0.1");
-            var projectB = SetupProject("FakePackage", "1.0.1", "[1,2)");
+            IProjectContextInfo projectA = SetupProject(projectManagerService, "FakePackage", "2.0.1");
+            IProjectContextInfo projectB = SetupProject(projectManagerService, "FakePackage", "1.0.1", "[1,2)");
             SetupRemotePackageMetadata("FakePackage", "0.0.1", "1.0.0", "2.0.1", "2.0.0", "1.0.1");
 
-            var _target = new UpdatePackageFeed(new[] { testPackageIdentity }, _metadataProvider, new[] { projectA, projectB }, null, new TestLogger());
+            UpdatePackageFeed _target = new UpdatePackageFeed(
+                serviceBroker.Object,
+                new[] { testPackageIdentity },
+                _metadataProvider,
+                new[] { projectA, projectB },
+                optionalCachedUpdates: null,
+                NullLogger.Instance);
 
             // Act
-            var packages = await _target.GetPackagesWithUpdatesAsync(
-                "fake", new SearchFilter(includePrerelease: false), CancellationToken.None);
+            IEnumerable<IPackageSearchMetadata> packages = await _target.GetPackagesWithUpdatesAsync(
+                searchText: "fake",
+                new SearchFilter(includePrerelease: false),
+                CancellationToken.None);
 
             // Assert
             Assert.Empty(packages);
@@ -223,41 +283,57 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         {
             // Arrange
             var testPackageIdentity = new PackageCollectionItem("FakePackage", new NuGetVersion("1.0.0"), null);
+            var serviceBroker = new Mock<IServiceBroker>();
+            Mock<INuGetProjectManagerService> projectManagerService = SetupProjectManagerService(serviceBroker);
 
-            var projectA = SetupProject("FakePackage", "1.0.0");
+            IProjectContextInfo projectA = SetupProject(projectManagerService, "FakePackage", "1.0.0");
             SetupRemotePackageMetadata("FakePackage", "0.0.1", "1.0.0", "2.0.0");
 
-            var _target = new UpdatePackageFeed(new[] { testPackageIdentity }, _metadataProvider, new[] { projectA }, null, new TestLogger());
+            var _target = new UpdatePackageFeed(
+                serviceBroker.Object,
+                new[] { testPackageIdentity },
+                _metadataProvider,
+                new[] { projectA },
+                optionalCachedUpdates: null,
+                NullLogger.Instance);
 
             // Act
-            var packages = await _target.GetPackagesWithUpdatesAsync(
-                "fake", new SearchFilter(includePrerelease: false), CancellationToken.None);
+            IEnumerable<IPackageSearchMetadata> packages = await _target.GetPackagesWithUpdatesAsync(
+                searchText: "fake",
+                new SearchFilter(includePrerelease: false),
+                CancellationToken.None);
 
             Assert.Single(packages);
-            var updateCandidate = packages.Single();
+            IPackageSearchMetadata updateCandidate = packages.Single();
             Assert.Equal("2.0.0", updateCandidate.Identity.Version.ToString());
 
             SetupRemotePackageMetadata("FakePackage", "0.0.1", "1.0.0", "2.0.1", "2.0.0", "1.0.1");
 
             packages = await _target.GetPackagesWithUpdatesAsync(
-                "fake", new SearchFilter(includePrerelease: false), CancellationToken.None);
+                searchText: "fake",
+                new SearchFilter(includePrerelease: false),
+                CancellationToken.None);
 
             Assert.Single(packages);
             updateCandidate = packages.Single();
             Assert.Equal("2.0.1", updateCandidate.Identity.Version.ToString());
 
-            var actualVersions = await updateCandidate.GetVersionsAsync();
+            IEnumerable<VersionInfo> actualVersions = await updateCandidate.GetVersionsAsync();
             Assert.NotEmpty(actualVersions);
             Assert.Equal(
                 new[] { "2.0.1", "2.0.0", "1.0.1", "1.0.0", "0.0.1" },
                 actualVersions.Select(v => v.Version.ToString()).ToArray());
         }
 
-        private IProjectContextInfo SetupProject(string packageId, string packageVersion, string allowedVersions = null)
+        private IProjectContextInfo SetupProject(
+            Mock<INuGetProjectManagerService> projectManagerService,
+            string packageId,
+            string packageVersion,
+            string allowedVersions = null)
         {
             var packageIdentity = new PackageIdentity(packageId, NuGetVersion.Parse(packageVersion));
 
-            var installedPackages = new[]
+            var installedPackages = new PackageReferenceContextInfo[]
             {
                 PackageReferenceContextInfo.Create(
                     new PackageReference(
@@ -269,16 +345,25 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                         allowedVersions: allowedVersions != null ? VersionRange.Parse(allowedVersions) : null))
             };
 
-            var project = Mock.Of<IProjectContextInfo>();
-            Mock.Get(project)
-                .Setup(x => x.GetInstalledPackagesAsync(It.IsAny<CancellationToken>()))
+            string projectId = Guid.NewGuid().ToString();
+
+            projectManagerService.Setup(
+                    x => x.GetInstalledPackagesAsync(
+                        It.Is<IReadOnlyCollection<string>>(projectIds => projectIds.Single() == projectId),
+                        It.IsAny<CancellationToken>()))
                 .Returns(new ValueTask<IReadOnlyCollection<IPackageReferenceContextInfo>>(installedPackages));
-            return project;
+
+            var project = new Mock<IProjectContextInfo>();
+
+            project.SetupGet(x => x.ProjectId)
+                .Returns(projectId);
+
+            return project.Object;
         }
 
         private void SetupRemotePackageMetadata(string id, params string[] versions)
         {
-            var metadata = versions
+            IEnumerable<IPackageSearchMetadata> metadata = versions
                 .Select(v => PackageSearchMetadataBuilder
                     .FromIdentity(new PackageIdentity(id, new NuGetVersion(v)))
                     .Build());
@@ -295,26 +380,51 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             var testPackageIdentity = new PackageCollectionItem("FakePackage", NuGetVersion.Parse("1.0.0"), null);
             var testPackageIdentity2 = new PackageCollectionItem("AFakePackage", NuGetVersion.Parse("1.0.0"), null);
             var testPackageIdentity3 = new PackageCollectionItem("ZFakePackage", NuGetVersion.Parse("1.0.0"), null);
+            var serviceBroker = new Mock<IServiceBroker>();
+            Mock<INuGetProjectManagerService> projectManagerService = SetupProjectManagerService(serviceBroker);
 
-            var projectA = SetupProject("FakePackage", "1.0.0");
-            var projectB = SetupProject("ZFakePackage", "1.0.0");
-            var projectC = SetupProject("AFakePackage", "1.0.0");
+            IProjectContextInfo projectA = SetupProject(projectManagerService, "FakePackage", "1.0.0");
+            IProjectContextInfo projectB = SetupProject(projectManagerService, "ZFakePackage", "1.0.0");
+            IProjectContextInfo projectC = SetupProject(projectManagerService, "AFakePackage", "1.0.0");
             SetupRemotePackageMetadata("FakePackage", "0.0.1", "1.0.0", "2.0.1", "2.0.0", "1.0.1");
             SetupRemotePackageMetadata("ZFakePackage", "0.0.1", "1.0.0", "4.0.0");
             SetupRemotePackageMetadata("AFakePackage", "1.0.0", "3.0.1");
 
-            var _target = new UpdatePackageFeed(new[] { testPackageIdentity, testPackageIdentity2, testPackageIdentity3 }
-                        , _metadataProvider, new[] { projectA, projectB, projectC }, null, new TestLogger());
+            var _target = new UpdatePackageFeed(
+                serviceBroker.Object,
+                new[] { testPackageIdentity, testPackageIdentity2, testPackageIdentity3 },
+                _metadataProvider,
+                new[] { projectA, projectB, projectC },
+                optionalCachedUpdates: null,
+                NullLogger.Instance);
 
             // Act
-            var packages = await _target.GetPackagesWithUpdatesAsync(
-                "fake", new SearchFilter(includePrerelease: false), CancellationToken.None);
+            IEnumerable<IPackageSearchMetadata> packages = await _target.GetPackagesWithUpdatesAsync(
+                searchText: "fake",
+                new SearchFilter(includePrerelease: false),
+                CancellationToken.None);
 
-            var actualPackageIds = packages.Select(p => p.Identity.Id);
+            IEnumerable<string> actualPackageIds = packages.Select(p => p.Identity.Id);
 
             // Assert
             var expectedPackageIdsSorted = new List<string>() { "AFakePackage", "FakePackage", "ZFakePackage" };
             Assert.Equal(expectedPackageIdsSorted, actualPackageIds); //Equal considers sort order of collections.
+        }
+
+        private static Mock<INuGetProjectManagerService> SetupProjectManagerService(Mock<IServiceBroker> serviceBroker)
+        {
+            var projectManagerService = new Mock<INuGetProjectManagerService>();
+
+            serviceBroker.Setup(
+#pragma warning disable ISB001 // Dispose of proxies
+                    x => x.GetProxyAsync<INuGetProjectManagerService>(
+                        It.Is<ServiceRpcDescriptor>(s => s == NuGetServices.ProjectManagerService),
+                        It.IsAny<ServiceActivationOptions>(),
+                        It.IsAny<CancellationToken>()))
+#pragma warning restore ISB001 // Dispose of proxies
+                .Returns(new ValueTask<INuGetProjectManagerService>(projectManagerService.Object));
+
+            return projectManagerService;
         }
     }
 }

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/NuGet.PackageManagement.VisualStudio.Test.csproj
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/NuGet.PackageManagement.VisualStudio.Test.csproj
@@ -23,6 +23,7 @@
     <Reference Include="System.IO.Compression" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Common\IProjectContextInfoExtensionsTests.cs" />
     <Compile Include="Feeds\SourceRepositoryCreator.cs" />
     <Compile Include="Feeds\SourceRepositoryExtensionsTests.cs" />
     <Compile Include="CpsPackageReferenceProjectTests.cs" />

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/CachingIServiceBrokerProviderTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/CachingIServiceBrokerProviderTests.cs
@@ -1,0 +1,30 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using Microsoft.ServiceHub.Framework;
+using Microsoft.VisualStudio.Sdk.TestFramework;
+using Xunit;
+
+namespace NuGet.VisualStudio.Implementation.Test
+{
+    [Collection(MockedVs.CollectionName)]
+    public class CachingIServiceBrokerProviderTests
+    {
+        public CachingIServiceBrokerProviderTests(GlobalServiceProvider serviceProvider)
+        {
+            serviceProvider.Reset();
+        }
+
+        [Fact]
+        public async Task GetAsync_Always_IsIdempotent()
+        {
+            var provider = new CachingIServiceBrokerProvider();
+
+            IServiceBroker serviceBroker1 = await provider.GetAsync();
+            IServiceBroker serviceBroker2 = await provider.GetAsync();
+
+            Assert.Same(serviceBroker1, serviceBroker2);
+        }
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/Extensibility/VsPathContextProviderTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/Extensibility/VsPathContextProviderTests.cs
@@ -7,7 +7,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft;
+using Microsoft.VisualStudio.Sdk.TestFramework;
 using Microsoft.VisualStudio.Threading;
 using Moq;
 using NuGet.Common;
@@ -22,22 +22,16 @@ using NuGet.ProjectManagement.Projects;
 using NuGet.ProjectModel;
 using NuGet.Test.Utility;
 using NuGet.Versioning;
-using Test.Utility.Threading;
 using Xunit;
 
 namespace NuGet.VisualStudio.Implementation.Test.Extensibility
 {
-    [Collection(DispatcherThreadCollection.CollectionName)]
+    [Collection(MockedVs.CollectionName)]
     public class VsPathContextProviderTests
     {
-        private readonly JoinableTaskFactory _jtf;
-
-        public VsPathContextProviderTests(DispatcherThreadFixture fixture)
+        public VsPathContextProviderTests(GlobalServiceProvider serviceProvider)
         {
-            Assumes.Present(fixture);
-
-            _jtf = fixture.JoinableTaskFactory;
-            NuGetUIThreadHelper.SetCustomJoinableTaskFactory(_jtf);
+            serviceProvider.Reset();
         }
 
         [Fact]

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/MockedVS.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/MockedVS.cs
@@ -1,0 +1,20 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.VisualStudio.Sdk.TestFramework;
+using Xunit;
+
+namespace NuGet.VisualStudio.Implementation.Test
+{
+    /// <summary>
+    /// Defines the "MockedVS" xunit test collection.
+    /// </summary>
+    [CollectionDefinition(CollectionName)]
+    public class MockedVs : ICollectionFixture<GlobalServiceProvider>, ICollectionFixture<MefHostingFixture>
+    {
+        /// <summary>
+        /// The name of the xunit test collection.
+        /// </summary>
+        public const string CollectionName = "MockedVS";
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/NuGet.VisualStudio.Implementation.Test.csproj
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/NuGet.VisualStudio.Implementation.Test.csproj
@@ -55,7 +55,8 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" NoWarn="NU1605" />
     <PackageReference Include="Microsoft.ServiceHub.Framework" />
-</ItemGroup>
+    <PackageReference Include="Microsoft.VisualStudio.Sdk.TestFramework" />
+  </ItemGroup>
 
   <Import Project="$(BuildCommonDirectory)common.targets"/>
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />

--- a/test/NuGet.Tests.Apex/NuGet.PackageManagement.UI.TestContract/NuGetApexUITestService.cs
+++ b/test/NuGet.Tests.Apex/NuGet.PackageManagement.UI.TestContract/NuGetApexUITestService.cs
@@ -6,6 +6,7 @@ using System.ComponentModel.Composition;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;
+using Microsoft.ServiceHub.Framework;
 using Microsoft.TeamFoundation.WorkItemTracking.Process.WebApi.Models;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell.Interop;
@@ -77,7 +78,10 @@ namespace NuGet.PackageManagement.UI.TestContract
                         }
 
                         IProjectContextInfo existingProject = projects.First();
-                        IProjectMetadataContextInfo projectMetadata = await existingProject.GetMetadataAsync(CancellationToken.None);
+                        IServiceBroker serviceBroker = packageManagerWindowPane.Model.Context.ServiceBroker;
+                        IProjectMetadataContextInfo projectMetadata = await existingProject.GetMetadataAsync(
+                            serviceBroker,
+                            CancellationToken.None);
 
                         if (string.Equals(projectMetadata.Name, projectUniqueName, StringComparison.OrdinalIgnoreCase))
                         {


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/10141 and makes progress on https://github.com/NuGet/Home/issues/10112
Regression: No

## Fix

Details: As a widely used pattern, querying for an `IServiceBroker` instance and discarding it immediately after its use can be expensive.  For example, in the Browse tab of the solution-level PM UI for the [NuGet.Client solution](https://github.com/NuGet/NuGet.Client/blob/c5f496dae608298cb9d57768444717613400d3dc/NuGet.sln), selecting all projects for a selected package queried for an `IServiceBroker` instance 7,308 times with a ~2.2 second overhead.  This change eliminates those calls and overhead. 

While VS OE services should only use the `IServiceBroker` instance passed to its constructor, VS OE clients are free to cache and reuse `IServiceBroker` instances obtained from VS for the lifetime of the VS process.

As part of this work I moved most methods out of `IProjectContextInfo`.

## Testing/Validation

Tests Added: Yes

CC @rrelyea, @sbanni