### PR TITLE
Ensure all packages are created in CI 

### DIFF
--- a/build/build.proj
+++ b/build/build.proj
@@ -369,6 +369,25 @@
 
   <!--
     ============================================================
+    Get missing packages List
+    ============================================================
+  -->
+    <Target Name="GetMissingPackageList">
+        <MsBuild
+          Projects="@(SolutionProjects)"
+          Targets="_IsNupkgOrSymbolsExist">
+            <Output
+                TaskParameter="TargetOutputs"
+                ItemName="MissingPackages" />
+        </MsBuild>
+        <Message Text="All wanted nupkgs and symbols are created. " Importance="high"
+                 Condition=" '@(MissingPackages->Count())' == '0' "/>
+        <Error Text="Failed to create following @(MissingPackages->Count()) nupkg or symbols in $(PackageFolder) :'%0D%0A' @(MissingPackages, '%0D%0A')"
+               Condition=" '@(MissingPackages->Count())' != '0' " />
+    </Target>
+
+    <!--
+    ============================================================
     RunTestsOnProjects
     Finds all test assemblies and allows Xunit to run them as 
     efficiently as the xunit.runner.json settings allow.

--- a/build/build.proj
+++ b/build/build.proj
@@ -342,7 +342,7 @@
   <Target Name="GetPackProjects">
       <MsBuild
         Projects="@(SolutionProjects)"
-        Targets="GetPackProject">
+        Targets="_IsProjectNeedsPack">
           <Output
               TaskParameter="TargetOutputs"
               ItemName="PackProjects" />

--- a/build/build.proj
+++ b/build/build.proj
@@ -135,7 +135,7 @@
 
   <!--
     ============================================================
-    Build 
+    Build
     ============================================================
   -->
   <Target Name="BuildVS"  Condition=" '$(IsXPlat)' != 'true' " >
@@ -144,7 +144,7 @@
 
     <!--
     ============================================================
-    Build for XPLAT 
+    Build for XPLAT
     ============================================================
   -->
   <Target Name="BuildXPLAT" DependsOnTargets="GetXPLATProjects">
@@ -286,7 +286,7 @@
   -->
   <Target Name="RestoreXPLAT" DependsOnTargets="GetXPLATProjects">
     <Message Text="Restoring for XPLAT" Importance="high" />
-    
+
     <PropertyGroup>
       <ProjectListValue>@(XPLATProjects)</ProjectListValue>
     </PropertyGroup>
@@ -302,7 +302,7 @@
 
   <!--
     ============================================================
-    Restore Apex 
+    Restore Apex
     ============================================================
   -->
   <Target Name="RestoreApex">
@@ -336,8 +336,40 @@
 
   <!--
     ============================================================
+    Get projects need to be packed
+    ============================================================
+  -->
+  <Target Name="GetPackProjects">
+    <MsBuild
+      Projects="@(SolutionProjects)"
+      Targets="GetPackProject">
+      <Output
+          TaskParameter="TargetOutputs"
+          ItemName="PackProjects" />
+    </MsBuild>
+  </Target>
+
+  <!--
+    ============================================================
+    Ensure all the nupkg and symbol.nugkg files created
+    ============================================================
+  -->
+  <Target Name="EnsurePackagesExist" DependsOnTargets="GetPackProjects">
+    <ItemGroup>
+      <NupkgsFiles Include="$(NupkgOutputDirectory)\*.nupkg"
+                   Exclude="$(NupkgOutputDirectory)\*.symbols.nupkg" />
+      <SymbolFiles Include="$(NupkgOutputDirectory)\*.symbols.nupkg" />
+    </ItemGroup>
+
+    <Message Text="Count of Projects need to be packed: @(PackProjects->Count())        Nupkg Count: @(NupkgsFiles->Count())        Symbol Count: @(SymbolFiles->Count())" Importance="high" />
+
+    <Error Text="There are @(PackProjects->Count()) projects need to be packed, but only @(NupkgsFiles->Count()) nupkg files and  @(SymbolFiles->Count()) symbol nupkg files are created under '$(NupkgOutputDirectory)'."
+           Condition=" '@(PackProjects->Count())' != '@(NupkgsFiles->Count())' OR '@(PackProjects->Count())' != '@(SymbolFiles->Count())' " />
+  </Target>
+  <!--
+    ============================================================
     RunTestsOnProjects
