### PR TITLE
Used ConfigureAwait(false) where applicable in Nuget.Protocol/Resources.

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/Resources/AutoCompleteResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/AutoCompleteResourceV3.cs
@@ -53,7 +53,7 @@ namespace NuGet.Protocol
             var results = await _client.GetJObjectAsync(
                 new HttpSourceRequest(queryUri, Common.NullLogger.Instance),
                 Common.NullLogger.Instance,
-                token);
+                token).ConfigureAwait(false);
             token.ThrowIfCancellationRequested();
             if (results == null)
             {
@@ -87,7 +87,7 @@ namespace NuGet.Protocol
             CancellationToken token)
         {
             //*TODOs : Take prerelease as parameter. Also it should return both listed and unlisted for powershell ?
-            var packages = await _regResource.GetPackageMetadata(packageId, includePrerelease, false, sourceCacheContext, Common.NullLogger.Instance, token);
+            var packages = await _regResource.GetPackageMetadata(packageId, includePrerelease, false, sourceCacheContext, Common.NullLogger.Instance, token).ConfigureAwait(false);
             var versions = new List<NuGetVersion>();
             foreach (var package in packages)
             {

--- a/src/NuGet.Core/NuGet.Protocol/Resources/DependencyInfoResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/DependencyInfoResourceV3.cs
@@ -71,7 +71,7 @@ namespace NuGet.Protocol
 
                 // Retrieve the registration blob
                 var singleVersion = new VersionRange(minVersion: package.Version, includeMinVersion: true, maxVersion: package.Version, includeMaxVersion: true);
-                var regInfo = await ResolverMetadataClient.GetRegistrationInfo(_client, uri, package.Id, singleVersion, cacheContext, projectFramework, log, token);
+                var regInfo = await ResolverMetadataClient.GetRegistrationInfo(_client, uri, package.Id, singleVersion, cacheContext, projectFramework, log, token).ConfigureAwait(false);
 
                 // regInfo is null if the server returns a 404 for the package to indicate that it does not exist
                 if (regInfo != null)
@@ -109,7 +109,7 @@ namespace NuGet.Protocol
                 var uri = _regResource.GetUri(packageId);
 
                 // Retrieve the registration blob
-                var regInfo = await ResolverMetadataClient.GetRegistrationInfo(_client, uri, packageId, VersionRange.All, cacheContext, projectFramework, log, token);
+                var regInfo = await ResolverMetadataClient.GetRegistrationInfo(_client, uri, packageId, VersionRange.All, cacheContext, projectFramework, log, token).ConfigureAwait(false);
 
                 // regInfo is null if the server returns a 404 for the package to indicate that it does not exist
                 if (regInfo != null)

--- a/src/NuGet.Core/NuGet.Protocol/Resources/DownloadResourcePlugin.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/DownloadResourcePlugin.cs
@@ -110,12 +110,12 @@ namespace NuGet.Protocol
                 await _utilities.DoOncePerPluginLifetimeAsync(
                     MessageMethod.SetLogLevel.ToString(),
                     () => SetLogLevelAsync(logger, cancellationToken),
-                    cancellationToken);
+                    cancellationToken).ConfigureAwait(false);
 
                 var response = await _plugin.Connection.SendRequestAndReceiveResponseAsync<PrefetchPackageRequest, PrefetchPackageResponse>(
                     MessageMethod.PrefetchPackage,
                     new PrefetchPackageRequest(_packageSource.Source, identity.Id, identity.Version.ToNormalizedString()),
-                    cancellationToken);
+                    cancellationToken).ConfigureAwait(false);
 
                 if (response != null)
                 {
@@ -169,7 +169,7 @@ namespace NuGet.Protocol
             await _plugin.Connection.SendRequestAndReceiveResponseAsync<SetLogLevelRequest, SetLogLevelResponse>(
                 MessageMethod.SetLogLevel,
                 new SetLogLevelRequest(logLevel),
-                cancellationToken);
+                cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/Resources/DownloadResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/DownloadResourceV3.cs
@@ -110,7 +110,7 @@ namespace NuGet.Protocol
                 using (var sourceCacheContext = new SourceCacheContext())
                 {
                     // Read the url from the registration information
-                    var blob = await _regResource.GetPackageMetadata(identity, sourceCacheContext, log, token);
+                    var blob = await _regResource.GetPackageMetadata(identity, sourceCacheContext, log, token).ConfigureAwait(false);
 
                     if (blob != null
                         && blob["packageContent"] != null)
@@ -148,7 +148,7 @@ namespace NuGet.Protocol
             var stopwatch = Stopwatch.StartNew();
             try
             {
-                var uri = await GetDownloadUrl(identity, logger, token);
+                var uri = await GetDownloadUrl(identity, logger, token).ConfigureAwait(false);
 
                 if (uri != null)
                 {
@@ -159,7 +159,7 @@ namespace NuGet.Protocol
                         downloadContext,
                         globalPackagesFolder,
                         logger,
-                        token);
+                        token).ConfigureAwait(false);
                 }
 
                 return new DownloadResourceResult(DownloadResourceResultStatus.NotFound);

--- a/src/NuGet.Core/NuGet.Protocol/Resources/MetadataResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/MetadataResource.cs
@@ -20,7 +20,7 @@ namespace NuGet.Protocol.Core.Types
         /// </summary>
         public async Task<IEnumerable<NuGetVersion>> GetVersions(string packageId, SourceCacheContext sourceCacheContext, Common.ILogger log, CancellationToken token)
         {
-            return await GetVersions(packageId, true, false, sourceCacheContext, log, token);
+            return await GetVersions(packageId, true, false, sourceCacheContext, log, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -34,7 +34,7 @@ namespace NuGet.Protocol.Core.Types
         /// </summary>
         public async Task<bool> Exists(PackageIdentity identity, SourceCacheContext sourceCacheContext, Common.ILogger log, CancellationToken token)
         {
-            return await Exists(identity, true, sourceCacheContext, log, token);
+            return await Exists(identity, true, sourceCacheContext, log, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -44,7 +44,7 @@ namespace NuGet.Protocol.Core.Types
 
         public async Task<bool> Exists(string packageId, SourceCacheContext sourceCacheContext, Common.ILogger log, CancellationToken token)
         {
-            return await Exists(packageId, true, false, sourceCacheContext, log, token);
+            return await Exists(packageId, true, false, sourceCacheContext, log, token).ConfigureAwait(false);
         }
 
         public abstract Task<bool> Exists(string packageId, bool includePrerelease, bool includeUnlisted, SourceCacheContext sourceCacheContext, Common.ILogger log, CancellationToken token);
@@ -53,7 +53,7 @@ namespace NuGet.Protocol.Core.Types
 
         public async Task<NuGetVersion> GetLatestVersion(string packageId, bool includePrerelease, bool includeUnlisted, SourceCacheContext sourceCacheContext, Common.ILogger log, CancellationToken token)
         {
-            var results = await GetLatestVersions(new string[] { packageId }, includePrerelease, includeUnlisted, sourceCacheContext, log, token);
+            var results = await GetLatestVersions(new string[] { packageId }, includePrerelease, includeUnlisted, sourceCacheContext, log, token).ConfigureAwait(false);
             var result = results.SingleOrDefault();
 
             if (!result.Equals(default(KeyValuePair<string, bool>)))

--- a/src/NuGet.Core/NuGet.Protocol/Resources/MetadataResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/MetadataResourceV3.cs
@@ -46,7 +46,7 @@ namespace NuGet.Protocol
                 IEnumerable<NuGetVersion> allVersions;
                 try
                 {
-                    var catalogEntries = await _regResource.GetPackageMetadata(id, includePrerelease, includeUnlisted, sourceCacheContext, log, token);
+                    var catalogEntries = await _regResource.GetPackageMetadata(id, includePrerelease, includeUnlisted, sourceCacheContext, log, token).ConfigureAwait(false);
                     allVersions = catalogEntries.Select(p => NuGetVersion.Parse(p["version"].ToString()));
                 }
                 catch (Exception ex)
@@ -71,7 +71,7 @@ namespace NuGet.Protocol
             CancellationToken token)
         {
             // TODO: get the url and just check the headers?
-            var metadata = await _regResource.GetPackageMetadata(identity, sourceCacheContext, log, token);
+            var metadata = await _regResource.GetPackageMetadata(identity, sourceCacheContext, log, token).ConfigureAwait(false);
 
             // TODO: listed check
             return metadata != null;
@@ -85,7 +85,7 @@ namespace NuGet.Protocol
             Common.ILogger log,
             CancellationToken token)
         {
-            var entries = await GetVersions(packageId, includePrerelease, includeUnlisted, sourceCacheContext, log, token);
+            var entries = await GetVersions(packageId, includePrerelease, includeUnlisted, sourceCacheContext, log, token).ConfigureAwait(false);
 
             return entries != null && entries.Any();
         }
@@ -100,7 +100,7 @@ namespace NuGet.Protocol
         {
             var results = new List<NuGetVersion>();
 
-            var entries = await _regResource.GetPackageEntries(packageId, includeUnlisted, sourceCacheContext, log, token);
+            var entries = await _regResource.GetPackageEntries(packageId, includeUnlisted, sourceCacheContext, log, token).ConfigureAwait(false);
 
             foreach (var catalogEntry in entries)
             {

--- a/src/NuGet.Core/NuGet.Protocol/Resources/PackageMetadataResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/PackageMetadataResourceV3.cs
@@ -51,7 +51,7 @@ namespace NuGet.Protocol
             Common.ILogger log,
             CancellationToken token)
         {
-            return await GetMetadataAsync(packageId, includePrerelease, includeUnlisted, range: VersionRange.All, sourceCacheContext, log, token);
+            return await GetMetadataAsync(packageId, includePrerelease, includeUnlisted, range: VersionRange.All, sourceCacheContext, log, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -70,7 +70,7 @@ namespace NuGet.Protocol
             CancellationToken token)
         {
             var range = new VersionRange(package.Version, includeMinVersion: true, package.Version, includeMaxVersion: true);
-            var packageMetaDatas = await GetMetadataAsync(package.Id, includePrerelease: true, includeUnlisted: true, range, sourceCacheContext, log, token);
+            var packageMetaDatas = await GetMetadataAsync(package.Id, includePrerelease: true, includeUnlisted: true, range, sourceCacheContext, log, token).ConfigureAwait(false);
 
             return packageMetaDatas.SingleOrDefault();
         }
@@ -94,7 +94,7 @@ namespace NuGet.Protocol
                 sourceCacheContext,
                 httpSourceResult => DeserializeStreamDataAsync<RegistrationIndex>(httpSourceResult.Stream, token),
                 log,
-                token);
+                token).ConfigureAwait(false);
 
             if (registrationIndex == null)
             {
@@ -119,7 +119,7 @@ namespace NuGet.Protocol
                     if (registrationPage.Items == null)
                     {
                         var rangeUri = registrationPage.Url;
-                        var leafRegistrationPage = await GetRegistratioIndexPageAsync(_client, rangeUri, packageId, lower, upper, httpSourceCacheContext, log, token);
+                        var leafRegistrationPage = await GetRegistratioIndexPageAsync(_client, rangeUri, packageId, lower, upper, httpSourceCacheContext, log, token).ConfigureAwait(false);
 
                         if (registrationPage == null)
                         {
@@ -160,7 +160,7 @@ namespace NuGet.Protocol
                 var registrationIndex = JsonExtensions.JsonObjectSerializer
                     .Deserialize<T>(jsonReader);
 
-                return await Task.FromResult(registrationIndex);
+                return await Task.FromResult(registrationIndex).ConfigureAwait(false);
             }
         }
 
@@ -197,9 +197,9 @@ namespace NuGet.Protocol
                 {
                     IgnoreNotFounds = true,
                 },
-                async httpSourceResult => await processAsync(httpSourceResult),
+                async httpSourceResult => await processAsync(httpSourceResult).ConfigureAwait(false),
                 log,
-                token);
+                token).ConfigureAwait(false);
 
             return new ValueTuple<RegistrationIndex, HttpSourceCacheContext>(index, httpSourceCacheContext);
         }

--- a/src/NuGet.Core/NuGet.Protocol/Resources/PackageSearchResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/PackageSearchResourceV3.cs
@@ -62,12 +62,12 @@ namespace NuGet.Protocol
                     skip,
                     take,
                     log,
-                    cancellationToken);
+                    cancellationToken).ConfigureAwait(false);
             }
             else
             {
 #pragma warning disable CS0618
-                var searchResultJsonObjects = await _rawSearchResource.Search(searchTerm, filter, skip, take, Common.NullLogger.Instance, cancellationToken);
+                var searchResultJsonObjects = await _rawSearchResource.Search(searchTerm, filter, skip, take, Common.NullLogger.Instance, cancellationToken).ConfigureAwait(false);
 #pragma warning restore CS0618
                 searchResultMetadata = searchResultJsonObjects
                     .Select(s => s.FromJToken<PackageSearchMetadata>());
@@ -155,7 +155,7 @@ namespace NuGet.Protocol
                 {
                     log.LogVerbose($"Querying {queryUrl.Uri}");
 
-                    searchResult = await getResultAsync(queryUrl.Uri);
+                    searchResult = await getResultAsync(queryUrl.Uri).ConfigureAwait(false);
                 }
                 catch (OperationCanceledException)
                 {
@@ -200,7 +200,7 @@ namespace NuGet.Protocol
                 skip,
                 take,
                 log,
-                cancellationToken);
+                cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -233,7 +233,7 @@ namespace NuGet.Protocol
                 skip,
                 take,
                 log,
-                cancellationToken);
+                cancellationToken).ConfigureAwait(false);
         }
 
         internal async Task<IEnumerable<PackageSearchMetadata>> ProcessHttpStreamTakeCountedItemAsync(HttpResponseMessage httpInitialResponse, int take, CancellationToken token)
