### PR TITLE
Removing a key using CLI now actually saves changes to nuget.config

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/NuGet.CommandLine.csproj
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGet.CommandLine.csproj
@@ -1,4 +1,4 @@
-﻿<Project>
+<Project>
 
   <PropertyGroup>
     <IsCommandLinePackage>true</IsCommandLinePackage>

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGet.CommandLine.csproj
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGet.CommandLine.csproj
@@ -1,4 +1,4 @@
-<Project>
+﻿<Project>
 
   <PropertyGroup>
     <IsCommandLinePackage>true</IsCommandLinePackage>

--- a/src/NuGet.Core/NuGet.Configuration/Utility/SettingsUtility.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Utility/SettingsUtility.cs
@@ -55,6 +55,7 @@ namespace NuGet.Configuration
             if (element != null)
             {
                 settings.Remove(section, element);
+                settings.SaveToDisk();
 
                 return true;
             }

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsUtilityTests.cs
@@ -255,6 +255,33 @@ namespace NuGet.Configuration.Test
         }
 
         [Fact]
+        public void DeleteConfigValue_WithValidSettings_DeletesKey()
+        {
+            // Arrange
+            var keyName = "dependencyVersion";
+            var nugetConfigPath = "NuGet.Config";
+            var config = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+  <config>
+    <add key=""" + keyName + @""" value=""Highest"" />
+  </config>
+</configuration>";
+
+            using (var mockBaseDirectory = TestDirectory.Create())
+            {
+                SettingsTestUtils.CreateConfigurationFile(nugetConfigPath, mockBaseDirectory, config);
+                var settings = new Settings(mockBaseDirectory);
+
+                // Act
+                SettingsUtility.DeleteConfigValue(settings, keyName);
+
+                // Assert
+                var content = File.ReadAllText(Path.Combine(mockBaseDirectory, nugetConfigPath));
+                content.Should().NotContain(keyName);
+            }
+        }
+
+        [Fact]
         public void GetGlobalPackagesFolder_WithNullSettings_Throws()
         {
             var ex = Record.Exception(() => SettingsUtility.GetGlobalPackagesFolder(settings: null));


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/8223

Regression? Last working version: No (not in this major version at least)

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
It seems that removing a key has never actually updated the nuget.config file. 

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added - I added a test, which failed before making this code change, and now it passes. 
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A - we already have docs that indicate this behavior, it's just that it didn't work as indicated.