-    Finds all test assemblies and allows Xunit to run them as 
+    Finds all test assemblies and allows Xunit to run them as
     efficiently as the xunit.runner.json settings allow.
     ============================================================
   -->
@@ -375,7 +407,7 @@
       <!-- Sort assemblies -->
       <DesktopInputTestAssemblies>@(TestAssemblyPath->WithMetadataValue("IsDesktop", "true"))</DesktopInputTestAssemblies>
       <DesktopInputTestAssembliesSpaced>$(DesktopInputTestAssemblies.Replace(';', ' '))</DesktopInputTestAssembliesSpaced>
-      
+
       <!-- Build exe commands -->
       <DesktopTestCommand>$(XunitConsoleExePath) $(DesktopInputTestAssembliesSpaced) -verbose</DesktopTestCommand>
       <DesktopTestCommand Condition=" '$(TestResultsXunit)' != '' ">$(DesktopTestCommand) -$(TestResultOutputFormat) $(TestResultsXunit)</DesktopTestCommand>
@@ -390,7 +422,7 @@
     </PropertyGroup>
 
     <!-- Desktop -->
-    <Message Text="Running $(DesktopTestCommand)" 
+    <Message Text="Running $(DesktopTestCommand)"
           Condition=" '$(SkipDesktopAssemblies)' != 'true' AND '$(DesktopInputTestAssemblies)' != '' "/>
 
     <Exec Command="$(DesktopTestCommand)"
@@ -400,7 +432,7 @@
     </Exec>
 
     <!-- VSTest/NETCore -->
-    <Message Text="Running $(VSTestCommand)" 
+    <Message Text="Running $(VSTestCommand)"
           Condition=" '$(SkipCoreAssemblies)' != 'true' AND '$(CoreInputTestAssemblies)' != '' "/>
 
     <Exec Command="$(VSTestCommand)"

--- a/build/build.proj
+++ b/build/build.proj
@@ -135,7 +135,7 @@
 
   <!--
     ============================================================
-    Build
+    Build 
     ============================================================
   -->
   <Target Name="BuildVS"  Condition=" '$(IsXPlat)' != 'true' " >
@@ -144,7 +144,7 @@
 
     <!--
     ============================================================
-    Build for XPLAT
+    Build for XPLAT 
     ============================================================
   -->
   <Target Name="BuildXPLAT" DependsOnTargets="GetXPLATProjects">
@@ -286,7 +286,7 @@
   -->
   <Target Name="RestoreXPLAT" DependsOnTargets="GetXPLATProjects">
     <Message Text="Restoring for XPLAT" Importance="high" />
-
+    
     <PropertyGroup>
       <ProjectListValue>@(XPLATProjects)</ProjectListValue>
     </PropertyGroup>
@@ -302,7 +302,7 @@
 
   <!--
     ============================================================
-    Restore Apex
+    Restore Apex 
     ============================================================
   -->
   <Target Name="RestoreApex">
@@ -336,40 +336,8 @@
 
   <!--
     ============================================================
-    Get projects need to be packed
-    ============================================================
-  -->
-  <Target Name="GetPackProjects">
-    <MsBuild
-      Projects="@(SolutionProjects)"
-      Targets="GetPackProject">
-      <Output
-          TaskParameter="TargetOutputs"
-          ItemName="PackProjects" />
-    </MsBuild>
-  </Target>
-
-  <!--
-    ============================================================
-    Ensure all the nupkg and symbol.nugkg files created
-    ============================================================
-  -->
-  <Target Name="EnsurePackagesExist" DependsOnTargets="GetPackProjects">
-    <ItemGroup>
-      <NupkgsFiles Include="$(NupkgOutputDirectory)\*.nupkg"
-                   Exclude="$(NupkgOutputDirectory)\*.symbols.nupkg" />
-      <SymbolFiles Include="$(NupkgOutputDirectory)\*.symbols.nupkg" />
-    </ItemGroup>
-
-    <Message Text="Count of Projects need to be packed: @(PackProjects->Count())        Nupkg Count: @(NupkgsFiles->Count())        Symbol Count: @(SymbolFiles->Count())" Importance="high" />
-
-    <Error Text="There are @(PackProjects->Count()) projects need to be packed, but only @(NupkgsFiles->Count()) nupkg files and  @(SymbolFiles->Count()) symbol nupkg files are created under '$(NupkgOutputDirectory)'."
-           Condition=" '@(PackProjects->Count())' != '@(NupkgsFiles->Count())' OR '@(PackProjects->Count())' != '@(SymbolFiles->Count())' " />
-  </Target>
-  <!--
-    ============================================================
     RunTestsOnProjects
