### PR TITLE
set UseHardlinksIfPossible="true" for MSBuild Copy task

### DIFF
--- a/build/loc.proj
+++ b/build/loc.proj
@@ -27,7 +27,7 @@
         <DestinationDir>$(ArtifactsDirectory)vsixlangpack\extension.vsixlangpack</DestinationDir>
       </NonProjectFilesToMove>
     </ItemGroup>
-    <Copy SourceFiles="@(NonProjectFilesToMove)" DestinationFiles="@(NonProjectFilesToMove->'%(DestinationDir)')"/>
+    <Copy SourceFiles="@(NonProjectFilesToMove)" DestinationFiles="@(NonProjectFilesToMove->'%(DestinationDir)')" UseHardlinksIfPossible="true" />
     <ItemGroup>
       <FilesToLocalize Include="@(NonProjectFilesToMove->'%(DestinationDir)')">
         <TranslationFile Condition="'%(Extension)' == '.dll'">$(LocalizationRootDirectory)\{Lang}\15\%(Filename).dll.lcl</TranslationFile>    <!--Required: translation file-->
@@ -72,7 +72,7 @@
           <DestinationDir>$(ArtifactsDirectory)eulas\%(SupportedCultures.FNCulture)\eula.rtf</DestinationDir>
       </EulaFiles>
     </ItemGroup>
-    <Copy SourceFiles="@(EulaFiles->'%(Identity)')" DestinationFiles="@(EulaFiles->'%(DestinationDir)')"/>
+    <Copy SourceFiles="@(EulaFiles->'%(Identity)')" DestinationFiles="@(EulaFiles->'%(DestinationDir)')" UseHardlinksIfPossible="true" />
   </Target>
 
   <Target Name="CopyLcgFilesToArtifacts" AfterTargets="Localize">
@@ -81,7 +81,7 @@
         <DestinationDir>$(ArtifactsDirectory)$([MSBuild]::MakeRelative($(ArtifactsDirectory)localize\%(LocalizedToolFiles.lang), %(LocalizedToolFiles.RootDir)%(LocalizedToolFiles.Directory)))%(LocalizedToolFiles.Culture)\%(LocalizedToolFiles.Filename)%(LocalizedToolFiles.Extension)</DestinationDir>
       </_MoveLcgFiles>
     </ItemGroup>
-    <Copy SourceFiles="@(_MoveLcgFiles->'%(Identity)')" DestinationFiles="@(_MoveLcgFiles->'%(DestinationDir)')"/>
+    <Copy SourceFiles="@(_MoveLcgFiles->'%(Identity)')" DestinationFiles="@(_MoveLcgFiles->'%(DestinationDir)')" UseHardlinksIfPossible="true" />
   </Target>
 
   <Target Name="CopyBinariesToLocalizeENU" AfterTargets="Localize">
@@ -90,7 +90,7 @@
         <DestinationPath>$(ArtifactsDirectory)localize\ENU\$([MSBuild]::MakeRelative($(ArtifactsDirectory), %(FilesToLocalize.RootDir)%(FilesToLocalize.Directory)))%(FilesToLocalize.Filename)%(FilesToLocalize.Extension)</DestinationPath>
       </_EnglishBinaires>
     </ItemGroup>
-    <Copy SourceFiles="@(_EnglishBinaires)" DestinationFiles="@(_EnglishBinaires->'%(DestinationPath)')" />
+    <Copy SourceFiles="@(_EnglishBinaires)" DestinationFiles="@(_EnglishBinaires->'%(DestinationPath)')" UseHardlinksIfPossible="true" />
   </Target>
 
   <Target Name="AfterBuild" DependsOnTargets="LocalizeNonProjectFiles;BatchLocalize"/>

--- a/build/symbols.proj
+++ b/build/symbols.proj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="GetSymbolsAndAssembliesToIndex" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common.props" />
-  
+
   <!-- Configuration/global properties -->
   <PropertyGroup>
     <CommonMSBuildProperties>
