### PR TITLE
add extension point for placing symbols to custom places.

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.targets
@@ -433,9 +433,8 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <Target Name="_GetBuildOutputFilesWithTfm"
           DependsOnTargets="BuiltProjectOutputGroup;DocumentationProjectOutputGroup;SatelliteDllsProjectOutputGroup;_AddPriFileToPackBuildOutput;$(TargetsForTfmSpecificBuildOutput)"
-          Condition="'$(IncludeBuildOutput)' == 'true'"
           Returns="@(BuildOutputInPackage)">
-    <ItemGroup>
+    <ItemGroup Condition="'$(IncludeBuildOutput)' == 'true'">
       <BuildOutputInPackage Include="@(SatelliteDllsProjectOutputGroupOutput);
                             @(BuiltProjectOutputGroupOutput);
                             @(DocumentationProjectOutputGroupOutput);
@@ -456,10 +455,9 @@ Copyright (c) .NET Foundation. All rights reserved.
   </Target>
 
   <Target Name="_GetDebugSymbolsWithTfm"
-          DependsOnTargets="DebugSymbolsProjectOutputGroup"
-          Condition="'$(IncludeBuildOutput)' == 'true'"
+          DependsOnTargets="DebugSymbolsProjectOutputGroup;$(TargetsForTfmSpecificDebugSymbolsInPackage)" 
           Returns="@(_TargetPathsToSymbolsWithTfm)">
-    <ItemGroup>
+    <ItemGroup Condition="'$(IncludeBuildOutput)' == 'true'">
       <_TargetPathsToSymbolsWithTfm Include="@(DebugSymbolsProjectOutputGroupOutput)">
         <TargetFramework>$(TargetFramework)</TargetFramework>
       </_TargetPathsToSymbolsWithTfm>

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.targets
@@ -462,6 +462,9 @@ Copyright (c) .NET Foundation. All rights reserved.
         <TargetFramework>$(TargetFramework)</TargetFramework>
       </_TargetPathsToSymbolsWithTfm>
     </ItemGroup>
+    <ItemGroup>
+      <_TargetPathsToSymbolsWithTfm Include="@(TfmSpecificDebugSymbolsFile)" />
+    </ItemGroup>
   </Target>
 
   <!--Projects with target framework like UWP, Win8, wpa81 produce a Pri file

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
@@ -2751,7 +2751,6 @@ namespace ClassLibrary
                     ProjectFileUtils.WriteXmlToFile(xml, stream);
                 }
 
-                msbuildFixture.RestoreProject(workingDirectory, projectName, string.Empty);
                 msbuildFixture.PackProject(workingDirectory, projectName, $"/p:PackageOutputPath={workingDirectory}");
 
                 var nupkgPath = Path.Combine(workingDirectory, $"{projectName}.1.0.0.symbols.nupkg");
@@ -2801,7 +2800,6 @@ namespace ClassLibrary
                     ProjectFileUtils.WriteXmlToFile(xml, stream);
                 }
 
-                msbuildFixture.RestoreProject(workingDirectory, projectName, string.Empty);
                 msbuildFixture.PackProject(workingDirectory, projectName, $"/p:PackageOutputPath={workingDirectory}");
 
                 var nupkgPath = Path.Combine(workingDirectory, $"{projectName}.1.0.0.symbols.nupkg");
@@ -2813,6 +2811,8 @@ namespace ClassLibrary
                     Assert.Contains(@"runtimes/win/lib/net46/abc.pdb", files);
                     Assert.DoesNotContain(@"lib/netstandard1.4/abc.pdb", files);
                     Assert.DoesNotContain(@"lib/netstandard1.4/abc.dll", files);
+                    Assert.DoesNotContain(@"lib/net46/abc.pdb", files);
+                    Assert.DoesNotContain(@"lib/net46/abc.dll", files);
                 }
             }
         }

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
@@ -2809,10 +2809,10 @@ namespace ClassLibrary
                     var files = nupkgReader.GetFiles();
                     Assert.Contains(@"runtimes/win/lib/netstandard1.4/abc.pdb", files);
                     Assert.Contains(@"runtimes/win/lib/net46/abc.pdb", files);
