### PR TITLE
Use IVsSolutionEvents in VsSolutionManager

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
@@ -63,7 +63,6 @@ namespace NuGet.PackageManagement.VisualStudio
 
         private bool _initialized;
         private bool _cacheInitialized;
-        private bool _disposed = false;
 
         //add solutionOpenedRasied to make sure ProjectRename and ProjectAdded event happen after solutionOpened event
         private bool _solutionOpenedRaised;
@@ -1080,6 +1079,7 @@ namespace NuGet.PackageManagement.VisualStudio
         }
         #endregion
 
+        private bool _disposed = false;
         public void Dispose()
         {
             if (!_disposed)

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
@@ -36,7 +36,7 @@ namespace NuGet.PackageManagement.VisualStudio
     [Export(typeof(ISolutionManager))]
     [Export(typeof(IVsSolutionManager))]
     [PartCreationPolicy(CreationPolicy.Shared)]
-    public sealed class VSSolutionManager : IVsSolutionManager, IVsSelectionEvents
+    public sealed class VSSolutionManager : IVsSolutionManager, IVsSelectionEvents, IVsSolutionEvents, IDisposable
     {
         private static readonly INuGetProjectContext EmptyNuGetProjectContext = new EmptyNuGetProjectContext();
         private const string VSNuGetClientName = "NuGet VS VSIX";
@@ -50,6 +50,8 @@ namespace NuGet.PackageManagement.VisualStudio
         private IVsMonitorSelection _vsMonitorSelection;
         private uint _solutionLoadedUICookie;
         private IVsSolution _vsSolution;
+        private uint _selectionEventsCookie;
+        private uint _solutionEventsCookie;
 
         private readonly IAsyncServiceProvider _asyncServiceProvider;
         private readonly IProjectSystemCache _projectSystemCache;
@@ -61,6 +63,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
         private bool _initialized;
         private bool _cacheInitialized;
+        private bool _disposed = false;
 
         //add solutionOpenedRasied to make sure ProjectRename and ProjectAdded event happen after solutionOpened event
         private bool _solutionOpenedRaised;
@@ -192,8 +195,9 @@ namespace NuGet.PackageManagement.VisualStudio
             var solutionLoadedGuid = VSConstants.UICONTEXT.SolutionExistsAndFullyLoaded_guid;
             _vsMonitorSelection.GetCmdUIContextCookie(ref solutionLoadedGuid, out _solutionLoadedUICookie);
 
-            uint cookie;
-            var hr = _vsMonitorSelection.AdviseSelectionEvents(this, out cookie);
+            var hr = _vsMonitorSelection.AdviseSelectionEvents(this, out _selectionEventsCookie);
+            ErrorHandler.ThrowOnFailure(hr);
+            hr = _vsSolution.AdviseSolutionEvents(this, out _solutionEventsCookie);
             ErrorHandler.ThrowOnFailure(hr);
 
             // Keep a reference to SolutionEvents so that it doesn't get GC'ed. Otherwise, we won't receive events.
@@ -914,13 +918,6 @@ namespace NuGet.PackageManagement.VisualStudio
 
         public int OnCmdUIContextChanged(uint dwCmdUICookie, int fActive)
         {
-            if (dwCmdUICookie == _solutionLoadedUICookie
-                && fActive == 1)
-            {
-                NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async () =>
-                    await OnSolutionExistsAndFullyLoadedAsync()).PostOnFailure(nameof(VSSolutionManager));
-            }
-
             return VSConstants.S_OK;
         }
 
@@ -1027,7 +1024,85 @@ namespace NuGet.PackageManagement.VisualStudio
 
             return nuGetProject;
         }
-
         #endregion
+
+        #region IVsSolutionEvents
+        public int OnAfterOpenProject(IVsHierarchy pHierarchy, int fAdded)
+        {
+            return VSConstants.S_OK;
+        }
+
+        public int OnQueryCloseProject(IVsHierarchy pHierarchy, int fRemoving, ref int pfCancel)
+        {
+            return VSConstants.S_OK;
+        }
+
+        public int OnBeforeCloseProject(IVsHierarchy pHierarchy, int fRemoved)
+        {
+            return VSConstants.S_OK;
+        }
+
+        public int OnAfterLoadProject(IVsHierarchy pStubHierarchy, IVsHierarchy pRealHierarchy)
+        {
+            return VSConstants.S_OK;
+        }
+
+        public int OnQueryUnloadProject(IVsHierarchy pRealHierarchy, ref int pfCancel)
+        {
+            return VSConstants.S_OK;
+        }
+
+        public int OnBeforeUnloadProject(IVsHierarchy pRealHierarchy, IVsHierarchy pStubHierarchy)
+        {
+            return VSConstants.S_OK;
+        }
+
+        public int OnAfterOpenSolution(object pUnkReserved, int fNewSolution)
+        {
+            NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+                await OnSolutionExistsAndFullyLoadedAsync()).PostOnFailure(nameof(OnAfterOpenSolution));
+            return VSConstants.S_OK;
+        }
+
+        public int OnQueryCloseSolution(object pUnkReserved, ref int pfCancel)
+        {
+            return VSConstants.S_OK;
+        }
+
+        public int OnBeforeCloseSolution(object pUnkReserved)
+        {
+            return VSConstants.S_OK;
+        }
+
+        public int OnAfterCloseSolution(object pUnkReserved)
+        {
+            return VSConstants.S_OK;
+        }
+        #endregion
+
+        public void Dispose()
+        {
+            if (!_disposed)
+            {
+                _disposed = true;
+
+                if (ThreadHelper.JoinableTaskContext?.IsOnMainThread == true)
+                {
+                    if (_vsMonitorSelection != null && _selectionEventsCookie != 0)
+                    {
+                        _vsMonitorSelection.UnadviseSelectionEvents(_selectionEventsCookie);
+                        _selectionEventsCookie = 0;
+                    }
+
+                    if (_vsSolution != null && _solutionEventsCookie != 0)
+                    {
+                        _vsSolution.UnadviseSolutionEvents(_solutionEventsCookie);
+                        _solutionEventsCookie = 0;
+                    }
+                }
+
+                _semaphoreLock?.Dispose();
+            }
+        }
     }
 }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Related: https://github.com/NuGet/Client.Engineering/issues/754

Regression? yes?  It's unclear at this stage whether VS2022 deprecated an API, or if it's a bug, but the recommendation is to 

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Use `IVsSolutionEvent.OnAfterSolutionLoad`, instead of `IVsSelectionEvent.OnCmdUIContextChanged` to get "solution finished loading" notification.

## PR Checklist

- [X] PR has a meaningful title
- [X] PR has a linked issue.
- [X] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [X] Test exception: existing tests
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [X] N/A
