### PR TITLE
Fix source link in pdb file before publishing to symbol server

### DIFF
--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -80,6 +80,15 @@ steps:
       dotnet tool restore
   condition: "and(not(eq(variables['IsOfficialBuild'], 'true')), eq(variables['BuildRTM'], 'true'))"   #skip this task for nonRTM in private build
 
+- task: PowerShell@1
+  displayName: "Prepare for source link"
+  inputs:
+    scriptType: "inlineScript"
+    inlineScript: |
+      git remote add github https://github.com/NuGet/NuGet.Client.git
+      Write-Host "##vso[task.setvariable variable=gitRepositoryRemoteName]github"
+  condition: " and(succeeded(),eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))" #run in official non-RTM builds, for generating sourcelink
+
 - task: MSBuild@1
   displayName: "Restore for VS2019"
   inputs:
@@ -94,7 +103,7 @@ steps:
     solution: "build\\build.proj"
     msbuildVersion: "16.0"
     configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/t:BuildNoVSIX /p:BuildRTM=$(BuildRTM) /p:BuildNumber=$(BuildNumber) /p:SkipILMergeOfNuGetExe=true"
+    msbuildArguments: "/t:BuildNoVSIX /p:BuildRTM=$(BuildRTM) /p:BuildNumber=$(BuildNumber) /p:SkipILMergeOfNuGetExe=true /p:GitRepositoryRemoteName=$(gitRepositoryRemoteName)"
 
 - task: MSBuild@1
   displayName: "Ensure msbuild.exe can parse nuget.sln"


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug
Fixes:
might be a partial fix on https://github.com/NuGet/Client.Engineering/issues/700
If the source link in pdb file after publishing is still incorrect, then will need to fix the publishing as well.

Regression? Last working version:

## Description
Fix the source link in pdb files before publishing：
1. Add “git remote add github https://github.com/NuGet/NuGet.Client.git”, since official build is from ADO.
2. Pass `/p:SkipILMergeOfNuGetExe=true` for official non-RTM build, so that it will generate source link correctly in pdb before publishing.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

  Manually tested locally by he following steps:
  1. git clone from ADO
  2. run `git submodule init` and `git submodule update`
  3. run `git remote add github https://github.com/NuGet/NuGet.Client.git`
  4. run `msbuild /t:restore,build src\NuGet.Core\NuGet.Versioning\NuGet.Versioning.csproj /p:GitRepositoryRemoteName=github`
  5. Check the generated pdb file by running `findstr document .\NuGet.Versioning.pdb`
  And the source link is correct as following:
 ```
 {"documents":
{"C:\\repos\\NuGet-NuGet.Client-Trusted\\*":"https://raw.githubusercontent.com/NuGet/NuGet.Client/1729f1616e9b1812012bd4e0170ddffe1a2991ae/*",
"C:\\repos\\NuGet-NuGet.Client-Trusted\\submodules\\Common\\*":"https://raw.githubusercontent.com/aspnet/Common/e6fac8061686c18531e2621ccef97dd5e0687a65/*",
"C:\\repos\\NuGet-NuGet.Client-Trusted\\submodules\\FileSystem\\*":"https://raw.githubusercontent.com/NuGet/FileSystem/f1f3f0820a573b96b2faaf5b7e6be9a036e4c7aa/*",
"C:\\repos\\NuGet-NuGet.Client-Trusted\\submodules\\NuGet.Build.Localization\\*":"https://raw.githubusercontent.com/NuGet/NuGet.Build.Localization/f15db7b7c6f5affbea268632ef8333d2687c8031/*"}}
```
- **Documentation**
  - [x] N/A
