### PR TITLE
Use JsonConverter for reading/writing NupkeMetadataFile

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/NupkgMetadata/NupkgMetadataFileFormat.cs
+++ b/src/NuGet.Core/NuGet.Packaging/NupkgMetadata/NupkgMetadataFileFormat.cs
@@ -5,7 +5,6 @@ using System;
 using System.Globalization;
 using System.IO;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using NuGet.Common;
 
 namespace NuGet.Packaging
@@ -18,11 +17,7 @@ namespace NuGet.Packaging
         private const string HashProperty = "contentHash";
         private const string SourceProperty = "source";
 
-        private static readonly JsonLoadSettings DefaultLoadSettings = new JsonLoadSettings()
-        {
-            LineInfoHandling = LineInfoHandling.Ignore,
-            CommentHandling = CommentHandling.Ignore
-        };
+        private static readonly JsonSerializer JsonSerializer = JsonSerializer.Create(GetSerializerSettings());
 
         public static NupkgMetadataFile Read(string filePath)
         {
@@ -49,9 +44,15 @@ namespace NuGet.Packaging
         {
             try
             {
-                var json = LoadJson(reader);
-                var hashFile = ReadHashFile(json);
-                return hashFile;
+                using (var jsonReader = new JsonTextReader(reader))
+                {
+                    var nupkgMetadata = JsonSerializer.Deserialize<NupkgMetadataFile>(jsonReader);
+                    if (nupkgMetadata == null)
+                    {
+                        throw new InvalidDataException();
+                    }
+                    return nupkgMetadata;
+                }
             }
             catch (Exception ex)
             {
@@ -61,58 +62,6 @@ namespace NuGet.Packaging
 
                 throw;
             }
-        }
-
-        private static JObject LoadJson(TextReader reader)
-        {
-            using (var jsonReader = new JsonTextReader(reader))
-            {
-                while (jsonReader.TokenType != JsonToken.StartObject)
-                {
-                    if (!jsonReader.Read())
-                    {
-                        throw new InvalidDataException();
-                    }
-                }
-
-                return JObject.Load(jsonReader, DefaultLoadSettings);
-            }
-        }
-
-        private static NupkgMetadataFile ReadHashFile(JObject cursor)
-        {
-            var hashFile = new NupkgMetadataFile()
-            {
-                Version = ReadInt(cursor, VersionProperty, defaultValue: int.MinValue),
-                ContentHash = ReadProperty<string>(cursor, HashProperty),
-                Source = ReadProperty<string>(cursor, SourceProperty),
-            };
-
-            return hashFile;
-        }
-
-        internal static int ReadInt(JToken cursor, string property, int defaultValue)
-        {
-            var valueToken = cursor[property];
-            if (valueToken == null)
-            {
-                return defaultValue;
-            }
-            return valueToken.Value<int>();
-        }
-
-        internal static TItem ReadProperty<TItem>(JObject jObject, string propertyName)
-        {
-            if (jObject != null)
-            {
-                JToken value;
-                if (jObject.TryGetValue(propertyName, out value) && value != null)
-                {
-                    return value.Value<TItem>();
-                }
-            }
-
-            return default(TItem);
         }
 
         public static void Write(string filePath, NupkgMetadataFile hashFile)
@@ -141,22 +90,100 @@ namespace NuGet.Packaging
             {
                 jsonWriter.Formatting = Formatting.Indented;
 
-                var json = WriteHashFile(hashFile);
-                json.WriteTo(jsonWriter);
+                JsonSerializer.Serialize(jsonWriter, hashFile);
             }
         }
 
-        private static JObject WriteHashFile(NupkgMetadataFile hashFile)
+        private static JsonSerializerSettings GetSerializerSettings()
         {
-            var json = new JObject
+            var settings = new JsonSerializerSettings()
             {
-                [VersionProperty] = new JValue(hashFile.Version),
-                [HashProperty] = hashFile.ContentHash,
-                [SourceProperty] = hashFile.Source,
+                Formatting = Formatting.Indented
             };
-
-            return json;
+            settings.Converters.Add(NupkgMetadataConverter.Default);
+            return settings;
         }
 
+        private class NupkgMetadataConverter : JsonConverter
+        {
+            internal static NupkgMetadataConverter Default { get; } = new NupkgMetadataConverter();
+
+            private static readonly Type TargetType = typeof(NupkgMetadataFile);
+            public override bool CanConvert(Type objectType)
+            {
+                return objectType == TargetType;
+            }
+
+            public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+            {
+                NupkgMetadataFile nupkgMetadataFile = existingValue as NupkgMetadataFile;
+                if (nupkgMetadataFile == null)
+                {
+                    nupkgMetadataFile = new NupkgMetadataFile();
+                }
+
+                if (reader.TokenType != JsonToken.StartObject)
+                {
+                    throw new InvalidDataException();
+                }
+
+                while (reader.Read())
+                {
+                    switch (reader.TokenType)
+                    {
+                        case JsonToken.EndObject:
+                            return nupkgMetadataFile;
+
+                        case JsonToken.PropertyName:
+                            switch ((string)reader.Value)
+                            {
+                                case VersionProperty:
+                                    var intValue = reader.ReadAsInt32();
+                                    if (intValue.HasValue)
+                                    {
+                                        nupkgMetadataFile.Version = intValue.Value;
+                                    }
+                                    break;
+
+                                case HashProperty:
+                                    nupkgMetadataFile.ContentHash = reader.ReadAsString();
+                                    break;
+
+                                case SourceProperty:
+                                    nupkgMetadataFile.Source = reader.ReadAsString();
+                                    break;
+                            }
+                            break;
+
+                        default:
+                            reader.Skip();
+                            break;
+                    }
+                }
+
+                throw new JsonReaderException();
+            }
+
+            public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+            {
+                if (!(value is NupkgMetadataFile nupkgMetadataFile))
+                {
+                    throw new ArgumentException(message: "value is not of type NupkgMetadataFile", paramName: nameof(value));
+                }
+
+                writer.WriteStartObject();
+
+                writer.WritePropertyName(VersionProperty);
+                writer.WriteValue(nupkgMetadataFile.Version);
+
+                writer.WritePropertyName(HashProperty);
+                writer.WriteValue(nupkgMetadataFile.ContentHash);
+
+                writer.WritePropertyName(SourceProperty);
+                writer.WriteValue(nupkgMetadataFile.Source);
+
+                writer.WriteEndObject();
+            }
+        }
     }
 }


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/10358
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: Create `JsonConverter` for `NupkgMetataFile`, and use it with `JsonSerializer` in `NupkgMetadataFileFormat`, rather than converting to/from `JObject`.