@@ -243,7 +243,7 @@ namespace NuGet.Protocol
                 return Enumerable.Empty<PackageSearchMetadata>();
             }
 
-            return (await ProcessHttpStreamWithoutBufferingAsync(httpInitialResponse, (uint)take, token)).Data;
+            return (await ProcessHttpStreamWithoutBufferingAsync(httpInitialResponse, (uint)take, token).ConfigureAwait(false)).Data;
         }
 
         private async Task<V3SearchResults> ProcessHttpStreamWithoutBufferingAsync(HttpResponseMessage httpInitialResponse, uint take, CancellationToken token)
@@ -256,7 +256,7 @@ namespace NuGet.Protocol
             var _newtonsoftConvertersSerializer = JsonSerializer.Create(JsonExtensions.ObjectSerializationSettings);
             _newtonsoftConvertersSerializer.Converters.Add(new Converters.V3SearchResultsConverter(take));
 
-            using (var stream = await httpInitialResponse.Content.ReadAsStreamAsync())
+            using (var stream = await httpInitialResponse.Content.ReadAsStreamAsync().ConfigureAwait(false))
             using (var streamReader = new StreamReader(stream))
             using (var jsonReader = new JsonTextReader(streamReader))
             {

--- a/src/NuGet.Core/NuGet.Protocol/Resources/PackageUpdateResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/PackageUpdateResource.cs
@@ -80,7 +80,7 @@ namespace NuGet.Protocol.Core.Types
                     if (!packagePath.EndsWith(NuGetConstants.SnupkgExtension, StringComparison.OrdinalIgnoreCase))
                     {
                         await PushPackage(packagePath, _source, apiKey, noServiceEndpoint, skipDuplicate,
-                            requestTimeout, log, tokenSource.Token);
+                            requestTimeout, log, tokenSource.Token).ConfigureAwait(false);
 
                         //Since this was not a snupkg push (probably .nupkg), when we try pushing symbols later, don't error if there are no snupkg files found.
                         explicitSnupkgPush = false;
@@ -95,7 +95,7 @@ namespace NuGet.Protocol.Core.Types
 
                         await PushSymbols(packagePath, symbolSource, symbolApiKey,
                             noServiceEndpoint, skipDuplicate, symbolPackageUpdateResource,
-                            requestTimeout, log, explicitSnupkgPush, tokenSource.Token);
+                            requestTimeout, log, explicitSnupkgPush, tokenSource.Token).ConfigureAwait(false);
                     }
                 }
             }
