### PR TITLE
use using for disposable memorystream in NuGetPackageFileService

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageItemListViewModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageItemListViewModel.cs
@@ -1,4 +1,3 @@
-
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
@@ -548,28 +547,25 @@ namespace NuGet.PackageManagement.UI
                     // to support downloading on a worker thread, we need to download the image
                     // data and put into a memorystream. Then have the BitmapImage decode the
                     // image from the memorystream.
-#pragma warning disable CA2000 // Dispose objects before losing scope
-                    var memoryStream = new MemoryStream();
-#pragma warning restore CA2000 // Dispose objects before losing scope
-
-                    // Cannot call CopyToAsync as we'll get an InvalidOperationException due to CheckAccess() in next line.
-                    stream.CopyTo(memoryStream);
-                    iconBitmapImage.StreamSource = memoryStream;
-
-                    try
+                    using (var memoryStream = new MemoryStream())
                     {
-                        FinalizeBitmapImage(iconBitmapImage);
-                        iconBitmapImage.Freeze();
-                        IconBitmap = iconBitmapImage;
-                        BitmapStatus = IconBitmapStatus.FetchedIcon;
-                    }
-                    catch (Exception ex) when (IsHandleableBitmapEncodingException(ex))
-                    {
-                        IconBitmap = Images.DefaultPackageIcon;
-                        BitmapStatus = IconBitmapStatus.DefaultIconDueToDecodingError;
-                    }
+                        // Cannot call CopyToAsync as we'll get an InvalidOperationException due to CheckAccess() in next line.
+                        stream.CopyTo(memoryStream);
+                        iconBitmapImage.StreamSource = memoryStream;
 
-                    memoryStream.Dispose();
+                        try
+                        {
+                            FinalizeBitmapImage(iconBitmapImage);
+                            iconBitmapImage.Freeze();
+                            IconBitmap = iconBitmapImage;
+                            BitmapStatus = IconBitmapStatus.FetchedIcon;
+                        }
+                        catch (Exception ex) when (IsHandleableBitmapEncodingException(ex))
+                        {
+                            IconBitmap = Images.DefaultPackageIcon;
+                            BitmapStatus = IconBitmapStatus.DefaultIconDueToDecodingError;
+                        }
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/10503

Regression? yes, introduced yesterday

## Description
Use using for disposable memory stream. Also could use Finally in try/catch block, but this is cleaner.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
