### PR TITLE
Replace icons from ProjectSystem with Image Service monikers

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/Items/PackageAssemblyGroupItem.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/Items/PackageAssemblyGroupItem.cs
@@ -5,8 +5,8 @@
 
 using System;
 using System.ComponentModel;
+using Microsoft.VisualStudio.Imaging;
 using Microsoft.VisualStudio.Imaging.Interop;
-using Microsoft.VisualStudio.ProjectSystem.VS;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections;
 using NuGet.VisualStudio.Implementation.Resources;
 using NuGet.VisualStudio.SolutionExplorer.Models;
@@ -52,7 +52,7 @@ namespace NuGet.VisualStudio.SolutionExplorer
             _ => throw new InvalidEnumArgumentException(nameof(GroupType), (int)GroupType, typeof(PackageAssemblyGroupType))
         };
 
-        public override ImageMoniker IconMoniker => ManagedImageMonikers.ReferenceGroup;
+        public override ImageMoniker IconMoniker => KnownMonikers.ReferencePrivate;
 
     }
 }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/Items/PackageAssemblyGroupItem.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/Items/PackageAssemblyGroupItem.cs
@@ -52,7 +52,7 @@ namespace NuGet.VisualStudio.SolutionExplorer
             _ => throw new InvalidEnumArgumentException(nameof(GroupType), (int)GroupType, typeof(PackageAssemblyGroupType))
         };
 
-        public override ImageMoniker IconMoniker => KnownMonikers.ReferencePrivate;
+        public override ImageMoniker IconMoniker => KnownMonikers.ReferenceGroup;
 
     }
 }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/Items/PackageReferenceItem.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/Items/PackageReferenceItem.cs
@@ -49,7 +49,7 @@ namespace NuGet.VisualStudio.SolutionExplorer
 
         public override int Priority => AttachedItemPriority.Package;
 
-        public override ImageMoniker IconMoniker => KnownMonikers.PackageReference;
+        public override ImageMoniker IconMoniker => KnownMonikers.NuGetNoColor;
 
         protected override IContextMenuController? ContextMenuController => MenuController.TransitivePackage;
 

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/Items/PackageReferenceItem.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/Items/PackageReferenceItem.cs
@@ -6,9 +6,9 @@
 using System.Diagnostics.CodeAnalysis;
 
 using Microsoft.Internal.VisualStudio.PlatformUI;
+using Microsoft.VisualStudio.Imaging;
 using Microsoft.VisualStudio.Imaging.Interop;
 using Microsoft.VisualStudio.ProjectSystem;
-using Microsoft.VisualStudio.ProjectSystem.VS;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections;
 using NuGet.VisualStudio.Implementation.Resources;
 using NuGet.VisualStudio.SolutionExplorer.Models;
@@ -49,7 +49,7 @@ namespace NuGet.VisualStudio.SolutionExplorer
 
         public override int Priority => AttachedItemPriority.Package;
 
-        public override ImageMoniker IconMoniker => ManagedImageMonikers.NuGetGrey;
+        public override ImageMoniker IconMoniker => KnownMonikers.PackageReference;
 
         protected override IContextMenuController? ContextMenuController => MenuController.TransitivePackage;
 

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/Items/ProjectReferenceItem.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/Items/ProjectReferenceItem.cs
@@ -5,9 +5,9 @@
 
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.Internal.VisualStudio.PlatformUI;
+using Microsoft.VisualStudio.Imaging;
 using Microsoft.VisualStudio.Imaging.Interop;
 using Microsoft.VisualStudio.ProjectSystem;
-using Microsoft.VisualStudio.ProjectSystem.VS;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections;
 using NuGet.VisualStudio.Implementation.Resources;
 using NuGet.VisualStudio.SolutionExplorer.Models;
@@ -45,7 +45,7 @@ namespace NuGet.VisualStudio.SolutionExplorer
 
         public override int Priority => AttachedItemPriority.Project;
 
-        public override ImageMoniker IconMoniker => ManagedImageMonikers.Application;
+        public override ImageMoniker IconMoniker => KnownMonikers.Application;
 
         protected override IContextMenuController? ContextMenuController => MenuController.TransitiveProject;
 


### PR DESCRIPTION
## Bug

Fixes: https://github.com/nuget/home/issues/9977
Regression: No

## Fix

Details: Project System monikers are going away, so switch to the recommended Image Service equivalents.

### PackageReference and NuGet icons - no visual change
![image](https://user-images.githubusercontent.com/49205731/104230105-1e0dc080-541b-11eb-90ec-cb724eb7c33d.png)

### Application - no visual change
(left) ManagedImageMonikers.Application;
to
(right) KnownMonikers.Application;
![image](https://user-images.githubusercontent.com/49205731/104107087-e15d9000-5287-11eb-947d-9867dc467058.png)

## EDIT: No longer using the following after discussion with Drew

### ~Package references no longer a gray NuGet icon…~
~(left) ManagedImageMonikers.NuGetGrey;
to
(right) KnownMonikers.PackageReference;
**Note** PackageReferencePrivate is not currently available as a known moniker, even though it was suggested we use that.~

### ~Compile Time Assemblies changed to an icon with a lock….~
~(left) ManagedImageMonikers.ReferenceGroup;
to
(right) KnownMonikers.ReferencePrivate~

![image](https://user-images.githubusercontent.com/49205731/104107061-c428c180-5287-11eb-9e8e-b9bd6a881f0b.png)



## Testing/Validation

Tests Added: No
Reason for not adding tests:  
Validation:  Opened VS, compared Solution Explorer with and without changes and included screenshots of those in PR.

