### PR TITLE
Unwrapped LINQ Where to be a conditional check inside for each loop

### DIFF
--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/Remote/RemoteDependencyWalker.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/Remote/RemoteDependencyWalker.cs
@@ -161,8 +161,13 @@ namespace NuGet.DependencyResolver
 
             // do not add nodes for all the centrally managed package versions to the graph
             // they will be added only if they are transitive
-            foreach (var dependency in node.Item.Data.Dependencies.Where(d => IsDependencyValidForGraph(d)))
+            foreach (var dependency in node.Item.Data.Dependencies)
             {
+                if (!IsDependencyValidForGraph(dependency))
+                {
+                    continue;
+                }
+
                 // Skip dependencies if the dependency edge has 'all' excluded and
                 // the node is not a direct dependency.
                 if (outerEdge == null


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/10920

Regression? Last working version: N/A

## Description
Unwrapped the LINQ where to be a conditional check inside the for each loop so it does not allocate extra objects on a hot code path in the DependencyWalker.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  Existing tests already cover the functionality
  - [x] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
