### PR TITLE
Docs:  fix broken link in internal documentation

### DIFF
--- a/docs/design-review-guide.md
+++ b/docs/design-review-guide.md
@@ -38,7 +38,7 @@ The core participation rules are as follows:
 
 ## Design rules
 
-1. Use the [template](https://github.com/NuGet/Home/blob/dev/designs/SPEC_TEMPLATE.md).
+1. Use the template detailed [here](https://github.com/NuGet/Home/tree/dev/meta).
 1. All public facing designs live in the [Home](https://github.com/NuGet/Home/blob/dev/designs/) repo.
 1. Designs that do not affect the product, guides, etc, live in the private [Client.Engineering](https://github.com/NuGet/Client.Engineering/blob/master/designs/)) repo. Sometimes early iterations of a design stay private, and the Client.Engineering repository can be used for that.
 1. Follow the usual PR lifecycle to get the design to the best state that it can be and merge when accepted. See the workflow below.


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes:  https://github.com/NuGet/Home/issues/10659

Regression? Last working version: No

## Description
Fix broken template link in internal docs.

## PR Checklist

- [X] PR has a meaningful title
- [X] PR has a linked issue.
- [X] Described changes

- **Tests**
  - [X] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  - [X] N/A
