### PR TITLE
Adding SVG to the list of support Icon format

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PackageBuilder.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PackageBuilder.cs
@@ -696,7 +696,8 @@ namespace NuGet.Packaging
                 if (string.IsNullOrEmpty(ext) || (
                         !ext.Equals(".jpeg", StringComparison.OrdinalIgnoreCase) &&
                         !ext.Equals(".jpg", StringComparison.OrdinalIgnoreCase) &&
-                        !ext.Equals(".png", StringComparison.OrdinalIgnoreCase)))
+                        !ext.Equals(".png", StringComparison.OrdinalIgnoreCase))) &&
+                        !ext.Equals(".svg", StringComparison.OrdinalIgnoreCase))) &&
                 {
                     throw new PackagingException(
                         NuGetLogCode.NU5045,


### PR DESCRIPTION
## Enhancement
This PR intend to bring up the discussion about SVG on the table to see if it could be a thing or not
I see a lots of question on Twitter, Slack, Discord about the "how to use vectorial image well known standard (like SVG) for icon rather that only png, jpeg, jpg"
As I would have understood 10 years ago, is there still limitation today that could block this feature to move forward ?

## Testing/Validation

Tests Added: No (Not yet)
Reason for not adding tests: Bringing the discussion to the table before starting to work on it
Validation:  