### PR TITLE
Change 35 tests to use SimpleTestPathContext for better isolation, so that they could run in parallel

### DIFF
--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Util.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Util.cs
@@ -1061,19 +1061,6 @@ EndProject";
                  </Project>".Replace("$NAME$", projectName);
         }
 
-        public static void ClearWebCache()
-        {
-            var nugetExe = Util.GetNuGetExePath();
-
-            var r = CommandRunner.Run(
-            nugetExe,
-            ".",
-            "locals http-cache -Clear",
-            waitForExit: true);
-
-            Assert.Equal(0, r.Item1);
-        }
-
         public static string CreateBasicTwoProjectSolution(TestDirectory workingPath, string proj1ConfigFileName, string proj2ConfigFileName)
         {
             var repositoryPath = Path.Combine(workingPath, "Repository");

--- a/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestSettingsContext.cs
+++ b/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestSettingsContext.cs
@@ -110,11 +110,41 @@ namespace NuGet.Test.Utility
             return node;
         }
 
+        public static void AddPackageSourceCredentialsSection(XDocument doc, string sourceName, string userName, string password, bool clearTextPassword)
+        {
+            var root = doc.Element(XName.Get("configuration"));
+
+            var sourceNode = new XElement(XName.Get(sourceName));
+            AddEntry(sourceNode, "Username", userName);
+            if (clearTextPassword)
+            {
+                AddEntry(sourceNode, "ClearTextPassword", password);
+            }
+            else
+            {
+                AddEntry(sourceNode, "Password", password);
+            }
+
+            var packageSourceCredentialsNode = new XElement(XName.Get("packageSourceCredentials"));
+            packageSourceCredentialsNode.Add(sourceNode);
+
+            root.Add(packageSourceCredentialsNode);
+        }
+
         public static void AddEntry(XElement section, string key, string value)
         {
             var setting = new XElement(XName.Get("add"));
             setting.Add(new XAttribute(XName.Get("key"), key));
             setting.Add(new XAttribute(XName.Get("value"), value));
+            section.Add(setting);
+        }
+
+        public static void AddEntry(XElement section, string key, string value, string additionalAtrributeName, string additionalAttributeValue)
+        {
+            var setting = new XElement(XName.Get("add"));
+            setting.Add(new XAttribute(XName.Get("key"), key));
+            setting.Add(new XAttribute(XName.Get("value"), value));
+            setting.Add(new XAttribute(XName.Get(additionalAtrributeName), additionalAttributeValue));
             section.Add(setting);
         }
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes:
This is a progress on making NuGet.CommandLine.Tests be able to run in parallel NuGet/Client.Engineering#518

Regression? Last working version:
No.

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
Details:
Util.ClearWebCache() clears the default shared http-cache. It will cause problem when running tests in parallel.
So this fix 
1.Changed the 35 tests to use SimpleTestPathContext for better isolation.
2.Delete Util.ClearWebCache() 
3.Add two methods in SimpleTestSettingsContext.cs. 
   `AddPackageSourceCredentialsSection` : add PackageSourceCredentials section
   `AddEntry ` : an overload method to add extra attributes for key value pair, such as protocolVersion="3"  in   `<add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />`
## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
