### PR TITLE
Update the background and foreground colors of the PMUI under experimentation flag

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Experimentation/ExperimentationConstants.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Experimentation/ExperimentationConstants.cs
@@ -1,0 +1,18 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGet.PackageManagement.UI
+{
+    internal static class ExperimentationConstants
+    {
+        internal static class FlightFlags
+        {
+            public const string PackageManagerBackgroundColor = "nuGetPackageManagerBackgroundColor";
+        }
+
+        internal static class EnvironmentVariables
+        {
+            public const string PackageManagerBackgroundColor = "NUGET_PACKAGE_MANAGER_BACKGROUND_COLOR";
+        }
+    }
+}

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/NuGet.PackageManagement.UI.csproj
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/NuGet.PackageManagement.UI.csproj
@@ -73,6 +73,7 @@
     <Compile Include="Converters\EnumDescriptionValueConverter.cs" />
     <Compile Include="Converters\NotNullOrTrueToBooleanConverter.cs" />
     <Compile Include="DisplayVersion.cs" />
+    <Compile Include="Experimentation\ExperimentationConstants.cs" />
     <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="IPackageItemLoader.cs" />
     <Compile Include="Models\FreeText.cs" />

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources/Brushes.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources/Brushes.cs
@@ -2,10 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
+using System.Security;
 using System.Windows;
+using Microsoft.VisualStudio.Experimentation;
 using Microsoft.VisualStudio.PlatformUI;
 using Microsoft.VisualStudio.Shell;
 
@@ -174,25 +173,27 @@ namespace NuGet.PackageManagement.UI
 
         public static void LoadVsBrushes()
         {
+            var isBgColorFlightEnabled = IsBackgroundColorFlightEnabled();
+
             FocusVisualStyleBrushKey = VsBrushes.ToolWindowTextKey;
             ActiveBorderKey = VsBrushes.ActiveBorderKey;
             BorderBrush = VsBrushes.BrandedUIBorderKey;
             ComboBoxBorderKey = VsBrushes.ComboBoxBorderKey;
             ControlLinkTextHoverKey = VsBrushes.ControlLinkTextHoverKey;
             ControlLinkTextKey = VsBrushes.ControlLinkTextKey;
-            DetailPaneBackground = VsBrushes.BrandedUIBackgroundKey;
-            HeaderBackground = VsBrushes.BrandedUIBackgroundKey;
+            DetailPaneBackground = isBgColorFlightEnabled ? CommonDocumentColors.PageBrushKey : VsBrushes.BrandedUIBackgroundKey;
+            HeaderBackground = isBgColorFlightEnabled ? CommonDocumentColors.PageBrushKey : VsBrushes.BrandedUIBackgroundKey;
             InfoBackgroundKey = VsBrushes.InfoBackgroundKey;
             InfoTextKey = VsBrushes.InfoTextKey;
-            LegalMessageBackground = VsBrushes.BrandedUIBackgroundKey;
-            ListPaneBackground = VsBrushes.BrandedUIBackgroundKey;
+            LegalMessageBackground = isBgColorFlightEnabled ? CommonDocumentColors.PageBrushKey : VsBrushes.BrandedUIBackgroundKey;
+            ListPaneBackground = isBgColorFlightEnabled ? CommonDocumentColors.PageBrushKey : VsBrushes.BrandedUIBackgroundKey;
             SplitterBackgroundKey = VsBrushes.CommandShelfBackgroundGradientKey;
             ToolWindowBorderKey = VsBrushes.ToolWindowBorderKey;
             ToolWindowButtonDownBorderKey = VsBrushes.ToolWindowButtonDownBorderKey;
             ToolWindowButtonDownKey = VsBrushes.ToolWindowButtonDownKey;
             ToolWindowButtonHoverActiveBorderKey = VsBrushes.ToolWindowButtonHoverActiveBorderKey;
             ToolWindowButtonHoverActiveKey = VsBrushes.ToolWindowButtonHoverActiveKey;
-            UIText = VsBrushes.BrandedUITextKey;
+            UIText = isBgColorFlightEnabled ? CommonDocumentColors.PageTextBrushKey : VsBrushes.BrandedUITextKey;
             WindowTextKey = VsBrushes.WindowTextKey;
 
             HeaderColorsDefaultBrushKey = HeaderColors.DefaultBrushKey;
@@ -257,6 +258,21 @@ namespace NuGet.PackageManagement.UI
             // Mapping color keys directly for use to create brushes using these colors
             ListItemBackgroundSelectedColorKey = CommonDocumentColors.ListItemBackgroundSelectedColorKey;
             ListItemTextSelectedColorKey = CommonDocumentColors.ListItemTextSelectedColorKey;
+        }
+
+        private static bool IsBackgroundColorFlightEnabled()
+        {
+            var forceFlightEnabled = false;
+            try
+            {
+                forceFlightEnabled = Environment.GetEnvironmentVariable(ExperimentationConstants.EnvironmentVariables.PackageManagerBackgroundColor) == "1";
+            }
+            catch (SecurityException)
+            {
+                // Don't force the flight to be enabled if we are not able to read the environment variable
+            }
+
+            return forceFlightEnabled || ExperimentationService.Default.IsCachedFlightEnabled(ExperimentationConstants.FlightFlags.PackageManagerBackgroundColor);
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources/Brushes.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources/Brushes.cs
@@ -173,7 +173,7 @@ namespace NuGet.PackageManagement.UI
 
         public static void LoadVsBrushes()
         {
-            var isBgColorFlightEnabled = IsBackgroundColorFlightEnabled();
+            bool isBgColorFlightEnabled = IsBackgroundColorFlightEnabled();
 
             FocusVisualStyleBrushKey = VsBrushes.ToolWindowTextKey;
             ActiveBorderKey = VsBrushes.ActiveBorderKey;
@@ -260,7 +260,11 @@ namespace NuGet.PackageManagement.UI
             ListItemTextSelectedColorKey = CommonDocumentColors.ListItemTextSelectedColorKey;
         }
 
-        private static bool IsBackgroundColorFlightEnabled()
+        private static bool IsBackgroundColorFlightEnabled() =>
+            ExperimentationService.Default.IsCachedFlightEnabled(ExperimentationConstants.FlightFlags.PackageManagerBackgroundColor)
+            || IsForceBackgroundColorFlightEnabled();
+
+        private static bool IsForceBackgroundColorFlightEnabled()
         {
             var forceFlightEnabled = false;
             try
@@ -271,8 +275,7 @@ namespace NuGet.PackageManagement.UI
             {
                 // Don't force the flight to be enabled if we are not able to read the environment variable
             }
-
-            return forceFlightEnabled || ExperimentationService.Default.IsCachedFlightEnabled(ExperimentationConstants.FlightFlags.PackageManagerBackgroundColor);
+            return forceFlightEnabled;
         }
     }
 }


### PR DESCRIPTION
## Bug

Fixes: https://github.com/nuget/home/issues/10608

Regression? Last working version: N/A

## Description
Updated the background and foreground colors of the PMUI to use VS recommended colors for doc well UI and put this behind an experimentation flag with an environment variable override for debugging.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
Change affects the visual appearance, (background and foreground colors) and does not affect business logic. Manually tested by ensuring the change did not take effect while the environment variable override was not set (as experiment is not yet active) and that the changes appeared when it was set.
  - [x] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
