### PR TITLE
PM UI:  fix exception on window close

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/PackageManagerToolWindowPane.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/PackageManagerToolWindowPane.cs
@@ -2,12 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using System.Threading;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
-using NuGet.VisualStudio;
 
 namespace NuGet.PackageManagement.UI
 {
@@ -73,15 +70,9 @@ namespace NuGet.PackageManagement.UI
 
         public int OnClose(ref uint pgrfSaveOptions)
         {
-            PackageManagerControl content = _content;
-
-            if (content != null)
+            if (_content is PackageManagerControl content)
             {
-                NuGetUIThreadHelper.JoinableTaskFactory.Run(async () =>
-                {
-                    await content.SaveSettingsAsync(CancellationToken.None);
-                });
-
+                content.SaveSettings();
                 content.Model.Context.UserSettingsManager.PersistSettings();
             }
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/PackageManagerWindowPane.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/PackageManagerWindowPane.cs
@@ -2,11 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Threading;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
-using NuGet.VisualStudio;
 
 namespace NuGet.PackageManagement.UI
 {
@@ -67,13 +65,11 @@ namespace NuGet.PackageManagement.UI
 
         public int OnClose(ref uint pgrfSaveOptions)
         {
-            NuGetUIThreadHelper.JoinableTaskFactory.Run(async () =>
-            {
-                await _content.SaveSettingsAsync(CancellationToken.None);
-            });
+            _content.SaveSettings();
             _content.Model.Context.UserSettingsManager.PersistSettings();
 
             pgrfSaveOptions = (uint)__FRAMECLOSE.FRAMECLOSE_NoSave;
+
             return VSConstants.S_OK;
         }
 


### PR DESCRIPTION
## Bug

**Partially** fixes: https://github.com/NuGet/Home/issues/9935
Regression: No 

## Fix

Details: In a CodeSpaces-connected client, when PM UI closes it tries to persist settings.  In the process it tries to get the project name so the name can be used in a settings key.  However, querying for the project's metadata fails because the project is already unavailable.

The fix is to cache the settings key on PM UI load and update it if/when the project is renamed.  Then, on PM UI close use the cached settings key.

## Testing/Validation

Tests Added: No
Reason for not adding tests:  No CodeSpaces tests yet --- that's a separate work item.
Validation:  Manually validated closure in standalone and CodeSpaces-connected cases.

CC @rrelyea, @sbanni