### PR TITLE
Write NU1004 errors to the assets file, ensure that all 3 restore output files are generated in all failure scenarios

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -217,7 +217,7 @@ namespace NuGet.Commands
                             restoreGraphs: new List<RestoreTargetGraph>(),
                             compatibilityCheckResults: new List<CompatibilityCheckResult>(),
                             msbuildFiles: new List<MSBuildOutputFile>(),
-                            lockFile: _request.ExistingLockFile,
+                            lockFile: _request.ExistingLockFile, // The lock file needs updated.
                             previousLockFile: _request.ExistingLockFile,
                             lockFilePath: _request.ExistingLockFile?.Path,
                             cacheFile: cacheFile,

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -527,7 +527,7 @@ namespace NuGet.Commands
 
                 // directly log to the request logger when we're not going to rewrite the assets file otherwise this log will
                 // be skipped for netcore projects.
-                await _logger.LogAsync(RestoreLogMessage.CreateError(NuGetLogCode.NU1005, message));
+                await _request.Log.LogAsync(RestoreLogMessage.CreateError(NuGetLogCode.NU1005, message));
 
                 return (success, isLockFileValid, packagesLockFile);
             }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -555,7 +555,7 @@ namespace NuGet.Commands
 
                 // directly log to the request logger when we're not going to rewrite the assets file otherwise this log will
                 // be skipped for netcore projects.
-                await _request.Log.LogAsync(RestoreLogMessage.CreateError(NuGetLogCode.NU1005, message));
+                await _logger.LogAsync(RestoreLogMessage.CreateError(NuGetLogCode.NU1005, message));
 
                 return (success, isLockFileValid, packagesLockFile);
             }
@@ -595,7 +595,7 @@ namespace NuGet.Commands
                         // bail restore since it's the locked mode but required to update the lock file.
                         // directly log to the request logger when we're not going to rewrite the assets file otherwise this log will
                         // be skipped for netcore projects.
-                        await _request.Log.LogAsync(RestoreLogMessage.CreateError(NuGetLogCode.NU1004, Strings.Error_RestoreInLockedMode));
+                        await _logger.LogAsync(RestoreLogMessage.CreateError(NuGetLogCode.NU1004, Strings.Error_RestoreInLockedMode));
                     }
                 }
             }

--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -1682,6 +1682,15 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Skipping the lock file regeneration for &apos;{0}&apos;..
+        /// </summary>
+        internal static string Log_SkippingPackagesLockFileGeneration {
+            get {
+                return ResourceManager.GetString("Log_SkippingPackagesLockFileGeneration", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Skipping runtime dependency walk, no runtimes defined in project.json..
         /// </summary>
         internal static string Log_SkippingRuntimeWalk {

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -1118,4 +1118,7 @@ For more information, visit https://docs.nuget.org/docs/reference/command-line-r
     <value>Platform version is not present for one or more target frameworks, even though they have specified a platform: {0}</value>
     <comment>0 - comma-separated list of TFMs missing a platform version</comment>
   </data>
+  <data name="Log_SkippingPackagesLockFileGeneration" xml:space="preserve">
+    <value>Skipping the lock file regeneration for '{0}'.</value>
+  </data>
 </root>

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/RestoreCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/RestoreCommandTests.cs
@@ -925,7 +925,6 @@ namespace NuGet.CommandLine.FuncTest.Commands
                 // Remove old obj folders.
                 Directory.Delete(Path.GetDirectoryName(projectA.AssetsFileOutputPath), recursive: true);
 
-
                 // Act
                 result = RunRestore(pathContext, _failureExitCode, "-LockedMode");
 

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/RestoreCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/RestoreCommandTests.cs
@@ -872,6 +872,70 @@ namespace NuGet.CommandLine.FuncTest.Commands
             }
         }
 
+        [Fact]
+        public async Task Restore_WithLockedModeAndNoObjFolder_RestoreFailsAndWritesOutRestoreResultFiles()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Set up solution, project, and packages
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+
+                var net461 = NuGetFramework.Parse("net461");
+
+                var projectA = SimpleTestProjectContext.CreateLegacyPackageReference(
+                    "a",
+                    pathContext.SolutionRoot,
+                    net461);
+
+                var packageX = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.0"
+                };
+                packageX.Files.Clear();
+                packageX.AddFile("lib/net461/a.dll");
+
+                var packageY = new SimpleTestPackageContext()
+                {
+                    Id = "y",
+                    Version = "1.0.0"
+                };
+                packageY.AddFile("lib/net461/y.dll");
+
+                projectA.AddPackageToAllFrameworks(packageX);
+                solution.Projects.Add(projectA);
+                solution.Create(pathContext.SolutionRoot);
+
+                await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                    pathContext.PackageSource,
+                    PackageSaveMode.Defaultv3,
+                    packageX,
+                    packageY);
+
+                var result = RunRestore(pathContext, _successExitCode, "-UseLockFile");
+                Assert.True(result.Success);
+                Assert.True(File.Exists(projectA.NuGetLockFileOutputPath));
+
+                projectA.AddPackageToAllFrameworks(packageY);
+                projectA.Save();
+
+                // Remove old obj folders.
+                Directory.Delete(Path.GetDirectoryName(projectA.AssetsFileOutputPath), recursive: true);
+
+                // Act
+                result = RunRestore(pathContext, _failureExitCode, "-LockedMode");
+
+                // Assert
+                Assert.Contains("NU1004:", result.Errors);
+                var logCodes = projectA.AssetsFile.LogMessages.Select(e => e.Code);
+                Assert.Contains(NuGetLogCode.NU1004, logCodes);
+                Assert.True(File.Exists(projectA.PropsOutput));
+                Assert.True(File.Exists(projectA.TargetsOutput));
+                Assert.True(File.Exists(projectA.CacheFileOutputPath));
+            }
+        }
+
         public static CommandRunnerResult RunRestore(SimpleTestPathContext pathContext, int expectedExitCode = 0, params string[] additionalArguments)
         {
             var nugetExe = Util.GetNuGetExePath();

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/RestoreCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/RestoreCommandTests.cs
@@ -291,6 +291,8 @@ namespace NuGet.CommandLine.FuncTest.Commands
 
                 // Assert
                 Assert.Contains("NU1004:", result.Errors);
+                var logCodes = projectA.AssetsFile.LogMessages.Select(e => e.Code);
+                Assert.Contains(NuGetLogCode.NU1004, logCodes);
             }
         }
 

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreLoggingTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreLoggingTests.cs
@@ -2128,6 +2128,8 @@ namespace NuGet.CommandLine.Test
                 // Assert
                 r.Success.Should().BeFalse();
                 r.AllOutput.Should().Contain("NU1004");
