### PR TITLE
Make PackageCollectionItem.PackageReferences property value read-only

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Common/PackageCollectionItem.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Common/PackageCollectionItem.cs
@@ -25,7 +25,8 @@ namespace NuGet.PackageManagement.VisualStudio
         public PackageCollectionItem(string id, NuGetVersion version, IEnumerable<IPackageReferenceContextInfo> installedReferences)
             : base(id, version)
         {
-            PackageReferences = installedReferences?.ToArray() ?? Array.Empty<IPackageReferenceContextInfo>();
+            PackageReferences = installedReferences?.ToList()
+                ?? (IReadOnlyCollection<IPackageReferenceContextInfo>)Array.Empty<IPackageReferenceContextInfo>();
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Common/PackageCollectionItem.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Common/PackageCollectionItem.cs
@@ -3,6 +3,7 @@
 
 #nullable enable
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using NuGet.Packaging.Core;
@@ -19,12 +20,12 @@ namespace NuGet.PackageManagement.VisualStudio
         /// <summary>
         /// Installed package references.
         /// </summary>
-        public List<IPackageReferenceContextInfo> PackageReferences { get; }
+        public IReadOnlyCollection<IPackageReferenceContextInfo> PackageReferences { get; }
 
         public PackageCollectionItem(string id, NuGetVersion version, IEnumerable<IPackageReferenceContextInfo> installedReferences)
             : base(id, version)
         {
-            PackageReferences = installedReferences?.ToList() ?? new List<IPackageReferenceContextInfo>();
+            PackageReferences = installedReferences?.ToArray() ?? Array.Empty<IPackageReferenceContextInfo>();
         }
     }
 }


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/10338
Regression: No   

## Fix

Details: Making the property value read-only

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  not necessary

CC @sbanni, @rrelyea 
