### PR TITLE
Save all build artifacts that are copied to file share as pipeline artifact

### DIFF
--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -446,9 +446,7 @@ steps:
       **\*.lcg
       !localize\**\*
     TargetFolder: "$(Build.ArtifactStagingDirectory)\\PLOC"
-  # TODO: reinstate official build after testing
-  #condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
-  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
+  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
 
 
 - task: CopyFiles@2
@@ -470,9 +468,7 @@ steps:
   inputs:
     targetPath: "$(Build.ArtifactStagingDirectory)\\PLOC"
     artifactName: "legacy localizeInputs"
-  # TODO: reinstate official build after testing
-  #condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
-  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
+  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
 
 - task: NuGetCommand@2
   displayName: Publish public Nuget packages to nuget-build
@@ -492,8 +488,7 @@ steps:
     configuration: "$(BuildConfiguration)"
     msbuildArguments: "/p:IsSymbolBuild=true /p:BuildRTM=$(BuildRTM)"
     maximumCpuCount: true
-  # TODO: reinstate official build after testing
-  #condition: " and(succeeded(), eq(variables['IsOfficialBuild'], 'true')) "
+  condition: " and(succeeded(), eq(variables['IsOfficialBuild'], 'true')) "
 
 - task: CopyFiles@2
   displayName: "Copy Symbols (non-rtm)"
@@ -516,8 +511,7 @@ steps:
   inputs:
     targetPath: "$(Build.Repository.LocalPath)\\artifacts\\symbolstoindex"
     artifactName: "symbols - $(RtmLabel)"
-  # TODO: reinstate official build after testing
-  #condition: " and(succeeded(), eq(variables['IsOfficialBuild'], 'true')) "
+  condition: " and(succeeded(), eq(variables['IsOfficialBuild'], 'true')) "
 
 - task: ms-vscs-artifact.build-tasks.artifactSymbolTask-1.artifactSymbolTask@0
   displayName: "Publish Symbols on Symweb"

--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -439,12 +439,22 @@ steps:
     ArtifactType: "Container"
 
 - task: CopyFiles@2
-  displayName: "Copy LCG Files (deprecated)"
+  displayName: "Copy LCG Files to staging (deprecated)"
   inputs:
     SourceFolder: "artifacts\\"
     Contents: |
       **\*.lcg
       !localize\**\*
+    TargetFolder: "$(Build.ArtifactStagingDirectory)\\PLOC"
+  # TODO: reinstate official build after testing
+  #condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
+  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
+
+
+- task: CopyFiles@2
+  displayName: "Copy LCG Files to destination (deprecated)"
+  inputs:
+    SourceFolder: "$(Build.ArtifactStagingDirectory)\\PLOC"
     TargetFolder: "$(CIRoot)\\PLOC\\$(Build.SourceBranchName)\\$(Build.BuildNumber)"
   condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
 
@@ -458,8 +468,10 @@ steps:
 - task: PublishPipelineArtifact@1
   displayName: "Upload legacy localizeInputs artifact"
   inputs:
-    targetPath: "$(Build.Repository.LocalPath)\\artifacts\\**\\*.lcg;!$(Build.Repository.LocalPath)\\artifacts\\localize\\**\\*"
+    targetPath: "$(Build.ArtifactStagingDirectory)\\PLOC"
     artifactName: "legacy localizeInputs"
+  # TODO: reinstate official build after testing
+  #condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
   condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
 
 - task: NuGetCommand@2
@@ -503,6 +515,8 @@ steps:
   inputs:
     targetPath: "$(Build.Repository.LocalPath)\\artifacts\\symbolstoindex"
     artifactName: "symbols - $(RtmLabel)"
+  # TODO: reinstate official build after testing
+  #condition: " and(succeeded(), eq(variables['IsOfficialBuild'], 'true')) "
 
 - task: ms-vscs-artifact.build-tasks.artifactSymbolTask-1.artifactSymbolTask@0
   displayName: "Publish Symbols on Symweb"

--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -492,7 +492,8 @@ steps:
     configuration: "$(BuildConfiguration)"
     msbuildArguments: "/p:IsSymbolBuild=true /p:BuildRTM=$(BuildRTM)"
     maximumCpuCount: true
-  condition: " and(succeeded(), eq(variables['IsOfficialBuild'], 'true')) "
+  # TODO: reinstate official build after testing
+  #condition: " and(succeeded(), eq(variables['IsOfficialBuild'], 'true')) "
 
 - task: CopyFiles@2
   displayName: "Copy Symbols (non-rtm)"

