### PR TITLE
Set binding redirects upper bound through a target

### DIFF
--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/NuGet.SolutionRestoreManager.csproj
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/NuGet.SolutionRestoreManager.csproj
@@ -143,6 +143,30 @@
       <Name>NuGet.Versioning</Name>
     </ProjectReference>
   </ItemGroup>
+
+  <PropertyGroup>
+    <_BindingRedirectsFile>$(IntermediateOutputPath)$(MSBuildProjectName).BindingRedirects.cs</_BindingRedirectsFile>
+    <_AssemblyVersion>$(SemanticVersion).$(PreReleaseVersion)</_AssemblyVersion>
+  </PropertyGroup>
+
+  <!-- This is a workaround for the bug in the Microsoft.VSSDK.BuildTools that doesn't set the correct upper bound when not provided. -->
+  <Target Name="GenerateNuGetSolutionRestoreManagerBindingRedirects" BeforeTargets="CoreCompile" Inputs="$(MSBuildAllProjects)" Outputs="$(_BindingRedirectsFile)">
+    <PropertyGroup>
+      <_GeneratedVSIXBindingRedirectContent><![CDATA[
+// Generated in NuGet.SolutionRestoreManager.csproj 
+using Microsoft.VisualStudio.Shell;
+[assembly: ProvideBindingRedirection(CodeBase = @"$PackageFolder$\NuGet.SolutionRestoreManager.Interop.dll", OldVersionLowerBound = "0.0.0.0", OldVersionUpperBound = "$(_AssemblyVersion)")]
+]]></_GeneratedVSIXBindingRedirectContent>
+    </PropertyGroup>
+    <WriteLinesToFile Lines="$([MSBuild]::Escape($(_GeneratedVSIXBindingRedirectContent)))" File="$(_BindingRedirectsFile)" Overwrite="True" WriteOnlyWhenDifferent="True" />
+    <ItemGroup>
+      <Compile Include="$(_BindingRedirectsFile)">
+        <Visible>false</Visible>
+      </Compile>
+      <FileWrites Include="$(_BindingRedirectsFile)" />
+    </ItemGroup>
+  </Target>
+
   <Import Project="$(BuildCommonDirectory)common.targets" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/Properties/AssemblyInfo.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/Properties/AssemblyInfo.cs
