### PR TITLE
Make RadioButton's default style be based on the VS style

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources/Resources.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources/Resources.xaml
@@ -4,7 +4,8 @@
   xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
   xmlns:nuget="clr-namespace:NuGet.PackageManagement.UI"
   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-  xmlns:ui="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Utilities">
+  xmlns:ui="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Utilities"
+  xmlns:vs="clr-namespace:Microsoft.VisualStudio.Shell;assembly=Microsoft.VisualStudio.Shell.15.0">
   <nuget:StyleKeyConverter
     x:Key="StyleKeyConverter" />
 
@@ -227,6 +228,8 @@
       </Setter.Value>
     </Setter>
   </Style>
+
+  <Style x:Key="{x:Type RadioButton}" TargetType="{x:Type RadioButton}" BasedOn="{StaticResource {x:Static vs:VsResourceKeys.ThemedDialogRadioButtonStyleKey}}" />
 
   <Style x:Key="ExpanderRightHeaderStyle" TargetType="{x:Type ToggleButton}">
     <Setter Property="Template">


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9729
Regression: No
* Last working version: N/A
* How are we preventing it in future: N/A

## Fix

Details: Radio buttons are not styled to use a color-themed dashed border when they have focus, so it is difficult to see the border in the dark theme. This fix makes a new default style for radio buttons and has it basing off of the ThemedDialogRadioButton in VS so it inherits all its properties, including the appropriate styling for the focus visual style, and it will stay in sync with any changes made to the style in VS.

## Testing/Validation

Tests Added: No
Reason for not adding tests: Requires manual testing in the UI to observe the desired color when a RadioButton has focus.
Validation: Followed bug repro steps and then tabbed through controls on the “Choose NuGet Package Manager Format” dialog to set focus to the radio buttons and validated the dotted line around the radio buttons was themed in dark, blue, and light themes.
