### PR TITLE
Respect empty user-wide NuGet.Config file, no matter if there is a track file or not

### DIFF
--- a/src/NuGet.Core/NuGet.Configuration/PackageSource/NuGetConstants.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSource/NuGetConstants.cs
@@ -39,8 +39,6 @@ namespace NuGet.Configuration
 
         public static readonly string FeedName = "nuget.org";
 
-        public static readonly string AddV3TrackFile = "nugetorgadd.trk";
-
         public static readonly string DefaultConfigContent = @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
   <packageSources>

--- a/src/NuGet.Core/NuGet.Configuration/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Configuration/PublicAPI.Shipped.txt
@@ -484,7 +484,6 @@ static readonly NuGet.Configuration.ConfigurationConstants.UserKey -> string
 static readonly NuGet.Configuration.ConfigurationConstants.UsernameToken -> string
 static readonly NuGet.Configuration.ConfigurationConstants.ValidAuthenticationTypesToken -> string
 static readonly NuGet.Configuration.ConfigurationConstants.ValueAttribute -> string
-static readonly NuGet.Configuration.NuGetConstants.AddV3TrackFile -> string
 static readonly NuGet.Configuration.NuGetConstants.DefaultConfigContent -> string
 static readonly NuGet.Configuration.NuGetConstants.DefaultGalleryServerUrl -> string
 static readonly NuGet.Configuration.NuGetConstants.DefaultSymbolServerUrl -> string

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
@@ -545,12 +545,13 @@ namespace NuGet.Configuration
                     yield break;
                 }
 
-                // If the default user config NuGet.Config does not exist, we need to create it.
                 var defaultSettingsFilePath = Path.Combine(userSettingsDir, DefaultSettingsFileName);
 
                 var defaultSettingsFilePathExistsPreviously = File.Exists(defaultSettingsFilePath);
 
+                // If the default user config NuGet.Config does not exist, we need to create an empty one.
                 SettingsFile userSpecificSettings = ReadSettings(rootDirectory, defaultSettingsFilePath, settingsLoadingContext: settingsLoadingContext);
