### PR TITLE
read buildinfo json file from build artifact in TagNuGetClientGitRepostoryOnRelease script

### DIFF
--- a/scripts/utils/TagNuGetClientGitRepostoryOnRelease.ps1
+++ b/scripts/utils/TagNuGetClientGitRepostoryOnRelease.ps1
@@ -9,7 +9,7 @@ Uses the Personal Access Token of NuGetLurker to automate the tagging process.
 PersonalAccessToken of the NuGetLurker account
 
 .PARAMETER VsTargetBranch
-The VS Branch that the NuGet build is being inserted into. 
+The VS Branch that the NuGet build is being inserted into.
 
 .PARAMETER BuildOutputPath
 The output path for NuGet Build artifacts.
@@ -48,7 +48,7 @@ if($index -ne '-1')
 
 $Date = Get-Date
 $Message = "Insert $ProductVersion into $VsTargetBranch on $Date"
-$BuildInfoJsonFile = [System.IO.Path]::Combine($BuildOutputPath, $Branch, $Build, 'buildinfo.json')
+$BuildInfoJsonFile = [System.IO.Path]::Combine('$(System.ArtifactsDirectory)','$(Build.DefinitionName)','BuildInfo','buildinfo.json')
 $buildInfoJson = (Get-Content $BuildInfoJsonFile -Raw) | ConvertFrom-Json
 $LocRepoCommitHash = $buildInfoJson.LocalizationRepositoryCommitHash
 
@@ -76,12 +76,12 @@ try {
         type = 'commit';
         message= $TagMessage;
         } | ConvertTo-Json;
-        
+
         Write-Host $Body
-        
+
     $tagObject = "refs/tags/$TagName"
     $r1 = Invoke-RestMethod -Headers $Headers -Method Post -Uri "https://api.github.com/repos/NuGet/$NuGetRepository/git/tags" -Body $Body
-    Write-Host $r1    
+    Write-Host $r1
 }
 catch {
     # The above would fail if the tag already existed, in which case we would append the attempt number to the tag name to make it unique
@@ -93,9 +93,9 @@ catch {
         type = 'commit';
         message= $TagMessage;
         } | ConvertTo-Json;
-        
+
         Write-Host $Body
-        
+
     $tagObject = "refs/tags/$TagName"
     $r1 = Invoke-RestMethod -Headers $Headers -Method Post -Uri "https://api.github.com/repos/NuGet/$NuGetRepository/git/tags" -Body $Body
     Write-Host $r1

--- a/scripts/utils/TagNuGetClientGitRepostoryOnRelease.ps1
+++ b/scripts/utils/TagNuGetClientGitRepostoryOnRelease.ps1
@@ -13,6 +13,9 @@ The VS Branch that the NuGet build is being inserted into.
 
 .PARAMETER BuildOutputPath
 The output path for NuGet Build artifacts.
+
+.PARAMETER BuildInfoJsonFile
+Path to the buildInfo.json file that is published as artifact for every build.
 #>
 
 [CmdletBinding()]
@@ -23,7 +26,9 @@ param
     [Parameter(Mandatory=$True)]
     [string]$VsTargetBranch,
     [Parameter(Mandatory=$True)]
-    [string]$BuildOutputPath
+    [string]$BuildOutputPath,
+    [Parameter(Mandatory=$True)]
+    [string]$BuildInfoJsonFile
 )
 
 # Set security protocol to tls1.2 for Invoke-RestMethod powershell cmdlet
@@ -48,7 +53,6 @@ if($index -ne '-1')
 
 $Date = Get-Date
 $Message = "Insert $ProductVersion into $VsTargetBranch on $Date"
-$BuildInfoJsonFile = [System.IO.Path]::Combine('$(System.ArtifactsDirectory)','$(Build.DefinitionName)','BuildInfo','buildinfo.json')
 $buildInfoJson = (Get-Content $BuildInfoJsonFile -Raw) | ConvertFrom-Json
 $LocRepoCommitHash = $buildInfoJson.LocalizationRepositoryCommitHash
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/733

I missed modifying `TagNuGetClientGitRepostoryOnRelease` script to read `buildinfo.json` from build artifacts in the PR I created for https://github.com/NuGet/Client.Engineering/issues/394 issue. @zkat informed me that nuget client release failed due to this issue.  https://devdiv.visualstudio.com/DevDiv/_releaseProgress?_a=release-pipeline-progress&releaseId=938402

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.https://github.com/NuGet/Client.Engineering/issues/733
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A Updated NuGet VS Insertion process in OneNote.
