### PR TITLE
Add fault telemetry for (hopefully) all VS APIs

### DIFF
--- a/src/NuGet.Clients/NuGet.Tools/NuGetBrokeredServiceFactory.cs
+++ b/src/NuGet.Clients/NuGet.Tools/NuGetBrokeredServiceFactory.cs
@@ -179,15 +179,13 @@ namespace NuGetVSExtension
             return new NuGetProjectService(solutionManager, settings, telemetryProvider);
         }
 
-        private Task InitializeAsync()
+        private async Task InitializeAsync()
         {
             _lazySettings = new AsyncLazy<ISettings>(ServiceLocator.GetInstanceAsync<ISettings>, ThreadHelper.JoinableTaskFactory);
             _lazySolutionManager = new AsyncLazy<IVsSolutionManager>(ServiceLocator.GetInstanceAsync<IVsSolutionManager>, ThreadHelper.JoinableTaskFactory);
             _projectManagerServiceSharedState = new NuGetProjectManagerServiceState();
             _sharedServiceState = await SharedServiceState.CreateAsync(CancellationToken.None);
             _lazyTelemetryProvider = new AsyncLazy<INuGetTelemetryProvider>(ServiceLocator.GetInstanceAsync<INuGetTelemetryProvider>, ThreadHelper.JoinableTaskFactory);
-
-            return Task.CompletedTask;
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.Tools/NuGetBrokeredServiceFactory.cs
+++ b/src/NuGet.Clients/NuGet.Tools/NuGetBrokeredServiceFactory.cs
@@ -13,6 +13,7 @@ using NuGet.PackageManagement.VisualStudio;
 using NuGet.VisualStudio;
 using NuGet.VisualStudio.Implementation.Extensibility;
 using NuGet.VisualStudio.Internal.Contracts;
+using NuGet.VisualStudio.Telemetry;
 using ContractsNuGetServices = NuGet.VisualStudio.Contracts.NuGetServices;
 using IBrokeredServiceContainer = Microsoft.VisualStudio.Shell.ServiceBroker.IBrokeredServiceContainer;
 using ISettings = NuGet.Configuration.ISettings;
@@ -29,6 +30,7 @@ namespace NuGetVSExtension
         private AsyncLazy<IVsSolutionManager> _lazySolutionManager;
         private INuGetProjectManagerServiceState _projectManagerServiceSharedState;
         private ISharedServiceState _sharedServiceState;
+        private AsyncLazy<INuGetTelemetryProvider> _lazyTelemetryProvider;
 
         private NuGetBrokeredServiceFactory()
         {
@@ -172,16 +174,20 @@ namespace NuGetVSExtension
 
             IVsSolutionManager solutionManager = await _lazySolutionManager.GetValueAsync(cancellationToken);
             ISettings settings = await _lazySettings.GetValueAsync(cancellationToken);
+            INuGetTelemetryProvider telemetryProvider = await _lazyTelemetryProvider.GetValueAsync(cancellationToken);
 
-            return new NuGetProjectService(solutionManager, settings);
+            return new NuGetProjectService(solutionManager, settings, telemetryProvider);
         }
 
-        private async Task InitializeAsync()
+        private Task InitializeAsync()
         {
             _lazySettings = new AsyncLazy<ISettings>(ServiceLocator.GetInstanceAsync<ISettings>, ThreadHelper.JoinableTaskFactory);
             _lazySolutionManager = new AsyncLazy<IVsSolutionManager>(ServiceLocator.GetInstanceAsync<IVsSolutionManager>, ThreadHelper.JoinableTaskFactory);
             _projectManagerServiceSharedState = new NuGetProjectManagerServiceState();
             _sharedServiceState = await SharedServiceState.CreateAsync(CancellationToken.None);
+            _lazyTelemetryProvider = new AsyncLazy<INuGetTelemetryProvider>(ServiceLocator.GetInstanceAsync<INuGetTelemetryProvider>, ThreadHelper.JoinableTaskFactory);
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/INuGetTelemetryProvider.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/INuGetTelemetryProvider.cs
@@ -1,0 +1,18 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using NuGet.Common;
+
+namespace NuGet.VisualStudio.Telemetry
+{
+    public interface INuGetTelemetryProvider
+    {
+        Task EmitEventAsync(TelemetryEvent telemetryEvent);
+        Task PostFaultAsync(Exception e, string callerClassName, [CallerMemberName] string callerMemberName = null, IDictionary<string, object> extraProperties = null);
+        void PostFault(Exception e, string callerClassName, [CallerMemberName] string callerMemberName = null, IDictionary<string, object> extraProperties = null);
+    }
+}

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/INuGetTelemetryProvider.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/INuGetTelemetryProvider.cs
@@ -11,7 +11,7 @@ namespace NuGet.VisualStudio.Telemetry
 {
     public interface INuGetTelemetryProvider
     {
-        Task EmitEventAsync(TelemetryEvent telemetryEvent);
+        void EmitEvent(TelemetryEvent telemetryEvent);
         Task PostFaultAsync(Exception e, string callerClassName, [CallerMemberName] string callerMemberName = null, IDictionary<string, object> extraProperties = null);
         void PostFault(Exception e, string callerClassName, [CallerMemberName] string callerMemberName = null, IDictionary<string, object> extraProperties = null);
     }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/NuGetTelemetryProvider.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/NuGetTelemetryProvider.cs
@@ -1,0 +1,35 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using NuGet.Common;
+
+namespace NuGet.VisualStudio.Telemetry
+{
+    [Export(typeof(INuGetTelemetryProvider))]
+    internal class NuGetTelemetryProvider : INuGetTelemetryProvider
+    {
+        public Task EmitEventAsync(TelemetryEvent telemetryEvent)
+        {
+            TelemetryActivity.EmitTelemetryEvent(telemetryEvent);
+            return Task.CompletedTask;
+        }
+
+        public async Task PostFaultAsync(Exception e, string callerClassName, [CallerMemberName] string callerMemberName = null, IDictionary<string, object> extraProperties = null)
+        {
+            await TelemetryUtility.PostFaultAsync(e, callerClassName, callerMemberName, extraProperties);
+        }
+
+        public void PostFault(Exception e, string callerClassName, [CallerMemberName] string callerMemberName = null, IDictionary<string, object> extraProperties = null)
+        {
+            NuGetUIThreadHelper.JoinableTaskFactory.Run(async () =>
+            {
+                await TelemetryUtility.PostFaultAsync(e, callerClassName, callerMemberName, extraProperties);
+            });
+        }
+    }
+}

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/NuGetTelemetryProvider.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/NuGetTelemetryProvider.cs
@@ -28,7 +28,7 @@ namespace NuGet.VisualStudio.Telemetry
         {
             NuGetUIThreadHelper.JoinableTaskFactory.Run(async () =>
             {
-                await TelemetryUtility.PostFaultAsync(e, callerClassName, callerMemberName, extraProperties);
+                await PostFaultAsync(e, callerClassName, callerMemberName, extraProperties);
             });
         }
     }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/NuGetTelemetryProvider.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/NuGetTelemetryProvider.cs
@@ -13,10 +13,9 @@ namespace NuGet.VisualStudio.Telemetry
     [Export(typeof(INuGetTelemetryProvider))]
     internal class NuGetTelemetryProvider : INuGetTelemetryProvider
     {
-        public Task EmitEventAsync(TelemetryEvent telemetryEvent)
+        public void EmitEvent(TelemetryEvent telemetryEvent)
         {
             TelemetryActivity.EmitTelemetryEvent(telemetryEvent);
-            return Task.CompletedTask;
         }
 
         public async Task PostFaultAsync(Exception e, string callerClassName, [CallerMemberName] string callerMemberName = null, IDictionary<string, object> extraProperties = null)

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/TelemetryUtility.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/TelemetryUtility.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
@@ -19,7 +20,7 @@ namespace NuGet.VisualStudio.Telemetry
 {
     public static class TelemetryUtility
     {
-        public static async Task PostFaultAsync(Exception e, string callerClassName, [CallerMemberName] string callerMemberName = null)
+        public static async Task PostFaultAsync(Exception e, string callerClassName, [CallerMemberName] string callerMemberName = null, IDictionary<string, object> extraProperties = null)
         {
             if (e == null)
             {
@@ -33,6 +34,14 @@ namespace NuGet.VisualStudio.Telemetry
 
             var fault = new FaultEvent($"{VSTelemetrySession.VSEventNamePrefix}Fault", description, FaultSeverity.General, e, gatherEventDetails: null);
             fault.Properties[$"{VSTelemetrySession.VSPropertyNamePrefix}Fault.Caller"] = caller;
+            if (extraProperties != null)
+            {
+                foreach (var kvp in extraProperties)
+                {
+                    fault.Properties[VSTelemetrySession.VSEventNamePrefix + kvp.Key] = kvp.Value;
+                }
+            }
+
             TelemetryService.DefaultSession.PostEvent(fault);
 
             if (await IsShellAvailable.GetValueAsync())

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/TelemetryUtility.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/TelemetryUtility.cs
@@ -32,7 +32,7 @@ namespace NuGet.VisualStudio.Telemetry
 
             await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
-            var fault = new FaultEvent($"{VSTelemetrySession.VSEventNamePrefix}Fault", description, FaultSeverity.General, e, gatherEventDetails: null);
+            var fault = new FaultEvent(VSTelemetrySession.VSEventNamePrefix + "Fault", description, FaultSeverity.General, e, gatherEventDetails: null);
             fault.Properties[$"{VSTelemetrySession.VSPropertyNamePrefix}Fault.Caller"] = caller;
             if (extraProperties != null)
             {

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsFrameworkCompatibility.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsFrameworkCompatibility.cs
@@ -104,7 +104,7 @@ namespace NuGet.VisualStudio
                 {
                     if (frameworkName == null)
                     {
-                        throw new ArgumentException("null item in " + argumentName);
+                        throw new ArgumentException(message: VsResourcesFormat.PropertyCannotBeNull(nameof(FrameworkName)), paramName: nameof(frameworks));
                     }
 
                     NuGetFramework nugetFramework = NuGetFramework.ParseFrameworkName(frameworkName.ToString(), DefaultFrameworkNameProvider.Instance);

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsFrameworkCompatibility.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsFrameworkCompatibility.cs
@@ -33,7 +33,8 @@ namespace NuGet.VisualStudio
                 return DefaultFrameworkNameProvider
                     .Instance
                     .GetNetStandardVersions()
-                    .Select(framework => new FrameworkName(framework.DotNetFrameworkName));
+                    .Select(framework => new FrameworkName(framework.DotNetFrameworkName))
+                    .ToList();
             }
             catch (Exception exception)
             {
@@ -65,7 +66,8 @@ namespace NuGet.VisualStudio
                 return CompatibilityListProvider
                     .Default
                     .GetFrameworksSupporting(nuGetFramework)
-                    .Select(framework => new FrameworkName(framework.DotNetFrameworkName));
+                    .Select(framework => new FrameworkName(framework.DotNetFrameworkName))
+                    .ToList();
             }
             catch (Exception exception)
             {

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsFrameworkParser.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsFrameworkParser.cs
@@ -7,6 +7,7 @@ using System.Globalization;
 using System.Runtime.Versioning;
 using NuGet.Frameworks;
 using NuGet.VisualStudio.Implementation.Resources;
+using NuGet.VisualStudio.Telemetry;
 
 namespace NuGet.VisualStudio
 {
@@ -14,6 +15,14 @@ namespace NuGet.VisualStudio
     [Export(typeof(IVsFrameworkParser2))]
     public class VsFrameworkParser : IVsFrameworkParser, IVsFrameworkParser2
     {
+        private INuGetTelemetryProvider _telemetryProvider;
+
+        [ImportingConstructor]
+        public VsFrameworkParser(INuGetTelemetryProvider telemetryProvider)
+        {
+            _telemetryProvider = telemetryProvider;
+        }
+
         public FrameworkName ParseFrameworkName(string shortOrFullName)
         {
             if (shortOrFullName == null)
@@ -21,8 +30,20 @@ namespace NuGet.VisualStudio
                 throw new ArgumentNullException(nameof(shortOrFullName));
             }
 
-            var nuGetFramework = NuGetFramework.Parse(shortOrFullName);
-            return new FrameworkName(nuGetFramework.DotNetFrameworkName);
+            try
+            {
+                var nuGetFramework = NuGetFramework.Parse(shortOrFullName);
+                return new FrameworkName(nuGetFramework.DotNetFrameworkName);
+            }
+            catch (ArgumentException)
+            {
+                throw;
+            }
+            catch (Exception exception)
+            {
+                _telemetryProvider.PostFault(exception, typeof(VsFrameworkParser).FullName);
+                throw;
+            }
         }
 
         public string GetShortFrameworkName(FrameworkName frameworkName)
@@ -32,28 +53,40 @@ namespace NuGet.VisualStudio
                 throw new ArgumentNullException(nameof(frameworkName));
             }
 
-            var nuGetFramework = NuGetFramework.ParseFrameworkName(
-                frameworkName.ToString(),
-                DefaultFrameworkNameProvider.Instance);
-
             try
             {
-                return nuGetFramework.GetShortFolderName();
+                var nuGetFramework = NuGetFramework.ParseFrameworkName(
+                    frameworkName.ToString(),
+                    DefaultFrameworkNameProvider.Instance);
+
+                try
+                {
+                    return nuGetFramework.GetShortFolderName();
+                }
+                catch (FrameworkException e)
+                {
+                    // Wrap this exception for two reasons:
+                    //
+                    // 1) FrameworkException is not a .NET Framework type and therefore is not
+                    //    recognized by other components in Visual Studio.
+                    //
+                    // 2) Changing our NuGet code to throw ArgumentException is not appropriate in
+                    //    this case because the failure does not occur in a method that has arguments!
+                    var message = string.Format(
+                        CultureInfo.CurrentCulture,
+                        VsResources.CouldNotGetShortFrameworkName,
+                        frameworkName);
+                    throw new ArgumentException(message, e);
+                }
             }
-            catch (FrameworkException e)
+            catch (ArgumentException)
             {
-                // Wrap this exception for two reasons:
-                //
-                // 1) FrameworkException is not a .NET Framework type and therefore is not
-                //    recognized by other components in Visual Studio.
-                //
-                // 2) Changing our NuGet code to throw ArgumentException is not appropriate in
-                //    this case because the failure does not occur in a method that has arguments!
-                var message = string.Format(
-                    CultureInfo.CurrentCulture,
-                    VsResources.CouldNotGetShortFrameworkName,
-                    frameworkName);
-                throw new ArgumentException(message, e);
+                throw;
+            }
+            catch (Exception exception)
+            {
+                _telemetryProvider.PostFault(exception, typeof(VsFrameworkParser).FullName);
+                throw;
             }
         }
 
@@ -64,14 +97,22 @@ namespace NuGet.VisualStudio
                 throw new ArgumentNullException(nameof(input));
             }
 
-            NuGetFramework framework = NuGetFramework.Parse(input);
+            try
+            {
+                NuGetFramework framework = NuGetFramework.Parse(input);
 
-            string targetFrameworkMoniker = framework.DotNetFrameworkName;
-            string targetPlatformMoniker = framework.DotNetPlatformName;
-            string targetPlatforMinVersion = null;
+                string targetFrameworkMoniker = framework.DotNetFrameworkName;
+                string targetPlatformMoniker = framework.DotNetPlatformName;
+                string targetPlatforMinVersion = null;
 
-            nuGetFramework = new VsNuGetFramework(targetFrameworkMoniker, targetPlatformMoniker, targetPlatforMinVersion);
-            return framework.IsSpecificFramework;
+                nuGetFramework = new VsNuGetFramework(targetFrameworkMoniker, targetPlatformMoniker, targetPlatforMinVersion);
+                return framework.IsSpecificFramework;
+            }
+            catch (Exception exception)
+            {
+                _telemetryProvider.PostFault(exception, typeof(VsFrameworkParser).FullName);
+                throw;
+            }
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsGlobalPackagesInitScriptExecutor.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsGlobalPackagesInitScriptExecutor.cs
@@ -24,7 +24,7 @@ namespace NuGet.VisualStudio
             _telemetryProvider = telemetryProvider ?? throw new ArgumentNullException(nameof(telemetryProvider));
         }
 
-        public Task<bool> ExecuteInitScriptAsync(string packageId, string packageVersion)
+        public async Task<bool> ExecuteInitScriptAsync(string packageId, string packageVersion)
         {
             if (string.IsNullOrEmpty(packageId))
             {
@@ -42,11 +42,11 @@ namespace NuGet.VisualStudio
 
             try
             {
-                return _scriptExecutor.ExecuteInitScriptAsync(packageIdentity);
+                return await _scriptExecutor.ExecuteInitScriptAsync(packageIdentity);
             }
             catch (Exception exception)
             {
-                _telemetryProvider.PostFault(exception, typeof(VsGlobalPackagesInitScriptExecutor).FullName);
+                await _telemetryProvider.PostFaultAsync(exception, typeof(VsGlobalPackagesInitScriptExecutor).FullName);
                 throw;
             }
         }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPackageRestorer.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPackageRestorer.cs
@@ -71,7 +71,7 @@ namespace NuGet.VisualStudio
             }
             catch (Exception exception)
             {
-                    _telemetryProvider.PostFault(exception, typeof(VsPackageRestorer).FullName);
+                _telemetryProvider.PostFault(exception, typeof(VsPackageRestorer).FullName);
             }
         }
     }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPackageSourceProvider.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPackageSourceProvider.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.IO;
 using NuGet.Protocol.Core.Types;
+using NuGet.VisualStudio.Telemetry;
 
 namespace NuGet.VisualStudio
 {
@@ -13,9 +14,10 @@ namespace NuGet.VisualStudio
     public class VsPackageSourceProvider : IVsPackageSourceProvider
     {
         private readonly Configuration.IPackageSourceProvider _packageSourceProvider;
+        private readonly INuGetTelemetryProvider _telemetryProvider;
 
         [ImportingConstructor]
-        public VsPackageSourceProvider(ISourceRepositoryProvider sourceRepositoryProvider)
+        public VsPackageSourceProvider(ISourceRepositoryProvider sourceRepositoryProvider, INuGetTelemetryProvider telemetryProvider)
         {
             if (sourceRepositoryProvider == null)
             {
@@ -23,6 +25,8 @@ namespace NuGet.VisualStudio
             }
 
             _packageSourceProvider = sourceRepositoryProvider.PackageSourceProvider;
+            _telemetryProvider = telemetryProvider;
+
             _packageSourceProvider.PackageSourcesChanged += PackageSourcesChanged;
         }
 
@@ -45,6 +49,7 @@ namespace NuGet.VisualStudio
             }
             catch (Exception ex) when (!IsExpected(ex))
             {
+                _telemetryProvider.PostFault(ex, typeof(VsPackageSourceProvider).FullName);
                 throw new InvalidOperationException(ex.Message, ex);
             }
 

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPathContextProvider.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPathContextProvider.cs
@@ -24,6 +24,7 @@ using NuGet.ProjectManagement;
 using NuGet.ProjectManagement.Projects;
 using NuGet.ProjectModel;
 using NuGet.VisualStudio.Implementation.Resources;
+using NuGet.VisualStudio.Telemetry;
 using Task = System.Threading.Tasks.Task;
 
 namespace NuGet.VisualStudio
@@ -42,6 +43,7 @@ namespace NuGet.VisualStudio
         private readonly Func<BuildIntegratedNuGetProject, Task<LockFile>> _getLockFileOrNullAsync;
 
         private readonly Lazy<INuGetProjectContext> _projectContext;
+        private readonly INuGetTelemetryProvider _telemetryProvider;
 
 
         [ImportingConstructor]
@@ -50,12 +52,14 @@ namespace NuGet.VisualStudio
             Lazy<IVsSolutionManager> solutionManager,
             [Import("VisualStudioActivityLogger")]
             Lazy<ILogger> logger,
-            Lazy<IMachineWideSettings> machineWideSettings)
+            Lazy<IMachineWideSettings> machineWideSettings,
+            INuGetTelemetryProvider telemetryProvider)
             : this(AsyncServiceProvider.GlobalProvider,
                   settings,
                   solutionManager,
                   logger,
-                  machineWideSettings)
+                  machineWideSettings,
+                  telemetryProvider)
         { }
 
         public VsPathContextProvider(
@@ -63,7 +67,8 @@ namespace NuGet.VisualStudio
             Lazy<ISettings> settings,
             Lazy<IVsSolutionManager> solutionManager,
             Lazy<ILogger> logger,
-            Lazy<IMachineWideSettings> machineWideSettings)
+            Lazy<IMachineWideSettings> machineWideSettings,
+            INuGetTelemetryProvider telemetryProvider)
         {
             _asyncServiceprovider = asyncServiceProvider ?? throw new ArgumentNullException(nameof(asyncServiceProvider));
             _settings = settings ?? throw new ArgumentNullException(nameof(settings));
@@ -83,6 +88,7 @@ namespace NuGet.VisualStudio
                         NullLogger.Instance)
             });
             _userWideSettings = new Microsoft.VisualStudio.Threading.AsyncLazy<ISettings>(() => Task.FromResult(Settings.LoadDefaultSettings(null, null, machineWideSettings.Value)), NuGetUIThreadHelper.JoinableTaskFactory);
