### PR TITLE
Remove unused lookup of installed/transitive packages in PM UI

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/PackageLoadContext.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/PackageLoadContext.cs
@@ -19,7 +19,6 @@ namespace NuGet.PackageManagement.UI
     internal class PackageLoadContext
     {
         private readonly Task<PackageCollection> _installedPackagesTask;
-        private readonly JoinableTask<InstalledAndTransitivePackageCollections> _allPackagesTask;
 
         public PackageLoadContext(bool isSolution, INuGetUIContext uiContext)
         {
@@ -34,10 +33,6 @@ namespace NuGet.PackageManagement.UI
                 ServiceBroker,
                 Projects,
                 CancellationToken.None);
-            _allPackagesTask = NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(() => PackageCollection.FromProjectsIncludeTransitiveAsync(
-                ServiceBroker,
-                Projects,
-                CancellationToken.None));
         }
 
         public NuGetPackageManager PackageManager { get; }
@@ -56,8 +51,6 @@ namespace NuGet.PackageManagement.UI
         internal IServiceBroker ServiceBroker { get; }
 
         public Task<PackageCollection> GetInstalledPackagesAsync() => _installedPackagesTask;
-
-        public async Task<InstalledAndTransitivePackageCollections> GetInstalledAndTransitivePackagesAsync() => await _allPackagesTask;
 
         // Returns the list of frameworks that we need to pass to the server during search
         public async Task<IReadOnlyCollection<string>> GetSupportedFrameworksAsync()


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/10790

Regression? Last working version: 16.8ish - package recommender specific

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
The lookup being removed here does not appear to be consumed by any logic. It's executed once or twice per load/refresh of any tab (once for packages list, once for Update Count retrieval on refresh).

The call here appears to cost about (112.8 before - 47.83 after = ) **64.97ms or 58%** of the work being done to retrieve Installed/transitive packages.

However, I couldn't perceive a visual difference when manually testing on my VM, even with a large solution with 170 projects. Would be good to test on slower machines.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception - removal of unreferenced code
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
