### PR TITLE
Fix F# EndToEnd tests

### DIFF
--- a/test/EndToEnd/ProjectTemplates/FSharpConsoleApplication.zip/App.config
+++ b/test/EndToEnd/ProjectTemplates/FSharpConsoleApplication.zip/App.config
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
-<configuration>
-    <startup> 
-        $if$ ($targetframeworkversion$ >= 4.0)<supportedRuntime version="v4.0" sku=".NETFramework,Version=v$targetframeworkversion$,Profile=Client" />$endif$$if$ ($targetframeworkversion$ < 4.0)<supportedRuntime version="v2.0.50727" />$endif$
-    </startup>
-</configuration>

--- a/test/EndToEnd/ProjectTemplates/FSharpConsoleApplication.zip/ConsoleApplication.fsproj
+++ b/test/EndToEnd/ProjectTemplates/FSharpConsoleApplication.zip/ConsoleApplication.fsproj
@@ -1,66 +1,13 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
-    <ProductVersion>8.0.30703</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
-    <ProjectGuid>$guid1$</ProjectGuid>
     <OutputType>Exe</OutputType>
-    <RootNamespace>$safeprojectname$</RootNamespace>
-    <AssemblyName>$safeprojectname$</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFramework>net5.0</TargetFramework>
+    <WarnOn>3390;$(WarnOn)</WarnOn>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <Tailcalls>false</Tailcalls>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <WarningLevel>3</WarningLevel>
-    <PlatformTarget>x86</PlatformTarget>
-    <DocumentationFile>bin\Debug\$safeprojectname$.XML</DocumentationFile>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <Tailcalls>true</Tailcalls>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <WarningLevel>3</WarningLevel>
-    <PlatformTarget>x86</PlatformTarget>
-    <DocumentationFile>bin\Release\$safeprojectname$.XML</DocumentationFile>
-  </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="mscorlib"/>
-    <Reference Include="FSharp.Core"/>
-    <Reference Include="System"/>
-    $if$ ($targetframeworkversion$ >= 3.5)
-    <Reference Include="System.Core"/>
-    $endif$
-    $if$ ($targetframeworkversion$ > 3.5)
-    <Reference Include="System.Numerics"/>
-    $endif$
-  </ItemGroup>
+
   <ItemGroup>
     <Compile Include="Program.fs" />
   </ItemGroup>
-  $if$ ($targetframeworkversion$ > 4.0)
-  <ItemGroup>
-    <None Include="App.config" />
-  </ItemGroup>
-  $endif$
 
-  <PropertyGroup Condition=" '$(FSharpTargetsPath)' == '' AND Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets') ">
-    <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
-  </PropertyGroup>
-  <Import Project="$(FSharpTargetsPath)" />
-    <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-	     Other similar extension points exist, see Microsoft.Common.targets.
-	<Target Name="BeforeBuild">
-	</Target>
-	<Target Name="AfterBuild">
-	</Target>
-	-->
 </Project>

--- a/test/EndToEnd/ProjectTemplates/FSharpConsoleApplication.zip/Program.fs
+++ b/test/EndToEnd/ProjectTemplates/FSharpConsoleApplication.zip/Program.fs
@@ -1,2 +1,13 @@
-﻿// Learn more about F# at http://fsharp.net
+﻿// Learn more about F# at http://docs.microsoft.com/dotnet/fsharp
 
+open System
+
+// Define a function to construct a message to print
+let from whom =
+    sprintf "from %s" whom
+
+[<EntryPoint>]
+let main argv =
+    let message = from "F#" // Call the function
+    printfn "Hello world %s" message
+    0 // return an integer exit code

--- a/test/EndToEnd/ProjectTemplates/FSharpConsoleApplication.zip/fsConsoleApplication.vstemplate
+++ b/test/EndToEnd/ProjectTemplates/FSharpConsoleApplication.zip/fsConsoleApplication.vstemplate
@@ -17,7 +17,6 @@
   <TemplateContent>
     <Project File="ConsoleApplication.fsproj" ReplaceParameters="true">
       <ProjectItem ReplaceParameters="true" OpenInEditor="true">Program.fs</ProjectItem>
-      <ProjectItem ReplaceParameters="true">App.config</ProjectItem>
     </Project>
   </TemplateContent>
 </VSTemplate>

--- a/test/EndToEnd/ProjectTemplates/FSharpLibrary.zip/Library.fs
+++ b/test/EndToEnd/ProjectTemplates/FSharpLibrary.zip/Library.fs
@@ -1,0 +1,5 @@
+﻿namespace FSharpLibrary
+
+module Say =
+    let hello name =
+        printfn "Hello %s" name

--- a/test/EndToEnd/ProjectTemplates/FSharpLibrary.zip/Library.fsproj
+++ b/test/EndToEnd/ProjectTemplates/FSharpLibrary.zip/Library.fsproj
@@ -1,59 +1,13 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>8.0.30703</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
-    <ProjectGuid>$guid1$</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <RootNamespace>$safeprojectname$</RootNamespace>
-    <AssemblyName>$safeprojectname$</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFramework>net5.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <WarnOn>3390;$(WarnOn)</WarnOn>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <Tailcalls>false</Tailcalls>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <WarningLevel>3</WarningLevel>
-    <DocumentationFile>bin\Debug\$safeprojectname$.XML</DocumentationFile>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <Tailcalls>true</Tailcalls>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <WarningLevel>3</WarningLevel>
-    <DocumentationFile>bin\Release\$safeprojectname$.XML</DocumentationFile>
-  </PropertyGroup>
+
   <ItemGroup>
-    <Reference Include="mscorlib"/>
-    <Reference Include="FSharp.Core"/>
-    <Reference Include="System"/>
-    $if$ ($targetframeworkversion$ >= 3.5)
-    <Reference Include="System.Core"/>
-    $endif$
-    $if$ ($targetframeworkversion$ > 3.5)
-    <Reference Include="System.Numerics"/>
-    $endif$
+    <Compile Include="Library.fs" />
   </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Module1.fs" />
