### PR TITLE
Add IVsProjectRestoreInfoSource and IVsSolutionRestoreService4 to coordinate bulk project changes restore 

### DIFF
--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager.Interop/IVsProjectRestoreInfoSource.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager.Interop/IVsProjectRestoreInfoSource.cs
@@ -36,6 +36,6 @@ namespace NuGet.SolutionRestoreManager
         /// The task will be failed, if the source runs into a problem, so it cannot get correct data to nominate (for exammple: DT build failed)
         /// </summary>
         /// <param name="cancellationToken">Cancellation token.</param>
-        Task WhenNominated(CancellationToken cancellationToken);
+        Task WhenNominatedAsync(CancellationToken cancellationToken);
     }
 }

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager.Interop/IVsProjectRestoreInfoSource.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager.Interop/IVsProjectRestoreInfoSource.cs
@@ -23,17 +23,17 @@ namespace NuGet.SolutionRestoreManager
         string Name { get; }
 
         /// <summary>
-        /// Whether the source needs to do some work that could lead to a nomination.
+        /// Whether the source needs to do some work that could lead to a nomination. <br/>
         /// This method may be called frequently, so it should be very efficient.
         /// </summary> 
         bool HasPendingNomination();
 
         /// <summary>
-        /// NuGet calls this method to wait on a potential nomination.
-        /// If the project has no pending restore data, it will return a completed task.
-        /// Otherwise, the task will be completed once the project nominates.
-        /// The task will be cancelled, if the source decide it no longer needs to nominate (for example: the restore state has no change)
-        /// The task will be failed, if the source runs into a problem, and it cannot get the correct data to nominate (for example: DT build failed)
+        /// NuGet calls this method to wait on a potential nomination. <br/>
+        /// If the project has no pending restore data, it will return a completed task. <br/>
+        /// Otherwise, the task will be completed once the project nominates. <br/>
+        /// The task will be cancelled, if the source decide it no longer needs to nominate (for example: the restore state has no change) <br/>
+        /// The task will be failed, if the source runs into a problem, and it cannot get the correct data to nominate (for example: DT build failed) <br/>
         /// </summary>
         /// <param name="cancellationToken">Cancellation token.</param>
         Task WhenNominatedAsync(CancellationToken cancellationToken);

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager.Interop/IVsProjectRestoreInfoSource.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager.Interop/IVsProjectRestoreInfoSource.cs
@@ -33,7 +33,7 @@ namespace NuGet.SolutionRestoreManager
         /// If the project has no pending restore data, it will return a completed task.
         /// Otherwise, the task will be completed once the project nominates.
         /// The task will be cancelled, if the source decide it no longer needs to nominate (for example: the restore state has no change)
-        /// The task will be failed, if the source runs into a problem, so it cannot get correct data to nominate (for exammple: DT build failed)
+        /// The task will be failed, if the source runs into a problem, and it cannot get the correct data to nominate (for example: DT build failed)
         /// </summary>
         /// <param name="cancellationToken">Cancellation token.</param>
         Task WhenNominatedAsync(CancellationToken cancellationToken);

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager.Interop/IVsProjectRestoreInfoSource.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager.Interop/IVsProjectRestoreInfoSource.cs
@@ -1,0 +1,41 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NuGet.SolutionRestoreManager
+{
+    /// <summary>
+    /// Represents a package restore service API for integration with a project system.
+    /// Implemented by the project-system.
+    /// </summary>
+    [ComImport]
+    [Guid("35AD5FF2-6AB7-48E9-BCC0-189042410FA6")]
+    public interface IVsProjectRestoreInfoSource
+    {
+        /// <summary>
+        /// Project Unique Name.
+        /// Must be equivalent to the name provided in the <see cref="IVsSolutionRestoreService3.NominateProjectAsync(string, IVsProjectRestoreInfo2, CancellationToken)"/> or equivalent.
+        /// </summary>
+        /// <remarks>Never <see langword="null"/>.</remarks>
+        string Name { get; }
+
+        /// <summary>
+        /// Whether the source needs to do some work that could lead to a nomination.
+        /// This method may be called frequently, so it should be very efficient.
+        /// </summary> 
+        bool HasPendingNomination();
+
+        /// <summary>
+        /// NuGet calls this method to wait on a potential nomination.
+        /// If the project has no pending restore data, it will return a completed task.
+        /// Otherwise, the task will be completed once the project nominates.
+        /// The task will be cancelled, if the source decide it no longer needs to nominate (for example: the restore state has no change)
+        /// The task will be failed, if the source runs into a problem, so it cannot get correct data to nominate (for exammple: DT build failed)
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        Task WhenNominated(CancellationToken cancellationToken);
+    }
+}

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager.Interop/IVsSolutionRestoreService4.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager.Interop/IVsSolutionRestoreService4.cs
@@ -1,0 +1,28 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NuGet.SolutionRestoreManager
+{
+    /// <summary>
+    /// Represents a package restore service API for integration with a project system.
+    /// Implemented by NuGet.
+    /// </summary>
+    [ComImport]
+    [Guid("72327117-6552-4685-BD7E-9C40A04B6EE5")]
+    public interface IVsSolutionRestoreService4
+    {
+        /// <summary>
+        /// A project system can call this service (optionally) to register itself to coordinate restore.
+        /// Each project can only register once. NuGet will call into the source to wait for nominations for restore.
+        /// NuGet will remove the registered object when a project is unloaded.
+        /// </summary>
+        /// <param name="restoreInfoSource">Represents a project specific info source</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        public Task RegisterRestoreInfoSourceAsync(IVsProjectRestoreInfoSource restoreInfoSource, CancellationToken cancellationToken);
+    }
+}

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager.Interop/IVsSolutionRestoreService4.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager.Interop/IVsSolutionRestoreService4.cs
@@ -17,12 +17,15 @@ namespace NuGet.SolutionRestoreManager
     public interface IVsSolutionRestoreService4
     {
         /// <summary>
-        /// A project system can call this service (optionally) to register itself to coordinate restore.
-        /// Each project can only register once. NuGet will call into the source to wait for nominations for restore.
+        /// A project system can call this service (optionally) to register itself to coordinate restore. <br/>
+        /// Each project can only register once. NuGet will call into the source to wait for nominations for restore. <br/>
         /// NuGet will remove the registered object when a project is unloaded.
         /// </summary>
         /// <param name="restoreInfoSource">Represents a project specific info source</param>
         /// <param name="cancellationToken">Cancellation token.</param>
+        /// <exception cref="InvalidOperationException">If the project has already been registered.</exception>
+        /// <exception cref="ArgumentNullException">If <paramref name="restoreInfoSource"/> is null. </exception>
+        /// <exception cref="ArgumentException">If <paramref name="restoreInfoSource"/>'s <see cref="IVsProjectRestoreInfoSource.Name"/> is <see langword="null"/>. </exception>
         public Task RegisterRestoreInfoSourceAsync(IVsProjectRestoreInfoSource restoreInfoSource, CancellationToken cancellationToken);
     }
 }

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager.Interop/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager.Interop/PublicAPI.Unshipped.txt
@@ -1,6 +1,6 @@
 NuGet.SolutionRestoreManager.IVsProjectRestoreInfoSource
 NuGet.SolutionRestoreManager.IVsProjectRestoreInfoSource.HasPendingNomination() -> bool
 NuGet.SolutionRestoreManager.IVsProjectRestoreInfoSource.Name.get -> string
