### PR TITLE
VS OE:  deduplicate formatter implementations through base class

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/FloatRangeFormatter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/FloatRangeFormatter.cs
@@ -10,7 +10,7 @@ using NuGet.Versioning;
 
 namespace NuGet.VisualStudio.Internal.Contracts
 {
-    internal sealed class FloatRangeFormatter : IMessagePackFormatter<FloatRange?>
+    internal sealed class FloatRangeFormatter : NuGetMessagePackFormatter<FloatRange>
     {
         private const string FloatBehaviorPropertyName = "floatbehavior";
         private const string MinVersionPropertyName = "minversion";
@@ -22,65 +22,43 @@ namespace NuGet.VisualStudio.Internal.Contracts
         {
         }
 
-        public FloatRange? Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
+        protected override FloatRange? DeserializeCore(ref MessagePackReader reader, MessagePackSerializerOptions options)
         {
-            if (reader.TryReadNil())
+            NuGetVersionFloatBehavior? floatBehavior = null;
+            NuGetVersion? minVersion = null;
+            string? releasePrefix = null;
+
+            int propertyCount = reader.ReadMapHeader();
+
+            for (var propertyIndex = 0; propertyIndex < propertyCount; ++propertyIndex)
             {
-                return null;
-            }
-
-            // stack overflow mitigation - see https://github.com/neuecc/MessagePack-CSharp/security/advisories/GHSA-7q36-4xx7-xcxf
-            options.Security.DepthStep(ref reader);
-
-            try
-            {
-                NuGetVersionFloatBehavior? floatBehavior = null;
-                NuGetVersion? minVersion = null;
-                string? releasePrefix = null;
-
-                int propertyCount = reader.ReadMapHeader();
-
-                for (var propertyIndex = 0; propertyIndex < propertyCount; ++propertyIndex)
+                switch (reader.ReadString())
                 {
-                    switch (reader.ReadString())
-                    {
-                        case FloatBehaviorPropertyName:
-                            floatBehavior = options.Resolver.GetFormatter<NuGetVersionFloatBehavior>().Deserialize(ref reader, options);
-                            break;
+                    case FloatBehaviorPropertyName:
+                        floatBehavior = options.Resolver.GetFormatter<NuGetVersionFloatBehavior>().Deserialize(ref reader, options);
+                        break;
 
-                        case MinVersionPropertyName:
-                            minVersion = NuGetVersionFormatter.Instance.Deserialize(ref reader, options);
-                            break;
+                    case MinVersionPropertyName:
+                        minVersion = NuGetVersionFormatter.Instance.Deserialize(ref reader, options);
+                        break;
 
-                        case ReleasePrefixPropertyName:
-                            releasePrefix = reader.ReadString();
-                            break;
+                    case ReleasePrefixPropertyName:
+                        releasePrefix = reader.ReadString();
+                        break;
 
-                        default:
-                            reader.Skip();
-                            break;
-                    }
+                    default:
+                        reader.Skip();
+                        break;
                 }
-
-                Assumes.True(floatBehavior.HasValue);
-
-                return new FloatRange(floatBehavior.Value, minVersion, releasePrefix);
             }
-            finally
-            {
-                // stack overflow mitigation - see https://github.com/neuecc/MessagePack-CSharp/security/advisories/GHSA-7q36-4xx7-xcxf
-                reader.Depth--;
-            }
+
+            Assumes.True(floatBehavior.HasValue);
+
+            return new FloatRange(floatBehavior.Value, minVersion, releasePrefix);
         }
 
-        public void Serialize(ref MessagePackWriter writer, FloatRange? value, MessagePackSerializerOptions options)
+        protected override void SerializeCore(ref MessagePackWriter writer, FloatRange value, MessagePackSerializerOptions options)
         {
-            if (value == null)
-            {
-                writer.WriteNil();
-                return;
-            }
-
             writer.WriteMapHeader(count: 3);
             writer.Write(MinVersionPropertyName);
             NuGetVersionFormatter.Instance.Serialize(ref writer, value.MinVersion, options);

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/IPackageReferenceContextInfoFormatter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/IPackageReferenceContextInfoFormatter.cs
@@ -12,7 +12,7 @@ using NuGet.Versioning;
 
 namespace NuGet.VisualStudio.Internal.Contracts
 {
-    internal class IPackageReferenceContextInfoFormatter : IMessagePackFormatter<IPackageReferenceContextInfo?>
+    internal sealed class IPackageReferenceContextInfoFormatter : NuGetMessagePackFormatter<IPackageReferenceContextInfo>
     {
         private const string IdentityPropertyName = "identity";
         private const string FrameworkPropertyName = "framework";
@@ -27,89 +27,67 @@ namespace NuGet.VisualStudio.Internal.Contracts
         {
         }
 
-        public IPackageReferenceContextInfo? Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
+        protected override IPackageReferenceContextInfo? DeserializeCore(ref MessagePackReader reader, MessagePackSerializerOptions options)
         {
-            if (reader.TryReadNil())
+            PackageIdentity? identity = null;
+            NuGetFramework? framework = null;
+            bool isUserInstalled = false;
+            bool isAutoReferenced = false;
+            bool isDevelopmentDependency = false;
+            string? allowedVersions = null;
+
+            int propertyCount = reader.ReadMapHeader();
+            for (int propertyIndex = 0; propertyIndex < propertyCount; propertyIndex++)
             {
-                return null;
-            }
-
-            // stack overflow mitigation - see https://github.com/neuecc/MessagePack-CSharp/security/advisories/GHSA-7q36-4xx7-xcxf
-            options.Security.DepthStep(ref reader);
-
-            try
-            {
-                PackageIdentity? identity = null;
-                NuGetFramework? framework = null;
-                bool isUserInstalled = false;
-                bool isAutoReferenced = false;
-                bool isDevelopmentDependency = false;
-                string? allowedVersions = null;
-
-                int propertyCount = reader.ReadMapHeader();
-                for (int propertyIndex = 0; propertyIndex < propertyCount; propertyIndex++)
+                switch (reader.ReadString())
                 {
-                    switch (reader.ReadString())
-                    {
-                        case IdentityPropertyName:
-                            identity = PackageIdentityFormatter.Instance.Deserialize(ref reader, options);
-                            break;
-                        case FrameworkPropertyName:
-                            framework = NuGetFrameworkFormatter.Instance.Deserialize(ref reader, options);
-                            break;
-                        case IsUserInstalledPropertyName:
-                            isUserInstalled = reader.ReadBoolean();
-                            break;
-                        case IsAutoReferencedPropertyName:
-                            isAutoReferenced = reader.ReadBoolean();
-                            break;
-                        case IsDevelopmentDependencyPropertyName:
-                            isDevelopmentDependency = reader.ReadBoolean();
-                            break;
-                        case AllowedVersionsPropertyName:
-                            if (!reader.TryReadNil()) // Advances beyond the current value if the current value is nil and returns true; otherwise leaves the reader's position unchanged and returns false.
-                            {
-                                allowedVersions = reader.ReadString();
-                            }
-                            break;
-                        default:
-                            reader.Skip();
-                            break;
-                    }
+                    case IdentityPropertyName:
+                        identity = PackageIdentityFormatter.Instance.Deserialize(ref reader, options);
+                        break;
+                    case FrameworkPropertyName:
+                        framework = NuGetFrameworkFormatter.Instance.Deserialize(ref reader, options);
+                        break;
+                    case IsUserInstalledPropertyName:
+                        isUserInstalled = reader.ReadBoolean();
+                        break;
+                    case IsAutoReferencedPropertyName:
+                        isAutoReferenced = reader.ReadBoolean();
+                        break;
+                    case IsDevelopmentDependencyPropertyName:
+                        isDevelopmentDependency = reader.ReadBoolean();
+                        break;
+                    case AllowedVersionsPropertyName:
+                        if (!reader.TryReadNil()) // Advances beyond the current value if the current value is nil and returns true; otherwise leaves the reader's position unchanged and returns false.
+                        {
+                            allowedVersions = reader.ReadString();
+                        }
+                        break;
+                    default:
+                        reader.Skip();
+                        break;
                 }
-
-                Assumes.NotNull(identity);
-                Assumes.NotNull(framework);
-
-                var packageReferenceContextInfo = new PackageReferenceContextInfo(identity, framework)
-                {
-                    IsUserInstalled = isUserInstalled,
-                    IsAutoReferenced = isAutoReferenced,
-                    IsDevelopmentDependency = isDevelopmentDependency
-                };
-
-                if (!string.IsNullOrWhiteSpace(allowedVersions) && VersionRange.TryParse(allowedVersions, out VersionRange versionRange))
-                {
-                    packageReferenceContextInfo.AllowedVersions = versionRange;
-                }
-
-                return packageReferenceContextInfo;
             }
-            finally
+
+            Assumes.NotNull(identity);
+            Assumes.NotNull(framework);
+
+            var packageReferenceContextInfo = new PackageReferenceContextInfo(identity, framework)
             {
-                // stack overflow mitigation - see https://github.com/neuecc/MessagePack-CSharp/security/advisories/GHSA-7q36-4xx7-xcxf
-                reader.Depth--;
+                IsUserInstalled = isUserInstalled,
+                IsAutoReferenced = isAutoReferenced,
+                IsDevelopmentDependency = isDevelopmentDependency
+            };
+
+            if (!string.IsNullOrWhiteSpace(allowedVersions) && VersionRange.TryParse(allowedVersions, out VersionRange versionRange))
+            {
+                packageReferenceContextInfo.AllowedVersions = versionRange;
             }
+
+            return packageReferenceContextInfo;
         }
 
-        public void Serialize(ref MessagePackWriter writer, IPackageReferenceContextInfo? value, MessagePackSerializerOptions options)
+        protected override void SerializeCore(ref MessagePackWriter writer, IPackageReferenceContextInfo value, MessagePackSerializerOptions options)
         {
-            if (value == null)
-            {
-                writer.WriteNil();
-                return;
-            }
-
             writer.WriteMapHeader(count: 6);
             writer.Write(IdentityPropertyName);
             PackageIdentityFormatter.Instance.Serialize(ref writer, value.Identity, options);

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/IProjectContextInfoFormatter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/IProjectContextInfoFormatter.cs
@@ -10,7 +10,7 @@ using NuGet.ProjectModel;
 
 namespace NuGet.VisualStudio.Internal.Contracts
 {
-    internal sealed class IProjectContextInfoFormatter : IMessagePackFormatter<IProjectContextInfo?>
+    internal sealed class IProjectContextInfoFormatter : NuGetMessagePackFormatter<IProjectContextInfo>
     {
         private const string ProjectIdPropertyName = "projectid";
         private const string ProjectKindPropertyName = "projectkind";
@@ -22,61 +22,39 @@ namespace NuGet.VisualStudio.Internal.Contracts
         {
         }
 
-        public IProjectContextInfo? Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
+        protected override IProjectContextInfo? DeserializeCore(ref MessagePackReader reader, MessagePackSerializerOptions options)
         {
-            if (reader.TryReadNil())
+            NuGetProjectKind projectKind = NuGetProjectKind.Unknown;
+            ProjectStyle projectStyle = ProjectStyle.Unknown;
+            string? projectId = null;
+
+            int propertyCount = reader.ReadMapHeader();
+            for (int propertyIndex = 0; propertyIndex < propertyCount; propertyIndex++)
             {
-                return null;
-            }
-
-            // stack overflow mitigation - see https://github.com/neuecc/MessagePack-CSharp/security/advisories/GHSA-7q36-4xx7-xcxf
-            options.Security.DepthStep(ref reader);
-
-            try
-            {
-                NuGetProjectKind projectKind = NuGetProjectKind.Unknown;
-                ProjectStyle projectStyle = ProjectStyle.Unknown;
-                string? projectId = null;
-
-                int propertyCount = reader.ReadMapHeader();
-                for (int propertyIndex = 0; propertyIndex < propertyCount; propertyIndex++)
+                switch (reader.ReadString())
                 {
-                    switch (reader.ReadString())
-                    {
-                        case ProjectIdPropertyName:
-                            projectId = reader.ReadString();
-                            break;
-                        case ProjectKindPropertyName:
-                            projectKind = options.Resolver.GetFormatter<NuGetProjectKind>().Deserialize(ref reader, options);
-                            break;
-                        case ProjectStylePropertyName:
-                            projectStyle = options.Resolver.GetFormatter<ProjectStyle>().Deserialize(ref reader, options);
-                            break;
-                        default:
-                            reader.Skip();
-                            break;
-                    }
+                    case ProjectIdPropertyName:
+                        projectId = reader.ReadString();
+                        break;
+                    case ProjectKindPropertyName:
+                        projectKind = options.Resolver.GetFormatter<NuGetProjectKind>().Deserialize(ref reader, options);
+                        break;
+                    case ProjectStylePropertyName:
+                        projectStyle = options.Resolver.GetFormatter<ProjectStyle>().Deserialize(ref reader, options);
+                        break;
+                    default:
+                        reader.Skip();
+                        break;
                 }
-
-                Assumes.NotNull(projectId);
-
-                return new ProjectContextInfo(projectId, projectStyle, projectKind);
             }
-            finally
-            {
-                // stack overflow mitigation - see https://github.com/neuecc/MessagePack-CSharp/security/advisories/GHSA-7q36-4xx7-xcxf
-                reader.Depth--;
-            }
+
+            Assumes.NotNull(projectId);
+
+            return new ProjectContextInfo(projectId, projectStyle, projectKind);
         }
 
-        public void Serialize(ref MessagePackWriter writer, IProjectContextInfo? value, MessagePackSerializerOptions options)
+        protected override void SerializeCore(ref MessagePackWriter writer, IProjectContextInfo value, MessagePackSerializerOptions options)
         {
-            if (value == null)
-            {
-                writer.WriteNil();
-                return;
-            }
-
             writer.WriteMapHeader(count: 3);
             writer.Write(ProjectIdPropertyName);
             writer.Write(value.ProjectId);

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/IProjectMetadataContextInfoFormatter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/IProjectMetadataContextInfoFormatter.cs
@@ -10,7 +10,7 @@ using NuGet.Frameworks;
 
 namespace NuGet.VisualStudio.Internal.Contracts
 {
-    internal sealed class IProjectMetadataContextInfoFormatter : IMessagePackFormatter<IProjectMetadataContextInfo?>
+    internal sealed class IProjectMetadataContextInfoFormatter : NuGetMessagePackFormatter<IProjectMetadataContextInfo>
     {
         private const string FullPathPropertyName = "fullpath";
         private const string NamePropertyName = "name";
@@ -25,91 +25,69 @@ namespace NuGet.VisualStudio.Internal.Contracts
         {
         }
 
-        public IProjectMetadataContextInfo? Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
+        protected override IProjectMetadataContextInfo? DeserializeCore(ref MessagePackReader reader, MessagePackSerializerOptions options)
         {
-            if (reader.TryReadNil())
+            string? fullPath = null;
+            string? name = null;
+            string? projectId = null;
+            NuGetFramework[]? supportedFrameworks = null;
+            NuGetFramework? targetFramework = null;
+            string? uniqueName = null;
+
+            int propertyCount = reader.ReadMapHeader();
+
+            for (var propertyIndex = 0; propertyIndex < propertyCount; ++propertyIndex)
             {
-                return null;
-            }
-
-            // stack overflow mitigation - see https://github.com/neuecc/MessagePack-CSharp/security/advisories/GHSA-7q36-4xx7-xcxf
-            options.Security.DepthStep(ref reader);
-
-            try
-            {
-                string? fullPath = null;
-                string? name = null;
-                string? projectId = null;
-                NuGetFramework[]? supportedFrameworks = null;
-                NuGetFramework? targetFramework = null;
-                string? uniqueName = null;
-
-                int propertyCount = reader.ReadMapHeader();
-
-                for (var propertyIndex = 0; propertyIndex < propertyCount; ++propertyIndex)
+                switch (reader.ReadString())
                 {
-                    switch (reader.ReadString())
-                    {
-                        case FullPathPropertyName:
-                            fullPath = reader.ReadString();
-                            break;
+                    case FullPathPropertyName:
+                        fullPath = reader.ReadString();
+                        break;
 
-                        case NamePropertyName:
-                            name = reader.ReadString();
-                            break;
+                    case NamePropertyName:
+                        name = reader.ReadString();
+                        break;
 
-                        case ProjectIdPropertyName:
-                            projectId = reader.ReadString();
-                            break;
+                    case ProjectIdPropertyName:
+                        projectId = reader.ReadString();
+                        break;
 
-                        case SupportedFrameworksPropertyName:
-                            if (!reader.TryReadNil())
+                    case SupportedFrameworksPropertyName:
+                        if (!reader.TryReadNil())
+                        {
+                            int elementCount = reader.ReadArrayHeader();
+                            supportedFrameworks = new NuGetFramework[elementCount];
+
+                            for (var i = 0; i < elementCount; ++i)
                             {
-                                int elementCount = reader.ReadArrayHeader();
-                                supportedFrameworks = new NuGetFramework[elementCount];
+                                NuGetFramework? framework = NuGetFrameworkFormatter.Instance.Deserialize(ref reader, options);
 
-                                for (var i = 0; i < elementCount; ++i)
-                                {
-                                    NuGetFramework? framework = NuGetFrameworkFormatter.Instance.Deserialize(ref reader, options);
+                                Assumes.NotNull(framework);
 
-                                    Assumes.NotNull(framework);
-
-                                    supportedFrameworks[i] = framework;
-                                }
+                                supportedFrameworks[i] = framework;
                             }
-                            break;
+                        }
+                        break;
 
-                        case TargetFrameworkPropertyName:
-                            targetFramework = NuGetFrameworkFormatter.Instance.Deserialize(ref reader, options);
-                            break;
+                    case TargetFrameworkPropertyName:
+                        targetFramework = NuGetFrameworkFormatter.Instance.Deserialize(ref reader, options);
+                        break;
 
-                        case UniqueNamePropertyName:
-                            uniqueName = reader.ReadString();
-                            break;
+                    case UniqueNamePropertyName:
+                        uniqueName = reader.ReadString();
+                        break;
 
-                        default:
-                            reader.Skip();
-                            break;
-                    }
+                    default:
+                        reader.Skip();
+                        break;
                 }
+            }
 
-                return new ProjectMetadataContextInfo(fullPath, name, projectId, supportedFrameworks, targetFramework, uniqueName);
-            }
-            finally
-            {
-                // stack overflow mitigation - see https://github.com/neuecc/MessagePack-CSharp/security/advisories/GHSA-7q36-4xx7-xcxf
-                reader.Depth--;
-            }
+            return new ProjectMetadataContextInfo(fullPath, name, projectId, supportedFrameworks, targetFramework, uniqueName);
         }
 
-        public void Serialize(ref MessagePackWriter writer, IProjectMetadataContextInfo? value, MessagePackSerializerOptions options)
+        protected override void SerializeCore(ref MessagePackWriter writer, IProjectMetadataContextInfo value, MessagePackSerializerOptions options)
         {
-            if (value == null)
-            {
-                writer.WriteNil();
-                return;
-            }
-
             writer.WriteMapHeader(count: 6);
             writer.Write(FullPathPropertyName);
             writer.Write(value.FullPath);

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/ImplicitProjectActionFormatter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/ImplicitProjectActionFormatter.cs
@@ -11,7 +11,7 @@ using NuGet.Packaging.Core;
 
 namespace NuGet.VisualStudio.Internal.Contracts
 {
-    internal sealed class ImplicitProjectActionFormatter : IMessagePackFormatter<ImplicitProjectAction?>
+    internal sealed class ImplicitProjectActionFormatter : NuGetMessagePackFormatter<ImplicitProjectAction>
     {
         private const string IdPropertyName = "id";
         private const string PackageIdentityPropertyName = "packageidentity";
@@ -23,67 +23,45 @@ namespace NuGet.VisualStudio.Internal.Contracts
         {
         }
 
-        public ImplicitProjectAction? Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
+        protected override ImplicitProjectAction? DeserializeCore(ref MessagePackReader reader, MessagePackSerializerOptions options)
         {
-            if (reader.TryReadNil())
+            string? id = null;
+            PackageIdentity? packageIdentity = null;
+            NuGetProjectActionType? projectActionType = null;
+
+            int propertyCount = reader.ReadMapHeader();
+
+            for (var propertyIndex = 0; propertyIndex < propertyCount; ++propertyIndex)
             {
-                return null;
-            }
-
-            // stack overflow mitigation - see https://github.com/neuecc/MessagePack-CSharp/security/advisories/GHSA-7q36-4xx7-xcxf
-            options.Security.DepthStep(ref reader);
-
-            try
-            {
-                string? id = null;
-                PackageIdentity? packageIdentity = null;
-                NuGetProjectActionType? projectActionType = null;
-
-                int propertyCount = reader.ReadMapHeader();
-
-                for (var propertyIndex = 0; propertyIndex < propertyCount; ++propertyIndex)
+                switch (reader.ReadString())
                 {
-                    switch (reader.ReadString())
-                    {
-                        case IdPropertyName:
-                            id = reader.ReadString();
-                            break;
+                    case IdPropertyName:
+                        id = reader.ReadString();
+                        break;
 
-                        case PackageIdentityPropertyName:
-                            packageIdentity = PackageIdentityFormatter.Instance.Deserialize(ref reader, options);
-                            break;
+                    case PackageIdentityPropertyName:
+                        packageIdentity = PackageIdentityFormatter.Instance.Deserialize(ref reader, options);
+                        break;
 
-                        case ProjectActionTypePropertyName:
-                            projectActionType = options.Resolver.GetFormatter<NuGetProjectActionType>().Deserialize(ref reader, options);
-                            break;
+                    case ProjectActionTypePropertyName:
+                        projectActionType = options.Resolver.GetFormatter<NuGetProjectActionType>().Deserialize(ref reader, options);
+                        break;
 
-                        default:
-                            reader.Skip();
-                            break;
-                    }
+                    default:
+                        reader.Skip();
+                        break;
                 }
-
-                Assumes.NotNullOrEmpty(id);
-                Assumes.NotNull(packageIdentity);
-                Assumes.True(projectActionType.HasValue);
-
-                return new ImplicitProjectAction(id, packageIdentity, projectActionType!.Value);
             }
-            finally
-            {
-                // stack overflow mitigation - see https://github.com/neuecc/MessagePack-CSharp/security/advisories/GHSA-7q36-4xx7-xcxf
-                reader.Depth--;
-            }
+
+            Assumes.NotNullOrEmpty(id);
+            Assumes.NotNull(packageIdentity);
+            Assumes.True(projectActionType.HasValue);
+
+            return new ImplicitProjectAction(id, packageIdentity, projectActionType!.Value);
         }
 
-        public void Serialize(ref MessagePackWriter writer, ImplicitProjectAction? value, MessagePackSerializerOptions options)
+        protected override void SerializeCore(ref MessagePackWriter writer, ImplicitProjectAction value, MessagePackSerializerOptions options)
         {
-            if (value == null)
-            {
-                writer.WriteNil();
-                return;
-            }
-
             writer.WriteMapHeader(count: 3);
             writer.Write(IdPropertyName);
             writer.Write(value.Id);

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/NuGetFrameworkFormatter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/NuGetFrameworkFormatter.cs
@@ -9,7 +9,7 @@ using NuGet.Frameworks;
 
 namespace NuGet.VisualStudio.Internal.Contracts
 {
-    internal class NuGetFrameworkFormatter : IMessagePackFormatter<NuGetFramework?>
+    internal sealed class NuGetFrameworkFormatter : NuGetMessagePackFormatter<NuGetFramework>
     {
         private const string DotNetFrameworkNamePropertyName = "dotnetframeworkname";
         private const string DotNetPlatformNamePropertyName = "dotnetplatformname";
@@ -20,58 +20,36 @@ namespace NuGet.VisualStudio.Internal.Contracts
         {
         }
 
-        public NuGetFramework? Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
+        protected override NuGetFramework? DeserializeCore(ref MessagePackReader reader, MessagePackSerializerOptions options)
         {
-            if (reader.TryReadNil())
+            string? frameworkName = null;
+            string? platformName = null;
+
+            int propertyCount = reader.ReadMapHeader();
+
+            for (int propertyIndex = 0; propertyIndex < propertyCount; propertyIndex++)
             {
-                return null;
-            }
-
-            // stack overflow mitigation - see https://github.com/neuecc/MessagePack-CSharp/security/advisories/GHSA-7q36-4xx7-xcxf
-            options.Security.DepthStep(ref reader);
-
-            try
-            {
-                string? frameworkName = null;
-                string? platformName = null;
-
-                int propertyCount = reader.ReadMapHeader();
-
-                for (int propertyIndex = 0; propertyIndex < propertyCount; propertyIndex++)
+                switch (reader.ReadString())
                 {
-                    switch (reader.ReadString())
-                    {
-                        case DotNetFrameworkNamePropertyName:
-                            frameworkName = reader.ReadString();
-                            break;
+                    case DotNetFrameworkNamePropertyName:
+                        frameworkName = reader.ReadString();
+                        break;
 
-                        case DotNetPlatformNamePropertyName:
-                            platformName = reader.ReadString();
-                            break;
+                    case DotNetPlatformNamePropertyName:
+                        platformName = reader.ReadString();
+                        break;
 
-                        default:
-                            reader.Skip();
-                            break;
-                    }
+                    default:
+                        reader.Skip();
+                        break;
                 }
+            }
 
-                return NuGetFramework.ParseComponents(frameworkName, platformName);
-            }
-            finally
-            {
-                // stack overflow mitigation - see https://github.com/neuecc/MessagePack-CSharp/security/advisories/GHSA-7q36-4xx7-xcxf
-                reader.Depth--;
-            }
+            return NuGetFramework.ParseComponents(frameworkName, platformName);
         }
 
-        public void Serialize(ref MessagePackWriter writer, NuGetFramework? value, MessagePackSerializerOptions options)
+        protected override void SerializeCore(ref MessagePackWriter writer, NuGetFramework value, MessagePackSerializerOptions options)
         {
-            if (value == null)
-            {
-                writer.WriteNil();
-                return;
-            }
-
             writer.WriteMapHeader(count: 2);
             writer.Write(DotNetFrameworkNamePropertyName);
             writer.Write(value.DotNetFrameworkName);

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/NuGetMessagePackFormatter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/NuGetMessagePackFormatter.cs
@@ -1,0 +1,50 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#nullable enable
+
+using MessagePack;
+using MessagePack.Formatters;
+
+namespace NuGet.VisualStudio.Internal.Contracts
+{
+    internal abstract class NuGetMessagePackFormatter<T> : IMessagePackFormatter<T?>
+        where T : class
+    {
+        public T? Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
+        {
+            if (reader.TryReadNil())
+            {
+                return null;
+            }
+
+            // stack overflow mitigation - see https://github.com/neuecc/MessagePack-CSharp/security/advisories/GHSA-7q36-4xx7-xcxf
+            options.Security.DepthStep(ref reader);
+
+            try
+            {
+                return DeserializeCore(ref reader, options);
+            }
+            finally
+            {
+                // stack overflow mitigation - see https://github.com/neuecc/MessagePack-CSharp/security/advisories/GHSA-7q36-4xx7-xcxf
+                reader.Depth--;
+            }
+        }
+
+        public void Serialize(ref MessagePackWriter writer, T? value, MessagePackSerializerOptions options)
+        {
+            if (value is null)
+            {
+                writer.WriteNil();
+                return;
+            }
+
+            SerializeCore(ref writer, value, options);
+        }
+
+        protected abstract T? DeserializeCore(ref MessagePackReader reader, MessagePackSerializerOptions options);
+
+        protected abstract void SerializeCore(ref MessagePackWriter writer, T value, MessagePackSerializerOptions options);
+    }
+}

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/NuGetVersionFormatter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/NuGetVersionFormatter.cs
@@ -9,7 +9,7 @@ using NuGet.Versioning;
 
 namespace NuGet.VisualStudio.Internal.Contracts
 {
-    internal class NuGetVersionFormatter : IMessagePackFormatter<NuGetVersion?>
+    internal sealed class NuGetVersionFormatter : NuGetMessagePackFormatter<NuGetVersion>
     {
         private const string OriginalStringOrToStringPropertyName = "originalstringortostring";
 
@@ -19,52 +19,30 @@ namespace NuGet.VisualStudio.Internal.Contracts
         {
         }
 
-        public NuGetVersion? Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
+        protected override NuGetVersion? DeserializeCore(ref MessagePackReader reader, MessagePackSerializerOptions options)
         {
-            if (reader.TryReadNil())
+            int propertyCount = reader.ReadMapHeader();
+
+            string? version = null;
+
+            for (int propertyIndex = 0; propertyIndex < propertyCount; propertyIndex++)
             {
-                return null;
-            }
-
-            // stack overflow mitigation - see https://github.com/neuecc/MessagePack-CSharp/security/advisories/GHSA-7q36-4xx7-xcxf
-            options.Security.DepthStep(ref reader);
-
-            try
-            {
-                int propertyCount = reader.ReadMapHeader();
-
-                string? version = null;
-
-                for (int propertyIndex = 0; propertyIndex < propertyCount; propertyIndex++)
+                switch (reader.ReadString())
                 {
-                    switch (reader.ReadString())
-                    {
-                        case OriginalStringOrToStringPropertyName:
-                            version = reader.ReadString();
-                            break;
-                        default:
-                            reader.Skip();
-                            break;
-                    }
+                    case OriginalStringOrToStringPropertyName:
+                        version = reader.ReadString();
+                        break;
+                    default:
+                        reader.Skip();
+                        break;
                 }
+            }
 
-                return NuGetVersion.Parse(version);
-            }
-            finally
-            {
-                // stack overflow mitigation - see https://github.com/neuecc/MessagePack-CSharp/security/advisories/GHSA-7q36-4xx7-xcxf
-                reader.Depth--;
-            }
+            return NuGetVersion.Parse(version);
         }
 
-        public void Serialize(ref MessagePackWriter writer, NuGetVersion? value, MessagePackSerializerOptions options)
+        protected override void SerializeCore(ref MessagePackWriter writer, NuGetVersion value, MessagePackSerializerOptions options)
         {
-            if (value == null)
-            {
-                writer.WriteNil();
-                return;
-            }
-
             writer.WriteMapHeader(count: 1);
             writer.Write(OriginalStringOrToStringPropertyName);
             writer.Write(value.OriginalVersion ?? value.ToString());

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/PackageDependencyFormatter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/PackageDependencyFormatter.cs
@@ -12,7 +12,7 @@ using NuGet.Versioning;
 
 namespace NuGet.VisualStudio.Internal.Contracts
 {
-    internal sealed class PackageDependencyFormatter : IMessagePackFormatter<PackageDependency?>
+    internal sealed class PackageDependencyFormatter : NuGetMessagePackFormatter<PackageDependency>
     {
         private const string ExcludePropertyName = "exclude";
         private const string IdPropertyName = "id";
@@ -25,70 +25,48 @@ namespace NuGet.VisualStudio.Internal.Contracts
         {
         }
 
-        public PackageDependency? Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
+        protected override PackageDependency? DeserializeCore(ref MessagePackReader reader, MessagePackSerializerOptions options)
         {
-            if (reader.TryReadNil())
+            string? id = null;
+            VersionRange? versionRange = null;
+            IReadOnlyList<string>? include = null;
+            IReadOnlyList<string>? exclude = null;
+
+            int propertyCount = reader.ReadMapHeader();
+
+            for (var propertyIndex = 0; propertyIndex < propertyCount; ++propertyIndex)
             {
-                return null;
-            }
-
-            // stack overflow mitigation - see https://github.com/neuecc/MessagePack-CSharp/security/advisories/GHSA-7q36-4xx7-xcxf
-            options.Security.DepthStep(ref reader);
-
-            try
-            {
-                string? id = null;
-                VersionRange? versionRange = null;
-                IReadOnlyList<string>? include = null;
-                IReadOnlyList<string>? exclude = null;
-
-                int propertyCount = reader.ReadMapHeader();
-
-                for (var propertyIndex = 0; propertyIndex < propertyCount; ++propertyIndex)
+                switch (reader.ReadString())
                 {
-                    switch (reader.ReadString())
-                    {
-                        case ExcludePropertyName:
-                            exclude = options.Resolver.GetFormatter<IReadOnlyList<string>>().Deserialize(ref reader, options);
-                            break;
+                    case ExcludePropertyName:
+                        exclude = options.Resolver.GetFormatter<IReadOnlyList<string>>().Deserialize(ref reader, options);
+                        break;
 
-                        case IdPropertyName:
-                            id = reader.ReadString();
-                            break;
+                    case IdPropertyName:
+                        id = reader.ReadString();
+                        break;
 
-                        case IncludePropertyName:
-                            include = options.Resolver.GetFormatter<IReadOnlyList<string>>().Deserialize(ref reader, options);
-                            break;
+                    case IncludePropertyName:
+                        include = options.Resolver.GetFormatter<IReadOnlyList<string>>().Deserialize(ref reader, options);
+                        break;
 
-                        case VersionRangePropertyName:
-                            versionRange = VersionRangeFormatter.Instance.Deserialize(ref reader, options);
-                            break;
+                    case VersionRangePropertyName:
+                        versionRange = VersionRangeFormatter.Instance.Deserialize(ref reader, options);
+                        break;
 
-                        default:
-                            reader.Skip();
-                            break;
-                    }
+                    default:
+                        reader.Skip();
+                        break;
                 }
-
-                Assumes.NotNullOrEmpty(id);
-
-                return new PackageDependency(id, versionRange, include, exclude);
             }
-            finally
-            {
-                // stack overflow mitigation - see https://github.com/neuecc/MessagePack-CSharp/security/advisories/GHSA-7q36-4xx7-xcxf
-                reader.Depth--;
-            }
+
+            Assumes.NotNullOrEmpty(id);
+
+            return new PackageDependency(id, versionRange, include, exclude);
         }
 
-        public void Serialize(ref MessagePackWriter writer, PackageDependency? value, MessagePackSerializerOptions options)
+        protected override void SerializeCore(ref MessagePackWriter writer, PackageDependency value, MessagePackSerializerOptions options)
         {
-            if (value == null)
-            {
-                writer.WriteNil();
-                return;
-            }
-
             writer.WriteMapHeader(count: 4);
             writer.Write(IdPropertyName);
             writer.Write(value.Id);

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/PackageDependencyGroupFormatter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/PackageDependencyGroupFormatter.cs
@@ -13,7 +13,7 @@ using NuGet.Packaging.Core;
 
 namespace NuGet.VisualStudio.Internal.Contracts
 {
-    internal sealed class PackageDependencyGroupFormatter : IMessagePackFormatter<PackageDependencyGroup?>
+    internal sealed class PackageDependencyGroupFormatter : NuGetMessagePackFormatter<PackageDependencyGroup>
     {
         private const string TargetFrameworkPropertyName = "targetframework";
         private const string PackagesPropertyName = "packages";
@@ -24,59 +24,37 @@ namespace NuGet.VisualStudio.Internal.Contracts
         {
         }
 
-        public PackageDependencyGroup? Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
+        protected override PackageDependencyGroup? DeserializeCore(ref MessagePackReader reader, MessagePackSerializerOptions options)
         {
-            if (reader.TryReadNil())
+            NuGetFramework? framework = null;
+            IEnumerable<PackageDependency>? packageDependencies = null;
+
+            int propertyCount = reader.ReadMapHeader();
+
+            for (var propertyIndex = 0; propertyIndex < propertyCount; ++propertyIndex)
             {
-                return null;
-            }
-
-            // stack overflow mitigation - see https://github.com/neuecc/MessagePack-CSharp/security/advisories/GHSA-7q36-4xx7-xcxf
-            options.Security.DepthStep(ref reader);
-
-            try
-            {
-                NuGetFramework? framework = null;
-                IEnumerable<PackageDependency>? packageDependencies = null;
-
-                int propertyCount = reader.ReadMapHeader();
-
-                for (var propertyIndex = 0; propertyIndex < propertyCount; ++propertyIndex)
+                switch (reader.ReadString())
                 {
-                    switch (reader.ReadString())
-                    {
-                        case TargetFrameworkPropertyName:
-                            framework = NuGetFrameworkFormatter.Instance.Deserialize(ref reader, options);
-                            break;
-                        case PackagesPropertyName:
-                            packageDependencies = options.Resolver.GetFormatter<IEnumerable<PackageDependency>>().Deserialize(ref reader, options);
-                            break;
-                        default:
-                            reader.Skip();
-                            break;
-                    }
+                    case TargetFrameworkPropertyName:
+                        framework = NuGetFrameworkFormatter.Instance.Deserialize(ref reader, options);
+                        break;
+                    case PackagesPropertyName:
+                        packageDependencies = options.Resolver.GetFormatter<IEnumerable<PackageDependency>>().Deserialize(ref reader, options);
+                        break;
+                    default:
+                        reader.Skip();
+                        break;
                 }
-
-                Assumes.NotNull(framework);
-                Assumes.NotNull(packageDependencies);
-
-                return new PackageDependencyGroup(framework, packageDependencies);
             }
-            finally
-            {
-                // stack overflow mitigation - see https://github.com/neuecc/MessagePack-CSharp/security/advisories/GHSA-7q36-4xx7-xcxf
-                reader.Depth--;
-            }
+
+            Assumes.NotNull(framework);
+            Assumes.NotNull(packageDependencies);
+
+            return new PackageDependencyGroup(framework, packageDependencies);
         }
 
-        public void Serialize(ref MessagePackWriter writer, PackageDependencyGroup? value, MessagePackSerializerOptions options)
+        protected override void SerializeCore(ref MessagePackWriter writer, PackageDependencyGroup value, MessagePackSerializerOptions options)
         {
-            if (value == null)
-            {
-                writer.WriteNil();
-                return;
-            }
-
             writer.WriteMapHeader(count: 2);
             writer.Write(TargetFrameworkPropertyName);
             NuGetFrameworkFormatter.Instance.Serialize(ref writer, value.TargetFramework, options);

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/PackageDependencyInfoFormatter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/PackageDependencyInfoFormatter.cs
@@ -12,7 +12,7 @@ using NuGet.Packaging.Core;
 
 namespace NuGet.VisualStudio.Internal.Contracts
 {
-    internal sealed class PackageDependencyInfoFormatter : IMessagePackFormatter<PackageDependencyInfo?>
+    internal sealed class PackageDependencyInfoFormatter : NuGetMessagePackFormatter<PackageDependencyInfo>
     {
         private const string PackageDependenciesPropertyName = "packagedependencies";
         private const string PackageIdentityPropertyName = "packageidentity";
@@ -23,71 +23,49 @@ namespace NuGet.VisualStudio.Internal.Contracts
         {
         }
 
-        public PackageDependencyInfo? Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
+        protected override PackageDependencyInfo? DeserializeCore(ref MessagePackReader reader, MessagePackSerializerOptions options)
         {
-            if (reader.TryReadNil())
+            PackageIdentity? packageIdentity = null;
+            List<PackageDependency>? packageDependencies = null;
+
+            int propertyCount = reader.ReadMapHeader();
+
+            for (var propertyIndex = 0; propertyIndex < propertyCount; ++propertyIndex)
             {
-                return null;
-            }
-
-            // stack overflow mitigation - see https://github.com/neuecc/MessagePack-CSharp/security/advisories/GHSA-7q36-4xx7-xcxf
-            options.Security.DepthStep(ref reader);
-
-            try
-            {
-                PackageIdentity? packageIdentity = null;
-                List<PackageDependency>? packageDependencies = null;
-
-                int propertyCount = reader.ReadMapHeader();
-
-                for (var propertyIndex = 0; propertyIndex < propertyCount; ++propertyIndex)
+                switch (reader.ReadString())
                 {
-                    switch (reader.ReadString())
-                    {
-                        case PackageIdentityPropertyName:
-                            packageIdentity = PackageIdentityFormatter.Instance.Deserialize(ref reader, options);
-                            break;
+                    case PackageIdentityPropertyName:
+                        packageIdentity = PackageIdentityFormatter.Instance.Deserialize(ref reader, options);
+                        break;
 
-                        case PackageDependenciesPropertyName:
-                            packageDependencies = new List<PackageDependency>();
+                    case PackageDependenciesPropertyName:
+                        packageDependencies = new List<PackageDependency>();
 
-                            int dependenciesCount = reader.ReadArrayHeader();
+                        int dependenciesCount = reader.ReadArrayHeader();
 
-                            for (var i = 0; i < dependenciesCount; ++i)
-                            {
-                                PackageDependency? packageDependency = PackageDependencyFormatter.Instance.Deserialize(ref reader, options);
+                        for (var i = 0; i < dependenciesCount; ++i)
+                        {
+                            PackageDependency? packageDependency = PackageDependencyFormatter.Instance.Deserialize(ref reader, options);
 
-                                Assumes.NotNull(packageDependency);
+                            Assumes.NotNull(packageDependency);
 
-                                packageDependencies.Add(packageDependency);
-                            }
-                            break;
+                            packageDependencies.Add(packageDependency);
+                        }
+                        break;
 
-                        default:
-                            reader.Skip();
-                            break;
-                    }
+                    default:
+                        reader.Skip();
+                        break;
                 }
-
-                Assumes.NotNull(packageIdentity);
-
-                return new PackageDependencyInfo(packageIdentity, packageDependencies);
             }
-            finally
-            {
-                // stack overflow mitigation - see https://github.com/neuecc/MessagePack-CSharp/security/advisories/GHSA-7q36-4xx7-xcxf
-                reader.Depth--;
-            }
+
+            Assumes.NotNull(packageIdentity);
+
+            return new PackageDependencyInfo(packageIdentity, packageDependencies);
         }
 
-        public void Serialize(ref MessagePackWriter writer, PackageDependencyInfo? value, MessagePackSerializerOptions options)
+        protected override void SerializeCore(ref MessagePackWriter writer, PackageDependencyInfo value, MessagePackSerializerOptions options)
         {
-            if (value == null)
-            {
-                writer.WriteNil();
-                return;
-            }
-
             writer.WriteMapHeader(count: 2);
             writer.Write(PackageIdentityPropertyName);
             PackageIdentityFormatter.Instance.Serialize(ref writer, value, options);

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/PackageIdentityFormatter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/PackageIdentityFormatter.cs
@@ -10,7 +10,7 @@ using NuGet.Versioning;
 
 namespace NuGet.VisualStudio.Internal.Contracts
 {
-    internal class PackageIdentityFormatter : IMessagePackFormatter<PackageIdentity?>
+    internal sealed class PackageIdentityFormatter : NuGetMessagePackFormatter<PackageIdentity>
     {
         private const string NuGetVersionPropertyName = "version";
         private const string IdPropertyName = "id";
@@ -21,55 +21,33 @@ namespace NuGet.VisualStudio.Internal.Contracts
         {
         }
 
-        public PackageIdentity? Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
+        protected override PackageIdentity? DeserializeCore(ref MessagePackReader reader, MessagePackSerializerOptions options)
         {
-            if (reader.TryReadNil())
+            string? id = null;
+            NuGetVersion? version = null;
+
+            int propertyCount = reader.ReadMapHeader();
+            for (int propertyIndex = 0; propertyIndex < propertyCount; propertyIndex++)
             {
-                return null;
-            }
-
-            // stack overflow mitigation - see https://github.com/neuecc/MessagePack-CSharp/security/advisories/GHSA-7q36-4xx7-xcxf
-            options.Security.DepthStep(ref reader);
-
-            try
-            {
-                string? id = null;
-                NuGetVersion? version = null;
-
-                int propertyCount = reader.ReadMapHeader();
-                for (int propertyIndex = 0; propertyIndex < propertyCount; propertyIndex++)
+                switch (reader.ReadString())
                 {
-                    switch (reader.ReadString())
-                    {
-                        case IdPropertyName:
-                            id = reader.ReadString();
-                            break;
-                        case NuGetVersionPropertyName:
-                            version = NuGetVersionFormatter.Instance.Deserialize(ref reader, options);
-                            break;
-                        default:
-                            reader.Skip();
-                            break;
-                    }
+                    case IdPropertyName:
+                        id = reader.ReadString();
+                        break;
+                    case NuGetVersionPropertyName:
+                        version = NuGetVersionFormatter.Instance.Deserialize(ref reader, options);
+                        break;
+                    default:
+                        reader.Skip();
+                        break;
                 }
+            }
 
-                return new PackageIdentity(id, version);
-            }
-            finally
-            {
-                // stack overflow mitigation - see https://github.com/neuecc/MessagePack-CSharp/security/advisories/GHSA-7q36-4xx7-xcxf
-                reader.Depth--;
-            }
+            return new PackageIdentity(id, version);
         }
 
-        public void Serialize(ref MessagePackWriter writer, PackageIdentity? value, MessagePackSerializerOptions options)
+        protected override void SerializeCore(ref MessagePackWriter writer, PackageIdentity value, MessagePackSerializerOptions options)
         {
-            if (value == null)
-            {
-                writer.WriteNil();
-                return;
-            }
-
             writer.WriteMapHeader(count: 2);
             writer.Write(IdPropertyName);
             writer.Write(value.Id);

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/PackageReferenceFormatter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/PackageReferenceFormatter.cs
@@ -13,7 +13,7 @@ using NuGet.Versioning;
 
 namespace NuGet.VisualStudio.Internal.Contracts
 {
-    internal class PackageReferenceFormatter : IMessagePackFormatter<PackageReference?>
+    internal sealed class PackageReferenceFormatter : NuGetMessagePackFormatter<PackageReference>
     {
         private const string AllowedVersionsPropertyName = "allowedversions";
         private const string IsDevelopmentDependencyPropertyName = "isdevelopmentdependency";
@@ -28,87 +28,65 @@ namespace NuGet.VisualStudio.Internal.Contracts
         {
         }
 
-        public PackageReference? Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
+        protected override PackageReference? DeserializeCore(ref MessagePackReader reader, MessagePackSerializerOptions options)
         {
-            if (reader.TryReadNil())
+            VersionRange? allowedVersions = null;
+            bool isDevelopmentDependency = false;
+            bool isUserInstalled = true;
+            bool requireReinstallation = false;
+            PackageIdentity? identity = null;
+            NuGetFramework? framework = null;
+
+            int propertyCount = reader.ReadMapHeader();
+
+            for (int propertyIndex = 0; propertyIndex < propertyCount; propertyIndex++)
             {
-                return null;
-            }
-
-            // stack overflow mitigation - see https://github.com/neuecc/MessagePack-CSharp/security/advisories/GHSA-7q36-4xx7-xcxf
-            options.Security.DepthStep(ref reader);
-
-            try
-            {
-                VersionRange? allowedVersions = null;
-                bool isDevelopmentDependency = false;
-                bool isUserInstalled = true;
-                bool requireReinstallation = false;
-                PackageIdentity? identity = null;
-                NuGetFramework? framework = null;
-
-                int propertyCount = reader.ReadMapHeader();
-
-                for (int propertyIndex = 0; propertyIndex < propertyCount; propertyIndex++)
+                switch (reader.ReadString())
                 {
-                    switch (reader.ReadString())
-                    {
-                        case AllowedVersionsPropertyName:
-                            allowedVersions = VersionRangeFormatter.Instance.Deserialize(ref reader, options);
-                            break;
+                    case AllowedVersionsPropertyName:
+                        allowedVersions = VersionRangeFormatter.Instance.Deserialize(ref reader, options);
+                        break;
 
-                        case IsDevelopmentDependencyPropertyName:
-                            isDevelopmentDependency = reader.ReadBoolean();
-                            break;
+                    case IsDevelopmentDependencyPropertyName:
+                        isDevelopmentDependency = reader.ReadBoolean();
+                        break;
 
-                        case IsUserInstalledPropertyName:
-                            isUserInstalled = reader.ReadBoolean();
-                            break;
+                    case IsUserInstalledPropertyName:
+                        isUserInstalled = reader.ReadBoolean();
+                        break;
 
-                        case PackageIdentityPropertyName:
-                            identity = PackageIdentityFormatter.Instance.Deserialize(ref reader, options);
-                            break;
+                    case PackageIdentityPropertyName:
+                        identity = PackageIdentityFormatter.Instance.Deserialize(ref reader, options);
+                        break;
 
-                        case RequireReinstallationPropertyName:
-                            requireReinstallation = reader.ReadBoolean();
-                            break;
+                    case RequireReinstallationPropertyName:
+                        requireReinstallation = reader.ReadBoolean();
+                        break;
 
-                        case TargetFrameworkPropertyName:
-                            framework = NuGetFrameworkFormatter.Instance.Deserialize(ref reader, options);
-                            break;
+                    case TargetFrameworkPropertyName:
+                        framework = NuGetFrameworkFormatter.Instance.Deserialize(ref reader, options);
+                        break;
 
-                        default:
-                            reader.Skip();
-                            break;
-                    }
+                    default:
+                        reader.Skip();
+                        break;
                 }
-
-                Assumes.NotNull(identity);
-                Assumes.NotNull(framework);
-
-                return new PackageReference(
-                    identity,
-                    framework,
-                    isUserInstalled,
-                    isDevelopmentDependency,
-                    requireReinstallation,
-                    allowedVersions);
             }
-            finally
-            {
-                // stack overflow mitigation - see https://github.com/neuecc/MessagePack-CSharp/security/advisories/GHSA-7q36-4xx7-xcxf
-                reader.Depth--;
-            }
+
+            Assumes.NotNull(identity);
+            Assumes.NotNull(framework);
+
+            return new PackageReference(
+                identity,
+                framework,
+                isUserInstalled,
+                isDevelopmentDependency,
+                requireReinstallation,
+                allowedVersions);
         }
 
-        public void Serialize(ref MessagePackWriter writer, PackageReference? value, MessagePackSerializerOptions options)
+        protected override void SerializeCore(ref MessagePackWriter writer, PackageReference value, MessagePackSerializerOptions options)
         {
-            if (value == null)
-            {
-                writer.WriteNil();
-                return;
-            }
-
             writer.WriteMapHeader(count: 6);
             writer.Write(PackageIdentityPropertyName);
             PackageIdentityFormatter.Instance.Serialize(ref writer, value.PackageIdentity, options);

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/PackageSearchMetadataContextInfoFormatter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/PackageSearchMetadataContextInfoFormatter.cs
@@ -12,7 +12,7 @@ using NuGet.Packaging.Core;
 
 namespace NuGet.VisualStudio.Internal.Contracts
 {
-    internal class PackageSearchMetadataContextInfoFormatter : IMessagePackFormatter<PackageSearchMetadataContextInfo?>
+    internal sealed class PackageSearchMetadataContextInfoFormatter : NuGetMessagePackFormatter<PackageSearchMetadataContextInfo>
     {
         private const string IdentityPropertyName = "identity";
         private const string DescriptionPropertyName = "description";
@@ -42,187 +42,165 @@ namespace NuGet.VisualStudio.Internal.Contracts
         {
         }
 
-        public PackageSearchMetadataContextInfo? Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
+        protected override PackageSearchMetadataContextInfo? DeserializeCore(ref MessagePackReader reader, MessagePackSerializerOptions options)
         {
-            if (reader.TryReadNil())
+            PackageIdentity? identity = null;
+            string? title = null;
+            string? description = null;
+            string? authors = null;
+            Uri? iconUrl = null;
+            string? tags = null;
+            Uri? licenseUrl = null;
+            string? owners = null;
+            Uri? projectUrl = null;
+            DateTimeOffset? published = null;
+            Uri? reportAbuseUrl = null;
+            Uri? packageDetailsUrl = null;
+            bool requireLicenseAcceptance = false;
+            string? summary = null;
+            bool prefixReserved = false;
+            bool isRecommended = false;
+            (string modelVersion, string vsixVersion)? recommenderVersion = null;
+            bool isListed = false;
+            long? downloadCount = null;
+            IReadOnlyCollection<PackageDependencyGroup>? dependencySets = null;
+            IReadOnlyCollection<PackageVulnerabilityMetadataContextInfo>? vulnerabilities = null;
+
+            int propertyCount = reader.ReadMapHeader();
+            for (int propertyIndex = 0; propertyIndex < propertyCount; propertyIndex++)
             {
-                return null;
-            }
-
-            // stack overflow mitigation - see https://github.com/neuecc/MessagePack-CSharp/security/advisories/GHSA-7q36-4xx7-xcxf
-            options.Security.DepthStep(ref reader);
-
-            try
-            {
-                PackageIdentity? identity = null;
-                string? title = null;
-                string? description = null;
-                string? authors = null;
-                Uri? iconUrl = null;
-                string? tags = null;
-                Uri? licenseUrl = null;
-                string? owners = null;
-                Uri? projectUrl = null;
-                DateTimeOffset? published = null;
-                Uri? reportAbuseUrl = null;
-                Uri? packageDetailsUrl = null;
-                bool requireLicenseAcceptance = false;
-                string? summary = null;
-                bool prefixReserved = false;
-                bool isRecommended = false;
-                (string modelVersion, string vsixVersion)? recommenderVersion = null;
-                bool isListed = false;
-                long? downloadCount = null;
-                IReadOnlyCollection<PackageDependencyGroup>? dependencySets = null;
-                IReadOnlyCollection<PackageVulnerabilityMetadataContextInfo>? vulnerabilities = null;
-
-                int propertyCount = reader.ReadMapHeader();
-                for (int propertyIndex = 0; propertyIndex < propertyCount; propertyIndex++)
+                switch (reader.ReadString())
                 {
-                    switch (reader.ReadString())
-                    {
-                        case IdentityPropertyName:
-                            if (!reader.TryReadNil())
-                            {
-                                identity = PackageIdentityFormatter.Instance.Deserialize(ref reader, options);
-                            }
-                            break;
-                        case DescriptionPropertyName:
-                            description = reader.ReadString();
-                            break;
-                        case AuthorsPropertyName:
-                            authors = reader.ReadString();
-                            break;
-                        case IconUrlPropertyName:
-                            if (!reader.TryReadNil())
-                            {
-                                iconUrl = options.Resolver.GetFormatter<Uri>().Deserialize(ref reader, options);
-                            }
-                            break;
-                        case TitlePropertyName:
-                            title = reader.ReadString();
-                            break;
-                        case TagsPropertyName:
-                            tags = reader.ReadString();
-                            break;
-                        case LicenseUrlPropertyName:
-                            if (!reader.TryReadNil())
-                            {
-                                licenseUrl = options.Resolver.GetFormatter<Uri>().Deserialize(ref reader, options);
-                            }
-                            break;
-                        case ProjectUrlPropertyName:
-                            if (!reader.TryReadNil())
-                            {
-                                projectUrl = options.Resolver.GetFormatter<Uri>().Deserialize(ref reader, options);
-                            }
-                            break;
-                        case PublishedPropertyName:
-                            if (!reader.TryReadNil())
-                            {
-                                published = options.Resolver.GetFormatter<DateTimeOffset>().Deserialize(ref reader, options);
-                            }
-                            break;
-                        case OwnersPropertyName:
-                            owners = reader.ReadString();
-                            break;
-                        case ReportAbuseUrlPropertyName:
-                            if (!reader.TryReadNil())
-                            {
-                                reportAbuseUrl = options.Resolver.GetFormatter<Uri>().Deserialize(ref reader, options);
-                            }
-                            break;
-                        case PackageDetailsUrlPropertyName:
-                            if (!reader.TryReadNil())
-                            {
-                                packageDetailsUrl = options.Resolver.GetFormatter<Uri>().Deserialize(ref reader, options);
-                            }
-                            break;
-                        case RequireLicenseAcceptancePropertyName:
-                            requireLicenseAcceptance = reader.ReadBoolean();
-                            break;
-                        case SummaryPropertyName:
-                            summary = reader.ReadString();
-                            break;
-                        case PrefixReservedPropertyName:
-                            prefixReserved = reader.ReadBoolean();
-                            break;
-                        case IsRecommendedPropertyName:
-                            isRecommended = reader.ReadBoolean();
-                            break;
-                        case RecommenderVersionPropertyName:
-                            if (!reader.TryReadNil())
-                            {
-                                recommenderVersion = options.Resolver.GetFormatter<(string, string)>().Deserialize(ref reader, options);
-                            }
-                            break;
-                        case DownloadCountPropertyName:
-                            if (!reader.TryReadNil())
-                            {
-                                downloadCount = reader.ReadInt64();
-                            }
-                            break;
-                        case DependencySetsPropertyName:
-                            if (!reader.TryReadNil())
-                            {
-                                dependencySets = options.Resolver.GetFormatter<IReadOnlyCollection<PackageDependencyGroup>>().Deserialize(ref reader, options);
-                            }
-                            break;
-                        case VulnerabilitiesPropertyName:
-                            if (!reader.TryReadNil())
-                            {
-                                vulnerabilities = options.Resolver.GetFormatter<IReadOnlyCollection<PackageVulnerabilityMetadataContextInfo>>().Deserialize(ref reader, options);
-                            }
-                            break;
-                        case IsListedPropertyName:
-                            isListed = reader.ReadBoolean();
-                            break;
-                        default:
-                            reader.Skip();
-                            break;
-                    }
+                    case IdentityPropertyName:
+                        if (!reader.TryReadNil())
+                        {
+                            identity = PackageIdentityFormatter.Instance.Deserialize(ref reader, options);
+                        }
+                        break;
+                    case DescriptionPropertyName:
+                        description = reader.ReadString();
+                        break;
+                    case AuthorsPropertyName:
+                        authors = reader.ReadString();
+                        break;
+                    case IconUrlPropertyName:
+                        if (!reader.TryReadNil())
+                        {
+                            iconUrl = options.Resolver.GetFormatter<Uri>().Deserialize(ref reader, options);
+                        }
+                        break;
+                    case TitlePropertyName:
+                        title = reader.ReadString();
+                        break;
+                    case TagsPropertyName:
+                        tags = reader.ReadString();
+                        break;
+                    case LicenseUrlPropertyName:
+                        if (!reader.TryReadNil())
+                        {
+                            licenseUrl = options.Resolver.GetFormatter<Uri>().Deserialize(ref reader, options);
+                        }
+                        break;
+                    case ProjectUrlPropertyName:
+                        if (!reader.TryReadNil())
+                        {
+                            projectUrl = options.Resolver.GetFormatter<Uri>().Deserialize(ref reader, options);
+                        }
+                        break;
+                    case PublishedPropertyName:
+                        if (!reader.TryReadNil())
+                        {
+                            published = options.Resolver.GetFormatter<DateTimeOffset>().Deserialize(ref reader, options);
+                        }
+                        break;
+                    case OwnersPropertyName:
+                        owners = reader.ReadString();
+                        break;
+                    case ReportAbuseUrlPropertyName:
+                        if (!reader.TryReadNil())
+                        {
+                            reportAbuseUrl = options.Resolver.GetFormatter<Uri>().Deserialize(ref reader, options);
+                        }
+                        break;
+                    case PackageDetailsUrlPropertyName:
+                        if (!reader.TryReadNil())
+                        {
+                            packageDetailsUrl = options.Resolver.GetFormatter<Uri>().Deserialize(ref reader, options);
+                        }
+                        break;
+                    case RequireLicenseAcceptancePropertyName:
+                        requireLicenseAcceptance = reader.ReadBoolean();
+                        break;
+                    case SummaryPropertyName:
+                        summary = reader.ReadString();
+                        break;
+                    case PrefixReservedPropertyName:
+                        prefixReserved = reader.ReadBoolean();
+                        break;
+                    case IsRecommendedPropertyName:
+                        isRecommended = reader.ReadBoolean();
+                        break;
+                    case RecommenderVersionPropertyName:
+                        if (!reader.TryReadNil())
+                        {
+                            recommenderVersion = options.Resolver.GetFormatter<(string, string)>().Deserialize(ref reader, options);
+                        }
+                        break;
+                    case DownloadCountPropertyName:
+                        if (!reader.TryReadNil())
+                        {
+                            downloadCount = reader.ReadInt64();
+                        }
+                        break;
+                    case DependencySetsPropertyName:
+                        if (!reader.TryReadNil())
+                        {
+                            dependencySets = options.Resolver.GetFormatter<IReadOnlyCollection<PackageDependencyGroup>>().Deserialize(ref reader, options);
+                        }
+                        break;
+                    case VulnerabilitiesPropertyName:
+                        if (!reader.TryReadNil())
+                        {
+                            vulnerabilities = options.Resolver.GetFormatter<IReadOnlyCollection<PackageVulnerabilityMetadataContextInfo>>().Deserialize(ref reader, options);
+                        }
+                        break;
+                    case IsListedPropertyName:
+                        isListed = reader.ReadBoolean();
+                        break;
+                    default:
+                        reader.Skip();
+                        break;
                 }
+            }
 
-                return new PackageSearchMetadataContextInfo()
-                {
-                    Title = title,
-                    Description = description,
-                    Authors = authors,
-                    IconUrl = iconUrl,
-                    Tags = tags,
-                    Identity = identity,
-                    LicenseUrl = licenseUrl,
-                    IsRecommended = isRecommended,
-                    RecommenderVersion = recommenderVersion,
-                    Owners = owners,
-                    ProjectUrl = projectUrl,
-                    Published = published,
-                    ReportAbuseUrl = reportAbuseUrl,
-                    PackageDetailsUrl = packageDetailsUrl,
-                    RequireLicenseAcceptance = requireLicenseAcceptance,
-                    Summary = summary,
-                    PrefixReserved = prefixReserved,
-                    IsListed = isListed,
-                    DependencySets = dependencySets,
-                    DownloadCount = downloadCount,
-                    Vulnerabilities = vulnerabilities,
-                };
-            }
-            finally
+            return new PackageSearchMetadataContextInfo()
             {
-                // stack overflow mitigation - see https://github.com/neuecc/MessagePack-CSharp/security/advisories/GHSA-7q36-4xx7-xcxf
-                reader.Depth--;
-            }
+                Title = title,
+                Description = description,
+                Authors = authors,
+                IconUrl = iconUrl,
+                Tags = tags,
+                Identity = identity,
+                LicenseUrl = licenseUrl,
+                IsRecommended = isRecommended,
+                RecommenderVersion = recommenderVersion,
+                Owners = owners,
+                ProjectUrl = projectUrl,
+                Published = published,
+                ReportAbuseUrl = reportAbuseUrl,
+                PackageDetailsUrl = packageDetailsUrl,
+                RequireLicenseAcceptance = requireLicenseAcceptance,
+                Summary = summary,
+                PrefixReserved = prefixReserved,
+                IsListed = isListed,
+                DependencySets = dependencySets,
+                DownloadCount = downloadCount,
+                Vulnerabilities = vulnerabilities
+            };
         }
 
-        public void Serialize(ref MessagePackWriter writer, PackageSearchMetadataContextInfo? value, MessagePackSerializerOptions options)
+        protected override void SerializeCore(ref MessagePackWriter writer, PackageSearchMetadataContextInfo value, MessagePackSerializerOptions options)
         {
-            if (value == null)
-            {
-                writer.WriteNil();
-                return;
-            }
-
             writer.WriteMapHeader(count: 21);
             writer.Write(AuthorsPropertyName);
             writer.Write(value.Authors);

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/PackageSourceFormatter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/PackageSourceFormatter.cs
@@ -9,7 +9,7 @@ using NuGet.Configuration;
 
 namespace NuGet.VisualStudio.Internal.Contracts
 {
-    internal class PackageSourceFormatter : IMessagePackFormatter<PackageSource?>
+    internal sealed class PackageSourceFormatter : NuGetMessagePackFormatter<PackageSource>
     {
         private const string NamePropertyName = "name";
         private const string SourcePropertyName = "source";
@@ -22,66 +22,44 @@ namespace NuGet.VisualStudio.Internal.Contracts
         {
         }
 
-        public PackageSource? Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
+        protected override PackageSource? DeserializeCore(ref MessagePackReader reader, MessagePackSerializerOptions options)
         {
-            if (reader.TryReadNil())
+            string? name = null;
+            string? source = null;
+            bool isEnabled = false;
+            bool isMachineWide = false;
+
+            int propertyCount = reader.ReadMapHeader();
+            for (int propertyIndex = 0; propertyIndex < propertyCount; propertyIndex++)
             {
-                return null;
-            }
-
-            // stack overflow mitigation - see https://github.com/neuecc/MessagePack-CSharp/security/advisories/GHSA-7q36-4xx7-xcxf
-            options.Security.DepthStep(ref reader);
-
-            try
-            {
-                string? name = null;
-                string? source = null;
-                bool isEnabled = false;
-                bool isMachineWide = false;
-
-                int propertyCount = reader.ReadMapHeader();
-                for (int propertyIndex = 0; propertyIndex < propertyCount; propertyIndex++)
+                switch (reader.ReadString())
                 {
-                    switch (reader.ReadString())
-                    {
-                        case NamePropertyName:
-                            name = reader.ReadString();
-                            break;
-                        case SourcePropertyName:
-                            source = reader.ReadString();
-                            break;
-                        case IsEnabledPropertyName:
-                            isEnabled = reader.ReadBoolean();
-                            break;
-                        case IsMachineWidePropertyName:
-                            isMachineWide = reader.ReadBoolean();
-                            break;
-                        default:
-                            reader.Skip();
-                            break;
-                    }
+                    case NamePropertyName:
+                        name = reader.ReadString();
+                        break;
+                    case SourcePropertyName:
+                        source = reader.ReadString();
+                        break;
+                    case IsEnabledPropertyName:
+                        isEnabled = reader.ReadBoolean();
+                        break;
+                    case IsMachineWidePropertyName:
+                        isMachineWide = reader.ReadBoolean();
+                        break;
+                    default:
+                        reader.Skip();
+                        break;
                 }
+            }
 
-                return new PackageSource(source, name, isEnabled)
-                {
-                    IsMachineWide = isMachineWide
-                };
-            }
-            finally
+            return new PackageSource(source, name, isEnabled)
             {
-                // stack overflow mitigation - see https://github.com/neuecc/MessagePack-CSharp/security/advisories/GHSA-7q36-4xx7-xcxf
-                reader.Depth--;
-            }
+                IsMachineWide = isMachineWide
+            };
         }
 
-        public void Serialize(ref MessagePackWriter writer, PackageSource? value, MessagePackSerializerOptions options)
+        protected override void SerializeCore(ref MessagePackWriter writer, PackageSource value, MessagePackSerializerOptions options)
         {
-            if (value == null)
-            {
-                writer.WriteNil();
-                return;
-            }
-
             writer.WriteMapHeader(count: 4);
             writer.Write(NamePropertyName);
             writer.Write(value.Name);

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/PackageSourceUpdateOptionsFormatter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/PackageSourceUpdateOptionsFormatter.cs
@@ -10,7 +10,7 @@ using NuGet.Configuration;
 namespace NuGet.VisualStudio.Internal.Contracts
 {
 #pragma warning disable CS0618 // Type or member is obsolete
-    internal class PackageSourceUpdateOptionsFormatter : IMessagePackFormatter<PackageSourceUpdateOptions?>
+    internal sealed class PackageSourceUpdateOptionsFormatter : NuGetMessagePackFormatter<PackageSourceUpdateOptions>
 #pragma warning restore CS0618 // Type or member is obsolete
     {
         private const string UpdateCredentialsPropertyName = "updatecredentials";
@@ -25,60 +25,38 @@ namespace NuGet.VisualStudio.Internal.Contracts
         }
 
 #pragma warning disable CS0618 // Type or member is obsolete
-        public PackageSourceUpdateOptions? Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
+        protected override PackageSourceUpdateOptions? DeserializeCore(ref MessagePackReader reader, MessagePackSerializerOptions options)
 #pragma warning restore CS0618 // Type or member is obsolete
         {
-            if (reader.TryReadNil())
+            bool updateCredentials = true;
+            bool updateEnabled = true;
+
+            int propertyCount = reader.ReadMapHeader();
+            for (int propertyIndex = 0; propertyIndex < propertyCount; propertyIndex++)
             {
-                return null;
-            }
-
-            // stack overflow mitigation - see https://github.com/neuecc/MessagePack-CSharp/security/advisories/GHSA-7q36-4xx7-xcxf
-            options.Security.DepthStep(ref reader);
-
-            try
-            {
-                bool updateCredentials = true;
-                bool updateEnabled = true;
-
-                int propertyCount = reader.ReadMapHeader();
-                for (int propertyIndex = 0; propertyIndex < propertyCount; propertyIndex++)
+                switch (reader.ReadString())
                 {
-                    switch (reader.ReadString())
-                    {
-                        case UpdateCredentialsPropertyName:
-                            updateCredentials = reader.ReadBoolean();
-                            break;
-                        case UpdateEnabledPropertyName:
-                            updateEnabled = reader.ReadBoolean();
-                            break;
-                        default:
-                            reader.Skip();
-                            break;
-                    }
+                    case UpdateCredentialsPropertyName:
+                        updateCredentials = reader.ReadBoolean();
+                        break;
+                    case UpdateEnabledPropertyName:
+                        updateEnabled = reader.ReadBoolean();
+                        break;
+                    default:
+                        reader.Skip();
+                        break;
                 }
+            }
 
 #pragma warning disable CS0618 // Type or member is obsolete
-                return new PackageSourceUpdateOptions(updateCredentials, updateEnabled);
+            return new PackageSourceUpdateOptions(updateCredentials, updateEnabled);
 #pragma warning restore CS0618 // Type or member is obsolete
-            }
-            finally
-            {
-                // stack overflow mitigation - see https://github.com/neuecc/MessagePack-CSharp/security/advisories/GHSA-7q36-4xx7-xcxf
-                reader.Depth--;
-            }
         }
 
 #pragma warning disable CS0618 // Type or member is obsolete
-        public void Serialize(ref MessagePackWriter writer, PackageSourceUpdateOptions? value, MessagePackSerializerOptions options)
+        protected override void SerializeCore(ref MessagePackWriter writer, PackageSourceUpdateOptions value, MessagePackSerializerOptions options)
 #pragma warning restore CS0618 // Type or member is obsolete
         {
-            if (value == null)
-            {
-                writer.WriteNil();
-                return;
-            }
-
             writer.WriteMapHeader(count: 2);
             writer.Write(UpdateCredentialsPropertyName);
             writer.Write(value.UpdateCredentials);

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/PackageVulnerabilityMetadataContextInfoFormatter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/PackageVulnerabilityMetadataContextInfoFormatter.cs
@@ -10,7 +10,7 @@ using Microsoft;
 
 namespace NuGet.VisualStudio.Internal.Contracts
 {
-    internal class PackageVulnerabilityMetadataContextInfoFormatter : IMessagePackFormatter<PackageVulnerabilityMetadataContextInfo?>
+    internal sealed class PackageVulnerabilityMetadataContextInfoFormatter : NuGetMessagePackFormatter<PackageVulnerabilityMetadataContextInfo>
     {
         private const string AdvisoryUrlPropertyName = "advisoryurl";
         private const string SeverityPropertyName = "severity";
@@ -21,57 +21,35 @@ namespace NuGet.VisualStudio.Internal.Contracts
         {
         }
 
-        public PackageVulnerabilityMetadataContextInfo? Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
+        protected override PackageVulnerabilityMetadataContextInfo? DeserializeCore(ref MessagePackReader reader, MessagePackSerializerOptions options)
         {
-            if (reader.TryReadNil())
+            Uri? advisoryUrl = null;
+            int severity = 0;
+
+            int propertyCount = reader.ReadMapHeader();
+            for (int propertyIndex = 0; propertyIndex < propertyCount; propertyIndex++)
             {
-                return null;
-            }
-
-            // stack overflow mitigation - see https://github.com/neuecc/MessagePack-CSharp/security/advisories/GHSA-7q36-4xx7-xcxf
-            options.Security.DepthStep(ref reader);
-
-            try
-            {
-                Uri? advisoryUrl = null;
-                int severity = 0;
-
-                int propertyCount = reader.ReadMapHeader();
-                for (int propertyIndex = 0; propertyIndex < propertyCount; propertyIndex++)
+                switch (reader.ReadString())
                 {
-                    switch (reader.ReadString())
-                    {
-                        case AdvisoryUrlPropertyName:
-                            advisoryUrl = options.Resolver.GetFormatter<Uri>().Deserialize(ref reader, options);
-                            break;
-                        case SeverityPropertyName:
-                            severity = reader.ReadInt32();
-                            break;
-                        default:
-                            reader.Skip();
-                            break;
-                    }
+                    case AdvisoryUrlPropertyName:
+                        advisoryUrl = options.Resolver.GetFormatter<Uri>().Deserialize(ref reader, options);
+                        break;
+                    case SeverityPropertyName:
+                        severity = reader.ReadInt32();
+                        break;
+                    default:
+                        reader.Skip();
+                        break;
                 }
-
-                Assumes.NotNull(advisoryUrl);
-
-                return new PackageVulnerabilityMetadataContextInfo(advisoryUrl, severity);
             }
-            finally
-            {
-                // stack overflow mitigation - see https://github.com/neuecc/MessagePack-CSharp/security/advisories/GHSA-7q36-4xx7-xcxf
-                reader.Depth--;
-            }
+
+            Assumes.NotNull(advisoryUrl);
+
+            return new PackageVulnerabilityMetadataContextInfo(advisoryUrl, severity);
         }
 
-        public void Serialize(ref MessagePackWriter writer, PackageVulnerabilityMetadataContextInfo? value, MessagePackSerializerOptions options)
+        protected override void SerializeCore(ref MessagePackWriter writer, PackageVulnerabilityMetadataContextInfo value, MessagePackSerializerOptions options)
         {
-            if (value == null)
-            {
-                writer.WriteNil();
-                return;
-            }
-
             writer.WriteMapHeader(count: 2);
             writer.Write(AdvisoryUrlPropertyName);
             options.Resolver.GetFormatter<Uri>().Serialize(ref writer, value.AdvisoryUrl, options);

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/ProjectActionFormatter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/ProjectActionFormatter.cs
@@ -11,7 +11,7 @@ using NuGet.Packaging.Core;
 
 namespace NuGet.VisualStudio.Internal.Contracts
 {
-    internal sealed class ProjectActionFormatter : IMessagePackFormatter<ProjectAction?>
+    internal sealed class ProjectActionFormatter : NuGetMessagePackFormatter<ProjectAction>
     {
         private const string IdPropertyName = "id";
         private const string ImplicitActionsPropertyName = "implicitactions";
@@ -25,88 +25,66 @@ namespace NuGet.VisualStudio.Internal.Contracts
         {
         }
 
-        public ProjectAction? Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
+        protected override ProjectAction? DeserializeCore(ref MessagePackReader reader, MessagePackSerializerOptions options)
         {
-            if (reader.TryReadNil())
+            string? id = null;
+            ImplicitProjectAction[]? implicitActions = null;
+            PackageIdentity? packageIdentity = null;
+            NuGetProjectActionType? projectActionType = null;
+            string? projectId = null;
+
+            int propertyCount = reader.ReadMapHeader();
+
+            for (var propertyIndex = 0; propertyIndex < propertyCount; ++propertyIndex)
             {
-                return null;
-            }
-
-            // stack overflow mitigation - see https://github.com/neuecc/MessagePack-CSharp/security/advisories/GHSA-7q36-4xx7-xcxf
-            options.Security.DepthStep(ref reader);
-
-            try
-            {
-                string? id = null;
-                ImplicitProjectAction[]? implicitActions = null;
-                PackageIdentity? packageIdentity = null;
-                NuGetProjectActionType? projectActionType = null;
-                string? projectId = null;
-
-                int propertyCount = reader.ReadMapHeader();
-
-                for (var propertyIndex = 0; propertyIndex < propertyCount; ++propertyIndex)
+                switch (reader.ReadString())
                 {
-                    switch (reader.ReadString())
-                    {
-                        case IdPropertyName:
-                            id = reader.ReadString();
-                            break;
+                    case IdPropertyName:
+                        id = reader.ReadString();
+                        break;
 
-                        case ImplicitActionsPropertyName:
-                            int elementCount = reader.ReadArrayHeader();
-                            implicitActions = new ImplicitProjectAction[elementCount];
+                    case ImplicitActionsPropertyName:
+                        int elementCount = reader.ReadArrayHeader();
+                        implicitActions = new ImplicitProjectAction[elementCount];
 
-                            for (var i = 0; i < elementCount; ++i)
-                            {
-                                ImplicitProjectAction? implicitAction = ImplicitProjectActionFormatter.Instance.Deserialize(ref reader, options);
+                        for (var i = 0; i < elementCount; ++i)
+                        {
+                            ImplicitProjectAction? implicitAction = ImplicitProjectActionFormatter.Instance.Deserialize(ref reader, options);
 
-                                Assumes.NotNull(implicitAction);
+                            Assumes.NotNull(implicitAction);
 
-                                implicitActions[i] = implicitAction;
-                            }
-                            break;
+                            implicitActions[i] = implicitAction;
+                        }
+                        break;
 
-                        case PackageIdentityPropertyName:
-                            packageIdentity = PackageIdentityFormatter.Instance.Deserialize(ref reader, options);
-                            break;
+                    case PackageIdentityPropertyName:
+                        packageIdentity = PackageIdentityFormatter.Instance.Deserialize(ref reader, options);
+                        break;
 
-                        case ProjectActionTypePropertyName:
-                            projectActionType = options.Resolver.GetFormatter<NuGetProjectActionType>().Deserialize(ref reader, options);
-                            break;
+                    case ProjectActionTypePropertyName:
+                        projectActionType = options.Resolver.GetFormatter<NuGetProjectActionType>().Deserialize(ref reader, options);
+                        break;
 
-                        case ProjectIdPropertyName:
-                            projectId = reader.ReadString();
-                            break;
+                    case ProjectIdPropertyName:
+                        projectId = reader.ReadString();
+                        break;
 
-                        default:
-                            reader.Skip();
-                            break;
-                    }
+                    default:
+                        reader.Skip();
+                        break;
                 }
-
-                Assumes.NotNullOrEmpty(id);
-                Assumes.NotNull(packageIdentity);
-                Assumes.True(projectActionType.HasValue);
-                Assumes.NotNullOrEmpty(projectId);
-
-                return new ProjectAction(id, projectId, packageIdentity, projectActionType.Value, implicitActions);
             }
-            finally
-            {
-                // stack overflow mitigation - see https://github.com/neuecc/MessagePack-CSharp/security/advisories/GHSA-7q36-4xx7-xcxf
-                reader.Depth--;
-            }
+
+            Assumes.NotNullOrEmpty(id);
+            Assumes.NotNull(packageIdentity);
+            Assumes.True(projectActionType.HasValue);
+            Assumes.NotNullOrEmpty(projectId);
+
+            return new ProjectAction(id, projectId, packageIdentity, projectActionType.Value, implicitActions);
         }
 
-        public void Serialize(ref MessagePackWriter writer, ProjectAction? value, MessagePackSerializerOptions options)
+        protected override void SerializeCore(ref MessagePackWriter writer, ProjectAction value, MessagePackSerializerOptions options)
         {
-            if (value == null)
-            {
-                writer.WriteNil();
-                return;
-            }
-
             writer.WriteMapHeader(count: 5);
             writer.Write(IdPropertyName);
             writer.Write(value.Id);

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/VersionRangeFormatter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/VersionRangeFormatter.cs
@@ -10,7 +10,7 @@ using NuGet.Versioning;
 
 namespace NuGet.VisualStudio.Internal.Contracts
 {
-    internal sealed class VersionRangeFormatter : IMessagePackFormatter<VersionRange?>
+    internal sealed class VersionRangeFormatter : NuGetMessagePackFormatter<VersionRange>
     {
         private const string FloatRangePropertyName = "floatrange";
         private const string IsMaxInclusivePropertyName = "ismaxinclusive";
@@ -25,87 +25,65 @@ namespace NuGet.VisualStudio.Internal.Contracts
         {
         }
 
-        public VersionRange? Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
+        protected override VersionRange? DeserializeCore(ref MessagePackReader reader, MessagePackSerializerOptions options)
         {
-            if (reader.TryReadNil())
+            FloatRange? floatRange = null;
+            bool? isMaxInclusive = null;
+            bool? isMinInclusive = null;
+            NuGetVersion? maxVersion = null;
+            NuGetVersion? minVersion = null;
+            string? originalString = null;
+
+            int propertyCount = reader.ReadMapHeader();
+
+            for (var propertyIndex = 0; propertyIndex < propertyCount; ++propertyIndex)
             {
-                return null;
-            }
-
-            // stack overflow mitigation - see https://github.com/neuecc/MessagePack-CSharp/security/advisories/GHSA-7q36-4xx7-xcxf
-            options.Security.DepthStep(ref reader);
-
-            try
-            {
-                FloatRange? floatRange = null;
-                bool? isMaxInclusive = null;
-                bool? isMinInclusive = null;
-                NuGetVersion? maxVersion = null;
-                NuGetVersion? minVersion = null;
-                string? originalString = null;
-
-                int propertyCount = reader.ReadMapHeader();
-
-                for (var propertyIndex = 0; propertyIndex < propertyCount; ++propertyIndex)
+                switch (reader.ReadString())
                 {
-                    switch (reader.ReadString())
-                    {
-                        case FloatRangePropertyName:
-                            floatRange = FloatRangeFormatter.Instance.Deserialize(ref reader, options);
-                            break;
+                    case FloatRangePropertyName:
+                        floatRange = FloatRangeFormatter.Instance.Deserialize(ref reader, options);
+                        break;
 
-                        case IsMaxInclusivePropertyName:
-                            isMaxInclusive = reader.ReadBoolean();
-                            break;
+                    case IsMaxInclusivePropertyName:
+                        isMaxInclusive = reader.ReadBoolean();
+                        break;
 
-                        case IsMinInclusivePropertyName:
-                            isMinInclusive = reader.ReadBoolean();
-                            break;
+                    case IsMinInclusivePropertyName:
+                        isMinInclusive = reader.ReadBoolean();
+                        break;
 
-                        case MaxVersionPropertyName:
-                            maxVersion = NuGetVersionFormatter.Instance.Deserialize(ref reader, options);
-                            break;
+                    case MaxVersionPropertyName:
+                        maxVersion = NuGetVersionFormatter.Instance.Deserialize(ref reader, options);
+                        break;
 
-                        case MinVersionPropertyName:
-                            minVersion = NuGetVersionFormatter.Instance.Deserialize(ref reader, options);
-                            break;
+                    case MinVersionPropertyName:
+                        minVersion = NuGetVersionFormatter.Instance.Deserialize(ref reader, options);
+                        break;
 
-                        case OriginalStringPropertyName:
-                            originalString = reader.ReadString();
-                            break;
+                    case OriginalStringPropertyName:
+                        originalString = reader.ReadString();
+                        break;
 
-                        default:
-                            reader.Skip();
-                            break;
-                    }
+                    default:
+                        reader.Skip();
+                        break;
                 }
-
-                Assumes.True(isMinInclusive.HasValue);
-                Assumes.True(isMaxInclusive.HasValue);
-
-                return new VersionRange(
-                    minVersion,
-                    isMinInclusive.Value,
-                    maxVersion,
-                    isMaxInclusive.Value,
-                    floatRange,
-                    originalString);
             }
-            finally
-            {
-                // stack overflow mitigation - see https://github.com/neuecc/MessagePack-CSharp/security/advisories/GHSA-7q36-4xx7-xcxf
-                reader.Depth--;
-            }
+
+            Assumes.True(isMinInclusive.HasValue);
+            Assumes.True(isMaxInclusive.HasValue);
+
+            return new VersionRange(
+                minVersion,
+                isMinInclusive.Value,
+                maxVersion,
+                isMaxInclusive.Value,
+                floatRange,
+                originalString);
         }
 
-        public void Serialize(ref MessagePackWriter writer, VersionRange? value, MessagePackSerializerOptions options)
+        protected override void SerializeCore(ref MessagePackWriter writer, VersionRange value, MessagePackSerializerOptions options)
         {
-            if (value == null)
-            {
-                writer.WriteNil();
-                return;
-            }
-
             writer.WriteMapHeader(count: 6);
             writer.Write(MinVersionPropertyName);
             NuGetVersionFormatter.Instance.Serialize(ref writer, value.MinVersion, options);


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/10175
Regression: No

## Fix

Details: Share implementation details through a base class.

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  Formatters already have tests.
Validation:  CI

CC @sbanni, @rrelyea