### PR TITLE
Add ignoreDirectories for Component Detection task, to ignore the components under test projects.

### DIFF
--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -298,6 +298,8 @@ steps:
 
 - task: ComponentGovernanceComponentDetection@0
   displayName: 'Component Detection'
+  inputs:
+    ignoreDirectories: '$(Build.Repository.LocalPath)\\test,$(Build.Repository.LocalPath)\\packages\\nuget.client.endtoend.testdata'
   condition: "and(succeeded(),eq(variables['BuildRTM'], 'true'))"
 
 - task: PublishPipelineArtifact@1


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/970

Regression? Last working version:

## Description
For now, component detection task detects too many component(including the test projects which will not be shipped). 
We exclude those unnecessary components from the detection results by specifying [ignoreDirectories](https://docs.opensource.microsoft.com/tools/cg/buildtask.html#build-variables).

Two paths are added into the ignoreDirectories. So the components under those packages will not be detected.
```
.\test 
.\packages\nuget.client.endtoend.testdata
```

The comparison of components detection results:
Before adding ignoreDirectories:  800+ components: 
https://devdiv.visualstudio.com/DevDiv/_componentGovernance/108836?_a=components&typeId=466265&alerts-view-option=active
After adding ignoreDirectories : 200+ components: 
https://devdiv.visualstudio.com/DevDiv/_componentGovernance/108836?_a=components&typeId=7217749&alerts-view-option=active


## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
