### PR TITLE
Ensure MEF initialization is completed for NugetPackage before used

### DIFF
--- a/src/NuGet.Clients/NuGet.Tools/NuGetPackage.cs
+++ b/src/NuGet.Clients/NuGet.Tools/NuGetPackage.cs
@@ -1160,14 +1160,18 @@ namespace NuGetVSExtension
                 {
                     isConsoleBusy = ConsoleStatus.Value.IsBusy;
                 }
-                // Enable the 'Manage NuGet Packages For Solution' dialog menu
-                // - if the console is NOT busy executing a command, AND
-                // - if the solution exists and not debugging and not building AND
-                // - if there are NuGetProjects. This means there are loaded, supported projects.
-                command.Enabled =
-                    IsSolutionExistsAndNotDebuggingAndNotBuilding() &&
-                    !isConsoleBusy &&
-                    await SolutionManager.Value.DoesNuGetSupportsAnyProjectAsync();
+
+                if (SolutionManager != null)
+                {
+                    // Enable the 'Manage NuGet Packages For Solution' dialog menu
+                    // - if the console is NOT busy executing a command, AND
+                    // - if the solution exists and not debugging and not building AND
+                    // - if there are NuGetProjects. This means there are loaded, supported projects.
+                    command.Enabled =
+                        IsSolutionExistsAndNotDebuggingAndNotBuilding() &&
+                        !isConsoleBusy &&
+                        await SolutionManager.Value.DoesNuGetSupportsAnyProjectAsync();
+                }
             });
         }
 

--- a/src/NuGet.Clients/NuGet.Tools/NuGetPackage.cs
+++ b/src/NuGet.Clients/NuGet.Tools/NuGetPackage.cs
@@ -1161,7 +1161,7 @@ namespace NuGetVSExtension
                     isConsoleBusy = ConsoleStatus.Value.IsBusy;
                 }
 
-                if (SolutionManager != null)
+                try
                 {
                     // Enable the 'Manage NuGet Packages For Solution' dialog menu
                     // - if the console is NOT busy executing a command, AND
@@ -1171,6 +1171,10 @@ namespace NuGetVSExtension
                         IsSolutionExistsAndNotDebuggingAndNotBuilding() &&
                         !isConsoleBusy &&
                         await SolutionManager.Value.DoesNuGetSupportsAnyProjectAsync();
+                }
+                catch (Exception e)
+                {
+                    await TelemetryUtility.PostFaultAsync(e, nameof(NuGetPackage), nameof(BeforeQueryStatusForAddPackageForSolutionDialog));
                 }
             });
         }

--- a/src/NuGet.Clients/NuGet.Tools/NuGetPackage.cs
+++ b/src/NuGet.Clients/NuGet.Tools/NuGetPackage.cs
@@ -1161,7 +1161,7 @@ namespace NuGetVSExtension
                     isConsoleBusy = ConsoleStatus.Value.IsBusy;
                 }
 
-                try
+                if (SolutionManager != null)
                 {
                     // Enable the 'Manage NuGet Packages For Solution' dialog menu
                     // - if the console is NOT busy executing a command, AND
@@ -1171,10 +1171,6 @@ namespace NuGetVSExtension
                         IsSolutionExistsAndNotDebuggingAndNotBuilding() &&
                         !isConsoleBusy &&
                         await SolutionManager.Value.DoesNuGetSupportsAnyProjectAsync();
-                }
-                catch (Exception e)
-                {
-                    await TelemetryUtility.PostFaultAsync(e, nameof(NuGetPackage), nameof(BeforeQueryStatusForAddPackageForSolutionDialog));
                 }
             });
         }


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Home/issues/10559

Regression? Last working version:

## Description

During VS experimental instance debugging it always throws exception due to MEF init is not completed yet. So we're fixing this with JTF aware Reentrant lock. It doesn't prematurely set `_initialized` to `true`, but wait until MEF init is complete.

Currently there's no any telemetry is emitted this situation. 
## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
