### PR TITLE
remove file share dependency for buildinfo.json file and download the file from artifacts during release

### DIFF
--- a/build/templates/Build_and_UnitTest.yml
+++ b/build/templates/Build_and_UnitTest.yml
@@ -34,7 +34,7 @@ steps:
 - task: PowerShell@1
   inputs:
     scriptName: "$(Build.Repository.LocalPath)\\scripts\\cibuild\\ConfigureVstsBuild.ps1"
-    arguments: "-BuildCounterFile $(BuildCounterFile) -BuildInfoJsonFile $(BuildInfoJsonFile) -BuildRTM $(BuildRTM) -SkipUpdateBuildNumber"
+    arguments: "-BuildRTM $(BuildRTM)"
   displayName: "Configure VSTS CI Environment"
 
 - task: PublishBuildArtifacts@1


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Client.Engineering/issues/394

Regression: No 

## Fix 
Modified CI scripts to remove file share dependency for `buildinfo.json` file. The following build step runs the `ConfigureVstsBuild.ps1`. 
FolderSuffix | StepName | PhaseName | Comment |
-- | -- | -- | --|
Build | Configure VSTS CI Environment| Build_and_UnitTest NonRTM  | Generates buildinfo.json file |

I have removed logic to support `-SkipUpdateBuildNumber` switch in the `ConfigureVstsBuild.ps1` script as I found it redundant, and we always pass this switch to the command. Happy to bring to back based on the feedback.

https://github.com/NuGet/NuGet.Client/blob/b293bd5cac6ef6d88c315f75ba69cbe47db3227e/build/templates/Build_and_UnitTest.yml#L37

For e.g. `Build_and_UnitTest_NonRTM` - https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=4378624&view=logs&j=2ea8c801-c4c3-578e-0ff0-bcf4c12d9404&t=ca35e91d-75ae-5ed4-785b-bfd3ac3f2ddd&l=9

```
'C:\A\1\280\s\scripts\cibuild\ConfigureVstsBuild.ps1' -BuildCounterFile \\ddfiles\drops\NuGet\Drops\CI\NuGet.Client\buildcounter_official.txt -BuildInfoJsonFile \\ddfiles\drops\NuGet\Drops\CI\NuGet.Client\dev\5.9.0.7050\buildinfo.json -BuildRTM false -SkipUpdateBuildNumber
```

`Build_and_UnitTest_RTM` - https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=4378624&view=logs&j=3662048e-4e2d-5ad0-bcc2-35d49e82de1c&t=f7bff3ac-56d9-56f8-3e0e-88c5057834ef&l=9

```
'C:\A\1\330\s\scripts\cibuild\ConfigureVstsBuild.ps1' -BuildCounterFile \\ddfiles\drops\NuGet\Drops\CI\NuGet.Client\buildcounter_official.txt -BuildInfoJsonFile \\ddfiles\drops\NuGet\Drops\CI\NuGet.Client\dev\5.9.0.7050\buildinfo.json -BuildRTM true -SkipUpdateBuildNumber
```

With this change `buildinfo.json` will not be stored on the file share and we already have a build step to publish the file to Artifcats.

https://github.com/NuGet/NuGet.Client/blob/b293bd5cac6ef6d88c315f75ba69cbe47db3227e/build/templates/Build_and_UnitTest.yml#L40-L46

For e.g., https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=4389897&view=artifacts&pathAsName=false&type=publishedArtifacts (`buildinfo.json` has been published to build artifacts)

AFAIK, `buildinfo.json` is read from the file share in [NuGet.Client Release pipeline](https://dev.azure.com/devdiv/DevDiv/_release?definitionId=257&view=mine&_a=releases). I propose following changes to the pipeline definition to read `buildinfo.json` file from build artifacts.

- Download `buildinfo.json` file from build artifacts. Change `Insert into VS` task as shown below. Thank you @dominoFire for teaching me on how to download build artifacts in the release pipeline.

![image](https://user-images.githubusercontent.com/52756182/105257778-55781d80-5b3d-11eb-909e-228a13e55a79.png)

- Change `Get VS Target Branch` script to read `buildinfo.json` from [`$(System.ArtifactsDirectory)`](https://docs.microsoft.com/en-us/azure/devops/pipelines/release/variables?view=azure-devops&tabs=batch#default-variables---system).

``` powershell
if(-not $env:VSTARGETBRANCH)
{
    $BuildInfoJsonFile = [System.IO.Path]::Combine('$(System.ArtifactsDirectory)','$(Build.DefinitionName)','BuildInfo','buildinfo.json')
//no change in the other lines of the inline script.
}
else
{
Write-Output "Using overridden branch $(VsTargetBranch)"
}
```
- Change `Get Assembly Version` script to read `buildinfo.json` from `$(System.ArtifactsDirectory)`.

```powershell
$BuildInfoJsonFile = [System.IO.Path]::Combine('$(System.ArtifactsDirectory)','$(Build.DefinitionName)','BuildInfo','buildinfo.json')
//no change in the other lines of the inline script.
```
- Save the pipeline.

Details: 

## Testing/Validation

Tests Added: No 
Reason for not adding tests:  Modified CI scripts.
Validation:  Manual validation (Hopefully VS insertion completes successfully)
