### PR TITLE
PM UI:  propagate implicit actions for "Preview Changes" summary in update package operation

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetProjectManagerService.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetProjectManagerService.cs
@@ -443,30 +443,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
                 foreach (ResolvedAction resolvedAction in resolvedActions)
                 {
-                    List<ImplicitProjectAction>? implicitActions = null;
-
-                    if (resolvedAction.Action is BuildIntegratedProjectAction buildIntegratedAction)
-                    {
-                        implicitActions = new List<ImplicitProjectAction>();
-
-                        foreach (NuGetProjectAction? buildAction in buildIntegratedAction.GetProjectActions())
-                        {
-                            var implicitAction = new ImplicitProjectAction(
-                                CreateProjectActionId(),
-                                buildAction.PackageIdentity,
-                                buildAction.NuGetProjectActionType);
-
-                            implicitActions.Add(implicitAction);
-                        }
-                    }
-
-                    string projectId = resolvedAction.Project.GetMetadata<string>(NuGetProjectMetadataKeys.ProjectId);
-                    var projectAction = new ProjectAction(
-                        CreateProjectActionId(),
-                        projectId,
-                        resolvedAction.Action.PackageIdentity,
-                        resolvedAction.Action.NuGetProjectActionType,
-                        implicitActions);
+                    ProjectAction projectAction = CreateProjectAction(resolvedAction);
 
                     _state.ResolvedActions[projectAction.Id] = resolvedAction;
 
@@ -578,26 +555,20 @@ namespace NuGet.PackageManagement.VisualStudio
 
                 NuGetPackageManager packageManager = await _sharedState.PackageManager.GetValueAsync(cancellationToken);
                 IEnumerable<NuGetProjectAction> actions = await packageManager.PreviewUpdatePackagesAsync(
-                      packageIdentities.ToList(),
-                      projects,
-                      resolutionContext,
-                      projectContext,
-                      primarySources,
-                      secondarySources,
-                      cancellationToken);
+                    packageIdentities.ToList(),
+                    projects,
+                    resolutionContext,
+                    projectContext,
+                    primarySources,
+                    secondarySources,
+                    cancellationToken);
 
                 var projectActions = new List<ProjectAction>();
 
                 foreach (NuGetProjectAction action in actions)
                 {
-                    string projectId = action.Project.GetMetadata<string>(NuGetProjectMetadataKeys.ProjectId);
                     var resolvedAction = new ResolvedAction(action.Project, action);
-                    var projectAction = new ProjectAction(
-                        CreateProjectActionId(),
-                        projectId,
-                        action.PackageIdentity,
-                        action.NuGetProjectActionType,
-                        implicitActions: null);
+                    ProjectAction projectAction = CreateProjectAction(resolvedAction);
 
                     _state.ResolvedActions[projectAction.Id] = resolvedAction;
 
@@ -620,6 +591,36 @@ namespace NuGet.PackageManagement.VisualStudio
                 .Select(affectedProject => ProjectContextInfo.CreateAsync(affectedProject, cancellationToken).AsTask());
 
             return await Task.WhenAll(tasks);
+        }
+
+        private static ProjectAction CreateProjectAction(ResolvedAction resolvedAction)
+        {
+            List<ImplicitProjectAction>? implicitActions = null;
+
+            if (resolvedAction.Action is BuildIntegratedProjectAction buildIntegratedAction)
+            {
+                implicitActions = new List<ImplicitProjectAction>();
+
+                foreach (NuGetProjectAction? buildAction in buildIntegratedAction.GetProjectActions())
+                {
+                    var implicitAction = new ImplicitProjectAction(
+                        CreateProjectActionId(),
+                        buildAction.PackageIdentity,
+                        buildAction.NuGetProjectActionType);
+
+                    implicitActions.Add(implicitAction);
+                }
+            }
+
+            string projectId = resolvedAction.Project.GetMetadata<string>(NuGetProjectMetadataKeys.ProjectId);
+            var projectAction = new ProjectAction(
+                CreateProjectActionId(),
+                projectId,
+                resolvedAction.Action.PackageIdentity,
+                resolvedAction.Action.NuGetProjectActionType,
+                implicitActions);
+
+            return projectAction;
         }
 
         private static string CreateProjectActionId()

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetProjectManagerService.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetProjectManagerService.cs
@@ -601,7 +601,7 @@ namespace NuGet.PackageManagement.VisualStudio
             {
                 implicitActions = new List<ImplicitProjectAction>();
 
-                foreach (NuGetProjectAction? buildAction in buildIntegratedAction.GetProjectActions())
+                foreach (NuGetProjectAction buildAction in buildIntegratedAction.GetProjectActions())
                 {
                     var implicitAction = new ImplicitProjectAction(
                         CreateProjectActionId(),


### PR DESCRIPTION
## Bug

Fixes:  https://github.com/NuGet/Home/issues/10483
Regression: Yes  
* Last working version:   16.8.3 (?)
* How are we preventing it in future:   add unit test

## Fix

Details:  For PackageReference-(.NET SDK-style)-based projects, updating an installed package involves other implicit actions (like first uninstalling the existing package).  Propagating these implicit actions from server to client are necessary for the client to generate an update summary in the "Preview Changes" dialog.

## Testing/Validation

Tests Added: Yes  
Reason for not adding tests:  
Validation:  Manually validated against 16.6.5.

CC @rrelyea, @sbanni