### PR TITLE
PM UI:  allow null target framework in package reference context info

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/ContextInfos/IPackageReferenceContextInfo.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/ContextInfos/IPackageReferenceContextInfo.cs
@@ -10,7 +10,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
     public interface IPackageReferenceContextInfo
     {
         PackageIdentity Identity { get; }
-        NuGetFramework Framework { get; }
+        NuGetFramework? Framework { get; }
         VersionRange? AllowedVersions { get; }
         bool IsAutoReferenced { get; }
         bool IsUserInstalled { get; }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/ContextInfos/PackageReferenceContextInfo.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/ContextInfos/PackageReferenceContextInfo.cs
@@ -12,16 +12,17 @@ namespace NuGet.VisualStudio.Internal.Contracts
 {
     public sealed class PackageReferenceContextInfo : IPackageReferenceContextInfo
     {
-        public PackageReferenceContextInfo(PackageIdentity identity, NuGetFramework framework)
+        public PackageReferenceContextInfo(PackageIdentity identity, NuGetFramework? framework)
         {
             Assumes.NotNull(identity);
-            Assumes.NotNull(framework);
+            // framework is null for project.json package references. 
 
             Identity = identity;
             Framework = framework;
         }
 
-        public static PackageReferenceContextInfo Create(PackageIdentity identity, NuGetFramework framework)
+        // For testing only
+        internal static PackageReferenceContextInfo Create(PackageIdentity identity, NuGetFramework? framework)
         {
             return new PackageReferenceContextInfo(identity, framework);
         }
@@ -42,7 +43,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
         }
 
         public PackageIdentity Identity { get; internal set; }
-        public NuGetFramework Framework { get; internal set; }
+        public NuGetFramework? Framework { get; internal set; }
         public VersionRange? AllowedVersions { get; internal set; }
         public bool IsAutoReferenced { get; internal set; }
         public bool IsUserInstalled { get; internal set; }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/IPackageReferenceContextInfoFormatter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/IPackageReferenceContextInfoFormatter.cs
@@ -67,7 +67,6 @@ namespace NuGet.VisualStudio.Internal.Contracts
             }
 
             Assumes.NotNull(identity);
-            Assumes.NotNull(framework);
 
             var packageReferenceContextInfo = new PackageReferenceContextInfo(identity, framework)
             {

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/ProjectMetadataContextInfo.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/ProjectMetadataContextInfo.cs
@@ -34,7 +34,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
             UniqueName = uniqueName;
         }
 
-        public static ProjectMetadataContextInfo Create(IReadOnlyDictionary<string, object> projectMetadata)
+        public static ProjectMetadataContextInfo Create(IReadOnlyDictionary<string, object?> projectMetadata)
         {
             if (projectMetadata is null)
             {
@@ -47,7 +47,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
             IReadOnlyCollection<NuGetFramework>? supportedFrameworks = null;
             NuGetFramework? targetFramework = null;
             string? uniqueName = null;
-            object value;
+            object? value;
 
             if (projectMetadata.TryGetValue(NuGetProjectMetadataKeys.FullPath, out value))
             {
@@ -91,7 +91,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
                 uniqueName);
         }
 
-        private static NuGetFramework? ToNuGetFramework(object value)
+        private static NuGetFramework? ToNuGetFramework(object? value)
         {
             // See https://github.com/NuGet/Home/issues/4491
             if (value is string stringValue)

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/PublicAPI.Unshipped.txt
@@ -61,7 +61,7 @@ NuGet.VisualStudio.Internal.Contracts.INuGetSourcesService.GetPackageSourcesAsyn
 NuGet.VisualStudio.Internal.Contracts.INuGetSourcesService.PackageSourcesChanged -> System.EventHandler<System.Collections.Generic.IReadOnlyList<NuGet.VisualStudio.Internal.Contracts.PackageSourceContextInfo!>!>?
 NuGet.VisualStudio.Internal.Contracts.INuGetSourcesService.SavePackageSourceContextInfosAsync(System.Collections.Generic.IReadOnlyList<NuGet.VisualStudio.Internal.Contracts.PackageSourceContextInfo!>! sources, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask
 NuGet.VisualStudio.Internal.Contracts.INuGetSourcesService.SavePackageSourcesAsync(System.Collections.Generic.IReadOnlyList<NuGet.Configuration.PackageSource!>! sources, NuGet.Configuration.PackageSourceUpdateOptions! packageSourceUpdateOptions, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask
-NuGet.VisualStudio.Internal.Contracts.IPackageReferenceContextInfo.Framework.get -> NuGet.Frameworks.NuGetFramework!
+NuGet.VisualStudio.Internal.Contracts.IPackageReferenceContextInfo.Framework.get -> NuGet.Frameworks.NuGetFramework?
 NuGet.VisualStudio.Internal.Contracts.IPackageReferenceContextInfo.Identity.get -> NuGet.Packaging.Core.PackageIdentity!
 NuGet.VisualStudio.Internal.Contracts.IProjectContextInfo.ProjectId.get -> string!
 NuGet.VisualStudio.Internal.Contracts.IProjectMetadataContextInfo.SupportedFrameworks.get -> System.Collections.Generic.IReadOnlyCollection<NuGet.Frameworks.NuGetFramework!>?
@@ -91,9 +91,9 @@ NuGet.VisualStudio.Internal.Contracts.InstalledAndTransitivePackages
 NuGet.VisualStudio.Internal.Contracts.InstalledAndTransitivePackages.InstalledAndTransitivePackages(System.Collections.Generic.IReadOnlyCollection<NuGet.VisualStudio.Internal.Contracts.IPackageReferenceContextInfo!>? installedPackages, System.Collections.Generic.IReadOnlyCollection<NuGet.VisualStudio.Internal.Contracts.IPackageReferenceContextInfo!>? transitivePackages) -> void
 NuGet.VisualStudio.Internal.Contracts.InstalledAndTransitivePackages.InstalledPackages.get -> System.Collections.Generic.IReadOnlyCollection<NuGet.VisualStudio.Internal.Contracts.IPackageReferenceContextInfo!>!
 NuGet.VisualStudio.Internal.Contracts.InstalledAndTransitivePackages.TransitivePackages.get -> System.Collections.Generic.IReadOnlyCollection<NuGet.VisualStudio.Internal.Contracts.IPackageReferenceContextInfo!>!
-NuGet.VisualStudio.Internal.Contracts.PackageReferenceContextInfo.Framework.get -> NuGet.Frameworks.NuGetFramework!
+NuGet.VisualStudio.Internal.Contracts.PackageReferenceContextInfo.Framework.get -> NuGet.Frameworks.NuGetFramework?
 NuGet.VisualStudio.Internal.Contracts.PackageReferenceContextInfo.Identity.get -> NuGet.Packaging.Core.PackageIdentity!
-NuGet.VisualStudio.Internal.Contracts.PackageReferenceContextInfo.PackageReferenceContextInfo(NuGet.Packaging.Core.PackageIdentity! identity, NuGet.Frameworks.NuGetFramework! framework) -> void
+NuGet.VisualStudio.Internal.Contracts.PackageReferenceContextInfo.PackageReferenceContextInfo(NuGet.Packaging.Core.PackageIdentity! identity, NuGet.Frameworks.NuGetFramework? framework) -> void
 NuGet.VisualStudio.Internal.Contracts.PackageSearchMetadataContextInfo
 NuGet.VisualStudio.Internal.Contracts.PackageSearchMetadataContextInfo.Authors.get -> string?
 NuGet.VisualStudio.Internal.Contracts.PackageSearchMetadataContextInfo.DependencySets.get -> System.Collections.Generic.IReadOnlyCollection<NuGet.Packaging.PackageDependencyGroup!>?
@@ -183,13 +183,12 @@ override NuGet.VisualStudio.Internal.Contracts.PackageVulnerabilityMetadataConte
 override NuGet.VisualStudio.Internal.Contracts.ProjectAction.Equals(object! obj) -> bool
 static NuGet.VisualStudio.Internal.Contracts.AlternatePackageMetadataContextInfo.Create(NuGet.Protocol.AlternatePackageMetadata! alternatePackageMetadata) -> NuGet.VisualStudio.Internal.Contracts.AlternatePackageMetadataContextInfo!
 static NuGet.VisualStudio.Internal.Contracts.PackageDeprecationMetadataContextInfo.Create(NuGet.Protocol.PackageDeprecationMetadata! packageDeprecationMetadata) -> NuGet.VisualStudio.Internal.Contracts.PackageDeprecationMetadataContextInfo!
-static NuGet.VisualStudio.Internal.Contracts.PackageReferenceContextInfo.Create(NuGet.Packaging.Core.PackageIdentity! identity, NuGet.Frameworks.NuGetFramework! framework) -> NuGet.VisualStudio.Internal.Contracts.PackageReferenceContextInfo!
 static NuGet.VisualStudio.Internal.Contracts.PackageReferenceContextInfo.Create(NuGet.Packaging.PackageReference! packageReference) -> NuGet.VisualStudio.Internal.Contracts.PackageReferenceContextInfo!
 static NuGet.VisualStudio.Internal.Contracts.PackageSearchMetadataContextInfo.Create(NuGet.Protocol.Core.Types.IPackageSearchMetadata! packageSearchMetadata) -> NuGet.VisualStudio.Internal.Contracts.PackageSearchMetadataContextInfo!
 static NuGet.VisualStudio.Internal.Contracts.PackageSearchMetadataContextInfo.Create(NuGet.Protocol.Core.Types.IPackageSearchMetadata! packageSearchMetadata, bool isRecommended, (string!, string!)? recommenderVersion) -> NuGet.VisualStudio.Internal.Contracts.PackageSearchMetadataContextInfo!
 static NuGet.VisualStudio.Internal.Contracts.PackageSourceContextInfo.Create(NuGet.Configuration.PackageSource! packageSource) -> NuGet.VisualStudio.Internal.Contracts.PackageSourceContextInfo!
 static NuGet.VisualStudio.Internal.Contracts.ProjectContextInfo.CreateAsync(NuGet.ProjectManagement.NuGetProject! nugetProject, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<NuGet.VisualStudio.Internal.Contracts.IProjectContextInfo!>
-static NuGet.VisualStudio.Internal.Contracts.ProjectMetadataContextInfo.Create(System.Collections.Generic.IReadOnlyDictionary<string!, object!>! projectMetadata) -> NuGet.VisualStudio.Internal.Contracts.ProjectMetadataContextInfo!
+static NuGet.VisualStudio.Internal.Contracts.ProjectMetadataContextInfo.Create(System.Collections.Generic.IReadOnlyDictionary<string!, object?>! projectMetadata) -> NuGet.VisualStudio.Internal.Contracts.ProjectMetadataContextInfo!
 static NuGet.VisualStudio.Internal.Contracts.RemoteErrorUtility.ToRemoteError(System.Exception! exception) -> NuGet.VisualStudio.Internal.Contracts.RemoteError!
 static NuGet.VisualStudio.Internal.Contracts.VersionInfoContextInfo.CreateAsync(NuGet.Protocol.Core.Types.VersionInfo! versionInfo) -> System.Threading.Tasks.ValueTask<NuGet.VisualStudio.Internal.Contracts.VersionInfoContextInfo!>
 static readonly NuGet.VisualStudio.Internal.Contracts.NuGetServices.ProjectManagerService -> Microsoft.ServiceHub.Framework.ServiceRpcDescriptor!

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/NuGetProjectManagerServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/NuGetProjectManagerServiceTests.cs
@@ -44,7 +44,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
     {
         private NuGetPackageManager _packageManager;
         private NuGetProjectManagerService _projectManager;
-        private TestNuGetProjectContext _projectContext;
+        private readonly TestNuGetProjectContext _projectContext;
         private TestSharedServiceState _sharedState;
         private TestVsSolutionManager _solutionManager;
         private NuGetProjectManagerServiceState _state;

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/ContextInfos/PackageDeprecationMetadataContextInfoTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/ContextInfos/PackageDeprecationMetadataContextInfoTests.cs
@@ -13,11 +13,18 @@ namespace NuGet.VisualStudio.Internal.Contracts.Test
         [MemberData(nameof(TestData))]
         public void SerializeThenDeserialize_WithValidArguments_RoundTrips(PackageDeprecationMetadataContextInfo expectedResult)
         {
-            PackageDeprecationMetadataContextInfo actualResult = SerializeThenDeserialize(PackageDeprecationMetadataContextInfoFormatter.Instance, expectedResult);
+            PackageDeprecationMetadataContextInfo? actualResult = SerializeThenDeserialize(PackageDeprecationMetadataContextInfoFormatter.Instance, expectedResult);
 
-            Assert.Equal(expectedResult.Message, actualResult.Message);
-            Assert.Equal(expectedResult.AlternatePackage.PackageId, actualResult.AlternatePackage.PackageId);
-            Assert.Equal(expectedResult.AlternatePackage.VersionRange, actualResult.AlternatePackage.VersionRange);
+            Assert.NotNull(actualResult);
+            Assert.Equal(expectedResult.Message, actualResult!.Message);
+            Assert.Equal(expectedResult.AlternatePackage is null, actualResult.AlternatePackage is null);
+
+            if (expectedResult.AlternatePackage is object)
+            {
+                Assert.Equal(expectedResult.AlternatePackage.PackageId, actualResult.AlternatePackage!.PackageId);
+                Assert.Equal(expectedResult.AlternatePackage.VersionRange, actualResult.AlternatePackage.VersionRange);
+            }
+
             Assert.Equal(expectedResult.Reasons, actualResult.Reasons);
         }
 

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/ContextInfos/ProjectMetadataContextInfoTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/ContextInfos/ProjectMetadataContextInfoTests.cs
@@ -15,7 +15,9 @@ namespace NuGet.VisualStudio.Internal.Contracts.Test
         public void Create_IfProjectMetadataIsNull_Throws()
         {
             ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
                 () => ProjectMetadataContextInfo.Create(projectMetadata: null));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
 
             Assert.Equal("projectMetadata", exception.ParamName);
         }
@@ -23,7 +25,7 @@ namespace NuGet.VisualStudio.Internal.Contracts.Test
         [Fact]
         public void Create_IfProjectMetadataIsEmpty_DoesNotThrow()
         {
-            ProjectMetadataContextInfo projectMetadata = ProjectMetadataContextInfo.Create(new Dictionary<string, object>());
+            ProjectMetadataContextInfo projectMetadata = ProjectMetadataContextInfo.Create(new Dictionary<string, object?>());
 
             AssertAllPropertiesAreNull(projectMetadata);
         }
@@ -31,7 +33,7 @@ namespace NuGet.VisualStudio.Internal.Contracts.Test
         [Fact]
         public void Create_IfProjectMetadataValueDataTypesAreUnexpected_ReturnsNullPropertyValues()
         {
-            var metadata = new Dictionary<string, object>()
+            var metadata = new Dictionary<string, object?>()
             {
                 { NuGetProjectMetadataKeys.FullPath, 1 },
                 { NuGetProjectMetadataKeys.Name, 1 },
@@ -49,7 +51,7 @@ namespace NuGet.VisualStudio.Internal.Contracts.Test
         [Fact]
         public void Create_IfProjectMetadataValuesAreNull_ReturnsNullPropertyValues()
         {
-            var metadata = new Dictionary<string, object>()
+            var metadata = new Dictionary<string, object?>()
             {
                 { NuGetProjectMetadataKeys.FullPath, null },
                 { NuGetProjectMetadataKeys.Name, null },
@@ -67,7 +69,7 @@ namespace NuGet.VisualStudio.Internal.Contracts.Test
         [Fact]
         public void Create_IfProjectMetadataValuesAreNonNullAndValid_ReturnsNonNullPropertyValues()
         {
-            var metadata = new Dictionary<string, object>()
+            var metadata = new Dictionary<string, object?>()
             {
                 { NuGetProjectMetadataKeys.FullPath, "a" },
                 { NuGetProjectMetadataKeys.Name, "b" },
@@ -87,7 +89,7 @@ namespace NuGet.VisualStudio.Internal.Contracts.Test
         {
             NuGetFramework expectedFramework = NuGetFramework.Parse("net50");
 
-            var metadata = new Dictionary<string, object>()
+            var metadata = new Dictionary<string, object?>()
             {
                 { NuGetProjectMetadataKeys.TargetFramework, expectedFramework.DotNetFrameworkName }
             };
@@ -107,7 +109,7 @@ namespace NuGet.VisualStudio.Internal.Contracts.Test
             Assert.Null(projectMetadata.UniqueName);
         }
 
-        private static void AssertEqual(Dictionary<string, object> expectedResults, ProjectMetadataContextInfo actualResult)
+        private static void AssertEqual(Dictionary<string, object?> expectedResults, ProjectMetadataContextInfo actualResult)
         {
             Assert.Equal(expectedResults[NuGetProjectMetadataKeys.FullPath] as string, actualResult.FullPath);
             Assert.Equal(expectedResults[NuGetProjectMetadataKeys.Name] as string, actualResult.Name);

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/Formatters/AlternatePackageMetadataContextInfoFormatterTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/Formatters/AlternatePackageMetadataContextInfoFormatterTests.cs
@@ -12,9 +12,10 @@ namespace NuGet.VisualStudio.Internal.Contracts.Test
         [MemberData(nameof(TestData))]
         public void SerializeThenDeserialize_WithValidArguments_RoundTrips(AlternatePackageMetadataContextInfo expectedResult)
         {
-            AlternatePackageMetadataContextInfo actualResult = SerializeThenDeserialize(AlternatePackageMetadataContextInfoFormatter.Instance, expectedResult);
+            AlternatePackageMetadataContextInfo? actualResult = SerializeThenDeserialize(AlternatePackageMetadataContextInfoFormatter.Instance, expectedResult);
 
-            Assert.Equal(expectedResult.PackageId, actualResult.PackageId);
+            Assert.NotNull(actualResult);
+            Assert.Equal(expectedResult.PackageId, actualResult!.PackageId);
             Assert.Equal(expectedResult.VersionRange, actualResult.VersionRange);
         }
 

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/Formatters/FloatRangeFormatterTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/Formatters/FloatRangeFormatterTests.cs
@@ -15,10 +15,11 @@ namespace NuGet.VisualStudio.Internal.Contracts.Test
         [MemberData(nameof(FloatRanges))]
         public void SerializeThenDeserialize_WithValidArguments_RoundTrips(FloatRange expectedResult)
         {
-            FloatRange actualResult = SerializeThenDeserialize(FloatRangeFormatter.Instance, expectedResult);
+            FloatRange? actualResult = SerializeThenDeserialize(FloatRangeFormatter.Instance, expectedResult);
 
+            Assert.NotNull(actualResult);
             Assert.Equal(expectedResult, actualResult);
-            Assert.Equal(expectedResult.OriginalReleasePrefix, actualResult.OriginalReleasePrefix);
+            Assert.Equal(expectedResult.OriginalReleasePrefix, actualResult!.OriginalReleasePrefix);
         }
 
         public static TheoryData FloatRanges => new TheoryData<FloatRange>

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/Formatters/IInstalledAndTransitivePackagesFormatterTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/Formatters/IInstalledAndTransitivePackagesFormatterTests.cs
@@ -36,10 +36,11 @@ namespace NuGet.VisualStudio.Internal.Contracts.Test
         [MemberData(nameof(IInstalledAndTransitivePackages))]
         public void SerializeThenDeserialize_WithValidArguments_RoundTrips(InstalledAndTransitivePackages expectedResult)
         {
-            IInstalledAndTransitivePackages actualResult = SerializeThenDeserialize(IInstalledAndTransitivePackagesFormatter.Instance, expectedResult);
+            IInstalledAndTransitivePackages? actualResult = SerializeThenDeserialize(IInstalledAndTransitivePackagesFormatter.Instance, expectedResult);
 
-            Assert.Equal(actualResult.InstalledPackages.Count, expectedResult.InstalledPackages.Count);
-            Assert.Equal(actualResult.TransitivePackages.Count, expectedResult.TransitivePackages.Count);
+            Assert.NotNull(actualResult);
+            Assert.Equal(expectedResult.InstalledPackages.Count, actualResult!.InstalledPackages.Count);
+            Assert.Equal(expectedResult.TransitivePackages.Count, actualResult.TransitivePackages.Count);
 
             foreach (IPackageReferenceContextInfo expectedPackage in expectedResult.InstalledPackages)
             {

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/Formatters/ILogMessageFormatterTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/Formatters/ILogMessageFormatterTests.cs
@@ -16,9 +16,10 @@ namespace NuGet.VisualStudio.Internal.Contracts.Test
         [MemberData(nameof(ILogMessages))]
         public void SerializeThenDeserialize_WithValidArguments_RoundTrips(ILogMessage expectedResult)
         {
-            ILogMessage actualResult = SerializeThenDeserialize(ILogMessageFormatter.Instance, expectedResult);
+            ILogMessage? actualResult = SerializeThenDeserialize(ILogMessageFormatter.Instance, expectedResult);
 
-            TestUtility.AssertEqual(expectedResult, actualResult);
+            Assert.NotNull(actualResult);
+            TestUtility.AssertEqual(expectedResult, actualResult!);
         }
 
         public static TheoryData ILogMessages => new TheoryData<ILogMessage>

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/Formatters/IPackageReferenceContextInfoFormatterTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/Formatters/IPackageReferenceContextInfoFormatterTests.cs
@@ -19,9 +19,10 @@ namespace NuGet.VisualStudio.Internal.Contracts.Test
         [MemberData(nameof(IPackageReferenceContextInfos))]
         public void SerializeThenDeserialize_WithValidArguments_RoundTrips(IPackageReferenceContextInfo expectedResult)
         {
-            IPackageReferenceContextInfo actualResult = SerializeThenDeserialize(IPackageReferenceContextInfoFormatter.Instance, expectedResult);
+            IPackageReferenceContextInfo? actualResult = SerializeThenDeserialize(IPackageReferenceContextInfoFormatter.Instance, expectedResult);
 
-            Assert.Equal(expectedResult.Identity, actualResult.Identity);
+            Assert.NotNull(actualResult);
+            Assert.Equal(expectedResult.Identity, actualResult!.Identity);
             Assert.Equal(expectedResult.Framework, actualResult.Framework);
             Assert.Equal(expectedResult.AllowedVersions, actualResult.AllowedVersions);
             Assert.Equal(expectedResult.IsAutoReferenced, actualResult.IsAutoReferenced);
@@ -31,7 +32,8 @@ namespace NuGet.VisualStudio.Internal.Contracts.Test
 
         public static TheoryData IPackageReferenceContextInfos => new TheoryData<IPackageReferenceContextInfo>
             {
-                { PackageReferenceContextInfo.Create(PackageIdentity ,Framework) },
+                { PackageReferenceContextInfo.Create(PackageIdentity, Framework) },
+                { PackageReferenceContextInfo.Create(PackageIdentity, framework: null) },
                 { PackageReferenceContextInfo.Create(PackageReference) }
             };
     }

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/Formatters/IProjectContextInfoFormatterTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/Formatters/IProjectContextInfoFormatterTests.cs
@@ -13,9 +13,10 @@ namespace NuGet.VisualStudio.Internal.Contracts.Test
         [MemberData(nameof(IProjectContextInfos))]
         public void SerializeThenDeserialize_WithValidArguments_RoundTrips(IProjectContextInfo expectedResult)
         {
-            IProjectContextInfo actualResult = SerializeThenDeserialize(IProjectContextInfoFormatter.Instance, expectedResult);
+            IProjectContextInfo? actualResult = SerializeThenDeserialize(IProjectContextInfoFormatter.Instance, expectedResult);
 
-            Assert.Equal(expectedResult.ProjectId, actualResult.ProjectId);
+            Assert.NotNull(actualResult);
+            Assert.Equal(expectedResult.ProjectId, actualResult!.ProjectId);
             Assert.Equal(expectedResult.ProjectStyle, actualResult.ProjectStyle);
             Assert.Equal(expectedResult.ProjectKind, actualResult.ProjectKind);
         }

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/Formatters/IProjectMetadataContextInfoFormatterTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/Formatters/IProjectMetadataContextInfoFormatterTests.cs
@@ -13,9 +13,10 @@ namespace NuGet.VisualStudio.Internal.Contracts.Test
         [MemberData(nameof(IProjectMetadataContextInfos))]
         public void SerializeThenDeserialize_WithValidArguments_RoundTrips(IProjectMetadataContextInfo expectedResult)
         {
-            IProjectMetadataContextInfo actualResult = SerializeThenDeserialize(IProjectMetadataContextInfoFormatter.Instance, expectedResult);
+            IProjectMetadataContextInfo? actualResult = SerializeThenDeserialize(IProjectMetadataContextInfoFormatter.Instance, expectedResult);
 
-            Assert.Equal(expectedResult.FullPath, actualResult.FullPath);
+            Assert.NotNull(actualResult);
+            Assert.Equal(expectedResult.FullPath, actualResult!.FullPath);
             Assert.Equal(expectedResult.Name, actualResult.Name);
             Assert.Equal(expectedResult.ProjectId, actualResult.ProjectId);
             Assert.Equal(expectedResult.SupportedFrameworks, actualResult.SupportedFrameworks);

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/Formatters/ImplicitProjectActionFormatterTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/Formatters/ImplicitProjectActionFormatterTests.cs
@@ -17,8 +17,9 @@ namespace NuGet.VisualStudio.Internal.Contracts.Test
         [MemberData(nameof(ImplicitProjectActions))]
         public void SerializeThenDeserialize_WithValidArguments_RoundTrips(ImplicitProjectAction expectedResult)
         {
-            ImplicitProjectAction actualResult = SerializeThenDeserialize(ImplicitProjectActionFormatter.Instance, expectedResult);
+            ImplicitProjectAction? actualResult = SerializeThenDeserialize(ImplicitProjectActionFormatter.Instance, expectedResult);
 
+            Assert.NotNull(actualResult);
             Assert.Equal(expectedResult, actualResult);
         }
 

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/Formatters/NuGetFrameworkFormatterTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/Formatters/NuGetFrameworkFormatterTests.cs
@@ -13,8 +13,9 @@ namespace NuGet.VisualStudio.Internal.Contracts.Test
         [MemberData(nameof(NuGetFrameworks))]
         public void SerializeThenDeserialize_WithValidArguments_RoundTrips(NuGetFramework expectedResult)
         {
-            NuGetFramework actualResult = SerializeThenDeserialize(NuGetFrameworkFormatter.Instance, expectedResult);
+            NuGetFramework? actualResult = SerializeThenDeserialize(NuGetFrameworkFormatter.Instance, expectedResult);
 
+            Assert.NotNull(actualResult);
             Assert.Equal(expectedResult, actualResult);
         }
 

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/Formatters/NuGetVersionFormatterTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/Formatters/NuGetVersionFormatterTests.cs
@@ -17,10 +17,11 @@ namespace NuGet.VisualStudio.Internal.Contracts.Test
         [MemberData(nameof(Versions))]
         public void SerializeThenDeserialize_WithValidArguments_RoundTrips(NuGetVersion expectedResult)
         {
-            NuGetVersion actualResult = SerializeThenDeserialize(NuGetVersionFormatter.Instance, expectedResult);
+            NuGetVersion? actualResult = SerializeThenDeserialize(NuGetVersionFormatter.Instance, expectedResult);
 
+            Assert.NotNull(actualResult);
             Assert.Equal(expectedResult, actualResult);
-            Assert.Equal(expectedResult.OriginalVersion, actualResult.OriginalVersion);
+            Assert.Equal(expectedResult.OriginalVersion, actualResult!.OriginalVersion);
             Assert.Equal(expectedResult.ToString(), actualResult.ToString());
         }
 

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/Formatters/PackageDependencyFormatterTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/Formatters/PackageDependencyFormatterTests.cs
@@ -19,8 +19,9 @@ namespace NuGet.VisualStudio.Internal.Contracts.Test
         [MemberData(nameof(PackageDependencies))]
         public void SerializeThenDeserialize_WithValidArguments_RoundTrips(PackageDependency expectedResult)
         {
-            PackageDependency actualResult = SerializeThenDeserialize(PackageDependencyFormatter.Instance, expectedResult);
+            PackageDependency? actualResult = SerializeThenDeserialize(PackageDependencyFormatter.Instance, expectedResult);
 
+            Assert.NotNull(actualResult);
             Assert.Equal(expectedResult, actualResult);
         }
 

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/Formatters/PackageDependencyInfoFormatterTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/Formatters/PackageDependencyInfoFormatterTests.cs
@@ -18,8 +18,9 @@ namespace NuGet.VisualStudio.Internal.Contracts.Test
         [MemberData(nameof(PackageDependencyInfos))]
         public void SerializeThenDeserialize_WithValidArguments_RoundTrips(PackageDependencyInfo expectedResult)
         {
-            PackageDependencyInfo actualResult = SerializeThenDeserialize(PackageDependencyInfoFormatter.Instance, expectedResult);
+            PackageDependencyInfo? actualResult = SerializeThenDeserialize(PackageDependencyInfoFormatter.Instance, expectedResult);
 
+            Assert.NotNull(actualResult);
             Assert.Equal(expectedResult, actualResult);
         }
 

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/Formatters/PackageDeprecationMetadataContextInfoFormatterTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/Formatters/PackageDeprecationMetadataContextInfoFormatterTests.cs
@@ -24,12 +24,18 @@ namespace NuGet.VisualStudio.Internal.Contracts.Test
             var resolvers = new IFormatterResolver[] { MessagePackSerializerOptions.Standard.Resolver };
             var options = MessagePackSerializerOptions.Standard.WithSecurity(MessagePackSecurity.UntrustedData).WithResolver(CompositeResolver.Create(formatters, resolvers));
 
-            PackageDeprecationMetadataContextInfo actualResult = SerializeThenDeserialize(PackageDeprecationMetadataContextInfoFormatter.Instance, expectedResult, options);
+            PackageDeprecationMetadataContextInfo? actualResult = SerializeThenDeserialize(PackageDeprecationMetadataContextInfoFormatter.Instance, expectedResult, options);
 
-            Assert.Equal(expectedResult.Message, actualResult.Message);
+            Assert.NotNull(actualResult);
+            Assert.Equal(expectedResult.Message, actualResult!.Message);
             Assert.Equal(expectedResult.Reasons.First(), actualResult.Reasons.First());
-            Assert.Equal(expectedResult.AlternatePackage.PackageId, actualResult.AlternatePackage.PackageId);
-            Assert.Equal(expectedResult.AlternatePackage.VersionRange, actualResult.AlternatePackage.VersionRange);
+            Assert.Equal(expectedResult.AlternatePackage is null, actualResult.AlternatePackage is null);
+
+            if (expectedResult.AlternatePackage is object)
+            {
+                Assert.Equal(expectedResult.AlternatePackage.PackageId, actualResult.AlternatePackage!.PackageId);
+                Assert.Equal(expectedResult.AlternatePackage.VersionRange, actualResult.AlternatePackage.VersionRange);
+            }
         }
 
         public static TheoryData TestData => new TheoryData<PackageDeprecationMetadataContextInfo>

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/Formatters/PackageIdentityFormatterTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/Formatters/PackageIdentityFormatterTests.cs
@@ -16,8 +16,9 @@ namespace NuGet.VisualStudio.Internal.Contracts.Test
         [MemberData(nameof(PackageIdentities))]
         public void SerializeThenDeserialize_WithValidArguments_RoundTrips(PackageIdentity expectedResult)
         {
-            PackageIdentity actualResult = SerializeThenDeserialize(PackageIdentityFormatter.Instance, expectedResult);
+            PackageIdentity? actualResult = SerializeThenDeserialize(PackageIdentityFormatter.Instance, expectedResult);
 
+            Assert.NotNull(actualResult);
             Assert.Equal(expectedResult, actualResult);
         }
 

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/Formatters/PackageReferenceFormatterTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/Formatters/PackageReferenceFormatterTests.cs
@@ -19,9 +19,10 @@ namespace NuGet.VisualStudio.Internal.Contracts.Test
         [MemberData(nameof(PackageReferences))]
         public void SerializeThenDeserialize_WithValidArguments_RoundTrips(PackageReference expectedResult)
         {
-            PackageReference actualResult = SerializeThenDeserialize(PackageReferenceFormatter.Instance, expectedResult);
+            PackageReference? actualResult = SerializeThenDeserialize(PackageReferenceFormatter.Instance, expectedResult);
 
-            Assert.Equal(expectedResult.AllowedVersions, actualResult.AllowedVersions);
+            Assert.NotNull(actualResult);
+            Assert.Equal(expectedResult.AllowedVersions, actualResult!.AllowedVersions);
             Assert.Equal(expectedResult.HasAllowedVersions, actualResult.HasAllowedVersions);
             Assert.Equal(expectedResult.IsDevelopmentDependency, actualResult.IsDevelopmentDependency);
             Assert.Equal(expectedResult.IsUserInstalled, actualResult.IsUserInstalled);

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/Formatters/PackageSearchMetadataContextInfoFormatterTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/Formatters/PackageSearchMetadataContextInfoFormatterTests.cs
@@ -31,8 +31,10 @@ namespace NuGet.VisualStudio.Internal.Contracts.Test
             var resolvers = new IFormatterResolver[] { MessagePackSerializerOptions.Standard.Resolver };
             var options = MessagePackSerializerOptions.Standard.WithSecurity(MessagePackSecurity.UntrustedData).WithResolver(CompositeResolver.Create(formatters, resolvers));
 
-            PackageSearchMetadataContextInfo actualResult = SerializeThenDeserialize(PackageSearchMetadataContextInfoFormatter.Instance, expectedResult, options);
-            Assert.Equal(expectedResult.Identity, actualResult.Identity);
+            PackageSearchMetadataContextInfo? actualResult = SerializeThenDeserialize(PackageSearchMetadataContextInfoFormatter.Instance, expectedResult, options);
+
+            Assert.NotNull(actualResult);
+            Assert.Equal(expectedResult.Identity, actualResult!.Identity);
             Assert.Equal(expectedResult.DependencySets, actualResult.DependencySets);
             Assert.Equal(expectedResult.Description, actualResult.Description);
             Assert.Equal(expectedResult.DownloadCount, actualResult.DownloadCount);

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/Formatters/PackageSourceContextInfoFormatterTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/Formatters/PackageSourceContextInfoFormatterTests.cs
@@ -11,8 +11,9 @@ namespace NuGet.VisualStudio.Internal.Contracts.Test
         [MemberData(nameof(TestData))]
         public void SerializeThenDeserialize_WithValidArguments_RoundTrips(PackageSourceContextInfo expectedResult)
         {
-            PackageSourceContextInfo actualResult = SerializeThenDeserialize(PackageSourceContextInfoFormatter.Instance, expectedResult);
+            PackageSourceContextInfo? actualResult = SerializeThenDeserialize(PackageSourceContextInfoFormatter.Instance, expectedResult);
 
+            Assert.NotNull(actualResult);
             Assert.Equal(expectedResult, actualResult);
         }
 

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/Formatters/PackageSourceFormatterTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/Formatters/PackageSourceFormatterTests.cs
@@ -15,9 +15,10 @@ namespace NuGet.VisualStudio.Internal.Contracts.Test
         [MemberData(nameof(PackageSources))]
         public void SerializeThenDeserialize_WithValidArguments_RoundTrips(PackageSource expectedResult)
         {
-            PackageSource actualResult = SerializeThenDeserialize(PackageSourceFormatter.Instance, expectedResult);
+            PackageSource? actualResult = SerializeThenDeserialize(PackageSourceFormatter.Instance, expectedResult);
 
-            Assert.Equal(expectedResult.Name, actualResult.Name);
+            Assert.NotNull(actualResult);
+            Assert.Equal(expectedResult.Name, actualResult!.Name);
             Assert.Equal(expectedResult.Source, actualResult.Source);
             Assert.Equal(expectedResult.IsEnabled, actualResult.IsEnabled);
             Assert.Equal(expectedResult.IsMachineWide, actualResult.IsMachineWide);

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/Formatters/PackageSourceUpdateOptionsFormatterTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/Formatters/PackageSourceUpdateOptionsFormatterTests.cs
@@ -14,9 +14,10 @@ namespace NuGet.VisualStudio.Internal.Contracts.Test
 
         public void SerializeThenDeserialize_WithValidArguments_RoundTrips(PackageSourceUpdateOptions expectedResult)
         {
-            PackageSourceUpdateOptions actualResult = SerializeThenDeserialize(PackageSourceUpdateOptionsFormatter.Instance, expectedResult);
+            PackageSourceUpdateOptions? actualResult = SerializeThenDeserialize(PackageSourceUpdateOptionsFormatter.Instance, expectedResult);
 
-            Assert.Equal(expectedResult.UpdateCredentials, actualResult.UpdateCredentials);
+            Assert.NotNull(actualResult);
+            Assert.Equal(expectedResult.UpdateCredentials, actualResult!.UpdateCredentials);
             Assert.Equal(expectedResult.UpdateEnabled, actualResult.UpdateEnabled);
         }
 

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/Formatters/PackageVulnerabilityMetadataContextInfoFormatterTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/Formatters/PackageVulnerabilityMetadataContextInfoFormatterTests.cs
@@ -12,8 +12,9 @@ namespace NuGet.VisualStudio.Internal.Contracts.Test
         [MemberData(nameof(TestData))]
         public void SerializeThenDeserialize_WithValidArguments_RoundTrips(PackageVulnerabilityMetadataContextInfo expectedResult)
         {
-            PackageVulnerabilityMetadataContextInfo actualResult = SerializeThenDeserialize(PackageVulnerabilityMetadataContextInfoFormatter.Instance, expectedResult);
+            PackageVulnerabilityMetadataContextInfo? actualResult = SerializeThenDeserialize(PackageVulnerabilityMetadataContextInfoFormatter.Instance, expectedResult);
 
+            Assert.NotNull(actualResult);
             Assert.Equal(expectedResult, actualResult);
         }
 

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/Formatters/ProjectActionFormatterTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/Formatters/ProjectActionFormatterTests.cs
@@ -23,8 +23,9 @@ namespace NuGet.VisualStudio.Internal.Contracts.Test
         [MemberData(nameof(ProjectActions))]
         public void SerializeThenDeserialize_WithValidArguments_RoundTrips(ProjectAction expectedResult)
         {
-            ProjectAction actualResult = SerializeThenDeserialize(ProjectActionFormatter.Instance, expectedResult);
+            ProjectAction? actualResult = SerializeThenDeserialize(ProjectActionFormatter.Instance, expectedResult);
 
+            Assert.NotNull(actualResult);
             Assert.Equal(expectedResult, actualResult);
         }
 

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/Formatters/RemoteErrorFormatterTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/Formatters/RemoteErrorFormatterTests.cs
@@ -17,9 +17,10 @@ namespace NuGet.VisualStudio.Internal.Contracts.Test
         [MemberData(nameof(RemoteErrors))]
         public void SerializeThenDeserialize_WithValidArguments_RoundTrips(RemoteError expectedResult)
         {
-            RemoteError actualResult = SerializeThenDeserialize(RemoteErrorFormatter.Instance, expectedResult);
+            RemoteError? actualResult = SerializeThenDeserialize(RemoteErrorFormatter.Instance, expectedResult);
 
-            Assert.Equal(expectedResult.ActivityLogMessage, actualResult.ActivityLogMessage);
+            Assert.NotNull(actualResult);
+            Assert.Equal(expectedResult.ActivityLogMessage, actualResult!.ActivityLogMessage);
             TestUtility.AssertEqual(expectedResult.LogMessage, actualResult.LogMessage);
             TestUtility.AssertEqual(expectedResult.LogMessages, actualResult.LogMessages);
             Assert.Equal(expectedResult.ProjectContextLogMessage, actualResult.ProjectContextLogMessage);

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/Formatters/SearchFilterFormatterTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/Formatters/SearchFilterFormatterTests.cs
@@ -13,9 +13,10 @@ namespace NuGet.VisualStudio.Internal.Contracts.Test
         [MemberData(nameof(TestData))]
         public void SerializeThenDeserialize_WithValidArguments_RoundTrips(SearchFilter expectedResult)
         {
-            SearchFilter actualResult = SerializeThenDeserialize(SearchFilterFormatter.Instance, expectedResult);
+            SearchFilter? actualResult = SerializeThenDeserialize(SearchFilterFormatter.Instance, expectedResult);
 
-            Assert.Equal(expectedResult.Filter, actualResult.Filter);
+            Assert.NotNull(actualResult);
+            Assert.Equal(expectedResult.Filter, actualResult!.Filter);
             Assert.Equal(expectedResult.IncludeDelisted, actualResult.IncludeDelisted);
             Assert.Equal(expectedResult.IncludePrerelease, actualResult.IncludePrerelease);
             Assert.Equal(expectedResult.OrderBy, actualResult.OrderBy);

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/Formatters/SearchResultContextInfoFormatterTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/Formatters/SearchResultContextInfoFormatterTests.cs
@@ -30,8 +30,10 @@ namespace NuGet.VisualStudio.Internal.Contracts.Test
             var resolvers = new IFormatterResolver[] { MessagePackSerializerOptions.Standard.Resolver };
             var options = MessagePackSerializerOptions.Standard.WithSecurity(MessagePackSecurity.UntrustedData).WithResolver(CompositeResolver.Create(formatters, resolvers));
 
-            SearchResultContextInfo actualResult = SerializeThenDeserialize(SearchResultContextInfoFormatter.Instance, expectedResult, options);
-            Assert.Equal(expectedResult.OperationId, actualResult.OperationId);
+            SearchResultContextInfo? actualResult = SerializeThenDeserialize(SearchResultContextInfoFormatter.Instance, expectedResult, options);
+
+            Assert.NotNull(actualResult);
+            Assert.Equal(expectedResult.OperationId, actualResult!.OperationId);
             Assert.Equal(expectedResult.HasMoreItems, actualResult.HasMoreItems);
             Assert.Equal(expectedResult.SourceLoadingStatus, actualResult.SourceLoadingStatus);
             Assert.Equal(expectedResult.PackageSearchItems.Count, actualResult.PackageSearchItems.Count);

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/Formatters/VersionInfoContextInfoFormatterTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/Formatters/VersionInfoContextInfoFormatterTests.cs
@@ -19,31 +19,45 @@ namespace NuGet.VisualStudio.Internal.Contracts.Test
         public void SerializeThenDeserialize_WithValidArguments_RoundTrips(VersionInfoContextInfo expectedResult)
         {
             var formatters = new IMessagePackFormatter[]
-{
-                PackageSearchMetadataContextInfoFormatter.Instance,
-                PackageVulnerabilityMetadataContextInfoFormatter.Instance,
-};
+                {
+                    PackageSearchMetadataContextInfoFormatter.Instance,
+                    PackageVulnerabilityMetadataContextInfoFormatter.Instance
+                };
             var resolvers = new IFormatterResolver[] { MessagePackSerializerOptions.Standard.Resolver };
             var options = MessagePackSerializerOptions.Standard.WithSecurity(MessagePackSecurity.UntrustedData).WithResolver(CompositeResolver.Create(formatters, resolvers));
 
-            VersionInfoContextInfo actualResult = SerializeThenDeserialize(VersionInfoContextInfoFormatter.Instance, expectedResult, options);
+            VersionInfoContextInfo? actualResult = SerializeThenDeserialize(VersionInfoContextInfoFormatter.Instance, expectedResult, options);
 
-            Assert.Equal(expectedResult.DownloadCount, actualResult.DownloadCount);
+            Assert.NotNull(actualResult);
+            Assert.Equal(expectedResult.DownloadCount, actualResult!.DownloadCount);
             Assert.Equal(expectedResult.Version, actualResult.Version);
-            Assert.Equal(expectedResult.PackageDeprecationMetadata.Message, actualResult.PackageDeprecationMetadata.Message);
-            Assert.Equal(expectedResult.PackageSearchMetadata.Identity, actualResult.PackageSearchMetadata.Identity);
+            Assert.Equal(expectedResult.PackageDeprecationMetadata is null, actualResult.PackageDeprecationMetadata is null);
+
+            if (expectedResult.PackageDeprecationMetadata is object)
+            {
+                Assert.Equal(expectedResult.PackageDeprecationMetadata.Message, actualResult.PackageDeprecationMetadata!.Message);
+            }
+
+            Assert.Equal(expectedResult.PackageSearchMetadata is null, actualResult.PackageSearchMetadata is null);
+
+            if (expectedResult.PackageSearchMetadata is object)
+            {
+                Assert.Equal(expectedResult.PackageSearchMetadata.Identity, actualResult.PackageSearchMetadata!.Identity);
+            }
         }
 
         public static TheoryData TestData => new TheoryData<VersionInfoContextInfo>
             {
-                { new VersionInfoContextInfo(NuGetVersion.Parse("1.0.0"), 100)
+                {
+                    new VersionInfoContextInfo(NuGetVersion.Parse("1.0.0"), 100)
                     {
                         PackageSearchMetadata = PackageSearchMetadataContextInfo.Create(new PackageSearchMetadataBuilder.ClonedPackageSearchMetadata()
                         {
                             Identity = new PackageIdentity("NuGet.Versioning", NuGetVersion.Parse("4.3.0")),
                         }),
                         PackageDeprecationMetadata = new PackageDeprecationMetadataContextInfo("message", new List<string>{"string1" }, new AlternatePackageMetadataContextInfo("packageId", new VersionRange(new NuGetVersion("0.1"))))
-                    } },
+                    }
+                }
             };
     }
 }

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/Formatters/VersionRangeFormatterTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/Formatters/VersionRangeFormatterTests.cs
@@ -16,8 +16,9 @@ namespace NuGet.VisualStudio.Internal.Contracts.Test
         [MemberData(nameof(VersionRanges))]
         public void SerializeThenDeserialize_WithValidArguments_RoundTrips(VersionRange expectedResult)
         {
-            VersionRange actualResult = SerializeThenDeserialize(VersionRangeFormatter.Instance, expectedResult);
+            VersionRange? actualResult = SerializeThenDeserialize(VersionRangeFormatter.Instance, expectedResult);
 
+            Assert.NotNull(actualResult);
             Assert.Equal(expectedResult, actualResult);
         }
 

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/ImplicitProjectActionTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/ImplicitProjectActionTests.cs
@@ -31,7 +31,9 @@ namespace NuGet.VisualStudio.Internal.Contracts.Test
         public void Constructor_WhenPackageIdentityIsNull_Throws()
         {
             ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
                 () => new ImplicitProjectAction(Id, packageIdentity: null, NuGetProjectActionType.Uninstall));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
 
             Assert.Equal("packageIdentity", exception.ParamName);
         }
@@ -51,7 +53,9 @@ namespace NuGet.VisualStudio.Internal.Contracts.Test
         [Fact]
         public void Equals_WithObject_WhenArgumentIsNull_ReturnsFalse()
         {
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
             Assert.False(Action.Equals(obj: null));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
         }
 
         [Fact]

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/NuGet.VisualStudio.Internal.Contracts.Test.csproj
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/NuGet.VisualStudio.Internal.Contracts.Test.csproj
@@ -6,7 +6,7 @@
     <TargetFramework>$(NETFXTargetFramework)</TargetFramework>
     <TestProject>true</TestProject>
     <Description>Unit and integration tests for NuGet.VisualStudio.Internal.Contracts.</Description>
-    <NullableContextOptions>enable</NullableContextOptions>
+    <Nullable>enable</Nullable>
     <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/NuGetJsonRpcTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/NuGetJsonRpcTests.cs
@@ -16,7 +16,9 @@ namespace NuGet.VisualStudio.Internal.Contracts.Test
         {
             using (var rpc = new TestJsonRpc())
             {
-                Type type = rpc.GetErrorDetailsDataTypeHelper(error: null);
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+                Type? type = rpc.GetErrorDetailsDataTypeHelper(error: null);
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
 
                 Assert.Equal(typeof(CommonErrorData), type);
             }
@@ -27,7 +29,7 @@ namespace NuGet.VisualStudio.Internal.Contracts.Test
         {
             using (var rpc = new TestJsonRpc())
             {
-                Type type = rpc.GetErrorDetailsDataTypeHelper(
+                Type? type = rpc.GetErrorDetailsDataTypeHelper(
                     new JsonRpcError()
                     {
                         Error = null
@@ -42,7 +44,7 @@ namespace NuGet.VisualStudio.Internal.Contracts.Test
         {
             using (var rpc = new TestJsonRpc())
             {
-                Type type = rpc.GetErrorDetailsDataTypeHelper(
+                Type? type = rpc.GetErrorDetailsDataTypeHelper(
                     new JsonRpcError()
                     {
                         Error = new JsonRpcError.ErrorDetail()
@@ -60,7 +62,7 @@ namespace NuGet.VisualStudio.Internal.Contracts.Test
         {
             using (var rpc = new TestJsonRpc())
             {
-                Type type = rpc.GetErrorDetailsDataTypeHelper(
+                Type? type = rpc.GetErrorDetailsDataTypeHelper(
                     new JsonRpcError()
                     {
                         Error = new JsonRpcError.ErrorDetail()
@@ -80,7 +82,7 @@ namespace NuGet.VisualStudio.Internal.Contracts.Test
             {
             }
 
-            internal Type GetErrorDetailsDataTypeHelper(JsonRpcError error)
+            internal Type? GetErrorDetailsDataTypeHelper(JsonRpcError error)
             {
                 return GetErrorDetailsDataType(error);
             }

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/ProjectActionTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/ProjectActionTests.cs
@@ -45,7 +45,9 @@ namespace NuGet.VisualStudio.Internal.Contracts.Test
         public void Constructor_WhenPackageIdentityIsNull_Throws()
         {
             ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
                 () => new ProjectAction(Id, ProjectId, packageIdentity: null, NuGetProjectActionType.Uninstall, implicitActions: null));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
 
             Assert.Equal("packageIdentity", exception.ParamName);
         }
@@ -67,7 +69,9 @@ namespace NuGet.VisualStudio.Internal.Contracts.Test
         [Fact]
         public void Equals_WithObject_WhenArgumentIsNull_ReturnsFalse()
         {
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
             Assert.False(Action.Equals(obj: null));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
         }
 
         [Fact]

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/TestUtility.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/TestUtility.cs
@@ -10,7 +10,7 @@ namespace NuGet.VisualStudio.Internal.Contracts.Test
 {
     internal static class TestUtility
     {
-        internal static void AssertEqual(ILogMessage expectedResult, ILogMessage actualResult)
+        internal static void AssertEqual(ILogMessage? expectedResult, ILogMessage? actualResult)
         {
             if (expectedResult is null)
             {
@@ -23,7 +23,7 @@ namespace NuGet.VisualStudio.Internal.Contracts.Test
                 Assert.NotNull(actualResult);
             }
 
-            Assert.Equal(expectedResult.Code, actualResult.Code);
+            Assert.Equal(expectedResult.Code, actualResult!.Code);
             Assert.Equal(expectedResult.Level, actualResult.Level);
             Assert.Equal(expectedResult.Message, actualResult.Message);
             Assert.Equal(expectedResult.ProjectPath, actualResult.ProjectPath);
@@ -73,8 +73,8 @@ namespace NuGet.VisualStudio.Internal.Contracts.Test
         }
 
         internal static void AssertEqual(
-            IReadOnlyList<ILogMessage> expectedResults,
-            IReadOnlyList<ILogMessage> actualResults)
+            IReadOnlyList<ILogMessage>? expectedResults,
+            IReadOnlyList<ILogMessage>? actualResults)
         {
             if (expectedResults is null)
             {
@@ -83,7 +83,7 @@ namespace NuGet.VisualStudio.Internal.Contracts.Test
             else
             {
                 Assert.NotNull(actualResults);
-                Assert.Equal(expectedResults.Count, actualResults.Count);
+                Assert.Equal(expectedResults.Count, actualResults!.Count);
 
                 for (var i = 0; i < expectedResults.Count; ++i)
                 {

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/Utility/RemoteErrorTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/Utility/RemoteErrorTests.cs
@@ -42,7 +42,9 @@ namespace NuGet.VisualStudio.Internal.Contracts.Test
             ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
                 () => new RemoteError(
                     TypeName,
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
                     logMessage: null,
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
                     LogMessages,
                     ProjectContextLogMessage,
                     ActivityLogMessage));

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/Utility/RemoteErrorUtilityTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/Utility/RemoteErrorUtilityTests.cs
@@ -12,7 +12,9 @@ namespace NuGet.VisualStudio.Internal.Contracts.Test
         public void ToRemoteError_WhenExceptionIsNull_Throws()
         {
             ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
                 () => RemoteErrorUtility.ToRemoteError(exception: null));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
 
             Assert.Equal("exception", exception.ParamName);
         }


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/10336
Regression: Yes
* Last working version:   previous preview release
* How are we preventing it in future:   add test

## Fix

Details: While adding CodeSpaces support to PM UI, an assumption was made that all package references have a non-null target framework.  However, project.json project package references have a null target framework.  This bug caused PM UI to fail to display results in the Browse tab.

By allowing null target frameworks, PM UI works as expected for project.json projects.

Most of this PR is enabling nullable reference types in the NuGet.VisualStudio.Internal.Contracts.Test project.

## Testing/Validation

Tests Added: Yes
Validation:  manually verified that browse, install, update, and uninstall scenarios work

CC @rrelyea, @sbanni
