### PR TITLE
Make "nuget spec" command generates a .nuspec file with a icon instead or iconUrl

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/SpecCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/SpecCommand.cs
@@ -38,7 +38,7 @@ namespace NuGet.CommandLine
         public override void ExecuteCommand()
         {
             string sampleProjectUrl = "http://project_url_here_or_delete_this_line/";
-            string sampleIconUrl = "http://icon_url_here_or_delete_this_line/";
+            string sampleIconPath = "$icon_image_file_path_within_the_package_here_or_delete_this_line$";
             string sampleTags = "Tag1 Tag2";
             string sampleReleaseNotes = "Summary of changes made in this release of the package.";
             string sampleDescription = "Package description";
@@ -110,7 +110,7 @@ namespace NuGet.CommandLine
 
             manifest.Metadata.SetProjectUrl(sampleProjectUrl);
             manifest.Metadata.LicenseMetadata = new LicenseMetadata(LicenseType.Expression, "MIT", NuGetLicenseExpression.Parse("MIT"), Array.Empty<string>(), LicenseMetadata.CurrentVersion);
-            manifest.Metadata.SetIconUrl(sampleIconUrl);
+            manifest.Metadata.Icon = sampleIconPath;
             manifest.Metadata.Tags = sampleTags;
             manifest.Metadata.Copyright = "$copyright$";
             manifest.Metadata.ReleaseNotes = sampleReleaseNotes;

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/SpecCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/SpecCommand.cs
@@ -113,7 +113,6 @@ namespace NuGet.CommandLine
             manifest.Metadata.Tags = sampleTags;
             manifest.Metadata.Copyright = "$copyright$";
             manifest.Metadata.ReleaseNotes = sampleReleaseNotes;
-
             string nuspecFile = fileName + PackagingConstants.ManifestExtension;
 
             // Skip the creation if the file exists and force wasn't specified

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/SpecCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/SpecCommand.cs
@@ -169,13 +169,9 @@ namespace NuGet.CommandLine
         private static string AddCommentedIconAttribute(string content, string iconFile)
         {
             string sampleIconFile = string.Format("    <!-- <icon>{0}</icon> -->", iconFile);
-            string filesSection = string.Format(@"  <files>
-    <!-- <file src=""{0}"" target="""" /> -->
-  </files>", iconFile);
 
             return content
-                .Replace($"</license>{Environment.NewLine}", string.Format("</license>{0}{1}{2}", Environment.NewLine, sampleIconFile, Environment.NewLine))
-                .Replace($"</metadata>{Environment.NewLine}", string.Format("</metadata>{0}{1}{2}", Environment.NewLine, filesSection, Environment.NewLine));
+                .Replace($"</license>{Environment.NewLine}", string.Format("</license>{0}{1}{2}", Environment.NewLine, sampleIconFile, Environment.NewLine));
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/SpecCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/SpecCommand.cs
@@ -38,7 +38,7 @@ namespace NuGet.CommandLine
         public override void ExecuteCommand()
         {
             string sampleProjectUrl = "http://project_url_here_or_delete_this_line/";
-            string sampleIconFile = "$icon_file_name_within_the_package_here_or_delete_this_line$";
+            string sampleIconFile = "icon.png";
             string sampleTags = "Tag1 Tag2";
             string sampleReleaseNotes = "Summary of changes made in this release of the package.";
             string sampleDescription = "Package description";
@@ -113,13 +113,7 @@ namespace NuGet.CommandLine
             manifest.Metadata.Tags = sampleTags;
             manifest.Metadata.Copyright = "$copyright$";
             manifest.Metadata.ReleaseNotes = sampleReleaseNotes;
-            var iconManifestFile = new ManifestFile
-            {
-                Source = sampleIconFile,
-                Target = ""
-            };
 
-            manifest.Files.Add(iconManifestFile);
             string nuspecFile = fileName + PackagingConstants.ManifestExtension;
 
             // Skip the creation if the file exists and force wasn't specified
@@ -175,10 +169,14 @@ namespace NuGet.CommandLine
 
         private static string AddCommentedIconAttribute(string content, string iconFile)
         {
-            string sampleIconFile = string.Format(CultureInfo.CurrentCulture, "<!-- <icon>{0}</icon> -->", iconFile);
+            string sampleIconFile = string.Format("    <!-- <icon>{0}</icon> -->", iconFile);
+            string filesSection = string.Format(@"  <files>
+    <!-- <file src=""{0}"" target="""" /> -->
+  </files>", iconFile);
 
             return content
-                .Replace($"</license>{Environment.NewLine}", string.Format(CultureInfo.CurrentCulture, "</license>{0}{1}{2}", Environment.NewLine, sampleIconFile, Environment.NewLine));
+                .Replace($"</license>{Environment.NewLine}", string.Format("</license>{0}{1}{2}", Environment.NewLine, sampleIconFile, Environment.NewLine))
+                .Replace($"</metadata>{Environment.NewLine}", string.Format("</metadata>{0}{1}{2}", Environment.NewLine, filesSection, Environment.NewLine));
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/SpecCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/SpecCommand.cs
@@ -110,7 +110,6 @@ namespace NuGet.CommandLine
 
             manifest.Metadata.SetProjectUrl(sampleProjectUrl);
             manifest.Metadata.LicenseMetadata = new LicenseMetadata(LicenseType.Expression, "MIT", NuGetLicenseExpression.Parse("MIT"), Array.Empty<string>(), LicenseMetadata.CurrentVersion);
-            manifest.Metadata.Icon = sampleIconFile;
             manifest.Metadata.Tags = sampleTags;
             manifest.Metadata.Copyright = "$copyright$";
             manifest.Metadata.ReleaseNotes = sampleReleaseNotes;
@@ -144,7 +143,7 @@ namespace NuGet.CommandLine
                             content = content.Replace("<id>mydummyidhere123123123</id>", "<id>$id$</id>");
                             content = content.Replace("<version>1.0.0</version>", "<version>$version$</version>");
                         }
-                        File.WriteAllText(nuspecFile, RemoveSchemaNamespace(content));
+                        File.WriteAllText(nuspecFile, RemoveSchemaNamespace(AddCommentedIconAttribute(content, sampleIconFile)));
                     }
 
                     Console.WriteLine(LocalizedResourceManager.GetString("SpecCommandCreatedNuSpec"), nuspecFile);
@@ -172,6 +171,14 @@ namespace NuGet.CommandLine
         {
             // This seems to be the only way to clear out xml namespaces.
             return Regex.Replace(content, @"(xmlns:?[^=]*=[""][^""]*[""])", string.Empty, RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.CultureInvariant);
+        }
+
+        private static string AddCommentedIconAttribute(string content, string iconFile)
+        {
+            string sampleIconFile = string.Format(CultureInfo.CurrentCulture, "<!-- <icon>{0}</icon> -->", iconFile);
+
+            return content
+                .Replace($"</license>{Environment.NewLine}", string.Format(CultureInfo.CurrentCulture, "</license>{0}{1}{2}", Environment.NewLine, sampleIconFile, Environment.NewLine));
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/SpecCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/SpecCommand.cs
@@ -38,7 +38,7 @@ namespace NuGet.CommandLine
         public override void ExecuteCommand()
         {
             string sampleProjectUrl = "http://project_url_here_or_delete_this_line/";
-            string sampleIconPath = "$icon_image_file_path_within_the_package_here_or_delete_this_line$";
+            string sampleIconFile = "$icon_file_name_within_the_package_here_or_delete_this_line$";
             string sampleTags = "Tag1 Tag2";
             string sampleReleaseNotes = "Summary of changes made in this release of the package.";
             string sampleDescription = "Package description";
@@ -110,10 +110,17 @@ namespace NuGet.CommandLine
 
             manifest.Metadata.SetProjectUrl(sampleProjectUrl);
             manifest.Metadata.LicenseMetadata = new LicenseMetadata(LicenseType.Expression, "MIT", NuGetLicenseExpression.Parse("MIT"), Array.Empty<string>(), LicenseMetadata.CurrentVersion);
-            manifest.Metadata.Icon = sampleIconPath;
+            manifest.Metadata.Icon = sampleIconFile;
             manifest.Metadata.Tags = sampleTags;
             manifest.Metadata.Copyright = "$copyright$";
             manifest.Metadata.ReleaseNotes = sampleReleaseNotes;
+            var iconManifestFile = new ManifestFile
+            {
+                Source = sampleIconFile,
+                Target = ""
+            };
+
+            manifest.Files.Add(iconManifestFile);
             string nuspecFile = fileName + PackagingConstants.ManifestExtension;
 
             // Skip the creation if the file exists and force wasn't specified

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
@@ -7321,20 +7321,22 @@ using System.Runtime.InteropServices;
 
                 // Assert
                 var path = Path.Combine(workingDirectory, "Package.1.0.0.nupkg");
-                var package = new OptimizedZipPackage(path);
-                var files = package.GetFiles().Select(f => f.Path).OrderBy(s => s).ToArray();
+                using (var package = new PackageArchiveReader(path))
+                {
+                    var files = package.GetNonPackageDefiningFiles().OrderBy(s => s).ToArray();
 
-                Assert.Equal(
-                    new string[]
-                    {
+                    Assert.Equal(
+                        new string[]
+                        {
                         "data.txt",
-                         Path.Combine("images", "1.png"),
-                         Path.Combine("lib", "uap10.0", "a.dll"),
-                         Path.Combine("tools", "install.ps1"),
-                    },
-                    files);
+                         "images/1.png",
+                         "lib/uap10.0/a.dll",
+                         "tools/install.ps1",
+                        },
+                        files);
 
-                Assert.False(packResult.Item2.Contains("Assembly outside lib folder"));
+                    Assert.False(packResult.Item2.Contains("Assembly outside lib folder"));
+                }
             }
         }
 
@@ -7399,17 +7401,19 @@ namespace proj1
 
                 // Assert
                 var path = Path.Combine(workingDirectory, "proj1.1.0.0.nupkg");
-                var package = new OptimizedZipPackage(path);
-                var files = package.GetFiles().Select(f => f.Path).OrderBy(s => s).ToArray();
+                using (var package = new PackageArchiveReader(path))
+                {
+                    var files = package.GetNonPackageDefiningFiles().OrderBy(s => s).ToArray();
 
-                Assert.Equal(
-                    new string[]
-                    {
-                         Path.Combine("lib", "net40", "proj1.dll"),
-                    },
-                    files);
+                    Assert.Equal(
+                        new string[]
+                        {
+                          "lib/net40/proj1.dll"
+                        },
+                        files);
 
-                Assert.False(packResult.Item2.Contains("Assembly outside lib folder"));
+                    Assert.False(packResult.Item2.Contains("Assembly outside lib folder"));
+                }
             }
         }
     }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
