### PR TITLE
Don't fail build if CI agent already has 'github' remote

### DIFF
--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -62,6 +62,11 @@ steps:
       dotnet tool restore
   condition: "and(not(eq(variables['IsOfficialBuild'], 'true')), eq(variables['BuildRTM'], 'true'))"   #skip this task for nonRTM in private build
 
+# NuGet.Client's official repo is on github, hence the source link metadata should use the github URL.
+# However, our official builds are built from a mirror in Azure DevOps, hence without any extra help, the SourceLink.GitHub package
+# won't be able to determine the URL to embed in the pdbs.
+# Therefore, when the git origin remote is not github (official builds), we need to add the GitHub repo URL as a remote, and
+# tell SourceLink.GitHub what that remote name is
 - task: PowerShell@1
   displayName: "Prepare for source link"
   inputs:
@@ -71,7 +76,7 @@ steps:
       Write-Host "If the above command failed, it's ok. It's not easy to check if the remote exists or not. We want to ignore that error."
       git remote add github https://github.com/NuGet/NuGet.Client.git
       Write-Host "##vso[task.setvariable variable=gitRepositoryRemoteName]github"
-  condition: " and(succeeded(), eq(variables['IsOfficialBuild'], 'true'))" #run in official non-RTM builds, for generating sourcelink
+  condition: " and(succeeded(), eq(variables['IsOfficialBuild'], 'true'))"
 
 - task: MSBuild@1
   displayName: "Restore for VS2019"

--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -72,10 +72,32 @@ steps:
   inputs:
     scriptType: "inlineScript"
     inlineScript: |
-      git remote remove github
-      Write-Host "If the above command failed, it's ok. It's not easy to check if the remote exists or not. We want to ignore that error."
-      git remote add github https://github.com/NuGet/NuGet.Client.git
-      Write-Host "##vso[task.setvariable variable=gitRepositoryRemoteName]github"
+      try {
+        $nugetUrl = "https://github.com/NuGet/NuGet.Client.git"
+        if (@(& git remote).Contains("github"))
+        {
+          $currentGitHubRemoteUrl = & git remote get-url github
+          Write-Host "Current github remote URL: $currentGitHubRemoteUrl"
+          if ($currentGitHubRemoteUrl -ne $nugetUrl)
+          {
+            Write-Host "git remote set-url github $nugetUrl"
+            & git remote set-url github $nugetUrl
+          }
+          else
+          {
+            Write-Host "Git remote url already correct"
+          }
+        }
+        else
+        {
+          Write-Host "git remote add github $nugetUrl"
+          & git remote add github $nugetUrl
+        }
+        Write-Host "##vso[task.setvariable variable=gitRepositoryRemoteName]github"
+      } catch {
+        Write-Host "##vso[task.LogIssue type=error;]$Error[0]"
+        exit 1
+      }
   condition: " and(succeeded(), eq(variables['IsOfficialBuild'], 'true'))"
 
 - task: MSBuild@1

--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -67,9 +67,11 @@ steps:
   inputs:
     scriptType: "inlineScript"
     inlineScript: |
+      git remote remove github
+      Write-Host "If the above command failed, it's ok. It's not easy to check if the remote exists or not. We want to ignore that error."
       git remote add github https://github.com/NuGet/NuGet.Client.git
       Write-Host "##vso[task.setvariable variable=gitRepositoryRemoteName]github"
-  condition: " and(succeeded(),eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))" #run in official non-RTM builds, for generating sourcelink
+  condition: " and(succeeded(), eq(variables['IsOfficialBuild'], 'true'))" #run in official non-RTM builds, for generating sourcelink
 
 - task: MSBuild@1
   displayName: "Restore for VS2019"


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/791

Regression? no

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Remove the `github` remote, if it exists, before adding it back again. This ensures the URL is correct. I didn't find a super easy way to check if the remote exists or not, so we'll just ignore errors in `git remote remove` for now.

Also, fix an issue where only one set of packages were getting the correct sourcelink settings.

## PR Checklist

- [X] PR has a meaningful title
- [X] PR has a linked issue.
- [X] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [X] N/A (Infrastructure)

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [X] N/A
