### PR TITLE
Fix copy-paste error in V2FeedPackageInfo

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/LegacyFeed/V2FeedPackageInfo.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LegacyFeed/V2FeedPackageInfo.cs
@@ -279,7 +279,7 @@ namespace NuGet.Protocol
                                     var frameworkString = parts[2];
 
                                     if (!string.IsNullOrWhiteSpace(frameworkString)
-                                        && !string.Equals(NullString, versionRangeString, StringComparison.OrdinalIgnoreCase))
+                                        && !string.Equals(NullString, frameworkString, StringComparison.OrdinalIgnoreCase))
                                     {
                                         framework = NuGetFramework.Parse(frameworkString);
                                     }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/V2FeedParserTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/V2FeedParserTests.cs
@@ -660,7 +660,7 @@ namespace NuGet.Protocol.Tests
             Assert.Equal(DateTimeOffset.Parse("2016-04-06T12:46:30.942Z"), latest.Published.Value);
             Assert.Equal(DateTimeOffset.Parse("2016-04-06T12:46:30.942Z"), latest.Created.Value);
             Assert.Equal(DateTimeOffset.Parse("2017-04-06T12:46:30.942Z"), latest.LastEdited.Value);
-            Assert.Equal("PackageB:null|EntityFramework:6.1.3|PackageC:3.7.0.15", latest.Dependencies);
+            Assert.Equal("PackageB:null|EntityFramework:6.1.3|PackageC:3.7.0.15|PackageD:3.14.15:null", latest.Dependencies);
             Assert.Equal(1, latest.DependencySets.Count());
             Assert.Equal(VersionRange.All, latest.DependencySets.Single().Packages.Where(p => p.Id == "PackageB").Single().VersionRange);
             Assert.Equal("any", latest.DependencySets.First().TargetFramework.GetShortFolderName());

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/compiler/resources/NexusFindPackagesById.xml
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/compiler/resources/NexusFindPackagesById.xml
@@ -20,7 +20,7 @@
       <d:Version>1.0.0.99</d:Version>
       <d:Copyright>Copyright 2016</d:Copyright>
       <d:Created m:type="Edm.DateTime">2016-04-06T12:46:30.942Z</d:Created>
-      <d:Dependencies>PackageB:null|EntityFramework:6.1.3|PackageC:3.7.0.15</d:Dependencies>
+      <d:Dependencies>PackageB:null|EntityFramework:6.1.3|PackageC:3.7.0.15|PackageD:3.14.15:null</d:Dependencies>
       <d:Description>Some description</d:Description>
       <d:DownloadCount m:type="Edm.Int32">0</d:DownloadCount>
       <d:GalleryDetailsUrl m:null="true"></d:GalleryDetailsUrl>


### PR DESCRIPTION
The line was copy-pasted without changing `versionRangeString` to `frameworkString`. `versionRangeString` is already taken care of a few lines above, and this chunk of code is all about null-testing`frameworkString`.

## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/10480

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

The line was copy-pasted without changing `versionRangeString` to `frameworkString`. `versionRangeString` is already taken care of a few lines above, and this chunk of code is all about null-testing`frameworkString`.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