@@ -7278,7 +7278,7 @@ using System.Runtime.InteropServices;
         }
 
         [Fact]
-        public void PackCommand_NoRepo_GlobAllFiles_WithDefaultNuspec_Succeeds()
+        public void PackCommand_NoProjectFileWithDefaultNuspec_GlobsAllFiles()
         {
             var nugetexe = Util.GetNuGetExePath();
 
@@ -7341,7 +7341,7 @@ using System.Runtime.InteropServices;
         }
 
         [Fact]
-        public void PackCommand_WithRepo_WithDefaultNuspec_Succeeds()
+        public void PackCommand_WithProjectFileWithDefaultNuspec_Succeeds()
         {
             var nugetexe = Util.GetNuGetExePath();
 
@@ -7391,15 +7391,18 @@ namespace proj1
                     workingDirectory,
                     "spec",
                     waitForExit: true);
+
+                Assert.True(0 == specResult.ExitCode, specResult.AllOutput);
+
                 CommandRunnerResult packResult = CommandRunner.Run(
                     nugetexe,
                     workingDirectory,
                     " pack -properties tagVar=CustomTag;author=microsoft.com;Description=aaaaaaa -build",
                     waitForExit: true);
-                Assert.True(0 == specResult.ExitCode, specResult.AllOutput);
-                Assert.True(0 == packResult.ExitCode, packResult.AllOutput);
 
                 // Assert
