### PR TITLE
Re-enable dependency on VsWebSite.Interop

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -9,6 +9,7 @@
     <add key="NuGet.org" value="https://api.nuget.org/v3/index.json" />
     <add key="vside_vs-impl" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl/nuget/v3/index.json" />
     <add key="vside_vssdk" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vssdk/nuget/v3/index.json" />
+    <add key="vssdk-unifiedPIAs" value="https://devdiv.pkgs.visualstudio.com/DevDiv/_packaging/vssdk-unifiedPIAs/nuget/v3/index.json" />
   </packageSources>
   <disabledPackageSources>
     <clear />

--- a/build/packages.targets
+++ b/build/packages.targets
@@ -75,7 +75,7 @@
         <PackageReference Update="Microsoft.VisualStudio.Shell.Interop.12.0" Version="12.0.30111" ExcludeAssets="all" PrivateAssets="all" NoWarn="NU1605" />
 
         <!-- TODO: PIA workaround, move to $(VSFrameworkVersion) -->
-        <PackageReference Update="Microsoft.VisualStudio.Interop" Version="17.0.0-preview-1-31207-1111" NoWarn="NU1605" />
+        <PackageReference Update="Microsoft.VisualStudio.Interop" Version="17.0.0-preview-1-31209-1111" NoWarn="NU1605,NU3027,NU3018" />
 
         <PackageReference Update="Microsoft.VisualStudio.Interop.Embeddable" Version="$(VSFrameworkVersion)" />
         <PackageReference Update="Microsoft.Internal.VisualStudio.Interop" Version="$(VSFrameworkVersion)" NoWarn="NU1605" />
@@ -109,7 +109,7 @@
         <PackageReference Update="System.Security.Cryptography.Pkcs" Version="$(CryptographyPackagesVersion)" />
         <PackageReference Update="System.Security.Cryptography.ProtectedData" Version="4.4.0" />
         <PackageReference Update="System.Threading.Tasks.Dataflow" Version="4.9.0" />
-        <PackageReference Update="VsWebSite.Interop" Version="17.0.0-preview-1-31108-209" />
+        <PackageReference Update="VsWebSite.Interop" Version="17.0.0-preview-1-31216-1112" />
 
         <!-- Need to remove these once we've cleaned up all our package references -->
         <PackageReference Update="VSSDK.DTE" Version="[7.0.4,8.0.0)" ExcludeAssets="all" PrivateAssets="all" />

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectSystems/WebSiteProjectSystem.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectSystems/WebSiteProjectSystem.cs
@@ -40,7 +40,7 @@ namespace NuGet.PackageManagement.VisualStudio
             var name = Path.GetFileNameWithoutExtension(referencePath);
             try
             {
-                //EnvDTEProjectUtility.GetAssemblyReferences(VsProjectAdapter.Project).AddFromFile(PathUtility.GetAbsolutePath(ProjectFullPath, referencePath));
+                EnvDTEProjectUtility.GetAssemblyReferences(VsProjectAdapter.Project).AddFromFile(PathUtility.GetAbsolutePath(ProjectFullPath, referencePath));
 
                 // Always create a refresh file. Vs does this for us in most cases, however for GACed binaries, it resorts to adding a web.config entry instead.
                 // This may result in deployment issues. To work around ths, we'll always attempt to add a file to the bin.
@@ -58,7 +58,7 @@ namespace NuGet.PackageManagement.VisualStudio
         {
             ThreadHelper.ThrowIfNotOnUIThread();
 
-            //EnvDTEProjectUtility.GetAssemblyReferences(VsProjectAdapter.Project).AddFromGAC(name);
+            EnvDTEProjectUtility.GetAssemblyReferences(VsProjectAdapter.Project).AddFromGAC(name);
         }
 
         public override async Task RemoveReferenceAsync(string name)
@@ -92,33 +92,33 @@ namespace NuGet.PackageManagement.VisualStudio
         private void RemoveDTEReference(string name)
         {
             // Get the reference name without extension
-            //var referenceName = Path.GetFileNameWithoutExtension(name);
+            var referenceName = Path.GetFileNameWithoutExtension(name);
 
             // Remove the reference from the project
-            //AssemblyReference reference = null;
-            //try
-            //{
-            //    //reference = EnvDTEProjectUtility.GetAssemblyReferences(VsProjectAdapter.Project).Item(referenceName);
-            //    if (reference != null)
-            //    {
-            //        reference.Remove();
-            //        NuGetProjectContext.Log(ProjectManagement.MessageLevel.Debug, Strings.Debug_RemoveReference, name, ProjectName);
-            //    }
-            //}
-            //catch (Exception ex)
-            //{
-            //    var messageLevel = ProjectManagement.MessageLevel.Warning;
-            //    if (reference != null
-            //        && reference.ReferenceKind == AssemblyReferenceType.AssemblyReferenceConfig)
-            //    {
-            //        // Bug 2319: Strong named assembly references are specified via config and may be specified in the root web.config. Attempting to remove these
-            //        // references always throws and there isn't an easy way to identify this. Instead, we'll attempt to lower the level of the message so it doesn't
-            //        // appear as readily.
+            AssemblyReference reference = null;
+            try
+            {
+                reference = EnvDTEProjectUtility.GetAssemblyReferences(VsProjectAdapter.Project).Item(referenceName);
+                if (reference != null)
+                {
+                    reference.Remove();
+                    NuGetProjectContext.Log(ProjectManagement.MessageLevel.Debug, Strings.Debug_RemoveReference, name, ProjectName);
+                }
+            }
+            catch (Exception ex)
+            {
+                var messageLevel = ProjectManagement.MessageLevel.Warning;
+                if (reference != null
+                    && reference.ReferenceKind == AssemblyReferenceType.AssemblyReferenceConfig)
+                {
+                    // Bug 2319: Strong named assembly references are specified via config and may be specified in the root web.config. Attempting to remove these
+                    // references always throws and there isn't an easy way to identify this. Instead, we'll attempt to lower the level of the message so it doesn't
+                    // appear as readily.
 
-            //        messageLevel = ProjectManagement.MessageLevel.Debug;
-            //    }
-            //    NuGetProjectContext.Log(messageLevel, ex.Message);
-            //}
+                    messageLevel = ProjectManagement.MessageLevel.Debug;
+                }
+                NuGetProjectContext.Log(messageLevel, ex.Message);
+            }
         }
 
         public override string ResolvePath(string path)

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Utility/EnvDTEProjectUtility.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Utility/EnvDTEProjectUtility.cs
@@ -410,15 +410,15 @@ namespace NuGet.PackageManagement.VisualStudio
             return nuGetProject;
         }
 
