### PR TITLE
Add PMC powershell version into powershellloaded event

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/NuGetPowerShellUsageCollector.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/NuGetPowerShellUsageCollector.cs
@@ -22,6 +22,7 @@ namespace NuGet.VisualStudio.Common.Telemetry
         public const string FirstTimeLoadedFromPmc = nameof(FirstTimeLoadedFromPmc);
         public const string SolutionLoaded = nameof(SolutionLoaded);
         public const string Trigger = nameof(Trigger);
+        public const string PSVersion = nameof(PSVersion);
         public const string Pmc = nameof(Pmc);
         public const string Pmui = nameof(Pmui);
 

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/Powershell/PowerShellLoadedEvent.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/Powershell/PowerShellLoadedEvent.cs
@@ -7,10 +7,11 @@ namespace NuGet.VisualStudio.Common.Telemetry.PowerShell
 {
     public class PowerShellLoadedEvent : TelemetryEvent
     {
-        public PowerShellLoadedEvent(bool isPmc)
+        public PowerShellLoadedEvent(bool isPmc, string psVersion)
             : base(NuGetPowerShellUsageCollector.PowerShellLoaded)
         {
             base[NuGetPowerShellUsageCollector.Trigger] = isPmc ? NuGetPowerShellUsageCollector.Pmc : NuGetPowerShellUsageCollector.Pmui;
+            base[NuGetPowerShellUsageCollector.PSVersion] = psVersion;
         }
     }
 }

--- a/src/NuGet.Clients/NuGetConsole.Host.PowerShell/PowerShellHost.cs
+++ b/src/NuGet.Clients/NuGetConsole.Host.PowerShell/PowerShellHost.cs
@@ -317,7 +317,7 @@ namespace NuGetConsole.Host.PowerShell.Implementation
 
                         if (!PowerShellLoaded)
                         {
-                            var telemetryEvent = new PowerShellLoadedEvent(isPmc: _isPmc);
+                            var telemetryEvent = new PowerShellLoadedEvent(isPmc: _isPmc, psVersion: Runspace.PSVersion.ToString());
                             TelemetryActivity.EmitTelemetryEvent(telemetryEvent);
                             PowerShellLoaded = true;
                         }

--- a/src/NuGet.Clients/NuGetConsole.Host.PowerShell/RunspaceDispatcher.cs
+++ b/src/NuGet.Clients/NuGetConsole.Host.PowerShell/RunspaceDispatcher.cs
@@ -37,6 +37,11 @@ namespace NuGetConsole.Host.PowerShell.Implementation
             get { return _runspace.RunspaceAvailability; }
         }
 
+        public Version PSVersion
+        {
+            get { return _runspace.Version; }
+        }
+
         public RunspaceDispatcher(Runspace runspace)
         {
             _runspace = runspace;


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Home/issues/10609

Regression? Last working version: N/A

## Description
In order to understand why PMC host is crashing problem, we need to know powershell version involved with it. Added `vs.nuget.psversion` property into `vs.nuget.psversion` event. It's emitted only once when PMC powershell host loaded first time.

![image](https://user-images.githubusercontent.com/8766776/114481809-37f5a580-9bba-11eb-8676-a11c4415e1e3.png)

![image](https://user-images.githubusercontent.com/8766776/114482010-a470a480-9bba-11eb-957a-a5ca637940d6.png)

Side note here registry gives me bit different version, but I believe above one is more accurate:

![image](https://user-images.githubusercontent.com/8766776/114482572-a1c27f00-9bbb-11eb-9089-ce9f7d098cd6.png)

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
