### PR TITLE
fix dotnet nuget verify default verbosity level

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Signing/VerifyCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Signing/VerifyCommand.cs
@@ -55,7 +55,11 @@ namespace NuGet.CommandLine.XPlat
                         new List<Verification>() { Verification.Signatures };
                     args.CertificateFingerprint = fingerPrint.Values;
                     args.Logger = getLogger();
-                    setLogLevel(XPlatUtility.MSBuildVerbosityToNuGetLogLevel(verbosity.Value()));
+
+                    if (verbosity.HasValue())
+                    {
+                        setLogLevel(XPlatUtility.MSBuildVerbosityToNuGetLogLevel(verbosity.Value()));
+                    }
 
                     var runner = getCommandRunner();
                     var verifyTask = runner.ExecuteCommandAsync(args);

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetVerifyTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetVerifyTests.cs
@@ -112,7 +112,7 @@ namespace Dotnet.Integration.Test
         }
 
         [CIOnlyFact]
-        public void Verify_MultipleSignedPackagesWithWildCardAndDetailedVerbosity_MixedResults()
+        public void Verify_MultipleSignedPackagesWithWildCard_MixedResults()
         {
             // Arrange
             using (var testDirectory1 = TestDirectory.Create())
@@ -130,7 +130,7 @@ namespace Dotnet.Integration.Test
                     //Act
                     var result = _msbuildFixture.RunDotnet(
                         testDirectory1,
-                        $"nuget verify {packagX.FullName} {Path.Combine(testDirectory2, "*.nupkg")} -v d",
+                        $"nuget verify {packagX.FullName} {Path.Combine(testDirectory2, "*.nupkg")}",
                         ignoreExitCode: true);
 
                     result.Success.Should().BeFalse(because: result.AllOutput);

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatVerifyTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatVerifyTests.cs
@@ -53,6 +53,7 @@ namespace NuGet.XPlat.FuncTest
         }
 
         [Theory]
+        [InlineData("", "", LogLevel.Information)]
         [InlineData("--verbosity", "q", LogLevel.Warning)]
         [InlineData("-v", "quiet", LogLevel.Warning)]
         [InlineData("--verbosity", "m", LogLevel.Minimal)]

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatVerifyTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatVerifyTests.cs
@@ -53,7 +53,6 @@ namespace NuGet.XPlat.FuncTest
         }
 
         [Theory]
-        [InlineData("", "", LogLevel.Information)]
         [InlineData("--verbosity", "q", LogLevel.Warning)]
         [InlineData("-v", "quiet", LogLevel.Warning)]
         [InlineData("--verbosity", "m", LogLevel.Minimal)]


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/10316
Regression: No

## Fix

Details: The default verbosity for `dotnet` commands is [`LogLevel.Information`](https://github.com/NuGet/NuGet.Client/blob/dev/src/NuGet.Core/NuGet.CommandLine.XPlat/Program.cs#L31). If the user didn't pass value for `--verbosity` option, then the log level is set to [`LogLevel.Minimal`](https://github.com/NuGet/NuGet.Client/blob/dev/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/XPlatUtility.cs#L43). Hence by default this command did not display any log messages. Changed this logic so that default verbosity will be overridden only when the value is passed explicitly to the command.

## Testing/Validation

Tests Added: Yes, modified existing test