### PR TITLE
Update to new interop packages for compat with VS main

### DIFF
--- a/build/packages.targets
+++ b/build/packages.targets
@@ -3,7 +3,7 @@
         <MicrosoftBuildPackageVersion Condition="'$(MicrosoftBuildPackageVersion)' == ''">16.8.0</MicrosoftBuildPackageVersion>
         <NewtonsoftJsonPackageVersion Condition="$(NewtonsoftJsonPackageVersion) == ''">9.0.1</NewtonsoftJsonPackageVersion>
         <SystemPackagesVersion>4.3.0</SystemPackagesVersion>
-        <VSFrameworkVersion>17.0.0-preview-2-31221-277</VSFrameworkVersion>
+        <VSFrameworkVersion>17.0.0-previews-1-31318-023</VSFrameworkVersion>
         <VSServicesVersion>16.153.0</VSServicesVersion>
         <CryptographyPackagesVersion>5.0.0</CryptographyPackagesVersion>
         <NuGetCoreV2Version>2.14.0-rtm-832</NuGetCoreV2Version>
@@ -44,7 +44,7 @@
         <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.0.0" />
         <PackageReference Update="Microsoft.ServiceHub.Framework" Version="2.7.327-preview" />
         <PackageReference Update="Microsoft.TeamFoundationServer.ExtendedClient" Version="$(VSServicesVersion)" />
-        <PackageReference Update="Microsoft.VisualStudio.ComponentModelHost" Version="17.0.30-g62d2639511" />
+        <PackageReference Update="Microsoft.VisualStudio.ComponentModelHost" Version="17.0.61-g037ce4283b" />
         <PackageReference Update="Microsoft.VisualStudio.Composition" Version="16.4.11" />
         <PackageReference Update="Microsoft.VisualStudio.Editor" Version="17.0.24-g4265d215ae" />
         <PackageReference Update="Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime" Version="$(VSFrameworkVersion)" />
@@ -66,7 +66,7 @@
         <PackageReference Update="Microsoft.VisualStudio.Shell.Framework" Version="$(VSFrameworkVersion)" />
         <PackageReference Update="Microsoft.VisualStudio.Shell.Immutable.15.0" Version="15.0.25123-Dev15Preview" />
         <!-- 6.0 temp workaround -->
-        <PackageReference Update="Microsoft.VisualStudio.OLE.Interop" Version="17.0.0-preview-1-31108-209" ExcludeAssets="all" PrivateAssets="all" />
+        <PackageReference Update="Microsoft.VisualStudio.OLE.Interop" Version="17.0.0-preview-2-31221-277" ExcludeAssets="all" PrivateAssets="all" />
         <PackageReference Update="Microsoft.VisualStudio.Shell.Interop" Version="17.0.0-preview-1-31108-209" ExcludeAssets="all" PrivateAssets="all" NoWarn="NU1605" />
         <PackageReference Update="Microsoft.VisualStudio.Shell.Interop.8.0" Version="17.0.0-preview-1-31108-209" ExcludeAssets="all" PrivateAssets="all" NoWarn="NU1605" />
         <PackageReference Update="Microsoft.VisualStudio.Shell.Interop.10.0" Version="16.9.30921.310" ExcludeAssets="all" PrivateAssets="all" NoWarn="NU1605" />
@@ -90,7 +90,7 @@
         <PackageReference Update="Microsoft.VisualStudio.TextManager.Interop" Version="17.0.0-preview-1-31108-209" ExcludeAssets="all" PrivateAssets="all" />
         <PackageReference Update="Microsoft.VisualStudio.TextManager.Interop.8.0" Version="17.0.0-preview-1-31108-209" ExcludeAssets="all" PrivateAssets="all" />
         <PackageReference Update="Microsoft.VisualStudio.TextManager.Interop.10.0" Version="17.0.0-preview-1-31108-209" ExcludeAssets="all" PrivateAssets="all" />
-        <PackageReference Update="Microsoft.VisualStudio.Threading" Version="16.10.53-alpha" />
+        <PackageReference Update="Microsoft.VisualStudio.Threading" Version="17.0.15-alpha" />
         <PackageReference Update="Microsoft.VisualStudio.Utilities" Version="$(VSFrameworkVersion)" />
         <PackageReference Update="Microsoft.VisualStudio.VCProjectEngine" Version="$(VSFrameworkVersion)" />
         <PackageReference Update="Microsoft.VisualStudio.Workspace.VSIntegration" Version="17.0.7-preview-0001-g5492e466a9" />

--- a/src/NuGet.Clients/NuGet.Console/WpfConsole/WpfConsoleKeyProcessor.cs
+++ b/src/NuGet.Clients/NuGet.Console/WpfConsole/WpfConsoleKeyProcessor.cs
@@ -149,7 +149,6 @@ namespace NuGetConsole.Implementation.Console
         }
 
         [SuppressMessage("Microsoft.Maintainability", "CA1502:AvoidExcessiveComplexity")]
-        [SuppressMessage("Usage", "VSTHRD110:Observe result of async calls", Justification = "https://github.com/NuGet/Client.Engineering/issues/956")]
         protected override int InternalExec(ref Guid pguidCmdGroup, uint nCmdID, uint nCmdexecopt, IntPtr pvaIn, IntPtr pvaOut)
         {
             ThreadHelper.ThrowIfNotOnUIThread();
@@ -361,7 +360,8 @@ namespace NuGetConsole.Implementation.Console
                                 }
                                 else
                                 {
-                                    NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async delegate { await TriggerCompletionAsync(); });
+                                    NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async delegate { await TriggerCompletionAsync(); })
+                                                                           .PostOnFailure(nameof(WpfConsoleKeyProcessor));
                                 }
                             }
                             hr = VSConstants.S_OK;

--- a/src/NuGet.Clients/NuGet.Console/WpfConsole/WpfConsoleKeyProcessor.cs
+++ b/src/NuGet.Clients/NuGet.Console/WpfConsole/WpfConsoleKeyProcessor.cs
@@ -19,6 +19,7 @@ using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.Win32;
 using NuGet.PackageManagement.VisualStudio;
 using NuGet.VisualStudio;
+using NuGet.VisualStudio.Telemetry;
 using ActivityLog = Microsoft.VisualStudio.Shell.ActivityLog;
 using Task = System.Threading.Tasks.Task;
 

--- a/src/NuGet.Clients/NuGet.Console/WpfConsole/WpfConsoleKeyProcessor.cs
+++ b/src/NuGet.Clients/NuGet.Console/WpfConsole/WpfConsoleKeyProcessor.cs
@@ -360,7 +360,7 @@ namespace NuGetConsole.Implementation.Console
                                 }
                                 else
                                 {
-                                    NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async delegate { await TriggerCompletionAsync(); });
+                                    NuGetUIThreadHelper.JoinableTaskFactory.Run(async delegate { await TriggerCompletionAsync(); });
                                 }
                             }
                             hr = VSConstants.S_OK;