@@ -28,7 +28,7 @@
           <DestinationDir>$(ArtifactsDirectory)symbolstoindex\$([MSBuild]::MakeRelative($(ArtifactsDirectory), %(SymbolsToIndex.Identity)))</DestinationDir>
       </FilteredSymbolsToIndex>
     </ItemGroup>
-    <Copy SourceFiles="@(FilteredSymbolsToIndex->'%(Identity)')" DestinationFiles="@(FilteredSymbolsToIndex->'%(DestinationDir)')"/>
+    <Copy SourceFiles="@(FilteredSymbolsToIndex->'%(Identity)')" DestinationFiles="@(FilteredSymbolsToIndex->'%(DestinationDir)')" UseHardlinksIfPossible="true" />
     <Message Text="SymbolsToIndex: @(FilteredSymbolsToIndex, '%0a')" Importance="High"/>
   </Target>
 </Project>

--- a/setup/Microsoft.VisualStudio.NuGet.BuildTools.vsmanproj
+++ b/setup/Microsoft.VisualStudio.NuGet.BuildTools.vsmanproj
@@ -30,8 +30,8 @@
   </ItemGroup>
 
   <Target Name="CopyToDropFolder" AfterTargets="Build" Condition="'$(IsVsixBuild)' == 'true'">
-    <Copy SourceFiles="$(OutputPath)$(MSBuildProjectName).vsix" DestinationFolder="$(DropFolder)" />
-    <Copy SourceFiles="$(OutputPath)$(MSBuildProjectName).json" DestinationFolder="$(DropFolder)" />
+    <Copy SourceFiles="$(OutputPath)$(MSBuildProjectName).vsix" DestinationFolder="$(DropFolder)" UseHardlinksIfPossible="true" />
+    <Copy SourceFiles="$(OutputPath)$(MSBuildProjectName).json" DestinationFolder="$(DropFolder)" UseHardlinksIfPossible="true" />
   </Target>
 
   <Import Project="$(MicroBuildDirectory)Microsoft.VisualStudioEng.MicroBuild.Core.targets" />

--- a/src/NuGet.Clients/NuGet.VisualStudio.Client/NuGet.VisualStudio.Client.csproj
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Client/NuGet.VisualStudio.Client.csproj
@@ -386,14 +386,14 @@
     </ItemGroup>
     <Message Text="Publishing VS VSIX package files..." Importance="high" />
     <Message Text="$(TargetVsixContainer) -&gt; $(VsixPublishDestination)\NuGet.Tools.vsix" Importance="high" />
-    <Copy SourceFiles="$(TargetVsixContainer)" DestinationFiles="$(VsixPublishDestination)NuGet.Tools.vsix" OverwriteReadOnlyFiles="true" />
+    <Copy SourceFiles="$(TargetVsixContainer)" DestinationFiles="$(VsixPublishDestination)NuGet.Tools.vsix" OverwriteReadOnlyFiles="true" UseHardlinksIfPossible="true" />
     <Message Text="@(PackageManifest) -&gt; $(VsixPublishDestination)" Importance="high" />
-    <Copy SourceFiles="@(PackageManifest)" DestinationFolder="$(VsixPublishDestination)" OverwriteReadOnlyFiles="true" />
+    <Copy SourceFiles="@(PackageManifest)" DestinationFolder="$(VsixPublishDestination)" OverwriteReadOnlyFiles="true" UseHardlinksIfPossible="true" />
     <ItemGroup Condition="'$(IsCIBuild)' !='true'">
       <NuGetSymbolFiles Include="$(OutputPath)NuGet*.pdb" />
     </ItemGroup>
     <Message Text="Copying symbols file '%(NuGetSymbolFiles.Identity)'" Condition=" '@(NuGetSymbolFiles)' != '' " />
-    <Copy SourceFiles="@(NuGetSymbolFiles)" DestinationFolder="$(VsixPublishDestination)symbols" OverwriteReadOnlyFiles="true" Condition="'$(IsCIBuild)' !='true'" />
+    <Copy SourceFiles="@(NuGetSymbolFiles)" DestinationFolder="$(VsixPublishDestination)symbols" OverwriteReadOnlyFiles="true" Condition="'$(IsCIBuild)' !='true'" UseHardlinksIfPossible="true" />
   </Target>
   <Target Name="ReadVsixIncludeListFromFile">
     <ReadLinesFromFile File="@(VsixIncludeFile)">

