### PR TITLE
Disable the up to date status message in VS

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreSummary.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreSummary.cs
@@ -173,7 +173,7 @@ namespace NuGet.Commands
                 }
             }
 
-            if (RuntimeEnvironmentHelper.IsRunningInVisualStudio)
+            if (!RuntimeEnvironmentHelper.IsRunningInVisualStudio)
             {
                 if (noOpCount == restoreSummaries.Count)
                 {

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreSummary.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreSummary.cs
@@ -173,13 +173,16 @@ namespace NuGet.Commands
                 }
             }
 
-            if (noOpCount == restoreSummaries.Count)
+            if (RuntimeEnvironmentHelper.IsRunningInVisualStudio)
             {
-                logger.LogMinimal(Strings.Log_AllProjectsUpToDate);
-            }
-            else if (noOpCount > 0)
-            {
-                logger.LogMinimal(string.Format(CultureInfo.CurrentCulture, Strings.Log_ProjectUpToDateSummary, noOpCount, restoreSummaries.Count));
+                if (noOpCount == restoreSummaries.Count)
+                {
+                    logger.LogMinimal(Strings.Log_AllProjectsUpToDate);
+                }
+                else if (noOpCount > 0)
+                {
+                    logger.LogMinimal(string.Format(CultureInfo.CurrentCulture, Strings.Log_ProjectUpToDateSummary, noOpCount, restoreSummaries.Count));
+                }
             }
         }
 


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/9402
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: The "x out of y projects are up to date" is a status that makes *a lot more sense* on the commandline thna VS. 

It was added in https://github.com/NuGet/NuGet.Client/pull/3111. 

This is a temporary fix until 
https://github.com/NuGet/Home/issues/9915 and https://github.com/NuGet/Home/issues/4376 are fixed.

Note that with the partial no-op optimization this can only happen at solution load. 

## Testing/Validation

Tests Added: No  
Reason for not adding tests: VS  
Validation:  
