### PR TITLE
set maximumCpuCount to true on the applicable MSBuild tasks on CI for building in parallel

### DIFF
--- a/eng/pipelines/templates/Apex_Tests_On_Windows.yml
+++ b/eng/pipelines/templates/Apex_Tests_On_Windows.yml
@@ -80,6 +80,7 @@ steps:
     msbuildVersion: "16.0"
     configuration: "$(BuildConfiguration)"
     msbuildArguments: "/t:ApexTestsStandalone /p:TestResultOutputFormat=xml /p:BuildNumber=$(BuildNumber)"
+    maximumCpuCount: true
   condition: "and(succeeded(), eq(variables['IsOfficialBuild'], 'true'))"
 
 - task: MSBuild@1
@@ -91,6 +92,7 @@ steps:
     msbuildVersion: "16.0"
     configuration: "$(BuildConfiguration)"
     msbuildArguments: "/t:ApexTestsStandalone /p:TestResultOutputFormat=xml /p:BuildNumber=$(BuildNumber)"
+    maximumCpuCount: true
   condition: "and(succeeded(), not(eq(variables['IsOfficialBuild'], 'true')))"
 
 - task: PublishTestResults@2

--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -106,7 +106,6 @@ steps:
     solution: "build\\build.proj"
     msbuildVersion: "16.0"
     msbuildArguments: "/t:EnsurePackageReferenceVersionsInSolution"
-    maximumCpuCount: true
   condition: "and(succeeded(), or(eq(variables['IsOfficialBuild'], 'true'), eq(variables['BuildRTM'], 'true')))"  #skip this task for nonRTM in private build
 
 
@@ -237,7 +236,6 @@ steps:
     msbuildVersion: "16.0"
     configuration: "$(BuildConfiguration)"
     msbuildArguments: "/p:BuildNumber=$(BuildNumber) /p:IsVsixBuild=true"
-    maximumCpuCount: true
   condition: " and(succeeded(), eq(variables['BuildRTM'], 'false'))"
 
 - task: MSBuild@1

--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -78,6 +78,7 @@ steps:
     msbuildVersion: "16.0"
     configuration: "$(BuildConfiguration)"
     msbuildArguments: "/t:RestoreVS /p:BuildNumber=$(BuildNumber) /p:BuildRTM=$(BuildRTM) /v:m"
+    maximumCpuCount: true
 
 - task: MSBuild@1
   displayName: "Build for VS2019"
@@ -86,6 +87,7 @@ steps:
     msbuildVersion: "16.0"
     configuration: "$(BuildConfiguration)"
     msbuildArguments: "/t:BuildNoVSIX /p:BuildRTM=$(BuildRTM) /p:BuildNumber=$(BuildNumber) /p:SkipILMergeOfNuGetExe=true /p:GitRepositoryRemoteName=$(gitRepositoryRemoteName)"
+    maximumCpuCount: true
 
 - task: MSBuild@1
   displayName: "Ensure msbuild.exe can parse nuget.sln"
@@ -94,6 +96,7 @@ steps:
     solution: "nuget.sln"
     msbuildVersion: "16.0"
     msbuildArguments: "/t:EnsureNewtonsoftJsonVersion"
+    maximumCpuCount: true
   condition: "and(succeeded(), or(eq(variables['IsOfficialBuild'], 'true'), eq(variables['BuildRTM'], 'true')))"  #skip this task for nonRTM in private build
 
 - task: MSBuild@1
@@ -103,6 +106,7 @@ steps:
     solution: "build\\build.proj"
     msbuildVersion: "16.0"
     msbuildArguments: "/t:EnsurePackageReferenceVersionsInSolution"
+    maximumCpuCount: true
   condition: "and(succeeded(), or(eq(variables['IsOfficialBuild'], 'true'), eq(variables['BuildRTM'], 'true')))"  #skip this task for nonRTM in private build
 
 
@@ -194,6 +198,7 @@ steps:
     msbuildVersion: "16.0"
     configuration: "$(BuildConfiguration)"
     msbuildArguments: "/t:AfterBuild"
