### PR TITLE
Add two static analysis tools to the CI pipeline

### DIFF
--- a/eng/pipelines/compliance.yml
+++ b/eng/pipelines/compliance.yml
@@ -1,3 +1,10 @@
+resources:
+  pipelines:
+  - pipeline: NuGet.Client-Compliance
+    source: NuGet.Client-Official
+    trigger:
+    - dev
+
 jobs:
   - job: Static Analysis
     pool:

--- a/eng/pipelines/compliance.yml
+++ b/eng/pipelines/compliance.yml
@@ -1,9 +1,9 @@
 resources:
   pipelines:
-  - pipeline: NuGet.Client-Compliance
-    source: NuGet.Client-Official
-    trigger:
-    - dev
+    - pipeline: NuGet.Client-Compliance
+      source: NuGet.Client-Official
+      trigger:
+        - dev
 
 jobs:
   - job: Static Analysis

--- a/eng/pipelines/compliance.yml
+++ b/eng/pipelines/compliance.yml
@@ -1,0 +1,73 @@
+jobs:
+  - job: Static Analysis
+    pool:
+      vmImage: windows-latest
+
+    steps:
+
+  - task: CredScan@2
+    inputs:
+      toolMajorVersion: "V2"
+
+  - task: PoliCheck@1
+    inputs:
+      inputType: "Basic"
+      targetType: "F"
+      targetArgument: "$(Build.SourcesDirectory)"
+      result: "PoliCheck.xml"
+
+  - task: SdtReport@1
+    displayName: "Generate Analysis Report"
+    inputs:
+      CredScan: true
+      PoliCheck: true
+      ToolLogsNotFoundAction: "Standard"
+
+  - task: TSAUpload@1
+    displayName: "Upload to TSA"
+    inputs:
+      tsaVersion: "TsaV2"
+      codebase: "Existing"
+      tsaEnvironment: "PROD"
+      codeBaseName: "$(TSACODEBASENAME)"
+      notificationAlias: "$(TSANOTIFICATIONALIAS)"
+      notifyAlwaysV2: true
+      codeBaseAdmins: "$(TSACODEBASEADMINS)"
+      instanceUrlForTsaV2: "$(TSAINSTANCEURL)"
+      projectNameDEVDIV: "$(TSAORGNAME)"
+      areaPath: "$(TSAAZDOAREAPATH)"
+      iterationPath: "$(TSAORGNAME)"
+      uploadAPIScan: false
+      uploadBinSkim: false
+      uploadCredScan: true
+      uploadFortifySCA: false
+      uploadFxCop: false
+      uploadModernCop: false
+      uploadPoliCheck: true
+      uploadPREfast: false
+      uploadRoslyn: false
+      uploadTSLint: false
+      uploadAsync: true
+
+  - task: PublishSecurityAnalysisLogs@2
+    displayName: "Publish CodeAnalysis Logs"
+    inputs:
+      ArtifactName: "CodeAnalysisLogs"
+      ArtifactType: "Container"
+      AllTools: false
+      AntiMalware: false
+      APIScan: false
+      BinSkim: false
+      CodesignValidation: false
+      CredScan: true
+      FortifySCA: false
+      FxCop: false
+      ModernCop: false
+      MSRD: false
+      PoliCheck: true
+      RoslynAnalyzers: false
+      SDLNativeRules: false
+      Semmle: false
+      TSLint: false
+      WebScout: false
+      ToolLogsNotFoundAction: "Standard"

--- a/eng/pipelines/compliance.yml
+++ b/eng/pipelines/compliance.yml
@@ -1,6 +1,6 @@
 resources:
   pipelines:
-    - pipeline: NuGet.Client-Compliance
+    - pipeline: nugetclientofficial
       source: NuGet.Client-Official
       trigger:
         - dev

--- a/eng/pipelines/compliance.yml
+++ b/eng/pipelines/compliance.yml
@@ -29,14 +29,14 @@ jobs:
       tsaVersion: "TsaV2"
       codebase: "Existing"
       tsaEnvironment: "PROD"
-      codeBaseName: "$(TSACODEBASENAME)"
-      notificationAlias: "$(TSANOTIFICATIONALIAS)"
+      codeBaseName: "$(TsaCodebaseName)"
+      notificationAlias: "$(TsaNotificationEmail)"
       notifyAlwaysV2: true
-      codeBaseAdmins: "$(TSACODEBASEADMINS)"
-      instanceUrlForTsaV2: "$(TSAINSTANCEURL)"
-      projectNameDEVDIV: "$(TSAORGNAME)"
-      areaPath: "$(TSAAZDOAREAPATH)"
-      iterationPath: "$(TSAORGNAME)"
+      codeBaseAdmins: "$(TsaCodebaseAdmins)"
+      instanceUrlForTsaV2: "$(TsaInstanceUrl)"
+      projectNameDEVDIV: "$(TsaProjectName)"
+      areaPath: "$(TsaBugAreaPath)"
+      iterationPath: "$(TsaIterationPath)"
       uploadAPIScan: false
       uploadBinSkim: false
       uploadCredScan: true


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/812
Fixes: https://github.com/NuGet/Client.Engineering/issues/810

Regression? Last working version:

## Description
Added two static analysis tools to the CI pipeline as per [spec](https://github.com/NuGet/Client.Engineering/blob/main/designs/CI-AutomatedComplianceTools.md). Once this PR has been merged, I will create a new pipeline on AzDo with required variables and settings so that it will be triggered after successful completion of `official` builds.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] N/A <!-- Infrastructure, documentation etc. --> - Manually tested new pipeline.

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [x] Documentation PR or issue filled https://github.com/NuGet/Client.Engineering/issues/946