### PR TITLE
Make by default validation disabled on Linux, but enabled by default on Windows

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/NuGet.CommandLine.XPlat.csproj
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/NuGet.CommandLine.XPlat.csproj
@@ -1,4 +1,4 @@
-﻿<Project>
+<Project>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common.props" />
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/NuGet.CommandLine.XPlat.csproj
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/NuGet.CommandLine.XPlat.csproj
@@ -1,4 +1,4 @@
-<Project>
+﻿<Project>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common.props" />
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 

--- a/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs
@@ -452,6 +452,10 @@ namespace NuGet.Packaging
             {
                 return false;
             }
+            else if (RuntimeEnvironmentHelper.IsLinux || RuntimeEnvironmentHelper.IsMacOSX)
+            {
+                return false;
+            }
             else
             {
                 return true;

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
@@ -224,9 +224,9 @@ EndGlobal";
 
                 _msbuildFixture.CreateDotnetNewProject(pathContext.SolutionRoot, projectName, "classlib");
 
-                using (var stream = File.Open(projectFile, FileMode.Open, FileAccess.ReadWrite))
+                using (FileStream stream = File.Open(projectFile, FileMode.Open, FileAccess.ReadWrite))
                 {
-                    var xml = XDocument.Load(stream);
+                    XDocument xml = XDocument.Load(stream);
 
                     var attributes = new Dictionary<string, string>() { { "Version", "1.0.0" } };
 
@@ -257,7 +257,7 @@ EndGlobal";
                 File.WriteAllText(Path.Combine(workingDirectory, "NuGet.Config"), doc.ToString());
 
                 // Act                
-                var result = _msbuildFixture.RunDotnet(workingDirectory, "restore", ignoreExitCode: true);
+                CommandRunnerResult result = _msbuildFixture.RunDotnet(workingDirectory, "restore", ignoreExitCode: true);
 
                 result.AllOutput.Should().NotContain($"error NU3004");
                 result.Success.Should().BeTrue();

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
@@ -121,7 +121,7 @@ EndGlobal";
         }
 
 #if IS_SIGNING_SUPPORTED
-        [Fact]
+        [PlatformFact(Platform.Windows)]
         public async Task DotnetRestore_WithUnSignedPackageAndSignatureValidationModeAsRequired_Fails()
         {
             using (var pathContext = _msbuildFixture.CreateSimpleTestPathContext())
@@ -193,7 +193,7 @@ EndGlobal";
             }
         }
 
-        [Fact]
+        [PlatformFact(Platform.Windows)]
         public void DotnetRestore_WithAuthorSignedPackageAndSignatureValidationModeAsRequired_Succeeds()
         {
             using (var pathContext = _msbuildFixture.CreateSimpleTestPathContext())

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
@@ -122,7 +122,7 @@ EndGlobal";
 
 #if IS_SIGNING_SUPPORTED
         [PlatformFact(Platform.Windows)]
-        public async Task DotnetRestore_WithUnSignedPackageAndSignatureValidationModeAsRequired_Fails()
+        public async Task DotnetRestore_WithUnSignedPackageAndSignatureValidationModeAsRequired_FailsAsync()
         {
             using (var pathContext = _msbuildFixture.CreateSimpleTestPathContext())
             {
@@ -194,7 +194,7 @@ EndGlobal";
         }
 
         [PlatformFact(Platform.Linux, Platform.Darwin)]
-        public async Task DotnetRestore_WithUnSignedPackageAndSignatureValidationModeAsRequired_Succeed()
+        public async Task DotnetRestore_WithUnSignedPackageAndSignatureValidationModeAsRequired_SucceedAsync()
         {
             using (var pathContext = _msbuildFixture.CreateSimpleTestPathContext())
             {

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
@@ -193,6 +193,78 @@ EndGlobal";
             }
         }
 
+        [PlatformFact(Platform.Linux, Platform.Darwin)]
+        public async Task DotnetRestore_WithUnSignedPackageAndSignatureValidationModeAsRequired_Succeed()
+        {
+            using (var pathContext = _msbuildFixture.CreateSimpleTestPathContext())
+            {
+                //Setup packages and feed
+                var packageX = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.0"
+                };
+                packageX.Files.Clear();
+                packageX.AddFile("lib/netcoreapp2.0/x.dll");
+                packageX.AddFile("ref/netcoreapp2.0/x.dll");
+                packageX.AddFile("lib/net472/x.dll");
+                packageX.AddFile("ref/net472/x.dll");
+
+                await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                    pathContext.PackageSource,
+                    PackageSaveMode.Defaultv3,
+                    packageX);
+
+                // Set up solution, and project
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+
+                var projectName = "ClassLibrary1";
+                var workingDirectory = Path.Combine(pathContext.SolutionRoot, projectName);
+                var projectFile = Path.Combine(workingDirectory, $"{projectName}.csproj");
+
+                _msbuildFixture.CreateDotnetNewProject(pathContext.SolutionRoot, projectName, "classlib");
+
+                using (var stream = File.Open(projectFile, FileMode.Open, FileAccess.ReadWrite))
+                {
+                    var xml = XDocument.Load(stream);
+
+                    var attributes = new Dictionary<string, string>() { { "Version", "1.0.0" } };
+
+                    ProjectFileUtils.AddItem(
+                        xml,
+                        "PackageReference",
+                        packageX.Id,
+                        string.Empty,
+                        new Dictionary<string, string>(),
+                        attributes);
+
+                    ProjectFileUtils.WriteXmlToFile(xml, stream);
+                }
+
+                //set nuget.config properties
+                var doc = new XDocument();
+                var configuration = new XElement(XName.Get("configuration"));
+                doc.Add(configuration);
+
+                var config = new XElement(XName.Get("config"));
+                configuration.Add(config);
+
+                var signatureValidationMode = new XElement(XName.Get("add"));
+                signatureValidationMode.Add(new XAttribute(XName.Get("key"), "signatureValidationMode"));
+                signatureValidationMode.Add(new XAttribute(XName.Get("value"), "require"));
+                config.Add(signatureValidationMode);
+
+                File.WriteAllText(Path.Combine(workingDirectory, "NuGet.Config"), doc.ToString());
+
+                // Act                
+                var result = _msbuildFixture.RunDotnet(workingDirectory, "restore", ignoreExitCode: true);
+
+                result.AllOutput.Should().NotContain($"error NU3004");
+                result.Success.Should().BeTrue();
+                result.ExitCode.Should().Be(0);
+            }
+        }
+
         [PlatformFact(Platform.Windows)]
         public void DotnetRestore_WithAuthorSignedPackageAndSignatureValidationModeAsRequired_Succeeds()
         {

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
@@ -121,7 +121,7 @@ EndGlobal";
         }
 
 #if IS_SIGNING_SUPPORTED
