### PR TITLE
Fix crash for passwords starting with '@' for Issue #7707

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Common/CommandLineResponseFile.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Common/CommandLineResponseFile.cs
@@ -1,6 +1,7 @@
 #if IS_DESKTOP
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
@@ -40,11 +41,20 @@ namespace NuGet.Common
 
             const int MaxRecursionDepth = 3;
             var parsedArgs = new List<string>();
+            string previousArg = "";
             foreach (var arg in args)
             {
                 if (string.IsNullOrWhiteSpace(arg) || !arg.StartsWith("@", StringComparison.InvariantCultureIgnoreCase))
                 {
+                    previousArg = arg;
                     parsedArgs.Add(arg);
+                    continue;
+                }
+
+                if (previousArg.ToLower(CultureInfo.CurrentCulture).Contains("password"))
+                {
+                    parsedArgs.Add(arg);
+                    previousArg = arg;
                     continue;
                 }
 

--- a/src/NuGet.Clients/NuGet.CommandLine/Common/CommandLineResponseFile.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Common/CommandLineResponseFile.cs
@@ -65,7 +65,7 @@ namespace NuGet.Common
 
                 if (!File.Exists(responseFilePath))
                 {
-                    throw new ArgumentException(string.Format(LocalizedResourceManager.GetString("Error_ResponseFileDoesNotExist")), arg);
+                    throw new ArgumentException(string.Format(LocalizedResourceManager.GetString("Error_ResponseFileDoesNotExist"), arg));
                 }
 
                 var fileInfo = new FileInfo(responseFilePath);

--- a/src/NuGet.Clients/NuGet.CommandLine/Common/CommandLineResponseFile.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Common/CommandLineResponseFile.cs
@@ -65,7 +65,11 @@ namespace NuGet.Common
 
                 if (!File.Exists(responseFilePath))
                 {
-                    throw new ArgumentException(string.Format(LocalizedResourceManager.GetString("Error_ResponseFileDoesNotExist"), arg));
+                    //if the file could not be found, report this back to the user, but dont crash yet, the use of '@' in the argument might be intentional here.
+                    System.Console.WriteLine(string.Format(LocalizedResourceManager.GetString("Error_ResponseFileDoesNotExist"), arg));
+                    System.Console.WriteLine(LocalizedResourceManager.GetString("Error_ResponseFileDoesNotExistUsingOriginalValue"));
+                    parsedArgs.Add(arg);
+                    continue;
                 }
 
                 var fileInfo = new FileInfo(responseFilePath);

--- a/src/NuGet.Clients/NuGet.CommandLine/Common/CommandLineResponseFile.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Common/CommandLineResponseFile.cs
@@ -41,20 +41,11 @@ namespace NuGet.Common
 
             const int MaxRecursionDepth = 3;
             var parsedArgs = new List<string>();
-            string previousArg = "";
             foreach (var arg in args)
             {
                 if (string.IsNullOrWhiteSpace(arg) || !arg.StartsWith("@", StringComparison.InvariantCultureIgnoreCase))
                 {
-                    previousArg = arg;
                     parsedArgs.Add(arg);
-                    continue;
-                }
-
-                if (previousArg.ToLower(CultureInfo.CurrentCulture).Contains("password"))
-                {
-                    parsedArgs.Add(arg);
-                    previousArg = arg;
                     continue;
                 }
 

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.Designer.cs
@@ -3130,6 +3130,15 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Using the originally entered value as an argument instead..
+        /// </summary>
+        public static string Error_ResponseFileDoesNotExistUsingOriginalValue {
+            get {
+                return ResourceManager.GetString("Error_ResponseFileDoesNotExistUsingOriginalValue", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Invalid response file, &apos;@&apos; does not exist.
         /// </summary>
         public static string Error_ResponseFileInvalid {

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
@@ -5427,4 +5427,7 @@ Oluşturma sırasında NuGet'in paketleri indirmesini önlemek için, Visual Stu
   <data name="ArgumentNullOrEmpty" xml:space="preserve">
     <value>Argument cannot be null or empty.</value>
   </data>
+  <data name="Error_ResponseFileDoesNotExistUsingOriginalValue" xml:space="preserve">
+    <value>Using the originally entered value as an argument instead.</value>
+  </data>
 </root>


### PR DESCRIPTION
## Bug

Fixes: [NuGet/Home#7707](https://github.com/NuGet/Home/issues/7707)
Regression: Yes/No  
* Last working version:  Unsure when this stopped working, i only started using nuget.exe today
![proof](https://user-images.githubusercontent.com/43607839/103292160-8f964980-49ed-11eb-869b-94284dce5fde.png)
## Fix

Details: In the check for arguments starting with an '@' i added a check for password so that it doesnt crash when a password that starts with '@' is used. 
A check for other CLI arguments might also be needed, but i discovered the issue upon entering my password.


## Testing/Validation

Tests Added: No
Reason for not adding tests:  I couldnt get the project to compile, it errord on the 'extern alias CoreV2;' in Commands.cs and  several other files.