-    Finds all test assemblies and allows Xunit to run them as
+    Finds all test assemblies and allows Xunit to run them as 
     efficiently as the xunit.runner.json settings allow.
     ============================================================
   -->
@@ -407,7 +375,7 @@
       <!-- Sort assemblies -->
       <DesktopInputTestAssemblies>@(TestAssemblyPath->WithMetadataValue("IsDesktop", "true"))</DesktopInputTestAssemblies>
       <DesktopInputTestAssembliesSpaced>$(DesktopInputTestAssemblies.Replace(';', ' '))</DesktopInputTestAssembliesSpaced>
-
+      
       <!-- Build exe commands -->
       <DesktopTestCommand>$(XunitConsoleExePath) $(DesktopInputTestAssembliesSpaced) -verbose</DesktopTestCommand>
       <DesktopTestCommand Condition=" '$(TestResultsXunit)' != '' ">$(DesktopTestCommand) -$(TestResultOutputFormat) $(TestResultsXunit)</DesktopTestCommand>
@@ -422,7 +390,7 @@
     </PropertyGroup>
 
     <!-- Desktop -->
-    <Message Text="Running $(DesktopTestCommand)"
+    <Message Text="Running $(DesktopTestCommand)" 
           Condition=" '$(SkipDesktopAssemblies)' != 'true' AND '$(DesktopInputTestAssemblies)' != '' "/>
 
     <Exec Command="$(DesktopTestCommand)"
@@ -432,7 +400,7 @@
     </Exec>
 
     <!-- VSTest/NETCore -->
-    <Message Text="Running $(VSTestCommand)"
+    <Message Text="Running $(VSTestCommand)" 
           Condition=" '$(SkipCoreAssemblies)' != 'true' AND '$(CoreInputTestAssemblies)' != '' "/>
 
     <Exec Command="$(VSTestCommand)"

--- a/build/build.proj
+++ b/build/build.proj
@@ -369,25 +369,6 @@
 
   <!--
     ============================================================
-    Get missing packages List
-    ============================================================
-  -->
-    <Target Name="GetMissingPackageList">
-        <MsBuild
-          Projects="@(SolutionProjects)"
-          Targets="_IsNupkgOrSymbolsExist">
-            <Output
-                TaskParameter="TargetOutputs"
-                ItemName="MissingPackages" />
-        </MsBuild>
-        <Message Text="All wanted nupkgs and symbols are created. " Importance="high"
-                 Condition=" '@(MissingPackages->Count())' == '0' "/>
-        <Error Text="Failed to create following @(MissingPackages->Count()) nupkg or symbols in $(PackageFolder) :'%0D%0A' @(MissingPackages, '%0D%0A')"
-               Condition=" '@(MissingPackages->Count())' != '0' " />
-    </Target>
-
-    <!--
-    ============================================================
     RunTestsOnProjects
     Finds all test assemblies and allows Xunit to run them as 
     efficiently as the xunit.runner.json settings allow.

--- a/build/build.proj
+++ b/build/build.proj
@@ -336,6 +336,39 @@
 
   <!--
     ============================================================
