### PR TITLE
fix registry probing for PresinstalledPackageInstaller and PreinstalledRepositoryProvider

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/PreinstalledPackageInstaller.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/PreinstalledPackageInstaller.cs
@@ -100,11 +100,12 @@ namespace NuGet.VisualStudio
             string repositoryValue = null;
 
             // When pulling the repository from the registry, use CurrentUser first, falling back onto LocalMachine
+            // Documented here: https://docs.microsoft.com/nuget/visual-studio-extensibility/visual-studio-templates#registry-specified-folder-path
             registryKeys = registryKeys ??
                            new[]
                                {
-                                   new RegistryKeyWrapper(Registry.CurrentUser),
-                                   new RegistryKeyWrapper(Registry.LocalMachine)
+                                   new RegistryKeyWrapper(RegistryHive.CurrentUser),
+                                   new RegistryKeyWrapper(RegistryHive.LocalMachine, RegistryView.Registry32)
                                };
 
             // Find the first registry key that supplies the necessary subkey/value

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/PreinstalledRepositoryProvider.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/PreinstalledRepositoryProvider.cs
@@ -142,10 +142,11 @@ namespace NuGet.VisualStudio
             string repositoryValue = null;
 
             // When pulling the repository from the registry, use CurrentUser first, falling back onto LocalMachine