-        [Fact]
+        [PlatformFact(Platform.Windows)]
         public async Task DotnetRestore_WithUnSignedPackageAndSignatureValidationModeAsRequired_Fails()
         {
             using (var pathContext = _msbuildFixture.CreateSimpleTestPathContext())
@@ -187,9 +187,81 @@ EndGlobal";
                 // Act                
                 var result = _msbuildFixture.RunDotnet(workingDirectory, "restore", ignoreExitCode: true);
 
+                // Assert
                 result.AllOutput.Should().Contain($"error NU3004: Package '{packageX.Id} {packageX.Version}' from source '{pathContext.PackageSource}': signatureValidationMode is set to require, so packages are allowed only if signed by trusted signers; however, this package is unsigned.");
                 result.Success.Should().BeFalse();
                 result.ExitCode.Should().Be(1, because: "error text should be displayed as restore failed");
+            }
+        }
+
+        [CIOnlyFact]
+        public async Task DotnetRestore_WithUnSignedPackageAndSignatureValidationModeAsRequired_Success()
+        {
+            using (var pathContext = _msbuildFixture.CreateSimpleTestPathContext())
+            {
+                //Setup packages and feed
+                var packageX = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.0"
+                };
+                packageX.Files.Clear();
+                packageX.AddFile("lib/netcoreapp2.0/x.dll");
+                packageX.AddFile("ref/netcoreapp2.0/x.dll");
+                packageX.AddFile("lib/net472/x.dll");
+                packageX.AddFile("ref/net472/x.dll");
+
+                await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                    pathContext.PackageSource,
+                    PackageSaveMode.Defaultv3,
+                    packageX);
+
+                // Set up solution, and project
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+
+                var projectName = "ClassLibrary1";
+                var workingDirectory = Path.Combine(pathContext.SolutionRoot, projectName);
+                var projectFile = Path.Combine(workingDirectory, $"{projectName}.csproj");
+
+                _msbuildFixture.CreateDotnetNewProject(pathContext.SolutionRoot, projectName, "classlib");
+
+                using (var stream = File.Open(projectFile, FileMode.Open, FileAccess.ReadWrite))
+                {
+                    var xml = XDocument.Load(stream);
+
+                    var attributes = new Dictionary<string, string>() { { "Version", "1.0.0" } };
+
+                    ProjectFileUtils.AddItem(
+                        xml,
+                        "PackageReference",
+                        packageX.Id,
+                        string.Empty,
+                        new Dictionary<string, string>(),
+                        attributes);
+
+                    ProjectFileUtils.WriteXmlToFile(xml, stream);
+                }
+
+                //set nuget.config properties
+                var doc = new XDocument();
+                var configuration = new XElement(XName.Get("configuration"));
+                doc.Add(configuration);
+
+                var config = new XElement(XName.Get("config"));
+                configuration.Add(config);
+
+                var signatureValidationMode = new XElement(XName.Get("add"));
+                signatureValidationMode.Add(new XAttribute(XName.Get("key"), "signatureValidationMode"));
+                signatureValidationMode.Add(new XAttribute(XName.Get("value"), "require"));
+                config.Add(signatureValidationMode);
+
+                File.WriteAllText(Path.Combine(workingDirectory, "NuGet.Config"), doc.ToString());
+
+                // Act                
+                var result = _msbuildFixture.RunDotnet(workingDirectory, "restore", ignoreExitCode: true);
+
+                // Assert
+                result.Success.Should().BeTrue();
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
@@ -1044,7 +1044,7 @@ namespace NuGet.Commands.Test
             }
         }
 
-        [CIOnlyFact]
+        [PlatformFact(Platform.Linux, Platform.Darwin)]
         public async Task RestoreCommand_InvalidSignedPackageAsync_Success()
         {
             // Arrange

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
@@ -975,7 +975,7 @@ namespace NuGet.Commands.Test
 
 #if IS_SIGNING_SUPPORTED
         [PlatformFact(Platform.Windows)]
-        public async Task RestoreCommand_InvalidSignedPackageAsync_Fails()
+        public async Task RestoreCommand_InvalidSignedPackageAsync_FailsAsync()
         {
             // Arrange
             var sources = new List<PackageSource>();
@@ -1045,7 +1045,7 @@ namespace NuGet.Commands.Test
         }
 
         [PlatformFact(Platform.Linux, Platform.Darwin)]
-        public async Task RestoreCommand_InvalidSignedPackageAsync_Success()
+        public async Task RestoreCommand_InvalidSignedPackageAsync_SuccessAsync()
         {
             // Arrange
             var sources = new List<PackageSource>();

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
@@ -974,8 +974,8 @@ namespace NuGet.Commands.Test
         }
 
 #if IS_SIGNING_SUPPORTED
-        [Fact]
-        public async Task RestoreCommand_InvalidSignedPackageAsync()
+        [PlatformFact(Platform.Windows)]
+        public async Task RestoreCommand_InvalidSignedPackageAsync_Fails()
         {
             // Arrange
             var sources = new List<PackageSource>();
@@ -1041,6 +1041,76 @@ namespace NuGet.Commands.Test
 
                 // Assert
                 Assert.False(result.Success);
+            }
+        }
+
+        [CIOnlyFact]
+        public async Task RestoreCommand_InvalidSignedPackageAsync_Success()
+        {
+            // Arrange
+            var sources = new List<PackageSource>();
+
+            var project1Json = @"
+            {
+              ""version"": ""1.0.0"",
+              ""description"": """",
+              ""authors"": [ ""author"" ],
+              ""tags"": [ """" ],
+              ""projectUrl"": """",
+              ""licenseUrl"": """",
+              ""frameworks"": {
+                ""net46"": {
+                    ""dependencies"": {
+                        ""packageA"": ""1.0.0""
+                    }
+                }
+              }
+            }";
+
+            using (var workingDir = TestDirectory.Create())
+            {
+                var packagesDir = new DirectoryInfo(Path.Combine(workingDir, "globalPackages"));
+                var packageSource = new DirectoryInfo(Path.Combine(workingDir, "packageSource"));
+                var project1 = new DirectoryInfo(Path.Combine(workingDir, "projects", "project1"));
+                packagesDir.Create();
+                packageSource.Create();
+                project1.Create();
+                sources.Add(new PackageSource(packageSource.FullName));
+
+                File.WriteAllText(Path.Combine(project1.FullName, "project.json"), project1Json);
+
+                var specPath1 = Path.Combine(project1.FullName, "project.json");
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1).EnsureProjectJsonRestoreMetadata();
+
+                var logger = new TestLogger();
+
+                var signedPackageVerifier = new Mock<IPackageSignatureVerifier>(MockBehavior.Strict);
+
+                signedPackageVerifier.Setup(x => x.VerifySignaturesAsync(
+                    It.IsAny<ISignedPackageReader>(),
+                    It.Is<SignedPackageVerifierSettings>(s => SigningTestUtility.AreVerifierSettingsEqual(s, DefaultSettings)),
+                    It.IsAny<CancellationToken>(),
+                    It.IsAny<Guid>())).
+                    ReturnsAsync(new VerifySignaturesResult(isValid: false, isSigned: true));
+
+                var clientPolicyContext = ClientPolicyContext.GetClientPolicy(NullSettings.Instance, logger);
+                var request = new TestRestoreRequest(spec1, sources, packagesDir.FullName, clientPolicyContext, logger)
+                {
+                    LockFilePath = Path.Combine(project1.FullName, "project.lock.json"),
+                    SignedPackageVerifier = signedPackageVerifier.Object
+                };
+
+                var packageAContext = new SimpleTestPackageContext("packageA");
+                packageAContext.AddFile("lib/net46/a.dll");
+
+                await SimpleTestPackageUtility.CreateFullPackageAsync(packageSource.FullName, packageAContext);
+
+                // Act
+                var command = new RestoreCommand(request);
+                var result = await command.ExecuteAsync();
+
+                // Assert
+                Assert.True(result.Success);
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
@@ -1080,7 +1080,7 @@ namespace NuGet.Commands.Test
                 File.WriteAllText(Path.Combine(project1.FullName, "project.json"), project1Json);
 
                 var specPath1 = Path.Combine(project1.FullName, "project.json");
-                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1).EnsureProjectJsonRestoreMetadata();
+                PackageSpec spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1).EnsureProjectJsonRestoreMetadata();
 
                 var logger = new TestLogger();
 
