### PR TITLE
Remove code for UI filtering in Packages List

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
@@ -115,13 +115,6 @@ namespace NuGet.PackageManagement.UI
         public bool IsSolution { get; set; }
 
         public ObservableCollection<object> Items { get; } = new ObservableCollection<object>();
-        private ICollectionView CollectionView
-        {
-            get
-            {
-                return CollectionViewSource.GetDefaultView(Items);
-            }
-        }
 
         /// <summary>
         /// Count of Items (excluding Loading indicator) that are currently shown after applying any UI filtering.
@@ -130,7 +123,7 @@ namespace NuGet.PackageManagement.UI
         {
             get
             {
-                return PackageItemsFiltered.Count();
+                return PackageItems.Count();
             }
         }
 
@@ -138,24 +131,6 @@ namespace NuGet.PackageManagement.UI
         /// All loaded Items (excluding Loading indicator) regardless of filtering.
         /// </summary>
         public IEnumerable<PackageItemViewModel> PackageItems => Items.OfType<PackageItemViewModel>().ToArray();
-
-        /// <summary>
-        /// Items (excluding Loading indicator) that are currently shown after applying any UI filtering.
-        /// </summary>
-        public IEnumerable<PackageItemViewModel> PackageItemsFiltered
-        {
-            get
-            {
-                if (CollectionView.Filter != null)
-                {
-                    return CollectionView.OfType<PackageItemViewModel>();
-                }
-                else
-                {
-                    return PackageItems;
-                }
-            }
-        }
 
         public PackageItemViewModel SelectedPackageItem => _list.SelectedItem as PackageItemViewModel;
 
@@ -219,12 +194,12 @@ namespace NuGet.PackageManagement.UI
             if (selectedItem != null)
             {
                 // select the the previously selected item if it still exists.
-                selectedItem = PackageItemsFiltered
+                selectedItem = PackageItems
                     .FirstOrDefault(item => item.Id.Equals(selectedItem.Id, StringComparison.OrdinalIgnoreCase));
             }
 
             // select the first item if none was selected before
-            _list.SelectedItem = selectedItem ?? PackageItemsFiltered.FirstOrDefault();
+            _list.SelectedItem = selectedItem ?? PackageItems.FirstOrDefault();
         }
 
         private async Task LoadItemsAsync(PackageItemViewModel selectedPackageItem, CancellationToken token)
@@ -254,9 +229,6 @@ namespace NuGet.PackageManagement.UI
                 await LoadItemsCoreAsync(currentLoader, loadCts.Token);
 
                 await _joinableTaskFactory.Value.SwitchToMainThreadAsync();
-
-                //Any UI filter should be cleared when Loading.
-                ClearUIFilter();
 
                 if (selectedPackageItem != null)
                 {
@@ -323,61 +295,6 @@ namespace NuGet.PackageManagement.UI
             UpdateCheckBoxStatus();
 
             LoadItemsCompleted?.Invoke(this, EventArgs.Empty);
-        }
-
-        internal void FilterItems(ItemFilter itemFilter, CancellationToken token)
-        {
-            if (!Items.Contains(_loadingStatusIndicator))
-            {
-                Items.Add(_loadingStatusIndicator);
-            }
-            _loadingStatusIndicator.Status = LoadingStatus.Loading;
-
-            // If there is another async loading process - cancel it.
-            var loadCts = CancellationTokenSource.CreateLinkedTokenSource(token);
-            Interlocked.Exchange(ref _loadCts, loadCts)?.Cancel();
-
-            try
-            {
-                if (itemFilter == ItemFilter.UpdatesAvailable)
-                {
-                    ApplyUIFilterForUpdatesAvailable();
-                }
-                else
-                {
-                    //Show all the items, without an Update filter.
-                    ClearUIFilter();
-                }
-            }
-            finally
-            {
-                //If no items are shown in the filter, indicate in the list that no packages are found.
-                if (FilteredItemsCount == 0)
-                {
-                    _loadingStatusIndicator.Status = LoadingStatus.NoItemsFound;
-                }
-                else
-                {
-                    if (Items.Contains(_loadingStatusIndicator))
-                    {
-                        Items.Remove(_loadingStatusIndicator);
-                    }
-                }
-            }
-
-            UpdateCheckBoxStatus();
-
-            LoadItemsCompleted?.Invoke(this, EventArgs.Empty);
-        }
-
-        private void ApplyUIFilterForUpdatesAvailable()
-        {
-            CollectionView.Filter = (item) => item == _loadingStatusIndicator || (item as PackageItemViewModel).IsUpdateAvailable;
-        }
-
-        private void ClearUIFilter()
-        {
-            CollectionView.Filter = null;
         }
 
         private async Task LoadItemsCoreAsync(IPackageItemLoader currentLoader, CancellationToken token)
