### PR TITLE
Skip UninstallPackageFromUI flaky test

### DIFF
--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetUITestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetUITestCase.cs
@@ -94,7 +94,7 @@ namespace NuGet.Tests.Apex
             CommonUtility.AssertPackageInPackagesConfig(VisualStudio, nuProject, "newtonsoft.json", "9.0.1", XunitLogger);
         }
 
-        [StaFact]
+        [StaFact(Skip = "https://github.com/NuGet/Home/issues/10412")]
         public void UninstallPackageFromUI()
         {
             // Arrange


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/10413
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: The test in question is *extremely* flaky, fails more often than it passes on the private CI, and it's happening on many different branches.
![flakytest](https://user-images.githubusercontent.com/2878341/103028889-7c770b80-450d-11eb-9d89-9f9a336bfc24.png)

## Testing/Validation

Tests Added: No  
Reason for not adding tests: Infra  
Validation:  