+    maximumCpuCount: true
   condition: and(succeeded(), or(eq(variables['IsOfficialBuild'], 'true'), eq(variables['BuildRTM'], 'true')))  #skip this task for nonRTM in private build
 
 - task: MSBuild@1
@@ -203,6 +208,7 @@ steps:
     msbuildVersion: "16.0"
     configuration: "$(BuildConfiguration)"
     msbuildArguments: "/t:Pack /p:BuildRTM=$(BuildRTM) /p:ExcludeTestProjects=$(BuildRTM) /p:BuildNumber=$(BuildNumber)"
+    maximumCpuCount: true
   condition: and(succeeded(), or(eq(variables['IsOfficialBuild'], 'true'), eq(variables['BuildRTM'], 'true')))  #skip this task for nonRTM in private build
 
 - task: MSBuild@1
@@ -221,6 +227,7 @@ steps:
     msbuildVersion: "16.0"
     configuration: "$(BuildConfiguration)"
     msbuildArguments: "/t:BuildVSIX /p:BuildRTM=$(BuildRTM) /p:ExcludeTestProjects=$(BuildRTM) /p:IsCIBuild=true"
+    maximumCpuCount: true
   condition: "and(succeeded(),eq(variables['BuildRTM'], 'false'))"
 
 - task: MSBuild@1
@@ -230,6 +237,7 @@ steps:
     msbuildVersion: "16.0"
     configuration: "$(BuildConfiguration)"
     msbuildArguments: "/p:BuildNumber=$(BuildNumber) /p:IsVsixBuild=true"
+    maximumCpuCount: true
   condition: " and(succeeded(), eq(variables['BuildRTM'], 'false'))"
 
 - task: MSBuild@1
@@ -431,6 +439,7 @@ steps:
     msbuildVersion: "16.0"
     configuration: "$(BuildConfiguration)"
     msbuildArguments: "/p:IsSymbolBuild=true /p:BuildRTM=$(BuildRTM)"
+    maximumCpuCount: true
   condition: " and(succeeded(), eq(variables['IsOfficialBuild'], 'true')) "
 
 - task: CopyFiles@2

--- a/eng/pipelines/templates/Functional_Tests_On_Windows.yml
+++ b/eng/pipelines/templates/Functional_Tests_On_Windows.yml
@@ -40,6 +40,7 @@ steps:
     msbuildVersion: "16.0"
     configuration: "$(BuildConfiguration)"
     msbuildArguments: "/t:CoreFuncTests /p:BuildRTM=false /p:BuildNumber=$(BuildNumber) /p:TestResultOutputFormat=xml /p:SkipDesktopAssemblies=$(SkipDesktopAssemblies) /p:SkipCoreAssemblies=$(SkipCoreAssemblies)"
+    maximumCpuCount: true
   condition: "and(succeeded(), eq(variables['IsOfficialBuild'], 'true'))"
 
 - task: MSBuild@1
@@ -50,6 +51,7 @@ steps:
     msbuildVersion: "16.0"
     configuration: "$(BuildConfiguration)"
     msbuildArguments: "/t:CoreFuncTests /p:BuildRTM=false /p:BuildNumber=$(BuildNumber) /p:TestResultOutputFormat=xml /p:SkipDesktopAssemblies=$(SkipDesktopAssemblies) /p:SkipCoreAssemblies=$(SkipCoreAssemblies)"
+    maximumCpuCount: true
   condition: "and(succeeded(), not(eq(variables['IsOfficialBuild'], 'true')))"
 
 - task: PublishTestResults@2


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/829

