### PR TITLE
Deprecation and Installed version no longer overlap

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageItemControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageItemControl.xaml
@@ -219,9 +219,9 @@
       </Grid>
 
       <Grid
-                    Grid.Column="3"
-                    VerticalAlignment="Top"
-                    Margin="10,0,0,0">
+              Grid.Column="3"
+              VerticalAlignment="Top"
+              Margin="10,0,0,0">
         <Grid.RowDefinitions>
           <RowDefinition />
           <RowDefinition />
@@ -229,50 +229,44 @@
         <Grid.ColumnDefinitions>
           <ColumnDefinition Width="auto" />
           <ColumnDefinition Width="auto" />
+          <ColumnDefinition Width="auto" />
         </Grid.ColumnDefinitions>
 
         <!-- row 0: -->
-        <Grid
+        <!-- deprecation indicator -->
+        <imaging:CrispImage
+                      x:Name="_deprecationIndicator"
                       Grid.Row="0"
                       Grid.Column="0"
-                      HorizontalAlignment="Right">
-          <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="auto" />
-            <ColumnDefinition Width="auto" />
-          </Grid.ColumnDefinitions>
+                      Visibility="{Binding IsPackageDeprecated,Converter={StaticResource BooleanToVisibilityConverter}}"
+                      VerticalAlignment="Center"
+                      ToolTip="{x:Static nuget:Resources.Label_Deprecated}"
+                      AutomationProperties.Name="{x:Static nuget:Resources.Label_Deprecated}"
+                      Moniker="{x:Static catalog:KnownMonikers.StatusWarning}"/>
 
-          <!-- deprecation indicator -->
-          <imaging:CrispImage
-                        x:Name="_deprecationIndicator"
-                        Grid.Column="0"
-                        Visibility="{Binding IsPackageDeprecated,Converter={StaticResource BooleanToVisibilityConverter}}"
-                        VerticalAlignment="Center"
-                        ToolTip="{x:Static nuget:Resources.Label_Deprecated}"
-                        AutomationProperties.Name="{x:Static nuget:Resources.Label_Deprecated}"
-                        Moniker="{x:Static catalog:KnownMonikers.StatusWarning}"/>
-
-          <!-- installed version -->
-          <TextBlock
-                        x:Name="_installedVersion"
-                        Grid.Column="1"
-                        Margin="4,0,4,0"
-                        VerticalAlignment="Center"
-                        Visibility="{Binding IsNotInstalled, Converter={StaticResource InvertedBooleanToVisibilityConverter}}"
-                        Text="{Binding InstalledVersion, Converter={StaticResource VersionToStringConverter}, ConverterParameter=vN}">
-            <TextBlock.ToolTip>
-              <MultiBinding Converter="{StaticResource StringFormatConverter}">
-                <Binding Source="{x:Static nuget:Resources.ToolTip_InstalledVersion}" />
-                <Binding Path="InstalledVersion" Converter="{StaticResource VersionToStringConverter}" />
-              </MultiBinding>
-            </TextBlock.ToolTip>
-            <AutomationProperties.Name>
-              <MultiBinding Converter="{StaticResource StringFormatConverter}">
-                <Binding Source="{x:Static nuget:Resources.ToolTip_InstalledVersion}" />
-                <Binding Path="InstalledVersion" Converter="{StaticResource VersionToStringConverter}" />
-              </MultiBinding>
-            </AutomationProperties.Name>
-          </TextBlock>
-        </Grid>
+        <!-- installed version -->
+        <TextBlock
+                      x:Name="_installedVersion"
+                      Grid.Row="0"
+                      Grid.Column="1"
+                      Margin="4,0,4,0"
+                      VerticalAlignment="Center"
+                      HorizontalAlignment="Right"
+                      Visibility="{Binding IsNotInstalled, Converter={StaticResource InvertedBooleanToVisibilityConverter}}"
+                      Text="{Binding InstalledVersion, Converter={StaticResource VersionToStringConverter}, ConverterParameter=vN}">
+          <TextBlock.ToolTip>
+            <MultiBinding Converter="{StaticResource StringFormatConverter}">
+              <Binding Source="{x:Static nuget:Resources.ToolTip_InstalledVersion}" />
+              <Binding Path="InstalledVersion" Converter="{StaticResource VersionToStringConverter}" />
+            </MultiBinding>
+          </TextBlock.ToolTip>
+          <AutomationProperties.Name>
+            <MultiBinding Converter="{StaticResource StringFormatConverter}">
+              <Binding Source="{x:Static nuget:Resources.ToolTip_InstalledVersion}" />
+              <Binding Path="InstalledVersion" Converter="{StaticResource VersionToStringConverter}" />
+            </MultiBinding>
+          </AutomationProperties.Name>
+        </TextBlock>
 
         <!-- version to install. It occupies the same position as the installed version -->
         <TextBlock
