### PR TITLE
Save binlog for some steps in CI builds

### DIFF
--- a/eng/pipelines/templates/Apex_Tests_On_Windows.yml
+++ b/eng/pipelines/templates/Apex_Tests_On_Windows.yml
@@ -23,7 +23,7 @@ steps:
     solution: "build\\bootstrap.proj"
     msbuildVersion: "16.0"
     configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/t:Restore"
+    msbuildArguments: "/t:Restore -bl:$(Build.Repository.LocalPath)\\artifacts\\binlog\\bootstrap.binlog"
 
 - task: PowerShell@1
   displayName: "Bootstrap.ps1"
@@ -69,7 +69,7 @@ steps:
     solution: "build\\build.proj"
     msbuildVersion: "16.0"
     configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/t:RestoreApex /p:BuildNumber=$(BuildNumber)"
+    msbuildArguments: "/t:RestoreApex /p:BuildNumber=$(BuildNumber) -bl:$(Build.Repositoru.LocalPath)\\artifacts\\binlog\\restore.binlog"
 
 - task: MSBuild@1
   displayName: "Run Apex Tests (continue on error)"
@@ -79,7 +79,7 @@ steps:
     solution: "build\\build.proj"
     msbuildVersion: "16.0"
     configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/t:ApexTestsStandalone /p:TestResultOutputFormat=xml /p:BuildNumber=$(BuildNumber)"
+    msbuildArguments: "/t:ApexTestsStandalone /p:TestResultOutputFormat=xml /p:BuildNumber=$(BuildNumber) -bl:$(Build.Repository.LocalPath)\\artifacts\\binlog\\test.binlog"
     maximumCpuCount: true
   condition: "and(succeeded(), eq(variables['IsOfficialBuild'], 'true'))"
 
@@ -91,7 +91,7 @@ steps:
     solution: "build\\build.proj"
     msbuildVersion: "16.0"
     configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/t:ApexTestsStandalone /p:TestResultOutputFormat=xml /p:BuildNumber=$(BuildNumber)"
+    msbuildArguments: "/t:ApexTestsStandalone /p:TestResultOutputFormat=xml /p:BuildNumber=$(BuildNumber) -bl:$(Build.Repository.LocalPath)\\artifacts\\binlog\\test.binlog"
     maximumCpuCount: true
   condition: "and(succeeded(), not(eq(variables['IsOfficialBuild'], 'true')))"
 
@@ -104,6 +104,13 @@ steps:
     mergeTestResults: "true"
     testRunTitle: "NuGet.Client Apex Tests On Windows"
   condition: "succeededOrFailed()"
+
+- task: PublishPipelineArtifact@1
+  displayName: "Publish binlogs"
+  inputs:
+    artifactName: binlog - $(Agent.JobName)
+    targetPath: "$(Build.Repository.LocalPath)\\artifacts\\binlog"
+  condition: "always()"
 
 - task: PowerShell@1
   displayName: "Initialize Git Commit Status on GitHub"

--- a/eng/pipelines/templates/Apex_Tests_On_Windows.yml
+++ b/eng/pipelines/templates/Apex_Tests_On_Windows.yml
@@ -108,7 +108,7 @@ steps:
 - task: PublishPipelineArtifact@1
   displayName: "Publish binlogs"
   inputs:
-    artifactName: binlog - $(Agent.JobName)
+    artifactName: binlog - $(Agent.JobName) - Attempt $(System.JobAttempt)
     targetPath: "$(Build.Repository.LocalPath)\\artifacts\\binlog"
   condition: "always()"
 

--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -514,7 +514,7 @@ steps:
 - task: PublishPipelineArtifact@1
   displayName: "Publish binlogs"
   inputs:
-    artifactName: binlog - $(Agent.JobName)
+    artifactName: binlog - $(Agent.JobName) - Attempt $(System.JobAttempt)
     targetPath: "$(Build.Repository.LocalPath)\\artifacts\\binlog"
   condition: "always()"
 

