### PR TITLE
Only get metadata for the selected specific version for the details pane in PM UI

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/PackageFeeds/IPackageMetadataProvider.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/PackageFeeds/IPackageMetadataProvider.cs
@@ -56,5 +56,13 @@ namespace NuGet.PackageManagement.VisualStudio
         /// <returns>Package metadata</returns>
         Task<IPackageSearchMetadata> GetLocalPackageMetadataAsync(PackageIdentity identity,
             bool includePrerelease, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Retrieves a package metadata of a specific version without a list of all available versions
+        /// </summary>
+        /// <param name="identity">Desired package id with version</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>Package metadata</returns>
+        Task<IPackageSearchMetadata> GetPackageMetadataForIdentityAsync(PackageIdentity identity, CancellationToken cancellationToken);
     }
 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/PackageFeeds/MultiSourcePackageMetadataProvider.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/PackageFeeds/MultiSourcePackageMetadataProvider.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -52,27 +51,22 @@ namespace NuGet.PackageManagement.VisualStudio
             _logger = logger;
         }
 
+        public async Task<IPackageSearchMetadata> GetPackageMetadataForIdentityAsync(PackageIdentity identity, CancellationToken cancellationToken)
+        {
+            List<Task<IPackageSearchMetadata>> tasks = _sourceRepositories
+                .Select(r => GetMetadataTaskSafeAsync(() => r.GetPackageMetadataForIdentityAsync(identity, cancellationToken)))
+                .ToList();
+
+            return await GetPackageMetadataAsync(identity, tasks, cancellationToken);
+        }
+
         public async Task<IPackageSearchMetadata> GetPackageMetadataAsync(PackageIdentity identity, bool includePrerelease, CancellationToken cancellationToken)
         {
-            cancellationToken.ThrowIfCancellationRequested();
-            var tasks = _sourceRepositories
+            List<Task<IPackageSearchMetadata>> tasks = _sourceRepositories
                 .Select(r => GetMetadataTaskSafeAsync(() => r.GetPackageMetadataAsync(identity, includePrerelease, cancellationToken)))
                 .ToList();
 
-            if (_localRepository != null)
-            {
-                tasks.Add(_localRepository.GetPackageMetadataFromLocalSourceAsync(identity, cancellationToken));
-            }
-
-            var completed = (await Task.WhenAll(tasks))
-                .Where(m => m != null);
-
-            var master = completed.FirstOrDefault(m => !string.IsNullOrEmpty(m.Summary))
-                ?? completed.FirstOrDefault()
-                ?? PackageSearchMetadataBuilder.FromIdentity(identity).Build();
-
-            return master.WithVersions(
-                asyncValueFactory: () => MergeVersionsAsync(identity, completed));
+            return await GetPackageMetadataAsync(identity, tasks, cancellationToken);
         }
 
         public async Task<IPackageSearchMetadata> GetLatestPackageMetadataAsync(
@@ -173,6 +167,26 @@ namespace NuGet.PackageManagement.VisualStudio
             }
 
             return null;
+        }
+
+        private async Task<IPackageSearchMetadata> GetPackageMetadataAsync(PackageIdentity identity, List<Task<IPackageSearchMetadata>> tasks, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (_localRepository != null)
+            {
+                tasks.Add(_localRepository.GetPackageMetadataFromLocalSourceAsync(identity, cancellationToken));
+            }
+
+            var completed = (await Task.WhenAll(tasks))
+                .Where(m => m != null);
+
+            var master = completed.FirstOrDefault(m => !string.IsNullOrEmpty(m.Summary))
+                ?? completed.FirstOrDefault()
+                ?? PackageSearchMetadataBuilder.FromIdentity(identity).Build();
+
+            return master.WithVersions(
+                asyncValueFactory: () => MergeVersionsAsync(identity, completed));
         }
 
         private static async Task<IEnumerable<VersionInfo>> MergeVersionsAsync(PackageIdentity identity, IEnumerable<IPackageSearchMetadata> packages)

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/PackageFeeds/MultiSourcePackageMetadataProvider.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/PackageFeeds/MultiSourcePackageMetadataProvider.cs
@@ -178,10 +178,10 @@ namespace NuGet.PackageManagement.VisualStudio
                 tasks.Add(_localRepository.GetPackageMetadataFromLocalSourceAsync(identity, cancellationToken));
             }
 
-            var completed = (await Task.WhenAll(tasks))
+            IEnumerable<IPackageSearchMetadata> completed = (await Task.WhenAll(tasks))
                 .Where(m => m != null);
 
-            var master = completed.FirstOrDefault(m => !string.IsNullOrEmpty(m.Summary))
+            IPackageSearchMetadata master = completed.FirstOrDefault(m => !string.IsNullOrEmpty(m.Summary))
                 ?? completed.FirstOrDefault()
                 ?? PackageSearchMetadataBuilder.FromIdentity(identity).Build();
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/PackageFeeds/SourceRepositoryExtensions.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/PackageFeeds/SourceRepositoryExtensions.cs
@@ -95,12 +95,17 @@ namespace NuGet.PackageManagement.VisualStudio
             cancellationToken.ThrowIfCancellationRequested();
             var metadataResource = await sourceRepository.GetResourceAsync<PackageMetadataResource>(cancellationToken);
 