@@ -281,6 +275,7 @@
                       Grid.Column="1"
                       Margin="2,0,4,0"
                       VerticalAlignment="Center"
+                      HorizontalAlignment="Right"
                       TextAlignment="Right"
                       Visibility="{Binding IsNotInstalled, Converter={StaticResource BooleanToVisibilityConverter}}"
                       Text="{Binding LatestVersion, Converter={StaticResource VersionToStringConverter}, ConverterParameter=vN}"
@@ -291,7 +286,7 @@
         <Button
                       x:Name="_uninstallButton"
                       Grid.Row="0"
-                      Grid.Column="1"
+                      Grid.Column="2"
                       Command="{x:Static nuget:Commands.UninstallPackageCommand}"
                       CommandParameter="{Binding}"
                       AutomationProperties.Name="{x:Static nuget:Resources.Button_Uninstall}"
@@ -338,7 +333,7 @@
         <Button
                       x:Name="_installButton"
                       Grid.Row="0"
-                      Grid.Column="1"
+                      Grid.Column="2"
                       Command="{x:Static nuget:Commands.InstallPackageCommand}"
                       CommandParameter="{Binding}"
                       ToolTip="{Binding InstalledVersionToolTip}"
@@ -378,7 +373,7 @@
         <TextBlock
                       x:Name="_versionToUpdateTo"
                       Grid.Row="1"
-                      Grid.Column="0"
+                      Grid.Column="1"
                       Margin="2,5,4,0"
                       VerticalAlignment="Center"
                       TextAlignment="Right"

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageItemControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageItemControl.xaml
@@ -278,7 +278,7 @@
         <TextBlock
                       x:Name="_versionToInstall"
                       Grid.Row="0"
-                      Grid.Column="0"
+                      Grid.Column="1"
                       Margin="2,0,4,0"
                       VerticalAlignment="Center"
                       TextAlignment="Right"


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/10452
Regression: Yes

## Fix

Details: 
 I think recent CodeSpace work fixed a bug where deprecation icon wasn't showing on browse tab sometimes.
Nobody ever knew about the XAML bug because deprecation wasn't shown for uninstalled packages until now.

Also reworked the Grid layout.
Removed unnecessary inner Grid.
Added 3rd column so deprecation gets its own column:

Column 0 - Deprecation Indicator
Column 1 - Installed and/or LastestAvailable version
Column 2 - Uninstall/Update buttons or Install button (project-level PMUI only)

This PR fixes the XAML bug:

![image](https://user-images.githubusercontent.com/49205731/104490872-6bb33600-559f-11eb-815d-f0d86edcb346.png)

![image](https://user-images.githubusercontent.com/49205731/104509300-77aaf200-55b7-11eb-8deb-a9992cedfbb2.png)

## Testing/Validation

Tests Added: No
Reason for not adding tests:  
Validation:  See screenshot. Manually tested Browse tab.