@@ -601,7 +518,7 @@ namespace NuGet.PackageManagement.UI
         {
             // in this case, we only need to update PackageStatus of
             // existing items in the package list
-            foreach (var package in PackageItemsFiltered)
+            foreach (var package in PackageItems)
             {
                 package.UpdatePackageStatus(installedPackages);
             }
@@ -761,7 +678,7 @@ namespace NuGet.PackageManagement.UI
 
         private void _updateButton_Click(object sender, RoutedEventArgs e)
         {
-            var selectedPackages = PackageItemsFiltered.Where(p => p.IsSelected).ToArray();
+            var selectedPackages = PackageItems.Where(p => p.IsSelected).ToArray();
             UpdateButtonClicked(selectedPackages);
         }
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -51,8 +51,6 @@ namespace NuGet.PackageManagement.UI
         private readonly Guid _sessionGuid = Guid.NewGuid();
         private Stopwatch _sinceLastRefresh;
         private CancellationTokenSource _refreshCts;
-        private bool _installedTabDataIsLoaded;
-        private bool _updatesTabDataIsLoaded;
         private bool _forceRecommender;
         // used to prevent starting new search when we update the package sources
         // list in response to PackageSourcesChanged event.
@@ -411,7 +409,6 @@ namespace NuGet.PackageManagement.UI
             if (!_loadedAndInitialized)
             {
                 _loadedAndInitialized = true;
-                ResetTabDataLoadFlags();
                 await SearchPackagesAndRefreshUpdateCountAsync(useCacheForUpdates: false);
                 EmitRefreshEvent(timeSpan, RefreshOperationSource.PackageManagerLoaded, RefreshOperationStatus.Success);
             }
@@ -505,7 +502,6 @@ namespace NuGet.PackageManagement.UI
             // search when needed by itself.
             _dontStartNewSearch = true;
             TimeSpan timeSpan = GetTimeSinceLastRefreshAndRestart();
-            ResetTabDataLoadFlags();
 
             NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(() => PackageSourcesChangedAsync(e, timeSpan))
                 .PostOnFailure(nameof(PackageManagerControl), nameof(PackageSourcesChanged));
@@ -850,7 +846,6 @@ namespace NuGet.PackageManagement.UI
             else // Invalidate cache
             {
                 Model.CachedUpdates = null;
-                FlagTabDataAsLoaded(filterToRender, isLoaded: false);
             }
 
             try
@@ -889,21 +884,11 @@ namespace NuGet.PackageManagement.UI
                 {
                     await RefreshInstalledAndUpdatesTabsAsync();
                 }
-
-                FlagTabDataAsLoaded(filterToRender);
-
-                // Loading Data on Installed tab should also consider the Data on Updates tab as loaded to indicate
-                // UI filtering for Updates is ready.
-                if (filterToRender == ItemFilter.Installed)
-                {
-                    FlagTabDataAsLoaded(ItemFilter.UpdatesAvailable);
-                }
             }
             catch (OperationCanceledException)
             {
                 // Invalidate cache.
                 Model.CachedUpdates = null;
-                FlagTabDataAsLoaded(filterToRender, isLoaded: false);
             }
         }
 
@@ -932,43 +917,6 @@ namespace NuGet.PackageManagement.UI
             {
                 return false;
             }
