### PR TITLE
Use CPSPackageReferenceNuGetProject only when both CPS and PR capabilities are set

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/CpsPackageReferenceProjectProvider.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/CpsPackageReferenceProjectProvider.cs
@@ -75,7 +75,8 @@ namespace NuGet.PackageManagement.VisualStudio
             }
 
             // Check that the project supports both CPS and PackageReferences
-            if (!(VsHierarchyUtility.IsCPSCapabilityCompliant(hierarchy) && VsHierarchyUtility.IsPackageReferenceCapabilityCompliant(hierarchy)))
+            if (!(await vsProject.IsCapabilityMatchAsync(NuGet.VisualStudio.IDE.ProjectCapabilities.Cps) &&
+                await vsProject.IsCapabilityMatchAsync(NuGet.VisualStudio.IDE.ProjectCapabilities.PackageReferences)))
             {
                 return null;
             }

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/CpsPackageReferenceProjectProvider.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/CpsPackageReferenceProjectProvider.cs
@@ -74,9 +74,8 @@ namespace NuGet.PackageManagement.VisualStudio
                 return null;
             }
 
-            // Check if the project is not CPS capable or if it is CPS capable that its opt'd in PackageReferences
-            if (!VsHierarchyUtility.IsCPSCapabilityCompliant(hierarchy) ||
-                !VsHierarchyUtility.IsProjectCapabilityCompliant(hierarchy))
+            // Check that the project supports both CPS and PackageReferences
+            if (!(VsHierarchyUtility.IsCPSCapabilityCompliant(hierarchy) && VsHierarchyUtility.IsPackageReferenceCapabilityCompliant(hierarchy)))
             {
                 return null;
             }

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/VsProjectAdapter.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/VsProjectAdapter.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Runtime.Versioning;
 using System.Threading.Tasks;
 using Microsoft;
+using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using NuGet.Commands;
 using NuGet.Common;
@@ -442,6 +443,13 @@ namespace NuGet.PackageManagement.VisualStudio
                 targetPlatformMinVersion: platformMinVersion);
 
             return frameworkStrings.FirstOrDefault();
+        }
+
+        public async Task<bool> IsCapabilityMatchAsync(string capabilityExpression)
+        {
+            await _threadingService.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+            return VsHierarchy.IsCapabilityMatch(capabilityExpression);
         }
 
         #endregion Getters

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/IDE/ProjectCapabilities.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/IDE/ProjectCapabilities.cs
@@ -1,0 +1,30 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGet.VisualStudio.IDE
+{
+    public static class ProjectCapabilities
+    {
+        /// <summary>
+        /// All CPS projects will have CPS capability except VisualC projects.
+        /// So checking for VisualC explicitly with a OR flag.
+        /// </summary>
+        /// <remarks>This does not mean the project uses PackageReference.</remarks>
+        public const string Cps = "CPS | VisualC";
+
+        /// <summary>
+        /// Capability string for projects that want to support PackageReferences
+        /// </summary>
+        /// <remarks>There are multiple project systems that support PackageReferences, we can't assume which one without more information.</remarks>
+        public const string PackageReferences = "PackageReferences";
+
+        /// <summary>
+        /// Capability expression to try to determine if the (MSBuild based) project supports NuGet.
+        /// </summary>
+        /// <remarks>
+        /// VS project systems that are not MSBuild based (project.json) will not get detected by this.
+        /// Similarly, there are multiple project systems that match this expression, so additional information is needed to determine which project system.
+        /// </remarks>
+        public const string SupportsNuGet = "(AssemblyReferences + DeclaredSourceItems + UserSourceItems) | PackageReferences";
+    }
+}

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/IDE/VsHierarchyUtility.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/IDE/VsHierarchyUtility.cs
@@ -43,6 +43,10 @@ namespace NuGet.VisualStudio
             return !string.IsNullOrEmpty(projectTypeGuid) && SupportedProjectTypes.IsSupported(projectTypeGuid) && !HasUnsupportedProjectCapability(hierarchy);
         }
 
