### PR TITLE
error when attempting to pack multiple files into the same destination

### DIFF
--- a/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
@@ -878,6 +878,11 @@ namespace NuGet.Common
         NU5132 = 5132,
 
         /// <summary>
+        /// Attempted to write files from multiple sources into the same location
+        /// </summary>
+        NU5133 = 5133,
+
+        /// <summary>
         /// Undefined package warning
         /// </summary>
         NU5500 = 5500,

--- a/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
@@ -718,6 +718,11 @@ namespace NuGet.Common
         NU5049 = 5049,
 
         /// <summary>
+        /// Attempted to write files from multiple sources into the same location
+        /// </summary>
+        NU5050 = 5050,
+
+        /// <summary>
         /// AssemblyOutsideLibWarning
         /// </summary>
         NU5100 = 5100,
@@ -876,11 +881,6 @@ namespace NuGet.Common
         /// File last write timestamp is out of range of what the zip format supports warning
         /// </summary>
         NU5132 = 5132,
-
-        /// <summary>
-        /// Attempted to write files from multiple sources into the same location
-        /// </summary>
-        NU5133 = 5133,
 
         /// <summary>
         /// Undefined package warning

--- a/src/NuGet.Core/NuGet.Common/PublicAPI/net45/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Common/PublicAPI/net45/PublicAPI.Unshipped.txt
@@ -1,4 +1,5 @@
 NuGet.Common.NuGetLogCode.NU5132 = 5132 -> NuGet.Common.NuGetLogCode
+NuGet.Common.NuGetLogCode.NU5133 = 5133 -> NuGet.Common.NuGetLogCode
 NuGet.Common.NuGetLogCode.NU5501 = 5501 -> NuGet.Common.NuGetLogCode
 NuGet.Common.NuGetLogCode.NU1012 = 1012 -> NuGet.Common.NuGetLogCode
 NuGet.Common.NuGetLogCode.NU5045 = 5045 -> NuGet.Common.NuGetLogCode

--- a/src/NuGet.Core/NuGet.Common/PublicAPI/net45/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Common/PublicAPI/net45/PublicAPI.Unshipped.txt
@@ -1,5 +1,5 @@
+NuGet.Common.NuGetLogCode.NU5050 = 5050 -> NuGet.Common.NuGetLogCode
 NuGet.Common.NuGetLogCode.NU5132 = 5132 -> NuGet.Common.NuGetLogCode
-NuGet.Common.NuGetLogCode.NU5133 = 5133 -> NuGet.Common.NuGetLogCode
 NuGet.Common.NuGetLogCode.NU5501 = 5501 -> NuGet.Common.NuGetLogCode
 NuGet.Common.NuGetLogCode.NU1012 = 1012 -> NuGet.Common.NuGetLogCode
 NuGet.Common.NuGetLogCode.NU5045 = 5045 -> NuGet.Common.NuGetLogCode

--- a/src/NuGet.Core/NuGet.Common/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Common/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -1,4 +1,5 @@
 NuGet.Common.NuGetLogCode.NU5132 = 5132 -> NuGet.Common.NuGetLogCode
+NuGet.Common.NuGetLogCode.NU5133 = 5133 -> NuGet.Common.NuGetLogCode
 NuGet.Common.NuGetLogCode.NU5501 = 5501 -> NuGet.Common.NuGetLogCode
 NuGet.Common.NuGetLogCode.NU1012 = 1012 -> NuGet.Common.NuGetLogCode
 NuGet.Common.NuGetLogCode.NU5045 = 5045 -> NuGet.Common.NuGetLogCode

--- a/src/NuGet.Core/NuGet.Common/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Common/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -1,5 +1,5 @@
+NuGet.Common.NuGetLogCode.NU5050 = 5050 -> NuGet.Common.NuGetLogCode
 NuGet.Common.NuGetLogCode.NU5132 = 5132 -> NuGet.Common.NuGetLogCode