+            // Documented here: https://docs.microsoft.com/nuget/visual-studio-extensibility/visual-studio-templates#registry-specified-folder-path
             var registryKeys = new[]
                                {
-                                   new RegistryKeyWrapper(Registry.CurrentUser),
-                                   new RegistryKeyWrapper(Registry.LocalMachine)
+                                   new RegistryKeyWrapper(RegistryHive.CurrentUser),
+                                   new RegistryKeyWrapper(RegistryHive.LocalMachine, RegistryView.Registry32)
                                };
 
             // Find the first registry key that supplies the necessary subkey/value

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/RegistryKeyWrapper.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/RegistryKeyWrapper.cs
@@ -12,7 +12,12 @@ namespace NuGet.VisualStudio
     {
         private readonly RegistryKey _registryKey;
 
-        public RegistryKeyWrapper(RegistryKey registryKey)
+        public RegistryKeyWrapper(RegistryHive registryHive, RegistryView registryView = RegistryView.Registry32)
+        {
+            _registryKey = RegistryKey.OpenBaseKey(registryHive, registryView);
+        }
+
+        private RegistryKeyWrapper(RegistryKey registryKey)
         {
             Debug.Assert(registryKey != null);
             _registryKey = registryKey;

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/VsTemplateWizard.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/VsTemplateWizard.cs
@@ -37,7 +37,7 @@ namespace NuGet.VisualStudio
         private IEnumerable<PreinstalledPackageConfiguration> _configurations;
 
         private DTE _dte;
-        private PreinstalledPackageInstaller _preinstalledPackageInstaller;
+        private Lazy<PreinstalledPackageInstaller> _preinstalledPackageInstaller;
         private readonly IVsPackageInstallerServices _packageServices;
         private readonly IOutputConsoleProvider _consoleProvider;
         private readonly IVsSolutionManager _solutionManager;
@@ -65,7 +65,10 @@ namespace NuGet.VisualStudio
             _settings = settings;
             _sourceProvider = sourceProvider;
             _vsProjectAdapterProvider = vsProjectAdapterProvider;
-
+            _preinstalledPackageInstaller = new Lazy<PreinstalledPackageInstaller>(() =>
+                                            {
+                                                return new PreinstalledPackageInstaller(_packageServices, _solutionManager, _settings, _sourceProvider, (VsPackageInstaller)_installer, _vsProjectAdapterProvider);
+                                            });
             PumpingJTF = new PumpingJTF(NuGetUIThreadHelper.JoinableTaskFactory);
         }
 
@@ -73,12 +76,7 @@ namespace NuGet.VisualStudio
         {
             get
             {
-                if (_preinstalledPackageInstaller == null)
-                {
-                    _preinstalledPackageInstaller = new PreinstalledPackageInstaller(_packageServices, _solutionManager, _settings, _sourceProvider, (VsPackageInstaller)_installer, _vsProjectAdapterProvider);
-                }
-
-                return _preinstalledPackageInstaller;
+                return _preinstalledPackageInstaller.Value;
             }
         }
 

--- a/src/NuGet.Clients/NuGetConsole.Host.PowerShell/HostUtilities.cs
+++ b/src/NuGet.Clients/NuGetConsole.Host.PowerShell/HostUtilities.cs
@@ -151,6 +151,7 @@ namespace NuGetConsole.Host.PowerShell
         {
             string engineKeyPath = MonadRootKeyPath + "\\" + RegistryVersionKey + "\\" + MonadEngineKey;
 
+            // Registration exists in both 32bit and 64bit localmachine keys, no need for explicit use of RegistryHive.
             using (RegistryKey engineKey = Registry.LocalMachine.OpenSubKey(engineKeyPath))
             {
                 if (engineKey != null)
@@ -164,7 +165,7 @@ namespace NuGetConsole.Host.PowerShell
             Assembly assem = Assembly.GetEntryAssembly();
             if (assem != null)
             {
-                // For minishells, we just return the executable path. 
+                // For minishells, we just return the executable path.
                 return Path.GetDirectoryName(assem.Location);
             }
 
@@ -173,7 +174,7 @@ namespace NuGetConsole.Host.PowerShell
             assem = Assembly.GetAssembly(typeof(PSObject));
             if (assem != null)
             {
-                // For other hosts. 
+                // For other hosts.
                 return Path.GetDirectoryName(assem.Location);
             }
 

--- a/src/NuGet.Clients/NuGetConsole.Host.PowerShell/RegistryHelper.cs
+++ b/src/NuGet.Clients/NuGetConsole.Host.PowerShell/RegistryHelper.cs
@@ -36,6 +36,7 @@ namespace NuGetConsole.Host
 
         private static string GetSubKeyValue(string keyPath, string valueName)
         {
+            // Registration exists in both 32bit and 64bit localmachine keys, no need for explicit use of RegistryHive.
             RegistryKey currentKey = Registry.LocalMachine;
 
             foreach (string subKeyName in keyPath.Split('\\'))

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/PreinstalledRepositoryProviderTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/PreinstalledRepositoryProviderTests.cs
@@ -16,7 +16,7 @@ namespace NuGet.VisualStudio.Implementation.Test
     public class PreinstalledRepositoryProviderTests : IDisposable
     {
         private readonly TestDirectory _testDirectory;
-
+        private const string LocalMachineRepoKey = "NuGetPackages";
         public PreinstalledRepositoryProviderTests()
         {
             _testDirectory = TestDirectory.Create();
@@ -27,8 +27,10 @@ namespace NuGet.VisualStudio.Implementation.Test
             _testDirectory.Dispose();
         }
 
-        [Fact]
-        public void AddFromRegistry_WithValidRegistryValue_Succeeds()
+        [Theory]
+        [InlineData(RegistryHive.CurrentUser, null)]
+        [InlineData(RegistryHive.LocalMachine, LocalMachineRepoKey)] // seems to always be in LocalMachine, but not positive which component is writing that key.
+        public void AddFromRegistry_WithValidRegistryValue_Succeeds(RegistryHive registryHive, string repoKeyName)
         {
             var srp = Mock.Of<ISourceRepositoryProvider>();
             Mock.Get(srp)
@@ -39,9 +41,9 @@ namespace NuGet.VisualStudio.Implementation.Test
             var provider = new PreinstalledRepositoryProvider(_ => { }, srp);
 
             // Act
-            using (var tc = new TestContext(_testDirectory.Path))
+            using (var tc = new TestContext(_testDirectory.Path, registryHive))
             {
-                provider.AddFromRegistry(tc.RepoKeyName, isPreUnzipped: true);
+                provider.AddFromRegistry(repoKeyName == null ? tc.RepoKeyName : repoKeyName, isPreUnzipped: true);
             }
 
             Assert.NotNull(provider.GetRepositories().Single());
@@ -77,8 +79,10 @@ namespace NuGet.VisualStudio.Implementation.Test
                 StringComparison.OrdinalIgnoreCase);
         }
 
-        [Fact]
-        public void AddFromRegistry_WithInvalidRegistryValue_Fails()
+        [Theory]
+        [InlineData(RegistryHive.CurrentUser)]
+        [InlineData(RegistryHive.LocalMachine)]
+        public void AddFromRegistry_WithInvalidRegistryValue_Fails(RegistryHive registryHive)
         {
             var srp = Mock.Of<ISourceRepositoryProvider>();
 
@@ -87,7 +91,7 @@ namespace NuGet.VisualStudio.Implementation.Test
                 errorMessage => { errorHandlerMessage = errorMessage; }, srp);
 
             // Act
-            using (var tc = new TestContext(string.Empty))
+            using (var tc = new TestContext(string.Empty, registryHive))
             {
                 var exception = Assert.Throws<InvalidOperationException>(() =>
                     provider.AddFromRegistry(tc.RepoKeyName, isPreUnzipped: true)
@@ -106,18 +110,29 @@ namespace NuGet.VisualStudio.Implementation.Test
         private class TestContext : IDisposable
         {
             private readonly RegistryKey _repoKey;
+            private readonly bool _writeKey;
             public string RepoKeyName { get; } = $"NuGetTest_{Guid.NewGuid()}";
 
-            public TestContext(string repositoryPath)
+            public TestContext(string repositoryPath, RegistryHive registryHive)
             {
-                _repoKey = Registry.CurrentUser.CreateSubKey(
-                    PreinstalledRepositoryProvider.DefaultRegistryKeyRoot);
-                _repoKey.SetValue(RepoKeyName, repositoryPath);
+                _writeKey = registryHive == RegistryHive.CurrentUser;
+
+                _repoKey = RegistryKey.OpenBaseKey(registryHive, RegistryView.Registry32).OpenSubKey(
+                    PreinstalledRepositoryProvider.DefaultRegistryKeyRoot, writable: _writeKey);
+
+                if (_writeKey)
+                {
+                    _repoKey.SetValue(RepoKeyName, repositoryPath);
+                }
             }
 
             public void Dispose()
             {
-                _repoKey.DeleteValue(RepoKeyName);
+                if (_writeKey)
+                {
+                    _repoKey.DeleteValue(RepoKeyName);
+                }
+
                 _repoKey.Dispose();
             }
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/806

Regression? no

## Description
make registry access explicitly use the wow6432 part of localmachine.
improved test coverage to cover current user (already did) and localmachine (read-only).
made vstemplatewizard delay create the PreinstalledRepositoryProvider.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
