### PR TITLE
Remove partial ngen flag from optprof config

### DIFF
--- a/build/OptProfV2.props
+++ b/build/OptProfV2.props
@@ -23,7 +23,6 @@
       <Technology>IBC</Technology>
       <InstallationPath>Common7\IDE\CommonExtensions\Microsoft\NuGet\$(AssemblyName).dll</InstallationPath>
       <InstrumentationArguments>/ExeConfig:"%VisualStudio.InstallationUnderTest.Path%\Common7\IDE\vsn.exe"</InstrumentationArguments>
-      <OptimizationArguments>-PartialNGEN</OptimizationArguments>
       <Scenarios>
         <TestContainer Name="NuGet.Tests">
           <TestCase Weight="100" FullyQualifiedName="NuGet.OptProfV2Tests.IVsPackageSourceProvider_GetSources" />
@@ -41,7 +40,6 @@
       <Technology>IBC</Technology>
       <InstallationPath>Common7\IDE\CommonExtensions\Microsoft\NuGet\$(AssemblyName).dll</InstallationPath>
       <InstrumentationArguments>/ExeConfig:"%VisualStudio.InstallationUnderTest.Path%\Common7\IDE\vsn.exe"</InstrumentationArguments>
-      <OptimizationArguments>-PartialNGEN</OptimizationArguments>
       <Scenarios>
         <TestContainer Name="NuGet.Tests">
           <TestCase Weight="100" FullyQualifiedName="NuGet.OptProfV2Tests.IVsPackageSourceProvider_GetSources" />


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/987

Regression? No

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

As requested by VS Engineering team

## PR Checklist

- [X] PR has a meaningful title
- [X] PR has a linked issue.
- [X] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [X] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [X] N/A
