### PR TITLE
Don't wrap output when output has been redirected to a file.

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Common/Console.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Common/Console.cs
@@ -77,7 +77,7 @@ namespace NuGet.CommandLine
                     {
                         // This happens when redirecting output to a file, on
                         // Linux and OS X (running with Mono).
-                        return 80;
+                        return int.MaxValue;
                     }
                 }
                 catch (IOException)


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/10198
Regression: I think so (since this has been fixed twice, the first time like I'm proposing here).

* Last working version: don't know
* How are we preventing it in future:   

## Fix

This was introduced as a fix for https://github.com/NuGet/Home/issues/1893, which was previously fixed like I'm proposing here (https://github.com/NuGet/NuGet2/commit/98d15b3b5d18a3100136d8b9a5aaf857d7b8b5b4).

I can't see a reason to wrap output when it has been redirected to a file, so I'm proposing to apply the original fix.

## Testing/Validation

Tests Added: No
Reason for not adding tests: it would require running nuget on mono as a subprocess with output redirected to a file
Validation:  