--- a/src/NuGet.Clients/NuGetConsole.Host.PowerShell/NuGetConsole.Host.PowerShell.csproj
+++ b/src/NuGet.Clients/NuGetConsole.Host.PowerShell/NuGetConsole.Host.PowerShell.csproj
@@ -160,7 +160,8 @@
       <PowerShellScripts Include="$(MSBuildProjectDirectory)\Scripts\*.ps*" Exclude="$(MSBuildProjectDirectory)\Scripts\NuGet.psd1" />
     </ItemGroup>
     <Copy SourceFiles="@(PowerShellScripts)"
-          DestinationFolder="$(ArtifactsDirectory)Scripts" />
+          DestinationFolder="$(ArtifactsDirectory)Scripts"
+          UseHardlinksIfPossible="true" />
     <Exec Command="powershell.exe -ExecutionPolicy Bypass &quot;$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\UpdateNuGetModuleManifest.ps1&quot; -NuGetPackageManagementPowerShellCmdletsFilePath &quot;$(ArtifactsDirectory)NuGet.PackageManagement.PowerShellCmdlets\$(BuildVariationFolder)\bin\$(Configuration)\NuGet.PackageManagement.PowerShellCmdlets.dll&quot; -ManifestModuleSourceFilePath &quot;$(MSBuildProjectDirectory)\Scripts\NuGet.psd1&quot; -ManifestModuleDestinationFilePath &quot;$(ArtifactsDirectory)Scripts\NuGet.psd1&quot;" />
   </Target>
   <Target Name="GetScriptsForSigning" Returns="@(ScriptsToSign)">

--- a/src/NuGet.Core/NuGet.Localization/NuGet.Localization.csproj
+++ b/src/NuGet.Core/NuGet.Localization/NuGet.Localization.csproj
@@ -48,7 +48,7 @@
       </_LocalizedFilePaths>
     </ItemGroup>
 
-    <Copy SourceFiles="@(_LocalizedFilePaths->'%(Identity)')" DestinationFiles="@(_LocalizedFilePaths->'%(TargetPath)')" />
+    <Copy SourceFiles="@(_LocalizedFilePaths->'%(Identity)')" DestinationFiles="@(_LocalizedFilePaths->'%(TargetPath)')" UseHardlinksIfPossible="true" />
   </Target>
 
   <Import Project="$(BuildCommonDirectory)common.targets"/>

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/NuGet.CommandLine.FuncTest.csproj
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/NuGet.CommandLine.FuncTest.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <EmbeddedResource Include="compiler\resources\*" />
   </ItemGroup>
- 
+
   <ItemGroup>
     <None Remove="compiler\resources\pc.packages.lock.json" />
   </ItemGroup>
@@ -32,9 +32,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-  
+
   <Target Name="CopyFinalNuGetExeToOutputPath" AfterTargets="Build" Condition="'$(SkipILMergeOfNuGetExe)' != 'true'">
-      <Copy SourceFiles="$(ArtifactsDirectory)$(VsixOutputDirName)\NuGet.exe" DestinationFolder="$(OutputPath)NuGet\" />
+      <Copy SourceFiles="$(ArtifactsDirectory)$(VsixOutputDirName)\NuGet.exe" DestinationFolder="$(OutputPath)NuGet\" UseHardlinksIfPossible="true" />
   </Target>
 
   <Import Project="$(BuildCommonDirectory)common.targets" />

--- a/test/NuGet.Clients.FuncTests/NuGet.MSSigning.Extensions.FuncTest/NuGet.MSSigning.Extensions.FuncTest.csproj
+++ b/test/NuGet.Clients.FuncTests/NuGet.MSSigning.Extensions.FuncTest/NuGet.MSSigning.Extensions.FuncTest.csproj
@@ -19,7 +19,8 @@
 
   <Target Name="CopyFinalNuGetExeToOutputPath" AfterTargets="Build" Condition="'$(SkipILMergeOfNuGetExe)' != 'true'">
       <Copy SourceFiles="$(ArtifactsDirectory)$(VsixOutputDirName)\NuGet.exe"
