### PR TITLE
Move SolutionView and ProjectView click handlers

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/DetailControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/DetailControl.xaml
@@ -129,8 +129,7 @@
       <nuget:ProjectView
         Grid.Row="1"
         Margin="0,8"
-        InstallButtonClicked="ProjectInstallButtonClicked"
-        UninstallButtonClicked="ProjectUninstallButtonClicked"
+        x:Name="_projectView"
         Visibility="{Binding Path=IsSolution, Converter={StaticResource InvertedBooleanToVisibilityConverter}}" />
 
       <!-- solution view when in solution package manager -->
@@ -139,8 +138,6 @@
         x:Name="_solutionView"
         Grid.Row="1"
         Margin="0,8"
-        InstallButtonClicked="SolutionInstallButtonClicked"
-        UninstallButtonClicked="SolutionUninstallButtonClicked"
         Visibility="{Binding Path=IsSolution,Converter={StaticResource BooleanToVisibilityConverter}}" />
 
       <!-- the splitter is shown when in solution package manager -->

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/DetailControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/DetailControl.xaml.cs
@@ -26,7 +26,32 @@ namespace NuGet.PackageManagement.UI
 
         private void PackageSolutionDetailControl_DataContextChanged(object sender, DependencyPropertyChangedEventArgs e)
         {
-            _root.Visibility = DataContext is DetailControlModel ? Visibility.Visible : Visibility.Collapsed;
+            var dataContext = DataContext as DetailControlModel;
+
+            if (dataContext == null)
+            {
+                _root.Visibility = Visibility.Collapsed;
+                return;
+            }
+
+            _root.Visibility = Visibility.Visible;
+
+            if (dataContext.IsSolution)
+            {
+                _solutionView.InstallButtonClicked += SolutionInstallButtonClicked;
+                _solutionView.UninstallButtonClicked += SolutionUninstallButtonClicked;
+
+                _projectView.InstallButtonClicked -= ProjectInstallButtonClicked;
+                _projectView.UninstallButtonClicked -= ProjectUninstallButtonClicked;
+            }
+            else
+            {
+                _projectView.InstallButtonClicked += ProjectInstallButtonClicked;
+                _projectView.UninstallButtonClicked += ProjectUninstallButtonClicked;
+
+                _solutionView.InstallButtonClicked -= SolutionInstallButtonClicked;
+                _solutionView.UninstallButtonClicked -= SolutionUninstallButtonClicked;
+            }
         }
 
         private void ExecuteOpenLicenseLink(object sender, ExecutedRoutedEventArgs e)


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/10416
Regression: Yes  
* Last working version:  I believe this regressed 
On 9/14/2020, this CreateAsync was added which creates a PackageManagerControl, which calls InitializeComponent
https://github.com/NuGet/NuGet.Client/blob/dev/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs#L81
* How are we preventing it in future:   Great question. Not sure this type of problem gets exposed until you debug an Experimental VS and realize it's not a transient issue.

## Fix

Details: https://github.com/NuGet/Home/issues/10416

I found the line of XAML generated code where these event handlers get hooked up. I have no idea how it's happening (maybe it's a XAML bug?), but it always tries to cast to a ProjectView before adding the click event handlers. 
So, I'm simply making it conditional logic in code-behind.

I do not think the DataContextChanged event is necessary. In my testing, I never saw it change the context and use the -= logic.
However, I am just refactoring what we have, and trying to keep this event complete for now.
MVVM refactoring will likely obliterate this code. 

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  This is only a refactoring of an event handler hookup.
Validation:  Opened Project PMUI and Solution PMUI. Repeated multiple times.
On another branch where I'm debugging actively, I've cherry-picked this change . If I ever see the exception, I'll abort this PR...