@@ -139,7 +139,7 @@ namespace NuGet.Protocol.Core.Types
                 noServiceEndpoint,
                 skipDuplicate: false,
                 symbolPackageUpdateResource: null,
-                log: log);
+                log: log).ConfigureAwait(false);
         }
 
         public async Task Delete(string packageId,
@@ -166,7 +166,7 @@ namespace NuGet.Protocol.Core.Types
                     packageVersion,
                     sourceDisplayName
                     ));
-                await DeletePackage(_source, apiKey, packageId, packageVersion, noServiceEndpoint, log, CancellationToken.None);
+                await DeletePackage(_source, apiKey, packageId, packageVersion, noServiceEndpoint, log, CancellationToken.None).ConfigureAwait(false);
                 log.LogInformation(string.Format(CultureInfo.CurrentCulture,
                     Strings.DeleteCommandDeletedPackage,
                     packageId,
@@ -220,7 +220,7 @@ namespace NuGet.Protocol.Core.Types
                         Strings.DefaultSymbolServer));
                 }
 
-                await PushAll(source, apiKey, noServiceEndpoint, skipDuplicate, requestTimeout, log, packagesToPush: symbolsToPush, token);
+                await PushAll(source, apiKey, noServiceEndpoint, skipDuplicate, requestTimeout, log, packagesToPush: symbolsToPush, token).ConfigureAwait(false);
             }
         }
 
