### PR TITLE
Update the SDK and msbuild package version

### DIFF
--- a/build/bootstrap.proj
+++ b/build/bootstrap.proj
@@ -23,7 +23,7 @@
         <PackageDownload Include="Microsoft.VisualStudio.ProjectSystem.Managed.VS" version="[16.7.0-beta1-65318-02]" />
         <PackageDownload Include="Microsoft.Web.Xdt" version="[2.1.2]" />
         <PackageDownload Include="Newtonsoft.Json" version="[9.0.1]" />
-        <PackageDownload Include="NuGet.Build.Tasks.Pack" version="[5.7.0]" />
+        <PackageDownload Include="NuGet.Build.Tasks.Pack" version="[5.8.0]" />
         <PackageDownload Include="NuGet.Client.EndToEnd.TestData" version="[1.0.0]" />
         <PackageDownload Include="NuGet.Core" version="[2.14.0-rtm-832]" />
         <PackageDownload Include="NuGetValidator" version="[2.0.3]" />

--- a/build/config.props
+++ b/build/config.props
@@ -37,8 +37,8 @@
     <!--TODO: remove temporary workaround of using LockSDKVersion. Tracking issue: https://github.com/NuGet/Home/issues/9712 -->
     <LockSDKVersion>true</LockSDKVersion>
     <OverrideCliBranchForTesting Condition="'$(LockSDKVersion)' == 'false'"></OverrideCliBranchForTesting>
-    <OverrideCliBranchForTesting Condition="'$(LockSDKVersion)' == 'true'">master 5.0.100-preview.7.20319.6</OverrideCliBranchForTesting>
-    <CliVersionForBuilding>"master 5.0.100-preview.4.20258.7"</CliVersionForBuilding>
+    <OverrideCliBranchForTesting Condition="'$(LockSDKVersion)' == 'true'">master 5.0.100-preview.7.20366.6</OverrideCliBranchForTesting>
+    <CliVersionForBuilding>"master 5.0.100-preview.7.20366.6"</CliVersionForBuilding>
     <CliBranchForTesting Condition="'$(OverrideCliBranchForTesting)' != ''">$(OverrideCliBranchForTesting)</CliBranchForTesting>
     <CliBranchForTesting Condition="'$(OverrideCliBranchForTesting)' == ''">master</CliBranchForTesting>
     <CliTargetBranches Condition="'$(OverrideCliTargetBranches)' != ''">$(OverrideCliTargetBranches)</CliTargetBranches>

--- a/build/config.props
+++ b/build/config.props
@@ -37,8 +37,8 @@
     <!--TODO: remove temporary workaround of using LockSDKVersion. Tracking issue: https://github.com/NuGet/Home/issues/9712 -->
     <LockSDKVersion>true</LockSDKVersion>
     <OverrideCliBranchForTesting Condition="'$(LockSDKVersion)' == 'false'"></OverrideCliBranchForTesting>
-    <OverrideCliBranchForTesting Condition="'$(LockSDKVersion)' == 'true'">master 5.0.100-preview.7.20366.6</OverrideCliBranchForTesting>
-    <CliVersionForBuilding>"master 5.0.100-preview.7.20366.6"</CliVersionForBuilding>
+    <OverrideCliBranchForTesting Condition="'$(LockSDKVersion)' == 'true'">master 5.0.100</OverrideCliBranchForTesting>
+    <CliVersionForBuilding>"master 5.0.100"</CliVersionForBuilding>
     <CliBranchForTesting Condition="'$(OverrideCliBranchForTesting)' != ''">$(OverrideCliBranchForTesting)</CliBranchForTesting>
     <CliBranchForTesting Condition="'$(OverrideCliBranchForTesting)' == ''">master</CliBranchForTesting>
     <CliTargetBranches Condition="'$(OverrideCliTargetBranches)' != ''">$(OverrideCliTargetBranches)</CliTargetBranches>

--- a/build/packages.targets
+++ b/build/packages.targets
@@ -7,7 +7,6 @@
         <VSFrameworkVersion>16.6.30107.105</VSFrameworkVersion>
         <VSServicesVersion>16.153.0</VSServicesVersion>
         <VSThreadingVersion>16.7.56</VSThreadingVersion>
