### PR TITLE
Prevent boxing of bool when combining hash codes

### DIFF
--- a/build/Shared/HashCodeCombiner.cs
+++ b/build/Shared/HashCodeCombiner.cs
@@ -34,6 +34,12 @@ namespace NuGet.Shared
             AddHashCode(i);
         }
 
+        internal void AddObject(bool b)
+        {
+            CheckInitialized();
+            AddHashCode(b ? 1 : 0);
+        }
+
         internal void AddObject<TValue>(TValue o, IEqualityComparer<TValue> comparer)
         {
             CheckInitialized();


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/10917

Regression? Last working version: N/A

## Description
Added a method override to the HashCodeCombiner to handle bool values and compute the hashcode for the bool directly rather than boxing it as a Boolean object. This avoids the allocation of a Boolean object on each call.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  Existing tests already cover the functionality
  - [x] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
