### PR TITLE
Fire OnPropertyChanged event sooner for version changes

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailControlModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailControlModel.cs
@@ -559,6 +559,9 @@ namespace NuGet.PackageManagement.UI
 
                         NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(() => SelectedVersionChangedAsync(_searchResultPackage, _selectedVersion.Version, loadCts.Token).AsTask());
                     }
+
+                    OnPropertyChanged(nameof(SelectedVersion));
+                    OnSelectedVersionChanged();
                 }
             }
         }
@@ -604,9 +607,6 @@ namespace NuGet.PackageManagement.UI
                     PackageMetadata = detailedPackageMetadata;
                 }
             }
-
-            OnPropertyChanged(nameof(SelectedVersion));
-            OnSelectedVersionChanged();
         }
 
         // Calculate the version to select among _versions and select it

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/PackageSearchMetadataCacheItemEntry.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/PackageSearchMetadataCacheItemEntry.cs
@@ -41,7 +41,7 @@ namespace NuGet.PackageManagement.VisualStudio
             {
                 IPackageSearchMetadata detailedMetadata = await _detailedPackageSearchMetadata.Value;
                 deprecationMetadata = await detailedMetadata.GetDeprecationMetadataAsync();
-                if(deprecationMetadata == null)
+                if (deprecationMetadata == null)
                 {
                     return null;
                 }


### PR DESCRIPTION
Fire OnPropertyChanged event sooner for version changes
Get deprecation metadata from the metadataprovider

## Bug

Fixes: https://github.com/NuGet/Home/issues/10380
Regression: Yes  
* Last working version: Pre codespaces search feature

## Fix

Details: 
Fire OnPropertyChanged event when the property actually changes rather than when we get the detailed pane data
We also need to query the PackageMetadataProvider for deprecation metadata in the event it is initially null since the search object that is returned may not contain that information depending on the provider.

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  
Validation:  Tested manually with deprecated package sources and with packages that contain thousands of versions that cause the data retrieval to be very slow.