-                    Assert.Contains(@"lib/net46/abc.pdb", files);
-                    Assert.Contains(@"lib/net46/abc.dll", files);
-                    Assert.DoesNotContain(@"lib/netstandard1.4/abc.pdb", files);
-                    Assert.DoesNotContain(@"lib/netstandard1.4/abc.dll", files);
+                    Assert.Contains(@"lib/net46/ClassLibrary1.pdb", files);
+                    Assert.Contains(@"lib/net46/ClassLibrary1.dll", files);
+                    Assert.DoesNotContain(@"lib/netstandard1.4/ClassLibrary1.pdb", files);
+                    Assert.DoesNotContain(@"lib/netstandard1.4/ClassLibrary1.dll", files);
                 }
             }
         }

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
@@ -2721,6 +2721,105 @@ namespace ClassLibrary
         [PlatformTheory(Platform.Windows)]
         [InlineData("TargetFramework", "netstandard1.4")]
         [InlineData("TargetFrameworks", "netstandard1.4;net46")]
+        public void PackCommand_ContentInnerTargetExtension_AddsExtraSymbolFiles(string tfmProperty, string tfmValue)
+        {
+            using (var testDirectory = msbuildFixture.CreateTestDirectory())
+            {
+                var projectName = "ClassLibrary1";
+                var workingDirectory = Path.Combine(testDirectory, projectName);
+                var projectFile = Path.Combine(workingDirectory, $"{projectName}.csproj");
+                Directory.CreateDirectory(workingDirectory);
+                File.WriteAllText(Path.Combine(workingDirectory, "abc.pdb"), "hello world");
+
+                msbuildFixture.CreateDotnetNewProject(testDirectory.Path, projectName, " classlib");
+
+                using (var stream = new FileStream(projectFile, FileMode.Open, FileAccess.ReadWrite))
+                {
+                    var xml = XDocument.Load(stream);
+                    var target = @"<Target Name=""CustomContentTarget"">
+    <ItemGroup>
+      <_TargetPathsToSymbolsWithTfm Include=""abc.pdb"">
+        <TargetPath>/runtimes/win/lib/$(TargetFramework)/abc.pdb</TargetPath>
+        <TargetFramework>$(TargetFramework)</TargetFramework>
+      </_TargetPathsToSymbolsWithTfm>
+    </ItemGroup>
+  </Target>";
+                    ProjectFileUtils.SetTargetFrameworkForProject(xml, tfmProperty, tfmValue);
+                    ProjectFileUtils.AddProperty(xml, "TargetsForTfmSpecificDebugSymbolsInPackage", "CustomContentTarget");
+                    ProjectFileUtils.AddProperty(xml, "IncludeSymbols", "true");
+                    ProjectFileUtils.AddCustomXmlToProjectRoot(xml, target);
+                    ProjectFileUtils.WriteXmlToFile(xml, stream);
+                }
+
+                msbuildFixture.RestoreProject(workingDirectory, projectName, string.Empty);
+                msbuildFixture.PackProject(workingDirectory, projectName, $"/p:PackageOutputPath={workingDirectory}");
+
+                var nupkgPath = Path.Combine(workingDirectory, $"{projectName}.1.0.0.symbols.nupkg");
+                Assert.True(File.Exists(nupkgPath), "The output .nupkg is not in the expected place");
+                using (var nupkgReader = new PackageArchiveReader(nupkgPath))
+                {
+                    var files = nupkgReader.GetFiles();
+                    Assert.Contains(@"runtimes/win/lib/netstandard1.4/abc.pdb", files);
+
+                    if (tfmProperty == "TargetFrameworks")
+                    {
+                        Assert.Contains(@"runtimes/win/lib/net46/abc.pdb", files);
+                    }
+                }
+            }
+        }
+
+        [PlatformFact(Platform.Windows)]
+        public void PackCommand_ContentInnerTargetExtension_SymbolFilesWithoutDll()
+        {
+            using (var testDirectory = msbuildFixture.CreateTestDirectory())
+            {
+                var projectName = "ClassLibrary1";
+                var workingDirectory = Path.Combine(testDirectory, projectName);
+                var projectFile = Path.Combine(workingDirectory, $"{projectName}.csproj");
+                Directory.CreateDirectory(workingDirectory);
+                File.WriteAllText(Path.Combine(workingDirectory, "abc.pdb"), "hello world");
+
+                msbuildFixture.CreateDotnetNewProject(testDirectory.Path, projectName, " classlib");
+
+                using (var stream = new FileStream(projectFile, FileMode.Open, FileAccess.ReadWrite))
+                {
+                    var xml = XDocument.Load(stream);
+                    var target = @"<Target Name=""CustomContentTarget"">
+    <ItemGroup>
+      <_TargetPathsToSymbolsWithTfm Include=""abc.pdb"">
+        <TargetPath>/runtimes/win/lib/$(TargetFramework)/abc.pdb</TargetPath>
+        <TargetFramework>$(TargetFramework)</TargetFramework>
+      </_TargetPathsToSymbolsWithTfm>
+    </ItemGroup>
+  </Target>";
+                    ProjectFileUtils.SetTargetFrameworkForProject(xml, "TargetFrameworks", "netstandard1.4;net46");
+                    ProjectFileUtils.AddProperty(xml, "TargetsForTfmSpecificDebugSymbolsInPackage", "CustomContentTarget");
+                    ProjectFileUtils.AddProperty(xml, "IncludeBuildOutput", "false", $"'$(TargetFramework)'=='netstandard1.4'");
+                    ProjectFileUtils.AddProperty(xml, "IncludeSymbols", "true");
+                    ProjectFileUtils.AddCustomXmlToProjectRoot(xml, target);
+                    ProjectFileUtils.WriteXmlToFile(xml, stream);
+                }
+
+                msbuildFixture.RestoreProject(workingDirectory, projectName, string.Empty);
+                msbuildFixture.PackProject(workingDirectory, projectName, $"/p:PackageOutputPath={workingDirectory}");
+
+                var nupkgPath = Path.Combine(workingDirectory, $"{projectName}.1.0.0.symbols.nupkg");
+                Assert.True(File.Exists(nupkgPath), "The output .nupkg is not in the expected place");
+                using (var nupkgReader = new PackageArchiveReader(nupkgPath))
+                {
+                    var files = nupkgReader.GetFiles();
+                    Assert.Contains(@"runtimes/win/lib/netstandard1.4/abc.pdb", files);
+                    Assert.Contains(@"runtimes/win/lib/net46/abc.pdb", files);
+                    Assert.DoesNotContain(@"lib/netstandard1.4/abc.pdb", files);
+                    Assert.DoesNotContain(@"lib/netstandard1.4/abc.dll", files);
+                }
+            }
+        }
+
+        [PlatformTheory(Platform.Windows)]
+        [InlineData("TargetFramework", "netstandard1.4")]
+        [InlineData("TargetFrameworks", "netstandard1.4;net46")]
         public void PackCommand_BuildOutputInnerTargetExtension_AddsTfmSpecificBuildOuput(string tfmProperty,
     string tfmValue)
         {

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
@@ -2738,10 +2738,10 @@ namespace ClassLibrary
                     var xml = XDocument.Load(stream);
                     var target = @"<Target Name=""CustomContentTarget"">
     <ItemGroup>
-      <_TargetPathsToSymbolsWithTfm Include=""abc.pdb"">
+      <TfmSpecificDebugSymbolsFile Include=""abc.pdb"">
         <TargetPath>/runtimes/win/lib/$(TargetFramework)/abc.pdb</TargetPath>
         <TargetFramework>$(TargetFramework)</TargetFramework>
-      </_TargetPathsToSymbolsWithTfm>
+      </TfmSpecificDebugSymbolsFile>
     </ItemGroup>
   </Target>";
                     ProjectFileUtils.SetTargetFrameworkForProject(xml, tfmProperty, tfmValue);
@@ -2786,10 +2786,10 @@ namespace ClassLibrary
                     var xml = XDocument.Load(stream);
                     var target = @"<Target Name=""CustomContentTarget"">
     <ItemGroup>
-      <_TargetPathsToSymbolsWithTfm Include=""abc.pdb"">
+      <TfmSpecificDebugSymbolsFile Include=""abc.pdb"">
         <TargetPath>/runtimes/win/lib/$(TargetFramework)/abc.pdb</TargetPath>
         <TargetFramework>$(TargetFramework)</TargetFramework>
-      </_TargetPathsToSymbolsWithTfm>
+      </TfmSpecificDebugSymbolsFile>
     </ItemGroup>
   </Target>";
                     ProjectFileUtils.SetTargetFrameworkForProject(xml, "TargetFrameworks", "netstandard1.4;net46");

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
@@ -2817,6 +2817,56 @@ namespace ClassLibrary
             }
         }
 
