### PR TITLE
Change VS target branch to d16.9 for QB approval mode (5.9.0.preview3)

### DIFF
--- a/build/config.props
+++ b/build/config.props
@@ -21,7 +21,7 @@
     <!-- Check the VS schedule and manually enter a preview number here that makes sense. -->
     <ReleaseLabel Condition=" '$(ReleaseLabel)' == '' ">preview.3</ReleaseLabel>
 
-    <IsEscrowMode>false</IsEscrowMode>
+    <IsEscrowMode>true</IsEscrowMode>
 
     <!-- Visual Studio Insertion Logic -->
     <VsTargetMajorVersion>$([MSBuild]::Add(11, $(MajorNuGetVersion)))</VsTargetMajorVersion>


### PR DESCRIPTION
## Bug

Fixes: none - engineering/branding change
Regression: No

Last working version:
How are we preventing it in future:

## Fix
Details: 
According to schedule, the next insertion should target branch d16.9, in QB approval mode.
So change  `IsEscrowMode` to true, so that VS target branch changes from main to d16.9.

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  
Validation:  
