### PR TITLE
Creates CI localizationArtifacts for localization team

### DIFF
--- a/build/loc.proj
+++ b/build/loc.proj
@@ -75,25 +75,23 @@
     <Copy SourceFiles="@(EulaFiles->'%(Identity)')" DestinationFiles="@(EulaFiles->'%(DestinationDir)')"/>
   </Target>
 
-  <Target Name="MoveLcgFilesToArtifacts" AfterTargets="Localize">
+  <Target Name="CopyLcgFilesToArtifacts" AfterTargets="Localize">
     <ItemGroup>
-      <_MoveLcgFiles Include="@(LocalizedToolFiles)" Condition="'%(LocalizedToolFiles.Extension)'== '.lcg'">
+      <_LcgFiles Include="@(LocalizedToolFiles)" Condition="'%(LocalizedToolFiles.Extension)'== '.lcg'">
         <DestinationDir>$(ArtifactsDirectory)$([MSBuild]::MakeRelative($(ArtifactsDirectory)localize\%(LocalizedToolFiles.lang), %(LocalizedToolFiles.RootDir)%(LocalizedToolFiles.Directory)))%(LocalizedToolFiles.Culture)\%(LocalizedToolFiles.Filename)%(LocalizedToolFiles.Extension)</DestinationDir>
-      </_MoveLcgFiles>
+      </_LcgFiles>
     </ItemGroup>
-    <Move SourceFiles="@(_MoveLcgFiles->'%(Identity)')" DestinationFiles="@(_MoveLcgFiles->'%(DestinationDir)')"/>
+    <Copy SourceFiles="@(_LcgFiles->'%(Identity)')" DestinationFiles="@(_LcgFiles->'%(DestinationDir)')"/>
   </Target>
 
-  <!--
   <Target Name="CopyBinariesToLocalizeENU" AfterTargets="Localize">
     <ItemGroup>
-      <_EnglishBinaires Include="@(FilesToLocalize)" Condition="'%(FilesToLocalize.Extension)'== '.dll'">
+      <_EnglishBinaries Include="@(FilesToLocalize)" Condition="'%(FilesToLocalize.Extension)'== '.dll'">
         <DestinationPath>$(ArtifactsDirectory)localize\ENU\$([MSBuild]::MakeRelative($(ArtifactsDirectory), %(FilesToLocalize.RootDir)%(FilesToLocalize.Directory)))%(FilesToLocalize.Filename)%(FilesToLocalize.Extension)</DestinationPath>
-      </_EnglishBinaires>
+      </_EnglishBinaries>
     </ItemGroup>
-    <Copy SourceFiles="@(_EnglishBinaires)" DestinationFiles="@(_EnglishBinaires->'%(DestinationPath)')" />
+    <Copy SourceFiles="@(_EnglishBinaries)" DestinationFiles="@(_EnglishBinaries->'%(DestinationPath)')" />
   </Target>
--->
 
   <Target Name="AfterBuild" DependsOnTargets="LocalizeNonProjectFiles;BatchLocalize"/>
   <Import Project="$(MicroBuildDirectory)Microsoft.VisualStudioEng.MicroBuild.Core.targets" />

--- a/build/loc.proj
+++ b/build/loc.proj
@@ -98,9 +98,14 @@
       <_LocalizeFiles Include="$(ArtifactsDirectory)localize\ResponseFiles\*.loc.002\ENU\LocProject.json">
         <DestinationPath>$(ArtifactsDirectory)\localizationArtifacts\ENU\LocProject.json</DestinationPath>
       </_LocalizeFiles>
+      <_SubmoduleRepo Include="$(LocalizationRootDirectory)\**\*" />
+      <_SubmoduleFiles Include="@(_SubmoduleRepo)">
+        <DestinationPath>$(ArtifactsDirectory)\localizationArtifacts\submodules\NuGet.Build.Localization\$([MSBuild]::MakeRelative($(LocalizationRootDirectory), %(_SubmoduleRepo.Identity)))</DestinationPath>
+      </_SubmoduleFiles>
     </ItemGroup>
     <Copy SourceFiles="@(_EnglishBinaries)" DestinationFiles="@(_EnglishBinaries->'%(DestinationPath)')" />
     <Copy SourceFiles="@(_LocalizeFiles)" DestinationFiles="@(_LocalizeFiles->'%(DestinationPath)')" />
