### PR TITLE
Fix the background color for selected list items to use the appropriate color in PMUI

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources/Brushes.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources/Brushes.cs
@@ -244,8 +244,8 @@ namespace NuGet.PackageManagement.UI
             ContentMouseOverTextBrushKey = CommonDocumentColors.ListItemTextHoverBrushKey;
             ContentInactiveSelectedBrushKey = CommonDocumentColors.ListItemBackgroundUnfocusedBrushKey;
             ContentInactiveSelectedTextBrushKey = CommonDocumentColors.ListItemTextUnfocusedBrushKey;
-            ContentSelectedBrushKey = CommonDocumentColors.ListItemBackgroundFocusedBrushKey;
-            ContentSelectedTextBrushKey = CommonDocumentColors.ListItemTextFocusedBrushKey;
+            ContentSelectedBrushKey = CommonDocumentColors.ListItemBackgroundSelectedBrushKey;
+            ContentSelectedTextBrushKey = CommonDocumentColors.ListItemTextSelectedBrushKey;
 
             // Brushes/Colors for FilterLabel (Top Tabs)
             TabSelectedBrushKey = CommonDocumentColors.InnerTabTextFocusedBrushKey;


### PR DESCRIPTION
## Bug

Fixes: https://github.com/nuget/home/issues/9538

Regression? Last working version: Not a regression

## Description
Changed the color brushes for the background and foreground of selected list items to point to the VS selected item brushes rather than the focus item brushes. Previously, the selected list items and the hovered list items had the same background color, making it difficult to distinguish which was selected.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
Changes to highlight color in the UI. Manually tested in all three themes and used Accessibility Insights to validate color ratios.
  - [x] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A

Blue theme:
![image](https://user-images.githubusercontent.com/10777837/108792548-60581080-7536-11eb-9476-daa1be405cc9.png)

Light theme:
![image](https://user-images.githubusercontent.com/10777837/108792593-7b2a8500-7536-11eb-8f98-dee9ecffccc3.png)

Dark theme:
![image](https://user-images.githubusercontent.com/10777837/108792614-8978a100-7536-11eb-8af3-b514c7a51854.png)