### PR TITLE
When restore locked mode fails, ensure the assets file contains a target for each target framework so that SDK doesn't overwrite the error messages

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -221,9 +221,8 @@ namespace NuGet.Commands
                 }
                 else
                 {
-
                     // Being in an unsuccessful state before ExecuteRestoreAsync means there was a problem with the
-                    // project or we're in locked and out of date.
+                    // project or we're in locked mode and out of date.
                     // For example, project TFM or package versions couldn't be parsed. Although the minimal
                     // fake package spec generated has no packages requested, it also doesn't have any project TFMs
                     // and will generate validation errors if we tried to call ExecuteRestoreAsync. So, to avoid

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -577,12 +577,9 @@ namespace NuGet.Commands
                     }
                     else if (_request.IsRestoreOriginalAction && _request.Project.RestoreMetadata.RestoreLockProperties.RestoreLockedMode)
                     {
-
                         success = false;
 
                         // bail restore since it's the locked mode but required to update the lock file.
-                        var framework = _request.Project.TargetFrameworks.Select(e => e.FrameworkName.GetShortFolderName()).ToArray();
-
                         await _logger.LogAsync(RestoreLogMessage.CreateError(NuGetLogCode.NU1004, Strings.Error_RestoreInLockedMode));
                     }
                 }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
@@ -541,7 +541,8 @@ namespace NuGet.Commands
                 var projectGraph = targetGraph.Graphs.FirstOrDefault();
 
                 // Packages with GeneratePathProperty=true
-                var packageIdsToCreatePropertiesFor = new HashSet<string>(projectGraph.Item.Data.Dependencies.Where(i => i.GeneratePathProperty).Select(i => i.Name), StringComparer.OrdinalIgnoreCase);
+                var packages = projectGraph?.Item.Data.Dependencies.Where(i => i.GeneratePathProperty).Select(i => i.Name);
+                var packageIdsToCreatePropertiesFor = packages != null ? new HashSet<string>(packages, StringComparer.OrdinalIgnoreCase) : Enumerable.Empty<string>();
 
                 var localPackages = sortedPackages.Select(e => e.Value);
 

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/RestoreCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/RestoreCommandTests.cs
@@ -932,6 +932,8 @@ namespace NuGet.CommandLine.FuncTest.Commands
                 Assert.Contains("NU1004:", result.Errors);
                 var logCodes = projectA.AssetsFile.LogMessages.Select(e => e.Code);
                 Assert.Contains(NuGetLogCode.NU1004, logCodes);
+                var ridlessMainTarget = projectA.AssetsFile.Targets.FirstOrDefault(e => string.IsNullOrEmpty(e.RuntimeIdentifier));
+                Assert.Equal(net461, ridlessMainTarget.TargetFramework);
                 Assert.True(File.Exists(projectA.PropsOutput));
                 Assert.True(File.Exists(projectA.TargetsOutput));
                 Assert.True(File.Exists(projectA.CacheFileOutputPath));


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/10486

Regression? Last working version:

## Description

When a restore fails due to locked mode or because of an invalid project a build makes the error disappear in VS.
The reason for that is that the assets file contains no targets. This adds a dummy target and avoids that problem.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [ ] N/A
