### PR TITLE
Uploads localization inputs with English binaries to an Azure Artifact

### DIFF
--- a/build/loc.proj
+++ b/build/loc.proj
@@ -77,19 +77,20 @@
 
   <Target Name="CopyLcgFilesToArtifacts" AfterTargets="Localize">
     <ItemGroup>
-      <_LcgFiles Include="@(LocalizedToolFiles)" Condition="'%(LocalizedToolFiles.Extension)'== '.lcg'">
+      <_MoveLcgFiles Include="@(LocalizedToolFiles)" Condition="'%(LocalizedToolFiles.Extension)'== '.lcg'">
         <DestinationDir>$(ArtifactsDirectory)$([MSBuild]::MakeRelative($(ArtifactsDirectory)localize\%(LocalizedToolFiles.lang), %(LocalizedToolFiles.RootDir)%(LocalizedToolFiles.Directory)))%(LocalizedToolFiles.Culture)\%(LocalizedToolFiles.Filename)%(LocalizedToolFiles.Extension)</DestinationDir>
-      </_LcgFiles>
+      </_MoveLcgFiles>
     </ItemGroup>
-    <Copy SourceFiles="@(_LcgFiles->'%(Identity)')" DestinationFiles="@(_LcgFiles->'%(DestinationDir)')"/>
+    <Copy SourceFiles="@(_MoveLcgFiles->'%(Identity)')" DestinationFiles="@(_MoveLcgFiles->'%(DestinationDir)')"/>
   </Target>
 
-  <Target Name="CopyEnglishBinariesToLocalize" AfterTargets="Localize">
+  <Target Name="CopyBinariesToLocalizeENU" AfterTargets="Localize">
     <ItemGroup>
-      <EnglishBinaires Include="@(FilesToLocalize)" Condition="'%(FilesToLocalize.Extension)'== '.dll'" />
+      <_EnglishBinaires Include="@(FilesToLocalize)" Condition="'%(FilesToLocalize.Extension)'== '.dll'">
+        <DestinationPath>$(ArtifactsDirectory)localize\ENU\$([MSBuild]::MakeRelative($(ArtifactsDirectory), %(FilesToLocalize.RootDir)%(FilesToLocalize.Directory)))%(FilesToLocalize.Filename)%(FilesToLocalize.Extension)</DestinationPath>
+      </_EnglishBinaires>
     </ItemGroup>
-    <!-- Multi-targeting will leave last assembly found -->
-    <Copy SourceFiles="@(EnglishBinaires)" DestinationFolder="$(ArtifactsDirectory)\localize" />
+    <Copy SourceFiles="@(_EnglishBinaires)" DestinationFiles="@(_EnglishBinaires->'%(DestinationPath)')" />
   </Target>
 
   <Target Name="AfterBuild" DependsOnTargets="LocalizeNonProjectFiles;BatchLocalize"/>

--- a/build/loc.proj
+++ b/build/loc.proj
@@ -75,16 +75,16 @@
     <Copy SourceFiles="@(EulaFiles->'%(Identity)')" DestinationFiles="@(EulaFiles->'%(DestinationDir)')"/>
   </Target>
 
-  <Target Name="MoveLcgFilesToArtifacts" AfterTargets="Localize">
+  <Target Name="CopyLcgFilesToArtifacts" AfterTargets="Localize">
     <ItemGroup>
-      <_MoveLcgFiles Include="@(LocalizedToolFiles)" Condition="'%(LocalizedToolFiles.Extension)'== '.lcg'">
+      <_LcgFiles Include="@(LocalizedToolFiles)" Condition="'%(LocalizedToolFiles.Extension)'== '.lcg'">
         <DestinationDir>$(ArtifactsDirectory)$([MSBuild]::MakeRelative($(ArtifactsDirectory)localize\%(LocalizedToolFiles.lang), %(LocalizedToolFiles.RootDir)%(LocalizedToolFiles.Directory)))%(LocalizedToolFiles.Culture)\%(LocalizedToolFiles.Filename)%(LocalizedToolFiles.Extension)</DestinationDir>
-      </_MoveLcgFiles>
+      </_LcgFiles>
     </ItemGroup>