+                Assert.True(0 == packResult.ExitCode, packResult.AllOutput);
+
                 var path = Path.Combine(workingDirectory, "proj1.1.0.0.nupkg");
                 using (var package = new PackageArchiveReader(path))
                 {

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
@@ -7276,6 +7276,148 @@ using System.Runtime.InteropServices;
                 }
             }
         }
+
+        [Fact]
+        public void PackCommand_NoRepo_GlobFiles_WithDefaultNuspec_Succeeds()
+        {
+            var nugetexe = Util.GetNuGetExePath();
+
+            using (var workingDirectory = TestDirectory.Create())
+            {
+                // Arrange
+                Util.CreateFile(
+                    Path.Combine(workingDirectory, "lib", "uap10.0"),
+                    "a.dll",
+                    string.Empty);
+
+                Util.CreateFile(
+                    Path.Combine(workingDirectory, "tools"),
+                    "install.ps1",
+                    string.Empty);
+
+                Util.CreateFile(
+                    Path.Combine(workingDirectory, "images"),
+                    "1.png",
+                    string.Empty);
+
+                Util.CreateFile(
+                    workingDirectory,
+                    "data.txt",
+                    string.Empty);
+
+                // Act
+                CommandRunnerResult specResult = CommandRunner.Run(
+                    nugetexe,
+                    workingDirectory,
+                    "spec",
+                    waitForExit: true);
+                CommandRunnerResult packResult = CommandRunner.Run(
+                    nugetexe,
+                    workingDirectory,
+                    "pack Package.nuspec",
+                    waitForExit: true);
+                Assert.True(0 == specResult.ExitCode, specResult.AllOutput);
+                Assert.True(0 == packResult.ExitCode, packResult.AllOutput);
+
+                // Assert
+                var path = Path.Combine(workingDirectory, "Package.1.0.0.nupkg");
+                var package = new OptimizedZipPackage(path);
+                var files = package.GetFiles().Select(f => f.Path).OrderBy(s => s).ToArray();
+
+                Assert.Equal(
+                    new string[]
+                    {
+                        "data.txt",
+                         Path.Combine("images", "1.png"),
+                         Path.Combine("lib", "uap10.0", "a.dll"),
+                         Path.Combine("tools", "install.ps1"),
+                    },
+                    files);
+
+                Assert.False(packResult.Item2.Contains("Assembly outside lib folder"));
+            }
+        }
+
+        [Fact]
+        public void PackCommand_WithRepo_GlobFiles_WithDefaultNuspec_Succeeds()
+        {
+            var nugetexe = Util.GetNuGetExePath();
+
+            using (var workingDirectory = TestDirectory.Create())
+            {
+                // Arrange
+                var projectName = Path.GetFileName(workingDirectory);
+
+                Util.CreateFile(
+                    workingDirectory,
+                    "proj1.csproj",
+    @"<Project ToolsVersion='4.0' DefaultTargets='Build'
+    xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <OutputPath>out</OutputPath>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include='file1.cs' />
+  </ItemGroup>
+  <Import Project='$(MSBuildToolsPath)\Microsoft.CSharp.targets' />
+</Project>");
+
+                Util.CreateFile(
+                    workingDirectory,
+                    "file1.cs",
+    @"using System;
+using System.Reflection;
+
+[assembly: AssemblyVersion(" + "\"1.0.0.0\"" + @")]
+namespace proj1
+{
+    public class Class1
+    {
+        public int A { get; set; }
+    }
+}");
+                Util.CreateFile(
+                    Path.Combine(workingDirectory, "images"),
+                    "1.png",
+                    string.Empty);
+
+                Util.CreateFile(
+                    workingDirectory,
+                    "data.txt",
+                    string.Empty);
+
+                // Act
+                CommandRunnerResult specResult = CommandRunner.Run(
+                    nugetexe,
+                    workingDirectory,
+                    "spec",
+                    waitForExit: true);
+                CommandRunnerResult packResult = CommandRunner.Run(
+                    nugetexe,
+                    workingDirectory,
+                    " pack -properties tagVar=CustomTag;author=microsoft.com;Description=aaaaaaa -build",
+                    waitForExit: true);
+                Assert.True(0 == specResult.ExitCode, specResult.AllOutput);
+                Assert.True(0 == packResult.ExitCode, packResult.AllOutput);
+
+                // Assert
+                var path = Path.Combine(workingDirectory, "proj1.1.0.0.nupkg");
+                var package = new OptimizedZipPackage(path);
+                var files = package.GetFiles().Select(f => f.Path).OrderBy(s => s).ToArray();
+
+                Assert.Equal(
+                    new string[]
+                    {
+                        "data.txt",
+                         Path.Combine("lib", "net40", "proj1.dll"),
+                    },
+                    files);
+
+                Assert.False(packResult.Item2.Contains("Assembly outside lib folder"));
+            }
+        }
     }
 
     internal static class PackageArchiveReaderTestExtensions

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
@@ -7278,7 +7278,7 @@ using System.Runtime.InteropServices;
         }
 
         [Fact]
-        public void PackCommand_NoRepo_GlobFiles_WithDefaultNuspec_Succeeds()
+        public void PackCommand_NoRepo_GlobAllFiles_WithDefaultNuspec_Succeeds()
         {
             var nugetexe = Util.GetNuGetExePath();
 
@@ -7339,7 +7339,7 @@ using System.Runtime.InteropServices;
         }
 
         [Fact]
-        public void PackCommand_WithRepo_GlobFiles_WithDefaultNuspec_Succeeds()
+        public void PackCommand_WithRepo_WithDefaultNuspec_Succeeds()
         {
             var nugetexe = Util.GetNuGetExePath();
 
@@ -7379,11 +7379,6 @@ namespace proj1
     }
 }");
                 Util.CreateFile(
-                    Path.Combine(workingDirectory, "images"),
-                    "1.png",
-                    string.Empty);
-
-                Util.CreateFile(
                     workingDirectory,
                     "data.txt",
                     string.Empty);
@@ -7410,7 +7405,6 @@ namespace proj1
                 Assert.Equal(
                     new string[]
                     {
-                        "data.txt",
                          Path.Combine("lib", "net40", "proj1.dll"),
                     },
                     files);

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetSpecCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetSpecCommandTest.cs
@@ -36,7 +36,7 @@ namespace NuGet.CommandLine.Test
                 Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
 
                 var nuspec = File.ReadAllText(Path.Combine(workingDirectory, "Package.nuspec"));
-                Assert.Equal($@"<?xml version=""1.0"" encoding=""utf-8""?>
+                var expected = $@"<?xml version=""1.0"" encoding=""utf-8""?>
 <package >
   <metadata>
     <id>Package</id>
@@ -44,8 +44,8 @@ namespace NuGet.CommandLine.Test
     <authors>{Environment.UserName}</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <license type=""expression"">MIT</license>
+    <icon>$icon_file_name_within_the_package_here_or_delete_this_line$</icon>
     <projectUrl>http://project_url_here_or_delete_this_line/</projectUrl>
-    <iconUrl>http://icon_url_here_or_delete_this_line/</iconUrl>
     <description>Package description</description>
     <releaseNotes>Summary of changes made in this release of the package.</releaseNotes>
     <copyright>$copyright$</copyright>
@@ -56,7 +56,11 @@ namespace NuGet.CommandLine.Test
       </group>
     </dependencies>
   </metadata>
-</package>".Replace("\r\n", "\n"), nuspec.Replace("\r\n", "\n"));
+  <files>
+    <file src=""$icon_file_name_within_the_package_here_or_delete_this_line$"" target="""" />
+  </files>
+</package>".Replace("\r\n", "\n");
+                Assert.Equal(expected, nuspec.Replace("\r\n", "\n"));
             }
         }
 
@@ -86,8 +90,8 @@ namespace NuGet.CommandLine.Test
     <authors>{Environment.UserName}</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <license type=""expression"">MIT</license>
+    <icon>$icon_file_name_within_the_package_here_or_delete_this_line$</icon>
     <projectUrl>http://project_url_here_or_delete_this_line/</projectUrl>
-    <iconUrl>http://icon_url_here_or_delete_this_line/</iconUrl>
     <description>Package description</description>
     <releaseNotes>Summary of changes made in this release of the package.</releaseNotes>
     <copyright>$copyright$</copyright>
@@ -98,6 +102,9 @@ namespace NuGet.CommandLine.Test
       </group>
     </dependencies>
   </metadata>
+  <files>
+    <file src=""$icon_file_name_within_the_package_here_or_delete_this_line$"" target="""" />
+  </files>
 </package>".Replace("\r\n", "\n"), nuspec.Replace("\r\n", "\n"));
             }
         }