+    <Copy SourceFiles="@(_SubmoduleFiles)" DestinationFiles="@(_SubmoduleFiles->'%(DestinationPath)')" />
   </Target>
 
   <Target Name="AfterBuild" DependsOnTargets="LocalizeNonProjectFiles;BatchLocalize"/>

--- a/build/loc.proj
+++ b/build/loc.proj
@@ -87,11 +87,11 @@
   <Target Name="CopyBinariesToLocalizationArtifacts" AfterTargets="Localize">
     <ItemGroup>
       <_EnglishBinaries Include="@(FilesToLocalize)" Condition="'%(FilesToLocalize.Extension)'== '.dll'">
-        <DestinationPath>$(ArtifactsDirectory)\localizationArtifacts\$([MSBuild]::MakeRelative($(ArtifactsDirectory), %(FilesToLocalize.RootDir)%(FilesToLocalize.Directory)))%(FilesToLocalize.Filename)%(FilesToLocalize.Extension)</DestinationPath>
+        <DestinationPath>$(ArtifactsDirectory)\localizationArtifacts\artifacts\$([MSBuild]::MakeRelative($(ArtifactsDirectory), %(FilesToLocalize.RootDir)%(FilesToLocalize.Directory)))%(FilesToLocalize.Filename)%(FilesToLocalize.Extension)</DestinationPath>
       </_EnglishBinaries>
       <_LocalizeFolder Include="$(ArtifactsDirectory)localize\**\*" />
       <_LocalizeFiles Include="@(_LocalizeFolder)">
-        <DestinationPath>$(ArtifactsDirectory)\localizationArtifacts\$([MSBuild]::MakeRelative($(ArtifactsDirectory), %(_LocalizeFolder.Identity)))</DestinationPath>
+        <DestinationPath>$(ArtifactsDirectory)\localizationArtifacts\artifacts\$([MSBuild]::MakeRelative($(ArtifactsDirectory), %(_LocalizeFolder.Identity)))</DestinationPath>
       </_LocalizeFiles>
     </ItemGroup>
     <Copy SourceFiles="@(_EnglishBinaries)" DestinationFiles="@(_EnglishBinaries->'%(DestinationPath)')" />

--- a/build/loc.proj
+++ b/build/loc.proj
@@ -75,15 +75,16 @@
     <Copy SourceFiles="@(EulaFiles->'%(Identity)')" DestinationFiles="@(EulaFiles->'%(DestinationDir)')"/>
   </Target>
 
-  <Target Name="CopyLcgFilesToArtifacts" AfterTargets="Localize">
+  <Target Name="MoveLcgFilesToArtifacts" AfterTargets="Localize">
     <ItemGroup>
       <_MoveLcgFiles Include="@(LocalizedToolFiles)" Condition="'%(LocalizedToolFiles.Extension)'== '.lcg'">
         <DestinationDir>$(ArtifactsDirectory)$([MSBuild]::MakeRelative($(ArtifactsDirectory)localize\%(LocalizedToolFiles.lang), %(LocalizedToolFiles.RootDir)%(LocalizedToolFiles.Directory)))%(LocalizedToolFiles.Culture)\%(LocalizedToolFiles.Filename)%(LocalizedToolFiles.Extension)</DestinationDir>
       </_MoveLcgFiles>
     </ItemGroup>
-    <Copy SourceFiles="@(_MoveLcgFiles->'%(Identity)')" DestinationFiles="@(_MoveLcgFiles->'%(DestinationDir)')"/>
+    <Move SourceFiles="@(_MoveLcgFiles->'%(Identity)')" DestinationFiles="@(_MoveLcgFiles->'%(DestinationDir)')"/>
   </Target>
 
+  <!--
   <Target Name="CopyBinariesToLocalizeENU" AfterTargets="Localize">
     <ItemGroup>
       <_EnglishBinaires Include="@(FilesToLocalize)" Condition="'%(FilesToLocalize.Extension)'== '.dll'">
