### PR TITLE
Refresh asynchronously when the missing packages event is fired

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -690,7 +690,6 @@ namespace NuGet.PackageManagement.UI
                 {
                     await RefreshAsync();
                 }).PostOnFailure(nameof(PackageManagerControl), nameof(PackageRestoreManager_PackagesMissingStatusChanged));
-                _packageDetail.Refresh();
             }
 
             _missingPackageStatus = e.PackagesMissing;

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -689,8 +689,8 @@ namespace NuGet.PackageManagement.UI
                 NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async () =>
                 {
                     await RefreshAsync();
-                    _packageDetail.Refresh();
                 }).PostOnFailure(nameof(PackageManagerControl), nameof(PackageRestoreManager_PackagesMissingStatusChanged));
+                _packageDetail.Refresh();
             }
 
             _missingPackageStatus = e.PackagesMissing;

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -681,8 +681,6 @@ namespace NuGet.PackageManagement.UI
             // Don't do anything if solution is closed.
             // Add MissingPackageStatus to keep previous packageMissing status to avoid unnecessarily refresh
             // only when package is missing last time and is not missing this time, we need to refresh
-            // Note that the PackagesMissingStatusChanged event can be fired from a non-UI thread in one case:
-            // the VsSolutionManager.Init() method, which is scheduled on the thread pool.
             if (!e.PackagesMissing && _missingPackageStatus)
             {
                 EmitRefreshEvent(GetTimeSinceLastRefreshAndRestart(), RefreshOperationSource.PackagesMissingStatusChanged, RefreshOperationStatus.Success);


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/10854

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

The UI thread is synchronously waiting on a bunch of threadpool thread work. 

When there are missing packages in packages.config and you open the PM UI, you'd get a yellow bar at the top. 
That yellow bar has a button for restore and you can click that. 

As restore happens if it succeeds events are raised PackagesMissingStatusChanged, to effectively removed that yellow bar. 
That event is raised on the UI thread and always has been. 

See 16.8 - https://github.com/NuGet/NuGet.Client/blob/b257acfcdd76b32d4cddd549c177d99e800f4d83/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageRestoreBar.xaml.cs#L156
See current (16.10) - https://github.com/NuGet/NuGet.Client/blob/87e9eab3090d2074f90d9190ecd2d95685f9e2e5/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageRestoreBar.xaml.cs#L156

In 16.8, this calls:
https://github.com/NuGet/NuGet.Client/blob/release-5.8.x/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs#L645
.. https://github.com/NuGet/NuGet.Client/blob/release-5.8.x/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs#L645
....https://github.com/NuGet/NuGet.Client/blob/release-5.8.x/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs#L1242
...... https://github.com/NuGet/NuGet.Client/blob/release-5.8.x/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs#L945

Note that the last method fire and forget. As needed that method may switch to the UI thread, but the original event will complete.
Given that the caller thread is the UI thread, this didn't use to create a UI delay/hang. 

Now in 16.10 this calls: 

https://github.com/NuGet/NuGet.Client/blob/87e9eab3090d2074f90d9190ecd2d95685f9e2e5/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs#L679
.. https://github.com/NuGet/NuGet.Client/blob/87e9eab3090d2074f90d9190ecd2d95685f9e2e5/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs#L707
....https://github.com/NuGet/NuGet.Client/blob/87e9eab3090d2074f90d9190ecd2d95685f9e2e5/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs#L1149
....... https://github.com/NuGet/NuGet.Client/blob/87e9eab3090d2074f90d9190ecd2d95685f9e2e5/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs#L1149


Note that there's no fire and forget in the refresh code. This is all async/await code. 
Now normally, this wouldn't be a problem, but the original event was raised on the UI thread and there's a JTF.Run blocking the refreshing code. 

Looking at a cab,, I discovered that there are ~466 threads that are blocking that JoinableTask. 

Same stacks:

abdb692c <0> * NuGet.PackageManagement.VisualStudio.MultiSourcePackageMetadataProvider+<>c__DisplayClass8_0+<<GetLocalPackageMetadataAsync>b__1>d @ 1b4d7860
..8d915b54 <0> NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder+ClonedPackageSearchMetadata+<GetDeprecationMetadataAsync>d__83 @ 1b4d7640
..8d915c48 <0> NuGet.PackageManagement.VisualStudio.PackageSearchMetadataCacheItemEntry+<GetPackageDeprecationMetadataContextInfoAsync>d__7 @ 1b4d7418
..8d915d10 <1> NuGet.PackageManagement.VisualStudio.NuGetPackageSearchService+<GetDeprecationMetadataAsync>d__13 @ 1b4d68e8
..8d915e10 <0> Microsoft.ServiceHub.Framework.ServiceJsonRpcDescriptor+LocalProxyGeneration+<ReturnedValueTaskOfTHelper>d__25<NuGet.VisualStudio.Internal.Contracts.PackageDeprecationMetadataContextInfo> @ 625dd174
..8d6a9e1c <2> NuGet.PackageManagement.UI.PackageManagerControl+<GetPackageDeprecationMetadataAsync>d__99 @ 20faab88
..a3f281ac <2> NuGet.PackageManagement.UI.PackageManagerControl+<GetInstalledDeprecatedPackagesCountAsync>d__98 @ 1b4db900
..a3f2826c <2> NuGet.PackageManagement.UI.PackageManagerControl+<RefreshInstalledAndUpdatesTabsAsync>d__97 @ 1b4d9538
..a1b80848 <4> NuGet.PackageManagement.UI.PackageManagerControl+<SearchPackagesAndRefreshUpdateCountAsync>d__93 @ 805cc40
..a1b80970 <1> NuGet.PackageManagement.UI.PackageManagerControl+<SearchPackagesAndRefreshUpdateCountAsync>d__91 @ 805c8e0
..a1b80a70 <0> NuGet.PackageManagement.UI.PackageManagerControl+<RefreshAsync>d__108 @ 7a5909a0
..a1b80b50 <0> NuGet.PackageManagement.UI.PackageManagerControl+<UpdateAfterPackagesMissingStatusChangedAsync>d__86 @ 7a5906a8
..a1b80c20 <1> NuGet.PackageManagement.UI.PackageManagerControl+<>c__DisplayClass85_0+<<packageRestoreManager_PackagesMissingStatusChanged>b__0>d @ 808caa0
-- Thread TID:[6b68] - JoinableTask: 1ffc019c SynchronouslyBlockingMainThread

abdb730c <0> * NuGet.PackageManagement.VisualStudio.MultiSourcePackageMetadataProvider+<>c__DisplayClass8_0+<<GetLocalPackageMetadataAsync>b__1>d @ 1b4d7860
..8d915f48 <0> NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder+ClonedPackageSearchMetadata+<GetDeprecationMetadataAsync>d__83 @ 1b4d7640
..8d91603c <0> NuGet.PackageManagement.VisualStudio.PackageSearchMetadataCacheItemEntry+<GetPackageDeprecationMetadataContextInfoAsync>d__7 @ 1b4d7418
..8d916104 <1> NuGet.PackageManagement.VisualStudio.NuGetPackageSearchService+<GetDeprecationMetadataAsync>d__13 @ 1b4d68e8
..8d916204 <0> Microsoft.ServiceHub.Framework.ServiceJsonRpcDescriptor+LocalProxyGeneration+<ReturnedValueTaskOfTHelper>d__25<NuGet.VisualStudio.Internal.Contracts.PackageDeprecationMetadataContextInfo> @ 625dd174
..8d69ea00 <2> NuGet.PackageManagement.UI.PackageManagerControl+<GetPackageDeprecationMetadataAsync>d__99 @ 20faab88
..a3f281ac <2> NuGet.PackageManagement.UI.PackageManagerControl+<GetInstalledDeprecatedPackagesCountAsync>d__98 @ 1b4db900
..a3f2826c <2> NuGet.PackageManagement.UI.PackageManagerControl+<RefreshInstalledAndUpdatesTabsAsync>d__97 @ 1b4d9538
..a1b80848 <4> NuGet.PackageManagement.UI.PackageManagerControl+<SearchPackagesAndRefreshUpdateCountAsync>d__93 @ 805cc40
..a1b80970 <1> NuGet.PackageManagement.UI.PackageManagerControl+<SearchPackagesAndRefreshUpdateCountAsync>d__91 @ 805c8e0
..a1b80a70 <0> NuGet.PackageManagement.UI.PackageManagerControl+<RefreshAsync>d__108 @ 7a5909a0
..a1b80b50 <0> NuGet.PackageManagement.UI.PackageManagerControl+<UpdateAfterPackagesMissingStatusChangedAsync>d__86 @ 7a5906a8
..a1b80c20 <1> NuGet.PackageManagement.UI.PackageManagerControl+<>c__DisplayClass85_0+<<packageRestoreManager_PackagesMissingStatusChanged>b__0>d @ 808caa0
-- Thread TID:[6b68] - JoinableTask: 1ffc019c SynchronouslyBlockingMainThread

This codepath changed in https://github.com/NuGet/NuGet.Client/commit/b5b44526dea0379ebd6c8e51e8a041c06d5845ca#diff-80991ce1edef4f242608751b70dd2d48dad8e24a28dbefd2b68a3a7784a12f21. 

The fix is obviously to not block the UI thread on the refreshing logic. 
It's likely that some of this code needs to be fire and forget.
The rest of the calls to `RefreshAsync` happen in a fire and forget fashion (either directly, or a few calls above it), so it's possible that this was simply an oversight.

My best bet is that it should happen here: https://github.com/NuGet/NuGet.Client/blob/87e9eab3090d2074f90d9190ecd2d95685f9e2e5/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs#L707

There's a precedence for that, as the refresh here is called in a fire and forget fashion https://github.com/NuGet/NuGet.Client/blob/87e9eab3090d2074f90d9190ecd2d95685f9e2e5/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs#L259-L262

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