-NuGet.Common.NuGetLogCode.NU5133 = 5133 -> NuGet.Common.NuGetLogCode
 NuGet.Common.NuGetLogCode.NU5501 = 5501 -> NuGet.Common.NuGetLogCode
 NuGet.Common.NuGetLogCode.NU1012 = 1012 -> NuGet.Common.NuGetLogCode
 NuGet.Common.NuGetLogCode.NU5045 = 5045 -> NuGet.Common.NuGetLogCode

--- a/src/NuGet.Core/NuGet.Common/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Common/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,4 +1,5 @@
 NuGet.Common.NuGetLogCode.NU5132 = 5132 -> NuGet.Common.NuGetLogCode
+NuGet.Common.NuGetLogCode.NU5133 = 5133 -> NuGet.Common.NuGetLogCode
 NuGet.Common.NuGetLogCode.NU5501 = 5501 -> NuGet.Common.NuGetLogCode
 NuGet.Common.NuGetLogCode.NU1012 = 1012 -> NuGet.Common.NuGetLogCode
 NuGet.Common.NuGetLogCode.NU5045 = 5045 -> NuGet.Common.NuGetLogCode

--- a/src/NuGet.Core/NuGet.Common/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Common/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,5 +1,5 @@
+NuGet.Common.NuGetLogCode.NU5050 = 5050 -> NuGet.Common.NuGetLogCode
 NuGet.Common.NuGetLogCode.NU5132 = 5132 -> NuGet.Common.NuGetLogCode
-NuGet.Common.NuGetLogCode.NU5133 = 5133 -> NuGet.Common.NuGetLogCode
 NuGet.Common.NuGetLogCode.NU5501 = 5501 -> NuGet.Common.NuGetLogCode
 NuGet.Common.NuGetLogCode.NU1012 = 1012 -> NuGet.Common.NuGetLogCode
 NuGet.Common.NuGetLogCode.NU5045 = 5045 -> NuGet.Common.NuGetLogCode

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PackageBuilder.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PackageBuilder.cs
@@ -407,6 +407,7 @@ namespace NuGet.Packaging
             }
 
             ValidateDependencies(Version, DependencyGroups);
+            ValidateFilesUnique(Files);
             ValidateReferenceAssemblies(Files, PackageAssemblyReferences);
             ValidateFrameworkAssemblies(FrameworkReferences, FrameworkReferenceGroups);
             ValidateLicenseFile(Files, LicenseMetadata);
@@ -679,6 +680,18 @@ namespace NuGet.Packaging
 
             // We searched all of the package files and didn't find what we were looking for
             return null;
