### PR TITLE
Update version of SharpZipLib pulled in by Lucene.Net

### DIFF
--- a/build/packages.targets
+++ b/build/packages.targets
@@ -64,6 +64,7 @@
         <PackageReference Update="Microsoft.VSSDK.BuildTools" Version="16.8.3038" />
         <PackageReference Update="Microsoft.Web.Xdt" Version="3.0.0" />
         <PackageReference Update="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
+        <PackageReference Update="SharpZipLib" Version="1.3.2" />
         <PackageReference Update="System.ComponentModel.Composition" Version="4.5.0" />
         <!--
           The Microsoft.VisualStudio.SDK metapackage brings in System.Threading.Tasks.Dataflow 4.11.1 (assembly version 4.9.5.0).

--- a/src/NuGet.Clients/NuGet.Indexing/NuGet.Indexing.csproj
+++ b/src/NuGet.Clients/NuGet.Indexing/NuGet.Indexing.csproj
@@ -18,6 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="Lucene.Net" />
+    <PackageReference Include="SharpZipLib" /> <!-- dependency of Lucene.net. Can delete when Lucene.net has an update with a newer dependency on sharpziplib -->
   </ItemGroup>
 
   <Import Project="$(BuildCommonDirectory)common.targets"/>

--- a/src/NuGet.Clients/NuGet.VisualStudio.Client/NuGet.VisualStudio.Client.csproj
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Client/NuGet.VisualStudio.Client.csproj
@@ -332,6 +332,7 @@
     <!-- This is important because otherwise the VSSDK will include the unsigned version coming from the global packages folder instead of the in-place signed one from the bootstrapped packages folder -->
     <PackageReference Include="Lucene.Net" ExcludeAssets="all" />
     <PackageReference Include="Newtonsoft.Json" NoWarn="NU1605" />
+    <PackageReference Include="SharpZipLib" ExcludeAssets="all" /> <!-- dependency of Lucene.net. Can delete when Lucene.net has an update with a newer dependency on sharpziplib -->
   </ItemGroup>
   <ItemGroup>
     <Content Include="eula.rtf">


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/10878

Regression? No

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

As per linked issue, the version of `SharpZipLib` that `Lucene.Net` depends on is old, and we need to update. There is no newer stable version of `Lucene.Net` at this time, so I'm updating `SharpZipLib` instead.

## PR Checklist

- [X] PR has a meaningful title
- [X] PR has a linked issue.
- [X] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [X] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [X] N/A
