### PR TITLE
NuGet.Client builds: Don't use Visual Studio version in bin, obj folder paths 

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -81,11 +81,6 @@ Trace-Log "Build #$BuildNumber started at $startTime"
 
 Test-BuildEnvironment -CI:$CI
 
-if (-not $VSToolsetInstalled) {
-    Warning-Log "The build is requested, but no toolset is available"
-    exit 1
-}
-
 $BuildErrors = @()
 
 Invoke-BuildStep 'Cleaning artifacts' {
@@ -104,6 +99,8 @@ else {
     $VSMessage = "Running Build, Pack, Core unit tests, and Unit tests";
 }
 
+$MSBuildExe = Get-MSBuildExe
+
 Invoke-BuildStep 'Running Restore' {
     # Restore
     $args = "build\build.proj", "/t:EnsurePackageReferenceVersionsInSolution", "/p:Configuration=$Configuration"
@@ -115,7 +112,7 @@ Invoke-BuildStep 'Running Restore' {
     Trace-Log ". `"$MSBuildExe`" $args"
     & $MSBuildExe @args
 
-    $args = "build\build.proj", "/t:RestoreVS", "/p:Configuration=$Configuration", "/p:ReleaseLabel=$ReleaseLabel", "/p:BuildNumber=$BuildNumber", "/p:IncludeApex=$IncludeApex", "/v:m", "/m:1"
+    $args = "build\build.proj", "/t:RestoreVS", "/p:Configuration=$Configuration", "/p:ReleaseLabel=$ReleaseLabel", "/p:BuildNumber=$BuildNumber", "/p:IncludeApex=$IncludeApex", "/v:m", "/m"
     if ($Binlog)
     {
         $args += "-bl:msbuild.restore.binlog"
@@ -163,7 +160,7 @@ Invoke-BuildStep 'Creating the EndToEnd test package' {
         param($Configuration)
         $EndToEndScript = Join-Path $PSScriptRoot scripts\cibuild\CreateEndToEndTestPackage.ps1 -Resolve
         $OutDir = Join-Path $Artifacts VS15
-        & $EndToEndScript -c $Configuration -tv 16 -out $OutDir
+        & $EndToEndScript -c $Configuration -out $OutDir
     } `
     -args $Configuration `
     -skip:(-not $PackageEndToEnd) `

--- a/build/build.proj
+++ b/build/build.proj
@@ -130,21 +130,21 @@
     ============================================================
   -->
   <Target Name="RunVS" DependsOnTargets="BuildVS;Pack;CoreUnitTests;UnitTestsVS">
-    <Message Text="Running NuGet Build for VS $(VisualStudioVersion)" Importance="high" />
+    <Message Text="Running NuGet Build" Importance="high" />
   </Target>
 
   <!--
     ============================================================
-    Build 
+    Build
     ============================================================
   -->
   <Target Name="BuildVS"  Condition=" '$(IsXPlat)' != 'true' " >
-    <Message Text="Building for VS $(VisualStudioVersion)" Importance="high" />
+    <Message Text="Building" Importance="high" />
   </Target>
 
     <!--
     ============================================================
-    Build for XPLAT 
+    Build for XPLAT
     ============================================================
   -->
   <Target Name="BuildXPLAT" DependsOnTargets="GetXPLATProjects">
@@ -157,12 +157,11 @@
     ============================================================
   -->
   <Target Name="BuildNoVSIX" AfterTargets="BuildVS" Condition=" '$(IsXPlat)' != 'true' ">
-    <Message Text="Building for VS $(VisualStudioVersion)" Importance="high" />
+    <Message Text="Building" Importance="high" />
 
     <MSBuild Projects="@(SolutionProjectsWithoutVSIX)"
              Targets="Build"
-             Properties="$(CommonMSBuildProperties);
-                         VisualStudioVersion=$(VisualStudioVersion);" />
+             Properties="$(CommonMSBuildProperties)" />
   </Target>
 
   <!--
@@ -175,8 +174,7 @@
 
     <MSBuild Projects="@(XPLATProjects)"
              Targets="Build"
-             Properties="$(CommonMSBuildProperties);
-                         VisualStudioVersion=$(VisualStudioVersion);" />
+             Properties="$(CommonMSBuildProperties);" />
   </Target>
 
   <!--
@@ -187,14 +185,13 @@
     ============================================================
   -->
   <Target Name="BuildVSIX" AfterTargets= "BuildVS" Condition=" '$(IsXPlat)' != 'true' AND '$(BuildRTM)' != 'true'">
-    <Message Text="Building the VSIX for VS $(VisualStudioVersion)" Importance="high" />
+    <Message Text="Building the VSIX" Importance="high" />
 
     <MSBuild Projects="$(VSIXProject)"
              Targets="Build"
              Properties="$(CommonMSBuildProperties);
                          BuildProjectReferences=false;
-                         IsVsixBuild=true;
-                         VisualStudioVersion=$(VisualStudioVersion);" />
+                         IsVsixBuild=true;" />
   </Target>
 
   <!--
@@ -209,8 +206,7 @@
     <MSBuild BuildInParallel="true"
              Projects="@(SolutionProjects)"
              Targets="Clean"
-             Properties="$(CommonMSBuildProperties);
-                         VisualStudioVersion=$(VisualStudioVersion);" />
+             Properties="$(CommonMSBuildProperties);" />
   </Target>
 
   <!--
@@ -219,13 +215,12 @@
     ============================================================
   -->
   <Target Name="Pack">
-    <Message Text="Packing for Visual Studio $(VisualStudioVersion)" Importance="high" />
+    <Message Text="Packing" Importance="high" />
 
     <MSBuild BuildInParallel="false"
              Projects="@(SolutionProjects)"
              Targets="PackProjects"
-             Properties="$(CommonMSBuildProperties);
-                         VisualStudioVersion=$(VisualStudioVersion);" />
+             Properties="$(CommonMSBuildProperties)" />
   </Target>
 
   <!--
@@ -239,8 +234,7 @@
     <MSBuild BuildInParallel="false"
              Projects="@(XPLATProjects)"
              Targets="PackProjects"
-             Properties="$(CommonMSBuildProperties);
-                         VisualStudioVersion=$(VisualStudioVersion);" />
+             Properties="$(CommonMSBuildProperties)" />
   </Target>
 
   <!--
@@ -249,7 +243,7 @@
     ============================================================
   -->
   <Target Name="Restore">
-    <Message Text="Restoring for Visual Studio $(VisualStudioVersion)" Importance="high" />
+    <Message Text="Restoring" Importance="high" />
 
     <!-- Convert list of projects to a property -->
     <PropertyGroup>
@@ -260,8 +254,7 @@
       Projects="restorehelper.targets"
       Targets="Restore"
       Properties="RestoreGraphProjectInput=$(ProjectListValue);
-                  $(CommonMSBuildProperties);
-                  VisualStudioVersion=$(VisualStudioVersion)">
+                  $(CommonMSBuildProperties)">
     </MSBuild>
   </Target>
 
@@ -274,8 +267,7 @@
     <MSBuild
       Projects="$(MSBuildThisFileFullPath)"
       Targets="Restore"
-      Properties="$(CommonMSBuildProperties);
-                  VisualStudioVersion=$(VisualStudioVersion)">
+      Properties="$(CommonMSBuildProperties)">
     </MSBuild>
   </Target>
 
@@ -286,7 +278,7 @@
   -->
   <Target Name="RestoreXPLAT" DependsOnTargets="GetXPLATProjects">
     <Message Text="Restoring for XPLAT" Importance="high" />
-    
+
     <PropertyGroup>
       <ProjectListValue>@(XPLATProjects)</ProjectListValue>
     </PropertyGroup>
@@ -295,14 +287,13 @@
       Projects="restorehelper.targets"
       Targets="Restore"
       Properties="RestoreGraphProjectInput=$(ProjectListValue);
-                  $(CommonMSBuildProperties);
-                  VisualStudioVersion=$(VisualStudioVersion)">
+                  $(CommonMSBuildProperties)">
     </MSBuild>
   </Target>
 
   <!--
     ============================================================
-    Restore Apex 
+    Restore Apex
     ============================================================
   -->
   <Target Name="RestoreApex">
@@ -316,8 +307,7 @@
       Projects="restorehelper.targets"
       Targets="Restore"
       Properties="RestoreGraphProjectInput=$(ProjectListValue);
-                  $(CommonMSBuildProperties);
-                  VisualStudioVersion=$(VisualStudioVersion)">
+                  $(CommonMSBuildProperties)">
     </MSBuild>
   </Target>
 
@@ -370,7 +360,7 @@
   <!--
     ============================================================
     RunTestsOnProjects
-    Finds all test assemblies and allows Xunit to run them as 
+    Finds all test assemblies and allows Xunit to run them as
     efficiently as the xunit.runner.json settings allow.
     ============================================================
   -->
@@ -384,8 +374,7 @@
     <MSBuild
             Projects="@(TestProjectToSearch)"
             Targets="GetTestAssemblies"
-            Properties="$(CommonMSBuildProperties);
-                         VisualStudioVersion=$(VisualStudioVersion);"
+            Properties="$(CommonMSBuildProperties)"
             Condition=" '$(TestProjectPaths)' != '' ">
       <Output TaskParameter="TargetOutputs"
               ItemName="TestAssemblyPath" />
@@ -408,7 +397,7 @@
       <!-- Sort assemblies -->
       <DesktopInputTestAssemblies>@(TestAssemblyPath->WithMetadataValue("IsDesktop", "true"))</DesktopInputTestAssemblies>
       <DesktopInputTestAssembliesSpaced>$(DesktopInputTestAssemblies.Replace(';', ' '))</DesktopInputTestAssembliesSpaced>
-      
+
       <!-- Build exe commands -->
       <DesktopTestCommand>$(XunitConsoleExePath) $(DesktopInputTestAssembliesSpaced) -verbose</DesktopTestCommand>
       <DesktopTestCommand Condition=" '$(TestResultsXunit)' != '' ">$(DesktopTestCommand) -$(TestResultOutputFormat) $(TestResultsXunit)</DesktopTestCommand>
@@ -423,7 +412,7 @@
     </PropertyGroup>
 
     <!-- Desktop -->
-    <Message Text="Running $(DesktopTestCommand)" 
+    <Message Text="Running $(DesktopTestCommand)"
           Condition=" '$(SkipDesktopAssemblies)' != 'true' AND '$(DesktopInputTestAssemblies)' != '' "/>
 
     <Exec Command="$(DesktopTestCommand)"
@@ -433,7 +422,7 @@
     </Exec>
 
     <!-- VSTest/NETCore -->
-    <Message Text="Running $(VSTestCommand)" 
+    <Message Text="Running $(VSTestCommand)"
           Condition=" '$(SkipCoreAssemblies)' != 'true' AND '$(CoreInputTestAssemblies)' != '' "/>
 
     <Exec Command="$(VSTestCommand)"

--- a/build/common.project.props
+++ b/build/common.project.props
@@ -33,8 +33,7 @@
     <SharedDirectory>$(BuildCommonDirectory)Shared</SharedDirectory>
     <NuGetCoreSrcDirectory>$(RepositoryRootDirectory)src\NuGet.Core\</NuGetCoreSrcDirectory>
     <NuGetClientsSrcDirectory>$(RepositoryRootDirectory)src\NuGet.Clients\</NuGetClientsSrcDirectory>
-    <NupkgOutputDirectory Condition=" '$(BuildRTM)' != 'true' ">$(ArtifactsDirectory)nupkgs\</NupkgOutputDirectory>
-    <NupkgOutputDirectory Condition=" '$(BuildRTM)' == 'true' ">$(ArtifactsDirectory)ReleaseNupkgs\</NupkgOutputDirectory>
+    <NupkgOutputDirectory>$(ArtifactsDirectory)nupkgs\</NupkgOutputDirectory>
     <SolutionPackagesFolder>$(RepositoryRootDirectory)packages\</SolutionPackagesFolder>
     <XunitConsoleExePath>$(SolutionPackagesFolder)xunit.runner.console\2.4.1\tools\net472\xunit.console.x86.exe</XunitConsoleExePath>
     <ILMergeExePath>$(SolutionPackagesFolder)ilmerge\3.0.21\tools\net452\ILMerge.exe</ILMergeExePath>
@@ -113,10 +112,6 @@
     <VsixPublishDestination>$(ArtifactRoot)$(VsixOutputDirName)\</VsixPublishDestination>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(BuildRTM)' == 'true' ">
-    <VsixOutputDirName>$(VsixOutputDirName)-RTM</VsixOutputDirName>
-  </PropertyGroup>
-
   <PropertyGroup Condition=" '$(PreReleaseVersion)' == '' ">
     <PreReleaseVersion>0</PreReleaseVersion>
   </PropertyGroup>
@@ -146,17 +141,13 @@
     <Version>$(SemanticVersion)$(PreReleaseInformationVersion)</Version>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <BuildVariationFolder>$(VisualStudioVersion)</BuildVariationFolder>
-    <BuildVariationFolder Condition=" '$(BuildRTM)' == 'true' ">$(BuildVariationFolder)-RTM</BuildVariationFolder>
-  </PropertyGroup>
   <!-- Set the output location for all non-test projects -->
   <!-- Test projects currently fail when the output dir is moved -->
   <PropertyGroup Condition=" '$(TestProject)' != 'true' OR '$(Shipping)' == 'true'">
     <!-- output paths -->
-    <BaseIntermediateOutputPath>$(ArtifactsDirectory)$(MSBuildProjectName)\$(BuildVariationFolder)\obj\</BaseIntermediateOutputPath>
+    <BaseIntermediateOutputPath>$(ArtifactsDirectory)$(MSBuildProjectName)\obj\</BaseIntermediateOutputPath>
     <IntermediateOutputPath>$(BaseIntermediateOutputPath)$(Configuration)\</IntermediateOutputPath>
-    <BaseOutputPath>$(ArtifactsDirectory)$(MSBuildProjectName)\$(BuildVariationFolder)\bin\</BaseOutputPath>
+    <BaseOutputPath>$(ArtifactsDirectory)$(MSBuildProjectName)\bin\</BaseOutputPath>
     <OutputPath>$(BaseOutputPath)$(Configuration)\</OutputPath>
     <AppxPackageDir>$(OutputPath)</AppxPackageDir>
   </PropertyGroup>

--- a/build/common.ps1
+++ b/build/common.ps1
@@ -122,7 +122,6 @@ Function Invoke-BuildStep {
                 Trace-Log "[STOPPED +$(Format-ElapsedTime $sw.Elapsed)] $BuildStep"
             }
             else {
-                $err
                 Error-Log "[FAILED +$(Format-ElapsedTime $sw.Elapsed)] $BuildStep"
             }
         }

--- a/build/common.targets
+++ b/build/common.targets
@@ -105,7 +105,7 @@
   <PropertyGroup Condition=" '$(NETCoreWPFProject)' == 'true' ">
     <TargetFrameworkVersion>$(NETFXTargetFrameworkVersion)</TargetFrameworkVersion>
     <BaseOutputPath>bin\</BaseOutputPath>
-    <OutputPath>bin\$(VisualStudioVersion)\$(Configuration)</OutputPath>
+    <OutputPath>bin\$(Configuration)</OutputPath>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
@@ -146,7 +146,6 @@
       Projects="$(MSBuildProjectFullPath)"
       Targets="Pack"
       Properties="Configuration=$(Configuration);
-                  VisualStudioVersion=$(VisualStudioVersion);
                   PackageOutputPath=$(NupkgOutputDirectory);
                   IncludeSymbols=true;
                   NoBuild=true;">
@@ -336,8 +335,7 @@ Condition=" ('%(Extension)' == '.dll' OR '%(Filename)' == 'NuGet.CommandLine.XPl
       Projects="$(MSBuildProjectFullPath)"
       Targets="GetTestAssembliesInner"
       Properties="TargetFramework=%(ProjectTargetFrameworkEntries.Identity);
-                  Configuration=$(Configuration);
-                  VisualStudioVersion=$(VisualStudioVersion);">
+                  Configuration=$(Configuration);">
       <Output TaskParameter="TargetOutputs"
               ItemName="TestAssemblyPath" />
     </MSBuild>

--- a/build/docs.proj
+++ b/build/docs.proj
@@ -2,7 +2,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common.props" />
 
   <PropertyGroup>
-    <MarkdownAssemblyPath>$(ArtifactsDirectory)doc.tasks\$(VisualStudioVersion)\bin\$(Configuration)\$(NetStandardVersion)\doc.tasks.dll</MarkdownAssemblyPath>
+    <MarkdownAssemblyPath>$(ArtifactsDirectory)doc.tasks\bin\$(Configuration)\$(NetStandardVersion)\doc.tasks.dll</MarkdownAssemblyPath>
     <DocTaskPath>$(RepositoryRootDirectory)\tools-local\doc.tasks\doc.tasks.csproj</DocTaskPath>
   </PropertyGroup>
 
@@ -35,14 +35,12 @@
     <MsBuild
       Projects="$(DocTaskPath)"
       Targets="Restore"
-      Properties="$(CommonMSBuildProperties);
-                  VisualStudioVersion=$(VisualStudioVersion);" />
+      Properties="$(CommonMSBuildProperties);" />
 
     <MsBuild
       Projects="$(DocTaskPath)"
       Targets="Build"
-      Properties="$(CommonMSBuildProperties);
-                  VisualStudioVersion=$(VisualStudioVersion);" />
+      Properties="$(CommonMSBuildProperties);" />
   </Target>
 
   <UsingTask TaskName="NuGetTasks.GenerateMarkdownDoc" AssemblyFile="$(MarkdownAssemblyPath)" />

--- a/eng/pipelines/templates/Apex_Tests_On_Windows.yml
+++ b/eng/pipelines/templates/Apex_Tests_On_Windows.yml
@@ -39,7 +39,7 @@ steps:
   displayName: "InstallNuGetVSIX.ps1"
   inputs:
     scriptName: "$(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\InstallNuGetVSIX.ps1"
-    arguments: "-NuGetDropPath $(Build.Repository.LocalPath)\\artifacts\\$(VsixPublishDir) -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts -NuGetVSIXID $(NuGetVsixId) -ProcessExitTimeoutInSeconds 180"
+    arguments: "-NuGetDropPath $(Build.Repository.LocalPath)\\artifacts\\$(VsixPublishDir) -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts -ProcessExitTimeoutInSeconds 180"
     failOnStandardError: "false"
 
 # - task: PowerShell@1

--- a/eng/pipelines/templates/Apex_Tests_On_Windows.yml
+++ b/eng/pipelines/templates/Apex_Tests_On_Windows.yml
@@ -21,7 +21,6 @@ steps:
   displayName: "Bootstrap NuGet packages"
   inputs:
     solution: "build\\bootstrap.proj"
-    msbuildVersion: "16.0"
     configuration: "$(BuildConfiguration)"
     msbuildArguments: "/t:Restore"
 
@@ -35,13 +34,12 @@ steps:
   displayName: "SetupFunctionalTests.ps1"
   inputs:
     scriptName: "$(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\SetupFunctionalTests.ps1"
-    arguments: "-VSVersion 17.0"
 
 - task: PowerShell@1
   displayName: "InstallNuGetVSIX.ps1"
   inputs:
     scriptName: "$(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\InstallNuGetVSIX.ps1"
-    arguments: "-NuGetDropPath $(Build.Repository.LocalPath)\\artifacts\\$(VsixPublishDir) -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts -NuGetVSIXID $(NuGetVsixId) -ProcessExitTimeoutInSeconds 180 -VSVersion 17.0"
+    arguments: "-NuGetDropPath $(Build.Repository.LocalPath)\\artifacts\\$(VsixPublishDir) -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts -NuGetVSIXID $(NuGetVsixId) -ProcessExitTimeoutInSeconds 180"
     failOnStandardError: "false"
 
 # - task: PowerShell@1
@@ -67,7 +65,6 @@ steps:
   displayName: "Restore Apex Tests"
   inputs:
     solution: "build\\build.proj"
-    msbuildVersion: "16.0"
     configuration: "$(BuildConfiguration)"
     # Set MSBuildEnableWorkloadResolver to work around https://github.com/dotnet/sdk/issues/17461
     msbuildArguments: "/t:RestoreApex /p:BuildNumber=$(BuildNumber) /p:MSBuildEnableWorkloadResolver=false"
@@ -78,7 +75,6 @@ steps:
   continueOnError: "true"
   inputs:
     solution: "build\\build.proj"
-    msbuildVersion: "16.0"
     configuration: "$(BuildConfiguration)"
     # Set MSBuildEnableWorkloadResolver to work around https://github.com/dotnet/sdk/issues/17461
     msbuildArguments: "/t:ApexTestsStandalone /p:TestResultOutputFormat=xml /p:BuildNumber=$(BuildNumber) /p:MSBuildEnableWorkloadResolver=false"
@@ -91,7 +87,6 @@ steps:
   continueOnError: "false"
   inputs:
     solution: "build\\build.proj"
-    msbuildVersion: "16.0"
     configuration: "$(BuildConfiguration)"
     # Set MSBuildEnableWorkloadResolver to work around https://github.com/dotnet/sdk/issues/17461
     msbuildArguments: "/t:ApexTestsStandalone /p:TestResultOutputFormat=xml /p:BuildNumber=$(BuildNumber) /p:MSBuildEnableWorkloadResolver=false"

--- a/eng/pipelines/templates/Apex_Tests_On_Windows.yml
+++ b/eng/pipelines/templates/Apex_Tests_On_Windows.yml
@@ -33,12 +33,12 @@ steps:
 - task: PowerShell@1
   displayName: "SetupFunctionalTests.ps1"
   inputs:
-    scriptName: "$(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\SetupFunctionalTests.ps1"
+    scriptName: "$(System.DefaultWorkingDirectory)/scripts/e2etests/SetupFunctionalTests.ps1"
 
 - task: PowerShell@1
   displayName: "InstallNuGetVSIX.ps1"
   inputs:
-    scriptName: "$(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\InstallNuGetVSIX.ps1"
+    scriptName: "$(System.DefaultWorkingDirectory)/scripts/e2etests/InstallNuGetVSIX.ps1"
     arguments: "-NuGetDropPath $(Build.Repository.LocalPath)\\artifacts\\$(VsixPublishDir) -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts -ProcessExitTimeoutInSeconds 180"
     failOnStandardError: "false"
 

--- a/eng/pipelines/templates/Apex_Tests_On_Windows.yml
+++ b/eng/pipelines/templates/Apex_Tests_On_Windows.yml
@@ -118,5 +118,5 @@ steps:
     scriptType: "inlineScript"
     inlineScript: |
       . $(Build.Repository.LocalPath)\\scripts\\e2etests\\VSUtils.ps1
-      KillRunningInstancesOfVS
+      KillRunningInstancesOfVS Get-LatestVSInstance
   condition: "always()"

--- a/eng/pipelines/templates/Apex_Tests_On_Windows.yml
+++ b/eng/pipelines/templates/Apex_Tests_On_Windows.yml
@@ -118,5 +118,5 @@ steps:
     scriptType: "inlineScript"
     inlineScript: |
       . $(Build.Repository.LocalPath)\\scripts\\e2etests\\VSUtils.ps1
-      KillRunningInstancesOfVS Get-LatestVSInstance
+      KillRunningInstancesOfVS (Get-LatestVSInstance -VersionRange (Get-VisualStudioVersionRangeFromConfig))
   condition: "always()"

--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -102,7 +102,6 @@ steps:
   displayName: "Restore for VS2019"
   inputs:
     solution: "build\\build.proj"
-    msbuildVersion: "16.0"
     configuration: "$(BuildConfiguration)"
     msbuildArguments: "/t:RestoreVS /p:BuildNumber=$(BuildNumber) /p:BuildRTM=$(BuildRTM) /v:m"
     maximumCpuCount: true
@@ -111,7 +110,6 @@ steps:
   displayName: "Build for VS2019"
   inputs:
     solution: "build\\build.proj"
-    msbuildVersion: "16.0"
     configuration: "$(BuildConfiguration)"
     msbuildArguments: "/t:BuildNoVSIX /p:BuildRTM=$(BuildRTM) /p:BuildNumber=$(BuildNumber) /p:SkipILMergeOfNuGetExe=true /p:GitRepositoryRemoteName=github"
     maximumCpuCount: true
@@ -121,7 +119,6 @@ steps:
   continueOnError: "false"
   inputs:
     solution: "nuget.sln"
-    msbuildVersion: "16.0"
     msbuildArguments: "/t:EnsureNewtonsoftJsonVersion"
     maximumCpuCount: true
   condition: "and(succeeded(), or(eq(variables['IsOfficialBuild'], 'true'), eq(variables['BuildRTM'], 'true')))"  #skip this task for nonRTM in private build
@@ -131,7 +128,6 @@ steps:
   continueOnError: "false"
   inputs:
     solution: "build\\build.proj"
-    msbuildVersion: "16.0"
     msbuildArguments: "/t:EnsurePackageReferenceVersionsInSolution"
   condition: "and(succeeded(), or(eq(variables['IsOfficialBuild'], 'true'), eq(variables['BuildRTM'], 'true')))"  #skip this task for nonRTM in private build
 
@@ -140,7 +136,6 @@ steps:
   displayName: "Localize Assemblies"
   inputs:
     solution: "build\\loc.proj"
-    msbuildVersion: "16.0"
     configuration: "$(BuildConfiguration)"
     msbuildArguments: "/t:AfterBuild"
 
@@ -148,7 +143,6 @@ steps:
   displayName: "Build Final NuGet.exe (via ILMerge)"
   inputs:
     solution: "src\\NuGet.Clients\\NuGet.CommandLine\\NuGet.CommandLine.csproj"
-    msbuildVersion: "16.0"
     configuration: "$(BuildConfiguration)"
     msbuildArguments: "/t:ILMergeNuGetExe /p:ExpectedLocalizedArtifactCount=$(LocalizedLanguageCount)"
 
@@ -156,7 +150,6 @@ steps:
   displayName: "Publish NuGet.exe (ILMerged) into NuGet.CommandLine.Test (Mac tests use this)"
   inputs:
     solution: "test\\NuGet.Clients.Tests\\NuGet.CommandLine.Test\\NuGet.CommandLine.Test.csproj"
-    msbuildVersion: "16.0"
     configuration: "$(BuildConfiguration)"
     msbuildArguments: "/t:CopyFinalNuGetExeToOutputPath"
   condition: "and(succeeded(),eq(variables['BuildRTM'], 'false'))"
@@ -166,7 +159,6 @@ steps:
   continueOnError: "false"
   inputs:
     solution: "build\\build.proj"
-    msbuildVersion: "16.0"
     configuration: "$(BuildConfiguration)"
     msbuildArguments: "/t:CoreUnitTests;UnitTestsVS /p:BuildRTM=$(BuildRTM) /p:BuildNumber=$(BuildNumber) /p:TestResultOutputFormat=xml /p:SkipILMergeOfNuGetExe=true"
   condition: "and(succeeded(), eq(variables['BuildRTM'], 'true'), not(eq(variables['IsOfficialBuild'], 'true')))"
@@ -176,7 +168,6 @@ steps:
   continueOnError: "true"
   inputs:
     solution: "build\\build.proj"
-    msbuildVersion: "16.0"
     configuration: "$(BuildConfiguration)"
     msbuildArguments: "/t:CoreUnitTests;UnitTestsVS /p:BuildRTM=$(BuildRTM) /p:BuildNumber=$(BuildNumber) /p:TestResultOutputFormat=xml /p:SkipILMergeOfNuGetExe=true"
   condition: "and(succeeded(), eq(variables['BuildRTM'], 'true'), eq(variables['IsOfficialBuild'], 'true'))"
@@ -221,7 +212,6 @@ steps:
   displayName: "Sign Assemblies"
   inputs:
     solution: "build\\sign.proj"
-    msbuildVersion: "16.0"
     configuration: "$(BuildConfiguration)"
     msbuildArguments: "/t:AfterBuild"
     maximumCpuCount: true
@@ -230,7 +220,6 @@ steps:
   displayName: "Pack Nupkgs"
   inputs:
     solution: "build\\build.proj"
-    msbuildVersion: "16.0"
     configuration: "$(BuildConfiguration)"
     msbuildArguments: "/t:Pack /p:BuildRTM=$(BuildRTM) /p:ExcludeTestProjects=$(BuildRTM) /p:BuildNumber=$(BuildNumber)"
     maximumCpuCount: true
@@ -239,7 +228,6 @@ steps:
   displayName: "Ensure all Nupkgs and Symbols are created"
   inputs:
     solution: "build\\build.proj"
-    msbuildVersion: "16.0"
     configuration: "$(BuildConfiguration)"
     msbuildArguments: "/t:EnsurePackagesExist /p:ExcludeTestProjects=$(BuildRTM)"
 
@@ -247,7 +235,6 @@ steps:
   displayName: "Pack VSIX"
   inputs:
     solution: "build\\build.proj"
-    msbuildVersion: "16.0"
     configuration: "$(BuildConfiguration)"
     msbuildArguments: "/t:BuildVSIX /p:BuildRTM=$(BuildRTM) /p:ExcludeTestProjects=$(BuildRTM) /p:IsCIBuild=true"
     maximumCpuCount: true
@@ -257,7 +244,6 @@ steps:
   displayName: "Generate Build Tools package"
   inputs:
     solution: "setup/Microsoft.VisualStudio.NuGet.BuildTools.vsmanproj"
-    msbuildVersion: "16.0"
     configuration: "$(BuildConfiguration)"
     msbuildArguments: "/p:BuildNumber=$(BuildNumber) /p:IsVsixBuild=true"
   condition: " and(succeeded(), eq(variables['BuildRTM'], 'false'))"
@@ -266,7 +252,6 @@ steps:
   displayName: "Sign Nupkgs and VSIX"
   inputs:
     solution: "build\\sign.proj"
-    msbuildVersion: "16.0"
     configuration: "$(BuildConfiguration)"
     msbuildArguments: "/t:AfterBuild /p:SignPackages=true"
 
@@ -303,7 +288,6 @@ steps:
   displayName: "Generate VSMAN file for NuGet Core VSIX"
   inputs:
     solution: "setup\\Microsoft.VisualStudio.NuGet.Core.vsmanproj"
-    msbuildVersion: "16.0"
     configuration: "$(BuildConfiguration)"
   condition: " and(succeeded(),eq(variables['BuildRTM'], 'false')) "
 
@@ -311,7 +295,6 @@ steps:
   displayName: "Generate VSMAN file for Build Tools VSIX"
   inputs:
     solution: "setup\\Microsoft.VisualStudio.NuGet.BuildTools.vsmanproj"
-    msbuildVersion: "16.0"
     configuration: "$(BuildConfiguration)"
   condition: " and(succeeded(),eq(variables['BuildRTM'], 'false')) "
 
@@ -319,7 +302,7 @@ steps:
   displayName: "Create EndToEnd Test Package"
   inputs:
     scriptName: "$(Build.Repository.LocalPath)\\scripts\\cibuild\\CreateEndToEndTestPackage.ps1"
-    arguments: "-c $(BuildConfiguration) -tv 16 -out $(Build.Repository.LocalPath)\\artifacts\\$(VsixPublishDir)"
+    arguments: "-c $(BuildConfiguration) -out $(Build.Repository.LocalPath)\\artifacts\\$(VsixPublishDir)"
     failOnStandardError: "true"
   condition: " and(succeeded(),eq(variables['BuildRTM'], 'false')) "
 
@@ -373,7 +356,6 @@ steps:
   displayName: 'OptProfV2:  generate a .runsettings file'
   inputs:
     solution: 'build\NuGet.OptProfV2.runsettingsproj'
-    msbuildVersion: '16.0'
     msbuildArguments: '/p:OutputPath="$(Build.Repository.LocalPath)\artifacts\RunSettings" /p:TestDrop="$(TestDrop)" /p:ProfilingInputsDrop="ProfilingInputs/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildId)"'
   condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
 
@@ -426,7 +408,6 @@ steps:
   displayName: "Collect Build Symbols"
   inputs:
     solution: "build\\symbols.proj"
-    msbuildVersion: "16.0"
     configuration: "$(BuildConfiguration)"
     msbuildArguments: "/p:IsSymbolBuild=true /p:BuildRTM=$(BuildRTM)"
     maximumCpuCount: true

--- a/eng/pipelines/templates/End_To_End_Tests_On_Windows.yml
+++ b/eng/pipelines/templates/End_To_End_Tests_On_Windows.yml
@@ -41,7 +41,7 @@ steps:
   displayName: "InstallNuGetVSIX.ps1"
   inputs:
     scriptName: "$(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\InstallNuGetVSIX.ps1"
-    arguments: "-NuGetDropPath $(System.DefaultWorkingDirectory)\\artifacts\\$(VsixPublishDir) -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts -NuGetVSIXID $(NuGetVsixId) -ProcessExitTimeoutInSeconds 180"
+    arguments: "-NuGetDropPath $(System.DefaultWorkingDirectory)\\artifacts\\$(VsixPublishDir) -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts -ProcessExitTimeoutInSeconds 180"
     failOnStandardError: "false"
 
 - task: PowerShell@1

--- a/eng/pipelines/templates/End_To_End_Tests_On_Windows.yml
+++ b/eng/pipelines/templates/End_To_End_Tests_On_Windows.yml
@@ -96,5 +96,5 @@ steps:
     scriptType: "inlineScript"
     inlineScript: |
       . $(Build.Repository.LocalPath)\\scripts\\e2etests\\VSUtils.ps1
-      KillRunningInstancesOfVS Get-LatestVSInstance
+      KillRunningInstancesOfVS (Get-LatestVSInstance -VersionRange (Get-VisualStudioVersionRangeFromConfig))
   condition: "always()"

--- a/eng/pipelines/templates/End_To_End_Tests_On_Windows.yml
+++ b/eng/pipelines/templates/End_To_End_Tests_On_Windows.yml
@@ -41,7 +41,7 @@ steps:
   displayName: "InstallNuGetVSIX.ps1"
   inputs:
     scriptName: "$(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\InstallNuGetVSIX.ps1"
-    arguments: "-NuGetDropPath $(System.DefaultWorkingDirectory)\\artifacts\\$(VsixPublishDir) -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts -NuGetVSIXID $(NuGetVsixId) -ProcessExitTimeoutInSeconds 180 -VSVersion 17.0"
+    arguments: "-NuGetDropPath $(System.DefaultWorkingDirectory)\\artifacts\\$(VsixPublishDir) -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts -NuGetVSIXID $(NuGetVsixId) -ProcessExitTimeoutInSeconds 180"
     failOnStandardError: "false"
 
 - task: PowerShell@1
@@ -59,7 +59,7 @@ steps:
   continueOnError: "false"
   inputs:
     scriptName: "$(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\RunFunctionalTests.ps1"
-    arguments: "-PMCCommand $(EndToEndTestCommandToRunPart) -PMCLaunchWaitTimeInSecs 30 -EachTestTimoutInSecs 600 -NuGetDropPath $(System.DefaultWorkingDirectory)\\artifacts -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts -RunCounter $(Build.BuildNumber) -VSVersion 17.0"
+    arguments: "-PMCCommand $(EndToEndTestCommandToRunPart) -PMCLaunchWaitTimeInSecs 30 -EachTestTimoutInSecs 600 -NuGetDropPath $(System.DefaultWorkingDirectory)\\artifacts -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts -RunCounter $(Build.BuildNumber)"
   condition: "and(succeeded(), not(eq(variables['IsOfficialBuild'], 'true')))"
 
 - task: PowerShell@1
@@ -68,7 +68,7 @@ steps:
   continueOnError: "true"
   inputs:
     scriptName: "$(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\RunFunctionalTests.ps1"
-    arguments: "-PMCCommand $(EndToEndTestCommandToRunPart) -PMCLaunchWaitTimeInSecs 30 -EachTestTimoutInSecs 600 -NuGetDropPath $(System.DefaultWorkingDirectory)\\artifacts -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts -RunCounter $(Build.BuildNumber) -VSVersion 17.0"
+    arguments: "-PMCCommand $(EndToEndTestCommandToRunPart) -PMCLaunchWaitTimeInSecs 30 -EachTestTimoutInSecs 600 -NuGetDropPath $(System.DefaultWorkingDirectory)\\artifacts -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts -RunCounter $(Build.BuildNumber)"
   condition: "and(succeeded(), eq(variables['IsOfficialBuild'], 'true'))"
 
 - task: PublishTestResults@2

--- a/eng/pipelines/templates/End_To_End_Tests_On_Windows.yml
+++ b/eng/pipelines/templates/End_To_End_Tests_On_Windows.yml
@@ -4,7 +4,7 @@ steps:
   inputs:
     scriptType: "inlineScript"
     inlineScript: |
-      $EndToEndTestCommandToRunPart = "Run-Test -Exclude '${env:PART}' -Verbose *>&1 | Tee-Object $(System.DefaultWorkingDirectory)\artifacts\EndToEnd\FullLog_$(Build.BuildNumber).txt" +'"'
+      $EndToEndTestCommandToRunPart = '"' + "Run-Test -Exclude '${env:PART}' -Verbose *>&1 | Tee-Object $(System.DefaultWorkingDirectory)\artifacts\EndToEnd\FullLog_$(Build.BuildNumber).txt" +'"'
       Write-Host "##vso[task.setvariable variable=EndToEndTestCommandToRunPart]$EndToEndTestCommandToRunPart"
 
 - task: PowerShell@1

--- a/eng/pipelines/templates/End_To_End_Tests_On_Windows.yml
+++ b/eng/pipelines/templates/End_To_End_Tests_On_Windows.yml
@@ -58,8 +58,8 @@ steps:
   timeoutInMinutes: 75
   continueOnError: "false"
   inputs:
-    scriptName: "$(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\RunFunctionalTests.ps1"
-    arguments: "-PMCCommand $(EndToEndTestCommandToRunPart) -PMCLaunchWaitTimeInSecs 30 -EachTestTimoutInSecs 600 -NuGetDropPath $(System.DefaultWorkingDirectory)\\artifacts -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts -RunCounter $(Build.BuildNumber)"
+    scriptName: "$(System.DefaultWorkingDirectory)/scripts/e2etests/RunFunctionalTests.ps1"
+    arguments: "-PMCCommand $(EndToEndTestCommandToRunPart) -PMCLaunchWaitTimeInSecs 30 -EachTestTimoutInSecs 600 -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts"
   condition: "and(succeeded(), not(eq(variables['IsOfficialBuild'], 'true')))"
 
 - task: PowerShell@1
@@ -67,8 +67,8 @@ steps:
   timeoutInMinutes: 75
   continueOnError: "true"
   inputs:
-    scriptName: "$(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\RunFunctionalTests.ps1"
-    arguments: "-PMCCommand $(EndToEndTestCommandToRunPart) -PMCLaunchWaitTimeInSecs 30 -EachTestTimoutInSecs 600 -NuGetDropPath $(System.DefaultWorkingDirectory)\\artifacts -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts -RunCounter $(Build.BuildNumber)"
+    scriptName: "$(System.DefaultWorkingDirectory)/scripts/e2etests/RunFunctionalTests.ps1"
+    arguments: "-PMCCommand $(EndToEndTestCommandToRunPart) -PMCLaunchWaitTimeInSecs 30 -EachTestTimoutInSecs 600 -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts"
   condition: "and(succeeded(), eq(variables['IsOfficialBuild'], 'true'))"
 
 - task: PublishTestResults@2

--- a/eng/pipelines/templates/End_To_End_Tests_On_Windows.yml
+++ b/eng/pipelines/templates/End_To_End_Tests_On_Windows.yml
@@ -4,7 +4,7 @@ steps:
   inputs:
     scriptType: "inlineScript"
     inlineScript: |
-      $EndToEndTestCommandToRunPart = '"' + "Run-Test -Exclude '${env:PART}' -Verbose *>&1 | Tee-Object $(System.DefaultWorkingDirectory)\artifacts\EndToEnd\FullLog_$(Build.BuildNumber).txt" +'"'
+      $EndToEndTestCommandToRunPart = "Run-Test -Exclude '${env:PART}' -Verbose *>&1 | Tee-Object $(System.DefaultWorkingDirectory)\artifacts\EndToEnd\FullLog_$(Build.BuildNumber).txt" +'"'
       Write-Host "##vso[task.setvariable variable=EndToEndTestCommandToRunPart]$EndToEndTestCommandToRunPart"
 
 - task: PowerShell@1
@@ -59,7 +59,7 @@ steps:
   continueOnError: "false"
   inputs:
     scriptName: "$(System.DefaultWorkingDirectory)/scripts/e2etests/RunFunctionalTests.ps1"
-    arguments: "-PMCCommand $(EndToEndTestCommandToRunPart) -PMCLaunchWaitTimeInSecs 30 -EachTestTimoutInSecs 600 -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts"
+    arguments: "-PMCCommand $(EndToEndTestCommandToRunPart) -PMCLaunchWaitTimeInSecs 30 -EachTestTimoutInSecs 600 -NuGetDropPath $(System.DefaultWorkingDirectory)\\artifacts -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts -RunCounter $(Build.BuildNumber)"
   condition: "and(succeeded(), not(eq(variables['IsOfficialBuild'], 'true')))"
 
 - task: PowerShell@1
@@ -68,7 +68,7 @@ steps:
   continueOnError: "true"
   inputs:
     scriptName: "$(System.DefaultWorkingDirectory)/scripts/e2etests/RunFunctionalTests.ps1"
-    arguments: "-PMCCommand $(EndToEndTestCommandToRunPart) -PMCLaunchWaitTimeInSecs 30 -EachTestTimoutInSecs 600 -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts"
+    arguments: "-PMCCommand $(EndToEndTestCommandToRunPart) -PMCLaunchWaitTimeInSecs 30 -EachTestTimoutInSecs 600 -NuGetDropPath $(System.DefaultWorkingDirectory)\\artifacts -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts -RunCounter $(Build.BuildNumber)"
   condition: "and(succeeded(), eq(variables['IsOfficialBuild'], 'true'))"
 
 - task: PublishTestResults@2
@@ -96,5 +96,5 @@ steps:
     scriptType: "inlineScript"
     inlineScript: |
       . $(Build.Repository.LocalPath)\\scripts\\e2etests\\VSUtils.ps1
-      KillRunningInstancesOfVS
+      KillRunningInstancesOfVS Get-LatestVSInstance
   condition: "always()"

--- a/eng/pipelines/templates/End_To_End_Tests_On_Windows.yml
+++ b/eng/pipelines/templates/End_To_End_Tests_On_Windows.yml
@@ -30,17 +30,17 @@ steps:
 - task: PowerShell@1
   displayName: "SetupFunctionalTests.ps1"
   inputs:
-    scriptName: "$(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\SetupFunctionalTests.ps1"
+    scriptName: "$(System.DefaultWorkingDirectory)/scripts/e2etests/SetupFunctionalTests.ps1"
 
 - task: PowerShell@1
   displayName: "SetupMachine.ps1"
   inputs:
-    scriptName: "$(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\SetupMachine.ps1"
+    scriptName: "$(System.DefaultWorkingDirectory)/scripts/e2etests/SetupMachine.ps1"
 
 - task: PowerShell@1
   displayName: "InstallNuGetVSIX.ps1"
   inputs:
-    scriptName: "$(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\InstallNuGetVSIX.ps1"
+    scriptName: "$(System.DefaultWorkingDirectory)/scripts/e2etests/InstallNuGetVSIX.ps1"
     arguments: "-NuGetDropPath $(System.DefaultWorkingDirectory)\\artifacts\\$(VsixPublishDir) -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts -ProcessExitTimeoutInSeconds 180"
     failOnStandardError: "false"
 

--- a/eng/pipelines/templates/Functional_Tests_On_Windows.yml
+++ b/eng/pipelines/templates/Functional_Tests_On_Windows.yml
@@ -28,7 +28,6 @@ steps:
   displayName: "Restore for VS2019"
   inputs:
     solution: "build\\build.proj"
-    msbuildVersion: "16.0"
     configuration: "$(BuildConfiguration)"
     msbuildArguments: "/t:RestoreVS /p:BuildNumber=$(BuildNumber) /p:BuildRTM=false /v:m"
 
@@ -37,7 +36,6 @@ steps:
   continueOnError: "true"
   inputs:
     solution: "build\\build.proj"
-    msbuildVersion: "16.0"
     configuration: "$(BuildConfiguration)"
     msbuildArguments: "/t:CoreFuncTests /p:BuildRTM=false /p:BuildNumber=$(BuildNumber) /p:TestResultOutputFormat=xml /p:SkipDesktopAssemblies=$(SkipDesktopAssemblies) /p:SkipCoreAssemblies=$(SkipCoreAssemblies)"
     maximumCpuCount: true
@@ -48,7 +46,6 @@ steps:
   continueOnError: "false"
   inputs:
     solution: "build\\build.proj"
-    msbuildVersion: "16.0"
     configuration: "$(BuildConfiguration)"
     msbuildArguments: "/t:CoreFuncTests /p:BuildRTM=false /p:BuildNumber=$(BuildNumber) /p:TestResultOutputFormat=xml /p:SkipDesktopAssemblies=$(SkipDesktopAssemblies) /p:SkipCoreAssemblies=$(SkipCoreAssemblies)"
     maximumCpuCount: true

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -1,3 +1,6 @@
+variables:
+  DOTNET_NOLOGO: 1
+
 jobs:
 - job: Initialize_Build_SemanticVersion
   timeoutInMinutes: 2

--- a/scripts/cibuild/ConfigureVstsBuild.ps1
+++ b/scripts/cibuild/ConfigureVstsBuild.ps1
@@ -15,7 +15,7 @@ True/false depending on whether nupkgs are being with or without the release lab
 param
 (
     [Parameter(Mandatory=$True)]
-    [boolean]$BuildRTM
+    [string]$BuildRTM
 )
 
 Function Get-Version {
@@ -65,10 +65,11 @@ Function Update-VsixVersion {
 
 Function Set-RtmLabel {
     param(
-        [boolean]$BuildRTM
+        [Parameter(Mandatory = $true)]
+        [boolean]$isRTMBuild
     )
 
-    if ($BuildRTM -eq $true) {
+    if ($isRTMBuild -eq $true) {
         $label = "RTM"
     } else {
         $label = "NonRTM"
@@ -78,7 +79,9 @@ Function Set-RtmLabel {
     Write-Host "##vso[task.setvariable variable=RtmLabel;]$label"
 }
 
-Set-RtmLabel -BuildRTM $BuildRTM
+$isRTMBuild = [boolean]::Parse($BuildRTM)
+
+Set-RtmLabel -isRTMBuild $isRTMBuild
 
 # Disable strong name verification of common public keys so that scenarios like building the VSIX or running unit tests
 # will not fail because of strong name verification errors.

--- a/scripts/cibuild/ConfigureVstsBuild.ps1
+++ b/scripts/cibuild/ConfigureVstsBuild.ps1
@@ -15,7 +15,7 @@ True/false depending on whether nupkgs are being with or without the release lab
 param
 (
     [Parameter(Mandatory=$True)]
-    [string]$BuildRTM
+    [boolean]$BuildRTM
 )
 
 Function Get-Version {
@@ -25,13 +25,13 @@ Function Get-Version {
     )
         Write-Host "Evaluating the new VSIX Version : ProductVersion $ProductVersion, build $build"
         # The major version is NuGetMajorVersion + 11, to match VS's number.
-        # The new minor version is: 4.0.0 => 40000, 4.11.5 => 41105. 
-        # This assumes we only get to NuGet major/minor/patch 99 at worst, otherwise the logic breaks. 
+        # The new minor version is: 4.0.0 => 40000, 4.11.5 => 41105.
+        # This assumes we only get to NuGet major/minor/patch 99 at worst, otherwise the logic breaks.
         # The final version for NuGet 4.0.0, build number 3128 would be 15.0.40000.3128
         $versionParts = $ProductVersion -split '\.'
         $major = $($versionParts[0] / 1) + 11
-        $finalVersion = "$major.0.$((-join ($versionParts | %{ '{0:D2}' -f ($_ -as [int]) } )).TrimStart("0")).$build"    
-    
+        $finalVersion = "$major.0.$((-join ($versionParts | %{ '{0:D2}' -f ($_ -as [int]) } )).TrimStart("0")).$build"
+
         Write-Host "The new VSIX Version is: $finalVersion"
         return $finalVersion
 }
@@ -65,7 +65,7 @@ Function Update-VsixVersion {
 
 Function Set-RtmLabel {
     param(
-        [string]$BuildRTM
+        [boolean]$BuildRTM
     )
 
     if ($BuildRTM -eq $true) {
@@ -80,8 +80,6 @@ Function Set-RtmLabel {
 
 Set-RtmLabel -BuildRTM $BuildRTM
 
-$msbuildExe = 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\bin\msbuild.exe'
-
 # Disable strong name verification of common public keys so that scenarios like building the VSIX or running unit tests
 # will not fail because of strong name verification errors.
 . "$PSScriptRoot\..\utils\DisableStrongNameVerification.ps1"
@@ -95,7 +93,7 @@ $Submodules = Join-Path $NuGetClientRoot submodules -Resolve
 # NuGet.Build.Localization repository set-up
 $NuGetLocalization = Join-Path $Submodules NuGet.Build.Localization -Resolve
 
-# Check if there is a localization branch associated with this branch repo 
+# Check if there is a localization branch associated with this branch repo
 $currentNuGetBranch = $env:BUILD_SOURCEBRANCHNAME
 $lsRemoteOpts = 'ls-remote', 'origin', $currentNuGetBranch
 Write-Host "Looking for branch '$currentNuGetBranch' in NuGet.Build.Localization"
@@ -118,23 +116,17 @@ Write-Host "git update NuGet.Build.Localization at $NuGetLocalization"
 # Get the commit of the localization repository that will be used for this build.
 $LocalizationRepoCommitHash = & git -C $NuGetLocalization log --pretty=format:'%H' -n 1
 
-if (-not (Test-Path $regKeyFileSystem)) 
+if (-not (Test-Path $regKeyFileSystem))
 {
     Write-Host "Enabling long path support on the build machine"
     Set-ItemProperty -Path $regKeyFileSystem -Name $enableLongPathSupport -Value 1
 }
 
 
-if ($BuildRTM -eq 'true')
-{
-    # Set the $(NupkgOutputDir) build variable in VSTS build
-    Write-Host "##vso[task.setvariable variable=NupkgOutputDir;]ReleaseNupkgs"
-    Write-Host "##vso[task.setvariable variable=VsixPublishDir;]VS15-RTM"
-}
-else
+if ($BuildRTM -ne $true)
 {
     $newBuildCounter = $env:BUILD_BUILDNUMBER
-    $VsTargetBranch = & $msbuildExe $env:BUILD_REPOSITORY_LOCALPATH\build\config.props /v:m /nologo /t:GetVsTargetBranch
+    $VsTargetBranch = & dotnet msbuild $env:BUILD_REPOSITORY_LOCALPATH\build\config.props /v:m /nologo /t:GetVsTargetBranch
     Write-Host $VsTargetBranch
     $jsonRepresentation = @{
         BuildNumber = $newBuildCounter
@@ -151,7 +143,7 @@ else
     New-Item $localBuildInfoJsonFilePath -Force
     $jsonRepresentation | ConvertTo-Json | Set-Content $localBuildInfoJsonFilePath
 
-    $productVersion = & $msbuildExe $env:BUILD_REPOSITORY_LOCALPATH\build\config.props /v:m /nologo /t:GetSemanticVersion
+    $productVersion = & dotnet msbuild $env:BUILD_REPOSITORY_LOCALPATH\build\config.props /v:m /nologo /t:GetSemanticVersion
     if (-not $?)
     {
         Write-Error "Failed to get product version."

--- a/scripts/cibuild/CreateEndToEndTestPackage.ps1
+++ b/scripts/cibuild/CreateEndToEndTestPackage.ps1
@@ -5,9 +5,6 @@ Creates end-to-end test package for test pass
 .PARAMETER Configuration
 API.Test build configuration to place in test package. Debug by default.
 
-.PARAMETER ToolsetVersion
-Toolset version
-
 .PARAMETER OutputDirectory
 Output directory where EndToEnd.zip package file will be created.
 Will use current directory if not provided.
@@ -20,10 +17,6 @@ param(
     [Parameter(Mandatory=$False)]
     [Alias('c')]
     [string]$Configuration = 'Debug',
-    [Parameter(Mandatory=$True)]
-    [ValidateSet(15,16,17)]
-    [Alias('tv')]
-    [int]$ToolsetVersion,
     [Parameter(Mandatory=$False)]
     [Alias('out')]
     [string]$OutputDirectory = $PWD,
@@ -102,7 +95,7 @@ try {
     Write-Verbose "Copying all test data from '$TestSource' to '$packagesDirectory'"
     Run-RoboCopy $TestSource $packagesDirectory $opts
 
-    $TestExtensionDirectoryPath = Join-Path $NuGetRoot "artifacts\API.Test\${ToolsetVersion}.0\bin\${Configuration}\net472"
+    $TestExtensionDirectoryPath = Join-Path $NuGetRoot "artifacts\API.Test\bin\${Configuration}\net472"
     if (!(Test-Path "$TestExtensionDirectoryPath\API.Test.dll"))
     {
         $errorMessage = "API.Test binaries not found at $TestExtensionDirectoryPath\API.Test.dll. Make sure the project has been built."
@@ -112,7 +105,7 @@ try {
     Write-Verbose "Copying test extension from '$TestExtensionDirectoryPath' to '$WorkingDirectory'"
     Run-RoboCopy $TestExtensionDirectoryPath $WorkingDirectory $(@('API.Test.*') + $opts)
 
-    $GeneratePackagesUtil = Join-Path $NuGetRoot "artifacts\GenerateTestPackages\${ToolsetVersion}.0\bin\${Configuration}\net472"
+    $GeneratePackagesUtil = Join-Path $NuGetRoot "artifacts\GenerateTestPackages\bin\${Configuration}\net472"
     if (!(Test-Path "$GeneratePackagesUtil\GenerateTestPackages.exe"))
     {
         $errorMessage = "GenerateTestPackages binaries not found at $GeneratePackagesUtil\GenerateTestPackages.exe. Make sure the project has been built."
@@ -138,7 +131,7 @@ try {
     Remove-Item $TestPackage -Force -ea Ignore | Out-Null
     Compress-Archive -Path "$WorkingDirectory\*" -DestinationPath $TestPackage -CompressionLevel Optimal
 
-    Write-Output "Created end-to-end test package for toolset '${ToolsetVersion}.0' at '$TestPackage'"
+    Write-Output "Created end-to-end test package at '$TestPackage'"
 }
 finally {
     Remove-Item $workingDirectory -r -Force -WhatIf:$false

--- a/scripts/e2etests/Bootstrap.ps1
+++ b/scripts/e2etests/Bootstrap.ps1
@@ -8,11 +8,7 @@ function ExtractZip($source, $destination)
 {
     Write-Host 'Extracting files from ' $source ' to ' $destination '...'
 
-    $shell = New-Object -ComObject Shell.Application
-    $zip = $shell.NameSpace($source)
-    $files = $zip.Items()
-    # 0x14 means that the existing files will be overwritten silently
-    $timeTaken = measure-command { $shell.NameSpace($destination).CopyHere($files, 0x14) }
+    $timeTaken = measure-command { Expand-Archive -Path $source -DestinationPath $destination -Force }
     Write-Host 'Extraction Completed in ' $timeTaken.TotalSeconds ' seconds.'
 }
 
@@ -27,16 +23,13 @@ function ExtractEndToEndZip
     [string]$NuGetTestPath)
 
     $endToEndZipSrc = Join-Path $NuGetDropPath 'EndToEnd.zip'
-    $endToEndZip = Join-Path $FuncTestRoot 'EndToEnd.zip'
     $artifactsNuGetExe = Join-Path $NuGetDropPath 'NuGet.exe'
     $endToEndNuGetExe = Join-Path $NuGetTestPath 'NuGet.exe'
 
-    Copy-Item $endToEndZipSrc $endToEndZip -Force
-
     Write-Host 'Creating ' $NuGetTestPath
-    mkdir $NuGetTestPath
+    mkdir $NuGetTestPath | Out-Null
 
-    ExtractZip $endToEndZip $NuGetTestPath
+    ExtractZip $endToEndZipSrc $NuGetTestPath
 
     if(Test-Path $artifactsNuGetExe){
         Write-Host 'Copying ' $artifactsNuGetExe ' to ' $endToEndNuGetExe
@@ -78,7 +71,7 @@ if ($pcs.Count -gt 0)
 
 if(-Not (Test-Path $FuncTestRoot))
 {
-    mkdir $FuncTestRoot
+    mkdir $FuncTestRoot | Out-Null
 }
 
 $NuGetTestPath = Join-Path $FuncTestRoot "EndToEnd"

--- a/scripts/e2etests/InstallNuGetVSIX.ps1
+++ b/scripts/e2etests/InstallNuGetVSIX.ps1
@@ -26,7 +26,7 @@ $VSIXPath = Join-Path $FuncTestRoot 'NuGet.Tools.vsix'
 Copy-Item $VSIXSrcPath $VSIXPath
 
 if ([System.String]::IsNullOrEmpty($VSInstanceId)) {
-    $VSInstance = Get-LatestVSInstance
+    $VSInstance = Get-LatestVSInstance -VersionRange (Get-VisualStudioVersionRangeFromConfig)
 }
 else {
     $VSInstance = Get-SpecificVSInstance $VSInstanceId

--- a/scripts/e2etests/InstallNuGetVSIX.ps1
+++ b/scripts/e2etests/InstallNuGetVSIX.ps1
@@ -4,12 +4,9 @@ param (
     [Parameter(Mandatory = $true)]
     [string]$FuncTestRoot,
     [Parameter(Mandatory = $true)]
-    [string]$NuGetVSIXID,
-    [Parameter(Mandatory = $true)]
     [int]$ProcessExitTimeoutInSeconds,
-    [Parameter(Mandatory = $true)]
-    [ValidateSet("17.0")]
-    [string]$VSVersion)
+    [Parameter()]
+    [string]$VSInstanceId)
 
 . "$PSScriptRoot\VSUtils.ps1"
 
@@ -28,28 +25,35 @@ $VSIXPath = Join-Path $FuncTestRoot 'NuGet.Tools.vsix'
 
 Copy-Item $VSIXSrcPath $VSIXPath
 
+if ([System.String]::IsNullOrEmpty($VSInstanceId)) {
+    $VSInstance = Get-LatestVSInstance
+}
+else {
+    $VSInstance = Get-SpecificVSInstance $VSInstanceId
+}
+
 # Because we are upgrading an installed system component VSIX, we need to downgrade first.
 $numberOfTries = 0
 $success = $false
 do {
-    KillRunningInstancesOfVS
+    KillRunningInstancesOfVS $VSInstance
     $numberOfTries++
     Write-Host "Attempt # $numberOfTries to downgrade VSIX..."
-    $success = DowngradeVSIX $NuGetVSIXID $VSVersion $ProcessExitTimeoutInSeconds
+    $success = DowngradeVSIX $VSInstance $ProcessExitTimeoutInSeconds
 }
 until (($success -eq $true) -or ($numberOfTries -gt 3))
 
 # Clearing MEF cache helps load the right dlls for VSIX
-ClearMEFCache
+ClearMEFCache $VSInstance
 
 
 $numberOfTries = 0
 $success = $false
 do {
-    KillRunningInstancesOfVS
+    KillRunningInstancesOfVS $VSInstance
     $numberOfTries++
     Write-Host "Attempt # $numberOfTries to install VSIX..."
-    $success = InstallVSIX $VSIXPath $VSVersion $ProcessExitTimeoutInSeconds
+    $success = InstallVSIX $VSIXPath $VSInstance $ProcessExitTimeoutInSeconds
 }
 until (($success -eq $true) -or ($numberOfTries -gt 3))
 
@@ -57,5 +61,5 @@ if ($success -eq $false) {
     exit 1
 }
 
-ClearMEFCache
-Update-Configuration
+ClearMEFCache $VSInstance
+Update-Configuration $VSInstance

--- a/scripts/e2etests/RunFunctionalTests.ps1
+++ b/scripts/e2etests/RunFunctionalTests.ps1
@@ -16,7 +16,7 @@ param (
 . "$PSScriptRoot\VSUtils.ps1"
 . "$PSScriptRoot\NuGetFunctionalTestUtils.ps1"
 
-$VSInstance = Get-LatestVSInstance
+$VSInstance = Get-LatestVSInstance -VersionRange (Get-VisualStudioVersionRangeFromConfig)
 
 trap
 {

--- a/scripts/e2etests/RunFunctionalTests.ps1
+++ b/scripts/e2etests/RunFunctionalTests.ps1
@@ -6,11 +6,11 @@ param (
     [Parameter(Mandatory=$true)]
     [int]$EachTestTimoutInSecs,
     [Parameter(Mandatory=$true)]
-    [string]$NuGetDropPath,
-    [Parameter(Mandatory=$true)]
-    [string]$FuncTestRoot,
-    [Parameter(Mandatory=$true)]
-    [string]$RunCounter)
+    [string]$FuncTestRoot)
+
+. "$PSScriptRoot\Utils.ps1"
+. "$PSScriptRoot\VSUtils.ps1"
+. "$PSScriptRoot\NuGetFunctionalTestUtils.ps1"
 
 $VSInstance = Get-LatestVSInstance
 
@@ -22,10 +22,6 @@ trap
     KillRunningInstancesOfVS $VsInstance
     exit 1
 }
-
-. "$PSScriptRoot\Utils.ps1"
-. "$PSScriptRoot\VSUtils.ps1"
-. "$PSScriptRoot\NuGetFunctionalTestUtils.ps1"
 
 $NuGetTestPath = Join-Path $FuncTestRoot "EndToEnd"
 

--- a/scripts/e2etests/RunFunctionalTests.ps1
+++ b/scripts/e2etests/RunFunctionalTests.ps1
@@ -6,7 +6,11 @@ param (
     [Parameter(Mandatory=$true)]
     [int]$EachTestTimoutInSecs,
     [Parameter(Mandatory=$true)]
-    [string]$FuncTestRoot)
+    [string]$NuGetDropPath,
+    [Parameter(Mandatory=$true)]
+    [string]$FuncTestRoot,
+    [Parameter(Mandatory=$true)]
+    [string]$RunCounter)
 
 . "$PSScriptRoot\Utils.ps1"
 . "$PSScriptRoot\VSUtils.ps1"

--- a/scripts/e2etests/RunFunctionalTests.ps1
+++ b/scripts/e2etests/RunFunctionalTests.ps1
@@ -10,17 +10,16 @@ param (
     [Parameter(Mandatory=$true)]
     [string]$FuncTestRoot,
     [Parameter(Mandatory=$true)]
-    [string]$RunCounter,
-    [Parameter(Mandatory=$true)]
-    [ValidateSet("17.0")]
-    [string]$VSVersion)
+    [string]$RunCounter)
+
+$VSInstance = Get-LatestVSInstance
 
 trap
 {
     Write-Host "RunFunctionalTests.ps1 threw an exception: " -ForegroundColor Red
     Write-Error ($_.Exception | Format-List -Force | Out-String) -ErrorAction Continue
     Write-Error ($_.InvocationInfo | Format-List -Force | Out-String) -ErrorAction Continue
-    KillRunningInstancesOfVS
+    KillRunningInstancesOfVS $VsInstance
     exit 1
 }
 
@@ -37,23 +36,15 @@ Write-Host 'Before starting the functional tests, force delete all the Results.h
 
 CleanTempFolder
 
-$result = LaunchVSAndWaitForDTE -VSVersion $VSVersion -DTEReadyPollFrequencyInSecs 6 -NumberOfPolls 50
-if ($result -eq $true) {
+
+$dte2 = LaunchVSAndWaitForDTE -VSInstance $VSInstance -DTEReadyPollFrequencyInSecs 6 -NumberOfPolls 50
+if (-not $dte2) {
     Write-Host 'Do the kill VS, Launch VS and wait for DTE one more time'
-    $result = LaunchVSAndWaitForDTE -VSVersion $VSVersion -DTEReadyPollFrequencyInSecs 6 -NumberOfPolls 50 -ActivityLogFullPath $env:ActivityLogFullPath
-    if ($result -eq $false) {
+    $dte2 = LaunchVSAndWaitForDTE -VSInstance $VSInstance -DTEReadyPollFrequencyInSecs 6 -NumberOfPolls 50 -ActivityLogFullPath $env:ActivityLogFullPath
+    if (-not $dte2) {
         Write-Error "Could not obtain DTE after waiting $NumberOfPolls * $DTEReadyPollFrequencyInSecs = " $NumberOfPolls * $DTEReadyPollFrequencyInSecs " secs"
         exit 1
     }
-}
-
-$dte2 = GetDTE2 $VSVersion
-
-if (!$dte2)
-{
-    Write-Error 'DTE could not be obtained'
-    KillRunningInstancesOfVS
-    exit 1
 }
 
 Write-Host "Launching the Package Manager Console inside VS and waiting for $PMCLaunchWaitTimeInSecs seconds"
@@ -80,7 +71,7 @@ ExecuteCommand $dte2 "View.PackageManagerConsole" $PMCCommand "Running command: 
 Write-Host "Starting functional tests with command '$PMCCommand'"
 RealTimeLogResults $NuGetTestPath $EachTestTimoutInSecs
 
-KillRunningInstancesOfVS
+KillRunningInstancesOfVS $VSInstance
 
 
 

--- a/scripts/e2etests/VSUtils.ps1
+++ b/scripts/e2etests/VSUtils.ps1
@@ -2,11 +2,44 @@ $VSInstallerProcessName = "VSIXInstaller"
 
 . "$PSScriptRoot\Utils.ps1"
 
+function Get-LatestVSInstance
+{
+    $VsVersion = & dotnet msbuild "$PSScriptRoot\..\..\build\config.props" -t:GetVSTargetMajorVersion -NoLogo
+    Write-Host "Looking for VS version $vsVersion"
+    $VsVersionRange = "["+$VsVersion+".0,"+(1+$VsVersion)+".0)"
+
+    $vswhere = "${Env:\ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+
+    $VSInstanceData = & $vswhere -latest -prerelease -version "$VsVersionRange" -nologo -format json | ConvertFrom-Json
+
+    return $VSInstanceData
+}
+
+function Get-SpecificVSInstance
+{
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$instanceId
+    )
+
+    $vswhere = "${Env:\ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+
+    $allInstances = & $vswhere -prerelease -nologo -format json | ConvertFrom-Json
+
+    $specificInstance = $allInstances | Where-Object { $_.instanceId -eq $instanceId }
+
+    if ($null -eq $specificInstance)
+    {
+        throw "Could not find VS instance $instanceId"
+    }
+
+    return $specificInstance
+}
+
 function GetVSFolderPath {
     param(
         [Parameter(Mandatory = $true)]
-        [ValidateSet("17.0")]
-        [string]$VSVersion
+        [Object]$VsInstance
     )
 
     $ProgramFilesPath = ${env:ProgramFiles}
@@ -24,8 +57,7 @@ function LaunchVSAndWaitForDTE {
     param (
         [string]$ActivityLogFullPath,
         [Parameter(Mandatory = $true)]
-        [ValidateSet("17.0")]
-        [string]$VSVersion,
+        [Object]$VSInstance,
         [Parameter(Mandatory = $true)]
         $DTEReadyPollFrequencyInSecs,
         [Parameter(Mandatory = $true)]
@@ -35,11 +67,14 @@ function LaunchVSAndWaitForDTE {
     KillRunningInstancesOfVS
 
     if ($ActivityLogFullPath) {
-        LaunchVS -VSVersion $VSVersion -ActivityLogFullPath $ActivityLogFullPath
+        LaunchVS -VSInstance $VSInstance -ActivityLogFullPath $ActivityLogFullPath
     }
     else {
-        LaunchVS -VSVersion $VSVersion
+        LaunchVS -VSInstance $VSInstance
     }
+
+    $VSVersionString = $VsInstance.installationVersion
+    $VSVersion = $VSVersionString.Substring(0, $VSVersionString.IndexOf("."))
 
     $dte2 = $null
     $count = 0
@@ -61,24 +96,16 @@ function LaunchVSAndWaitForDTE {
     }
 }
 
-function GetVSIDEFolderPath {
+function KillRunningInstancesOfVS {
     param(
         [Parameter(Mandatory = $true)]
-        [ValidateSet("17.0")]
-        [string]$VSVersion
+        [Object]$VSInstance
     )
 
-    $VSFolderPath = GetVSFolderPath $VSVersion
-    $VSIDEFolderPath = Join-Path $VSFolderPath "Common7\IDE"
-
-    return $VSIDEFolderPath
-}
-
-function KillRunningInstancesOfVS {
     Get-Process | ForEach-Object {
         if (-not [string]::IsNullOrEmpty($_.Path)) {
             $processPath = $_.Path | Out-String
-            if ($processPath.StartsWith("C:\Program Files\Microsoft Visual Studio", [System.StringComparison]::OrdinalIgnoreCase)) {
+            if ($processPath.StartsWith($VSInstance.installationPath, [System.StringComparison]::OrdinalIgnoreCase)) {
                 Write-Host $processPath
                 Stop-Process $_ -ErrorAction SilentlyContinue -Force
                 if ($_.HasExited) {
@@ -92,13 +119,11 @@ function KillRunningInstancesOfVS {
 function LaunchVS {
     param(
         [Parameter(Mandatory = $true)]
-        [ValidateSet("17.0")]
-        [string]$VSVersion,
+        [Object]$VSInstance,
         [string]$ActivityLogFullPath
     )
 
-    $VSIDEFolderPath = GetVSIDEFolderPath $VSVersion
-    $VSPath = Join-Path $VSIDEFolderPath "devenv.exe"
+    $VSPath = $VSInstance.productPath
     Write-Host 'Starting ' $VSPath
     if ($ActivityLogFullPath) {
         start-process $VSPath -ArgumentList "/log $ActivityLogFullPath"
@@ -111,7 +136,6 @@ function LaunchVS {
 function GetDTE2 {
     param(
         [Parameter(Mandatory = $true)]
-        [ValidateSet("17.0")]
         [string]$VSVersion
     )
 
@@ -161,7 +185,7 @@ function ExecuteCommand {
             }
         }
         catch {
-            Write-Host "$command threw an exception: $PSItem" 
+            Write-Host "$command threw an exception: $PSItem"
             Write-Host "Will wait for $waitTime seconds and retry"
             $success = $false
             start-sleep $waitTime
@@ -173,58 +197,56 @@ function ExecuteCommand {
 function GetVSIXInstallerPath {
     param(
         [Parameter(Mandatory = $true)]
-        [ValidateSet("17.0")]
-        [string]$VSVersion
+        [Object]$VSInstance
     )
 
-    $VSIDEFolderPath = GetVSIDEFolderPath $VSVersion
-    $VSIXInstallerPath = Join-Path $VSIDEFolderPath "$VSInstallerProcessName.exe"
+    $VSIXInstallerPath = Get-ChildItem -Recurse $VSInstance.installationPath -filter "$VSInstallerProcessName.exe"
 
-    # TODO: This needs to be removed when https://developercommunity.visualstudio.com/content/problem/441998/vsixinstallerexe-not-working-in-vs2019-preview-20.html is fixed (it should be in Preview 4)
-    return "C:\Program Files (x86)\Microsoft Visual Studio\Installer\resources\app\ServiceHub\Services\Microsoft.VisualStudio.Setup.Service\VSIXInstaller.exe"
+    return $VSIXInstallerPath.FullName
 }
 
 function GetMEFCachePath {
+    param(
+        [Parameter(Mandatory = $true)]
+        [Object]$VSInstance
+    )
+
     $cachePath = $env:localappdata
-    @( "Microsoft", "VisualStudio", "17.*", "ComponentModelCache" ) | % { $cachePath = Join-Path $cachePath $_ }
+    $exeVersion = $VSInstance.installationVersion
+    $vsVersion = $exeVersion.Substring(0, $exeVersion.IndexOf('.'))
+    @( "Microsoft", "VisualStudio", "$vsVersion.0_$($VSInstance.instanceId)", "ComponentModelCache" ) | % { $cachePath = Join-Path $cachePath $_ }
 
     return $cachePath
 }
 
 function Update-Configuration(
-        [ValidateSet('17.0')]
-        [string] $vsVersion = '17.0') {
+        [Parameter(Mandatory = $true)]
+        [Object] $vsInstance) {
 
-    $vsIdeFolderPath = GetVSIDEFolderPath $vsVersion
-    $vsFilePath = Join-Path $vsIdeFolderPath 'devenv.exe'
+    Write-Host "Updating configuration for $($vsInstance.productPath)"
 
-    Write-Host "Updating configuration for $vsFilePath"
-
-    Start-Process -FilePath $vsFilePath -ArgumentList '/updateConfiguration' -Wait
+    Start-Process -FilePath $vsInstance.productPath -ArgumentList '/updateConfiguration' -Wait
 }
 
 function UpdateVSInstaller {
     param(
-        [ValidateSet("17.0")]
         [string]$VSVersion,
         [Parameter(Mandatory = $true)]
         [int]$ProcessExitTimeoutInSeconds
     )
 
-    $vsMajorVersion = [System.Version]::Parse($VSVersion).Major
-
-    # The public Preview channel is intentional since the --update command will update the installer to the latest public preview version.  
-    # It matches the channel of VS installed on CI 
-    $vsBootstrapperUrl = "https://aka.ms/vs/$vsMajorVersion/pre/vs_enterprise.exe"
+    # The public Preview channel is intentional since the --update command will update the installer to the latest public preview version.
+    # It matches the channel of VS installed on CI
+    $vsBootstrapperUrl = "https://aka.ms/vs/$VSVersion/pre/vs_enterprise.exe"
 
     $tempdir = [System.IO.Path]::GetTempPath()
     $VSBootstrapperPath =  "$tempdir" + "vs_enterprise.exe"
-    if (Test-Path $VSBootstrapperPath) 
+    if (Test-Path $VSBootstrapperPath)
     {
         Remove-Item $VSBootstrapperPath
     }
-    
-    Write-Host "Downloading [$VSBootstrapperUrl]`nSaving at [$VSBootstrapperPath]" 
+
+    Write-Host "Downloading [$VSBootstrapperUrl]`nSaving at [$VSBootstrapperPath]"
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
     Invoke-WebRequest -Uri $VSBootstrapperUrl -OutFile $VSBootstrapperPath
 
@@ -244,8 +266,8 @@ function UpdateVSInstaller {
 
 function ResumeVSInstall {
     param(
-        [ValidateSet("17.0")]
-        [string]$VSVersion,
+        [Parameter(Mandatory = $true)]
+        [Object]$VSInstance,
         [Parameter(Mandatory = $true)]
         [int]$ProcessExitTimeoutInSeconds
     )
@@ -255,7 +277,7 @@ function ResumeVSInstall {
         $ProgramFilesPath = ${env:ProgramFiles(x86)}
     }
     $VSInstallerPath = "$ProgramFilesPath\Microsoft Visual Studio\Installer\vs_installer.exe"
-    $VSFolderPath = GetVSFolderPath $VSVersion
+    $VSFolderPath = $VSInstance.installationPath
 
     Write-Host 'Resuming any incomplete install'
     $args = "resume --installPath ""$VSFolderPath"" -q"
@@ -265,6 +287,9 @@ function ResumeVSInstall {
     if ($p.ExitCode -ne 0) {
         if ($p.ExitCode -eq 1)
         {
+            $vsExeVersion = $VSInstance.installationVersion
+            $VSVersion = $vsExeVersion.Substring(0, $vsExeVersion.IndexOf('.'))
+
             Write-Host "VS installer appears to need updating. Updating VS installer."
             $resumeResult = UpdateVSInstaller $VSVersion $ProcessExitTimeoutInSeconds
             if ( $resumeResult -eq $true) {
@@ -284,56 +309,18 @@ function ResumeVSInstall {
     }
 }
 
-function UninstallVSIX {
-    param(
-        [Parameter(Mandatory = $true)]
-        [string]$vsixID,
-        [Parameter(Mandatory = $true)]
-        [ValidateSet("17.0")]
-        [string]$VSVersion,
-        [Parameter(Mandatory = $true)]
-        [int]$ProcessExitTimeoutInSeconds
-    )
-
-    $VSIXInstallerPath = GetVSIXInstallerPath $VSVersion
-
-    Write-Host 'Uninstalling VSIX...'
-    $args = "/q /a /u:$vsixID"
-    Write-Host """$VSIXInstallerPath"" $args"
-    $p = start-process "$VSIXInstallerPath" -Wait -PassThru -NoNewWindow -ArgumentList $args
-
-    if ($p.ExitCode -ne 0) {
-        if ($p.ExitCode -eq 1002) {
-            Write-Host "VSIX already uninstalled. Moving on to installing the VSIX! Exit code: $($p.ExitCode)"
-            return $true
-        }
-        else {
-            Write-Error "Error uninstalling the VSIX! Exit code: $($p.ExitCode)"
-            return $false
-        }
-    }
-
-    WaitForProcessExit -ProcessName $VSInstallerProcessName -TimeoutInSeconds $ProcessExitTimeoutInSeconds
-    Write-Host "VSIX has been uninstalled successfully."
-
-    return $true
-}
-
 function DowngradeVSIX {
     param(
         [Parameter(Mandatory = $true)]
-        [string]$vsixID,
-        [Parameter(Mandatory = $true)]
-        [ValidateSet("17.0")]
-        [string]$VSVersion,
+        [Object]$VSInstance,
         [Parameter(Mandatory = $true)]
         [int]$ProcessExitTimeoutInSeconds
     )
 
-    $VSIXInstallerPath = GetVSIXInstallerPath $VSVersion
+    $VSIXInstallerPath = GetVSIXInstallerPath $VSInstance
 
     Write-Host 'Downgrading VSIX...'
-    $args = "/q /a /d:$vsixID"
+    $args = "/q /a /d:NuGet.72c5d240-f742-48d4-a0f1-7016671e405b /instanceIds:$($VSInstance.instanceId)"
     Write-Host """$VSIXInstallerPath"" $args"
     $p = start-process "$VSIXInstallerPath" -Wait -PassThru -NoNewWindow -ArgumentList $args
 
@@ -341,6 +328,8 @@ function DowngradeVSIX {
         if ($p.ExitCode -eq -2146233079)
         {
             Write-Host "Previous VSIX install appears not to have completed. Resuming VS install."
+            $exeVersion = $VSInstance.installationVersion
+            $VSVersion = $exeVersion.Substring(0, $exeVersion.IndexOf("."))
             $resumeResult = ResumeVSInstall $VSVersion $ProcessExitTimeoutInSeconds
             if ( $resumeResult -eq $true) {
                 Write-Host """$VSIXInstallerPath"" $args"
@@ -349,7 +338,7 @@ function DowngradeVSIX {
         }
 
         if ($p.ExitCode -eq 2001) {
-            Write-Host "This VS2017 version does not support downgrade. Moving on to installing the VSIX! Exit code: $($p.ExitCode)" 
+            Write-Host "This VS2017 version does not support downgrade. Moving on to installing the VSIX! Exit code: $($p.ExitCode)"
             return $true
         }
         elseif ($p.ExitCode -ne 0) {
@@ -370,13 +359,12 @@ function InstallVSIX {
         [Parameter(Mandatory = $true)]
         [string]$vsixpath,
         [Parameter(Mandatory = $true)]
-        [ValidateSet("17.0")]
-        [string]$VSVersion,
+        [Object]$VSInstance,
         [Parameter(Mandatory = $true)]
         [int]$ProcessExitTimeoutInSeconds
     )
 
-    $VSIXInstallerPath = GetVSIXInstallerPath $VSVersion
+    $VSIXInstallerPath = GetVSIXInstallerPath $VSInstance
 
     Write-Host "Installing VSIX from $vsixpath..."
     $args = "/q /a $vsixpath"
@@ -396,7 +384,12 @@ function InstallVSIX {
 
 
 function ClearMEFCache {
-    $mefCachePath = GetMEFCachePath
+    param(
+        [Parameter(Mandatory = $true)]
+        [Object]$VSInstance
+    )
+
+    $mefCachePath = GetMEFCachePath $VSInstance
 
     Write-Host "rm -r $mefCachePath..."
     rm -r $mefCachePath

--- a/scripts/e2etests/VSUtils.ps1
+++ b/scripts/e2etests/VSUtils.ps1
@@ -2,15 +2,28 @@ $VSInstallerProcessName = "VSIXInstaller"
 
 . "$PSScriptRoot\Utils.ps1"
 
-function Get-LatestVSInstance
+function Get-VisualStudioVersionRangeFromConfig
 {
     $VsVersion = & dotnet msbuild "$PSScriptRoot\..\..\build\config.props" -t:GetVSTargetMajorVersion -NoLogo
-    Write-Host "Looking for VS version $vsVersion"
+    Write-Host "config.props targets VS version $vsVersion"
     $VsVersionRange = "["+$VsVersion+".0,"+(1+$VsVersion)+".0)"
+    return $VsVersionRange
+}
+
+function Get-LatestVSInstance
+{
+    param(
+        [string]$VersionRange
+    )
 
     $vswhere = "${Env:\ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
 
-    $VSInstanceData = & $vswhere -latest -prerelease -version "$VsVersionRange" -nologo -format json | ConvertFrom-Json
+    if (-not $VersionRange) {
+        $VSInstanceData = & $vswhere -latest -prerelease -nologo -format json | ConvertFrom-Json
+    }
+    else {
+        $VSInstanceData = & $vswhere -latest -prerelease -version "$VersionRange" -nologo -format json | ConvertFrom-Json
+    }
 
     return $VSInstanceData
 }

--- a/scripts/nuget-debug-helpers.ps1
+++ b/scripts/nuget-debug-helpers.ps1
@@ -1,55 +1,54 @@
 $NuGetClientRoot= Resolve-Path $(Join-Path $PSScriptRoot "..\")
 
-$VSVersion = if (-Not [string]::IsNullOrEmpty($env:VisualStudioVersion)) { $env:VisualStudioVersion } else { "17.0" }
 $Configuration = "Debug"
 $NETFramework = "net472"
 $NETStandard = "netstandard2.0"
 $NETCoreApp = "netcoreapp5.0"
 
 <#
-Auto bootstraps NuGet for debugging the targets. This includes both restore and pack and is the recommended way to test things :) 
+Auto bootstraps NuGet for debugging the targets. This includes both restore and pack and is the recommended way to test things :)
 
 .EXAMPLE
-    This runs restore on the NuGet.sln. The args here are equivalent to the args you would pass to an MSBuild invocation. 
+    This runs restore on the NuGet.sln. The args here are equivalent to the args you would pass to an MSBuild invocation.
     C:\PS> Invoke-NuGetCustom /t:restore NuGet.sln
 #>
 Function Invoke-NuGetCustom()
 {
-    $packDllPath = Join-Path $NuGetClientRoot "artifacts\NuGet.Build.Tasks.Pack\$VSVersion\bin\$Configuration\$NETFramework\NuGet.Build.Tasks.Pack.dll"
+    $packDllPath = Join-Path $NuGetClientRoot "artifacts\NuGet.Build.Tasks.Pack\bin\$Configuration\$NETFramework\NuGet.Build.Tasks.Pack.dll"
     $packTargetsPath = Join-Path $NuGetClientRoot "src\NuGet.Core\NuGet.Build.Tasks.Pack\NuGet.Build.Tasks.Pack.targets"
-    $restoreDllPath = Join-Path $NuGetClientRoot "artifacts\NuGet.Build.Tasks\$VSVersion\bin\$Configuration\$NETFramework\NuGet.Build.Tasks.dll"
+    $restoreDllPath = Join-Path $NuGetClientRoot "artifacts\NuGet.Build.Tasks\bin\$Configuration\$NETFramework\NuGet.Build.Tasks.dll"
     $nugetRestoreTargetsPath = Join-Path $NuGetClientRoot "src\NuGet.Core\NuGet.Build.Tasks\NuGet.targets"
-    $consoleExePath = Join-Path $NuGetClientRoot "artifacts\NuGet.Build.Tasks.Console\$VSVersion\bin\$Configuration\$NETFramework\NuGet.Build.Tasks.Console.exe"
-    Write-Host "msbuild /p:NuGetRestoreTargets=$nugetRestoreTargetsPath /p:RestoreTaskAssemblyFile=$restoreDllPath /p:NuGetBuildTasksPackTargets=$packTargetsPath /p:NuGetConsoleProcessFileName=$consoleExePath /p:ImportNuGetBuildTasksPackTargetsFromSdk=true /p:NuGetPackTaskAssemblyFile=$packDllPath $($args[0..$args.Count])" 
+    $consoleExePath = Join-Path $NuGetClientRoot "artifacts\NuGet.Build.Tasks.Console\bin\$Configuration\$NETFramework\NuGet.Build.Tasks.Console.exe"
+    Write-Host "msbuild /p:NuGetRestoreTargets=$nugetRestoreTargetsPath /p:RestoreTaskAssemblyFile=$restoreDllPath /p:NuGetBuildTasksPackTargets=$packTargetsPath /p:NuGetConsoleProcessFileName=$consoleExePath /p:ImportNuGetBuildTasksPackTargetsFromSdk=true /p:NuGetPackTaskAssemblyFile=$packDllPath $($args[0..$args.Count])"
     & msbuild /p:NuGetRestoreTargets=$nugetRestoreTargetsPath /p:RestoreTaskAssemblyFile=$restoreDllPath /p:NuGetBuildTasksPackTargets=$packTargetsPath /p:NuGetConsoleProcessFileName=$consoleExePath /p:ImportNuGetBuildTasksPackTargetsFromSdk=true /p:NuGetPackTaskAssemblyFile=$packDllPath $args[0..$args.Count]
 }
 
 <#
 Auto bootstraps NuGet for debugging the restore targets only (this doesn't include the pack targets!)
 .EXAMPLE
-    This runs restore on the NuGet.sln. The args here are equivalent to the args you would pass to an MSBuild invocation. 
+    This runs restore on the NuGet.sln. The args here are equivalent to the args you would pass to an MSBuild invocation.
     C:\PS> Invoke-NuGetCustom /t:restore NuGet.sln
 #>
 Function Invoke-NuGetRestoreCustom()
 {
-    $restoreDllPath = Join-Path $NuGetClientRoot "artifacts\NuGet.Build.Tasks\$VSVersion\bin\$Configuration\$NETFramework\NuGet.Build.Tasks.dll"
+    $restoreDllPath = Join-Path $NuGetClientRoot "artifacts\NuGet.Build.Tasks\bin\$Configuration\$NETFramework\NuGet.Build.Tasks.dll"
     $nugetRestoreTargetsPath = Join-Path $NuGetClientRoot "src\NuGet.Core\NuGet.Build.Tasks\NuGet.targets"
-    $consoleExePath = Join-Path $NuGetClientRoot "artifacts\NuGet.Build.Tasks.Console\$VSVersion\bin\$Configuration\$NETFramework\NuGet.Build.Console.exe"
-    Write-Host "msbuild /p:NuGetRestoreTargets=$nugetRestoreTargetsPath /p:RestoreTaskAssemblyFile=$restoreDllPath /p:NuGetConsoleProcessFileName=$consoleExePath $($args[0..$args.Count])" 
+    $consoleExePath = Join-Path $NuGetClientRoot "artifacts\NuGet.Build.Tasks.Console\bin\$Configuration\$NETFramework\NuGet.Build.Console.exe"
+    Write-Host "msbuild /p:NuGetRestoreTargets=$nugetRestoreTargetsPath /p:RestoreTaskAssemblyFile=$restoreDllPath /p:NuGetConsoleProcessFileName=$consoleExePath $($args[0..$args.Count])"
     & msbuild /p:NuGetRestoreTargets=$nugetRestoreTargetsPath /p:RestoreTaskAssemblyFile=$restoreDllPath /p:NuGetConsoleProcessFileName=$consoleExePath $args[0..$args.Count]
 }
 
 <#
 Auto bootstraps NuGet for debugging the pack targets only (this doesn't include the restore targets!)
 .EXAMPLE
-    This runs pack on the NuGet.sln. The args here are equivalent to the args you would pass to an MSBuild invocation. 
+    This runs pack on the NuGet.sln. The args here are equivalent to the args you would pass to an MSBuild invocation.
     C:\PS> Invoke-NuGetPackCustom /t:pack NuGet.sln
 #>
 Function Invoke-NuGetPackCustom()
 {
-    $packDllPath = Join-Path $NuGetClientRoot "artifacts\NuGet.Build.Tasks.Pack\$VSVersion\bin\$Configuration\$NETFramework\NuGet.Build.Tasks.Pack.dll"
+    $packDllPath = Join-Path $NuGetClientRoot "artifacts\NuGet.Build.Tasks.Pack\bin\$Configuration\$NETFramework\NuGet.Build.Tasks.Pack.dll"
     $packTargetsPath = Join-Path $NuGetClientRoot "src\NuGet.Core\NuGet.Build.Tasks.Pack\NuGet.Build.Tasks.Pack.targets"
-    Write-Host "msbuild /p:NuGetBuildTasksPackTargets=$packTargetsPath /p:ImportNuGetBuildTasksPackTargetsFromSdk=true /p:NuGetPackTaskAssemblyFile=$packDllPath $($args[0..$args.Count])" 
+    Write-Host "msbuild /p:NuGetBuildTasksPackTargets=$packTargetsPath /p:ImportNuGetBuildTasksPackTargetsFromSdk=true /p:NuGetPackTaskAssemblyFile=$packDllPath $($args[0..$args.Count])"
     & msbuild /p:NuGetBuildTasksPackTargets=$packTargetsPath /p:ImportNuGetBuildTasksPackTargetsFromSdk=true /p:NuGetPackTaskAssemblyFile=$packDllPath $args[0..$args.Count]
 }
 
@@ -79,16 +78,16 @@ Function Add-NuGetToCLI {
         }
     }
     $sdk_path = $sdkLocation
-    
-    $nugetXplatArtifactsPath = [System.IO.Path]::Combine($NuGetClientRoot, 'artifacts', 'NuGet.CommandLine.XPlat', $VSVersion, 'bin', $Configuration, $NETCoreApp)
-    $nugetBuildTasks = [System.IO.Path]::Combine($NuGetClientRoot, 'artifacts', 'NuGet.Build.Tasks', $VSVersion, 'bin', $Configuration, $NETCoreApp, 'NuGet.Build.Tasks.dll')
-    $nugetBuildTasksConsole = [System.IO.Path]::Combine($NuGetClientRoot, 'artifacts', 'NuGet.Build.Tasks.Console', $VSVersion, 'bin', $Configuration, $NETCoreApp, 'NuGet.Build.Tasks.Console.dll')
+
+    $nugetXplatArtifactsPath = [System.IO.Path]::Combine($NuGetClientRoot, 'artifacts', 'NuGet.CommandLine.XPlat', 'bin', $Configuration, $NETCoreApp)
+    $nugetBuildTasks = [System.IO.Path]::Combine($NuGetClientRoot, 'artifacts', 'NuGet.Build.Tasks', 'bin', $Configuration, $NETCoreApp, 'NuGet.Build.Tasks.dll')
+    $nugetBuildTasksConsole = [System.IO.Path]::Combine($NuGetClientRoot, 'artifacts', 'NuGet.Build.Tasks.Console', 'bin', $Configuration, $NETCoreApp, 'NuGet.Build.Tasks.Console.dll')
     $nugetTargets = [System.IO.Path]::Combine($NuGetClientRoot, 'src', 'NuGet.Core', 'NuGet.Build.Tasks', 'NuGet.targets')
     $nugetExTargets = [System.IO.Path]::Combine($NuGetClientRoot, 'src', 'NuGet.Core', 'NuGet.Build.Tasks', 'NuGet.RestoreEx.targets')
-    $ilmergedCorePackTasks = [System.IO.Path]::Combine($NuGetClientRoot, 'artifacts', 'NuGet.Build.Tasks.Pack', $VSVersion, 'bin', $Configuration, $NETStandard, "ilmerge", "NuGet.Build.Tasks.Pack.dll")
-    $ilmergedFrameworkPackTasks = [System.IO.Path]::Combine($NuGetClientRoot, 'artifacts', 'NuGet.Build.Tasks.Pack', $VSVersion, 'bin', $Configuration, $NETFramework, "ilmerge",  "NuGet.Build.Tasks.Pack.dll")
+    $ilmergedCorePackTasks = [System.IO.Path]::Combine($NuGetClientRoot, 'artifacts', 'NuGet.Build.Tasks.Pack', 'bin', $Configuration, $NETStandard, "ilmerge", "NuGet.Build.Tasks.Pack.dll")
+    $ilmergedFrameworkPackTasks = [System.IO.Path]::Combine($NuGetClientRoot, 'artifacts', 'NuGet.Build.Tasks.Pack', 'bin', $Configuration, $NETFramework, "ilmerge",  "NuGet.Build.Tasks.Pack.dll")
     $nugetPackTargets = [System.IO.Path]::Combine($NuGetClientRoot, 'src', 'NuGet.Core', 'NuGet.Build.Tasks.Pack', 'NuGet.Build.Tasks.Pack.targets')
-    $msbuildSdkResolverTasks = [System.IO.Path]::Combine($NuGetClientRoot, 'artifacts', 'Microsoft.Build.NuGetSdkResolver', $VSVersion, 'bin', $Configuration, $NETCoreApp, 'Microsoft.Build.NuGetSdkResolver.dll')
+    $msbuildSdkResolverTasks = [System.IO.Path]::Combine($NuGetClientRoot, 'artifacts', 'Microsoft.Build.NuGetSdkResolver', 'bin', $Configuration, $NETCoreApp, 'Microsoft.Build.NuGetSdkResolver.dll')
 
 
     if (-Not (Test-Path $nugetXplatArtifactsPath)) {
@@ -140,32 +139,32 @@ Function Add-NuGetToCLI {
     Write-Host "Source commandline path - $nugetXplatArtifactsPath"
     Write-Host "Destination sdk path - $sdk_path"
     Write-Host
-    
+
     ## Copy the xplat artifacts
 
-    Get-ChildItem $nugetXplatArtifactsPath -Filter NuGet*.dll | 
-        Foreach-Object {	
+    Get-ChildItem $nugetXplatArtifactsPath -Filter NuGet*.dll |
+        Foreach-Object {
             $new_position = "$($sdk_path)\$($_.BaseName )$($_.Extension )"
-                
+
             Write-Host "Moving to - $($new_position)"
             Copy-Item $_.FullName $new_position
         }
-    
+
     ## Copy the  restore artifacts
 
-    $buildTasksDest = "$($sdk_path)\NuGet.Build.Tasks.dll" 
+    $buildTasksDest = "$($sdk_path)\NuGet.Build.Tasks.dll"
     Write-Host "Moving to - $($buildTasksDest)"
     Copy-Item $nugetBuildTasks $buildTasksDest
 
-    $buildTasksConsoleDest = "$($sdk_path)\NuGet.Build.Tasks.Console.dll" 
+    $buildTasksConsoleDest = "$($sdk_path)\NuGet.Build.Tasks.Console.dll"
     Write-Host "Moving to - $($buildTasksConsoleDest)"
     Copy-Item $nugetBuildTasksConsole $buildTasksConsoleDest
 
-    $nugetTargetsDest = "$($sdk_path)\NuGet.targets" 
+    $nugetTargetsDest = "$($sdk_path)\NuGet.targets"
     Write-Host "Moving to - $($nugetTargetsDest)"
     Copy-Item $nugetTargets $nugetTargetsDest
 
-    $nugetRestoreExTargetsDest = "$($sdk_path)\NuGet.RestoreEx.targets" 
+    $nugetRestoreExTargetsDest = "$($sdk_path)\NuGet.RestoreEx.targets"
     Write-Host "Moving to - $($nugetRestoreExTargetsDest)"
     Copy-Item $nugetExTargets $nugetRestoreExTargetsDest
 
@@ -173,25 +172,25 @@ Function Add-NuGetToCLI {
 
     $packSdkPath = "$($sdk_path)\Sdks\NuGet.Build.Tasks.Pack"
 
-    $nugetPackTargetsCrossTargetingDest = "$($packSdkPath)\buildCrossTargeting\NuGet.Build.Tasks.Pack.targets" 
+    $nugetPackTargetsCrossTargetingDest = "$($packSdkPath)\buildCrossTargeting\NuGet.Build.Tasks.Pack.targets"
     Write-Host "Moving to - $($nugetPackTargetsCrossTargetingDest)"
     Copy-Item $nugetPackTargets $nugetPackTargetsCrossTargetingDest
 
-    $nugetPackTargetsDest = "$($packSdkPath)\build\NuGet.Build.Tasks.Pack.targets" 
+    $nugetPackTargetsDest = "$($packSdkPath)\build\NuGet.Build.Tasks.Pack.targets"
     Write-Host "Moving to - $($nugetPackTargetsDest)"
     Copy-Item $nugetPackTargets $nugetPackTargetsDest
 
-    $packTasksCoreDest = "$($packSdkPath)\CoreCLR\NuGet.Build.Tasks.Pack.dll" 
+    $packTasksCoreDest = "$($packSdkPath)\CoreCLR\NuGet.Build.Tasks.Pack.dll"
     Write-Host "Moving to - $($packTasksCoreDest)"
     Copy-Item $ilmergedCorePackTasks $packTasksCoreDest
 
-    $packTasksFrameworkDest = "$($packSdkPath)\Desktop\NuGet.Build.Tasks.Pack.dll" 
+    $packTasksFrameworkDest = "$($packSdkPath)\Desktop\NuGet.Build.Tasks.Pack.dll"
     Write-Host "Moving to - $($packTasksFrameworkDest)"
     Copy-Item $ilmergedFrameworkPackTasks $packTasksFrameworkDest
 
     ## Copy the resolver
 
-    $msbuildSdkResolverTasksDest = "$($sdk_path)\Microsoft.Build.NuGetSdkResolver.dll" 
+    $msbuildSdkResolverTasksDest = "$($sdk_path)\Microsoft.Build.NuGetSdkResolver.dll"
     Write-Host "Moving to - $($msbuildSdkResolverTasksDest)"
     Copy-Item $msbuildSdkResolverTasks $msbuildSdkResolverTasksDest
 }

--- a/setup/Microsoft.VisualStudio.NuGet.BuildTools.swixproj
+++ b/setup/Microsoft.VisualStudio.NuGet.BuildTools.swixproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <ReferenceOutputPath>$(ArtifactsDirectory)NuGet.VisualStudio.Client\$(VisualStudioVersion)\bin\$(Configuration)\</ReferenceOutputPath>
+    <ReferenceOutputPath>$(ArtifactsDirectory)NuGet.VisualStudio.Client\bin\$(Configuration)\</ReferenceOutputPath>
     <NuGetTargetsBasePath>$(RepositoryRootDirectory)src\NuGet.Core\NuGet.Build.Tasks\</NuGetTargetsBasePath>
     <XmlTransformPath>$(ArtifactsDirectory)microsoft.web.xdt\3.0.0\lib\net40\</XmlTransformPath>
     <NewtonsoftJsonPath>$(SolutionPackagesFolder)newtonsoft.json\9.0.1\lib\net45\</NewtonsoftJsonPath>

--- a/src/NuGet.Clients/NuGetConsole.Host.PowerShell/NuGetConsole.Host.PowerShell.csproj
+++ b/src/NuGet.Clients/NuGetConsole.Host.PowerShell/NuGetConsole.Host.PowerShell.csproj
@@ -164,7 +164,7 @@
     </ItemGroup>
     <Copy SourceFiles="@(PowerShellScripts)"
           DestinationFolder="$(ArtifactsDirectory)Scripts" />
-    <Exec Command="powershell.exe -ExecutionPolicy Bypass &quot;$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\UpdateNuGetModuleManifest.ps1&quot; -NuGetPackageManagementPowerShellCmdletsFilePath &quot;$(ArtifactsDirectory)NuGet.PackageManagement.PowerShellCmdlets\$(BuildVariationFolder)\bin\$(Configuration)\NuGet.PackageManagement.PowerShellCmdlets.dll&quot; -ManifestModuleSourceFilePath &quot;$(MSBuildProjectDirectory)\Scripts\NuGet.psd1&quot; -ManifestModuleDestinationFilePath &quot;$(ArtifactsDirectory)Scripts\NuGet.psd1&quot;" />
+    <Exec Command="powershell.exe -ExecutionPolicy Bypass &quot;$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\UpdateNuGetModuleManifest.ps1&quot; -NuGetPackageManagementPowerShellCmdletsFilePath &quot;$(ArtifactsDirectory)NuGet.PackageManagement.PowerShellCmdlets\bin\$(Configuration)\NuGet.PackageManagement.PowerShellCmdlets.dll&quot; -ManifestModuleSourceFilePath &quot;$(MSBuildProjectDirectory)\Scripts\NuGet.psd1&quot; -ManifestModuleDestinationFilePath &quot;$(ArtifactsDirectory)Scripts\NuGet.psd1&quot;" />
   </Target>
   <Target Name="GetScriptsForSigning" Returns="@(ScriptsToSign)">
     <ItemGroup>

--- a/src/NuGet.Core/NuGet.Packaging.Extraction/NuGet.Packaging.Extraction.csproj
+++ b/src/NuGet.Core/NuGet.Packaging.Extraction/NuGet.Packaging.Extraction.csproj
@@ -19,7 +19,7 @@
     <DefineConstants>$(DefineConstants);IS_DESKTOP</DefineConstants>
     <IsDesktop>true</IsDesktop>
     <ILMergeDirectory Condition=" '$(OutputPath)' != '' ">$(OutputPath)$(TargetFramework)\ilmerge\</ILMergeDirectory>
-    <ILMergeDirectory Condition=" '$(OutputPath)' == '' ">$(ArtifactsDirectory)$(MSBuildProjectName)\$(BuildVariationFolder)\bin\$(Configuration)\$(TargetFramework)\ilmerge\</ILMergeDirectory>
+    <ILMergeDirectory Condition=" '$(OutputPath)' == '' ">$(ArtifactsDirectory)$(MSBuildProjectName)\bin\$(Configuration)\$(TargetFramework)\ilmerge\</ILMergeDirectory>
   </PropertyGroup>
 
   <Target

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGet.CommandLine.Test.csproj
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGet.CommandLine.Test.csproj
@@ -53,9 +53,9 @@
 
   <PropertyGroup>
     <PostBuildEvent>
-      xcopy /diy $(ArtifactsDirectory)TestableCredentialProvider\$(BuildVariationFolder)\bin\$(Configuration)\$(TargetFramework)\CredentialProvider.Testable.exe $(OutputPath)TestableCredentialProvider\
-      xcopy /diy $(ArtifactsDirectory)TestableCredentialProvider\$(BuildVariationFolder)\bin\$(Configuration)\$(TargetFramework)\*.dll $(OutputPath)TestableCredentialProvider\
-      xcopy /diy $(ArtifactsDirectory)SampleCommandLineExtensions\$(BuildVariationFolder)\bin\$(Configuration)\$(TargetFramework)\SampleCommandLineExtensions.dll $(OutputPath)NuGet\
+      xcopy /diy $(ArtifactsDirectory)TestableCredentialProvider\bin\$(Configuration)\$(TargetFramework)\CredentialProvider.Testable.exe $(OutputPath)TestableCredentialProvider\
+      xcopy /diy $(ArtifactsDirectory)TestableCredentialProvider\bin\$(Configuration)\$(TargetFramework)\*.dll $(OutputPath)TestableCredentialProvider\
+      xcopy /diy $(ArtifactsDirectory)SampleCommandLineExtensions\bin\$(Configuration)\$(TargetFramework)\SampleCommandLineExtensions.dll $(OutputPath)NuGet\
       if exist $(ArtifactsDirectory)$(VsixOutputDirName)\NuGet.exe xcopy /diy $(ArtifactsDirectory)$(VsixOutputDirName)\NuGet.exe $(OutputPath)NuGet\
     </PostBuildEvent>
   </PropertyGroup>

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/MsbuildIntegrationTestFixture.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/MsbuildIntegrationTestFixture.cs
@@ -452,12 +452,11 @@ SDKs found: {string.Join(", ", Directory.EnumerateDirectories(sdkDir).Select(Pat
 #else
                 "Release";
 #endif
-            const string toolsetVersion = "16.0";
-            CopyPackSdkArtifacts(artifactsDirectory, pathToSdkInCli, configuration, toolsetVersion);
-            CopyRestoreArtifacts(artifactsDirectory, pathToSdkInCli, configuration, toolsetVersion);
+            CopyPackSdkArtifacts(artifactsDirectory, pathToSdkInCli, configuration);
+            CopyRestoreArtifacts(artifactsDirectory, pathToSdkInCli, configuration);
         }
 
-        private void CopyRestoreArtifacts(string artifactsDirectory, string pathToSdkInCli, string configuration, string toolsetVersion)
+        private void CopyRestoreArtifacts(string artifactsDirectory, string pathToSdkInCli, string configuration)
         {
             const string restoreProjectName = "NuGet.Build.Tasks";
             const string restoreTargetsName = "NuGet.targets";
@@ -470,7 +469,7 @@ SDKs found: {string.Join(", ", Directory.EnumerateDirectories(sdkDir).Select(Pat
             // Copy rest of the NuGet assemblies.
             foreach (var projectName in sdkDependencies)
             {
-                var projectArtifactsBinFolder = Path.Combine(artifactsDirectory, projectName, toolsetVersion, "bin", configuration);
+                var projectArtifactsBinFolder = Path.Combine(artifactsDirectory, projectName, "bin", configuration);
 
                 var tfmToCopy = GetTfmToCopy(sdkTfm, projectArtifactsBinFolder);
                 var frameworkArtifactsFolder = new DirectoryInfo(Path.Combine(projectArtifactsBinFolder, tfmToCopy));
@@ -519,7 +518,7 @@ project TFMs found: {string.Join(", ", compiledTfms.Keys.Select(k => k.ToString(
             return selectedVersion;
         }
 
-        private void CopyPackSdkArtifacts(string artifactsDirectory, string pathToSdkInCli, string configuration, string toolsetVersion)
+        private void CopyPackSdkArtifacts(string artifactsDirectory, string pathToSdkInCli, string configuration)
         {
             var pathToPackSdk = Path.Combine(pathToSdkInCli, "Sdks", "NuGet.Build.Tasks.Pack");
             var sdkTfm = AssemblyReader.GetTargetFramework(Path.Combine(pathToSdkInCli, "dotnet.dll"));
@@ -528,7 +527,7 @@ project TFMs found: {string.Join(", ", compiledTfms.Keys.Select(k => k.ToString(
             const string packTargetsName = "NuGet.Build.Tasks.Pack.targets";
 
             // Copy the pack SDK.
-            var packProjectBinDirectory = Path.Combine(artifactsDirectory, packProjectName, toolsetVersion, "bin", configuration);
+            var packProjectBinDirectory = Path.Combine(artifactsDirectory, packProjectName, "bin", configuration);
             var tfmToCopy = GetTfmToCopy(sdkTfm, packProjectBinDirectory);
 
             var packProjectCoreArtifactsDirectory = new DirectoryInfo(Path.Combine(packProjectBinDirectory, tfmToCopy));

--- a/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/NuGet.Protocol.FuncTest.csproj
+++ b/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/NuGet.Protocol.FuncTest.csproj
@@ -30,10 +30,10 @@
 
   <PropertyGroup>
     <PostBuildEvent Condition="'$(OS)' == 'Windows_NT'">
-      xcopy /diye $(ArtifactsDirectory)TestablePlugin\$(BuildVariationFolder)\bin\$(Configuration)\$(TargetFramework)\* $(MSBuildProjectDirectory)\bin\$(Configuration)\$(TargetFramework)\TestablePlugin\
+      xcopy /diye $(ArtifactsDirectory)TestablePlugin\bin\$(Configuration)\$(TargetFramework)\* $(MSBuildProjectDirectory)\bin\$(Configuration)\$(TargetFramework)\TestablePlugin\
     </PostBuildEvent>
   </PropertyGroup>
-  
+
   <Import Project="$(BuildCommonDirectory)common.targets"/>
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 </Project>

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/DotnetCliUtil.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/DotnetCliUtil.cs
@@ -131,7 +131,7 @@ namespace NuGet.XPlat.FuncTest
 
                 var relativePaths = new string[]
                 {
-                    Path.Combine("artifacts", "NuGet.CommandLine.XPlat", "16.0", "bin", configuration, "netcoreapp5.0", XPlatDll)
+                    Path.Combine("artifacts", "NuGet.CommandLine.XPlat", "bin", configuration, "netcoreapp5.0", XPlatDll)
                 };
 
                 foreach (var relativePath in relativePaths)

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/NuGet.XPlat.FuncTest.csproj
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/NuGet.XPlat.FuncTest.csproj
@@ -38,9 +38,9 @@
   </ItemGroup>
   <Target Name="CopyTargets" AfterTargets="AfterBuild">
     <Copy Condition=" '$(IsCore)' == 'true' " SourceFiles="$(MSBuildProjectDirectory)\$(OutputPath)\Microsoft.CSharp.Core.targets" DestinationFolder="$(MSBuildProjectDirectory)\$(OutputPath)\Roslyn\" />
-    <Copy Condition="'$(TargetFramework)' == '$(NETFXTargetFramework)'" SourceFiles="$(MSBuildProjectDirectory)\$(OutputPath)\Microsoft.CSharp.Core.targets" DestinationFolder="$(MSBuildProjectDirectory)\$(OutputPath)\..\..\$(VisualStudioVersion)\Bin\Roslyn\" />
+    <Copy Condition="'$(TargetFramework)' == '$(NETFXTargetFramework)'" SourceFiles="$(MSBuildProjectDirectory)\$(OutputPath)\Microsoft.CSharp.Core.targets" DestinationFolder="$(MSBuildProjectDirectory)\$(OutputPath)\..\..\Bin\Roslyn\" />
   </Target>
-  
+
   <Import Project="$(BuildCommonDirectory)common.targets" />
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 </Project>


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1014

Regression? No

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

For years, when you build NuGet.Client, it used the VS version in the bin/obj folder path. This PR will:

* Change build.ps1 to tell MSBuild to use all CPU cores when building `build\build.proj`, rather than just 1.  Although, I'm not sure this actually worked for some reason. I feel like building NuGet.sln is much faster than build\build.proj.
* Remove VisualStudioVersion from obj/bin folder path
* Stop adding `-RTM` to folder path when BuildRTM is true
* There were a few tests that looked for assemblies in bin folder. These no longer expect the Visual Studio version folder.
* Stop setting DOTNET_HOME and DOTNET_INSTALL_DIRECTORY in configure.ps1.
* Scripts look for msbuild on the PATH, and fall back to using vswhere.
* Change our InstallVSIX.ps1 script, used for E2E tests and Apex, to use vswhere to find the VS install path, to locate vsixinstaller.exe, no matter what the install directory is, and also find and pass through the VS instance ID, so theoretically it might install/downgrade one of the VS installs, not multiple. Although this didn't appear to actually improve at all.

There's probably more, but basically it's about making builds more reliable.

## PR Checklist

- [X] PR has a meaningful title
- [X] PR has a linked issue.
- [X] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [X] N/A: Build scripts

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [X] N/A
