### PR TITLE
Add content hash to installed package message

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/PackageExtractor.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageExtractor.cs
@@ -432,6 +432,7 @@ namespace NuGet.Packaging
                             var tempHashPath = Path.Combine(targetPath, Path.GetRandomFileName());
                             var tempNupkgMetadataPath = Path.Combine(targetPath, Path.GetRandomFileName());
                             var packageSaveMode = packageExtractionContext.PackageSaveMode;
+                            string contentHash;
 
                             try
                             {
@@ -494,7 +495,7 @@ namespace NuGet.Packaging
                                         File.WriteAllText(tempHashPath, packageHash);
 
                                         // get hash for the unsigned content of package
-                                        var contentHash = packageReader.GetContentHash(cancellationToken, GetUnsignedPackageHash: () => packageHash);
+                                        contentHash = packageReader.GetContentHash(cancellationToken, GetUnsignedPackageHash: () => packageHash);
 
                                         // write the new hash file
                                         var hashFile = new NupkgMetadataFile()
@@ -554,7 +555,7 @@ namespace NuGet.Packaging
 
                             File.Move(tempNupkgMetadataPath, nupkgMetadataFilePath);
 
-                            logger.LogVerbose($"Completed installation of {packageIdentity.Id} {packageIdentity.Version} from {source}");
+                            logger.LogVerbose($"Completed installation of {packageIdentity.Id} {packageIdentity.Version} from {source} with content hash {contentHash}");
 
                             packageExtractionTelemetryEvent.SetResult(NuGetOperationStatus.Succeeded);
                             return true;
@@ -827,7 +828,7 @@ namespace NuGet.Packaging
 
                             File.Move(tempNupkgMetadataFilePath, nupkgMetadataFilePath);
 
-                            logger.LogVerbose($"Completed installation of {packageIdentity.Id} {packageIdentity.Version} from {packageDownloader.Source}");
+                            logger.LogVerbose($"Completed installation of {packageIdentity.Id} {packageIdentity.Version} from {packageDownloader.Source} with content hash {contentHash}");
 
                             packageExtractionTelemetryEvent.SetResult(NuGetOperationStatus.Succeeded);
                             return true;

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageExtractorTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageExtractorTests.cs
@@ -3803,7 +3803,8 @@ namespace NuGet.Packaging.Test
 
                     // Assert
                     File.Exists(resolver.GetPackageFilePath(identity.Id, identity.Version)).Should().BeTrue();
-                    testLogger.VerboseMessages.Should().Contain($"Completed installation of {identity.Id} {identity.Version} from {source}");
+                    var nupkgMetadata = NupkgMetadataFileFormat.Read(resolver.GetNupkgMetadataPath(identity.Id, identity.Version));
+                    testLogger.VerboseMessages.Should().Contain($"Completed installation of {identity.Id} {identity.Version} from {source} with content hash {nupkgMetadata.ContentHash}");
                 }
             }
         }
@@ -3897,7 +3898,8 @@ namespace NuGet.Packaging.Test
 
                     // Assert
                     File.Exists(resolver.GetPackageFilePath(identity.Id, identity.Version)).Should().BeTrue();
-                    testLogger.VerboseMessages.Should().Contain($"Completed installation of {identity.Id} {identity.Version} from {source}");
+                    var nupkgMetadata = NupkgMetadataFileFormat.Read(resolver.GetNupkgMetadataPath(identity.Id, identity.Version));
+                    testLogger.VerboseMessages.Should().Contain($"Completed installation of {identity.Id} {identity.Version} from {source} with content hash {nupkgMetadata.ContentHash}");
                 }
             }
         }


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/10384
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: Add content hash to "installed package {package identity} from {source}" message.

## Testing/Validation

Tests Added: Yes
Reason for not adding tests:  
Validation:  
