### PR TITLE
VS nomination errors should create an assets file with the error message

### DIFF
--- a/docs/nuget-project-types.md
+++ b/docs/nuget-project-types.md
@@ -1,0 +1,79 @@
+# NuGet Project Types
+
+NuGet's primary use-case is restoring packages for a project, hence an abstraction for projects is an important part of the software architecture. Especially for features which can install, upgrade, or uninstall packages.
+
+Using Visual Studio's "find implementations" feature and then quickly checking each class to determine the inheritance hierarchy, these are the classes that implement `NuGetProject`:
+
+* [NuGetProject](#nugetproject)
+  * [BuildIntegratedNuGetProject](#buildintegratednugetproject)
+    * [CpsPackageReferenceProject](#cpspackagereferenceproject)
+    * [LegacyPackageReferenceProject](#legacypackagereferenceproject)
+  * [FolderNuGetProject](#foldernugetproject)
+    * [InstallCommandProject](#installcommandproject)
+  * [MSBuildNuGetProject](#msbuildnugetproject)
+    * [VsMSBuildNuGetProject](#vsmsbuildnugetproject)
+  * [PackagesConfigNuGetProject](#packagesconfignugetproject)
+  * [ProjectJsonNuGetProject](#projectjsonnugetproject)
+    * [VsProjectJsonNuGetProject](#vsprojectjsonnugetproject)
+
+These classes are implemented in `NuGet.PackageManagement`, `NuGet.PackageManagement.VisualStudio`, with a special mention that `InstallCommandProject` is implemented in `NuGet.CommandLine`.
+
+## Visual Studio architecture
+
+In Visual Studio, only the project system is supposed to interact with the project file and MSBuild, and other components (such as NuGet) should communicate with the project system itself. This means when NuGet needs to write changes (package was installed, upgraded, or uninstalled), NuGet needs to call APIs on the project system to have changes made to the project file.
+
+For reading package information, there are two different designs, a pull and a push model. The push model is used only by `CpsPackageReferenceProject`. The pull model is used by all other Visual Studio `NuGetProject` implementations.
+
+The pull model means that when `GetInstalledPackagesAsync` is called, NuGet will call APIs on the project system. Since NuGet has no way of knowing when the project system has changed, NuGet does not cache this information, and the project system will be called every time `GetInstalledPackagesAsync` is called. Since a project system is typically exposed over COM, rather than being a direct .NET managed object reference, this means that all calls to the project system must be on the main (UI) thread.  Therefore, NuGet cannot query multiple projects in parallel, and if the UI thread is being used by any other VS component, it increases latency of the result.
+
+The push model used by `CpsPackageReferenceProject` means that when the project is loaded, or any time that the CPS project has any change it thinks may be relevant to NuGet, they call NuGet's `IVsSolutionResolveService`'s `NominateProjectAsync` method. You may hear NuGet or CPS/dotnet project system team members talk about project nomination. This is what it's about. This project nomination is how NuGet learns what target frameworks the project is targeting, and what PackageReference, PackageDownload, FrameworkReference and other properties, are defined. NuGet caches this nomination data in its `VsProjectSystemCache` class, and when NuGet APIs like `GetInstalledPackagesAsync` or `GetPackageSpecsAndAdditionalMessagesAsync` is called, NuGet uses the information in the cache.
+
+## Project summaries
+
+### BuildIntegratedNuGetProject
+
+This class was introduced for `project.json`, which was the project format for preview versions of .NET Core 1.0, and then adapted when .NET Core returned to MSBuild `csproj` files (although with much simplified content). The name Build Integrated represents that this is the first time that restore is naturally part of the build system, unlike `packages.config`.
+
+### CpsPackageReferenceProject
+
+The [Common Project System (CPS)](https://github.com/microsoft/VSProjectSystem) is a new framework to build Visual Studio project systems, that simplifies the process compared to the previous sample. It is what the SDK style .NET project system is based on, hence this project system is typically only used for SDK style .NET projects.
+
+It is the only project system to use the push model, described above. Additionally, the NuGet and .NET Project System teams have an agreement that NuGet will not log restore messages to Visual Studio's Error List window. Instead, NuGet must write all messages to the `project.assets.json` file, and the project system will replay the messages in Visual Studio's Error List window. Hence, even in catastrophic failures where NuGet is unable to perform a restore (such as nomination data is invalid), NuGet must still generate a `project.assets.json` file, just to report the errors.
+
+### FolderNuGetProject
+
+This is not actually a project type, but represents a folder/directory where packages are extracted, such as the global packages directory or solution packages directory. I'm not sure why it extends `NuGetProject`, as it violates the [is-a design guideline for object oriented design](https://en.wikipedia.org/wiki/Is-a). My best guess is because `NuGetProject` has a `InstallPackageAsync` and `DeletePackageAsync` method, which are actions that `FolderNuGetProject` need to implement, despite the fact it's not actually a project.
+
+### InstallCommandProject
+
+This project class is implemented in `NuGet.CommandLine`, which is the project for `nuget.exe`. `nuget.exe` supports running `nuget.exe install <package_id>` which will treat the current folder as a `FolderNuGetProject`, and then install (extract) the requested package into it. I'm not sure how its behavior differs from `FolderNuGetProject`.
+
+### LegacyPackageReferenceProject
+
+Although `PackageReference` was added to support .NET Core and the new project format that it introduced, from an MSBuild point of view, the new and old project styles are indistinguishable. Therefore, `PackageReference` could be brought to the older project format with a significant amount of code reuse, and it was implemented. Unlike `CpsPackageReferenceProject`, this project type uses the pull model. Additionally, the project system itself is written in C++, so NuGet sees it via .NET's COM interop. As a result, all interactions between the project system and NuGet must happen on the main (UI) thread.
+
+This project type is typically used by non-SDK style .NET projects that use `PackageReference`, rather than `packages.config`.
+
+### MSBuildNuGetProject
+
+This is the project type that represents a project that supports NuGet, but either uses `packages.config`, or does not have any packages installed and has not explicitly opt into `PackageReference` restore style. It's typically used by non-SDK style .NET projects, but is sometimes also used by packaging projects like Service Fabric or WiX that pretend to support .NET only so MSBuild's project references work.
+
+### NuGetProject
+
+This is the base, abstract type used by all the project implementations. It has some shared code, and defines the abstract/virtual methods that other projects need to implement.
+
+### PackagesConfigNuGetProject
+
+This represents a `packages.config` file itself, not the project that uses `packages.config`. I'm not sure why it extends `NuGetProject`, as it violates the [is-a design guideline for object oriented design](https://en.wikipedia.org/wiki/Is-a). My best guess is because `NuGetProject` has a `InstallPackageAsync` and `DeletePackageAsync` method, which are actions that `PackagesConfigNuGetProject` need to implement, despite the fact it's not actually a project.
+
+### ProjectJsonNuGetProject
+
+In early .NET Core development, the ASP.NET team experimented with replacing the long and complicated MSBuild XML project file with a simplified JSON project file, `project.json`. This is basically what NuGet's `PackageSpec` represents, used by all `PackageReference` via `DependencyGraphSpec` and the `project.assets.json` file. In order to support solution actions like restore and build, the ASP.NET team had to introduce an MSBuild file, and they used the `xproj` file extension
+
+### VsMSBuildNuGetProject
+
+As described in the above [Visual Studio architecture](#visual-studio-architecture) section, components in Visual Studio should not read/write the project file directly, but should go through the appropriate Visual Studio project system. Therefore, NuGet needs to have references to project system packages/assemblies. Since `NuGet.CommandLine` (`nuget.nexe`) references `FolderNuGetProject` and therefore `NuGet.PackageManagement`, `NuGet.PackageManagement` had to remove all the VS specific code and use OO polymorphism to delegate all this Visual Studio specific code to another class in a different project/assembly. Hence, `VsMSBuildNuGetProject` is the implementation of [`MSBuildNuGetProject`](#msbuildnugetproject)'s Visual Studio project system communication.
+
+### VsProjectJsonNuGetProject
+
+See the description for [`VsMSBuildNuGetProject`](#vsmsbuildnugetproject). This class is the Visual Studio communication code for `ProjectJsonNuGetProject`.

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
@@ -169,7 +169,7 @@ namespace NuGet.SolutionRestoreManager
                 catch (Exception e)
                 {
                     var restoreLogMessage = RestoreLogMessage.CreateError(NuGetLogCode.NU1105, string.Format(Resources.NU1105, projectNames.ShortName, e.Message));
-                    restoreLogMessage.LibraryId = projectUniqueName;
+                    restoreLogMessage.ProjectPath = projectUniqueName;
 
                     nominationErrors = new List<IAssetsLogMessage>()
                     {
@@ -305,14 +305,16 @@ namespace NuGet.SolutionRestoreManager
                     msbuildProjectExtensionsPath));
         }
 
-        private static DependencyGraphSpec CreateMinimalDependencyGraphSpec(string projectPath, string outputPath)
+        internal static DependencyGraphSpec CreateMinimalDependencyGraphSpec(string projectPath, string outputPath)
         {
             var packageSpec = new PackageSpec();
             packageSpec.FilePath = projectPath;
             packageSpec.RestoreMetadata = new ProjectRestoreMetadata();
             packageSpec.RestoreMetadata.ProjectUniqueName = projectPath;
             packageSpec.RestoreMetadata.ProjectStyle = ProjectStyle.PackageReference;
+            packageSpec.RestoreMetadata.ProjectPath = projectPath;
             packageSpec.RestoreMetadata.OutputPath = outputPath;
+            packageSpec.RestoreMetadata.CacheFilePath = Path.Combine(outputPath, "project.nuget.cache");
 
             var dgSpec = new DependencyGraphSpec();
             dgSpec.AddProject(packageSpec);

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsSolutionRestoreServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsSolutionRestoreServiceTests.cs
@@ -21,6 +21,7 @@ using NuGet.ProjectManagement;
 using NuGet.ProjectModel;
 using NuGet.Test.Utility;
 using NuGet.VisualStudio;
+using Test.Utility.ProjectManagement;
 using Xunit;
 using static NuGet.Frameworks.FrameworkConstants;
 
@@ -2108,6 +2109,39 @@ namespace NuGet.SolutionRestoreManager.Test
             Assert.Equal("tfm1", targetFrameworkInfo.TargetAlias);
             targetFrameworkInfo = Assert.Single(result.TargetFrameworks, tf => tf.FrameworkName == CommonFrameworks.NetStandard21);
             Assert.Equal("tfm2", targetFrameworkInfo.TargetAlias);
+        }
+
+        // In VS, when a PackageReference CPS (SDK style) project gets loaded, the project system needs to send us a nomination.
+        // We then parse/transform that nomination input into a DependencyGraphSpec. If there's any problem, we need to display a message.
+        // However, the "contract" is that NuGet only ever writes errors for CPS projects to the assets file, and CPS will read the assets
+        // file and replay the errors in Visual Studio's Error List. Therefore, in VS, we must generate an assets file, even when there's
+        // a nomination error. We do this by creating a minimal DependencyGraphSpec, and do a normal restore with it. This is the only
+        // production code that needs to create the minimal DGSpec, hence the method to create the minimal DGSpec is in our VS assembly.
+        //
+        // For testing, we want to be able to test the minimal DGSpec in NuGet.Commands.Test and NuGet.PackageManagement.Test. There are a
+        // few problems here. First, NuGet.SolutionRestoreManager.dll is only net472, but NuGet.Commands.Test and NuGet.PackageManagement.Test
+        // also target netstandard and net5. Additionally, NuGet.Commands is part of the NuGet SDK, meaning it only uses other NuGet SDK projects
+        // and I don't want to add CreateMinimalDependencyGraphSpec to the public API.
+        //
+        // Therefore, what I've done is duplicated the method, once in NuGet.SolutionRestoreManagement, once in Test.Utilities. This test
+        // makes sure the implementations are the same, so if someone modifies some restore code and the minimum DGSpec grows, they will
+        // naturally change the Test.Utilities copy of the method as tests that use that will fail. This test will make sure they update the
+        // NuGet.SolutionRestoreManager copy as well.
+        [Fact]
+        public void CreateMinimalDependencyGraphSpec_ComparedToTestUtility_AreEqual()
+        {
+            // Arrange
+            var projectPath = @"c:\src\project\project.csproj";
+            var outputPath = @"c:\src\project\obj";
+
+            var productionMinimalDGSpec = VsSolutionRestoreService.CreateMinimalDependencyGraphSpec(projectPath, outputPath);
+            var testMinimalDGSpec = DependencyGraphSpecTestUtilities.CreateMinimalDependencyGraphSpec(projectPath, outputPath);
+
+            var prodJson = Newtonsoft.Json.JsonConvert.SerializeObject(productionMinimalDGSpec);
+            var testJson = Newtonsoft.Json.JsonConvert.SerializeObject(testMinimalDGSpec);
+
+            // Act/Assert
+            Assert.Equal(prodJson, testJson);
         }
 
         private delegate void TryGetProjectNamesCallback(string projectPath, out ProjectNames projectNames);

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsSolutionRestoreServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsSolutionRestoreServiceTests.cs
@@ -2131,14 +2131,14 @@ namespace NuGet.SolutionRestoreManager.Test
         public void CreateMinimalDependencyGraphSpec_ComparedToTestUtility_AreEqual()
         {
             // Arrange
-            var projectPath = @"c:\src\project\project.csproj";
-            var outputPath = @"c:\src\project\obj";
+            const string projectPath = @"c:\src\project\project.csproj";
+            const string outputPath = @"c:\src\project\obj";
 
-            var productionMinimalDGSpec = VsSolutionRestoreService.CreateMinimalDependencyGraphSpec(projectPath, outputPath);
-            var testMinimalDGSpec = DependencyGraphSpecTestUtilities.CreateMinimalDependencyGraphSpec(projectPath, outputPath);
+            DependencyGraphSpec productionMinimalDGSpec = VsSolutionRestoreService.CreateMinimalDependencyGraphSpec(projectPath, outputPath);
+            DependencyGraphSpec testMinimalDGSpec = DependencyGraphSpecTestUtilities.CreateMinimalDependencyGraphSpec(projectPath, outputPath);
 
-            var prodJson = Newtonsoft.Json.JsonConvert.SerializeObject(productionMinimalDGSpec);
-            var testJson = Newtonsoft.Json.JsonConvert.SerializeObject(testMinimalDGSpec);
+            string prodJson = Newtonsoft.Json.JsonConvert.SerializeObject(productionMinimalDGSpec);
+            string testJson = Newtonsoft.Json.JsonConvert.SerializeObject(testMinimalDGSpec);
 
             // Act/Assert
             Assert.Equal(prodJson, testJson);

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
@@ -22,6 +22,7 @@ using NuGet.Protocol.Core.Types;
 using NuGet.Test.Utility;
 using NuGet.Versioning;
 using Test.Utility;
+using Test.Utility.ProjectManagement;
 using Test.Utility.Signing;
 using Xunit;
 
@@ -1364,7 +1365,7 @@ namespace NuGet.Commands.Test
                 project1.Create();
                 sources.Add(new PackageSource(packageSource.FullName));
 
-                var dgspec1 = CreateMinimalDependencyGraphSpec(Path.Combine(project1.FullName, "project1.csproj"), project1Obj.FullName);
+                var dgspec1 = DependencyGraphSpecTestUtilities.CreateMinimalDependencyGraphSpec(Path.Combine(project1.FullName, "project1.csproj"), project1Obj.FullName);
                 var spec1 = dgspec1.Projects[0];
 
                 var logger = new TestLogger();
@@ -2031,21 +2032,6 @@ namespace NuGet.Commands.Test
             };
 
             return walker.WalkAsync(range, framework, runtimeIdentifier: null, runtimeGraph: null, recursive: true);
-        }
-
-        private static DependencyGraphSpec CreateMinimalDependencyGraphSpec(string projectPath, string outputPath)
-        {
-            var packageSpec = new PackageSpec();
-            packageSpec.FilePath = projectPath;
-            packageSpec.RestoreMetadata = new ProjectRestoreMetadata();
-            packageSpec.RestoreMetadata.ProjectUniqueName = projectPath;
-            packageSpec.RestoreMetadata.ProjectStyle = ProjectStyle.PackageReference;
-            packageSpec.RestoreMetadata.OutputPath = outputPath;
-            packageSpec.RestoreMetadata.CacheFilePath = Path.Combine(outputPath, "project.nuget.cache");
-            var dgSpec = new DependencyGraphSpec();
-            dgSpec.AddProject(packageSpec);
-
-            return dgSpec;
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegration/DependencyGraphRestoreUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegration/DependencyGraphRestoreUtilityTests.cs
@@ -133,8 +133,8 @@ namespace NuGet.PackageManagement.Test
                 // Assert
                 var assetsFilePath = Path.Combine(objFolder.FullName, "project.assets.json");
                 Assert.True(File.Exists(assetsFilePath), "Assets file does not exist");
-                var assetsFile = new LockFileFormat().Read(assetsFilePath);
-                var actualMessage = Assert.Single(assetsFile.LogMessages);
+                LockFile assetsFile = new LockFileFormat().Read(assetsFilePath);
+                IAssetsLogMessage actualMessage = Assert.Single(assetsFile.LogMessages);
                 Assert.Equal(restoreLogMessage.Level, actualMessage.Level);
                 Assert.Equal(restoreLogMessage.Code, actualMessage.Code);
                 Assert.Equal(restoreLogMessage.Message, actualMessage.Message);

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegration/DependencyGraphRestoreUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegration/DependencyGraphRestoreUtilityTests.cs
@@ -6,14 +6,18 @@ using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using Moq;
 using NuGet.Commands;
+using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Frameworks;
 using NuGet.ProjectManagement;
+using NuGet.ProjectModel;
 using NuGet.Protocol.Core.Types;
 using NuGet.Protocol.VisualStudio;
 using NuGet.Test.Utility;
 using Test.Utility;
+using Test.Utility.ProjectManagement;
 using Xunit;
 
 namespace NuGet.PackageManagement.Test
@@ -71,6 +75,69 @@ namespace NuGet.PackageManagement.Test
                     Assert.Equal(0, logger.Errors);
                     Assert.Equal(0, logger.Warnings);
                 }
+            }
+        }
+
+        [Fact]
+        public async Task RestoreAsync_WithMinimalProjectAndAdditionalErrorMessage_WritesErrorsToAssetsFile()
+        {
+            // Arrange
+            var projectName = "testproj";
+            var logger = new TestLogger();
+
+            using (var rootFolder = TestDirectory.Create())
+            {
+                var projectFolder = new DirectoryInfo(Path.Combine(rootFolder, projectName));
+                projectFolder.Create();
+                var objFolder = projectFolder.CreateSubdirectory("obj");
+                var msbuildProjectPath = new FileInfo(Path.Combine(projectFolder.FullName, $"{projectName}.csproj"));
+                var globalPackagesFolder = Path.Combine(rootFolder, "gpf");
+
+                var sources = new SourceRepository[0];
+                var restoreContext = new DependencyGraphCacheContext(logger, NullSettings.Instance);
+                var solutionManager = new Mock<ISolutionManager>();
+                var restoreCommandProvidersCache = new RestoreCommandProvidersCache();
+
+                // When a VS nomination results in an exception, we use this minimal DGSpec to do a restore.
+                var dgSpec = DependencyGraphSpecTestUtilities.CreateMinimalDependencyGraphSpec(msbuildProjectPath.FullName, objFolder.FullName);
+                dgSpec.AddRestore(dgSpec.Projects[0].FilePath);
+                // CpsPackageReferenceProject sets some additional properties, from settings, in GetPackageSpecsAndAdditionalMessages(...)
+                dgSpec.Projects[0].RestoreMetadata.PackagesPath = globalPackagesFolder;
+
+                // Having an "additional" error message is also critical
+                var restoreLogMessage = new RestoreLogMessage(LogLevel.Error, NuGetLogCode.NU1000, "Test error")
+                {
+                    FilePath = msbuildProjectPath.FullName,
+                    ProjectPath = msbuildProjectPath.FullName
+                };
+                var additionalMessages = new List<IAssetsLogMessage>()
+                {
+                    AssetsLogMessage.Create(restoreLogMessage)
+                };
+
+                // Act
+                await DependencyGraphRestoreUtility.RestoreAsync(
+                    solutionManager.Object,
+                    dgSpec,
+                    restoreContext,
+                    restoreCommandProvidersCache,
+                    cacheContextModifier: _ => { },
+                    sources,
+                    parentId: Guid.Empty,
+                    forceRestore: false,
+                    isRestoreOriginalAction: true,
+                    additionalMessages,
+                    logger,
+                    CancellationToken.None);
+
+                // Assert
+                var assetsFilePath = Path.Combine(objFolder.FullName, "project.assets.json");
+                Assert.True(File.Exists(assetsFilePath), "Assets file does not exist");
+                var assetsFile = new LockFileFormat().Read(assetsFilePath);
+                var actualMessage = Assert.Single(assetsFile.LogMessages);
+                Assert.Equal(restoreLogMessage.Level, actualMessage.Level);
+                Assert.Equal(restoreLogMessage.Code, actualMessage.Code);
+                Assert.Equal(restoreLogMessage.Message, actualMessage.Message);
             }
         }
     }

--- a/test/TestUtilities/Test.Utility/ProjectManagement/DependencyGraphSpecTestUtilities.cs
+++ b/test/TestUtilities/Test.Utility/ProjectManagement/DependencyGraphSpecTestUtilities.cs
@@ -1,0 +1,28 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO;
+using NuGet.ProjectModel;
+
+namespace Test.Utility.ProjectManagement
+{
+    public static class DependencyGraphSpecTestUtilities
+    {
+        public static DependencyGraphSpec CreateMinimalDependencyGraphSpec(string projectPath, string outputPath)
+        {
+            var packageSpec = new PackageSpec();
+            packageSpec.FilePath = projectPath;
+            packageSpec.RestoreMetadata = new ProjectRestoreMetadata();
+            packageSpec.RestoreMetadata.ProjectUniqueName = projectPath;
+            packageSpec.RestoreMetadata.ProjectStyle = ProjectStyle.PackageReference;
+            packageSpec.RestoreMetadata.ProjectPath = projectPath;
+            packageSpec.RestoreMetadata.OutputPath = outputPath;
+            packageSpec.RestoreMetadata.CacheFilePath = Path.Combine(outputPath, "project.nuget.cache");
+
+            var dgSpec = new DependencyGraphSpec();
+            dgSpec.AddProject(packageSpec);
+
+            return dgSpec;
+        }
+    }
+}


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/10406
Regression: It's complicated. We thought we fixed this 9 months ago, so yes. But that fix probably never worked, so no.
* Last working version:   
* How are we preventing it in future:   more tests, will ask test vendors to occasionally test manually as well.

## Fix

Details: When VsSolutionRestoreService creates the "additional messages", it needs to set the `ProjectPath` property to the project file's full path.

## Testing/Validation

Tests Added: Yes
Reason for not adding tests:  
Validation:  