+        [PlatformFact(Platform.Windows)]
+        public void PackCommand_ContentInnerTargetExtension_SymbolFilesDllWithRecursive()
+        {
+            using (var testDirectory = msbuildFixture.CreateTestDirectory())
+            {
+                var projectName = "ClassLibrary1";
+                var workingDirectory = Path.Combine(testDirectory, projectName);
+                var projectFile = Path.Combine(workingDirectory, $"{projectName}.csproj");
+                string symbolPath = Path.Combine(workingDirectory, "Random", "AnotherRandom");
+                Directory.CreateDirectory(symbolPath);
+                File.WriteAllText(Path.Combine(symbolPath, "abc.pdb"), "hello world");
+
+                msbuildFixture.CreateDotnetNewProject(testDirectory.Path, projectName, " classlib");
+
+                using (var stream = new FileStream(projectFile, FileMode.Open, FileAccess.ReadWrite))
+                {
+                    var xml = XDocument.Load(stream);
+                    var target = @"<Target Name=""CustomContentTarget"">
+    <ItemGroup>
+      <TfmSpecificDebugSymbolsFile Include=""Random/**/abc.pdb"">
+        <TargetPath>/runtimes/win/lib/$(TargetFramework)/random/abc.pdb</TargetPath>
+        <TargetFramework>$(TargetFramework)</TargetFramework>
+      </TfmSpecificDebugSymbolsFile>
+    </ItemGroup>
+  </Target>";
+                    ProjectFileUtils.SetTargetFrameworkForProject(xml, "TargetFrameworks", "netstandard1.4;net46");
+                    ProjectFileUtils.AddProperty(xml, "TargetsForTfmSpecificDebugSymbolsInPackage", "CustomContentTarget");
+                    ProjectFileUtils.AddProperty(xml, "IncludeBuildOutput", "false", $"'$(TargetFramework)'=='netstandard1.4'");
+                    ProjectFileUtils.AddProperty(xml, "IncludeSymbols", "true");
+                    ProjectFileUtils.AddCustomXmlToProjectRoot(xml, target);
+                    ProjectFileUtils.WriteXmlToFile(xml, stream);
+                }
+
+                msbuildFixture.PackProject(workingDirectory, projectName, $"/p:PackageOutputPath={workingDirectory}");
+
+                var nupkgPath = Path.Combine(workingDirectory, $"{projectName}.1.0.0.symbols.nupkg");
+                Assert.True(File.Exists(nupkgPath), "The output .nupkg is not in the expected place");
+                using (var nupkgReader = new PackageArchiveReader(nupkgPath))
+                {
+                    var files = nupkgReader.GetFiles();
+                    Assert.Contains(@"runtimes/win/lib/netstandard1.4/random/abc.pdb", files);
+                    Assert.Contains(@"runtimes/win/lib/net46/random/abc.pdb", files);
+                    Assert.Contains(@"lib/net46/ClassLibrary1.pdb", files);
+                    Assert.Contains(@"lib/net46/ClassLibrary1.dll", files);
+                    Assert.DoesNotContain(@"lib/netstandard1.4/ClassLibrary1.pdb", files);
+                    Assert.DoesNotContain(@"lib/netstandard1.4/ClassLibrary1.dll", files);
+                }
+            }
+        }
+
         [PlatformTheory(Platform.Windows)]
         [InlineData("TargetFramework", "netstandard1.4")]
         [InlineData("TargetFrameworks", "netstandard1.4;net46")]

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
@@ -2809,10 +2809,10 @@ namespace ClassLibrary
                     var files = nupkgReader.GetFiles();
                     Assert.Contains(@"runtimes/win/lib/netstandard1.4/abc.pdb", files);
                     Assert.Contains(@"runtimes/win/lib/net46/abc.pdb", files);
