### PR TITLE
Fix conditions of "stop on error" and "continue on error" in E2E tests 

### DIFF
--- a/build/templates/End_To_End_Tests_On_Windows.yml
+++ b/build/templates/End_To_End_Tests_On_Windows.yml
@@ -67,7 +67,7 @@ steps:
   inputs:
     scriptName: "$(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\RunFunctionalTests.ps1"
     arguments: "-PMCCommand $(EndToEndTestCommandToRunPart) -PMCLaunchWaitTimeInSecs 30 -EachTestTimoutInSecs 600 -NuGetDropPath $(System.DefaultWorkingDirectory)\\artifacts -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts -RunCounter $(Build.BuildNumber) -VSVersion 16.0"
-  condition: "and(succeeded(), eq(variables['IsOfficialBuild'], 'true'))"
+  condition: "and(succeeded(), not(eq(variables['IsOfficialBuild'], 'true')))"
 
 - task: PowerShell@1
   displayName: "RunFunctionalTests.ps1 (continue on error)"
@@ -76,7 +76,7 @@ steps:
   inputs:
     scriptName: "$(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\RunFunctionalTests.ps1"
     arguments: "-PMCCommand $(EndToEndTestCommandToRunPart) -PMCLaunchWaitTimeInSecs 30 -EachTestTimoutInSecs 600 -NuGetDropPath $(System.DefaultWorkingDirectory)\\artifacts -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts -RunCounter $(Build.BuildNumber) -VSVersion 16.0"
-  condition: "and(succeeded(), not(eq(variables['IsOfficialBuild'], 'true')))"
+  condition: "and(succeeded(), eq(variables['IsOfficialBuild'], 'true'))"
 
 - task: PublishTestResults@2
   displayName: "Publish Test Results"

--- a/build/templates/End_To_End_Tests_On_Windows.yml
+++ b/build/templates/End_To_End_Tests_On_Windows.yml
@@ -63,7 +63,7 @@ steps:
 - task: PowerShell@1
   displayName: "RunFunctionalTests.ps1 (stop on error)"
   timeoutInMinutes: 75
-  continueOnError: "true"
+  continueOnError: "false"
   inputs:
     scriptName: "$(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\RunFunctionalTests.ps1"
     arguments: "-PMCCommand $(EndToEndTestCommandToRunPart) -PMCLaunchWaitTimeInSecs 30 -EachTestTimoutInSecs 600 -NuGetDropPath $(System.DefaultWorkingDirectory)\\artifacts -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts -RunCounter $(Build.BuildNumber) -VSVersion 16.0"


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Client.Engineering/issues/630
Regression: Yes  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: Exchange the conditions of "stop on error" and "continue on error". 

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  
Validation:  
