### PR TITLE
Fix string.Replace not having the expected effect

### DIFF
--- a/src/NuGet.Core/NuGet.PackageManagement/Utility/PackagesConfigLockFileUtility.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Utility/PackagesConfigLockFileUtility.cs
@@ -57,7 +57,7 @@ namespace NuGet.PackageManagement.Utility
                     var lockFileRelativePath = projectUri.MakeRelativeUri(lockFileUri).OriginalString;
                     if (Path.DirectorySeparatorChar != '/')
                     {
-                        lockFileRelativePath.Replace('/', Path.DirectorySeparatorChar);
+                        lockFileRelativePath = lockFileRelativePath.Replace('/', Path.DirectorySeparatorChar);
                     }
                     msbuildProject.ProjectSystem.AddExistingFile(lockFileRelativePath);
                 }


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/10477
Regression: Not sure. I haven't seen a functional impact
* Last working version:   
* How are we preventing it in future:  I am going to run static analysis more often, and pay attention to the result.

## Fix

Details: string.Replace returns a modified copy. We need to update the variable to use that modified copy if we want to make use of the change. 

## Testing/Validation

Tests Added: No
Reason for not adding tests: caught via static analysis  
Validation:  