+                var logCodes = projectA.AssetsFile.LogMessages.Select(e => e.Code);
+                logCodes.Should().Contain(NuGetLogCode.NU1004);
             }
         }
     }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
@@ -8621,7 +8621,7 @@ namespace NuGet.CommandLine.Test
                 var lockFile = PackagesLockFileFormat.Read(projectA.NuGetLockFileOutputPath);
                 var lockFrameworks = lockFile.Targets.Select(t => t.TargetFramework.DotNetFrameworkName).Distinct().ToList();
                 _output.WriteLine($"PackageLockFrameworks First Evaluation: {string.Join(",", lockFrameworks)}");
-                lockFrameworkTransformed.ShouldBeEquivalentTo(lockFrameworks);
+                lockFrameworks.ShouldBeEquivalentTo(lockFrameworkTransformed);
 
                 // Setup - change frameworks
                 projectA.Properties.Add("RestoreLockedMode", "true");
@@ -8636,8 +8636,8 @@ namespace NuGet.CommandLine.Test
                 lockFile = PackagesLockFileFormat.Read(projectA.NuGetLockFileOutputPath);
                 lockFrameworks = lockFile.Targets.Select(t => t.TargetFramework.DotNetFrameworkName).Distinct().ToList();
                 _output.WriteLine($"PackageLockFrameworks Second Evaluation: {string.Join(",", lockFrameworks)}");
-                // The frameworks should not chnage in the lock file.
-                lockFrameworkTransformed.ShouldBeEquivalentTo(lockFrameworks);
+                // The frameworks should not change in the lock file.
+                lockFrameworks.ShouldBeEquivalentTo(lockFrameworkTransformed);
                 Assert.Contains("NU1004", r.Errors);
                 var logCodes = projectA.AssetsFile.LogMessages.Select(e => e.Code);
                 Assert.Contains(NuGetLogCode.NU1004, logCodes);

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
@@ -8581,6 +8581,8 @@ namespace NuGet.CommandLine.Test
                 // No change expected in the lock file.
                 intitialRuntimes.ShouldBeEquivalentTo(lockRuntimes);
                 Assert.Contains("NU1004", r.Errors);
+                var logCodes = projectA.AssetsFile.LogMessages.Select(e => e.Code);
+                Assert.Contains(NuGetLogCode.NU1004, logCodes);
             }
         }
 
@@ -8637,6 +8639,8 @@ namespace NuGet.CommandLine.Test
                 // The frameworks should not chnage in the lock file.
                 lockFrameworkTransformed.ShouldBeEquivalentTo(lockFrameworks);
                 Assert.Contains("NU1004", r.Errors);
+                var logCodes = projectA.AssetsFile.LogMessages.Select(e => e.Code);
+                Assert.Contains(NuGetLogCode.NU1004, logCodes);
             }
         }
 
@@ -8729,6 +8733,8 @@ namespace NuGet.CommandLine.Test
                 // Assert
                 r.Success.Should().BeFalse();
                 Assert.Contains("NU1004", r.Errors);
