### PR TITLE
When PackageReference references Packages.Config, ignore compat check during lock file up to date checks 

### DIFF
--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileUtilities.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileUtilities.cs
@@ -172,6 +172,13 @@ namespace NuGet.ProjectModel
                             // The package spec not found in the dg spec. This could mean that the project does not exist anymore.
                             if (p2pSpec != null)
                             {
+                                if(p2pSpec.RestoreMetadata.ProjectStyle != ProjectStyle.PackageReference)
+                                {
+                                    // Skip compat check and dependency check for non PR projects.
+                                    // Projects that are not PR do not undergo compat checks and do not contribute anything transitively.
+                                    continue;
+                                }
+
                                 // This does not consider ATF.
                                 var p2pSpecTargetFrameworkInformation = NuGetFrameworkUtility.GetNearest(p2pSpec.TargetFrameworks, framework.FrameworkName, e => e.FrameworkName);
 

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileUtilities.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileUtilities.cs
@@ -172,16 +172,18 @@ namespace NuGet.ProjectModel
                             // The package spec not found in the dg spec. This could mean that the project does not exist anymore.
                             if (p2pSpec != null)
                             {
-                                if(p2pSpec.RestoreMetadata.ProjectStyle != ProjectStyle.PackageReference)
+                                TargetFrameworkInformation p2pSpecTargetFrameworkInformation = default;
+                                if (p2pSpec.RestoreMetadata.ProjectStyle == ProjectStyle.PackagesConfig || p2pSpec.RestoreMetadata.ProjectStyle == ProjectStyle.Unknown)
                                 {
                                     // Skip compat check and dependency check for non PR projects.
-                                    // Projects that are not PR do not undergo compat checks and do not contribute anything transitively.
-                                    continue;
+                                    // Projects that are not PR do not undergo compat checks by NuGet and do not contribute anything transitively.
+                                    p2pSpecTargetFrameworkInformation = p2pSpec.TargetFrameworks.FirstOrDefault();
                                 }
-
-                                // This does not consider ATF.
-                                var p2pSpecTargetFrameworkInformation = NuGetFrameworkUtility.GetNearest(p2pSpec.TargetFrameworks, framework.FrameworkName, e => e.FrameworkName);
-
+                                else
+                                {
+                                    // This does not consider ATF.
+                                    p2pSpecTargetFrameworkInformation = NuGetFrameworkUtility.GetNearest(p2pSpec.TargetFrameworks, framework.FrameworkName, e => e.FrameworkName);
+                                }
                                 // No compatible framework found
                                 if (p2pSpecTargetFrameworkInformation != null)
                                 {

--- a/test/TestUtilities/Test.Utility/Commands/ProjectJsonTestHelpers.cs
+++ b/test/TestUtilities/Test.Utility/Commands/ProjectJsonTestHelpers.cs
@@ -194,6 +194,31 @@ namespace NuGet.Commands.Test
             return updated;
         }
 
+        public static PackageSpec WithPackagesConfigRestoreMetadata(this PackageSpec spec)
+        {
+            var updated = spec.Clone();
+            var packageSpecFile = new FileInfo(spec.FilePath);
+            var projectDir = packageSpecFile.Directory.FullName;
+
+            var projectPath = Path.Combine(projectDir, spec.Name + ".csproj");
+            updated.FilePath = projectPath;
+
+            updated.RestoreMetadata = new PackagesConfigProjectRestoreMetadata();
+            updated.RestoreMetadata.OutputPath = projectDir;
+            updated.RestoreMetadata.ProjectStyle = ProjectStyle.PackagesConfig;
+            updated.RestoreMetadata.ProjectName = spec.Name;
+            updated.RestoreMetadata.ProjectUniqueName = projectPath;
+            updated.RestoreMetadata.ProjectPath = projectPath;
+            updated.RestoreMetadata.ConfigFilePaths = new List<string>();
+            (updated.RestoreMetadata as PackagesConfigProjectRestoreMetadata).PackagesConfigPath = Path.GetFullPath(Path.Combine(projectDir, "../packages"));
+
+            foreach (var framework in updated.TargetFrameworks)
+            {
+                updated.RestoreMetadata.TargetFrameworks.Add(new ProjectRestoreMetadataFrameworkInfo(framework.FrameworkName));
+            }
+            return updated;
+        }
+
         public static PackageSpec GetPackageSpec(string projectName, string rootPath = @"C:\", string framework = "net5.0")
         {
             const string referenceSpec = @"
@@ -210,6 +235,22 @@ namespace NuGet.Commands.Test
             var packageSpec = JsonPackageSpecReader.GetPackageSpec(spec, projectName, Path.Combine(rootPath, projectName, projectName)).WithTestRestoreMetadata();
             packageSpec.RestoreSettings.HideWarningsAndErrors = true; // Pretend this is running in VS and this is a .NET Core project.
             return packageSpec;
+        }
+
+        public static PackageSpec GetPackagesConfigPackageSpec(string projectName, string rootPath = @"C:\", string framework = "net472")
+        {
+            const string referenceSpec = @"
+                {
+                    ""frameworks"": {
+                        ""TARGET_FRAMEWORK"": {
+                            ""dependencies"": {
+                            }
+                        }
+                    }
+                }";
+
+            var spec = referenceSpec.Replace("TARGET_FRAMEWORK", framework);
+            return JsonPackageSpecReader.GetPackageSpec(spec, projectName, Path.Combine(rootPath, projectName, projectName)).WithPackagesConfigRestoreMetadata();
         }
     }
 }


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9623
Regression: Yes? But not really? Earlier versions of the tooling *incorrectly* suggested the project is locked.  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: 

When a PR project references a PR project, NuGet ensures compatibility to discover transitively flowing dependencies. 
When a PR project references a PC project, NuGet does not do any compat checks. 

The lock file logic falsely performed compat checks in these mixed projects.


## Testing/Validation

Tests Added: Yes  
Reason for not adding tests:  
Validation:  Manual, repros from the issue + automation.
