### PR TITLE
Change the background and foreground colors in the PMUI to increase contrast ratio in Light theme and use the correct colors for doc well UI

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources/Brushes.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources/Brushes.cs
@@ -176,19 +176,19 @@ namespace NuGet.PackageManagement.UI
             ComboBoxBorderKey = VsBrushes.ComboBoxBorderKey;
             ControlLinkTextHoverKey = VsBrushes.ControlLinkTextHoverKey;
             ControlLinkTextKey = VsBrushes.ControlLinkTextKey;
-            DetailPaneBackground = VsBrushes.BrandedUIBackgroundKey;
-            HeaderBackground = VsBrushes.BrandedUIBackgroundKey;
+            DetailPaneBackground = CommonDocumentColors.PageBrushKey;
+            HeaderBackground = CommonDocumentColors.PageBrushKey;
             InfoBackgroundKey = VsBrushes.InfoBackgroundKey;
             InfoTextKey = VsBrushes.InfoTextKey;
-            LegalMessageBackground = VsBrushes.BrandedUIBackgroundKey;
-            ListPaneBackground = VsBrushes.BrandedUIBackgroundKey;
+            LegalMessageBackground = CommonDocumentColors.PageBrushKey;
+            ListPaneBackground = CommonDocumentColors.PageBrushKey;
             SplitterBackgroundKey = VsBrushes.CommandShelfBackgroundGradientKey;
             ToolWindowBorderKey = VsBrushes.ToolWindowBorderKey;
             ToolWindowButtonDownBorderKey = VsBrushes.ToolWindowButtonDownBorderKey;
             ToolWindowButtonDownKey = VsBrushes.ToolWindowButtonDownKey;
             ToolWindowButtonHoverActiveBorderKey = VsBrushes.ToolWindowButtonHoverActiveBorderKey;
             ToolWindowButtonHoverActiveKey = VsBrushes.ToolWindowButtonHoverActiveKey;
-            UIText = VsBrushes.BrandedUITextKey;
+            UIText = CommonDocumentColors.PageTextBrushKey;
             WindowTextKey = VsBrushes.WindowTextKey;
 
             HeaderColorsDefaultBrushKey = HeaderColors.DefaultBrushKey;


### PR DESCRIPTION
Change the background and foreground colors in the PMUI to increase contrast ratio in Light theme and use the correct colors for doc well UI. In addition, the background and foreground of the PMUI was using colors from the BrandedUI category not intended for this type of UI and also resulted in a gray background in the Light theme that resembled the color of the VS toolbar. The light theme is intended to have a center stage area that is white so the grayish background was violating the design idea for the light theme which this PR also fixes.

## Bug

Fixes: https://github.com/NuGet/Client.Engineering/issues/714
Regression: No
* Last working version:  N/A
* How are we preventing it in future:  N/A

## Fix

Details: Updated the mapping of color tokens to use the CommonDocument Page background and foreground for the PMUI which are the colors that should be used for doc well UI. This has the desirable effect of making the background White (instead of grayish) in the Light theme and slightly darker in the Dark theme.

## Testing/Validation

Tests Added: Yes/No  No
Reason for not adding tests:  UI color changes
Validation:  Tested in Blue, Light, and Dark themes visually and with Accessibility Insights to ensure contrast ratio tests passed.
