### PR TITLE
Remove unnecessary ToList enumerations in restore codepaths

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/PackagesLockFileBuilder.cs
+++ b/src/NuGet.Core/NuGet.Commands/PackagesLockFileBuilder.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using NuGet.Common;
@@ -32,14 +33,14 @@ namespace NuGet.Commands
                 var framework = assetsFile.PackageSpec.TargetFrameworks.FirstOrDefault(
                     f => EqualityUtility.EqualsWithNullCheck(f.FrameworkName, target.TargetFramework));
 
-                var libraries = target.Libraries;
+                IEnumerable<LockFileTargetLibrary> libraries = target.Libraries;
 
                 // check if this is RID-based graph then only add those libraries which differ from original TFM.
                 if (!string.IsNullOrEmpty(target.RuntimeIdentifier))
                 {
                     var onlyTFM = assetsFile.Targets.First(t => EqualityUtility.EqualsWithNullCheck(t.TargetFramework, target.TargetFramework));
 
-                    libraries = target.Libraries.Where(lib => !onlyTFM.Libraries.Any(tfmLib => tfmLib.Equals(lib))).ToList();
+                    libraries = target.Libraries.Where(lib => !onlyTFM.Libraries.Any(tfmLib => tfmLib.Equals(lib)));
                 }
 
                 foreach (var library in libraries.Where(e => e.Type == LibraryType.Package))

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/CompatibilityCheckResult.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/CompatibilityCheckResult.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using NuGet.Shared;
 
 namespace NuGet.Commands
 {
@@ -17,7 +18,7 @@ namespace NuGet.Commands
         public CompatibilityCheckResult(RestoreTargetGraph graph, IEnumerable<CompatibilityIssue> issues)
         {
             Graph = graph;
-            Issues = issues.ToList().AsReadOnly();
+            Issues = issues.AsList().AsReadOnly();
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/CompatibilityChecker.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/CompatibilityChecker.cs
@@ -249,7 +249,7 @@ namespace NuGet.Commands
             return RestoreLogMessage.CreateError(logCode, issue.Format(), issue.Package.Id, graph.TargetGraphName);
         }
 
-        private static List<NuGetFramework> GetPackageFrameworks(
+        private static IEnumerable<NuGetFramework> GetPackageFrameworks(
             CompatibilityData compatibilityData,
             RestoreTargetGraph graph)
         {
@@ -290,7 +290,7 @@ namespace NuGet.Commands
                 }
             }
 
-            return available.ToList();
+            return available;
         }
 
         private static List<NuGetFramework> GetProjectFrameworks(Library localLibrary)

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Diagnostics/DiagnosticUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Diagnostics/DiagnosticUtility.cs
@@ -141,7 +141,7 @@ namespace NuGet.Commands
                 }
             }
 
