### PR TITLE
Use HttpRequestMessage.Options on .NET 5

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpRequestMessageExtensions.cs
+++ b/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpRequestMessageExtensions.cs
@@ -34,20 +34,17 @@ namespace NuGet.Protocol
                 clone.Headers.TryAddWithoutValidation(header.Key, header.Value);
             }
 
-#if USE_HTTPREQUESTMESSAGE_OPTIONS
+#if NET5_0
             var clonedOptions = (IDictionary<string, object>)clone.Options;
             foreach (var option in request.Options)
             {
                 clonedOptions.Add(option.Key, option.Value);
             }
 #else
-            // stop ignoring CS0618 when fixing https://github.com/NuGet/Home/issues/9981
-#pragma warning disable CS0618
             foreach (var property in request.Properties)
             {
                 clone.Properties.Add(property);
             }
-#pragma warning restore CS0618
 #endif
             return clone;
         }
@@ -121,27 +118,21 @@ namespace NuGet.Protocol
                 throw new ArgumentNullException(nameof(configuration));
             }
 
-#if USE_HTTPREQUESTMESSAGE_OPTIONS
+#if NET5_0
             request.Options.Set(new HttpRequestOptionsKey<HttpRequestMessageConfiguration>(NuGetConfigurationKey), configuration);
 #else
-            // stop ignoring CS0618 when fixing https://github.com/NuGet/Home/issues/9981
-#pragma warning disable CS0618
             request.Properties[NuGetConfigurationKey] = configuration;
-#pragma warning restore CS0618
 #endif
         }
 
         private static T GetProperty<T>(this HttpRequestMessage request, string key)
         {
 
-#if USE_HTTPREQUESTMESSAGE_OPTIONS
+#if NET5_0
             if (request.Options.TryGetValue<T>(new HttpRequestOptionsKey<T>(key), out T result))
 #else
-            // stop ignoring CS0618 when fixing https://github.com/NuGet/Home/issues/9981
-#pragma warning disable CS0618
             object result;
             if (request.Properties.TryGetValue(key, out result) && result is T)
-#pragma warning restore CS0618
 #endif
             {
                 return (T)result;

--- a/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpRetryHandler.cs
+++ b/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpRetryHandler.cs
@@ -81,13 +81,10 @@ namespace NuGet.Protocol
                         headerStopwatch = new Stopwatch();
                         stopwatches.Add(headerStopwatch);
                     }
-#if USE_HTTPREQUESTMESSAGE_OPTIONS
+#if NET5_0
                     requestMessage.Options.Set(new HttpRequestOptionsKey<List<Stopwatch>>(StopwatchPropertyName), stopwatches);
 #else
-                    // stop ignoring CS0618 when fixing https://github.com/NuGet/Home/issues/9981
-#pragma warning disable CS0618
                     requestMessage.Properties[StopwatchPropertyName] = stopwatches;
-#pragma warning restore CS0618
 #endif
                     var requestUri = requestMessage.RequestUri;
 

--- a/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpSourceAuthenticationHandler.cs
+++ b/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpSourceAuthenticationHandler.cs
@@ -98,18 +98,15 @@ namespace NuGet.Protocol
                 {
                     List<Stopwatch> stopwatches = null;
 
-#if USE_HTTPREQUESTMESSAGE_OPTIONS
+#if NET5_0
                     if (request.Options.TryGetValue(
                         new HttpRequestOptionsKey<List<Stopwatch>>(HttpRetryHandler.StopwatchPropertyName),
                         out stopwatches))
                     {
 #else
-                    // stop ignoring CS0618 when fixing https://github.com/NuGet/Home/issues/9981
-#pragma warning disable CS0618
                     if (request.Properties.TryGetValue(HttpRetryHandler.StopwatchPropertyName, out var value))
                     {
                         stopwatches = value as List<Stopwatch>;
-#pragma warning restore CS0618
 #endif
                         if (stopwatches != null)
                         {

--- a/src/NuGet.Core/NuGet.Protocol/NuGet.Protocol.csproj
+++ b/src/NuGet.Core/NuGet.Protocol/NuGet.Protocol.csproj
@@ -13,16 +13,7 @@
     <XPLATProject>true</XPLATProject>
     <Description>NuGet's implementation for interacting with feeds. Contains functionality for all feed types.</Description>
     <UsePublicApiAnalyzer>perTfm</UsePublicApiAnalyzer>
-    <!-- Uncomment when fixing https://github.com/NuGet/Home/issues/9981
-    <CoreCompileDependsOn>$(CoreCompileDependsOn);DefineHttpRequestMessageOptions</CoreCompileDependsOn>
-    -->
   </PropertyGroup>
-
-  <Target Name="DefineHttpRequestMessageOptions">
-    <PropertyGroup Condition =" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionGreaterThanOrEquals('$(TargetFrameworkVersion)', '5.0')) ">
-      <DefineConstants >$(DefineConstants);USE_HTTPREQUESTMESSAGE_OPTIONS</DefineConstants>
-    </PropertyGroup>
-  </Target>
 
   <PropertyGroup Condition=" '$(IsVsixBuild)' == 'true' ">
     <TargetFrameworks />


### PR DESCRIPTION
Undo the workaround when .NET 5 was in preview, and our CI was stuck on an old preview with the new API.

## Bug

Fixes: https://github.com/NuGet/Home/issues/9981
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: .NET 5 added a new property `Options` to `HttpRequestMessage`, and marked the `Properties` property as obsolete. This PR uses the new property on .NET 5 (and above)

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  No product/feature change, just adapting to the .NET runtime changing under us.
Validation:  
