### PR TITLE
Make VersionRange.TryParse handle single-number version specs

### DIFF
--- a/src/NuGet.Core/NuGet.Versioning/VersionRangeFactory.cs
+++ b/src/NuGet.Core/NuGet.Versioning/VersionRangeFactory.cs
@@ -92,12 +92,11 @@ namespace NuGet.Versioning
         {
             versionRange = null;
 
-            if (value == null)
+            var trimmedValue = value?.Trim();
+            if (string.IsNullOrEmpty(trimmedValue))
             {
                 return false;
             }
-
-            var trimmedValue = value.Trim();
 
             var charArray = trimmedValue.ToCharArray();
 
@@ -108,12 +107,6 @@ namespace NuGet.Versioning
             {
                 versionRange = new VersionRange(new NuGetVersion(0, 0, 0), true, null, true, FloatRange.Parse(trimmedValue), originalString: value);
                 return true;
-            }
-
-            // Fail early if the string is too short to be valid
-            if (charArray.Length < 3)
-            {
-                return false;
             }
 
             string minVersionString = null;

--- a/test/NuGet.Core.Tests/NuGet.Versioning.Test/VersionRangeTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Versioning.Test/VersionRangeTests.cs
@@ -288,6 +288,22 @@ namespace NuGet.Versioning.Test
         }
 
         [Theory]
+        [InlineData("1", "1.0")]
+        [InlineData("1", "1.0.0.0")]
+        [InlineData("123.456", "123.456.0.0")]
+        [InlineData("[2021,)", "[2021.0.0.0,)")]
+        [InlineData("[,2021)", "[,2021.0.0.0)")]
+        public void VersionRange_MissingVersionComponents_AssumedToBeZero(string shortVersionSpec, string longVersionSpec)
+        {
+            // Act
+            var versionRange1 = VersionRange.Parse(shortVersionSpec);
+            var versionRange2 = VersionRange.Parse(longVersionSpec);
+
+            // Assert
+            Assert.Equal(versionRange2, versionRange1);
+        }
+
+        [Theory]
         [InlineData("1.0.0", "0.0.0")]
         [InlineData("[1.0.0, 2.0.0]", "2.0.1")]
         [InlineData("[1.0.0, 2.0.0]", "0.0.0")]

--- a/test/NuGet.Core.Tests/NuGet.Versioning.Test/VersionRangeTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Versioning.Test/VersionRangeTests.cs
@@ -466,6 +466,10 @@ namespace NuGet.Versioning.Test
         [InlineData(".1")]
         [InlineData("1,")]
         [InlineData(",1")]
+        [InlineData(",")]
+        [InlineData("-")]
+        [InlineData("+")]
+        [InlineData("a")]
         public void ParseVersionRangeWithBadVersionThrows(string version)
         {
             // Act & Assert

--- a/test/NuGet.Core.Tests/NuGet.Versioning.Test/VersionRangeTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Versioning.Test/VersionRangeTests.cs
@@ -288,12 +288,13 @@ namespace NuGet.Versioning.Test
         }
 
         [Theory]
-        [InlineData("1", "1.0")]
-        [InlineData("1", "1.0.0.0")]
+        [InlineData("0", "0.0")]
+        [InlineData("1", "1.0.0")]
+        [InlineData("02", "2.0.0.0")]
         [InlineData("123.456", "123.456.0.0")]
         [InlineData("[2021,)", "[2021.0.0.0,)")]
         [InlineData("[,2021)", "[,2021.0.0.0)")]
-        public void VersionRange_MissingVersionComponents_AssumedToBeZero(string shortVersionSpec, string longVersionSpec)
+        public void VersionRange_MissingVersionComponents_DefaultToZero(string shortVersionSpec, string longVersionSpec)
         {
             // Act
             var versionRange1 = VersionRange.Parse(shortVersionSpec);
@@ -459,6 +460,12 @@ namespace NuGet.Versioning.Test
         [Theory]
         [InlineData("")]
         [InlineData("      ")]
+        [InlineData("-1")]
+        [InlineData("+1")]
+        [InlineData("1.")]
+        [InlineData(".1")]
+        [InlineData("1,")]
+        [InlineData(",1")]
         public void ParseVersionRangeWithBadVersionThrows(string version)
         {
             // Act & Assert


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/10342

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
- Adapt `VersionRange.TryParse` so it can handle single-number version specifications such as "1"
- Add tests to validate this

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
