### PR TITLE
Replace repo name variable with hardcoded string in build definition

### DIFF
--- a/build/templates/Build_and_UnitTest.yml
+++ b/build/templates/Build_and_UnitTest.yml
@@ -70,7 +70,7 @@ steps:
   inputs:
     getDropNameByDrop: true
     optimizationInputsDropNamePrefix: OptimizationInputs/$(System.TeamProject)/$(Build.Repository.Name)
-  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
+  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'), eq(variables['GetOptProfOptimizationData'], 'true'))"
 
 - task: PowerShell@1
   displayName: "Restore dotnet tools"


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Client.Engineering/issues/698
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: Replace `$(Build.Repository.Name)` CI build variable with `NuGet/NuGet.Client`, so building from a mirror doesn't break our build.

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  CI build script change.
Validation:  
