### PR TITLE
SemanticVersion exceptions use Resource Strings

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio/LegacyTypes/SemanticVersion.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio/LegacyTypes/SemanticVersion.cs
@@ -55,7 +55,7 @@ namespace NuGet
         {
             if (version == null)
             {
-                throw new ArgumentNullException("version");
+                throw new ArgumentNullException(nameof(version));
             }
             Version = NormalizeVersionValue(version);
             SpecialVersion = specialVersion ?? string.Empty;
@@ -137,13 +137,15 @@ namespace NuGet
         {
             if (string.IsNullOrEmpty(version))
             {
-                throw new ArgumentException("Value cannot be null or an empty string.", "version");
+                throw new ArgumentException(Strings.Argument_Cannot_Be_Null_Or_Empty, nameof(version));
             }
 
             SemanticVersion semVer;
             if (!TryParse(version, out semVer))
             {
-                throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, "'{0}' is not a valid version string.", version), "version");
+                throw new ArgumentException(
+                    message: string.Format(CultureInfo.CurrentCulture, Strings.SemanticVersionStringInvalid, version),
+                    paramName: nameof(version));
             }
             return semVer;
         }
@@ -267,7 +269,7 @@ namespace NuGet
         {
             if (version1 == null)
             {
-                throw new ArgumentNullException("version1");
+                throw new ArgumentNullException(nameof(version1));
             }
             return version1.CompareTo(version2) < 0;
         }
@@ -281,7 +283,7 @@ namespace NuGet
         {
             if (version1 == null)
             {
-                throw new ArgumentNullException("version1");
+                throw new ArgumentNullException(nameof(version1));
             }
             return version2 < version1;
         }

