### PR TITLE
use the just-built nuget pack task to build nuget nupkgs

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -53,7 +53,9 @@ param (
     [switch]$PackageEndToEnd,
     [switch]$SkipDelaySigning,
     [switch]$Binlog,
-    [switch]$IncludeApex
+    [switch]$IncludeApex,
+    [switch]$VSVersion = $env:VisualStudioVersion,
+    [switch]$NoDogFood
 )
 
 . "$PSScriptRoot\build\common.ps1"
@@ -197,6 +199,14 @@ Invoke-BuildStep 'Packing RTM' {
 
     # Build and (If not $SkipUnitTest) Pack, Core unit tests, and Unit tests for VS
     $args = "build\build.proj", "/t:BuildVS`;Pack", "/p:Configuration=$Configuration", "/p:BuildRTM=true", "/p:ReleaseLabel=$ReleaseLabel", "/p:BuildNumber=$BuildNumber", "/p:ExcludeTestProjects=true", "/v:m", "/m:1"
+
+    if (!$NoDogFood)
+    {
+        $args += "/p:ImportNuGetBuildTasksPackTargetsFromSdk=true"
+        $args += "/p:NuGetPackTaskAssemblyFile=$Artifacts\NuGet.Build.Tasks.Pack\$VSVersion-RTM\bin\$Configuration\net472\NuGet.Build.Tasks.Pack.dll"
+        $args += "/p:NuGetBuildTasksPackTargets=$Artifacts\NuGet.Build.Tasks.Pack\$VSVersion-RTM\bin\$Configuration\net472\NuGet.Build.Tasks.Pack.targets"
+    }
+
     if ($Binlog)
     {
         $args += "-bl:msbuild.pack.binlog"

--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -234,7 +234,7 @@ steps:
     solution: "build\\build.proj"
     msbuildVersion: "16.0"
     configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/t:Pack /p:BuildRTM=$(BuildRTM) /p:ExcludeTestProjects=$(BuildRTM) /p:BuildNumber=$(BuildNumber) /p:ImportNuGetBuildTasksPackTargetsFromSdk=true /p:NuGetPackTaskAssemblyFile=$(Build.Repository.LocalPath)\\artifacts\\NuGet.Build.Tasks.Pack\\16.0\\bin\\Release\\net472\\NuGet.Build.Tasks.Pack.dll /p:NuGetBuildTasksPackTargets=$(Build.Repository.LocalPath)\\artifacts\\NuGet.Build.Tasks.Pack\\16.0\\bin\\Release\\net472\\NuGet.Build.Tasks.Pack.targets"
+    msbuildArguments: "/t:Pack /p:BuildRTM=$(BuildRTM) /p:ExcludeTestProjects=$(BuildRTM) /p:BuildNumber=$(BuildNumber) /p:ImportNuGetBuildTasksPackTargetsFromSdk=true /p:NuGetPackTaskAssemblyFile=$(Build.Repository.LocalPath)\\artifacts\\NuGet.Build.Tasks.Pack\\16.0-RTM\\bin\\Release\\net472\\NuGet.Build.Tasks.Pack.dll /p:NuGetBuildTasksPackTargets=$(Build.Repository.LocalPath)\\artifacts\\NuGet.Build.Tasks.Pack\\16.0-RTM\\bin\\Release\\net472\\NuGet.Build.Tasks.Pack.targets"
     maximumCpuCount: true
   condition: and(succeeded(), or(eq(variables['IsOfficialBuild'], 'true'), eq(variables['BuildRTM'], 'true')))  #skip this task for nonRTM in private build
 

--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -234,7 +234,7 @@ steps:
     solution: "build\\build.proj"
     msbuildVersion: "16.0"
     configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/t:Pack /p:BuildRTM=$(BuildRTM) /p:ExcludeTestProjects=$(BuildRTM) /p:BuildNumber=$(BuildNumber)"
+    msbuildArguments: "/t:Pack /p:BuildRTM=$(BuildRTM) /p:ExcludeTestProjects=$(BuildRTM) /p:BuildNumber=$(BuildNumber) /p:ImportNuGetBuildTasksPackTargetsFromSdk=true /p:NuGetPackTaskAssemblyFile=$(Build.Repository.LocalPath)\\artifacts\\NuGet.Build.Tasks.Pack\\16.0\\bin\\Release\\net472\\NuGet.Build.Tasks.Pack.dll /p:NuGetBuildTasksPackTargets=$(Build.Repository.LocalPath)\\artifacts\\NuGet.Build.Tasks.Pack\\16.0\\bin\\Release\\net472\\NuGet.Build.Tasks.Pack.targets"
     maximumCpuCount: true
   condition: and(succeeded(), or(eq(variables['IsOfficialBuild'], 'true'), eq(variables['BuildRTM'], 'true')))  #skip this task for nonRTM in private build
 

--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -234,7 +234,7 @@ steps:
     solution: "build\\build.proj"
     msbuildVersion: "16.0"
     configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/t:Pack /p:BuildRTM=$(BuildRTM) /p:ExcludeTestProjects=$(BuildRTM) /p:BuildNumber=$(BuildNumber) /p:ImportNuGetBuildTasksPackTargetsFromSdk=true /p:NuGetPackTaskAssemblyFile=$(Build.Repository.LocalPath)\\artifacts\\NuGet.Build.Tasks.Pack\\16.0-RTM\\bin\\Release\\net472\\NuGet.Build.Tasks.Pack.dll /p:NuGetBuildTasksPackTargets=$(Build.Repository.LocalPath)\\artifacts\\NuGet.Build.Tasks.Pack\\16.0-RTM\\bin\\Release\\net472\\NuGet.Build.Tasks.Pack.targets"
+    msbuildArguments: "/t:Pack /p:BuildRTM=$(BuildRTM) /p:ExcludeTestProjects=$(BuildRTM) /p:BuildNumber=$(BuildNumber) /p:ImportNuGetBuildTasksPackTargetsFromSdk=true /p:NuGetPackTaskAssemblyFile=$(Build.Repository.LocalPath)\\artifacts\\NuGet.Build.Tasks.Pack\\16.0-RTM\\bin\\$(BuildConfiguration)\\net472\\NuGet.Build.Tasks.Pack.dll /p:NuGetBuildTasksPackTargets=$(Build.Repository.LocalPath)\\artifacts\\NuGet.Build.Tasks.Pack\\16.0-RTM\\bin\\$(BuildConfiguration)\\net472\\NuGet.Build.Tasks.Pack.targets"
     maximumCpuCount: true
   condition: and(succeeded(), or(eq(variables['IsOfficialBuild'], 'true'), eq(variables['BuildRTM'], 'true')))  #skip this task for nonRTM in private build
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/665

Regression? Last working version: no

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

This PR makes it so we use the freshly-built NuGet Pack itself to pack our nupkgs instead of NuGet from nuget.org.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
