### PR TITLE
Files regex processing boost

### DIFF
--- a/src/NuGet.Core/NuGet.Common/PathUtil/PathResolver.cs
+++ b/src/NuGet.Core/NuGet.Common/PathUtil/PathResolver.cs
@@ -23,7 +23,7 @@ namespace NuGet.Common
             Func<T, string> getPath,
             IEnumerable<string> wildcards)
         {
-            IEnumerable<Regex> filters = wildcards.Select(WildcardToRegex).ToList();
+            List<Regex> filters = wildcards.Select(WildcardToRegex).ToList();
 
             return source.AsParallel().Where(item =>
             {

--- a/src/NuGet.Core/NuGet.Common/PathUtil/PathResolver.cs
+++ b/src/NuGet.Core/NuGet.Common/PathUtil/PathResolver.cs
@@ -90,7 +90,7 @@ namespace NuGet.Common
                 pattern = pattern
                     .Replace("/", @"\\") // On Windows, / is treated the same as \.
                     .Replace(@"\.\*\*", @"\.[^\\.]*") // .** should not match on ../file or ./file but will match .file
-                    .Replace(@"\*\*\\", @"([^\\]+\\)*?") //For recursive wildcards \**\, include the current directory.
+                    .Replace(@"\*\*\\", @"(\\\\)?([^\\]+\\)*?") //For recursive wildcards \**\, include the current directory.
                     .Replace(@"\*\*", ".*") // For recursive wildcards that don't end in a slash e.g. **.txt would be treated as a .txt file at any depth
                     .Replace(@"\*", @"[^\\]*(\\)?") // For non recursive searches, limit it any character that is not a directory separator
                     .Replace(@"\?", "."); // ? translates to a single any character

--- a/src/NuGet.Core/NuGet.Common/PathUtil/PathResolver.cs
+++ b/src/NuGet.Core/NuGet.Common/PathUtil/PathResolver.cs
@@ -29,7 +29,7 @@ namespace NuGet.Common
             {
                 string path = getPath(item);
                 return filters.Any(f => f.IsMatch(path));
-            }).ToList();
+            });
         }
 
         /// <summary>
@@ -89,12 +89,12 @@ namespace NuGet.Common
             {
                 // regex wildcard adjustments for Windows-style file systems
                 pattern = pattern
-                    .Replace("/", @"\\")                 // On Windows, / is treated the same as \.
-                    .Replace(@"\.\*\*", @"\.[^\\.]*")    // .** should not match on ../file or ./file but will match .file
+                    .Replace("/", @"\\") // On Windows, / is treated the same as \.
+                    .Replace(@"\.\*\*", @"\.[^\\.]*") // .** should not match on ../file or ./file but will match .file
                     .Replace(@"\*\*\\", @"([^\\]+\\)*?") //For recursive wildcards \**\, include the current directory.
-                    .Replace(@"\*\*", ".*")              // For recursive wildcards that don't end in a slash e.g. **.txt would be treated as a .txt file at any depth
-                    .Replace(@"\*", @"[^\\]*(\\)?")      // For non recursive searches, limit it any character that is not a directory separator
-                    .Replace(@"\?", ".");                // ? translates to a single any character
+                    .Replace(@"\*\*", ".*") // For recursive wildcards that don't end in a slash e.g. **.txt would be treated as a .txt file at any depth
+                    .Replace(@"\*", @"[^\\]*(\\)?") // For non recursive searches, limit it any character that is not a directory separator
+                    .Replace(@"\?", "."); // ? translates to a single any character
             }
 
             return new Regex('^' + pattern + '$', RegexOptions.IgnoreCase | RegexOptions.ExplicitCapture | RegexOptions.CultureInvariant);

--- a/src/NuGet.Core/NuGet.Common/PathUtil/PathResolver.cs
+++ b/src/NuGet.Core/NuGet.Common/PathUtil/PathResolver.cs
@@ -79,7 +79,7 @@ namespace NuGet.Common
                 // regex wildcard adjustments for *nix-style file systems
                 pattern = pattern
                     .Replace(@"\.\*\*", @"\.[^/.]*") // .** should not match on ../file or ./file but will match .file