@@ -251,14 +251,14 @@ namespace NuGet.Protocol.Core.Types
                     GetSourceDisplayName(source)));
             }
 
-            await PushAll(source, apiKey, noServiceEndpoint, skipDuplicate, requestTimeout, log, packagesToPush: nupkgsToPush, token);
+            await PushAll(source, apiKey, noServiceEndpoint, skipDuplicate, requestTimeout, log, packagesToPush: nupkgsToPush, token).ConfigureAwait(false);
         }
 
         private async Task PushAll(string source, string apiKey, bool noServiceEndpoint, bool skipDuplicate, TimeSpan requestTimeout, ILogger log, IEnumerable<string> packagesToPush, CancellationToken token)
         {
             foreach (var packageToPush in packagesToPush)
             {
-                await PushPackageCore(source, apiKey, packageToPush, noServiceEndpoint, skipDuplicate, requestTimeout, log, token);
+                await PushPackageCore(source, apiKey, packageToPush, noServiceEndpoint, skipDuplicate, requestTimeout, log, token).ConfigureAwait(false);
             }
         }
 
@@ -283,13 +283,13 @@ namespace NuGet.Protocol.Core.Types
 
             if (sourceUri.IsFile)
             {
-                await PushPackageToFileSystem(sourceUri, packageToPush, skipDuplicate, log, token);
+                await PushPackageToFileSystem(sourceUri, packageToPush, skipDuplicate, log, token).ConfigureAwait(false);
             }
             else
             {
                 var length = new FileInfo(packageToPush).Length;
                 showPushCommandPackagePushed = await PushPackageToServer(source, apiKey, packageToPush, length, noServiceEndpoint, skipDuplicate
-                                                    , requestTimeout, log, token);
+                                                    , requestTimeout, log, token).ConfigureAwait(false);
 
             }
 