-NuGet.SolutionRestoreManager.IVsProjectRestoreInfoSource.WhenNominated(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task
+NuGet.SolutionRestoreManager.IVsProjectRestoreInfoSource.WhenNominatedAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task
 NuGet.SolutionRestoreManager.IVsSolutionRestoreService4
 NuGet.SolutionRestoreManager.IVsSolutionRestoreService4.RegisterRestoreInfoSourceAsync(NuGet.SolutionRestoreManager.IVsProjectRestoreInfoSource restoreInfoSource, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager.Interop/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager.Interop/PublicAPI.Unshipped.txt
@@ -1,0 +1,6 @@
+NuGet.SolutionRestoreManager.IVsProjectRestoreInfoSource
+NuGet.SolutionRestoreManager.IVsProjectRestoreInfoSource.HasPendingNomination() -> bool
+NuGet.SolutionRestoreManager.IVsProjectRestoreInfoSource.Name.get -> string
+NuGet.SolutionRestoreManager.IVsProjectRestoreInfoSource.WhenNominated(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task
+NuGet.SolutionRestoreManager.IVsSolutionRestoreService4
+NuGet.SolutionRestoreManager.IVsSolutionRestoreService4.RegisterRestoreInfoSourceAsync(NuGet.SolutionRestoreManager.IVsProjectRestoreInfoSource restoreInfoSource, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/10807

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Add a new API to coordinate solution restore when bulk operations such as branch switch occur. 

Note that this is just the API so that the project-system can start working on their end. 
We'll only implement it on NuGet side later when the project system has implemented their side, because we need to perform a lot of tests on our end.
The implementation will be handled in https://github.com/NuGet/Home/issues/10678. 

Design at https://github.com/NuGet/Home/pull/10874.


<!-- Explain the proposal in sufficient detail with implementation details, interaction models, and clarification of corner cases. -->
#### Target scenario

Ex:
Given a solution with 3 projects.
Proj A -> Proj B -> Proj C.

Say a Directory.Build.Props is edited that affect *all* projects.
Say the nominations come in the following order:

Proj B
Proj C
Proj A

- When the nomination for B comes in, NuGet will trigger a restore that will affect projects B & A, given that A depends on B.
- While that first restore runs, it possible that C & A nominations have arrived. When NuGet receives these nominations and the previous restore completes, which happens last, a new restore will be kicked off, with the nomination data for C & A.
- This second restore will affect A, B & C. Project A & B have been restored twice, thus causing unnecessary work.
- In the ideal scenario, only 1 restore for each 3 projects is done.

#### Restore batching

At solution load, project-system runs DT builds and call the `IVsSolutionRestoreService` to nominate a project.
NuGet is aware of *all* projects that are supposed to nominate, so NuGet can wait for *all* projects to be nominated.
Currently NuGet has a sliding window to account for potentially failed projects.

When the solution is loaded, NuGet doesn't have an additional heuristic to determine whether there are other projects that might need a restore done.
The proposal is that each time NuGet determines a restore might need run, it checks whether there are *any* projects with pending *design time builds*, that *might* nominate. If yes, NuGet will wait.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception - No implementation here yet. Just defining the contract so that partner teams can depend on it.
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. --> 

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [x] Documentation PR or issue filled - https://github.com/NuGet/docs.microsoft.com-nuget/issues/2435
  - **OR**
  - [ ] N/A
