### PR TITLE
Ignore Microsoft.NET.StringTools.dll in VSIX

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Client/.vsixignore
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Client/.vsixignore
@@ -13,6 +13,7 @@ Microsoft.IdentityModel.Logging.dll
 Microsoft.IdentityModel.Tokens.dll
 Microsoft.Internal.VisualStudio.Shell.Embeddable.dll
 Microsoft.Internal.VisualStudio.Shell.Interop.10.0.DesignTime.dll
+Microsoft.NET.StringTools.dll
 Microsoft.ServiceHub.Client.dll
 Microsoft.ServiceHub.Framework.dll
 Microsoft.ServiceHub.Framework.resources.dll


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/771

Regression? Last working version: yes 16.9

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
I believe this commit(ish) may be to blame:
https://github.com/dotnet/msbuild/commit/40c716bee401beac9a6c35b3d9d860f99903ec7c#diff-3d6d7ee734011d622b7ffe80e787644d409b9caa01256c03a008f46d017e034eR21 
@ladipro are you the one who's knowledgeable about this change in MSBuild? I think we can exclude this safely, do you agree? Also any idea if this change will insert into 16.9 as well ?


## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