+                var logCodes = projectA.AssetsFile.LogMessages.Select(e => e.Code);
+                Assert.Contains(NuGetLogCode.NU1004, logCodes);
             }
         }
 
@@ -8829,6 +8835,8 @@ namespace NuGet.CommandLine.Test
                 // Assert
                 r.Success.Should().BeFalse();
                 Assert.Contains("NU1004", r.Errors);
+                var logCodes = projectA.AssetsFile.LogMessages.Select(e => e.Code);
+                Assert.Contains(NuGetLogCode.NU1004, logCodes);
             }
         }
 
@@ -8884,6 +8892,8 @@ namespace NuGet.CommandLine.Test
                 // Assert
                 r.Success.Should().BeFalse();
                 Assert.Contains("NU1004", r.Errors);
+                var logCodes = projectA.AssetsFile.LogMessages.Select(e => e.Code);
+                Assert.Contains(NuGetLogCode.NU1004, logCodes);
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
@@ -1396,7 +1396,7 @@ namespace NuGet.Commands.Test
             {
                 var projectName = "TestProject";
                 var projectPath = Path.Combine(pathContext.SolutionRoot, projectName);
-
+                var outputPath = Path.Combine(projectPath, "obj");
                 var dependencyBar = new LibraryDependency(new LibraryRange("bar", VersionRange.Parse("3.0.0"), LibraryDependencyTarget.All),
                         LibraryDependencyType.Default,
                         LibraryIncludeFlags.All,
@@ -1418,6 +1418,7 @@ namespace NuGet.Commands.Test
                     ProjectUniqueName = projectName,
                     CentralPackageVersionsEnabled = true,
                     ProjectStyle = ProjectStyle.PackageReference,
+                    OutputPath = outputPath,
                 };
                 packageSpec.FilePath = projectPath;
 
@@ -1455,7 +1456,7 @@ namespace NuGet.Commands.Test
             {
                 var projectName = "TestProject";
                 var projectPath = Path.Combine(pathContext.SolutionRoot, projectName);
-
+                var outputPath = Path.Combine(projectPath, "obj");
                 var dependencyBar = new LibraryDependency(new LibraryRange(autoreferencedpackageId, VersionRange.Parse("3.0.0"), LibraryDependencyTarget.All),
                LibraryDependencyType.Default,
                LibraryIncludeFlags.All,
@@ -1477,6 +1478,7 @@ namespace NuGet.Commands.Test
                     ProjectUniqueName = projectName,
                     CentralPackageVersionsEnabled = true,
                     ProjectStyle = ProjectStyle.PackageReference,
+                    OutputPath = outputPath,
                 };
                 packageSpec.FilePath = projectPath;
 
@@ -1721,7 +1723,7 @@ namespace NuGet.Commands.Test
             {
                 var projectName = "TestProject";
                 var projectPath = Path.Combine(pathContext.SolutionRoot, projectName);
-
+                var outputPath = Path.Combine(projectPath, "obj");
                 // Package Bar does not have a corresponding PackageVersion 
                 var packageRefDependecyFoo = new LibraryDependency()
                 {
@@ -1740,6 +1742,7 @@ namespace NuGet.Commands.Test
                     ProjectUniqueName = projectName,
                     CentralPackageVersionsEnabled = true,
                     ProjectStyle = ProjectStyle.PackageReference,
+                    OutputPath = outputPath,
                 };
                 packageSpec.FilePath = projectPath;
 
@@ -1778,7 +1781,7 @@ namespace NuGet.Commands.Test
             {
                 var projectName = "TestProject";
                 var projectPath = Path.Combine(pathContext.SolutionRoot, projectName);
-
+                var outputPath = Path.Combine(projectPath, "obj");
                 // Package Bar does not have a corresponding PackageVersion 
                 var packageRefDependecyBar = new LibraryDependency()
                 {
@@ -1797,6 +1800,7 @@ namespace NuGet.Commands.Test
                     ProjectUniqueName = projectName,
                     CentralPackageVersionsEnabled = true,
                     ProjectStyle = ProjectStyle.PackageReference,
+                    OutputPath = outputPath,
                 };
                 packageSpec.FilePath = projectPath;
 


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/8973
Regression: No 
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: 

The restore command collects warnings and errors using a `CollectorLogger` that's initialized from the logger passed in to the restore command. 
https://github.com/NuGet/NuGet.Client/blob/85f17f0525048c36cdd080324019729884b1d998/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs#L91-L95

When restore fails/succeeds and the assets file is generated, the collector logger is inspected to generated the correct warnings/errors. All warnings and errors are written to the assets file.

NU1004 was incorrectly using the non collector logger so those errors were never considered. 
Furthermore when NU1004 was raised, the old assets file was provided to the result, thus one that would not contain the log messages. 

## Testing/Validation

Tests Added: Yes 
Reason for not adding tests:  
Validation:  
