### PR TITLE
catch OperationCanceledExceptions where expected. don't spam PostAsFailure.

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailControlModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailControlModel.cs
@@ -118,7 +118,8 @@ namespace NuGet.PackageManagement.UI
         public async virtual Task SetCurrentPackageAsync(
             PackageItemListViewModel searchResultPackage,
             ItemFilter filter,
-            Func<PackageItemListViewModel> getPackageItemListViewModel)
+            Func<PackageItemListViewModel> getPackageItemListViewModel,
+            CancellationToken cancellationToken)
         {
             // Clear old data
             PackageMetadata = null;
@@ -146,7 +147,7 @@ namespace NuGet.PackageManagement.UI
                     // cache allowed version range for each nuget project for current selected package
                     IReadOnlyCollection<IPackageReferenceContextInfo> installedPackages = await project.GetInstalledPackagesAsync(
                         ServiceBroker,
-                        CancellationToken.None);
+                        cancellationToken);
                     IPackageReferenceContextInfo packageReference = installedPackages
                         .FirstOrDefault(r => StringComparer.OrdinalIgnoreCase.Equals(r.Identity.Id, searchResultPackage.Id));
 
@@ -156,7 +157,7 @@ namespace NuGet.PackageManagement.UI
                     {
                         IProjectMetadataContextInfo projectMetadata = await project.GetMetadataAsync(
                             ServiceBroker,
-                            CancellationToken.None);
+                            cancellationToken);
                         var constraint = new ProjectVersionConstraint()
                         {
                             ProjectName = projectMetadata.Name,
@@ -171,7 +172,7 @@ namespace NuGet.PackageManagement.UI
                 {
                     IReadOnlyCollection<IPackageReferenceContextInfo> packageReferences = await project.GetInstalledPackagesAsync(
                         ServiceBroker,
-                        CancellationToken.None);
+                        cancellationToken);
 
                     // Find the lowest auto referenced version of this package.
                     IPackageReferenceContextInfo autoReferenced = packageReferences
@@ -185,7 +186,7 @@ namespace NuGet.PackageManagement.UI
                     {
                         IProjectMetadataContextInfo projectMetadata = await project.GetMetadataAsync(
                             ServiceBroker,
-                            CancellationToken.None);
+                            cancellationToken);
 
                         // Add constraint for auto referenced package.
                         var constraint = new ProjectVersionConstraint()
@@ -211,7 +212,7 @@ namespace NuGet.PackageManagement.UI
                 (searchResultPackage.Version, false)
             };
 
-            await CreateVersionsAsync(CancellationToken.None);
+            await CreateVersionsAsync(cancellationToken);
             OnCurrentPackageChanged();
 
             var versions = await getVersionsTask;
@@ -229,7 +230,7 @@ namespace NuGet.PackageManagement.UI
                 .Select(GetVersion)
                 .ToList();
 
-            await CreateVersionsAsync(CancellationToken.None);
+            await CreateVersionsAsync(cancellationToken);
             OnCurrentPackageChanged();
 
             (PackageSearchMetadataContextInfo packageSearchMetadata, PackageDeprecationMetadataContextInfo packageDeprecationMetadata) =

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageDetailControlModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageDetailControlModel.cs
@@ -32,12 +32,13 @@ namespace NuGet.PackageManagement.UI
         public async override Task SetCurrentPackageAsync(
             PackageItemListViewModel searchResultPackage,
             ItemFilter filter,
-            Func<PackageItemListViewModel> getPackageItemListViewModel)
+            Func<PackageItemListViewModel> getPackageItemListViewModel,
+            CancellationToken cancellationToken)
         {
             // Set InstalledVersion before fetching versions list.
             InstalledVersion = searchResultPackage.InstalledVersion;
 
-            await base.SetCurrentPackageAsync(searchResultPackage, filter, getPackageItemListViewModel);
+            await base.SetCurrentPackageAsync(searchResultPackage, filter, getPackageItemListViewModel, cancellationToken);
 
             // SetCurrentPackage can take long time to return, user might changed selected package.
             // Check selected package.

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageItemListViewModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageItemListViewModel.cs
@@ -643,13 +643,14 @@ namespace NuGet.PackageManagement.UI
             try
             {
                 NuGetVersion latestVersion = await _backgroundLatestVersionLoader.Value;
+                await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
                 LatestVersion = latestVersion;
                 Status = GetPackageStatus(LatestVersion, InstalledVersion, AutoReferenced);
             }
-            // Cancelled async operations inside of _backgroundLatestVersionLoader callpaths are expected to raise an InvalidOperationException.
+            // Cancelled async operations inside of _backgroundLatestVersionLoader callpaths are expected to raise an OperationCanceledException.
             // One shouldn't spam PostOnFailure since these are to be expected when UI interaction causes previous operations
             // (searches, or metadata downloads or deprecationMetadata downloads, etc...) to no longer be needed.
-            catch (InvalidOperationException)
+            catch (OperationCanceledException)
             {
             }
         }