@@ -366,7 +366,7 @@ namespace NuGet.Protocol.Core.Types
                             retry++;
                             success = true;
                             // If user push to https://nuget.smbsrc.net/, use temp api key.
-                            var tmpApiKey = await GetSecureApiKey(packageIdentity, apiKey, noServiceEndpoint, requestTimeout, logger, token);
+                            var tmpApiKey = await GetSecureApiKey(packageIdentity, apiKey, noServiceEndpoint, requestTimeout, logger, token).ConfigureAwait(false);
 
                             await _httpSource.ProcessResponseAsync(
                                 new HttpSourceRequest(() => CreateRequest(serviceEndpointUrl, pathToPackage, tmpApiKey, logger))
@@ -384,7 +384,7 @@ namespace NuGet.Protocol.Core.Types
                                     return Task.FromResult(0);
                                 },
                                 logger,
-                                token);
+                                token).ConfigureAwait(false);
                         }
                         catch (OperationCanceledException)
                         {
@@ -426,7 +426,7 @@ namespace NuGet.Protocol.Core.Types
                         return Task.FromResult(0);
                     },
                     logger,
-                    token);
+                    token).ConfigureAwait(false);
             }
 
             return showPushCommandPackagePushed;
@@ -623,7 +623,7 @@ namespace NuGet.Protocol.Core.Types
                     throwIfPackageExists: !skipDuplicate,
                     extractionContext: packageExtractionContext);
 