-                    .Replace(@"\*\*/", "([^/]+/)*?") //For recursive wildcards /**/, include the current directory.
+                    .Replace(@"\*\*/", "/?([^/]+/)*?") //For recursive wildcards /**/, include the current directory.
                     .Replace(@"\*\*", ".*") // For recursive wildcards that don't end in a slash e.g. **.txt would be treated as a .txt file at any depth
                     .Replace(@"\*", @"[^/]*(/)?") // For non recursive searches, limit it any character that is not a directory separator
                     .Replace(@"\?", "."); // ? translates to a single any character

--- a/src/NuGet.Core/NuGet.Common/PathUtil/PathResolver.cs
+++ b/src/NuGet.Core/NuGet.Common/PathUtil/PathResolver.cs
@@ -80,7 +80,7 @@ namespace NuGet.Common
                 pattern = pattern
                     .Replace(@"\.\*\*", @"\.[^/.]*") // .** should not match on ../file or ./file but will match .file
                     .Replace(@"\*\*/", "(.+/)*") //For recursive wildcards /**/, include the current directory.
-                    .Replace(@"\*\*/", "([^/]+/)*") //For recursive wildcards /**/, include the current directory.
+                    .Replace(@"\*\*/", "([^/]+/)*?") //For recursive wildcards /**/, include the current directory.
                     .Replace(@"\*\*", ".*") // For recursive wildcards that don't end in a slash e.g. **.txt would be treated as a .txt file at any depth
                     .Replace(@"\*", @"[^/]*(/)?") // For non recursive searches, limit it any character that is not a directory separator
                     .Replace(@"\?", "."); // ? translates to a single any character

--- a/src/NuGet.Core/NuGet.Common/PathUtil/PathResolver.cs
+++ b/src/NuGet.Core/NuGet.Common/PathUtil/PathResolver.cs
@@ -79,7 +79,6 @@ namespace NuGet.Common
                 // regex wildcard adjustments for *nix-style file systems
                 pattern = pattern
                     .Replace(@"\.\*\*", @"\.[^/.]*") // .** should not match on ../file or ./file but will match .file
-                    .Replace(@"\*\*/", "(.+/)*") //For recursive wildcards /**/, include the current directory.
                     .Replace(@"\*\*/", "([^/]+/)*?") //For recursive wildcards /**/, include the current directory.
                     .Replace(@"\*\*", ".*") // For recursive wildcards that don't end in a slash e.g. **.txt would be treated as a .txt file at any depth
                     .Replace(@"\*", @"[^/]*(/)?") // For non recursive searches, limit it any character that is not a directory separator

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/PathResolverTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/PathResolverTests.cs
@@ -135,7 +135,10 @@ namespace NuGet.Common.Test
             IEnumerable<string> actualResults = PathResolver.GetMatches(sources, source => source, wildcards);
             IEnumerable<string> expectedResults = GetPlatformSpecificPaths(new[] { ".c" });
 
-            Assert.Equal(expectedResults, actualResults);
+            IEnumerable<string> orderedActualResults = actualResults.OrderBy(path => path);
+            IEnumerable<string> orderedExpectedResults = expectedResults.OrderBy(path => path);
+
+            Assert.Equal(orderedExpectedResults, orderedActualResults);
         }
 
         [Fact]
@@ -216,7 +219,10 @@ namespace NuGet.Common.Test
             IEnumerable<string> actualResults = PathResolver.GetMatches(sources, source => source, wildcards);
             IEnumerable<string> expectedResults = GetPlatformSpecificPaths(new[] { "a{0}b{0}c{0}d" });
 
-            Assert.Equal(expectedResults, actualResults);
+            IEnumerable<string> orderedActualResults = actualResults.OrderBy(path => path);
+            IEnumerable<string> orderedExpectedResults = expectedResults.OrderBy(path => path);
+
+            Assert.Equal(orderedExpectedResults, orderedActualResults);
         }
 
         [Fact]
@@ -227,7 +233,10 @@ namespace NuGet.Common.Test
             IEnumerable<string> actualResults = PathResolver.GetMatches(sources, source => source, wildcards);
             string[] expectedResults = new[] { "abc", "adc" };
 