--- a/src/NuGet.Clients/NuGet.Console/WpfConsole/WpfConsoleKeyProcessor.cs
+++ b/src/NuGet.Clients/NuGet.Console/WpfConsole/WpfConsoleKeyProcessor.cs
@@ -149,6 +149,7 @@ namespace NuGetConsole.Implementation.Console
         }
 
         [SuppressMessage("Microsoft.Maintainability", "CA1502:AvoidExcessiveComplexity")]
+        [SuppressMessage("Usage", "VSTHRD110:Observe result of async calls", Justification = "https://github.com/NuGet/Client.Engineering/issues/956")]
         protected override int InternalExec(ref Guid pguidCmdGroup, uint nCmdID, uint nCmdexecopt, IntPtr pvaIn, IntPtr pvaOut)
         {
             ThreadHelper.ThrowIfNotOnUIThread();
@@ -360,7 +361,7 @@ namespace NuGetConsole.Implementation.Console
                                 }
                                 else
                                 {
-                                    NuGetUIThreadHelper.JoinableTaskFactory.Run(async delegate { await TriggerCompletionAsync(); });
+                                    NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async delegate { await TriggerCompletionAsync(); });
                                 }
                             }
                             hr = VSConstants.S_OK;

--- a/src/NuGet.Clients/NuGet.Console/Xamls/ConsoleContainer.xaml.cs
+++ b/src/NuGet.Clients/NuGet.Console/Xamls/ConsoleContainer.xaml.cs
@@ -15,6 +15,7 @@ using NuGet.VisualStudio;
 using NuGet.VisualStudio.Common;
 using NuGet.VisualStudio.Common.Telemetry.PowerShell;
 using NuGet.VisualStudio.Internal.Contracts;
+using NuGet.VisualStudio.Telemetry;
 
 namespace NuGetConsole
 {

--- a/src/NuGet.Clients/NuGet.Console/Xamls/ConsoleContainer.xaml.cs
+++ b/src/NuGet.Clients/NuGet.Console/Xamls/ConsoleContainer.xaml.cs
@@ -58,7 +58,7 @@ namespace NuGetConsole
                             RootLayout.Children.Add(new PackageRestoreBar(_solutionManager, packageRestoreManager));
                             RootLayout.Children.Add(new RestartRequestBar(deleteOnRestartManager, shell));
                         });
-                }, VsTaskRunContext.UIThreadIdlePriority).FileAndForget("ConsoleContainer");
+                }, VsTaskRunContext.UIThreadIdlePriority).PostOnFailure(nameof(ConsoleContainer));
 
             // Set DynamicResource binding in code
             // The reason we can't set it in XAML is that the VsBrushes class come from either

--- a/src/NuGet.Clients/NuGet.Console/Xamls/ConsoleContainer.xaml.cs
+++ b/src/NuGet.Clients/NuGet.Console/Xamls/ConsoleContainer.xaml.cs
@@ -58,7 +58,7 @@ namespace NuGetConsole
                             RootLayout.Children.Add(new PackageRestoreBar(_solutionManager, packageRestoreManager));
                             RootLayout.Children.Add(new RestartRequestBar(deleteOnRestartManager, shell));
                         });
-                }, VsTaskRunContext.UIThreadIdlePriority);
+                }, VsTaskRunContext.UIThreadIdlePriority).FileAndForget("ConsoleContainer");
 
             // Set DynamicResource binding in code
             // The reason we can't set it in XAML is that the VsBrushes class come from either

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailControlModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailControlModel.cs
@@ -532,7 +532,6 @@ namespace NuGet.PackageManagement.UI
 
         private DisplayVersion _selectedVersion;
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "VSTHRD110:Observe result of async calls", Justification = "https://github.com/NuGet/Client.Engineering/issues/956")]
         public DisplayVersion SelectedVersion
         {
             get { return _selectedVersion; }
@@ -557,7 +556,8 @@ namespace NuGet.PackageManagement.UI
                             PackageMetadata = detailedPackageMetadata;
                         }
 
-                        NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(() => SelectedVersionChangedAsync(_searchResultPackage, _selectedVersion.Version, loadCts.Token).AsTask());
+                        NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(() => SelectedVersionChangedAsync(_searchResultPackage, _selectedVersion.Version, loadCts.Token).AsTask())
+                                                               .PostOnFailure(nameof(DetailControlModel));
                     }
 
                     OnPropertyChanged(nameof(SelectedVersion));

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailControlModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailControlModel.cs
@@ -556,7 +556,7 @@ namespace NuGet.PackageManagement.UI
                             PackageMetadata = detailedPackageMetadata;
                         }
 
-                        NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(() => SelectedVersionChangedAsync(_searchResultPackage, _selectedVersion.Version, loadCts.Token).AsTask());
+                        NuGetUIThreadHelper.JoinableTaskFactory.Run(() => SelectedVersionChangedAsync(_searchResultPackage, _selectedVersion.Version, loadCts.Token).AsTask());
                     }
 
                     OnPropertyChanged(nameof(SelectedVersion));

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailControlModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailControlModel.cs
@@ -532,6 +532,7 @@ namespace NuGet.PackageManagement.UI
 
         private DisplayVersion _selectedVersion;
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "VSTHRD110:Observe result of async calls", Justification = "https://github.com/NuGet/Client.Engineering/issues/956")]
         public DisplayVersion SelectedVersion
         {
             get { return _selectedVersion; }
@@ -556,7 +557,7 @@ namespace NuGet.PackageManagement.UI
                             PackageMetadata = detailedPackageMetadata;
                         }
 
-                        NuGetUIThreadHelper.JoinableTaskFactory.Run(() => SelectedVersionChangedAsync(_searchResultPackage, _selectedVersion.Version, loadCts.Token).AsTask());
+                        NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(() => SelectedVersionChangedAsync(_searchResultPackage, _selectedVersion.Version, loadCts.Token).AsTask());
                     }
 
                     OnPropertyChanged(nameof(SelectedVersion));

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/NuGetPackageManagerControlSearchTask.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/NuGetPackageManagerControlSearchTask.cs
@@ -24,7 +24,6 @@ namespace NuGet.PackageManagement.UI
 
         }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "VSTHRD110:Observe result of async calls", Justification = "https://github.com/NuGet/Client.Engineering/issues/956")]
         public void Start()
         {
             SetStatus(VsSearchTaskStatus.Started);
@@ -41,7 +40,7 @@ namespace NuGet.PackageManagement.UI
 
                 await _packageManagerControl.SearchPackagesAndRefreshUpdateCountAsync(searchText: _searchQuery.SearchString, useCachedPackageMetadata: true, pSearchCallback: _searchCallback, searchTask: this);
                 SetStatus(VsSearchTaskStatus.Completed);
-            });
+            }).PostOnFailure(nameof(NuGetPackageManagerControlSearchTask));
         }
 
         public uint Id { get; private set; }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/NuGetPackageManagerControlSearchTask.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/NuGetPackageManagerControlSearchTask.cs
