### PR TITLE
Avoid framework reducer allocations by using a static in ManagedCodeConventions

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/ContentModel/ManagedCodeConventions.cs
+++ b/src/NuGet.Core/NuGet.Packaging/ContentModel/ManagedCodeConventions.cs
@@ -65,6 +65,8 @@ namespace NuGet.Client
                 AnyFramework.Instance )
         });
 
+        private static readonly FrameworkReducer FrameworkReducer = new();
+
         private RuntimeGraph _runtimeGraph;
 
         private Dictionary<string, NuGetFramework> _frameworkCache
@@ -268,11 +270,10 @@ namespace NuGet.Client
                 // If the frameworks are the same this can be skipped
                 if (!criteriaFrameworkName.Equals(availableFrameworkName))
                 {
-                    var reducer = new FrameworkReducer();
                     var frameworks = new NuGetFramework[] { criteriaFrameworkName, availableFrameworkName };
 
                     // Find the nearest compatible framework to the project framework.
-                    var nearest = reducer.GetNearest(projectFrameworkName, frameworks);
+                    var nearest = FrameworkReducer.GetNearest(projectFrameworkName, frameworks);
 
                     if (criteriaFrameworkName.Equals(nearest))
                     {


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/10925

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

In commandline orchardcore clean restore, 20MB out of 9GB allocations are framework reducer.
Note that the framework reducer allocated uses shared instances of the compat provider, and there's no state beyond that, so no concurrency concerns.

After this change, the allocations for framework reducer are down to under 1MB.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception - no functional change
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
