### PR TITLE
skip flaky test GetPackageUpdatesAfterSwitchToSourceThatDoesNotContainInstalledPackageId

### DIFF
--- a/test/EndToEnd/tests/GetPackageTest.ps1
+++ b/test/EndToEnd/tests/GetPackageTest.ps1
@@ -497,6 +497,7 @@ function Test-GetInstalledPackageWithFilterReturnsCorrectPackage
 
 function Test-GetPackageUpdatesAfterSwitchToSourceThatDoesNotContainInstalledPackageId
 {
+    [SkipTest('https://github.com/NuGet/Home/issues/10254')]
     param
     (
         $context


### PR DESCRIPTION
tracking issue: https://github.com/NuGet/Home/issues/10254