@@ -92,6 +93,7 @@
     </ItemGroup>
     <Copy SourceFiles="@(_EnglishBinaires)" DestinationFiles="@(_EnglishBinaires->'%(DestinationPath)')" />
   </Target>
+-->
 
   <Target Name="AfterBuild" DependsOnTargets="LocalizeNonProjectFiles;BatchLocalize"/>
   <Import Project="$(MicroBuildDirectory)Microsoft.VisualStudioEng.MicroBuild.Core.targets" />

--- a/build/loc.proj
+++ b/build/loc.proj
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" DefaultTargets="AfterBuild" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="AfterBuild">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common.props" />
   <Import Project="$(MicroBuildDirectory)Microsoft.VisualStudioEng.MicroBuild.Core.props"/>
 
@@ -50,7 +49,9 @@
           TaskParameter="TargetOutputs"
           ItemName="FilesToLocalize" />
     </MSBuild>
-    <Message Text="Files to localize : @(FilesToLocalize, '%0a')" Importance="High"/>
+
+    <!-- Delete previous lsbuild.exe response outputs, so we keep last two ResponseFiles folders -->
+    <RemoveDir Directories="$(ArtifactsDirectory)localize\ResponseFiles\" />
   </Target>
 
   <Target Name="MoveLocalizedFilesToProjectSpecificArtifacts" AfterTargets="Localize">
@@ -89,9 +90,13 @@
       <_EnglishBinaries Include="@(FilesToLocalize)" Condition="'%(FilesToLocalize.Extension)'== '.dll'">
         <DestinationPath>$(ArtifactsDirectory)\localizationArtifacts\artifacts\$([MSBuild]::MakeRelative($(ArtifactsDirectory), %(FilesToLocalize.RootDir)%(FilesToLocalize.Directory)))%(FilesToLocalize.Filename)%(FilesToLocalize.Extension)</DestinationPath>
       </_EnglishBinaries>
-      <_LocalizeFolder Include="$(ArtifactsDirectory)localize\**\*" />
+      <_LocalizeFolder Include="$(ArtifactsDirectory)localize\**\*" Exclude="$(ArtifactsDirectory)localize\ResponseFiles\**\*" />
       <_LocalizeFiles Include="@(_LocalizeFolder)">
         <DestinationPath>$(ArtifactsDirectory)\localizationArtifacts\artifacts\$([MSBuild]::MakeRelative($(ArtifactsDirectory), %(_LocalizeFolder.Identity)))</DestinationPath>
+      </_LocalizeFiles>
+      <!-- Second Localize run creates appropiate LocProject.json -->
+      <_LocalizeFiles Include="$(ArtifactsDirectory)localize\ResponseFiles\*.loc.002\ENU\LocProject.json">
+        <DestinationPath>$(ArtifactsDirectory)\localizationArtifacts\ENU\LocProject.json</DestinationPath>
       </_LocalizeFiles>
     </ItemGroup>
     <Copy SourceFiles="@(_EnglishBinaries)" DestinationFiles="@(_EnglishBinaries->'%(DestinationPath)')" />

--- a/build/loc.proj
+++ b/build/loc.proj
@@ -84,13 +84,18 @@
     <Copy SourceFiles="@(_LcgFiles->'%(Identity)')" DestinationFiles="@(_LcgFiles->'%(DestinationDir)')"/>
   </Target>
 
-  <Target Name="CopyBinariesToLocalizeENU" AfterTargets="Localize">
+  <Target Name="CopyBinariesToLocalizationArtifacts" AfterTargets="Localize">
     <ItemGroup>
       <_EnglishBinaries Include="@(FilesToLocalize)" Condition="'%(FilesToLocalize.Extension)'== '.dll'">