-            return output.OrderBy(e => e.Time).ToList();
+            return output.OrderBy(e => e.Time);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Logging/WarningPropertiesCollection.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Logging/WarningPropertiesCollection.cs
@@ -97,10 +97,8 @@ namespace NuGet.Commands
                 PackageSpecificWarningProperties != null &&
                 !string.IsNullOrEmpty(message.LibraryId))
             {
-                var messageTargetFrameworks = message.TargetGraphs.Select(GetNuGetFramework).ToList();
-
                 // If the message does not contain a target graph, assume that it is applicable for all project frameworks.
-                if (messageTargetFrameworks.Count == 0)
+                if (!message.TargetGraphs.Select(GetNuGetFramework).Any())
                 {
                     // Suppress the warning if the code + libraryId combination is suppressed for all project frameworks.
                     if (ProjectFrameworks.Count > 0 &&

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/MSBuildItem.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/MSBuildItem.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
+using NuGet.Shared;
 
 namespace NuGet.Commands
 {
@@ -20,7 +20,7 @@ namespace NuGet.Commands
         {
             get
             {
-                return _metadata.Keys.ToList();
+                return _metadata.Keys.AsList();
             }
         }
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/RestoreSpecException.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/RestoreSpecException.cs
@@ -39,7 +39,7 @@ namespace NuGet.Commands
                 throw new ArgumentNullException(nameof(files));
             }
 
-            files = files.Where(path => !string.IsNullOrEmpty(path)).Distinct(StringComparer.Ordinal).ToList();
+            files = files.Where(path => !string.IsNullOrEmpty(path)).Distinct(StringComparer.Ordinal);
 
             string completeMessage = null;
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreSummary.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreSummary.cs
@@ -77,6 +77,7 @@ namespace NuGet.Commands
             Errors = errors;
         }
 
+        [Obsolete("Use the method that takes IReadOnlyList<RestoreSummary> as the 2nd parameter.")]
         public static void Log(ILogger logger, IEnumerable<RestoreSummary> restoreSummaries, bool logErrors = false)
         {
             Log(logger, restoreSummaries.ToList(), logErrors);

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/IncludeFlagUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/IncludeFlagUtils.cs
@@ -8,7 +8,6 @@ using System.Linq;
 using NuGet.DependencyResolver;
 using NuGet.LibraryModel;
 using NuGet.ProjectModel;
-using NuGet.Shared;
 
 namespace NuGet.Commands
 {
@@ -39,7 +38,7 @@ namespace NuGet.Commands
             FlattenDependencyTypesUnified(targetGraph, result);
 
             // Override flags for direct dependencies
-            var directDependencies = spec.Dependencies.AsList();
+            var directDependencies = spec.Dependencies.ToList();
 
             // Add dependencies defined under the framework node
             var specFramework = spec.GetTargetFramework(targetGraph.Framework);

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/IncludeFlagUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/IncludeFlagUtils.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using NuGet.DependencyResolver;
 using NuGet.LibraryModel;
 using NuGet.ProjectModel;
+using NuGet.Shared;
 
 namespace NuGet.Commands
 {
@@ -38,7 +39,7 @@ namespace NuGet.Commands
             FlattenDependencyTypesUnified(targetGraph, result);
 
             // Override flags for direct dependencies
-            var directDependencies = spec.Dependencies.ToList();
+            var directDependencies = spec.Dependencies.AsList();
 
             // Add dependencies defined under the framework node
             var specFramework = spec.GetTargetFramework(targetGraph.Framework);

--- a/src/NuGet.Core/NuGet.Common/Errors/RestoreLogMessage.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/RestoreLogMessage.cs
@@ -74,7 +74,7 @@ namespace NuGet.Common
             {
                 Code = code,
                 LibraryId = libraryId,
-                TargetGraphs = targetGraphs.ToList()
+                TargetGraphs = targetGraphs
             };
         }
 
@@ -111,7 +111,7 @@ namespace NuGet.Common
             {
                 Code = code,
                 LibraryId = libraryId,
-                TargetGraphs = targetGraphs.ToList()
+                TargetGraphs = targetGraphs
             };
         }
 

--- a/src/NuGet.Core/NuGet.Frameworks/NuGetFramework.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/NuGetFramework.cs
@@ -286,7 +286,7 @@ namespace NuGet.Frameworks
                         mappings.TryGetPortableFrameworks(framework.Profile, false, out frameworks);
 
                         // sort the PCL frameworks by alphabetical order
-                        var sortedFrameworks = required.Select(e => e.GetShortFolderName(mappings)).OrderBy(e => e, StringComparer.OrdinalIgnoreCase).ToList();
+                        var sortedFrameworks = required.Select(e => e.GetShortFolderName(mappings)).OrderBy(e => e, StringComparer.OrdinalIgnoreCase);
 
                         sb.Append(string.Join("+", sortedFrameworks));
                     }

--- a/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileFormat.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileFormat.cs
@@ -741,8 +741,7 @@ namespace NuGet.ProjectModel
         {
             var orderedItems = items
                 .Select(f => GetPathWithForwardSlashes(f))
-                .OrderBy(f => f, StringComparer.Ordinal)
-                .ToList();
+                .OrderBy(f => f, StringComparer.Ordinal);
 
             WriteArray(json, property, orderedItems, writeItem);
         }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/10835

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

We have some unnecessary ToList enumerations in some of the restore codepaths. 
After I was done with the initial restore pass based on some traces, I also did an exhaustive `ToList` search and eliminated the unnecessary ones.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception - No functional changes.
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