+                    Assert.Contains(@"lib/net46/abc.pdb", files);
+                    Assert.Contains(@"lib/net46/abc.dll", files);
                     Assert.DoesNotContain(@"lib/netstandard1.4/abc.pdb", files);
                     Assert.DoesNotContain(@"lib/netstandard1.4/abc.dll", files);
-                    Assert.DoesNotContain(@"lib/net46/abc.pdb", files);
-                    Assert.DoesNotContain(@"lib/net46/abc.dll", files);
                 }
             }
         }


### PR DESCRIPTION
## Bug

No good way to place symbols outside of the lib folder

Fixes: https://github.com/NuGet/Home/issues/10913

Related to : https://github.com/NuGet/Home/issues/10860

Currently there was no way to add extra symbols files in the innerbuilds, this change provide that hook. It still wont address the problem of targetpath being an absolute path. I added the tests which should help in understanding the workflow for innerbuilds.


## Description

- added a variable  TargetsForTfmSpecificDebugSymbolsInPackage  which could be set to run the targets to populate _TargetPathsToSymbolsWithTfm 
-  Moved IncludeBuildOutput added here https://github.com/NuGet/NuGet.Client/pull/3810 in itemgroup in order to allow the user to put the buildOutput\symbols at some other place other than lib. the same pattern is used from other targets as well like _AddPriFileToPackBuildOutput and _GetFrameworksWithSuppressedDependencies

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
- [x] needs to be added


- **Documentation**
  - [x] Documentation issue https://github.com/NuGet/Home/issues/10891

cc @ViktorHofer @safern @ericstj @nkolev92 