+            if (metadataResource == null)
+            {
+                return null;
+            }
+
             using (var sourceCacheContext = new SourceCacheContext())
             {
                 // Update http source cache context MaxAge so that it can always go online to fetch latest version of packages.
                 sourceCacheContext.MaxAge = DateTimeOffset.UtcNow;
 
-                return await metadataResource?.GetMetadataAsync(identity, sourceCacheContext, Common.NullLogger.Instance, cancellationToken);
+                return await metadataResource.GetMetadataAsync(identity, sourceCacheContext, Common.NullLogger.Instance, cancellationToken);
             }
         }
 
@@ -113,13 +118,18 @@ namespace NuGet.PackageManagement.VisualStudio
             cancellationToken.ThrowIfCancellationRequested();
             var metadataResource = await sourceRepository.GetResourceAsync<PackageMetadataResource>(cancellationToken);
 
+            if(metadataResource == null)
+            {
+                return null;
+            }
+
             using (var sourceCacheContext = new SourceCacheContext())
             {
                 // Update http source cache context MaxAge so that it can always go online to fetch
                 // latest version of packages.
                 sourceCacheContext.MaxAge = DateTimeOffset.UtcNow;
 
-                var packages = await metadataResource?.GetMetadataAsync(
+                var packages = await metadataResource.GetMetadataAsync(
                     identity.Id,
                     includePrerelease: true,
                     includeUnlisted: false,

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/PackageFeeds/SourceRepositoryExtensions.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/PackageFeeds/SourceRepositoryExtensions.cs
@@ -87,6 +87,26 @@ namespace NuGet.PackageManagement.VisualStudio
             return result;
         }
 
+        /// <summary>
+        /// Get the package metadata for the given identity
+        /// </summary>
+        public static async Task<IPackageSearchMetadata> GetPackageMetadataForIdentityAsync(this SourceRepository sourceRepository, PackageIdentity identity, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var metadataResource = await sourceRepository.GetResourceAsync<PackageMetadataResource>(cancellationToken);
+
+            using (var sourceCacheContext = new SourceCacheContext())
+            {
+                // Update http source cache context MaxAge so that it can always go online to fetch latest version of packages.
+                sourceCacheContext.MaxAge = DateTimeOffset.UtcNow;
+
+                return await metadataResource?.GetMetadataAsync(identity, sourceCacheContext, Common.NullLogger.Instance, cancellationToken);
+            }
+        }
+
+        /// <summary>
+        /// Get the package metadata for the given identity.Id
+        /// </summary>
         public static async Task<IPackageSearchMetadata> GetPackageMetadataAsync(
             this SourceRepository sourceRepository, PackageIdentity identity, bool includePrerelease, CancellationToken cancellationToken)
         {

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/PackageFeeds/SourceRepositoryExtensions.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/PackageFeeds/SourceRepositoryExtensions.cs
@@ -118,7 +118,7 @@ namespace NuGet.PackageManagement.VisualStudio
             cancellationToken.ThrowIfCancellationRequested();
             var metadataResource = await sourceRepository.GetResourceAsync<PackageMetadataResource>(cancellationToken);
 
-            if(metadataResource == null)
+            if (metadataResource == null)
             {
                 return null;
             }

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/PackageSearchMetadataCacheItem.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/PackageSearchMetadataCacheItem.cs
@@ -47,7 +47,10 @@ namespace NuGet.PackageManagement.VisualStudio
 
             if (!_cachedItemEntries.TryGetValue(packageIdentity.Version, out PackageSearchMetadataCacheItemEntry cacheItemEntry))
             {
-                IPackageSearchMetadata packageSearchMetadata = await _packageMetadataProvider.GetPackageMetadataAsync(packageIdentity, includePrerelease: true, cancellationToken);
+                var multiSourceProvider = _packageMetadataProvider as MultiSourcePackageMetadataProvider;
+                IPackageSearchMetadata packageSearchMetadata = multiSourceProvider != null
+                        ? await multiSourceProvider.GetPackageMetadataForIdentityAsync(packageIdentity, cancellationToken)
+                        : await _packageMetadataProvider.GetPackageMetadataAsync(packageIdentity, includePrerelease: true, cancellationToken);
                 cacheItemEntry = new PackageSearchMetadataCacheItemEntry(packageSearchMetadata, _packageMetadataProvider);
                 _cachedItemEntries[packageIdentity.Version] = cacheItemEntry;
             }

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/PackageSearchMetadataCacheItem.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/PackageSearchMetadataCacheItem.cs
@@ -47,10 +47,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
             if (!_cachedItemEntries.TryGetValue(packageIdentity.Version, out PackageSearchMetadataCacheItemEntry cacheItemEntry))
             {
-                var multiSourceProvider = _packageMetadataProvider as MultiSourcePackageMetadataProvider;
-                IPackageSearchMetadata packageSearchMetadata = multiSourceProvider != null
-                        ? await multiSourceProvider.GetPackageMetadataForIdentityAsync(packageIdentity, cancellationToken)
-                        : await _packageMetadataProvider.GetPackageMetadataAsync(packageIdentity, includePrerelease: true, cancellationToken);
+                IPackageSearchMetadata packageSearchMetadata = await _packageMetadataProvider.GetPackageMetadataForIdentityAsync(packageIdentity, cancellationToken);
                 cacheItemEntry = new PackageSearchMetadataCacheItemEntry(packageSearchMetadata, _packageMetadataProvider);
                 _cachedItemEntries[packageIdentity.Version] = cacheItemEntry;
             }

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/PackageSearchMetadataCacheItemEntry.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/PackageSearchMetadataCacheItemEntry.cs
@@ -25,13 +25,7 @@ namespace NuGet.PackageManagement.VisualStudio
             _packageMetadataProvider = packageMetadataProvider;
             _detailedPackageSearchMetadata = AsyncLazy.New(() =>
             {
-                var multiSourceMetadataProvider = packageMetadataProvider as MultiSourcePackageMetadataProvider;
-                if (multiSourceMetadataProvider != null)
-                {
-                    return multiSourceMetadataProvider.GetPackageMetadataForIdentityAsync(_packageSearchMetadata.Identity, CancellationToken.None);
-                }
-
-                return _packageMetadataProvider.GetPackageMetadataAsync(_packageSearchMetadata.Identity, includePrerelease: true, CancellationToken.None);
+                return _packageMetadataProvider.GetPackageMetadataForIdentityAsync(_packageSearchMetadata.Identity, CancellationToken.None);
             });
         }
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/PackageSearchMetadataCacheItemEntry.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/PackageSearchMetadataCacheItemEntry.cs
@@ -25,6 +25,12 @@ namespace NuGet.PackageManagement.VisualStudio
             _packageMetadataProvider = packageMetadataProvider;
             _detailedPackageSearchMetadata = AsyncLazy.New(() =>
             {
+                var multiSourceMetadataProvider = packageMetadataProvider as MultiSourcePackageMetadataProvider;
+                if (multiSourceMetadataProvider != null)
+                {
+                    return multiSourceMetadataProvider.GetPackageMetadataForIdentityAsync(_packageSearchMetadata.Identity, CancellationToken.None);
+                }
+
                 return _packageMetadataProvider.GetPackageMetadataAsync(_packageSearchMetadata.Identity, includePrerelease: true, CancellationToken.None);
             });
         }

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Feeds/MultiSourcePackageMetadataProviderTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Feeds/MultiSourcePackageMetadataProviderTests.cs
@@ -199,6 +199,26 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             }
 
             [Fact]
