### PR TITLE
NuGetProjectService.GetInstalledPackagesAsync does not throw when leg…

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/NuGetProjectService.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/NuGetProjectService.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -95,6 +96,11 @@ namespace NuGet.VisualStudio.Implementation.Extensibility
             InstalledPackageResultStatus status;
             IReadOnlyCollection<NuGetInstalledPackage> installedPackages;
 
+            (InstalledPackageResultStatus, IReadOnlyCollection<NuGetInstalledPackage>) ErrorResult(InstalledPackageResultStatus status)
+            {
+                return (status, null);
+            }
+
             var cacheContext = new DependencyGraphCacheContext();
             IReadOnlyList<ProjectModel.PackageSpec> packageSpecs;
             IReadOnlyList<ProjectModel.IAssetsLogMessage> messages;
@@ -104,9 +110,11 @@ namespace NuGet.VisualStudio.Implementation.Extensibility
             }
             catch (ProjectNotNominatedException)
             {
-                status = InstalledPackageResultStatus.ProjectNotReady;
-                installedPackages = null;
-                return (status, installedPackages);
+                return ErrorResult(InstalledPackageResultStatus.ProjectNotReady);
+            }
+            catch (InvalidDataException)
+            {
+                return ErrorResult(InstalledPackageResultStatus.ProjectInvalid);
             }
 
             if (messages?.Any(m => m.Level == LogLevel.Error) == true)

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/Extensibility/NuGetProjectServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/Extensibility/NuGetProjectServiceTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Moq;
@@ -28,6 +29,7 @@ namespace NuGet.VisualStudio.Implementation.Test.Extensibility
             var settings = new Mock<ISettings>();
             var telemetryProvider = new Mock<INuGetTelemetryProvider>(MockBehavior.Strict);
 
+            // emulate the ProjectNotNominatedException when we have a CpsPackageReference project, but there's no nomination data yet.
             var project = new Mock<BuildIntegratedNuGetProject>();
             project.Setup(p => p.GetPackageSpecsAndAdditionalMessagesAsync(It.IsAny<DependencyGraphCacheContext>()))
                 .Throws<ProjectNotNominatedException>();
@@ -43,6 +45,33 @@ namespace NuGet.VisualStudio.Implementation.Test.Extensibility
             // Assert
             Assert.NotNull(actual);
             Assert.Equal(InstalledPackageResultStatus.ProjectNotReady, actual.Status);
+        }
+
+        [Fact]
+        public async Task GetInstalledPackagesAsync_LegacyProjectInvalidDataException_ReturnsProjectInvalidResult()
+        {
+            // Arrange
+            var projectGuid = Guid.NewGuid();
+
+            var settings = new Mock<ISettings>();
+            var telemetryProvider = new Mock<INuGetTelemetryProvider>(MockBehavior.Strict);
+
+            // Emulate the InvalidDataException thrown by LegacyPackageReferenceProject when the project doesn't have MSBuildProjectExtensionsPath
+            var project = new Mock<BuildIntegratedNuGetProject>();
+            project.Setup(p => p.GetPackageSpecsAndAdditionalMessagesAsync(It.IsAny<DependencyGraphCacheContext>()))
+                .Throws<InvalidDataException>();
+
+            var solutionManager = new Mock<IVsSolutionManager>();
+            solutionManager.Setup(sm => sm.GetNuGetProjectAsync(projectGuid.ToString()))
+                .Returns(() => Task.FromResult<NuGetProject>(project.Object));
+
+            // Act
+            var target = new NuGetProjectService(solutionManager.Object, settings.Object, telemetryProvider.Object);
+            InstalledPackagesResult actual = await target.GetInstalledPackagesAsync(projectGuid, CancellationToken.None);
+
+            // Assert
+            Assert.NotNull(actual);
+            Assert.Equal(InstalledPackageResultStatus.ProjectInvalid, actual.Status);
         }
     }
 }


### PR DESCRIPTION
…acy project is missing required msbuild properties

<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/10739

Regression? Last working version: New API in VS 16.8

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Catch `InvalidDataException`, and return appropriate failure result.

`InvalidDataException` is a sealed class, so we're unable to subclass this exception to be more specific, but other VS `IVs*` APIs that we provide depend on this exception type, so it would be a breaking change to change. Fortunately, I don't see other instances of `InvalidDataException` being thrown in classes that might be used by `GetInstalledPackagesAsync`, so I expect that we shouldn't be hiding any product bugs by catching the "generic" exception type.

## PR Checklist

- [X] PR has a meaningful title
- [X] PR has a linked issue.
- [X] Described changes

- **Tests**
  - [X] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [X] N/A