+    Get projects need to be packed
+    ============================================================
+  -->
+  <Target Name="GetPackProjects">
+      <MsBuild
+        Projects="@(SolutionProjects)"
+        Targets="GetPackProject">
+          <Output
+              TaskParameter="TargetOutputs"
+              ItemName="PackProjects" />
+      </MsBuild>
+  </Target>
+
+  <!--
+    ============================================================
+    Ensure all the nupkg and symbol.nugkg files created
+    ============================================================
+  -->
+  <Target Name="EnsurePackagesExist" DependsOnTargets="GetPackProjects">
+      <ItemGroup>
+          <NupkgsFiles Include="$(NupkgOutputDirectory)\*.nupkg"
+                       Exclude="$(NupkgOutputDirectory)\*.symbols.nupkg" />
+          <SymbolFiles Include="$(NupkgOutputDirectory)\*.symbols.nupkg" />
+      </ItemGroup>
+
+      <Message Text="Count of Projects need to be packed: @(PackProjects->Count())        Nupkg Count: @(NupkgsFiles->Count())        Symbol Count: @(SymbolFiles->Count())" Importance="high" />
+
+      <Error Text="There are @(PackProjects->Count()) projects need to be packed, but only @(NupkgsFiles->Count()) nupkg files and  @(SymbolFiles->Count()) symbol nupkg files are created under '$(NupkgOutputDirectory)'."
+             Condition=" '@(PackProjects->Count())' != '@(NupkgsFiles->Count())' OR '@(PackProjects->Count())' != '@(SymbolFiles->Count())' " />
+  </Target>
+
+  <!--
+    ============================================================
     RunTestsOnProjects
     Finds all test assemblies and allows Xunit to run them as 
     efficiently as the xunit.runner.json settings allow.

--- a/build/common.targets
+++ b/build/common.targets
@@ -151,6 +151,25 @@
 
   <!--
     ============================================================
+    _IsNupkgAndSymbolsExist
+    Verify if predicted package path exists.
+    ============================================================
+  -->
+  <Target Name="_IsNupkgOrSymbolsExist" Condition="'$(PackProject)' == 'true'" Returns="@(MissingPackages)" >
+    <PropertyGroup>
+      <!-- If we want to check in packages in another folder, e.g. publish folder, we can pass /p:PackageFolder=$(AnthorFolder) -->
+      <PackageFolder Condition=" '$(PackageFolder)' == '' ">$(NupkgOutputDirectory)</PackageFolder>
+      <PrediectNupkgPath>$(PackageFolder)$(PackageId).$(Version).nupkg</PrediectNupkgPath>
+      <PrediectSymbolsPath>$(PackageFolder)$(PackageId).$(Version).symbols.nupkg</PrediectSymbolsPath>
+    </PropertyGroup>
+    <ItemGroup>
+      <MissingPackages Include="$(PackageId).$(Version).nupkg" Condition="!Exists('$(PrediectNupkgPath)')" />
+      <MissingPackages Include="$(PackageId).$(Version).symbols.nupkg" Condition="!Exists('$(PrediectSymbolsPath)')" />
+    </ItemGroup>
+  </Target>
+
+  <!--
+    ============================================================
     _IsProjectNeedsPack
     Verify if the project needs to be packed.
     ============================================================

--- a/build/common.targets
+++ b/build/common.targets
@@ -144,8 +144,21 @@
       Properties="Configuration=$(Configuration);
                   VisualStudioVersion=$(VisualStudioVersion);
                   PackageOutputPath=$(NupkgOutputDirectory);
+                  IncludeSymbols=true;
                   NoBuild=true;">
     </MSBuild>
+  </Target>
+
+  <!--
+    ============================================================
+    GetPackProject - gets the list of projects need to be packed
+    ============================================================
+  -->
+  <Target Name="GetPackProject" Returns="@(PackProjects)">
+    <ItemGroup Condition="'$(PackProject)' == 'true'">
+      <PackProjects Include="$(MSBuildProjectFullPath)">
+      </PackProjects>
+    </ItemGroup>
   </Target>
 
   <!--

--- a/build/common.targets
+++ b/build/common.targets
@@ -151,10 +151,11 @@
 
   <!--
     ============================================================
-    GetPackProject - gets the list of projects need to be packed
+    _IsProjectNeedsPack
+    Verify if the project needs to be packed.
     ============================================================
   -->
-  <Target Name="GetPackProject" Returns="@(PackProjects)">
+  <Target Name="_IsProjectNeedsPack" Returns="@(PackProjects)">
     <ItemGroup Condition="'$(PackProject)' == 'true'">
       <PackProjects Include="$(MSBuildProjectFullPath)">
       </PackProjects>

--- a/build/common.targets
+++ b/build/common.targets
@@ -151,25 +151,6 @@
 
   <!--
     ============================================================
