### PR TITLE
always create a 32x32 image, even if application.current is null

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources/Images.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources/Images.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Windows;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
@@ -31,17 +32,28 @@ namespace NuGet.PackageManagement.UI
                 image.Freeze();
                 DefaultPackageIcon = image;
             }
-            else // for tests, don't actually load the icon, just use a 1x1 image.
+            else // for tests, don't actually load the icon, just use a 32x32 image.
             {
+                const int size = PackageItemListViewModel.DecodePixelWidth;
+                var bytes = new List<byte>();
+                byte[] pixel = new byte[] { 0, 0, 255, 0 };
+                for (int y = 0; y < size; y++)
+                {
+                    for (int x = 0; x < size; x++)
+                    {
+                        bytes.AddRange(pixel);
+                    }
+                }
+
                 BitmapSource image = BitmapSource.Create(
-                    pixelWidth: 1,
-                    pixelHeight: 1,
+                    pixelWidth: size,
+                    pixelHeight: size,
                     dpiX: 96.0,
                     dpiY: 96.0,
                     PixelFormats.Bgr32,
                     palette: null,
-                    pixels: new byte[] { 0, 0, 255, 0 },
-                    stride: 32);
+                    pixels: bytes.ToArray(),
+                    stride: 4 * size);
                 image.Freeze();
                 DefaultPackageIcon = image;
             }

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/PackageItemListViewModelTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/PackageItemListViewModelTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using System.Threading.Tasks;
+using System.Windows;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using Microsoft;
@@ -379,11 +380,8 @@ namespace NuGet.PackageManagement.UI.Test
             Assert.True(result is BitmapImage || result is CachedBitmap);
             var image = result as BitmapSource;
             Assert.NotNull(image);
-            int expectedSize = IconBitmapStatusUtility.GetIsDefaultIcon(bitmapStatus)
-                ? 1
-                : PackageItemListViewModel.DecodePixelWidth;
-            Assert.Equal(expectedSize, image.PixelWidth);
-            Assert.Equal(expectedSize, image.PixelHeight);
+            Assert.Equal( PackageItemListViewModel.DecodePixelWidth, image.PixelWidth);
+            Assert.Equal( PackageItemListViewModel.DecodePixelWidth, image.PixelHeight);
         }
 
         /// <summary>

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/PackageItemListViewModelTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/PackageItemListViewModelTests.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using System.Threading.Tasks;
-using System.Windows;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using Microsoft;

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/PackageItemListViewModelTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/PackageItemListViewModelTests.cs
@@ -379,8 +379,8 @@ namespace NuGet.PackageManagement.UI.Test
             Assert.True(result is BitmapImage || result is CachedBitmap);
             var image = result as BitmapSource;
             Assert.NotNull(image);
-            Assert.Equal( PackageItemListViewModel.DecodePixelWidth, image.PixelWidth);
-            Assert.Equal( PackageItemListViewModel.DecodePixelWidth, image.PixelHeight);
+            Assert.Equal(PackageItemListViewModel.DecodePixelWidth, image.PixelWidth);
+            Assert.Equal(PackageItemListViewModel.DecodePixelWidth, image.PixelHeight);
         }
 
         /// <summary>


### PR DESCRIPTION
## Bug

Fixes: https://github.com/nuget/client.engineering/issues/603
Regression: no

## Fix

Details: tests sometimes run with application.current not null, sometimes not. make tests handle both cases. 

## Testing/Validation

Tests Added: no
Reason for not adding tests:  tweaking the new ones i had as part of feature work
Validation:  ran unit tests in VS. Then CI.
