### PR TITLE
Fix CpsPackageReferenceProjectTests flaky test due to not threadsafe logger

### DIFF
--- a/test/TestUtilities/Test.Utility/ProjectManagement/TestNuGetProjectContext.cs
+++ b/test/TestUtilities/Test.Utility/ProjectManagement/TestNuGetProjectContext.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using System.Xml.Linq;
@@ -17,7 +18,7 @@ namespace Test.Utility
     {
         private Guid _operationId;
         public TestExecutionContext TestExecutionContext { get; set; }
-        public Lazy<List<string>> Logs { get; } = new Lazy<List<string>>();
+        public Lazy<ConcurrentBag<string>> Logs { get; } = new Lazy<ConcurrentBag<string>>();
         public bool EnableLogging { get; set; }
 
         public void Log(MessageLevel level, string message, params object[] args)


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Home/issues/10719

Regression? Last working version: n/a

## Description
It looks logger fails when uninstall action run in parallel, so I changed to `List` to threadsafe `ConcurrentBag` type.

## PR Checklist

- [x] PR has a meaningful title
- x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x ] N/A