-        <DestinationPath>$(ArtifactsDirectory)localize\ENU\$([MSBuild]::MakeRelative($(ArtifactsDirectory), %(FilesToLocalize.RootDir)%(FilesToLocalize.Directory)))%(FilesToLocalize.Filename)%(FilesToLocalize.Extension)</DestinationPath>
+        <DestinationPath>$(ArtifactsDirectory)\localizationArtifacts\$([MSBuild]::MakeRelative($(ArtifactsDirectory), %(FilesToLocalize.RootDir)%(FilesToLocalize.Directory)))%(FilesToLocalize.Filename)%(FilesToLocalize.Extension)</DestinationPath>
       </_EnglishBinaries>
+      <_LocalizeFolder Include="$(ArtifactsDirectory)localize\**\*" />
+      <_LocalizeFiles Include="@(_LocalizeFolder)">
+        <DestinationPath>$(ArtifactsDirectory)\localizationArtifacts\$([MSBuild]::MakeRelative($(ArtifactsDirectory), %(_LocalizeFolder.Identity)))</DestinationPath>
+      </_LocalizeFiles>
     </ItemGroup>
     <Copy SourceFiles="@(_EnglishBinaries)" DestinationFiles="@(_EnglishBinaries->'%(DestinationPath)')" />
+    <Copy SourceFiles="@(_LocalizeFiles)" DestinationFiles="@(_LocalizeFiles->'%(DestinationPath)')" />
   </Target>
 
   <Target Name="AfterBuild" DependsOnTargets="LocalizeNonProjectFiles;BatchLocalize"/>

--- a/build/loc.proj
+++ b/build/loc.proj
@@ -101,7 +101,7 @@
       </_LocalizeFiles>
       <_SubmoduleRepo Include="$(LocalizationRootDirectory)\**\*" />
       <_SubmoduleFiles Include="@(_SubmoduleRepo)">
-        <DestinationPath>$(ArtifactsDirectory)\localizationArtifacts\submodules\NuGet.Build.Localization\$([MSBuild]::MakeRelative($(LocalizationRootDirectory), %(_SubmoduleRepo.Identity)))</DestinationPath>
+        <DestinationPath>$(ArtifactsDirectory)\localizationArtifacts\submodules\NuGet.Build.Localization\localize\$([MSBuild]::MakeRelative($(LocalizationRootDirectory), %(_SubmoduleRepo.Identity)))</DestinationPath>
       </_SubmoduleFiles>
     </ItemGroup>
     <Copy SourceFiles="@(_EnglishBinaries)" DestinationFiles="@(_EnglishBinaries->'%(DestinationPath)')" />

--- a/build/loc.proj
+++ b/build/loc.proj
@@ -57,14 +57,13 @@
   <Target Name="MoveLocalizedFilesToProjectSpecificArtifacts" AfterTargets="Localize">
     <ItemGroup>
       <_MoveLocalizedFiles Include="@(LocalizedUserFiles)">
-        <DestinationDir>$(ArtifactsDirectory)$([MSBuild]::MakeRelative($(ArtifactsDirectory)localize\%(LocalizedUserFiles.lang), %(LocalizedUserFiles.RootDir)%(LocalizedUserFiles.Directory)))%(LocalizedUserFiles.Culture)\%(LocalizedUserFiles.Filename)%(LocalizedUserFiles.Extension)</DestinationDir>
+        <DestinationDir>$(ArtifactsDirectory)$([MSBuild]::MakeRelative($(ArtifactsDirectory)localize\%(LocalizedUserFiles.lang), %(LocalizedUserFiles.RootDir)%(LocalizedUserFiles.Directory)))\%(LocalizedUserFiles.Culture)\%(LocalizedUserFiles.Filename)%(LocalizedUserFiles.Extension)</DestinationDir>
       </_MoveLocalizedFiles>
     </ItemGroup>
     <Move SourceFiles="@(_MoveLocalizedFiles->'%(Identity)')" DestinationFiles="@(_MoveLocalizedFiles->'%(DestinationDir)')"/>
-    <Delete Files="$(ArtifactsDirectory)vsixlangpack\extension.vsixlangpack"/>
   </Target>
 
-  <Target Name="MoveEulasToArtifacts" AfterTargets="Localize">
+  <Target Name="MoveLocalizedEulasToArtifacts" AfterTargets="Localize">
     <ItemGroup>
       <!-- SupportedCultures is defined in MicroBuild.Plugins.Localization.targets which is installed as a plugin
       in VSTS MicroBuild -->
