### PR TITLE
Fix package validation fallback issue

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/Signing/Verification/SignatureTrustAndValidityVerificationProvider.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Verification/SignatureTrustAndValidityVerificationProvider.cs
@@ -167,7 +167,8 @@ namespace NuGet.Packaging.Signing
 
                                     status = SignatureVerificationStatus.Valid;
                                 }
-                            }else if (IsSignatureExpired(primarySummary) &&
+                            }
+                            else if (IsSignatureExpired(primarySummary) &&
                                 countersignatureSummary.Timestamp != null &&
                                 Rfc3161TimestampVerificationUtility.ValidateSignerCertificateAgainstTimestamp(signature.SignerInfo.Certificate, countersignatureSummary.Timestamp))
                             {
@@ -175,7 +176,8 @@ namespace NuGet.Packaging.Signing
                                 issues = issues.Where(log => log.Code != NuGetLogCode.NU3037);
 
                                 status = SignatureVerificationStatus.Valid;
-                            }else if (HasUntrustedRoot(primarySummary))
+                            }
+                            else if (HasUntrustedRoot(primarySummary))
                             {
                                 // Exclude the issue of the primary signature being untrusted since the repository countersignature fulfills the role of a trust anchor.
                                 issues = issues.Where(log => log.Code != NuGetLogCode.NU3018);

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Verification/SignatureTrustAndValidityVerificationProvider.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Verification/SignatureTrustAndValidityVerificationProvider.cs
@@ -154,7 +154,20 @@ namespace NuGet.Packaging.Signing
                     {
                         if (countersignatureSummary.Status == SignatureVerificationStatus.Valid)
                         {
-                            if (IsSignatureExpired(primarySummary) &&
+                            if (IsSignatureExpired(primarySummary) && HasUntrustedRoot(primarySummary))
+                            {
+                                // Exclude the issue of the primary signature being untrusted since the repository countersignature fulfills the role of a trust anchor.
+                                issues = issues.Where(log => log.Code != NuGetLogCode.NU3018);
+
+                                if (countersignatureSummary.Timestamp != null &&
+                                Rfc3161TimestampVerificationUtility.ValidateSignerCertificateAgainstTimestamp(signature.SignerInfo.Certificate, countersignatureSummary.Timestamp))
+                                {
+                                    // Exclude the issue of the primary signature being expired since the repository countersignature fulfills the role of a trusted timestamp.
+                                    issues = issues.Where(log => log.Code != NuGetLogCode.NU3037);
+
+                                    status = SignatureVerificationStatus.Valid;
+                                }
+                            }else if (IsSignatureExpired(primarySummary) &&
                                 countersignatureSummary.Timestamp != null &&
                                 Rfc3161TimestampVerificationUtility.ValidateSignerCertificateAgainstTimestamp(signature.SignerInfo.Certificate, countersignatureSummary.Timestamp))
                             {
@@ -162,9 +175,7 @@ namespace NuGet.Packaging.Signing
                                 issues = issues.Where(log => log.Code != NuGetLogCode.NU3037);
 
                                 status = SignatureVerificationStatus.Valid;
-                            }
-
-                            if (HasUntrustedRoot(primarySummary))
+                            }else if (HasUntrustedRoot(primarySummary))
                             {
                                 // Exclude the issue of the primary signature being untrusted since the repository countersignature fulfills the role of a trust anchor.
                                 issues = issues.Where(log => log.Code != NuGetLogCode.NU3018);

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignatureTrustAndValidityVerificationProviderTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignatureTrustAndValidityVerificationProviderTests.cs
@@ -1552,10 +1552,11 @@ namespace NuGet.Packaging.FuncTest
                 _provider = new SignatureTrustAndValidityVerificationProvider();
             }
 
+            // Case1: primary signature (trusted + non-expired) doesn't fall back to countersiganture (trusted + non-expired).
+            // The verification result is the primary signature status(valid). 
             [CIOnlyFact]
-            public async Task GetTrustResultAsync_FallbackFromTrustedPrimarySigntuareToValidCountersignature_NoFallbackAndReturnsValidAsync()
+            public async Task GetTrustResultAsync_FallbackFromGoodPrimarySigntuareToGoodCountersignature_NoFallbackAndReturnsValidAsync()
             {
-                //Same settings with validating packages from nuget.org (AcceptModeDefaultPolicy + allowUnsigned:false + allowUntrusted:false)
                 var settings = _defaultNuGetOrgSettings;
 
                 using (Test test = await Test.CreateAuthorSignedRepositoryCountersignedPackageAsync(
@@ -1570,10 +1571,11 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
+            // Case2: primary signature (trusted + non-expired) doesn't fall back to countersiganture untrusted + non-expired).
+            // The verification result is the primary signature status(valid).
             [CIOnlyFact]
-            public async Task GetTrustResultAsync_FallbackFromTrustedPrimarySigntuareToUntrustedCountersignature_NoFallbackAndReturnsValidAsync()
+            public async Task GetTrustResultAsync_FallbackFromGoodPrimarySigntuareToUntrustedCountersignature_NoFallbackAndReturnsValidAsync()
             {
-                //Same settings with validating packages from nuget.org (AcceptModeDefaultPolicy + allowUnsigned:false + allowUntrusted:false)
                 var settings = _defaultNuGetOrgSettings;
 
                 using (Test test = await Test.CreateAuthorSignedRepositoryCountersignedPackageAsync(
@@ -1588,10 +1590,11 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
+            // Case3: primary signature (untrusted + non-expired) falls back to countersiganture (trusted + non-expired).
+            // The verification result is the sever one of fallback status(valid) and the countersignature status(valid), so it's valid.
             [CIOnlyFact]
-            public async Task GetTrustResultAsync_FallbackFromUntrustedPrimarySigntuareToValidCountersignature_FallbackAndReturnsValidAsync()
+            public async Task GetTrustResultAsync_FallbackFromUntrustedPrimarySigntuareToGoodCountersignature_FallbackAndReturnsValidAsync()
             {
-                //Same settings with validating packages from nuget.org (AcceptModeDefaultPolicy + allowUnsigned:false + allowUntrusted:false)
                 var settings = _defaultNuGetOrgSettings;
 
                 using (Test test = await Test.CreateAuthorSignedRepositoryCountersignedPackageAsync(
@@ -1606,10 +1609,11 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
+            // Case4: primary signature (untrusted + non-expired) falls back to countersiganture (untrusted + non-expired).
+            // The verification result is the sever one of fallback status(disallowed) and the countersignature status(disallowed), so it's disallowed.
             [CIOnlyFact]
             public async Task GetTrustResultAsync_FallbackFromUntrustedPrimarySigntuareToUntrustedCountersignature_FallbackAndReturnsDisallowedAsync()
             {
-                //Same settings with validating packages from nuget.org (AcceptModeDefaultPolicy + allowUnsigned:false + allowUntrusted:false)
                 var settings = _defaultNuGetOrgSettings;
 
                 using (Test test = await Test.CreateAuthorSignedRepositoryCountersignedPackageAsync(
@@ -1624,12 +1628,14 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
+            // Case5: primary signature (trusted + expired) falls back to countersiganture (trusted + non-expired).
+            // And the timestamp on countersignature could fullfill the role of a trust anchor for primary signature.
+            // The verification result is the sever one of fallback status(valid) and the countersignature status(valid), so it's valid.
             [CIOnlyFact]
-            public async Task GetTrustResultAsync_FallbackFromExpiredPrimarySigntuareToValidCountersignatureWithTimestamp_FallbackAndReturnsValidAsync()
+            public async Task GetTrustResultAsync_FallbackFromExpiredPrimarySigntuareToGoodCountersignatureWithTimestamp_FallbackAndReturnsValidAsync()
             {
                 TimestampService timestampService = await _fixture.GetDefaultTrustedTimestampServiceAsync();
 
-                //Same settings with validating packages from nuget.org (AcceptModeDefaultPolicy + allowUnsigned:false + allowUntrusted:false)
                 var settings = _defaultNuGetOrgSettings;
 
                 using (X509Certificate2 authorSigningCertificate = await GetExpiringCertificateAsync(_fixture))
@@ -1648,12 +1654,13 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
+            // Case6: primary signature (trusted + expired) falls back to countersiganture (untrusted + non-expired).
+            // The verification result is the sever one of fallback status(disallowed) and the countersignature status(disallowed), so it's disallowed.
             [CIOnlyFact]
             public async Task GetTrustResultAsync_FallbackFromExpiredPrimarySigntuareToUntrustedCountersignatureWithTimestamp_FallbackAndReturnsDisallowedAsync()
             {
                 TimestampService timestampService = await _fixture.GetDefaultTrustedTimestampServiceAsync();
 
-                //Same settings with validating packages from nuget.org (AcceptModeDefaultPolicy + allowUnsigned:false + allowUntrusted:false)
                 var settings = _defaultNuGetOrgSettings;
 
                 using (X509Certificate2 authorSigningCertificate = await GetExpiringCertificateAsync(_fixture))
@@ -1672,10 +1679,12 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
+            // Case7: primary signature (trusted + expired) falls back to countersiganture (trusted + non-expired).
+            // But the timestamp on countersignature could NOT fullfill the role of a trust anchor for primary signature.
+            // The verification result is the sever one of fallback status(disallowed) and the countersignature status(valid), so it's disallowed.
             [CIOnlyFact]
-            public async Task GetTrustResultAsync_FallbackFromExpiredPrimarySigntuareToValidCountersignatureWithNoTimestamp_FallbackAndReturnsDisallowedAsync()
+            public async Task GetTrustResultAsync_FallbackFromExpiredPrimarySigntuareToGoodCountersignatureWithNoTimestamp_FallbackAndReturnsDisallowedAsync()
             {
-                //Same settings with validating packages from nuget.org (AcceptModeDefaultPolicy + allowUnsigned:false + allowUntrusted:false)
                 var settings = _defaultNuGetOrgSettings;
 
                 using (X509Certificate2 authorSigningCertificate = await GetExpiringCertificateAsync(_fixture))
@@ -1692,12 +1701,14 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
+            // Case8: primary signature (trusted + expired) falls back to countersiganture (trusted + expired but protected by a timestamp).
+            // And the timestamp on countersignature could fullfill the role of a trust anchor for primary signature.
+            // The verification result is the sever one of fallback status(valid) and the countersignature status(valid), so it's valid.
             [CIOnlyFact]
             public async Task GetTrustResultAsync_FallbackFromExpiredPrimarySigntuareToExpiredCountersignatureWithTimestamp_FallbackAndReturnsValidAsync()
             {
                 TimestampService timestampService = await _fixture.GetDefaultTrustedTimestampServiceAsync();
 
-                //Same settings with validating packages from nuget.org (AcceptModeDefaultPolicy + allowUnsigned:false + allowUntrusted:false)
                 var settings = _defaultNuGetOrgSettings;
 
                 using (X509Certificate2 authorSigningCertificate = await GetExpiringCertificateAsync(_fixture))
@@ -1718,10 +1729,12 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
+            // Case9: primary signature (untrusted + expired) falls back to countersiganture (trusted + non-expired).
+            // But the timestamp on countersignature could NOT fullfill the role of a trust anchor for primary signature.
+            // The verification result is the sever one of fallback status(disallowed) and the countersignature status(valid), so it's disallowed.
             [CIOnlyFact]
-            public async Task GetTrustResultAsync_FallbackFromUntrustedExpiredPrimarySigntuareToValidCountersignatureWithNoTimestamp_FallbackAndReturnsDisallowedAsync()
+            public async Task GetTrustResultAsync_FallbackFromUntrustedExpiredPrimarySigntuareToGoodCountersignatureWithNoTimestamp_FallbackAndReturnsDisallowedAsync()
             {
-                //Same settings with validating packages from nuget.org (AcceptModeDefaultPolicy + allowUnsigned:false + allowUntrusted:false)
                 var settings = _defaultNuGetOrgSettings;
 
                 using (X509Certificate2 authorSigningCertificate = _fixture.CreateUntrustedTestCertificateThatWillExpireSoon().Cert)
@@ -1738,12 +1751,14 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
+            // Case10: primary signature (untrusted + expired) falls back to countersiganture (trusted + non-expired).
+            // And the timestamp on countersignature could fullfill the role of a trust anchor for primary signature.
+            // The verification result is the sever one of fallback status(valid) and the countersignature status(valid), so it's valid.
             [CIOnlyFact]
-            public async Task GetTrustResultAsync_FallbackFromUntrustedExpiredPrimarySigntuareToValidCountersignatureWithTimestamp_FallbackAndReturnsValidAsync()
+            public async Task GetTrustResultAsync_FallbackFromUntrustedExpiredPrimarySigntuareToGoodCountersignatureWithTimestamp_FallbackAndReturnsValidAsync()
             {
                 TimestampService timestampService = await _fixture.GetDefaultTrustedTimestampServiceAsync();
 
-                //Same settings with validating packages from nuget.org (AcceptModeDefaultPolicy + allowUnsigned:false + allowUntrusted:false)
                 var settings = _defaultNuGetOrgSettings;
 
                 using (X509Certificate2 authorSigningCertificate = _fixture.CreateUntrustedTestCertificateThatWillExpireSoon().Cert)

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignatureTrustAndValidityVerificationProviderTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignatureTrustAndValidityVerificationProviderTests.cs
@@ -1778,8 +1778,6 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-
-
         private sealed class Test : IDisposable
         {
             private readonly TestDirectory _directory;

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignatureTrustAndValidityVerificationProviderTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignatureTrustAndValidityVerificationProviderTests.cs
@@ -1523,8 +1523,8 @@ namespace NuGet.Packaging.FuncTest
 
         [Collection(SigningTestCollection.Name)]
         public class FallbackFromPrimarySignaturesToCountersignatures
-        { 
-            //The settings when validating packages from nuget.org (AcceptModeDefaultPolicy + allowUnsigned:false + allowUntrusted:false)
+        {
+            //The settings when validating packages from nuget.org in accept mode (AcceptModeDefaultPolicy + allowUnsigned:false + allowUntrusted:false)
             private readonly SignedPackageVerifierSettings _defaultNuGetOrgSettings = new SignedPackageVerifierSettings(
                 allowUnsigned: false,
                 allowIllegal: true,

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignatureTrustAndValidityVerificationProviderTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignatureTrustAndValidityVerificationProviderTests.cs
@@ -1552,91 +1552,97 @@ namespace NuGet.Packaging.FuncTest
                 _provider = new SignatureTrustAndValidityVerificationProvider();
             }
 
-            // Case1: primary signature (trusted + non-expired) doesn't fall back to countersiganture (trusted + non-expired).
+            // Case1: primary signature (trusted + non-expired) doesn't fall back to countersignature (trusted + non-expired).
             // The verification result is the primary signature status(valid). 
             [CIOnlyFact]
-            public async Task GetTrustResultAsync_FallbackFromGoodPrimarySigntuareToGoodCountersignature_NoFallbackAndReturnsValidAsync()
+            public async Task GetTrustResultAsync_WithGoodPrimarySignatureAndGoodCountersignature_NoFallbackAndReturnsValidAsync()
             {
-                var settings = _defaultNuGetOrgSettings;
-
                 using (Test test = await Test.CreateAuthorSignedRepositoryCountersignedPackageAsync(
                     authorCertificate: _fixture.TrustedTestCertificate.Source.Cert,
                     repositoryCertificate: _fixture.TrustedRepositoryCertificate.Source.Cert))
                 using (var packageReader = new PackageArchiveReader(test.PackageFile.FullName))
                 {
                     PrimarySignature primarySignature = await packageReader.GetPrimarySignatureAsync(CancellationToken.None);
-                    PackageVerificationResult status = await _provider.GetTrustResultAsync(packageReader, primarySignature, settings, CancellationToken.None);
+                    PackageVerificationResult status = await _provider.GetTrustResultAsync(packageReader, primarySignature, _defaultNuGetOrgSettings, CancellationToken.None);
 
                     Assert.Equal(SignatureVerificationStatus.Valid, status.Trust);
+                    IEnumerable<SignatureLog> NU3018Issues = status.Issues.Where(log => log.Code == NuGetLogCode.NU3018);
+                    IEnumerable<SignatureLog> NU3037Issues = status.Issues.Where(log => log.Code == NuGetLogCode.NU3037);
+                    Assert.Empty(NU3018Issues);
+                    Assert.Empty(NU3037Issues);
                 }
             }
 
-            // Case2: primary signature (trusted + non-expired) doesn't fall back to countersiganture untrusted + non-expired).
+            // Case2: primary signature (trusted + non-expired) doesn't fall back to countersignature untrusted + non-expired).
             // The verification result is the primary signature status(valid).
             [CIOnlyFact]
-            public async Task GetTrustResultAsync_FallbackFromGoodPrimarySigntuareToUntrustedCountersignature_NoFallbackAndReturnsValidAsync()
+            public async Task GetTrustResultAsync_WithGoodPrimarySignatureAndUntrustedCountersignature_NoFallbackAndReturnsValidAsync()
             {
-                var settings = _defaultNuGetOrgSettings;
-
                 using (Test test = await Test.CreateAuthorSignedRepositoryCountersignedPackageAsync(
                     authorCertificate: _fixture.TrustedTestCertificate.Source.Cert,
                     repositoryCertificate: _fixture.UntrustedTestCertificate.Cert))
                 using (var packageReader = new PackageArchiveReader(test.PackageFile.FullName))
                 {
                     PrimarySignature primarySignature = await packageReader.GetPrimarySignatureAsync(CancellationToken.None);
-                    PackageVerificationResult status = await _provider.GetTrustResultAsync(packageReader, primarySignature, settings, CancellationToken.None);
+                    PackageVerificationResult status = await _provider.GetTrustResultAsync(packageReader, primarySignature, _defaultNuGetOrgSettings, CancellationToken.None);
 
                     Assert.Equal(SignatureVerificationStatus.Valid, status.Trust);
+                    IEnumerable<SignatureLog> NU3018Issues = status.Issues.Where(log => log.Code == NuGetLogCode.NU3018);
+                    IEnumerable<SignatureLog> NU3037Issues = status.Issues.Where(log => log.Code == NuGetLogCode.NU3037);
+                    Assert.Empty(NU3018Issues);
+                    Assert.Empty(NU3037Issues);
                 }
             }
 
-            // Case3: primary signature (untrusted + non-expired) falls back to countersiganture (trusted + non-expired).
-            // The verification result is the sever one of fallback status(valid) and the countersignature status(valid), so it's valid.
+            // Case3: primary signature (untrusted + non-expired) falls back to countersignature (trusted + non-expired).
+            // The verification result is the severe one of fallback status(valid) and the countersignature status(valid), so it's valid.
             [CIOnlyFact]
-            public async Task GetTrustResultAsync_FallbackFromUntrustedPrimarySigntuareToGoodCountersignature_FallbackAndReturnsValidAsync()
+            public async Task GetTrustResultAsync_WithUntrustedPrimarySignatureAndGoodCountersignature_FallbackAndReturnsValidAsync()
             {
-                var settings = _defaultNuGetOrgSettings;
-
                 using (Test test = await Test.CreateAuthorSignedRepositoryCountersignedPackageAsync(
                     authorCertificate: _fixture.UntrustedTestCertificate.Cert,
                     repositoryCertificate: _fixture.TrustedRepositoryCertificate.Source.Cert))
                 using (var packageReader = new PackageArchiveReader(test.PackageFile.FullName))
                 {
                     PrimarySignature primarySignature = await packageReader.GetPrimarySignatureAsync(CancellationToken.None);
-                    PackageVerificationResult status = await _provider.GetTrustResultAsync(packageReader, primarySignature, settings, CancellationToken.None);
+                    PackageVerificationResult status = await _provider.GetTrustResultAsync(packageReader, primarySignature, _defaultNuGetOrgSettings, CancellationToken.None);
 
                     Assert.Equal(SignatureVerificationStatus.Valid, status.Trust);
+                    IEnumerable<SignatureLog> NU3018Issues = status.Issues.Where(log => log.Code == NuGetLogCode.NU3018);
+                    IEnumerable<SignatureLog> NU3037Issues = status.Issues.Where(log => log.Code == NuGetLogCode.NU3037);
+                    Assert.Empty(NU3018Issues);
+                    Assert.Empty(NU3037Issues);
                 }
             }
 
-            // Case4: primary signature (untrusted + non-expired) falls back to countersiganture (untrusted + non-expired).
-            // The verification result is the sever one of fallback status(disallowed) and the countersignature status(disallowed), so it's disallowed.
+            // Case4: primary signature (untrusted + non-expired) falls back to countersignature (untrusted + non-expired).
+            // The verification result is the severe one of fallback status(disallowed) and the countersignature status(disallowed), so it's disallowed.
             [CIOnlyFact]
-            public async Task GetTrustResultAsync_FallbackFromUntrustedPrimarySigntuareToUntrustedCountersignature_FallbackAndReturnsDisallowedAsync()
+            public async Task GetTrustResultAsync_WithUntrustedPrimarySignatureAndUntrustedCountersignature_FallbackAndReturnsDisallowedAsync()
             {
-                var settings = _defaultNuGetOrgSettings;
-
                 using (Test test = await Test.CreateAuthorSignedRepositoryCountersignedPackageAsync(
                     authorCertificate: _fixture.UntrustedTestCertificate.Cert,
                     repositoryCertificate: _fixture.UntrustedTestCertificate.Cert))
                 using (var packageReader = new PackageArchiveReader(test.PackageFile.FullName))
                 {
                     PrimarySignature primarySignature = await packageReader.GetPrimarySignatureAsync(CancellationToken.None);
-                    PackageVerificationResult status = await _provider.GetTrustResultAsync(packageReader, primarySignature, settings, CancellationToken.None);
+                    PackageVerificationResult status = await _provider.GetTrustResultAsync(packageReader, primarySignature, _defaultNuGetOrgSettings, CancellationToken.None);
 
                     Assert.Equal(SignatureVerificationStatus.Disallowed, status.Trust);
+                    IEnumerable<SignatureLog> NU3018Issues = status.Issues.Where(log => log.Code == NuGetLogCode.NU3018);
+                    IEnumerable<SignatureLog> NU3037Issues = status.Issues.Where(log => log.Code == NuGetLogCode.NU3037);
+                    Assert.Equal(NU3018Issues.Count(), 2);
+                    Assert.Empty(NU3037Issues);
                 }
             }
 
-            // Case5: primary signature (trusted + expired) falls back to countersiganture (trusted + non-expired).
+            // Case5: primary signature (trusted + expired) falls back to countersignature (trusted + non-expired).
             // And the timestamp on countersignature could fullfill the role of a trust anchor for primary signature.
-            // The verification result is the sever one of fallback status(valid) and the countersignature status(valid), so it's valid.
+            // The verification result is the severe one of fallback status(valid) and the countersignature status(valid), so it's valid.
             [CIOnlyFact]
-            public async Task GetTrustResultAsync_FallbackFromExpiredPrimarySigntuareToGoodCountersignatureWithTimestamp_FallbackAndReturnsValidAsync()
+            public async Task GetTrustResultAsync_WithExpiredPrimarySignatureAndGoodCountersignatureWithTimestamp_FallbackAndReturnsValidAsync()
             {
                 TimestampService timestampService = await _fixture.GetDefaultTrustedTimestampServiceAsync();
-
-                var settings = _defaultNuGetOrgSettings;
 
                 using (X509Certificate2 authorSigningCertificate = await GetExpiringCertificateAsync(_fixture))
                 using (Test test = await Test.CreateAuthorSignedRepositoryCountersignedPackageAsync(
@@ -1648,20 +1654,22 @@ namespace NuGet.Packaging.FuncTest
                 {
                     await SignatureTestUtility.WaitForCertificateExpirationAsync(authorSigningCertificate);
                     PrimarySignature primarySignature = await packageReader.GetPrimarySignatureAsync(CancellationToken.None);
-                    PackageVerificationResult status = await _provider.GetTrustResultAsync(packageReader, primarySignature, settings, CancellationToken.None);
+                    PackageVerificationResult status = await _provider.GetTrustResultAsync(packageReader, primarySignature, _defaultNuGetOrgSettings, CancellationToken.None);
 
                     Assert.Equal(SignatureVerificationStatus.Valid, status.Trust);
+                    IEnumerable<SignatureLog> NU3018Issues = status.Issues.Where(log => log.Code == NuGetLogCode.NU3018);
+                    IEnumerable<SignatureLog> NU3037Issues = status.Issues.Where(log => log.Code == NuGetLogCode.NU3037);
+                    Assert.Empty(NU3018Issues);
+                    Assert.Empty(NU3037Issues);
                 }
             }
 
-            // Case6: primary signature (trusted + expired) falls back to countersiganture (untrusted + non-expired).
-            // The verification result is the sever one of fallback status(disallowed) and the countersignature status(disallowed), so it's disallowed.
+            // Case6: primary signature (trusted + expired) falls back to countersignature (untrusted + non-expired).
+            // The verification result is the severe one of fallback status(disallowed) and the countersignature status(disallowed), so it's disallowed.
             [CIOnlyFact]
-            public async Task GetTrustResultAsync_FallbackFromExpiredPrimarySigntuareToUntrustedCountersignatureWithTimestamp_FallbackAndReturnsDisallowedAsync()
+            public async Task GetTrustResultAsync_WithExpiredPrimarySignatureAndUntrustedCountersignatureWithTimestamp_FallbackAndReturnsDisallowedAsync()
             {
                 TimestampService timestampService = await _fixture.GetDefaultTrustedTimestampServiceAsync();
-
-                var settings = _defaultNuGetOrgSettings;
 
                 using (X509Certificate2 authorSigningCertificate = await GetExpiringCertificateAsync(_fixture))
                 using (Test test = await Test.CreateAuthorSignedRepositoryCountersignedPackageAsync(
@@ -1673,20 +1681,22 @@ namespace NuGet.Packaging.FuncTest
                 {
                     await SignatureTestUtility.WaitForCertificateExpirationAsync(authorSigningCertificate);
                     PrimarySignature primarySignature = await packageReader.GetPrimarySignatureAsync(CancellationToken.None);
-                    PackageVerificationResult status = await _provider.GetTrustResultAsync(packageReader, primarySignature, settings, CancellationToken.None);
+                    PackageVerificationResult status = await _provider.GetTrustResultAsync(packageReader, primarySignature, _defaultNuGetOrgSettings, CancellationToken.None);
 
                     Assert.Equal(SignatureVerificationStatus.Disallowed, status.Trust);
+                    IEnumerable<SignatureLog> NU3018Issues = status.Issues.Where(log => log.Code == NuGetLogCode.NU3018);
+                    IEnumerable<SignatureLog> NU3037Issues = status.Issues.Where(log => log.Code == NuGetLogCode.NU3037);
+                    Assert.Equal(NU3018Issues.Count(), 1);
+                    Assert.Equal(NU3037Issues.Count(), 1);
                 }
             }
 
-            // Case7: primary signature (trusted + expired) falls back to countersiganture (trusted + non-expired).
+            // Case7: primary signature (trusted + expired) falls back to countersignature (trusted + non-expired).
             // But the timestamp on countersignature could NOT fullfill the role of a trust anchor for primary signature.
-            // The verification result is the sever one of fallback status(disallowed) and the countersignature status(valid), so it's disallowed.
+            // The verification result is the severe one of fallback status(disallowed) and the countersignature status(valid), so it's disallowed.
             [CIOnlyFact]
-            public async Task GetTrustResultAsync_FallbackFromExpiredPrimarySigntuareToGoodCountersignatureWithNoTimestamp_FallbackAndReturnsDisallowedAsync()
+            public async Task GetTrustResultAsync_WithExpiredPrimarySignatureAndGoodCountersignatureWithNoTimestamp_FallbackAndReturnsDisallowedAsync()
             {
-                var settings = _defaultNuGetOrgSettings;
-
                 using (X509Certificate2 authorSigningCertificate = await GetExpiringCertificateAsync(_fixture))
                 using (Test test = await Test.CreateAuthorSignedRepositoryCountersignedPackageAsync(
                     authorCertificate: authorSigningCertificate,
@@ -1695,21 +1705,23 @@ namespace NuGet.Packaging.FuncTest
                 {
                     await SignatureTestUtility.WaitForCertificateExpirationAsync(authorSigningCertificate);
                     PrimarySignature primarySignature = await packageReader.GetPrimarySignatureAsync(CancellationToken.None);
-                    PackageVerificationResult status = await _provider.GetTrustResultAsync(packageReader, primarySignature, settings, CancellationToken.None);
+                    PackageVerificationResult status = await _provider.GetTrustResultAsync(packageReader, primarySignature, _defaultNuGetOrgSettings, CancellationToken.None);
 
                     Assert.Equal(SignatureVerificationStatus.Disallowed, status.Trust);
+                    IEnumerable<SignatureLog> NU3018Issues = status.Issues.Where(log => log.Code == NuGetLogCode.NU3018);
+                    IEnumerable<SignatureLog> NU3037Issues = status.Issues.Where(log => log.Code == NuGetLogCode.NU3037);
+                    Assert.Empty(NU3018Issues);
+                    Assert.Equal(NU3037Issues.Count(), 1);
                 }
             }
 
-            // Case8: primary signature (trusted + expired) falls back to countersiganture (trusted + expired but protected by a timestamp).
+            // Case8: primary signature (trusted + expired) falls back to countersignature (trusted + expired but protected by a timestamp).
             // And the timestamp on countersignature could fullfill the role of a trust anchor for primary signature.
-            // The verification result is the sever one of fallback status(valid) and the countersignature status(valid), so it's valid.
+            // The verification result is the severe one of fallback status(valid) and the countersignature status(valid), so it's valid.
             [CIOnlyFact]
-            public async Task GetTrustResultAsync_FallbackFromExpiredPrimarySigntuareToExpiredCountersignatureWithTimestamp_FallbackAndReturnsValidAsync()
+            public async Task GetTrustResultAsync_WithExpiredPrimarySignatureAndExpiredCountersignatureWithTimestamp_FallbackAndReturnsValidAsync()
             {
                 TimestampService timestampService = await _fixture.GetDefaultTrustedTimestampServiceAsync();
-
-                var settings = _defaultNuGetOrgSettings;
 
                 using (X509Certificate2 authorSigningCertificate = await GetExpiringCertificateAsync(_fixture))
                 using (X509Certificate2 repositorySigningCertificate = await GetExpiringCertificateAsync(_fixture))
@@ -1723,20 +1735,22 @@ namespace NuGet.Packaging.FuncTest
                     await SignatureTestUtility.WaitForCertificateExpirationAsync(authorSigningCertificate);
                     await SignatureTestUtility.WaitForCertificateExpirationAsync(repositorySigningCertificate);
                     PrimarySignature primarySignature = await packageReader.GetPrimarySignatureAsync(CancellationToken.None);
-                    PackageVerificationResult status = await _provider.GetTrustResultAsync(packageReader, primarySignature, settings, CancellationToken.None);
+                    PackageVerificationResult status = await _provider.GetTrustResultAsync(packageReader, primarySignature, _defaultNuGetOrgSettings, CancellationToken.None);
 
                     Assert.Equal(SignatureVerificationStatus.Valid, status.Trust);
+                    IEnumerable<SignatureLog> NU3018Issues = status.Issues.Where(log => log.Code == NuGetLogCode.NU3018);
+                    IEnumerable<SignatureLog> NU3037Issues = status.Issues.Where(log => log.Code == NuGetLogCode.NU3037);
+                    Assert.Empty(NU3018Issues);
+                    Assert.Empty(NU3018Issues);
                 }
             }
 
-            // Case9: primary signature (untrusted + expired) falls back to countersiganture (trusted + non-expired).
+            // Case9: primary signature (untrusted + expired) falls back to countersignature (trusted + non-expired).
             // But the timestamp on countersignature could NOT fullfill the role of a trust anchor for primary signature.
-            // The verification result is the sever one of fallback status(disallowed) and the countersignature status(valid), so it's disallowed.
+            // The verification result is the severe one of fallback status(disallowed) and the countersignature status(valid), so it's disallowed.
             [CIOnlyFact]
-            public async Task GetTrustResultAsync_FallbackFromUntrustedExpiredPrimarySigntuareToGoodCountersignatureWithNoTimestamp_FallbackAndReturnsDisallowedAsync()
+            public async Task GetTrustResultAsync_WithUntrustedExpiredPrimarySignatureAndGoodCountersignatureWithNoTimestamp_FallbackAndReturnsDisallowedAsync()
             {
-                var settings = _defaultNuGetOrgSettings;
-
                 using (X509Certificate2 authorSigningCertificate = _fixture.CreateUntrustedTestCertificateThatWillExpireSoon().Cert)
                 using (Test test = await Test.CreateAuthorSignedRepositoryCountersignedPackageAsync(
                     authorCertificate: authorSigningCertificate,
@@ -1745,21 +1759,23 @@ namespace NuGet.Packaging.FuncTest
                 {
                     await SignatureTestUtility.WaitForCertificateExpirationAsync(authorSigningCertificate);
                     PrimarySignature primarySignature = await packageReader.GetPrimarySignatureAsync(CancellationToken.None);
-                    PackageVerificationResult status = await _provider.GetTrustResultAsync(packageReader, primarySignature, settings, CancellationToken.None);
+                    PackageVerificationResult status = await _provider.GetTrustResultAsync(packageReader, primarySignature, _defaultNuGetOrgSettings, CancellationToken.None);
 
                     Assert.Equal(SignatureVerificationStatus.Disallowed, status.Trust);
+                    IEnumerable<SignatureLog> NU3018Issues = status.Issues.Where(log => log.Code == NuGetLogCode.NU3018);
+                    IEnumerable<SignatureLog> NU3037Issues = status.Issues.Where(log => log.Code == NuGetLogCode.NU3037);
+                    Assert.Empty(NU3018Issues);
+                    Assert.Equal(NU3037Issues.Count(), 1);
                 }
             }
 
-            // Case10: primary signature (untrusted + expired) falls back to countersiganture (trusted + non-expired).
+            // Case10: primary signature (untrusted + expired) falls back to countersignature (trusted + non-expired).
             // And the timestamp on countersignature could fullfill the role of a trust anchor for primary signature.
-            // The verification result is the sever one of fallback status(valid) and the countersignature status(valid), so it's valid.
+            // The verification result is the severe one of fallback status(valid) and the countersignature status(valid), so it's valid.
             [CIOnlyFact]
-            public async Task GetTrustResultAsync_FallbackFromUntrustedExpiredPrimarySigntuareToGoodCountersignatureWithTimestamp_FallbackAndReturnsValidAsync()
+            public async Task GetTrustResultAsync_WithUntrustedExpiredPrimarySignatureAndGoodCountersignatureWithTimestamp_FallbackAndReturnsValidAsync()
             {
                 TimestampService timestampService = await _fixture.GetDefaultTrustedTimestampServiceAsync();
-
-                var settings = _defaultNuGetOrgSettings;
 
                 using (X509Certificate2 authorSigningCertificate = _fixture.CreateUntrustedTestCertificateThatWillExpireSoon().Cert)
                 using (Test test = await Test.CreateAuthorSignedRepositoryCountersignedPackageAsync(
@@ -1771,9 +1787,13 @@ namespace NuGet.Packaging.FuncTest
                 {
                     await SignatureTestUtility.WaitForCertificateExpirationAsync(authorSigningCertificate);
                     PrimarySignature primarySignature = await packageReader.GetPrimarySignatureAsync(CancellationToken.None);
-                    PackageVerificationResult status = await _provider.GetTrustResultAsync(packageReader, primarySignature, settings, CancellationToken.None);
+                    PackageVerificationResult status = await _provider.GetTrustResultAsync(packageReader, primarySignature, _defaultNuGetOrgSettings, CancellationToken.None);
 
                     Assert.Equal(SignatureVerificationStatus.Valid, status.Trust);
+                    IEnumerable<SignatureLog> NU3018Issues = status.Issues.Where(log => log.Code == NuGetLogCode.NU3018);
+                    IEnumerable<SignatureLog> NU3037Issues = status.Issues.Where(log => log.Code == NuGetLogCode.NU3037);
+                    Assert.Empty(NU3018Issues);
+                    Assert.Empty(NU3037Issues);
                 }
             }
         }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

Fixes: https://github.com/NuGet/Client.Engineering/issues/737

Regression? Last working version:

## Description
Background : [validation flow,](https://github.com/NuGet/Client.Engineering/blob/c1d8807fd3f6956d80ae1755bf78f4925c22c0d8/docs/HowDoesPackageSignatureValidationWork.md#signatures-validation-process-overview)   [draft proposal](https://github.com/NuGet/Client.Engineering/blob/abed5ee2350b35ef81975e18ee612757d5e88c34/designs/packageverification_fallbacktorepositorysignature.md)

1.Add a `FallbackFromPrimarySignaturesToCountersignatures ` test class and add 10 test cases with detailed description.
2.Run test and the case9 failed as expected in [build ](https://dev.azure.com/devdiv/DevDiv/_build/results?buildId=4834312&view=results)
3. Apply the fix in `src/NuGet.Core/NuGet.Packaging/Signing/Verification/SignatureTrustAndValidityVerificationProvider.cs` and run those tests again, all tests passed.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
