### PR TITLE
Added Update context menu items for package dependencies that launches PMUI with preselected packages to update

### DIFF
--- a/build/packages.targets
+++ b/build/packages.targets
@@ -45,6 +45,7 @@
         <PackageReference Update="Microsoft.VisualStudio.Shell.Embeddable" Version="$(VSFrameworkVersion)" />
         <PackageReference Update="Microsoft.VisualStudio.Shell.Immutable.15.0" Version="15.0.25123-Dev15Preview" />
         <PackageReference Update="Microsoft.VisualStudio.Shell.Interop.12.0" Version="12.0.30111" />
+        <PackageReference Update="Microsoft.VisualStudio.Shell.Interop.12.1.DesignTime" Version="12.1.30328" />
         <PackageReference Update="Microsoft.VisualStudio.Shell.Interop.16.0.DesignTime" Version="16.0.0" />
         <PackageReference Update="Microsoft.VisualStudio.Shell.Interop.16.3.DesignTime" Version="16.5.29616.81" />
         <PackageReference Update="Microsoft.VisualStudio.Shell.Interop.16.6.DesignTime" Version="16.7.30014.49" />

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageItemListViewModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageItemListViewModel.cs
@@ -55,7 +55,7 @@ namespace NuGet.PackageManagement.UI
 
         public event PropertyChangedEventHandler PropertyChanged;
 
-        public string Id  { get; set; }
+        public string Id { get; set; }
 
         public NuGetVersion Version { get; set; }
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageItemListViewModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageItemListViewModel.cs
@@ -55,7 +55,7 @@ namespace NuGet.PackageManagement.UI
 
         public event PropertyChangedEventHandler PropertyChanged;
 
-        public string Id { get; set; }
+        public string Id  { get; set; }
 
         public NuGetVersion Version { get; set; }
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/NuGet.PackageManagement.UI.csproj
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/NuGet.PackageManagement.UI.csproj
@@ -119,6 +119,7 @@
     <Compile Include="Resources\Resources.xaml.cs">
       <DependentUpon>Resources.xaml</DependentUpon>
     </Compile>
