### PR TITLE
skip RestoreNetCore_MultipleProjects_SameToolDifferentVersionsAsync test

### DIFF
--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
@@ -1740,7 +1740,7 @@ namespace NuGet.CommandLine.Test
             }
         }
 
-        [Fact(Skip = "https://github.com/NuGet/Home/issues/10192")]
+        [Fact(Skip = "https://github.com/NuGet/Home/issues/10075")]
         public async Task RestoreNetCore_MultipleProjects_SameToolDifferentVersionsAsync()
         {
             // Arrange

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
@@ -1740,7 +1740,7 @@ namespace NuGet.CommandLine.Test
             }
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/NuGet/Home/issues/10192")]
         public async Task RestoreNetCore_MultipleProjects_SameToolDifferentVersionsAsync()
         {
             // Arrange


### PR DESCRIPTION
## Bug

tracking issue: https://github.com/NuGet/Home/issues/10075
Regression: No  

## Fix

Details: Skip `RestoreNetCore_MultipleProjects_SameToolDifferentVersionsAsync` as per [this comment](https://github.com/NuGet/Home/issues/10075#issuecomment-716746748).

//cc @nkolev92 

## Testing/Validation

Tests Added: No
Reason for not adding tests:  Disabled a test
Validation:  