+        /// <summary>Check if this project appears to support NuGet.</summary>
+        /// <param name="hierarchy">IVsHierarchy representing the project in the solution.</param>
+        /// <returns>True if NuGet should enable this project, false if NuGet should ignore the project.</returns>
+        /// <remarks>The project may be packages.config or PackageReference. This method does not tell you which.</remarks>
         public static bool IsProjectCapabilityCompliant(IVsHierarchy hierarchy)
         {
             ThreadHelper.ThrowIfNotOnUIThread();
@@ -83,11 +87,23 @@ namespace NuGet.VisualStudio
         /// Check for CPS capability in IVsHierarchy. All CPS projects will have CPS capability except VisualC projects.
         /// So checking for VisualC explicitly with a OR flag.
         /// </summary>
+        /// <remarks>This does not mean the project also supports PackageReference!</remarks>
         public static bool IsCPSCapabilityCompliant(IVsHierarchy hierarchy)
         {
             ThreadHelper.ThrowIfNotOnUIThread();
 
             return hierarchy.IsCapabilityMatch("CPS | VisualC");
+        }
+
+        /// <summary>Checks if the project advertises PackageReferences capability.</summary>
+        /// <param name="hierarchy">IVsHierarchy representing the project in the solution.</param>
+        /// <returns>True if the project has the PackageReferences capability, false otherwise.</returns>
+        /// <remarks>This method does not tell us which project system the project uses.</remarks>
+        public static bool IsPackageReferenceCapabilityCompliant(IVsHierarchy hierarchy)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            return hierarchy.IsCapabilityMatch("PackageReferences");
         }
 
         /// <summary>

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/IDE/VsHierarchyUtility.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/IDE/VsHierarchyUtility.cs
@@ -53,7 +53,7 @@ namespace NuGet.VisualStudio
 
             // NOTE: (AssemblyReferences + DeclaredSourceItems + UserSourceItems) exists solely for compatibility reasons
             // with existing custom CPS-based projects that existed before "PackageReferences" capability was introduced.
-            return hierarchy.IsCapabilityMatch("(AssemblyReferences + DeclaredSourceItems + UserSourceItems) | PackageReferences");
+            return hierarchy.IsCapabilityMatch(IDE.ProjectCapabilities.SupportsNuGet);
         }
 
         public static bool HasUnsupportedProjectCapability(IVsHierarchy hierarchy)
@@ -84,26 +84,14 @@ namespace NuGet.VisualStudio
         }
 
         /// <summary>
-        /// Check for CPS capability in IVsHierarchy. All CPS projects will have CPS capability except VisualC projects.
-        /// So checking for VisualC explicitly with a OR flag.
+        /// Check for CPS capability in IVsHierarchy.
         /// </summary>
         /// <remarks>This does not mean the project also supports PackageReference!</remarks>
         public static bool IsCPSCapabilityCompliant(IVsHierarchy hierarchy)
         {
             ThreadHelper.ThrowIfNotOnUIThread();
 
-            return hierarchy.IsCapabilityMatch("CPS | VisualC");
-        }
-
-        /// <summary>Checks if the project advertises PackageReferences capability.</summary>
-        /// <param name="hierarchy">IVsHierarchy representing the project in the solution.</param>
-        /// <returns>True if the project has the PackageReferences capability, false otherwise.</returns>
-        /// <remarks>This method does not tell us which project system the project uses.</remarks>
-        public static bool IsPackageReferenceCapabilityCompliant(IVsHierarchy hierarchy)
-        {
-            ThreadHelper.ThrowIfNotOnUIThread();
-
-            return hierarchy.IsCapabilityMatch("PackageReferences");
+            return hierarchy.IsCapabilityMatch(IDE.ProjectCapabilities.Cps);
         }
 
         /// <summary>

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/IVsProjectAdapter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/IVsProjectAdapter.cs
@@ -159,5 +159,10 @@ namespace NuGet.VisualStudio
         /// <param name="metadataNames">The metadata names to read.</param>
         /// <returns>An <see cref="IEnumerable{(string ItemId, string[] ItemMetadata)}"/> containing the itemId and the metadata values.</returns>
         Task<IEnumerable<(string ItemId, string[] ItemMetadata)>> GetBuildItemInformationAsync(string itemName, params string[] metadataNames);
+
+        /// <summary>
+        /// See <see cref="Microsoft.VisualStudio.Shell.PackageUtilities.IsCapabilityMatch(IVsHierarchy, string)"/>
+        /// </summary>
+        Task<bool> IsCapabilityMatchAsync(string capabilityExpression);
     }
 }

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/NuGet.PackageManagement.VisualStudio.Test.csproj
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/NuGet.PackageManagement.VisualStudio.Test.csproj
@@ -36,6 +36,7 @@
     <Compile Include="ProjectSystems\ProjectKNuGetProjectTests.cs" />
     <Compile Include="ProjectSystems\ProjectSystemCacheTests.cs" />
     <Compile Include="ProjectSystems\TestVSProjectAdapter.cs" />
+    <Compile Include="Projects\CpsPackageReferenceProjectProviderTests.cs" />
     <Compile Include="Services\NuGetLockServiceTests.cs" />
     <Compile Include="Services\NuGetProjectManagerServiceTests.cs" />
     <Compile Include="Services\TestSharedServiceState.cs" />

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/TestVSProjectAdapter.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/TestVSProjectAdapter.cs
@@ -246,5 +246,10 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
             return string.Empty;
         }
