### PR TITLE
Write source to .nupkg.metadata on package install

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/NupkgMetadata/NupkgMetadataFile.cs
+++ b/src/NuGet.Core/NuGet.Packaging/NupkgMetadata/NupkgMetadataFile.cs
@@ -42,10 +42,7 @@ namespace NuGet.Packaging
 
             combiner.AddObject(Version);
             combiner.AddSequence(ContentHash);
-            if (Source != null)
-            {
-                combiner.AddSequence(Source);
-            }
+            combiner.AddSequence(Source);
 
             return combiner.CombinedHash;
         }

--- a/src/NuGet.Core/NuGet.Packaging/NupkgMetadata/NupkgMetadataFile.cs
+++ b/src/NuGet.Core/NuGet.Packaging/NupkgMetadata/NupkgMetadataFile.cs
@@ -12,6 +12,8 @@ namespace NuGet.Packaging
 
         public string ContentHash { get; set; }
 
+        public string Source { get; set; }
+
         public bool Equals(NupkgMetadataFile other)
         {
             if (other == null)
@@ -25,7 +27,8 @@ namespace NuGet.Packaging
             }
 
             return Version == other.Version &&
-                ContentHash.Equals(other.ContentHash);
+                StringComparer.Ordinal.Equals(ContentHash, other.ContentHash) &&
+                StringComparer.Ordinal.Equals(Source, other.Source);
         }
 
         public override bool Equals(object obj)
@@ -39,6 +42,10 @@ namespace NuGet.Packaging
 
             combiner.AddObject(Version);
             combiner.AddSequence(ContentHash);
+            if (Source != null)
+            {
+                combiner.AddSequence(Source);
+            }
 
             return combiner.CombinedHash;
         }

