### PR TITLE
No longer use UI Filter starting from Installed tab

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -891,13 +891,6 @@ namespace NuGet.PackageManagement.UI
                 }
 
                 FlagTabDataAsLoaded(filterToRender);
-
-                // Loading Data on Installed tab should also consider the Data on Updates tab as loaded to indicate
-                // UI filtering for Updates is ready.
-                if (filterToRender == ItemFilter.Installed)
-                {
-                    FlagTabDataAsLoaded(ItemFilter.UpdatesAvailable);
-                }
             }
             catch (OperationCanceledException)
             {


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Home/issues/10510

Regression? Last working version: Yes, 16.9 regression

## Description
For a bug fix (https://github.com/NuGet/NuGet.Client/pull/3864) I switched back to passing the `Version` property in the Updates tab. However, if Installed tab is loaded first, then a UI filter is applied, `Version` will not bet set to "Latest Version", so it results in an incorrect or broken update action. 

This PR takes the simplest approach for 16.9 and no longer uses the first-load of Installed data as a perf improvement for Updates tab. 

UI Filter Scenarios:
- Updates tab loaded first, switch to Installed tab.
- ~Installed tab loaded first, switch to Updates tab.~ (this PR disables)
- After both Installed/Updates have loaded once, switching between them repetitively.

The expected Error is shown, when opening PMUI to Installed tab, switching to Updates tab, then performing an Update all:
![image](https://user-images.githubusercontent.com/49205731/106485062-343cf880-647e-11eb-83db-a4a953615ecb.png)

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception - This is a code-behind change. I believe the Issue's indication that an Update error message indicates that no update occurred is appropriate, and that's already tested. https://github.com/NuGet/Home/issues/10514
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
