### PR TITLE
Override foreground and background brushes used when highlighting Dependencies TreeViewItems

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources/Brushes.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources/Brushes.cs
@@ -168,6 +168,10 @@ namespace NuGet.PackageManagement.UI
 
         public static object TabHoverBrushKey { get; private set; } = SystemColors.HotTrackBrushKey;
 
+        public static object ListItemBackgroundSelectedColorKey { get; private set; } = SystemColors.HighlightColorKey;
+
+        public static object ListItemTextSelectedColorKey { get; private set; } = SystemColors.HighlightTextColorKey;
+
         public static void LoadVsBrushes()
         {
             FocusVisualStyleBrushKey = VsBrushes.ToolWindowTextKey;
@@ -249,6 +253,10 @@ namespace NuGet.PackageManagement.UI
             TabHoverBrushKey = CommonDocumentColors.InnerTabInactiveHoverTextBrushKey;
             TabPopupBrushKey = CommonControlsColors.ButtonPressedBrushKey;
             TabPopupTextBrushKey = CommonControlsColors.ButtonPressedTextBrushKey;
+
+            // Mapping color keys directly for use to create brushes using these colors
+            ListItemBackgroundSelectedColorKey = CommonDocumentColors.ListItemBackgroundSelectedColorKey;
+            ListItemTextSelectedColorKey = CommonDocumentColors.ListItemTextSelectedColorKey;
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageMetadataControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageMetadataControl.xaml
@@ -6,7 +6,7 @@
   xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
   xmlns:nuget="clr-namespace:NuGet.PackageManagement.UI"
   xmlns:imaging="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.Imaging"
-  xmlns:catalog="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.ImageCatalog"  
+  xmlns:catalog="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.ImageCatalog"
   Background="{DynamicResource {x:Static nuget:Brushes.DetailPaneBackground}}"
   Foreground="{DynamicResource {x:Static nuget:Brushes.UIText}}"
   mc:Ignorable="d"
@@ -18,6 +18,7 @@
         <nuget:SharedResources />
       </ResourceDictionary.MergedDictionaries>
       <nuget:DateTimeConverter x:Key="DateFormatConverter" />
+      <nuget:AccessibleConverter x:Key="AccNameWorkaround" />
       <DataTemplate DataType="{x:Type nuget:LicenseText}">
         <TextBlock>
                 <Hyperlink
@@ -60,6 +61,17 @@
             AutomationProperties.AutomationId="{Binding Id, Mode=OneWay, StringFormat='LicenseOperator_{0}'}"
             Text="{Binding Text}" />
       </DataTemplate>
+
+      <Style x:Key="TreeViewItemHeaderStyle" TargetType="TreeViewItem">
+        <Setter Property="IsExpanded" Value="True" />
+        <Setter Property="AutomationProperties.Name" Value="{Binding RelativeSource={RelativeSource Self},Converter={StaticResource AccNameWorkaround}}" />
+        <Setter Property="Foreground" Value="{DynamicResource {x:Static nuget:Brushes.UIText}}" />
+        <Setter Property="FontWeight" Value="Bold" />
+      </Style>
+
+      <Style TargetType="TreeViewItem" BasedOn="{StaticResource TreeViewItemHeaderStyle}">
+        <Setter Property="FontWeight" Value="Normal" />
+      </Style>
     </ResourceDictionary>
   </UserControl.Resources>
   <Grid>
@@ -322,32 +334,26 @@
         </ControlTemplate>
       </TreeView.Template>
       <TreeView.Resources>
-        <nuget:AccessibleConverter x:Key="AccNameWorkaround" />
         <HierarchicalDataTemplate ItemsSource="{Binding Dependencies}" DataType="{x:Type nuget:PackageDependencySetMetadata}">
           <TextBlock Text="{Binding TargetFrameworkDisplay}" Padding="0,2,0,0" />
         </HierarchicalDataTemplate>
         <DataTemplate DataType="{x:Type nuget:PackageDependencyMetadata}">
           <TextBlock Text="{Binding}" ToolTip="{Binding}" />
         </DataTemplate>
+        <!--
+          Override the background and foreground brushes that TreeViewItems use for highlighting the item
+          when in the selected state and point to VS themed colors instead of using the defaults.
+        -->
+        <SolidColorBrush
+          x:Key="{x:Static SystemColors.HighlightBrushKey}"
+          Color="{DynamicResource {x:Static nuget:Brushes.ListItemBackgroundSelectedColorKey}}" />
+        <SolidColorBrush
+          x:Key="{x:Static SystemColors.HighlightTextBrushKey}"
+          Color="{DynamicResource {x:Static nuget:Brushes.ListItemTextSelectedColorKey}}" />
       </TreeView.Resources>
-      <TreeView.ItemContainerStyle>
-        <Style TargetType="TreeViewItem">
-          <Setter Property="IsExpanded" Value="True" />
-          <Setter Property="AutomationProperties.Name" Value="{Binding RelativeSource={RelativeSource Self},Converter={StaticResource AccNameWorkaround}}" />
-          <Setter Property="Foreground" Value="{DynamicResource {x:Static nuget:Brushes.UIText}}" />
-          <Setter Property="FontWeight" Value="Bold" />
-        </Style>
-      </TreeView.ItemContainerStyle>
       <TreeViewItem Header="{x:Static nuget:Resources.Label_Dependencies}"
-                    ItemsSource="{Binding Path=DependencySets}">
-        <TreeViewItem.ItemContainerStyle>
-          <Style TargetType="TreeViewItem">
-            <Setter Property="IsExpanded" Value="True" />
-            <Setter Property="AutomationProperties.Name" Value="{Binding RelativeSource={RelativeSource Self},Converter={StaticResource AccNameWorkaround}}" />
-            <Setter Property="Foreground" Value="{DynamicResource {x:Static nuget:Brushes.UIText}}" />
-            <Setter Property="FontWeight" Value="Normal" />
-          </Style>
-        </TreeViewItem.ItemContainerStyle>
+                    ItemsSource="{Binding Path=DependencySets}"
+                    Style="{StaticResource TreeViewItemHeaderStyle}">
       </TreeViewItem>
     </TreeView>
   </Grid>


### PR DESCRIPTION
Override foreground and background brushes used by the TreeViewItem in the selected state for the Dependencies tree and  make them use VS theme-aware colors

## Bug

Fixes: https://github.com/nuget/client.engineering/issues/774

Regression? Last working version: N/A

## Description
Set a background and foreground color for the TreeViewItems in the Dependencies tree of the PMUI Details pane to a VS themed color so it displays correctly, with the appropriate contrast ratio, in all themes.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
Test affects UI display. Testing was done manually using Accessibility Insights and the results are as follows in each theme:

Light theme:
![image](https://user-images.githubusercontent.com/10777837/107724145-02a30900-6c98-11eb-9141-492e00112e39.png)

Blue theme:
![image](https://user-images.githubusercontent.com/10777837/107724154-08005380-6c98-11eb-9348-80a6ed9be0f0.png)

Dark theme:
![image](https://user-images.githubusercontent.com/10777837/107724159-0cc50780-6c98-11eb-912d-27dbefd1d5fd.png)

  - [x] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
