### PR TITLE
Message in DeprecationMetadata can be null after all

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/ContextInfos/PackageDeprecationMetadataContextInfo.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/ContextInfos/PackageDeprecationMetadataContextInfo.cs
@@ -9,12 +9,12 @@ namespace NuGet.VisualStudio.Internal.Contracts
 {
     public sealed class PackageDeprecationMetadataContextInfo
     {
-        public string Message { get; }
+        public string? Message { get; }
         public IReadOnlyCollection<string>? Reasons { get; }
         public AlternatePackageMetadataContextInfo? AlternatePackage { get; }
 
         public PackageDeprecationMetadataContextInfo(
-            string message,
+            string? message,
             IReadOnlyCollection<string>? reasons,
             AlternatePackageMetadataContextInfo? alternatePackageContextInfo)
         {

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/PackageDeprecationMetadataContextInfoFormatter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/PackageDeprecationMetadataContextInfoFormatter.cs
@@ -46,8 +46,6 @@ namespace NuGet.VisualStudio.Internal.Contracts
                 }
             }
 
-            Assumes.NotNullOrEmpty(message);
-
             return new PackageDeprecationMetadataContextInfo(message, reasons, alternatePackageMetadataContextInfo);
         }
 

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/PublicAPI.Unshipped.txt
@@ -87,8 +87,8 @@ NuGet.VisualStudio.Internal.Contracts.LoadingStatus.Ready = 6 -> NuGet.VisualStu
 NuGet.VisualStudio.Internal.Contracts.LoadingStatus.Unknown = 0 -> NuGet.VisualStudio.Internal.Contracts.LoadingStatus
 NuGet.VisualStudio.Internal.Contracts.PackageDeprecationMetadataContextInfo
 NuGet.VisualStudio.Internal.Contracts.PackageDeprecationMetadataContextInfo.AlternatePackage.get -> NuGet.VisualStudio.Internal.Contracts.AlternatePackageMetadataContextInfo?
-NuGet.VisualStudio.Internal.Contracts.PackageDeprecationMetadataContextInfo.Message.get -> string!
-NuGet.VisualStudio.Internal.Contracts.PackageDeprecationMetadataContextInfo.PackageDeprecationMetadataContextInfo(string! message, System.Collections.Generic.IReadOnlyCollection<string!>? reasons, NuGet.VisualStudio.Internal.Contracts.AlternatePackageMetadataContextInfo? alternatePackageContextInfo) -> void
+NuGet.VisualStudio.Internal.Contracts.PackageDeprecationMetadataContextInfo.Message.get -> string?
+NuGet.VisualStudio.Internal.Contracts.PackageDeprecationMetadataContextInfo.PackageDeprecationMetadataContextInfo(string? message, System.Collections.Generic.IReadOnlyCollection<string!>? reasons, NuGet.VisualStudio.Internal.Contracts.AlternatePackageMetadataContextInfo? alternatePackageContextInfo) -> void
 NuGet.VisualStudio.Internal.Contracts.PackageDeprecationMetadataContextInfo.Reasons.get -> System.Collections.Generic.IReadOnlyCollection<string!>?
 NuGet.VisualStudio.Internal.Contracts.InstalledAndTransitivePackages
 NuGet.VisualStudio.Internal.Contracts.InstalledAndTransitivePackages.InstalledAndTransitivePackages(System.Collections.Generic.IReadOnlyCollection<NuGet.VisualStudio.Internal.Contracts.IPackageReferenceContextInfo!>? installedPackages, System.Collections.Generic.IReadOnlyCollection<NuGet.VisualStudio.Internal.Contracts.IPackageReferenceContextInfo!>? transitivePackages) -> void

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/Formatters/PackageDeprecationMetadataContextInfoFormatterTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/Formatters/PackageDeprecationMetadataContextInfoFormatterTests.cs
@@ -41,6 +41,8 @@ namespace NuGet.VisualStudio.Internal.Contracts.Test
         public static TheoryData TestData => new TheoryData<PackageDeprecationMetadataContextInfo>
             {
                 { new PackageDeprecationMetadataContextInfo("message", new List<string>{"string1" }, new AlternatePackageMetadataContextInfo("packageId", new VersionRange(new NuGetVersion("0.1")))) },
+                { new PackageDeprecationMetadataContextInfo(null, new List<string>{"string1" }, new AlternatePackageMetadataContextInfo("packageId", new VersionRange(new NuGetVersion("0.1")))) },
+                { new PackageDeprecationMetadataContextInfo(string.Empty, new List<string>{"string1" }, new AlternatePackageMetadataContextInfo("packageId", new VersionRange(new NuGetVersion("0.1")))) },
             };
     }
 }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/10549

Regression? Last working version: Yes

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
The message in deprecationmetadata can be null after all, remove check to make sure it is not null, this only impacts codespaces scenarios
## PR Checklist

- [X] PR has a meaningful title
- [X] PR has a linked issue.
- [X] Described changes

- **Tests**
  - [X] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [X] Documentation PR or issue filled
  - **OR**
  - [ ] N/A
