### PR TITLE
Remove unnecessary minimal log message for static graph restore

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs
@@ -607,8 +607,6 @@ namespace NuGet.Build.Tasks.Console
                     // Get the PackageSpecs in parallel because creating each one is relatively expensive so parallelism speeds things up
                     Parallel.ForEach(projects, new ParallelOptions { MaxDegreeOfParallelism = Environment.ProcessorCount }, project =>
                     {
-                        MSBuildLogger.LogMinimal($"For {project.OuterProject.FullPath}," +
-                            $" the value of MSBuildStartupDirectory:{project.OuterProject.GetProperty("MSBuildStartupDirectory")}");
                         var packageSpec = GetPackageSpec(project.OuterProject, project);
 
                         if (packageSpec != null)

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
@@ -278,8 +278,10 @@ EndGlobal";
         }
 #endif //IS_SIGNING_SUPPORTED
 
-        [PlatformFact(Platform.Windows)]
-        public async Task DotnetRestore_OneLinePerRestore()
+        [PlatformTheory(Platform.Windows)]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task DotnetRestore_OneLinePerRestore(bool useStaticGraphRestore)
         {
             using (var pathContext = _msbuildFixture.CreateSimpleTestPathContext())
             {
@@ -340,14 +342,15 @@ EndGlobal";
                 File.WriteAllText(slnPath, slnContents);
 
                 // Act
-                var result = _msbuildFixture.RunDotnet(pathContext.SolutionRoot, $"restore proj.sln {$"--source \"{pathContext.PackageSource}\""}", ignoreExitCode: true);
+                var arguments = $"restore proj.sln {$"--source \"{pathContext.PackageSource}\""}" + (useStaticGraphRestore ? " /p:RestoreUseStaticGraphEvaluation=true" : string.Empty);
+                var result = _msbuildFixture.RunDotnet(pathContext.SolutionRoot, arguments, ignoreExitCode: true);
 
                 // Assert
                 Assert.True(result.ExitCode == 0);
                 Assert.True(2 == result.AllOutput.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries).Length, result.AllOutput);
 
                 // Act - make sure no-op does the same thing.
-                result = _msbuildFixture.RunDotnet(pathContext.SolutionRoot, $"restore proj.sln {$"--source \"{pathContext.PackageSource}\""}", ignoreExitCode: true);
+                result = _msbuildFixture.RunDotnet(pathContext.SolutionRoot, arguments, ignoreExitCode: true);
 
                 // Assert
                 Assert.True(result.ExitCode == 0);


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/10335
Regression: Yes  
* Last working version: 5.7.0
* How are we preventing it in future: Test, test was checking regular, but not static graph restore.

## Fix

Details: 

At minimal verbosity, NuGet is supposed to log only 1 line per restore. 
There was already a test covering regular restore, but not one covering static graph. 

## Testing/Validation

Tests Added: Yes  
Reason for not adding tests:  
Validation:  
