### PR TITLE
Do not install unlisted package in NuGet.exe

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/InstallCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/InstallCommand.cs
@@ -286,7 +286,7 @@ namespace NuGet.CommandLine
                 var resolutionContext = new ResolutionContext(
                 dependencyBehavior,
                 includePrelease: allowPrerelease,
-                includeUnlisted: true,
+                includeUnlisted: false,
                 versionConstraints: VersionConstraints.None,
                 gatherCache: new GatherCache(),
                 sourceCacheContext: sourceCacheContext);

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/FileSystemBackedV3MockServer.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/FileSystemBackedV3MockServer.cs
@@ -128,6 +128,30 @@ namespace NuGet.CommandLine.Test
                         });
                     }
                 }
+                else if (path.StartsWith("/packages/"))
+                {
+                    var file = new FileInfo(Path.Combine(_packageDirectory, parts.Last()));
+
+                    if (file.Exists)
+                    {
+                        return new Action<HttpListenerResponse>(response =>
+                        {
+                            response.ContentType = "application/zip";
+                            using (var stream = file.OpenRead())
+                            {
+                                var content = stream.ReadAllBytes();
+                                MockServer.SetResponseContent(response, content);
+                            }
+                        });
+                    }
+                    else
+                    {
+                        return new Action<HttpListenerResponse>(response =>
+                        {
+                            response.StatusCode = 404;
+                        });
+                    }
+                }
                 else
                 {
                     throw new Exception("This test needs to be updated to support: " + path);

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/FileSystemBackedV3MockServer.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/FileSystemBackedV3MockServer.cs
@@ -128,30 +128,6 @@ namespace NuGet.CommandLine.Test
                         });
                     }
                 }
-                else if (path.StartsWith("/packages/"))
-                {
-                    var file = new FileInfo(Path.Combine(_packageDirectory, parts.Last()));
-
-                    if (file.Exists)
-                    {
-                        return new Action<HttpListenerResponse>(response =>
-                        {
-                            response.ContentType = "application/zip";
-                            using (var stream = file.OpenRead())
-                            {
-                                var content = stream.ReadAllBytes();
-                                MockServer.SetResponseContent(response, content);
-                            }
-                        });
-                    }
-                    else
-                    {
-                        return new Action<HttpListenerResponse>(response =>
-                        {
-                            response.StatusCode = 404;
-                        });
-                    }
-                }
                 else
                 {
                     throw new Exception("This test needs to be updated to support: " + path);

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetInstallCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetInstallCommandTest.cs
@@ -1719,7 +1719,7 @@ namespace NuGet.CommandLine.Test
             }
         }
 
-        [Fact]
+        [SkipMono(Skip = "Mono has issues if the MockServer has anything else running in the same process https://github.com/NuGet/Home/issues/8594")]
         public async Task InstallCommand_DoNotSpecifyVersion_IgnoresUnlistedPackagesAsync()
         {
             using (var pathContext = new SimpleTestPathContext())
@@ -1759,7 +1759,7 @@ namespace NuGet.CommandLine.Test
                 var a2Nupkg = pathResolver.GetInstalledPackageFilePath(a2.Identity);
                 var b1Nupkg = pathResolver.GetInstalledPackageFilePath(b1.Identity);
                 var b2Nupkg = pathResolver.GetInstalledPackageFilePath(b2.Identity);
-   
+
                 r1.Success.Should().BeTrue();
                 r2.Success.Should().BeTrue();
                 File.Exists(a1Nupkg).Should().BeTrue();
@@ -1769,7 +1769,7 @@ namespace NuGet.CommandLine.Test
             }
         }
 
-        [Fact]
+        [SkipMono(Skip = "Mono has issues if the MockServer has anything else running in the same process https://github.com/NuGet/Home/issues/8594")]
         public async Task InstallCommand_SpecifyUnlistedVersion_InstallUnlistedPackagesAsync()
         {
             using (var pathContext = new SimpleTestPathContext())

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetInstallCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetInstallCommandTest.cs
@@ -1719,6 +1719,96 @@ namespace NuGet.CommandLine.Test
             }
         }
 
