### PR TITLE
Fix signature verification on big-endian systems

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/Signing/Archive/SignedPackageArchiveUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Archive/SignedPackageArchiveUtility.cs
@@ -409,7 +409,7 @@ namespace NuGet.Packaging.Signing
             byte[] array = BitConverter.GetBytes(value);
             if (!BitConverter.IsLittleEndian)
             {
-                    Array.Reverse(array);
+                Array.Reverse(array);
             }
             SignedPackageArchiveIOUtility.HashBytes(hashAlgorithm, array);
         }
@@ -419,7 +419,7 @@ namespace NuGet.Packaging.Signing
             byte[] array = BitConverter.GetBytes(value);
             if (!BitConverter.IsLittleEndian)
             {
-                    Array.Reverse(array);
+                Array.Reverse(array);
             }
             SignedPackageArchiveIOUtility.HashBytes(hashAlgorithm, array);
         }
@@ -571,7 +571,7 @@ namespace NuGet.Packaging.Signing
             byte[] array = BitConverter.GetBytes(value);
             if (!BitConverter.IsLittleEndian)
             {
-                    Array.Reverse(array);
+                Array.Reverse(array);
             }
             SignedPackageArchiveIOUtility.HashBytes(hashFunc, array);
         }
@@ -581,7 +581,7 @@ namespace NuGet.Packaging.Signing
             byte[] array = BitConverter.GetBytes(value);
             if (!BitConverter.IsLittleEndian)
             {
-                    Array.Reverse(array);
+                Array.Reverse(array);
             }
             SignedPackageArchiveIOUtility.HashBytes(hashFunc, array);
         }

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Archive/SignedPackageArchiveUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Archive/SignedPackageArchiveUtility.cs
@@ -404,6 +404,26 @@ namespace NuGet.Packaging.Signing
             SignedPackageArchiveIOUtility.RemoveSignature(reader, writer);
         }
 
+        internal static void HashUInt16(HashAlgorithm hashAlgorithm, ushort value)
+        {
+            byte[] array = BitConverter.GetBytes(value);
+            if (!BitConverter.IsLittleEndian)
+            {
+                    Array.Reverse(array);
+            }
+            SignedPackageArchiveIOUtility.HashBytes(hashAlgorithm, array);
+        }
+
+        internal static void HashUInt32(HashAlgorithm hashAlgorithm, uint value)
+        {
+            byte[] array = BitConverter.GetBytes(value);
+            if (!BitConverter.IsLittleEndian)
+            {
+                    Array.Reverse(array);
+            }
+            SignedPackageArchiveIOUtility.HashBytes(hashAlgorithm, array);
+        }
+
         /// <summary>
         /// Verifies that a signed package archive's signature is valid and it has not been tampered with.
         ///
@@ -463,7 +483,7 @@ namespace NuGet.Packaging.Signing
                     SignedPackageArchiveIOUtility.ReadAndHashUntilPosition(reader, hashAlgorithm, reader.BaseStream.Position + 42);
 
                     var relativeOffsetOfLocalFileHeader = (uint)(reader.ReadUInt32() + record.ChangeInOffset);
-                    SignedPackageArchiveIOUtility.HashBytes(hashAlgorithm, BitConverter.GetBytes(relativeOffsetOfLocalFileHeader));
+                    HashUInt32(hashAlgorithm, relativeOffsetOfLocalFileHeader);
 
                     // Continue hashing file name, extra field, and file comment fields.
                     SignedPackageArchiveIOUtility.ReadAndHashUntilPosition(reader, hashAlgorithm, reader.BaseStream.Position + record.HeaderSize - CentralDirectoryHeader.SizeInBytesOfFixedLengthFields);
@@ -477,15 +497,15 @@ namespace NuGet.Packaging.Signing
                 var eocdrTotalEntries = (ushort)(reader.ReadUInt16() - 1);
                 var eocdrTotalEntriesOnDisk = (ushort)(reader.ReadUInt16() - 1);
 
-                SignedPackageArchiveIOUtility.HashBytes(hashAlgorithm, BitConverter.GetBytes(eocdrTotalEntries));
-                SignedPackageArchiveIOUtility.HashBytes(hashAlgorithm, BitConverter.GetBytes(eocdrTotalEntriesOnDisk));
+                HashUInt16(hashAlgorithm, eocdrTotalEntries);
+                HashUInt16(hashAlgorithm, eocdrTotalEntriesOnDisk);
 
                 // update the central directory size by substracting the size of the package signature file's central directory header
                 var eocdrSizeOfCentralDirectory = (uint)(reader.ReadUInt32() - signatureCentralDirectoryHeader.HeaderSize);
-                SignedPackageArchiveIOUtility.HashBytes(hashAlgorithm, BitConverter.GetBytes(eocdrSizeOfCentralDirectory));
+                HashUInt32(hashAlgorithm, eocdrSizeOfCentralDirectory);
 
                 var eocdrOffsetOfCentralDirectory = reader.ReadUInt32() - (uint)signatureCentralDirectoryHeader.FileEntryTotalSize;