@@ -76,19 +75,21 @@
     <Copy SourceFiles="@(EulaFiles->'%(Identity)')" DestinationFiles="@(EulaFiles->'%(DestinationDir)')"/>
   </Target>
 
+  <!-- Prepares localization folder  -->
   <Target Name="CopyLcgFilesToArtifacts" AfterTargets="Localize">
     <ItemGroup>
       <_LcgFiles Include="@(LocalizedToolFiles)" Condition="'%(LocalizedToolFiles.Extension)'== '.lcg'">
-        <DestinationDir>$(ArtifactsDirectory)$([MSBuild]::MakeRelative($(ArtifactsDirectory)localize\%(LocalizedToolFiles.lang), %(LocalizedToolFiles.RootDir)%(LocalizedToolFiles.Directory)))%(LocalizedToolFiles.Culture)\%(LocalizedToolFiles.Filename)%(LocalizedToolFiles.Extension)</DestinationDir>
+        <DestinationDir>$(ArtifactsDirectory)$([MSBuild]::MakeRelative($(ArtifactsDirectory)localize\%(LocalizedToolFiles.lang), %(LocalizedToolFiles.RootDir)%(LocalizedToolFiles.Directory)))\%(LocalizedToolFiles.Culture)\%(LocalizedToolFiles.Filename)%(LocalizedToolFiles.Extension)</DestinationDir>
       </_LcgFiles>
     </ItemGroup>
     <Copy SourceFiles="@(_LcgFiles->'%(Identity)')" DestinationFiles="@(_LcgFiles->'%(DestinationDir)')"/>
   </Target>
 
+  <!-- Prepares localization artifact -->
   <Target Name="CopyBinariesToLocalizationArtifacts" AfterTargets="Localize">
     <ItemGroup>
-      <_EnglishBinaries Include="@(FilesToLocalize)" Condition="'%(FilesToLocalize.Extension)'== '.dll'">
-        <DestinationPath>$(ArtifactsDirectory)\localizationArtifacts\artifacts\$([MSBuild]::MakeRelative($(ArtifactsDirectory), %(FilesToLocalize.RootDir)%(FilesToLocalize.Directory)))%(FilesToLocalize.Filename)%(FilesToLocalize.Extension)</DestinationPath>
+      <_EnglishBinaries Include="@(FilesToLocalize)">
+        <DestinationPath>$(ArtifactsDirectory)\localizationArtifacts\artifacts\$([MSBuild]::MakeRelative($(ArtifactsDirectory), %(FilesToLocalize.RootDir)%(FilesToLocalize.Directory)))\%(FilesToLocalize.Filename)%(FilesToLocalize.Extension)</DestinationPath>
       </_EnglishBinaries>
       <_LocalizeFolder Include="$(ArtifactsDirectory)localize\**\*" Exclude="$(ArtifactsDirectory)localize\ResponseFiles\**\*" />
       <_LocalizeFiles Include="@(_LocalizeFolder)">

--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -461,7 +461,7 @@ steps:
   inputs:
     targetPath: "$(Build.Repository.LocalPath)\\artifacts\\localize\\"
     artifactName: "localizeInputs"
-  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
+  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
 
 - task: PublishPipelineArtifact@1
   displayName: "Upload legacy localizeInputs artifact"

--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -454,13 +454,13 @@ steps:
   inputs:
     SourceFolder: "$(Build.ArtifactStagingDirectory)\\PLOC"
     TargetFolder: "$(CIRoot)\\PLOC\\$(Build.SourceBranchName)\\$(Build.BuildNumber)"
-  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
+  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
 
 - task: PublishPipelineArtifact@1
-  displayName: "Upload localizeInputs artifact"
+  displayName: "Upload localizationArtifacts artifact"
   inputs:
-    targetPath: "$(Build.Repository.LocalPath)\\artifacts\\localize\\"
-    artifactName: "localizeInputs"
+    targetPath: "$(Build.Repository.LocalPath)\\artifacts\\localizationArtifacts\\"
+    artifactName: "localizationArtifacts"
   condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
 
 - task: PublishPipelineArtifact@1

