### PR TITLE
Add switch for building the apex project as part of the build script

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -52,7 +52,8 @@ param (
     [switch]$CI,
     [switch]$PackageEndToEnd,
     [switch]$SkipDelaySigning,
-    [switch]$Binlog
+    [switch]$Binlog,
+    [switch]$IncludeApex
 )
 
 . "$PSScriptRoot\build\common.ps1"
@@ -115,7 +116,7 @@ Invoke-BuildStep 'Running Restore' {
     Trace-Log ". `"$MSBuildExe`" $args"
     & $MSBuildExe @args
 
-    $args = "build\build.proj", "/t:RestoreVS", "/p:Configuration=$Configuration", "/p:ReleaseLabel=$ReleaseLabel", "/p:BuildNumber=$BuildNumber", "/v:m", "/m:1"
+    $args = "build\build.proj", "/t:RestoreVS", "/p:Configuration=$Configuration", "/p:ReleaseLabel=$ReleaseLabel", "/p:BuildNumber=$BuildNumber", "/p:IncludeApex=$IncludeApex", "/v:m", "/m:1"
     if ($Binlog)
     {
         $args += "-bl:msbuild.restore.binlog"
@@ -134,7 +135,7 @@ Invoke-BuildStep 'Running Restore' {
 
 Invoke-BuildStep $VSMessage {
 
-    $args = 'build\build.proj', "/t:$VSTarget", "/p:Configuration=$Configuration", "/p:ReleaseLabel=$ReleaseLabel", "/p:BuildNumber=$BuildNumber", '/v:m', '/m:1'
+    $args = 'build\build.proj', "/t:$VSTarget", "/p:Configuration=$Configuration", "/p:ReleaseLabel=$ReleaseLabel", "/p:BuildNumber=$BuildNumber", "/p:IncludeApex=$IncludeApex", '/v:m', '/m:1'
 
     If ($SkipDelaySigning)
     {

--- a/build/common.project.props
+++ b/build/common.project.props
@@ -255,7 +255,9 @@
                                $(RepositoryRootDirectory)test\NuGet.Tests.Apex\*\NuGet.Tests.Apex.csproj"
                       Condition=" '$(ExcludeTestProjects)' != 'true' " />
 
+    <SolutionProjects Include="$(RepositoryRootDirectory)test\NuGet.Tests.Apex\*\NuGet.Tests.Apex.csproj" Condition="'$(IncludeApex)' == 'true'" />
     <SolutionProjects Include="$(RepositoryRootDirectory)src\*\*\*.csproj" />
+
     <SolutionProjectsWithoutVSIX Include="@(SolutionProjects)"
                                 Exclude="$(VSIXProject)" />
   </ItemGroup>


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/662

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
When running Apex tests we need to build the Apex project as part of the build process to generate the VSIX, this is to ensure that the assemblies that are built for the product match so that when we remote types back and forth we don't get mismatched assemblies.

## PR Checklist

- [X] PR has a meaningful title
- [X] PR has a linked issue.
- [X] Described changes

- **Tests**
  - [X] N/A <!-- Infrastructure, documentation etc. -->
