### PR TITLE
Allow the PMUI to refresh on load only once for all tabs

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -406,9 +406,9 @@ namespace NuGet.PackageManagement.UI
         private async Task PackageManagerLoadedAsync()
         {
             var timeSpan = GetTimeSinceLastRefreshAndRestart();
-            // Do not trigger a refresh if the browse tab is open and this is not the first load of the control.
+            // Do not trigger a refresh if this is not the first load of the control.
             // The loaded event is triggered once all the data binding has occurred, which effectively means we'll just display what was loaded earlier and not trigger another search
-            if (!(_loadedAndInitialized && _topPanel.Filter == ItemFilter.All))
+            if (!_loadedAndInitialized)
             {
                 _loadedAndInitialized = true;
                 ResetTabDataLoadFlags();


### PR DESCRIPTION
Allow the PMUI to refresh on load only once for all tabs, not just the Browse tab

## Bug

Fixes: https://github.com/NuGet/Home/issues/4176
Regression: Yes/No  No
* Last working version:   N/A
* How are we preventing it in future:   N/A

## Fix

Details: The Loaded event handler for the PMUI control prevents a refresh from occurring after the initial load when the active tab is Browse. This fix removes the condition that the active tab is Browse and prevents a refresh from occurring when the Loaded event is fired after the initial load for all tabs.

## Testing/Validation

Tests Added: Yes/No  No
Reason for not adding tests:  Adjusted logic in Loaded event handler for WPF control that is difficult to mock in its current state.
Validation:  Launched the PMUI had Browse tab active, switched to code editor and back to PMUI, observed refresh was not invoked, and repeated steps for Installed and Updates tabs.
