### PR TITLE
Asynchronize post line input

### DIFF
--- a/src/NuGet.Clients/NuGet.Console/WpfConsole/WpfConsoleKeyProcessor.cs
+++ b/src/NuGet.Clients/NuGet.Console/WpfConsole/WpfConsoleKeyProcessor.cs
@@ -347,7 +347,7 @@ namespace NuGetConsole.Implementation.Console
                                 ExecuteCommand(VSConstants.VSStd2KCmdID.END);
                                 ExecuteCommand(VSConstants.VSStd2KCmdID.RETURN);
 
-                                WpfConsole.EndInputLine();
+                                NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(() => EndInputLineAsync(WpfConsole));
                             }
                             hr = VSConstants.S_OK;
                             break;
@@ -391,6 +391,12 @@ namespace NuGetConsole.Implementation.Console
                 }
             }
             return hr;
+        }
+
+        private static Task EndInputLineAsync(WpfConsole wpfConsole)
+        {
+            wpfConsole.EndInputLine();
+            return Task.CompletedTask;
         }
 
         private VsKeyInfo GetVsKeyInfo(IntPtr pvaIn, VSConstants.VSStd2KCmdID commandID)

--- a/src/NuGet.Clients/NuGet.Console/WpfConsole/WpfConsoleKeyProcessor.cs
+++ b/src/NuGet.Clients/NuGet.Console/WpfConsole/WpfConsoleKeyProcessor.cs
@@ -347,7 +347,9 @@ namespace NuGetConsole.Implementation.Console
                                 ExecuteCommand(VSConstants.VSStd2KCmdID.END);
                                 ExecuteCommand(VSConstants.VSStd2KCmdID.RETURN);
 
-                                NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(() => EndInputLineAsync(WpfConsole));
+                                NuGetUIThreadHelper.JoinableTaskFactory
+                                    .RunAsync(() => EndInputLineAsync(WpfConsole))
+                                    .PostOnFailure(nameof(WpfConsoleKeyProcessor));
                             }
                             hr = VSConstants.S_OK;
                             break;

--- a/src/NuGet.Clients/NuGetConsole.Host.PowerShell/PowerShellHost.cs
+++ b/src/NuGet.Clients/NuGetConsole.Host.PowerShell/PowerShellHost.cs
@@ -424,10 +424,10 @@ namespace NuGetConsole.Host.PowerShell.Implementation
             });
         }
 
-        [SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes", Justification = "We don't want execution of init scripts to crash our console.")]
         private async Task ExecuteInitScriptsAsync()
         {
             // Fix for Bug 1426 Disallow ExecuteInitScripts from being executed concurrently by multiple threads.
+            await TaskScheduler.Default;
             using (await _initScriptsLock.EnterAsync())
             {
                 if (!await _solutionManager.Value.IsSolutionOpenAsync())
@@ -451,6 +451,8 @@ namespace NuGetConsole.Host.PowerShell.Implementation
 
                     return;
                 }
+                // We may be enumerating packages from disk here. Always do it from a background thread.
+                await TaskScheduler.Default;
 
                 var packageManager = new NuGetPackageManager(
                     _sourceRepositoryProvider,

--- a/src/NuGet.Clients/NuGetConsole.Host.PowerShell/PowerShellHost.cs
+++ b/src/NuGet.Clients/NuGetConsole.Host.PowerShell/PowerShellHost.cs
@@ -427,7 +427,6 @@ namespace NuGetConsole.Host.PowerShell.Implementation
         private async Task ExecuteInitScriptsAsync()
         {
             // Fix for Bug 1426 Disallow ExecuteInitScripts from being executed concurrently by multiple threads.
-            await TaskScheduler.Default;
             using (await _initScriptsLock.EnterAsync())
             {
                 if (!await _solutionManager.Value.IsSolutionOpenAsync())


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/792383
Fixes: https://github.com/NuGet/Home/issues/10947

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Asynchronize the processing of the command when return is pressed. 
This would allow us to *not* block the UI thread as we are executing the command in question. 

In particular the problem here is sometimes we end up enumerating files on disk, and that can cause a massive UI delay. 
Asynchronizing this codepath does introduce a possibility for some timing weirdness, but in my testing, there was no action that *can* be taken when a command is getting executed.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
