### PR TITLE
Allow null frameworks when filtering assemblyreferences

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PackageBuilder.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PackageBuilder.cs
@@ -606,7 +606,7 @@ namespace NuGet.Packaging
         {
             var frameworksMissingPlatformVersion = new HashSet<string>(packageAssemblyReferences
                 .Select(group => group.TargetFramework)
-                .Where(groupFramework => groupFramework.HasPlatform && groupFramework.PlatformVersion == FrameworkConstants.EmptyVersion)
+                .Where(groupFramework => groupFramework != null && groupFramework.HasPlatform && groupFramework.PlatformVersion == FrameworkConstants.EmptyVersion)
                 .Select(framework => framework.GetShortFolderName()));
             if (frameworksMissingPlatformVersion.Any())
             {

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageBuilderTest.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageBuilderTest.cs
@@ -2292,6 +2292,24 @@ Description is required.");
         }
 
         [Fact]
+        public void ValidateReferencesAllowsNullFramework()
+        {
+            // Arrange
+            var files = new[] {
+                        new PhysicalPackageFile { TargetPath = @"lib" + Path.DirectorySeparatorChar + "net40" + Path.DirectorySeparatorChar + "foo.dll" },
+                        new PhysicalPackageFile { TargetPath = @"lib" + Path.DirectorySeparatorChar + "net40" + Path.DirectorySeparatorChar + "bar.dll" },
+                        new PhysicalPackageFile { TargetPath = @"lib" + Path.DirectorySeparatorChar + "net40" + Path.DirectorySeparatorChar + "baz.exe" },
+                    };
+            var packageAssemblyReferences = new PackageReferenceSet((NuGetFramework)null, new string[] { "foo.dll", "bar", "baz" });
+
+            // Act and Assert
+            PackageBuilder.ValidateReferenceAssemblies(files, new[] { packageAssemblyReferences });
+
+            // If we've got this far, no exceptions were thrown.
+            Assert.True(true);
+        }
+
+        [Fact]
         public void ValidateReferencesThrowsForPartialNamesThatDoNotHaveAKnownExtension()
         {
             // Arrange


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/10685

Regression? Last working version: Yes, 5.8

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

When I added an error for when a tpv for an existing platform (https://github.com/NuGet/NuGet.Client/pull/3691), I missed that the NuGetFramework could be null. This fixes that and adds a test.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
