### PR TITLE
Remove unnecessary `#nullable enable` directives

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/ContextInfos/AlternatePackageMetadataContextInfo.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/ContextInfos/AlternatePackageMetadataContextInfo.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable enable
-
 using Microsoft;
 using NuGet.Protocol;
 using NuGet.Versioning;

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/ContextInfos/PackageDeprecationMetadataContextInfo.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/ContextInfos/PackageDeprecationMetadataContextInfo.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable enable
-
 using System.Collections.Generic;
 using System.Linq;
 using NuGet.Protocol;

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/ContextInfos/PackageSearchMetadataContextInfo.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/ContextInfos/PackageSearchMetadataContextInfo.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/ContextInfos/PackageSourceContextInfo.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/ContextInfos/PackageSourceContextInfo.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable enable
-
 using System;
 using Microsoft;
 using NuGet.Configuration;
@@ -51,7 +49,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
             }
 
             return Name.Equals(other.Name, StringComparison.CurrentCultureIgnoreCase) &&
-                   Source.Equals(other.Source, StringComparison.OrdinalIgnoreCase);
+                Source.Equals(other.Source, StringComparison.OrdinalIgnoreCase);
         }
 
         public override bool Equals(object obj)

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/ContextInfos/PackageVulnerabilityMetadataContextInfo.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/ContextInfos/PackageVulnerabilityMetadataContextInfo.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable enable
-
 using System;
 
 namespace NuGet.VisualStudio.Internal.Contracts

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/ContextInfos/SearchResultContextInfo.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/ContextInfos/SearchResultContextInfo.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -37,9 +35,9 @@ namespace NuGet.VisualStudio.Internal.Contracts
 
         public SearchResultContextInfo(Guid? operationId)
             : this(Array.Empty<PackageSearchMetadataContextInfo>(),
-                  ImmutableDictionary<string, LoadingStatus>.Empty,
-                  hasMoreItems: false,
-                  operationId: operationId)
+                ImmutableDictionary<string, LoadingStatus>.Empty,
+                hasMoreItems: false,
+                operationId: operationId)
         {
         }
 

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/ContextInfos/VersionInfoContextInfo.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/ContextInfos/VersionInfoContextInfo.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable enable
-
 using System.Threading.Tasks;
 using Microsoft;
 using NuGet.Protocol;

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/AlternatePackageMetadataContextInfoFormatter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/AlternatePackageMetadataContextInfoFormatter.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable enable
-
 using MessagePack;
 using MessagePack.Formatters;
 using Microsoft;

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/FloatRangeFormatter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/FloatRangeFormatter.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable enable
-
 using MessagePack;
 using MessagePack.Formatters;
 using Microsoft;

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/ILogMessageFormatter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/ILogMessageFormatter.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using MessagePack;

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/IPackageReferenceContextInfoFormatter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/IPackageReferenceContextInfoFormatter.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable enable
-
 using MessagePack;
 using MessagePack.Formatters;
 using Microsoft;

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/IProjectContextInfoFormatter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/IProjectContextInfoFormatter.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable enable
-
 using MessagePack;
 using MessagePack.Formatters;
 using Microsoft;

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/IProjectMetadataContextInfoFormatter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/IProjectMetadataContextInfoFormatter.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable enable
-
 using MessagePack;
 using MessagePack.Formatters;
 using Microsoft;

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/ImplicitProjectActionFormatter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/ImplicitProjectActionFormatter.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable enable
-
 using MessagePack;
 using MessagePack.Formatters;
 using Microsoft;

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/NuGetFrameworkFormatter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/NuGetFrameworkFormatter.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable enable
-
 using MessagePack;
 using MessagePack.Formatters;
 using NuGet.Frameworks;

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/NuGetMessagePackFormatter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/NuGetMessagePackFormatter.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable enable
-
 using MessagePack;
 using MessagePack.Formatters;
 

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/NuGetVersionFormatter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/NuGetVersionFormatter.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable enable
-
 using MessagePack;
 using MessagePack.Formatters;
 using NuGet.Versioning;

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/PackageDependencyFormatter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/PackageDependencyFormatter.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable enable
-
 using System.Collections.Generic;
 using MessagePack;
 using MessagePack.Formatters;

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/PackageDependencyGroupFormatter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/PackageDependencyGroupFormatter.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable enable
-
 using System.Collections.Generic;
 using MessagePack;
 using MessagePack.Formatters;

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/PackageDependencyInfoFormatter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/PackageDependencyInfoFormatter.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable enable
-
 using System.Collections.Generic;
 using System.Linq;
 using MessagePack;

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/PackageDeprecationMetadataContextInfoFormatter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/PackageDeprecationMetadataContextInfoFormatter.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable enable
-
 using System.Collections.Generic;
 using MessagePack;
 using MessagePack.Formatters;

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/PackageIdentityFormatter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/PackageIdentityFormatter.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable enable
-
 using MessagePack;
 using MessagePack.Formatters;
 using NuGet.Packaging.Core;

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/PackageReferenceFormatter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/PackageReferenceFormatter.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable enable
-
 using MessagePack;
 using MessagePack.Formatters;
 using Microsoft;

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/PackageSearchMetadataContextInfoFormatter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/PackageSearchMetadataContextInfoFormatter.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using MessagePack;

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/PackageSourceContextInfoFormatter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/PackageSourceContextInfoFormatter.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable enable
-
 using MessagePack;
 using MessagePack.Formatters;
 using Microsoft;

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/PackageSourceFormatter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/PackageSourceFormatter.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable enable
-
 using MessagePack;
 using MessagePack.Formatters;
 using NuGet.Configuration;

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/PackageSourceUpdateOptionsFormatter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/PackageSourceUpdateOptionsFormatter.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable enable
-
 using MessagePack;
 using MessagePack.Formatters;
 using NuGet.Configuration;

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/PackageVulnerabilityMetadataContextInfoFormatter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/PackageVulnerabilityMetadataContextInfoFormatter.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable enable
-
 using System;
 using MessagePack;
 using MessagePack.Formatters;

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/ProjectActionFormatter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/ProjectActionFormatter.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable enable
-
 using MessagePack;
 using MessagePack.Formatters;
 using Microsoft;

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/RemoteErrorFormatter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/RemoteErrorFormatter.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable enable
-
 using System.Collections.Generic;
 using MessagePack;
 using MessagePack.Formatters;

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/SearchFilterFormatter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/SearchFilterFormatter.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable enable
-
 using System.Collections.Generic;
 using MessagePack;
 using MessagePack.Formatters;

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/SearchResultContextInfoFormatter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/SearchResultContextInfoFormatter.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using MessagePack;

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/VersionInfoContextInfoFormatter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/VersionInfoContextInfoFormatter.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable enable
-
 using MessagePack;
 using MessagePack.Formatters;
 using Microsoft;

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/VersionRangeFormatter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/VersionRangeFormatter.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable enable
-
 using MessagePack;
 using MessagePack.Formatters;
 using Microsoft;

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/INuGetSearchService.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/INuGetSearchService.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.Threading;

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/ItemFilter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/ItemFilter.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable enable
-
 namespace NuGet.VisualStudio.Internal.Contracts
 {
     public enum ItemFilter

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/LoadingStatus.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/LoadingStatus.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable enable
-
 namespace NuGet.VisualStudio.Internal.Contracts
 {
     public enum LoadingStatus


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/10337
Regression: No

## Fix

Details: Remove `#nullable enable` directives from the NuGet.VisualStudio.Internal.Contracts project, since the feature is already enabled at the project level.

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  unnecessary

CC @sbanni, @rrelyea