### PR TITLE
Avoid blocking a threadpool thread while waiting on the UI thread 

### DIFF
--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/RestoreOperationLogger.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/RestoreOperationLogger.cs
@@ -123,7 +123,7 @@ namespace NuGet.SolutionRestoreManager
             if (_showErrorList)
             {
                 // Give the error list focus
-                _errorList.Value.BringToFrontIfSettingsPermit();
+                await _errorList.Value.BringToFrontIfSettingsPermitAsync();
             }
         }
 
@@ -302,12 +302,12 @@ namespace NuGet.SolutionRestoreManager
             ExceptionHelper.WriteErrorToActivityLog(ex);
         }
 
-        public void ShowError(string errorText)
+        public async Task ShowErrorAsync(string errorText)
         {
             var entry = new ErrorListTableEntry(errorText, LogLevel.Error);
 
             _errorList.Value.AddNuGetEntries(entry);
-            _errorList.Value.BringToFrontIfSettingsPermit();
+            await _errorList.Value.BringToFrontIfSettingsPermitAsync();
         }
 
         public Task WriteHeaderAsync()

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreJob.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreJob.cs
@@ -198,7 +198,7 @@ namespace NuGet.SolutionRestoreManager
                         if (projects.Any() && solutionDirectory == null)
                         {
                             _status = NuGetOperationStatus.Failed;
-                            _logger.ShowError(Resources.SolutionIsNotSaved);
+                            await _logger.ShowErrorAsync(Resources.SolutionIsNotSaved);
                             await _logger.WriteLineAsync(VerbosityLevel.Minimal, Resources.SolutionIsNotSaved);
 
                             return;
@@ -480,7 +480,7 @@ namespace NuGet.SolutionRestoreManager
             }
             else if (restoreSource == RestoreOperationSource.Explicit)
             {
-                _logger.ShowError(Resources.PackageRefNotRestoredBecauseOfNoConsent);
+                await _logger.ShowErrorAsync(Resources.PackageRefNotRestoredBecauseOfNoConsent);
             }
         }
 
@@ -558,7 +558,7 @@ namespace NuGet.SolutionRestoreManager
                             projectName,
                             exceptionMessage);
                         await _logger.WriteLineAsync(VerbosityLevel.Quiet, message);
-                        _logger.ShowError(message);
+                        await _logger.ShowErrorAsync(message);
                         await _logger.WriteLineAsync(VerbosityLevel.Normal, Resources.PackageRestoreFinishedForProject, projectName);
                     }
                 });
@@ -590,7 +590,7 @@ namespace NuGet.SolutionRestoreManager
                     if (!isSolutionAvailable
                         && await CheckPackagesConfigAsync())
                     {
-                        _logger.ShowError(Resources.SolutionIsNotSaved);
+                        await _logger.ShowErrorAsync(Resources.SolutionIsNotSaved);
                         await _logger.WriteLineAsync(VerbosityLevel.Quiet, Resources.SolutionIsNotSaved);
                     }
 
@@ -676,7 +676,7 @@ namespace NuGet.SolutionRestoreManager
         /// Checks if there are missing packages that should be restored. If so, a warning will
         /// be added to the error list.
         /// </summary>
-        private Task CheckForMissingPackagesAsync(IEnumerable<PackageRestoreData> installedPackages)
+        private async Task CheckForMissingPackagesAsync(IEnumerable<PackageRestoreData> installedPackages)
         {
             var missingPackages = installedPackages.Where(p => p.IsMissing);
 
@@ -686,9 +686,8 @@ namespace NuGet.SolutionRestoreManager
                     CultureInfo.CurrentCulture,
                     Resources.PackageNotRestoredBecauseOfNoConsent,
                     string.Join(", ", missingPackages.Select(p => p.PackageReference.PackageIdentity.ToString())));
-                _logger.ShowError(errorText);
+                await _logger.ShowErrorAsync(errorText);
             }
