### PR TITLE
Increase idle timeout at solution load for dev16

### DIFF
--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreWorker.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreWorker.cs
@@ -33,7 +33,7 @@ namespace NuGet.SolutionRestoreManager
         private const int RequestQueueLimit = 150;
         private const int PromoteAttemptsLimit = 150;
         private const int DelaySolutionLoadRetry = 100;
-        private const int MaxIdleWaitTimeMs = 10000;
+        private const int MaxIdleWaitTimeMs = 60000;
 
         private readonly object _lockPendingRequestsObj = new object();
 
@@ -497,7 +497,8 @@ namespace NuGet.SolutionRestoreManager
                                 }
                                 else
                                 {
-                                    // Break if we've waited for more than 10s without an actual nomination.
+                                    // Break if we've waited for more than 60s without an actual nomination.
+                                    // Normally we would expect nominations to come quickly, but on slow machines it's quite possible this takes a while.
                                     if (lastNominationReceived.AddMilliseconds(MaxIdleWaitTimeMs) < DateTime.UtcNow)
                                     {
                                         break;


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/10950

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

As part of the solution load and branch swithing investigations, we're learning that the timeout of 10s is too short.

There are plans to change up the behavior in 17.0, but the proposal is to increase it to a reasonable number in 16.11 to avoid unnecessary and incorrect work on slower machines.

Related #10874, #10678.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
