### PR TITLE
When checking the validity of the lock file, skip transitive project references marked with `PrivateAssets`

### DIFF
--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileUtilities.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileUtilities.cs
@@ -157,7 +157,6 @@ namespace NuGet.ProjectModel
                             var projectNames = queue.Dequeue();
                             var p2pUniqueName = projectNames.Item2;
                             var p2pProjectName = projectNames.Item1;
-
                             var projectDependency = target.Dependencies.FirstOrDefault(
                                 dep => dep.Type == PackageDependencyType.Project &&
                                 StringComparer.OrdinalIgnoreCase.Equals(dep.Id, p2pProjectName));
@@ -193,7 +192,8 @@ namespace NuGet.ProjectModel
 
                                         foreach (var reference in p2pSpecProjectRestoreMetadataFrameworkInfo.ProjectReferences)
                                         {
-                                            if (visitedP2PReference.Add(reference.ProjectUniqueName))
+                                            // Do not add private assets for processing.
+                                            if (visitedP2PReference.Add(reference.ProjectUniqueName) && reference.PrivateAssets != LibraryIncludeFlags.All)
                                             {
                                                 var referenceSpec = dgSpec.GetProjectSpec(reference.ProjectUniqueName);
                                                 queue.Enqueue(new Tuple<string, string>(referenceSpec.Name, reference.ProjectUniqueName));
@@ -323,7 +323,7 @@ namespace NuGet.ProjectModel
         private static bool HasProjectDependencyChanged(IEnumerable<LibraryDependency> newDependencies, IEnumerable<LockFileDependency> lockFileDependencies)
         {
             // If the count is not the same, something has changed.
-            // Otherwise we N^2 walk below determines whether anything has changed.
+            // Otherwise the N^2 walk below determines whether anything has changed.
             var newPackageDependencies = newDependencies.Where(dep => dep.LibraryRange.TypeConstraint == LibraryDependencyTarget.Package);
             if (newPackageDependencies.Count() != lockFileDependencies.Count())
             {
@@ -356,9 +356,11 @@ namespace NuGet.ProjectModel
             // If the count is not the same, something has changed.
             // Otherwise we N^2 walk below determines whether anything has changed.
             var transitivelyFlowingDependencies = newDependencies.Where(
-                dep => (dep.LibraryRange.TypeConstraint == LibraryDependencyTarget.Package && dep.SuppressParent != LibraryIncludeFlags.All));
+                dep => dep.LibraryRange.TypeConstraint == LibraryDependencyTarget.Package && dep.SuppressParent != LibraryIncludeFlags.All);
 
-            if (transitivelyFlowingDependencies.Count() + projectRestoreReferences.Count() != projectDependency.Dependencies.Count)
+            var transitivelyFlowingProjectReferences = projectRestoreReferences.Where(e => e.PrivateAssets != LibraryIncludeFlags.All);
+
+            if (transitivelyFlowingDependencies.Count() + transitivelyFlowingProjectReferences.Count() != projectDependency.Dependencies.Count)
             {
                 return true;
             }
@@ -374,7 +376,7 @@ namespace NuGet.ProjectModel
                 }
             }
 
-            foreach (var dependency in projectRestoreReferences)
+            foreach (var dependency in transitivelyFlowingProjectReferences)
             {
                 var referenceSpec = dgSpec.GetProjectSpec(dependency.ProjectUniqueName);
                 var matchedP2PLibrary = projectDependency.Dependencies.FirstOrDefault(dep => StringComparer.OrdinalIgnoreCase.Equals(dep.Id, referenceSpec.Name));

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
@@ -10234,7 +10234,6 @@ namespace NuGet.CommandLine.Test
         /// A -> B (PrivateAssets)-> C
         /// A has packages lock file enabled. Locked should succeed and ignore `C`.
         /// </summary>
-        /// <returns></returns>
         [Fact]
         public void RestoreWithPackagesLockFile_ProjectToProjectWithPrivateAssets_SucceedsInLockedMode()
         {
@@ -10277,6 +10276,163 @@ namespace NuGet.CommandLine.Test
                 Util.RestoreSolution(pathContext).Success.Should().BeTrue();
 
                 // Second Restore
+                var r = Util.RestoreSolution(pathContext, additionalArgs: "-LockedMode");
+
+                // Assert
+                r.Success.Should().BeTrue();
+            }
+        }
+
+        /// <summary>
+        /// A -> B (PrivateAssets)-> C -> PackageC
+        /// A -> D -> C -> PackageC
+        /// </summary>
+        [Fact]
+        public async Task RestoreWithPackagesLockFile_ProjectToProject_MultipleEdgesWithDifferentPrivateAssets_SucceedsInLockedMode()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Set up solution, project, and packages
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+
+                var projectA = SimpleTestProjectContext.CreateNETCore(
+                   "a",
+                   pathContext.SolutionRoot,
+                   NuGetFramework.Parse("net472"));
+
+                var projectB = SimpleTestProjectContext.CreateNETCore(
+                   "b",
+                   pathContext.SolutionRoot,
+                   NuGetFramework.Parse("net472"));
+
+                var projectC = SimpleTestProjectContext.CreateNETCore(
+                   "c",
+                   pathContext.SolutionRoot,
+                   NuGetFramework.Parse("net472"));
+
+                var projectCWithPrivateAssets = SimpleTestProjectContext.CreateNETCore(
+                    "c",
+                    pathContext.SolutionRoot,
+                    NuGetFramework.Parse("net472"));
+
+                var projectD = SimpleTestProjectContext.CreateNETCore(
+                    "d",
+                    pathContext.SolutionRoot,
+                    NuGetFramework.Parse("net472"));
+
+                // Enable lock file everywhere:
+                projectA.Properties.Add("RestorePackagesWithLockFile", "true");
+                projectB.Properties.Add("RestorePackagesWithLockFile", "true");
+                projectC.Properties.Add("RestorePackagesWithLockFile", "true");
+                projectD.Properties.Add("RestorePackagesWithLockFile", "true");
+
+                // A -> B
+                projectA.AddProjectToAllFrameworks(projectB);
+
+                // B -> C with PrivateAssets
+                projectCWithPrivateAssets.PrivateAssets = LibraryIncludeFlags.All.ToString();
+                projectB.AddProjectToAllFrameworks(projectCWithPrivateAssets);
+
+                // A -> D
+                projectA.AddProjectToAllFrameworks(projectD);
+
+                // D -> C
+                projectD.AddProjectToAllFrameworks(projectC);
+
+                // C - package X
+                var packageX = new SimpleTestPackageContext("X", "1.0.0");
+                projectC.AddPackageToAllFrameworks(packageX);
+
+                // Create packages
+                await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                    pathContext.PackageSource,
+                    PackageSaveMode.Defaultv3,
+                    packageX);
+
+                // Solution
+                solution.Projects.Add(projectA);
+                solution.Projects.Add(projectB);
+                solution.Projects.Add(projectC);
+                solution.Projects.Add(projectD);
+                solution.Create(pathContext.SolutionRoot);
+
+                // Pre-Conditions, Act & Assert.
+                Util.RestoreSolution(pathContext).Success.Should().BeTrue();
+
+                // Second Restore
+                var r = Util.RestoreSolution(pathContext, additionalArgs: "-LockedMode");
+
+                // Assert
+                r.Success.Should().BeTrue();
+            }
+        }
+
+        /// <summary>
+        /// A -> B (PrivateAssets)-> C
+        /// A has packages lock file enabled.
+        /// A change in C's dependencies should not affect A's locked mode.
+        /// </summary>
+        /// <returns></returns>
+        [Fact]
+        public async Task RestoreWithPackagesLockFile_ChangesInSuppressedProjects_DoNotAffectLockedMode()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Set up solution, project, and packages
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+
+                var projectA = SimpleTestProjectContext.CreateNETCore(
+                   "a",
+                   pathContext.SolutionRoot,
+                   NuGetFramework.Parse("net472"));
+
+                var projectB = SimpleTestProjectContext.CreateNETCore(
+                   "b",
+                   pathContext.SolutionRoot,
+                   NuGetFramework.Parse("net472"));
+
+                var projectC = SimpleTestProjectContext.CreateNETCore(
+                   "c",
+                   pathContext.SolutionRoot,
+                   NuGetFramework.Parse("net472"));
+
+                // Enable lock for A
+                projectA.Properties.Add("RestorePackagesWithLockFile", "true");
+
+                // A -> B
+                projectA.AddProjectToAllFrameworks(projectB);
+
+                // B -> C with PrivateAssets
+                projectC.PrivateAssets = LibraryIncludeFlags.All.ToString();
+                projectB.AddProjectToAllFrameworks(projectC);
+
+                // C - package X
+                var packageX = new SimpleTestPackageContext("X", "1.0.0");
+                var packageY = new SimpleTestPackageContext("Y", "1.0.0");
+                projectC.AddPackageToAllFrameworks(packageX);
+
+                // Create packages
+                await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                    pathContext.PackageSource,
+                    PackageSaveMode.Defaultv3,
+                    packageX,
+                    packageY);
+
+                // Solution
+                solution.Projects.Add(projectA);
+                solution.Projects.Add(projectB);
+                solution.Projects.Add(projectC);
+                solution.Create(pathContext.SolutionRoot);
+
+                // Pre-Conditions, Act & Assert.
+                Util.RestoreSolution(pathContext).Success.Should().BeTrue();
+
+                // Set-up again.
+                projectC.AddPackageToAllFrameworks(packageY);
+                projectC.Save();
+                // Second Restore - changes in C should *not* affect A.
                 var r = Util.RestoreSolution(pathContext, additionalArgs: "-LockedMode");
 
                 // Assert

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/Builders/LockFileDependencyBuilder.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/Builders/LockFileDependencyBuilder.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
+using NuGet.Packaging.Core;
 using NuGet.Versioning;
 
 namespace NuGet.ProjectModel.Test.Builders