--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -77,7 +77,7 @@ steps:
     solution: "build\\build.proj"
     msbuildVersion: "16.0"
     configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/t:RestoreVS /p:BuildNumber=$(BuildNumber) /p:BuildRTM=$(BuildRTM) /v:m"
+    msbuildArguments: "/t:RestoreVS /p:BuildNumber=$(BuildNumber) /p:BuildRTM=$(BuildRTM) /v:m -bl:$(Build.Repository.LocalPath)\\artifacts\\binlog\\restore.binlog"
     maximumCpuCount: true
 
 - task: MSBuild@1
@@ -86,7 +86,7 @@ steps:
     solution: "build\\build.proj"
     msbuildVersion: "16.0"
     configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/t:BuildNoVSIX /p:BuildRTM=$(BuildRTM) /p:BuildNumber=$(BuildNumber) /p:SkipILMergeOfNuGetExe=true /p:GitRepositoryRemoteName=$(gitRepositoryRemoteName)"
+    msbuildArguments: "/t:BuildNoVSIX /p:BuildRTM=$(BuildRTM) /p:BuildNumber=$(BuildNumber) /p:SkipILMergeOfNuGetExe=true /p:GitRepositoryRemoteName=$(gitRepositoryRemoteName) -bl:$(Build.Repository.LocalPath)\\artifacts\\binlog\\build.binlog"
     maximumCpuCount: true
 
 - task: MSBuild@1
@@ -95,7 +95,7 @@ steps:
   inputs:
     solution: "nuget.sln"
     msbuildVersion: "16.0"
-    msbuildArguments: "/t:EnsureNewtonsoftJsonVersion"
+    msbuildArguments: "/t:EnsureNewtonsoftJsonVersion -bl:$(Build.Repository.LocalPath)\\artifacts\\binlog\\EnsureNewtonsoftJsonVersion.binlog"
     maximumCpuCount: true
   condition: "and(succeeded(), or(eq(variables['IsOfficialBuild'], 'true'), eq(variables['BuildRTM'], 'true')))"  #skip this task for nonRTM in private build
 
@@ -105,7 +105,7 @@ steps:
   inputs:
     solution: "build\\build.proj"
     msbuildVersion: "16.0"
-    msbuildArguments: "/t:EnsurePackageReferenceVersionsInSolution"
+    msbuildArguments: "/t:EnsurePackageReferenceVersionsInSolution -bl:$(Build.Repository.LocalPath)\\artifacts\\binlog\\EnsurePackageReferenceVersionsInSolution.binlog"
   condition: "and(succeeded(), or(eq(variables['IsOfficialBuild'], 'true'), eq(variables['BuildRTM'], 'true')))"  #skip this task for nonRTM in private build
 
 
@@ -115,7 +115,7 @@ steps:
     solution: "build\\loc.proj"
     msbuildVersion: "16.0"
     configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/t:AfterBuild"
+    msbuildArguments: "/t:AfterBuild -bl:$(Build.Repository.LocalPath)\\artifacts\\binlog\\localize.binlog"
 
 - task: MSBuild@1
   displayName: "Build Final NuGet.exe (via ILMerge)"
@@ -123,7 +123,7 @@ steps:
     solution: "src\\NuGet.Clients\\NuGet.CommandLine\\NuGet.CommandLine.csproj"
     msbuildVersion: "16.0"
     configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/t:ILMergeNuGetExe /p:ExpectedLocalizedArtifactCount=$(LocalizedLanguageCount)"
+    msbuildArguments: "/t:ILMergeNuGetExe /p:ExpectedLocalizedArtifactCount=$(LocalizedLanguageCount) -bl:$(Build.Repository.LocalPath)\\artifacts\\binlog\\ILMergeNuGetExe.binlog"
 
 - task: MSBuild@1
   displayName: "Publish NuGet.exe (ILMerged) into NuGet.CommandLine.Test (Mac tests use this)"
