### PR TITLE
Initialize TelemetryActivity.NuGetTelemetryService for VS Codespaces client

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.OnlineEnvironment.Client/NuGetClientPackage.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.OnlineEnvironment.Client/NuGetClientPackage.cs
@@ -2,6 +2,7 @@ using System;
 using System.Runtime.InteropServices;
 using System.Threading;
 using Microsoft.VisualStudio.Shell;
+using NuGet.Common;
 using NuGet.PackageManagement.UI;
 using Task = System.Threading.Tasks.Task;
 
@@ -49,6 +50,8 @@ namespace NuGet.VisualStudio.OnlineEnvironment.Client
         {
             // When initialized asynchronously, the current thread may be a background thread at this point.
             // Do any initialization that requires the UI thread after switching to the UI thread
+            TelemetryActivity.NuGetTelemetryService = new NuGetVSTelemetryService();
+
             return Task.CompletedTask;
         }
     }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/767

Regression? Last working version: 16.10 Classic VS

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Initializes static variable `TelemetryActivity.NuGetTelemetryService` on Codespaces Client NuGet AsyncPackage located in `NuGet.VisualStudio.OnlineEnvironment.Client` project (`NuGetClientPackage` class) . Classic VS uses AsyncPackage located in `NuGet.Tools` project (`NuGetPackage` class)

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. --> There's no infrastructure to create automated tests on NuGet Codespaces scenarios.

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
