### PR TITLE
Handle no nomination info in VS GetInstalledPackagesAsync API

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Exceptions/ProjectNotNominatedException.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Exceptions/ProjectNotNominatedException.cs
@@ -1,0 +1,20 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace NuGet.PackageManagement.VisualStudio.Exceptions
+{
+    [Serializable]
+    public class ProjectNotNominatedException : InvalidOperationException
+    {
+        public ProjectNotNominatedException() : base()
+        {
+        }
+
+        public ProjectNotNominatedException(string message)
+            : base(message)
+        {
+        }
+    }
+}

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/NuGet.PackageManagement.VisualStudio.csproj
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/NuGet.PackageManagement.VisualStudio.csproj
@@ -61,6 +61,7 @@
   <ItemGroup>
     <Compile Include="Common\IProjectContextInfoExtensions.cs" />
     <Compile Include="Common\InstalledAndTransitivePackageCollections.cs" />
+    <Compile Include="Exceptions\ProjectNotNominatedException.cs" />
     <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="PackageFeeds\PackageSourceMoniker.cs" />
     <Compile Include="PackageFeeds\RecommenderPackageFeed.cs" />

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/CpsPackageReferenceProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/CpsPackageReferenceProject.cs
@@ -17,6 +17,7 @@ using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Frameworks;
 using NuGet.LibraryModel;
+using NuGet.PackageManagement.VisualStudio.Exceptions;
 using NuGet.PackageManagement.VisualStudio.Utility;
 using NuGet.Packaging.Core;
 using NuGet.ProjectManagement;
@@ -88,7 +89,7 @@ namespace NuGet.PackageManagement.VisualStudio
             {
                 if (shouldThrow)
                 {
-                    throw new InvalidOperationException(
+                    throw new ProjectNotNominatedException(
                         string.Format(Strings.ProjectNotLoaded_RestoreFailed, ProjectName));
                 }
                 else
@@ -129,7 +130,7 @@ namespace NuGet.PackageManagement.VisualStudio
             IReadOnlyList<IAssetsLogMessage> additionalMessages;
             if (!_projectSystemCache.TryGetProjectRestoreInfo(_projectFullPath, out projectRestoreInfo, out additionalMessages))
             {
-                throw new InvalidOperationException(
+                throw new ProjectNotNominatedException(
                     string.Format(Strings.ProjectNotLoaded_RestoreFailed, ProjectName));
             }
 
@@ -422,7 +423,7 @@ namespace NuGet.PackageManagement.VisualStudio
             var spec = GetPackageSpec();
             if (spec == null)
             {
-                throw new InvalidOperationException(
+                throw new ProjectNotNominatedException(
                     string.Format(Strings.ProjectNotLoaded_RestoreFailed, ProjectName));
             }
 

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/Extensibility/NuGetProjectServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/Extensibility/NuGetProjectServiceTests.cs
@@ -1,0 +1,48 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using NuGet.Configuration;
+using NuGet.PackageManagement.VisualStudio;
+using NuGet.PackageManagement.VisualStudio.Exceptions;
+using NuGet.ProjectManagement;
+using NuGet.ProjectManagement.Projects;
+using NuGet.VisualStudio.Contracts;
+using NuGet.VisualStudio.Implementation.Extensibility;
+using NuGet.VisualStudio.Telemetry;
+using Xunit;
+
+namespace NuGet.VisualStudio.Implementation.Test.Extensibility
+{
+    public class NuGetProjectServiceTests
+    {
+        [Fact]
+        public async Task GetInstalledPackagesAsync_CpsProjectNotNominated_ReturnsProjectNotReadyResult()
+        {
+            // Arrange
+            var projectGuid = Guid.NewGuid();
+
+            var settings = new Mock<ISettings>();
+            var telemetryProvider = new Mock<INuGetTelemetryProvider>(MockBehavior.Strict);
+
+            var project = new Mock<BuildIntegratedNuGetProject>();
+            project.Setup(p => p.GetPackageSpecsAndAdditionalMessagesAsync(It.IsAny<DependencyGraphCacheContext>()))
+                .Throws<ProjectNotNominatedException>();
+
+            var solutionManager = new Mock<IVsSolutionManager>();
+            solutionManager.Setup(sm => sm.GetNuGetProjectAsync(projectGuid.ToString()))
+                .Returns(() => Task.FromResult<NuGetProject>(project.Object));
+
+            // Act
+            var target = new NuGetProjectService(solutionManager.Object, settings.Object, telemetryProvider.Object);
+            InstalledPackagesResult actual = await target.GetInstalledPackagesAsync(projectGuid, CancellationToken.None);
+
+            // Assert
+            Assert.NotNull(actual);
+            Assert.Equal(InstalledPackageResultStatus.ProjectNotReady, actual.Status);
+        }
+    }
+}


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/10681

Regression? Last working version: new API in VS 16.8

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Make `CpsPackageReferenceProject` throw a new `ProjectNotNominatedException`, rather than the generic `InvalidOperationException`, and catch it in `GetInstalledPackagesAsync`'s implementation.

## PR Checklist

- [X] PR has a meaningful title
- [X] PR has a linked issue.
- [X] Described changes

- **Tests**
  - [X] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [X] N/A
