### PR TITLE
Use system installed msbuild in msbuild.integration.tests

### DIFF
--- a/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/Msbuild.Integration.Test.csproj
+++ b/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/Msbuild.Integration.Test.csproj
@@ -11,12 +11,7 @@
     <Compile Remove="compiler\resources\*" />
     <EmbeddedResource Include="compiler\resources\*" />
   </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Build.Runtime" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Build.Tasks" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
-  </ItemGroup>
-  
+
   <ItemGroup>
     <ProjectReference Include="$(NuGetCoreSrcDirectory)NuGet.Build.Tasks\NuGet.Build.Tasks.csproj" />
     <ProjectReference Include="$(NuGetCoreSrcDirectory)NuGet.Build.Tasks.Console\NuGet.Build.Tasks.Console.csproj" />
@@ -33,9 +28,6 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-  <Target Name="CopyTargets" AfterTargets="AfterBuild">
-    <Copy Condition="'$(TargetFramework)' == '$(NETFXTargetFramework)'" SourceFiles="$(MSBuildProjectDirectory)\$(OutputPath)\Microsoft.CSharp.Core.targets" DestinationFolder="$(MSBuildProjectDirectory)\$(OutputPath)\Roslyn\" />
-  </Target>
 
   <Import Project="$(BuildCommonDirectory)common.targets" />
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />

--- a/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildIntegrationTestFixture.cs
+++ b/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildIntegrationTestFixture.cs
@@ -3,7 +3,9 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.IO;
+using NuGet.Common;
 using NuGet.Test.Utility;
 using Xunit;
 
@@ -13,6 +15,76 @@ namespace Msbuild.Integration.Test
     {
         internal readonly string _testDir;
         private readonly Dictionary<string, string> _processEnvVars = new Dictionary<string, string>();
+        private readonly Lazy<string> _msbuildPath = new Lazy<string>(() =>
+            {
+                string msbuildPath = FindMsbuildOnPath();
+                if (msbuildPath == null)
+                {
+                    msbuildPath = FindMsbuildWithVsWhere();
+                }
+                if (msbuildPath == null)
+                {
+                    throw new Exception("Could not find msbuild.exe");
+                }
+                return msbuildPath;
+
+                string FindMsbuildOnPath()
+                {
+                    string msbuild = RuntimeEnvironmentHelper.IsMono
+                        ? "mono msbuild.exe"
+                        : "msbuild.exe";
+
+                    try
+                    {
+                        var result = CommandRunner.Run(
+                            process: msbuild,
+                            workingDirectory: Environment.CurrentDirectory,
+                            arguments: "-help",
+                            waitForExit: true);
+                        if (result.Success)
+                        {
+                            return msbuild;
+                        }
+                    }
+                    catch (Win32Exception)
+                    {
+                        // can't find program
+                    }
+
+                    return null;
+                }
+
+                string FindMsbuildWithVsWhere()
+                {
+                    string vswherePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86), "Microsoft Visual Studio", "Installer", "vswhere.exe");
+
+                    CommandRunnerResult result = CommandRunner.Run(process: vswherePath,
+                        workingDirectory: Environment.CurrentDirectory,
+                        arguments: "-latest -prerelease -requires Microsoft.Component.MSBuild -find MSBuild\\**\\Bin\\MSBuild.exe",
+                        waitForExit: true);
+
+                    if (!result.Success)
+                    {
+                        throw new Exception("vswhere did not return success");
+                    }
+
+                    string path = null;
+                    using (var stringReader = new StringReader(result.Output))
+                    {
+                        string line;
+                        while ((line = stringReader.ReadLine()) != null)
+                        {
+                            if (path != null)
+                            {
+                                throw new Exception("vswhere returned more than 1 line");
+                            }
+                            path = line;
+                        }
+                    }
+
+                    return path;
+                }
+            });
 
         public MsbuildIntegrationTestFixture()
         {
@@ -27,14 +99,12 @@ namespace Msbuild.Integration.Test
         /// </summary>
         internal CommandRunnerResult RunMsBuild(string workingDirectory, string args, bool ignoreExitCode = false)
         {
-
-            var msBuildExe = Path.Combine(_testDir, "MSBuild.exe");
             var restoreDllPath = Path.Combine(_testDir, "NuGet.Build.Tasks.dll");
             var nugetRestoreTargetsPath = Path.Combine(_testDir, "NuGet.targets");
             // Uncomment to debug the msbuild call
             // _processEnvVars.Add("DEBUG_RESTORE_TASK", "true");
             _processEnvVars["UNIT_TEST_RESTORE_TASK"] = bool.TrueString;
-            var result = CommandRunner.Run(msBuildExe,
+            var result = CommandRunner.Run(_msbuildPath.Value,
                 workingDirectory,
                 $"/p:NuGetRestoreTargets={nugetRestoreTargetsPath} /p:RestoreTaskAssemblyFile={restoreDllPath} /p:ImportNuGetBuildTasksPackTargetsFromSdk=true {args}",
                 waitForExit: true,


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/10869

Regression? No

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Try to detect msbuild automatically by shelling out to `msbuild.exe` to see if one exists on the system path already, and if not, use `vswhere.exe` in the default VS Installer install directory, to locate msbuild.exe.

This makes Visual Studio a pre-requisite for running this test, but msbuild.integration.test are tests for the VS-only msbuild.exe anyway. We have a different project, dotnet.integration.tests, for testing the dotnet cli.

## PR Checklist

- [X] PR has a meaningful title
- [X] PR has a linked issue.
- [X] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [X] N/A: Making the existing tests run more reliably

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [X] N/A