@@ -4,6 +4,7 @@
 using System.Threading;
 using Microsoft.VisualStudio.Shell.Interop;
 using NuGet.VisualStudio;
+using NuGet.VisualStudio.Telemetry;
 
 namespace NuGet.PackageManagement.UI
 {

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/NuGetPackageManagerControlSearchTask.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/NuGetPackageManagerControlSearchTask.cs
@@ -23,10 +23,12 @@ namespace NuGet.PackageManagement.UI
             SetStatus(VsSearchTaskStatus.Created);
 
         }
+
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "VSTHRD110:Observe result of async calls", Justification = "https://github.com/NuGet/Client.Engineering/issues/956")]
         public void Start()
         {
             SetStatus(VsSearchTaskStatus.Started);
-            NuGetUIThreadHelper.JoinableTaskFactory.Run(async () =>
+            NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async () =>
             {
                 await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/NuGetPackageManagerControlSearchTask.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/NuGetPackageManagerControlSearchTask.cs
@@ -26,7 +26,7 @@ namespace NuGet.PackageManagement.UI
         public void Start()
         {
             SetStatus(VsSearchTaskStatus.Started);
-            NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            NuGetUIThreadHelper.JoinableTaskFactory.Run(async () =>
             {
                 await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/DetailControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/DetailControl.xaml.cs
@@ -72,7 +72,7 @@ namespace NuGet.PackageManagement.UI
 
         public void Refresh()
         {
-            NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            NuGetUIThreadHelper.JoinableTaskFactory.Run(async () =>
             {
                 await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/DetailControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/DetailControl.xaml.cs
@@ -70,7 +70,6 @@ namespace NuGet.PackageManagement.UI
             _root.ScrollToHome();
         }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "VSTHRD110:Observe result of async calls", Justification = "https://github.com/NuGet/Client.Engineering/issues/956")]
         public void Refresh()
         {
             NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async () =>
@@ -85,7 +84,7 @@ namespace NuGet.PackageManagement.UI
                 {
                     await model.RefreshAsync(CancellationToken.None);
                 }
-            });
+            }).PostOnFailure(nameof(DetailControl));
         }
 
         private void ProjectInstallButtonClicked(object sender, EventArgs e)

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/DetailControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/DetailControl.xaml.cs
@@ -9,6 +9,7 @@ using System.Windows.Documents;
 using System.Windows.Input;
 using NuGet.ProjectManagement;
 using NuGet.VisualStudio;
+using NuGet.VisualStudio.Telemetry;
 
 namespace NuGet.PackageManagement.UI
 {

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/DetailControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/DetailControl.xaml.cs
@@ -70,9 +70,10 @@ namespace NuGet.PackageManagement.UI
             _root.ScrollToHome();
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "VSTHRD110:Observe result of async calls", Justification = "https://github.com/NuGet/Client.Engineering/issues/956")]
         public void Refresh()
         {
-            NuGetUIThreadHelper.JoinableTaskFactory.Run(async () =>
+            NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async () =>
             {
                 await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
@@ -642,7 +642,7 @@ namespace NuGet.PackageManagement.UI
                 var last = _scrollViewer.ViewportHeight + first;
                 if (_scrollViewer.ViewportHeight > 0 && last >= Items.Count)
                 {
-                    NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(() =>
+                    NuGetUIThreadHelper.JoinableTaskFactory.Run(() =>
                         LoadItemsAsync(selectedPackageItem: null, token: CancellationToken.None)
                     );
                 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
@@ -634,6 +634,7 @@ namespace NuGet.PackageManagement.UI
             _scrollViewer.ScrollChanged += ScrollViewer_ScrollChanged;
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "VSTHRD110:Observe result of async calls", Justification = "https://github.com/NuGet/Client.Engineering/issues/956")]
         private void ScrollViewer_ScrollChanged(object sender, ScrollChangedEventArgs e)
         {
             if (_loader?.State.LoadingStatus == LoadingStatus.Ready)
@@ -642,7 +643,7 @@ namespace NuGet.PackageManagement.UI
                 var last = _scrollViewer.ViewportHeight + first;
                 if (_scrollViewer.ViewportHeight > 0 && last >= Items.Count)
                 {
-                    NuGetUIThreadHelper.JoinableTaskFactory.Run(() =>
+                    NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(() =>
                         LoadItemsAsync(selectedPackageItem: null, token: CancellationToken.None)
                     );
                 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
@@ -19,6 +19,7 @@ using NuGet.Common;
 using NuGet.PackageManagement.VisualStudio;
 using NuGet.VisualStudio;
 using NuGet.VisualStudio.Internal.Contracts;
+using NuGet.VisualStudio.Telemetry;
 using Mvs = Microsoft.VisualStudio.Shell;
 using Resx = NuGet.PackageManagement.UI;
 using Task = System.Threading.Tasks.Task;

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
@@ -634,7 +634,6 @@ namespace NuGet.PackageManagement.UI
             _scrollViewer.ScrollChanged += ScrollViewer_ScrollChanged;
         }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "VSTHRD110:Observe result of async calls", Justification = "https://github.com/NuGet/Client.Engineering/issues/956")]
         private void ScrollViewer_ScrollChanged(object sender, ScrollChangedEventArgs e)
         {
             if (_loader?.State.LoadingStatus == LoadingStatus.Ready)
@@ -645,7 +644,7 @@ namespace NuGet.PackageManagement.UI
                 {
                     NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(() =>
                         LoadItemsAsync(selectedPackageItem: null, token: CancellationToken.None)
-                    );
+                    ).PostOnFailure(nameof(InfiniteScrollList));
                 }
             }
         }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PRMigratorBar.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PRMigratorBar.xaml.cs
@@ -74,9 +74,10 @@ namespace NuGet.PackageManagement.UI
             ShowMessage(message.FormatWithCode());
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "VSTHRD110:Observe result of async calls", Justification = "https://github.com/NuGet/Client.Engineering/issues/956")]
         private void ShowMessage(string message)
         {
-            NuGetUIThreadHelper.JoinableTaskFactory.Run(async () =>
+            NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async () =>
             {
                 await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
                 UpgradeMessage.Text = message;
@@ -88,9 +89,10 @@ namespace NuGet.PackageManagement.UI
             return FileConflictAction.IgnoreAll;
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "VSTHRD110:Observe result of async calls", Justification = "https://github.com/NuGet/Client.Engineering/issues/956")]
         private void UserControl_Loaded(object sender, RoutedEventArgs e)
         {
-            NuGetUIThreadHelper.JoinableTaskFactory.Run(async () =>
+            NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async () =>
             {
                 await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PRMigratorBar.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PRMigratorBar.xaml.cs
@@ -74,14 +74,13 @@ namespace NuGet.PackageManagement.UI
             ShowMessage(message.FormatWithCode());
         }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "VSTHRD110:Observe result of async calls", Justification = "https://github.com/NuGet/Client.Engineering/issues/956")]
         private void ShowMessage(string message)
         {
             NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async () =>
             {
                 await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
                 UpgradeMessage.Text = message;
-            });
+            }).PostOnFailure(nameof(PRMigratorBar));
         }
 
         public FileConflictAction ResolveFileConflict(string message)
