### PR TITLE
Add integration tests for all dotnet new templates, Part 2

### DIFF
--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
@@ -1512,38 +1512,6 @@ EndGlobal";
             }
         }
 
-        [PlatformTheory(Platform.Linux)]
-        [InlineData("nunit-test")]
-        [InlineData("razorcomponent")]
-        [InlineData("page")]
-        [InlineData("viewimports")]
-        [InlineData("viewstart")]
-        [InlineData("gitignore")]
-        [InlineData("globaljson")]
-        [InlineData("nugetconfig")]
-        [InlineData("tool-manifest")]
-        [InlineData("webconfig")]
-        [InlineData("sln")]
-        [InlineData("proto")]
-        public void Dotnet_New_Template_CreateItem_Success(string template)
-        {
-            // Arrange
-            using (var pathContext = new SimpleTestPathContext())
-            {
-                var projectName = new DirectoryInfo(pathContext.SolutionRoot).Name;
-                var solutionDirectory = pathContext.SolutionRoot;
-
-                // Act
-                CommandRunnerResult newResult = _msbuildFixture.RunDotnet(solutionDirectory, "new " + template);
-
-                // Assert
-                // Make sure new template action was success.
-                newResult.Success.Should().BeTrue(because: newResult.AllOutput);
-                // No actual restore happen here
-                // Pack doesn't work because `IsPackable` is set to false.
-            }
-        }
-
         private static SimpleTestPackageContext CreateNetstandardCompatiblePackage(string id, string version)
         {
             var pkgX = new SimpleTestPackageContext(id, version);

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
@@ -1512,7 +1512,7 @@ EndGlobal";
             }
         }
 
-        [PlatformTheory(Platform.Windows)]
+        [PlatformTheory(Platform.Linux)]
         [InlineData("nunit-test")]
         [InlineData("razorcomponent")]
         [InlineData("page")]

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
@@ -1478,9 +1478,21 @@ EndGlobal";
             }
         }
 
-        [PlatformTheory(Platform.Linux)]
+        [PlatformTheory(Platform.Windows)]
         [InlineData("worker")]
         [InlineData("mstest")]
+        [InlineData("nunit")]
+        [InlineData("xunit")]
+        [InlineData("blazorserver")]
+        [InlineData("blazorwasm")]
+        [InlineData("web")]
+        [InlineData("mvc")]
+        [InlineData("webapp")]
+        [InlineData("angular")]
+        [InlineData("react")]
+        [InlineData("reactredux")]
+        [InlineData("webapi")]
+        [InlineData("grpc")]
         public void Dotnet_New_Template_Restore_Success(string template)
         {
             // Arrange
@@ -1496,6 +1508,38 @@ EndGlobal";
                 // Make sure restore action was success.
                 newResult.Success.Should().BeTrue(because: newResult.AllOutput);
                 Assert.True(File.Exists(Path.Combine(solutionDirectory, "obj", "project.assets.json")));
+                // Pack doesn't work because `IsPackable` is set to false.
+            }
+        }
+
+        [PlatformTheory(Platform.Windows)]
+        [InlineData("nunit-test")]
+        [InlineData("razorcomponent")]
+        [InlineData("page")]
+        [InlineData("viewimports")]
+        [InlineData("viewstart")]
+        [InlineData("gitignore")]
+        [InlineData("globaljson")]
+        [InlineData("nugetconfig")]
+        [InlineData("tool-manifest")]
+        [InlineData("webconfig")]
+        [InlineData("sln")]
+        [InlineData("proto")]
+        public void Dotnet_New_Template_CreateItem_Success(string template)
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                var projectName = new DirectoryInfo(pathContext.SolutionRoot).Name;
+                var solutionDirectory = pathContext.SolutionRoot;
+
+                // Act
+                CommandRunnerResult newResult = _msbuildFixture.RunDotnet(solutionDirectory, "new " + template);
+
+                // Assert
+                // Make sure new template action was success.
+                newResult.Success.Should().BeTrue(because: newResult.AllOutput);
+                // No actual restore happen here
                 // Pack doesn't work because `IsPackable` is set to false.
             }
         }

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
@@ -1478,7 +1478,7 @@ EndGlobal";
             }
         }
 
-        [PlatformTheory(Platform.Windows)]
+        [PlatformTheory(Platform.Linux)]
         [InlineData("worker")]
         [InlineData("mstest")]
         [InlineData("nunit")]

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
@@ -5638,6 +5638,7 @@ namespace ClassLibrary
         [InlineData("winforms")]
         [InlineData("winformscontrollib")]
         [InlineData("winformslib")]
+        [InlineData("razorclasslib")]
         public void Dotnet_New_Template_Restore_Pack_Success(string template)
         {
             // Arrange

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
@@ -5642,11 +5642,12 @@ namespace ClassLibrary
         public void Dotnet_New_Template_Restore_Pack_Success(string template)
         {
             // Arrange
-            using (var pathContext = new SimpleTestPathContext())
+            using (var testDirectory = TestDirectory.Create())
             {
-                var projectName = new DirectoryInfo(pathContext.SolutionRoot).Name;
-                var workDirectory = pathContext.WorkingDirectory;
-                var solutionDirectory = pathContext.SolutionRoot;
+                var projectName = "ClassLibrary1";
+                var workDirectory = Path.Combine(testDirectory);
+                var projectFile = Path.Combine(workDirectory, $"{projectName}.csproj");
+                var solutionDirectory = Path.Combine(testDirectory, projectName);
                 var nupkgPath = Path.Combine(solutionDirectory, "bin", "Debug", $"{projectName}.1.0.0.nupkg");
 
                 // Act


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Home/issues/10553

Regression? Last working version: N/A

## Description
We're adding `dotnet new templates` integration tests to prevent from regression in `dotnet new` command. This is one of the corrective actions related to https://github.com/NuGet/Client.Engineering/issues/727

Here are all remaining test cases, Part 2.  I address others in previous [Part 1](https://github.com/NuGet/NuGet.Client/pull/3964).

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [ ] N/A
