### PR TITLE
Set Pack=false for contentFiles in nuget.g.targets files

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
@@ -222,7 +222,8 @@ namespace NuGet.Commands
                                 new XAttribute("Condition", $"Exists('{path}')"),
                                 new XElement(Namespace + "NuGetPackageId", packageId),
                                 new XElement(Namespace + "NuGetPackageVersion", packageVersion),
-                                new XElement(Namespace + "NuGetItemType", item.BuildAction));
+                                new XElement(Namespace + "NuGetItemType", item.BuildAction),
+                                new XElement(Namespace + "Pack", false));
 
             var privateFlag = false;
 

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
@@ -729,6 +729,85 @@ namespace Dotnet.Integration.Test
             }
         }
 
+        [PlatformFact(Platform.Windows)]
+        public void PackCommand_DoesNotIncludeContentFromDependencies_PackSuceeds()
+        {
+            // Arrange
+            using (var testDirectory = msbuildFixture.CreateTestDirectory())
+            {
+                // layout
+                var topName = "top";
+                var basePackageName = "BasePackage";
+                var topPath = Path.Combine(testDirectory, topName);
+                var basePackagePath = Path.Combine(testDirectory, basePackageName);
+                var pkgsPath = Path.Combine(testDirectory, "pkgs");
+                Directory.CreateDirectory(topPath);
+                Directory.CreateDirectory(pkgsPath);
+                Directory.CreateDirectory(basePackagePath);
+
+                // Base Package
+                var basePackageProjectContent = @"<Project Sdk='Microsoft.NET.Sdk'>
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <PackageOutputPath>$(MSBuildThisFileDirectory)..\pkgs</PackageOutputPath>
+  </PropertyGroup>
+  <ItemGroup>
+    <Content Include='data.json'>
+      <PackagePath>contentFiles/any/any/data.json</PackagePath>
+    </Content>
+  </ItemGroup>
+</Project>";
+                File.WriteAllText(Path.Combine(basePackagePath, $"{basePackageName}.csproj"), basePackageProjectContent);
+
+                var dataJsonContent = @"{""data"":""file""}";
+
+                File.WriteAllText(Path.Combine(basePackagePath, "data.json"), dataJsonContent);
+
+                // Top package
+                var customNuGetConfigContent = @"<configuration>
+  <packageSources>
+    <clear />
+    <add key='nuget' value ='https://api.nuget.org/v3/index.json' />
+    <add key ='local' value ='../pkgs' />
+  </packageSources>
+</configuration>";
+
+                File.WriteAllText(Path.Combine(topPath, "NuGet.Config"), customNuGetConfigContent);
+
+                var topProjectContent = @"<Project Sdk='Microsoft.NET.Sdk'>
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include='BasePackage' Version='1.0.0' />
+  </ItemGroup>
+</Project>";
+
+                File.WriteAllText(Path.Combine(topPath, $"{topName}.csproj"), topProjectContent);
+
+                // create the base package
+                msbuildFixture.PackProject(basePackagePath, basePackageName, "");
+
+                // create the top package
+                msbuildFixture.PackProject(topPath, topName, $"-o {topPath}");
+
+                var basePkgPath = Path.Combine(pkgsPath, "BasePackage.1.0.0.nupkg");
+                Assert.True(File.Exists(basePkgPath));
+                var topPkgPath = Path.Combine(topPath, "top.1.0.0.nupkg");
+                Assert.True(File.Exists(topPkgPath));
+
+                // Asset package content
+                using (var par = new PackageArchiveReader(topPkgPath))
+                {
+                    foreach (var pkgFile in par.GetFiles())
+                    {
+                        Assert.DoesNotContain("data.json", pkgFile);
+                    }
+                }
+            }
+        }
+
+
         [PlatformTheory(Platform.Windows)]
         [InlineData(null, null, null, true, "", "Analyzers,Build")]
         [InlineData(null, "Native", null, true, "", "Analyzers,Build,Native")]

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
@@ -748,7 +748,7 @@ namespace Dotnet.Integration.Test
                 // Base Package
                 var basePackageProjectContent = @"<Project Sdk='Microsoft.NET.Sdk'>
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <PackageOutputPath>$(MSBuildThisFileDirectory)..\pkgs</PackageOutputPath>
   </PropertyGroup>
   <ItemGroup>
@@ -806,7 +806,6 @@ namespace Dotnet.Integration.Test
                 }
             }
         }