@@ -89,7 +88,6 @@ namespace NuGet.PackageManagement.UI
             return FileConflictAction.IgnoreAll;
         }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "VSTHRD110:Observe result of async calls", Justification = "https://github.com/NuGet/Client.Engineering/issues/956")]
         private void UserControl_Loaded(object sender, RoutedEventArgs e)
         {
             NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async () =>
@@ -104,7 +102,7 @@ namespace NuGet.PackageManagement.UI
                 {
                     HideMigratorBar();
                 }
-            });
+            }).PostOnFailure(nameof(PRMigratorBar));
         }
 
         private async Task<bool> ShouldShowUpgradeProjectAsync()

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PRMigratorBar.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PRMigratorBar.xaml.cs
@@ -76,7 +76,7 @@ namespace NuGet.PackageManagement.UI
 
         private void ShowMessage(string message)
         {
-            NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            NuGetUIThreadHelper.JoinableTaskFactory.Run(async () =>
             {
                 await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
                 UpgradeMessage.Text = message;
@@ -90,7 +90,7 @@ namespace NuGet.PackageManagement.UI
 
         private void UserControl_Loaded(object sender, RoutedEventArgs e)
         {
-            NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            NuGetUIThreadHelper.JoinableTaskFactory.Run(async () =>
             {
                 await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageRestoreBar.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageRestoreBar.xaml.cs
@@ -78,7 +78,6 @@ namespace NuGet.PackageManagement.UI
             }
         }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "VSTHRD110:Observe result of async calls", Justification = "https://github.com/NuGet/Client.Engineering/issues/956")]
         private void UserControl_Loaded(object sender, RoutedEventArgs e)
         {
             if (_packageRestoreManager != null)
@@ -99,7 +98,7 @@ namespace NuGet.PackageManagement.UI
                         var unwrappedException = ExceptionUtility.Unwrap(ex);
                         ShowErrorUI(unwrappedException.Message);
                     }
-                });
+                }).PostOnFailure(nameof(PackageRestoreBar));
             }
         }
 
@@ -131,10 +130,9 @@ namespace NuGet.PackageManagement.UI
             }
         }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "VSTHRD110:Observe result of async calls", Justification = "https://github.com/NuGet/Client.Engineering/issues/956")]
         private void OnRestoreLinkClick(object sender, RoutedEventArgs e)
         {
-            NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(() => UIRestorePackagesAsync(CancellationToken.None));
+            NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(() => UIRestorePackagesAsync(CancellationToken.None)).PostOnFailure(nameof(PackageRestoreBar));
         }
 
         public async Task<bool> UIRestorePackagesAsync(CancellationToken token)
@@ -250,14 +248,13 @@ namespace NuGet.PackageManagement.UI
             StatusMessage.Text = UI.Resources.PackageRestoreErrorTryAgain + " " + error;
         }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "VSTHRD110:Observe result of async calls", Justification = "https://github.com/NuGet/Client.Engineering/issues/956")]
         private void ShowMessage(string message)
         {
             NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async () =>
             {
                 await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
                 StatusMessage.Text = message;
-            });
+            }).PostOnFailure(nameof(PackageRestoreBar));
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageRestoreBar.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageRestoreBar.xaml.cs
@@ -16,6 +16,7 @@ using NuGet.Packaging;
 using NuGet.ProjectManagement;
 using NuGet.VisualStudio;
 using NuGet.VisualStudio.Internal.Contracts;
+using NuGet.VisualStudio.Telemetry;
 using VsBrushes = Microsoft.VisualStudio.Shell.VsBrushes;
 
 namespace NuGet.PackageManagement.UI

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageRestoreBar.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageRestoreBar.xaml.cs
@@ -78,11 +78,12 @@ namespace NuGet.PackageManagement.UI
             }
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "VSTHRD110:Observe result of async calls", Justification = "https://github.com/NuGet/Client.Engineering/issues/956")]
         private void UserControl_Loaded(object sender, RoutedEventArgs e)
         {
             if (_packageRestoreManager != null)
             {
-                NuGetUIThreadHelper.JoinableTaskFactory.Run(async delegate
+                NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async delegate
                 {
                     try
                     {
@@ -130,9 +131,10 @@ namespace NuGet.PackageManagement.UI
             }
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "VSTHRD110:Observe result of async calls", Justification = "https://github.com/NuGet/Client.Engineering/issues/956")]
         private void OnRestoreLinkClick(object sender, RoutedEventArgs e)
         {
-            NuGetUIThreadHelper.JoinableTaskFactory.Run(() => UIRestorePackagesAsync(CancellationToken.None));
+            NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(() => UIRestorePackagesAsync(CancellationToken.None));
         }
 
         public async Task<bool> UIRestorePackagesAsync(CancellationToken token)
@@ -248,9 +250,10 @@ namespace NuGet.PackageManagement.UI
             StatusMessage.Text = UI.Resources.PackageRestoreErrorTryAgain + " " + error;
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "VSTHRD110:Observe result of async calls", Justification = "https://github.com/NuGet/Client.Engineering/issues/956")]
         private void ShowMessage(string message)
         {
-            NuGetUIThreadHelper.JoinableTaskFactory.Run(async () =>
+            NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async () =>
             {
                 await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
                 StatusMessage.Text = message;

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageRestoreBar.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageRestoreBar.xaml.cs
@@ -82,7 +82,7 @@ namespace NuGet.PackageManagement.UI
         {
             if (_packageRestoreManager != null)
             {
-                NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async delegate
+                NuGetUIThreadHelper.JoinableTaskFactory.Run(async delegate
                 {
                     try
                     {
@@ -132,7 +132,7 @@ namespace NuGet.PackageManagement.UI
 
         private void OnRestoreLinkClick(object sender, RoutedEventArgs e)
         {
-            NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(() => UIRestorePackagesAsync(CancellationToken.None));
+            NuGetUIThreadHelper.JoinableTaskFactory.Run(() => UIRestorePackagesAsync(CancellationToken.None));
         }
 
         public async Task<bool> UIRestorePackagesAsync(CancellationToken token)
@@ -250,7 +250,7 @@ namespace NuGet.PackageManagement.UI
 
         private void ShowMessage(string message)
         {
-            NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            NuGetUIThreadHelper.JoinableTaskFactory.Run(async () =>
             {
                 await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
                 StatusMessage.Text = message;

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/ProductUpdateBar.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/ProductUpdateBar.xaml.cs
@@ -8,6 +8,7 @@ using System.Windows.Controls;
 using System.Windows.Threading;
 using Microsoft.VisualStudio.Shell;
 using NuGet.VisualStudio;
+using NuGet.VisualStudio.Telemetry;
 
 namespace NuGet.PackageManagement.UI
 {

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/ProductUpdateBar.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/ProductUpdateBar.xaml.cs
@@ -63,7 +63,7 @@ namespace NuGet.PackageManagement.UI
             NuGetUIThreadHelper.JoinableTaskFactory.StartOnIdle(() =>
             {
                 _productUpdateService.Update();
-            }).FileAndForget("OnUpdateLinkClick");
+            }).PostOnFailure(nameof(ProductUpdateBar));
         }
 
         private void OnDeclineUpdateLinkClick(object sender, RoutedEventArgs e)

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/ProductUpdateBar.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/ProductUpdateBar.xaml.cs
@@ -63,7 +63,7 @@ namespace NuGet.PackageManagement.UI
             NuGetUIThreadHelper.JoinableTaskFactory.StartOnIdle(() =>
             {
                 _productUpdateService.Update();
-            });
+            }).FileAndForget("OnUpdateLinkClick");
         }
 
         private void OnDeclineUpdateLinkClick(object sender, RoutedEventArgs e)

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/RestartRequestBar.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/RestartRequestBar.xaml.cs
@@ -71,7 +71,6 @@ namespace NuGet.PackageManagement.UI
             UpdateRestartBar(packageDirectoriesMarkedForDeletion);
         }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "VSTHRD110:Observe result of async calls", Justification = "https://github.com/NuGet/Client.Engineering/issues/956")]
         private void UpdateRestartBar(IReadOnlyList<string> packagesMarkedForDeletion)
         {
             NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async () =>
@@ -98,7 +97,7 @@ namespace NuGet.PackageManagement.UI
                 {
                     RestartBar.Visibility = Visibility.Collapsed;
                 }
-            });
+            }).PostOnFailure(nameof(RestartRequestBar));
         }
 
         private void ExecuteRestart(object sender, EventArgs e)
