### PR TITLE
Improve argument validation in DownloadResourceV3.GetDownloadUrl

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/Resources/DownloadResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/DownloadResourceV3.cs
@@ -88,6 +88,16 @@ namespace NuGet.Protocol
         /// </summary>
         private async Task<Uri> GetDownloadUrl(PackageIdentity identity, ILogger log, CancellationToken token)
         {
+            if (identity == null)
+            {
+                throw new ArgumentNullException(nameof(identity));
+            }
+
+            if (identity.Version == null)
+            {
+                throw new ArgumentException("The package identity must have a non-null version.", nameof(identity));
+            }
+
             Uri downloadUri = null;
             var sourcePackage = identity as SourcePackageDependencyInfo;
 


### PR DESCRIPTION
Better have an `ArgumentNullException` or an `ArgumentException` than a `NullReferenceException` if misused.