### PR TITLE
Fix UIActionEngine to use codespaces aware sources

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailedPackageMetadata.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailedPackageMetadata.cs
@@ -111,8 +111,6 @@ namespace NuGet.PackageManagement.UI
 
         public IEnumerable<PackageVulnerabilityMetadataContextInfo> Vulnerabilities { get; set; }
 
-        public IReadOnlyList<IText> LicenseLinks => PackageLicenseUtilities.GenerateLicenseLinks(this);
-
         private static readonly IReadOnlyList<PackageDependencySetMetadata> NoDependenciesPlaceholder = new PackageDependencySetMetadata[] { new PackageDependencySetMetadata(dependencyGroup: null) };
 
         public string PackagePath { get; set; }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/PackageLicenseUtilities.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/PackageLicenseUtilities.cs
@@ -22,9 +22,9 @@ namespace NuGet.PackageManagement.UI
 {
     internal class PackageLicenseUtilities
     {
-        internal static IReadOnlyList<IText> GenerateLicenseLinks(DetailedPackageMetadata metadata)
+        internal static IReadOnlyList<IText> GenerateLicenseLinks(PackageSearchMetadataContextInfo metadata)
         {
-            return GenerateLicenseLinks(metadata.LicenseMetadata, metadata.LicenseUrl, string.Format(CultureInfo.CurrentCulture, Resources.WindowTitle_LicenseFileWindow, metadata.Id), metadata.PackagePath, new PackageIdentity(metadata.Id, metadata.Version));
+            return GenerateLicenseLinks(metadata.LicenseMetadata, metadata.LicenseUrl, string.Format(CultureInfo.CurrentCulture, Resources.WindowTitle_LicenseFileWindow, metadata.Identity.Id), metadata.PackagePath, metadata.Identity);
         }
 
         internal static IReadOnlyList<IText> GenerateLicenseLinks(IPackageSearchMetadata metadata)


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/10563

Regression? No, it has never worked in codespaces scenarios yet.

## Description
Move to use INuGetSourcesService to get sources & INuGetSearchService to get metadata. (unless the feeds were configured on the client as well as the server...which is a bad requirement to have)

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [ ] N/A
