### PR TITLE
Use AzureDevOps counter expression to generate CI version instead of using a text file on the file-share

### DIFF
--- a/eng/pipelines/templates/Initialize_Build.yml
+++ b/eng/pipelines/templates/Initialize_Build.yml
@@ -35,10 +35,7 @@ steps:
     scriptType: "inlineScript"
     inlineScript: |
       try {
-        $revision = Get-Content $env:BUILDCOUNTERFILE
-        $newBuildCounter = [System.Decimal]::Parse($revision)
-        $newBuildCounter++
-        Set-Content $env:BUILDCOUNTERFILE $newBuildCounter
+        $revision = $(BuildRevision)
         $msbuildExe = 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\bin\msbuild.exe'
         $productVersion = & $msbuildExe $env:BUILD_REPOSITORY_LOCALPATH\build\config.props /v:m /nologo /t:GetSemanticVersion
         $productVersion = $productVersion.Trim()

--- a/eng/pipelines/templates/Initialize_Build.yml
+++ b/eng/pipelines/templates/Initialize_Build.yml
@@ -35,13 +35,10 @@ steps:
     scriptType: "inlineScript"
     inlineScript: |
       try {
-        $revision = $(BuildRevision)
         Write-Output "Semantic Version is $(SemanticVersion)"
-        Write-Output "Build Revision is $(revision)"
+        Write-Output "Build Revision is $(BuildRevision)"
+        $FullBuildNumber = "$(SemanticVersion).$(BuildRevision)"
         $msbuildExe = 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\bin\msbuild.exe'
-        $productVersion = & $msbuildExe $env:BUILD_REPOSITORY_LOCALPATH\build\config.props /v:m /nologo /t:GetSemanticVersion
-        $productVersion = $productVersion.Trim()
-        $FullBuildNumber = "$productVersion.$revision"
         $targetChannel = & $msbuildExe $env:BUILD_REPOSITORY_LOCALPATH\build\config.props /v:m /nologo /t:GetVsTargetChannel
         $targetChannel = $targetChannel.Trim()
         $targetMajorVersion = & $msbuildExe $env:BUILD_REPOSITORY_LOCALPATH\build\config.props /v:m /nologo /t:GetVsTargetMajorVersion
@@ -49,7 +46,7 @@ steps:
         Write-Host "##vso[task.setvariable variable=VsTargetChannel;isOutput=true]$targetChannel"
         Write-Host "##vso[task.setvariable variable=VsTargetMajorVersion;isOutput=true]$targetMajorVersion"
         Write-Host "##vso[build.updatebuildnumber]$FullBuildNumber"
-        Write-Host "##vso[task.setvariable variable=BuildNumber;isOutput=true]$revision"
+        Write-Host "##vso[task.setvariable variable=BuildNumber;isOutput=true]$(BuildRevision)"
         Write-Host "##vso[task.setvariable variable=FullVstsBuildNumber;isOutput=true]$FullBuildNumber"
       } catch {
         Write-Host "##vso[task.LogIssue type=error;]Unable to set build number"

--- a/eng/pipelines/templates/Initialize_Build.yml
+++ b/eng/pipelines/templates/Initialize_Build.yml
@@ -36,10 +36,12 @@ steps:
     inlineScript: |
       try {
         $revision = $(BuildRevision)
+        Write-Output "Semantic Version is $(SemanticVersion)"
+        Write-Output "Build Revision is $(revision)"
         $msbuildExe = 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\bin\msbuild.exe'
         $productVersion = & $msbuildExe $env:BUILD_REPOSITORY_LOCALPATH\build\config.props /v:m /nologo /t:GetSemanticVersion
         $productVersion = $productVersion.Trim()
-        $FullBuildNumber = "$productVersion.$newBuildCounter"
+        $FullBuildNumber = "$productVersion.$revision"
         $targetChannel = & $msbuildExe $env:BUILD_REPOSITORY_LOCALPATH\build\config.props /v:m /nologo /t:GetVsTargetChannel
         $targetChannel = $targetChannel.Trim()
         $targetMajorVersion = & $msbuildExe $env:BUILD_REPOSITORY_LOCALPATH\build\config.props /v:m /nologo /t:GetVsTargetMajorVersion
@@ -47,7 +49,7 @@ steps:
         Write-Host "##vso[task.setvariable variable=VsTargetChannel;isOutput=true]$targetChannel"
         Write-Host "##vso[task.setvariable variable=VsTargetMajorVersion;isOutput=true]$targetMajorVersion"
         Write-Host "##vso[build.updatebuildnumber]$FullBuildNumber"
-        Write-Host "##vso[task.setvariable variable=BuildNumber;isOutput=true]$newBuildCounter"
+        Write-Host "##vso[task.setvariable variable=BuildNumber;isOutput=true]$revision"
         Write-Host "##vso[task.setvariable variable=FullVstsBuildNumber;isOutput=true]$FullBuildNumber"
       } catch {
         Write-Host "##vso[task.LogIssue type=error;]Unable to set build number"

--- a/eng/pipelines/templates/Initialize_Build.yml
+++ b/eng/pipelines/templates/Initialize_Build.yml
@@ -35,8 +35,6 @@ steps:
     scriptType: "inlineScript"
     inlineScript: |
       try {
-        Write-Output "Semantic Version is $(SemanticVersion)"
-        Write-Output "Build Revision is $(BuildRevision)"
         $FullBuildNumber = "$(SemanticVersion).$(BuildRevision)"
         $msbuildExe = 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\bin\msbuild.exe'
         $targetChannel = & $msbuildExe $env:BUILD_REPOSITORY_LOCALPATH\build\config.props /v:m /nologo /t:GetVsTargetChannel

--- a/eng/pipelines/templates/Initialize_Build_SemanticVersion.yml
+++ b/eng/pipelines/templates/Initialize_Build_SemanticVersion.yml
@@ -1,5 +1,5 @@
 steps:
-- task: PowerShell@2
+- task: PowerShell@1
   displayName: "Set Semantic Version"
   name: "setsemanticversion"
   inputs:

--- a/eng/pipelines/templates/Initialize_Build_SemanticVersion.yml
+++ b/eng/pipelines/templates/Initialize_Build_SemanticVersion.yml
@@ -1,0 +1,16 @@
+steps:
+- task: PowerShell@2
+  displayName: "Set Semantic Version"
+  name: "setsemanticversion"
+  inputs:
+    scriptType: "inlineScript"
+    inlineScript: |
+      try {
+        $msbuildExe = 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\bin\msbuild.exe'
+        $version = & $msbuildExe $env:BUILD_REPOSITORY_LOCALPATH\build\config.props /v:m /nologo /t:GetSemanticVersion
+        $version = $version.Trim()
+        Write-Host "##vso[task.setvariable variable=SemanticVersion;isOutput=true]$version"
+        } catch {
+        Write-Host "##vso[task.LogIssue type=error;]Unable to set product version"
+        exit 1
+      }

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -15,7 +15,7 @@ jobs:
   timeoutInMinutes: 10
   variables:
     SemanticVersion: $[dependencies.Initialize_Build_SemanticVersion.outputs['setsemanticversion.SemanticVersion']]
-    BuildRevision: $[counter(format('{0}.{1}', variables['build.definitionname'], variables['SemanticVersion']), 0)]
+    BuildRevision: $[counter(format('{0}.{1}', variables['build.definitionname'], variables['SemanticVersion']), 7130)]
 
   pool:
     name: VSEng-MicroBuildVS2019

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -2,7 +2,7 @@ jobs:
 - job: Initialize_Build_SemanticVersion
   timeoutInMinutes: 2
   pool:
-    name: VSEng-MicroBuildVS2019
+    vmImage: windows-latest
     demands:
       - DotNetFramework
       - msbuild
@@ -18,7 +18,7 @@ jobs:
     BuildRevision: $[counter(format('{0}.{1}', variables['SemanticVersion'], variables['build.definitionname']), 7130)]
 
   pool:
-    name: VSEng-MicroBuildVS2019
+    vmImage: windows-latest
     demands:
       - DotNetFramework
       - msbuild

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -15,7 +15,7 @@ jobs:
   timeoutInMinutes: 10
   variables:
     SemanticVersion: $[dependencies.Initialize_Build_SemanticVersion.outputs['setsemanticversion.SemanticVersion']]
-    BuildRevision: $[counter(format('{0}.{1}', variables['build.definitionname'], variables['SemanticVersion']), 7130)]
+    BuildRevision: $[counter(format('{0}.{1}', variables['SemanticVersion'], variables['build.definitionname']), 7130)]
 
   pool:
     name: VSEng-MicroBuildVS2019

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -1,6 +1,22 @@
 jobs:
+- job: Initialize_Build_SemanticVersion
+  timeoutInMinutes: 1
+  pool:
+    name: VSEng-MicroBuildVS2019
+    demands:
+      - DotNetFramework
+      - msbuild
+
+  steps:
+  - template: Initialize_Build_SemanticVersion.yml
+
 - job: Initialize_Build
+  dependsOn: Initialize_Build_Version
   timeoutInMinutes: 10
+  variables:
+    SemanticVersion: $[dependencies.Initialize_Build_Version.outputs['setsemanticversion.SemanticVersion']]
+    BuildRevision: $[counter(format('{0}.{1}', variables['build.definitionname'], variables['SemanticVersion']), 7130)]
+
   pool:
     name: VSEng-MicroBuildVS2019
     demands:

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -11,10 +11,10 @@ jobs:
   - template: Initialize_Build_SemanticVersion.yml
 
 - job: Initialize_Build
-  dependsOn: Initialize_Build_Version
+  dependsOn: Initialize_Build_SemanticVersion
   timeoutInMinutes: 10
   variables:
-    SemanticVersion: $[dependencies.Initialize_Build_Version.outputs['setsemanticversion.SemanticVersion']]
+    SemanticVersion: $[dependencies.Initialize_Build_SemanticVersion.outputs['setsemanticversion.SemanticVersion']]
     BuildRevision: $[counter(format('{0}.{1}', variables['build.definitionname'], variables['SemanticVersion']), 7130)]
 
   pool:

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -15,7 +15,7 @@ jobs:
   timeoutInMinutes: 10
   variables:
     SemanticVersion: $[dependencies.Initialize_Build_SemanticVersion.outputs['setsemanticversion.SemanticVersion']]
-    BuildRevision: $[counter(format('{0}.{1}', variables['build.definitionname'], variables['SemanticVersion']), 7130)]
+    BuildRevision: $[counter(format('{0}.{1}', variables['build.definitionname'], variables['SemanticVersion']), 0)]
 
   pool:
     name: VSEng-MicroBuildVS2019

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -1,6 +1,6 @@
 jobs:
 - job: Initialize_Build_SemanticVersion
-  timeoutInMinutes: 1
+  timeoutInMinutes: 2
   pool:
     name: VSEng-MicroBuildVS2019
     demands:


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/258

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
The Semantic Version for NuGet assemblies/Packages is generated [here](https://github.com/NuGet/NuGet.Client/blob/dev/build/config.props#L18). There is a dependency on fileshare (\\ddfiles) to generate CI version. I am sure there could be other ways to fix the linked issue. This PR suggests an approach to increment the CI version using [counter expression](https://docs.microsoft.com/en-us/azure/devops/pipelines/process/expressions?view=azure-devops#counter) in Azure DevOps. I added a new job the CI pipeline which could increase CI duration by a minute due to the dependency on [fetching semantic version from `config.props`](https://github.com/NuGet/NuGet.Client/blob/dev/build/config.props#L18) using `msbuild.exe`.

I have defined `prefix` of `counter expression` on `build definition name (official or private builds)` and `semantic version` so that the CI version increments separately for official or private builds. As of this minute, the official build CI version is 7121. The `seed` starts with `7130` and increments by 1 separately for official or private builds. The following tables displays CI version number for next three builds after this PR have been merged to `dev` and all the team members rebase their branches with `dev`

Build Definition   Name | Build Number | CI Version
-- | -- | --
NuGet-Client Private Build | 1 | 7132 (I ran 2 private builds hence CI version starts with 7132)
NuGet-Client Private Build | 2 | 7133
NuGet-Client Private Build | 3 | 7134

Build Definition   Name | Build Number | CI Version
-- | -- | --
NuGet-Client Official Build | 1 | 7130
NuGet-Client Official Build | 2 | 7131
NuGet-Client Official Build | 3 | 7132

This approach ensures that for every CI build, version number of binaries is higher than previous version of the product. After we merge this PR into `dev` and cherry-pick these commits onto our servicing branches then I will create a follow up PR to change the seed back to 0 so that CI revision number starts from `0` for any change in major, minor or patch versions.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [x] N/A