-        //internal static AssemblyReferences GetAssemblyReferences(EnvDTE.Project project)
-        //{
-        //    ThreadHelper.ThrowIfNotOnUIThread();
+        internal static AssemblyReferences GetAssemblyReferences(EnvDTE.Project project)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
 
-        //    dynamic projectObj = project.Object;
-        //    var references = (AssemblyReferences)projectObj.References;
-        //    projectObj = null;
-        //    return references;
-        //}
+            dynamic projectObj = project.Object;
+            var references = (AssemblyReferences)projectObj.References;
+            projectObj = null;
+            return references;
+        }
 
         /// <summary>
         /// Recursively retrieves all supported child projects of a virtual folder.
@@ -524,29 +524,29 @@ namespace NuGet.PackageManagement.VisualStudio
             return assemblies;
         }
 
-        private static Task<HashSet<string>> GetWebsiteLocalAssembliesAsync(EnvDTE.Project envDTEProject)
+        private static async Task<HashSet<string>> GetWebsiteLocalAssembliesAsync(EnvDTE.Project envDTEProject)
         {
             var assemblies = new HashSet<string>(PathComparer.Default);
-            //var references = GetAssemblyReferences(envDTEProject);
-            //foreach (AssemblyReference reference in references)
-            //{
-            //    // For websites only include bin assemblies
-            //    if (reference.ReferencedProject == null
-            //        &&
-            //        reference.ReferenceKind == AssemblyReferenceType.AssemblyReferenceBin
-            //        &&
-            //        File.Exists(reference.FullPath))
-            //    {
-            //        assemblies.Add(reference.FullPath);
-            //    }
-            //}
+            var references = GetAssemblyReferences(envDTEProject);
+            foreach (AssemblyReference reference in references)
+            {
+                // For websites only include bin assemblies
+                if (reference.ReferencedProject == null
+                    &&
+                    reference.ReferenceKind == AssemblyReferenceType.AssemblyReferenceBin
+                    &&
+                    File.Exists(reference.FullPath))
+                {
+                    assemblies.Add(reference.FullPath);
+                }
+            }
 
-            //// For website projects, we always add .refresh files that point to the corresponding binaries in packages. In the event of bin deployed assemblies that are also GACed,
-            //// the ReferenceKind is not AssemblyReferenceBin. Consequently, we work around this by looking for any additional assembly declarations specified via .refresh files.
-            //var envDTEProjectPath = await envDTEProject.GetFullPathAsync();
-            //CollectionsUtility.AddRange(assemblies, RefreshFileUtility.ResolveRefreshPaths(envDTEProjectPath));
+            // For website projects, we always add .refresh files that point to the corresponding binaries in packages. In the event of bin deployed assemblies that are also GACed,
+            // the ReferenceKind is not AssemblyReferenceBin. Consequently, we work around this by looking for any additional assembly declarations specified via .refresh files.
+            var envDTEProjectPath = await envDTEProject.GetFullPathAsync();
+            CollectionsUtility.AddRange(assemblies, RefreshFileUtility.ResolveRefreshPaths(envDTEProjectPath));
 
-            return System.Threading.Tasks.Task.FromResult(assemblies);
+            return assemblies;
         }
 
         private class PathComparer : IEqualityComparer<string>
