### PR TITLE
Add AutomationProperty Name for License hyperlink

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageMetadataControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageMetadataControl.xaml
@@ -24,7 +24,8 @@
                     Style="{StaticResource HyperlinkStyle}"
                     Command="{x:Static nuget:PackageManagerControlCommands.OpenExternalLink}"
                     ToolTip="{Binding Link}"
-                    NavigateUri="{Binding Link}">
+                    NavigateUri="{Binding Link}"
+                    AutomationProperties.Name="{x:Static nuget:Resources.Label_License}">
                     <Run Text="{Binding Text}"></Run>
                 </Hyperlink>
         </TextBlock>


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/10425
Regression: No  

## Fix

Details: Attach automation property for the label's text.

## Testing/Validation

Tests Added: No
Reason for not adding tests:  
Validation:  
Tested manually with Narrator...
Tab to the metadata area, observe it announces "Package metadata".

**Example 1: (Newtonsoft.Json) ** 
Tab to the License link,  observe it announces "Hyperlink, License". 
Drill-in to the link, observe "View License".
![image](https://user-images.githubusercontent.com/49205731/103704149-cc76b900-4f76-11eb-99e3-5254bf47222b.png)

**Example 2: (gRPC) ** 
Note: this scenario is currently broken on dev due to VS.OE work, so I had to patch an older VS 16.9.0 p3 to test.
Tab to the License link: observe it announces  "Hyperlink, License"
Drill-in: "Apache-2.0".
![image](https://user-images.githubusercontent.com/49205731/103703820-3cd10a80-4f76-11eb-97a0-5e93a3ee329b.png)

