### PR TITLE
Revert: No longer use UI Filter starting from Installed tab #3881

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -891,6 +891,13 @@ namespace NuGet.PackageManagement.UI
                 }
 
                 FlagTabDataAsLoaded(filterToRender);
+
+                // Loading Data on Installed tab should also consider the Data on Updates tab as loaded to indicate
+                // UI filtering for Updates is ready.
+                if (filterToRender == ItemFilter.Installed)
+                {
+                    FlagTabDataAsLoaded(ItemFilter.UpdatesAvailable);
+                }
             }
             catch (OperationCanceledException)
             {


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/10654 by reverting https://github.com/NuGet/NuGet.Client/pull/3881

Regression? Last working version: 16.9 Preview 4

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
Revert a bug fix that introduces a new bug of switching between Installed/Updates tabs does not refresh the packages list. 
**This PR will restore the bug** where Update button sometimes throws an NullReferenceException.

Reopening https://github.com/NuGet/Home/issues/10510 to continue finding a better bug fix.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception - this PR is just reverting another PR.
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. --> 

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [ ] N/A
