### PR TITLE
Mark IVsPackageInstallerServices as obsolete

### DIFF
--- a/build/NuGet-WithApex.sln
+++ b/build/NuGet-WithApex.sln
@@ -241,6 +241,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NuGet.PackageManagement.UI.
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NuGet.Tests.Apex", "..\test\NuGet.Tests.Apex\NuGet.Tests.Apex\NuGet.Tests.Apex.csproj", "{81EB90B9-7FA5-434E-8502-09A9892A0FA7}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NuGet.VisualStudio.Contracts", "..\src\NuGet.Clients\NuGet.VisualStudio.Contracts\NuGet.VisualStudio.Contracts.csproj", "{5E23CEFF-16ED-42B7-BCB9-42F14B5ACB7B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -583,6 +585,10 @@ Global
 		{81EB90B9-7FA5-434E-8502-09A9892A0FA7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{81EB90B9-7FA5-434E-8502-09A9892A0FA7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{81EB90B9-7FA5-434E-8502-09A9892A0FA7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5E23CEFF-16ED-42B7-BCB9-42F14B5ACB7B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5E23CEFF-16ED-42B7-BCB9-42F14B5ACB7B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5E23CEFF-16ED-42B7-BCB9-42F14B5ACB7B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5E23CEFF-16ED-42B7-BCB9-42F14B5ACB7B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -683,6 +689,7 @@ Global
 		{A792EA9A-4291-4DB6-90B2-E7DBC03C3BB2} = {8155136C-FFEA-450B-BF55-3418A6B091CC}
 		{DF56DB8F-F7A3-4EA6-912B-1CBC1741547F} = {8155136C-FFEA-450B-BF55-3418A6B091CC}
 		{81EB90B9-7FA5-434E-8502-09A9892A0FA7} = {8155136C-FFEA-450B-BF55-3418A6B091CC}
+		{5E23CEFF-16ED-42B7-BCB9-42F14B5ACB7B} = {08F523EC-3C2A-4A00-A54C-2E54C5AC856B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {3747A66A-00D1-41B8-A9C5-ED0D7BEA9D25}

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPackageInstallerServices.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPackageInstallerServices.cs
@@ -28,6 +28,7 @@ using NuGet.VisualStudio.Telemetry;
 
 namespace NuGet.VisualStudio
 {
+    [Obsolete]
     [Export(typeof(IVsPackageInstallerServices))]
     public class VsPackageInstallerServices : IVsPackageInstallerServices
     {

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/PreinstalledPackageInstaller.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/PreinstalledPackageInstaller.cs
@@ -34,7 +34,9 @@ namespace NuGet.VisualStudio
     internal class PreinstalledPackageInstaller
     {
         private const string RegistryKeyRoot = @"SOFTWARE\NuGet\Repository";
+#pragma warning disable CS0618 // Type or member is obsolete
         private readonly IVsPackageInstallerServices _packageServices;
+#pragma warning restore CS0618 // Type or member is obsolete
         private readonly IVsSolutionManager _solutionManager;
         private readonly ISourceRepositoryProvider _sourceProvider;
         private readonly VsPackageInstaller _installer;
@@ -44,7 +46,9 @@ namespace NuGet.VisualStudio
         public Action<string> InfoHandler { get; set; }
 
         public PreinstalledPackageInstaller(
+#pragma warning disable CS0618 // Type or member is obsolete
             IVsPackageInstallerServices packageServices,
+#pragma warning restore CS0618 // Type or member is obsolete
             IVsSolutionManager solutionManager,
             Configuration.ISettings settings,
             ISourceRepositoryProvider sourceProvider,
@@ -218,10 +222,12 @@ namespace NuGet.VisualStudio
                     var packageIdentity = new PackageIdentity(package.Id, package.Version);
 
                     // Does the project already have this package installed?
+#pragma warning disable CS0618 // Type or member is obsolete
                     if (_packageServices.IsPackageInstalled(project, package.Id))
                     {
                         // If so, is it the right version?
                         if (!_packageServices.IsPackageInstalledEx(project, package.Id, package.Version.ToNormalizedString()))
+#pragma warning restore CS0618 // Type or member is obsolete
                         {
                             // No? Raise a warning (likely written to the Output window) and ignore this package.
                             warningHandler(string.Format(VsResources.PreinstalledPackages_VersionConflict, package.Id, package.Version));

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/VsTemplateWizard.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/VsTemplateWizard.cs
@@ -38,7 +38,9 @@ namespace NuGet.VisualStudio
 
         private DTE _dte;
         private Lazy<PreinstalledPackageInstaller> _preinstalledPackageInstaller;
+#pragma warning disable CS0618 // Type or member is obsolete
         private readonly IVsPackageInstallerServices _packageServices;
+#pragma warning restore CS0618 // Type or member is obsolete
         private readonly IOutputConsoleProvider _consoleProvider;
         private readonly IVsSolutionManager _solutionManager;
         private readonly Configuration.ISettings _settings;
@@ -50,7 +52,9 @@ namespace NuGet.VisualStudio
         [ImportingConstructor]
         public VsTemplateWizard(
             IVsPackageInstaller installer,
+#pragma warning disable CS0618 // Type or member is obsolete
             IVsPackageInstallerServices packageServices,
+#pragma warning restore CS0618 // Type or member is obsolete
             IOutputConsoleProvider consoleProvider,
             IVsSolutionManager solutionManager,
             Configuration.ISettings settings,

--- a/src/NuGet.Clients/NuGet.VisualStudio/Extensibility/IVsPackageInstallerServices.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio/Extensibility/IVsPackageInstallerServices.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using EnvDTE;
@@ -12,6 +13,7 @@ namespace NuGet.VisualStudio
     /// </summary>
     [ComImport]
     [Guid("B858E847-4920-4313-9D3B-176BB0D2F5C2")]
+    [Obsolete("Use INuGetProjectService in the NuGet.VisualStudio.Contracts package instead.")]
     public interface IVsPackageInstallerServices
     {
         // IMPORTANT: do NOT rearrange the methods here. The order is important to maintain 
@@ -20,6 +22,7 @@ namespace NuGet.VisualStudio
         /// <summary>
         /// Get the list of NuGet packages installed in the current solution.
         /// </summary>
+        [Obsolete("This method can cause UI delays if called on the UI thread. Use INuGetProjectService.GetInstalledPackagesAsync in the NuGet.VisualStudio.Contracts package instead, and iterate all projects in the solution")]
         IEnumerable<IVsPackageMetadata> GetInstalledPackages();
 
         /// <summary>
@@ -28,6 +31,7 @@ namespace NuGet.VisualStudio
         /// <param name="project">The project to check for NuGet package.</param>
         /// <param name="id">The id of the package to check.</param>
         /// <returns><c>true</c> if the package is install. <c>false</c> otherwise.</returns>
+        [Obsolete("This method can cause UI delays if called on the UI thread. Use INuGetProjectService.GetInstalledPackagesAsync in the NuGet.VisualStudio.Contracts package instead, and check the specific package you're interested in")]
         bool IsPackageInstalled(Project project, string id);
 
         /// <summary>
@@ -37,6 +41,7 @@ namespace NuGet.VisualStudio
         /// <param name="id">The id of the package to check.</param>
         /// <param name="version">The version of the package to check.</param>
         /// <returns><c>true</c> if the package is install. <c>false</c> otherwise.</returns>
+        [Obsolete("This method can cause UI delays if called on the UI thread. Use INuGetProjectService.GetInstalledPackagesAsync in the NuGet.VisualStudio.Contracts package instead, and check the specific package you're interested in")]
         bool IsPackageInstalled(Project project, string id, SemanticVersion version);
 
         /// <summary>
@@ -51,12 +56,14 @@ namespace NuGet.VisualStudio
         /// when client project compiles against this assembly, the compiler would attempt to bind against
         /// the other overload which accepts SemanticVersion and would require client project to reference NuGet.Core.
         /// </remarks>
+        [Obsolete("This method can cause UI delays if called on the UI thread. Use INuGetProjectService.GetInstalledPackagesAsync in the NuGet.VisualStudio.Contracts package instead, and check the specific package you're interested in")]
         bool IsPackageInstalledEx(Project project, string id, string versionString);
 
         /// <summary>
         /// Get the list of NuGet packages installed in the specified project.
         /// </summary>
         /// <param name="project">The project to get NuGet packages from.</param>
+        [Obsolete("This method can cause UI delays if called on the UI thread. Use INuGetProjectService.GetInstalledPackagesAsync in the NuGet.VisualStudio.Contracts package instead")]
         IEnumerable<IVsPackageMetadata> GetInstalledPackages(Project project);
     }
 }

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/Extensibility/VsPackageInstallerServicesTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/Extensibility/VsPackageInstallerServicesTests.cs
@@ -15,6 +15,7 @@ using Xunit;
 
 namespace NuGet.VisualStudio.Implementation.Test.Extensibility
 {
+    [Obsolete]
     public class VsPackageInstallerServicesTests
     {
         [Fact]

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Apex/NuGetApexVerifier.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Apex/NuGetApexVerifier.cs
@@ -11,54 +11,5 @@ namespace NuGet.Tests.Apex
         /// Gets the Nuget Package Manager test service
         /// </summary>
         private NuGetApexTestService NugetPackageManager => (NuGetApexTestService)Owner;
-
-        /// <summary>
-        /// Validate whether a NuGet package is installed
-        /// </summary>
-        /// <param name="project">project name</param>
-        /// <param name="packageName">NuGet package name</param>
-        /// <returns>True if the package is installed; otherwise false</returns>
-        public bool PackageIsInstalled(string projectName, string packageName)
-        {
-            var project = NugetPackageManager.Dte.Solution.Projects.Item(projectName);
-            return IsTrue(NugetPackageManager.InstallerServices.IsPackageInstalled(project, packageName), "Expected NuGet package {0} to be installed in project {1}.", packageName, project.Name);
-        }
-
-        /// <summary>
-        /// Validate whether a NuGet package is installed
-        /// </summary>
-        /// <param name="project">project name</param>
-        /// <param name="packageName">NuGet package name</param>
-        /// <param name="packageVersion">NuGet package version</param>
-        /// <returns>True if the package is installed; otherwise false</returns>
-        public bool PackageIsInstalled(string projectName, string packageName, string packageVersion)
-        {
-            var project = NugetPackageManager.Dte.Solution.Projects.Item(projectName);
-            return IsTrue(NugetPackageManager.InstallerServices.IsPackageInstalledEx(project, packageName, packageVersion), "Expected NuGet package {0}-{1} to be installed in project {2}.", packageName, packageVersion, project.Name);
-        }
-
-        /// <summary>
-        /// Validate whether a NuGet package is not installed
-        /// </summary>
-        /// <param name="project">Project name</param>
-        /// <param name="packageName">NuGet package name</param>
-        /// <returns>True if the package is not installed; otherwise false</returns>
-        public bool PackageIsNotInstalled(string projectName, string packageName)
-        {
-            var project = NugetPackageManager.Dte.Solution.Projects.Item(projectName);
-            return IsFalse(NugetPackageManager.InstallerServices.IsPackageInstalled(project, packageName), "Expected NuGet package {0} to not be installed in project {1}.", packageName, project.Name);
-        }
-
-        /// <summary>
-        /// Validate whether specific version of a NuGet package is not installed
-        /// </summary>
-        /// <param name="project">Project name</param>
-        /// <param name="packageName">NuGet package name</param>
-        /// <returns>True if the package is not installed; otherwise false</returns>
-        public bool PackageIsNotInstalled(string projectName, string packageName, string packageVersion)
-        {
-            var project = NugetPackageManager.Dte.Solution.Projects.Item(projectName);
-            return IsFalse(NugetPackageManager.InstallerServices.IsPackageInstalledEx(project, packageName, packageVersion), "Expected NuGet package {0}-{1} to not be installed in project {2}.", packageName, packageVersion, project.Name);
-        }
     }
 }

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGet.Tests.Apex.csproj
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGet.Tests.Apex.csproj
@@ -62,6 +62,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Test.Apex.VisualStudio" />
+    <PackageReference Include="Microsoft.VisualStudio.Sdk" />
     <PackageReference Include="Newtonsoft.Json" NoWarn="NU1605" />
     <PackageReference Include="Xunit.StaFact" />
   </ItemGroup>
@@ -77,6 +78,7 @@
       <Name>NuGet.VisualStudio</Name>
       <EmbedInteropTypes>True</EmbedInteropTypes>
     </ProjectReference>
+    <ProjectReference Include="..\..\..\src\NuGet.Clients\NuGet.VisualStudio.Contracts\NuGet.VisualStudio.Contracts.csproj" />
     <ProjectReference Include="..\..\TestUtilities\Test.Utility\Test.Utility.csproj" />
     <ProjectReference Include="..\..\TestExtensions\NuGet.StaFact\NuGet.StaFact.csproj" />
     <ProjectReference Include="..\NuGet.Console.TestContract\NuGet.Console.TestContract.csproj" />

--- a/test/TestExtensions/API.Test/Cmdlets/GetInstalledPackageCommand.cs
+++ b/test/TestExtensions/API.Test/Cmdlets/GetInstalledPackageCommand.cs
@@ -36,8 +36,10 @@ namespace API.Test.Cmdlets
 
             if (string.IsNullOrEmpty(ProjectName))
             {
+#pragma warning disable CS0618 // Type or member is obsolete
                 var services = ServiceLocator.GetComponent<IVsPackageInstallerServices>();
                 packages = services.GetInstalledPackages();
+#pragma warning restore CS0618 // Type or member is obsolete
             }
             else
             {
@@ -59,8 +61,10 @@ namespace API.Test.Cmdlets
                 throw new ItemNotFoundException($"Project '{ProjectName}' is not found.");
             }
 
+#pragma warning disable CS0618 // Type or member is obsolete
             var services = ServiceLocator.GetComponent<IVsPackageInstallerServices>();
             return services.GetInstalledPackages(project);
+#pragma warning restore CS0618 // Type or member is obsolete
         }
     }
 }

--- a/test/TestExtensions/API.Test/Cmdlets/TestInstalledPackageCommand.cs
+++ b/test/TestExtensions/API.Test/Cmdlets/TestInstalledPackageCommand.cs
@@ -32,6 +32,7 @@ namespace API.Test.Cmdlets
                 throw new ItemNotFoundException($"Project '{ProjectName}' is not found.");
             }
 
+#pragma warning disable CS0618 // Type or member is obsolete
             var services = ServiceLocator.GetComponent<IVsPackageInstallerServices>();
             if (string.IsNullOrEmpty(Version))
             {
@@ -41,6 +42,7 @@ namespace API.Test.Cmdlets
             {
                 WriteObject(services.IsPackageInstalledEx(project, Id, Version));
             }
+#pragma warning restore CS0618 // Type or member is obsolete
         }
     }
 }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/10836

Regression? No

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Marked `IVsPackageInstallerServices` as obsolete, as well as the implementation and test classes. Any other usage had inline suppressions of the warning added.

## PR Checklist

- [X] PR has a meaningful title
- [X] PR has a linked issue.
- [X] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [X] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [X] N/A
