### PR TITLE
PM UI:  do not cache NuGetPackageManager instance

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/ISharedServiceState.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/ISharedServiceState.cs
@@ -15,10 +15,11 @@ namespace NuGet.PackageManagement.VisualStudio
 {
     public interface ISharedServiceState : IDisposable
     {
-        AsyncLazy<NuGetPackageManager> PackageManager { get; }
         AsyncLazy<IVsSolutionManager> SolutionManager { get; }
         ISourceRepositoryProvider SourceRepositoryProvider { get; }
         AsyncLazy<IReadOnlyCollection<SourceRepository>> SourceRepositories { get; }
+
+        ValueTask<NuGetPackageManager> GetPackageManagerAsync(CancellationToken cancellationToken);
         ValueTask<IReadOnlyCollection<SourceRepository>> GetRepositoriesAsync(
             IReadOnlyCollection<PackageSourceContextInfo> packageSourceContextInfos,
             CancellationToken cancellationToken);

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetPackageSearchService.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetPackageSearchService.cs
@@ -406,8 +406,8 @@ namespace NuGet.PackageManagement.VisualStudio
 
         private async Task<IReadOnlyList<SourceRepository>> GetGlobalPackageFolderRepositoriesAsync()
         {
-            var settings = ServiceLocator.GetInstance<ISettings>();
-            NuGetPackageManager packageManager = await _sharedServiceState.PackageManager.GetValueAsync();
+            NuGetPackageManager packageManager = await _sharedServiceState.GetPackageManagerAsync(CancellationToken.None);
+
             return packageManager.GlobalPackageFolderRepositories;
         }
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetProjectManagerService.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetProjectManagerService.cs
@@ -206,8 +206,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
             cancellationToken.ThrowIfCancellationRequested();
 
-            NuGetPackageManager? packageManager = await _sharedState.PackageManager.GetValueAsync(cancellationToken);
-            Assumes.NotNull(packageManager);
+            NuGetPackageManager packageManager = await _sharedState.GetPackageManagerAsync(cancellationToken);
 
             NuGetProject? project = await SolutionUtility.GetNuGetProjectAsync(
                 _sharedState.SolutionManager,
@@ -371,7 +370,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
                     Assumes.NotNullOrEmpty(nugetProjectActions);
 
-                    NuGetPackageManager packageManager = await _sharedState.PackageManager.GetValueAsync(cancellationToken);
+                    NuGetPackageManager packageManager = await _sharedState.GetPackageManagerAsync(cancellationToken);
                     IEnumerable<NuGetProject> projects = nugetProjectActions.Select(action => action.Project);
 
                     await packageManager.ExecuteNuGetProjectActionsAsync(
@@ -430,7 +429,7 @@ namespace NuGet.PackageManagement.VisualStudio
                     new GatherCache(),
                     _state.SourceCacheContext);
 
-                NuGetPackageManager packageManager = await _sharedState.PackageManager.GetValueAsync(cancellationToken);
+                NuGetPackageManager packageManager = await _sharedState.GetPackageManagerAsync(cancellationToken);
                 IEnumerable<ResolvedAction> resolvedActions = await packageManager.PreviewProjectsInstallPackageAsync(
                     projects,
                     _state.PackageIdentity,
@@ -478,7 +477,7 @@ namespace NuGet.PackageManagement.VisualStudio
                 var projectActions = new List<ProjectAction>();
                 var uninstallationContext = new UninstallationContext(removeDependencies, forceRemove);
 
-                NuGetPackageManager packageManager = await _sharedState.PackageManager.GetValueAsync(cancellationToken);
+                NuGetPackageManager packageManager = await _sharedState.GetPackageManagerAsync(cancellationToken);
                 IEnumerable<NuGetProjectAction> projectsWithActions = await packageManager.PreviewProjectsUninstallPackageAsync(
                     projects,
                     packageIdentity.Id,
@@ -553,7 +552,7 @@ namespace NuGet.PackageManagement.VisualStudio
                     new GatherCache(),
                     _state.SourceCacheContext);
 
-                NuGetPackageManager packageManager = await _sharedState.PackageManager.GetValueAsync(cancellationToken);
+                NuGetPackageManager packageManager = await _sharedState.GetPackageManagerAsync(cancellationToken);
                 IEnumerable<NuGetProjectAction> actions = await packageManager.PreviewUpdatePackagesAsync(
                     packageIdentities.ToList(),
                     projects,

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetProjectUpgraderService.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetProjectUpgraderService.cs
@@ -147,7 +147,7 @@ namespace NuGet.PackageManagement.VisualStudio
             IEnumerable<NuGetProjectAction>? actions = packageIdentities
                 .Select(packageIdentity => NuGetProjectAction.CreateUninstallProjectAction(packageIdentity, project));
 
-            NuGetPackageManager packageManager = await _state.PackageManager.GetValueAsync(cancellationToken);
+            NuGetPackageManager packageManager = await _state.GetPackageManagerAsync(cancellationToken);
             Assumes.NotNull(packageManager);
 
             INuGetProjectContext projectContext = await ServiceLocator.GetInstanceAsync<INuGetProjectContext>();
@@ -183,7 +183,7 @@ namespace NuGet.PackageManagement.VisualStudio
             IEnumerable<NuGetProjectAction>? actions = packageIdentities
                 .Select(packageIdentity => NuGetProjectAction.CreateInstallProjectAction(packageIdentity, sourceRepository, project));
 
-            NuGetPackageManager packageManager = await _state.PackageManager.GetValueAsync(cancellationToken);
+            NuGetPackageManager packageManager = await _state.GetPackageManagerAsync(cancellationToken);
             Assumes.NotNull(packageManager);
 
             INuGetProjectContext projectContext = await ServiceLocator.GetInstanceAsync<INuGetProjectContext>();

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/NuGet.PackageManagement.VisualStudio.Test.csproj
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/NuGet.PackageManagement.VisualStudio.Test.csproj
@@ -43,6 +43,7 @@
     <Compile Include="Services\NuGetProjectManagerServiceTests.cs" />
     <Compile Include="Services\NuGetPackageFileServiceTests.cs" />
     <Compile Include="Services\NuGetSourcesServiceTests.cs" />
+    <Compile Include="Services\SharedServiceStateTests.cs" />
     <Compile Include="Services\TestSharedServiceState.cs" />
     <Compile Include="Services\NuGetPackageSearchServiceTests.cs" />
     <Compile Include="Telemetry\ActionsTelemetryServiceTests.cs" />

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/SharedServiceStateTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/SharedServiceStateTests.cs
@@ -1,0 +1,52 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Sdk.TestFramework;
+using Moq;
+using NuGet.Configuration;
+using NuGet.Protocol.Core.Types;
+using Test.Utility;
+using Xunit;
+
+namespace NuGet.PackageManagement.VisualStudio.Test
+{
+    [Collection(MockedVS.Collection)]
+    public class SharedServiceStateTests : MockedVSCollectionTests
+    {
+        public SharedServiceStateTests(GlobalServiceProvider globalServiceProvider)
+            : base(globalServiceProvider)
+        {
+            var solutionManager = new Mock<IVsSolutionManager>();
+
+            solutionManager.SetupGet(x => x.SolutionDirectory)
+                .Returns(@"C:\a");
+
+            SourceRepositoryProvider sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
+
+            AddService<IDeleteOnRestartManager>(Task.FromResult<object>(Mock.Of<IDeleteOnRestartManager>()));
+            AddService<ISettings>(Task.FromResult<object>(Mock.Of<ISettings>()));
+            AddService<ISourceRepositoryProvider>(Task.FromResult<object>(sourceRepositoryProvider));
+            AddService<IVsSolutionManager>(Task.FromResult<object>(solutionManager.Object));
+        }
+
+        [Fact]
+        public async Task GetPackageManagerAsync_Always_ReturnsNewInstance()
+        {
+            using (SharedServiceState state = await SharedServiceState.CreateAsync(CancellationToken.None))
+            {
+                NuGetPackageManager packageManager0 = await state.GetPackageManagerAsync(CancellationToken.None);
+                NuGetPackageManager packageManager1 = await state.GetPackageManagerAsync(CancellationToken.None);
+                NuGetPackageManager packageManager2 = await state.GetPackageManagerAsync(CancellationToken.None);
+
+                Assert.NotNull(packageManager0);
+                Assert.NotNull(packageManager1);
+                Assert.NotNull(packageManager2);
+
+                Assert.NotSame(packageManager0, packageManager1);
+                Assert.NotSame(packageManager0, packageManager2);
+            }
+        }
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/TestSharedServiceState.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/TestSharedServiceState.cs
@@ -13,7 +13,8 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 {
     internal sealed class TestSharedServiceState : ISharedServiceState
     {
-        public AsyncLazy<NuGetPackageManager> PackageManager { get; }
+        private readonly AsyncLazy<NuGetPackageManager> _packageManager;
+
         public AsyncLazy<IVsSolutionManager> SolutionManager { get; }
         public ISourceRepositoryProvider SourceRepositoryProvider { get; }
         public AsyncLazy<IReadOnlyCollection<SourceRepository>> SourceRepositories { get; }
@@ -24,10 +25,15 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             ISourceRepositoryProvider sourceRepositoryProvider,
             AsyncLazy<IReadOnlyCollection<SourceRepository>> sourceRepositories)
         {
-            PackageManager = packageManager;
+            _packageManager = packageManager;
             SolutionManager = solutionManager;
             SourceRepositoryProvider = sourceRepositoryProvider;
             SourceRepositories = sourceRepositories;
+        }
+
+        public async ValueTask<NuGetPackageManager> GetPackageManagerAsync(CancellationToken cancellationToken)
+        {
+            return await _packageManager.GetValueAsync(cancellationToken);
         }
 
         public async ValueTask<IReadOnlyCollection<SourceRepository>> GetRepositoriesAsync(IReadOnlyCollection<PackageSourceContextInfo> packageSourceContextInfos, CancellationToken cancellationToken)


### PR DESCRIPTION
## Bug

Fixes:  https://github.com/nuget/home/issues/10024

Regression? Last working version:  any build before Codespaces work

## Description

`NuGetPackageManager` instances are created frequently, except in `SharedServiceState` which creates and reuses 1 instance.  This is a problem because some properties cache items (like resources) from the project that `NuGetPackageManager` instance was created for.

In this bug, the reuse of a `NuGetPackageManager` instance across separate solutions resulted in the second solution inheriting the solution packages directory of the first solution.

The fix is to not cache `NuGetPackageManager` instances; `SharedServiceState` will always return a new instance.

## PR Checklist

- [X] PR has a meaningful title
- [X] PR has a linked issue.
- [X] Described changes

- **Tests**
  - [X] Automated tests added

- **Documentation**
  - [X] N/A
