### PR TITLE
Extend apex test time limit to 120

### DIFF
--- a/eng/pipelines/templates/Apex_Tests_On_Windows.yml
+++ b/eng/pipelines/templates/Apex_Tests_On_Windows.yml
@@ -73,7 +73,7 @@ steps:
 
 - task: MSBuild@1
   displayName: "Run Apex Tests (continue on error)"
-  timeoutInMinutes: 45
+  timeoutInMinutes: 120
   continueOnError: "true"
   inputs:
     solution: "build\\build.proj"
@@ -85,7 +85,7 @@ steps:
 
 - task: MSBuild@1
   displayName: "Run Apex Tests (stop on error)"
-  timeoutInMinutes: 45
+  timeoutInMinutes: 120
   continueOnError: "false"
   inputs:
     solution: "build\\build.proj"


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
A temporary workaround of https://github.com/NuGet/Client.Engineering/issues/852

Regression? Last working version:

## Description
Extend the time limit of Apex tests from 45 to 120 min.
Since the whole job has a limitation of 120 mins, it will allow the tests running about 100 mins.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