-    _IsNupkgAndSymbolsExist
-    Verify if predicted package path exists.
-    ============================================================
-  -->
-  <Target Name="_IsNupkgOrSymbolsExist" Condition="'$(PackProject)' == 'true'" Returns="@(MissingPackages)" >
-    <PropertyGroup>
-      <!-- If we want to check in packages in another folder, e.g. publish folder, we can pass /p:PackageFolder=$(AnthorFolder) -->
-      <PackageFolder Condition=" '$(PackageFolder)' == '' ">$(NupkgOutputDirectory)</PackageFolder>
-      <PrediectNupkgPath>$(PackageFolder)$(PackageId).$(Version).nupkg</PrediectNupkgPath>
-      <PrediectSymbolsPath>$(PackageFolder)$(PackageId).$(Version).symbols.nupkg</PrediectSymbolsPath>
-    </PropertyGroup>
-    <ItemGroup>
-      <MissingPackages Include="$(PackageId).$(Version).nupkg" Condition="!Exists('$(PrediectNupkgPath)')" />
-      <MissingPackages Include="$(PackageId).$(Version).symbols.nupkg" Condition="!Exists('$(PrediectSymbolsPath)')" />
-    </ItemGroup>
-  </Target>
-
-  <!--
-    ============================================================
     _IsProjectNeedsPack
     Verify if the project needs to be packed.
     ============================================================

--- a/build/templates/Build_and_UnitTest.yml
+++ b/build/templates/Build_and_UnitTest.yml
@@ -60,8 +60,7 @@ steps:
     signType: "$(SigningType)"
     esrpSigning: "true"
   displayName: "Install Signing Plugin"
-  #condition: or(eq(variables['IsOfficialBuild'], 'true'), eq(variables['BuildRTM'], 'true'))  #skip this task for nonRTM in private build
-  condition: "eq(variables['BuildRTM'], 'true')"  #test
+  condition: or(eq(variables['IsOfficialBuild'], 'true'), eq(variables['BuildRTM'], 'true'))  #skip this task for nonRTM in private build
 
 - task: MicroBuildSwixPlugin@1
   displayName: "Install Swix Plugin"
@@ -79,8 +78,7 @@ steps:
     scriptType: "inlineScript"
     inlineScript: |
       dotnet tool restore
-  #condition: "and(not(eq(variables['IsOfficialBuild'], 'true')), eq(variables['BuildRTM'], 'true'))"   #skip this task for nonRTM in private build
-  condition: "eq(variables['BuildRTM'], 'true')"  #test
+  condition: "and(not(eq(variables['IsOfficialBuild'], 'true')), eq(variables['BuildRTM'], 'true'))"   #skip this task for nonRTM in private build
 
 - task: MSBuild@1
   displayName: "Restore for VS2019"
@@ -105,8 +103,7 @@ steps:
     solution: "nuget.sln"
     msbuildVersion: "16.0"
     msbuildArguments: "/t:EnsureNewtonsoftJsonVersion"
-  #condition: "and(succeeded(), or(eq(variables['IsOfficialBuild'], 'true'), eq(variables['BuildRTM'], 'true')))"  #skip this task for nonRTM in private build
-  condition: "and(succeeded(), eq(variables['BuildRTM'], 'true'))"  #test
+  condition: "and(succeeded(), or(eq(variables['IsOfficialBuild'], 'true'), eq(variables['BuildRTM'], 'true')))"  #skip this task for nonRTM in private build
 
 - task: MSBuild@1
   displayName: "Ensure package versions are declared in packages.targets"
@@ -115,8 +112,7 @@ steps:
     solution: "build\\build.proj"
     msbuildVersion: "16.0"
     msbuildArguments: "/t:EnsurePackageReferenceVersionsInSolution"
-  #condition: "and(succeeded(), or(eq(variables['IsOfficialBuild'], 'true'), eq(variables['BuildRTM'], 'true')))"  #skip this task for nonRTM in private build
-  condition: "and(succeeded(), eq(variables['BuildRTM'], 'true'))"  #test
+  condition: "and(succeeded(), or(eq(variables['IsOfficialBuild'], 'true'), eq(variables['BuildRTM'], 'true')))"  #skip this task for nonRTM in private build
 
 
 - task: MSBuild@1
@@ -152,8 +148,7 @@ steps:
     msbuildVersion: "16.0"
     configuration: "$(BuildConfiguration)"
     msbuildArguments: "/t:CoreUnitTests;UnitTestsVS /p:BuildRTM=$(BuildRTM) /p:BuildNumber=$(BuildNumber) /p:TestResultOutputFormat=xml /p:SkipILMergeOfNuGetExe=true"
