### PR TITLE
Only get metadata for the selected specific version for the details pane in PM UI

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/PackageFeeds/MultiSourcePackageMetadataProvider.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/PackageFeeds/MultiSourcePackageMetadataProvider.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -52,27 +51,22 @@ namespace NuGet.PackageManagement.VisualStudio
             _logger = logger;
         }
 
+        public async Task<IPackageSearchMetadata> GetPackageMetadataForIdentityAsync(PackageIdentity identity, CancellationToken cancellationToken)
+        {
+            List<Task<IPackageSearchMetadata>> tasks = _sourceRepositories
+                .Select(r => GetMetadataTaskSafeAsync(() => r.GetPackageMetadataForIdentityAsync(identity, cancellationToken)))
+                .ToList();
+
+            return await GetPackageMetadataAsync(identity, tasks, cancellationToken);
+        }
+
         public async Task<IPackageSearchMetadata> GetPackageMetadataAsync(PackageIdentity identity, bool includePrerelease, CancellationToken cancellationToken)
         {
-            cancellationToken.ThrowIfCancellationRequested();
-            var tasks = _sourceRepositories
+            List<Task<IPackageSearchMetadata>> tasks = _sourceRepositories
                 .Select(r => GetMetadataTaskSafeAsync(() => r.GetPackageMetadataAsync(identity, includePrerelease, cancellationToken)))
                 .ToList();
 
-            if (_localRepository != null)
-            {
-                tasks.Add(_localRepository.GetPackageMetadataFromLocalSourceAsync(identity, cancellationToken));
-            }
-
-            var completed = (await Task.WhenAll(tasks))
-                .Where(m => m != null);
-
-            var master = completed.FirstOrDefault(m => !string.IsNullOrEmpty(m.Summary))
-                ?? completed.FirstOrDefault()
-                ?? PackageSearchMetadataBuilder.FromIdentity(identity).Build();
-
-            return master.WithVersions(
-                asyncValueFactory: () => MergeVersionsAsync(identity, completed));
+            return await GetPackageMetadataAsync(identity, tasks, cancellationToken);
         }
 
         public async Task<IPackageSearchMetadata> GetLatestPackageMetadataAsync(
@@ -173,6 +167,26 @@ namespace NuGet.PackageManagement.VisualStudio
             }
 
             return null;
+        }
+
+        private async Task<IPackageSearchMetadata> GetPackageMetadataAsync(PackageIdentity identity, List<Task<IPackageSearchMetadata>> tasks, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (_localRepository != null)
+            {
+                tasks.Add(_localRepository.GetPackageMetadataFromLocalSourceAsync(identity, cancellationToken));
+            }
+
+            var completed = (await Task.WhenAll(tasks))
+                .Where(m => m != null);
+
+            var master = completed.FirstOrDefault(m => !string.IsNullOrEmpty(m.Summary))
+                ?? completed.FirstOrDefault()
+                ?? PackageSearchMetadataBuilder.FromIdentity(identity).Build();
+
+            return master.WithVersions(
+                asyncValueFactory: () => MergeVersionsAsync(identity, completed));
         }
 
         private static async Task<IEnumerable<VersionInfo>> MergeVersionsAsync(PackageIdentity identity, IEnumerable<IPackageSearchMetadata> packages)

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/PackageFeeds/SourceRepositoryExtensions.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/PackageFeeds/SourceRepositoryExtensions.cs
@@ -87,6 +87,26 @@ namespace NuGet.PackageManagement.VisualStudio
             return result;
         }
 
+        /// <summary>
+        /// Get the package metadata for the given identity
+        /// </summary>
+        public static async Task<IPackageSearchMetadata> GetPackageMetadataForIdentityAsync(this SourceRepository sourceRepository, PackageIdentity identity, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var metadataResource = await sourceRepository.GetResourceAsync<PackageMetadataResource>(cancellationToken);
+
+            using (var sourceCacheContext = new SourceCacheContext())
+            {
+                // Update http source cache context MaxAge so that it can always go online to fetch latest version of packages.
+                sourceCacheContext.MaxAge = DateTimeOffset.UtcNow;
+
+                return await metadataResource?.GetMetadataAsync(identity, sourceCacheContext, Common.NullLogger.Instance, cancellationToken);
+            }
+        }
+
+        /// <summary>
+        /// Get the package metadata for the given identity.Id
+        /// </summary>
         public static async Task<IPackageSearchMetadata> GetPackageMetadataAsync(
             this SourceRepository sourceRepository, PackageIdentity identity, bool includePrerelease, CancellationToken cancellationToken)
         {

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/PackageSearchMetadataCacheItem.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/PackageSearchMetadataCacheItem.cs
@@ -47,7 +47,10 @@ namespace NuGet.PackageManagement.VisualStudio
 
             if (!_cachedItemEntries.TryGetValue(packageIdentity.Version, out PackageSearchMetadataCacheItemEntry cacheItemEntry))
             {
-                IPackageSearchMetadata packageSearchMetadata = await _packageMetadataProvider.GetPackageMetadataAsync(packageIdentity, includePrerelease: true, cancellationToken);
+                var multiSourceProvider = _packageMetadataProvider as MultiSourcePackageMetadataProvider;
+                IPackageSearchMetadata packageSearchMetadata = multiSourceProvider != null
+                        ? await multiSourceProvider.GetPackageMetadataForIdentityAsync(packageIdentity, cancellationToken)
+                        : await _packageMetadataProvider.GetPackageMetadataAsync(packageIdentity, includePrerelease: true, cancellationToken);
                 cacheItemEntry = new PackageSearchMetadataCacheItemEntry(packageSearchMetadata, _packageMetadataProvider);
                 _cachedItemEntries[packageIdentity.Version] = cacheItemEntry;
             }

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/PackageSearchMetadataCacheItemEntry.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/PackageSearchMetadataCacheItemEntry.cs
@@ -25,6 +25,12 @@ namespace NuGet.PackageManagement.VisualStudio
             _packageMetadataProvider = packageMetadataProvider;
             _detailedPackageSearchMetadata = AsyncLazy.New(() =>
             {
+                var multiSourceMetadataProvider = packageMetadataProvider as MultiSourcePackageMetadataProvider;
+                if (multiSourceMetadataProvider != null)
+                {
+                    return multiSourceMetadataProvider.GetPackageMetadataForIdentityAsync(_packageSearchMetadata.Identity, CancellationToken.None);
+                }
+
                 return _packageMetadataProvider.GetPackageMetadataAsync(_packageSearchMetadata.Identity, includePrerelease: true, CancellationToken.None);
             });
         }


### PR DESCRIPTION
## Bug

Fixes: https://github.com/nuget/client.engineering/issues/710

## Fix

Details: Add an overload method that allows us to use the PackageIdentity.Version to only parse the registration page that contains the version we care about.  This is targeted to the scenario of packages that contain enough versions that we page the results into multiple files, test10k from https://apidev.nugettest.org/v3-index/index.json is a prime example.

## Testing/Validation

Tests Added: No  
Validation:  unit tests and manual testing around small/medium/large packages
