### PR TITLE
Allow specifying binlog path for RestoreTaskEx

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.RestoreEx.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.RestoreEx.targets
@@ -32,6 +32,7 @@ Copyright (c) .NET Foundation. All rights reserved.
         SolutionPath="$(SolutionPath)"
         ProcessFileName="$(NuGetConsoleProcessFileName)"
         MSBuildStartupDirectory="$(MSBuildStartupDirectory)"
+        BinlogPath="$(RestoreBinlogPath)"
         />
   </Target>
 

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.RestoreEx.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.RestoreEx.targets
@@ -32,7 +32,7 @@ Copyright (c) .NET Foundation. All rights reserved.
         SolutionPath="$(SolutionPath)"
         ProcessFileName="$(NuGetConsoleProcessFileName)"
         MSBuildStartupDirectory="$(MSBuildStartupDirectory)"
-        BinlogPath="$(RestoreBinlogPath)"
+        BinlogPath="$(RestoreStaticGraphBinLogPath)"
         />
   </Target>
 

--- a/src/NuGet.Core/NuGet.Build.Tasks/RestoreTaskEx.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/RestoreTaskEx.cs
@@ -110,6 +110,11 @@ namespace NuGet.Build.Tasks
         /// MSBuildStartupDirectory - Used to calculate relative paths
         /// </summary>
         public string MSBuildStartupDirectory { get; set; }
+        
+        /// <summary>
+        /// The path to the binlog file to generate during restore.
+        ///
+        public string BinlogPath { get; set; }
 
         /// <inheritdoc cref="ICancelableTask.Cancel" />
         public void Cancel() => _cancellationTokenSource.Cancel();
@@ -146,6 +151,12 @@ namespace NuGet.Build.Tasks
                         UseShellExecute = false,
                         WorkingDirectory = Environment.CurrentDirectory,
                     };
+                    
+                    // Add environment variable to generate a restore binlog
+                    if (!string.IsNullOrWhiteSpace(BinlogPath))
+                    {
+                        process.StartInfo.EnvironmentVariables.Add("RESTORE_TASK_BINLOG_PARAMETERS", BinlogPath);
+                    }                    
 
                     // Place the output in the queue which handles logging messages coming through on StdOut
                     process.OutputDataReceived += (sender, args) => loggingQueue.Enqueue(args?.Data);

--- a/src/NuGet.Core/NuGet.Build.Tasks/RestoreTaskEx.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/RestoreTaskEx.cs
@@ -153,9 +153,10 @@ namespace NuGet.Build.Tasks
                     };
                     
                     // Add environment variable to generate a restore binlog
-                    if (!string.IsNullOrWhiteSpace(BinlogPath))
+                    const string BinlogEnvironmentKey = "RESTORE_TASK_BINLOG_PARAMETERS";
+                    if (!string.IsNullOrWhiteSpace(BinlogPath) && !process.StartInfo.EnvironmentVariables.ContainsKey(BinlogEnvironmentKey))
                     {
-                        process.StartInfo.EnvironmentVariables.Add("RESTORE_TASK_BINLOG_PARAMETERS", BinlogPath);
+                        process.StartInfo.EnvironmentVariables.Add(BinlogEnvironmentKey, BinlogPath);
                     }                    
 
                     // Place the output in the queue which handles logging messages coming through on StdOut


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/10789

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
As it's hard to set environment variables from inside MSBuild without a custom task and the nuget static graph console reads from the environment variables, allow specifying a path for the restore binlog to be written to.

## PR Checklist

- [ ] PR has a meaningful title
- [ ] PR has a linked issue.
- [ ] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [ ] N/A