--- a/src/NuGet.Clients/NuGet.VisualStudio/Strings.Designer.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio/Strings.Designer.cs
@@ -61,11 +61,29 @@ namespace NuGet.VisualStudio {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Value cannot be null or an empty string..
+        /// </summary>
+        internal static string Argument_Cannot_Be_Null_Or_Empty {
+            get {
+                return ResourceManager.GetString("Argument_Cannot_Be_Null_Or_Empty", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Argument must be of type &apos;{0}&apos;..
         /// </summary>
         internal static string ArgumentTypeExceptionMessage {
             get {
                 return ResourceManager.GetString("ArgumentTypeExceptionMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &apos;{0}&apos; is not a valid version string..
+        /// </summary>
+        internal static string SemanticVersionStringInvalid {
+            get {
+                return ResourceManager.GetString("SemanticVersionStringInvalid", resourceCulture);
             }
         }
     }

--- a/src/NuGet.Clients/NuGet.VisualStudio/Strings.resx
+++ b/src/NuGet.Clients/NuGet.VisualStudio/Strings.resx
@@ -121,4 +121,11 @@
     <value>Argument must be of type '{0}'.</value>
     <comment>0 - Type name</comment>
   </data>
+  <data name="Argument_Cannot_Be_Null_Or_Empty" xml:space="preserve">
+    <value>Value cannot be null or an empty string.</value>
+  </data>
+  <data name="SemanticVersionStringInvalid" xml:space="preserve">
+    <value>'{0}' is not a valid version string.</value>
+    <comment>0 - Version string</comment>
+  </data>
 </root>

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/Extensibility/VsSemanticVersionTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/Extensibility/VsSemanticVersionTests.cs
@@ -8,14 +8,14 @@ namespace NuGet.VisualStudio.Implementation.Test.Extensibility
 {
     public class VsSemanticVersionTests
     {
-        [Fact]
-        public void SemanticVersion_ParseVersion_ThrowsIfNullOrEmpty()
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void SemanticVersion_ParseVersion_ThrowsIfNullOrEmpty(string version)
         {
-            var nullException = Assert.Throws<ArgumentException>(paramName: "version", () => SemanticVersion.Parse(null));
-            var emptyException = Assert.Throws<ArgumentException>(paramName: "version", () => SemanticVersion.Parse(string.Empty));
+            var exception = Assert.Throws<ArgumentException>(paramName: "version", () => SemanticVersion.Parse(version));
 
-            Assert.StartsWith("Value cannot be null or an empty string.", nullException.Message);
-            Assert.StartsWith("Value cannot be null or an empty string.", emptyException.Message);
+            Assert.StartsWith("Value cannot be null or an empty string.", exception.Message);
         }
 
         [Theory]

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/Extensibility/VsSemanticVersionTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/Extensibility/VsSemanticVersionTests.cs
@@ -1,0 +1,33 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Xunit;
+
+namespace NuGet.VisualStudio.Implementation.Test.Extensibility
+{
+    public class VsSemanticVersionTests
+    {
+        [Fact]
+        public void SemanticVersion_ParseVersion_ThrowsIfNullOrEmpty()
+        {
+            var nullException = Assert.Throws<ArgumentException>(paramName: "version", () => SemanticVersion.Parse(null));
+            var emptyException = Assert.Throws<ArgumentException>(paramName: "version", () => SemanticVersion.Parse(string.Empty));
+
+            Assert.StartsWith("Value cannot be null or an empty string.", nullException.Message);
+            Assert.StartsWith("Value cannot be null or an empty string.", emptyException.Message);
+        }
+
+        [Theory]
+        [InlineData(" ")]
+        [InlineData("invalid")]
+        [InlineData("1.1.1.1.1")]
+        [InlineData("%")]
+        public void SemanticVersion_ParseVersion_ThrowsIfInvalid(string invalidVersion)
+        {
+            var invalidException = Assert.Throws<ArgumentException>(paramName: "version", () => SemanticVersion.Parse(invalidVersion));
+
+            Assert.StartsWith("'" + invalidVersion + "' is not a valid version string.", invalidException.Message);
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Versioning.Test/ExceptionAssert.cs
+++ b/test/NuGet.Core.Tests/NuGet.Versioning.Test/ExceptionAssert.cs
@@ -45,15 +45,15 @@ namespace NuGet.Versioning.Test
         {
             if (minimum == null)
             {
-                return String.Format(equalAllowed ? "Argument_Must_Be_LessThanOrEqualTo" : "Argument_Must_Be_LessThan", maximum);
+                return string.Format(equalAllowed ? "Argument_Must_Be_LessThanOrEqualTo" : "Argument_Must_Be_LessThan", maximum);
             }
             else if (maximum == null)
             {
-                return String.Format(equalAllowed ? "Argument_Must_Be_GreaterThanOrEqualTo" : "Argument_Must_Be_GreaterThan", minimum);
+                return string.Format(equalAllowed ? "Argument_Must_Be_GreaterThanOrEqualTo" : "Argument_Must_Be_GreaterThan", minimum);
             }
             else
             {
-                return String.Format("Argument_Must_Be_Between", minimum, maximum);
+                return string.Format("Argument_Must_Be_Between", minimum, maximum);
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Versioning.Test/NuGetVersionTest.cs
+++ b/test/NuGet.Core.Tests/NuGet.Versioning.Test/NuGetVersionTest.cs
@@ -322,7 +322,7 @@ namespace NuGet.Versioning.Test
             // Arrange 
             var version = new Version(versionString);
 
-               // Act
+            // Act
             var semVer = new NuGetVersion(version, specialVersion);
 
             // Assert

--- a/test/NuGet.Core.Tests/NuGet.Versioning.Test/NuGetVersionTest.cs
+++ b/test/NuGet.Core.Tests/NuGet.Versioning.Test/NuGetVersionTest.cs
@@ -322,11 +322,11 @@ namespace NuGet.Versioning.Test
             // Arrange 
             var version = new Version(versionString);
 
-            // Act
+               // Act
             var semVer = new NuGetVersion(version, specialVersion);
 
             // Assert
-            Assert.Equal(expected, string.Format("{0}", semVer));
+            Assert.Equal(expected, semVer.ToString());
         }
 
         [Fact]

--- a/test/NuGet.Core.Tests/NuGet.Versioning.Test/NuGetVersionTest.cs
+++ b/test/NuGet.Core.Tests/NuGet.Versioning.Test/NuGetVersionTest.cs
@@ -82,7 +82,7 @@ namespace NuGet.Versioning.Test
         public void ParseThrowsIfStringIsNullOrEmpty()
         {
             ExceptionAssert.ThrowsArgNullOrEmpty(() => NuGetVersion.Parse(null), "value");
-            ExceptionAssert.ThrowsArgNullOrEmpty(() => NuGetVersion.Parse(String.Empty), "value");
+            ExceptionAssert.ThrowsArgNullOrEmpty(() => NuGetVersion.Parse(string.Empty), "value");
         }
 
         [Theory]
@@ -106,7 +106,7 @@ namespace NuGet.Versioning.Test
         {
             ExceptionAssert.ThrowsArgumentException(() => NuGetVersion.Parse(versionString),
                 "value",
-                String.Format(CultureInfo.InvariantCulture, "'{0}' is not a valid version string.", versionString));
+                string.Format(CultureInfo.InvariantCulture, "'{0}' is not a valid version string.", versionString));
         }
 
         [Theory]
@@ -326,7 +326,7 @@ namespace NuGet.Versioning.Test
             var semVer = new NuGetVersion(version, specialVersion);
 
             // Assert
-            Assert.Equal(expected, String.Format("{0}", semVer));
+            Assert.Equal(expected, string.Format("{0}", semVer));
         }
 
         [Fact]


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/10392

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Add resource strings for `ArgumentExceptions` in `SemanticVersion`.
Notice that this Issue/PR was for legacy `SemanticVersion`, not the `SemanticVersionFactory` from NuGet.Versioning.
Also made several `String` to `string` corrections.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added - New tests for null, empty, and invalid version strings.
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
