### PR TITLE
PM UI:  propagate any remote exception from NuGetProjectManagerService

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/UserInterfaceService/NuGetUIProjectContext.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/UserInterfaceService/NuGetUIProjectContext.cs
@@ -42,9 +42,9 @@ namespace NuGet.PackageManagement.UI
             }
         }
 
-        public void Log(ProjectManagement.MessageLevel level, string message, params object[] args)
+        public void Log(MessageLevel level, string message, params object[] args)
         {
-            _logger.Log(new LogMessage(level.ToLogLevel(), string.Format(CultureInfo.CurrentCulture, message, args)));
+            _logger.Log(level, message, args);
         }
 
         public FileConflictAction ShowFileConflictResolution(string message)

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/UserInterfaceService/INuGetUILogger.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/UserInterfaceService/INuGetUILogger.cs
@@ -8,8 +8,18 @@ namespace NuGet.PackageManagement.VisualStudio
     /// <summary> UI logger abstraction. </summary>
     public interface INuGetUILogger
     {
+        /// <summary>
+        /// Log a message.
+        /// </summary>
+        /// <param name="level">log level</param>
+        /// <param name="message">log message</param>
+        /// <param name="args">arguments for a string.Format(...) call on <paramref name="message"/> </param>
+        void Log(ProjectManagement.MessageLevel level, string message, params object[] args);
+
         /// <summary> Log a message. </summary>
         /// <param name="message"> Log message. </param>
+        /// <remarks>If the message has a log level of warning or error,
+        /// the message is also logged to the Error List.</remarks>
         void Log(ILogMessage message);
 
         /// <summary> Report an error or warning. </summary>

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Utility/RemoteErrorUtility.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Utility/RemoteErrorUtility.cs
@@ -60,6 +60,10 @@ namespace NuGet.VisualStudio.Internal.Contracts
                         .ToArray();
                 }
             }
+            else
+            {
+                projectContextLogMessage = exception.ToString();
+            }
 
             return new RemoteError(typeName, logMessage, logMessages, projectContextLogMessage, activityLogMessage);
         }

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/UserInterfaceService/NuGetUITests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/UserInterfaceService/NuGetUITests.cs
@@ -101,9 +101,8 @@ namespace NuGet.PackageManagement.UI.Test
                         && logMessage.Message == ExceptionUtilities.DisplayMessage(exception, indent))));
             projectLogger.Setup(
                 x => x.Log(
-                    It.Is<ILogMessage>(
-                        logMessage => logMessage.Level == LogLevel.Error
-                        && logMessage.Message == exception.ToString())));
+                    It.Is<MessageLevel>(level => level == MessageLevel.Error),
+                    It.Is<string>(message => message == exception.ToString())));
 
             using (NuGetUI ui = CreateNuGetUI(defaultLogger.Object, projectLogger.Object))
             {

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/NuGetProjectManagerServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/NuGetProjectManagerServiceTests.cs
@@ -94,6 +94,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 Assert.IsType<RemoteError>(exception.ErrorData);
 
                 var remoteError = (RemoteError)exception.ErrorData;
+                string expectedProjectContextLogMessage = exception.InnerException.ToString();
 
                 Assert.Null(remoteError.ActivityLogMessage);
                 Assert.Equal(NuGetLogCode.Undefined, remoteError.LogMessage.Code);
@@ -103,7 +104,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 Assert.InRange(remoteError.LogMessage.Time, DateTimeOffset.UtcNow.AddSeconds(-10), DateTimeOffset.UtcNow.AddSeconds(1));
                 Assert.Equal(WarningLevel.Severe, remoteError.LogMessage.WarningLevel);
                 Assert.Null(remoteError.LogMessages);
-                Assert.Null(remoteError.ProjectContextLogMessage);
+                Assert.Equal(expectedProjectContextLogMessage, remoteError.ProjectContextLogMessage);
                 Assert.Equal(typeof(ArgumentException).FullName, remoteError.TypeName);
             });
         }

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/Utility/RemoteErrorUtilityTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/Utility/RemoteErrorUtilityTests.cs
@@ -18,5 +18,14 @@ namespace NuGet.VisualStudio.Internal.Contracts.Test
 
             Assert.Equal("exception", exception.ParamName);
         }
+
+        [Fact]
+        public void ToRemoteError_WhenExceptionIsOtherType_SetsProjectContextLogMessage()
+        {
+            var exception = new DivideByZeroException();
+            RemoteError remoteError = RemoteErrorUtility.ToRemoteError(exception);
+
+            Assert.Equal(exception.ToString(), remoteError.ProjectContextLogMessage);
+        }
     }
 }


### PR DESCRIPTION
## Bug

Fixes:  https://github.com/NuGet/Home/issues/10497
Also fixes:  https://github.com/nuget/client.engineering/issues/719

Regression? Last working version:  Yes, the release before NuGet/NuGet.Client#3711

## Description
First, I had to partially undo https://github.com/NuGet/NuGet.Client/pull/3532, because a refactoring must not introduce behavioral changes.  That change caused warnings/errors written to the Output window to also be added to the Error List.  This was a regression from previous releases.

Second, I ensured that `Exception.ToString()` is included in the `RemoteError`, so current code can preserve [older, released behavior](https://github.com/NuGet/NuGet.Client/blob/release-5.7.x/src/NuGet.Clients/NuGet.PackageManagement.UI/UserInterfaceService/NuGetUI.cs#L353).

Before this change, when I forced a `NullReferenceException` in the service, current dev client showed this Error List and Output window:

![before1](https://user-images.githubusercontent.com/12734758/106191461-c0d67680-615f-11eb-983b-01dfb41b093b.png)
![before2](https://user-images.githubusercontent.com/12734758/106191484-c764ee00-615f-11eb-9221-46452a1fb42d.png)

After this change:

![after1](https://user-images.githubusercontent.com/12734758/106191547-d9df2780-615f-11eb-9b5e-545332bef2cb.png)
![after2](https://user-images.githubusercontent.com/12734758/106191561-dea3db80-615f-11eb-8404-38c5800e2967.PNG)

## PR Checklist

- [X] PR has a meaningful title
- [X] PR has a linked issue.
- [X] Described changes

- **Tests**
  - [X] Automated tests added

- **Documentation**
  - [X] N/A


CC @rrelyea, @sbanni, @donnie-msft 