+        }
+
+        private void ValidateFilesUnique(IEnumerable<IPackageFile> files)
+        {
+            var set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (string file in files.Where(t => t.Path != null).Select(t => PathUtility.GetPathWithDirectorySeparator(t.Path)))
+            {
+                if (!set.Add(file))
+                {
+                    throw new PackagingException(NuGetLogCode.NU5133, string.Format(CultureInfo.CurrentCulture, NuGetResources.FoundDuplicateFile, file));
+                }
+            }
         }
 
         private void ValidateLicenseFile(IEnumerable<IPackageFile> files, LicenseMetadata licenseMetadata)

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PackageBuilder.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PackageBuilder.cs
@@ -695,7 +695,7 @@ namespace NuGet.Packaging
             }
             if (duplicates.Any())
             {
-                throw new PackagingException(NuGetLogCode.NU5050, string.Format(CultureInfo.CurrentCulture, NuGetResources.FoundDuplicateFile, string.Join(",", duplicates)));
+                throw new PackagingException(NuGetLogCode.NU5050, string.Format(CultureInfo.CurrentCulture, NuGetResources.FoundDuplicateFile, string.Join(", ", duplicates)));
             }
 
         }

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PackageBuilder.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PackageBuilder.cs
@@ -684,14 +684,20 @@ namespace NuGet.Packaging
 
         private void ValidateFilesUnique(IEnumerable<IPackageFile> files)
         {
-            var set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            foreach (string file in files.Where(t => t.Path != null).Select(t => PathUtility.GetPathWithDirectorySeparator(t.Path)))
+            var seen = new HashSet<string>(StringComparer.Ordinal);
+            var duplicates = new HashSet<string>(StringComparer.Ordinal);
+            foreach (string destination in files.Where(t => t.Path != null).Select(t => PathUtility.GetPathWithDirectorySeparator(t.Path)))
             {
-                if (!set.Add(file))
+                if (!seen.Add(destination))
                 {
-                    throw new PackagingException(NuGetLogCode.NU5133, string.Format(CultureInfo.CurrentCulture, NuGetResources.FoundDuplicateFile, file));
+                    duplicates.Add(destination);
                 }
             }
+            if (duplicates.Any())
+            {
+                throw new PackagingException(NuGetLogCode.NU5050, string.Format(CultureInfo.CurrentCulture, NuGetResources.FoundDuplicateFile, string.Join(",", duplicates)));
+            }
+
         }
 
         private void ValidateLicenseFile(IEnumerable<IPackageFile> files, LicenseMetadata licenseMetadata)

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Resources/NuGetResources.Designer.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Resources/NuGetResources.Designer.cs
@@ -88,7 +88,7 @@ namespace NuGet.Packaging.PackageCreation.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Attempted to pack multiple files into the same location(s). The following destinations were used multiple times: &apos;{0}&apos;.
+        ///   Looks up a localized string similar to Attempted to pack multiple files into the same location(s). The following destinations were used multiple times: {0}.
         /// </summary>
         internal static string FoundDuplicateFile {
             get {

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Resources/NuGetResources.Designer.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Resources/NuGetResources.Designer.cs
@@ -88,7 +88,7 @@ namespace NuGet.Packaging.PackageCreation.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Attempted to pack multiple files into the same location: &apos;{0}&apos;.
+        ///   Looks up a localized string similar to Attempted to pack multiple files into the same location(s). The following destinations were used multiple times: &apos;{0}&apos;.
         /// </summary>
         internal static string FoundDuplicateFile {
             get {

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Resources/NuGetResources.Designer.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Resources/NuGetResources.Designer.cs
@@ -88,6 +88,15 @@ namespace NuGet.Packaging.PackageCreation.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Attempted to pack multiple files into the same location: &apos;{0}&apos;.
+        /// </summary>
+        internal static string FoundDuplicateFile {
+            get {
+                return ResourceManager.GetString("FoundDuplicateFile", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Cannot open the icon file &apos;{0}&apos;: {1}..
         /// </summary>
         internal static string IconCannotOpenFile {

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Resources/NuGetResources.resx
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Resources/NuGetResources.resx
@@ -228,7 +228,7 @@
     <value>EmitRequireLicenseAcceptance must not be set to false if RequireLicenseAcceptance is set to true.</value>
   </data>
   <data name="FoundDuplicateFile" xml:space="preserve">
-    <value>Attempted to pack multiple files into the same location: '{0}'</value>
-    <comment>0 - The duplicated file</comment>
+    <value>Attempted to pack multiple files into the same location(s). The following destinations were used multiple times: '{0}'</value>
+    <comment>0 - One or more duplicate files</comment>
   </data>
 </root>

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Resources/NuGetResources.resx
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Resources/NuGetResources.resx
@@ -227,4 +227,8 @@
   <data name="Manifest_RequireLicenseAcceptanceRequiresEmit" xml:space="preserve">
     <value>EmitRequireLicenseAcceptance must not be set to false if RequireLicenseAcceptance is set to true.</value>
   </data>
+  <data name="FoundDuplicateFile" xml:space="preserve">
+    <value>Attempted to pack multiple files into the same location: '{0}'</value>
+    <comment>0 - The duplicated file</comment>
+  </data>
 </root>

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Resources/NuGetResources.resx
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Resources/NuGetResources.resx
@@ -228,7 +228,7 @@
     <value>EmitRequireLicenseAcceptance must not be set to false if RequireLicenseAcceptance is set to true.</value>
   </data>
   <data name="FoundDuplicateFile" xml:space="preserve">
-    <value>Attempted to pack multiple files into the same location(s). The following destinations were used multiple times: '{0}'</value>
+    <value>Attempted to pack multiple files into the same location(s). The following destinations were used multiple times: {0}</value>
     <comment>0 - One or more duplicate files</comment>
   </data>
 </root>

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageBuilderTest.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageBuilderTest.cs
@@ -1396,7 +1396,7 @@ namespace NuGet.Packaging.Test
             builder.Files.Add(new PhysicalPackageFile { TargetPath = @"lib\net5.0\Foo.dll" });
             builder.Files.Add(new PhysicalPackageFile { TargetPath = @"lib\net5.0\Foo.dll" });
 
-            ExceptionAssert.Throws<PackagingException>(() => builder.Save(new MemoryStream()), @"Attempted to pack multiple files into the same location: 'lib\net5.0\Foo.dll'");
+            ExceptionAssert.Throws<PackagingException>(() => builder.Save(new MemoryStream()), $@"Attempted to pack multiple files into the same location: 'lib{Path.DirectorySeparatorChar}net5.0{Path.DirectorySeparatorChar}Foo.dll'");
         }
 
         [Fact]

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageBuilderTest.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageBuilderTest.cs
@@ -1383,6 +1383,23 @@ namespace NuGet.Packaging.Test
         }
 
         [Fact]
+        public void AddingDuplicateFiles_Throws()
+        {
+            // Arrange
+            var builder = new PackageBuilder
+            {
+                Id = "A",
+                Version = NuGetVersion.Parse("1.0"),
+                Description = "Test",
+            };
+            builder.Authors.Add("Test");
+            builder.Files.Add(new PhysicalPackageFile { TargetPath = @"lib\net5.0\Foo.dll" });
+            builder.Files.Add(new PhysicalPackageFile { TargetPath = @"lib\net5.0\Foo.dll" });
+
+            ExceptionAssert.Throws<PackagingException>(() => builder.Save(new MemoryStream()), @"Attempted to pack multiple files into the same location: 'lib\net5.0\Foo.dll'");
+        }
+
+        [Fact]
         public void SavingPackageValidatesReferences()
         {
             // Arrange

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageBuilderTest.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageBuilderTest.cs
@@ -1395,8 +1395,11 @@ namespace NuGet.Packaging.Test
             builder.Authors.Add("Test");
             builder.Files.Add(new PhysicalPackageFile { TargetPath = @"lib\net5.0\Foo.dll" });
             builder.Files.Add(new PhysicalPackageFile { TargetPath = @"lib\net5.0\Foo.dll" });
+            builder.Files.Add(new PhysicalPackageFile { TargetPath = @"lib\net5.0\Bar.dll" });
+            builder.Files.Add(new PhysicalPackageFile { TargetPath = @"lib\net5.0\Bar.dll" });
+            builder.Files.Add(new PhysicalPackageFile { TargetPath = @"lib\net5.0\Baz.dll" });
 
-            ExceptionAssert.Throws<PackagingException>(() => builder.Save(new MemoryStream()), $@"Attempted to pack multiple files into the same location: 'lib{Path.DirectorySeparatorChar}net5.0{Path.DirectorySeparatorChar}Foo.dll'");
+            ExceptionAssert.Throws<PackagingException>(() => builder.Save(new MemoryStream()), $@"Attempted to pack multiple files into the same location(s). The following destinations were used multiple times: lib{Path.DirectorySeparatorChar}net5.0{Path.DirectorySeparatorChar}Foo.dll, lib{Path.DirectorySeparatorChar}net5.0{Path.DirectorySeparatorChar}Bar.dll");
         }
 
         [Fact]


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/6941

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
This PR makes it so that pack fails if you try to pack two or more files into the exact same destination. We believe this is acceptable because, even though this would be a new error, the packages generated when this was happening are pretty much broken.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [x] Documentation PR or issue filled: https://github.com/NuGet/Home/issues/13491
  - **OR**
  - [ ] N/A
