### PR TITLE
More careful null checking in NuGet.PackageManagement

### DIFF
--- a/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
@@ -3687,8 +3687,14 @@ namespace NuGet.PackageManagement
                 PackagesFolderSourceRepository
             };
 
-            effectiveSources.AddRange(primarySources);
-            effectiveSources.AddRange(secondarySources);
+            if (primarySources != null)
+            {
+                effectiveSources.AddRange(primarySources);
+            }
+            if (secondarySources != null)
+            {
+                effectiveSources.AddRange(secondarySources);
+            }
 
             return new HashSet<SourceRepository>(effectiveSources, new SourceRepositoryComparer());
         }

--- a/src/NuGet.Core/NuGet.PackageManagement/Projects/ProjectJsonNuGetProject.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Projects/ProjectJsonNuGetProject.cs
@@ -220,7 +220,7 @@ namespace NuGet.ProjectManagement.Projects
 
                 var references = (await ProjectServices
                     .ReferencesReader
-                    .GetProjectReferencesAsync(context.Logger, CancellationToken.None))
+                    .GetProjectReferencesAsync(context?.Logger, CancellationToken.None))
                     .ToList();
 
                 if (references != null && references.Count > 0)

--- a/src/NuGet.Core/NuGet.PackageManagement/Projects/ProjectJsonNuGetProject.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Projects/ProjectJsonNuGetProject.cs
@@ -220,7 +220,7 @@ namespace NuGet.ProjectManagement.Projects
 
                 var references = (await ProjectServices
                     .ReferencesReader
-                    .GetProjectReferencesAsync(context?.Logger, CancellationToken.None))
+                    .GetProjectReferencesAsync(context?.Logger ?? NullLogger.Instance, CancellationToken.None))
                     .ToList();
 
                 if (references != null && references.Count > 0)

--- a/src/NuGet.Core/NuGet.PackageManagement/Resolution/ResolverGather.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Resolution/ResolverGather.cs
@@ -595,7 +595,7 @@ namespace NuGet.PackageManagement
                     {
                         var resource = await depResources[source];
 
-                        if (source != null && !_primaryResources.Any(sourceResource => sourceResource.Source.PackageSource.Equals(source)))
+                        if (!_primaryResources.Any(sourceResource => sourceResource.Source.PackageSource.Equals(source)))
                         {
                             _primaryResources.Add(new SourceResource(source, resource));
                         }
@@ -612,7 +612,7 @@ namespace NuGet.PackageManagement
                         //var resource = await depResources[source];
                         var resource = depResources[source];
 
-                        if (source != null && !_allResources.Any(sourceResource => sourceResource.Source.PackageSource.Equals(source)))
+                        if (!_allResources.Any(sourceResource => sourceResource.Source.PackageSource.Equals(source)))
                         {
                             currentSource = source.PackageSource.Source;
                             _allResources.Add(new SourceResource(source, resource.Result));

--- a/src/NuGet.Core/NuGet.PackageManagement/Utility/PackagesConfigLockFileUtility.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Utility/PackagesConfigLockFileUtility.cs
@@ -67,7 +67,7 @@ namespace NuGet.PackageManagement.Utility
         internal static string GetPackagesLockFilePath(MSBuildNuGetProject msbuildProject)
         {
             var directory = (string)msbuildProject.Metadata["FullPath"];
-            var msbuildProperty = msbuildProject?.ProjectSystem?.GetPropertyValue("NuGetLockFilePath");
+            var msbuildProperty = msbuildProject.ProjectSystem?.GetPropertyValue("NuGetLockFilePath");
             var projectName = (string)msbuildProject.Metadata["UniqueName"];
 
             return GetPackagesLockFilePath(directory, msbuildProperty, projectName);


### PR DESCRIPTION
These were caught by running a static scanner on NuGet.Client sources.

## Bug

Fixes: https://github.com/NuGet/Home/issues/10476
Regression: No  
* How are we preventing it in future:  I will be running this static analyzer more often, and paying attention to its results.

## Fix

Be more careful with the checks

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  Caught by static analyzer, manual tests would be redundant. Also, can't run tests, because of https://github.com/NuGet/Home/issues/10139
Validation: None.