-    <None Include="Script.fsx" />
-  </ItemGroup>
-    <PropertyGroup Condition=" '$(FSharpTargetsPath)' == '' AND Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets') ">
-    <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
-  </PropertyGroup>
-  <Import Project="$(FSharpTargetsPath)" />
-    <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-	     Other similar extension points exist, see Microsoft.Common.targets.
-	<Target Name="BeforeBuild">
-	</Target>
-	<Target Name="AfterBuild">
-	</Target>
-	-->
+
 </Project>

--- a/test/EndToEnd/ProjectTemplates/FSharpLibrary.zip/Module1.fs
+++ b/test/EndToEnd/ProjectTemplates/FSharpLibrary.zip/Module1.fs
@@ -1,4 +1,0 @@
-﻿// Learn more about F# at http://fsharp.net
-
-module Module1
-

--- a/test/EndToEnd/ProjectTemplates/FSharpLibrary.zip/Script.fsx
+++ b/test/EndToEnd/ProjectTemplates/FSharpLibrary.zip/Script.fsx
@@ -1,7 +1,0 @@
-﻿// This file is a script that can be executed with the F# Interactive.  
-// It can be used to explore and test the library project.
-// Note that script files will not be part of the project build.
-
-#load "Module1.fs"
-open Module1
-

--- a/test/EndToEnd/ProjectTemplates/FSharpLibrary.zip/fsLibrary.vstemplate
+++ b/test/EndToEnd/ProjectTemplates/FSharpLibrary.zip/fsLibrary.vstemplate
@@ -16,8 +16,7 @@
   </TemplateData>
   <TemplateContent>
     <Project File="Library.fsproj" ReplaceParameters="true">
-      <ProjectItem ReplaceParameters="true" OpenInEditor="true">Module1.fs</ProjectItem>
-      <ProjectItem ReplaceParameters="true">Script.fsx</ProjectItem>
+      <ProjectItem ReplaceParameters="true" OpenInEditor="true">Library.fs</ProjectItem>
     </Project>
   </TemplateContent>
 </VSTemplate>