@@ -141,13 +148,16 @@ namespace NuGet.CommandLine.Test
     <authors>$author$</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <license type=""expression"">MIT</license>
+    <icon>$icon_file_name_within_the_package_here_or_delete_this_line$</icon>
     <projectUrl>http://project_url_here_or_delete_this_line/</projectUrl>
-    <iconUrl>http://icon_url_here_or_delete_this_line/</iconUrl>
     <description>$description$</description>
     <releaseNotes>Summary of changes made in this release of the package.</releaseNotes>
     <copyright>$copyright$</copyright>
     <tags>Tag1 Tag2</tags>
   </metadata>
+  <files>
+    <file src=""$icon_file_name_within_the_package_here_or_delete_this_line$"" target="""" />
+  </files>
 </package>".Replace("\r\n", "\n"), nuspec.Replace("\r\n", "\n"));
             }
         }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetSpecCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetSpecCommandTest.cs
@@ -56,9 +56,6 @@ namespace NuGet.CommandLine.Test
       </group>
     </dependencies>
   </metadata>
-  <files>
-    <!-- <file src=""icon.png"" target="""" /> -->
-  </files>
 </package>".Replace("\r\n", "\n"), nuspec.Replace("\r\n", "\n"));
             }
         }
@@ -101,9 +98,6 @@ namespace NuGet.CommandLine.Test
       </group>
     </dependencies>
   </metadata>