-                await OfflineFeedUtility.AddPackageToSource(context, token);
+                await OfflineFeedUtility.AddPackageToSource(context, token).ConfigureAwait(false);
             }
         }
 
@@ -643,7 +643,7 @@ namespace NuGet.Protocol.Core.Types
             }
             else
             {
-                await DeletePackageFromServer(source, apiKey, packageId, packageVersion, noServiceEndpoint, logger, token);
+                await DeletePackageFromServer(source, apiKey, packageId, packageVersion, noServiceEndpoint, logger, token).ConfigureAwait(false);
             }
         }
 
@@ -688,7 +688,7 @@ namespace NuGet.Protocol.Core.Types
                     return Task.FromResult(0);
                 },
                 logger,
-                token);
+                token).ConfigureAwait(false);
         }
 
         // Deletes a package from a FileSystem.
@@ -840,7 +840,7 @@ namespace NuGet.Protocol.Core.Types
                         MaxTries = 1
                     },
                    logger,
-                   token);
+                   token).ConfigureAwait(false);
 
                 return result.Value<string>("Key") ?? InvalidApiKey;
             }

--- a/src/NuGet.Core/NuGet.Protocol/Resources/PluginResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/PluginResource.cs
@@ -82,7 +82,7 @@ namespace NuGet.Protocol.Core.Types
                     await result.PluginMulticlientUtilities.DoOncePerPluginLifetimeAsync(
                         key,
                         () => SetPackageSourceCredentialsAsync(result.Plugin, cancellationToken),
-                        cancellationToken);
+                        cancellationToken).ConfigureAwait(false);
 
                     return new GetPluginResult(result.Plugin, result.PluginMulticlientUtilities);
                 }
@@ -98,7 +98,7 @@ namespace NuGet.Protocol.Core.Types
             await plugin.Connection.SendRequestAndReceiveResponseAsync<SetCredentialsRequest, SetCredentialsResponse>(
                 MessageMethod.SetCredentials,
                 payload,
-                cancellationToken);
+                cancellationToken).ConfigureAwait(false);
         }
 
         private SetCredentialsRequest CreateRequest()

