### PR TITLE
Scroll to the first package selected to be updated in the PMUI

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -1401,6 +1401,13 @@ namespace NuGet.PackageManagement.UI
                     packageItem.IsSelected = packagesToSelect.Contains(packageItem.Id, StringComparer.OrdinalIgnoreCase);
                 }
             }
+
+            var firstSelected = _packageList.PackageItems.FirstOrDefault(p => p.IsSelected);
+            if (firstSelected != null)
+            {
+                _packageList._list.SelectedItem = firstSelected;
+                _packageList._list.ScrollIntoView(firstSelected);
+            }
         }
 
         public void CleanUp()

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -1396,17 +1396,17 @@ namespace NuGet.PackageManagement.UI
             else if (updatePackageOptions.PackagesToUpdate.Any())
             {
                 var packagesToSelect = new HashSet<string>(updatePackageOptions.PackagesToUpdate);
+                PackageItemListViewModel firstSelectedItem = null;
                 foreach (var packageItem in _packageList.PackageItems)
                 {
                     packageItem.IsSelected = packagesToSelect.Contains(packageItem.Id, StringComparer.OrdinalIgnoreCase);
-                }
-            }
 
-            var firstSelected = _packageList.PackageItems.FirstOrDefault(p => p.IsSelected);
-            if (firstSelected != null)
-            {
-                _packageList._list.SelectedItem = firstSelected;
-                _packageList._list.ScrollIntoView(firstSelected);
+                    if (packageItem.IsSelected && firstSelectedItem is null)
+                    {
+                        firstSelectedItem = packageItem;
+                        _packageList._list.ScrollIntoView(firstSelectedItem);
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
## Bug

Fixes: https://github.com/nuget/home/issues/10498

Regression? Last working version: N/A

## Description
Make the packages list scroll to the first of the packages that are selected to be updated in the Solution Explorer when the Update menu item is clicked. If only one package is selected, the first package will be that one.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
Change affects UI interaction and no business logic was updated. Tested manually with a project with enough packages to scroll off the screen, selected one package from the top, one from middle, one from bottom, multiple contiguous packages, a non-contiguous selection of packages, and Update All both without the PMUI first loaded and with it already loaded and observed the first package in the list scrolled to in all cases.
  - [x] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
