### PR TITLE
Implement CopyNupkgAsync overload for PackageArchieveReader

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs
@@ -177,6 +177,38 @@ namespace NuGet.Packaging
             return stream;
         }
 
+        /// <summary>
+        /// Asynchronously copies a package to the specified destination file path.
+        /// </summary>
+        /// <param name="nupkgFilePath">The destination file path.</param>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        /// <returns>A task that represents the asynchronous operation.
+        /// The task result (<see cref="Task{TResult}.Result" />) returns a <see cref="string" />.</returns>
+        /// <exception cref="ArgumentException">Thrown if <paramref name="nupkgFilePath" />
+        /// is either <c>null</c> or an empty string.</exception>
+        /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
+        /// is cancelled.</exception>
+        public override async Task<string> CopyNupkgAsync(
+            string nupkgFilePath,
+            CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrEmpty(nupkgFilePath))
+            {
+                throw new ArgumentException(Strings.ArgumentCannotBeNullOrEmpty, nameof(nupkgFilePath));
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            ZipReadStream.Seek(offset: 0, origin: SeekOrigin.Begin);
+
+            using (var destination = File.OpenWrite(nupkgFilePath))
+            {
+                await ZipReadStream.CopyToAsync(destination);
+            }
+
+            return nupkgFilePath;
+        }
+
         protected override void Dispose(bool disposing)
         {
             if (disposing)

--- a/src/NuGet.Core/NuGet.Packaging/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Packaging/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -11,5 +11,6 @@ NuGet.Packaging.ManifestMetadata.Readme.set -> void
 NuGet.Packaging.NuspecReader.GetReadme() -> string
 NuGet.Packaging.PackageBuilder.Readme.get -> string
 NuGet.Packaging.PackageBuilder.Readme.set -> void
+override NuGet.Packaging.PackageArchiveReader.CopyNupkgAsync(string nupkgFilePath, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<string>
 static NuGet.Packaging.Licenses.NuGetLicenseData.LicenseListVersion.get -> string
 static NuGet.Packaging.Signing.SignatureLog.MinimalLog(string message) -> NuGet.Packaging.Signing.SignatureLog

--- a/src/NuGet.Core/NuGet.Packaging/PublicAPI/netcoreapp5.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Packaging/PublicAPI/netcoreapp5.0/PublicAPI.Unshipped.txt
@@ -11,5 +11,6 @@ NuGet.Packaging.ManifestMetadata.Readme.set -> void
 NuGet.Packaging.NuspecReader.GetReadme() -> string
 NuGet.Packaging.PackageBuilder.Readme.get -> string
 NuGet.Packaging.PackageBuilder.Readme.set -> void
+override NuGet.Packaging.PackageArchiveReader.CopyNupkgAsync(string nupkgFilePath, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<string>
 static NuGet.Packaging.Licenses.NuGetLicenseData.LicenseListVersion.get -> string
 static NuGet.Packaging.Signing.SignatureLog.MinimalLog(string message) -> NuGet.Packaging.Signing.SignatureLog

--- a/src/NuGet.Core/NuGet.Packaging/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Packaging/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -11,5 +11,6 @@ NuGet.Packaging.ManifestMetadata.Readme.set -> void
 NuGet.Packaging.NuspecReader.GetReadme() -> string
 NuGet.Packaging.PackageBuilder.Readme.get -> string
 NuGet.Packaging.PackageBuilder.Readme.set -> void
+override NuGet.Packaging.PackageArchiveReader.CopyNupkgAsync(string nupkgFilePath, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<string>
 static NuGet.Packaging.Licenses.NuGetLicenseData.LicenseListVersion.get -> string
 static NuGet.Packaging.Signing.SignatureLog.MinimalLog(string message) -> NuGet.Packaging.Signing.SignatureLog

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageArchiveReaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageArchiveReaderTests.cs
@@ -1589,14 +1589,18 @@ namespace NuGet.Packaging.Test
         }
 
         [Fact]
-        public async Task CopyNupkgAsync_Throws()
+        public async Task CopyNupkgAsync_SucceedsAsync()
         {
+            // Arrange
             using (var test = PackageReaderTest.Create(TestPackagesCore.GetPackageCoreReaderTestPackage()))
             {
-                await Assert.ThrowsAsync<NotImplementedException>(
-                    () => test.Reader.CopyNupkgAsync(
+                // Act
+                var result = await test.Reader.CopyNupkgAsync(
                         nupkgFilePath: "a",
-                        cancellationToken: CancellationToken.None));
+                        cancellationToken: CancellationToken.None);
+
+                // Assert
+                Assert.Equal("a", result);
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageFolderReaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageFolderReaderTests.cs
@@ -1070,18 +1070,6 @@ namespace NuGet.Packaging.Test
             }
         }
 
-        [Fact]
-        public async Task CopyNupkgAsync_Throws()
-        {
-            using (var test = PackageReaderTest.Create(TestPackagesCore.GetPackageCoreReaderTestPackage()))
-            {
-                await Assert.ThrowsAsync<NotImplementedException>(
-                    () => test.Reader.CopyNupkgAsync(
-                        nupkgFilePath: "a",
-                        cancellationToken: CancellationToken.None));
-            }
-        }
-
         private static string ExtractFile(string sourcePath, string targetPath, Stream sourceStream)
         {
             using (var targetStream = File.OpenWrite(targetPath))


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Home/issues/10708

Regression? Last working version: N/A

## Description
Implemented overload for CopyNupkgAsync  method in PackageArchieveReader. Otherwise it throws not implemented exception. I problem writing unit test last time calling [PackageExtractor.ExtractPackageAsync](https://github.com/NuGet/NuGet.Client/blob/c6ca6ebcfe3fdad5815f19669c96431b53055b3b/src/NuGet.Core/NuGet.Packaging/PackageExtractor.cs#L244-L250) when I was writing unit test, only notice it if there is `PackageSaveMode.Nupkg` flag for `PackageSaveMode`. 

 

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [ ] N/A
