### PR TITLE
Supress NU5104 as no stable version of Microsoft.ServiceHub.Framework

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Contracts/NuGet.VisualStudio.Contracts.csproj
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Contracts/NuGet.VisualStudio.Contracts.csproj
@@ -4,6 +4,8 @@
 
   <PropertyGroup>
     <TargetFramework>$(NetStandardVersion)</TargetFramework>
+    <!-- Preview version of Microsoft.ServiceHub.Framework causes a NU5104 warning. When upgrading to a stable version of this package, remove the below NoWarn="NU5104". -->
+    <NoWarn>$(NoWarn);NU5104</NoWarn>
     <SkipShared>true</SkipShared>
     <PackProject>true</PackProject>
     <Shipping>true</Shipping>


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Client.Engineering/issues/717
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: 
Suppress NU5104 when packing project NuGet.VisualStudio.Contracts. 

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  
Validation:  
Verified by running the following commands locally:
```
msbuild .\build\build.proj /t:RestoreVS /p:BuildNumber=12345 /p:BuildRTM=true /v:m /p:configuration="release"
msbuild .\build\build.proj /t:BuildNoVSIX /p:BuildRTM=true /p:BuildNumber=12345 /p:SkipILMergeOfNuGetExe=true /p:configuration="release"
msbuild .\build\build.proj /t:Pack /p:BuildRTM=true /p:ExcludeTestProjects=true /p:BuildNumber=12345 /p:configuration="release"
```