@@ -131,7 +131,7 @@ steps:
     solution: "test\\NuGet.Clients.Tests\\NuGet.CommandLine.Test\\NuGet.CommandLine.Test.csproj"
     msbuildVersion: "16.0"
     configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/t:CopyFinalNuGetExeToOutputPath"
+    msbuildArguments: "/t:CopyFinalNuGetExeToOutputPath -bl:$(Build.Repository.LocalPath)\\artifacts\\binlog\\CopyFinalNuGetExeToOutputPath.binlog"
   condition: "and(succeeded(),eq(variables['BuildRTM'], 'false'))"
 
 - task: MSBuild@1
@@ -141,7 +141,7 @@ steps:
     solution: "build\\build.proj"
     msbuildVersion: "16.0"
     configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/t:CoreUnitTests;UnitTestsVS /p:BuildRTM=$(BuildRTM) /p:BuildNumber=$(BuildNumber) /p:TestResultOutputFormat=xml /p:SkipILMergeOfNuGetExe=true"
+    msbuildArguments: "/t:CoreUnitTests;UnitTestsVS /p:BuildRTM=$(BuildRTM) /p:BuildNumber=$(BuildNumber) /p:TestResultOutputFormat=xml /p:SkipILMergeOfNuGetExe=true -bl:$(Build.Repository.LocalPath)\\artifacts\\binlog\\tests.binlog"
   condition: "and(succeeded(), eq(variables['BuildRTM'], 'true'), not(eq(variables['IsOfficialBuild'], 'true')))"
 
 - task: MSBuild@1
@@ -151,7 +151,7 @@ steps:
     solution: "build\\build.proj"
     msbuildVersion: "16.0"
     configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/t:CoreUnitTests;UnitTestsVS /p:BuildRTM=$(BuildRTM) /p:BuildNumber=$(BuildNumber) /p:TestResultOutputFormat=xml /p:SkipILMergeOfNuGetExe=true"
+    msbuildArguments: "/t:CoreUnitTests;UnitTestsVS /p:BuildRTM=$(BuildRTM) /p:BuildNumber=$(BuildNumber) /p:TestResultOutputFormat=xml /p:SkipILMergeOfNuGetExe=true -bl:$(Build.Repository.LocalPath)\\artifacts\\binlog\\tests.binlog"
   condition: "and(succeeded(), eq(variables['BuildRTM'], 'true'), eq(variables['IsOfficialBuild'], 'true'))"
 
 - task: PublishTestResults@2
@@ -196,7 +196,7 @@ steps:
     solution: "build\\sign.proj"
     msbuildVersion: "16.0"
     configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/t:AfterBuild"
+    msbuildArguments: "/t:AfterBuild -bl:$(Build.Repository.LocalPath)\\artifacts\\binlog\\sign.binlog"
     maximumCpuCount: true
   condition: and(succeeded(), or(eq(variables['IsOfficialBuild'], 'true'), eq(variables['BuildRTM'], 'true')))  #skip this task for nonRTM in private build
 
@@ -206,7 +206,7 @@ steps:
     solution: "build\\build.proj"
     msbuildVersion: "16.0"
     configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/t:Pack /p:BuildRTM=$(BuildRTM) /p:ExcludeTestProjects=$(BuildRTM) /p:BuildNumber=$(BuildNumber)"
+    msbuildArguments: "/t:Pack /p:BuildRTM=$(BuildRTM) /p:ExcludeTestProjects=$(BuildRTM) /p:BuildNumber=$(BuildNumber) -bl:$(Build.Repository.LocalPath)\\artifacts\\binlog\\pack.binlog"
     maximumCpuCount: true
   condition: and(succeeded(), or(eq(variables['IsOfficialBuild'], 'true'), eq(variables['BuildRTM'], 'true')))  #skip this task for nonRTM in private build
 
@@ -216,7 +216,7 @@ steps:
     solution: "build\\build.proj"
     msbuildVersion: "16.0"
     configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/t:EnsurePackagesExist /p:ExcludeTestProjects=$(BuildRTM)"