+            _telemetryProvider = telemetryProvider ?? throw new ArgumentNullException(nameof(telemetryProvider));
         }
 
         /// <summary>
@@ -92,7 +98,8 @@ namespace NuGet.VisualStudio
             ISettings settings,
             IVsSolutionManager solutionManager,
             ILogger logger,
-            Func<BuildIntegratedNuGetProject, Task<LockFile>> getLockFileOrNullAsync)
+            Func<BuildIntegratedNuGetProject, Task<LockFile>> getLockFileOrNullAsync,
+            INuGetTelemetryProvider telemetryProvider)
         {
             if (settings == null)
             {
@@ -125,6 +132,8 @@ namespace NuGet.VisualStudio
                         NullLogger.Instance)
                 };
             });
+
+            _telemetryProvider = telemetryProvider ?? throw new ArgumentNullException(nameof(telemetryProvider));
         }
 
         public bool TryCreateContext(string projectUniqueName, out IVsPathContext outputPathContext)
@@ -134,31 +143,47 @@ namespace NuGet.VisualStudio
                 throw new ArgumentNullException(nameof(projectUniqueName));
             }
 
-            // invoke async operation from within synchronous method
-            outputPathContext = NuGetUIThreadHelper.JoinableTaskFactory.Run(
-                async () =>
-                {
-                    var nuGetProject = await CreateNuGetProjectAsync(projectUniqueName);
+            try
+            {
+                // invoke async operation from within synchronous method
+                outputPathContext = NuGetUIThreadHelper.JoinableTaskFactory.Run(
+                    async () =>
+                    {
+                        var nuGetProject = await CreateNuGetProjectAsync(projectUniqueName);
 
                     // It's possible the project isn't a NuGet-compatible project at all.
                     if (nuGetProject == null)
-                    {
-                        return null;
-                    }
+                        {
+                            return null;
+                        }
 
-                    return await CreatePathContextAsync(nuGetProject, CancellationToken.None);
-                });
+                        return await CreatePathContextAsync(nuGetProject, CancellationToken.None);
+                    });
 
-            return outputPathContext != null;
+                return outputPathContext != null;
+            }
+            catch (Exception exception)
+            {
+                _telemetryProvider.PostFault(exception, typeof(VsPathContextProvider).FullName);
+                throw;
+            }
         }
 
         public bool TryCreateSolutionContext(out IVsPathContext2 outputPathContext)
         {
-            var packagesFolderPath = PackagesFolderPathUtility.GetPackagesFolderPath(_solutionManager.Value, _settings.Value);
+            try
+            {
+                var packagesFolderPath = PackagesFolderPathUtility.GetPackagesFolderPath(_solutionManager.Value, _settings.Value);
 
-            outputPathContext = new VsPathContext(NuGetPathContext.Create(_settings.Value), packagesFolderPath);
+                outputPathContext = new VsPathContext(NuGetPathContext.Create(_settings.Value), _telemetryProvider, packagesFolderPath);
 
-            return outputPathContext != null;
+                return outputPathContext != null;
+            }
+            catch (Exception exception)
+            {
+                _telemetryProvider.PostFault(exception, typeof(VsPathContextProvider).FullName);
+                throw;
+            }
         }
 
         public bool TryCreateSolutionContext(string solutionDirectory, out IVsPathContext2 outputPathContext)
