### PR TITLE
Fix the debug helper script to make it work with powershell < 7.0

### DIFF
--- a/scripts/nuget-debug-helpers.ps1
+++ b/scripts/nuget-debug-helpers.ps1
@@ -1,6 +1,6 @@
 $NuGetClientRoot= Resolve-Path $(Join-Path $PSScriptRoot "..\")
 
-$VSVersion = $env:VisualStudioVersion ?? "17.0"
+$VSVersion = if (-Not [string]::IsNullOrEmpty($env:VisualStudioVersion)) { $env:VisualStudioVersion } else { "17.0" }
 $Configuration = "Debug"
 $NETFramework = "net472"
 $NETStandard = "netstandard2.0"


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/957

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Coalescing is only available in 7.0, https://docs.microsoft.com/en-gb/powershell/scripting/whats-new/what-s-new-in-powershell-70?view=powershell-7#null-coalescing-assignment-and-conditional-operators. Developer command prompt uses earlier versions of powershell.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