+    msbuildArguments: "/t:EnsurePackagesExist /p:ExcludeTestProjects=$(BuildRTM) -bl:$(Build.Repository.LocalPath)\\artifacts\\binlog\\EnsurePackagesExist.binlog"
   condition: and(succeeded(), or(eq(variables['IsOfficialBuild'], 'true'), eq(variables['BuildRTM'], 'true')))  #skip this task for nonRTM in private build
 
 - task: MSBuild@1
@@ -225,7 +225,7 @@ steps:
     solution: "build\\build.proj"
     msbuildVersion: "16.0"
     configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/t:BuildVSIX /p:BuildRTM=$(BuildRTM) /p:ExcludeTestProjects=$(BuildRTM) /p:IsCIBuild=true"
+    msbuildArguments: "/t:BuildVSIX /p:BuildRTM=$(BuildRTM) /p:ExcludeTestProjects=$(BuildRTM) /p:IsCIBuild=true -bl:$(Build.Repository.LocalPath)\\artifacts\\binlog\\BuildVSIX.binlog"
     maximumCpuCount: true
   condition: "and(succeeded(),eq(variables['BuildRTM'], 'false'))"
 
@@ -235,7 +235,7 @@ steps:
     solution: "setup/Microsoft.VisualStudio.NuGet.BuildTools.vsmanproj"
     msbuildVersion: "16.0"
     configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/p:BuildNumber=$(BuildNumber) /p:IsVsixBuild=true"
+    msbuildArguments: "/p:BuildNumber=$(BuildNumber) /p:IsVsixBuild=true -bl:$(Build.Repository.LocalPath)\\artifacts\\binlog\\BuildTools.binlog"
   condition: " and(succeeded(), eq(variables['BuildRTM'], 'false'))"
 
 - task: MSBuild@1
@@ -244,7 +244,7 @@ steps:
     solution: "build\\sign.proj"
     msbuildVersion: "16.0"
     configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/t:AfterBuild /p:SignPackages=true"
+    msbuildArguments: "/t:AfterBuild /p:SignPackages=true -bl:$(Build.Repository.LocalPath)\\artifacts\\binlog\\SignPackages.binlog"
   condition: and(succeeded(), or(eq(variables['IsOfficialBuild'], 'true'), eq(variables['BuildRTM'], 'true')))  #skip this task for nonRTM in private build
 
 - task: NuGetCommand@2
@@ -286,6 +286,7 @@ steps:
     solution: "setup\\Microsoft.VisualStudio.NuGet.Core.vsmanproj"
     msbuildVersion: "16.0"
     configuration: "$(BuildConfiguration)"
+    msbuildArguments: "-bl:$(Build.Repository.LocalPath)\\artifacts\\binlog\\NuGetCoreVsman.binlog"
   condition: " and(succeeded(),eq(variables['BuildRTM'], 'false')) "
 
 - task: MSBuild@1
@@ -294,6 +295,7 @@ steps:
     solution: "setup\\Microsoft.VisualStudio.NuGet.BuildTools.vsmanproj"
     msbuildVersion: "16.0"
     configuration: "$(BuildConfiguration)"
+    msbuildArguments: "-bl:$(Build.Repository.LocalPath)\\artifacts\\binlog\\BuildToolsVsman.binlog"
   condition: " and(succeeded(),eq(variables['BuildRTM'], 'false')) "
 
 - task: PowerShell@1
@@ -371,7 +373,7 @@ steps:
   inputs:
     solution: 'build\NuGet.OptProfV2.runsettingsproj'
     msbuildVersion: '16.0'
-    msbuildArguments: '/p:OutputPath="$(Build.Repository.LocalPath)\artifacts\RunSettings" /p:TestDrop="$(TestDrop)" /p:ProfilingInputsDrop="ProfilingInputs/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildId)"'
+    msbuildArguments: '/p:OutputPath="$(Build.Repository.LocalPath)\artifacts\RunSettings" /p:TestDrop="$(TestDrop)" /p:ProfilingInputsDrop="ProfilingInputs/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildId)" -bl:$(Build.Repository.LocalPath)\\artifacts\\binlog\\GenerateRunsettings.binlog'
   condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
 
 - task: ms-vscs-artifact.build-tasks.artifactDropTask-1.artifactDropTask@0