-        <!-- TODO - remove this when temporary patching is no longer necessary. See https://github.com/nuget/home/issues/8952 -->
         <PatchedSystemPackagesVersion>5.0.0-preview.3.20214.6</PatchedSystemPackagesVersion>
     </PropertyGroup>
 
@@ -64,8 +63,8 @@
         <PackageReference Update="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
         <PackageReference Update="System.Collections.Immutable" Version="1.7.1" />
         <PackageReference Update="System.Diagnostics.Debug" Version="$(SystemPackagesVersion)" />
-        <PackageReference Update="System.Security.Cryptography.Pkcs" Version="$(PatchedSystemPackagesVersion)" />
-        <PackageReference Update="System.Security.Cryptography.Cng" Version="$(PatchedSystemPackagesVersion)" />
+        <PackageReference Update="System.Security.Cryptography.Pkcs" Version="$(CryptographyPackagesVersion)" />
+        <PackageReference Update="System.Security.Cryptography.Cng" Version="$(CryptographyPackagesVersion)" />
         <PackageReference Update="System.Security.Cryptography.ProtectedData" Version="4.4.0" />
         <PackageReference Update="System.Threading.Tasks.Dataflow" Version="4.9.0" />
         <PackageReference Update="VSLangProj" Version="7.0.3300" />

--- a/build/packages.targets
+++ b/build/packages.targets
@@ -7,7 +7,7 @@
         <VSFrameworkVersion>16.6.30107.105</VSFrameworkVersion>
         <VSServicesVersion>16.153.0</VSServicesVersion>
         <VSThreadingVersion>16.7.56</VSThreadingVersion>
-        <CryptographyPackagesVersion>5.0.0</PatchedSystemPackagesVersion>
+        <CryptographyPackagesVersion>5.0.0</CryptographyPackagesVersion>
     </PropertyGroup>
 
     <!-- Test and package versions -->

--- a/build/packages.targets
+++ b/build/packages.targets
@@ -1,13 +1,13 @@
 <Project>
     <PropertyGroup>
-        <MicrosoftBuildPackageVersion Condition="'$(MicrosoftBuildPackageVersion)' == ''">16.6.0</MicrosoftBuildPackageVersion>
+        <MicrosoftBuildPackageVersion Condition="'$(MicrosoftBuildPackageVersion)' == ''">16.8.0</MicrosoftBuildPackageVersion>
         <NewtonsoftJsonPackageVersion Condition="$(NewtonsoftJsonPackageVersion) == ''">9.0.1</NewtonsoftJsonPackageVersion>
         <SystemPackagesVersion>4.3.0</SystemPackagesVersion>
         <VSComponentsVersion>16.6.255</VSComponentsVersion>
         <VSFrameworkVersion>16.6.30107.105</VSFrameworkVersion>
         <VSServicesVersion>16.153.0</VSServicesVersion>
         <VSThreadingVersion>16.7.56</VSThreadingVersion>
-        <PatchedSystemPackagesVersion>5.0.0-preview.3.20214.6</PatchedSystemPackagesVersion>
+        <CryptographyPackagesVersion>5.0.0</PatchedSystemPackagesVersion>
     </PropertyGroup>
 
     <!-- Test and package versions -->

--- a/src/NuGet.Clients/NuGet.VisualStudio.Client/.vsixignore
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Client/.vsixignore
@@ -110,3 +110,5 @@ System.Threading.Tasks.Extensions.dll
 System.Web.Http.dll
 VSLangProj157.dll
 Microsoft.DataAI.NuGetRecommender.Contracts.dll