@@ -1093,7 +1093,7 @@ namespace NuGet.Commands.Test
                     It.IsAny<Guid>())).
                     ReturnsAsync(new VerifySignaturesResult(isValid: false, isSigned: true));
 
-                var clientPolicyContext = ClientPolicyContext.GetClientPolicy(NullSettings.Instance, logger);
+                ClientPolicyContext clientPolicyContext = ClientPolicyContext.GetClientPolicy(NullSettings.Instance, logger);
                 var request = new TestRestoreRequest(spec1, sources, packagesDir.FullName, clientPolicyContext, logger)
                 {
                     LockFilePath = Path.Combine(project1.FullName, "project.lock.json"),
@@ -1107,7 +1107,7 @@ namespace NuGet.Commands.Test
 
                 // Act
                 var command = new RestoreCommand(request);
-                var result = await command.ExecuteAsync();
+                RestoreResult result = await command.ExecuteAsync();
 
                 // Assert
                 Assert.True(result.Success);

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageArchiveReaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageArchiveReaderTests.cs
@@ -1946,7 +1946,7 @@ namespace NuGet.Packaging.Test
         }
 #endif
 
-        [Fact]
+        [PlatformFact(Platform.Windows)]
         public void CanVerifySignedPackages_ReturnsValueBasedOnOperatingSystemAndFramework()
         {
             // Arrange
@@ -1963,6 +1963,20 @@ namespace NuGet.Packaging.Test
                 // Cannot verify package signature when signing is not supported
                 Assert.False(result);
 #endif
+            }
+        }
+
+        [CIOnlyFact]
+        public void CanVerifySignedPackages_ReturnsValueBasedOnOperatingSystemAndFramework_Fails()
+        {
+            // Arrange
+            using (var test = TestPackagesCore.GetPackageContentReaderTestPackage())
+            using (var packageArchiveReader = new PackageArchiveReader(test))
+            {
+                // Act
+                var result = packageArchiveReader.CanVerifySignedPackages(null);
+                // Assert
+                Assert.False(result);
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageArchiveReaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageArchiveReaderTests.cs
@@ -1974,7 +1974,7 @@ namespace NuGet.Packaging.Test
             using (var packageArchiveReader = new PackageArchiveReader(test))
             {
                 // Act
-                var result = packageArchiveReader.CanVerifySignedPackages(null);
+                bool result = packageArchiveReader.CanVerifySignedPackages(null);
                 // Assert
                 Assert.False(result);
             }

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageArchiveReaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageArchiveReaderTests.cs
@@ -1966,7 +1966,7 @@ namespace NuGet.Packaging.Test
             }
         }
 
-        [CIOnlyFact]
+        [PlatformFact(Platform.Linux, Platform.Darwin)]
         public void CanVerifySignedPackages_ReturnsValueBasedOnOperatingSystemAndFramework_Fails()
         {
             // Arrange

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageExtractorTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageExtractorTests.cs
@@ -1796,7 +1796,7 @@ namespace NuGet.Packaging.Test
             {
                 await test.CreatePackageAsync();
 
-                var repositorySignatureInfo = CreateTestRepositorySignatureInfo(new List<X509Certificate2>(), allSigned: true);
+                RepositorySignatureInfo repositorySignatureInfo = CreateTestRepositorySignatureInfo(new List<X509Certificate2>(), allSigned: true);
                 var repositorySignatureInfoProvider = RepositorySignatureInfoProvider.Instance;
 
                 repositorySignatureInfoProvider.AddOrUpdateRepositorySignatureInfo(test.Source, repositorySignatureInfo);
@@ -1882,7 +1882,7 @@ namespace NuGet.Packaging.Test
             {
                 await test.CreatePackageAsync();
 
-                var repositorySignatureInfo = CreateTestRepositorySignatureInfo(new List<X509Certificate2>(), allSigned: true);
+                RepositorySignatureInfo repositorySignatureInfo = CreateTestRepositorySignatureInfo(new List<X509Certificate2>(), allSigned: true);
                 var repositorySignatureInfoProvider = RepositorySignatureInfoProvider.Instance;
 
                 repositorySignatureInfoProvider.AddOrUpdateRepositorySignatureInfo(test.Source, repositorySignatureInfo);
@@ -1911,7 +1911,7 @@ namespace NuGet.Packaging.Test
                 var resolver = new PackagePathResolver(dir);
                 var certificateFingerprint = SignatureTestUtility.GetFingerprint(repoCertificate.Source.Cert, HashAlgorithmName.SHA256);
 
-                var repositorySignatureInfo = CreateTestRepositorySignatureInfo(new List<X509Certificate2>(), allSigned: true);
+                RepositorySignatureInfo repositorySignatureInfo = CreateTestRepositorySignatureInfo(new List<X509Certificate2>(), allSigned: true);
                 var repositorySignatureInfoProvider = RepositorySignatureInfoProvider.Instance;
                 var repoSignedPackagePath = await SignedArchiveTestUtility.RepositorySignPackageAsync(repoCertificate.Source.Cert, nupkg, dir, new Uri(@"https://v3serviceIndex.test/api"));
 
@@ -1955,7 +1955,7 @@ namespace NuGet.Packaging.Test
                 var nupkg = new SimpleTestPackageContext();
                 var resolver = new PackagePathResolver(dir);
 
-                var repositorySignatureInfo = CreateTestRepositorySignatureInfo(new List<X509Certificate2>() { repoCertificate.Source.Cert }, allSigned: true);
+                RepositorySignatureInfo repositorySignatureInfo = CreateTestRepositorySignatureInfo(new List<X509Certificate2>() { repoCertificate.Source.Cert }, allSigned: true);
                 var repositorySignatureInfoProvider = RepositorySignatureInfoProvider.Instance;
                 var repoSignedPackagePath = await SignedArchiveTestUtility.RepositorySignPackageAsync(repoCertificate.Source.Cert, nupkg, dir, new Uri(@"https://v3serviceIndex.test/api"));
 
@@ -2140,7 +2140,7 @@ namespace NuGet.Packaging.Test
             {
                 var nupkg = new SimpleTestPackageContext();
                 var resolver = new PackagePathResolver(dir);
-                var fingerprintString = SignatureTestUtility.GetFingerprint(repoCertificate, HashAlgorithmName.SHA256);
+                string fingerprintString = SignatureTestUtility.GetFingerprint(repoCertificate, HashAlgorithmName.SHA256);
 
                 var repoSignedPackagePath = await SignedArchiveTestUtility.RepositorySignPackageAsync(
                     repoCertificate, nupkg, dir, new Uri(@"https://api.serviceindex.test/json"));
@@ -2877,7 +2877,7 @@ namespace NuGet.Packaging.Test
         }
 
         [PlatformFact(Platform.Windows)]
-        public async Task InstallFromSourceAsyncByPackageDownloader_InvalidSignPackageWithUnzip_Throws()
+        public async Task InstallFromSourceAsyncByPackageDownloader_InvalidSignPackageWithUnzip_ThrowsAsync()
         {
             // Arrange
             using (var root = TestDirectory.Create())
@@ -2934,7 +2934,7 @@ namespace NuGet.Packaging.Test
         }
 
         [PlatformFact(Platform.Linux, Platform.Darwin)]
-        public async Task InstallFromSourceAsyncByPackageDownloader_InvalidSignPackageWithUnzip_Success()
+        public async Task InstallFromSourceAsyncByPackageDownloader_InvalidSignPackageWithUnzip_SuccessAsync()
         {
             // Arrange
             using (var root = TestDirectory.Create())
@@ -2973,13 +2973,18 @@ namespace NuGet.Packaging.Test
                         SignedPackageVerifier = signedPackageVerifier.Object
                     };
 
-                    // Act & Assert
+                    // Act
                     await PackageExtractor.InstallFromSourceAsync(
                         identity,
                         packageDownloader,
                         resolver,
                         extractionContext,
                         CancellationToken.None);
+
+                    // Assert that footprint is left
+                    Directory.Exists(packageInstallPath).Should().BeTrue();
+                    Directory.Exists(packageInstallDirectory.FullName).Should().BeTrue();
+                    File.Exists(Path.Combine(resolver.GetInstallPath(identity.Id, identity.Version), "lib", "net45", "a.dll")).Should().BeTrue();
                 }
             }
         }