-  <files>
-    <!-- <file src=""icon.png"" target="""" /> -->
-  </files>
 </package>".Replace("\r\n", "\n"), nuspec.Replace("\r\n", "\n"));
             }
         }
@@ -154,9 +148,6 @@ namespace NuGet.CommandLine.Test
     <copyright>$copyright$</copyright>
     <tags>Tag1 Tag2</tags>
   </metadata>
-  <files>
-    <!-- <file src=""icon.png"" target="""" /> -->
-  </files>
 </package>".Replace("\r\n", "\n"), nuspec.Replace("\r\n", "\n"));
             }
         }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetSpecCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetSpecCommandTest.cs
@@ -44,7 +44,7 @@ namespace NuGet.CommandLine.Test
     <authors>{Environment.UserName}</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <license type=""expression"">MIT</license>
-    <icon>$icon_file_name_within_the_package_here_or_delete_this_line$</icon>
+<!-- <icon>$icon_file_name_within_the_package_here_or_delete_this_line$</icon> -->
     <projectUrl>http://project_url_here_or_delete_this_line/</projectUrl>
     <description>Package description</description>
     <releaseNotes>Summary of changes made in this release of the package.</releaseNotes>
@@ -89,7 +89,7 @@ namespace NuGet.CommandLine.Test
     <authors>{Environment.UserName}</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <license type=""expression"">MIT</license>
