### PR TITLE
CI builds should use 1 as the minimum build number

### DIFF
--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -15,7 +15,7 @@ jobs:
   timeoutInMinutes: 10
   variables:
     SemanticVersion: $[dependencies.Initialize_Build_SemanticVersion.outputs['setsemanticversion.SemanticVersion']]
-    BuildRevision: $[counter(format('{0}.{1}', variables['SemanticVersion'], variables['build.definitionname']), 0)]
+    BuildRevision: $[counter(format('{0}.{1}', variables['SemanticVersion'], variables['build.definitionname']), 1)]
 
   pool:
     vmImage: windows-latest


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/844

Regression? n/a

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Our build scripts treat build number 0 as special. Rather than changing that build script, it's easier to just set the minimum build number to 1.

## PR Checklist

- [X] PR has a meaningful title
- [X] PR has a linked issue.
- [X] Described changes

- **Tests**
  - [X] N/A (Infrastructure)

- **Documentation**
  - [X] N/A
