### PR TITLE
fix ca1802 warning which is blocking local builds on preview versions of the tooling

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/GetInstalledPackagesAsyncTelemetryEvent.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/GetInstalledPackagesAsyncTelemetryEvent.cs
@@ -9,7 +9,7 @@ namespace NuGet.PackageManagement.Telemetry
     {
         private const string Data = "Data";
 
-        private static readonly string EventName = $"{DiagnosticEventName}/GetInstalledPackagesAsync";
+        private const string EventName = DiagnosticEventName + "/GetInstalledPackagesAsync";
 
         public GetInstalledPackagesAsyncTelemetryEvent()
             : base(EventName)


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Client.Engineering/issues/677

Regression: No

## Fix

Details: Local builds are failing with the following CA error when I execute `build.ps1` on preview versions of the tooling. 

`GetInstalledPackagesAsyncTelemetryEvent.cs(12,40): error CA1802: Field 'EventName' is declared as 'readonly' but is initialized with a constant value. Mark this field as 'const' instead.` This class was recently added in https://github.com/NuGet/NuGet.Client/pull/3786 PR.

As per [blog](https://devblogs.microsoft.com/dotnet/whats-new-in-net-productivity/#tooling-improvements), starting in .NET 5.0, Roslyn analyzers are included with the .NET SDK. Roslyn analyzers are enabled, by default, for projects that target .NET 5.0 or later.

## Testing/Validation

Tests Added: No
Reason for not adding tests: No functional changes to the product.
Validation: [All CI checks passed](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=4309216&view=results)