-  #condition: "and(succeeded(), eq(variables['BuildRTM'], 'true'), not(eq(variables['IsOfficialBuild'], 'true')))"
-  condition: "failed()"
+  condition: "and(succeeded(), eq(variables['BuildRTM'], 'true'), not(eq(variables['IsOfficialBuild'], 'true')))"
 
 - task: MSBuild@1
   displayName: "Run unit tests (continue on error)"
@@ -209,8 +204,7 @@ steps:
     msbuildVersion: "16.0"
     configuration: "$(BuildConfiguration)"
     msbuildArguments: "/t:AfterBuild"
-  #condition: and(succeeded(), or(eq(variables['IsOfficialBuild'], 'true'), eq(variables['BuildRTM'], 'true')))  #skip this task for nonRTM in private build
-  condition: "and(succeeded(), eq(variables['BuildRTM'], 'true'))"  #test
+  condition: and(succeeded(), or(eq(variables['IsOfficialBuild'], 'true'), eq(variables['BuildRTM'], 'true')))  #skip this task for nonRTM in private build
 
 - task: MSBuild@1
   displayName: "Pack Nupkgs"
@@ -219,8 +213,7 @@ steps:
     msbuildVersion: "16.0"
     configuration: "$(BuildConfiguration)"
     msbuildArguments: "/t:Pack /p:BuildRTM=$(BuildRTM) /p:ExcludeTestProjects=$(BuildRTM) /p:BuildNumber=$(BuildNumber)"
-  #condition: and(succeeded(), or(eq(variables['IsOfficialBuild'], 'true'), eq(variables['BuildRTM'], 'true')))  #skip this task for nonRTM in private build
-  condition: "and(succeeded(), eq(variables['BuildRTM'], 'true'))"  #test
+  condition: and(succeeded(), or(eq(variables['IsOfficialBuild'], 'true'), eq(variables['BuildRTM'], 'true')))  #skip this task for nonRTM in private build
 
 - task: MSBuild@1
   displayName: "Ensure all Nupkgs and Symbols are created"
@@ -229,8 +222,7 @@ steps:
     msbuildVersion: "16.0"
     configuration: "$(BuildConfiguration)"
     msbuildArguments: "/t:EnsurePackagesExist /p:ExcludeTestProjects=$(BuildRTM)"
-  #condition: and(succeeded(), or(eq(variables['IsOfficialBuild'], 'true'), eq(variables['BuildRTM'], 'true')))  #skip this task for nonRTM in private build
-  condition: "and(succeeded(), eq(variables['BuildRTM'], 'true'))"  #test
+  condition: and(succeeded(), or(eq(variables['IsOfficialBuild'], 'true'), eq(variables['BuildRTM'], 'true')))  #skip this task for nonRTM in private build
 
 - task: MSBuild@1
   displayName: "Pack VSIX"

--- a/build/templates/Build_and_UnitTest.yml
+++ b/build/templates/Build_and_UnitTest.yml
@@ -60,7 +60,8 @@ steps:
     signType: "$(SigningType)"
     esrpSigning: "true"
   displayName: "Install Signing Plugin"
-  condition: or(eq(variables['IsOfficialBuild'], 'true'), eq(variables['BuildRTM'], 'true'))  #skip this task for nonRTM in private build
+  #condition: or(eq(variables['IsOfficialBuild'], 'true'), eq(variables['BuildRTM'], 'true'))  #skip this task for nonRTM in private build
+  condition: "eq(variables['BuildRTM'], 'true')"  #test
 
 - task: MicroBuildSwixPlugin@1
   displayName: "Install Swix Plugin"
@@ -78,7 +79,8 @@ steps:
     scriptType: "inlineScript"
     inlineScript: |
       dotnet tool restore
-  condition: "and(not(eq(variables['IsOfficialBuild'], 'true')), eq(variables['BuildRTM'], 'true'))"   #skip this task for nonRTM in private build
+  #condition: "and(not(eq(variables['IsOfficialBuild'], 'true')), eq(variables['BuildRTM'], 'true'))"   #skip this task for nonRTM in private build
+  condition: "eq(variables['BuildRTM'], 'true')"  #test
 
 - task: MSBuild@1
   displayName: "Restore for VS2019"