-            Assert.Equal(expectedResults, actualResults);
+            IEnumerable<string> orderedActualResults = actualResults.OrderBy(path => path);
+            IEnumerable<string> orderedExpectedResults = expectedResults.OrderBy(path => path);
+
+            Assert.Equal(orderedExpectedResults, orderedActualResults);
         }
 
         [Fact]

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/PathResolverTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/PathResolverTests.cs
@@ -146,7 +146,10 @@ namespace NuGet.Common.Test
             IEnumerable<string> actualResults = PathResolver.GetMatches(sources, source => source, wildcards);
             IEnumerable<string> expectedResults = GetPlatformSpecificPaths(new[] { "a{0}d", "a{0}b{0}d", "a{0}b{0}c{0}d" });
 
-            Assert.Equal(expectedResults, actualResults);
+            IEnumerable<string> orderedActualResults = actualResults.OrderBy(path => path);
+            IEnumerable<string> orderedExpectedResults = expectedResults.OrderBy(path => path);
+
+            Assert.Equal(orderedExpectedResults, orderedActualResults);
         }
 
         [Fact]
@@ -157,7 +160,10 @@ namespace NuGet.Common.Test
             IEnumerable<string> actualResults = PathResolver.GetMatches(sources, source => source, wildcards);
             IEnumerable<string> expectedResults = GetPlatformSpecificPaths(new[] { ".{0}.c", "a{0}.c", "a{0}{0}.c", "b.c", "a{0}b{0}bc.c", "a{0}b{0}.c" });
 
-            Assert.Equal(expectedResults, actualResults);
+            IEnumerable<string> orderedActualResults = actualResults.OrderBy(path => path);
+            IEnumerable<string> orderedExpectedResults = expectedResults.OrderBy(path => path);
+
+            Assert.Equal(orderedExpectedResults, orderedActualResults);
         }
 
         [Fact]
@@ -168,7 +174,10 @@ namespace NuGet.Common.Test
             IEnumerable<string> actualResults = PathResolver.GetMatches(sources, source => source, wildcards);
             IEnumerable<string> expectedResults = GetPlatformSpecificPaths(new[] { ".{0}.c", "a{0}.c", "a{0}{0}.c", "b.c", "a{0}b{0}bc.c", "a{0}b{0}.c" });
 
-            Assert.Equal(expectedResults, actualResults);
+            IEnumerable<string> orderedActualResults = actualResults.OrderBy(path => path);
+            IEnumerable<string> orderedExpectedResults = expectedResults.OrderBy(path => path);
+
+            Assert.Equal(orderedExpectedResults, orderedActualResults);
         }
 
         [Fact]
@@ -179,7 +188,10 @@ namespace NuGet.Common.Test
             IEnumerable<string> actualResults = PathResolver.GetMatches(sources, source => source, wildcards);
             IEnumerable<string> expectedResults = GetPlatformSpecificPaths(new[] { ".{0}c", "a{0}c" });
 
-            Assert.Equal(expectedResults, actualResults);
+            IEnumerable<string> orderedActualResults = actualResults.OrderBy(path => path);
+            IEnumerable<string> orderedExpectedResults = expectedResults.OrderBy(path => path);
+
+            Assert.Equal(orderedExpectedResults, orderedActualResults);
         }
 
         [Fact]
@@ -190,7 +202,10 @@ namespace NuGet.Common.Test
             IEnumerable<string> actualResults = PathResolver.GetMatches(sources, source => source, wildcards);
             IEnumerable<string> expectedResults = GetPlatformSpecificPaths(new[] { "a{0}d", "a{0}b{0}d", "a{0}b{0}c{0}d" });
 
-            Assert.Equal(expectedResults, actualResults);
+            IEnumerable<string> orderedActualResults = actualResults.OrderBy(path => path);
+            IEnumerable<string> orderedExpectedResults = expectedResults.OrderBy(path => path);
+
+            Assert.Equal(orderedExpectedResults, orderedActualResults);
         }
 
         [Fact]

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageBuilderTest.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageBuilderTest.cs
@@ -345,7 +345,7 @@ namespace NuGet.Packaging.Test
                 builder.AddFiles(directory.Path, source, destination, exclude);
 
                 // Assert