--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -309,6 +309,13 @@ steps:
     TargetFolder: "$(BuildOutputTargetPath)\\artifacts\\$(VsixPublishDir)\\$(NupkgOutputDir)"
   condition: and(succeeded(), or(eq(variables['IsOfficialBuild'], 'true'), eq(variables['BuildRTM'], 'true')))  #skip this task for nonRTM in private build
 
+- task: PublishPipelineArtifact@1
+  displayName: "Publish nupkgs"
+  inputs: 
+    targetPath: "$(Build.Repository.LocalPath)\\artifacts\\$(NupkgOutputDir)"
+    artifactName: "nupkgs - $(RtmLabel)"
+  condition: and(succeeded(), or(eq(variables['IsOfficialBuild'], 'true'), eq(variables['BuildRTM'], 'true')))  #skip this task for nonRTM in private build
+
 - task: MSBuild@1
   displayName: "Generate VSMAN file for NuGet Core VSIX"
   inputs:
@@ -430,7 +437,6 @@ steps:
     PathtoPublish: "$(Build.Repository.LocalPath)\\artifacts\\$(VsixPublishDir)"
     ArtifactName: "$(VsixPublishDir)"
     ArtifactType: "Container"
-  condition: "and(succeeded(),eq(variables['BuildRTM'], 'false'))"
 
 - task: CopyFiles@2
   displayName: "Copy LCG Files (deprecated)"
@@ -448,6 +454,13 @@ steps:
     targetPath: "$(Build.Repository.LocalPath)\\artifacts\\localize\\"
     artifactName: "localizeInputs"
   condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
+
+- task: PublishPipelineArtifact@1
+  displayName: "Upload legacy localizeInputs artifact"
+  inputs:
+    targetPath: "$(Build.Repository.LocalPath)\\artifacts\\**\\*.lcg;!$(Build.Repository.LocalPath)\\artifacts\\localize\\**\\*"
+    artifactName: "legacy localizeInputs"
+  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
 
 - task: NuGetCommand@2
   displayName: Publish public Nuget packages to nuget-build
@@ -484,6 +497,12 @@ steps:
     Contents: "**\\*"
     TargetFolder: "$(BuildOutputTargetPath)\\symbols-rtm"
   condition: " and(succeeded(), not(eq(variables['BuildRTM'], 'false')), eq(variables['IsOfficialBuild'], 'true')) "
+
+- task: PublishPipelineArtifact@1
+  displayName: "Publish symbols as pipeline artifacts"
+  inputs:
+    targetPath: "$(Build.Repository.LocalPath)\\artifacts\\symbolstoindex"
+    artifactName: "symbols - $(RtmLabel)"
 
 - task: ms-vscs-artifact.build-tasks.artifactSymbolTask-1.artifactSymbolTask@0
   displayName: "Publish Symbols on Symweb"

--- a/scripts/cibuild/ConfigureVstsBuild.ps1
+++ b/scripts/cibuild/ConfigureVstsBuild.ps1
@@ -63,6 +63,23 @@ Function Update-VsixVersion {
     Write-Host "Updated the VSIX version [$oldVersion] => [$($root.Metadata.Identity.Version)]"
 }
 
+Function Set-RtmLabel {
+    param(
+        [string]$BuildRTM
+    )
+
+    if ($BuildRTM -eq $true) {
+        $label = "RTM"
+    } else {
+        $label = "NonRTM"
+    }
+
+    Write-Host "RTM Label: $label"
+    Write-Host "##vso[task.setvariable variable=RtmLabel;]$label"
+}
+
+Set-RtmLabel -BuildRTM $BuildRTM
+
 $msbuildExe = 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\bin\msbuild.exe'
 
 # Disable strong name verification of common public keys so that scenarios like building the VSIX or running unit tests


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/818
Fixes: https://github.com/NuGet/Client.Engineering/issues/740

Regression? No

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

* Create a build variable with the value "RTM" or "NonRTM", so we don't have to duplicate every task, with conditions saying whether each should work on RTM or NonRTM builds
* publish `artifacts\vs15` as pipeline artifact on both rtm and non-rtm builds
* publish nupkgs as pipeline artifacts
* publish symbols as pipeline artifacts
* publish legacy localization files as pipeline artifacts

## PR Checklist

- [X] PR has a meaningful title
- [X] PR has a linked issue.
- [X] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [X] N/A (Infrastructure)

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [X] N/A