-    <icon>$icon_file_name_within_the_package_here_or_delete_this_line$</icon>
+<!-- <icon>$icon_file_name_within_the_package_here_or_delete_this_line$</icon> -->
     <projectUrl>http://project_url_here_or_delete_this_line/</projectUrl>
     <description>Package description</description>
     <releaseNotes>Summary of changes made in this release of the package.</releaseNotes>
@@ -147,7 +147,7 @@ namespace NuGet.CommandLine.Test
     <authors>$author$</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <license type=""expression"">MIT</license>
-    <icon>$icon_file_name_within_the_package_here_or_delete_this_line$</icon>
+<!-- <icon>$icon_file_name_within_the_package_here_or_delete_this_line$</icon> -->
     <projectUrl>http://project_url_here_or_delete_this_line/</projectUrl>
     <description>$description$</description>
     <releaseNotes>Summary of changes made in this release of the package.</releaseNotes>

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetSpecCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetSpecCommandTest.cs
@@ -44,7 +44,7 @@ namespace NuGet.CommandLine.Test
     <authors>{Environment.UserName}</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <license type=""expression"">MIT</license>
-<!-- <icon>$icon_file_name_within_the_package_here_or_delete_this_line$</icon> -->
+    <!-- <icon>icon.png</icon> -->
     <projectUrl>http://project_url_here_or_delete_this_line/</projectUrl>
     <description>Package description</description>
     <releaseNotes>Summary of changes made in this release of the package.</releaseNotes>