@@ -3142,7 +3147,7 @@ namespace NuGet.Packaging.Test
         }
 
         [PlatformFact(Platform.Windows)]
-        public async Task InstallFromSourceAsyncByStream_InvalidSignPackageWithUnzip_Throws()
+        public async Task InstallFromSourceAsyncByStream_InvalidSignPackageWithUnzip_ThrowsAsync()
         {
             // Arrange
             using (var root = TestDirectory.Create())
@@ -3160,7 +3165,7 @@ namespace NuGet.Packaging.Test
                     It.IsAny<Guid>())).
                     ReturnsAsync(new VerifySignaturesResult(isValid: false, isSigned: true));
 
-                var packageFileInfo = await SimpleTestPackageUtility.CreateFullPackageAsync(root, nupkg);
+                FileInfo packageFileInfo = await SimpleTestPackageUtility.CreateFullPackageAsync(root, nupkg);
 
                 var identity = new PackageIdentity("A", new NuGetVersion("1.0.0"));
 
@@ -3200,7 +3205,7 @@ namespace NuGet.Packaging.Test
         }
 
         [PlatformFact(Platform.Linux, Platform.Darwin)]
-        public async Task InstallFromSourceAsyncByStream_InvalidSignPackageWithUnzip_Success()
+        public async Task InstallFromSourceAsyncByStream_InvalidSignPackageWithUnzip_SuccessAsync()
         {
             // Arrange
             using (var root = TestDirectory.Create())
@@ -3218,7 +3223,7 @@ namespace NuGet.Packaging.Test
                     It.IsAny<Guid>())).
                     ReturnsAsync(new VerifySignaturesResult(isValid: false, isSigned: true));
 
-                var packageFileInfo = await SimpleTestPackageUtility.CreateFullPackageAsync(root, nupkg);
+                FileInfo packageFileInfo = await SimpleTestPackageUtility.CreateFullPackageAsync(root, nupkg);
 
                 var identity = new PackageIdentity("A", new NuGetVersion("1.0.0"));
 
@@ -3245,7 +3250,7 @@ namespace NuGet.Packaging.Test
                         extractionContext,
                         CancellationToken.None);
 
-                    // Assert that footprint is left
+                    // Assert
                     Directory.Exists(packageInstallPath).Should().BeTrue();
                     Directory.Exists(packageInstallDirectory.FullName).Should().BeTrue();
                     File.Exists(Path.Combine(resolver.GetInstallPath(identity.Id, identity.Version), "lib", "net45", "a.dll"))
@@ -3305,7 +3310,7 @@ namespace NuGet.Packaging.Test
         }
 
         [PlatformFact(Platform.Windows)]
-        public async Task ExtractPackageAsyncByStream_InvalidSignPackageWithUnzip_Throws()
+        public async Task ExtractPackageAsyncByStream_InvalidSignPackageWithUnzip_ThrowsAsync()
         {
             // Arrange
             using (var root = TestDirectory.Create())
@@ -3350,7 +3355,7 @@ namespace NuGet.Packaging.Test
         }
 
         [PlatformFact(Platform.Linux, Platform.Darwin)]
-        public async Task ExtractPackageAsyncByStream_InvalidSignPackageWithUnzip_Success()
+        public async Task ExtractPackageAsyncByStream_InvalidSignPackageWithUnzip_SuccessAsync()
         {
             // Arrange
             using (var root = TestDirectory.Create())
@@ -3373,8 +3378,11 @@ namespace NuGet.Packaging.Test
 
                 using (var packageStream = File.OpenRead(packageFileInfo.FullName))
                 {
+                    var packageInstallPath = resolver.GetInstallPath(identity);
+                    var packageInstallDirectory = Directory.GetParent(packageInstallPath);
+
                     var packageExtractionContext = new PackageExtractionContext(
-                        PackageSaveMode.Nupkg,
+                        PackageSaveMode.Files,
                         PackageExtractionBehavior.XmlDocFileSaveMode,
                         _defaultContext,
                         NullLogger.Instance)
@@ -3382,13 +3390,18 @@ namespace NuGet.Packaging.Test
                         SignedPackageVerifier = signedPackageVerifier.Object
                     };
 
-                    // Act & Assert
+                    // Act
                     await PackageExtractor.ExtractPackageAsync(
                             root,
                             packageStream,
                             resolver,
                             packageExtractionContext,
                             CancellationToken.None);
+
+                    // Assert
+                    Directory.Exists(packageInstallPath).Should().BeTrue();
+                    Directory.Exists(packageInstallDirectory.FullName).Should().BeTrue();
+                    File.Exists(Path.Combine(packageInstallPath, "lib", "net45", "a.dll")).Should().BeTrue();
                 }
             }
         }
@@ -3444,7 +3457,7 @@ namespace NuGet.Packaging.Test
         }
 
         [PlatformFact(Platform.Windows)]
-        public async Task ExtractPackageAsyncByPackageReader_InvalidSignPackageWithUnzip_Throws()
+        public async Task ExtractPackageAsyncByPackageReader_InvalidSignPackageWithUnzip_ThrowsAsync()
         {
             // Arrange
             using (var root = TestDirectory.Create())
@@ -3489,7 +3502,7 @@ namespace NuGet.Packaging.Test
         }
 
         [PlatformFact(Platform.Linux, Platform.Darwin)]
-        public async Task ExtractPackageAsyncByPackageReader_InvalidSignPackageWithUnzip_Succeed()
+        public async Task ExtractPackageAsyncByPackageReader_InvalidSignPackageWithUnzip_SucceedAsync()
         {
             // Arrange
             using (var root = TestDirectory.Create())
@@ -3587,7 +3600,7 @@ namespace NuGet.Packaging.Test
         }
 
         [PlatformFact(Platform.Windows)]
-        public async Task ExtractPackageAsyncByPackageReaderAndStream_InvalidSignPackageWithUnzipAsync_Throws()
+        public async Task ExtractPackageAsyncByPackageReaderAndStream_InvalidSignPackageWithUnzip_ThrowsAsync()
         {
             // Arrange
             using (var root = TestDirectory.Create())
@@ -3633,7 +3646,7 @@ namespace NuGet.Packaging.Test
         }
 
         [PlatformFact(Platform.Linux, Platform.Darwin)]
-        public async Task ExtractPackageAsyncByPackageReaderAndStream_InvalidSignPackageWithUnzipAsync_Success()
+        public async Task ExtractPackageAsyncByPackageReaderAndStream_InvalidSignPackageWithUnzip_SuccessAsync()
         {
             // Arrange
             using (var root = TestDirectory.Create())
@@ -3665,14 +3678,21 @@ namespace NuGet.Packaging.Test
                         SignedPackageVerifier = signedPackageVerifier.Object
                     };
 