+
                 if (!defaultSettingsFilePathExistsPreviously && File.Exists(defaultSettingsFilePath) && userSpecificSettings.IsEmpty())
                 {
                     var defaultSource = new SourceItem(NuGetConstants.FeedName, NuGetConstants.V3FeedUrl, protocolVersion: "3");

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
@@ -551,7 +551,7 @@ namespace NuGet.Configuration
                 var defaultSettingsFilePathExistsPreviously = File.Exists(defaultSettingsFilePath);
 
                 SettingsFile userSpecificSettings = ReadSettings(rootDirectory, defaultSettingsFilePath, settingsLoadingContext: settingsLoadingContext);
-                if (!defaultSettingsFilePathExistsPreviously && File.Exists(defaultSettingsFilePath))
+                if (!defaultSettingsFilePathExistsPreviously && File.Exists(defaultSettingsFilePath) && userSpecificSettings.IsEmpty())
                 {
                     var defaultSource = new SourceItem(NuGetConstants.FeedName, NuGetConstants.V3FeedUrl, protocolVersion: "3");
                     userSpecificSettings.AddOrUpdate(ConfigurationConstants.PackageSources, defaultSource);

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
@@ -549,7 +549,7 @@ namespace NuGet.Configuration
 
                 var defaultSettingsFilePathExistsPreviously = File.Exists(defaultSettingsFilePath);
 
-                // If the default user config NuGet.Config does not exist, we need to create an empty one.
+                // ReadSettings will try to create the config file if it doesn't exist, which is why we should check if it exists again afterwards
                 SettingsFile userSpecificSettings = ReadSettings(rootDirectory, defaultSettingsFilePath, settingsLoadingContext: settingsLoadingContext);
 
                 if (!defaultSettingsFilePathExistsPreviously && File.Exists(defaultSettingsFilePath) && userSpecificSettings.IsEmpty())

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
@@ -547,17 +547,8 @@ namespace NuGet.Configuration
 
                 var defaultSettingsFilePath = Path.Combine(userSettingsDir, DefaultSettingsFileName);
 
-                var defaultSettingsFilePathExistsPreviously = File.Exists(defaultSettingsFilePath);
-
-                // ReadSettings will try to create the config file if it doesn't exist, which is why we should check if it exists again afterwards
+                // ReadSettings will try to create the default config file if it doesn't exist
                 SettingsFile userSpecificSettings = ReadSettings(rootDirectory, defaultSettingsFilePath, settingsLoadingContext: settingsLoadingContext);
-
-                if (!defaultSettingsFilePathExistsPreviously && File.Exists(defaultSettingsFilePath) && userSpecificSettings.IsEmpty())
-                {
-                    var defaultSource = new SourceItem(NuGetConstants.FeedName, NuGetConstants.V3FeedUrl, protocolVersion: "3");
-                    userSpecificSettings.AddOrUpdate(ConfigurationConstants.PackageSources, defaultSource);
-                    userSpecificSettings.SaveToDisk();
-                }
 
                 yield return userSpecificSettings;
 

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
@@ -548,19 +548,14 @@ namespace NuGet.Configuration
                 // If the default user config NuGet.Config does not exist, we need to create it.
                 var defaultSettingsFilePath = Path.Combine(userSettingsDir, DefaultSettingsFileName);
 
+                var defaultSettingsFilePathExistsPreviously = File.Exists(defaultSettingsFilePath);
+
                 SettingsFile userSpecificSettings = ReadSettings(rootDirectory, defaultSettingsFilePath, settingsLoadingContext: settingsLoadingContext);
-                if (File.Exists(defaultSettingsFilePath) && userSpecificSettings.IsEmpty())
+                if (!defaultSettingsFilePathExistsPreviously && File.Exists(defaultSettingsFilePath))
                 {
-                    var trackFilePath = Path.Combine(Path.GetDirectoryName(defaultSettingsFilePath), NuGetConstants.AddV3TrackFile);
-
-                    if (!File.Exists(trackFilePath))
-                    {
-                        File.Create(trackFilePath).Dispose();
-
-                        var defaultSource = new SourceItem(NuGetConstants.FeedName, NuGetConstants.V3FeedUrl, protocolVersion: "3");
-                        userSpecificSettings.AddOrUpdate(ConfigurationConstants.PackageSources, defaultSource);
-                        userSpecificSettings.SaveToDisk();
-                    }
+                    var defaultSource = new SourceItem(NuGetConstants.FeedName, NuGetConstants.V3FeedUrl, protocolVersion: "3");
+                    userSpecificSettings.AddOrUpdate(ConfigurationConstants.PackageSources, defaultSource);
+                    userSpecificSettings.SaveToDisk();
                 }
 
                 yield return userSpecificSettings;

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
@@ -2253,7 +2253,7 @@ namespace NuGet.Configuration.Test
 
         private static void CreateSettingsFileInTestingGlobalDirectory(TestDirectory directory)
         {
-            var settingsFile = new FileInfo(Path.Combine(directory.Path, "TestingGlobalPath", "NuGet.config"));
+            var settingsFile = new FileInfo(Path.Combine(directory.Path, "TestingGlobalPath", "NuGet.Config"));
 
             settingsFile.Directory.Create();
 

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
@@ -1814,7 +1814,7 @@ namespace NuGet.Configuration.Test
                 List<PackageSource> sources = LoadPackageSources(useStaticMethod, settings);
 
                 // Assert
-                Assert.Equal(1, sources.Count);
+                Assert.Equal(0, sources.Count);
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsTests.cs
@@ -2042,12 +2042,12 @@ namespace NuGet.Configuration.Test
                     useTestingGlobalPath: true);
 
                 // Assert
-                var text = SettingsTestUtils.RemoveWhitespace(File.ReadAllText(Path.Combine(mockBaseDirectory, "TestingGlobalPath", "NuGet.Config")));
-                var result = SettingsTestUtils.RemoveWhitespace(@"<?xml version=""1.0"" encoding=""utf-8""?>
+                var actual = SettingsTestUtils.RemoveWhitespace(File.ReadAllText(Path.Combine(mockBaseDirectory, "TestingGlobalPath", "NuGet.Config")));
+                var expected = SettingsTestUtils.RemoveWhitespace(@"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
 </configuration>");
 
-                text.Should().Be(result);
+                actual.Should().Be(expected);
             }
         }
 
@@ -2075,12 +2075,12 @@ namespace NuGet.Configuration.Test
                     useTestingGlobalPath: true);
 
                 // Assert
-                var text = SettingsTestUtils.RemoveWhitespace(File.ReadAllText(Path.Combine(mockBaseDirectory, "TestingGlobalPath", "NuGet.Config")));
-                var result = SettingsTestUtils.RemoveWhitespace(@"<?xml version=""1.0"" encoding=""utf-8""?>
+                var actual = SettingsTestUtils.RemoveWhitespace(File.ReadAllText(Path.Combine(mockBaseDirectory, "TestingGlobalPath", "NuGet.Config")));
+                var expected = SettingsTestUtils.RemoveWhitespace(@"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
 </configuration>");
 
-                text.Should().Be(result);
+                actual.Should().Be(expected);
             }
         }
 
@@ -2103,15 +2103,15 @@ namespace NuGet.Configuration.Test
 
                 // Assert
                 File.Exists(nugetConfigPath).Should().BeTrue();
-                var text = SettingsTestUtils.RemoveWhitespace(File.ReadAllText(Path.Combine(mockBaseDirectory, "TestingGlobalPath", "NuGet.Config")));
-                var result = SettingsTestUtils.RemoveWhitespace(@"<?xml version=""1.0"" encoding=""utf-8""?>
+                var actual = SettingsTestUtils.RemoveWhitespace(File.ReadAllText(Path.Combine(mockBaseDirectory, "TestingGlobalPath", "NuGet.Config")));
+                var expected = SettingsTestUtils.RemoveWhitespace(@"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
     <packageSources>
         <add key=""nuget.org"" value=""https://api.nuget.org/v3/index.json"" protocolVersion=""3"" />
     </packageSources>
 </configuration>");
 
-                text.Should().Be(result);
+                actual.Should().Be(expected);
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsTests.cs
@@ -2103,7 +2103,7 @@ namespace NuGet.Configuration.Test
 
                 // Assert
                 File.Exists(nugetConfigPath).Should().BeTrue();
-                var actual = SettingsTestUtils.RemoveWhitespace(File.ReadAllText(Path.Combine(mockBaseDirectory, "TestingGlobalPath", "NuGet.Config")));
+                var actual = SettingsTestUtils.RemoveWhitespace(File.ReadAllText(nugetConfigPath));
                 var expected = SettingsTestUtils.RemoveWhitespace(@"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
     <packageSources>

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsTests.cs
@@ -2021,7 +2021,7 @@ namespace NuGet.Configuration.Test
         }
 
         [Fact]
-        public void LoadSettings_EmptyUserWideConfigFileAndNoTrackerFile_DoNotAddsV3()
+        public void LoadSettings_EmptyUserWideConfigFileAndNoTrackerFile_DoNotAddNuGetOrg()
         {
             using (var mockBaseDirectory = TestDirectory.Create())
             {
@@ -2043,18 +2043,16 @@ namespace NuGet.Configuration.Test
 
                 // Assert
                 var text = SettingsTestUtils.RemoveWhitespace(File.ReadAllText(Path.Combine(mockBaseDirectory, "TestingGlobalPath", "NuGet.Config")));
-                var v3feed = SettingsTestUtils.RemoveWhitespace(@"<add key=""nuget.org"" value=""https://api.nuget.org/v3/index.json"" protocolVersion=""3"" />");
                 var result = SettingsTestUtils.RemoveWhitespace(@"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
 </configuration>");
 
-                text.Should().NotContain(v3feed);
                 text.Should().Be(result);
             }
         }
 
         [Fact]
-        public void LoadSettings_EmptyUserWideConfigFileAndHasTrackerFile_DoNotAddsV3()
+        public void LoadSettings_EmptyUserWideConfigFileAndHasTrackerFile_DoNotAddNuGetOrg()
         {
             using (var mockBaseDirectory = TestDirectory.Create())
             {
@@ -2078,18 +2076,16 @@ namespace NuGet.Configuration.Test
 
                 // Assert
                 var text = SettingsTestUtils.RemoveWhitespace(File.ReadAllText(Path.Combine(mockBaseDirectory, "TestingGlobalPath", "NuGet.Config")));
-                var v3feed = SettingsTestUtils.RemoveWhitespace(@"<add key=""nuget.org"" value=""https://api.nuget.org/v3/index.json"" protocolVersion=""3"" />");
                 var result = SettingsTestUtils.RemoveWhitespace(@"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
 </configuration>");
 
-                text.Should().NotContain(v3feed);
                 text.Should().Be(result);
             }
         }
 
         [Fact]
-        public void LoadSettings_NonExistingUserWideConfigFile_CreateUserWideConfigFileAndAddsV3Feed()
+        public void LoadSettings_NonExistingUserWideConfigFile_CreateUserWideConfigFileWithNuGetOrg()
         {
             using (var mockBaseDirectory = TestDirectory.Create())
             {
@@ -2108,7 +2104,6 @@ namespace NuGet.Configuration.Test
                 // Assert
                 File.Exists(nugetConfigPath).Should().BeTrue();
                 var text = SettingsTestUtils.RemoveWhitespace(File.ReadAllText(Path.Combine(mockBaseDirectory, "TestingGlobalPath", "NuGet.Config")));
-                var v3feed = SettingsTestUtils.RemoveWhitespace(@"<add key=""nuget.org"" value=""https://api.nuget.org/v3/index.json"" protocolVersion=""3"" />");
                 var result = SettingsTestUtils.RemoveWhitespace(@"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
     <packageSources>
@@ -2116,7 +2111,6 @@ namespace NuGet.Configuration.Test
     </packageSources>
 </configuration>");
 
-                text.Should().Contain(v3feed);
                 text.Should().Be(result);
             }
         }

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsTests.cs
@@ -2021,7 +2021,7 @@ namespace NuGet.Configuration.Test
         }
 
         [Fact]
-        public void LoadSettings_EmptyUserWideConfigFileAndNoTrackerFile_DoNotAddNuGetOrg()
+        public void LoadSettings_EmptyUserWideConfigFile_DoNotAddNuGetOrg()
         {
             using (var mockBaseDirectory = TestDirectory.Create())
             {
@@ -2032,37 +2032,6 @@ namespace NuGet.Configuration.Test
 
                 var nugetConfigPath = "NuGet.Config";
                 SettingsTestUtils.CreateConfigurationFile(nugetConfigPath, Path.Combine(mockBaseDirectory, "TestingGlobalPath"), config);
-
-                // Act
-                var settings = Settings.LoadSettings(
-                    root: mockBaseDirectory,
-                    configFileName: null,
-                    machineWideSettings: null,
-                    loadUserWideSettings: true,
-                    useTestingGlobalPath: true);
-
-                // Assert
-                var actual = SettingsTestUtils.RemoveWhitespace(File.ReadAllText(Path.Combine(mockBaseDirectory, "TestingGlobalPath", "NuGet.Config")));
-                var expected = SettingsTestUtils.RemoveWhitespace(config);
-
-                actual.Should().Be(expected);
-            }
-        }
-
-        [Fact]
-        public void LoadSettings_EmptyUserWideConfigFileAndHasTrackerFile_DoNotAddNuGetOrg()
-        {
-            using (var mockBaseDirectory = TestDirectory.Create())
-            {
-                // Arrange
-                var config = @"<?xml version=""1.0"" encoding=""utf-8""?>
-<configuration>
-</configuration>";
-
-                var nugetConfigPath = "NuGet.Config";
-                SettingsTestUtils.CreateConfigurationFile(nugetConfigPath, Path.Combine(mockBaseDirectory, "TestingGlobalPath"), config);
-                var trackFilePath = Path.Combine(mockBaseDirectory, "TestingGlobalPath", "nugetorgadd.trk");
-                File.WriteAllText(trackFilePath, "");
 
                 // Act
                 var settings = Settings.LoadSettings(

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsTests.cs
@@ -2043,9 +2043,7 @@ namespace NuGet.Configuration.Test
 
                 // Assert
                 var actual = SettingsTestUtils.RemoveWhitespace(File.ReadAllText(Path.Combine(mockBaseDirectory, "TestingGlobalPath", "NuGet.Config")));
-                var expected = SettingsTestUtils.RemoveWhitespace(@"<?xml version=""1.0"" encoding=""utf-8""?>
-<configuration>
-</configuration>");
+                var expected = SettingsTestUtils.RemoveWhitespace(config);
 
                 actual.Should().Be(expected);
             }
@@ -2076,9 +2074,7 @@ namespace NuGet.Configuration.Test
 
                 // Assert
                 var actual = SettingsTestUtils.RemoveWhitespace(File.ReadAllText(Path.Combine(mockBaseDirectory, "TestingGlobalPath", "NuGet.Config")));
-                var expected = SettingsTestUtils.RemoveWhitespace(@"<?xml version=""1.0"" encoding=""utf-8""?>
-<configuration>
-</configuration>");
+                var expected = SettingsTestUtils.RemoveWhitespace(config);
 
                 actual.Should().Be(expected);
             }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/10745

Regression? Last working version:

## Description
1.Only create default user-wide NuGet.Config file when it doesn't exist. If the user-wide NuGet.Config file exists, but there is no feed, no matter there is a track file or not, we will respect the empty file. (Do we need to show a warning/message saying no source exists in this case?)
2.Remove track file.
3.Add tests for the following cases:
  user-wide NuGet.Config file exists and is empty, and  there is a track file => the empty config file should be respected
  user-wide NuGet.Config file exists and is empty, and  there is a track file => the empty config file should be respected
  user-wide NuGet.Config file doesn't exist  => the default config file with nuget.org feed will be created
4.Fix an existing test and correct the case so that it will pass on Linux.

Backgroud:
The nuget [blog ](https://devblogs.microsoft.com/nuget/introducing-nuget-3-4/) shows one of the changes in V3.4: The Visual Studio extension no longer are automatically adds the nuget.org repository source to your nuget.config files when you use the NuGet configuration user interface.
So in NuGet 3.3, client adds nuget.org by default if it's not there. (see https://github.com/NuGet/Home/issues/2053)
In NuGet 3.4, client tried to respect the config file, even it's empty. But for users migrate from 3.3 to 3.4, they might encounter an issue like https://github.com/NuGet/Home/issues/2445
So Zhi li added the tracker file for users migrate from 3.3 to 3.4, to add nuget.org into user-wide NuGet.Config for the first time, but do not add nuget.org  afterwards (when track file is there). The PR is https://github.com/NuGet/NuGet.Client/pull/458 The commit is https://github.com/NuGet/NuGet.Client/commit/1da590a88512fa58cdbaa71246eaf332d0b0b0d1

## Analysis:
The comparison between current behavior and the future behavior with this change:
| Case |   the current behavior without this commit |  the future behavior with this commit |
|-----|:---------:|---------:|
|The config file exists. And it is not empty  |The config file is respected | The config file is respected |
|The config file exists and it is empty, and there is a tracker file. | The empty config file is respected | The empty config file is respected |
|The config file exists and it is empty, and there is no tracker file |The empty config file is not respected. A default nuget.org feed will be added to this config file | The empty config file is respected |
|The config file doesn't exist|will create a default config file| will create a default config file|

So for customers using NuGet version 3.4 and later versions(doesn't contain this change) migrating to the new version(contains this change), the behavior changes only for the 3rd case. And this case is very rare,  it means the user has an empty user-wide NuGet.Config file, and has never run any commands approaching user-wide NuGet.Client.  If users run any commands which will approach config file just once, it will turn into the 2nd case.

For customers using NuGet version 3.3 and earlier versions migrating to the new versioin(contains this change, that is, 5.10), it will break them. But it is also very rare. 

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