@@ -168,11 +193,19 @@ namespace NuGet.VisualStudio
                 throw new ArgumentNullException(nameof(solutionDirectory));
             }
 
-            var packagesFolderPath = PackagesFolderPathUtility.GetPackagesFolderPath(solutionDirectory, _settings.Value);
+            try
+            {
+                var packagesFolderPath = PackagesFolderPathUtility.GetPackagesFolderPath(solutionDirectory, _settings.Value);
 
-            outputPathContext = new VsPathContext(NuGetPathContext.Create(_settings.Value), packagesFolderPath);
+                outputPathContext = new VsPathContext(NuGetPathContext.Create(_settings.Value), _telemetryProvider, packagesFolderPath);
 
-            return outputPathContext != null;
+                return outputPathContext != null;
+            }
+            catch (Exception exception)
+            {
+                _telemetryProvider.PostFault(exception, typeof(VsPathContextProvider).FullName);
+                throw;
+            }
         }
 
         private async Task<NuGetProject> CreateNuGetProjectAsync(string projectUniqueName)
@@ -196,7 +229,7 @@ namespace NuGet.VisualStudio
             return null;
         }
 
-        public async Task<IVsPathContext> CreatePathContextAsync(NuGetProject nuGetProject, CancellationToken token)
+        internal async Task<IVsPathContext> CreatePathContextAsync(NuGetProject nuGetProject, CancellationToken token)
         {
             IVsPathContext context;
 
@@ -238,9 +271,9 @@ namespace NuGet.VisualStudio
             return context;
         }
 
-        public IVsPathContext GetSolutionPathContext()
+        internal IVsPathContext GetSolutionPathContext()
         {
-            return new VsPathContext(NuGetPathContext.Create(_settings.Value));
+            return new VsPathContext(NuGetPathContext.Create(_settings.Value), _telemetryProvider);
         }
 
         private async Task<IVsPathContext> GetPathContextFromAssetsFileAsync(
@@ -266,7 +299,7 @@ namespace NuGet.VisualStudio
             if (lockFile.Libraries == null ||
                 lockFile.Libraries.Count == 0)
             {
-                return new VsPathContext(userPackageFolder, fallbackPackageFolders);
+                return new VsPathContext(userPackageFolder, fallbackPackageFolders, _telemetryProvider);
             }
 
             var fppr = new FallbackPackagePathResolver(userPackageFolder, fallbackPackageFolders);
@@ -290,7 +323,8 @@ namespace NuGet.VisualStudio
             return new VsIndexedPathContext(
                 userPackageFolder,
                 fallbackPackageFolders,
-                trie);
+                trie,
+                _telemetryProvider);
         }
 
         private async Task<IVsPathContext> GetPathContextFromPackagesConfigAsync(
@@ -319,7 +353,8 @@ namespace NuGet.VisualStudio
             return new VsIndexedPathContext(
                 pathContext.UserPackageFolder,
                 pathContext.FallbackPackageFolders.Cast<string>(),
-                trie);
+                trie,
+                _telemetryProvider);
         }
 
         private async Task<IEnumerable<Project>> GetProjectsInSolutionAsync(DTE dte)
@@ -339,10 +374,18 @@ namespace NuGet.VisualStudio
 
         public bool TryCreateNoSolutionContext(out IVsPathContext vsPathContext)
         {
-            // invoke async operation from within synchronous method
-            vsPathContext = NuGetUIThreadHelper.JoinableTaskFactory.Run(() => TryCreateUserWideContextAsync());
+            try
+            {
+                // invoke async operation from within synchronous method
+                vsPathContext = NuGetUIThreadHelper.JoinableTaskFactory.Run(() => TryCreateUserWideContextAsync());
 
-            return vsPathContext != null;
+                return vsPathContext != null;
+            }
+            catch (Exception exception)
+            {
+                _telemetryProvider.PostFault(exception, typeof(VsPathContextProvider).FullName);
+                throw;
+            }
         }
 
         private async Task<IVsPathContext> TryCreateUserWideContextAsync()
@@ -351,7 +394,7 @@ namespace NuGet.VisualStudio
             // 1. We do not reload configs
             // 2. There is no way to edit gpf/fallback folders through the PM UI.
             var settings = await _userWideSettings.GetValueAsync();
-            var outputPathContext = new VsPathContext(NuGetPathContext.Create(settings));
+            var outputPathContext = new VsPathContext(NuGetPathContext.Create(settings), _telemetryProvider);
             return outputPathContext;
         }
     }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPathContextProvider.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPathContextProvider.cs