@@ -42,8 +42,6 @@ using Microsoft.VisualStudio.Shell;
 [assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\NuGet.VisualStudio.dll")]
 [assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\NuGet.VisualStudio.Internal.Contracts.dll")]
 
-[assembly: ProvideBindingRedirection(CodeBase = @"$PackageFolder$\NuGet.SolutionRestoreManager.Interop.dll", OldVersionLowerBound = "0.0.0.0")]
-
 #if SIGNED_BUILD
 [assembly: InternalsVisibleTo("NuGet.SolutionRestoreManager.Test, PublicKey=002400000480000094000000060200000024000052534131000400000100010007d1fa57c4aed9f0a32e84aa0faefd0de9e8fd6aec8f87fb03766c834c99921eb23be79ad9d5dcc1dd9ad236132102900b723cf980957fc4e177108fc607774f29e8320e92ea05ece4e821c0a5efe8f1645c4c0c93c1ab99285d622caa652c1dfad63d745d6f2de5f17e5eaf0fc4963d261c8a12436518206dc093344d5ad293")]
 #else

--- a/src/NuGet.Clients/NuGet.Tools/NuGet.Tools.csproj
+++ b/src/NuGet.Clients/NuGet.Tools/NuGet.Tools.csproj
@@ -166,7 +166,7 @@
   <Target Name="GenerateNuGetToolsBindingRedirects" BeforeTargets="CoreCompile" Inputs="$(MSBuildAllProjects)" Outputs="$(_BindingRedirectsFile)">
     <PropertyGroup>
       <_GeneratedVSIXBindingRedirectContent><![CDATA[
-// Generated in NuGet.Toools.csproj 
+// Generated in NuGet.Tools.csproj 
 using Microsoft.VisualStudio.Shell;
 [assembly: ProvideBindingRedirection(CodeBase = @"$PackageFolder$\NuGet.VisualStudio.Contracts.dll", OldVersionLowerBound = "0.0.0.0", OldVersionUpperBound = "$(_AssemblyVersion)")]
 [assembly: ProvideBindingRedirection(CodeBase = @"$PackageFolder$\NuGet.VisualStudio.dll", OldVersionLowerBound = "0.0.0.0", OldVersionUpperBound = "$(_AssemblyVersion)")]

--- a/src/NuGet.Clients/NuGet.Tools/NuGet.Tools.csproj
+++ b/src/NuGet.Clients/NuGet.Tools/NuGet.Tools.csproj
@@ -143,6 +143,7 @@
       <SubType>Designer</SubType>
     </VSCTCompile>
   </ItemGroup>
+
   <ItemGroup>
     <EmbeddedResource Include="Resources.resx">
       <Generator>ResXFileCodeGenerator</Generator>
@@ -155,6 +156,31 @@
       <SubType>Designer</SubType>
     </EmbeddedResource>
   </ItemGroup>
+
+  <PropertyGroup>
+    <_BindingRedirectsFile>$(IntermediateOutputPath)$(MSBuildProjectName).BindingRedirects.cs</_BindingRedirectsFile>
+    <_AssemblyVersion>$(SemanticVersion).$(PreReleaseVersion)</_AssemblyVersion>
+  </PropertyGroup>
+
+  <!-- This is a workaround for the bug in the Microsoft.VSSDK.BuildTools that doesn't set the correct upper bound when not provided. -->
+  <Target Name="GenerateNuGetToolsBindingRedirects" BeforeTargets="CoreCompile" Inputs="$(MSBuildAllProjects)" Outputs="$(_BindingRedirectsFile)">
+    <PropertyGroup>
+      <_GeneratedVSIXBindingRedirectContent><![CDATA[
+// Generated in NuGet.Toools.csproj 
+using Microsoft.VisualStudio.Shell;
+[assembly: ProvideBindingRedirection(CodeBase = @"$PackageFolder$\NuGet.VisualStudio.Contracts.dll", OldVersionLowerBound = "0.0.0.0", OldVersionUpperBound = "$(_AssemblyVersion)")]
+[assembly: ProvideBindingRedirection(CodeBase = @"$PackageFolder$\NuGet.VisualStudio.dll", OldVersionLowerBound = "0.0.0.0", OldVersionUpperBound = "$(_AssemblyVersion)")]
+]]></_GeneratedVSIXBindingRedirectContent>
+    </PropertyGroup>
+    <WriteLinesToFile Lines="$([MSBuild]::Escape($(_GeneratedVSIXBindingRedirectContent)))" File="$(_BindingRedirectsFile)" Overwrite="True" WriteOnlyWhenDifferent="True" />
+    <ItemGroup>
+      <Compile Include="$(_BindingRedirectsFile)">
+        <Visible>false</Visible>
+      </Compile>
+      <FileWrites Include="$(_BindingRedirectsFile)" />
+    </ItemGroup>
+  </Target>
+
   <Import Project="$(BuildCommonDirectory)common.targets" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />

--- a/src/NuGet.Clients/NuGet.Tools/Properties/AssemblyInfo.cs
+++ b/src/NuGet.Clients/NuGet.Tools/Properties/AssemblyInfo.cs
@@ -36,9 +36,6 @@ using Microsoft.VisualStudio.Shell;
 [assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\NuGet.VisualStudio.Implementation.dll")]
 [assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\NuGet.VisualStudio.Interop.dll")]
 
-[assembly: ProvideBindingRedirection(CodeBase = @"$PackageFolder$\NuGet.VisualStudio.Contracts.dll", OldVersionLowerBound = "0.0.0.0")]
-[assembly: ProvideBindingRedirection(CodeBase = @"$PackageFolder$\NuGet.VisualStudio.dll", OldVersionLowerBound = "0.0.0.0")]
-
 #if SIGNED_BUILD
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2, PublicKey=0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7")]
 [assembly: InternalsVisibleTo("NuGet.Tools.Test, PublicKey=002400000480000094000000060200000024000052534131000400000100010007d1fa57c4aed9f0a32e84aa0faefd0de9e8fd6aec8f87fb03766c834c99921eb23be79ad9d5dcc1dd9ad236132102900b723cf980957fc4e177108fc607774f29e8320e92ea05ece4e821c0a5efe8f1645c4c0c93c1ab99285d622caa652c1dfad63d745d6f2de5f17e5eaf0fc4963d261c8a12436518206dc093344d5ad293")]


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/10946

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

The VSSDK has a bug where the binding redirects are generated without an upper bound, https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1342681. 

That means instead of forwarding

`0.0.0.0-6.0.0.100` to `6.0.0.100` it's forwarding only `0.0.0.0`.

I have added a workaround. 

*Note*
I will create a follow up issue to remove this workaround once it has been approved by the team.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