@@ -436,7 +438,7 @@ steps:
     solution: "build\\symbols.proj"
     msbuildVersion: "16.0"
     configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/p:IsSymbolBuild=true /p:BuildRTM=$(BuildRTM)"
+    msbuildArguments: "/p:IsSymbolBuild=true /p:BuildRTM=$(BuildRTM) -bl:$(Build.Repository.LocalPath)\\artifacts\\binlog\\CollectSymbols.binlog"
     maximumCpuCount: true
   condition: " and(succeeded(), eq(variables['IsOfficialBuild'], 'true')) "
 
@@ -501,13 +503,20 @@ steps:
 - task: CmdLine@2
   displayName: "Publish to the .NET Core build asset registry (BAR)"
   inputs:
-    script: dotnet msbuild $(Build.Repository.LocalPath)\build\publish.proj /t:PublishToBuildAssetRegistry /p:NuGetClientNupkgsDirectoryPath=$(Build.Repository.LocalPath)\artifacts\$(NupkgOutputDir) /p:BUILD_BUILDNUMBER=$(Build.BuildNumber) /p:BUILD_SOURCEBRANCH=$(Build.SourceBranchName) /p:BUILD_SOURCEVERSION=$(Build.SourceVersion) /p:BUILD_REPOSITORY_URI=$(Build.Repository.Uri)  /p:BUILD_REPOSITORY_NAME=$(Build.Repository.Name) /p:ArtifactsLogDir=$(Build.Repository.LocalPath)\artifacts\manifests\ /p:MaestroApiEndpoint=$(MaestroApiEndpoint) /p:MaestroAccessToken=$(MaestroAccessToken)
+    script: dotnet msbuild $(Build.Repository.LocalPath)\build\publish.proj /t:PublishToBuildAssetRegistry /p:NuGetClientNupkgsDirectoryPath=$(Build.Repository.LocalPath)\artifacts\$(NupkgOutputDir) /p:BUILD_BUILDNUMBER=$(Build.BuildNumber) /p:BUILD_SOURCEBRANCH=$(Build.SourceBranchName) /p:BUILD_SOURCEVERSION=$(Build.SourceVersion) /p:BUILD_REPOSITORY_URI=$(Build.Repository.Uri)  /p:BUILD_REPOSITORY_NAME=$(Build.Repository.Name) /p:ArtifactsLogDir=$(Build.Repository.LocalPath)\artifacts\manifests\ /p:MaestroApiEndpoint=$(MaestroApiEndpoint) /p:MaestroAccessToken=$(MaestroAccessToken) -bl:$(Build.Repository.LocalPath)\\artifacts\\binlog\\PublishBAR.binlog
     workingDirectory: cli
     failOnStderr: true
   env:
     DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
     DOTNET_MULTILEVEL_LOOKUP: true
   condition: " and(succeeded(),eq(variables['PublishArtifactsToDotNetBuildAssetRegistry'], 'true'), eq(variables['BuildRTM'], 'false')) "
+
+- task: PublishPipelineArtifact@1
+  displayName: "Publish binlogs"
+  inputs:
+    artifactName: binlog - $(Agent.JobName)
+    targetPath: "$(Build.Repository.LocalPath)\\artifacts\\binlog"
+  condition: "always()"
 
 - task: MicroBuildCleanup@1
   displayName: "Perform Cleanup Tasks"

--- a/eng/pipelines/templates/Functional_Tests_On_Windows.yml
+++ b/eng/pipelines/templates/Functional_Tests_On_Windows.yml
@@ -76,7 +76,7 @@ steps:
 - task: PublishPipelineArtifact@1
   displayName: "Publish binlogs"
   inputs:
