### PR TITLE
When restoring packages.config projects, ensure the target framework is read during the project walk

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -493,7 +493,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   </Target>
 
-  <!--_GetRestoreTargetFrameworksOutput
+  <!--
     ============================================================
     _GetRestoreTargetFrameworksOutput
     Read target frameworks from the project.

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -493,7 +493,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   </Target>
 
-  <!--
+  <!--_GetRestoreTargetFrameworksOutput
     ============================================================
     _GetRestoreTargetFrameworksOutput
     Read target frameworks from the project.
@@ -510,7 +510,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <!-- For project.json projects target frameworks will be read from project.json. -->
     <GetProjectTargetFrameworksTask
-      Condition=" '$(RestoreProjectStyle)' != 'ProjectJson' OR '$(PackageReferenceCompatibleProjectStyle)' == 'true' "
+      Condition=" '$(RestoreProjectStyle)' != 'ProjectJson'"
       ProjectPath="$(MSBuildProjectFullPath)"
       TargetFrameworks="$(TargetFrameworks)"
       TargetFramework="$(TargetFramework)"
@@ -766,7 +766,8 @@ Copyright (c) .NET Foundation. All rights reserved.
         <RepositoryPath>$(_OutputRepositoryPath)</RepositoryPath>
         <ConfigFilePaths>$(_OutputConfigFilePaths)</ConfigFilePaths>
         <PackagesPath>$(_OutputPackagesPath)</PackagesPath>
-      </_RestoreGraphEntry>
+        <TargetFrameworks>@(_RestoreTargetFrameworksOutputFiltered)</TargetFrameworks>
+        </_RestoreGraphEntry>
     </ItemGroup>
 
     <!-- Non-NuGet type -->

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
@@ -779,7 +779,7 @@ namespace NuGet.Commands
             spec.FilePath = specItem.GetProperty("ProjectPath");
             spec.RestoreMetadata.ProjectName = specItem.GetProperty("ProjectName");
 
-            if (projectStyle == ProjectStyle.DotnetCliTool || projectStyle == ProjectStyle.Unknown)
+            if (projectStyle == ProjectStyle.DotnetCliTool || projectStyle == ProjectStyle.Unknown || projectStyle == ProjectStyle.PackagesConfig)
             {
                 var tfmProperty = specItem.GetProperty("TargetFrameworks");
                 if (!string.IsNullOrEmpty(tfmProperty))

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/RestoreCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/RestoreCommandTests.cs
@@ -4,11 +4,16 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection;
+using System.Threading;
 using System.Threading.Tasks;
+using FluentAssertions;
 using NuGet.CommandLine.Test;
+using NuGet.Common;
 using NuGet.Frameworks;
 using NuGet.Packaging;
 using NuGet.ProjectModel;
+using NuGet.Protocol;
 using NuGet.Test.Utility;
 using Xunit;
 
@@ -501,6 +506,68 @@ namespace NuGet.CommandLine.FuncTest.Commands
         }
 
         [Fact]
+        public async Task RestorePackagesConfig_WithExistingLockFile_LockedMode_Succeeds()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Set up solution, project, and packages
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+
+                var net461 = NuGetFramework.Parse("net461");
+
+                var projectA = SimpleTestProjectContext.CreateLegacyPackageReference(
+                    "a",
+                    pathContext.SolutionRoot,
+                    net461);
+
+                var packageX = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.0"
+                };
+                packageX.Files.Clear();
+                packageX.AddFile("lib/net461/x.dll");
+
+                solution.Projects.Add(projectA);
+                solution.Create(pathContext.SolutionRoot);
+                Util.CreateFile(Path.GetDirectoryName(projectA.ProjectPath), "packages.config",
+@"<packages>
+  <package id=""x"" version=""1.0.0"" targetFramework=""net461"" />
+</packages>");
+
+                await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                    pathContext.PackageSource,
+                    PackageSaveMode.Defaultv3,
+                    packageX);
+
+                // Preconditions, regular restore
+                var result = RunRestore(pathContext, _successExitCode);
+                result.Success.Should().BeTrue(because: result.AllOutput);
+                new FileInfo(projectA.NuGetLockFileOutputPath).Exists.Should().BeFalse();
+
+                // Write expected lock file
+                var templateLockFile = GetResource("NuGet.CommandLine.FuncTest.compiler.resources.pc.packages.lock.json");
+
+                var packagePath = LocalFolderUtility.GetPackagesV3(pathContext.PackageSource, NullLogger.Instance).Single().Path;
+
+                string contentHash = null;
+                using (var reader = new PackageArchiveReader(packagePath))
+                {
+                    contentHash = reader.GetContentHash(CancellationToken.None);
+                }
+
+                var expectedLockFile = templateLockFile.Replace("TEMPLATE", contentHash);
+                File.WriteAllText(projectA.NuGetLockFileOutputPath, expectedLockFile);
+
+                // Run lockedmode restore.
+                result = RunRestore(pathContext, _successExitCode, "-LockedMode");
+                result.Success.Should().BeTrue(because: result.AllOutput);
+                new FileInfo(projectA.NuGetLockFileOutputPath).Exists.Should().BeTrue();
+            }
+        }
+
+        [Fact]
         public async Task Restore_LegacyPackageReference_EmbedInteropPackage()
         {
             // Arrange
@@ -837,6 +904,14 @@ namespace NuGet.CommandLine.FuncTest.Commands
             Assert.True(expectedExitCode == r.ExitCode, r.AllOutput);
 
             return r;
+        }
+
+        public static string GetResource(string name)
+        {
+            using (var reader = new StreamReader(Assembly.GetExecutingAssembly().GetManifestResourceStream(name)))
+            {
+                return reader.ReadToEnd();
+            }
         }
     }
 }

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/RestoreCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/RestoreCommandTests.cs
@@ -547,8 +547,6 @@ namespace NuGet.CommandLine.FuncTest.Commands
                 new FileInfo(projectA.NuGetLockFileOutputPath).Exists.Should().BeFalse();
 
                 // Write expected lock file
