### PR TITLE
Added bottom margin to the solution package details horizontal splitter so the Options border is not flush up against it

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/DetailControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/DetailControl.xaml
@@ -146,7 +146,7 @@
         Height="4"
         HorizontalAlignment="Stretch"
         VerticalAlignment="Top"
-        Margin="-24,0,-7,0"
+        Margin="-24,0,-7,12"
         AutomationProperties.Name="{x:Static nuget:Resources.Accessibility_ThumbName}"
         AutomationProperties.HelpText="{x:Static nuget:Resources.Accessibility_ThumbHelp}"
         Visibility="{Binding Path=IsSolution,Converter={StaticResource BooleanToVisibilityConverter}}"


### PR DESCRIPTION
## Bug

Fixes: https://github.com/nuget/home/issues/10533

Regression? Last working version: N/A

## Description
Added bottom margin to the horizontal splitter that divides the solution portion of the details pane from the package metadata portion. This gives the border around the Options expander more room so the top border line is not flush up against the horizontal splitter.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
Visual UI change. Manually tested with Solution Package Manager and Project Package Manager. Screenshot included below.
  - [x] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A

Solution PMUI:
![image](https://user-images.githubusercontent.com/10777837/108932814-d9229f80-75fe-11eb-83ff-9d2762f14064.png)

Project PMUI (Remains the same as before):
![image](https://user-images.githubusercontent.com/10777837/108932906-fe171280-75fe-11eb-807d-5b8f0bc4c69d.png)