### PR TITLE
Use myget-legacy AzDO feed instead of myget.org

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -2,15 +2,13 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="NuGet.org" value="https://api.nuget.org/v3/index.json" />
-    <add key="nuget-build" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/nuget-build/nuget/v3/index.json" />
-    <add key="vside_vs-impl" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl/nuget/v3/index.json" />
-    <add key="vside_vssdk" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vssdk/nuget/v3/index.json" />
     <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
-
-    <!-- Microsoft.VisualStudio.ProjectSystem.Managed* from roslyn. moving to vs-impl with new versions soon.  -->
-    <add key="dotnet-roslyn" value="https://dotnet.myget.org/F/roslyn/api/v3/index.json" />
+    <add key="myget-legacy@Local" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy%40Local/nuget/v3/index.json" />
+    <add key="nuget-build" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/nuget-build/nuget/v3/index.json" />
+    <add key="NuGet.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="vside_vs-impl" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl/nuget/v3/index.json" />
+    <add key="vside_vssdk" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vssdk/nuget/v3/index.json" />
   </packageSources>
   <disabledPackageSources>
     <clear />


### PR DESCRIPTION
## Bug

For: https://github.com/NuGet/Client.Engineering/issues/489
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: DncEng copied most of the myget packages to a feed named myget-legacy, so we can use that to get the same versions of the packages we already use.

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  nuget.config change
Validation:  