@@ -57,7 +57,7 @@ namespace NuGet.CommandLine.Test
     </dependencies>
   </metadata>
   <files>
-    <file src=""$icon_file_name_within_the_package_here_or_delete_this_line$"" target="""" />
+    <!-- <file src=""icon.png"" target="""" /> -->
   </files>
 </package>".Replace("\r\n", "\n"), nuspec.Replace("\r\n", "\n"));
             }
@@ -89,7 +89,7 @@ namespace NuGet.CommandLine.Test
     <authors>{Environment.UserName}</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <license type=""expression"">MIT</license>
-<!-- <icon>$icon_file_name_within_the_package_here_or_delete_this_line$</icon> -->
+    <!-- <icon>icon.png</icon> -->
     <projectUrl>http://project_url_here_or_delete_this_line/</projectUrl>
     <description>Package description</description>
     <releaseNotes>Summary of changes made in this release of the package.</releaseNotes>
@@ -102,7 +102,7 @@ namespace NuGet.CommandLine.Test
     </dependencies>
   </metadata>
   <files>
-    <file src=""$icon_file_name_within_the_package_here_or_delete_this_line$"" target="""" />
+    <!-- <file src=""icon.png"" target="""" /> -->
   </files>
 </package>".Replace("\r\n", "\n"), nuspec.Replace("\r\n", "\n"));
             }
@@ -147,7 +147,7 @@ namespace NuGet.CommandLine.Test
     <authors>$author$</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <license type=""expression"">MIT</license>
-<!-- <icon>$icon_file_name_within_the_package_here_or_delete_this_line$</icon> -->
+    <!-- <icon>icon.png</icon> -->
     <projectUrl>http://project_url_here_or_delete_this_line/</projectUrl>
     <description>$description$</description>
     <releaseNotes>Summary of changes made in this release of the package.</releaseNotes>
@@ -155,7 +155,7 @@ namespace NuGet.CommandLine.Test
     <tags>Tag1 Tag2</tags>
   </metadata>
   <files>
-    <file src=""$icon_file_name_within_the_package_here_or_delete_this_line$"" target="""" />
+    <!-- <file src=""icon.png"" target="""" /> -->
   </files>
 </package>".Replace("\r\n", "\n"), nuspec.Replace("\r\n", "\n"));
             }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetSpecCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetSpecCommandTest.cs
@@ -36,7 +36,7 @@ namespace NuGet.CommandLine.Test
                 Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
 
                 var nuspec = File.ReadAllText(Path.Combine(workingDirectory, "Package.nuspec"));