@@ -103,7 +105,8 @@ steps:
     solution: "nuget.sln"
     msbuildVersion: "16.0"
     msbuildArguments: "/t:EnsureNewtonsoftJsonVersion"
-  condition: "and(succeeded(), or(eq(variables['IsOfficialBuild'], 'true'), eq(variables['BuildRTM'], 'true')))"  #skip this task for nonRTM in private build
+  #condition: "and(succeeded(), or(eq(variables['IsOfficialBuild'], 'true'), eq(variables['BuildRTM'], 'true')))"  #skip this task for nonRTM in private build
+  condition: "and(succeeded(), eq(variables['BuildRTM'], 'true'))"  #test
 
 - task: MSBuild@1
   displayName: "Ensure package versions are declared in packages.targets"
@@ -112,7 +115,8 @@ steps:
     solution: "build\\build.proj"
     msbuildVersion: "16.0"
     msbuildArguments: "/t:EnsurePackageReferenceVersionsInSolution"
-  condition: "and(succeeded(), or(eq(variables['IsOfficialBuild'], 'true'), eq(variables['BuildRTM'], 'true')))"  #skip this task for nonRTM in private build
+  #condition: "and(succeeded(), or(eq(variables['IsOfficialBuild'], 'true'), eq(variables['BuildRTM'], 'true')))"  #skip this task for nonRTM in private build
+  condition: "and(succeeded(), eq(variables['BuildRTM'], 'true'))"  #test
 
 
 - task: MSBuild@1
@@ -148,7 +152,8 @@ steps:
     msbuildVersion: "16.0"
     configuration: "$(BuildConfiguration)"
     msbuildArguments: "/t:CoreUnitTests;UnitTestsVS /p:BuildRTM=$(BuildRTM) /p:BuildNumber=$(BuildNumber) /p:TestResultOutputFormat=xml /p:SkipILMergeOfNuGetExe=true"
-  condition: "and(succeeded(), eq(variables['BuildRTM'], 'true'), not(eq(variables['IsOfficialBuild'], 'true')))"
+  #condition: "and(succeeded(), eq(variables['BuildRTM'], 'true'), not(eq(variables['IsOfficialBuild'], 'true')))"
+  condition: "failed()"
 
 - task: MSBuild@1
   displayName: "Run unit tests (continue on error)"
@@ -204,7 +209,8 @@ steps:
     msbuildVersion: "16.0"
     configuration: "$(BuildConfiguration)"
     msbuildArguments: "/t:AfterBuild"
-  condition: and(succeeded(), or(eq(variables['IsOfficialBuild'], 'true'), eq(variables['BuildRTM'], 'true')))  #skip this task for nonRTM in private build
+  #condition: and(succeeded(), or(eq(variables['IsOfficialBuild'], 'true'), eq(variables['BuildRTM'], 'true')))  #skip this task for nonRTM in private build
+  condition: "and(succeeded(), eq(variables['BuildRTM'], 'true'))"  #test
 
 - task: MSBuild@1
   displayName: "Pack Nupkgs"
@@ -213,7 +219,18 @@ steps:
     msbuildVersion: "16.0"
     configuration: "$(BuildConfiguration)"
     msbuildArguments: "/t:Pack /p:BuildRTM=$(BuildRTM) /p:ExcludeTestProjects=$(BuildRTM) /p:BuildNumber=$(BuildNumber)"
-  condition: and(succeeded(), or(eq(variables['IsOfficialBuild'], 'true'), eq(variables['BuildRTM'], 'true')))  #skip this task for nonRTM in private build
+  #condition: and(succeeded(), or(eq(variables['IsOfficialBuild'], 'true'), eq(variables['BuildRTM'], 'true')))  #skip this task for nonRTM in private build
+  condition: "and(succeeded(), eq(variables['BuildRTM'], 'true'))"  #test
+
+- task: MSBuild@1
+  displayName: "Ensure all Nupkgs and Symbols are created"
+  inputs:
+    solution: "build\\build.proj"
+    msbuildVersion: "16.0"
+    configuration: "$(BuildConfiguration)"
+    msbuildArguments: "/t:EnsurePackagesExist /p:ExcludeTestProjects=$(BuildRTM)"
+  #condition: and(succeeded(), or(eq(variables['IsOfficialBuild'], 'true'), eq(variables['BuildRTM'], 'true')))  #skip this task for nonRTM in private build
+  condition: "and(succeeded(), eq(variables['BuildRTM'], 'true'))"  #test
 
 - task: MSBuild@1
   displayName: "Pack VSIX"

