### PR TITLE
Clarify example for  NUGET_PLUGIN_LOG_DIRECTORY_PATH env variable

### DIFF
--- a/docs/plugin-logging.md
+++ b/docs/plugin-logging.md
@@ -14,7 +14,7 @@ Here is an example using both environment variables in PowerShell:
 
 ```PowerShell
 $Env:NUGET_PLUGIN_ENABLE_LOG='true'
-$Env:NUGET_PLUGIN_LOG_DIRECTORY_PATH='C:\logs'
+$Env:NUGET_PLUGIN_LOG_DIRECTORY_PATH='C:\logs\log.txt'
 
 .\NuGet.exe restore .\MySolution.sln
 ```


### PR DESCRIPTION
Don't know for what reason (might befor historical, or compatibility), but NUGET_PLUGIN_LOG_DIRECTORY_PATH env variable name is misleading as LogEveryMessageFileLogger uses this variable as file path, not folder path.

This commit gives more accurate example of the working value for this variable

<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes:

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

## PR Checklist

- [ ] PR has a meaningful title
- [ ] PR has a linked issue.
- [ ] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [x] Documentation PR or issue filled
  - **OR**
  - [ ] N/A