@@ -574,50 +574,50 @@ namespace NuGet.PackageManagement.VisualStudio
             }
 
             var envDTEProjects = new List<EnvDTE.Project>();
-            //References references;
-            //try
-            //{
-            //    references = GetReferences(envDTEProject);
-            //}
-            //catch (RuntimeBinderException)
-            //{
-            //    //References property doesn't exist, project does not have references
-            //    references = null;
-            //}
-            //if (references != null)
-            //{
-            //    foreach (Reference reference in references)
-            //    {
-            //        var reference3 = reference as Reference3;
+            References references;
+            try
+            {
+                references = GetReferences(envDTEProject);
+            }
+            catch (RuntimeBinderException)
+            {
+                //References property doesn't exist, project does not have references
+                references = null;
+            }
+            if (references != null)
+            {
+                foreach (Reference reference in references)
+                {
+                    var reference3 = reference as Reference3;
 
-            //        // Get the referenced project from the reference if any
-            //        // C++ projects will throw on reference.SourceProject if reference3.Resolved is false.
-            //        // It's also possible that the referenced project is the project itself 
-            //        // for C++ projects. In this case this reference should be skipped to avoid circular
-            //        // references.
-            //        if (reference3 != null
-            //            && reference3.Resolved
-            //            && reference.SourceProject != null
-            //            && reference.SourceProject != envDTEProject)
-            //        {
-            //            envDTEProjects.Add(reference.SourceProject);
-            //        }
-            //    }
-            //}
+                    // Get the referenced project from the reference if any
+                    // C++ projects will throw on reference.SourceProject if reference3.Resolved is false.
+                    // It's also possible that the referenced project is the project itself
+                    // for C++ projects. In this case this reference should be skipped to avoid circular
+                    // references.
+                    if (reference3 != null
+                        && reference3.Resolved
+                        && reference.SourceProject != null
+                        && reference.SourceProject != envDTEProject)
+                    {
+                        envDTEProjects.Add(reference.SourceProject);
+                    }
+                }
+            }
             return envDTEProjects;
         }
 
         private static IList<EnvDTE.Project> GetWebsiteReferencedProjects(EnvDTE.Project envDTEProject)
         {
             var envDTEProjects = new List<EnvDTE.Project>();
-            //var references = GetAssemblyReferences(envDTEProject);
-            //foreach (AssemblyReference reference in references)
-            //{
-            //    if (reference.ReferencedProject != null)
-            //    {
-            //        envDTEProjects.Add(reference.ReferencedProject);
-            //    }
-            //}
+            var references = GetAssemblyReferences(envDTEProject);
+            foreach (AssemblyReference reference in references)
+            {
+                if (reference.ReferencedProject != null)
+                {
+                    envDTEProjects.Add(reference.ReferencedProject);
+                }
+            }
             return envDTEProjects;
         }
 

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/NuGet.VisualStudio.Internal.Contracts.Test.csproj
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/NuGet.VisualStudio.Internal.Contracts.Test.csproj
@@ -10,6 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.VisualStudio.Interop" />
     <PackageReference Include="Newtonsoft.Json" NoWarn="NU1605" />
   </ItemGroup>
   

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Test/NuGet.VisualStudio.Test.csproj
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Test/NuGet.VisualStudio.Test.csproj
@@ -17,6 +17,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.VisualStudio.Interop" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/754

Regression? No

## Description
An updated VsWebSite.Interop package has been published. This change updates NuGet.Client to consume the new package and re-enables the code dependent on VsWebSite.Interop which had previously been commented out.

## PR Checklist

- [X] PR has a meaningful title
- [X] PR has a linked issue.
- [X] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [X] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [X] N/A
