### PR TITLE
No longer need cleanup for failed jobs

### DIFF
--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -521,14 +521,3 @@ steps:
 
 - task: MicroBuildCleanup@1
   displayName: "Perform Cleanup Tasks"
-
-- task: PowerShell@1
-  displayName: "Cleanup on Failure"
-  inputs:
-    scriptType: "inlineScript"
-    arguments: "-BuildOutputTargetPath $(BuildOutputTargetPath)"
-    inlineScript: |
-      param([string]$BuildOutputTargetPath)
-      Get-ChildItem $(BuildOutputTargetPath) -Recurse | Remove-Item -Force -Recurse -ErrorAction SilentlyContinue
-      Remove-Item -Path $(BuildOutputTargetPath) -Force -Recurse -ErrorAction SilentlyContinue
-  condition: "eq(variables['Agent.JobStatus'], 'Failed')"


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/907

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
In NuGet/NuGet.Client#3997 for #395, I forgot to delete the cleanup step for ddfiles.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
