### PR TITLE
Handle nonce being null in Rfc3161TimestampTokenInfo

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/Rfc3161TimestampProvider.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/Rfc3161TimestampProvider.cs
@@ -208,7 +208,8 @@ namespace NuGet.Packaging.Signing
 
         private static void ValidateTimestampResponse(byte[] nonce, byte[] messageHash, IRfc3161TimestampToken timestampToken)
         {
-            if (!nonce.SequenceEqual(timestampToken.TokenInfo.GetNonce()))
+            var tokenNonce = timestampToken.TokenInfo.GetNonce();
+            if (tokenNonce == null || !nonce.SequenceEqual(tokenNonce))
             {
                 throw new TimestampException(NuGetLogCode.NU3026, Strings.TimestampFailureNonceMismatch);
             }

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/Rfc3161TimestampTokenInfo.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/Rfc3161TimestampTokenInfo.cs
@@ -112,8 +112,11 @@ namespace NuGet.Packaging.Signing
         {
             var nonce = (byte[])Decoded.Nonce?.Clone();
 
-            // Convert from big endian to little endian.
-            Array.Reverse(nonce);
+            if (nonce != null)
+            {
+                // Convert from big endian to little endian.
+                Array.Reverse(nonce);
+            }
 
             return nonce;
         }


### PR DESCRIPTION
The line above assigns nonce, where nonce is explicitly allowed to be
null. If it is null, calling Array.Reverse on it will throw.

<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/10484

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Handle nonce being `null` in `Rfc3161TimestampTokenInfo.GetNonce` correctly.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception: Caught by static analysis
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