+
+        public Task<bool> IsCapabilityMatchAsync(string capabilityExpression)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Projects/CpsPackageReferenceProjectProviderTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Projects/CpsPackageReferenceProjectProviderTests.cs
@@ -3,17 +3,30 @@
 
 using System;
 using System.Threading.Tasks;
+using Microsoft;
 using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.Threading;
 using Moq;
 using NuGet.ProjectManagement;
 using NuGet.VisualStudio;
+using Test.Utility.Threading;
 using Xunit;
 
 namespace NuGet.PackageManagement.VisualStudio.Test.Projects
 {
+    [Collection(DispatcherThreadCollection.CollectionName)]
     public class CpsPackageReferenceProjectProviderTests
     {
-        private delegate int IVsHierarchyGetPropertyDelegate(uint a, int b, out object result);
+        private readonly JoinableTaskFactory _jtf;
+
+        public CpsPackageReferenceProjectProviderTests(DispatcherThreadFixture fixture)
+        {
+            Assumes.Present(fixture);
+
+            _jtf = fixture.JoinableTaskFactory;
+
+            NuGetUIThreadHelper.SetCustomJoinableTaskFactory(_jtf);
+        }
 
         // As of October 2020, Service Fabric projects (sfproj) uses CPS, but does not support PackageReference. Make sure non-PR CPS projects do not use this project system.
         [Fact]
@@ -38,7 +51,11 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Projects
             var target = new CpsPackageReferenceProjectProvider(projectSystemCache.Object);
 
             // Act
-            var actual = await target.TryCreateNuGetProjectAsync(projectAdapter.Object, ppc, forceProjectType: false);
+            NuGetProject actual = await _jtf.RunAsync(async () =>
+            {
+                await _jtf.SwitchToMainThreadAsync();
+                return await target.TryCreateNuGetProjectAsync(projectAdapter.Object, ppc, forceProjectType: false);
+            });
 
             // Assert
             Assert.Null(actual);

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Projects/CpsPackageReferenceProjectProviderTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Projects/CpsPackageReferenceProjectProviderTests.cs
@@ -1,0 +1,49 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Shell.Interop;
+using Moq;
+using NuGet.ProjectManagement;
+using NuGet.VisualStudio;
+using Xunit;
+
+namespace NuGet.PackageManagement.VisualStudio.Test.Projects
+{
+    public class CpsPackageReferenceProjectProviderTests
+    {
+        private delegate int IVsHierarchyGetPropertyDelegate(uint a, int b, out object result);
+
+        // As of October 2020, Service Fabric projects (sfproj) uses CPS, but does not support PackageReference. Make sure non-PR CPS projects do not use this project system.
+        [Fact]
+        public async Task TryCreateNuGetProjectAsync_CpsProjectWithoutPackageReferencesCapability_ReturnsNull()
+        {
+            // Arrange
+            var hierarchy = new Mock<IVsHierarchy>();
+
+            var projectAdapter = new Mock<IVsProjectAdapter>();
+            projectAdapter.SetupGet(a => a.VsHierarchy)
+                .Returns(hierarchy.Object);
+            projectAdapter.Setup(a => a.IsCapabilityMatchAsync(NuGet.VisualStudio.IDE.ProjectCapabilities.Cps))
+                .Returns(Task.FromResult(true));
+            projectAdapter.Setup(a => a.IsCapabilityMatchAsync(NuGet.VisualStudio.IDE.ProjectCapabilities.PackageReferences))
+                .Returns(Task.FromResult(false));
+
+            var nugetProjectContext = new Mock<INuGetProjectContext>();
+
+            var ppc = new ProjectProviderContext(nugetProjectContext.Object, packagesPathFactory: () => throw new NotImplementedException());
+
+            var projectSystemCache = new Mock<IProjectSystemCache>();
+            var target = new CpsPackageReferenceProjectProvider(projectSystemCache.Object);
+
+            // Act
+            var actual = await target.TryCreateNuGetProjectAsync(projectAdapter.Object, ppc, forceProjectType: false);
+
+            // Assert
+            Assert.Null(actual);
+            projectAdapter.Verify(a => a.IsCapabilityMatchAsync(NuGet.VisualStudio.IDE.ProjectCapabilities.Cps), Times.Once);
+            projectAdapter.Verify(a => a.IsCapabilityMatchAsync(NuGet.VisualStudio.IDE.ProjectCapabilities.PackageReferences), Times.Once);
+        }
+    }
+}


### PR DESCRIPTION

## Bug

Fixes: https://github.com/NuGet/Home/issues/10169
Regression: Yes (but didn't ship)
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: Add new capability check just for `PackageReferences`, and improve xmldoc comments for existing capability checks to explain what they do and do not tell us.

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  I'm still looking into how to test this. I'm not sure if we can mock the VS project adapter, but having written this I think we can, which means I probably need to modify this PR to add tests.
Validation:  