@@ -660,12 +661,13 @@ namespace NuGet.PackageManagement.UI
             try
             {
                 deprecationMetadataContextInfo = await _backgroundDeprecationMetadataLoader.Value;
+                await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
                 IsPackageDeprecated = deprecationMetadataContextInfo != null;
             }
-            // Cancelled async operations inside of _backgroundDeprecationMetadataLoader callpaths are expected to raise an InvalidOperationException.
+            // Cancelled async operations inside of _backgroundDeprecationMetadataLoader callpaths are expected to raise an OperationCanceledException.
             // One shouldn't spam PostOnFailure since these are to be expected when UI interaction causes previous operations
             // (searches, or metadata downloads or deprecationMetadata downloads, etc...) to no longer be needed.
-            catch (InvalidOperationException)
+            catch (OperationCanceledException)
             {
             }
         }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageItemListViewModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageItemListViewModel.cs
@@ -640,36 +640,17 @@ namespace NuGet.PackageManagement.UI
 
         private async System.Threading.Tasks.Task ReloadPackageVersionsAsync()
         {
-            try
-            {
-                NuGetVersion latestVersion = await _backgroundLatestVersionLoader.Value;
-                await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-                LatestVersion = latestVersion;
-                Status = GetPackageStatus(LatestVersion, InstalledVersion, AutoReferenced);
-            }
-            // Cancelled async operations inside of _backgroundLatestVersionLoader callpaths are expected to raise an OperationCanceledException.
-            // One shouldn't spam PostOnFailure since these are to be expected when UI interaction causes previous operations
-            // (searches, or metadata downloads or deprecationMetadata downloads, etc...) to no longer be needed.
-            catch (OperationCanceledException)
-            {
-            }
+            NuGetVersion latestVersion = await _backgroundLatestVersionLoader.Value;
+            await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            LatestVersion = latestVersion;
+            Status = GetPackageStatus(LatestVersion, InstalledVersion, AutoReferenced);
         }
 
         private async System.Threading.Tasks.Task ReloadPackageDeprecationAsync()
         {
-            PackageDeprecationMetadataContextInfo deprecationMetadataContextInfo;
-            try
-            {
-                deprecationMetadataContextInfo = await _backgroundDeprecationMetadataLoader.Value;
-                await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-                IsPackageDeprecated = deprecationMetadataContextInfo != null;
-            }
-            // Cancelled async operations inside of _backgroundDeprecationMetadataLoader callpaths are expected to raise an OperationCanceledException.
-            // One shouldn't spam PostOnFailure since these are to be expected when UI interaction causes previous operations
-            // (searches, or metadata downloads or deprecationMetadata downloads, etc...) to no longer be needed.
-            catch (OperationCanceledException)
-            {
-            }
+            PackageDeprecationMetadataContextInfo deprecationMetadataContextInfo = await _backgroundDeprecationMetadataLoader.Value;
+            await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            IsPackageDeprecated = deprecationMetadataContextInfo != null;
         }
 
         private async System.Threading.Tasks.Task ReloadProvidersAsync()

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -1082,8 +1082,17 @@ namespace NuGet.PackageManagement.UI
 
                 EmitSearchSelectionTelemetry(selectedItem);
 