@@ -12,6 +14,7 @@ namespace NuGet.ProjectModel.Test.Builders
         private NuGetVersion _resolvedVersion = new NuGetVersion(1, 0, 0);
         private PackageDependencyType _type = PackageDependencyType.Direct;
         private string _contentHash = "ABC";
+        private IList<PackageDependency> _dependencies = new List<PackageDependency>();
 
         public LockFileDependencyBuilder WithId(string id)
         {
@@ -43,15 +46,32 @@ namespace NuGet.ProjectModel.Test.Builders
             return this;
         }
 
+        public LockFileDependencyBuilder WithDependency(PackageDependency dependency)
+        {
+            _dependencies.Add(dependency);
+            return this;
+        }
+
         public LockFileDependency Build()
         {
+            if (_type == PackageDependencyType.Project)
+            {
+                return new LockFileDependency()
+                {
+                    Id = _id,
+                    RequestedVersion = _requestedVersion,
+                    Type = _type,
+                    Dependencies = _dependencies,
+                };
+            }
             return new LockFileDependency()
             {
                 Id = _id,
                 RequestedVersion = _requestedVersion,
                 ResolvedVersion = _resolvedVersion,
                 Type = _type,
-                ContentHash = _contentHash
+                ContentHash = _contentHash,
+                Dependencies = _dependencies,
             };
         }
     }

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/ProjectLockFile/LockFileUtilitiesTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/ProjectLockFile/LockFileUtilitiesTests.cs
@@ -3,7 +3,10 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using FluentAssertions;
+using NuGet.Commands.Test;
 using NuGet.LibraryModel;
