### PR TITLE
Make nuget future proof for download count exceeding int.MaxValue

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Converters/DownloadCountToVisibilityConverter.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Converters/DownloadCountToVisibilityConverter.cs
@@ -15,7 +15,7 @@ namespace NuGet.PackageManagement.UI
         {
             if (targetType == typeof(Visibility))
             {
-                var downloadCount = value as int?;
+                long? downloadCount = value as long?;
                 if (downloadCount >= 0)
                 {
                     return Visibility.Visible;

--- a/src/NuGet.Core/NuGet.Protocol/Converters/VersionInfoConverter.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Converters/VersionInfoConverter.cs
@@ -3,7 +3,6 @@
 
 using System;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
 
@@ -19,7 +18,7 @@ namespace NuGet.Protocol
         {
             var v = JsonUtility.LoadJson(reader);
             var nugetVersion = NuGetVersion.Parse(v.Value<string>("version"));
-            var count = v.Value<int?>("downloads");
+            var count = v.Value<long?>("downloads");
             return new VersionInfo(nugetVersion, count);
         }
 

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SearchCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SearchCommandTests.cs
@@ -602,7 +602,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
                         ""James Newton-King""
                         ],
 
-                        ""totalDownloads"": 531607259,
+                        ""totalDownloads"": 2147483657,
                         ""verified"": true,
 
                         ""packageTypes"": [

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SearchCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SearchCommandTests.cs
@@ -602,7 +602,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
                         ""James Newton-King""
                         ],
 
-                        ""totalDownloads"": 2147483657,
+                        ""totalDownloads"": 531607259,
                         ""verified"": true,
 
                         ""packageTypes"": [

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Converters/DownloadCountToVisibilityConverterTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Converters/DownloadCountToVisibilityConverterTests.cs
@@ -1,0 +1,45 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading;
+using System.Windows;
+using Xunit;
+
+namespace NuGet.PackageManagement.UI.Test.Converters
+{
+    public class DownloadCountToVisibilityConverterTests
+    {
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(2147483657)]
+        public void Convert_ValidLongValue_Return_VisibilityVisible(long? downloadCount)
+        {
+            var converter = new DownloadCountToVisibilityConverter();
+
+            var converted = converter.Convert(
+                downloadCount,
+                typeof(Visibility),
+                null,
+                Thread.CurrentThread.CurrentCulture);
+
+            Assert.Equal(Visibility.Visible, converted);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData(-1)]
+        public void Convert_ValidLongValue_Return_VisibilityCollapsed(long? downloadCount)
+        {
+            var converter = new DownloadCountToVisibilityConverter();
+
+            var converted = converter.Convert(
+                downloadCount,
+                typeof(Visibility),
+                null,
+                Thread.CurrentThread.CurrentCulture);
+
+            Assert.Equal(Visibility.Collapsed, converted);
+        }
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Converters/DownloadCountToVisibilityConverterTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Converters/DownloadCountToVisibilityConverterTests.cs
@@ -17,7 +17,7 @@ namespace NuGet.PackageManagement.UI.Test.Converters
         {
             var converter = new DownloadCountToVisibilityConverter();
 
-            var converted = converter.Convert(
+            object converted = converter.Convert(
                 downloadCount,
                 typeof(Visibility),
                 null,
@@ -33,7 +33,7 @@ namespace NuGet.PackageManagement.UI.Test.Converters
         {
             var converter = new DownloadCountToVisibilityConverter();
 
-            var converted = converter.Convert(
+            object converted = converter.Convert(
                 downloadCount,
                 typeof(Visibility),
                 null,

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/NuGet.PackageManagement.UI.Test.csproj
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/NuGet.PackageManagement.UI.Test.csproj
@@ -31,6 +31,7 @@
     <Compile Include="Actions\UIActionEngineTests.cs" />
     <Compile Include="Actions\UpdatePreviewResultTests.cs" />
     <Compile Include="Converters\DateTimeConverterTests.cs" />
+    <Compile Include="Converters\DownloadCountToVisibilityConverterTests.cs" />
     <Compile Include="Converters\VersionToStringConverterTests.cs" />
     <Compile Include="ConverterTests.cs" />
     <Compile Include="GlobalSuppressions.cs" />

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/PackageSearchResourceV3Tests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/PackageSearchResourceV3Tests.cs
@@ -111,7 +111,7 @@ namespace NuGet.Protocol.Tests
         public async Task PackageSearchResourceV3_GetMetadataAsync_VersionsDownloadCount()
         {
             // Arrange
-            long largerThanIntMax = 2147483657; // int.MaxValue + 10
+            long largerThanIntMax = (long)int.MaxValue + 10;
             var responses = new Dictionary<string, string>();
             responses.Add("https://api-v3search-0.nuget.org/query?q=entityframework&skip=0&take=1&prerelease=false&semVerLevel=2.0.0",
                 ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.EntityFrameworkSearch.json", GetType()));
@@ -132,13 +132,15 @@ namespace NuGet.Protocol.Tests
 
             var package = packages.SingleOrDefault();
 
-            var versions = await package.GetVersionsAsync();
+            var versions = (await package.GetVersionsAsync()).ToList();
 
             // Assert
             Assert.Equal(28390569, package.DownloadCount);
             Assert.Equal(14, versions.Count());
-            Assert.Equal(64099, versions.First().DownloadCount);
-            Assert.Equal(largerThanIntMax, versions.Skip(1).First().DownloadCount);
+            Assert.Equal(64099, versions[0].DownloadCount);
+            // Make sure NuGet can handle package download count larger than int.MaxValue
+            // EntityFrameworkSearch.json has a 2nd version with download count that is too large for an int32
+            Assert.Equal(largerThanIntMax, versions[1].DownloadCount);
         }
 
         [Fact]

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/PackageSearchResourceV3Tests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/PackageSearchResourceV3Tests.cs
@@ -111,6 +111,7 @@ namespace NuGet.Protocol.Tests
         public async Task PackageSearchResourceV3_GetMetadataAsync_VersionsDownloadCount()
         {
             // Arrange
+            long largerThanIntMax = 2147483657; // int.MaxValue + 10
             var responses = new Dictionary<string, string>();
             responses.Add("https://api-v3search-0.nuget.org/query?q=entityframework&skip=0&take=1&prerelease=false&semVerLevel=2.0.0",
                 ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.EntityFrameworkSearch.json", GetType()));
@@ -137,6 +138,7 @@ namespace NuGet.Protocol.Tests
             Assert.Equal(28390569, package.DownloadCount);
             Assert.Equal(14, versions.Count());
             Assert.Equal(64099, versions.First().DownloadCount);
+            Assert.Equal(largerThanIntMax, versions.Skip(1).First().DownloadCount);
         }
 
         [Fact]

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/compiler/resources/EntityFrameworkSearch.json
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/compiler/resources/EntityFrameworkSearch.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "@context": {
     "@vocab": "http://schema.nuget.org/schema#",
     "@base": "http://api.nuget.org/v3/registration0/"
@@ -31,7 +31,7 @@
         },
         {
           "version": "4.1.10331",
-          "downloads": 612084,
+          "downloads": 2147483657,
           "@id": "http://api.nuget.org/v3/registration0/entityframework/4.1.10331.json"
         },
         {


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Home/issues/10715

Regression? Last working version: N/A

## Description
Mostly we're good, but found 3 places which still using `int` instead of `long`. I only fixed `DownloadCountToVisibilityConverter` and `VersionInfoConverter`. 
I used `downloadCount`/`totalDownloads` as search keyword, I hope I covered all  cases.

1. For count larger than int.MaxValue `DownloadCountToVisibilityConverter.cs` always return collapse.
2. Without this change `VersionInfoConverter` would throw exception like below:

![image](https://user-images.githubusercontent.com/8766776/115806418-96313e00-a39b-11eb-9f39-4400770fb6e3.png)

3. But last one is public api and V2 protocol so I decided to leave as it's, at least it doesn't throw exception.
https://github.com/NuGet/NuGet.Client/blob/5138176d007034f96afce7132f034403a3888c44/src/NuGet.Core/NuGet.Protocol/LegacyFeed/V2FeedPackageInfo.cs#L186-L188

For sake of completeness I include some results.
![image](https://user-images.githubusercontent.com/8766776/115918717-b5c47700-a42c-11eb-9d33-b36cd6ff16cd.png)

![image](https://user-images.githubusercontent.com/8766776/115919889-4b143b00-a42e-11eb-9026-9fbd64f54eb0.png)

![image](https://user-images.githubusercontent.com/8766776/115920846-9844dc80-a42f-11eb-98ba-c1fab4344e3d.png)

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