-                Assert.Collection(builder.Files,
+                Assert.Collection(builder.Files.OrderBy(f => f.Path.Length),
                     file =>
                     {
                         Assert.Equal(string.Format("Content{0}file1.txt", Path.DirectorySeparatorChar), file.Path);

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageBuilderTest.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageBuilderTest.cs
@@ -345,22 +345,29 @@ namespace NuGet.Packaging.Test
                 builder.AddFiles(directory.Path, source, destination, exclude);
 
                 // Assert
-                Assert.Collection(builder.Files.OrderBy(f => f.Path.Length),
-                    file =>
+                var expectedResults = new[]
+                {
+                    new
                     {
-                        Assert.Equal(string.Format("Content{0}file1.txt", Path.DirectorySeparatorChar), file.Path);
-                        Assert.Equal("file1.txt", file.EffectivePath);
+                        Path = string.Format("Content{0}file1.txt", Path.DirectorySeparatorChar),
+                        EffectivePath = "file1.txt"
                     },
-                    file =>
+                    new
                     {
-                        Assert.Equal(string.Format("Content{0}dir1{0}file1.txt", Path.DirectorySeparatorChar), file.Path);
-                        Assert.Equal(string.Format("dir1{0}file1.txt", Path.DirectorySeparatorChar), file.EffectivePath);
+                        Path = string.Format("Content{0}dir1{0}file1.txt", Path.DirectorySeparatorChar),
+                        EffectivePath = string.Format("dir1{0}file1.txt", Path.DirectorySeparatorChar)
                     },
-                    file =>
+                    new
                     {
-                        Assert.Equal(string.Format("Content{0}dir1{0}dir2{0}file1.txt", Path.DirectorySeparatorChar), file.Path);
-                        Assert.Equal(string.Format("dir1{0}dir2{0}file1.txt", Path.DirectorySeparatorChar), file.EffectivePath);
-                    });
+                        Path = string.Format("Content{0}dir1{0}dir2{0}file1.txt", Path.DirectorySeparatorChar),
+                        EffectivePath = string.Format("dir1{0}dir2{0}file1.txt", Path.DirectorySeparatorChar)
+                    }
+                };
+
+                var orderedExpectedResults = expectedResults.OrderBy(i => i.Path);
+                var orderedActualResults = builder.Files.Select(f => new { f.Path, f.EffectivePath }).OrderBy(i => i.Path);
+
+                Assert.Equal(orderedExpectedResults, orderedActualResults);
             }
         }
 


### PR DESCRIPTION
Changed recursive wildcards regex pattern to faster form
Added exclude pattern TPL provessing
Fixed linq lazy regex objects spawn

<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

https://github.com/NuGet/Home/issues/5016

https://github.com/NuGet/Home/issues/5706

Fixes:

Fixed include and exclude files performance

Regression? Last working version:

## Description

Changed regex pattern for recursive wildcards to faster one. 
Lazy quantifier in this case much faster. (.+\\)* -> ([^\\]+\\)*?

Added parallel processing in source files filtering 
https://docs.microsoft.com/en-us/dotnet/api/system.linq.parallelenumerable.asparallel?view=net-5.0

Fixed linq lazy regex objects spawn. 
Lazy filters enumeration in GetMatches method was called on every file entry. ([Source file](https://github.com/NuGet/NuGet.Client/blob/97311b5cb48d38402b49fd41a6384b11db7dd453/src/NuGet.Core/NuGet.Common/PathUtil/PathResolver.cs))

## PR Checklist

- [x ] PR has a meaningful title
- [x ] PR has a linked issue.
- [x ] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x ] Test exception

   [PathResolverTests ](https://github.com/NuGet/NuGet.Client/blob/97311b5cb48d38402b49fd41a6384b11db7dd453/test/NuGet.Core.Tests/NuGet.Common.Test/PathResolverTests.cs) already contains all needed tests.

  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [x ] Documentation PR or issue filled
  - **OR**
  - [ ] N/A