-                var expected = $@"<?xml version=""1.0"" encoding=""utf-8""?>
+                Assert.Equal($@"<?xml version=""1.0"" encoding=""utf-8""?>
 <package >
   <metadata>
     <id>Package</id>
@@ -59,8 +59,7 @@ namespace NuGet.CommandLine.Test
   <files>
     <file src=""$icon_file_name_within_the_package_here_or_delete_this_line$"" target="""" />
   </files>
-</package>".Replace("\r\n", "\n");
-                Assert.Equal(expected, nuspec.Replace("\r\n", "\n"));
+</package>".Replace("\r\n", "\n"), nuspec.Replace("\r\n", "\n"));
             }
         }
 


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Home/issues/10400

Regression? Last working version: N/A

## Description
Currently `nuget spec` creates `.nuspec` file with an iconUrl, which is a [deprecated property](https://docs.microsoft.com/en-us/nuget/reference/nuspec#iconurl). Now instead we generate one with `icon`.

## Detailed repro steps so we can see the same problem

1. Run `nuget spec` using nuget.exe v5.8.0
2. Inspect the contents of the generated nuspec file:

```xml
<?xml version="1.0" encoding="utf-8"?>
<package >
  <metadata>
    <id>Package</id>
    <version>1.0.0</version>
    <authors>Ninja</authors>
    <requireLicenseAcceptance>false</requireLicenseAcceptance>
    <license type="expression">MIT</license>
    <projectUrl>http://project_url_here_or_delete_this_line/</projectUrl>
    <iconUrl>http://icon_url_here_or_delete_this_line/</iconUrl>
    <description>Package description</description>
    <releaseNotes>Summary of changes made in this release of the package.</releaseNotes>
    <copyright>$copyright$</copyright>
    <tags>Tag1 Tag2</tags>
    <dependencies>
      <group targetFramework=".NETStandard2.1">
        <dependency id="SampleDependency" version="1.0.0" />
      </group>
    </dependencies>
  </metadata>
</package>
```

After change:

1. Run `nuget spec` using nuget.exe v5.10.0
```
C:\NuGetProj\IssueRepro\PackTest2>C:\NuGetProj\NuGet.Client\artifacts\NuGet.CommandLine\16.0\bin\Debug\net472\nuget.exe spec
Created 'Package.nuspec' successfully.
```
2. Inspect the contents of the generated nuspec file:

```<?xml version="1.0" encoding="utf-8"?>
<package >
  <metadata>
    <id>Package</id>
    <version>1.0.0</version>
    <authors>eryondon</authors>
    <requireLicenseAcceptance>false</requireLicenseAcceptance>
    <license type="expression">MIT</license>
    <!-- <icon>icon.png</icon> -->
    <projectUrl>http://project_url_here_or_delete_this_line/</projectUrl>
    <description>Package description</description>
    <releaseNotes>Summary of changes made in this release of the package.</releaseNotes>
    <copyright>$copyright$</copyright>
    <tags>Tag1 Tag2</tags>
    <dependencies>
      <group targetFramework=".NETStandard2.1">
        <dependency id="SampleDependency" version="1.0.0" />
      </group>
    </dependencies>
  </metadata>
  <files>
    <!-- <file src="icon.png" target="" /> -->
  </files>
</package>
```
`nuget pack` still works:

```
C:\NuGetProj\IssueRepro\PackTest2>C:\NuGetProj\NuGet.Client\artifacts\NuGet.CommandLine\16.0\bin\Debug\net472\nuget.exe pack
Attempting to build package from 'Package.nuspec'.
WARNING: NU5102: The value "http://project_url_here_or_delete_this_line/" for projectUrl is a sample value and should be removed. Replace it with an appropriate value or remove it and rebuild your package.
WARNING: NU5102: The value "Tag1 Tag2" for tags is a sample value and should be removed. Replace it with an appropriate value or remove it and rebuild your package.
WARNING: NU5102: The value "Summary of changes made in this release of the package." for releaseNotes is a sample value and should be removed. Replace it with an appropriate value or remove it and rebuild your package.
WARNING: NU5102: The value "Package description" for description is a sample value and should be removed. Replace it with an appropriate value or remove it and rebuild your package.
WARNING: NU5128: Some target frameworks declared in the dependencies group of the nuspec and the lib/ref folder do not have exact matches in the other location. Consult the list of actions below:
- Add lib or ref assemblies for the netstandard2.1 target framework
Successfully created package 'C:\NuGetProj\IssueRepro\PackTest2\Package.1.0.0.nupkg'.
```
## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
