### PR TITLE
Revert "add condition for excluding a specific tfm build output from package" merge

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.targets
@@ -432,7 +432,6 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <Target Name="_GetBuildOutputFilesWithTfm"
           DependsOnTargets="BuiltProjectOutputGroup;DocumentationProjectOutputGroup;SatelliteDllsProjectOutputGroup;_AddPriFileToPackBuildOutput;$(TargetsForTfmSpecificBuildOutput)"
-          Condition="'$(IncludeBuildOutput)' == 'true'"
           Returns="@(BuildOutputInPackage)">
     <ItemGroup>
       <BuildOutputInPackage Include="@(SatelliteDllsProjectOutputGroupOutput);
@@ -456,7 +455,6 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <Target Name="_GetDebugSymbolsWithTfm"
           DependsOnTargets="DebugSymbolsProjectOutputGroup"
-          Condition="'$(IncludeBuildOutput)' == 'true'"
           Returns="@(_TargetPathsToSymbolsWithTfm)">
     <ItemGroup>
       <_TargetPathsToSymbolsWithTfm Include="@(DebugSymbolsProjectOutputGroupOutput)">

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
@@ -3769,48 +3769,6 @@ namespace ClassLibrary
         }
 
         [PlatformTheory(Platform.Windows)]
-        [InlineData("net45", ".NETStandard,Version=v1.3")]
-        [InlineData("netstandard1.3", ".NETFramework,Version=v4.5")]
-        public void PackCommand_BuildOutput_DoesNotContainForSpecificFramework(string frameworkToExclude, string frameworkInPackage)
-        {
-            // Arrange
-            using (var testDirectory = msbuildFixture.CreateTestDirectory())
-            {
-                var projectName = "ClassLibrary1";
-                var workingDirectory = Path.Combine(testDirectory, projectName);
-                var projectFile = Path.Combine(workingDirectory, $"{projectName}.csproj");
-                msbuildFixture.CreateDotnetNewProject(testDirectory.Path, projectName);
-
-                using (var stream = new FileStream(projectFile, FileMode.Open, FileAccess.ReadWrite))
-                {
-                    var xml = XDocument.Load(stream);
-                    ProjectFileUtils.SetTargetFrameworkForProject(xml, "TargetFrameworks", "net45;netstandard1.3");
-                    ProjectFileUtils.AddProperty(xml, "IncludeBuildOutput", "false", $"'$(TargetFramework)'=='{frameworkToExclude}'");
-                    ProjectFileUtils.WriteXmlToFile(xml, stream);
-                }
-
-                msbuildFixture.RestoreProject(workingDirectory, projectName, string.Empty);
-
-                // Act
-                msbuildFixture.PackProject(workingDirectory, projectName, $"-o {workingDirectory}");
-
-                var nupkgPath = Path.Combine(workingDirectory, $"{projectName}.1.0.0.nupkg");
-                var nuspecPath = Path.Combine(workingDirectory, "obj", $"{projectName}.1.0.0.nuspec");
-                Assert.True(File.Exists(nupkgPath), "The output .nupkg is not in the expected place");
-                Assert.True(File.Exists(nuspecPath), "The intermediate nuspec file is not in the expected place");
-
-                // Assert
-                using (var nupkgReader = new PackageArchiveReader(nupkgPath))
-                {
-                    var nuspecReader = nupkgReader.NuspecReader;
-                    var libItems = nupkgReader.GetLibItems().ToList();
-                    Assert.Equal(1, libItems.Count);
-                    Assert.Contains(frameworkInPackage, libItems[0].TargetFramework.ToString());
-                }
-            }
-        }
-
-        [PlatformTheory(Platform.Windows)]
         [InlineData("MIT")]
         [InlineData("MIT OR Apache-2.0 WITH 389-exception")]
         public void PackCommand_PackLicense_SimpleExpression_StandardLicense(string licenseExpr)


### PR DESCRIPTION
## Bug
Fixes: NuGet/Home[Issue#10462](https://github.com/NuGet/Home/issues/10462)
Regression: Yes
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: 
Reverts [PR#3810](https://github.com/NuGet/NuGet.Client/pull/3810) Vendor reported regression bug after merged it. So we had to revert it. I already reopened the original [issue#10396](https://github.com/NuGet/Home/issues/10396) and requested contributor to fix the issue.

Testing/Validation
Tests Added: No
Reason for not adding tests: Reverting code
Validation: N/A