-                SignedPackageArchiveIOUtility.HashBytes(hashAlgorithm, BitConverter.GetBytes(eocdrOffsetOfCentralDirectory));
+                HashUInt32(hashAlgorithm, eocdrOffsetOfCentralDirectory);
 
                 // Hash until the end of the reader
                 SignedPackageArchiveIOUtility.ReadAndHashUntilPosition(reader, hashAlgorithm, reader.BaseStream.Length);
@@ -546,6 +566,26 @@ namespace NuGet.Packaging.Signing
             return centralDirectoryRecordsList;
         }
 
+        internal static void HashUInt16(Sha512HashFunction hashFunc, ushort value)
+        {
+            byte[] array = BitConverter.GetBytes(value);
+            if (!BitConverter.IsLittleEndian)
+            {
+                    Array.Reverse(array);
+            }
+            SignedPackageArchiveIOUtility.HashBytes(hashFunc, array);
+        }
+
+        internal static void HashUInt32(Sha512HashFunction hashFunc, uint value)
+        {
+            byte[] array = BitConverter.GetBytes(value);
+            if (!BitConverter.IsLittleEndian)
+            {
+                    Array.Reverse(array);
+            }
+            SignedPackageArchiveIOUtility.HashBytes(hashFunc, array);
+        }
+
         internal static string GetPackageContentHash(BinaryReader reader)
         {
             using (var hashFunc = new Sha512HashFunction())
@@ -578,7 +618,7 @@ namespace NuGet.Packaging.Signing
                     SignedPackageArchiveIOUtility.ReadAndHashUntilPosition(reader, hashFunc, reader.BaseStream.Position + 42);
 
                     var relativeOffsetOfLocalFileHeader = (uint)(reader.ReadUInt32() + record.ChangeInOffset);
-                    SignedPackageArchiveIOUtility.HashBytes(hashFunc, BitConverter.GetBytes(relativeOffsetOfLocalFileHeader));
+                    HashUInt32(hashFunc, relativeOffsetOfLocalFileHeader);
 
                     // Continue hashing file name, extra field, and file comment fields.
                     SignedPackageArchiveIOUtility.ReadAndHashUntilPosition(reader, hashFunc, reader.BaseStream.Position + record.HeaderSize - CentralDirectoryHeader.SizeInBytesOfFixedLengthFields);
@@ -592,15 +632,15 @@ namespace NuGet.Packaging.Signing
                 var eocdrTotalEntries = (ushort)(reader.ReadUInt16() - 1);
                 var eocdrTotalEntriesOnDisk = (ushort)(reader.ReadUInt16() - 1);
 
-                SignedPackageArchiveIOUtility.HashBytes(hashFunc, BitConverter.GetBytes(eocdrTotalEntries));
-                SignedPackageArchiveIOUtility.HashBytes(hashFunc, BitConverter.GetBytes(eocdrTotalEntriesOnDisk));
+                HashUInt16(hashFunc, eocdrTotalEntries);
+                HashUInt16(hashFunc, eocdrTotalEntriesOnDisk);
 
                 // update the central directory size by substracting the size of the package signature file's central directory header
                 var eocdrSizeOfCentralDirectory = (uint)(reader.ReadUInt32() - signatureCentralDirectoryHeader.HeaderSize);
-                SignedPackageArchiveIOUtility.HashBytes(hashFunc, BitConverter.GetBytes(eocdrSizeOfCentralDirectory));
+                HashUInt32(hashFunc, eocdrSizeOfCentralDirectory);
 
                 var eocdrOffsetOfCentralDirectory = reader.ReadUInt32() - (uint)signatureCentralDirectoryHeader.FileEntryTotalSize;
-                SignedPackageArchiveIOUtility.HashBytes(hashFunc, BitConverter.GetBytes(eocdrOffsetOfCentralDirectory));
+                HashUInt32(hashFunc, eocdrOffsetOfCentralDirectory);
 
                 // Hash until the end of the reader
                 SignedPackageArchiveIOUtility.ReadAndHashUntilPosition(reader, hashFunc, reader.BaseStream.Length);


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/10567

Regression? Last working version:  n/a

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
We are currently working on bringing up .NET on the IBM Z architecture (s390x-ibm-linux), which uses big-endian byte order. During that process we have run into an endian-specific bug in nuget code, specifically during package signature verification.

The code in SignedPackageArchiveUtility (VerifySignedPackageIntegrity and GetPackageContentHash) in some places does not hash the original package file contents but a slightly modified version.  In doing so, it needs to handle the fact that the binary image uses little-endian byte order.  It does so correctly when reading the original values (using BinaryReader primitives that are endian-safe), but when subsequently hashing the locally modified values, it simply uses BitConverter.GetBytes, which returns a byte buffer in host order, which may not be little-endian.  Add appropriate byte-swaps on big-endian host systems.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception - already covered by existing tests on big-endian machines
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
