### PR TITLE
Add script to validate if expected packages exist

### DIFF
--- a/scripts/utils/EnsureAllPackagesExist.ps1
+++ b/scripts/utils/EnsureAllPackagesExist.ps1
@@ -2,11 +2,12 @@
 
 [CmdletBinding(SupportsShouldProcess=$True)]
 Param (
-    [string]$NupkgOutputPath
+    [string]$NupkgOutputPath,
+    [switch]$BuildRTM
 )
 
 # The list of projects need to be packed.
-$ProjectsShouldPack = @(
+[System.Collections.ArrayList]$PackageIDListShouldExist = @(
 "NuGet.CommandLine",
 "NuGet.Indexing",
 "NuGet.SolutionRestoreManager.Interop",
@@ -33,15 +34,21 @@ $ProjectsShouldPack = @(
 "NuGet.Resolver",
 "NuGet.Versioning")
 
+if (!$BuildRTM)
+{
+    $PackageIDListShouldExist.Add("Test.Utility")
+    $PackageIDListShouldExist.Add("NuGet.Localization")
+}
+
 $ErrorMessage = ""
 $MissingNupkgs = ""
 $MissingSymbols = ""
 $MissingNupkgCount = 0
 $MissingSymbolsCount = 0
 
-ForEach ($ProjectShouldPack in $ProjectsShouldPack)
+ForEach ($PackageIDShouldExist in $PackageIDListShouldExist)
 {
-    $ProjectShouldPack = $ProjectShouldPack.trim()
+    $PackageIDShouldExist = $PackageIDShouldExist.trim()
 
     $PackagesName = Get-ChildItem $NupkgOutputPath -Filter *.nupkg -Name
 
@@ -51,7 +58,7 @@ ForEach ($ProjectShouldPack in $ProjectsShouldPack)
 
     Foreach ($PackageName in $PackagesName)
     {
-        $FoundNupkg = ( ($PackageName -match "${ProjectShouldPack}.[0-9][0-9a-zA-Z.-]*.nupkg") -and -not($PackageName -match "${ProjectShouldPack}.[0-9][0-9a-zA-Z.-]*.symbols.nupkg") )
+        $FoundNupkg = ( ($PackageName -match "${PackageIDShouldExist}.[0-9][0-9a-zA-Z.-]*.nupkg") -and -not($PackageName -match "${ProjectShouldPack}.[0-9][0-9a-zA-Z.-]*.symbols.nupkg") )
 
         if ($FoundNupkg)
         {
@@ -62,7 +69,7 @@ ForEach ($ProjectShouldPack in $ProjectsShouldPack)
 
     Foreach ($PackageName in $PackagesName)
     {
-        $FoundSymbols = $PackageName -match "${ProjectShouldPack}.[0-9][0-9a-zA-Z.-]*.symbols.nupkg"
+        $FoundSymbols = $PackageName -match "${PackageIDShouldExist}.[0-9][0-9a-zA-Z.-]*.symbols.nupkg"
 
         if ($FoundSymbols)
         {
@@ -73,12 +80,12 @@ ForEach ($ProjectShouldPack in $ProjectsShouldPack)
 
     if (-not($FoundNupkg))
     {
-        $MissingNupkg = $MissingNupkg + "$ProjectShouldPack "
+        $MissingNupkg = $MissingNupkg + "$PackageIDShouldExist "
         $MissingNupkgCount = $MissingNupkgCount + 1
     }
      if (-not($FoundSymbols))
     {
-        $MissingSymbols = $MissingSymbols + "$ProjectShouldPack "
+        $MissingSymbols = $MissingSymbols + "$PackageIDShouldExist "
         $MissingSymbolsCount = $MissingSymbolsCount + 1
     }
 }

--- a/scripts/utils/EnsureAllPackagesExist.ps1
+++ b/scripts/utils/EnsureAllPackagesExist.ps1
@@ -1,0 +1,75 @@
+# Ensure all packages are created before publishing
+
+[CmdletBinding(SupportsShouldProcess=$True)]
+Param (
+    [string]$NupkgOutputPath
+)
+
+# The list of projects need to be packed.
+$ProjectsShouldPack = @(
+"NuGet.CommandLine",
+"NuGet.Indexing",
+"NuGet.SolutionRestoreManager.Interop",
+"NuGet.VisualStudio.Contracts",
+"NuGet.VisualStudio",
+"Microsoft.Build.NuGetSdkResolver",
+"NuGet.Build.Tasks.Console",
+"NuGet.Build.Tasks.Pack",
+"NuGet.Build.Tasks",
+"NuGet.CommandLine.XPlat",
+"NuGet.Commands",
+"NuGet.Common",
+"NuGet.Configuration",
+"NuGet.Credentials",
+"NuGet.DependencyResolver.Core",
+"NuGet.Frameworks",
+"NuGet.LibraryModel",
+"NuGet.PackageManagement",
+"NuGet.Packaging.Core",
+"NuGet.Packaging.Extraction",
+"NuGet.Packaging",
+"NuGet.ProjectModel",
+"NuGet.Protocol",
+"NuGet.Resolver",
+"NuGet.Versioning")
+
+
+$ErrorMessage = ""
+$ErrorCount = 0
+
+ForEach ($ProjectShouldPack in $ProjectsShouldPack) {
+
+    $ProjectShouldPack = $ProjectShouldPack.trim()
+
+    $PackagesName = Get-ChildItem $NupkgOutputPath -Filter *.nupkg -Name
+
+    $FoundNupkg = $false
+
+    Foreach ($PackageName in $PackagesName) {
+
+        if ( ($PackageName -match "${ProjectShouldPack}.[0-9][0-9a-zA-Z.-]*.nupkg") -and -not($PackageName -match "${ProjectShouldPack}.[0-9][0-9a-zA-Z.-]*.symbols.nupkg") ) {
+            $FoundNupkg = $true
+            Write-Host "$ProjectShouldPack is packed as : $PackageName" -ForegroundColor Cyan
+            break
+        }
+    }
+
+    if (-not($FoundNupkg))
+    {
+        $ErrorMessage = $ErrorMessage + "$ProjectShouldPack "
+        $ErrorCount = $ErrorCount + 1
+    }
+
+}
+
+If ($ErrorCount -ne 0)
+{
+    $ErrorMessage = "The following project(s) are not packed in $NupkgOutputPath : " + $ErrorMessage
+    Write-Error "[FATAL] $ErrorMessage"
+    Exit 1
+}
+else
+{
+    Write-Host "All projects are packed in : $NupkgOutputPath" -ForegroundColor Cyan
+    Exit 0
+}


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Client.Engineering/issues/667
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: 
Add a powershell script to validate expected `*.nupkg` and `*.symbols.nupkg` files exist.
Any missing files will cause exitcode=1.
Will add a task to run this script in release pipeline later.
Will change the validation in build pipeline to this script if it's needed.

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  Engineering
Validation:  Run this script locally.