-        }
-
-        /// <summary>
-        /// Set a flag indicating this tab has been loaded for the first time since the control was loaded.
-        /// Purpose is to identify cache availability and improve performance.
-        /// When clearing this flag by <paramref name="isLoaded"/> to false, Installed and Updates will both be cleared
-        /// since they are treated as one logical load.
-        /// </summary>
-        /// <param name="filterToCheck">Tab to mark as initially loaded. Currently supports Installed and Updates.</param>
-        /// <param name="isLoaded">Set to false to reset the tab to its original state of not loaded.</param>
-        private void FlagTabDataAsLoaded(ItemFilter filterToCheck, bool isLoaded = true)
-        {
-            switch (filterToCheck)
-            {
-                case ItemFilter.Installed:
-                    _installedTabDataIsLoaded = isLoaded;
-                    if (!isLoaded)
-                    {
-                        _updatesTabDataIsLoaded = false;
-                    }
-                    break;
-                case ItemFilter.UpdatesAvailable:
-                    _updatesTabDataIsLoaded = isLoaded;
-                    if (!isLoaded)
-                    {
-                        _installedTabDataIsLoaded = false;
-                    }
-                    break;
-                default:
-                    break;
-            }
-        }
-
-        private void ResetTabDataLoadFlags()
-        {
-            _installedTabDataIsLoaded = false;
-            _updatesTabDataIsLoaded = false;
         }
 
         private async ValueTask RefreshInstalledAndUpdatesTabsAsync()
@@ -1122,7 +1070,6 @@ namespace NuGet.PackageManagement.UI
         private void SourceRepoList_SelectionChanged(object sender, EventArgs e)
         {
             var timeSpan = GetTimeSinceLastRefreshAndRestart();
-            ResetTabDataLoadFlags();
 
             if (_dontStartNewSearch || !_initialized)
             {
@@ -1165,34 +1112,12 @@ namespace NuGet.PackageManagement.UI
                 oldCts?.Cancel();
                 oldCts?.Dispose();
 
-                var switchedFromInstalledOrUpdatesTab = e.PreviousFilter.HasValue &&
-                    (e.PreviousFilter == ItemFilter.Installed || e.PreviousFilter == ItemFilter.UpdatesAvailable);
-                var switchedToInstalledOrUpdatesTab = _topPanel.Filter == ItemFilter.UpdatesAvailable || _topPanel.Filter == ItemFilter.Installed;
-                var installedAndUpdatesTabDataLoaded = _installedTabDataIsLoaded && _updatesTabDataIsLoaded;
-
-                var isUiFiltering = switchedFromInstalledOrUpdatesTab && switchedToInstalledOrUpdatesTab && installedAndUpdatesTabDataLoaded;
-
                 NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async () =>
                 {
                     await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
-                    // Installed and Updates tabs don't need to be refreshed when switching between the two, if they're both loaded.
-                    if (isUiFiltering)
-                    {
-                        // UI can apply filtering.
-                        _packageList.FilterItems(_topPanel.Filter, _loadCts.Token);
-                    }
-                    else // Refresh tab from Cache.
-                    {
-                        // If we came from a tab outside Installed/Updates, then they need to be Refreshed before UI filtering can take place.
-                        if (!switchedFromInstalledOrUpdatesTab)
-                        {
-                            ResetTabDataLoadFlags();
-                        }
-
-                        await SearchPackagesAndRefreshUpdateCountAsync(useCacheForUpdates: true);
-                    }
-                    EmitRefreshEvent(timeSpan, RefreshOperationSource.FilterSelectionChanged, RefreshOperationStatus.Success, isUiFiltering);
+                    await SearchPackagesAndRefreshUpdateCountAsync(useCacheForUpdates: true);
+                    EmitRefreshEvent(timeSpan, RefreshOperationSource.FilterSelectionChanged, RefreshOperationStatus.Success, isUIFiltering: false);
                     _detailModel.OnFilterChanged(e.PreviousFilter, _topPanel.Filter);
                 }).PostOnFailure(nameof(PackageManagerControl), nameof(Filter_SelectionChanged));
             }
