### PR TITLE
Change 35 tests to use SimpleTestPathContext for better isolation, so that they could run in parallel

### DIFF
--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Util.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Util.cs
@@ -1061,19 +1061,6 @@ EndProject";
                  </Project>".Replace("$NAME$", projectName);
         }
 
-        public static void ClearWebCache()
-        {
-            var nugetExe = Util.GetNuGetExePath();
-
-            var r = CommandRunner.Run(
-            nugetExe,
-            ".",
-            "locals http-cache -Clear",
-            waitForExit: true);
-
-            Assert.Equal(0, r.Item1);
-        }
-
         public static string CreateBasicTwoProjectSolution(TestDirectory workingPath, string proj1ConfigFileName, string proj2ConfigFileName)
         {
             var repositoryPath = Path.Combine(workingPath, "Repository");

--- a/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestSettingsContext.cs
+++ b/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestSettingsContext.cs
@@ -110,11 +110,41 @@ namespace NuGet.Test.Utility
             return node;
         }
 
+        public static void AddPackageSourceCredentialsSection(XDocument doc, string sourceName, string userName, string password, bool clearTextPassword)
+        {
+            var root = doc.Element(XName.Get("configuration"));
+
+            var sourceNode = new XElement(XName.Get(sourceName));
+            AddEntry(sourceNode, "Username", userName);
+            if (clearTextPassword)
+            {
+                AddEntry(sourceNode, "ClearTextPassword", password);
+            }
+            else
+            {
+                AddEntry(sourceNode, "Password", password);
+            }
+
+            var packageSourceCredentialsNode = new XElement(XName.Get("packageSourceCredentials"));
+            packageSourceCredentialsNode.Add(sourceNode);
+
+            root.Add(packageSourceCredentialsNode);
+        }
+
         public static void AddEntry(XElement section, string key, string value)
         {
             var setting = new XElement(XName.Get("add"));
             setting.Add(new XAttribute(XName.Get("key"), key));
             setting.Add(new XAttribute(XName.Get("value"), value));
+            section.Add(setting);
+        }
+
+        public static void AddEntry(XElement section, string key, string value, string additionalAtrributeName, string additionalAttributeValue)
+        {
+            var setting = new XElement(XName.Get("add"));
+            setting.Add(new XAttribute(XName.Get("key"), key));
+            setting.Add(new XAttribute(XName.Get("value"), value));
+            setting.Add(new XAttribute(XName.Get(additionalAtrributeName), additionalAttributeValue));
             section.Add(setting);
         }
 


### PR DESCRIPTION
## Bug

This is a progress on making NuGet.CommandLine.Tests be able to run in parallel  https://github.com/NuGet/Client.Engineering/issues/518

Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: 
Util.ClearWebCache() clears the default shared http-cache. It will cause problem when running tests in parallel.
~~So this fix creates individual http-cache for each test, override the default one by specifying the individual http-cache folder in the environment variable `NUGET_HTTP_CACHE_PATH`  https://docs.microsoft.com/en-us/nuget/consume-packages/managing-the-global-packages-and-cache-folders~~
So this fix changed the 35 tests to use SimpleTestPathContext for better isolation.

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  modify tests
Validation:  