-    artifactName: binlog - $(Agent.JobName)
+    artifactName: binlog - $(Agent.JobName) - Attempt $(System.JobAttempt)
     targetPath: "$(Build.Repository.LocalPath)\\artifacts\\binlog"
   condition: "always()"
 

--- a/eng/pipelines/templates/Functional_Tests_On_Windows.yml
+++ b/eng/pipelines/templates/Functional_Tests_On_Windows.yml
@@ -30,7 +30,7 @@ steps:
     solution: "build\\build.proj"
     msbuildVersion: "16.0"
     configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/t:RestoreVS /p:BuildNumber=$(BuildNumber) /p:BuildRTM=false /v:m"
+    msbuildArguments: "/t:RestoreVS /p:BuildNumber=$(BuildNumber) /p:BuildRTM=false /v:m -bl:$(Build.Repository.LocalPath)\\artifacts\\binlog\\restore.binlog"
 
 - task: MSBuild@1
   displayName: "Run Functional Tests (continue on error)"
@@ -39,7 +39,7 @@ steps:
     solution: "build\\build.proj"
     msbuildVersion: "16.0"
     configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/t:CoreFuncTests /p:BuildRTM=false /p:BuildNumber=$(BuildNumber) /p:TestResultOutputFormat=xml /p:SkipDesktopAssemblies=$(SkipDesktopAssemblies) /p:SkipCoreAssemblies=$(SkipCoreAssemblies)"
+    msbuildArguments: "/t:CoreFuncTests /p:BuildRTM=false /p:BuildNumber=$(BuildNumber) /p:TestResultOutputFormat=xml /p:SkipDesktopAssemblies=$(SkipDesktopAssemblies) /p:SkipCoreAssemblies=$(SkipCoreAssemblies) -bl:$(Build.Repository.LocalPath)\\artifacts\\binlog\\test.binlog"
     maximumCpuCount: true
   condition: "and(succeeded(), eq(variables['IsOfficialBuild'], 'true'))"
 
@@ -50,7 +50,7 @@ steps:
     solution: "build\\build.proj"
     msbuildVersion: "16.0"
     configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/t:CoreFuncTests /p:BuildRTM=false /p:BuildNumber=$(BuildNumber) /p:TestResultOutputFormat=xml /p:SkipDesktopAssemblies=$(SkipDesktopAssemblies) /p:SkipCoreAssemblies=$(SkipCoreAssemblies)"
+    msbuildArguments: "/t:CoreFuncTests /p:BuildRTM=false /p:BuildNumber=$(BuildNumber) /p:TestResultOutputFormat=xml /p:SkipDesktopAssemblies=$(SkipDesktopAssemblies) /p:SkipCoreAssemblies=$(SkipCoreAssemblies) -bl:$(Build.Repository.LocalPath)\\artifacts\\binlog\\test.binlog"
     maximumCpuCount: true
   condition: "and(succeeded(), not(eq(variables['IsOfficialBuild'], 'true')))"
 
@@ -72,6 +72,13 @@ steps:
     ArtifactName: "$(Agent.JobName)"
     ArtifactType: "Container"
   condition: "or(failed(), canceled())"
+
+- task: PublishPipelineArtifact@1
+  displayName: "Publish binlogs"
+  inputs:
+    artifactName: binlog - $(Agent.JobName)
+    targetPath: "$(Build.Repository.LocalPath)\\artifacts\\binlog"
+  condition: "always()"
 
 - task: PowerShell@1
   displayName: "Initialize Git Commit Status on GitHub"


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/849

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Any step we invoke msbuild in our CI YAML, save a binlog, and publish it as a build artifact.

This won't catch places where we invoke MSBuild in a `ps1` or `sh` script, but it's a start.

## PR Checklist

- [X] PR has a meaningful title
- [X] PR has a linked issue.
- [X] Described changes

- **Tests**
  - [X] N/A (Infrastructure)

- **Documentation**
  - [X] N/A