@@ -149,14 +148,13 @@ namespace NuGet.PackageManagement.UI
             return FileConflictAction.IgnoreAll;
         }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "VSTHRD110:Observe result of async calls", Justification = "https://github.com/NuGet/Client.Engineering/issues/956")]
         private void ShowMessage(string message)
         {
             NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async () =>
             {
                 await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
                 RequestRestartMessage.Text = message;
-            });
+            }).PostOnFailure(nameof(RestartRequestBar));
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/RestartRequestBar.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/RestartRequestBar.xaml.cs
@@ -13,6 +13,7 @@ using NuGet.Common;
 using NuGet.Packaging;
 using NuGet.ProjectManagement;
 using NuGet.VisualStudio;
+using NuGet.VisualStudio.Telemetry;
 using VsBrushes = Microsoft.VisualStudio.Shell.VsBrushes;
 
 namespace NuGet.PackageManagement.UI

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/RestartRequestBar.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/RestartRequestBar.xaml.cs
@@ -73,7 +73,7 @@ namespace NuGet.PackageManagement.UI
 
         private void UpdateRestartBar(IReadOnlyList<string> packagesMarkedForDeletion)
         {
-            NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            NuGetUIThreadHelper.JoinableTaskFactory.Run(async () =>
             {
                 await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
                 var count = packagesMarkedForDeletion.Count;
@@ -150,7 +150,7 @@ namespace NuGet.PackageManagement.UI
 
         private void ShowMessage(string message)
         {
-            NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            NuGetUIThreadHelper.JoinableTaskFactory.Run(async () =>
             {
                 await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
                 RequestRestartMessage.Text = message;

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/RestartRequestBar.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/RestartRequestBar.xaml.cs
@@ -71,9 +71,10 @@ namespace NuGet.PackageManagement.UI
             UpdateRestartBar(packageDirectoriesMarkedForDeletion);
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "VSTHRD110:Observe result of async calls", Justification = "https://github.com/NuGet/Client.Engineering/issues/956")]
         private void UpdateRestartBar(IReadOnlyList<string> packagesMarkedForDeletion)
         {
-            NuGetUIThreadHelper.JoinableTaskFactory.Run(async () =>
+            NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async () =>
             {
                 await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
                 var count = packagesMarkedForDeletion.Count;
@@ -148,9 +149,10 @@ namespace NuGet.PackageManagement.UI
             return FileConflictAction.IgnoreAll;
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "VSTHRD110:Observe result of async calls", Justification = "https://github.com/NuGet/Client.Engineering/issues/956")]
         private void ShowMessage(string message)
         {
-            NuGetUIThreadHelper.JoinableTaskFactory.Run(async () =>
+            NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async () =>
             {
                 await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
                 RequestRestartMessage.Text = message;

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Handlers/ProjectRetargetingHandler.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Handlers/ProjectRetargetingHandler.cs
@@ -15,6 +15,7 @@ using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using NuGet.ProjectManagement;
 using NuGet.VisualStudio;
+using NuGet.VisualStudio.Telemetry;
 
 namespace NuGet.PackageManagement.VisualStudio
 {

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Handlers/ProjectRetargetingHandler.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Handlers/ProjectRetargetingHandler.cs
@@ -306,7 +306,7 @@ namespace NuGet.PackageManagement.VisualStudio
             // Nothing is initialized if _vsTrackProjectRetargeting is null. Check if it is not null
             if (_vsTrackProjectRetargeting != null)
             {
-                NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+                NuGetUIThreadHelper.JoinableTaskFactory.Run(async () =>
                 {
                     await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Handlers/ProjectRetargetingHandler.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Handlers/ProjectRetargetingHandler.cs
@@ -301,12 +301,13 @@ namespace NuGet.PackageManagement.VisualStudio
         }
         #endregion
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "VSTHRD110:Observe result of async calls", Justification = "https://github.com/NuGet/Client.Engineering/issues/956")]
         public void Dispose()
         {
             // Nothing is initialized if _vsTrackProjectRetargeting is null. Check if it is not null
             if (_vsTrackProjectRetargeting != null)
             {
-                NuGetUIThreadHelper.JoinableTaskFactory.Run(async () =>
+                NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async () =>
                 {
                     await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Handlers/ProjectRetargetingHandler.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Handlers/ProjectRetargetingHandler.cs
@@ -301,7 +301,6 @@ namespace NuGet.PackageManagement.VisualStudio
         }
         #endregion
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "VSTHRD110:Observe result of async calls", Justification = "https://github.com/NuGet/Client.Engineering/issues/956")]
         public void Dispose()
         {
             // Nothing is initialized if _vsTrackProjectRetargeting is null. Check if it is not null
@@ -327,7 +326,7 @@ namespace NuGet.PackageManagement.VisualStudio
                         _dte.Events.BuildEvents.OnBuildBegin -= BuildEvents_OnBuildBegin;
                         _dte.Events.SolutionEvents.AfterClosing -= SolutionEvents_AfterClosing;
                     }
-                });
+                }).PostOnFailure(nameof(ProjectRetargetingHandler));
             }
         }
     }

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Handlers/ProjectUpgradeHandler.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Handlers/ProjectUpgradeHandler.cs
@@ -131,11 +131,12 @@ namespace NuGet.PackageManagement.VisualStudio
         #endregion
 
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "VSTHRD110:Observe result of async calls", Justification = "https://github.com/NuGet/Client.Engineering/issues/956")]
         public void Dispose()
         {
             if (_cookie != 0 && _vsSolution2 != null)
             {
-                NuGetUIThreadHelper.JoinableTaskFactory.Run(async () =>
+                NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async () =>
                 {
                     await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Handlers/ProjectUpgradeHandler.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Handlers/ProjectUpgradeHandler.cs
@@ -131,7 +131,6 @@ namespace NuGet.PackageManagement.VisualStudio
         #endregion
 
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "VSTHRD110:Observe result of async calls", Justification = "https://github.com/NuGet/Client.Engineering/issues/956")]
         public void Dispose()
         {
             if (_cookie != 0 && _vsSolution2 != null)
@@ -142,7 +141,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
                     _vsSolution2.UnadviseSolutionEvents(_cookie);
                     _cookie = VSConstants.VSCOOKIE_NIL;
-                });
+                }).PostOnFailure(nameof(ProjectUpgradeHandler));
             }
         }
     }

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Handlers/ProjectUpgradeHandler.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Handlers/ProjectUpgradeHandler.cs
@@ -13,6 +13,7 @@ using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using NuGet.Packaging.Core;
 using NuGet.VisualStudio;