--- a/build/templates/Build_and_UnitTest.yml
+++ b/build/templates/Build_and_UnitTest.yml
@@ -216,12 +216,21 @@ steps:
   condition: and(succeeded(), or(eq(variables['IsOfficialBuild'], 'true'), eq(variables['BuildRTM'], 'true')))  #skip this task for nonRTM in private build
 
 - task: MSBuild@1
-  displayName: "Ensure all Nupkgs and Symbols are created"
+  displayName: "Ensure the count of Nupkg and Symbols files are correct"
   inputs:
     solution: "build\\build.proj"
     msbuildVersion: "16.0"
     configuration: "$(BuildConfiguration)"
     msbuildArguments: "/t:EnsurePackagesExist /p:ExcludeTestProjects=$(BuildRTM)"
+  condition: and(succeeded(), or(eq(variables['IsOfficialBuild'], 'true'), eq(variables['BuildRTM'], 'true')))  #skip this task for nonRTM in private build
+
+- task: MSBuild@1
+  displayName: "Ensure all wanted Nupkgs and Symbols are created"
+  inputs:
+    solution: "build\\build.proj"
+    msbuildVersion: "16.0"
+    configuration: "$(BuildConfiguration)"
+    msbuildArguments: "/t:GetMissingPackageList /p:ExcludeTestProjects=$(BuildRTM)"
   condition: and(succeeded(), or(eq(variables['IsOfficialBuild'], 'true'), eq(variables['BuildRTM'], 'true')))  #skip this task for nonRTM in private build
 
 - task: MSBuild@1

--- a/build/templates/Build_and_UnitTest.yml
+++ b/build/templates/Build_and_UnitTest.yml
@@ -216,21 +216,12 @@ steps:
   condition: and(succeeded(), or(eq(variables['IsOfficialBuild'], 'true'), eq(variables['BuildRTM'], 'true')))  #skip this task for nonRTM in private build
 
 - task: MSBuild@1
-  displayName: "Ensure the count of Nupkg and Symbols files are correct"
+  displayName: "Ensure all Nupkgs and Symbols are created"
   inputs:
     solution: "build\\build.proj"
     msbuildVersion: "16.0"
     configuration: "$(BuildConfiguration)"
     msbuildArguments: "/t:EnsurePackagesExist /p:ExcludeTestProjects=$(BuildRTM)"
-  condition: and(succeeded(), or(eq(variables['IsOfficialBuild'], 'true'), eq(variables['BuildRTM'], 'true')))  #skip this task for nonRTM in private build
-
-- task: MSBuild@1
-  displayName: "Ensure all wanted Nupkgs and Symbols are created"
-  inputs:
-    solution: "build\\build.proj"
-    msbuildVersion: "16.0"
-    configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/t:GetMissingPackageList /p:ExcludeTestProjects=$(BuildRTM)"
   condition: and(succeeded(), or(eq(variables['IsOfficialBuild'], 'true'), eq(variables['BuildRTM'], 'true')))  #skip this task for nonRTM in private build
 
 - task: MSBuild@1


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Client.Engineering/issues/666
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: 
1.Enable packing symbol (revert https://github.com/NuGet/NuGet.Client/pull/3758) as it breaks the source link.

2.On CI, after packing, check if all packages are created by comparing the count of projects need to be packed and the count of  *.nupkg/*.symbol.nupkg files. 

If the three numbers match, show a message:
`Count of Projects need to be packed: 25        Nupkg Count: 25        Symbol Count: 25`

If the three numbers don't match, break the build and show both above message and an error as following:
`There are 25 projects need to be packed, but only 25 nupkg files and  24 symbol nupkg files are created under 'C:\A\1\318\s\artifacts\ReleaseNupkgs\'.`

Note: When building for RTM, the test project(Test.Utility) will not be packed. 
          So the projects need to be packed for RTM is less than that of nonRTM by 1.

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  Engineering change
Validation:  
Run `msbuild .\build\build.proj /t:EnsurePackagesExist /p:ExcludeTestProjects=$(BuildRTM)` locally and change the number of packages see if the message and error are correctly shown. 