-                    // Act & Assert
-                    await PackageExtractor.ExtractPackageAsync(
+                    // Act
+                    IEnumerable<string> files = await PackageExtractor.ExtractPackageAsync(
                                                 root,
                                                 packageReader,
                                                 packageStream,
                                                 resolver,
                                                 packageExtractionContext,
                                                 CancellationToken.None);
+
+                    // Assert
+                    files.Should().NotBeNull();
+                    Directory.Exists(Path.Combine(root.Path,
+                        $"{nupkg.Identity.Id}.{nupkg.Identity.Version.ToNormalizedString()}"))
+                        .Should()
+                        .BeTrue();
                 }
             }
         }
@@ -3728,7 +3748,7 @@ namespace NuGet.Packaging.Test
         }
 
         [PlatformFact(Platform.Linux, Platform.Darwin)]
-        public async Task VerifyPackageSignatureAsync_PassesCommonSettingsWhenNoRepoSignatureInfo_NoSigningVerify_Success()
+        public async Task VerifyPackageSignatureAsync_PassesCommonSettingsWhenNoRepoSignatureInfo_DonotVerify_SuccessAsync()
         {
             // Arrange
             using (var root = TestDirectory.Create())
@@ -3771,79 +3791,6 @@ namespace NuGet.Packaging.Test
                     signedPackageVerifier.Verify(mock => mock.VerifySignaturesAsync(
                         It.Is<ISignedPackageReader>(p => p.Equals(packageReader)),
                         It.Is<SignedPackageVerifierSettings>(s => SigningTestUtility.AreVerifierSettingsEqual(s, _defaultContext.VerifierSettings)),
-                        It.Is<CancellationToken>(t => t.Equals(CancellationToken.None)),
-                        It.IsAny<Guid>()), Times.Never);
-                }
-            }
-        }
-
-        [PlatformTheory(Platform.Linux, Platform.Darwin)]
-        [MemberData(nameof(KnownClientPoliciesList))]
-        public async Task VerifyPackageSignatureAsync_PassesModifiedSettingsWhenRepoSignatureInfo_DefaultSettings_DoesntVerifyAsync(ClientPolicyContext clientPolicyContext)
-        {
-            // Arrange
-            using (var root = TestDirectory.Create())
-            {
-                var nupkg = new SimpleTestPackageContext("A", "1.0.0");
-                var signedPackageVerifier = new Mock<IPackageSignatureVerifier>();
-                var resolver = new PackagePathResolver(root);
-                var identity = new PackageIdentity("A", new NuGetVersion("1.0.0"));
-                var packageFileInfo = await SimpleTestPackageUtility.CreateFullPackageAsync(root, nupkg);
-
-                signedPackageVerifier.Setup(x => x.VerifySignaturesAsync(
-                    It.IsAny<ISignedPackageReader>(),
-                    It.IsAny<SignedPackageVerifierSettings>(),
-                    It.IsAny<CancellationToken>(),
-                    It.IsAny<Guid>())).
-                    ReturnsAsync(new VerifySignaturesResult(isValid: true, isSigned: true));
-
-                var repositorySignatureInfoAndAllowList = CreateTestRepositorySignatureInfoAndExpectedAllowList();
-                var repositorySignatureInfo = repositorySignatureInfoAndAllowList.Item1;
-                var expectedAllowList = repositorySignatureInfoAndAllowList.Item2;
-                var repositorySignatureInfoProvider = RepositorySignatureInfoProvider.Instance;
-                var signedPackageVerifierSettings = clientPolicyContext.VerifierSettings;
-
-                repositorySignatureInfoProvider.AddOrUpdateRepositorySignatureInfo(root, repositorySignatureInfo);
-
-                var expectedVerifierSettings = new SignedPackageVerifierSettings(
-                    allowUnsigned: false,
-                    allowIllegal: signedPackageVerifierSettings.AllowIllegal,
-                    allowUntrusted: false,
-                    allowIgnoreTimestamp: signedPackageVerifierSettings.AllowIgnoreTimestamp,
-                    allowMultipleTimestamps: signedPackageVerifierSettings.AllowMultipleTimestamps,
-                    allowNoTimestamp: signedPackageVerifierSettings.AllowNoTimestamp,
-                    allowUnknownRevocation: signedPackageVerifierSettings.AllowUnknownRevocation,
-                    reportUnknownRevocation: signedPackageVerifierSettings.ReportUnknownRevocation,
-                    verificationTarget: signedPackageVerifierSettings.VerificationTarget,
-                    signaturePlacement: signedPackageVerifierSettings.SignaturePlacement,
-                    repositoryCountersignatureVerificationBehavior: signedPackageVerifierSettings.RepositoryCountersignatureVerificationBehavior,
-                    revocationMode: signedPackageVerifierSettings.RevocationMode);
-
-                using (var packageStream = File.OpenRead(packageFileInfo.FullName))
-                using (var packageReader = new PackageArchiveReader(packageStream))
-                {
-                    var packageExtractionContext = new PackageExtractionContext(
-                        PackageSaveMode.Nuspec | PackageSaveMode.Files,
-                        PackageExtractionBehavior.XmlDocFileSaveMode,
-                        clientPolicyContext,
-                        NullLogger.Instance)
-                    {
-                        SignedPackageVerifier = signedPackageVerifier.Object
-                    };
-
-                    // Act
-                    await PackageExtractor.ExtractPackageAsync(
-                        root,
-                        packageReader,
-                        packageStream,
-                        resolver,
-                        packageExtractionContext,
-                        CancellationToken.None);
-
-                    // Assert
-                    signedPackageVerifier.Verify(mock => mock.VerifySignaturesAsync(
-                        It.Is<ISignedPackageReader>(p => p.Equals(packageReader)),
-                        It.Is<SignedPackageVerifierSettings>(s => SigningTestUtility.AreVerifierSettingsEqual(s, expectedVerifierSettings)),
                         It.Is<CancellationToken>(t => t.Equals(CancellationToken.None)),
                         It.IsAny<Guid>()), Times.Never);
                 }
@@ -3925,7 +3872,7 @@ namespace NuGet.Packaging.Test
 
         [PlatformTheory(Platform.Linux, Platform.Darwin)]
         [MemberData(nameof(KnownClientPoliciesList))]
-        public async Task VerifyPackageSignatureAsync_PassesModifiedSettingsWhenRepoSignatureInfo_DefaultVerifyCommandSettingsAsync_NoSigningVerify_DonotVerifyAsync(ClientPolicyContext clientPolicyContext)
+        public async Task VerifyPackageSignatureAsync_PassesModifiedSettingsWhenRepoSignatureInfo_DefaultSettings_DonotVerifyAsync(ClientPolicyContext clientPolicyContext)
         {
             // Arrange
             using (var root = TestDirectory.Create())
@@ -3943,11 +3890,12 @@ namespace NuGet.Packaging.Test
                     It.IsAny<Guid>())).
                     ReturnsAsync(new VerifySignaturesResult(isValid: true, isSigned: true));
 
-                var repositorySignatureInfoAndAllowList = CreateTestRepositorySignatureInfoAndExpectedAllowList();
-                var repositorySignatureInfo = repositorySignatureInfoAndAllowList.Item1;
-                var expectedAllowList = repositorySignatureInfoAndAllowList.Item2;
+                Tuple<RepositorySignatureInfo, List<CertificateHashAllowListEntry>> repositorySignatureInfoAndAllowList = CreateTestRepositorySignatureInfoAndExpectedAllowList();
+                RepositorySignatureInfo repositorySignatureInfo = repositorySignatureInfoAndAllowList.Item1;
+                List<CertificateHashAllowListEntry> expectedAllowList = repositorySignatureInfoAndAllowList.Item2;
                 var repositorySignatureInfoProvider = RepositorySignatureInfoProvider.Instance;
-                var signedPackageVerifierSettings = clientPolicyContext.VerifierSettings;
+                SignedPackageVerifierSettings signedPackageVerifierSettings = clientPolicyContext.VerifierSettings;
+
                 repositorySignatureInfoProvider.AddOrUpdateRepositorySignatureInfo(root, repositorySignatureInfo);
 
                 var expectedVerifierSettings = new SignedPackageVerifierSettings(
@@ -3997,7 +3945,7 @@ namespace NuGet.Packaging.Test
 
         [PlatformTheory(Platform.Windows)]
         [MemberData(nameof(KnownClientPoliciesList))]
-        public async Task VerifyPackageSignatureAsync_PassesModifiedSettingsWhenRepoSignatureInfo_DefaultVerifyCommandSettingsAsync_NoSigningVerify_DoVerifyAsync(ClientPolicyContext clientPolicyContext)
+        public async Task VerifyPackageSignatureAsync_PassesModifiedSettingsWhenRepoSignatureInfo_DefaultVerifyCommandSettingsAsync_DoVerifyAsync(ClientPolicyContext clientPolicyContext)
         {
             // Arrange
             using (var root = TestDirectory.Create())
@@ -4063,6 +4011,78 @@ namespace NuGet.Packaging.Test
                         It.Is<SignedPackageVerifierSettings>(s => SigningTestUtility.AreVerifierSettingsEqual(s, expectedVerifierSettings)),
                         It.Is<CancellationToken>(t => t.Equals(CancellationToken.None)),
                         It.IsAny<Guid>()), Times.AtLeastOnce);
+                }
+            }
+        }
+
+        [PlatformTheory(Platform.Linux, Platform.Darwin)]
+        [MemberData(nameof(KnownClientPoliciesList))]
+        public async Task VerifyPackageSignatureAsync_PassesModifiedSettingsWhenRepoSignatureInfo_DefaultVerifyCommandSettingsAsync_DonotVerifyAsync(ClientPolicyContext clientPolicyContext)
+        {
+            // Arrange
+            using (var root = TestDirectory.Create())
+            {
+                var nupkg = new SimpleTestPackageContext("A", "1.0.0");
+                var signedPackageVerifier = new Mock<IPackageSignatureVerifier>();
+                var resolver = new PackagePathResolver(root);
+                var identity = new PackageIdentity("A", new NuGetVersion("1.0.0"));
+                var packageFileInfo = await SimpleTestPackageUtility.CreateFullPackageAsync(root, nupkg);
+
+                signedPackageVerifier.Setup(x => x.VerifySignaturesAsync(
+                    It.IsAny<ISignedPackageReader>(),
+                    It.IsAny<SignedPackageVerifierSettings>(),
+                    It.IsAny<CancellationToken>(),
+                    It.IsAny<Guid>())).
+                    ReturnsAsync(new VerifySignaturesResult(isValid: true, isSigned: true));
+
+                Tuple<RepositorySignatureInfo, List<CertificateHashAllowListEntry>> repositorySignatureInfoAndAllowList = CreateTestRepositorySignatureInfoAndExpectedAllowList();
+                RepositorySignatureInfo repositorySignatureInfo = repositorySignatureInfoAndAllowList.Item1;
+                List<CertificateHashAllowListEntry> expectedAllowList = repositorySignatureInfoAndAllowList.Item2;
+                var repositorySignatureInfoProvider = RepositorySignatureInfoProvider.Instance;
+                SignedPackageVerifierSettings signedPackageVerifierSettings = clientPolicyContext.VerifierSettings;
+                repositorySignatureInfoProvider.AddOrUpdateRepositorySignatureInfo(root, repositorySignatureInfo);
+
+                var expectedVerifierSettings = new SignedPackageVerifierSettings(
+                    allowUnsigned: false,
+                    allowIllegal: signedPackageVerifierSettings.AllowIllegal,
+                    allowUntrusted: false,
+                    allowIgnoreTimestamp: signedPackageVerifierSettings.AllowIgnoreTimestamp,
+                    allowMultipleTimestamps: signedPackageVerifierSettings.AllowMultipleTimestamps,
+                    allowNoTimestamp: signedPackageVerifierSettings.AllowNoTimestamp,
+                    allowUnknownRevocation: signedPackageVerifierSettings.AllowUnknownRevocation,
+                    reportUnknownRevocation: signedPackageVerifierSettings.ReportUnknownRevocation,
+                    verificationTarget: signedPackageVerifierSettings.VerificationTarget,
+                    signaturePlacement: signedPackageVerifierSettings.SignaturePlacement,
+                    repositoryCountersignatureVerificationBehavior: signedPackageVerifierSettings.RepositoryCountersignatureVerificationBehavior,
+                    revocationMode: signedPackageVerifierSettings.RevocationMode);
+
+                using (var packageStream = File.OpenRead(packageFileInfo.FullName))
+                using (var packageReader = new PackageArchiveReader(packageStream))
+                {
+                    var packageExtractionContext = new PackageExtractionContext(
+                        PackageSaveMode.Nuspec | PackageSaveMode.Files,
+                        PackageExtractionBehavior.XmlDocFileSaveMode,
+                        clientPolicyContext,
+                        NullLogger.Instance)
+                    {
+                        SignedPackageVerifier = signedPackageVerifier.Object
+                    };
+
+                    // Act
+                    await PackageExtractor.ExtractPackageAsync(
+                        root,
+                        packageReader,
+                        packageStream,
+                        resolver,
+                        packageExtractionContext,
+                        CancellationToken.None);
+
+                    // Assert
+                    signedPackageVerifier.Verify(mock => mock.VerifySignaturesAsync(
+                        It.Is<ISignedPackageReader>(p => p.Equals(packageReader)),
+                        It.Is<SignedPackageVerifierSettings>(s => SigningTestUtility.AreVerifierSettingsEqual(s, expectedVerifierSettings)),
+                        It.Is<CancellationToken>(t => t.Equals(CancellationToken.None)),
+                        It.IsAny<Guid>()), Times.Never);
                 }
             }
         }

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageExtractorTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageExtractorTests.cs
@@ -3945,7 +3945,7 @@ namespace NuGet.Packaging.Test
 
         [PlatformTheory(Platform.Windows)]
         [MemberData(nameof(KnownClientPoliciesList))]