--- a/test/EndToEnd/tests/GetPackageTest.ps1
+++ b/test/EndToEnd/tests/GetPackageTest.ps1
@@ -183,36 +183,18 @@ function Test-GetPackageForProjectReturnsCorrectPackages2 {
 function Test-GetPackageForFSharpProjectReturnsCorrectPackages {
     # Arrange
     $p = New-FSharpConsoleApplication
+    Build-Solution # wait for project nomination
 
     Install-Package jQuery -Version 1.5 -Source $context.RepositoryPath
+    Build-Solution # wait for restore & assets file
 
     # Act
-    $result = @(Get-Package -ProjectName $p.Name)
+    $result = @(Get-Package -ProjectName $p.Name) | where { $_.id -ne "FSharp.Core" }
 
     # Assert
     Assert-AreEqual 1 $result.Count
     Assert-AreEqual "jQuery" $result[0].Id
     Assert-AreEqual "1.5.0" $result[0].Version
-}
-
-function Test-GetPackageForFSharpProjectReturnsCorrectPackages2 {
-    # Arrange
-    $p = New-FSharpConsoleApplication
-
-    # Note that installation of the second package on a project involves update of an existing packages.config
-    # which is different from the installation of the first package
-    Install-Package jQuery -Version 1.5 -Source $context.RepositoryPath
-    Install-Package MyAwesomeLibrary -Version 1.0 -Source $context.RepositoryPath
-
-    # Act
-    $result = @(Get-Package -ProjectName $p.Name)
-
-    # Assert
-    Assert-AreEqual 2 $result.Count
-    Assert-AreEqual "jQuery" $result[0].Id
-    Assert-AreEqual "1.5.0" $result[0].Version
-    Assert-AreEqual "MyAwesomeLibrary" $result[1].Id
-    Assert-AreEqual "1.0.0" $result[1].Version
 }
 
 function Test-GetPackageForProjectReturnsEmptyIfItHasNoInstalledPackage {

--- a/test/EndToEnd/tests/InstallPackageTest.ps1
+++ b/test/EndToEnd/tests/InstallPackageTest.ps1
@@ -428,37 +428,6 @@ function Test-InstallPackageWithWebConfigDebugChanges {
     Assert-AreEqual "Data Source=ReleaseSQLServer;Initial Catalog=MyReleaseDB;Integrated Security=True" $addNode.connectionString
 }
 
-function Test-FSharpSimpleInstallWithContentFiles {
-    param(
-        $context
-    )
-
-    # Arrange
-    $p = New-FSharpLibrary
-
-    # Act
-    Install-Package jquery -Version 1.5 -Project $p.Name -Source $context.RepositoryPath
-
-    # Assert
-    Assert-Package $p jquery
-    Assert-SolutionPackage jquery
-    Assert-NotNull (Get-ProjectItem $p Scripts\jquery-1.5.js)
-    Assert-NotNull (Get-ProjectItem $p Scripts\jquery-1.5.min.js)
-}
-
-function Test-FSharpSimpleWithAssemblyReference {
-    # Arrange
-    $p = New-FSharpLibrary
-
-    # Act
-    Install-Package Antlr -Project $p.Name -Source $context.RepositoryPath
-
-    # Assert
-    Assert-Package $p Antlr
-    Assert-SolutionPackage Antlr
-    Assert-Reference $p Runtime
-}
-
 function Test-WebsiteInstallPackageWithRootNamespace {
     param(
         $context
@@ -491,13 +460,13 @@ function Test-AddBindingRedirectToWebsiteWithNonExistingOutputPath {
 function Test-InstallCanPipeToFSharpProjects {
     # Arrange
     $p = New-FSharpLibrary
+    Build-Solution # wait for project nomination
 
     # Act
     $p | Install-Package elmah -Version 1.1 -source $context.RepositoryPath
 
     # Assert
-    Assert-Package $p elmah
-    Assert-SolutionPackage elmah
+    Assert-NetCorePackageInLockFile $p elmah 1.1
 }
 
 function Test-PipingMultipleProjectsToInstall {
@@ -629,13 +598,11 @@ function Test-InstallPackageWithGacReferencesIntoMultipleProjectTypes {
     # Arrange
     $a = New-ClassLibrary
     $b = New-WebSite
-    $c = New-FSharpLibrary
-    $projects = @($a, $b, $c)
+    $projects = @($a, $b)
 
     # Act
     $a | Install-Package PackageWithGacReferences -Source $context.RepositoryRoot
     $b | Install-Package PackageWithGacReferences -Source $context.RepositoryRoot
-    $c | Install-Package PackageWithGacReferences -Source $context.RepositoryRoot
 
     # Assert
     $projects | %{ Assert-Reference $_ System.Web }

--- a/test/EndToEnd/tests/TabExpansionTest.ps1
+++ b/test/EndToEnd/tests/TabExpansionTest.ps1
@@ -35,12 +35,12 @@ function Test-TabExpansionForInstallPackageShowSuggestionsForProjectName {
 
     # Arrange
     $projectNames = @()
-    
+
     for ($i = 0; $i -lt 3; $i++) {
-        $project = New-ConsoleApplication 
+        $project = New-ConsoleApplication
         $projectNames = $projectNames + $project.Name
     }
-    
+
     $sortedProjectNames = $projectNames | Sort-Object
 
     # Act
@@ -60,11 +60,11 @@ function Test-TabExpansionForInstallPackageSortByDownloadCountDescending {
     # Assert
 
     $packages = $suggestions | % { Get-Package -Remote -Filter $_ } | Select-Object -First 1
-    
+
     $count = $packages.Count
     for ($i = 0; $i -lt $count-1; $i++) {
          Assert-True ($packages[$i].DownloadCount -ge $packages[$i+1].DownloadCount)
-    } 
+    }
 }
 
 # Tests for Uninstall-Package intellisense
@@ -87,12 +87,12 @@ function Test-TabExpansionForUninstallPackageShowSuggestionsForPackageId {
 function Test-TabExpansionForUninstallPackageShowSuggestionsForProjectNames {
     # Arrange
     $projectNames = @()
-    
+
     for ($i = 0; $i -lt 3; $i++) {
-        $project = New-ConsoleApplication 
+        $project = New-ConsoleApplication
         $projectNames = $projectNames + $project.Name
     }
-    
+
     $sortedProjectNames = $projectNames | Sort-Object
 
     # Act
@@ -155,7 +155,7 @@ function Test-TabExpansionForUpdatePackageWithVersionAndNoId {
     Install-Package 'NHibernate' -Project $project.Name -Version '2.1.2.4000'
 
     # Act
-    $suggestions = TabExpansion 'Update-Package -Version ' ''    
+    $suggestions = TabExpansion 'Update-Package -Version ' ''
 
     # Assert
     Assert-Null $suggestions
@@ -170,7 +170,7 @@ function Test-TabExpansionForUpdatePackageWithVersionOnlyShowsVersionsHigherThan
     $installedVersion = New-Object NuGet.Versioning.NuGetVersion("3.1.0.4000")
 
     # Act
-    $suggestions = TabExpansion 'Update-Package NHibernate -Version ' ''    
+    $suggestions = TabExpansion 'Update-Package NHibernate -Version ' ''
     $versions = $suggestions | %{ [NuGet.Versioning.NuGetVersion]::Parse($_) }
 
     # Assert
@@ -180,12 +180,12 @@ function Test-TabExpansionForUpdatePackageWithVersionOnlyShowsVersionsHigherThan
 function Test-TabExpansionForUpdatePackageShowSuggestionsForProjectNames {
     # Arrange
     $projectNames = @()
-    
+
     for ($i = 0; $i -lt 3; $i++) {
-        $project = New-ConsoleApplication 
+        $project = New-ConsoleApplication
         $projectNames = $projectNames + $project.Name
     }
-    
+
     $sortedProjectNames = $projectNames | Sort-Object
 
     # Act
@@ -201,7 +201,7 @@ function Test-TabExpansionForUpdatePackageShowSuggestionsForProjectNames {
 # Tests to make sure private functions & cmdlets do not show up in the intellisense
 
 function Test-TabExpansionDoNotSuggestFindPackage() {
-    
+
     # Act
     $suggestions = TabExpansion 'Find-Pac' 'Find-Pac'
 
@@ -210,7 +210,7 @@ function Test-TabExpansionDoNotSuggestFindPackage() {
 }
 
 function Test-TabExpansionDoNotSuggestGetProjectName() {
-    
+
     # Act
     $suggestions = TabExpansion 'GetProjectN' 'GetProjectN'
 
@@ -256,7 +256,7 @@ function Test-ComplexCustomTabExpansion {
         'John Doe' = 14
     }
 
-    Register-TabExpansion Foo @{ 
+    Register-TabExpansion Foo @{
         'Name' = { $ages.Keys }
         'Age' = { param($context) $ages[$context.Name] }
     }
@@ -308,16 +308,16 @@ function Test-TabExpansionForProjectsReturnsBothUniqueNamesAndSafeNames {
     # Assert
     Assert-AreEqual 4 $suggestions.Count
 
-    Assert-AreEqual 'Folder1\ProjectA' $suggestions[0] 
+    Assert-AreEqual 'Folder1\ProjectA' $suggestions[0]
     Assert-AreEqual 'Folder1\ProjectB'$suggestions[1]
-    Assert-AreEqual 'ProjectA' $suggestions[2] 
-    Assert-AreEqual 'ProjectB' $suggestions[3] 
-    
+    Assert-AreEqual 'ProjectA' $suggestions[2]
+    Assert-AreEqual 'ProjectB' $suggestions[3]
+
 }
 
-function Test-TabExpansionWorksWithOneProject { 
+function Test-TabExpansionWorksWithOneProject {
     # Arrange
-    $f = New-FSharpLibrary 'ProjectA'
+    $f = New-ClassLibrary 'ProjectA'
 
     # Act
     $suggestion = @(TabExpansion 'Get-Project -Name ')

--- a/test/EndToEnd/tests/UninstallPackageTest.ps1
+++ b/test/EndToEnd/tests/UninstallPackageTest.ps1
@@ -122,27 +122,17 @@ function Test-UninstallPackageWithNestedContentFiles {
 function Test-SimpleFSharpUninstall {
     # Arrange
     $p = New-FSharpLibrary
+    Build-Solution # wait for project nomination
 
     # Act
-    Install-Package Ninject -ProjectName $p.Name -Source $context.RepositoryPath
-    Assert-NotNull (Get-ProjectItem $p two.txt)
-    Assert-Package $p Ninject
-    Assert-SolutionPackage Ninject
+    Install-Package Ninject -ProjectName $p.Name -Source $context.RepositoryPath -version 2.0.1
+    Build-Solution # wait for assets file to be updated
+    Assert-NetCorePackageInLockFile $p Ninject 2.0.1
     Uninstall-Package Ninject -ProjectName $p.Name
+    Build-Solution # wait for assets file to be updated
 
     # Assert
-    Assert-Null (Get-ProjectPackage $p Ninject)
-    Assert-Null (Get-SolutionPackage Ninject)
-    Assert-Null (Get-ProjectItem $ two.txt)
-}
-
-function Test-FSharpDependentPackageUninstall {
-    # Arrange
-    $p = New-FSharpLibrary
-    $p | Install-Package -Source $context.RepositoryRoot PackageWithDependencyOnPrereleaseTestPackage -FileConflictAction Overwrite
-
-    # Act & Assert
-    Assert-Throws { $p | Uninstall-Package PreReleaseTestPackage } "Unable to uninstall 'PreReleaseTestPackage.1.0.0' because 'PackageWithDependencyOnPrereleaseTestPackage.1.0.0' depends on it."
+    Assert-NetCorePackageNotInLockFile $p Ninject
 }
 
 function Test-UninstallPackageThatIsNotInstalledThrows {
@@ -240,7 +230,7 @@ function UninstallSpecificPackageThrowsIfNotInstalledInProject {
 function Test-UninstallSpecificVersionOfPackage {
     # Arrange
     $p1 = New-ClassLibrary
-    $p2 = New-FSharpLibrary
+    $p2 = New-ClassLibrary
     $p1 | Install-Package Antlr -Version 3.1.1 -Source $context.RepositoryPath
     $p2 | Install-Package Antlr -Version 3.1.3.42154 -Source $context.RepositoryPath
 

--- a/test/EndToEnd/tests/UpdatePackageTest.ps1
+++ b/test/EndToEnd/tests/UpdatePackageTest.ps1
@@ -1,33 +1,33 @@
 function Test-UpdatingPackageInProjectDoesntRemoveFromSolutionIfInUse {
     # Arrange
     $p1 = New-WebApplication
-    $p2 = New-ClassLibrary 
+    $p2 = New-ClassLibrary
 
-    $oldReferences = @("Castle.Core", 
-                       "Castle.Services.Logging.log4netIntegration", 
-                       "Castle.Services.Logging.NLogIntegration", 
+    $oldReferences = @("Castle.Core",
+                       "Castle.Services.Logging.log4netIntegration",
+                       "Castle.Services.Logging.NLogIntegration",
                        "log4net",
                        "NLog")
-                       
+
     Install-Package Castle.Core -Version 1.2.0 -Project $p1.Name
     $oldReferences | %{ Assert-Reference $p1 $_ }
-    
+
     Install-Package Castle.Core -Version 1.2.0 -Project $p2.Name
     $oldReferences | %{ Assert-Reference $p2 $_ }
-    
+
     # Check that it's installed at solution level
     Assert-SolutionPackage Castle.Core 1.2.0
-    
+
     # Update the package in the first project
     Update-Package Castle.Core -Project $p1.Name -Version 2.5.1
     Assert-Reference $p1 Castle.Core 2.5.1.0
     Assert-SolutionPackage Castle.Core 2.5.1
     Assert-SolutionPackage Castle.Core 1.2.0
-    
+
     # Update the package in the second project
     Update-Package Castle.Core -Project $p2.Name -Version 2.5.1
     Assert-Reference $p2 Castle.Core 2.5.1.0
-    
+
     # Make sure that the old one is removed since no one is using it
     Assert-Null (Get-SolutionPackage Castle.Core 1.2.0)
 }
@@ -39,14 +39,14 @@ function Test-UpdatingPackageWithPackageSaveModeNuspec {
     $componentModel = Get-VSComponentModel
 	$setting = $componentModel.GetService([NuGet.Configuration.ISettings])
 
-    try {        
+    try {
         $p = New-ClassLibrary
 
         $setting.AddOrUpdate('config', [NuGet.Configuration.AddItem]::new('PackageSaveMode', 'nuspec'))
 
         Install-Package Castle.Core -Version 1.2.0 -Project $p.Name
         Assert-Package $p Castle.Core 1.2.0
-    
+
         # Act
         Update-Package Castle.Core
 
@@ -62,7 +62,7 @@ function Test-UpdatingPackageWithSharedDependency {
     param(
         $context
     )
-    
+
     # Arrange
     $p = New-ClassLibrary
 
@@ -77,7 +77,7 @@ function Test-UpdatingPackageWithSharedDependency {
     Assert-SolutionPackage C 1.0
     Assert-SolutionPackage A 2.0
     Assert-Null (Get-SolutionPackage A 1.0)
-    
+
     Update-Package D -Source $context.RepositoryPath
     # Make sure the new package is installed
     Assert-Package $p D 2.0
@@ -88,7 +88,7 @@ function Test-UpdatingPackageWithSharedDependency {
     Assert-SolutionPackage B 2.0
     Assert-SolutionPackage C 2.0
     Assert-SolutionPackage A 3.0
-    
+
     # Make sure the old package is removed
     Assert-Null (Get-ProjectPackage $p D 1.0)
     Assert-Null (Get-ProjectPackage $p B 1.0)
@@ -107,13 +107,13 @@ function Test-UpdatingPackageDependentPackageVersion {
     param(
         $context
     )
-    
+
     # Arrange
     $p = New-ClassLibrary
     Install-Package jquery.validation -Version 1.8
     Assert-Package $p jquery.validation 1.8
     Assert-Package $p jquery 1.4.1
-    
+
     # Act
     Update-Package jquery -version 2.0.3
 
@@ -127,7 +127,7 @@ function Test-UpdatingPackageWhatIf {
     param(
         $context
     )
-    
+
     # Arrange
     $p = New-ClassLibrary
     Install-Package D -Version 1.0 -Source $context.RepositoryPath
@@ -150,7 +150,7 @@ function Test-UpdatingPackageWithSharedDependencySimple {
     param(
         $context
     )
-    
+
     # Arrange
     $p = New-ClassLibrary
 
@@ -160,7 +160,7 @@ function Test-UpdatingPackageWithSharedDependencySimple {
     Assert-Package $p B 1.0
     Assert-SolutionPackage D 1.0
     Assert-SolutionPackage B 1.0
-    
+
     Update-Package D -Source $context.RepositoryPath
     # Make sure the new package is installed
     Assert-Package $p D 2.0
@@ -169,7 +169,7 @@ function Test-UpdatingPackageWithSharedDependencySimple {
     Assert-SolutionPackage D 2.0
     Assert-SolutionPackage B 2.0
     Assert-SolutionPackage C 2.0
-    
+
     # Make sure the old package is removed
     Assert-Null (Get-ProjectPackage $p D 1.0)
     Assert-Null (Get-ProjectPackage $p B 1.0)
@@ -186,7 +186,7 @@ function Test-UpdateWithoutPackageInstalledThrows {
 }
 
 #function Test-UpdateSolutionOnlyPackage {
-function UpdateSolutionOnlyPackage {    
+function UpdateSolutionOnlyPackage {
     param(
         $context
     )
@@ -198,7 +198,7 @@ function UpdateSolutionOnlyPackage {
     # Act
     $p | Install-Package SolutionOnlyPackage -Source $context.RepositoryRoot -Version 1.0
     Assert-SolutionPackage SolutionOnlyPackage 1.0
-    Assert-PathExists (Join-Path $solutionDir packages\SolutionOnlyPackage.1.0\file1.txt)    
+    Assert-PathExists (Join-Path $solutionDir packages\SolutionOnlyPackage.1.0\file1.txt)
 
     $p | Update-Package SolutionOnlyPackage -Source $context.RepositoryRoot
     Assert-Null (Get-SolutionPackage SolutionOnlyPackage 1.0)
@@ -219,7 +219,7 @@ function UpdateSolutionOnlyPackageWhenAmbiguous {
 
     Assert-SolutionPackage SolutionOnlyPackage 1.0
     Assert-SolutionPackage SolutionOnlyPackage 2.0
-        
+
     Assert-Throws { Update-Package SolutionOnlyPackage } "Unable to update 'SolutionOnlyPackage'. Found multiple versions installed."
 }
 
@@ -227,7 +227,7 @@ function Test-UpdatePackageResolvesDependenciesAcrossSources {
     param(
         $context
     )
-    
+
     # Arrange
     $p = New-ConsoleApplication
 
@@ -266,10 +266,10 @@ function Test-SubTreeUpdateWithDependencyInUse {
     param(
         $context
     )
-    
+
     # Arrange
     $p = New-ClassLibrary
-    
+
     # Act
     $p | Install-Package A -Source $context.RepositoryPath
     Assert-Package $p A 1.0
@@ -293,10 +293,10 @@ function Test-ComplexUpdateSubTree {
     param(
         $context
     )
-    
+
     # Arrange
     $p = New-ClassLibrary
-    
+
     # Act
     $p | Install-Package A -Source $context.RepositoryPath
     Assert-Package $p A 1.0
@@ -321,10 +321,10 @@ function Test-SubTreeUpdateWithConflict {
     param(
         $context
     )
-    
+
     # Arrange
     $p = New-ClassLibrary
-    
+
     # Act
     $p | Install-Package A -Source $context.RepositoryPath
     $p | Install-Package H -Source $context.RepositoryPath
@@ -348,10 +348,10 @@ function Test-AddingBindingRedirectAfterUpdate {
     param(
         $context
     )
-    
+
     # Arrange
     $p = New-WebApplication
-    
+
     # Act
     $p | Install-Package A -Source $context.RepositoryPath
     Assert-Package $p A 1.0
@@ -373,7 +373,7 @@ function Test-UpdatePackageWithOlderVersionOfSharedDependencyInUse {
     param(
         $context
     )
-    
+
     # Arrange
     $p = New-ClassLibrary
 
@@ -449,14 +449,14 @@ function Test-UpdatePackageAcceptsRelativePathSource {
     param(
         $context
     )
-    
+
     pushd
 
     # Arrange
     $p = New-ConsoleApplication
     Install-Package SkypePackage -Version 1.0 -Project $p.Name -Source $context.RepositoryRoot
     Assert-Package $p SkypePackage 1.0
-	
+
     $testPathName = Split-Path $context.TestRoot -Leaf
 
     cd $context.RepositoryRoot
@@ -475,7 +475,7 @@ function Test-UpdatePackageAcceptsRelativePathSource2 {
     param(
         $context
     )
-    
+
     pushd
 
     # Arrange
@@ -501,7 +501,7 @@ function Test-UpdateProjectLevelPackageNotInstalledInAnyProject {
 
     # Act
     $p1 | Install-Package Ninject -Version 2.0.1.0
-    Remove-ProjectItem $p1 packages.config    
+    Remove-ProjectItem $p1 packages.config
 
     # Assert
     Assert-Throws { Update-Package Ninject } "'Ninject' was not installed in any project. Update failed."
@@ -522,7 +522,7 @@ function Test-UpdateProjectLevelPackageNotInstalledInAnyProject {
 #
 #    # Act
 #	Update-Package Castle.Core -Version 2.5.1
-#	
+#
 #    # Assert
 #	Assert-Package $proj Castle.Core 2.5.1
 #}
@@ -555,7 +555,7 @@ function Test-UpdatePackageMissingPackageNoConsent {
 
 function Test-UpdatePackageInAllProjects {
     # Arrange
-    $p1 = New-FSharpLibrary
+    $p1 = New-ConsoleApplication
     $p2 = New-WebApplication
     $p3 = New-ClassLibrary
     $p4 = New-WebSite
@@ -597,11 +597,11 @@ function Test-UpdateAllPackagesInSolution {
     # Arrange
     $p1 = New-WebApplication
     $p2 = New-ClassLibrary
-    
+
     # Act
     $p1 | Install-Package A -Version 1.0 -Source $context.RepositoryPath
     $p2 | Install-Package C -Version 1.0 -Source $context.RepositoryPath
-    
+
     Assert-SolutionPackage A 1.0
     Assert-SolutionPackage B 1.0
     Assert-SolutionPackage C 1.0
@@ -638,6 +638,7 @@ function Test-UpdatePackageOnAnFSharpProjectWithMultiplePackages {
 
     # Arrange
     $p = New-FSharpLibrary
+    Build-Solution # wait for project nomination
 
     # Act
     $p | Install-Package SkypePackage -version 1.0 -source $context.RepositoryRoot
@@ -646,7 +647,7 @@ function Test-UpdatePackageOnAnFSharpProjectWithMultiplePackages {
     Update-Package -Source $context.RepositoryRoot -ProjectName $p.Name
 
     # Assert
-    Assert-Package $p SkypePackage 3.0
+    Assert-NetCorePackageInLockFile $p SkypePackage 3.0
 }
 
 function Test-UpdateScenariosWithConstraints {
@@ -666,7 +667,7 @@ function Test-UpdateScenariosWithConstraints {
     Add-PackageConstraint $p1 A "[1.0, 2.0)"
     Add-PackageConstraint $p2 D "[1.0]"
     Add-PackageConstraint $p3 E "[1.0]"
-     
+
     # Act
     Assert-Throws { Update-Package -Version 2.0 A -Source $context.RepositoryPath } "Unable to resolve 'A'. An additional constraint '(>= 1.0.0 && < 2.0.0)' defined in packages.config prevents this operation."
     Assert-Throws { Update-Package C -Source $context.RepositoryPath } "Unable to find a version of 'D' that is compatible with 'C 2.0.0 constraint: D (>= 2.0.0)'. 'D' has an additional constraint (= 1.0.0) defined in packages.config."
@@ -700,7 +701,7 @@ function Test-UpdateAllPackagesInSolutionWithSafeFlag {
     $p1 | Install-Package B -Version 1.0 -Source $context.RepositoryPath -IgnoreDependencies
     $p1 | Install-Package C -Version 1.0 -Source $context.RepositoryPath -IgnoreDependencies
 
-    # Act    
+    # Act
     Update-Package -Source $context.RepositoryPath -Safe
 
     # Assert
@@ -723,7 +724,7 @@ function Test-UpdatePackageWithSafeFlag {
     $p1 | Install-Package B -Version 1.0 -Source $context.RepositoryPath -IgnoreDependencies
     $p1 | Install-Package C -Version 1.0 -Source $context.RepositoryPath -IgnoreDependencies
 
-    # Act    
+    # Act
     Update-Package A -Source $context.RepositoryPath -Safe
 
     # Assert
@@ -847,7 +848,7 @@ function Test-UpdatePackageWithDependentsThatHaveNoAvailableUpdatesThrows {
 
 function Test-UpdatePackageThrowsWhenSourceIsInvalid {
     # Arrange
-    $p = New-WebApplication 
+    $p = New-WebApplication
     $p | Install-Package jQuery -Version 1.5.1 -Source $context.RepositoryPath
 
     # Act & Assert
@@ -976,13 +977,13 @@ function Test-UpdateAllPackagesInAllProjectsExecutesInstallPs1OnAllProjects {
     # The install.ps1 in the TestUpdatePackage package will add the project name to $global:InstallPackageMessages collection
     # The install.ps1 in the TestUpdateSecondPackage package will add the (project name + ' second') to $global:InstallPackageMessages collection
 
-	$global:InstallPackageMessages = $global:InstallPackageMessages | Sort-Object 
+	$global:InstallPackageMessages = $global:InstallPackageMessages | Sort-Object
     Assert-AreEqual 4 $global:InstallPackageMessages.Count
     Assert-AreEqual 'Project1' $global:InstallPackageMessages[0]
-	Assert-AreEqual 'Project1second' $global:InstallPackageMessages[1]    
+	Assert-AreEqual 'Project1second' $global:InstallPackageMessages[1]
     Assert-AreEqual 'Project2' $global:InstallPackageMessages[2]
 	Assert-AreEqual 'Project2second' $global:InstallPackageMessages[3]
-    
+
 
 	$global:UninstallPackageMessages = $global:UninstallPackageMessages | Sort-Object
     Assert-AreEqual 4 $global:UninstallPackageMessages.Count
@@ -1007,7 +1008,7 @@ function Test-UpdatePackageDoesNotConsiderPrereleasePackagesForUpdateIfFlagIsNot
     # Act
     $p | Install-Package -Source $context.RepositoryRoot -Id PreReleaseTestPackage -Version 1.0.0-a -Prerelease
     Assert-Package $p 'PreReleaseTestPackage'
-    $p | Update-Package -Source $context.RepositoryRoot -Id PreReleaseTestPackage 
+    $p | Update-Package -Source $context.RepositoryRoot -Id PreReleaseTestPackage
 
     # Assert
     Assert-Package $p PreReleaseTestPackage 1.0.0
@@ -1105,7 +1106,7 @@ function UpdatePackageDontMakeExcessiveNetworkRequests
     $a = New-ClassLibrary
 
     $nugetsource = "https://www.nuget.org/api/v2/"
-    
+
     $repository = Get-PackageRepository $nugetsource
     Assert-NotNull $repository
 
@@ -1118,7 +1119,7 @@ function UpdatePackageDontMakeExcessiveNetworkRequests
     $a | Install-Package "nugetpackageexplorer.types" -version 1.0 -source $nugetsource
     Assert-Package $a 'nugetpackageexplorer.types' '1.0'
 
-    try 
+    try
     {
         Register-ObjectEvent $packageDownloader "SendingRequest" $eventId { $global:numberOfRequests++; }
 
@@ -1129,7 +1130,7 @@ function UpdatePackageDontMakeExcessiveNetworkRequests
         Assert-Package $a 'nugetpackageexplorer.types' '2.0'
         Assert-AreEqual 1 $global:numberOfRequests
     }
-    finally 
+    finally
     {
         Unregister-Event $eventId -ea SilentlyContinue
         Remove-Variable 'numberOfRequests' -Scope 'Global' -ea SilentlyContinue
@@ -1179,7 +1180,7 @@ function Test-UpdatingSatellitePackageUpdatesReferences
     $solutionDir = Get-SolutionDir
     $packageDir = (Join-Path $solutionDir packages\Localized.1.0)
     Assert-PathExists (Join-Path $packageDir 'lib\net40\fr-FR\Main.1.0.resources.dll')
-    
+
 
     # Act
     $p | Update-Package Localized.fr-FR -Source $context.RepositoryPath
@@ -1215,7 +1216,7 @@ function Test-UpdatingSatellitePackageWhenMultipleVersionsInstalled
     $solutionDir = Get-SolutionDir
     Assert-PathExists (Join-Path $solutionDir 'packages\Localized.1.0\lib\net40\fr-FR\Main.1.0.resources.dll')
     Assert-PathExists (Join-Path $solutionDir 'packages\Localized.2.0\lib\net40\fr-FR\Main.2.0.resources.dll')
-    
+
     # Act - 2
     $p2 | Update-Package DependsOnLocalized -Source $context.RepositoryPath
 
@@ -1226,7 +1227,7 @@ function Test-UpdatingSatellitePackageWhenMultipleVersionsInstalled
 
     Assert-PathNotExists (Join-Path $solutionDir 'packages\Localized.2.0\')
     Assert-PathExists (Join-Path $solutionDir 'packages\Localized.3.0\lib\net40\fr-FR\Main.3.0.resources.dll')
-    
+
 }
 
 function Test-UpdatingPackagesWithDependenciesOnSatellitePackages
@@ -1235,7 +1236,7 @@ function Test-UpdatingPackagesWithDependenciesOnSatellitePackages
 
     # Arrange
     $p = New-ClassLibrary
-    
+
     # Act - 1
     $p | Install-Package Localized.LangPack -Version 1.0 -Source $context.RepositoryPath
 
@@ -1248,7 +1249,7 @@ function Test-UpdatingPackagesWithDependenciesOnSatellitePackages
     $solutionDir = Get-SolutionDir
     Assert-PathExists (Join-Path $solutionDir 'packages\Localized.1.0\lib\net40\ja-JP\Main.1.0.resources.dll')
     Assert-PathExists (Join-Path $solutionDir 'packages\Localized.1.0\lib\net40\fr-FR\Main.1.0.resources.dll')
-    
+
     # Act - 2
     $p | Update-Package Localized.LangPack -Source $context.RepositoryPath
 
@@ -1260,10 +1261,10 @@ function Test-UpdatingPackagesWithDependenciesOnSatellitePackages
 
     Assert-PathExists (Join-Path $solutionDir 'packages\Localized.2.0\lib\net40\ja-JP\Main.2.0.resources.dll')
     Assert-PathExists (Join-Path $solutionDir 'packages\Localized.2.0\lib\net40\fr-FR\Main.2.0.resources.dll')
-    
+
 }
 
-function Test-UpdatingMetaPackageRemovesSatelliteReferences 
+function Test-UpdatingMetaPackageRemovesSatelliteReferences
 {
     # Verification for work item 2313
     param ($context)
@@ -1273,7 +1274,7 @@ function Test-UpdatingMetaPackageRemovesSatelliteReferences
 
     # Act - 1
     $p | Install-Package A.Localized -Version 1.0.0 -Source $context.RepositoryPath
-    
+
     # Assert - 1
     Assert-Package $p A 1.0.0
     Assert-Package $p A.localized 1.0.0
@@ -1282,7 +1283,7 @@ function Test-UpdatingMetaPackageRemovesSatelliteReferences
 
     # Act - 2
     $p | Update-Package A.Localized -Source $context.RepositoryPath
-    
+
     # Assert - 1
     Assert-Package $p A 2.0.0
     Assert-Package $p A.localized 2.0.0
@@ -1296,10 +1297,10 @@ function Test-UpdatingMetaPackageRemovesSatelliteReferences
     Assert-PathNotExists (Join-Path $solutionDir 'packages\A.es.1.0.0\')
 }
 
-function Test-ReinstallPackageInvokeUninstallAndInstallScripts 
+function Test-ReinstallPackageInvokeUninstallAndInstallScripts
 {
-    param($context) 
-    
+    param($context)
+
     # Arrange
     $p = New-ClassLibrary
 
@@ -1316,14 +1317,14 @@ function Test-ReinstallPackageInvokeUninstallAndInstallScripts
     Assert-AreEqual 5 $global:UninstallScriptCount
 
     # clean up
-    Remove-Variable InstallScriptCount -Scope Global 
-    Remove-Variable UninstallScriptCount -Scope Global 
+    Remove-Variable InstallScriptCount -Scope Global
+    Remove-Variable UninstallScriptCount -Scope Global
 }
 
-function Test-ReinstallAllPackagesInAProjectInvokeUninstallAndInstallScripts 
+function Test-ReinstallAllPackagesInAProjectInvokeUninstallAndInstallScripts
 {
-    param($context) 
-    
+    param($context)
+
     # Arrange
     $p = New-ClassLibrary
 
@@ -1347,16 +1348,16 @@ function Test-ReinstallAllPackagesInAProjectInvokeUninstallAndInstallScripts
     Assert-AreEqual 7 $global:UninstallMagicScript
 
     # clean up
-    Remove-Variable InstallScriptCount -Scope Global 
-    Remove-Variable UninstallScriptCount -Scope Global 
-    Remove-Variable InstallMagicScript -Scope Global 
-    Remove-Variable UninstallMagicScript -Scope Global 
+    Remove-Variable InstallScriptCount -Scope Global
+    Remove-Variable UninstallScriptCount -Scope Global
+    Remove-Variable InstallMagicScript -Scope Global
+    Remove-Variable UninstallMagicScript -Scope Global
 }
 
-function Test-ReinstallPackageInAllProjectsInvokeUninstallAndInstallScripts 
+function Test-ReinstallPackageInAllProjectsInvokeUninstallAndInstallScripts
 {
-    param($context) 
-    
+    param($context)
+
     # Arrange
     $p = New-ClassLibrary
     $q = New-ConsoleApplication
@@ -1375,14 +1376,14 @@ function Test-ReinstallPackageInAllProjectsInvokeUninstallAndInstallScripts
     Assert-AreEqual 11 $global:UninstallScriptCount
 
     # clean up
-    Remove-Variable InstallScriptCount -Scope Global 
-    Remove-Variable UninstallScriptCount -Scope Global 
+    Remove-Variable InstallScriptCount -Scope Global
+    Remove-Variable UninstallScriptCount -Scope Global
 }
 
-function Test-ReinstallAllPackagesInAllProjectsInvokeUninstallAndInstallScripts 
+function Test-ReinstallAllPackagesInAllProjectsInvokeUninstallAndInstallScripts
 {
-    param($context) 
-    
+    param($context)
+
     # Arrange
     $p = New-ClassLibrary
     $q = New-ConsoleApplication
@@ -1407,17 +1408,17 @@ function Test-ReinstallAllPackagesInAllProjectsInvokeUninstallAndInstallScripts
     Assert-AreEqual 8 $global:UninstallMagicScript
 
     # clean up
-    Remove-Variable InstallScriptCount -Scope Global 
-    Remove-Variable UninstallScriptCount -Scope Global 
-    Remove-Variable InstallMagicScript -Scope Global 
-    Remove-Variable UninstallMagicScript -Scope Global 
+    Remove-Variable InstallScriptCount -Scope Global
+    Remove-Variable UninstallScriptCount -Scope Global
+    Remove-Variable InstallMagicScript -Scope Global
+    Remove-Variable UninstallMagicScript -Scope Global
 }
 
 #function Test-ReinstallPackageReinstallPrereleaseDependencyPackages
 function ReinstallPackageReinstallPrereleaseDependencyPackages
 {
-    param($context) 
-    
+    param($context)
+
     # Arrange
     $sol = New-Solution
 
@@ -1431,7 +1432,7 @@ function ReinstallPackageReinstallPrereleaseDependencyPackages
 
     Assert-Package $p2 "A" "1.0.0-alpha"
     Assert-Package $p2 "B" "2.0.0-beta"
-    
+
     # Act
     Update-Package A -Reinstall -Source $context.RepositoryPath
 
@@ -1573,8 +1574,8 @@ function Test-UpdatePackageWithContentInLicenseBlocks
 
     $name = 'PackageWithTextFile'
 
-    Install-Package $name -Version 1.0 -Source $context.RepositoryRoot 
-    
+    Install-Package $name -Version 1.0 -Source $context.RepositoryRoot
+
     $packages = Get-PackagesDir
     $fooFilePath = Join-Path $packages "$name.1.0\content\text"
 
@@ -1591,7 +1592,7 @@ This is a text file 1.0' > $fooFilePath
 
     # Assert
     Assert-Package $p $name '2.0'
-    
+
     $textFilePathInProject = Join-Path (Get-ProjectDir $p) 'text'
     Assert-True (Test-Path $textFilePathInProject)
 
@@ -1626,9 +1627,9 @@ function Test-UpdatePackagePreservesProjectConfigFile
 # Test update-package -WhatIf to downgrade an installed package.
 function Test-UpdatePackageDowngradeWhatIf {
     # Arrange
-    $project = New-ConsoleApplication    
-    
-    Install-Package TestUpdatePackage -Version 2.0.0.0 -Source $context.RepositoryRoot    
+    $project = New-ConsoleApplication
+
+    Install-Package TestUpdatePackage -Version 2.0.0.0 -Source $context.RepositoryRoot
     Assert-Package $project TestUpdatePackage '2.0.0.0'
 
     # Act
@@ -1644,7 +1645,7 @@ function Test-UpdatePackageWhatIfMultipleProjects {
     # Arrange
     $p1 = New-ConsoleApplication
     $p2 = New-ConsoleApplication
-    
+
     $p1 | Install-Package TestUpdatePackage -Version 1.0.0.0 -Source $context.RepositoryRoot
     $p2 | Install-Package TestUpdatePackage -Version 1.0.0.0 -Source $context.RepositoryRoot
     Assert-Package $p1 TestUpdatePackage '1.0.0.0'
@@ -1664,7 +1665,7 @@ function Test-UpdatingPackageInstallOrdering {
     param(
         $context
     )
-    
+
     # Arrange
     $p = New-ConsoleApplication
 
@@ -1675,13 +1676,13 @@ function Test-UpdatingPackageInstallOrdering {
     Assert-Package $p A 1.0
     Assert-Package $p B 1.0
     Assert-Package $p C 1.0
-    
+
     Update-Package A -Source $context.RepositoryPath
     # Make sure the new package is installed
     Assert-Package $p A 2.0
     Assert-Package $p B 2.0
     Assert-Package $p C 2.0
-    
+
     # Make sure the old package is removed
     Assert-Null (Get-ProjectPackage $p A 1.0)
     Assert-Null (Get-ProjectPackage $p B 1.0)
@@ -1700,7 +1701,7 @@ function Test-UpdatePackageWithToHighestPatchFlag {
     $p1 | Install-Package B -Version 1.0.0 -Source $context.RepositoryPath -IgnoreDependencies
     $p1 | Install-Package C -Version 1.0.0 -Source $context.RepositoryPath -IgnoreDependencies
 
-    # Act    
+    # Act
     Update-Package A -Source $context.RepositoryPath -Safe
 
     # Assert
@@ -1720,14 +1721,14 @@ function Test-UpdatePackageWithToHighestMinorFlag {
 
     # Arrange
     $p = New-ConsoleApplication
-    
+
 	$p | Install-Package A -Version 1.0.0 -Source $context.RepositoryPath
 
     Assert-Package $p A 1.0.0
     Assert-Package $p B 1.0.0
     Assert-Package $p C 1.0.0
 
-    # Act    
+    # Act
     Update-Package A -Source $context.RepositoryPath -ToHighestMinor
 
     # Assert
@@ -1771,7 +1772,7 @@ function Test-CanReinstallDelistedPackage
     $nugetsource = "https://www.nuget.org/api/v2/"
     $p = New-ClassLibrary
     $p | Install-Package Rx-Core -Version 2.2.5 -Source $nugetsource
-    
+
     # Act
     Update-Package Rx-Core -Reinstall -ProjectName $p.Name -Source $nugetsource
 


### PR DESCRIPTION
Since VS 16.6, all new F# projects are SDK style, so the tests project
templates were updated to also use SDK style projects. Tests were
updated as required, and tests that only make sense for non-SDK
style projects were deleted.

<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/10871

Regression? No

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

* Created new F# projects in another solution, then copied the project and code files, replacing our templates
* F# specific tests that tested packages.config behaviours were deleted
* Other packages.config tests were changed to not use F# projects
* Remaining tests (F#, PackageReference) were modified to work

## PR Checklist

- [X] PR has a meaningful title
- [X] PR has a linked issue.
- [X] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [X] N/A: Fixed tests

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [X] N/A
