### PR TITLE
Revert "Change the background and foreground colors in the PMUI to increase contrast ratio in Light theme and use the correct colors for doc well UI (#3858)"

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources/Brushes.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources/Brushes.cs
@@ -180,19 +180,19 @@ namespace NuGet.PackageManagement.UI
             ComboBoxBorderKey = VsBrushes.ComboBoxBorderKey;
             ControlLinkTextHoverKey = VsBrushes.ControlLinkTextHoverKey;
             ControlLinkTextKey = VsBrushes.ControlLinkTextKey;
-            DetailPaneBackground = CommonDocumentColors.PageBrushKey;
-            HeaderBackground = CommonDocumentColors.PageBrushKey;
+            DetailPaneBackground = VsBrushes.BrandedUIBackgroundKey;
+            HeaderBackground = VsBrushes.BrandedUIBackgroundKey;
             InfoBackgroundKey = VsBrushes.InfoBackgroundKey;
             InfoTextKey = VsBrushes.InfoTextKey;
-            LegalMessageBackground = CommonDocumentColors.PageBrushKey;
-            ListPaneBackground = CommonDocumentColors.PageBrushKey;
+            LegalMessageBackground = VsBrushes.BrandedUIBackgroundKey;
+            ListPaneBackground = VsBrushes.BrandedUIBackgroundKey;
             SplitterBackgroundKey = VsBrushes.CommandShelfBackgroundGradientKey;
             ToolWindowBorderKey = VsBrushes.ToolWindowBorderKey;
             ToolWindowButtonDownBorderKey = VsBrushes.ToolWindowButtonDownBorderKey;
             ToolWindowButtonDownKey = VsBrushes.ToolWindowButtonDownKey;
             ToolWindowButtonHoverActiveBorderKey = VsBrushes.ToolWindowButtonHoverActiveBorderKey;
             ToolWindowButtonHoverActiveKey = VsBrushes.ToolWindowButtonHoverActiveKey;
-            UIText = CommonDocumentColors.PageTextBrushKey;
+            UIText = VsBrushes.BrandedUITextKey;
             WindowTextKey = VsBrushes.WindowTextKey;
 
             HeaderColorsDefaultBrushKey = HeaderColors.DefaultBrushKey;


### PR DESCRIPTION
Revert "Change the background and foreground colors in the PMUI to increase contrast ratio in Light theme and use the correct colors for doc well UI (#3858)"

This reverts commit c21ea53349800e7da0749a9591b623a33d976ab4.

<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug 

Fixes: Reverts https://github.com/NuGet/NuGet.Client/pull/3858. We will get an exception instead of fixing this at this time.

Regression? Last working version: N/A

## Description
Reverts the fix that updated the background and foreground colors to use the CommonDocument colors. This fix resolved an issue with the headers not having high enough contrast ratio in the light theme. The fix changed the background from gray to white in the light theme which we will reintroduce in a future update.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  UI color change, tested manually with Accessibility Insights in all VS themes.
  - [x] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
