### PR TITLE
Enable Shift+Tab keyboard navigation to work beyond the PMUI Tabs

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml
@@ -47,7 +47,8 @@
     <DockPanel
       x:Name="_root"
       LastChildFill="True"
-      Width="{Binding ActualWidth, ElementName=_self}">
+      Width="{Binding ActualWidth, ElementName=_self}"
+      KeyboardNavigation.TabNavigation="Cycle">
       <DockPanel.MinWidth>
         <MultiBinding Converter="{StaticResource AdditionConverter}">
           <Binding Path="MinWidth" ElementName="_leftSideGridColumn" />


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/10234
Regression: No. Despite many changes in 16.x to the tabbing, this actually has been a problem since at least 15.9

## Fix

Details: Finally figured out that the DockPanel was catching the keyboard input, and suppressing it when shift+tabbing because the default is Continue mode.

## Testing/Validation

Tests Added: No
Reason for not adding tests:  😐
Validation:  Tried Shift+tab and Tab keys and verified I could cycle both directions through PMUI window (both Solution and Project level). Tried with no package selected (last item is the Thumb separator) and with a package selected (last item is Dependencies treeview).
