### PR TITLE
In the add package command, set-up the credential service before making any http calls

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommandRunner.cs
@@ -102,6 +102,11 @@ namespace NuGet.CommandLine.XPlat
 
             var originalPackageSpec = matchingPackageSpecs.FirstOrDefault();
 
+            // 2. Determine the version
+
+            // Setup the Credential Service before making any potential http calls.
+            DefaultCredentialServiceUtility.SetupDefaultCredentialService(packageReferenceArgs.Logger, !packageReferenceArgs.Interactive);
+
             PackageDependency packageDependency = default;
             if (packageReferenceArgs.NoVersion)
             {
@@ -145,7 +150,7 @@ namespace NuGet.CommandLine.XPlat
             var updatedDgSpec = dgSpec.WithReplacedSpec(updatedPackageSpec).WithoutRestores();
             updatedDgSpec.AddRestore(updatedPackageSpec.RestoreMetadata.ProjectUniqueName);
 
-            // 2. Run Restore Preview
+            // 3. Run Restore Preview
             packageReferenceArgs.Logger.LogDebug("Running Restore preview");
 
             var restorePreviewResult = await PreviewAddPackageReferenceAsync(packageReferenceArgs,
@@ -153,7 +158,7 @@ namespace NuGet.CommandLine.XPlat
 
             packageReferenceArgs.Logger.LogDebug("Restore Review completed");
 
-            // 3. Process Restore Result
+            // 4. Process Restore Result
             var compatibleFrameworks = new HashSet<NuGetFramework>(
                 restorePreviewResult
                 .Result
@@ -171,7 +176,7 @@ namespace NuGet.CommandLine.XPlat
                 compatibleFrameworks.IntersectWith(userSpecifiedFrameworkSet);
             }
 
-            // 4. Write to Project
+            // 5. Write to Project
             if (compatibleFrameworks.Count == 0)
             {
                 // Package is compatible with none of the project TFMs
@@ -221,7 +226,7 @@ namespace NuGet.CommandLine.XPlat
                     compatibleOriginalFrameworks);
             }
 
-            // 5. Commit restore result
+            // 6. Commit restore result
             await RestoreRunner.CommitAsync(restorePreviewResult, CancellationToken.None);
 
             return 0;
@@ -339,9 +344,6 @@ namespace NuGet.CommandLine.XPlat
 
                 // Generate Restore Requests. There will always be 1 request here since we are restoring for 1 project.
                 var restoreRequests = await RestoreRunner.GetRequests(restoreContext);
-
-                //Setup the Credential Service
-                DefaultCredentialServiceUtility.SetupDefaultCredentialService(restoreContext.Log, !packageReferenceArgs.Interactive);
 
                 // Run restore without commit. This will always return 1 Result pair since we are restoring for 1 request.
                 var restoreResult = await RestoreRunner.RunWithoutCommit(restoreRequests, restoreContext);


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/10305
Regression: Yes  
* Last working version:   
* How are we preventing it in future: Will add integration tests.

## Fix

Details: The fix is simple, the credential service needs to be set-up *before* any http calls are made.

## Testing/Validation

Tests Added: No  
Reason for not adding tests: No custom plugin to test. Given that this is a regression, it's important that the fix gets merged and inserted. Tests can and will come later. I am currently investigating the effort between *code infrastructure* and manual vendor tests infrastructure.
Validation: Manual
