### PR TITLE
removed NuGet.VisualStudio from OptProfV2 settings.

### DIFF
--- a/build/OptProfV2.props
+++ b/build/OptProfV2.props
@@ -17,8 +17,7 @@
         '$(AssemblyName)' == 'NuGet.Protocol' or
         '$(AssemblyName)' == 'NuGet.SolutionRestoreManager' or
         '$(AssemblyName)' == 'NuGet.Versioning' or
-        '$(AssemblyName)' == 'NuGet.VisualStudio.Common' or
-        '$(AssemblyName)' == 'NuGet.VisualStudio'
+        '$(AssemblyName)' == 'NuGet.VisualStudio.Common'
       )">
     <OptProf Include="$(OutputPath)$(AssemblyName).dll">
       <Technology>IBC</Technology>


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/764

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

[DD-Test-Private (NuGet)](https://devdiv.visualstudio.com/DevDiv/_releaseProgress?_a=release-environment-logs&releaseId=951142&environmentId=4962032), started failing from yesterday with the below error blocking all the VS insertions.

`No profile was generated for module 'C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Common7\IDE\CommonExtensions\Microsoft\NuGet\NuGet.VisualStudio.dll', which usually means that the scenario did not exercise the module`

Removed `NuGet.VisualStudio.dll` from the list of assemblies to check for training data because we assume some VS component may have changed and hence not loading this assembly while running tests on Internal Preview bits.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  - [x] N/A