+using NuGet.Packaging.Core;
 using NuGet.Versioning;
 using Xunit;
 using static NuGet.Frameworks.FrameworkConstants;
@@ -582,6 +585,112 @@ namespace NuGet.ProjectModel.Test.ProjectLockFile
             // Due to the increased version in the lock file the lock should be invalid
             var actual = PackagesLockFileUtilities.IsLockFileStillValid(dgSpec, lockFile);
             Assert.False(actual);
+        }
+
+        /// <summary>
+        /// A -> B (PrivateAssets)-> C
+        /// A has packages lock file enabled. Locked should succeed and ignore `C`.
+        /// </summary>
+        [Fact]
+        public void IsLockFileStillValid_WithProjectToProjectWithPrivateAssets_IgnoresSuppressedDependencies()
+        {
+            // Arrange
+            var framework = CommonFrameworks.Net50;
+            var frameworkShortName = framework.GetShortFolderName();
+            var projectA = ProjectJsonTestHelpers.GetPackageSpec("A", framework: frameworkShortName);
+            var projectB = ProjectJsonTestHelpers.GetPackageSpec("B", framework: frameworkShortName);
+            var projectC = ProjectJsonTestHelpers.GetPackageSpec("C", framework: frameworkShortName);
+
+            // B (PrivateAssets.All) -> C 
+            projectB = projectB.WithTestProjectReference(projectC, privateAssets: LibraryIncludeFlags.All);
+
+            // A -> B
+            projectA = projectA.WithTestProjectReference(projectB);
+
+            var dgSpec = ProjectJsonTestHelpers.GetDGSpec(projectA, projectB, projectC);
+
+            var lockFile = new PackagesLockFileBuilder()
+                        .WithTarget(target => target
+                        .WithFramework(framework)
+                        .WithDependency(dep => dep
+                            .WithId("B")
+                            .WithType(PackageDependencyType.Project)
+                            .WithRequestedVersion(VersionRange.Parse("1.0.0"))))
+                        .Build();
+
+            PackagesLockFileUtilities.IsLockFileStillValid(dgSpec, lockFile).Should().BeTrue();
+        }
+
+        /// <summary>
+        /// A -> B (PrivateAssets)-> C -> PackageC
+        /// A -> D -> C -> PackageC
+        /// </summary>
+        [Fact]
+        public void IsLockFileStillValid_WithProjectToProject_MultipleEdgesWithDifferentPrivateAssets_IncludesAllDependencies()
+        {
+            // Arrange
+            var framework = CommonFrameworks.Net50;
+            var frameworkShortName = framework.GetShortFolderName();
+            var projectA = ProjectJsonTestHelpers.GetPackageSpec("A", framework: frameworkShortName);
+            var projectB = ProjectJsonTestHelpers.GetPackageSpec("B", framework: frameworkShortName);
+            var projectC = ProjectJsonTestHelpers.GetPackageSpec("C", framework: frameworkShortName);
+            var projectD = ProjectJsonTestHelpers.GetPackageSpec("D", framework: frameworkShortName);
+
+            var packageC = new LibraryDependency(
+                new LibraryRange("packageC", versionRange: VersionRange.Parse("2.0.0"), LibraryDependencyTarget.Package),
+                type: LibraryDependencyType.Default,
+                includeType: LibraryIncludeFlags.All,
+                suppressParent: LibraryIncludeFlagUtils.DefaultSuppressParent,
+                noWarn: new List<Common.NuGetLogCode>(),
+                autoReferenced: false,
+                generatePathProperty: true,
+                versionCentrallyManaged: false,
+                libraryDependencyReferenceType: LibraryDependencyReferenceType.Direct,
+                aliases: null);
+
+            // B (PrivateAssets.All) -> C 
+            projectB = projectB.WithTestProjectReference(projectC, privateAssets: LibraryIncludeFlags.All);
+
+            // A -> B
+            projectA = projectA.WithTestProjectReference(projectB);
+
+            // A -> D
+            projectA = projectA.WithTestProjectReference(projectD);
+
+            // D -> C
+            projectD = projectD.WithTestProjectReference(projectC);
+
+            // C -> PackageC
+            projectC.TargetFrameworks.First().Dependencies.Add(packageC);
+
+            var dgSpec = ProjectJsonTestHelpers.GetDGSpec(projectA, projectB, projectC, projectD);
+
+            var lockFile = new PackagesLockFileBuilder()
+                        .WithTarget(target => target
+                        .WithFramework(framework)
+                        .WithDependency(dep => dep
+                            .WithId("B")
+                            .WithType(PackageDependencyType.Project)
+                            .WithRequestedVersion(VersionRange.Parse("1.0.0")))
+                        .WithDependency(dep => dep
+                            .WithId("C")
+                            .WithType(PackageDependencyType.Project)
+                            .WithRequestedVersion(VersionRange.Parse("1.0.0"))
+                            .WithDependency(new PackageDependency("packageC",VersionRange.Parse("2.0.0"))))
+                        .WithDependency(dep => dep
+                            .WithId("D")
+                            .WithType(PackageDependencyType.Project)
+                            .WithRequestedVersion(VersionRange.Parse("1.0.0"))
+                            .WithDependency(new PackageDependency("C", VersionRange.Parse("1.0.0"))))
+                        .WithDependency(dep => dep
+                            .WithId("packageC")
+                            .WithType(PackageDependencyType.Transitive)
+                            .WithRequestedVersion(VersionRange.Parse("2.0.0"))
+                            .WithResolvedVersion(NuGetVersion.Parse("2.0.0"))
+                        ))
+                        .Build();
+
+            PackagesLockFileUtilities.IsLockFileStillValid(dgSpec, lockFile).Should().BeTrue();
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/ProjectLockFile/LockFileUtilitiesTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/ProjectLockFile/LockFileUtilitiesTests.cs
@@ -676,7 +676,7 @@ namespace NuGet.ProjectModel.Test.ProjectLockFile
                             .WithId("C")
                             .WithType(PackageDependencyType.Project)
                             .WithRequestedVersion(VersionRange.Parse("1.0.0"))
-                            .WithDependency(new PackageDependency("packageC",VersionRange.Parse("2.0.0"))))
+                            .WithDependency(new PackageDependency("packageC", VersionRange.Parse("2.0.0"))))
                         .WithDependency(dep => dep
                             .WithId("D")
                             .WithType(PackageDependencyType.Project)


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/8565
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: PrivateAssets metadata means that the project/package should not flow transitively. The lock file up to date check considered packages, but did not handle projects.

## Testing/Validation

Tests Added: Yes  
Reason for not adding tests:  
Validation:  