-            DestinationFolder="$(OutputPath)NuGet\" />
+            DestinationFolder="$(OutputPath)NuGet\"
+            UseHardlinksIfPossible="true" />
   </Target>
 
   <Import Project="$(BuildCommonDirectory)common.targets" />

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGet.CommandLine.Test.csproj
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGet.CommandLine.Test.csproj
@@ -55,7 +55,7 @@
     <Compile Remove="compiler\resources\*" />
     <EmbeddedResource Include="compiler\resources\*" />
   </ItemGroup>
-    
+
   <PropertyGroup>
     <PostBuildEvent>
       xcopy /diy $(ArtifactsDirectory)TestableCredentialProvider\$(BuildVariationFolder)\bin\$(Configuration)\$(TargetFramework)\CredentialProvider.Testable.exe $(OutputPath)TestableCredentialProvider\
@@ -67,7 +67,8 @@
 
   <Target Name="CopyFinalNuGetExeToOutputPath">
     <Copy SourceFiles="$(ArtifactsDirectory)$(VsixOutputDirName)\NuGet.exe"
-          DestinationFolder="$(OutputPath)NuGet\" />
+          DestinationFolder="$(OutputPath)NuGet\"
+          UseHardlinksIfPossible="true" />
   </Target>
 
   <Import Project="$(BuildCommonDirectory)common.targets" />

--- a/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/Msbuild.Integration.Test.csproj
+++ b/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/Msbuild.Integration.Test.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.Build.Tasks" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <ProjectReference Include="$(NuGetCoreSrcDirectory)NuGet.Build.Tasks\NuGet.Build.Tasks.csproj" />
     <ProjectReference Include="$(NuGetCoreSrcDirectory)NuGet.Build.Tasks.Console\NuGet.Build.Tasks.Console.csproj" />
@@ -34,10 +34,13 @@
     </None>
   </ItemGroup>
   <Target Name="CopyTargets" AfterTargets="AfterBuild">
-    <Copy Condition="'$(TargetFramework)' == '$(NETFXTargetFramework)'" SourceFiles="$(MSBuildProjectDirectory)\$(OutputPath)\Microsoft.CSharp.Core.targets" DestinationFolder="$(MSBuildProjectDirectory)\$(OutputPath)\Roslyn\" />
+    <Copy Condition="'$(TargetFramework)' == '$(NETFXTargetFramework)'"
+          SourceFiles="$(MSBuildProjectDirectory)\$(OutputPath)\Microsoft.CSharp.Core.targets"
+          DestinationFolder="$(MSBuildProjectDirectory)\$(OutputPath)\Roslyn\"
+          UseHardlinksIfPossible="true" />
   </Target>
 
   <Import Project="$(BuildCommonDirectory)common.targets" />
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
-  
+
 </Project>

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/NuGet.XPlat.FuncTest.csproj
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/NuGet.XPlat.FuncTest.csproj
@@ -37,10 +37,16 @@
     <PackageReference Include="Microsoft.Net.Compilers.netcore" />
   </ItemGroup>
   <Target Name="CopyTargets" AfterTargets="AfterBuild">
