### PR TITLE
Do not require nuget.org to be only source when making recommendations

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/PackageItemLoader.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/PackageItemLoader.cs
@@ -70,7 +70,7 @@ namespace NuGet.PackageManagement.UI
             ContractItemFilter itemFilter,
             string searchText = null,
             bool includePrerelease = true,
-            bool useRecommender = true)
+            bool useRecommender = false)
         {
             var itemLoader = new PackageItemLoader(
                 serviceBroker,
@@ -95,7 +95,7 @@ namespace NuGet.PackageManagement.UI
             INuGetSearchService searchService,
             string searchText = null,
             bool includePrerelease = true,
-            bool useRecommender = true)
+            bool useRecommender = false)
         {
             var itemLoader = new PackageItemLoader(
                 serviceBroker,

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -918,8 +918,7 @@ namespace NuGet.PackageManagement.UI
             if (loadContext.IsSolution == false
                 && _topPanel.Filter == ItemFilter.All
                 && searchText == string.Empty
-                && SelectedSource.PackageSources.Count() == 1
-                && TelemetryUtility.IsNuGetOrg(SelectedSource.PackageSources.First()?.Source))
+                && SelectedSource.PackageSources.Any(item => TelemetryUtility.IsNuGetOrg(item.Source)))
             {
                 _recommendPackages = true;
             }

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/PackageFeeds/RecommenderPackageFeed.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/PackageFeeds/RecommenderPackageFeed.cs
@@ -13,6 +13,7 @@ using NuGet.Packaging.Core;
 using NuGet.Protocol.Core.Types;
 using NuGet.VisualStudio;
 using NuGet.VisualStudio.Internal.Contracts;
+using NuGet.VisualStudio.Telemetry;
 
 namespace NuGet.PackageManagement.VisualStudio
 {
@@ -39,14 +40,17 @@ namespace NuGet.PackageManagement.VisualStudio
         private const int MaxRecommended = 5;
 
         public RecommenderPackageFeed(
-            SourceRepository sourceRepository,
+            IEnumerable<SourceRepository> sourceRepositories,
             PackageCollection installedPackages,
             PackageCollection transitivePackages,
             IReadOnlyCollection<string> targetFrameworks,
             IPackageMetadataProvider metadataProvider,
             Common.ILogger logger)
         {
-            _sourceRepository = sourceRepository ?? throw new ArgumentNullException(nameof(sourceRepository));
+            if (sourceRepositories == null)
+            {
+                throw new ArgumentNullException(nameof(sourceRepositories));
+            }
             if (installedPackages is null)
             {
                 throw new ArgumentNullException(nameof(installedPackages));
@@ -58,6 +62,9 @@ namespace NuGet.PackageManagement.VisualStudio
             _targetFrameworks = targetFrameworks ?? throw new ArgumentNullException(nameof(targetFrameworks));
             _metadataProvider = metadataProvider ?? throw new ArgumentNullException(nameof(metadataProvider));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+            // get only the nuget.org repository. The recommender package feed is only created when one of the sources is nuget.org.
+            _sourceRepository = sourceRepositories.First(item => TelemetryUtility.IsNuGetOrg(item.PackageSource.Source));
 
             _installedPackages = installedPackages.Select(item => item.Id).ToList();
             _transitivePackages = transitivePackages.Select(item => item.Id).ToList();

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetPackageSearchService.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetPackageSearchService.cs
@@ -362,7 +362,7 @@ namespace NuGet.PackageManagement.VisualStudio
                 // if we get here, recommendPackages == true
                 packageFeeds.mainFeed = new MultiSourcePackageFeed(sourceRepositories, uiLogger, TelemetryActivity.NuGetTelemetryService);
                 packageFeeds.recommenderFeed = new RecommenderPackageFeed(
-                    sourceRepositories.First(),
+                    sourceRepositories,
                     installedPackageCollection,
                     transitivePackageCollection,
                     targetFrameworks,

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/NuGetPackageSearchServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/NuGetPackageSearchServiceTests.cs
@@ -236,7 +236,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                     searchText: "nuget",
                     new SearchFilter(includePrerelease: true),
                     NuGet.VisualStudio.Internal.Contracts.ItemFilter.All,
-                    useRecommender: true,
+                    useRecommender: false,
                     CancellationToken.None);
                 SearchResultContextInfo continueSearchResult = await searchService.ContinueSearchAsync(CancellationToken.None);
 


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Home/issues/10433
We decided that the recommender should make recommendations when one of the sources was nuget.org. Previously we had required that nuget.org was the only source. 
This was fixed, but the change was reverted during some of the codespaces work in https://github.com/NuGet/NuGet.Client/pull/3797
This just re-does the earlier fix. 
