### PR TITLE
Only run E2E tests when VSIX installed successfully

### DIFF
--- a/build/templates/End_To_End_Tests_On_Windows.yml
+++ b/build/templates/End_To_End_Tests_On_Windows.yml
@@ -67,7 +67,7 @@ steps:
   inputs:
     scriptName: "$(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\RunFunctionalTests.ps1"
     arguments: "-PMCCommand $(EndToEndTestCommandToRunPart) -PMCLaunchWaitTimeInSecs 30 -EachTestTimoutInSecs 600 -NuGetDropPath $(System.DefaultWorkingDirectory)\\artifacts -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts -RunCounter $(Build.BuildNumber) -VSVersion 16.0"
-  condition: "eq(variables['IsOfficialBuild'], 'true')"
+  condition: "and(succeeded(), eq(variables['IsOfficialBuild'], 'true'))"
 
 - task: PowerShell@1
   displayName: "RunFunctionalTests.ps1 (continue on error)"
@@ -76,7 +76,7 @@ steps:
   inputs:
     scriptName: "$(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\RunFunctionalTests.ps1"
     arguments: "-PMCCommand $(EndToEndTestCommandToRunPart) -PMCLaunchWaitTimeInSecs 30 -EachTestTimoutInSecs 600 -NuGetDropPath $(System.DefaultWorkingDirectory)\\artifacts -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts -RunCounter $(Build.BuildNumber) -VSVersion 16.0"
-  condition: "not(eq(variables['IsOfficialBuild'], 'true'))"
+  condition: "and(succeeded(), not(eq(variables['IsOfficialBuild'], 'true')))"
 
 - task: PublishTestResults@2
   displayName: "Publish Test Results"


### PR DESCRIPTION
## Bug

Fixes:https://github.com/NuGet/Home/issues/10190
Regression: No 
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: Only run E2E tests when job is in successful state.

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  CI yaml change
Validation:  
