### PR TITLE
Embedded icon only opens a stream for Read

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetPackageFileService.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetPackageFileService.cs
@@ -147,7 +147,7 @@ namespace NuGet.PackageManagement.VisualStudio
                 // use GetFullPath to normalize "..", so that zip slip attack cannot allow a user to walk up the file directory
                 if (Path.GetFullPath(extractedIconPath).StartsWith(dirPath, StringComparison.OrdinalIgnoreCase) && File.Exists(extractedIconPath))
                 {
-                    Stream fileStream = new FileStream(extractedIconPath, FileMode.Open);
+                    Stream fileStream = new FileStream(extractedIconPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
                     return fileStream;
                 }
                 else


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/10687

Regression? Last working version: No

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
Embedded icons no longer request Write access, which resulted in permissions errors. This accounts for Top 5 Fault Telemetry for `RemoteInvocationException`, which I expect to be reduced/eliminated with this PR.

![image](https://user-images.githubusercontent.com/49205731/112698282-ba166800-8e5f-11eb-8544-5143779fbb47.png)

TBD: this may improve local package sources as well: https://stackoverflow.com/questions/61593626/embedded-into-nuget-package-icon-doesnt-appear-in-vs


## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added - Unit testing to ensure when using an Embedded icon; we only require Read permission; we don't lock the file while reading it; we can read from a read-only file.
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A - 