+using NuGet.VisualStudio.Telemetry;
 
 namespace NuGet.PackageManagement.VisualStudio
 {

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Handlers/ProjectUpgradeHandler.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Handlers/ProjectUpgradeHandler.cs
@@ -135,7 +135,7 @@ namespace NuGet.PackageManagement.VisualStudio
         {
             if (_cookie != 0 && _vsSolution2 != null)
             {
-                NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+                NuGetUIThreadHelper.JoinableTaskFactory.Run(async () =>
                 {
                     await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSDeleteOnRestartManager.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSDeleteOnRestartManager.cs
@@ -213,7 +213,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
             // We need to do the check even on Solution Closed because, let's say if the yellow Update bar
             // is showing and the user closes the solution; in that case, we want to hide the Update bar.
-            NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async () => await DeleteMarkedPackageDirectoriesAsync(SolutionManager.NuGetProjectContext));
+            NuGetUIThreadHelper.JoinableTaskFactory.Run(async () => await DeleteMarkedPackageDirectoriesAsync(SolutionManager.NuGetProjectContext));
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSDeleteOnRestartManager.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSDeleteOnRestartManager.cs
@@ -206,7 +206,6 @@ namespace NuGet.PackageManagement.VisualStudio
             }
         }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "VSTHRD110:Observe result of async calls", Justification = "https://github.com/NuGet/Client.Engineering/issues/956")]
         private void OnSolutionOpenedOrClosed(object sender, EventArgs e)
         {
             // This is a solution event. Should be on the UI thread
@@ -214,7 +213,8 @@ namespace NuGet.PackageManagement.VisualStudio
 
             // We need to do the check even on Solution Closed because, let's say if the yellow Update bar
             // is showing and the user closes the solution; in that case, we want to hide the Update bar.
-            NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async () => await DeleteMarkedPackageDirectoriesAsync(SolutionManager.NuGetProjectContext));
+            NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async () => await DeleteMarkedPackageDirectoriesAsync(SolutionManager.NuGetProjectContext))
+                                                   .PostOnFailure(nameof(VsDeleteOnRestartManager));
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSDeleteOnRestartManager.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSDeleteOnRestartManager.cs
@@ -14,6 +14,7 @@ using Microsoft.VisualStudio.Threading;
 using NuGet.Packaging.Core;
 using NuGet.ProjectManagement;
 using NuGet.VisualStudio;
+using NuGet.VisualStudio.Telemetry;
 using Task = System.Threading.Tasks.Task;
 
 namespace NuGet.PackageManagement.VisualStudio

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSDeleteOnRestartManager.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSDeleteOnRestartManager.cs
@@ -206,6 +206,7 @@ namespace NuGet.PackageManagement.VisualStudio
             }
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "VSTHRD110:Observe result of async calls", Justification = "https://github.com/NuGet/Client.Engineering/issues/956")]
         private void OnSolutionOpenedOrClosed(object sender, EventArgs e)
         {
             // This is a solution event. Should be on the UI thread
@@ -213,7 +214,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
             // We need to do the check even on Solution Closed because, let's say if the yellow Update bar
             // is showing and the user closes the solution; in that case, we want to hide the Update bar.
-            NuGetUIThreadHelper.JoinableTaskFactory.Run(async () => await DeleteMarkedPackageDirectoriesAsync(SolutionManager.NuGetProjectContext));
+            NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async () => await DeleteMarkedPackageDirectoriesAsync(SolutionManager.NuGetProjectContext));
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
@@ -881,11 +881,12 @@ namespace NuGet.PackageManagement.VisualStudio
         /// </summary>
         /// <param name="sender">Event sender object</param>
         /// <param name="e">Event arguments. This will be EventArgs.Empty</param>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "VSTHRD110:Observe result of async calls", Justification = "https://github.com/NuGet/Client.Engineering/issues/956")]
         private void NuGetCacheUpdate_After(object sender, NuGetEventArgs<string> e)
         {
             // The AfterNuGetCacheUpdated event is raised on a separate Task to prevent blocking of the caller.
             // E.g. - If Restore updates the cache entries on CPS nomination, then restore should not be blocked till UI is restored.
-            NuGetUIThreadHelper.JoinableTaskFactory.Run(() => FireNuGetCacheUpdatedEventAsync(e));
+            NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(() => FireNuGetCacheUpdatedEventAsync(e));
         }
 
         private async Task FireNuGetCacheUpdatedEventAsync(NuGetEventArgs<string> e)
