### PR TITLE
Remove 'v' prefix on Packages List version numbers

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageItemControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageItemControl.xaml
@@ -256,7 +256,7 @@
                       VerticalAlignment="Center"
                       HorizontalAlignment="Right"
                       Visibility="{Binding IsNotInstalled, Converter={StaticResource InvertedBooleanToVisibilityConverter}}"
-                      Text="{Binding InstalledVersion, Converter={StaticResource VersionToStringConverter}, ConverterParameter=vN}">
+                      Text="{Binding InstalledVersion, Converter={StaticResource VersionToStringConverter}, ConverterParameter=N}">
           <TextBlock.ToolTip>
             <MultiBinding Converter="{StaticResource StringFormatConverter}">
               <Binding Source="{x:Static nuget:Resources.ToolTip_InstalledVersion}" />
@@ -281,7 +281,7 @@
                       HorizontalAlignment="Right"
                       TextAlignment="Right"
                       Visibility="{Binding IsNotInstalled, Converter={StaticResource BooleanToVisibilityConverter}}"
-                      Text="{Binding LatestVersion, Converter={StaticResource VersionToStringConverter}, ConverterParameter=vN}"
+                      Text="{Binding LatestVersion, Converter={StaticResource VersionToStringConverter}, ConverterParameter=N}"
                       ToolTip="{Binding LatestVersionToolTip}"
                       AutomationProperties.Name="{Binding LatestVersionToolTip}" />
 
@@ -383,7 +383,7 @@
                       Visibility="{Binding IsUpdateAvailable, Converter={StaticResource BooleanToVisibilityConverter}}"
                       ToolTip="{Binding LatestVersionToolTip}"
                       AutomationProperties.Name="{Binding LatestVersionToolTip}"
-                      Text="{Binding LatestVersion, Converter={StaticResource VersionToStringConverter}, ConverterParameter=vN}" />
+                      Text="{Binding LatestVersion, Converter={StaticResource VersionToStringConverter}, ConverterParameter=N}" />
 
         <!-- update button -->
         <Button


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/10677

Regression? Last working version: no

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
Removing the 'v' that is only shown in the Packages List (InfiniteScrollList) in the PMUI.

Verified that Accessibility Insights is still good. No change to screen-reader string here. **Only a visual change.**
![image](https://user-images.githubusercontent.com/49205731/112180160-ace44980-8bd1-11eb-953b-359235e6cf96.png)

## PR Checklist

- [X] PR has a meaningful title
- [X] PR has a linked issue.
- [X] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception - Manually tested all 4 tabs, checked Accessibility insights and Narrator to make sure no changes to the announced version strings.
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [X] N/A
