### PR TITLE
Prevent version comparisons if not needed

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailControlModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailControlModel.cs
@@ -705,10 +705,10 @@ namespace NuGet.PackageManagement.UI
 
         public Func<PackageReaderBase> PackageReader => _searchResultPackage?.PackageReader;
 
-        protected void AddBlockedVersions(NuGetVersion[] blockedVersions)
+        protected void AddBlockedVersions(List<NuGetVersion> blockedVersions)
         {
             // add a separator
-            if (blockedVersions.Length > 0)
+            if (blockedVersions.Count > 0)
             {
                 if (_versions.Count > 0)
                 {

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageDetailControlModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageDetailControlModel.cs
@@ -97,7 +97,7 @@ namespace NuGet.PackageManagement.UI
 
         protected override Task CreateVersionsAsync(CancellationToken cancellationToken)
         {
-            // allVersions is null if server doesn't return any versions.
+            // The value will be null if the server does not return any versions.
             if (_allPackageVersions == null || _allPackageVersions.Count == 0)
             {
                 return Task.CompletedTask;
@@ -112,7 +112,7 @@ namespace NuGet.PackageManagement.UI
             // installVersion is null if the package is not installed
             var installedVersion = installedDependency?.VersionRange?.MinVersion;
 
-            var allVersions = _allPackageVersions?.OrderByDescending(v => v.version.Version).ToList();
+            List<(NuGetVersion version, bool isDeprecated)> allVersions = _allPackageVersions?.OrderByDescending(v => v.version.Version).ToList();
 
             // null, if no version constraint defined in package.config
             VersionRange allowedVersions = _projectVersionConstraints.Select(e => e.VersionRange).FirstOrDefault();
@@ -128,11 +128,11 @@ namespace NuGet.PackageManagement.UI
             else
             {
                 allVersionsAllowed = allVersions.Where(v => allowedVersions.Satisfies(v.version)).ToList();
-                foreach (var version in allVersions)
+                foreach ((NuGetVersion version, bool isDeprecated) in allVersions)
                 {
-                    if (!allVersionsAllowed.Any(a => a.version.Version.Equals(version.version.Version)))
+                    if (!allVersionsAllowed.Any(a => a.version.Version.Equals(version.Version)))
                     {
-                        blockedVersions.Add(version.version);
+                        blockedVersions.Add(version);
                     }
                 }
             }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageSolutionDetailControlModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageSolutionDetailControlModel.cs
@@ -201,26 +201,25 @@ namespace NuGet.PackageManagement.UI
 
         protected override async Task CreateVersionsAsync(CancellationToken cancellationToken)
         {
-            // allVersions is null if server doesn't return any versions.
+            // The value will be null if the server does not return any versions.
             if (_allPackageVersions == null || _allPackageVersions.Count == 0)
             {
                 return;
             }
 
             _versions = new List<DisplayVersion>();
-            var allVersions = _allPackageVersions?.Where(v => v.version != null).OrderByDescending(v => v.version.Version).ToList();
+            List<(NuGetVersion version, bool isDeprecated)> allVersions = _allPackageVersions?.Where(v => v.version != null).OrderByDescending(v => v.version.Version).ToList();
 
             // null, if no version constraint defined in package.config
             VersionRange allowedVersions = await GetAllowedVersionsAsync(cancellationToken);
             var allVersionsAllowed = allVersions.Where(v => allowedVersions.Satisfies(v.version)).ToArray();
 
-            // null, if all versions are allowed to install or update
             var blockedVersions = new List<NuGetVersion>(allVersions.Count);
-            foreach (var version in allVersions)
+            foreach ((NuGetVersion version, bool isDeprecated) in allVersions)
             {
-                if (!allVersionsAllowed.Any(a => a.version.Version.Equals(version.version.Version)))
+                if (!allVersionsAllowed.Any(a => a.version.Version.Equals(version.Version)))
                 {
-                    blockedVersions.Add(version.version);
+                    blockedVersions.Add(version);
                 }
             }
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageSolutionDetailControlModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageSolutionDetailControlModel.cs
@@ -201,24 +201,28 @@ namespace NuGet.PackageManagement.UI
 
         protected override async Task CreateVersionsAsync(CancellationToken cancellationToken)
         {
-            _versions = new List<DisplayVersion>();
-            var allVersions = _allPackageVersions?.Where(v => v.version != null).OrderByDescending(v => v);
-
             // allVersions is null if server doesn't return any versions.
-            if (allVersions == null || !allVersions.Any())
+            if (_allPackageVersions == null || _allPackageVersions.Count == 0)
             {
                 return;
             }
+
+            _versions = new List<DisplayVersion>();
+            var allVersions = _allPackageVersions?.Where(v => v.version != null).OrderByDescending(v => v.version.Version).ToList();
 
             // null, if no version constraint defined in package.config
             VersionRange allowedVersions = await GetAllowedVersionsAsync(cancellationToken);
             var allVersionsAllowed = allVersions.Where(v => allowedVersions.Satisfies(v.version)).ToArray();
 
             // null, if all versions are allowed to install or update
-            var blockedVersions = allVersions
-                .Select(v => v.version)
-                .Where(v => !allVersionsAllowed.Any(allowed => allowed.version.Equals(v)))
-                .ToArray();
+            var blockedVersions = new List<NuGetVersion>(allVersions.Count);
+            foreach (var version in allVersions)
+            {
+                if (!allVersionsAllowed.Any(a => a.version.Version.Equals(version.version.Version)))
+                {
+                    blockedVersions.Add(version.version);
+                }
+            }
 
             // get latest prerelease or stable based on allowed versions
             var latestPrerelease = allVersionsAllowed.FirstOrDefault(v => v.version.IsPrerelease);


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/10436
Regression: No  

## Fix

Details: If there are no version constraints we do not need to look for blocked versions

## Testing/Validation

Tests Added: No  
Validation:  Tested with different packages, when comparing with the 'test10k' package was able to reduce the 1.4s to .12ms of time spent here
