### PR TITLE
always log exception to output

### DIFF
--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/RestoreOperationLogger.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/RestoreOperationLogger.cs
@@ -275,18 +275,7 @@ namespace NuGet.SolutionRestoreManager
 
         public async Task LogExceptionAsync(Exception ex)
         {
-            string message;
-            if (OutputVerbosity < 3)
-            {
-                message = string.Format(CultureInfo.CurrentCulture,
-                    Resources.ErrorOccurredRestoringPackages,
-                    ex.Message);
-            }
-            else
-            {
-                // output exception detail when _msBuildOutputVerbosity is >= Detailed.
-                message = string.Format(CultureInfo.CurrentCulture, Resources.ErrorOccurredRestoringPackages, ex);
-            }
+            string message = string.Format(CultureInfo.CurrentCulture, Resources.ErrorOccurredRestoringPackages, ex);
 
             if (_operationSource == RestoreOperationSource.Explicit)
             {


### PR DESCRIPTION
MSBuild verbosity should never result in an exception log entry that is useless.

So this PR changes the the logging logic so the full exception tostring is logged, instead of just the message.

Specifically the problem with (ever) logging just exception message is we end up with behavior like
 
![ElS0qhaUYAIpCES](https://user-images.githubusercontent.com/122666/97242165-3b34e900-1847-11eb-83f3-04643dee82ae.png)

Which means people need to tweak settings to help diagnose the problem