+        [Fact]
+        public async Task InstallCommand_DoNotSpecifyVersion_IgnoresUnlistedPackagesAsync()
+        {
+            using (var pathContext = new SimpleTestPathContext())
+            using (var mockServer = new FileSystemBackedV3MockServer(pathContext.PackageSource))
+            {
+                //Replace the default package source of folder to ServiceIndexUri
+                var settings = pathContext.Settings;
+                SimpleTestSettingsContext.RemoveSource(settings.XML, "source");
+                var section = SimpleTestSettingsContext.GetOrAddSection(settings.XML, "packageSources");
+                SimpleTestSettingsContext.AddEntry(section, "source", mockServer.ServiceIndexUri);
+                settings.Save();
+
+                // Arrange
+                var a1 = new SimpleTestPackageContext("a", "1.0.0");
+                var a2 = new SimpleTestPackageContext("a", "2.0.0");
+                var b1 = new SimpleTestPackageContext("b", "1.0.0");
+                var b2 = new SimpleTestPackageContext("b", "2.0.0");
+
+                SimpleTestPackageContext[] packages = new SimpleTestPackageContext[] { a1, a2, b1, b2 };
+                await SimpleTestPackageUtility.CreatePackagesAsync(pathContext.PackageSource, packages);
+
+                //Unlist a2 and b1
+                mockServer.UnlistedPackages.Add(a2.Identity);
+                mockServer.UnlistedPackages.Add(b1.Identity);
+
+                mockServer.Start();
+                var pathResolver = new PackagePathResolver(pathContext.SolutionRoot);
+
+                // Act
+                var r1 = RunInstall(pathContext, "A", 0, "-OutputDirectory", pathContext.SolutionRoot);
+                var r2 = RunInstall(pathContext, "B", 0, "-OutputDirectory", pathContext.SolutionRoot);
+
+                mockServer.Stop();
+
+                // Assert
+                var a1Nupkg = pathResolver.GetInstalledPackageFilePath(a1.Identity);
+                var a2Nupkg = pathResolver.GetInstalledPackageFilePath(a2.Identity);
+                var b1Nupkg = pathResolver.GetInstalledPackageFilePath(b1.Identity);
+                var b2Nupkg = pathResolver.GetInstalledPackageFilePath(b2.Identity);
+   
+                r1.Success.Should().BeTrue();
+                r2.Success.Should().BeTrue();
+                File.Exists(a1Nupkg).Should().BeTrue();
+                File.Exists(a2Nupkg).Should().BeFalse();
+                File.Exists(b1Nupkg).Should().BeFalse();
+                File.Exists(b2Nupkg).Should().BeTrue();
+            }
+        }
+
+        [Fact]
+        public async Task InstallCommand_SpecifyUnlistedVersion_InstallUnlistedPackagesAsync()
+        {
+            using (var pathContext = new SimpleTestPathContext())
+            using (var mockServer = new FileSystemBackedV3MockServer(pathContext.PackageSource))
+            {
+                //Replace the default package source of folder to ServiceIndexUri
+                var settings = pathContext.Settings;
+                SimpleTestSettingsContext.RemoveSource(settings.XML, "source");
+                var section = SimpleTestSettingsContext.GetOrAddSection(settings.XML, "packageSources");
+                SimpleTestSettingsContext.AddEntry(section, "source", mockServer.ServiceIndexUri);
+                settings.Save();
+
+                // Arrange
+                var a1 = new SimpleTestPackageContext("a", "1.0.0");
+                var a2 = new SimpleTestPackageContext("a", "2.0.0");
+
+                SimpleTestPackageContext[] packages = new SimpleTestPackageContext[] { a1, a2 };
+                await SimpleTestPackageUtility.CreatePackagesAsync(pathContext.PackageSource, packages);
+
+                //Unlist a2
+                mockServer.UnlistedPackages.Add(a2.Identity);
+
+                mockServer.Start();
+                var pathResolver = new PackagePathResolver(pathContext.SolutionRoot);
+
+                // Act
+                var r1 = RunInstall(pathContext, "a", 0, "-Version", "2.0.0", "-OutputDirectory", pathContext.SolutionRoot);
+
+                mockServer.Stop();
+
+                // Assert
+                var a1Nupkg = pathResolver.GetInstalledPackageFilePath(a1.Identity);
+                var a2Nupkg = pathResolver.GetInstalledPackageFilePath(a2.Identity);
+
+                r1.Success.Should().BeTrue();
+                File.Exists(a1Nupkg).Should().BeFalse();
+                File.Exists(a2Nupkg).Should().BeTrue();
+            }
+        }
         public static CommandRunnerResult RunInstall(SimpleTestPathContext pathContext, string input, int expectedExitCode = 0, params string[] additionalArgs)
         {
             var nugetexe = Util.GetNuGetExePath();

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Util.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Util.cs
@@ -762,7 +762,7 @@ namespace NuGet.CommandLine.Test
 
             var catalogEntry = new JObject();
             item.Add(new JProperty("catalogEntry", catalogEntry));
-            item.Add(new JProperty("packageContent", $"{server.Uri}packages/{id}.{version}.nupkg"));
+            item.Add(new JProperty("packageContent", $"{server.Uri}flat/{id}/{version}/{id}.{version}.nupkg"));
             item.Add(new JProperty("registration", indexUrl));
 
             catalogEntry.Add(new JProperty("@id",

--- a/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestSettingsContext.cs
+++ b/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestSettingsContext.cs
@@ -139,6 +139,16 @@ namespace NuGet.Test.Utility
             }
         }
 
+        public static void RemoveSource(XDocument doc, string key)
+        {
+            var packageSources = GetOrAddSection(doc, "packageSources");
+
+            foreach (var item in packageSources.Elements(XName.Get("add")).Where(e => e.FirstAttribute.Value.Equals(key, StringComparison.OrdinalIgnoreCase)).ToArray())
+            {
+                item.Remove();
+            }
+        }
+
         // Add NetStandard.Library and NetCorePlatforms to the feed and save the file.
         public void AddNetStandardFeeds()
         {


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/7466
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: 
1. Change `includeUnlisted `from `true` to `false` in `InstallPackageAsync`.
~~2. Change FileSystemBackedV3MockServer.cs to handle `path.StartsWith("/packages/")`.~~
2. Change the package content format from `{server.Uri}packages/{id}.{version}.nupkg` to `{server.Uri}flat/{id}/{version}/{id}.{version}.nupkg`
3. Change SimpleTestSettingsContext.cs to add a method removing a package source. 
4. Add 2 tests.

## Testing/Validation

Tests Added: Yes  
Reason for not adding tests:  
Validation:  
