### PR TITLE
Codespaces:  register all MessagePack formatters

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/NuGetServiceMessagePackRpcDescriptor.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/NuGetServiceMessagePackRpcDescriptor.cs
@@ -50,12 +50,16 @@ namespace NuGet.VisualStudio.Internal.Contracts
             return new NuGetJsonRpc(handler);
         }
 
-        private static MessagePackSerializerOptions CreateMessagePackSerializerOptions()
+        // Non-private for testing purposes only.
+        internal static IMessagePackFormatter[] CreateMessagePackFormatters()
         {
-            var formatters = new IMessagePackFormatter[]
+            return new IMessagePackFormatter[]
             {
                 AlternatePackageMetadataContextInfoFormatter.Instance,
                 FloatRangeFormatter.Instance,
+                IInstalledAndTransitivePackagesFormatter.Instance,
+                ILogMessageFormatter.Instance,
+                ImplicitProjectActionFormatter.Instance,
                 IPackageReferenceContextInfoFormatter.Instance,
                 IProjectContextInfoFormatter.Instance,
                 IProjectMetadataContextInfoFormatter.Instance,
@@ -68,16 +72,22 @@ namespace NuGet.VisualStudio.Internal.Contracts
                 PackageIdentityFormatter.Instance,
                 PackageReferenceFormatter.Instance,
                 PackageSearchMetadataContextInfoFormatter.Instance,
-                PackageSourceFormatter.Instance,
                 PackageSourceContextInfoFormatter.Instance,
+                PackageSourceFormatter.Instance,
                 PackageSourceUpdateOptionsFormatter.Instance,
                 PackageVulnerabilityMetadataContextInfoFormatter.Instance,
                 ProjectActionFormatter.Instance,
-                VersionRangeFormatter.Instance,
+                RemoteErrorFormatter.Instance,
                 SearchFilterFormatter.Instance,
                 SearchResultContextInfoFormatter.Instance,
                 VersionInfoContextInfoFormatter.Instance,
+                VersionRangeFormatter.Instance
             };
+        }
+
+        private static MessagePackSerializerOptions CreateMessagePackSerializerOptions()
+        {
+            IMessagePackFormatter[] formatters = CreateMessagePackFormatters();
             var resolvers = new IFormatterResolver[] { MessagePack.MessagePackSerializerOptions.Standard.Resolver };
 
             return MessagePack.MessagePackSerializerOptions.Standard

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/NuGetServiceMessagePackRpcDescriptorTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/NuGetServiceMessagePackRpcDescriptorTests.cs
@@ -1,0 +1,57 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using MessagePack.Formatters;
+using Xunit;
+
+namespace NuGet.VisualStudio.Internal.Contracts.Test
+{
+    public class NuGetServiceMessagePackRpcDescriptorTests
+    {
+        [Fact]
+        public void CreateMessagePackFormatters_Always_RegistersAllFormatters()
+        {
+            IMessagePackFormatter[] registeredFormatters = NuGetServiceMessagePackRpcDescriptor.CreateMessagePackFormatters();
+            IReadOnlyList<Type> definedFormatters = FindDefinedMessagePackFormatters();
+
+            HashSet<string> registeredFormatterNames = registeredFormatters
+                .Select(formatter => formatter.GetType().FullName)
+                .ToHashSet();
+
+            HashSet<string> definedFormatterNames = definedFormatters
+                .Where(definedFormatter => !definedFormatter.Equals(typeof(NuGetMessagePackFormatter<>))) // Exclude the base class.
+                .Select(formatter => formatter.FullName)
+                .ToHashSet();
+
+            definedFormatterNames.ExceptWith(registeredFormatterNames);
+
+            if (definedFormatterNames.Count > 0)
+            {
+                var message = new StringBuilder($"The following formatters are not registered.  Did you define a new one and forget to register it?");
+
+                message.AppendLine();
+
+                foreach (string definedFormatterName in definedFormatterNames)
+                {
+                    message.AppendLine(definedFormatterName);
+                }
+
+                Assert.True(false, message.ToString());
+            }
+        }
+
+        private static IReadOnlyList<Type> FindDefinedMessagePackFormatters()
+        {
+            Assembly assembly = typeof(NuGetServiceMessagePackRpcDescriptor).Assembly;
+
+            return assembly.GetTypes()
+                .Where(type => type.GetInterfaces().Contains(typeof(IMessagePackFormatter)))
+                .ToList();
+        }
+    }
+}


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/10467
Regression: Yes  
* Last working version:   build before each merged PR referenced in issue
* How are we preventing it in future:   added a unit test

## Fix

Details:  Two MessagePack formatters necessary for Codespaces experience were not registered.  One was (accidentally) unregistered while the other was never registered.

This PR adds a new test which ensures all MessagePack formatters defined in the NuGet.VisualStudio.Internal.Contracts assembly
are created by the `NuGetServiceMessagePackRpcDescriptor` type.

## Testing/Validation

Tests Added:  Yes
Validation:  automated and manual validation

CC @rrelyea, @sbanni