-            return Task.CompletedTask;
         }
 
         private async Task RestoreMissingPackagesInSolutionAsync(

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/ErrorListTableDataSource.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/ErrorListTableDataSource.cs
@@ -12,6 +12,7 @@ using Microsoft.VisualStudio.Shell.TableControl;
 using Microsoft.VisualStudio.Shell.TableManager;
 
 using IAsyncServiceProvider = Microsoft.VisualStudio.Shell.IAsyncServiceProvider;
+using Task = System.Threading.Tasks.Task;
 
 namespace NuGet.VisualStudio.Common
 {
@@ -168,34 +169,30 @@ namespace NuGet.VisualStudio.Common
         /// <summary>
         /// Show error window if settings permit.
         /// </summary>
-        public void BringToFrontIfSettingsPermit()
+        public async Task BringToFrontIfSettingsPermitAsync()
         {
             EnsureInitialized();
 
-            NuGetUIThreadHelper.JoinableTaskFactory.Run(async () =>
+            await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+            IVsShell vsShell = await _asyncServiceProvider.GetServiceAsync<IVsShell>();
+            int getPropertyReturnCode = vsShell.GetProperty((int)__VSSPROPID.VSSPROPID_ShowTasklistOnBuildEnd, out object propertyShowTaskListOnBuildEnd);
+            bool showErrorListOnBuildEnd = true;
+
+            if (getPropertyReturnCode == VSConstants.S_OK)
             {
-                await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-
-                IVsShell vsShell = await _asyncServiceProvider.GetServiceAsync<IVsShell>();
-                object propertyShowTaskListOnBuildEnd;
-                int getPropertyReturnCode = vsShell.GetProperty((int)__VSSPROPID.VSSPROPID_ShowTasklistOnBuildEnd, out propertyShowTaskListOnBuildEnd);
-                bool showErrorListOnBuildEnd = true;
-
-                if (getPropertyReturnCode == VSConstants.S_OK)
+                if (bool.TryParse(propertyShowTaskListOnBuildEnd?.ToString(), out bool result))
                 {
-                    if (bool.TryParse(propertyShowTaskListOnBuildEnd?.ToString(), out bool result))
-                    {
-                        showErrorListOnBuildEnd = result;
-                    }
+                    showErrorListOnBuildEnd = result;
                 }
+            }
 
-                if (showErrorListOnBuildEnd)
-                {
-                    // Give the error list focus.
-                    var vsErrorList = _errorList as IVsErrorList;
-                    vsErrorList?.BringToFront();
-                }
-            });
+            if (showErrorListOnBuildEnd)
+            {
+                // Give the error list focus.
+                var vsErrorList = _errorList as IVsErrorList;
+                vsErrorList?.BringToFront();
+            }
         }
 
         // Lock before calling

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/INuGetErrorList.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/INuGetErrorList.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Threading.Tasks;
 
 namespace NuGet.VisualStudio.Common
 {
@@ -13,7 +14,7 @@ namespace NuGet.VisualStudio.Common
         void AddNuGetEntries(params ErrorListTableEntry[] entries);
 
         /// <summary> Bring to front if settings permit. </summary>
-        void BringToFrontIfSettingsPermit();
+        Task BringToFrontIfSettingsPermitAsync();
 
         /// <summary> Clear NuGet entries. </summary>
         void ClearNuGetEntries();

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/OutputConsoleLogger.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/OutputConsoleLogger.cs
@@ -93,8 +93,7 @@ namespace NuGet.VisualStudio.Common
                 await _outputConsole.WriteLineAsync(string.Empty);
 
                 // Give the error list focus
-                await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-                _errorList.Value.BringToFrontIfSettingsPermit();
+                await _errorList.Value.BringToFrontIfSettingsPermitAsync();
             });
         }
 
@@ -135,7 +134,7 @@ namespace NuGet.VisualStudio.Common
                     if (message.Level == LogLevel.Error ||
                         message.Level == LogLevel.Warning)
                     {
-                        await ReportAsync(message);
+                        ReportError(message);
                     }
                 }
             });
@@ -167,13 +166,6 @@ namespace NuGet.VisualStudio.Common
 
         public void ReportError(ILogMessage message)
         {
-            Run(() => ReportAsync(message));
-        }
-
-        private async Task ReportAsync(ILogMessage message)
-        {
-            await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-
             var errorListEntry = new ErrorListTableEntry(message);
             _errorList.Value.AddNuGetEntries(errorListEntry);
         }

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Common.Test/OutputConsoleLoggerTests.End.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Common.Test/OutputConsoleLoggerTests.End.cs
@@ -31,7 +31,7 @@ namespace NuGet.VisualStudio.Common.Test
             [Fact]
             public void Gives_error_list_focus()
             {
-                _errorList.Verify(el => el.BringToFrontIfSettingsPermit());
+                _errorList.Verify(el => el.BringToFrontIfSettingsPermitAsync());
             }
         }
     }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/10775

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Avoid blocking a threadpool thread while waiting on a UI thread operation. Don't transition to the UI thread in a few unnecessary situations

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception - Did some manual testing. Manual testing + Apex/E2E exercise these codepaths
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
