### PR TITLE
Make LocalPackageFileCache methods virtual

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/PackagesFolder/LocalPackageFileCache.cs
+++ b/src/NuGet.Core/NuGet.Protocol/PackagesFolder/LocalPackageFileCache.cs
@@ -46,7 +46,7 @@ namespace NuGet.Protocol
         /// <summary>
         /// Read a nuspec file from disk. The nuspec is expected to exist.
         /// </summary>
-        public Lazy<NuspecReader> GetOrAddNuspec(string manifestPath, string expandedPath)
+        public virtual Lazy<NuspecReader> GetOrAddNuspec(string manifestPath, string expandedPath)
         {
             return _nuspecCache.GetOrAdd(expandedPath,
                 e => new Lazy<NuspecReader>(() => GetNuspec(manifestPath, e)));
@@ -55,7 +55,7 @@ namespace NuGet.Protocol
         /// <summary>
         /// Read a the package files from disk.
         /// </summary>
-        public Lazy<IReadOnlyList<string>> GetOrAddFiles(string expandedPath)
+        public virtual Lazy<IReadOnlyList<string>> GetOrAddFiles(string expandedPath)
         {
             return _filesCache.GetOrAdd(expandedPath,
                 e => new Lazy<IReadOnlyList<string>>(() => GetFiles(e)));
@@ -65,7 +65,7 @@ namespace NuGet.Protocol
         /// Read the .metadata.json file from disk.
         /// </summary>
         /// <remarks>Throws if the file is not found or corrupted.</remarks>
-        public Lazy<string> GetOrAddSha512(string sha512Path)
+        public virtual Lazy<string> GetOrAddSha512(string sha512Path)
         {
             return _sha512Cache.GetOrAdd(sha512Path,
                 e => new Lazy<string>(() =>
@@ -79,7 +79,7 @@ namespace NuGet.Protocol
         /// True if the path exists on disk. This also uses
         /// the SHA512 cache for already read files.
         /// </summary>
-        public bool Sha512Exists(string sha512Path)
+        public virtual bool Sha512Exists(string sha512Path)
         {
             // Avoid checking the desk if we have already read the file.
             var exists = _fileExistsCache.ContainsKey(sha512Path);
@@ -99,7 +99,7 @@ namespace NuGet.Protocol
         /// Read runtime.json from a package.
         /// Returns null if runtime.json does not exist.
         /// </summary>
-        public Lazy<RuntimeGraph> GetOrAddRuntimeGraph(string expandedPath)
+        public virtual Lazy<RuntimeGraph> GetOrAddRuntimeGraph(string expandedPath)
         {
             return _runtimeCache.GetOrAdd(expandedPath, p => new Lazy<RuntimeGraph>(() => GetRuntimeGraph(p)));
         }

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Shipped.txt
@@ -600,12 +600,12 @@ NuGet.Protocol.LocalPackageArchiveDownloader.SetThrottle(System.Threading.Semaph
 NuGet.Protocol.LocalPackageArchiveDownloader.SignedPackageReader.get -> NuGet.Packaging.Signing.ISignedPackageReader
 NuGet.Protocol.LocalPackageArchiveDownloader.Source.get -> string
 NuGet.Protocol.LocalPackageFileCache
-NuGet.Protocol.LocalPackageFileCache.GetOrAddFiles(string expandedPath) -> System.Lazy<System.Collections.Generic.IReadOnlyList<string>>
-NuGet.Protocol.LocalPackageFileCache.GetOrAddNuspec(string manifestPath, string expandedPath) -> System.Lazy<NuGet.Packaging.NuspecReader>
-NuGet.Protocol.LocalPackageFileCache.GetOrAddRuntimeGraph(string expandedPath) -> System.Lazy<NuGet.RuntimeModel.RuntimeGraph>
-NuGet.Protocol.LocalPackageFileCache.GetOrAddSha512(string sha512Path) -> System.Lazy<string>
+virtual NuGet.Protocol.LocalPackageFileCache.GetOrAddFiles(string expandedPath) -> System.Lazy<System.Collections.Generic.IReadOnlyList<string>>
+virtual NuGet.Protocol.LocalPackageFileCache.GetOrAddNuspec(string manifestPath, string expandedPath) -> System.Lazy<NuGet.Packaging.NuspecReader>
+virtual NuGet.Protocol.LocalPackageFileCache.GetOrAddRuntimeGraph(string expandedPath) -> System.Lazy<NuGet.RuntimeModel.RuntimeGraph>
+virtual NuGet.Protocol.LocalPackageFileCache.GetOrAddSha512(string sha512Path) -> System.Lazy<string>
 NuGet.Protocol.LocalPackageFileCache.LocalPackageFileCache() -> void
-NuGet.Protocol.LocalPackageFileCache.Sha512Exists(string sha512Path) -> bool
+virtual NuGet.Protocol.LocalPackageFileCache.Sha512Exists(string sha512Path) -> bool
 NuGet.Protocol.LocalPackageInfo
 NuGet.Protocol.LocalPackageInfo.LocalPackageInfo() -> void
 NuGet.Protocol.LocalPackageInfo.LocalPackageInfo(NuGet.Packaging.Core.PackageIdentity identity, string path, System.DateTime lastWriteTimeUtc, System.Lazy<NuGet.Packaging.NuspecReader> nuspec, System.Func<NuGet.Packaging.PackageReaderBase> getPackageReader) -> void

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/netcoreapp5.0/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/netcoreapp5.0/PublicAPI.Shipped.txt
@@ -600,12 +600,12 @@ NuGet.Protocol.LocalPackageArchiveDownloader.SetThrottle(System.Threading.Semaph
 NuGet.Protocol.LocalPackageArchiveDownloader.SignedPackageReader.get -> NuGet.Packaging.Signing.ISignedPackageReader
 NuGet.Protocol.LocalPackageArchiveDownloader.Source.get -> string
 NuGet.Protocol.LocalPackageFileCache
-NuGet.Protocol.LocalPackageFileCache.GetOrAddFiles(string expandedPath) -> System.Lazy<System.Collections.Generic.IReadOnlyList<string>>
-NuGet.Protocol.LocalPackageFileCache.GetOrAddNuspec(string manifestPath, string expandedPath) -> System.Lazy<NuGet.Packaging.NuspecReader>
-NuGet.Protocol.LocalPackageFileCache.GetOrAddRuntimeGraph(string expandedPath) -> System.Lazy<NuGet.RuntimeModel.RuntimeGraph>
-NuGet.Protocol.LocalPackageFileCache.GetOrAddSha512(string sha512Path) -> System.Lazy<string>
+virtual NuGet.Protocol.LocalPackageFileCache.GetOrAddFiles(string expandedPath) -> System.Lazy<System.Collections.Generic.IReadOnlyList<string>>
+virtual NuGet.Protocol.LocalPackageFileCache.GetOrAddNuspec(string manifestPath, string expandedPath) -> System.Lazy<NuGet.Packaging.NuspecReader>
+virtual NuGet.Protocol.LocalPackageFileCache.GetOrAddRuntimeGraph(string expandedPath) -> System.Lazy<NuGet.RuntimeModel.RuntimeGraph>
+virtual NuGet.Protocol.LocalPackageFileCache.GetOrAddSha512(string sha512Path) -> System.Lazy<string>
 NuGet.Protocol.LocalPackageFileCache.LocalPackageFileCache() -> void
-NuGet.Protocol.LocalPackageFileCache.Sha512Exists(string sha512Path) -> bool
+virtual NuGet.Protocol.LocalPackageFileCache.Sha512Exists(string sha512Path) -> bool
 NuGet.Protocol.LocalPackageInfo
 NuGet.Protocol.LocalPackageInfo.LocalPackageInfo() -> void
 NuGet.Protocol.LocalPackageInfo.LocalPackageInfo(NuGet.Packaging.Core.PackageIdentity identity, string path, System.DateTime lastWriteTimeUtc, System.Lazy<NuGet.Packaging.NuspecReader> nuspec, System.Func<NuGet.Packaging.PackageReaderBase> getPackageReader) -> void

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
@@ -600,12 +600,12 @@ NuGet.Protocol.LocalPackageArchiveDownloader.SetThrottle(System.Threading.Semaph
 NuGet.Protocol.LocalPackageArchiveDownloader.SignedPackageReader.get -> NuGet.Packaging.Signing.ISignedPackageReader
 NuGet.Protocol.LocalPackageArchiveDownloader.Source.get -> string
 NuGet.Protocol.LocalPackageFileCache
-NuGet.Protocol.LocalPackageFileCache.GetOrAddFiles(string expandedPath) -> System.Lazy<System.Collections.Generic.IReadOnlyList<string>>
-NuGet.Protocol.LocalPackageFileCache.GetOrAddNuspec(string manifestPath, string expandedPath) -> System.Lazy<NuGet.Packaging.NuspecReader>
-NuGet.Protocol.LocalPackageFileCache.GetOrAddRuntimeGraph(string expandedPath) -> System.Lazy<NuGet.RuntimeModel.RuntimeGraph>
-NuGet.Protocol.LocalPackageFileCache.GetOrAddSha512(string sha512Path) -> System.Lazy<string>
+virtual NuGet.Protocol.LocalPackageFileCache.GetOrAddFiles(string expandedPath) -> System.Lazy<System.Collections.Generic.IReadOnlyList<string>>
+virtual NuGet.Protocol.LocalPackageFileCache.GetOrAddNuspec(string manifestPath, string expandedPath) -> System.Lazy<NuGet.Packaging.NuspecReader>
+virtual NuGet.Protocol.LocalPackageFileCache.GetOrAddRuntimeGraph(string expandedPath) -> System.Lazy<NuGet.RuntimeModel.RuntimeGraph>
+virtual NuGet.Protocol.LocalPackageFileCache.GetOrAddSha512(string sha512Path) -> System.Lazy<string>
 NuGet.Protocol.LocalPackageFileCache.LocalPackageFileCache() -> void
-NuGet.Protocol.LocalPackageFileCache.Sha512Exists(string sha512Path) -> bool
+virtual NuGet.Protocol.LocalPackageFileCache.Sha512Exists(string sha512Path) -> bool
 NuGet.Protocol.LocalPackageInfo
 NuGet.Protocol.LocalPackageInfo.LocalPackageInfo() -> void
 NuGet.Protocol.LocalPackageInfo.LocalPackageInfo(NuGet.Packaging.Core.PackageIdentity identity, string path, System.DateTime lastWriteTimeUtc, System.Lazy<NuGet.Packaging.NuspecReader> nuspec, System.Func<NuGet.Packaging.PackageReaderBase> getPackageReader) -> void


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/10325
Regression: No

## Fix

Details: Making LocalPackageFileCache methods virtual would be the minimum requirement to give NuGet clients an extension point for optimizations.

## Testing/Validation

Tests Added: None
Reason for not adding tests:  Not needed
Validation:  Not needed
