### PR TITLE
Handle PackageSource 'All' with metadata caching

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/PackageItemLoader.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/PackageItemLoader.cs
@@ -272,6 +272,7 @@ namespace NuGet.PackageManagement.UI
                     AllowedVersions = allowedVersions,
                     PrefixReserved = metadata.PrefixReserved && !IsMultiSource,
                     Versions = AsyncLazy.New(() => { return GetVersionInfoAsync(metadata.Identity); }),
+                    DeprecationMetadata = AsyncLazy.New(() => { return GetDeprecationMetadataAsync(metadata.Identity); }),
                     DetailedPackageSearchMetadata = AsyncLazy.New(() => { return GetDetailedPackageSearchMetadataContextInfoAsync(metadata.Identity); }),
                     Recommended = metadata.IsRecommended,
                     RecommenderVersion = metadata.RecommenderVersion,

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/PackageSearchMetadataCacheItemEntry.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/PackageSearchMetadataCacheItemEntry.cs
@@ -20,13 +20,10 @@ namespace NuGet.PackageManagement.VisualStudio
         {
             _packageSearchMetadata = packageSearchMetadata;
             _packageMetadataProvider = packageMetadataProvider;
-
-            PackageDeprecationMetadataContextInfo = GetPackageDeprecationMetadataContextInfoAsync();
-            DetailedPackageSearchMetadataContextInfo = GetDetailedPackageSearchMetadataContextInfoAsync();
         }
 
-        public ValueTask<PackageDeprecationMetadataContextInfo?> PackageDeprecationMetadataContextInfo { get; }
-        public ValueTask<PackageSearchMetadataContextInfo> DetailedPackageSearchMetadataContextInfo { get; }
+        public ValueTask<PackageDeprecationMetadataContextInfo?> PackageDeprecationMetadataContextInfo => GetPackageDeprecationMetadataContextInfoAsync();
+        public ValueTask<PackageSearchMetadataContextInfo> DetailedPackageSearchMetadataContextInfo => GetDetailedPackageSearchMetadataContextInfoAsync();
 
         private async ValueTask<PackageDeprecationMetadataContextInfo?> GetPackageDeprecationMetadataContextInfoAsync()
         {


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Client.Engineering/issues/672
Regression: No  

## Fix

Details: Be less aggressive about caching metadata for search results, this gets rid of most of the performance win until we can handle the 'All' case better

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  Existing coverage
Validation:  Unit tests/manual testing