Regression? Last working version: No

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
After reading from [this](https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/build/msbuild?view=azure-devops#arguments) and [this](https://docs.microsoft.com/en-us/visualstudio/msbuild/building-multiple-projects-in-parallel-with-msbuild?view=vs-2019#-maxcpucount-switch) docs, I learnt over the weekend that we could make use of the no. of cores while running MSBuild tasks on CI for building in parallel. Let me know the feedback. Happy to close this PR if the team thinks that performance gain is not great.  My proposal would be to try running few official builds with this change so that we can make data driven decision about the timing improvements.

We have around `26` MBuild Tasks in our CI pipeline. I scanned through the logs of these build steps to check if passing `maximumCpuCount to true` makes use of available cores on the machine while running the step.

Job Name | Step | Enabled Parallelism | Comments
-- | -- | -- | --
Build_And_UnitTest_NonRTM/RTM | Restore for VS2019 | Yes | Compared   to last successful PR build the current build showed an improvement of ~5   seconds
Build_And_UnitTest_NonRTM/RTM | Build for VS2019 | Yes | Compared to last successful official   build the current build showed an improvement of ~30 seconds
Build_And_UnitTest_NonRTM/RTM | Ensure msbuild.exe can parse nuget.sln | Yes | Compared   to last successful official build the current build showed an improvement of   ~3 seconds
Build_And_UnitTest_NonRTM/RTM | Ensure package   versions are declared in packages.targets |   |  
Build_And_UnitTest_NonRTM/RTM | Localize   Assemblies |   |  
Build_And_UnitTest_NonRTM/RTM | Build Final NuGet.exe (via ILMerge) |   |  
Build_And_UnitTest_NonRTM/RTM | Publish   NuGet.exe (ILMerged) into NuGet.CommandLine.Test (Mac tests use this) |   |  
Build_And_UnitTest_NonRTM/RTM | Run unit tests (stop on error) |   |  
Build_And_UnitTest_NonRTM/RTM | Run unit tests   (continue on error) |   |  
Build_And_UnitTest_NonRTM/RTM | Sign Assemblies | Yes | Compared to last successful PR build the   current build showed an improvement of ~30 seconds
Build_And_UnitTest_NonRTM/RTM | Pack Nupkgs | Yes | Compared   to last successful PR build the current build showed an improvement of ~2   seconds
Build_And_UnitTest_NonRTM/RTM | Ensure all Nupkgs and Symbols are created |   |  
Build_And_UnitTest_NonRTM/RTM | Pack VSIX | Yes | Skipped   for PR builds hence no comparison information
Build_And_UnitTest_NonRTM/RTM | Generate Build Tools   package |   |  
Build_And_UnitTest_NonRTM/RTM | Sign Nupkgs and   VSIX |   |  
Build_And_UnitTest_NonRTM/RTM | Generate VSMAN file for NuGet Core VSIX |   |  
Build_And_UnitTest_NonRTM/RTM | Generate VSMAN   file for Build Tools VSIX |   |  
Build_And_UnitTest_NonRTM/RTM | OptProfV2:  generate   a .runsettings file |   |  
Build_And_UnitTest_NonRTM/RTM | Collect Build Symbols | Yes | Skipped   for PR builds hence no comparison information
Functional_Tests_On_Windows   IsDesktop/IsCore | Restore for VS2019 |   |  
Functional_Tests_On_Windows   IsDesktop/IsCore | Run Functional Tests (continue on error) | Yes | Skipped   for PR builds hence no comparision information
Functional_Tests_On_Windows   IsDesktop/IsCore | Run Functional Tests (stop on error) | Yes | Compared to last successful PR buid the   current build showed an improvement of ~50 seconds
Apex_Tests_On_Windows | Bootstrap NuGet   packages |   |  
Apex_Tests_On_Windows | Restore Apex Tests |   |  
Apex_Tests_On_Windows | Run Apex Tests (stop on error) | Yes | Compared to last successful   PR build the current build showed no improvement but from the logs I noticed   that MSBuild ran the build on different cores on the machine.
Apex_Tests_On_Windows | Run Apex Tests (continue on error) | Yes | Skipped for PR builds hence no   comparison information

Official Build used for comparison to calculate time improvements - https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=4512330&view=results
Last PR build used for comparison to calculate time improvements - https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=4513215&view=results

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [x] N/A
