### PR TITLE
Remove IncludeSymbols=true from common.targets

### DIFF
--- a/build/common.targets
+++ b/build/common.targets
@@ -144,7 +144,6 @@
       Properties="Configuration=$(Configuration);
                   VisualStudioVersion=$(VisualStudioVersion);
                   PackageOutputPath=$(NupkgOutputDirectory);
-                  IncludeSymbols=true;
                   NoBuild=true;">
     </MSBuild>
   </Target>


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Client.Engineering/issues/547
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: Remove IncludeSymbols=true from common.targets, as the symbol packages are not used.
             https://github.com/NuGet/Home/issues/10249 also caused a problem if specifying  IncludeSymbols=true. It won't fail the pack even if the packing on nupkg failed.

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  
Validation:  