## Testing/Validation

Tests Added: Yes
Reason for not adding tests:  
Validation:  

Read scenarios:

|        Method |           Job |       Runtime |     Mean |     Error |    StdDev | Ratio |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------------- |-------------- |-------------- |---------:|----------:|----------:|------:|-------:|------:|------:|----------:|
|   WithJObject |    .NET 4.7.2 |    .NET 4.7.2 | 2.890 us | 0.0270 us | 0.0225 us |  1.00 | 4.9248 |     - |     - |   3.79 KB |
| WithConverter |    .NET 4.7.2 |    .NET 4.7.2 | 1.492 us | 0.0063 us | 0.0049 us |  0.52 | 3.9673 |     - |     - |   3.05 KB |
|               |               |               |          |           |           |       |        |       |       |           |
|   WithJObject | .NET Core 5.0 | .NET Core 5.0 | 2.747 us | 0.0235 us | 0.0208 us |  1.00 | 0.9155 |     - |     - |   3.75 KB |
| WithConverter | .NET Core 5.0 | .NET Core 5.0 | 1.391 us | 0.0241 us | 0.0214 us |  0.51 | 0.7401 |     - |     - |   3.02 KB |

Write scenarios:
|        Method |           Job |       Runtime |     Mean |     Error |    StdDev | Ratio |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------------- |-------------- |-------------- |---------:|----------:|----------:|------:|-------:|------:|------:|----------:|
|   WithJObject |    .NET 4.7.2 |    .NET 4.7.2 | 2.208 us | 0.0133 us | 0.0111 us |  1.00 | 3.2845 |     - |     - |   2.52 KB |
| WithConverter |    .NET 4.7.2 |    .NET 4.7.2 | 1.417 us | 0.0085 us | 0.0071 us |  0.64 | 2.4681 |     - |     - |    1.9 KB |
|               |               |               |          |           |           |       |        |       |       |           |
|   WithJObject | .NET Core 5.0 | .NET Core 5.0 | 2.190 us | 0.0243 us | 0.0227 us |  1.00 | 0.5684 |     - |     - |   2.34 KB |
| WithConverter | .NET Core 5.0 | .NET Core 5.0 | 1.268 us | 0.0178 us | 0.0167 us |  0.58 | 0.4196 |     - |     - |   1.72 KB |

We can see that read benchmarks are about twice as fast, with about 20% fewer GCs due to fewer allocations. Writing, the new code is a bit over 50% faster, with net5.0 benefiting more than net472, both with about 25% GCs.

However, I didn't benchmark how much `.nupkg.metadata` reading/writing contributes to a real restore, so this change might have zero overall impact, but the microbenchmark of the `NupkgMetadataFileFormat.Read` and `NupkgMetadataFileFormat.Write` methods show fantastic gains.

<details><summary>Benchmark source</summary>
<p>

```cs
    public class Program
    {
        static void Main(string[] args)
        {
            BenchmarkRunner.Run<ReadBenchmarks>();
            BenchmarkRunner.Run<WriteBenchmarks>();
        }

        [MemoryDiagnoser]
        [SimpleJob(RuntimeMoniker.NetCoreApp50)]
        [SimpleJob(RuntimeMoniker.Net472)]
        public class ReadBenchmarks
        {
            private string contents = @"{""version"": 2,""contentHash"": ""1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678"", ""source"": ""https://api.nuget.org/v3/index.json""}";

            [Benchmark(Baseline = true)]
            public NupkgMetadataFile WithJObject()
            {
                using (var reader = new StringReader(contents))
                {
                    return NupkgMetadataFileFormat.Read(reader, NullLogger.Instance, ".nupkg.metadata");
                }
            }

            [Benchmark]
            public NupkgMetadataFile WithConverter()
            {
                using (var reader = new StringReader(contents))
                {
                    return NupkgMetadataFileFormatWithCOoverter.Read(reader, NullLogger.Instance, ".nupkg.metadata");
                }
            }
        }

        [MemoryDiagnoser]
        [SimpleJob(RuntimeMoniker.NetCoreApp50)]
        [SimpleJob(RuntimeMoniker.Net472)]
        public class WriteBenchmarks
        {
            private NupkgMetadataFile nupkgMetadata = new NupkgMetadataFile()
            {
                Version = 2,
                ContentHash = "1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678",
                Source = "https://api.nuget.org/v3/index.josn"
            };

            [Benchmark(Baseline = true)]
            public void WithJObject()
            {
                using (var stringWriter = new StringWriter())
                {
                    NupkgMetadataFileFormat.Write(stringWriter, nupkgMetadata);
                }
            }

            [Benchmark]
            public void WithConverter()
            {
                using (var stringWriter = new StringWriter())
                {
                    NupkgMetadataFileFormatWithCOoverter.Write(stringWriter, nupkgMetadata);
                }
            }
        }
    }
```

</p>
</details>