-        public async Task VerifyPackageSignatureAsync_PassesModifiedSettingsWhenRepoSignatureInfo_DefaultVerifyCommandSettingsAsync_DoVerifyAsync(ClientPolicyContext clientPolicyContext)
+        public async Task VerifyPackageSignatureAsync_PassesModifiedSettingsWhenRepoSignatureInfo_DefaultVerifyCommandSettings_DoVerifyAsync(ClientPolicyContext clientPolicyContext)
         {
             // Arrange
             using (var root = TestDirectory.Create())
@@ -4017,7 +4017,7 @@ namespace NuGet.Packaging.Test
 
         [PlatformTheory(Platform.Linux, Platform.Darwin)]
         [MemberData(nameof(KnownClientPoliciesList))]
-        public async Task VerifyPackageSignatureAsync_PassesModifiedSettingsWhenRepoSignatureInfo_DefaultVerifyCommandSettingsAsync_DonotVerifyAsync(ClientPolicyContext clientPolicyContext)
+        public async Task VerifyPackageSignatureAsync_PassesModifiedSettingsWhenRepoSignatureInfo_DefaultVerifyCommandSettings_DonotVerifyAsync(ClientPolicyContext clientPolicyContext)
         {
             // Arrange
             using (var root = TestDirectory.Create())

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageExtractorTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageExtractorTests.cs
@@ -1802,25 +1802,15 @@ namespace NuGet.Packaging.Test
                 repositorySignatureInfoProvider.AddOrUpdateRepositorySignatureInfo(test.Source, repositorySignatureInfo);
                 test.Context.PackageSaveMode = PackageSaveMode.Defaultv3;
 
-                SignatureException exception = null;
-                IEnumerable<string> files = null;
-
-                try
-                {
-                    files = await PackageExtractor.ExtractPackageAsync(
-                         test.Source,
-                         test.Stream,
-                         test.Resolver,
-                         test.Context,
-                         CancellationToken.None);
-                }
-                catch (SignatureException e)
-                {
-                    exception = e;
-                }
+                // Act
+                IEnumerable<string> files = await PackageExtractor.ExtractPackageAsync(
+                     test.Source,
+                     test.Stream,
+                     test.Resolver,
+                     test.Context,
+                     CancellationToken.None);
 
                 // Assert
-                exception.Should().BeNull();
                 files.Should().NotBeNull();
                 Directory.Exists(Path.Combine(test.DestinationDirectory.FullName,
                     $"{test.PackageIdentity.Id}.{test.PackageIdentity.Version.ToNormalizedString()}")).Should().BeTrue();
@@ -1898,30 +1888,16 @@ namespace NuGet.Packaging.Test
                 repositorySignatureInfoProvider.AddOrUpdateRepositorySignatureInfo(test.Source, repositorySignatureInfo);
                 test.Context.PackageSaveMode = PackageSaveMode.Defaultv3;
 
-                SignatureException exception = null;
-
-                try
-                {
-                    await PackageExtractor.ExtractPackageAsync(
-                         test.Source,
-                         test.Stream,
-                         test.Resolver,
-                         test.Context,
-                         CancellationToken.None);
-                }
-                catch (SignatureException e)
-                {
-                    exception = e;
-                }
+                // Act
+                IEnumerable<string> files = await PackageExtractor.ExtractPackageAsync(
+                     test.Source,
+                     test.Stream,
+                     test.Resolver,
+                     test.Context,
+                     CancellationToken.None);
 
                 // Assert
-                exception.Should().NotBeNull();
-                exception.Results.Count.Should().Be(1);
-
-                exception.Results.First().Issues.Count().Should().Be(1);
-                exception.Results.First().Issues.First().Code.Should().Be(NuGetLogCode.NU3004);
-                exception.Results.First().Issues.First().Message.Should()
-                    .Be(SigningTestUtility.AddSignatureLogPrefix(_notSignedPackageRequire, test.Reader.GetIdentity(), test.Source));
+                files.Should().NotBeNull();
             }
         }
 
