### PR TITLE
Update Maestro task version to publish to BAR using github url

### DIFF
--- a/build/bootstrap.proj
+++ b/build/bootstrap.proj
@@ -15,7 +15,7 @@
         <PackageDownload Include="Microsoft.VisualStudioEng.MicroBuild.Core" version="[0.4.1]" />
         <PackageDownload Include="Microsoft.Build" version="[15.1.262-preview5]" />
         <PackageDownload Include="Microsoft.DotNet.Build.Tasks.Feed" version="[6.0.0-beta.20528.5]" />  <!-- for publishing to the .NET Core build asset registry (BAR) -->
-        <PackageDownload Include="Microsoft.DotNet.Maestro.Tasks" version="[1.1.0-beta.20528.3]" />  <!-- for publishing to the .NET Core build asset registry (BAR) -->
+        <PackageDownload Include="Microsoft.DotNet.Maestro.Tasks" version="[1.1.0-beta.21117.3]" />  <!-- for publishing to the .NET Core build asset registry (BAR) -->
         <PackageDownload Include="Microsoft.VisualStudio.Composition" version="[16.4.11]" />
         <PackageDownload Include="Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime" version="[14.3.26930]" />
         <PackageDownload Include="Microsoft.VisualStudio.ProjectSystem" version="[16.7.156-pre]" />

--- a/build/common.project.props
+++ b/build/common.project.props
@@ -50,7 +50,7 @@
     <LocalizationFilesDirectory>$(ArtifactsDirectory)LocalizedFiles</LocalizationFilesDirectory>
     <MicroBuildDirectory>$(SolutionPackagesFolder)microsoft.visualstudioeng.microbuild.core\0.4.1\build\</MicroBuildDirectory>
     <MicrosoftDotNetBuildTasksFeedFilePath>$(SolutionPackagesFolder)microsoft.dotnet.build.tasks.feed\6.0.0-beta.20528.5\tools\netcoreapp2.1\Microsoft.DotNet.Build.Tasks.Feed.dll</MicrosoftDotNetBuildTasksFeedFilePath>
-    <MicrosoftDotNetMaestroTasksFilePath>$(SolutionPackagesFolder)microsoft.dotnet.maestro.tasks\1.1.0-beta.20528.3\tools\netcoreapp3.1\Microsoft.DotNet.Maestro.Tasks.dll</MicrosoftDotNetMaestroTasksFilePath>
+    <MicrosoftDotNetMaestroTasksFilePath>$(SolutionPackagesFolder)microsoft.dotnet.maestro.tasks\1.1.0-beta.21117.3\tools\netcoreapp3.1\Microsoft.DotNet.Maestro.Tasks.dll</MicrosoftDotNetMaestroTasksFilePath>
     <NoWarn>$(NoWarn);NU5105;NU5048</NoWarn>
   </PropertyGroup>
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/10602

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
Nuget started using Azdo mirror for build pipeline, this broke publishing to BAR and further dependency updates because all the subscriptions used Nuget github repo url(https://github.com/nuget/nuget.client)and not the Azdo repo url (https://dev.azure.com/devdiv/DevDiv/_git/NuGet-NuGet.Client-Trusted) . This updated maestro task helps to translate the azdo url to github url when publishing to BAR. 

## PR Checklist

- [ ] PR has a meaningful title
- [ ] PR has a linked issue.
- [ ] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->
Test - https://dev.azure.com/devdiv/DevDiv/_build/results?buildId=4482845&view=results
- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [ ] N/A
