### PR TITLE
Remove the need to allocate a Func on each compatibility cache lookup

### DIFF
--- a/src/NuGet.Core/NuGet.Frameworks/CompatibilityProvider.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/CompatibilityProvider.cs
@@ -48,8 +48,7 @@ namespace NuGet.Frameworks
             // check the cache for a solution
             var cacheKey = new CompatibilityCacheKey(target, candidate);
 
-            bool result;
-            if (!_cache.TryGetValue(cacheKey, out result))
+            if (!_cache.TryGetValue(cacheKey, out bool result))
             {
                 result = IsCompatibleCore(target, candidate) == true;
                 _cache.TryAdd(cacheKey, result);

--- a/src/NuGet.Core/NuGet.Frameworks/CompatibilityProvider.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/CompatibilityProvider.cs
@@ -48,11 +48,14 @@ namespace NuGet.Frameworks
             // check the cache for a solution
             var cacheKey = new CompatibilityCacheKey(target, candidate);
 
-            bool? result = _cache.GetOrAdd(cacheKey, (Func<CompatibilityCacheKey, bool>)((key)
-                =>
-            { return IsCompatibleCore(target, candidate) == true; }));
+            bool result;
+            if (!_cache.TryGetValue(cacheKey, out result))
+            {
+                result = IsCompatibleCore(target, candidate) == true;
+                _cache.TryAdd(cacheKey, result);
+            }
 
-            return result == true;
+            return result;
         }
 
         /// <summary>


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/10919

Regression? Last working version: N/A

## Description
Instead of allocating a func to pass to the GetOrAdd method of the concurrent dictionary on each lookup, check the dictionary first to see if the entry already exists and evaluate its compatibility and add it to the cache only if it does not. That way, a Func does not need to be allocated for each lookup and reduces the overall GC pressure.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
Code is covered by existing tests
  - [x] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