--- a/src/NuGet.Core/NuGet.Protocol/Resources/RawSearchResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/RawSearchResourceV3.cs
@@ -86,7 +86,7 @@ namespace NuGet.Protocol
                     searchJson = await _client.GetJObjectAsync(
                         new HttpSourceRequest(queryUrl.Uri, log),
                         log,
-                        cancellationToken);
+                        cancellationToken).ConfigureAwait(false);
                 }
                 catch (OperationCanceledException)
                 {
@@ -118,7 +118,7 @@ namespace NuGet.Protocol
         [Obsolete("Use PackageSearchResource instead (via SourceRepository.GetResourceAsync<PackageSearchResource>")]
         public virtual async Task<IEnumerable<JObject>> Search(string searchTerm, SearchFilter filters, int skip, int take, Common.ILogger log, CancellationToken cancellationToken)
         {
-            var results = await SearchPage(searchTerm, filters, skip, take, log, cancellationToken);
+            var results = await SearchPage(searchTerm, filters, skip, take, log, cancellationToken).ConfigureAwait(false);
 
             var data = results[JsonProperties.Data] as JArray ?? Enumerable.Empty<JToken>();
             return data.OfType<JObject>();

--- a/src/NuGet.Core/NuGet.Protocol/Resources/RegistrationResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/RegistrationResourceV3.cs
@@ -97,7 +97,7 @@ namespace NuGet.Protocol
         /// <remarks>The inlined entries are potentially going away soon</remarks>
         public virtual async Task<JObject> GetPackageMetadata(PackageIdentity identity, SourceCacheContext cacheContext, Common.ILogger log, CancellationToken token)
         {
-            return (await GetPackageMetadata(identity.Id, new VersionRange(identity.Version, true, identity.Version, true), true, true, cacheContext, log, token)).SingleOrDefault();
+            return (await GetPackageMetadata(identity.Id, new VersionRange(identity.Version, true, identity.Version, true), true, true, cacheContext, log, token).ConfigureAwait(false)).SingleOrDefault();
         }
 
         /// <summary>
@@ -106,7 +106,7 @@ namespace NuGet.Protocol
         /// <remarks>The inlined entries are potentially going away soon</remarks>
         public virtual async Task<IEnumerable<JObject>> GetPackageMetadata(string packageId, bool includePrerelease, bool includeUnlisted, SourceCacheContext cacheContext, Common.ILogger log, CancellationToken token)
         {
-            return await GetPackageMetadata(packageId, VersionRange.All, includePrerelease, includeUnlisted, cacheContext, log, token);
+            return await GetPackageMetadata(packageId, VersionRange.All, includePrerelease, includeUnlisted, cacheContext, log, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -126,7 +126,7 @@ namespace NuGet.Protocol
 
             var registrationUri = GetUri(packageId);
 
-            var ranges = await RegistrationUtility.LoadRanges(_client, registrationUri, packageId, range, cacheContext, log, token);
+            var ranges = await RegistrationUtility.LoadRanges(_client, registrationUri, packageId, range, cacheContext, log, token).ConfigureAwait(false);
 
             foreach (var rangeObj in ranges)
             {


### PR DESCRIPTION
## Bug

Fixes: [#7192](https://github.com/NuGet/Home/issues/7192)
Regression: No

## Fix

Classes in [NuGet.Protocol/Resources](https://github.com/NuGet/NuGet.Client/tree/dev/src/NuGet.Core/NuGet.Protocol/Resources) do not use `ConfigureAwait(false)` when calling async methods, which can result in deadlocking [as described here](https://github.com/NuGet/Home/issues/7192). 

## Testing/Validation

Tests Added: No
Reason for not adding tests:  Edited methods already have tests, which are still passing. 
