### PR TITLE
Give the Top-Level checkbox in the PackageReference migration dialog an automation name

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/NuGetProjectUpgradeWindow.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/NuGetProjectUpgradeWindow.xaml
@@ -247,6 +247,7 @@
               <StackPanel Orientation="Horizontal">
                 <CheckBox
                   AutomationProperties.LabeledBy="{Binding ElementName=_topLevelColumnHeader}"
+                  AutomationProperties.Name="{x:Static nuget:Resources.Accessibility_PromoteAllToTopLevel}"
                   IsChecked="False"
                   Checked="PromoteAllToTopLevel_Checked"
                   Unchecked="PromoteAllToTopLevel_Checked"


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/nuget/client.engineering/issues/871

Regression? Last working version: N/A

## Description
Added an automation name to the Top-Level checkbox so screen readers can read it when the control has focus.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  Accessibility fix, tested manually using Accessibility Insights and screen reader
  - [x] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