@@ -1203,8 +1128,6 @@ namespace NuGet.PackageManagement.UI
         /// </summary>
         private async ValueTask RefreshAsync()
         {
-            ResetTabDataLoadFlags();
-
             if (_topPanel.Filter != ItemFilter.All)
             {
                 // refresh the whole package list
@@ -1234,7 +1157,6 @@ namespace NuGet.PackageManagement.UI
                 return;
             }
 
-            ResetTabDataLoadFlags();
             var timeSpan = GetTimeSinceLastRefreshAndRestart();
             RegistrySettingUtility.SetBooleanSetting(Constants.IncludePrereleaseRegistryName, _topPanel.CheckboxPrerelease.IsChecked == true);
             EmitRefreshEvent(timeSpan, RefreshOperationSource.CheckboxPrereleaseChanged, RefreshOperationStatus.Success);
@@ -1267,7 +1189,6 @@ namespace NuGet.PackageManagement.UI
 
         public void ClearSearch()
         {
-            ResetTabDataLoadFlags();
             EmitRefreshEvent(GetTimeSinceLastRefreshAndRestart(), RefreshOperationSource.ClearSearch, RefreshOperationStatus.Success);
             NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async () =>
             {
@@ -1359,11 +1280,11 @@ namespace NuGet.PackageManagement.UI
                 return;
             }
 
-            if (_topPanel.Filter == ItemFilter.UpdatesAvailable && _updatesTabDataIsLoaded)
+            if (_topPanel.Filter == ItemFilter.UpdatesAvailable)
             {
                 SelectMatchingUpdatePackages(updatePackageOptions);
             }
-            else if (_topPanel.Filter == ItemFilter.Installed && _updatesTabDataIsLoaded)
+            else if (_topPanel.Filter == ItemFilter.Installed)
             {
                 _topPanel.SelectFilter(ItemFilter.UpdatesAvailable);
                 SelectMatchingUpdatePackages(updatePackageOptions);
@@ -1497,7 +1418,6 @@ namespace NuGet.PackageManagement.UI
                 {
                     //Invalidate cache.
                     Model.CachedUpdates = null;
-                    ResetTabDataLoadFlags();
 
                     IsEnabled = true;
                     _isExecutingAction = false;
@@ -1567,7 +1487,6 @@ namespace NuGet.PackageManagement.UI
         private void ExecuteRestartSearchCommand(object sender, ExecutedRoutedEventArgs e)
         {
             EmitRefreshEvent(GetTimeSinceLastRefreshAndRestart(), RefreshOperationSource.RestartSearchCommand, RefreshOperationStatus.Success);
-            ResetTabDataLoadFlags();
             NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(() => ExecuteRestartSearchCommandAsync())
                 .PostOnFailure(nameof(PackageManagerControl), nameof(ExecuteRestartSearchCommand));
         }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->


Fixes: https://github.com/nuget/home/issues/9887 (details pane default version)
Fixes: https://github.com/NuGet/Home/issues/10510 (batch/update all NRE)
Fixes: https://github.com/NuGet/Home/issues/10671 (fast tab-switch shows OperationCancelled)

Regression? Last working version: "No" for triage purposes. Technically "Yes" (see Description).

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
Generally, this reverts the tiny step of UI filtering I made in 16.7 in https://github.com/NuGet/NuGet.Client/pull/3444. Meaning, there will be a tiny perf regression in 16.10 when this PR is merged. 

The reason is, I kept finding myself chasing bugs with in-memory filtering of existing metadata from `InstalledPackageFeed` and `UpdatePackageFeed`. Existing work to re-architect portions of the PMUI is here: https://github.com/NuGet/Home/issues/10082. 
The decision is to regress slightly (back to 16.6 behavior), and focus on 10082 to make this perf improvement more whollistically.

Telemetry is unmodified. Property `IsUIFiltering` still exists, but will always be `false`.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception - refactoring/removal of logic. Manual testing passed and verified the 3 linked Issues are resolved.
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
