### PR TITLE
bump preview version to preview.2

### DIFF
--- a/build/config.props
+++ b/build/config.props
@@ -19,7 +19,7 @@
 
     <!-- ** Change for each new preview/rc -->
     <!-- Check the VS schedule and manually enter a preview number here that makes sense. -->
-    <ReleaseLabel Condition=" '$(ReleaseLabel)' == '' ">preview.1</ReleaseLabel>
+    <ReleaseLabel Condition=" '$(ReleaseLabel)' == '' ">preview.2</ReleaseLabel>
 
     <IsEscrowMode>false</IsEscrowMode>
 


### PR DESCRIPTION
## Bug

Ref: https://github.com/NuGet/Client.Engineering/issues/619#issuecomment-722078716
Regression: No  

## Fix

Needed to bump the preview number

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  It's a preview number bump.
Validation:  test suite