-    <Move SourceFiles="@(_MoveLcgFiles->'%(Identity)')" DestinationFiles="@(_MoveLcgFiles->'%(DestinationDir)')"/>
+    <Copy SourceFiles="@(_LcgFiles->'%(Identity)')" DestinationFiles="@(_LcgFiles->'%(DestinationDir)')"/>
   </Target>
 
-  <Target Name="MoveEnglishBinariesToArtifacts" AfterTargets="Localize">
+  <Target Name="CopyEnglishBinariesToLocalize" AfterTargets="Localize">
     <ItemGroup>
       <EnglishBinaires Include="@(FilesToLocalize)" Condition="'%(FilesToLocalize.Extension)'== '.dll'" />
     </ItemGroup>

--- a/build/loc.proj
+++ b/build/loc.proj
@@ -84,6 +84,14 @@
     <Move SourceFiles="@(_MoveLcgFiles->'%(Identity)')" DestinationFiles="@(_MoveLcgFiles->'%(DestinationDir)')"/>
   </Target>
 
+  <Target Name="MoveEnglishBinariesToArtifacts" AfterTargets="Localize">
+    <ItemGroup>
+      <EnglishBinaires Include="@(FilesToLocalize)" Condition="'%(FilesToLocalize.Extension)'== '.dll'" />
+    </ItemGroup>
+    <!-- Multi-targeting will leave last assembly found -->
+    <Copy SourceFiles="@(EnglishBinaires)" DestinationFolder="$(ArtifactsDirectory)\localize" />
+  </Target>
+
   <Target Name="AfterBuild" DependsOnTargets="LocalizeNonProjectFiles;BatchLocalize"/>
   <Import Project="$(MicroBuildDirectory)Microsoft.VisualStudioEng.MicroBuild.Core.targets" />
 </Project>

--- a/build/templates/Build_and_UnitTest.yml
+++ b/build/templates/Build_and_UnitTest.yml
@@ -420,6 +420,7 @@ steps:
   inputs:
     targetPath: "$(Build.Repository.LocalPath)\\artifacts\\localize\\"
     artifactName: "localizeInputs"
+  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
 
 - task: NuGetCommand@2
   displayName: Publish public Nuget packages to nuget-build

--- a/build/templates/Build_and_UnitTest.yml
+++ b/build/templates/Build_and_UnitTest.yml
@@ -414,14 +414,14 @@ steps:
       artifacts\**\*.lcg
       !artifacts\localize\**\*
     TargetFolder: "$(CIRoot)\\PLOC\\$(Build.SourceBranchName)\\$(Build.BuildNumber)"
-  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
+  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
 
 - task: PublishPipelineArtifact@1
   displayName: "Upload localizeInputs artifact"
   inputs:
     targetPath: "$(Build.Repository.LocalPath)\\artifacts\\localize\\"
     artifactName: "localizeInputs"
-  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
+  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
 
 - task: NuGetCommand@2
   displayName: Publish public Nuget packages to nuget-build

--- a/build/templates/Build_and_UnitTest.yml
+++ b/build/templates/Build_and_UnitTest.yml
@@ -410,7 +410,10 @@ steps:
 - task: CopyFiles@2
   displayName: "Copy LCG Files (deprecated)"
   inputs:
-    SourceFolder: "artifacts\\localize\\ENU\\"
+    Contents: |
+      artifacts\**\*.lcg
+      artifacts\localize\*.dll
+      !artifacts\localize\**\*
     TargetFolder: "$(CIRoot)\\PLOC\\$(Build.SourceBranchName)\\$(Build.BuildNumber)"
   condition: "and(succeeded(),eq(variables['BuildRTM'], 'false'))" # Enabled for all builds for testing
 

--- a/build/templates/Build_and_UnitTest.yml
+++ b/build/templates/Build_and_UnitTest.yml
@@ -418,7 +418,7 @@ steps:
 - task: PublishPipelineArtifact@1
   displayName: "Upload localize artifact"
   inputs:
-    pathToPublish: "artifacts\\localize"
+    pathToPublish: "$(Build.Repository.LocalPath)\\artifacts\\localize\\"
     artifactName: "localize"
 
 - task: NuGetCommand@2

