### PR TITLE
CPVM preview message should be visible at minimal verbosity

### DIFF
--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/RestoreOperationLogger.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/RestoreOperationLogger.cs
@@ -439,6 +439,7 @@ namespace NuGet.SolutionRestoreManager
                 case LogLevel.Warning:
                     return MSBuildVerbosityLevel.Quiet;
                 case LogLevel.Minimal:
+                    return MSBuildVerbosityLevel.Minimal;
                 case LogLevel.Information:
                     return MSBuildVerbosityLevel.Normal;
                 case LogLevel.Verbose:

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -116,7 +116,7 @@ namespace NuGet.Commands
                 telemetry.TelemetryEvent[IsCentralVersionManagementEnabled] = isCpvmEnabled;
                 if (isCpvmEnabled)
                 {
-                    _logger.LogInformation(string.Format(
+                    _logger.LogMinimal(string.Format(
                           CultureInfo.CurrentCulture,
                           Strings.CentralPackageVersionManagementInPreview,
                           _request.Project.FilePath));

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
@@ -765,7 +765,7 @@ EndGlobal";
         }
 
         [PlatformFact(Platform.Windows)]
-        public void RestoreCommand_DisplaysCPVMInPreviewMessageIfCPVMEnabled()
+        public void RestoreCommand_ProjectUsingCPVM_DisplaysCPVMInPreviewMessage()
         {
             using (var testDirectory = _msbuildFixture.CreateTestDirectory())
             {
@@ -798,39 +798,10 @@ EndGlobal";
                 File.WriteAllText(directoryPackagesPropsName, directoryPackagesPropsContent);
 
                 // Act
-                var result = _msbuildFixture.RunDotnet(workingDirectory, "restore /v:n");
+                var result = _msbuildFixture.RunDotnet(workingDirectory, "restore");
 
                 // Assert
                 Assert.True(result.Output.Contains($"The project {projectFile} is using CentralPackageVersionManagement, a NuGet preview feature."));
-            }
-        }
-
-        [PlatformFact(Platform.Windows)]
-        public void RestoreCommand_DoesNotDisplayCPVMInPreviewMessageIfCPVMNotEnabled()
-        {
-            using (var testDirectory = _msbuildFixture.CreateTestDirectory())
-            {
-                // Arrange
-                var projectName = "ClassLibrary1";
-                var workingDirectory = Path.Combine(testDirectory, projectName);
-                var projectFile = Path.Combine(workingDirectory, $"{projectName}.csproj");
-
-                _msbuildFixture.CreateDotnetNewProject(testDirectory.Path, projectName, " classlib", 60000);
-
-                // As long as the project does not have ManagePackageVersionsCentrally == true the project is not opted in
-                var directoryPackagesPropsName = Path.Combine(workingDirectory, $"Directory.Build.props");
-                var directoryPackagesPropsContent = @"<Project>                    
-                        <PropertyGroup>
-                            <CentralPackageVersionsFileImported>true</CentralPackageVersionsFileImported>
-                        </PropertyGroup>
-                    </Project>";
-                File.WriteAllText(directoryPackagesPropsName, directoryPackagesPropsContent);
-
-                // Act
-                var result = _msbuildFixture.RunDotnet(workingDirectory, "restore /v:n");
-
-                // Assert
-                Assert.True(!result.Output.Contains($"The project {projectFile} is using CentralPackageVersionManagement, a NuGet preview feature."));
             }
         }
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/10226

Regression? no

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

1. CPVM preview warning was changed to minimal, rather than "informational" (normal) verbosity
    * This is the same as .NET CLI's preview version warning
2.  Fixed a bug in our VS logger, where minimal verbosity messages were incorrectly being treated as normal verbosity
    * [Any existing `LogMinimal` calls](https://github.com/NuGet/NuGet.Client/search?q=LogMinimal) would previously be hidden, and will now be written to the Package Manager output.

## PR Checklist

- [X] PR has a meaningful title
- [X] PR has a linked issue.
- [X] Described changes

- **Tests**
  - [X] Automated tests added
    - RestoreCommand tested via modifying existing test to no longer explicitly use normal verbosity
  - **AND**
  <!-- Describe why you haven't added automation. -->
  - [X] Test exception
    - VS RestoreOperationLogger not tested because there are no existing tests for it, it depends on JTF, possibly AsyncServiceProvider, and looks generally difficult to test, which doesn't seem worthwhile given the simplicity of the change made to the production code
<!--  - **OR**
  - [ ] N/A  Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate 
  - [ ] Documentation PR or issue filled
  - **OR** -->
  - [X] N/A