--- a/src/NuGet.Core/NuGet.Packaging/NupkgMetadata/NupkgMetadataFileFormat.cs
+++ b/src/NuGet.Core/NuGet.Packaging/NupkgMetadata/NupkgMetadataFileFormat.cs
@@ -12,10 +12,11 @@ namespace NuGet.Packaging
 {
     public class NupkgMetadataFileFormat
     {
-        public static readonly int Version = 1;
+        public static readonly int Version = 2;
 
         private const string VersionProperty = "version";
         private const string HashProperty = "contentHash";
+        private const string SourceProperty = "source";
 
         private static readonly JsonLoadSettings DefaultLoadSettings = new JsonLoadSettings()
         {
@@ -84,6 +85,7 @@ namespace NuGet.Packaging
             {
                 Version = ReadInt(cursor, VersionProperty, defaultValue: int.MinValue),
                 ContentHash = ReadProperty<string>(cursor, HashProperty),
+                Source = ReadProperty<string>(cursor, SourceProperty)
             };
 
             return hashFile;
@@ -149,7 +151,8 @@ namespace NuGet.Packaging
             var json = new JObject
             {
                 [VersionProperty] = new JValue(hashFile.Version),
-                [HashProperty] = hashFile.ContentHash
+                [HashProperty] = hashFile.ContentHash,
+                [SourceProperty] = hashFile.Source
             };
 
             return json;

--- a/src/NuGet.Core/NuGet.Packaging/NupkgMetadata/NupkgMetadataFileFormat.cs
+++ b/src/NuGet.Core/NuGet.Packaging/NupkgMetadata/NupkgMetadataFileFormat.cs
@@ -85,7 +85,7 @@ namespace NuGet.Packaging
             {
                 Version = ReadInt(cursor, VersionProperty, defaultValue: int.MinValue),
                 ContentHash = ReadProperty<string>(cursor, HashProperty),
-                Source = ReadProperty<string>(cursor, SourceProperty)
+                Source = ReadProperty<string>(cursor, SourceProperty),
             };
 
             return hashFile;
@@ -152,7 +152,7 @@ namespace NuGet.Packaging
             {
                 [VersionProperty] = new JValue(hashFile.Version),
                 [HashProperty] = hashFile.ContentHash,
-                [SourceProperty] = hashFile.Source
+                [SourceProperty] = hashFile.Source,
             };
 
             return json;

--- a/src/NuGet.Core/NuGet.Packaging/PackageExtractor.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageExtractor.cs
@@ -499,7 +499,8 @@ namespace NuGet.Packaging
                                         // write the new hash file
                                         var hashFile = new NupkgMetadataFile()
                                         {
-                                            ContentHash = contentHash
+                                            ContentHash = contentHash,
+                                            Source = source
                                         };
 
                                         NupkgMetadataFileFormat.Write(tempNupkgMetadataPath, hashFile);
@@ -786,7 +787,8 @@ namespace NuGet.Packaging
                             // write the new hash file
                             var hashFile = new NupkgMetadataFile()
                             {
-                                ContentHash = contentHash
+                                ContentHash = contentHash,
+                                Source = packageDownloader.Source
                             };
 
                             NupkgMetadataFileFormat.Write(tempNupkgMetadataFilePath, hashFile);

--- a/src/NuGet.Core/NuGet.Packaging/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Packaging/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -1,3 +1,5 @@
+NuGet.Packaging.NupkgMetadataFile.Source.get -> string
+NuGet.Packaging.NupkgMetadataFile.Source.set -> void
 static NuGet.Packaging.Rules.AnalysisResources.InvalidUndottedFrameworkInDependencyGroupsWarning.get -> string
 static NuGet.Packaging.Rules.AnalysisResources.InvalidUndottedFrameworkInFilesWarning.get -> string
 static NuGet.Packaging.Rules.AnalysisResources.InvalidUndottedFrameworkInFrameworkAssemblyGroupsWarning.get -> string

--- a/src/NuGet.Core/NuGet.Packaging/PublicAPI/netcoreapp5.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Packaging/PublicAPI/netcoreapp5.0/PublicAPI.Unshipped.txt
@@ -1,3 +1,5 @@
+NuGet.Packaging.NupkgMetadataFile.Source.get -> string
+NuGet.Packaging.NupkgMetadataFile.Source.set -> void
 static NuGet.Packaging.Rules.AnalysisResources.InvalidUndottedFrameworkInDependencyGroupsWarning.get -> string
 static NuGet.Packaging.Rules.AnalysisResources.InvalidUndottedFrameworkInFilesWarning.get -> string
 static NuGet.Packaging.Rules.AnalysisResources.InvalidUndottedFrameworkInFrameworkAssemblyGroupsWarning.get -> string

--- a/src/NuGet.Core/NuGet.Packaging/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Packaging/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,3 +1,5 @@
+NuGet.Packaging.NupkgMetadataFile.Source.get -> string
+NuGet.Packaging.NupkgMetadataFile.Source.set -> void
 static NuGet.Packaging.Rules.AnalysisResources.InvalidUndottedFrameworkInDependencyGroupsWarning.get -> string
 static NuGet.Packaging.Rules.AnalysisResources.InvalidUndottedFrameworkInFilesWarning.get -> string
 static NuGet.Packaging.Rules.AnalysisResources.InvalidUndottedFrameworkInFrameworkAssemblyGroupsWarning.get -> string

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/NupkgMetadataFileFormatTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/NupkgMetadataFileFormatTests.cs
@@ -11,29 +11,59 @@ namespace NuGet.Packaging.Test
     public class NupkgMetadataFileFormatTests
     {
         [Fact]
-        public void NupkgMetadataFileFormat_Read()
+        public void Read_V1FileContents_ReturnsCorrectObject()
         {
+            // Arrange
             var nupkgMetadataFileContent = @"{
                 ""version"": 1,
                 ""contentHash"": ""NhfNp80eWq5ms7fMrjuRqpwhL1H56IVzXF9d+OIDcEfQ92m1DyE0c+ufUE1ogB09+sYLd58IO4eJ8jyn7AifbA==""
             }";
 
+            // Act
+            NupkgMetadataFile file;
             using (var reader = new StringReader(nupkgMetadataFileContent))
             {
-                var file = NupkgMetadataFileFormat.Read(reader, NullLogger.Instance, string.Empty);
-
-                Assert.NotNull(file);
-                Assert.Equal(1, file.Version);
-                Assert.Equal("NhfNp80eWq5ms7fMrjuRqpwhL1H56IVzXF9d+OIDcEfQ92m1DyE0c+ufUE1ogB09+sYLd58IO4eJ8jyn7AifbA==", file.ContentHash);
+                file = NupkgMetadataFileFormat.Read(reader, NullLogger.Instance, string.Empty);
             }
+
+            // Assert
+            Assert.NotNull(file);
+            Assert.Equal(1, file.Version);
+            Assert.Equal("NhfNp80eWq5ms7fMrjuRqpwhL1H56IVzXF9d+OIDcEfQ92m1DyE0c+ufUE1ogB09+sYLd58IO4eJ8jyn7AifbA==", file.ContentHash);
+            Assert.Null(file.Source);
+        }
+
+        [Fact]
+        public void Read_V2FileContents_ReturnsCorrectObject()
+        {
+            // Arrange
+            var nupkgMetadataFileContent = @"{
+                ""version"": 2,
+                ""contentHash"": ""NhfNp80eWq5ms7fMrjuRqpwhL1H56IVzXF9d+OIDcEfQ92m1DyE0c+ufUE1ogB09+sYLd58IO4eJ8jyn7AifbA=="",
+                ""source"": ""https://source/v3/index.json""
+            }";
+
+            // Act
+            NupkgMetadataFile file;
+            using (var reader = new StringReader(nupkgMetadataFileContent))
+            {
+                file = NupkgMetadataFileFormat.Read(reader, NullLogger.Instance, string.Empty);
+            }
+
+            // Assert
+            Assert.NotNull(file);
+            Assert.Equal(2, file.Version);
+            Assert.Equal("NhfNp80eWq5ms7fMrjuRqpwhL1H56IVzXF9d+OIDcEfQ92m1DyE0c+ufUE1ogB09+sYLd58IO4eJ8jyn7AifbA==", file.ContentHash);
+            Assert.Equal("https://source/v3/index.json", file.Source);
         }
 
         [Fact]
         public void NupkgMetadataFileFormat_Write()
         {
             var nupkgMetadataFileContent = @"{
-                ""version"": 1,
-                ""contentHash"": ""NhfNp80eWq5ms7fMrjuRqpwhL1H56IVzXF9d+OIDcEfQ92m1DyE0c+ufUE1ogB09+sYLd58IO4eJ8jyn7AifbA==""
+                ""version"": 2,
+                ""contentHash"": ""NhfNp80eWq5ms7fMrjuRqpwhL1H56IVzXF9d+OIDcEfQ92m1DyE0c+ufUE1ogB09+sYLd58IO4eJ8jyn7AifbA=="",
+                ""source"": ""https://source/v3/index.json""
             }";
 
             NupkgMetadataFile metadataFile = null;

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/NupkgMetadataFileTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/NupkgMetadataFileTests.cs
@@ -8,8 +8,35 @@ namespace NuGet.Packaging.Test
 {
     public class NupkgMetadataFileTests
     {
+        [Theory]
+        [InlineData(1)]
+        [InlineData(2)]
+        public void Equals_SameContents_ReturnsTrue(int fileVersion)
+        {
+            Func<NupkgMetadataFile> getMetadataFile = () =>
+            {
+                var metadataFile = new NupkgMetadataFile()
+                {
+                    Version = fileVersion,
+                    ContentHash = "tempContentHash"
+                };
+                if (fileVersion >= 2)
+                {
+                    metadataFile.Source = "https://source/v3/index.json";
+                }
+
+                return metadataFile;
+            };
+
+            var self = getMetadataFile();
+            var other = getMetadataFile();
+
+            Assert.NotSame(self, other);
+            Assert.Equal(self, other);
+        }
+
         [Fact]
-        public void NupkgMetadataFile_Equals()
+        public void Equals_DifferentVersion_ReturnsFalse()
         {
             Func<NupkgMetadataFile> getMetadataFile = () =>
             {
@@ -24,13 +51,14 @@ namespace NuGet.Packaging.Test
 
             var self = getMetadataFile();
             var other = getMetadataFile();
+            other.Version = 2;
 
             Assert.NotSame(self, other);
-            Assert.Equal(self, other);
+            Assert.NotEqual(self, other);
         }
 
         [Fact]
-        public void NupkgMetadataFile_NotEquals()
+        public void Equals_DifferentContentHash_ReturnsFalse()
         {
             Func<NupkgMetadataFile> getMetadataFile = () =>
             {
@@ -46,6 +74,29 @@ namespace NuGet.Packaging.Test
             var self = getMetadataFile();
             var other = getMetadataFile();
             other.ContentHash = "contentHashChanged";
+
+            Assert.NotSame(self, other);
+            Assert.NotEqual(self, other);
+        }
+
+        [Fact]
+        public void Equals_DifferentSource_ReturnsFalse()
+        {
+            Func<NupkgMetadataFile> getMetadataFile = () =>
+            {
+                var metadataFile = new NupkgMetadataFile()
+                {
+                    Version = 2,
+                    ContentHash = "tempContentHash",
+                    Source = "https://source/v3/index.json"
+                };
+
+                return metadataFile;
+            };
+
+            var self = getMetadataFile();
+            var other = getMetadataFile();
+            other.Source = "https://other/v3/index.json";
 
             Assert.NotSame(self, other);
             Assert.NotEqual(self, other);

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageExtractorTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageExtractorTests.cs
@@ -3809,6 +3809,51 @@ namespace NuGet.Packaging.Test
         }
 
         [Fact]
+        public async Task InstallFromSourceAsync_WriteSourceToNupkgMetadata()
+        {
+            // Arrange
+            using (var testDirectory = TestDirectory.Create())
+            {
+                var source = Path.Combine(testDirectory, "source");
+                Directory.CreateDirectory(source);
+                var resolver = new VersionFolderPathResolver(Path.Combine(testDirectory, "gpf"));
+                var identity = new PackageIdentity("A", new NuGetVersion("1.2.3"));
+
+                var packageFileInfo = await TestPackagesCore.GeneratePackageAsync(
+                   source,
+                   identity.Id,
+                   identity.Version.ToString(),
+                   DateTimeOffset.UtcNow.LocalDateTime,
+                   "content/A.nupkg");
+
+                using (var packageStream = File.OpenRead(packageFileInfo.FullName))
+                {
+                    var packageExtractionContext = new PackageExtractionContext(
+                        PackageSaveMode.Defaultv3,
+                        XmlDocFileSaveMode.None,
+                        clientPolicyContext: null,
+                        NullLogger.Instance);
+
+                    // Act
+                    await PackageExtractor.InstallFromSourceAsync(
+                        source,
+                        identity,
+                        (stream) => packageStream.CopyToAsync(stream, 4096, CancellationToken.None),
+                        resolver,
+                        packageExtractionContext,
+                        CancellationToken.None);
+
+                    // Assert
+                    var nupkgMetadataPath = resolver.GetNupkgMetadataPath(identity.Id, identity.Version);
+                    Assert.True(File.Exists(nupkgMetadataPath));
+
+                    var nupkgMetadata = NupkgMetadataFileFormat.Read(nupkgMetadataPath);
+                    Assert.Equal(source, nupkgMetadata.Source);
+                }
+            }
+        }
+
+        [Fact]
         public async Task InstallFromSourceAsync_WithPackageDownloader_LogsSourceOnVerboseLevel()
         {
             // Arrange


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/10354
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details:
* Add Source property to `NupkgMetadataFile`, and increment file version
* Write package source to `.nupkg.metadata` file when package is installed to global packages folder.
* Didn't check what happens when a packages.config installs a package from the global packages folder to the solution packages folder. But I don't care if the `.nupkg.metadata` file lists the "original" package source or the global package folder's path. If the solution package folder's `.nupkg.metadata` lists the GPF as the source, the customer can check the GPF folder's `.nupkg.metadata` file for the original source.

## Testing/Validation

Tests Added: Yes
Reason for not adding tests:  
Validation:  
