### PR TITLE
Fix no_proxy value is omitted during refactoring for WebProxy

### DIFF
--- a/src/NuGet.Core/NuGet.Configuration/Proxy/WebProxy.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Proxy/WebProxy.cs
@@ -58,7 +58,7 @@ namespace NuGet.Configuration
 #if NET45
                 _bypassList = value ?? new string[] { };
 #else
-                _bypassList = Array.Empty<string>();
+                _bypassList = value ?? Array.Empty<string>();
 #endif
 
                 UpdateRegExList();


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Home/issues/10902

Regression? Last working version: 5.9

## Description
During refactoring the code I missed passing `no_proxy` value for non net45 framework. I improved unit test to prevent same regression in the future.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [ ] N/A