--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -446,7 +446,7 @@ steps:
       **\*.lcg
       !localize\**\*
     TargetFolder: "$(Build.ArtifactStagingDirectory)\\PLOC"
-  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
+  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
 
 
 - task: CopyFiles@2

--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -144,7 +144,7 @@ steps:
     solution: "build\\loc.proj"
     msbuildVersion: "16.0"
     configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/t:AfterBuild"
+    msbuildArguments: "/t:AfterBuild /bl:$(Build.Repository.LocalPath)\\artifacts\\localize\\loc.binlog"
 
 - task: MSBuild@1
   displayName: "Build Final NuGet.exe (via ILMerge)"

--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -144,7 +144,7 @@ steps:
     solution: "build\\loc.proj"
     msbuildVersion: "16.0"
     configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/t:AfterBuild /bl:$(Build.Repository.LocalPath)\\artifacts\\localize\\loc.binlog"
+    msbuildArguments: "/t:AfterBuild /bl:$(Build.Repository.LocalPath)\\artifacts\\localizationArtifacts\\loc.binlog"
 
 - task: MSBuild@1
   displayName: "Build Final NuGet.exe (via ILMerge)"
@@ -457,7 +457,7 @@ steps:
   condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
 
 - task: PublishPipelineArtifact@1
-  displayName: "Upload localizationArtifacts artifact"
+  displayName: "Publish localizationArtifacts artifact"
   inputs:
     targetPath: "$(Build.Repository.LocalPath)\\artifacts\\localizationArtifacts\\"
     artifactName: "localizationArtifacts"

--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -446,7 +446,7 @@ steps:
       **\*.lcg
       !localize\**\*
     TargetFolder: "$(Build.ArtifactStagingDirectory)\\PLOC"
-  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
+  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
 
 
 - task: CopyFiles@2

--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -454,14 +454,14 @@ steps:
   inputs:
     SourceFolder: "$(Build.ArtifactStagingDirectory)\\PLOC"
     TargetFolder: "$(CIRoot)\\PLOC\\$(Build.SourceBranchName)\\$(Build.BuildNumber)"
-  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
+  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
 
 - task: PublishPipelineArtifact@1
   displayName: "Publish localizationArtifacts artifact"
   inputs:
     targetPath: "$(Build.Repository.LocalPath)\\artifacts\\localizationArtifacts\\"
     artifactName: "localizationArtifacts"
-  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
+  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
 
 - task: PublishPipelineArtifact@1
   displayName: "Upload legacy localizeInputs artifact"

--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -144,7 +144,7 @@ steps:
     solution: "build\\loc.proj"
     msbuildVersion: "16.0"
     configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/t:AfterBuild /bl:$(Build.Repository.LocalPath)\\artifacts\\localizationArtifacts\\loc.binlog"
+    msbuildArguments: "/t:AfterBuild"
 
 - task: MSBuild@1
   displayName: "Build Final NuGet.exe (via ILMerge)"


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/885

Regression? Last working version: No

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

This PR creates a new CI artifact named `localizationArtifact`. This artifacts contains:

- English NuGet binaries: All NuGet binaries that can be localizable.
- Localization metadata files: .lcg (genated in CI), .lci (localization comments), .lcl (localized files).
- LocProject.json file: Contains file entries that describe all files to be localized, contained in the artifact.

**Note**: This PR does not affect current localization workflow via build share.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - ~[ ] Automated tests added~
  - ~[ ] Test exception~
  - [x] N/A: This is a CI change. It does not contain product changes.

- **Validation**: Created a tool named `LocProjectValidator` to verify that `LocProject.json` file entries matches a file inside the localization artifact. The tool will be available in NuGet/Entropy once it's checked in. [PR here](https://github.com/NuGet/Entropy/pull/50). The tool reported 14 missing .lci files; to be addressed in this [issue](https://github.com/NuGet/Client.Engineering/issues/904).

- **Documentation**
  - ~[ ] Documentation PR or issue filled~
  - [x] N/A
