### PR TITLE
Publish EnsureAllPackagesExist.ps1 as artifacts

### DIFF
--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -236,7 +236,7 @@ steps:
 - task: PublishBuildArtifacts@1
   displayName: "Publish EnsureAllPackagesExist script"
   inputs:
-    PathtoPublish: "$(Build.Repository.LocalPath)\\scripts\utils\EnsureAllPackagesExist.ps1"
+    PathtoPublish: "$(Build.Repository.LocalPath)\\scripts\\utils\\EnsureAllPackagesExist.ps1"
     ArtifactName: "Scripts"
     ArtifactType: "Container"
   condition: "and(succeeded(),eq(variables['BuildRTM'], 'false'))"

--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -237,7 +237,7 @@ steps:
   displayName: "Publish EnsureAllPackagesExist script"
   inputs:
     PathtoPublish: "$(Build.Repository.LocalPath)\\scripts\utils\EnsureAllPackagesExist.ps1"
-    ArtifactName: "EnsureAllPackagesExist.ps1"
+    ArtifactName: "Scripts"
     ArtifactType: "Container"
   condition: "and(succeeded(),eq(variables['BuildRTM'], 'false'))"
 

--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -232,6 +232,15 @@ steps:
     msbuildArguments: "/t:EnsurePackagesExist /p:ExcludeTestProjects=$(BuildRTM)"
   condition: and(succeeded(), or(eq(variables['IsOfficialBuild'], 'true'), eq(variables['BuildRTM'], 'true')))  #skip this task for nonRTM in private build
 
+  # The list of nupkgs in the script might change, so we publish it as artifact, in order to make sure release pipeline check the right list.
+- task: PublishBuildArtifacts@1
+  displayName: "Publish EnsureAllPackagesExist script"
+  inputs:
+    PathtoPublish: "$(Build.Repository.LocalPath)\\scripts\utils\EnsureAllPackagesExist.ps1"
+    ArtifactName: "EnsureAllPackagesExist.ps1"
+    ArtifactType: "Container"
+  condition: "and(succeeded(),eq(variables['BuildRTM'], 'false'))"
+
 - task: MSBuild@1
   displayName: "Pack VSIX"
   inputs:


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/667

Regression? Last working version:

## Description
PR https://github.com/NuGet/NuGet.Client/pull/3862 added a script to run in release pipeline. There is a list of nupkgs inside of this script, which is used to check if all nupkgs are created. The release pipeline gets the script from dev branch.
But the nupkgs list might change from time to time. 
In order to make sure release pipeline gets the right list in the script, we  publish the script EnsureAllPackagesExist.ps1 as artifacts.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
