### PR TITLE
Doesn't allow multiple nupkg files for trusted-signers add command

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -1835,6 +1835,15 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Multiple nupkg files detected on &apos;{0}&apos; path to trust, only 1 is allowed..
+        /// </summary>
+        internal static string Multiple_Nupkgs_Detected {
+            get {
+                return ResourceManager.GetString("Multiple_Nupkgs_Detected", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to There are no client certificates..
         /// </summary>
         internal static string NoClientCertificates {

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -1121,4 +1121,7 @@ For more information, visit https://docs.nuget.org/docs/reference/command-line-r
   <data name="Log_SkippingPackagesLockFileGeneration" xml:space="preserve">
     <value>Skipping the lock file regeneration for '{0}'.</value>
   </data>
+  <data name="Multiple_Nupkgs_Detected" xml:space="preserve">
+    <value>Multiple nupkg files detected on '{0}' path to trust, only 1 is allowed.</value>
+  </data>
 </root>

--- a/src/NuGet.Core/NuGet.Commands/TrustedSignersCommand/TrustedSignersCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/TrustedSignersCommand/TrustedSignersCommandRunner.cs
@@ -92,6 +92,13 @@ namespace NuGet.Commands
                         var packagesToTrust = LocalFolderUtility.ResolvePackageFromPath(trustedSignersArgs.PackagePath);
                         LocalFolderUtility.EnsurePackageFileExists(trustedSignersArgs.PackagePath, packagesToTrust);
 
+                        if (packagesToTrust.Count() > 1)
+                        {
+                            throw new ArgumentException(string.Format(CultureInfo.CurrentCulture,
+                                Strings.Multiple_Nupkgs_Detected,
+                                trustedSignersArgs.PackagePath));
+                        }
+
                         foreach (var package in packagesToTrust)
                         {
                             using (var packageReader = new PackageArchiveReader(package))

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/TrustedSignersCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/TrustedSignersCommandTests.cs
@@ -244,7 +244,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
             }
         }
 
-        [Theory]
+        [CIOnlyTheory]
         [InlineData(true)]
         [InlineData(false)]
         public async Task TrustedSignersCommand_AddTrustedSigner_WithAuthorSignedPackage_AddsItSuccesfullyToConfigAsync(bool allowUntrustedRoot)
@@ -292,7 +292,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
             }
         }
 
-        [Theory]
+        [CIOnlyTheory]
         [InlineData(true)]
         [InlineData(false)]
         public async Task TrustedSignersCommand_AddTrustedSigner_WithAuthorSignedPackage_AddsMultipleFilesThrows(bool allowUntrustedRoot)

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/TrustedSignersCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/TrustedSignersCommandTests.cs
@@ -244,7 +244,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
             }
         }
 
-        [CIOnlyTheory]
+        [Theory]
         [InlineData(true)]
         [InlineData(false)]
         public async Task TrustedSignersCommand_AddTrustedSigner_WithAuthorSignedPackage_AddsItSuccesfullyToConfigAsync(bool allowUntrustedRoot)
@@ -289,6 +289,48 @@ namespace NuGet.CommandLine.FuncTest.Commands
 </configuration>");
 
                 SettingsTestUtils.RemoveWhitespace(File.ReadAllText(nugetConfigPath)).Should().Be(expectedResult);
+            }
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task TrustedSignersCommand_AddTrustedSigner_WithAuthorSignedPackage_AddsMultipleFilesThrows(bool allowUntrustedRoot)
+        {
+            // Arrange
+            var nugetConfigFileName = "NuGet.Config";
+            var config = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+</configuration>";
+
+            // Arrange
+            var nupkgA = new SimpleTestPackageContext("A", "1.0.0");
+            var nupkgB = new SimpleTestPackageContext("B", "1.0.0");
+            using (var dir = TestDirectory.Create())
+            using (var zipStream = await nupkgA.CreateAsStreamAsync())
+            using (var trustedTestCert = SigningTestUtility.GenerateTrustedTestCertificate())
+            {
+                var certFingerprint = SignatureTestUtility.GetFingerprint(trustedTestCert.Source.Cert, HashAlgorithmName.SHA256);
+                var signedPackagePathA = await SignedArchiveTestUtility.AuthorSignPackageAsync(trustedTestCert.Source.Cert, nupkgA, dir);
+                var signedPackagePathB = await SignedArchiveTestUtility.AuthorSignPackageAsync(trustedTestCert.Source.Cert, nupkgB, dir);
+
+                SettingsTestUtils.CreateConfigurationFile(nugetConfigFileName, dir, config);
+                var nugetConfigPath = Path.Combine(dir, nugetConfigFileName);
+                var allowUntrustedRootArg = allowUntrustedRoot ? "-AllowUntrustedRoot" : string.Empty;
+                var multiplePackagesPath = $"{dir}{Path.DirectorySeparatorChar}*.nupkg";
+
+                // Act
+                var commandResult = CommandRunner.Run(
+                    _nugetExePath,
+                    dir,
+                    $"trusted-signers add {multiplePackagesPath} -Name signer -Author {allowUntrustedRootArg} -Config {nugetConfigPath}",
+                    waitForExit: true);
+
+                // Assert
+                commandResult.Success.Should().BeFalse();
+                commandResult.AllOutput.Should().Contain(string.Format(CultureInfo.CurrentCulture,
+                    "Multiple nupkg files detected on '{0}' path to trust, only 1 is allowed.",
+                    multiplePackagesPath));
             }
         }
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug
Fixes: https://github.com/NuGet/Home/issues/10647

Regression? Last working version:

## Description
[Considering ](https://github.com/nuget/home/issues/10647#issuecomment-801523491) other certificate/security commands doesn't accept multiple files for add/trust action we'll throw if multiple nupkg files detected on path.  

Here are examples of other certificate/security commands doesn't accept multiple files: 
*  Windows' `certutil -addstore root <file path>`, which adds a certificate to a trusted certificate store as a trusted root authority, disallows wildcards in the file path.  The file path must resolve to a single file.
*  PowerShell's `Import-Certificate -CertStoreLocation Cert:\LocalMachine\Root -FilePath <file path>`, which adds a certificate to a certificate store as a trusted root authority, disallows wildcards in the file path.

Here sample command which can cause problem:
 `nuget trusted-signers add C:\MyPackages\*.nupkg -Name signer -Author`


## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [x] Documentation PR or issue filled
     *  https://github.com/NuGet/docs.microsoft.com-nuget/issues/2399
  - **OR**
  - [] N/A
