### PR TITLE
Added error when specifying a package icon or license file with the incorrect path casing.

### DIFF
--- a/src/NuGet.Core/NuGet.Common/PathUtil/PathUtility.cs
+++ b/src/NuGet.Core/NuGet.Common/PathUtil/PathUtility.cs
@@ -15,9 +15,13 @@ namespace NuGet.Common
         private static readonly Lazy<bool> _isFileSystemCaseInsensitive = new Lazy<bool>(CheckIfFileSystemIsCaseInsensitive);
 
         /// <summary>
-        /// Returns OrdinalIgnoreCase windows and mac. Ordinal for linux.
+        /// Returns OrdinalIgnoreCase Windows and Mac. Ordinal for Linux. (Do not use with package paths)
         /// </summary>
         /// <returns></returns>
+        /// <remarks>
+        /// This method should not be used with package paths.
+        /// Package paths are always case sensitive, using this with package paths leads to bugs like https://github.com/NuGet/Home/issues/9817.
+        /// </remarks>
         public static StringComparer GetStringComparerBasedOnOS()
         {
             if (IsFileSystemCaseInsensitive)
@@ -29,9 +33,13 @@ namespace NuGet.Common
         }
 
         /// <summary>
-        /// Returns OrdinalIgnoreCase windows and mac. Ordinal for linux.
+        /// Returns OrdinalIgnoreCase Windows and Mac. Ordinal for Linux. (Do not use with package paths)
         /// </summary>
         /// <returns></returns>
+        /// <remarks>
+        /// This method should not be used with package paths.
+        /// Package paths are always case sensitive, using this with package paths leads to bugs like https://github.com/NuGet/Home/issues/9817.
+        /// </remarks>
         public static StringComparison GetStringComparisonBasedOnOS()
         {
             if (IsFileSystemCaseInsensitive)

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Resources/NuGetResources.Designer.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Resources/NuGetResources.Designer.cs
@@ -133,6 +133,15 @@ namespace NuGet.Packaging.PackageCreation.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The icon file &apos;{0}&apos; does not exist in the package. (Did you mean &apos;{1}&apos;?).
+        /// </summary>
+        internal static string IconNoFileElementWithHint {
+            get {
+                return ResourceManager.GetString("IconNoFileElementWithHint", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The schema version of &apos;{0}&apos; is incompatible with version {1} of NuGet. Please upgrade NuGet to the latest version from http://go.microsoft.com/fwlink/?LinkId=213942..
         /// </summary>
         internal static string IncompatibleSchema {
@@ -219,6 +228,15 @@ namespace NuGet.Packaging.PackageCreation.Resources {
         internal static string Manifest_LicenseFileIsNotInNupkg {
             get {
                 return ResourceManager.GetString("Manifest_LicenseFileIsNotInNupkg", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The license file &apos;{0}&apos; does not exist in the package. (Did you mean &apos;{1}&apos;?).
+        /// </summary>
+        internal static string Manifest_LicenseFileIsNotInNupkgWithHint {
+            get {
+                return ResourceManager.GetString("Manifest_LicenseFileIsNotInNupkgWithHint", resourceCulture);
             }
         }
         

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Resources/NuGetResources.resx
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Resources/NuGetResources.resx
@@ -212,4 +212,12 @@
     <value>The element 'icon' cannot be empty.</value>
     <comment>Please, don't localize icon</comment>
   </data>
+  <data name="IconNoFileElementWithHint" xml:space="preserve">
+    <value>The icon file '{0}' does not exist in the package. (Did you mean '{1}'?)</value>
+    <comment>0 - the icon file, 1 - hint to guessed icon file</comment>
+  </data>
+  <data name="Manifest_LicenseFileIsNotInNupkgWithHint" xml:space="preserve">
+    <value>The license file '{0}' does not exist in the package. (Did you mean '{1}'?)</value>
+    <comment>0 - the license file, 1 - hint to guessed licensed file</comment>
+  </data>
 </root>


### PR DESCRIPTION
This implements [the design](https://github.com/NuGet/Home/blob/e4141f74ff152b0a28bfdd7a3dca30c6799edf2b/designs/PackageValidation/FileNameCaseSensitivity.md) set forth in https://github.com/NuGet/Home/pull/10049

## Bug

Fixes: https://github.com/NuGet/Home/issues/9817
Regression: No  
* Last working version:   N/A
* How are we preventing it in future:   This PR also [adds a note to `PathUtility.GetStringComparerBasedOnOS` and `PathUtilty.GetStringComparisonBasedOnOS`](https://github.com/PathogenDavid/NuGet.Client/commit/80eaa43dcf2a5fa7106471e1f5dc96c7fb6628b1#diff-a839c2cf45dfebc6afffc9589f537af9bd6d9b12d2bdd0ba1afa600f7aea9313) noting that they should not be used for package paths.

## Fix

Details: The details are in https://github.com/NuGet/Home/blob/e4141f74ff152b0a28bfdd7a3dca30c6799edf2b/designs/PackageValidation/FileNameCaseSensitivity.md

In short: License and package icon validation is now case-sensitive. A case-insensitive check is used to suggest the likely-correct path when the user specifies a path incorrect only by case.

## Testing/Validation

Tests Added: Yes
Reason for not adding tests:  N/A
Validation:  Test suite