@@ -1952,24 +1928,20 @@ namespace NuGet.Packaging.Test
 
                 using (var packageStream = File.OpenRead(repoSignedPackagePath))
                 {
-                    SignatureException exception = null;
-
-                    try
-                    {
-                        await PackageExtractor.ExtractPackageAsync(
-                             dir,
-                             packageStream,
-                             resolver,
-                             extractionContext,
-                             CancellationToken.None);
-                    }
-                    catch (SignatureException e)
-                    {
-                        exception = e;
-                    }
+                    // Act
+                    IEnumerable<string> files = await PackageExtractor.ExtractPackageAsync(
+                         dir,
+                         packageStream,
+                         resolver,
+                         extractionContext,
+                         CancellationToken.None);
 
                     // Assert
-                    exception.Should().BeNull();
+                    files.Should().NotBeNull();
+                    Directory.Exists(Path.Combine(dir.Path,
+                        $"{nupkg.Identity.Id}.{nupkg.Identity.Version.ToNormalizedString()}"))
+                        .Should()
+                        .BeTrue();
                 }
             }
         }
@@ -2000,25 +1972,15 @@ namespace NuGet.Packaging.Test
 
                 using (var packageStream = File.OpenRead(repoSignedPackagePath))
                 {
-                    SignatureException exception = null;
-                    IEnumerable<string> files = null;
-
-                    try
-                    {
-                        files = await PackageExtractor.ExtractPackageAsync(
-                             dir,
-                             packageStream,
-                             resolver,
-                             extractionContext,
-                             CancellationToken.None);
-                    }
-                    catch (SignatureException e)
-                    {
-                        exception = e;
-                    }
+                    // Act
+                    IEnumerable<string> files = await PackageExtractor.ExtractPackageAsync(
+                         dir,
+                         packageStream,
+                         resolver,
+                         extractionContext,
+                         CancellationToken.None);
 
                     // Assert
-                    exception.Should().BeNull();
                     files.Should().NotBeNull();
                     Directory.Exists(Path.Combine(dir.Path,
                         $"{nupkg.Identity.Id}.{nupkg.Identity.Version.ToNormalizedString()}")).Should().BeTrue();
@@ -2098,25 +2060,20 @@ namespace NuGet.Packaging.Test
                         NullLogger.Instance);
 
                     // Act
-                    SignatureException exception = null;
-
-                    try
-                    {
-                        await PackageExtractor.ExtractPackageAsync(
+                    IEnumerable<string> files = await PackageExtractor.ExtractPackageAsync(
                             dir,
                             packageReader,
                             packageStream,
                             resolver,
                             packageExtractionContext,
                             CancellationToken.None);
-                    }
-                    catch (SignatureException e)
-                    {
-                        exception = e;
-                    }
 
                     // Assert
-                    exception.Should().BeNull();
+                    files.Should().NotBeNull();
+                    Directory.Exists(Path.Combine(dir.Path,
+                        $"{nupkg.Identity.Id}.{nupkg.Identity.Version.ToNormalizedString()}"))
+                        .Should()
+                        .BeTrue();
                 }
             }
         }
