### PR TITLE
E2E F# tests should wait for restore before running test

### DIFF
--- a/test/EndToEnd/vs.ps1
+++ b/test/EndToEnd/vs.ps1
@@ -512,7 +512,9 @@ function New-FSharpLibrary {
         [string]$SolutionFolder
     )
 
-    New-Project FSharpLibrary $ProjectName $SolutionFolder
+    $project = New-Project FSharpLibrary $ProjectName $SolutionFolder
+    Wait-OnNetCoreRestoreCompletion $project
+    return $project
 }
 
 function New-FSharpConsoleApplication {
@@ -521,7 +523,9 @@ function New-FSharpConsoleApplication {
         [string]$SolutionFolder
     )
 
-    New-Project FSharpConsoleApplication $ProjectName $SolutionFolder
+    $project = New-Project FSharpConsoleApplication $ProjectName $SolutionFolder
+    Wait-OnNetCoreRestoreCompletion $project
+    return $project
 }
 
 function New-WPFApplication {
@@ -949,7 +953,7 @@ function Get-VSFolderPath
 }
 
 function Get-MSBuildExe {
-    
-    $MSBuildRoot = Get-VSFolderPath 
+
+    $MSBuildRoot = Get-VSFolderPath
     Join-Path $MSBuildRoot "MsBuild\Current\bin\msbuild.exe"
 }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: NuGet/Home#10871

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Use the same `Wait-OnNetCoreRestoreCompletion` method as `New-NetCore*` to try to make tests more reliable

## PR Checklist

- [X] PR has a meaningful title
- [X] PR has a linked issue.
- [X] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [X] N/A: Fixing tests

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [X] N/A