+            public async Task GetPackageMetadataForIdentityAsync_WithoutVersions()
+            {
+                // Arrange
+                var testProject = SetupProject(TestPackageIdentity, "[1,2)");
+                SetupRemotePackageMetadata(TestPackageIdentity.Id, "0.0.1", "1.0.0", "1.12", "2.0.1", "2.0.0", "1.0.1");
+
+                // Act
+                var specificVersion = await _target.GetPackageMetadataForIdentityAsync(
+                    new PackageIdentity(TestPackageIdentity.Id, new NuGetVersion("1.12")),
+                    cancellationToken: CancellationToken.None);
+
+                // Assert
+                Assert.NotNull(specificVersion);
+                Assert.Equal("1.12", specificVersion.Identity.Version.ToString());
+
+                var actualVersions = await specificVersion.GetVersionsAsync();
+                Assert.Equal(new[] { "1.12" }, actualVersions.Select(v => v.Version.ToString()).ToArray());
+            }
+
+            [Fact]
             public async Task GetLatestPackageMetadataAsync_WithAllowedVersions_RetrievesLatestVersion()
             {
                 // Arrange

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Feeds/SourceRepositoryExtensionsTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Feeds/SourceRepositoryExtensionsTests.cs
@@ -42,6 +42,22 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         }
 
         [Fact]
+        public async Task GetPackageMetadataForIdentityAsync_CancellationThrows()
+        {
+            // Arrange
+            var testProject = SetupProject(TestPackageIdentity, allowedVersions: null);
+
+            CancellationToken token = new CancellationToken(canceled: true);
+
+            // Act
+            Task task() => _source.GetPackageMetadataForIdentityAsync(
+                TestPackageIdentity,
+                cancellationToken: token);
+
+            await Assert.ThrowsAsync<OperationCanceledException>(task);
+        }
+
+        [Fact]
         public async Task GetPackageMetadataAsync_CancellationThrows()
         {
             // Arrange


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Client.Engineering/issues/710

## Fix

Details: Details: Add an overload method that allows us to use the PackageIdentity.Version to only parse the registration page that contains the version we care about. This is targeted to the scenario of packages that contain enough versions that we page the results into multiple files, test10k from https://apidev.nugettest.org/v3-index/index.json is a prime example.

## Testing/Validation

Tests Added: No  
Validation:  unit tests and manual testing around small/medium/large packages



This is related to NuGet/Home#8058 it doesn't prevent the downloading of all the index pages but this is a first step into only processing the one we care about.