-
 
         [PlatformTheory(Platform.Windows)]
         [InlineData(null, null, null, true, "", "Analyzers,Build")]

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
@@ -730,7 +730,7 @@ namespace Dotnet.Integration.Test
         }
 
         [PlatformFact(Platform.Windows)]
-        public void PackCommand_DoesNotIncludeContentFromDependencies_PackSuceeds()
+        public void PackProject_DependenciesWithContentFiles_NupkgExcludesContentFilesFromDependencies()
         {
             // Arrange
             using (var testDirectory = msbuildFixture.CreateTestDirectory())

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/BuildAssetsUtilsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/BuildAssetsUtilsTests.cs
@@ -102,6 +102,7 @@ namespace NuGet.Commands.Test
             Assert.Equal("Compile", metadata["NuGetItemType"]);
             Assert.Equal("False", metadata["Private"]);
             Assert.Equal("test/test.cs", metadata["Link"].Replace('\\', '/'));
+            Assert.Equal("False", metadata["Pack"]);
         }
 
         [Fact]
@@ -128,6 +129,7 @@ namespace NuGet.Commands.Test
             Assert.Equal("PreserveNewest", metadata["CopyToOutputDirectory"]);
             Assert.Equal("a/b/", metadata["DestinationSubDirectory"].Replace('\\', '/'));
             Assert.Equal("a/b/c.txt", metadata["TargetPath"].Replace('\\', '/'));
+            Assert.Equal("False", metadata["Pack"]);
         }
 
         [Fact]
@@ -154,6 +156,7 @@ namespace NuGet.Commands.Test
             Assert.Equal("a/b/c.txt", metadata["Link"].Replace('\\', '/'));
             Assert.Equal("PreserveNewest", metadata["CopyToOutputDirectory"]);
             Assert.False(metadata.ContainsKey("DestinationSubDirectory"));
+            Assert.Equal("False", metadata["Pack"]);
         }
 
         [Theory]

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/BuildAssetsUtilsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/BuildAssetsUtilsTests.cs
@@ -102,7 +102,7 @@ namespace NuGet.Commands.Test
             Assert.Equal("Compile", metadata["NuGetItemType"]);
             Assert.Equal("False", metadata["Private"]);
             Assert.Equal("test/test.cs", metadata["Link"].Replace('\\', '/'));
-            Assert.Equal("False", metadata["Pack"]);
+            Assert.Equal("false", metadata["Pack"]);
         }
 
         [Fact]
@@ -129,7 +129,7 @@ namespace NuGet.Commands.Test
             Assert.Equal("PreserveNewest", metadata["CopyToOutputDirectory"]);
             Assert.Equal("a/b/", metadata["DestinationSubDirectory"].Replace('\\', '/'));
             Assert.Equal("a/b/c.txt", metadata["TargetPath"].Replace('\\', '/'));
-            Assert.Equal("False", metadata["Pack"]);
+            Assert.Equal("false", metadata["Pack"]);
         }
 
         [Fact]
@@ -156,7 +156,7 @@ namespace NuGet.Commands.Test
             Assert.Equal("a/b/c.txt", metadata["Link"].Replace('\\', '/'));
             Assert.Equal("PreserveNewest", metadata["CopyToOutputDirectory"]);
             Assert.False(metadata.ContainsKey("DestinationSubDirectory"));
-            Assert.Equal("False", metadata["Pack"]);
+            Assert.Equal("false", metadata["Pack"]);
         }
 
         [Theory]


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/8867
Regression: No
* Last working version:   
* How are we preventing it in future:   

## Fix

Add an MSBuild attribute named Pack=false to avoid content files from dependencies to be included at pack time.

## Testing/Validation

Tests Added: No
Reason for not adding tests: Updated tests  
Validation: Manually Tested a patched dotnet.exe

### Before

```
Archive:  ./bin/Debug/top.1.0.0.nupkg
  inflating: pkg/_rels/.rels
  inflating: pkg/top.nuspec
  inflating: pkg/lib/net5.0/top.dll
  inflating: pkg/content/data.json
  inflating: pkg/contentFiles/any/net5.0/data.json
  inflating: pkg/[Content_Types].xml
  inflating: pkg/package/services/metadata/core-properties/c2e393253c86496993f5ab45207456a6.psmdcp
```


### After

```
Archive:  ./bin/Debug/top.1.0.0.nupkg
  inflating: pkg/_rels/.rels
  inflating: pkg/top.nuspec
  inflating: pkg/lib/net5.0/top.dll
  inflating: pkg/[Content_Types].xml
  inflating: pkg/package/services/metadata/core-properties/f4c107f9c46f441e88d8f926ff9ff56e.psmdcp
```