--- a/build/templates/Build_and_UnitTest.yml
+++ b/build/templates/Build_and_UnitTest.yml
@@ -408,12 +408,18 @@ steps:
   condition: "and(succeeded(),eq(variables['BuildRTM'], 'false'))"
 
 - task: CopyFiles@2
-  displayName: "Copy LCG Files"
+  displayName: "Copy LCG Files to Build Share (deprecated)"
   inputs:
     SourceFolder: "artifacts\\"
     Contents: "**\\*.lcg"
     TargetFolder: "$(CIRoot)\\PLOC\\$(Build.SourceBranchName)\\$(Build.BuildNumber)"
   condition: " and(succeeded(),eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true')) "
+
+- task: PublishPipelineArtifact@1
+  displayName: "Upload localize artifact"
+  inputs:
+    pathToPublish: "artifacts\\localize"
+    artifactName: "localize"
 
 - task: NuGetCommand@2
   displayName: Publish public Nuget packages to nuget-build

--- a/build/templates/Build_and_UnitTest.yml
+++ b/build/templates/Build_and_UnitTest.yml
@@ -411,7 +411,6 @@ steps:
   displayName: "Copy LCG Files (deprecated)"
   inputs:
     SourceFolder: "artifacts\\localize\\ENU\\"
-    Contents: "**\\*.lcg"
     TargetFolder: "$(CIRoot)\\PLOC\\$(Build.SourceBranchName)\\$(Build.BuildNumber)"
   condition: "and(succeeded(),eq(variables['BuildRTM'], 'false'))" # Enabled for all builds for testing
 

--- a/build/templates/Build_and_UnitTest.yml
+++ b/build/templates/Build_and_UnitTest.yml
@@ -408,12 +408,12 @@ steps:
   condition: "and(succeeded(),eq(variables['BuildRTM'], 'false'))"
 
 - task: CopyFiles@2
-  displayName: "Copy LCG Files to Build Share (deprecated)"
+  displayName: "Copy LCG Files (deprecated)"
   inputs:
-    SourceFolder: "artifacts\\"
+    SourceFolder: "artifacts\\localize\\ENU\\"
     Contents: "**\\*.lcg"
     TargetFolder: "$(CIRoot)\\PLOC\\$(Build.SourceBranchName)\\$(Build.BuildNumber)"
-  condition: " and(succeeded(),eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true')) "
+  condition: "and(succeeded(),eq(variables['BuildRTM'], 'false'))" # Enabled for all build for testing
 
 - task: PublishPipelineArtifact@1
   displayName: "Upload localize artifact"

--- a/build/templates/Build_and_UnitTest.yml
+++ b/build/templates/Build_and_UnitTest.yml
@@ -410,9 +410,10 @@ steps:
 - task: CopyFiles@2
   displayName: "Copy LCG Files (deprecated)"
   inputs:
+    SourceFolder: "artifacts\\"
     Contents: |
-      artifacts\**\*.lcg
-      !artifacts\localize\**\*
+      **\*.lcg
+      !localize\**\*
     TargetFolder: "$(CIRoot)\\PLOC\\$(Build.SourceBranchName)\\$(Build.BuildNumber)"
   condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
 

--- a/build/templates/Build_and_UnitTest.yml
+++ b/build/templates/Build_and_UnitTest.yml
@@ -412,7 +412,6 @@ steps:
   inputs:
     Contents: |
       artifacts\**\*.lcg
-      artifacts\localize\*.dll
       !artifacts\localize\**\*
     TargetFolder: "$(CIRoot)\\PLOC\\$(Build.SourceBranchName)\\$(Build.BuildNumber)"
   condition: "and(succeeded(),eq(variables['BuildRTM'], 'false'))" # Enabled for all builds for testing

--- a/build/templates/Build_and_UnitTest.yml
+++ b/build/templates/Build_and_UnitTest.yml
@@ -413,14 +413,14 @@ steps:
     SourceFolder: "artifacts\\localize\\ENU\\"
     Contents: "**\\*.lcg"
     TargetFolder: "$(CIRoot)\\PLOC\\$(Build.SourceBranchName)\\$(Build.BuildNumber)"