-                await _detailModel.SetCurrentPackageAsync(selectedItem, _topPanel.Filter, () => _packageList.SelectedItem);
-                _detailModel.SetCurrentSelectionInfo(selectedIndex, recommendedCount, _recommendPackages, selectedItem.RecommenderVersion);
+                try
+                {
+                    await _detailModel.SetCurrentPackageAsync(selectedItem, _topPanel.Filter, () => _packageList.SelectedItem);
+                    _detailModel.SetCurrentSelectionInfo(selectedIndex, recommendedCount, _recommendPackages, selectedItem.RecommenderVersion);
+                }
+                // Cancelled async operations inside of SetCurrentPackageAsync() callpaths are expected to raise an InvalidOperationException.
+                // One shouldn't spam PostOnFailure since these are to be expected when UI interaction causes previous operations
+                // (searches, or metadata downloads or deprecationMetadata downloads, etc...) to no longer be needed.
+                catch (InvalidOperationException)
+                {
+                }
 
                 _packageDetail.ScrollToHome();
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -1084,7 +1084,7 @@ namespace NuGet.PackageManagement.UI
 
                 try
                 {
-                    await _detailModel.SetCurrentPackageAsync(selectedItem, _topPanel.Filter, () => _packageList.SelectedItem);
+                    await _detailModel.SetCurrentPackageAsync(selectedItem, _topPanel.Filter, () => _packageList.SelectedItem, cancellationToken);
                     _detailModel.SetCurrentSelectionInfo(selectedIndex, recommendedCount, _recommendPackages, selectedItem.RecommenderVersion);
                 }
                 // Cancelled async operations inside of SetCurrentPackageAsync() callpaths are expected to raise an OperationCanceledException.

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -1082,17 +1082,8 @@ namespace NuGet.PackageManagement.UI
 
                 EmitSearchSelectionTelemetry(selectedItem);
 
-                try
-                {
-                    await _detailModel.SetCurrentPackageAsync(selectedItem, _topPanel.Filter, () => _packageList.SelectedItem, cancellationToken);
-                    _detailModel.SetCurrentSelectionInfo(selectedIndex, recommendedCount, _recommendPackages, selectedItem.RecommenderVersion);
-                }
-                // Cancelled async operations inside of SetCurrentPackageAsync() callpaths are expected to raise an OperationCanceledException.
-                // One shouldn't spam PostOnFailure since these are to be expected when UI interaction causes previous operations
-                // (searches, or metadata downloads or deprecationMetadata downloads, etc...) to no longer be needed.
-                catch (OperationCanceledException)
-                {
-                }
+                await _detailModel.SetCurrentPackageAsync(selectedItem, _topPanel.Filter, () => _packageList.SelectedItem, cancellationToken);
+                _detailModel.SetCurrentSelectionInfo(selectedIndex, recommendedCount, _recommendPackages, selectedItem.RecommenderVersion);
 
                 _packageDetail.ScrollToHome();
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -1087,10 +1087,10 @@ namespace NuGet.PackageManagement.UI
                     await _detailModel.SetCurrentPackageAsync(selectedItem, _topPanel.Filter, () => _packageList.SelectedItem);
                     _detailModel.SetCurrentSelectionInfo(selectedIndex, recommendedCount, _recommendPackages, selectedItem.RecommenderVersion);
                 }
-                // Cancelled async operations inside of SetCurrentPackageAsync() callpaths are expected to raise an InvalidOperationException.
+                // Cancelled async operations inside of SetCurrentPackageAsync() callpaths are expected to raise an OperationCanceledException.
                 // One shouldn't spam PostOnFailure since these are to be expected when UI interaction causes previous operations
                 // (searches, or metadata downloads or deprecationMetadata downloads, etc...) to no longer be needed.
-                catch (InvalidOperationException)
+                catch (OperationCanceledException)
                 {
                 }
 

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/JoinableTaskExtensions.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/JoinableTaskExtensions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
 using Microsoft.VisualStudio.Threading;
 
 namespace NuGet.VisualStudio.Telemetry
@@ -22,6 +23,10 @@ namespace NuGet.VisualStudio.Telemetry
 #pragma warning disable VSTHRD003 // Avoid awaiting foreign Tasks - As a fire-and-forget continuation, deadlocks can't happen.
                     await joinableTask.Task.ConfigureAwait(false);
 #pragma warning restore VSTHRD003
