### PR TITLE
Be more strict when parsing the TargetPlatformMoniker, remove the workaround that accepted bad data.

### DIFF
--- a/src/NuGet.Core/NuGet.Frameworks/NuGetFrameworkFactory.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/NuGetFrameworkFactory.cs
@@ -148,7 +148,7 @@ namespace NuGet.Frameworks
                 ));
             }
 
-            if (!string.IsNullOrEmpty(targetPlatformMoniker) && isNet5EraTfm && !IgnoreTargetPlatformMoniker(targetPlatformMoniker))
+            if (!string.IsNullOrEmpty(targetPlatformMoniker) && isNet5EraTfm)
             {
                 string targetPlatformIdentifier;
                 Version platformVersion;
@@ -161,15 +161,6 @@ namespace NuGet.Frameworks
             }
 
             return result;
-        }
-
-        private static bool IgnoreTargetPlatformMoniker(string targetPlatformMoniker)
-        {
-            if (targetPlatformMoniker.Trim().Equals(",Version=", StringComparison.OrdinalIgnoreCase))
-            {
-                return true;
-            }
-            return false;
         }
 
         private static string[] GetParts(string targetPlatformMoniker)

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/MSBuildProjectFrameworkUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/MSBuildProjectFrameworkUtilityTests.cs
@@ -237,10 +237,6 @@ namespace NuGet.Commands.Test
         [InlineData(".NETCoreApp,Version=v6.0", "UAP,Version=10.0.1.2", "10.0.1.3", "uap10.0.1.3")]
         [InlineData(".NETCoreApp,Version=v3.0", "android,Version=10.0", "", "netcoreapp3.0")]
         [InlineData(".NETCoreApp,Version=v3.0", "android,Version=10.0", "9.0", "netcoreapp3.0")]
-        // Hack scenarios: See https://github.com/NuGet/Home/issues/9913
-        [InlineData(".NETCoreApp,Version=v5.0", " ,Version= ", "", "net5.0")]
-        [InlineData(".NETCoreApp,Version=v5.0", ",Version= ", "", "net5.0")]
-        [InlineData(".NETCoreApp,Version=v5.0", " ,Version=", "", "net5.0")]
         public void GetProjectFramework_WithCanonicalProperties_Succeeds(
                 string targetFrameworkMoniker,
                 string targetPlatformMoniker,

--- a/test/NuGet.Core.Tests/NuGet.Frameworks.Test/NuGetFrameworkParseComponentsTest.cs
+++ b/test/NuGet.Core.Tests/NuGet.Frameworks.Test/NuGetFrameworkParseComponentsTest.cs
@@ -68,10 +68,6 @@ namespace NuGet.Test
         [InlineData("netcoreapp3.1-client", ".NETCoreApp,Version=3.1,Profile=client", null)]
         [InlineData("netcoreapp3.0-client", ".NETCoreApp,Version=v3.0,Profile=client", "Windows,Version=7.0")]
         [InlineData("netcoreapp3.0", ".NETCoreApp,Version=v3.0", "Windows,Version=7.0")]
-        // Hack scenarios: See https://github.com/NuGet/Home/issues/9913
-        [InlineData("net5.0", ".NETCoreApp,Version=5.0", ",Version=")]
-        [InlineData("net5.0", ".NETCoreApp,Version=5.0", " ,Version=")]
-        [InlineData("net5.0", ".NETCoreApp,Version=5.0", " ,Version= ")]
         public void NuGetFramework_ParseToShortName(string expected, string targetFrameworkMoniker, string targetPlatformMoniker)
         {
             // Arrange
@@ -142,10 +138,6 @@ namespace NuGet.Test
         [InlineData(".NETCoreApp,Version=v3.1,Profile=client", "10.15.2.3", ".NETCoreApp,Version=v3.1,Profile=Client")]
         [InlineData(".NETCoreApp,Version=v3.1,Profile=client", null, ".NETCoreApp,Version=v3.1,Profile=Client")]
         [InlineData(".NETCoreApp,Version=v3.0,Profile=client", "Windows,Version=7.0", ".NETCoreApp,Version=v3.0,Profile=Client")]
-        // Hack scenarios: See https://github.com/NuGet/Home/issues/9913
-        [InlineData(".NETCoreApp,Version=5.0", ",Version=", ".NETCoreApp,Version=v5.0")]
-        [InlineData(".NETCoreApp,Version=5.0", " ,Version=", ".NETCoreApp,Version=v5.0")]
-        [InlineData(".NETCoreApp,Version=5.0", " ,Version= ", ".NETCoreApp,Version=v5.0")]
         public void NuGetFramework_Basic(string targetFrameworkMoniker, string targetPlatformMoniker, string fullName)
         {
             string output = NuGetFramework.ParseComponents(targetFrameworkMoniker, targetPlatformMoniker).DotNetFrameworkName;


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/nuget/home/issues/9913

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

At a previous point a hack was added because a preview version of the SDK was putting a bad TargetPlatformMoniker. 
This change removes that hack.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
