### PR TITLE
Trigger on enabled sources instead of all sources populating Package Sources list

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/PackageFeeds/PackageSourceMoniker.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/PackageFeeds/PackageSourceMoniker.cs
@@ -111,7 +111,7 @@ namespace NuGet.PackageManagement.VisualStudio
                 .ToList();
 
             var packageSourceMonikers = new List<PackageSourceMoniker>();
-            if (packageSources.Count > 1) // If more than 1, add 'All'
+            if (enabledSources.Count > 1) // If more than 1, add 'All'
             {
                 packageSourceMonikers.Add(new PackageSourceMoniker(Strings.AggregateSourceName, enabledSources));
             }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/10541

Regression? Last working version:

## Description
Use Enabled Sources instead of all Package Sources when checking for aggregate sources

## PR Checklist

- [X] PR has a meaningful title
- [X] PR has a linked issue.
- [X] Described changes