@@ -911,12 +912,13 @@ namespace NuGet.PackageManagement.VisualStudio
 
         #region IVsSelectionEvents
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "VSTHRD110:Observe result of async calls", Justification = "https://github.com/NuGet/Client.Engineering/issues/956")]
         public int OnCmdUIContextChanged(uint dwCmdUICookie, int fActive)
         {
             if (dwCmdUICookie == _solutionLoadedUICookie
                 && fActive == 1)
             {
-                NuGetUIThreadHelper.JoinableTaskFactory.Run(async () =>
+                NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async () =>
                     await OnSolutionExistsAndFullyLoadedAsync());
             }
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
@@ -885,7 +885,7 @@ namespace NuGet.PackageManagement.VisualStudio
         {
             // The AfterNuGetCacheUpdated event is raised on a separate Task to prevent blocking of the caller.
             // E.g. - If Restore updates the cache entries on CPS nomination, then restore should not be blocked till UI is restored.
-            NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(() => FireNuGetCacheUpdatedEventAsync(e));
+            NuGetUIThreadHelper.JoinableTaskFactory.Run(() => FireNuGetCacheUpdatedEventAsync(e));
         }
 
         private async Task FireNuGetCacheUpdatedEventAsync(NuGetEventArgs<string> e)
@@ -916,7 +916,7 @@ namespace NuGet.PackageManagement.VisualStudio
             if (dwCmdUICookie == _solutionLoadedUICookie
                 && fActive == 1)
             {
-                NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+                NuGetUIThreadHelper.JoinableTaskFactory.Run(async () =>
                     await OnSolutionExistsAndFullyLoadedAsync());
             }
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
@@ -27,6 +27,7 @@ using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
 using NuGet.VisualStudio;
 using NuGet.VisualStudio.Common.Telemetry.PowerShell;
+using NuGet.VisualStudio.Telemetry;
 using IAsyncServiceProvider = Microsoft.VisualStudio.Shell.IAsyncServiceProvider;
 using Task = System.Threading.Tasks.Task;
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/InteractiveLoginProvider.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/InteractiveLoginProvider.cs
@@ -54,7 +54,7 @@ namespace NuGet.PackageManagement.VisualStudio
                 var parent = IntPtr.Zero;
                 if (_dte != null)
                 {
-                    parent = new IntPtr((await _dte.GetValueAsync()).MainWindow.HWnd);
+                    parent = (await _dte.GetValueAsync()).MainWindow.HWnd;
                 }
 
                 account = await provider.CreateAccountWithUIAsync(parent, cancellationToken);
@@ -95,7 +95,7 @@ namespace NuGet.PackageManagement.VisualStudio
                 var parent = IntPtr.Zero;
                 if (_dte != null)
                 {
-                    parent = new IntPtr((await _dte.GetValueAsync()).MainWindow.HWnd);
+                    parent = (await _dte.GetValueAsync()).MainWindow.HWnd;
                 }
 
                 try

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/PackageFeeds/MultiSourcePackageFeed.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/PackageFeeds/MultiSourcePackageFeed.cs
@@ -368,7 +368,7 @@ namespace NuGet.PackageManagement.VisualStudio
             }
 
             // UI logger only can be engaged from the main thread
-            NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            NuGetUIThreadHelper.JoinableTaskFactory.Run(async () =>
             {
                 await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/PackageFeeds/MultiSourcePackageFeed.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/PackageFeeds/MultiSourcePackageFeed.cs
@@ -358,6 +358,7 @@ namespace NuGet.PackageManagement.VisualStudio
             return result;
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "VSTHRD110:Observe result of async calls", Justification = "https://github.com/NuGet/Client.Engineering/issues/956")]
         private void LogError(Task task, object state)
         {
             if (_logger == null)
@@ -368,7 +369,7 @@ namespace NuGet.PackageManagement.VisualStudio
             }
 
             // UI logger only can be engaged from the main thread
-            NuGetUIThreadHelper.JoinableTaskFactory.Run(async () =>
+            NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async () =>
             {
                 await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/PackageFeeds/MultiSourcePackageFeed.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/PackageFeeds/MultiSourcePackageFeed.cs
@@ -358,7 +358,6 @@ namespace NuGet.PackageManagement.VisualStudio
             return result;
         }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "VSTHRD110:Observe result of async calls", Justification = "https://github.com/NuGet/Client.Engineering/issues/956")]
         private void LogError(Task task, object state)
         {
             if (_logger == null)
@@ -378,7 +377,7 @@ namespace NuGet.PackageManagement.VisualStudio
                     new LogMessage(
                         LogLevel.Error,
                         $"[{state.ToString()}] {errorMessage}"));