@@ -2315,25 +2272,14 @@ namespace NuGet.Packaging.Test
                 using (var packageStream = File.OpenRead(packageFile.FullName))
                 {
                     // Act
-                    SignatureException exception = null;
-                    IEnumerable<string> files = null;
-
-                    try
-                    {
-                        files = await PackageExtractor.ExtractPackageAsync(
+                    IEnumerable<string> files = await PackageExtractor.ExtractPackageAsync(
                             test.Source,
                             packageStream,
                             test.Resolver,
                             test.Context,
                             CancellationToken.None);
-                    }
-                    catch (SignatureException e)
-                    {
-                        exception = e;
-                    }
 
                     // Assert
-                    exception.Should().BeNull();
                     files.Should().NotBeNull();
                     Directory.Exists(Path.Combine(test.DestinationDirectory.FullName,
                         $"{packageContext.Identity.Id}.{packageContext.Identity.Version.ToNormalizedString()}"))
@@ -2382,25 +2328,14 @@ namespace NuGet.Packaging.Test
                 using (var packageReader = new PackageFolderReader(packageDir))
                 {
                     // Act
-                    SignatureException exception = null;
-                    IEnumerable<string> files = null;
-
-                    try
-                    {
-                        files = await PackageExtractor.ExtractPackageAsync(
+                    IEnumerable<string> files = await PackageExtractor.ExtractPackageAsync(
                             test.Source,
                             packageReader,
                             test.Resolver,
                             test.Context,
                             CancellationToken.None);
-                    }
-                    catch (SignatureException e)
-                    {
-                        exception = e;
-                    }
 
                     // Assert
-                    exception.Should().BeNull();
                     files.Should().NotBeNull();
                     files.Count().Should().Be(8);
                     var packagePath = Path.Combine(test.DestinationDirectory.FullName,
@@ -2573,25 +2508,14 @@ namespace NuGet.Packaging.Test
                 using (var packageReader = new PackageArchiveReader(File.OpenRead(packageFile.FullName)))
                 {
                     // Act
-                    SignatureException exception = null;
-                    IEnumerable<string> files = null;
-
-                    try
-                    {
-                        files = await PackageExtractor.ExtractPackageAsync(
+                    IEnumerable<string> files = await PackageExtractor.ExtractPackageAsync(
                             test.Source,
                             packageReader,
                             test.Resolver,
                             test.Context,
                             CancellationToken.None);
-                    }
-                    catch (SignatureException e)
-                    {
-                        exception = e;
-                    }
 
                     // Assert
-                    exception.Should().BeNull();
                     files.Should().NotBeNull();
                     files.Count().Should().Be(8);
                     var packagePath = Path.Combine(test.DestinationDirectory.FullName,
@@ -3564,7 +3488,7 @@ namespace NuGet.Packaging.Test
             }
         }
 
-        [CIOnlyFact]
+        [PlatformFact(Platform.Linux, Platform.Darwin)]
         public async Task ExtractPackageAsyncByPackageReader_InvalidSignPackageWithUnzip_Succeed()
         {
             // Arrange
@@ -3586,7 +3510,6 @@ namespace NuGet.Packaging.Test
                 var packageFileInfo = await SimpleTestPackageUtility.CreateFullPackageAsync(root, nupkg);
 
                 using (var packageStream = File.OpenRead(packageFileInfo.FullName))
-                using (var packageReader = new PackageArchiveReader(packageStream))
                 {
                     var packageExtractionContext = new PackageExtractionContext(
                         PackageSaveMode.Nupkg,
@@ -3597,14 +3520,18 @@ namespace NuGet.Packaging.Test
                         SignedPackageVerifier = signedPackageVerifier.Object
                     };
 
-                    // Act & Assert
-                    await Assert.ThrowsAsync<SignatureException>(
-                        () => PackageExtractor.ExtractPackageAsync(
+                    // Act
+                    IEnumerable<string> files = await PackageExtractor.ExtractPackageAsync(
                             root,
-                            packageReader,
+                            packageStream,
                             resolver,
                             packageExtractionContext,
-                            CancellationToken.None));
+                            CancellationToken.None);
+
+                    // Assert
+                    files.Should().NotBeNull();
+                    Directory.Exists(Path.Combine(root.Path,
+                        $"{nupkg.Identity.Id}.{nupkg.Identity.Version.ToNormalizedString()}")).Should().BeTrue();
                 }
             }
         }

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageExtractorTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageExtractorTests.cs
@@ -3698,7 +3698,7 @@ namespace NuGet.Packaging.Test
         }
 
         [PlatformFact(Platform.Windows)]
-        public async Task VerifyPackageSignatureAsync_PassesCommonSettingsWhenNoRepoSignatureInfoAsync()
+        public async Task VerifyPackageSignatureAsync_PassesCommonSettingsWhenNoRepoSignatureInfo_DoVerifyAsync()
         {
             // Arrange
             using (var root = TestDirectory.Create())
@@ -3748,7 +3748,7 @@ namespace NuGet.Packaging.Test
         }
 
         [PlatformFact(Platform.Linux, Platform.Darwin)]
-        public async Task VerifyPackageSignatureAsync_PassesCommonSettingsWhenNoRepoSignatureInfo_DonotVerify_SuccessAsync()
+        public async Task VerifyPackageSignatureAsync_PassesCommonSettingsWhenNoRepoSignatureInfo_DonotVerifyAsync()
         {
             // Arrange
             using (var root = TestDirectory.Create())

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageExtractorTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageExtractorTests.cs
@@ -1783,7 +1783,7 @@ namespace NuGet.Packaging.Test
             }
         }
 
-        [CIOnlyFact]
+        [PlatformFact(Platform.Linux, Platform.Darwin)]
         public async Task ExtractPackageAsync_UnsignedPackage_WhenRepositorySaysAllPackagesSigned_SuccessAsync()
         {
             var extractionContext = new PackageExtractionContext(
@@ -1872,7 +1872,7 @@ namespace NuGet.Packaging.Test
             }
         }
 
-        [CIOnlyFact]
+        [PlatformFact(Platform.Linux, Platform.Darwin)]
         public async Task ExtractPackageAsync_UnsignedPackage_RequireMode_SuccessAsync()
         {
             var extractionContext = new PackageExtractionContext(
@@ -2111,7 +2111,6 @@ namespace NuGet.Packaging.Test
 
                     // Assert
                     exception.Should().BeNull();
-                    exception.Results.Count.Should().Be(0);
                 }
             }
         }
@@ -2169,7 +2168,7 @@ namespace NuGet.Packaging.Test
             }
         }
 
-        [CIOnlyFact]
+        [PlatformFact(Platform.Linux, Platform.Darwin)]
         public async Task ExtractPackageAsync_WithAllowUntrusted_SucceedsNoWarning()
         {
             // Arrange
@@ -2275,7 +2274,7 @@ namespace NuGet.Packaging.Test
             }
         }
 
-        [CIOnlyFact]
+        [PlatformFact(Platform.Linux, Platform.Darwin)]
         public async Task ExtractPackageAsync_RequireMode_UnsignedPackage_PackageArchiveReader_WhenUnsignedPackagesDisallowed_SuccessAsync()
         {
             // Arrange
@@ -3000,7 +2999,7 @@ namespace NuGet.Packaging.Test
             }
         }
 
-        [CIOnlyFact]
+        [PlatformFact(Platform.Linux, Platform.Darwin)]
         public async Task InstallFromSourceAsyncByPackageDownloader_InvalidSignPackageWithUnzip_Success()
         {
             // Arrange
@@ -3266,7 +3265,7 @@ namespace NuGet.Packaging.Test
             }
         }
 
-        [CIOnlyFact]
+        [PlatformFact(Platform.Linux, Platform.Darwin)]
         public async Task InstallFromSourceAsyncByStream_InvalidSignPackageWithUnzip_Success()
         {
             // Arrange
@@ -3416,7 +3415,7 @@ namespace NuGet.Packaging.Test
             }
         }
 
-        [CIOnlyFact]
+        [PlatformFact(Platform.Linux, Platform.Darwin)]
         public async Task ExtractPackageAsyncByStream_InvalidSignPackageWithUnzip_Success()
         {
             // Arrange
@@ -3696,7 +3695,7 @@ namespace NuGet.Packaging.Test
             }
         }
 
-        [CIOnlyFact]
+        [PlatformFact(Platform.Linux, Platform.Darwin)]
         public async Task ExtractPackageAsyncByPackageReaderAndStream_InvalidSignPackageWithUnzipAsync_Success()
         {
             // Arrange
@@ -3791,7 +3790,7 @@ namespace NuGet.Packaging.Test
             }
         }
 
-        [CIOnlyFact]
+        [PlatformFact(Platform.Linux, Platform.Darwin)]
         public async Task VerifyPackageSignatureAsync_PassesCommonSettingsWhenNoRepoSignatureInfo_NoSigningVerify_Success()
         {
             // Arrange


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/10713 https://github.com/NuGet/Client.Engineering/issues/880
I'll add more details later if we go ahead with this change.

Regression? Last working version: N/A

## Description
Anticipating Mozilla going to drop Symantec certificate CA from their trusted database we need to release pre-empt mitigation. 
More details please check https://github.com/NuGet/Announcements/issues/56.
## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