-    <Copy Condition=" '$(IsCore)' == 'true' " SourceFiles="$(MSBuildProjectDirectory)\$(OutputPath)\Microsoft.CSharp.Core.targets" DestinationFolder="$(MSBuildProjectDirectory)\$(OutputPath)\Roslyn\" />
-    <Copy Condition="'$(TargetFramework)' == '$(NETFXTargetFramework)'" SourceFiles="$(MSBuildProjectDirectory)\$(OutputPath)\Microsoft.CSharp.Core.targets" DestinationFolder="$(MSBuildProjectDirectory)\$(OutputPath)\..\..\$(VisualStudioVersion)\Bin\Roslyn\" />
+    <Copy Condition=" '$(IsCore)' == 'true' "
+          SourceFiles="$(MSBuildProjectDirectory)\$(OutputPath)\Microsoft.CSharp.Core.targets"
+          DestinationFolder="$(MSBuildProjectDirectory)\$(OutputPath)\Roslyn\"
+          UseHardlinksIfPossible="true" />
+    <Copy Condition="'$(TargetFramework)' == '$(NETFXTargetFramework)'"
+          SourceFiles="$(MSBuildProjectDirectory)\$(OutputPath)\Microsoft.CSharp.Core.targets"
+          DestinationFolder="$(MSBuildProjectDirectory)\$(OutputPath)\..\..\$(VisualStudioVersion)\Bin\Roslyn\"
+          UseHardlinksIfPossible="true" />
   </Target>
-  
+
   <Import Project="$(BuildCommonDirectory)common.targets" />
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 </Project>

--- a/test/TestExtensions/API.Test/API.Test.csproj
+++ b/test/TestExtensions/API.Test/API.Test.csproj
@@ -37,7 +37,7 @@
     </PropertyGroup>
     <Message Text="Publishing test extension artifacts..." Importance="high" />
     <Message Text="$(TargetPath) -&gt; $(PublishDestination)" Importance="high" />
-    <Copy SourceFiles="$(TargetPath)" DestinationFolder="$(PublishDestination)" OverwriteReadOnlyFiles="true" />
+    <Copy SourceFiles="$(TargetPath)" DestinationFolder="$(PublishDestination)" OverwriteReadOnlyFiles="true" UseHardlinksIfPossible="true" />
   </Target>
 
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />

--- a/test/TestExtensions/GenerateTestPackages/GenerateTestPackages.csproj
+++ b/test/TestExtensions/GenerateTestPackages/GenerateTestPackages.csproj
@@ -50,7 +50,7 @@
     <Message Text="FilesToCopy:  %(FilesToCopy.Identity)" Importance="high" />
     <Message Text="Publishing test extension artifacts..." Importance="high" />
     <Message Text="$(TargetPath) -&gt; $(PublishDestination)" Importance="high" />
-    <Copy SourceFiles="@(FilesToCopy)" DestinationFolder="$(PublishDestination)" OverwriteReadOnlyFiles="true" />
+    <Copy SourceFiles="@(FilesToCopy)" DestinationFolder="$(PublishDestination)" OverwriteReadOnlyFiles="true" UseHardlinksIfPossible="true" />
   </Target>
 
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/870

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

As per [doc](https://docs.microsoft.com/en-us/visualstudio/msbuild/copy-task?view=vs-2019), MSBuild `Copy` task has `UseHardlinksIfPossible` optional parameter, if true, then hard links are created instead of copying the files. This is useful for speeding up the file copying process as well as saving disk space.

There are `481` occurrences where hard links are created instead of copying the file for this PR build.

I compared this PR build with [last green PR build](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=4583264&view=results) to calculate performance improvements.

Job Name | Step | No. of hard links created | Comments
-- | -- | -- | --
Build_And_UnitTest_NonRTM | Build for VS2019 | 15 | ~5 seconds improvement
Build_And_UnitTest_NonRTM | Localize Assemblies | 164 | not much performance gain noticed
Build_And_UnitTest_NonRTM | Publish NuGet.exe (ILMerged) into NuGet.CommandLine.Test (Mac tests use this) | 1 | not much performance gain noticed
Build_And_UnitTest_NonRTM | Pack VSIX | 2| not much performance gain noticed
Build_And_UnitTest_NonRTM | Generate Build Tools package | 2 | not much performance gain noticed
Build_And_UnitTest_RTM | Build for VS2019 | 15 | ~2 seconds improvement
Build_And_UnitTest_RTM | Localize Assemblies | 164 | ~7 seconds improvement
Functional_Tests_On_Windows IsDesktop| Run Functional Tests (stop on error) | 59 | not much performance gain noticed which may be due to the test's execution time
Functional_Tests_On_Windows Core| Run Functional Tests (stop on error) | 59 | not much performance gain noticed which may be due to the test's execution time


## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
