### PR TITLE
Fix throw of PackagingException on invalid nullable bool

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/NuspecReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/NuspecReader.cs
@@ -582,7 +582,7 @@ namespace NuGet.Packaging
             return node?.Value;
         }
 
-        private static bool? AttributeAsNullableBool(XElement element, string attributeName)
+        private bool? AttributeAsNullableBool(XElement element, string attributeName)
         {
             bool? result = null;
 
@@ -603,7 +603,8 @@ namespace NuGet.Packaging
                     var message = string.Format(
                             CultureInfo.CurrentCulture,
                             Strings.InvalidNuspecEntry,
-                            element.ToString().Trim());
+                            element.ToString().Trim(),
+                            GetIdentity());
 
                     throw new PackagingException(message);
                 }


### PR DESCRIPTION
Call `NuspecReader.GetContentFiles` on AppLoggerSenner007 1.1.8 (available on NuGet.org) to reproduce this error. It is because `Strings.InvalidNuspecEntry` has two format placeholders, not one. These exception is:

```
An exception occurred.
System.FormatException: Index (zero based) must be greater than or equal to zero and less than the size of the argument list.
   at System.Text.ValueStringBuilder.AppendFormatHelper(IFormatProvider provider, String format, ParamsArray args)
   at System.String.FormatHelper(IFormatProvider provider, String format, ParamsArray args)
   at System.String.Format(IFormatProvider provider, String format, Object arg0)
   at NuGet.Packaging.NuspecReader.AttributeAsNullableBool(XElement element, String attributeName)
   at NuGet.Packaging.NuspecReader.GetContentFiles()+MoveNext()
```
