### PR TITLE
Debug helper scripts: Add an Isolate Restore function that redirects all restore outputs

### DIFF
--- a/scripts/nuget-debug-helpers.ps1
+++ b/scripts/nuget-debug-helpers.ps1
@@ -232,7 +232,7 @@ Function DisableVisualStudioTelemetryFileLogging()
 }
 
 <#
-Isolate the restore output folders. When run, this too redirects all NuGet folders and caches to the directory passed in as $RootDirectory.
+Isolate the restore output folders. When run, this redirects all NuGet folders and caches to the directory passed in as $RootDirectory.
 The root folder *must* exist.
 .EXAMPLE
     C:\PS> IsolateRestore -sdkLocation D:\source\NuGet.Client


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/983

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

This is a function that when called redirects all restore outputs to a shared location. 

It makes it easy to do local testing for solutions *without* affecting the local machine global packages folder.

cc @jebriede 

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