-  condition: "and(succeeded(),eq(variables['BuildRTM'], 'false'))" # Enabled for all build for testing
+  condition: "and(succeeded(),eq(variables['BuildRTM'], 'false'))" # Enabled for all builds for testing
 
 - task: PublishPipelineArtifact@1
-  displayName: "Upload localize artifact"
+  displayName: "Upload localizeInputs artifact"
   inputs:
     targetPath: "$(Build.Repository.LocalPath)\\artifacts\\localize\\"
     artifactName: "localizeInputs"
-  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
+  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))" # Enabled for all builds for testing
 
 - task: NuGetCommand@2
   displayName: Publish public Nuget packages to nuget-build

--- a/build/templates/Build_and_UnitTest.yml
+++ b/build/templates/Build_and_UnitTest.yml
@@ -415,14 +415,14 @@ steps:
       **\*.lcg
       !localize\**\*
     TargetFolder: "$(CIRoot)\\PLOC\\$(Build.SourceBranchName)\\$(Build.BuildNumber)"
-  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
+  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
 
 - task: PublishPipelineArtifact@1
   displayName: "Upload localizeInputs artifact"
   inputs:
     targetPath: "$(Build.Repository.LocalPath)\\artifacts\\localize\\"
     artifactName: "localizeInputs"
-  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
+  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
 
 - task: NuGetCommand@2
   displayName: Publish public Nuget packages to nuget-build

--- a/build/templates/Build_and_UnitTest.yml
+++ b/build/templates/Build_and_UnitTest.yml
@@ -414,14 +414,14 @@ steps:
       artifacts\**\*.lcg
       !artifacts\localize\**\*
     TargetFolder: "$(CIRoot)\\PLOC\\$(Build.SourceBranchName)\\$(Build.BuildNumber)"
-  condition: "and(succeeded(),eq(variables['BuildRTM'], 'false'))" # Enabled for all builds for testing
+  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
 
 - task: PublishPipelineArtifact@1
   displayName: "Upload localizeInputs artifact"
   inputs:
     targetPath: "$(Build.Repository.LocalPath)\\artifacts\\localize\\"
     artifactName: "localizeInputs"
-  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))" # Enabled for all builds for testing
+  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
 
 - task: NuGetCommand@2
   displayName: Publish public Nuget packages to nuget-build

--- a/build/templates/Build_and_UnitTest.yml
+++ b/build/templates/Build_and_UnitTest.yml
@@ -418,8 +418,8 @@ steps:
 - task: PublishPipelineArtifact@1
   displayName: "Upload localize artifact"
   inputs:
-    pathToPublish: "$(Build.Repository.LocalPath)\\artifacts\\localize\\"
-    artifactName: "localize"
+    targetPath: "$(Build.Repository.LocalPath)\\artifacts\\localize\\"
+    artifactName: "localizeInputs"
 
 - task: NuGetCommand@2
   displayName: Publish public Nuget packages to nuget-build


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->

Fixes: https://github.com/NuGet/Client.Engineering/issues/622

Regression? No

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

- Adds binaries to artifacts\localize folder at localization time.
- Uploads artifact with localization inputs
- Updates 'Copy LCG files (deprecated)' CI step to avoid copying LCG files twice 


## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - ~[ ] Automated tests added~
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - ~[ ] Test exception~
  - **OR**
  <!-- Infrastructure, documentation etc. -->
  - [x] N/A: CI infrastructure. Validation: 

Artifact: Contains LCG files and English binaries.
https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=4422689&view=artifacts&pathAsName=false&type=publishedArtifacts

Copy LCG: Files are equal as official builds:
New: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=4422689&view=logs&j=2ea8c801-c4c3-578e-0ff0-bcf4c12d9404&t=7a45f490-e79a-5856-8c1e-614999f9b011
Baseline: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=4421355&view=logs&j=2ea8c801-c4c3-578e-0ff0-bcf4c12d9404&t=7a45f490-e79a-5856-8c1e-614999f9b011


- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - ~[ ] Documentation PR or issue filled~
  - **OR**
  - [x] N/A


NOTE: GitHub PR page didn't allow me to add @NuGet/client-team as a reviewer. Thus, I added all team members individually.