@@ -151,8 +151,8 @@ namespace NuGet.VisualStudio
                     {
                         var nuGetProject = await CreateNuGetProjectAsync(projectUniqueName);
 
-                    // It's possible the project isn't a NuGet-compatible project at all.
-                    if (nuGetProject == null)
+                        // It's possible the project isn't a NuGet-compatible project at all.
+                        if (nuGetProject == null)
                         {
                             return null;
                         }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Resources/VsResources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Resources/VsResources.Designer.cs
@@ -601,6 +601,15 @@ namespace NuGet.VisualStudio.Implementation.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to &apos;{0}&apos; cannot be null..
+        /// </summary>
+        internal static string PropertyCannotBeNull {
+            get {
+                return ResourceManager.GetString("PropertyCannotBeNull", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Package Installation Error.
         /// </summary>
         internal static string TemplateWizard_ErrorDialogTitle {

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Resources/VsResources.resx
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Resources/VsResources.resx
@@ -322,4 +322,8 @@ The string representation of the user's input framework name.</comment>
   <data name="PackageFrameworkAssemblyGroupName" xml:space="preserve">
     <value>Framework Assemblies</value>
   </data>
+  <data name="PropertyCannotBeNull" xml:space="preserve">
+    <value>'{0}' cannot be null.</value>
+    <comment>0 - property name</comment>
+  </data>
 </root>

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Resources/VsResourcesFormat.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Resources/VsResourcesFormat.cs
@@ -1,0 +1,13 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGet.VisualStudio.Implementation.Resources
+{
+    internal static class VsResourcesFormat
+    {
+        public static string PropertyCannotBeNull(string property)
+        {
+            return string.Format(VsResources.PropertyCannotBeNull, property);
+        }
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.Tools.Test/NuGetBrokeredServiceFactoryTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.Tools.Test/NuGetBrokeredServiceFactoryTests.cs
@@ -20,6 +20,7 @@ using NuGet.PackageManagement.VisualStudio;
 using NuGet.Protocol.Core.Types;
 using NuGet.VisualStudio.Implementation.Extensibility;
 using NuGet.VisualStudio.Internal.Contracts;
+using NuGet.VisualStudio.Telemetry;
 using NuGetVSExtension;
 using Test.Utility;
 using Xunit;
@@ -54,6 +55,7 @@ namespace NuGet.Tools.Test
             globalServiceProvider.AddService(typeof(ISettings), Mock.Of<ISettings>());
             globalServiceProvider.AddService(typeof(ISourceRepositoryProvider), sourceRepositoryProvider.Object);
             globalServiceProvider.AddService(typeof(SComponentModel), componentModel.Object);
+            globalServiceProvider.AddService(typeof(INuGetTelemetryProvider), Mock.Of<INuGetTelemetryProvider>());
 
             _serviceFactories = new Dictionary<ServiceRpcDescriptor, BrokeredServiceFactory>();
             _authorizingServiceFactories = new Dictionary<ServiceRpcDescriptor, AuthorizingBrokeredServiceFactory>();

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/Extensibility/VsFrameworkCompatibilityTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/Extensibility/VsFrameworkCompatibilityTests.cs
@@ -1,17 +1,25 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Linq;
 using System.Runtime.Versioning;
+using Moq;
+using NuGet.VisualStudio.Telemetry;
 using Xunit;
 
 namespace NuGet.VisualStudio.Implementation.Test.Extensibility
 {
     public class VsFrameworkCompatibilityTests
     {
+        // known/expected errors should not be reported to telemetry, hence use MockBehavior.Strict
+        private Mock<INuGetTelemetryProvider> _telemetryProvider = new Mock<INuGetTelemetryProvider>(MockBehavior.Strict);
+
         [Fact]
         public void VsFrameworkCompatibility_GetNearestRejectsNullTargetFramework()
         {
             // Arrange
-            var target = new VsFrameworkCompatibility();
+            var target = new VsFrameworkCompatibility(_telemetryProvider.Object);
             FrameworkName targetFramework = null;
             var frameworks = new[]
             {
@@ -27,7 +35,7 @@ namespace NuGet.VisualStudio.Implementation.Test.Extensibility
         public void VsFrameworkCompatibility_GetNearestRejectsNullFrameworks()
         {
             // Arrange
-            var target = new VsFrameworkCompatibility();
+            var target = new VsFrameworkCompatibility(_telemetryProvider.Object);
             var targetFramework = new FrameworkName(".NETFramework,Version=v4.5");
             FrameworkName[] frameworks = null;
 
@@ -39,7 +47,7 @@ namespace NuGet.VisualStudio.Implementation.Test.Extensibility
         public void VsFrameworkCompatibility_GetNearestRejectsNullFallbackFrameworks()
         {
             // Arrange
-            var target = new VsFrameworkCompatibility();
+            var target = new VsFrameworkCompatibility(_telemetryProvider.Object);
             var targetFramework = new FrameworkName(".NETFramework,Version=v4.5");
             FrameworkName[] fallbackTargetFrameworks = null;
             var frameworks = new[]
@@ -56,7 +64,7 @@ namespace NuGet.VisualStudio.Implementation.Test.Extensibility
         public void VsFrameworkCompatibility_GetNearestWithNoneCompatible()
         {
             // Arrange
-            var target = new VsFrameworkCompatibility();
+            var target = new VsFrameworkCompatibility(_telemetryProvider.Object);
             var targetFramework = new FrameworkName(".NETFramework,Version=v4.5");
             var frameworks = new[]
             {
@@ -75,7 +83,7 @@ namespace NuGet.VisualStudio.Implementation.Test.Extensibility
         public void VsFrameworkCompatibility_GetNearestWithMultipleCompatible()
         {
             // Arrange
-            var target = new VsFrameworkCompatibility();
+            var target = new VsFrameworkCompatibility(_telemetryProvider.Object);
             var targetFramework = new FrameworkName(".NETFramework,Version=v4.5.1");
             var frameworks = new[]
             {
@@ -96,7 +104,7 @@ namespace NuGet.VisualStudio.Implementation.Test.Extensibility
         public void VsFrameworkCompatibility_GetNearestWithCompatibleFallback()
         {
             // Arrange
-            var target = new VsFrameworkCompatibility();
+            var target = new VsFrameworkCompatibility(_telemetryProvider.Object);
             var targetFramework = new FrameworkName(".NETFramework,Version=v4.5");
             var fallbackTargetFrameworks = new[]
             {
@@ -119,7 +127,7 @@ namespace NuGet.VisualStudio.Implementation.Test.Extensibility
         public void VsFrameworkCompatibility_GetNearestWithIncompatibleFallback()
         {
             // Arrange
-            var target = new VsFrameworkCompatibility();
+            var target = new VsFrameworkCompatibility(_telemetryProvider.Object);
             var targetFramework = new FrameworkName(".NETFramework,Version=v4.5");
             var fallbackTargetFrameworks = new[]
             {
@@ -142,7 +150,7 @@ namespace NuGet.VisualStudio.Implementation.Test.Extensibility
         public void VsFrameworkCompatibility_GetNearestWithWithEmptyFallbackList()
         {
             // Arrange
-            var target = new VsFrameworkCompatibility();
+            var target = new VsFrameworkCompatibility(_telemetryProvider.Object);
             var targetFramework = new FrameworkName(".NETFramework,Version=v4.5.1");
             var fallbackTargetFrameworks = new FrameworkName[0];
             var frameworks = new[]
@@ -164,7 +172,7 @@ namespace NuGet.VisualStudio.Implementation.Test.Extensibility
         public void VsFrameworkCompatibility_GetNetStandardVersions()
         {
             // Arrange
-            var target = new VsFrameworkCompatibility();
+            var target = new VsFrameworkCompatibility(_telemetryProvider.Object);
 
             // Act
             var actual = target.GetNetStandardFrameworks().ToArray();
@@ -187,7 +195,7 @@ namespace NuGet.VisualStudio.Implementation.Test.Extensibility
         public void IVsFrameworkCompatibility3_GetNearest_WithCompatibleFramework_Succeeds()
         {
             // Arrange
-            var target = new VsFrameworkCompatibility();
+            var target = new VsFrameworkCompatibility(_telemetryProvider.Object);
             var net5 = new VsNuGetFramework(".NETCoreApp,Version=v5.0", targetPlatformMoniker: null, targetPlatformMinVersion: null);
             var net472 = new VsNuGetFramework(".NETFramework,Version=v4.7.2", targetPlatformMoniker: null, targetPlatformMinVersion: null);
             var netcoreapp31 = new VsNuGetFramework(".NETCoreApp,Version=v3.1", targetPlatformMoniker: null, targetPlatformMinVersion: null);
@@ -204,7 +212,7 @@ namespace NuGet.VisualStudio.Implementation.Test.Extensibility
         public void IVsFrameworkCompatibility3_GetNearest_WithFallbackTfm_Succeeds()
         {
             // Arrange
-            var target = new VsFrameworkCompatibility();
+            var target = new VsFrameworkCompatibility(_telemetryProvider.Object);
 
             var net5 = new VsNuGetFramework(".NETCoreApp,Version=v5.0", targetPlatformMoniker: null, targetPlatformMinVersion: null);
             var net472 = new VsNuGetFramework(".NETFramework,Version=v4.7.2", targetPlatformMoniker: null, targetPlatformMinVersion: null);
@@ -222,7 +230,7 @@ namespace NuGet.VisualStudio.Implementation.Test.Extensibility
         public void IVsFrameworkCompatibility3_GetNearest_NoCompatibleFramework_ReturnsNull()
         {
             // Arrange
-            var target = new VsFrameworkCompatibility();
+            var target = new VsFrameworkCompatibility(_telemetryProvider.Object);
 
             var net5 = new VsNuGetFramework(".NETCoreApp,Version=v5.0", targetPlatformMoniker: null, targetPlatformMinVersion: null);
             var net472 = new VsNuGetFramework(".NETFramework,Version=v4.7.2", targetPlatformMoniker: null, targetPlatformMinVersion: null);

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/Extensibility/VsFrameworkCompatibilityTests/IVsFrameworkCompatibility2Tests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/Extensibility/VsFrameworkCompatibilityTests/IVsFrameworkCompatibility2Tests.cs
@@ -1,0 +1,102 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Runtime.Versioning;
+using Moq;
+using NuGet.VisualStudio.Telemetry;
+using Xunit;
+
+namespace NuGet.VisualStudio.Implementation.Test.Extensibility.VsFrameworkCompatibilityTests
+{
+    public class IVsFrameworkCompatibility2Tests
+    {
+        // known/expected errors should not be reported to telemetry, hence use MockBehavior.Strict
+        private Mock<INuGetTelemetryProvider> _telemetryProvider = new Mock<INuGetTelemetryProvider>(MockBehavior.Strict);
+
+        [Fact]
+        public void GetNearest_NullArguments_ThrowsArgumentNullException()
+        {
+            // Arrange
+            var target = new VsFrameworkCompatibility(_telemetryProvider.Object);
+            var targetFramework = new FrameworkName(".NETCoreApp,Version=v3.1");
+            FrameworkName[] fallbackTargetFrameworks = new[]
+            {
+                new FrameworkName(".NETFramework,Version=v4.7.2")
+            };
+            var frameworks = new[]
+            {
+                new FrameworkName(".NETCoreApp,Version=v3.0"),
+                new FrameworkName(".NETStandard,Version=v2.0"),
+            };
+
+            // Act & Assert
+            Assert.Throws<ArgumentNullException>(() => target.GetNearest(null, fallbackTargetFrameworks, frameworks));
+            Assert.Throws<ArgumentNullException>(() => target.GetNearest(targetFramework, null, frameworks));
+            Assert.Throws<ArgumentNullException>(() => target.GetNearest(targetFramework, fallbackTargetFrameworks, null));
+        }
+
+        [Fact]
+        public void GetNearest_NullItemInArray_ThrowsArgumentException()
+        {
+            // Arrange
+            var target = new VsFrameworkCompatibility(_telemetryProvider.Object);
+            var targetFramework = new FrameworkName(".NETCoreApp,Version=v3.1");
+            var goodFrameworks = new[]
+            {
+                new FrameworkName(".NETStandard,Version=v2.0")
+            };
+            var nullFrameworks = new FrameworkName[] { null };
+
+            // Act & Assert
+            Assert.Throws<ArgumentException>(() => target.GetNearest(targetFramework, goodFrameworks, nullFrameworks));
+            Assert.Throws<ArgumentException>(() => target.GetNearest(targetFramework, nullFrameworks, goodFrameworks));
+        }
+
+        [Fact]
+        public void GetNearest_WithCompatibleFallback_Succeeds()
+        {
+            // Arrange
+            var target = new VsFrameworkCompatibility(_telemetryProvider.Object);
+            var targetFramework = new FrameworkName(".NETFramework,Version=v4.5");
+            var fallbackTargetFrameworks = new[]
+            {
+                new FrameworkName(".NETFramework,Version=v4.5.2")
+            };
+            var frameworks = new[]
+            {
+                new FrameworkName(".NETFramework,Version=v4.5.1"),
+                new FrameworkName(".NETFramework,Version=v4.6.1"),
+            };
+
+            // Act
+            var actual = target.GetNearest(targetFramework, fallbackTargetFrameworks, frameworks);
+
+            // Assert
+            Assert.Equal(".NETFramework,Version=v4.5.1", actual.ToString());
+        }
+
+        [Fact]
+        public void GetNearest_WithIncompatibleFallback_ReturnsNull()
+        {
+            // Arrange
+            var target = new VsFrameworkCompatibility(_telemetryProvider.Object);
+            var targetFramework = new FrameworkName(".NETFramework,Version=v4.5");
+            var fallbackTargetFrameworks = new[]
+            {
+                new FrameworkName(".NETFramework,Version=v4.5.2")
+            };
+            var frameworks = new[]
+            {
+                new FrameworkName(".NETFramework,Version=v4.6"),
+                new FrameworkName(".NETFramework,Version=v4.6.1"),
+            };
+
+            // Act
+            var actual = target.GetNearest(targetFramework, fallbackTargetFrameworks, frameworks);
+
+            // Assert
+            Assert.Null(actual);
+        }
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/Extensibility/VsFrameworkCompatibilityTests/IVsFrameworkCompatibility3Tests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/Extensibility/VsFrameworkCompatibilityTests/IVsFrameworkCompatibility3Tests.cs
@@ -1,0 +1,117 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Moq;
+using NuGet.VisualStudio.Telemetry;
+using Xunit;
+
+namespace NuGet.VisualStudio.Implementation.Test.Extensibility.VsFrameworkCompatibilityTests
+{
+    public class IVsFrameworkCompatibility3Tests
+    {
+        // known/expected errors should not be reported to telemetry, hence use MockBehavior.Strict
+        private Mock<INuGetTelemetryProvider> _telemetryProvider = new Mock<INuGetTelemetryProvider>(MockBehavior.Strict);
+
+        [Fact]
+        public void GetNearest_WithCompatibleFramework_Succeeds()
+        {
+            // Arrange
+            var target = new VsFrameworkCompatibility(_telemetryProvider.Object);
+            var net5 = new VsNuGetFramework(".NETCoreApp,Version=v5.0", targetPlatformMoniker: null, targetPlatformMinVersion: null);
+            var net472 = new VsNuGetFramework(".NETFramework,Version=v4.7.2", targetPlatformMoniker: null, targetPlatformMinVersion: null);
+            var netcoreapp31 = new VsNuGetFramework(".NETCoreApp,Version=v3.1", targetPlatformMoniker: null, targetPlatformMinVersion: null);
+            var frameworks = new IVsNuGetFramework[] { net472, netcoreapp31 };
+
+            // Act
+            var actual = target.GetNearest(net5, frameworks);
+
+            // Assert
+            Assert.Equal(netcoreapp31, actual);
+        }
+
+        [Fact]
+        public void GetNearest_WithFallbackTfm_Succeeds()
+        {
+            // Arrange
+            var target = new VsFrameworkCompatibility(_telemetryProvider.Object);
+
+            var net5 = new VsNuGetFramework(".NETCoreApp,Version=v5.0", targetPlatformMoniker: null, targetPlatformMinVersion: null);
+            var net472 = new VsNuGetFramework(".NETFramework,Version=v4.7.2", targetPlatformMoniker: null, targetPlatformMinVersion: null);
+            var fallbackFrameworks = new IVsNuGetFramework[] { net472 };
+            var frameworks = new IVsNuGetFramework[] { net472 };
+
+            // Act
+            var actual = target.GetNearest(net5, fallbackFrameworks, frameworks);
+
+            // Assert
+            Assert.Equal(net472, actual);
+        }
+
+        [Fact]
+        public void GetNearest_NoCompatibleFramework_ReturnsNull()
+        {
+            // Arrange
+            var target = new VsFrameworkCompatibility(_telemetryProvider.Object);
+
+            var net5 = new VsNuGetFramework(".NETCoreApp,Version=v5.0", targetPlatformMoniker: null, targetPlatformMinVersion: null);
+            var net472 = new VsNuGetFramework(".NETFramework,Version=v4.7.2", targetPlatformMoniker: null, targetPlatformMinVersion: null);
+            var frameworks = new IVsNuGetFramework[] { net472 };
+
+            // Act
+            var actual = target.GetNearest(net5, frameworks);
+
+            // Assert
+            Assert.Null(actual);
+        }
+
+        [Fact]
+        public void GetNearest_NullArguments_ThrowsArgumentNullException()
+        {
+            // Arrange
+            var target = new VsFrameworkCompatibility(_telemetryProvider.Object);
+
+            var net5 = new VsNuGetFramework(".NETCoreApp,Version=v5.0", targetPlatformMoniker: null, targetPlatformMinVersion: null);
+            var netstandard2_0 = new VsNuGetFramework(".NETStandard,Version=v2.0", targetPlatformMoniker: null, targetPlatformMinVersion: null);
+            var frameworks = new IVsNuGetFramework[] { netstandard2_0 };
+
+            // Act & Asset
+            Assert.Throws<ArgumentNullException>(() => target.GetNearest(targetFramework: null, frameworks: frameworks));
+            Assert.Throws<ArgumentNullException>(() => target.GetNearest(targetFramework: net5, frameworks: null));
+            Assert.Throws<ArgumentNullException>(() => target.GetNearest(targetFramework: null, fallbackTargetFrameworks: Array.Empty<IVsNuGetFramework>(), frameworks: frameworks));
+            Assert.Throws<ArgumentNullException>(() => target.GetNearest(targetFramework: net5, fallbackTargetFrameworks: null, frameworks: frameworks));
+            Assert.Throws<ArgumentNullException>(() => target.GetNearest(targetFramework: net5, fallbackTargetFrameworks: Array.Empty<IVsNuGetFramework>(), frameworks: null));
+        }
+
+        [Fact]
+        public void GetNearest_NullItemInEnumerable_ThrowsArgumentException()
+        {
+            // Arrange
+            var target = new VsFrameworkCompatibility(_telemetryProvider.Object);
+
+            var net5 = new VsNuGetFramework(".NETCoreApp,Version=v5.0", targetPlatformMoniker: null, targetPlatformMinVersion: null);
+            var netstandard2_0 = new VsNuGetFramework(".NETStandard,Version=v2.0", targetPlatformMoniker: null, targetPlatformMinVersion: null);
+            var goodFrameworks = new IVsNuGetFramework[] { netstandard2_0 };
+            var nullFrameworks = new IVsNuGetFramework[] { null };
+
+            // Act & Asset
+            Assert.Throws<ArgumentException>(() => target.GetNearest(targetFramework: net5, frameworks: nullFrameworks));
+            Assert.Throws<ArgumentException>(() => target.GetNearest(targetFramework: net5, fallbackTargetFrameworks: goodFrameworks, frameworks: nullFrameworks));
+            Assert.Throws<ArgumentException>(() => target.GetNearest(targetFramework: net5, fallbackTargetFrameworks: nullFrameworks, frameworks: goodFrameworks));
+        }
+
+        [Fact]
+        public void GetNearest_InvalidFramework_ThrowsArgumentException()
+        {
+            // Arrange
+            var target = new VsFrameworkCompatibility(_telemetryProvider.Object);
+
+            var invalidFramework = new VsNuGetFramework("Invalid,Version=vWrong", targetPlatformMoniker: null, targetPlatformMinVersion: null);
+            var netstandard2_0 = new VsNuGetFramework(".NETStandard,Version=v2.0", targetPlatformMoniker: null, targetPlatformMinVersion: null);
+            var frameworks = new IVsNuGetFramework[] { netstandard2_0 };
+
+            // Act & Assert
+            Assert.Throws<ArgumentException>(() => target.GetNearest(invalidFramework, frameworks));
+        }
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/Extensibility/VsFrameworkCompatibilityTests/IVsFrameworkCompatibilityTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/Extensibility/VsFrameworkCompatibilityTests/IVsFrameworkCompatibilityTests.cs
@@ -8,9 +8,9 @@ using Moq;
 using NuGet.VisualStudio.Telemetry;
 using Xunit;
 
-namespace NuGet.VisualStudio.Implementation.Test.Extensibility
+namespace NuGet.VisualStudio.Implementation.Test.Extensibility.VsFrameworkCompatibilityTests
 {
-    public class VsFrameworkCompatibilityTests
+    public class IVsFrameworkCompatibilityTests
     {
         // known/expected errors should not be reported to telemetry, hence use MockBehavior.Strict
         private Mock<INuGetTelemetryProvider> _telemetryProvider = new Mock<INuGetTelemetryProvider>(MockBehavior.Strict);
@@ -41,23 +41,6 @@ namespace NuGet.VisualStudio.Implementation.Test.Extensibility
 
             // Act & Assert
             Assert.Throws<ArgumentNullException>(() => target.GetNearest(targetFramework, frameworks));
-        }
-
-        [Fact]
-        public void VsFrameworkCompatibility_GetNearestRejectsNullFallbackFrameworks()
-        {
-            // Arrange
-            var target = new VsFrameworkCompatibility(_telemetryProvider.Object);
-            var targetFramework = new FrameworkName(".NETFramework,Version=v4.5");
-            FrameworkName[] fallbackTargetFrameworks = null;
-            var frameworks = new[]
-            {
-                new FrameworkName(".NETFramework,Version=v4.5.1"),
-                new FrameworkName(".NETFramework,Version=v4.5.2"),
-            };
-
-            // Act & Assert
-            Assert.Throws<ArgumentNullException>(() => target.GetNearest(targetFramework, fallbackTargetFrameworks, frameworks));
         }
 
         [Fact]
@@ -98,52 +81,6 @@ namespace NuGet.VisualStudio.Implementation.Test.Extensibility
 
             // Assert
             Assert.Equal(".NETFramework,Version=v4.5", actual.ToString());
-        }
-
-        [Fact]
-        public void VsFrameworkCompatibility_GetNearestWithCompatibleFallback()
-        {
-            // Arrange
-            var target = new VsFrameworkCompatibility(_telemetryProvider.Object);
-            var targetFramework = new FrameworkName(".NETFramework,Version=v4.5");
-            var fallbackTargetFrameworks = new[]
-            {
-                new FrameworkName(".NETFramework,Version=v4.5.2")
-            };
-            var frameworks = new[]
-            {
-                new FrameworkName(".NETFramework,Version=v4.5.1"),
-                new FrameworkName(".NETFramework,Version=v4.6.1"),
-            };
-
-            // Act
-            var actual = target.GetNearest(targetFramework, fallbackTargetFrameworks, frameworks);
-
-            // Assert
-            Assert.Equal(".NETFramework,Version=v4.5.1", actual.ToString());
-        }
-
-        [Fact]
-        public void VsFrameworkCompatibility_GetNearestWithIncompatibleFallback()
-        {
-            // Arrange
-            var target = new VsFrameworkCompatibility(_telemetryProvider.Object);
-            var targetFramework = new FrameworkName(".NETFramework,Version=v4.5");
-            var fallbackTargetFrameworks = new[]
-            {
-                new FrameworkName(".NETFramework,Version=v4.5.2")
-            };
-            var frameworks = new[]
-            {
-                new FrameworkName(".NETFramework,Version=v4.6"),
-                new FrameworkName(".NETFramework,Version=v4.6.1"),
-            };
-
-            // Act
-            var actual = target.GetNearest(targetFramework, fallbackTargetFrameworks, frameworks);
-
-            // Assert
-            Assert.Null(actual);
         }
 
         [Fact]
@@ -189,58 +126,6 @@ namespace NuGet.VisualStudio.Implementation.Test.Extensibility
             Assert.Equal(".NETStandard,Version=v2.0", actual[8].ToString());
             Assert.Equal(".NETStandard,Version=v2.1", actual[9].ToString());
             Assert.Equal(10, actual.Length);
-        }
-
-        [Fact]
-        public void IVsFrameworkCompatibility3_GetNearest_WithCompatibleFramework_Succeeds()
-        {
-            // Arrange
-            var target = new VsFrameworkCompatibility(_telemetryProvider.Object);
-            var net5 = new VsNuGetFramework(".NETCoreApp,Version=v5.0", targetPlatformMoniker: null, targetPlatformMinVersion: null);
-            var net472 = new VsNuGetFramework(".NETFramework,Version=v4.7.2", targetPlatformMoniker: null, targetPlatformMinVersion: null);
-            var netcoreapp31 = new VsNuGetFramework(".NETCoreApp,Version=v3.1", targetPlatformMoniker: null, targetPlatformMinVersion: null);
-            var frameworks = new IVsNuGetFramework[] { net472, netcoreapp31 };
-
-            // Act
-            var actual = target.GetNearest(net5, frameworks);
-
-            // Assert
-            Assert.Equal(netcoreapp31, actual);
-        }
-
-        [Fact]
-        public void IVsFrameworkCompatibility3_GetNearest_WithFallbackTfm_Succeeds()
-        {
-            // Arrange
-            var target = new VsFrameworkCompatibility(_telemetryProvider.Object);
-
-            var net5 = new VsNuGetFramework(".NETCoreApp,Version=v5.0", targetPlatformMoniker: null, targetPlatformMinVersion: null);
-            var net472 = new VsNuGetFramework(".NETFramework,Version=v4.7.2", targetPlatformMoniker: null, targetPlatformMinVersion: null);
-            var fallbackFrameworks = new IVsNuGetFramework[] { net472 };
-            var frameworks = new IVsNuGetFramework[] { net472 };
-
-            // Act
-            var actual = target.GetNearest(net5, fallbackFrameworks, frameworks);
-
-            // Assert
-            Assert.Equal(net472, actual);
-        }
-
-        [Fact]
-        public void IVsFrameworkCompatibility3_GetNearest_NoCompatibleFramework_ReturnsNull()
-        {
-            // Arrange
-            var target = new VsFrameworkCompatibility(_telemetryProvider.Object);
-
-            var net5 = new VsNuGetFramework(".NETCoreApp,Version=v5.0", targetPlatformMoniker: null, targetPlatformMinVersion: null);
-            var net472 = new VsNuGetFramework(".NETFramework,Version=v4.7.2", targetPlatformMoniker: null, targetPlatformMinVersion: null);
-            var frameworks = new IVsNuGetFramework[] { net472 };
-
-            // Act
-            var actual = target.GetNearest(net5, frameworks);
-
-            // Assert
-            Assert.Null(actual);
         }
     }
 }

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/Extensibility/VsFrameworkParserTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/Extensibility/VsFrameworkParserTests.cs
@@ -1,17 +1,22 @@
 using System;
 using System.Runtime.Versioning;
+using Moq;
 using NuGet.Frameworks;
+using NuGet.VisualStudio.Telemetry;
 using Xunit;
 
 namespace NuGet.VisualStudio.Implementation.Test.Extensibility
 {
     public class VsFrameworkParserTests
     {
+        // known/expected errors should not be reported to telemetry, hence use MockBehavior.Strict
+        private Mock<INuGetTelemetryProvider> _telemetryProvider = new Mock<INuGetTelemetryProvider>(MockBehavior.Strict);
+
         [Fact]
         public void VsFrameworkParser_ParseFrameworkName_RejectsNullInput()
         {
             // Arrange
-            var target = new VsFrameworkParser();
+            var target = new VsFrameworkParser(_telemetryProvider.Object);
 
             // Act & Assert
             Assert.Throws<ArgumentNullException>(() => target.ParseFrameworkName(null));
@@ -21,7 +26,7 @@ namespace NuGet.VisualStudio.Implementation.Test.Extensibility
         public void VsFrameworkParser_ParseFrameworkName_RejectsInvalidVersion()
         {
             // Arrange
-            var target = new VsFrameworkParser();
+            var target = new VsFrameworkParser(_telemetryProvider.Object);
 
             // Act & Assert
             Assert.Throws<ArgumentException>(() => target.ParseFrameworkName("foo,Version=a.b"));
@@ -31,7 +36,7 @@ namespace NuGet.VisualStudio.Implementation.Test.Extensibility
         public void VsFrameworkParser_ParseFrameworkName_RejectsInvalidProfile()
         {
             // Arrange
-            var target = new VsFrameworkParser();
+            var target = new VsFrameworkParser(_telemetryProvider.Object);
 
             // Act & Assert
             Assert.Throws<ArgumentException>(() => target.ParseFrameworkName(".NETPortable,Version=1.0,Profile=a-b"));
@@ -41,7 +46,7 @@ namespace NuGet.VisualStudio.Implementation.Test.Extensibility
         public void VsFrameworkParser_ParseFrameworkName_ParsesShortFrameworkName()
         {
             // Arrange
-            var target = new VsFrameworkParser();
+            var target = new VsFrameworkParser(_telemetryProvider.Object);
 
             // Act
             var frameworkName = target.ParseFrameworkName("net45");
@@ -54,7 +59,7 @@ namespace NuGet.VisualStudio.Implementation.Test.Extensibility
         public void VsFrameworkParser_ParseFrameworkName_ParsesLongFrameworkName()
         {
             // Arrange
-            var target = new VsFrameworkParser();
+            var target = new VsFrameworkParser(_telemetryProvider.Object);
 
             // Act
             var frameworkName = target.ParseFrameworkName(".NETFramework,Version=v4.5");
@@ -67,7 +72,7 @@ namespace NuGet.VisualStudio.Implementation.Test.Extensibility
         public void VsFrameworkParser_GetShortFrameworkName_Success()
         {
             // Arrange
-            var target = new VsFrameworkParser();
+            var target = new VsFrameworkParser(_telemetryProvider.Object);
             var frameworkName = new FrameworkName(".NETStandard", Version.Parse("1.3"));
 
             // Act
@@ -81,7 +86,7 @@ namespace NuGet.VisualStudio.Implementation.Test.Extensibility
         public void VsFrameworkParser_GetShortFrameworkName_RejectsNull()
         {
             // Arrange
-            var target = new VsFrameworkParser();
+            var target = new VsFrameworkParser(_telemetryProvider.Object);
 
             // Act & Assert
             Assert.Throws<ArgumentNullException>(() => target.GetShortFrameworkName(null));
@@ -91,7 +96,7 @@ namespace NuGet.VisualStudio.Implementation.Test.Extensibility
         public void VsFrameworkParser_GetShortFrameworkName_RejectsInvalidFrameworkIdentifier()
         {
             // Arrange
-            var target = new VsFrameworkParser();
+            var target = new VsFrameworkParser(_telemetryProvider.Object);
             var frameworkName = new FrameworkName("!?", Version.Parse("4.5"));
 
             // Act & Assert
@@ -102,7 +107,7 @@ namespace NuGet.VisualStudio.Implementation.Test.Extensibility
         public void VsFrameworkParser_GetShortFrameworkName_RejectsInvalidPortable()
         {
             // Arrange
-            var target = new VsFrameworkParser();
+            var target = new VsFrameworkParser(_telemetryProvider.Object);
             var frameworkName = new FrameworkName(".NETPortable", Version.Parse("4.5"), "net45+portable-net451");
 
             // Act & Assert
@@ -113,7 +118,7 @@ namespace NuGet.VisualStudio.Implementation.Test.Extensibility
         public void TryParse_NullInput_ThrowsArgumentNullException()
         {
             // Arrange
-            var target = new VsFrameworkParser();
+            var target = new VsFrameworkParser(_telemetryProvider.Object);
 
             // Act
             var exception = Assert.Throws<ArgumentNullException>(() => target.TryParse(input: null, out _));
@@ -137,7 +142,7 @@ namespace NuGet.VisualStudio.Implementation.Test.Extensibility
         public void TryParse_ValidInput_Succeeds(string input)
         {
             // Arrange
-            var target = new VsFrameworkParser();
+            var target = new VsFrameworkParser(_telemetryProvider.Object);
             IVsNuGetFramework actual;
             var expected = NuGetFramework.Parse(input);
 
@@ -158,7 +163,7 @@ namespace NuGet.VisualStudio.Implementation.Test.Extensibility
         public void TryParse_InvalidInput_ReturnsFalse(string input)
         {
             // Arrange
-            var target = new VsFrameworkParser();
+            var target = new VsFrameworkParser(_telemetryProvider.Object);
 
             // Act
             var actual = target.TryParse(input, out IVsNuGetFramework parsed);

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/Extensibility/VsGlobalPackagesInitScriptExecutorTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/Extensibility/VsGlobalPackagesInitScriptExecutorTests.cs
@@ -1,18 +1,25 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Threading.Tasks;
 using Moq;
 using NuGet.PackageManagement.VisualStudio;
+using NuGet.VisualStudio.Telemetry;
 using Xunit;
 
 namespace NuGet.VisualStudio.Implementation.Test
 {
     public class VsGlobalPackagesInitScriptExecutorTests
     {
+        // known/expected errors should not be reported to telemetry, hence use MockBehavior.Strict
+        private Mock<INuGetTelemetryProvider> _telemetryProvider = new Mock<INuGetTelemetryProvider>(MockBehavior.Strict);
+
         [Fact]
         public async Task NullPackageId()
         {
             var scriptExecutor = new Mock<IScriptExecutor>();
-            var executor = new VsGlobalPackagesInitScriptExecutor(scriptExecutor.Object);
+            var executor = new VsGlobalPackagesInitScriptExecutor(scriptExecutor.Object, _telemetryProvider.Object);
             await Assert.ThrowsAsync<ArgumentException>(async ()
                 => await executor.ExecuteInitScriptAsync(packageId: null, packageVersion: "1.0.0"));
         }
@@ -21,7 +28,7 @@ namespace NuGet.VisualStudio.Implementation.Test
         public async Task NullPackageVersion()
         {
             var scriptExecutor = new Mock<IScriptExecutor>();
-            var executor = new VsGlobalPackagesInitScriptExecutor(scriptExecutor.Object);
+            var executor = new VsGlobalPackagesInitScriptExecutor(scriptExecutor.Object, _telemetryProvider.Object);
             await Assert.ThrowsAsync<ArgumentException>(async ()
                 => await executor.ExecuteInitScriptAsync("A", packageVersion: null));
         }
@@ -30,7 +37,7 @@ namespace NuGet.VisualStudio.Implementation.Test
         public async Task EmptyPackageId()
         {
             var scriptExecutor = new Mock<IScriptExecutor>();
-            var executor = new VsGlobalPackagesInitScriptExecutor(scriptExecutor.Object);
+            var executor = new VsGlobalPackagesInitScriptExecutor(scriptExecutor.Object, _telemetryProvider.Object);
             await Assert.ThrowsAsync<ArgumentException>(async ()
                 => await executor.ExecuteInitScriptAsync(packageId: string.Empty, packageVersion: "1.0.0"));
         }
@@ -39,7 +46,7 @@ namespace NuGet.VisualStudio.Implementation.Test
         public async Task EmptyPackageVersion()
         {
             var scriptExecutor = new Mock<IScriptExecutor>();
-            var executor = new VsGlobalPackagesInitScriptExecutor(scriptExecutor.Object);
+            var executor = new VsGlobalPackagesInitScriptExecutor(scriptExecutor.Object, _telemetryProvider.Object);
             await Assert.ThrowsAsync<ArgumentException>(async ()
                 => await executor.ExecuteInitScriptAsync("A", packageVersion: string.Empty));
         }
@@ -48,7 +55,7 @@ namespace NuGet.VisualStudio.Implementation.Test
         public async Task InvalidPackageVersion()
         {
             var scriptExecutor = new Mock<IScriptExecutor>();
-            var executor = new VsGlobalPackagesInitScriptExecutor(scriptExecutor.Object);
+            var executor = new VsGlobalPackagesInitScriptExecutor(scriptExecutor.Object, _telemetryProvider.Object);
             await Assert.ThrowsAsync<ArgumentException>(async ()
                 => await executor.ExecuteInitScriptAsync("A", "1.abc.0"));
         }

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/Extensibility/VsPackageInstallerServicesTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/Extensibility/VsPackageInstallerServicesTests.cs
@@ -1,0 +1,195 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Moq;
+using NuGet.Configuration;
+using NuGet.PackageManagement;
+using NuGet.PackageManagement.VisualStudio;
+using NuGet.Protocol.Core.Types;
+using NuGet.VisualStudio.Implementation.Test.TestUtilities;
+using NuGet.VisualStudio.Telemetry;
+using Xunit;
+
+namespace NuGet.VisualStudio.Implementation.Test.Extensibility
+{
+    public class VsPackageInstallerServicesTests
+    {
+        [Fact]
+        public void SolutionGetInstalledPackages_InternalError_PostsFault()
+        {
+            // Arrange
+            var expectedException = new ArgumentException("Internal bug");
+
+            var solutionManager = new Mock<IVsSolutionManager>();
+            var telemetryProvider = new Mock<INuGetTelemetryProvider>();
+
+            var assemblyDirectory = Path.GetDirectoryName(typeof(VsPackageInstallerServicesTests).Assembly.Location);
+            solutionManager.SetupGet(sm => sm.SolutionDirectory)
+                .Throws(expectedException);
+
+            // Act
+            var target = CreateTarget(vsSolutionManager: solutionManager.Object, telemetryProvider: telemetryProvider.Object);
+            var actualException = Assert.Throws<ArgumentException>(() => target.GetInstalledPackages());
+
+            // Assert
+            telemetryProvider.Verify(t => t.PostFault(expectedException, typeof(VsPackageInstallerServices).FullName, nameof(VsPackageInstallerServices.GetInstalledPackages), It.IsAny<IDictionary<string, object>>()));
+            Assert.Same(expectedException, actualException);
+        }
+
+        [Fact]
+        public void ProjectGetInstalledPackages_NullProject_ThrowsArgumentNullException()
+        {
+            // Act
+            VsPackageInstallerServices target = CreateTarget();
+            Assert.Throws<ArgumentNullException>(() => target.GetInstalledPackages(null));
+        }
+
+        [Fact]
+        public void ProjectGetInstalledPackages_InternalError_PostsFault()
+        {
+            // Arrange
+            var expectedException = new ArgumentException("Internal bug");
+
+            var solutionManager = new Mock<IVsSolutionManager>();
+            var telemetryProvider = new Mock<INuGetTelemetryProvider>();
+
+            var assemblyDirectory = Path.GetDirectoryName(typeof(VsPackageInstallerServicesTests).Assembly.Location);
+            solutionManager.SetupGet(sm => sm.SolutionDirectory)
+                .Throws(expectedException);
+
+            var project = new Mock<EnvDTE.Project>();
+
+            // Act
+            VsPackageInstallerServices target = CreateTarget(vsSolutionManager: solutionManager.Object, telemetryProvider: telemetryProvider.Object);
+            var actualException = Assert.Throws<ArgumentException>(() => target.GetInstalledPackages(project.Object));
+
+            // Assert
+            telemetryProvider.Verify(t => t.PostFault(expectedException, typeof(VsPackageInstallerServices).FullName, nameof(VsPackageInstallerServices.GetInstalledPackages), It.IsAny<IDictionary<string, object>>()));
+            Assert.Same(expectedException, actualException);
+        }
+
+        [Fact]
+        public void IsPackageInstalled_NullParameters_ThrowsException()
+        {
+            // Arrange
+            var project = new Mock<EnvDTE.Project>();
+
+            // Act & Assert
+            VsPackageInstallerServices target = CreateTarget();
+            Assert.Throws<ArgumentException>(() => target.IsPackageInstalled(project.Object, null));
+            Assert.Throws<ArgumentException>(() => target.IsPackageInstalled(project.Object, string.Empty));
+            Assert.Throws<ArgumentNullException>(() => target.IsPackageInstalled(null, "packageId"));
+        }
+
+        [Fact]
+        public void IsPackageInstalled_InternalException_PostsFault()
+        {
+            // Arrange
+            var expectedException = new ArgumentException("Internal error");
+
+            var solutionManager = new Mock<IVsSolutionManager>();
+            solutionManager.SetupGet(s => s.SolutionDirectory)
+                .Throws(expectedException);
+
+            var telemetryProvider = new Mock<INuGetTelemetryProvider>();
+
+            var project = new Mock<EnvDTE.Project>();
+
+            // Act
+            VsPackageInstallerServices target = CreateTarget(vsSolutionManager: solutionManager.Object, telemetryProvider: telemetryProvider.Object);
+            var actualException = Assert.Throws<ArgumentException>(() => target.IsPackageInstalled(project.Object, "packageId"));
+
+            // Assert
+            telemetryProvider.Verify(t => t.PostFaultAsync(expectedException, typeof(VsPackageInstallerServices).FullName, nameof(VsPackageInstallerServices.IsPackageInstalled), It.IsAny<IDictionary<string, object>>()));
+            telemetryProvider.VerifyNoOtherCalls();
+            Assert.Equal(expectedException, actualException);
+        }
+
+        [Fact]
+        public void IsPackageInstalledEx_InvalidParameters_ThrowsException()
+        {
+            // Arrange
+            var project = new Mock<EnvDTE.Project>();
+            var packageId = "packagId";
+            var version = "1.2.3";
+
+            // Act & Assert
+            VsPackageInstallerServices target = CreateTarget();
+            Assert.Throws<ArgumentNullException>(() => target.IsPackageInstalledEx(null, packageId, version));
+            Assert.Throws<ArgumentException>(() => target.IsPackageInstalledEx(project.Object, null, version));
+            Assert.Throws<ArgumentException>(() => target.IsPackageInstalledEx(project.Object, packageId, string.Empty));
+            Assert.Throws<ArgumentException>(() => target.IsPackageInstalledEx(project.Object, packageId, "a.b.c"));
+        }
+
+        [Fact]
+        public void IsPackageInstalledEx_InternalException_PostsFault()
+        {
+            // Arrange
+            var expectedException = new ArgumentException("Internal error");
+
+            var solutionManager = new Mock<IVsSolutionManager>();
+            solutionManager.SetupGet(s => s.SolutionDirectory)
+                .Throws(expectedException);
+
+            var telemetryProvider = new Mock<INuGetTelemetryProvider>();
+
+            var project = new Mock<EnvDTE.Project>();
+
+            // Act
+            VsPackageInstallerServices target = CreateTarget(vsSolutionManager: solutionManager.Object, telemetryProvider: telemetryProvider.Object);
+            var actualException = Assert.Throws<ArgumentException>(() => target.IsPackageInstalledEx(project.Object, "packageId", "1.2.3"));
+
+            // Assert
+            // Both IsPackageInstalled and IsPackageInstalledEx use a private IsPackageInstalled overload, where the fault is reported.
+            // The additional compexity of getting this fault to report IsPackageInstalledEx is not considered worthwhile.
+            telemetryProvider.Verify(t => t.PostFaultAsync(expectedException, typeof(VsPackageInstallerServices).FullName, nameof(VsPackageInstallerServices.IsPackageInstalled), It.IsAny<IDictionary<string, object>>()));
+            telemetryProvider.VerifyNoOtherCalls();
+            Assert.Equal(expectedException, actualException);
+        }
+
+        private VsPackageInstallerServices CreateTarget(
+            IVsSolutionManager vsSolutionManager = null,
+            ISourceRepositoryProvider sourceRepositoryProvider = null,
+            ISettings settings = null,
+            IDeleteOnRestartManager deleteOnRestartManager = null,
+            IVsProjectThreadingService vsProjectThreadingService = null,
+            INuGetTelemetryProvider telemetryProvider = null)
+        {
+            if (vsSolutionManager == null)
+            {
+                vsSolutionManager = new Mock<IVsSolutionManager>().Object;
+            }
+
+            if (sourceRepositoryProvider == null)
+            {
+                sourceRepositoryProvider = new Mock<ISourceRepositoryProvider>().Object;
+            }
+
+            if (settings == null)
+            {
+                settings = new Mock<ISettings>().Object;
+            }
+
+            if (deleteOnRestartManager == null)
+            {
+                deleteOnRestartManager = new Mock<IDeleteOnRestartManager>().Object;
+            }
+
+            if (vsProjectThreadingService == null)
+            {
+                vsProjectThreadingService = new TestProjectThreadingService();
+            }
+
+            if (telemetryProvider == null)
+            {
+                // Expected/user input errors should not be recorded as faults, hence use strict mode
+                telemetryProvider = new Mock<INuGetTelemetryProvider>(MockBehavior.Strict).Object;
+            }
+
+            return new VsPackageInstallerServices(vsSolutionManager, sourceRepositoryProvider, settings, deleteOnRestartManager, vsProjectThreadingService, telemetryProvider);
+        }
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/Extensibility/VsPackageRestorerTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/Extensibility/VsPackageRestorerTests.cs
@@ -1,0 +1,92 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using Moq;
+using NuGet.Common;
+using NuGet.Configuration;
+using NuGet.PackageManagement;
+using NuGet.PackageManagement.VisualStudio;
+using NuGet.ProjectManagement;
+using NuGet.VisualStudio.Implementation.Test.TestUtilities;
+using NuGet.VisualStudio.Telemetry;
+using Xunit;
+
+namespace NuGet.VisualStudio.Implementation.Test.Extensibility
+{
+    public class VsPackageRestorerTests
+    {
+        [Fact]
+        public void RestorePackages_NullProject_CallsRestoreManager()
+        {
+            // Arrange
+            var restoreManager = new Mock<IPackageRestoreManager>();
+
+            // Act
+            VsPackageRestorer target = CreateTarget(restoreManager: restoreManager.Object);
+            target.RestorePackages(null);
+
+            // Assert
+            restoreManager.Verify(rm => rm.RestoreMissingPackagesInSolutionAsync(It.IsAny<string>(), It.IsAny<INuGetProjectContext>(), It.IsAny<ILogger>(), It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public void RestorePackages_InternalException_PostsFault()
+        {
+            // Arrange
+            var expectedException = new ArgumentException("Internal error");
+
+            var restoreManager = new Mock<IPackageRestoreManager>();
+            restoreManager.Setup(rm => rm.RestoreMissingPackagesInSolutionAsync(It.IsAny<string>(), It.IsAny<INuGetProjectContext>(), It.IsAny<ILogger>(), It.IsAny<CancellationToken>()))
+                .Throws(expectedException);
+
+            var telemetryProvider = new Mock<INuGetTelemetryProvider>();
+
+            // Act
+            VsPackageRestorer target = CreateTarget(restoreManager: restoreManager.Object, telemetryProvider: telemetryProvider.Object);
+            target.RestorePackages(null);
+
+            // Assert
+            telemetryProvider.Verify(t => t.PostFault(expectedException, typeof(VsPackageRestorer).FullName, nameof(VsPackageRestorer.RestorePackages), It.IsAny<IDictionary<string, object>>()), Times.Once);
+        }
+
+
+        private VsPackageRestorer CreateTarget(
+            ISettings settings = null,
+            ISolutionManager solutionManager = null,
+            IPackageRestoreManager restoreManager = null,
+            IVsProjectThreadingService threadingService = null,
+            INuGetTelemetryProvider telemetryProvider = null)
+        {
+            if (settings == null)
+            {
+                settings = new Mock<ISettings>().Object;
+            }
+
+            if (solutionManager == null)
+            {
+                solutionManager = new Mock<ISolutionManager>().Object;
+            }
+
+            if (restoreManager == null)
+            {
+                restoreManager = new Mock<IPackageRestoreManager>().Object;
+            }
+
+            if (threadingService == null)
+            {
+                threadingService = new TestProjectThreadingService();
+            }
+
+            if (telemetryProvider == null)
+            {
+                // Use strict mode, as known/expected errors should not post faults.
+                telemetryProvider = new Mock<INuGetTelemetryProvider>(MockBehavior.Strict).Object;
+            }
+
+            return new VsPackageRestorer(settings, solutionManager, restoreManager, threadingService, telemetryProvider);
+        }
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/Extensibility/VsPathContextProviderTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/Extensibility/VsPathContextProviderTests.cs
@@ -22,17 +22,15 @@ using NuGet.ProjectManagement.Projects;
 using NuGet.ProjectModel;
 using NuGet.Test.Utility;
 using NuGet.Versioning;
+using NuGet.VisualStudio.Telemetry;
 using Xunit;
 
 namespace NuGet.VisualStudio.Implementation.Test.Extensibility
 {
-    [Collection(MockedVs.CollectionName)]
     public class VsPathContextProviderTests
     {
-        public VsPathContextProviderTests(GlobalServiceProvider serviceProvider)
-        {
-            serviceProvider.Reset();
-        }
+        // known/expected errors should not be reported to telemetry, hence use MockBehavior.Strict
+        private Mock<INuGetTelemetryProvider> _telemetryProvider = new Mock<INuGetTelemetryProvider>(MockBehavior.Strict);
 
         [Fact]
         public void GetSolutionPathContext_WithConfiguredUserPackageFolder()
@@ -53,7 +51,8 @@ namespace NuGet.VisualStudio.Implementation.Test.Extensibility
                 settings,
                 Mock.Of<IVsSolutionManager>(),
                 Mock.Of<ILogger>(),
-                getLockFileOrNullAsync: null);
+                getLockFileOrNullAsync: null,
+                _telemetryProvider.Object);
 
             // Act
             var actual = target.GetSolutionPathContext();
@@ -84,7 +83,8 @@ namespace NuGet.VisualStudio.Implementation.Test.Extensibility
                 settings.Object,
                 Mock.Of<IVsSolutionManager>(),
                 Mock.Of<ILogger>(),
-                getLockFileOrNullAsync: null);
+                getLockFileOrNullAsync: null,
+                _telemetryProvider.Object);
 
             // Act
             var actual = target.GetSolutionPathContext();
@@ -151,7 +151,8 @@ namespace NuGet.VisualStudio.Implementation.Test.Extensibility
                         };
 
                         return Task.FromResult(lockFile);
-                    });
+                    },
+                    _telemetryProvider.Object);
 
                 var project = Mock.Of<BuildIntegratedNuGetProject>();
 
@@ -203,7 +204,8 @@ namespace NuGet.VisualStudio.Implementation.Test.Extensibility
                     settings,
                     Mock.Of<IVsSolutionManager>(),
                     Mock.Of<ILogger>(),
-                    getLockFileOrNullAsync: null);
+                    getLockFileOrNullAsync: null,
+                    _telemetryProvider.Object);
 
                 var project = new Mock<MSBuildNuGetProject>(
                     Mock.Of<IMSBuildProjectSystem>(), userPackageFolder, testDirectory.Path);
@@ -252,7 +254,8 @@ namespace NuGet.VisualStudio.Implementation.Test.Extensibility
                     settings,
                     Mock.Of<IVsSolutionManager>(),
                     Mock.Of<ILogger>(),
-                    getLockFileOrNullAsync: null);
+                    getLockFileOrNullAsync: null,
+                    _telemetryProvider.Object);
 
                 var projectUniqueName = Guid.NewGuid().ToString();
 
@@ -306,7 +309,8 @@ namespace NuGet.VisualStudio.Implementation.Test.Extensibility
                     settings,
                     solutionManager.Object,
                     Mock.Of<ILogger>(),
-                    getLockFileOrNullAsync: null);
+                    getLockFileOrNullAsync: null,
+                    _telemetryProvider.Object);
 
                 // Act
                 var result = target.TryCreateSolutionContext(out var actual);
@@ -345,7 +349,8 @@ namespace NuGet.VisualStudio.Implementation.Test.Extensibility
                     settings.Object,
                     solutionManager.Object,
                     Mock.Of<ILogger>(),
-                    getLockFileOrNullAsync: null);
+                    getLockFileOrNullAsync: null,
+                    _telemetryProvider.Object);
 
                 // Act
                 var result = target.TryCreateSolutionContext(out var actual);
@@ -387,7 +392,8 @@ namespace NuGet.VisualStudio.Implementation.Test.Extensibility
                 settings,
                 solutionManager.Object,
                 Mock.Of<ILogger>(),
-                getLockFileOrNullAsync: null);
+                getLockFileOrNullAsync: null,
+                _telemetryProvider.Object);
 
                 // Act
                 var result = target.TryCreateSolutionContext(out var actual);
@@ -412,7 +418,8 @@ namespace NuGet.VisualStudio.Implementation.Test.Extensibility
                 Mock.Of<ISettings>(),
                 Mock.Of<IVsSolutionManager>(),
                 Mock.Of<ILogger>(),
-                getLockFileOrNullAsync: null);
+                getLockFileOrNullAsync: null,
+                _telemetryProvider.Object);
 
                 // Act
                 var result = target.TryCreateSolutionContext(testDirectory.Path, out var actual);
@@ -432,7 +439,8 @@ namespace NuGet.VisualStudio.Implementation.Test.Extensibility
                 Mock.Of<ISettings>(),
                 Mock.Of<IVsSolutionManager>(),
                 Mock.Of<ILogger>(),
-                getLockFileOrNullAsync: _ => Task.FromResult(null as LockFile));
+                getLockFileOrNullAsync: _ => Task.FromResult(null as LockFile),
+                _telemetryProvider.Object);
 
             var projectUniqueName = Guid.NewGuid().ToString();
 

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/NuGet.VisualStudio.Implementation.Test.csproj
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/NuGet.VisualStudio.Implementation.Test.csproj
@@ -58,6 +58,6 @@
     <PackageReference Include="Microsoft.VisualStudio.Sdk.TestFramework" />
   </ItemGroup>
 
-  <Import Project="$(BuildCommonDirectory)common.targets"/>
+  <Import Project="$(BuildCommonDirectory)common.targets" />
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 </Project>

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/TestUtilities/TestProjectThreadingService.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/TestUtilities/TestProjectThreadingService.cs
@@ -1,0 +1,43 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Threading;
+using NuGet.PackageManagement.VisualStudio;
+
+namespace NuGet.VisualStudio.Implementation.Test.TestUtilities
+{
+    internal class TestProjectThreadingService : IVsProjectThreadingService
+    {
+        private readonly JoinableTaskContext _context;
+
+        public TestProjectThreadingService()
+        {
+#pragma warning disable VSSDK005 // Avoid instantiating JoinableTaskContext
+            _context = new JoinableTaskContext();
+#pragma warning restore VSSDK005 // Avoid instantiating JoinableTaskContext
+        }
+
+        public JoinableTaskFactory JoinableTaskFactory => _context.Factory;
+
+        public void ExecuteSynchronously(Func<Task> asyncAction)
+        {
+            JoinableTaskFactory.Run(asyncAction);
+        }
+
+        public T ExecuteSynchronously<T>(Func<Task<T>> asyncAction)
+        {
+            return JoinableTaskFactory.Run(asyncAction);
+        }
+
+        public void ThrowIfNotOnUIThread([CallerMemberName] string callerMemberName = "")
+        {
+            if (!_context.IsOnMainThread)
+            {
+                throw new Exception();
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/10062
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: 
* Created `INuGetTelemetryProvider`, with MEF implementation, so that this is easily testable.
* Tried to find all implementations of interfaces defined in NuGet.VisualStudio and NuGet.VisualStudio.Contracts, and add try-catch blocks to log faults on public methods, then rethrow exception.

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  Existing tests modified. Also, the telemetry is only supposed to record unexpected faults, not expected faults (tests are configured to fail if they try to report fault).
Validation:  