+                }
+                catch (TaskCanceledException taskCanceledException)
+                when (taskCanceledException.CancellationToken != null && taskCanceledException.CancellationToken.IsCancellationRequested)
+                {
                 }
                 catch (Exception e)
                 {

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/JoinableTaskExtensions.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/JoinableTaskExtensions.cs
@@ -24,10 +24,6 @@ namespace NuGet.VisualStudio.Telemetry
                     await joinableTask.Task.ConfigureAwait(false);
 #pragma warning restore VSTHRD003
                 }
-                catch (TaskCanceledException taskCanceledException)
-                when (taskCanceledException.CancellationToken != null && taskCanceledException.CancellationToken.IsCancellationRequested)
-                {
-                }
                 catch (Exception e)
                 {
                     await TelemetryUtility.PostFaultAsync(e, callerClassName, callerMemberName);

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/SourceRepositoryDependencyProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/SourceRepositoryDependencyProvider.cs
@@ -329,7 +329,7 @@ namespace NuGet.Commands
 
                 if (_throttle != null)
                 {
-                    await _throttle.WaitAsync();
+                    await _throttle.WaitAsync(cancellationToken);
                 }
 
                 // Read package info, this will download the package if needed.
@@ -415,7 +415,7 @@ namespace NuGet.Commands
 
                 if (_throttle != null)
                 {
-                    await _throttle.WaitAsync();
+                    await _throttle.WaitAsync(cancellationToken);
                 }
 
                 cancellationToken.ThrowIfCancellationRequested();
@@ -527,7 +527,7 @@ namespace NuGet.Commands
             {
                 if (_throttle != null)
                 {
-                    await _throttle.WaitAsync();
+                    await _throttle.WaitAsync(cancellationToken);
                 }
                 if (_findPackagesByIdResource == null)
                 {

--- a/src/NuGet.Core/NuGet.Packaging/LocalPackageArchiveDownloader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/LocalPackageArchiveDownloader.cs
@@ -166,7 +166,7 @@ namespace NuGet.Packaging
             {
                 if (_throttle != null)
                 {
-                    await _throttle.WaitAsync();
+                    await _throttle.WaitAsync(cancellationToken);
                 }
 
                 cancellationToken.ThrowIfCancellationRequested();

--- a/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpCacheUtility.cs
+++ b/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpCacheUtility.cs
@@ -73,7 +73,11 @@ namespace NuGet.Protocol
                 FileShare.None,
                 BufferSize))
             {
-                using (var networkStream = await response.Content.ReadAsStreamAsync())
+                using (var networkStream = await response.Content.ReadAsStreamAsync(
+#if NET5_0
+                    cancellationToken
+#endif
+                    ))
                 {
                     await networkStream.CopyToAsync(fileStream, BufferSize, cancellationToken);
                 }

--- a/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpRetryHandler.cs
+++ b/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpRetryHandler.cs
@@ -90,10 +90,10 @@ namespace NuGet.Protocol
 
                     try
                     {
-                        // The only time that we will be disposing this existing response is if we have 
+                        // The only time that we will be disposing this existing response is if we have
                         // successfully fetched an HTTP response but the response has an status code indicating
                         // failure (i.e. HTTP status code >= 500).
-                        // 
+                        //
                         // If we don't even get an HTTP response message because an exception is thrown, then there
                         // is no response instance to dispose. Additionally, we cannot use a finally here because
                         // the caller needs the response instance returned in a non-disposed state.
@@ -141,7 +141,11 @@ namespace NuGet.Protocol
                         // Wrap the response stream so that the download can timeout.
                         if (response.Content != null)
                         {
-                            var networkStream = await response.Content.ReadAsStreamAsync();
+                            var networkStream = await response.Content.ReadAsStreamAsync(
+#if NET5_0
+                                cancellationToken
+#endif
+                                );
                             var timeoutStream = new DownloadTimeoutStream(requestUri.ToString(), networkStream, request.DownloadTimeout);
                             var inProgressEvent = new ProtocolDiagnosticInProgressHttpEvent(
                                 source,

--- a/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpSource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpSource.cs
@@ -176,7 +176,11 @@ namespace NuGet.Protocol
                             // the cache. We cannot seek on the network stream and it is not valuable to download the
                             // content twice just to validate the first time (considering that the second download could
                             // be different from the first thus rendering the first validation meaningless).
-                            using (var stream = await throttledResponse.Response.Content.ReadAsStreamAsync())
+                            using (var stream = await throttledResponse.Response.Content.ReadAsStreamAsync(
+#if NET5_0
+                                lockedToken
+#endif
+                                ))
                             using (var httpSourceResult = new HttpSourceResult(
                                 HttpSourceResultStatus.OpenedFromNetwork,
                                 cacheFileName: null,

--- a/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpSourceAuthenticationHandler.cs
+++ b/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpSourceAuthenticationHandler.cs
@@ -151,7 +151,7 @@ namespace NuGet.Protocol
         private async Task<ICredentials> AcquireCredentialsAsync(HttpStatusCode statusCode, Guid credentialsVersion, ILogger log, CancellationToken cancellationToken)
         {
             // Only one request may prompt and attempt to auth at a time
-            await _httpClientLock.WaitAsync();
+            await _httpClientLock.WaitAsync(cancellationToken);
 
             try
             {
@@ -233,12 +233,12 @@ namespace NuGet.Protocol
             string message,
             AmbientAuthenticationState authState,
             ILogger log,
-            CancellationToken token)
+            CancellationToken cancellationToken)
         {
             ICredentials promptCredentials;
 
             // Only one prompt may display at a time.
-            await _credentialPromptLock.WaitAsync();
+            await _credentialPromptLock.WaitAsync(cancellationToken);
 
             try
             {
@@ -248,7 +248,7 @@ namespace NuGet.Protocol
                 var proxy = proxyCache?.GetProxy(_packageSource.SourceUri);
 
                 promptCredentials = await _credentialService
-                    .GetCredentialsAsync(_packageSource.SourceUri, proxy, type, message, token);
+                    .GetCredentialsAsync(_packageSource.SourceUri, proxy, type, message, cancellationToken);
 
                 if (promptCredentials == null)
                 {

--- a/src/NuGet.Core/NuGet.Protocol/HttpSource/ProxyAuthenticationHandler.cs
+++ b/src/NuGet.Core/NuGet.Protocol/HttpSource/ProxyAuthenticationHandler.cs
@@ -148,7 +148,7 @@ namespace NuGet.Protocol
         {
             try
             {
-                await _credentialPromptLock.WaitAsync();
+                await _credentialPromptLock.WaitAsync(cancellationToken);
 
                 cancellationToken.ThrowIfCancellationRequested();
 

--- a/src/NuGet.Core/NuGet.Protocol/LocalPackageArchiveDownloader.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LocalPackageArchiveDownloader.cs
@@ -167,7 +167,7 @@ namespace NuGet.Protocol
             {
                 if (_throttle != null)
                 {
-                    await _throttle.WaitAsync();
+                    await _throttle.WaitAsync(cancellationToken);
                 }
 
                 cancellationToken.ThrowIfCancellationRequested();

--- a/src/NuGet.Core/NuGet.Protocol/Providers/PackageMetadataResourceV3Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Providers/PackageMetadataResourceV3Provider.cs
@@ -22,9 +22,9 @@ namespace NuGet.Protocol
 
             if (await source.GetResourceAsync<ServiceIndexResourceV3>(token) != null)
             {
-                var regResource = await source.GetResourceAsync<RegistrationResourceV3>();
-                var reportAbuseResource = await source.GetResourceAsync<ReportAbuseResourceV3>();
-                var packageDetailsUriResource = await source.GetResourceAsync<PackageDetailsUriResourceV3>();
+                var regResource = await source.GetResourceAsync<RegistrationResourceV3>(token);
+                var reportAbuseResource = await source.GetResourceAsync<ReportAbuseResourceV3>(token);
+                var packageDetailsUriResource = await source.GetResourceAsync<PackageDetailsUriResourceV3>(token);
 
                 var httpSourceResource = await source.GetResourceAsync<HttpSourceResource>(token);
 

--- a/src/NuGet.Core/NuGet.Protocol/Providers/RawSearchResourceV3Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Providers/RawSearchResourceV3Provider.cs
@@ -21,7 +21,7 @@ namespace NuGet.Protocol
         public override async Task<Tuple<bool, INuGetResource>> TryCreate(SourceRepository source, CancellationToken token)
         {
             RawSearchResourceV3 curResource = null;
-            var serviceIndex = await source.GetResourceAsync<ServiceIndexResourceV3>();
+            var serviceIndex = await source.GetResourceAsync<ServiceIndexResourceV3>(token);
 
             if (serviceIndex != null)
             {

--- a/src/NuGet.Core/NuGet.Protocol/RemotePackageArchiveDownloader.cs
+++ b/src/NuGet.Core/NuGet.Protocol/RemotePackageArchiveDownloader.cs
@@ -162,7 +162,7 @@ namespace NuGet.Protocol
             {
                 if (_throttle != null)
                 {
-                    await _throttle.WaitAsync();
+                    await _throttle.WaitAsync(cancellationToken);
                 }
 
                 cancellationToken.ThrowIfCancellationRequested();

--- a/src/NuGet.Core/NuGet.Protocol/RemoteRepositories/HttpFileSystemBasedFindPackageByIdResourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/RemoteRepositories/HttpFileSystemBasedFindPackageByIdResourceProvider.cs
@@ -20,7 +20,7 @@ namespace NuGet.Protocol
         public override async Task<Tuple<bool, INuGetResource>> TryCreate(SourceRepository sourceRepository, CancellationToken token)
         {
             INuGetResource resource = null;
-            var serviceIndexResource = await sourceRepository.GetResourceAsync<ServiceIndexResourceV3>();
+            var serviceIndexResource = await sourceRepository.GetResourceAsync<ServiceIndexResourceV3>(token);
             var packageBaseAddress = serviceIndexResource?.GetServiceEntryUris(ServiceTypes.PackageBaseAddress);
 
             if (packageBaseAddress != null

--- a/src/NuGet.Core/NuGet.Protocol/RemoteRepositories/RemoteV3FindPackageByIdResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/RemoteRepositories/RemoteV3FindPackageByIdResource.cs
@@ -464,7 +464,7 @@ namespace NuGet.Protocol
                     await _dependencyInfoSemaphore.WaitAsync(cancellationToken);
                     if (_dependencyInfoResource == null)
                     {
-                        _dependencyInfoResource = await SourceRepository.GetResourceAsync<DependencyInfoResource>();
+                        _dependencyInfoResource = await SourceRepository.GetResourceAsync<DependencyInfoResource>(cancellationToken);
                     }
                 }
                 finally

--- a/src/NuGet.Core/NuGet.Protocol/RemoteRepositories/RemoteV3FindPackageByIdResourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/RemoteRepositories/RemoteV3FindPackageByIdResourceProvider.cs
@@ -21,7 +21,7 @@ namespace NuGet.Protocol
         {
             INuGetResource resource = null;
 
-            var serviceIndexResource = await sourceRepository.GetResourceAsync<ServiceIndexResourceV3>();
+            var serviceIndexResource = await sourceRepository.GetResourceAsync<ServiceIndexResourceV3>(token);
 
             if (serviceIndexResource != null)
             {

--- a/src/NuGet.Core/NuGet.Protocol/Resources/PackageSearchResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/PackageSearchResourceV3.cs
@@ -39,8 +39,8 @@ namespace NuGet.Protocol
         }
 
         /// <summary>
-        /// Query nuget package list from nuget server. This implementation optimized for performance so doesn't iterate whole result 
-        /// returned nuget server, so as soon as find "take" number of result packages then stop processing and return the result. 
+        /// Query nuget package list from nuget server. This implementation optimized for performance so doesn't iterate whole result
+        /// returned nuget server, so as soon as find "take" number of result packages then stop processing and return the result.
         /// </summary>
         /// <param name="searchTerm">The term we're searching for.</param>
         /// <param name="filter">Filter for whether to include prerelease, delisted, supportedframework flags in query.</param>
@@ -204,8 +204,8 @@ namespace NuGet.Protocol
         }
 
         /// <summary>
-        /// Query nuget package list from nuget server. This implementation optimized for performance so doesn't iterate whole result 
-        /// returned nuget server, so as soon as find "take" number of result packages then stop processing and return the result. 
+        /// Query nuget package list from nuget server. This implementation optimized for performance so doesn't iterate whole result
+        /// returned nuget server, so as soon as find "take" number of result packages then stop processing and return the result.
         /// </summary>
         /// <param name="searchTerm">The term we're searching for.</param>
         /// <param name="filters">Filter for whether to include prerelease, delisted, supportedframework flags in query.</param>
@@ -246,7 +246,7 @@ namespace NuGet.Protocol
             return (await ProcessHttpStreamWithoutBufferingAsync(httpInitialResponse, (uint)take, token)).Data;
         }
 
-        private async Task<V3SearchResults> ProcessHttpStreamWithoutBufferingAsync(HttpResponseMessage httpInitialResponse, uint take, CancellationToken token)
+        private async Task<V3SearchResults> ProcessHttpStreamWithoutBufferingAsync(HttpResponseMessage httpInitialResponse, uint take, CancellationToken cancellationToken)
         {
             if (httpInitialResponse == null)
             {
@@ -256,7 +256,11 @@ namespace NuGet.Protocol
             var _newtonsoftConvertersSerializer = JsonSerializer.Create(JsonExtensions.ObjectSerializationSettings);
             _newtonsoftConvertersSerializer.Converters.Add(new Converters.V3SearchResultsConverter(take));
 
-            using (var stream = await httpInitialResponse.Content.ReadAsStreamAsync())
+            using (var stream = await httpInitialResponse.Content.ReadAsStreamAsync(
+#if NET5_0
+                cancellationToken
+#endif
+                ))
             using (var streamReader = new StreamReader(stream))
             using (var jsonReader = new JsonTextReader(streamReader))
             {

--- a/src/NuGet.Core/NuGet.Protocol/SourceRepository.cs
+++ b/src/NuGet.Core/NuGet.Protocol/SourceRepository.cs
@@ -125,7 +125,7 @@ namespace NuGet.Protocol.Core.Types
         public virtual T GetResource<T>(CancellationToken token) where T : class, INuGetResource
         {
             var task = GetResourceAsync<T>(token);
-            task.Wait();
+            task.Wait(token);
 
             return task.Result;
         }

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/LocalDetailControlModelTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/LocalDetailControlModelTests.cs
@@ -57,7 +57,8 @@ namespace NuGet.PackageManagement.UI.Test.Models
             _testInstance.SetCurrentPackageAsync(
                 _testViewModel,
                 ItemFilter.All,
-                () => null).Wait();
+                () => null,
+                CancellationToken.None).Wait();
         }
 
         [Fact]
@@ -131,7 +132,8 @@ namespace NuGet.PackageManagement.UI.Test.Models
                     Version = installedVersion
                 },
                 ItemFilter.All,
-                () => null);
+                () => null,
+                CancellationToken.None);
 
             NuGetVersion selectedVersion = NuGetVersion.Parse("2.0.0");
 
@@ -159,7 +161,8 @@ namespace NuGet.PackageManagement.UI.Test.Models
                     Version = installedVersion
                 },
                 ItemFilter.All,
-                () => null);
+                () => null,
+                CancellationToken.None);
 
             model.SelectedVersion = new DisplayVersion(installedVersion, additionalInfo: null);
 
@@ -199,7 +202,8 @@ namespace NuGet.PackageManagement.UI.Test.Models
             _testInstance.SetCurrentPackageAsync(
                 _testViewModel,
                 ItemFilter.All,
-                () => null).Wait();
+                () => null,
+                CancellationToken.None).Wait();
         }
     }
 }

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/V3DetailControlModelTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/V3DetailControlModelTests.cs
@@ -109,7 +109,8 @@ namespace NuGet.PackageManagement.UI.Test.Models
             _testInstance.SetCurrentPackageAsync(
                 _testViewModel,
                 ItemFilter.All,
-                () => null).Wait();
+                () => null,
+                CancellationToken.None).Wait();
         }
 
         [Fact]
@@ -153,7 +154,8 @@ namespace NuGet.PackageManagement.UI.Test.Models
             await _testInstance.SetCurrentPackageAsync(
                 vm,
                 ItemFilter.All,
-                () => vm);
+                () => vm,
+                CancellationToken.None);
 
             // Assert
             var expectedAdditionalInfo = string.Empty;
@@ -274,7 +276,8 @@ namespace NuGet.PackageManagement.UI.Test.Models
             await _testInstance.SetCurrentPackageAsync(
                 vm,
                 ItemFilter.All,
-                () => vm);
+                () => vm,
+                CancellationToken.None);
 
             // Assert
             var expectedAdditionalInfo = string.Empty;

--- a/test/TestExtensions/TestablePlugin/ResponseReceiver.cs
+++ b/test/TestExtensions/TestablePlugin/ResponseReceiver.cs
@@ -44,7 +44,7 @@ namespace NuGet.Test.TestExtensions.TestablePlugin
 
                         var response = JsonSerializationUtilities.Deserialize<Response>(text);
 
-                        _responses.Add(response);
+                        _responses.Add(response, cancellationToken);
                     }
                 }
             }

--- a/test/TestExtensions/TestablePlugin/TestablePlugin.cs
+++ b/test/TestExtensions/TestablePlugin/TestablePlugin.cs
@@ -80,7 +80,7 @@ namespace NuGet.Test.TestExtensions.TestablePlugin
             IResponseHandler responseHandler,
             CancellationToken cancellationToken)
         {
-            var response = _responses.Take();
+            var response = _responses.Take(cancellationToken);
 
             if (message.Type == MessageType.Request)
             {

--- a/test/TestUtilities/Test.Utility/Signing/SigningTestServer.cs
+++ b/test/TestUtilities/Test.Utility/Signing/SigningTestServer.cs
@@ -60,7 +60,7 @@ namespace Test.Utility.Signing
             var portReserver = new PortReserver();
 
             return portReserver.ExecuteAsync(
-                (port, token) =>
+                (port, cancellationToken) =>
                 {
                     var url = new Uri($"http://127.0.0.1:{port}/");
                     var httpListener = new HttpListener();
@@ -73,9 +73,9 @@ namespace Test.Utility.Signing
 
                     using (var taskStartedEvent = new ManualResetEventSlim())
                     {
-                        Task.Factory.StartNew(() => server.HandleRequest(taskStartedEvent, token));
+                        Task.Factory.StartNew(() => server.HandleRequest(taskStartedEvent, cancellationToken), cancellationToken);
 
-                        taskStartedEvent.Wait(token);
+                        taskStartedEvent.Wait(cancellationToken);
                     }
 
                     return Task.FromResult(server);

--- a/test/TestUtilities/Test.Utility/TestServer/TcpListenerServer.cs
+++ b/test/TestUtilities/Test.Utility/TestServer/TcpListenerServer.cs
@@ -56,12 +56,12 @@ namespace NuGet.Test.Server
         public TestServerMode Mode { get; set; } = TestServerMode.ServerProtocolViolation;
         public TimeSpan SleepDuration { get; set; } = TimeSpan.FromSeconds(110);
 
-        private async Task StartSlowResponseBody(TcpListener tcpListener, CancellationToken token)
+        private async Task StartSlowResponseBody(TcpListener tcpListener, CancellationToken cancellationToken)
         {
             // This server does not process any request body.
-            while (!token.IsCancellationRequested)
+            while (!cancellationToken.IsCancellationRequested)
             {
-                using (var client = await Task.Run(tcpListener.AcceptTcpClientAsync, token))
+                using (var client = await Task.Run(tcpListener.AcceptTcpClientAsync, cancellationToken))
                 using (var stream = client.GetStream())
                 using (var reader = new StreamReader(stream, Encoding.ASCII, false, 1))
                 using (var writer = new StreamWriter(stream, Encoding.ASCII, 1, false))
@@ -80,7 +80,7 @@ namespace NuGet.Test.Server
                     writer.WriteLine();
                     writer.Write(contentBefore);
                     writer.Flush();
-                    await Task.Delay(SleepDuration);
+                    await Task.Delay(SleepDuration, cancellationToken);
                     writer.Write(contentAfter);
                 }
             }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/776

Regression? **We likely do more than before** Last working version: **16.6**

## Description
repro should hit these codepaths, dependent on timing, if you start a new search while the other one is still executing, or switch tabs quickly, or change selected package while associated details are being downloaded asynchronously.

Fix is to catch InvalidOperationException in the code paths that have things that are expected to be cancelled.
Usually, in our code, when we hit these exceptions, we log something, or raise errors. I believe we shouldn't in this case.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A - tested by injecting a throw of OperationCanceledExceptions in all 3 codepaths, and ensuring our operation was still smooth. Otherwise, I found it hard to repro.

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
