### PR TITLE
Fix SourceRoot item in generated props, use 1 folder per item

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
@@ -164,7 +164,7 @@ namespace NuGet.Commands
             string assetsFilePath,
             bool success)
         {
-            
+
             doc.Root.AddFirst(
                 new XElement(Namespace + "PropertyGroup",
                             new XAttribute("Condition", $" {ExcludeAllCondition} "),

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
@@ -164,6 +164,7 @@ namespace NuGet.Commands
             string assetsFilePath,
             bool success)
         {
+            
             doc.Root.AddFirst(
                 new XElement(Namespace + "PropertyGroup",
                             new XAttribute("Condition", $" {ExcludeAllCondition} "),
@@ -176,7 +177,7 @@ namespace NuGet.Commands
                             GenerateProperty("NuGetToolVersion", MinClientVersionUtility.GetNuGetClientVersion().ToFullString())),
                 new XElement(Namespace + "ItemGroup",
                             new XAttribute("Condition", $" {ExcludeAllCondition} "),
-                            GenerateItem("SourceRoot", "$([MSBuild]::EnsureTrailingSlash($(NuGetPackageFolders)))")));
+                            packageFolders.Select(e => GenerateItem("SourceRoot", PathUtility.EnsureTrailingSlash(e)))));
         }
 
         /// <summary>

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/BuildAssetsUtilsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/BuildAssetsUtilsTests.cs
@@ -61,7 +61,8 @@ namespace NuGet.Commands.Test
         public void AddNuGetProperty_WithPackageFolders_AddsSourceRootItem()
         {
             // Arrange
-            var packageFolders = @"/tmp/gpf;/tmp/fallbackFolder";
+            var separator = Path.DirectorySeparatorChar;
+            var packageFolders = $"{separator}tmp{separator}gpf;{separator}tmp{separator}fallbackFolder";
 
             var doc = BuildAssetsUtils.GenerateEmptyImportsFile();
 
@@ -76,11 +77,14 @@ namespace NuGet.Commands.Test
 
             var props = TargetsUtility.GetMSBuildProperties(doc);
             var items = TargetsUtility.GetMSBuildItems(doc);
+            var sourceRootItems = items.Where(e => e.Item1.Equals("SourceRoot")).Select(e => e.Item2).ToList();
 
             // Assert
             Assert.Equal(packageFolders, props["NuGetPackageFolders"]);
-            Assert.Equal(1, items.Count);
-            Assert.Equal("$([MSBuild]::EnsureTrailingSlash($(NuGetPackageFolders)))", items["SourceRoot"]["Include"]);
+            Assert.Equal(2, items.Count);
+            Assert.Equal(2, sourceRootItems.Count);
+            Assert.Equal($"{separator}tmp{separator}gpf{separator}", sourceRootItems[0]["Include"]);
+            Assert.Equal($"{separator}tmp{separator}fallbackFolder{separator}", sourceRootItems[1]["Include"]);
         }
 
         [Fact]

--- a/test/TestUtilities/Test.Utility/TargetsUtility.cs
+++ b/test/TestUtilities/Test.Utility/TargetsUtility.cs
@@ -54,9 +54,9 @@ namespace NuGet.Test.Utility
         /// <summary>
         /// Read a targets or props file and find all the items.
         /// </summary>
-        public static Dictionary<string, Dictionary<string, string>> GetMSBuildItems(XDocument doc)
+        public static List<(string, Dictionary<string, string>)> GetMSBuildItems(XDocument doc)
         {
-            var result = new Dictionary<string, Dictionary<string, string>>(StringComparer.OrdinalIgnoreCase);
+            var result = new List<(string, Dictionary<string, string>)>();
 
             var itemGroupName = XName.Get("ItemGroup", "http://schemas.microsoft.com/developer/msbuild/2003");
 
@@ -66,15 +66,12 @@ namespace NuGet.Test.Utility
                 {
                     var key = item.Name.LocalName;
 
-                    if (!result.ContainsKey(key))
-                    {
                         var attributeValues = new Dictionary<string, string>();
                         foreach (var attribute in item.Attributes())
                         {
                             attributeValues.Add(attribute.Name.LocalName, attribute.Value);
                         }
-                        result.Add(key, attributeValues);
-                    }
+                        result.Add((key, attributeValues));
                 }
             }
 

--- a/test/TestUtilities/Test.Utility/TargetsUtility.cs
+++ b/test/TestUtilities/Test.Utility/TargetsUtility.cs
@@ -66,12 +66,12 @@ namespace NuGet.Test.Utility
                 {
                     var key = item.Name.LocalName;
 
-                        var attributeValues = new Dictionary<string, string>();
-                        foreach (var attribute in item.Attributes())
-                        {
-                            attributeValues.Add(attribute.Name.LocalName, attribute.Value);
-                        }
-                        result.Add((key, attributeValues));
+                    var attributeValues = new Dictionary<string, string>();
+                    foreach (var attribute in item.Attributes())
+                    {
+                        attributeValues.Add(attribute.Name.LocalName, attribute.Value);
+                    }
+                    result.Add((key, attributeValues));
                 }
             }
 


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9810
Regression: No
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: 

For source root, one item per folder should be used.

## Testing/Validation

Tests Added: Yes  
Reason for not adding tests:  
Validation:  
