### PR TITLE
Move the format check to allow running the unit tests regardless of the format check status

### DIFF
--- a/build/templates/Build_and_UnitTest.yml
+++ b/build/templates/Build_and_UnitTest.yml
@@ -87,14 +87,6 @@ steps:
       dotnet tool restore
   condition: "and(not(eq(variables['IsOfficialBuild'], 'true')), eq(variables['BuildRTM'], 'true'))"   #skip this task for nonRTM in private build
 
-- task: PowerShell@1
-  displayName: "Check source file format"
-  inputs:
-    scriptType: "inlineScript"
-    inlineScript: |
-      dotnet format --check --exclude submodules --verbosity diagnostic
-  condition: "and(succeeded(), not(eq(variables['IsOfficialBuild'], 'true')), eq(variables['BuildRTM'], 'true'))"   #skip this task for nonRTM in private build
-
 - task: MSBuild@1
   displayName: "Restore for VS2019"
   inputs:
@@ -185,6 +177,14 @@ steps:
     mergeTestResults: "true"
     publishRunAttachments: "false"
   condition: "and(succeededOrFailed(),eq(variables['BuildRTM'], 'true'))"
+
+- task: PowerShell@1
+  displayName: "Check source file format"
+  inputs:
+    scriptType: "inlineScript"
+    inlineScript: |
+      dotnet format --check --exclude submodules --verbosity diagnostic
+  condition: "and(succeededOrFailed(), not(eq(variables['IsOfficialBuild'], 'true')), eq(variables['BuildRTM'], 'true'))"   #skip this task for nonRTM in private build
 
 - task: PowerShell@1
   displayName: "Initialize Git Commit Status on GitHub"


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Client.Engineering/issues/616
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: 

While I do believe that the format check is necessary and should block merges, I do think there's value in running the tests beyond that.

I recently got bit by this because the linux & mac tests did run, but the windows ones didn't. 

See https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=4187571&view=ms.vss-test-web.build-test-results-tab.

## Testing/Validation

Tests Added: No  
Reason for not adding tests: Infrastructure change  
Validation:  
