### PR TITLE
Fixed the styles of the Dependencies tree's root nodes and dashed border

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageMetadataControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageMetadataControl.xaml
@@ -309,7 +309,8 @@
         Background="{x:Null}"
         TreeViewItem.Selected="OnItemSelected"
         LostFocus="TreeView_LostFocus"
-        AutomationProperties.Name="{x:Static nuget:Resources.Label_Dependencies}">
+        AutomationProperties.Name="{x:Static nuget:Resources.Label_Dependencies}"
+        FocusVisualStyle="{StaticResource ControlsFocusVisualStyle}">
       <TreeView.Template>
         <!--
           Replaces default control template for this treeview with a slimmer control template.
@@ -329,17 +330,22 @@
           <TextBlock Text="{Binding}" ToolTip="{Binding}" />
         </DataTemplate>
       </TreeView.Resources>
+      <TreeView.ItemContainerStyle>
+        <Style TargetType="TreeViewItem">
+          <Setter Property="IsExpanded" Value="True" />
+          <Setter Property="AutomationProperties.Name" Value="{Binding RelativeSource={RelativeSource Self},Converter={StaticResource AccNameWorkaround}}" />
+          <Setter Property="Foreground" Value="{DynamicResource {x:Static nuget:Brushes.UIText}}" />
+          <Setter Property="FontWeight" Value="Bold" />
+        </Style>
+      </TreeView.ItemContainerStyle>
       <TreeViewItem Header="{x:Static nuget:Resources.Label_Dependencies}"
-                    ItemsSource="{Binding Path=DependencySets}"
-                    IsExpanded="true"
-                    Foreground="{DynamicResource {x:Static nuget:Brushes.UIText}}"
-                    FontWeight="Bold">
+                    ItemsSource="{Binding Path=DependencySets}">
         <TreeViewItem.ItemContainerStyle>
           <Style TargetType="TreeViewItem">
-            <Setter Property="IsExpanded" Value="true" />
+            <Setter Property="IsExpanded" Value="True" />
             <Setter Property="AutomationProperties.Name" Value="{Binding RelativeSource={RelativeSource Self},Converter={StaticResource AccNameWorkaround}}" />
             <Setter Property="Foreground" Value="{DynamicResource {x:Static nuget:Brushes.UIText}}" />
-            <Setter Property="FontWeight" Value="normal" />
+            <Setter Property="FontWeight" Value="Normal" />
           </Style>
         </TreeViewItem.ItemContainerStyle>
       </TreeViewItem>


### PR DESCRIPTION
Fixed the style of the Dependencies tree's root nodes so the roots appear correctly when selected in all themes. Also fixed the dashed border color of the Dependencies TreeView control for all themes.

## Bug

Fixes: https://github.com/NuGet/Client.Engineering/issues/715
Regression: No
* Last working version:  N/A 
* How are we preventing it in future:   N/A

## Fix

Details: The Dependencies TreeView was setting an explicit foreground color which was overriding the color change when the node was selected. Removed the explicit color setting and added a style that applies to all root nodes that gives it the right color. Also applied the FocusVisualStyle for all themed controls so the dashed border would look correct in the dark theme as well as all others.

## Testing/Validation

Tests Added: No
Reason for not adding tests:  Fix is purely visual in the UI
Validation:  For each theme, tabbed into the Dependencies tree view, observed the border was the appropriate color for the theme, then pressed the Down arrow key which selects the root node of the tree, and using Accessibility Insights, validated that the color ratio of the text to background was greater than 4.5:1.