-                var templateLockFile = GetResource("NuGet.CommandLine.FuncTest.compiler.resources.pc.packages.lock.json");
-
                 var packagePath = LocalFolderUtility.GetPackagesV3(pathContext.PackageSource, NullLogger.Instance).Single().Path;
 
                 string contentHash = null;
@@ -557,7 +555,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
                     contentHash = reader.GetContentHash(CancellationToken.None);
                 }
 
-                var expectedLockFile = templateLockFile.Replace("TEMPLATE", contentHash);
+                var expectedLockFile = GetResource("NuGet.CommandLine.FuncTest.compiler.resources.pc.packages.lock.json").Replace("TEMPLATE", contentHash);
                 File.WriteAllText(projectA.NuGetLockFileOutputPath, expectedLockFile);
 
                 // Run lockedmode restore.

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/NuGet.CommandLine.FuncTest.csproj
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/NuGet.CommandLine.FuncTest.csproj
@@ -10,6 +10,14 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <EmbeddedResource Include="compiler\resources\*" />
+  </ItemGroup>
+ 
+  <ItemGroup>
+    <None Remove="compiler\resources\pc.packages.lock.json" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="$(TestUtilitiesDirectory)Test.Utility\Test.Utility.csproj" />
     <ProjectReference Include="..\..\NuGet.Clients.Tests\NuGet.CommandLine.Test\NuGet.CommandLine.Test.csproj" />
     <ProjectReference Include="..\..\NuGet.Core.Tests\NuGet.Configuration.Test\NuGet.Configuration.Test.csproj" />
@@ -27,8 +35,7 @@
   </ItemGroup>
   
   <Target Name="CopyFinalNuGetExeToOutputPath" AfterTargets="Build" Condition="'$(SkipILMergeOfNuGetExe)' != 'true'">
-      <Copy SourceFiles="$(ArtifactsDirectory)$(VsixOutputDirName)\NuGet.exe"
-            DestinationFolder="$(OutputPath)NuGet\" />
+      <Copy SourceFiles="$(ArtifactsDirectory)$(VsixOutputDirName)\NuGet.exe" DestinationFolder="$(OutputPath)NuGet\" />
   </Target>
 
   <Import Project="$(BuildCommonDirectory)common.targets" />

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/compiler/resources/pc.packages.lock.json
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/compiler/resources/pc.packages.lock.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "dependencies": {
+    ".NETFramework,Version=v4.6.1": {
+      "x": {
+        "type": "Direct",
+        "requested": "[1.0.0, 1.0.0]",
+        "resolved": "1.0.0",
+        "contentHash": "TEMPLATE"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/10257
Regression: Yes  
* Last working version:   5.7
* How are we preventing it in future:   Better tests

## Fix

Details: During the major refactoring, we missed out on the fact that the packages.config tfm was being read for lock file purposes. 
This fixes that. 

Also adds a test that should catch any future lock file discrepancies. 

## Testing/Validation

Tests Added: Yes 
Reason for not adding tests:  
Validation:  