+    <Compile Include="ShowUpdatePackageOptions.cs" />
     <Compile Include="Telemetry\UpgradeInformationTelemetryEvent.cs" />
     <Compile Include="UserInterfaceService\DataStreamFromComStream.cs" />
     <Compile Include="UserInterfaceService\IModalProgressDialogSession.cs" />

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/ShowUpdatePackageOptions.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/ShowUpdatePackageOptions.cs
@@ -1,0 +1,21 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace NuGet.PackageManagement.UI
+{
+    public class ShowUpdatePackageOptions
+    {
+        public ShowUpdatePackageOptions(bool shouldUpdateAllPackages = false, IEnumerable<string> packagesToUpdate = null)
+        {
+            ShouldUpdateAllPackages = shouldUpdateAllPackages;
+            PackagesToUpdate = packagesToUpdate ?? Enumerable.Empty<string>();
+        }
+
+        public bool ShouldUpdateAllPackages { get; }
+
+        public IEnumerable<string> PackagesToUpdate { get; }
+    }
+}

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/ShowUpdatePackageOptions.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/ShowUpdatePackageOptions.cs
@@ -8,10 +8,27 @@ namespace NuGet.PackageManagement.UI
 {
     public class ShowUpdatePackageOptions
     {
-        public ShowUpdatePackageOptions(bool shouldUpdateAllPackages = false, IEnumerable<string> packagesToUpdate = null)
+        private static ShowUpdatePackageOptions UpdateAllPackagesInstance;
+
+        private ShowUpdatePackageOptions(bool shouldUpdateAllPackages = false, IEnumerable<string> packagesToUpdate = null)
         {
             ShouldUpdateAllPackages = shouldUpdateAllPackages;
             PackagesToUpdate = packagesToUpdate ?? Enumerable.Empty<string>();
+        }
+
+        public static ShowUpdatePackageOptions UpdateAllPackages()
+        {
+            if (UpdateAllPackagesInstance == null)
+            {
+                UpdateAllPackagesInstance = new ShowUpdatePackageOptions(shouldUpdateAllPackages: true);
+            }
+
+            return UpdateAllPackagesInstance;
+        }
+
+        public static ShowUpdatePackageOptions UpdatePackages(IEnumerable<string> packagesToUpdate)
+        {
+            return new ShowUpdatePackageOptions(shouldUpdateAllPackages: false, packagesToUpdate);
         }
 
         public bool ShouldUpdateAllPackages { get; }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
@@ -40,7 +40,7 @@ namespace NuGet.PackageManagement.UI
         public event UpdateButtonClickEventHandler UpdateButtonClicked;
 
         /// <summary>
-        /// This exists only to facilitate unit testing.
+        /// Fires when the items in the list have finished loading.
         /// It is triggered at <see cref="RepopulatePackageList(PackageItemListViewModel, IPackageItemLoader, CancellationToken) " />, just before it is finished
         /// </summary>
         internal event EventHandler LoadItemsCompleted;

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -1430,6 +1430,9 @@ namespace NuGet.PackageManagement.UI
             else
             {
                 _topPanel.SelectFilter(ItemFilter.UpdatesAvailable);
+
+                // Hook up an event handler to delay selecting packages until they've all loaded, then unhook
+                // the event handler so it doesn't keep happening on every refresh, only the initial load.
                 EventHandler handler = null;
                 handler = (s, e) =>
                 {
@@ -1449,7 +1452,7 @@ namespace NuGet.PackageManagement.UI
                 return;
             }
 
-            // The sentinal * was passed in as the list of update packages which indicates to select all
+            // Select all packages if the sentinal * is the first item of the update packages list
             if ("*".Equals(updatePackages[0], StringComparison.Ordinal))
             {
                 foreach (var packageItem in _packageList.PackageItems)

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Globalization;
 using System.Linq;

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -397,7 +397,7 @@ namespace NuGet.PackageManagement.UI
             var timeSpan = GetTimeSinceLastRefreshAndRestart();
             // Do not trigger a refresh if this is not the first load of the control.
             // The loaded event is triggered once all the data binding has occurred, which effectively means we'll just display what was loaded earlier and not trigger another search
-            if (!_loadedAndInitialized)
+            if (!(_loadedAndInitialized && _topPanel.Filter == ItemFilter.All))
             {
                 _loadedAndInitialized = true;
                 ResetTabDataLoadFlags();

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -395,7 +395,7 @@ namespace NuGet.PackageManagement.UI
         private void PackageManagerLoaded(object sender, RoutedEventArgs e)
         {
             var timeSpan = GetTimeSinceLastRefreshAndRestart();
-            // Do not trigger a refresh if this is not the first load of the control.
+            // Do not trigger a refresh if the browse tab is open and this is not the first load of the control.
             // The loaded event is triggered once all the data binding has occurred, which effectively means we'll just display what was loaded earlier and not trigger another search
             if (!(_loadedAndInitialized && _topPanel.Filter == ItemFilter.All))
             {

--- a/src/NuGet.Clients/NuGet.Tools/NuGet.Tools.csproj
+++ b/src/NuGet.Clients/NuGet.Tools/NuGet.Tools.csproj
@@ -130,6 +130,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" ExcludeAssets="build" />
     <PackageReference Include="Microsoft.VSSDK.BuildTools" GeneratePathProperty="true" PrivateAssets="all" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.Embeddable" ExcludeAssets="build" />
+    <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.12.1.DesignTime" />
   </ItemGroup>
   <ItemGroup>
     <VSCTCompile Include="NuGetTools.vsct">

--- a/src/NuGet.Clients/NuGet.Tools/NuGetPackage.cs
+++ b/src/NuGet.Clients/NuGet.Tools/NuGetPackage.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.ComponentModel.Composition;
 using System.ComponentModel.Design;
 using System.Globalization;

--- a/src/NuGet.Clients/NuGet.Tools/NuGetPackage.cs
+++ b/src/NuGet.Clients/NuGet.Tools/NuGetPackage.cs
@@ -656,7 +656,7 @@ namespace NuGetVSExtension
         private void ShowUpdatePackageDialog(object sender, EventArgs e)
         {
             ThreadHelper.ThrowIfNotOnUIThread();
-            var updatePackages = new ShowUpdatePackageOptions(packagesToUpdate: GetSelectedPackages());
+            var updatePackages = ShowUpdatePackageOptions.UpdatePackages(GetSelectedPackages());
 
             string parameterString = (e as OleMenuCmdEventArgs)?.InValue as string;
             NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async delegate
@@ -671,7 +671,7 @@ namespace NuGetVSExtension
             string parameterString = (e as OleMenuCmdEventArgs)?.InValue as string;
             NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async delegate
             {
-                await ShowManageLibraryPackageDialogAsync(GetSearchText(parameterString), new ShowUpdatePackageOptions(shouldUpdateAllPackages: true));
+                await ShowManageLibraryPackageDialogAsync(GetSearchText(parameterString), ShowUpdatePackageOptions.UpdateAllPackages());
             }).PostOnFailure(nameof(NuGetPackage), nameof(ShowUpdatePackagesDialog));
         }
 
@@ -728,6 +728,7 @@ namespace NuGetVSExtension
         /// A string array containing the list of selected packages in the same hierarchy.
         /// If only one package is selected, the array will contain one package name, otherwise, it will be a list of package names.
         /// If the selected packages are across multiple hierarchies or if no packages are selected, an empty array will be returned.
+        /// This method will return <c>null</c> if it fails to retrieve the selected hierarchy.
         /// </returns>
         private string[] GetSelectedPackages()
         {

--- a/src/NuGet.Clients/NuGet.Tools/NuGetTools.vsct
+++ b/src/NuGet.Clients/NuGet.Tools/NuGetTools.vsct
@@ -136,27 +136,23 @@
 
       <Button guid="guidDialogCmdSet" id="cmdidUpdatePackage" priority="0x0100" type="Button">
         <Parent guid="guidPackageManagementCmdSet" id="idPackageUpdateGroup" />
-        <Icon guid="ImageCatalogGuid" id="StatusAlert" />
-        <CommandFlag>IconIsMoniker</CommandFlag>
         <CommandFlag>AllowParams</CommandFlag>
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
           <CommandName>cmdidUpdatePackage</CommandName>
-          <ButtonText>&amp;Update...</ButtonText>
+          <ButtonText>U&amp;pdate...</ButtonText>
         </Strings>
       </Button>
 
       <Button guid="guidDialogCmdSet" id="cmdidUpdatePackages" priority="0x0100" type="Button">
         <Parent guid="guidPackageManagementCmdSet" id="idPackageManagementGroup" />
-        <Icon guid="ImageCatalogGuid" id="StatusAlert" />
-        <CommandFlag>IconIsMoniker</CommandFlag>
         <CommandFlag>AllowParams</CommandFlag>
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
           <CommandName>cmdidUpdatePackage</CommandName>
-          <ButtonText>U&amp;pdate All...</ButtonText>
+          <ButtonText>U&amp;pdate...</ButtonText>
         </Strings>
       </Button>
     </Buttons>

--- a/src/NuGet.Clients/NuGet.Tools/NuGetTools.vsct
+++ b/src/NuGet.Clients/NuGet.Tools/NuGetTools.vsct
@@ -38,6 +38,9 @@
       <Group guid="guidPackageManagementCmdSet" id="idPackageManagementGroup" priority="0x0100">
         <Parent guid="guidSHLMainMenu" id="IDM_VS_CTXT_PACKAGEREFERENCE_GROUP"/>
       </Group>
+      <Group guid="guidPackageManagementCmdSet" id="idPackageUpdateGroup" priority="0x0100">
+        <Parent guid="guidSHLMainMenu" id="IDM_VS_CTXT_PACKAGEREFERENCE"/>
+      </Group>
     </Groups>
 
     <Buttons>
@@ -128,6 +131,19 @@
         <Strings>
           <CommandName>cmdidGeneralSettings</CommandName>
           <ButtonText>&amp;Package Manager Settings</ButtonText>
+        </Strings>
+      </Button>
+
+      <Button guid="guidDialogCmdSet" id="cmdidUpdatePackage" priority="0x0100" type="Button">
+        <Parent guid="guidPackageManagementCmdSet" id="idPackageUpdateGroup" />
+        <Icon guid="ImageCatalogGuid" id="StatusAlert" />
+        <CommandFlag>IconIsMoniker</CommandFlag>
+        <CommandFlag>AllowParams</CommandFlag>
+        <CommandFlag>DefaultInvisible</CommandFlag>
+        <CommandFlag>DynamicVisibility</CommandFlag>
+        <Strings>
+          <CommandName>cmdidUpdatePackage</CommandName>
+          <ButtonText>&amp;Update...</ButtonText>
         </Strings>
       </Button>
     </Buttons>
@@ -253,6 +269,7 @@
       <IDSymbol name="cmdidRestorePackages" value="0x0300" />
       <IDSymbol name="cmdidUpgradeNuGetProject" value="0x0400" />
       <IDSymbol name="cmdidUpgradePackagesConfig" value="0x0410" />
+      <IDSymbol name="cmdidUpdatePackage" value="0x0500" />
     </GuidSymbol>
     <GuidSymbol name="guidVenusCmdId" value="{C7547851-4E3A-4E5B-9173-FA6E9C8BD82C}" >
       <IDSymbol name="IDG_VENUS_CTX_REFERENCE" value="27" />
@@ -262,6 +279,7 @@
     <GuidSymbol name="guidReferenceContext" value="{D309F791-903F-11D0-9EFC-00A0C911004F}">
       <IDSymbol name="cmdAddReferenceGroup" value="0x450" />
       <IDSymbol name="IDM_VS_CTXT_PACKAGEREFERENCE_GROUP" value="0x04A2"/>
+      <IDSymbol name="IDM_VS_CTXT_PACKAGEREFERENCE" value="0x04A3"/>
     </GuidSymbol>
     <GuidSymbol name="UICONTEXT_SolutionExistsAndNotBuildingAndNotDebugging" value="{D0E4DEEC-1B53-4CDA-8559-D454583AD23B}" />
     <GuidSymbol name="guidNuGetDebugConsoleCmdSet" value="{DDC61543-6CA7-4A6F-A5B7-984BE723C52F}">
@@ -275,6 +293,7 @@
     </GuidSymbol>
     <GuidSymbol name="guidPackageManagementCmdSet" value="{E586270E-92EC-427D-B218-0E81A25226F5}">
       <IDSymbol name="idPackageManagementGroup" value="0x0100" />
+      <IDSymbol name="idPackageUpdateGroup" value="0x0200" />
     </GuidSymbol>
   </Symbols>
 

--- a/src/NuGet.Clients/NuGet.Tools/NuGetTools.vsct
+++ b/src/NuGet.Clients/NuGet.Tools/NuGetTools.vsct
@@ -146,6 +146,19 @@
           <ButtonText>&amp;Update...</ButtonText>
         </Strings>
       </Button>
+
+      <Button guid="guidDialogCmdSet" id="cmdidUpdatePackages" priority="0x0100" type="Button">
+        <Parent guid="guidPackageManagementCmdSet" id="idPackageManagementGroup" />
+        <Icon guid="ImageCatalogGuid" id="StatusAlert" />
+        <CommandFlag>IconIsMoniker</CommandFlag>
+        <CommandFlag>AllowParams</CommandFlag>
+        <CommandFlag>DefaultInvisible</CommandFlag>
+        <CommandFlag>DynamicVisibility</CommandFlag>
+        <Strings>
+          <CommandName>cmdidUpdatePackage</CommandName>
+          <ButtonText>U&amp;pdate All...</ButtonText>
+        </Strings>
+      </Button>
     </Buttons>
 
     <Combos>
@@ -270,6 +283,7 @@
       <IDSymbol name="cmdidUpgradeNuGetProject" value="0x0400" />
       <IDSymbol name="cmdidUpgradePackagesConfig" value="0x0410" />
       <IDSymbol name="cmdidUpdatePackage" value="0x0500" />
+      <IDSymbol name="cmdidUpdatePackages" value="0x0600" />
     </GuidSymbol>
     <GuidSymbol name="guidVenusCmdId" value="{C7547851-4E3A-4E5B-9173-FA6E9C8BD82C}" >
       <IDSymbol name="IDG_VENUS_CTX_REFERENCE" value="27" />

--- a/src/NuGet.Clients/NuGet.Tools/NuGetTools.vsct
+++ b/src/NuGet.Clients/NuGet.Tools/NuGetTools.vsct
@@ -151,7 +151,7 @@
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
-          <CommandName>cmdidUpdatePackage</CommandName>
+          <CommandName>cmdidUpdatePackages</CommandName>
           <ButtonText>U&amp;pdate...</ButtonText>
         </Strings>
       </Button>

--- a/src/NuGet.Clients/NuGet.Tools/PkgCmdID.cs
+++ b/src/NuGet.Clients/NuGet.Tools/PkgCmdID.cs
@@ -15,5 +15,6 @@ namespace NuGetVSExtension
         public const int cmdIdGeneralSettings = 0x0300;
         public const int cmdIdVisualizer = 0x0310;
         public const int cmdidDebugConsole = 0x0900;
+        public const int cmdidUpdatePackage = 0x0500;
     }
 }

--- a/src/NuGet.Clients/NuGet.Tools/PkgCmdID.cs
+++ b/src/NuGet.Clients/NuGet.Tools/PkgCmdID.cs
@@ -16,5 +16,6 @@ namespace NuGetVSExtension
         public const int cmdIdVisualizer = 0x0310;
         public const int cmdidDebugConsole = 0x0900;
         public const int cmdidUpdatePackage = 0x0500;
+        public const int cmdidUpdatePackages = 0x0600;
     }
 }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/IDE/VsMonitorSelectionExtensions.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/IDE/VsMonitorSelectionExtensions.cs
@@ -35,21 +35,11 @@ namespace NuGet.VisualStudio
                 // multiple items are selected.
                 if (pitemid == (uint)VSConstants.VSITEMID.Selection)
                 {
-                    uint numberOfSelectedItems;
-                    int isSingleHierarchyInt;
-                    if (ErrorHandler.Succeeded(ppMIS.GetSelectionInfo(out numberOfSelectedItems, out isSingleHierarchyInt)))
+                    VSITEMSELECTION[] vsItemSelections = ppMIS.GetSelectedItemsInSingleHierachy();
+                    if (vsItemSelections != null && vsItemSelections.Length > 0)
                     {
-                        bool isSingleHierarchy = (isSingleHierarchyInt != 0);
-
-                        VSITEMSELECTION[] vsItemSelections = new VSITEMSELECTION[numberOfSelectedItems];
-                        uint flags = 0; // No flags, which will give us back a hierarchy for each item
-                        ErrorHandler.ThrowOnFailure(ppMIS.GetSelectedItems(flags, numberOfSelectedItems, vsItemSelections));
-
-                        if (isSingleHierarchy && vsItemSelections.Length > 0)
-                        {
-                            VSITEMSELECTION sel = vsItemSelections[0];
-                            hierarchy = sel.pHier;
-                        }
+                        VSITEMSELECTION sel = vsItemSelections[0];
+                        hierarchy = sel.pHier;
                     }
                 }
                 else

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/IDE/VsMultiItemSelectExtensions.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/IDE/VsMultiItemSelectExtensions.cs
@@ -1,0 +1,31 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+
+namespace NuGet.VisualStudio
+{
+    public static class VsMultiItemSelectExtensions
+    {
+        public static VSITEMSELECTION[] GetSelectedItemsInSingleHierachy(this IVsMultiItemSelect multiItemSelect)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            if (!ErrorHandler.Succeeded(multiItemSelect.GetSelectionInfo(out uint numberOfSelectedItems, out int isSingleHierarchyInt)) || isSingleHierarchyInt == 0)
+            {
+                return null;
+            }
+
+            VSITEMSELECTION[] vsItemSelections = new VSITEMSELECTION[numberOfSelectedItems];
+            uint flags = 0; // No flags, which will give us back a hierarchy for each item
+            if (!ErrorHandler.Succeeded(multiItemSelect.GetSelectedItems(flags, numberOfSelectedItems, vsItemSelections)))
+            {
+                return null;
+            }
+
+            return vsItemSelections;
+        }
+    }
+}


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/10378
Regression: Yes/No  No
* Last working version:  N/A
* How are we preventing it in future:   N/A

## Fix

Details: Adding an Update menu item to the package dependency nodes in solution explorer that will launch the Package Manager UI with the updates tab active and the packages selected in the solution explorer selected for update in the UI.

## Testing/Validation

Tests Added: Yes/No  No
Reason for not adding tests:  Most of this code deals with VS APIs and PMUI interaction and there is no new business logic to test.
Validation:  
Manually tested opened a .NET Core console app with package dependencies, right clicked on an individual package, clicked Update... and validated that the PMUI displayed on the Updates tab with the selected package selected in the PMUI for update. Validated the same with multiple packages selected. Right clicked on the parent 'Packages' node and clicked Update and validated that all the packages in the PMUI Update tab were selected. Tested the interaction of swapping between tabs and setting the focus to a code window and back to the PMUI.