+System.Text.Encodings.Web.dll
+System.Text.Json.dll

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/App.config
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/App.config
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.5.0" newVersion="1.2.5.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/CpsPackageReferenceProjectTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/CpsPackageReferenceProjectTests.cs
@@ -741,7 +741,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         [Fact]
         public async Task TestPackageManager_UpgradePackageFor_TopParentProject_Success()
         {
-            using (var testDirectory = TestDirectory.Create())
+            using (var testDirectory = new SimpleTestPathContext())
             using (var testSolutionManager = new TestSolutionManager())
             {
                 // Set up Package Source
@@ -752,16 +752,15 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 var packageA = packageA_Version100.Identity;
                 var packageB = packageB_Version100.Identity;
                 var packageB_UpgradeVersion = packageB_Version200.Identity;
-                var packageSource = Path.Combine(testDirectory, "packageSource");
                 await SimpleTestPackageUtility.CreateFolderFeedV3Async(
-                    packageSource,
+                    testDirectory.PackageSource,
                     PackageSaveMode.Defaultv3,
                     packageA_Version100,
                     packageB_Version100,
                     packageB_Version200
                     );
 
-                sources.Add(new PackageSource(packageSource));
+                sources.Add(new PackageSource(testDirectory.PackageSource));
                 var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateSourceRepositoryProvider(sources);
 
                 // Project
@@ -787,7 +786,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 for (var i = numberOfProjects - 1; i >= 0; i--)
                 {
                     var projectName = $"project{i}";
-                    var projectFullPath = Path.Combine(testDirectory.Path, projectName, projectName + ".csproj");
+                    var projectFullPath = Path.Combine(testDirectory.SolutionRoot, projectName, projectName + ".csproj");
                     var project = CreateTestCpsPackageReferenceProject(projectName, projectFullPath, projectCache);
 
                     // We need to treat NU1605 warning as error.

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/App.config
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/App.config
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.5.0" newVersion="1.2.5.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/App.config
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/App.config
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.5.0" newVersion="1.2.5.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Pack.Test/PackTaskTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Pack.Test/PackTaskTests.cs
@@ -372,9 +372,9 @@ namespace NuGet.Build.Tasks.Pack.Test
             var jsonModelBefore = JObject.FromObject(target, JsonSerializer.Create(settings));
 
             // Exclude properties on the build task but not used for the pack task request.
-            var excludedBuildEngineProperty = new List<string> (
-                jsonModelBefore.Properties().Where(p => p.Name.StartsWith("BuildEngine", StringComparison.OrdinalIgnoreCase))
-                .Select(p => p.Name));
+            var excludedBuildEngineProperty = new List<string>(jsonModelBefore.Properties().
+                Where(p => p.Name.StartsWith("BuildEngine", StringComparison.OrdinalIgnoreCase)).
+                Select(p => p.Name));
 
             var excludedOtherProperties = new[]
             {

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Pack.Test/PackTaskTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Pack.Test/PackTaskTests.cs
@@ -369,22 +369,26 @@ namespace NuGet.Build.Tasks.Pack.Test
                 Formatting = Formatting.Indented
             };
 
+            var jsonModelBefore = JObject.FromObject(target, JsonSerializer.Create(settings));
+
             // Exclude properties on the build task but not used for the pack task request.
-            var excludedProperties = new[]
+            var excludedBuildEngineProperty = new List<string> (
+                jsonModelBefore.Properties().Where(p => p.Name.StartsWith("BuildEngine", StringComparison.OrdinalIgnoreCase))
+                .Select(p => p.Name));
+
+            var excludedOtherProperties = new[]
             {
-                "BuildEngine",
-                "BuildEngine2",
-                "BuildEngine3",
-                "BuildEngine4",
-                "BuildEngine5",
-                "BuildEngine6",
                 "HostObject",
                 "Log",
                 "PackTaskLogic",
             };
 
-            var jsonModelBefore = JObject.FromObject(target, JsonSerializer.Create(settings));
-            foreach (var property in excludedProperties)
+            foreach (var property in excludedBuildEngineProperty)
+            {
+                jsonModelBefore.Remove(property);
+            }
+
+            foreach (var property in excludedOtherProperties)
             {
                 jsonModelBefore.Remove(property);
             }


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Client.Engineering/issues/367 and https://github.com/NuGet/Home/issues/8952
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: 
1. Update the SDK version for build and test to 5.0.100
2. Update the msbuild packages version from 16.6.0 to 16.8.0
3. Update the pack task package from 5.7.0 to 5.8.0
4. Update the cryptography packages version to 5.0.0
5. Add System.Text.Encodings.Web.dll and System.Text.Json.dll into .vsixignore, the two dlls are brought in by 
  Microsoft.Build/16.8.0  => System.Text.Json/4.7.0 => System.Text.Encodings.Web/4.7.0
6. Remove the temporary patching on deps.json from `MsbuildIntegrationTestFixture`.
7.Fix a test which failed as new BuildEngine7 property is brought in.


## Testing/Validation

Tests Added: No  
Reason for not adding tests:  Engineering
Validation:  
