### PR TITLE
Bump preview number to 5.9.0-preview.3

### DIFF
--- a/build/config.props
+++ b/build/config.props
@@ -19,7 +19,7 @@
 
     <!-- ** Change for each new preview/rc -->
     <!-- Check the VS schedule and manually enter a preview number here that makes sense. -->
-    <ReleaseLabel Condition=" '$(ReleaseLabel)' == '' ">preview.2</ReleaseLabel>
+    <ReleaseLabel Condition=" '$(ReleaseLabel)' == '' ">preview.3</ReleaseLabel>
 
     <IsEscrowMode>false</IsEscrowMode>
 


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Client.Engineering/issues/669
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: 

Bump preview number to P3.

## Testing/Validation

Tests Added: No  
Reason for not adding tests: Branding change  
Validation:  