-            });
+            }).PostOnFailure(nameof(MultiSourcePackageFeed));
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/JoinableTaskExtensions.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/JoinableTaskExtensions.cs
@@ -13,9 +13,10 @@ namespace NuGet.VisualStudio.Telemetry
         /// <param name="joinableTask"> Joinable task to execute. </param>
         /// <param name="callerClassName"> Caller class name. </param>
         /// <param name="callerMemberName"> Caller member name. </param>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "VSTHRD110:Observe result of async calls", Justification = "https://github.com/NuGet/Client.Engineering/issues/956")]
         public static void PostOnFailure(this JoinableTask joinableTask, string callerClassName, [CallerMemberName] string callerMemberName = null)
         {
-            NuGetUIThreadHelper.JoinableTaskFactory.Run(async () =>
+            NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async () =>
             {
                 try
                 {

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/JoinableTaskExtensions.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/JoinableTaskExtensions.cs
@@ -15,7 +15,7 @@ namespace NuGet.VisualStudio.Telemetry
         /// <param name="callerMemberName"> Caller member name. </param>
         public static void PostOnFailure(this JoinableTask joinableTask, string callerClassName, [CallerMemberName] string callerMemberName = null)
         {
-            NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            NuGetUIThreadHelper.JoinableTaskFactory.Run(async () =>
             {
                 try
                 {

--- a/src/NuGet.Clients/NuGet.VisualStudio.OnlineEnvironment.Client/SolutionExplorer/PackageManagerUICommandHandler.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.OnlineEnvironment.Client/SolutionExplorer/PackageManagerUICommandHandler.cs
@@ -25,6 +25,7 @@ using NuGet.PackageManagement.VisualStudio;
 using NuGet.ProjectManagement;
 using NuGet.VisualStudio.Common;
 using NuGet.VisualStudio.Internal.Contracts;
+using NuGet.VisualStudio.Telemetry;
 using IAsyncServiceProvider = Microsoft.VisualStudio.Shell.IAsyncServiceProvider;
 using Resx = NuGet.PackageManagement.UI.Resources;
 using Task = System.Threading.Tasks.Task;

--- a/src/NuGet.Clients/NuGet.VisualStudio.OnlineEnvironment.Client/SolutionExplorer/PackageManagerUICommandHandler.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.OnlineEnvironment.Client/SolutionExplorer/PackageManagerUICommandHandler.cs
@@ -137,7 +137,7 @@ namespace NuGet.VisualStudio.OnlineEnvironment.Client
 
         public void OpenPackageManagerUI(WorkspaceVisualNodeBase workspaceVisualNodeBase)
         {
-            _joinableTaskFactory.RunAsync(() => OpenPackageManagerUIAsync(workspaceVisualNodeBase));
+            _joinableTaskFactory.Run(() => OpenPackageManagerUIAsync(workspaceVisualNodeBase));
         }
 
         private async Task OpenPackageManagerUIAsync(WorkspaceVisualNodeBase workspaceVisualNodeBase)

--- a/src/NuGet.Clients/NuGet.VisualStudio.OnlineEnvironment.Client/SolutionExplorer/PackageManagerUICommandHandler.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.OnlineEnvironment.Client/SolutionExplorer/PackageManagerUICommandHandler.cs
@@ -135,9 +135,10 @@ namespace NuGet.VisualStudio.OnlineEnvironment.Client
             return IsPackageManagerUISupportAvailable;
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "VSTHRD110:Observe result of async calls", Justification = "https://github.com/NuGet/Client.Engineering/issues/956")]
         public void OpenPackageManagerUI(WorkspaceVisualNodeBase workspaceVisualNodeBase)
         {
-            _joinableTaskFactory.Run(() => OpenPackageManagerUIAsync(workspaceVisualNodeBase));
+            _joinableTaskFactory.RunAsync(() => OpenPackageManagerUIAsync(workspaceVisualNodeBase));
         }
 
         private async Task OpenPackageManagerUIAsync(WorkspaceVisualNodeBase workspaceVisualNodeBase)

--- a/src/NuGet.Clients/NuGet.VisualStudio.OnlineEnvironment.Client/SolutionExplorer/PackageManagerUICommandHandler.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.OnlineEnvironment.Client/SolutionExplorer/PackageManagerUICommandHandler.cs
@@ -135,10 +135,9 @@ namespace NuGet.VisualStudio.OnlineEnvironment.Client
             return IsPackageManagerUISupportAvailable;
         }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "VSTHRD110:Observe result of async calls", Justification = "https://github.com/NuGet/Client.Engineering/issues/956")]
         public void OpenPackageManagerUI(WorkspaceVisualNodeBase workspaceVisualNodeBase)
         {
-            _joinableTaskFactory.RunAsync(() => OpenPackageManagerUIAsync(workspaceVisualNodeBase));
+            _joinableTaskFactory.RunAsync(() => OpenPackageManagerUIAsync(workspaceVisualNodeBase)).PostOnFailure(nameof(PackageManagerUICommandHandler));
         }
 
         private async Task OpenPackageManagerUIAsync(WorkspaceVisualNodeBase workspaceVisualNodeBase)

--- a/src/NuGet.Clients/NuGet.VisualStudio.OnlineEnvironment.Client/SolutionExplorer/RestoreCommandHandler.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.OnlineEnvironment.Client/SolutionExplorer/RestoreCommandHandler.cs
@@ -28,9 +28,10 @@ namespace NuGet.VisualStudio.OnlineEnvironment.Client
             _asyncServiceProvider = asyncServiceProvider ?? throw new ArgumentNullException(nameof(asyncServiceProvider));
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "VSTHRD110:Observe result of async calls", Justification = "https://github.com/NuGet/Client.Engineering/issues/956")]
         public void RunSolutionRestore()
         {
-            _joinableTaskFactory.Run(RunSolutionRestoreAsync);
+            _joinableTaskFactory.RunAsync(RunSolutionRestoreAsync);
         }
 
         private async Task RunSolutionRestoreAsync()

--- a/src/NuGet.Clients/NuGet.VisualStudio.OnlineEnvironment.Client/SolutionExplorer/RestoreCommandHandler.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.OnlineEnvironment.Client/SolutionExplorer/RestoreCommandHandler.cs
@@ -28,10 +28,9 @@ namespace NuGet.VisualStudio.OnlineEnvironment.Client
             _asyncServiceProvider = asyncServiceProvider ?? throw new ArgumentNullException(nameof(asyncServiceProvider));
         }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "VSTHRD110:Observe result of async calls", Justification = "https://github.com/NuGet/Client.Engineering/issues/956")]
         public void RunSolutionRestore()
         {
-            _joinableTaskFactory.RunAsync(RunSolutionRestoreAsync);
+            _joinableTaskFactory.RunAsync(RunSolutionRestoreAsync).PostOnFailure(nameof(RestoreCommandHandler));
         }
 
         private async Task RunSolutionRestoreAsync()

--- a/src/NuGet.Clients/NuGet.VisualStudio.OnlineEnvironment.Client/SolutionExplorer/RestoreCommandHandler.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.OnlineEnvironment.Client/SolutionExplorer/RestoreCommandHandler.cs
@@ -30,7 +30,7 @@ namespace NuGet.VisualStudio.OnlineEnvironment.Client
 
         public void RunSolutionRestore()
         {
-            _joinableTaskFactory.RunAsync(RunSolutionRestoreAsync);
+            _joinableTaskFactory.Run(RunSolutionRestoreAsync);
         }
 
         private async Task RunSolutionRestoreAsync()

--- a/src/NuGet.Clients/NuGet.VisualStudio.OnlineEnvironment.Client/SolutionExplorer/RestoreCommandHandler.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.OnlineEnvironment.Client/SolutionExplorer/RestoreCommandHandler.cs
@@ -10,6 +10,7 @@ using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Threading;
 using NuGet.VisualStudio.Internal.Contracts;
+using NuGet.VisualStudio.Telemetry;
 using IAsyncServiceProvider = Microsoft.VisualStudio.Shell.IAsyncServiceProvider;
 using SB = Microsoft.VisualStudio.Shell.ServiceBroker;
 using Task = System.Threading.Tasks.Task;


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: NuGet/Client.Engineering#754

Regression? No

## Description
DTE.Window.HWnd changed from returning an int to an IntPtr in VS's main branch. This PR updates the release-6.0.x branch to use newer interop assemblies with this breaking change in preparation for an insertion.

The VS threading analyzers also flagged several new issues. I'm guessing this is because I had to upgrade the Microsoft.VisualStudio.Threading package. The errors are all RunAsync and StartOnIdle calls that were not awaited. I fixed these by:
1. Changed the RunAsync calls to Run calls, but it's possible that in some of these cases we were intentionally not blocking. I'm not sure.
2. Called FileAndForget on the JoinableTasks returned by the StartOnIdle calls. FileAndForget requires a telemetry fault event name to be passed in. That fault will be recorded if the task fails. I'm not sure what format NuGet uses for telemetry event names though. Should these be something along the lines of vs/nuget/featureName/blah?

## PR Checklist

- [X] PR has a meaningful title
- [X] PR has a linked issue.
- [X] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [X] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [X] N/A
