### PR TITLE
Warn when a MacCatalyst project consumes a Xamarin.iOS library

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/ContentFiles/ContentFileUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/ContentFiles/ContentFileUtils.cs
@@ -27,7 +27,8 @@ namespace NuGet.Commands
         internal static List<ContentItemGroup> GetContentGroupsForFramework(
             LockFileTargetLibrary lockFileLib,
             NuGetFramework framework,
-            IEnumerable<ContentItemGroup> contentGroups)
+            IEnumerable<ContentItemGroup> contentGroups,
+            MaccatalystFallback maccatalystFallback)
         {
             var groups = new List<ContentItemGroup>();
 
@@ -61,6 +62,19 @@ namespace NuGet.Commands
                 if (nearestGroup != null)
                 {
                     groups.Add(nearestGroup);
+
+                    if (maccatalystFallback != null)
+                    {
+                        object tfmObj;
+                        if (nearestGroup.Properties.TryGetValue(ManagedCodeConventions.PropertyNames.TargetFrameworkMoniker, out tfmObj))
+                        {
+                            var tfm = (NuGetFramework)tfmObj;
+                            if (tfm.Framework.Equals(FrameworkConstants.FrameworkIdentifiers.XamarinIOs, StringComparison.OrdinalIgnoreCase))
+                            {
+                                maccatalystFallback._usedXamarinIOs = true;
+                            }
+                        }
+                    }
                 }
             }
 
@@ -165,7 +179,7 @@ namespace NuGet.Commands
                 else
                 {
                     // apply each entry
-                    // entries may not have all the attributes, if a value is null 
+                    // entries may not have all the attributes, if a value is null
                     // ignore it and continue using the previous value.
                     foreach (var filesEntry in entryMappings[file])
                     {

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/ContentFiles/ContentFileUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/ContentFiles/ContentFileUtils.cs
@@ -61,20 +61,8 @@ namespace NuGet.Commands
                 // If a compatible group exists within the code language add it to the results
                 if (nearestGroup != null)
                 {
+                    MaccatalystFallback.CheckFallback(maccatalystFallback, nearestGroup.Properties);
                     groups.Add(nearestGroup);
-
-                    if (maccatalystFallback != null)
-                    {
-                        object tfmObj;
-                        if (nearestGroup.Properties.TryGetValue(ManagedCodeConventions.PropertyNames.TargetFrameworkMoniker, out tfmObj))
-                        {
-                            var tfm = (NuGetFramework)tfmObj;
-                            if (tfm.Framework.Equals(FrameworkConstants.FrameworkIdentifiers.XamarinIOs, StringComparison.OrdinalIgnoreCase))
-                            {
-                                maccatalystFallback._usedXamarinIOs = true;
-                            }
-                        }
-                    }
                 }
             }
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/LockFileBuilder.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/LockFileBuilder.cs
@@ -191,12 +191,7 @@ namespace NuGet.Commands
                         || target.TargetFramework is AssetTargetFallbackFramework);
 
                 // This is used for a special-case warning we need to do when net6.0-maccatalyst selects a xamarin.ios asset.
-                MaccatalystFallback maccatalystFallback = null;
-
-                if (targetGraph.Framework.HasPlatform && targetGraph.Framework.Version.Major >= 6 && targetGraph.Framework.Platform.Equals("maccatalyst", StringComparison.OrdinalIgnoreCase))
-                {
-                    maccatalystFallback = new MaccatalystFallback();
-                }
+                MaccatalystFallback maccatalystFallback = MaccatalystFallback.FallbackIfNeeded(targetGraph.Framework);
 
                 foreach (var graphItem in targetGraph.Flattened.OrderBy(x => x.Key))
                 {

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/MaccatalystFallback.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/MaccatalystFallback.cs
@@ -14,7 +14,6 @@ namespace NuGet.Commands
         internal bool _usedXamarinIOs { get; set; } = false;
 
         internal static MaccatalystFallback FallbackIfNeeded(NuGetFramework framework)
-
         {
             if (framework.HasPlatform && framework.Version.Major >= 6 && framework.Platform.Equals("maccatalyst", StringComparison.OrdinalIgnoreCase))
             {

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/MaccatalystFallback.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/MaccatalystFallback.cs
@@ -1,11 +1,46 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.Collections.Generic;
+
+using NuGet.Client;
+using NuGet.Frameworks;
+
 namespace NuGet.Commands
 {
     internal class MaccatalystFallback
     {
         internal bool _usedXamarinIOs { get; set; } = false;
+
+        internal static MaccatalystFallback FallbackIfNeeded(NuGetFramework framework)
+
+        {
+            if (framework.HasPlatform && framework.Version.Major >= 6 && framework.Platform.Equals("maccatalyst", StringComparison.OrdinalIgnoreCase))
+            {
+                return new MaccatalystFallback();
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+        internal static void CheckFallback(MaccatalystFallback fallback, IDictionary<string, object> properties)
+        {
+            if (fallback != null)
+            {
+                object tfmObj;
+                if (properties.TryGetValue(ManagedCodeConventions.PropertyNames.TargetFrameworkMoniker, out tfmObj))
+                {
+                    var tfm = (NuGetFramework)tfmObj;
+                    if (tfm.Framework.Equals(FrameworkConstants.FrameworkIdentifiers.XamarinIOs, StringComparison.OrdinalIgnoreCase))
+                    {
+                        fallback._usedXamarinIOs = true;
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/MaccatalystFallback.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/MaccatalystFallback.cs
@@ -1,0 +1,11 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGet.Commands
+{
+    internal class MaccatalystFallback
+    {
+        internal bool _usedXamarinIOs { get; set; } = false;
+    }
+}
+

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/MaccatalystFallback.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/MaccatalystFallback.cs
@@ -30,8 +30,7 @@ namespace NuGet.Commands
         {
             if (fallback != null)
             {
-                object tfmObj;
-                if (properties.TryGetValue(ManagedCodeConventions.PropertyNames.TargetFrameworkMoniker, out tfmObj))
+                if (properties.TryGetValue(ManagedCodeConventions.PropertyNames.TargetFrameworkMoniker, out object tfmObj))
                 {
                     var tfm = (NuGetFramework)tfmObj;
                     if (tfm.Framework.Equals(FrameworkConstants.FrameworkIdentifiers.XamarinIOs, StringComparison.OrdinalIgnoreCase))

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/LockFileUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/LockFileUtils.cs
@@ -39,7 +39,8 @@ namespace NuGet.Commands
                 dependencyType: dependencyType,
                 targetFrameworkOverride: null,
                 dependencies: null,
-                cache: new LockFileBuilderCache());
+                cache: new LockFileBuilderCache(),
+                maccatalystFallback: null);
         }
 
         /// <summary>
@@ -62,7 +63,8 @@ namespace NuGet.Commands
                 LibraryIncludeFlags dependencyType,
                 NuGetFramework targetFrameworkOverride,
                 List<LibraryDependency> dependencies,
-                LockFileBuilderCache cache)
+                LockFileBuilderCache cache,
+                MaccatalystFallback maccatalystFallback)
         {
             var runtimeIdentifier = targetGraph.RuntimeIdentifier;
             var framework = targetFrameworkOverride ?? targetGraph.Framework;
@@ -96,7 +98,7 @@ namespace NuGet.Commands
                         if (lockFileLib.PackageType.Contains(PackageType.DotnetTool))
                         {
                             AddToolsAssets(library, package, targetGraph, dependencyType, lockFileLib, framework,
-                                runtimeIdentifier, contentItems, nuspec, orderedCriteriaSets[i]);
+                                runtimeIdentifier, contentItems, nuspec, orderedCriteriaSets[i], maccatalystFallback);
                             if (CompatibilityChecker.HasCompatibleToolsAssets(lockFileLib))
                             {
                                 break;
@@ -105,8 +107,8 @@ namespace NuGet.Commands
                         else
                         {
                             AddAssets(aliases, library, package, targetGraph, dependencyType, lockFileLib,
-                                framework, runtimeIdentifier, contentItems, nuspec, orderedCriteriaSets[i]);
-                            // Check if compatile assets were found.
+                                framework, runtimeIdentifier, contentItems, nuspec, orderedCriteriaSets[i], maccatalystFallback);
+                            // Check if compatible assets were found.
                             // If no compatible assets were found and this is the last check
                             // continue on with what was given, this will fail in the normal
                             // compat verification.
@@ -120,7 +122,7 @@ namespace NuGet.Commands
                     }
 
                     // Add dependencies
-                    AddDependencies(dependencies, lockFileLib, framework, nuspec);
+                    AddDependencies(dependencies, lockFileLib, framework, nuspec, maccatalystFallback);
 
                     // Exclude items
                     ExcludeItems(lockFileLib, dependencyType);
@@ -189,7 +191,8 @@ namespace NuGet.Commands
             string runtimeIdentifier,
             ContentItemCollection contentItems,
             NuspecReader nuspec,
-            IReadOnlyList<SelectionCriteria> orderedCriteria)
+            IReadOnlyList<SelectionCriteria> orderedCriteria,
+            MaccatalystFallback maccatalystFallback)
         {
             // Add framework references for desktop projects.
             AddFrameworkReferences(lockFileLib, framework, nuspec);
@@ -203,6 +206,7 @@ namespace NuGet.Commands
                 orderedCriteria,
                 contentItems,
                 applyAliases,
+                maccatalystFallback,
                 targetGraph.Conventions.Patterns.CompileRefAssemblies,
                 targetGraph.Conventions.Patterns.CompileLibAssemblies);
 
@@ -212,6 +216,7 @@ namespace NuGet.Commands
             var runtimeGroup = GetLockFileItems(
                 orderedCriteria,
                 contentItems,
+                maccatalystFallback,
                 targetGraph.Conventions.Patterns.RuntimeAssemblies);
 
             lockFileLib.RuntimeAssemblies.AddRange(runtimeGroup);
@@ -220,6 +225,7 @@ namespace NuGet.Commands
             var embedGroup = GetLockFileItems(
                 orderedCriteria,
                 contentItems,
+                maccatalystFallback,
                 targetGraph.Conventions.Patterns.EmbedAssemblies);
 
             lockFileLib.EmbedAssemblies.AddRange(embedGroup);
@@ -228,6 +234,7 @@ namespace NuGet.Commands
             var resourceGroup = GetLockFileItems(
                 orderedCriteria,
                 contentItems,
+                maccatalystFallback,
                 targetGraph.Conventions.Patterns.ResourceAssemblies);
 
             lockFileLib.ResourceAssemblies.AddRange(resourceGroup);
@@ -236,20 +243,21 @@ namespace NuGet.Commands
             var nativeGroup = GetLockFileItems(
                 orderedCriteria,
                 contentItems,
+                maccatalystFallback,
                 targetGraph.Conventions.Patterns.NativeLibraries);
 
             lockFileLib.NativeLibraries.AddRange(nativeGroup);
 
-            // Add MSBuild files
-            AddMSBuildAssets(library, targetGraph, lockFileLib, orderedCriteria, contentItems);
+            // Add MSnuild files
+            AddMSBuildAssets(library, targetGraph, lockFileLib, orderedCriteria, contentItems, maccatalystFallback);
 
             // Add content files
-            AddContentFiles(targetGraph, lockFileLib, framework, contentItems, nuspec);
+            AddContentFiles(targetGraph, lockFileLib, framework, contentItems, nuspec, maccatalystFallback);
 
             // Runtime targets
             // These are applied only to non-RID target graphs.
             // They are not used for compatibility checks.
-            AddRuntimeTargets(targetGraph, dependencyType, lockFileLib, framework, runtimeIdentifier, contentItems);
+            AddRuntimeTargets(targetGraph, dependencyType, lockFileLib, framework, runtimeIdentifier, contentItems, maccatalystFallback);
 
             // COMPAT: Support lib/contract so older packages can be consumed
             ApplyLibContract(package, lockFileLib, framework, contentItems);
@@ -263,12 +271,14 @@ namespace NuGet.Commands
             RestoreTargetGraph targetGraph,
             LockFileTargetLibrary lockFileLib,
             IReadOnlyList<SelectionCriteria> orderedCriteria,
-            ContentItemCollection contentItems)
+            ContentItemCollection contentItems,
+            MaccatalystFallback maccatalystFallback)
         {
             // Build Transitive
             var btGroup = GetLockFileItems(
                 orderedCriteria,
                 contentItems,
+                maccatalystFallback,
                 targetGraph.Conventions.Patterns.MSBuildTransitiveFiles);
 
             var filteredBTGroup = GetBuildItemsForPackageId(btGroup, library.Name);
@@ -278,6 +288,7 @@ namespace NuGet.Commands
             var buildGroup = GetLockFileItems(
                 orderedCriteria,
                 contentItems,
+                maccatalystFallback,
                 targetGraph.Conventions.Patterns.MSBuildFiles);
 
             // filter any build asset already being added as part of build transitive
@@ -291,6 +302,7 @@ namespace NuGet.Commands
             var buildMultiTargetingGroup = GetLockFileItems(
                 orderedCriteria,
                 contentItems,
+                maccatalystFallback,
                 targetGraph.Conventions.Patterns.MSBuildMultiTargetingFiles);
 
             lockFileLib.BuildMultiTargeting.AddRange(GetBuildItemsForPackageId(buildMultiTargetingGroup, library.Name));
@@ -305,17 +317,19 @@ namespace NuGet.Commands
             string runtimeIdentifier,
             ContentItemCollection contentItems,
             NuspecReader nuspec,
-            IReadOnlyList<SelectionCriteria> orderedCriteria)
+            IReadOnlyList<SelectionCriteria> orderedCriteria,
+            MaccatalystFallback maccatalystFallback)
         {
             var toolsGroup = GetLockFileItems(
                 orderedCriteria,
                 contentItems,
+                maccatalystFallback,
                 targetGraph.Conventions.Patterns.ToolsAssemblies);
 
             lockFileLib.ToolsAssemblies.AddRange(toolsGroup);
         }
 
-        private static void AddContentFiles(RestoreTargetGraph targetGraph, LockFileTargetLibrary lockFileLib, NuGetFramework framework, ContentItemCollection contentItems, NuspecReader nuspec)
+        private static void AddContentFiles(RestoreTargetGraph targetGraph, LockFileTargetLibrary lockFileLib, NuGetFramework framework, ContentItemCollection contentItems, NuspecReader nuspec, MaccatalystFallback maccatalystFallback)
         {
             // content v2 items
             var contentFileGroups = contentItems.FindItemGroups(targetGraph.Conventions.Patterns.ContentFiles).ToList();
@@ -326,7 +340,8 @@ namespace NuGet.Commands
                 var contentFileGroupsForFramework = ContentFileUtils.GetContentGroupsForFramework(
                     lockFileLib,
                     framework,
-                    contentFileGroups);
+                    contentFileGroups,
+                    maccatalystFallback);
 
                 lockFileLib.ContentFiles = ContentFileUtils.GetContentFileGroup(
                     framework,
@@ -346,7 +361,8 @@ namespace NuGet.Commands
             LockFileTargetLibrary lockFileLib,
             NuGetFramework framework,
             string runtimeIdentifier,
-            ContentItemCollection contentItems)
+            ContentItemCollection contentItems,
+            MaccatalystFallback maccatalystFallback)
         {
             if (string.IsNullOrEmpty(runtimeIdentifier))
             {
@@ -363,7 +379,8 @@ namespace NuGet.Commands
                     dependencyType,
                     LibraryIncludeFlags.Runtime,
                     targetGraph.Conventions.Patterns.RuntimeAssemblies,
-                    "runtime"));
+                    "runtime",
+                    maccatalystFallback));
 
                 // Resource
                 runtimeTargetItems.AddRange(GetRuntimeTargetLockFileItems(
@@ -372,7 +389,8 @@ namespace NuGet.Commands
                     dependencyType,
                     LibraryIncludeFlags.Runtime,
                     targetGraph.Conventions.Patterns.ResourceAssemblies,
-                    "resource"));
+                    "resource",
+                    maccatalystFallback));
 
                 // Native
                 runtimeTargetItems.AddRange(GetRuntimeTargetLockFileItems(
@@ -381,7 +399,8 @@ namespace NuGet.Commands
                     dependencyType,
                     LibraryIncludeFlags.Native,
                     targetGraph.Conventions.Patterns.NativeLibraries,
-                    "native"));
+                    "native",
+                    maccatalystFallback));
 
                 lockFileLib.RuntimeTargets = runtimeTargetItems;
             }
@@ -456,7 +475,12 @@ namespace NuGet.Commands
             }
         }
 
-        private static void AddDependencies(IEnumerable<LibraryDependency> dependencies, LockFileTargetLibrary lockFileLib, NuGetFramework framework, NuspecReader nuspec)
+        private static void AddDependencies(
+            IEnumerable<LibraryDependency> dependencies,
+            LockFileTargetLibrary lockFileLib,
+            NuGetFramework framework,
+            NuspecReader nuspec,
+            MaccatalystFallback maccatalystFallback)
         {
             if (dependencies == null)
             {
@@ -507,6 +531,20 @@ namespace NuGet.Commands
             RestoreTargetGraph targetGraph,
             ProjectStyle rootProjectStyle)
         {
+            return CreateLockFileTargetProject(graphItem, library, dependencyType, targetGraph, rootProjectStyle, maccatalystFallback: null);
+        }
+
+        /// <summary>
+        /// Create a library for a project.
+        /// </summary>
+        internal static LockFileTargetLibrary CreateLockFileTargetProject(
+            GraphItem<RemoteResolveResult> graphItem,
+            LibraryIdentity library,
+            LibraryIncludeFlags dependencyType,
+            RestoreTargetGraph targetGraph,
+            ProjectStyle rootProjectStyle,
+            MaccatalystFallback maccatalystFallback)
+        {
             var localMatch = (LocalMatch)graphItem.Data.Match;
 
             // Target framework information is optional and may not exist for csproj projects
@@ -520,7 +558,16 @@ namespace NuGet.Commands
                 // Retrieve the resolved framework name, if this is null it means that the
                 // project is incompatible. This is marked as Unsupported.
                 var targetFrameworkInformation = (TargetFrameworkInformation)frameworkInfoObject;
-                projectFramework = targetFrameworkInformation.FrameworkName?.DotNetFrameworkName
+                var fwName = targetFrameworkInformation.FrameworkName;
+                if (maccatalystFallback != null && fwName != null)
+                {
+                    if (fwName.Framework.Equals(FrameworkConstants.FrameworkIdentifiers.XamarinIOs, StringComparison.OrdinalIgnoreCase))
+                    {
+                        maccatalystFallback._usedXamarinIOs = true;
+                    }
+                }
+
+                projectFramework = fwName?.DotNetFrameworkName
                     ?? NuGetFramework.UnsupportedFramework.DotNetFrameworkName;
             }
 
@@ -609,6 +656,7 @@ namespace NuGet.Commands
                     var compileGroup = GetLockFileItems(
                         orderedCriteria,
                         contentItems,
+                        maccatalystFallback,
                         targetGraph.Conventions.Patterns.CompileRefAssemblies,
                         targetGraph.Conventions.Patterns.CompileLibAssemblies);
 
@@ -619,6 +667,7 @@ namespace NuGet.Commands
                     var runtimeGroup = GetLockFileItems(
                         orderedCriteria,
                         contentItems,
+                        maccatalystFallback,
                         targetGraph.Conventions.Patterns.RuntimeAssemblies);
 
                     projectLib.RuntimeAssemblies.AddRange(
@@ -679,6 +728,7 @@ namespace NuGet.Commands
             IReadOnlyList<SelectionCriteria> criteria,
             ContentItemCollection items,
             Action<LockFileItem> additionalAction,
+            MaccatalystFallback maccatalystFallback,
             params PatternSet[] patterns)
         {
             // Loop through each criteria taking the first one that matches one or more items.
@@ -690,6 +740,19 @@ namespace NuGet.Commands
 
                 if (group != null)
                 {
+                    if (maccatalystFallback != null)
+                    {
+                        object tfmObj;
+                        if (group.Properties.TryGetValue(ManagedCodeConventions.PropertyNames.TargetFrameworkMoniker, out tfmObj))
+                        {
+                            var tfm = (NuGetFramework)tfmObj;
+                            if (tfm.Framework.Equals(FrameworkConstants.FrameworkIdentifiers.XamarinIOs, StringComparison.OrdinalIgnoreCase))
+                            {
+                                maccatalystFallback._usedXamarinIOs = true;
+                            }
+                        }
+                    }
+
                     foreach (var item in group.Items)
                     {
                         var newItem = new LockFileItem(item.Path);
@@ -717,9 +780,10 @@ namespace NuGet.Commands
         private static IEnumerable<LockFileItem> GetLockFileItems(
             IReadOnlyList<SelectionCriteria> criteria,
             ContentItemCollection items,
+            MaccatalystFallback maccatalystFallback,
             params PatternSet[] patterns)
         {
-            return GetLockFileItems(criteria, items, additionalAction: null, patterns);
+            return GetLockFileItems(criteria, items, additionalAction: null, maccatalystFallback, patterns);
         }
 
         /// <summary>
@@ -875,7 +939,8 @@ namespace NuGet.Commands
         private static List<ContentItemGroup> GetContentGroupsForFramework(
             NuGetFramework framework,
             List<ContentItemGroup> contentGroups,
-            string primaryKey)
+            string primaryKey,
+            MaccatalystFallback maccatalystFallback)
         {
             var groups = new List<ContentItemGroup>();
 
@@ -923,6 +988,18 @@ namespace NuGet.Commands
                 // If a compatible group exists within the secondary key add it to the results
                 if (nearestGroup != null)
                 {
+                    if (maccatalystFallback != null)
+                    {
+                        object tfmObj;
+                        if (nearestGroup.Properties.TryGetValue(ManagedCodeConventions.PropertyNames.TargetFrameworkMoniker, out tfmObj))
+                        {
+                            var tfm = (NuGetFramework)tfmObj;
+                            if (tfm.Framework.Equals(FrameworkConstants.FrameworkIdentifiers.XamarinIOs, StringComparison.OrdinalIgnoreCase))
+                            {
+                                maccatalystFallback._usedXamarinIOs = true;
+                            }
+                        }
+                    }
                     groups.Add(nearestGroup);
                 }
             }
@@ -936,14 +1013,16 @@ namespace NuGet.Commands
             LibraryIncludeFlags dependencyType,
             LibraryIncludeFlags groupType,
             PatternSet patternSet,
-            string assetType)
+            string assetType,
+            MaccatalystFallback maccatalystFallback)
         {
             var groups = contentItems.FindItemGroups(patternSet).ToList();
 
             var groupsForFramework = GetContentGroupsForFramework(
                 framework,
                 groups,
-                ManagedCodeConventions.PropertyNames.RuntimeIdentifier);
+                ManagedCodeConventions.PropertyNames.RuntimeIdentifier,
+                maccatalystFallback);
 
             var items = GetRuntimeTargetItems(groupsForFramework, assetType);
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/LockFileUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/LockFileUtils.cs
@@ -248,7 +248,7 @@ namespace NuGet.Commands
 
             lockFileLib.NativeLibraries.AddRange(nativeGroup);
 
-            // Add MSnuild files
+            // Add MSBuild files
             AddMSBuildAssets(library, targetGraph, lockFileLib, orderedCriteria, contentItems, maccatalystFallback);
 
             // Add content files
@@ -740,18 +740,7 @@ namespace NuGet.Commands
 
                 if (group != null)
                 {
-                    if (maccatalystFallback != null)
-                    {
-                        object tfmObj;
-                        if (group.Properties.TryGetValue(ManagedCodeConventions.PropertyNames.TargetFrameworkMoniker, out tfmObj))
-                        {
-                            var tfm = (NuGetFramework)tfmObj;
-                            if (tfm.Framework.Equals(FrameworkConstants.FrameworkIdentifiers.XamarinIOs, StringComparison.OrdinalIgnoreCase))
-                            {
-                                maccatalystFallback._usedXamarinIOs = true;
-                            }
-                        }
-                    }
+                    MaccatalystFallback.CheckFallback(maccatalystFallback, group.Properties);
 
                     foreach (var item in group.Items)
                     {
@@ -988,18 +977,7 @@ namespace NuGet.Commands
                 // If a compatible group exists within the secondary key add it to the results
                 if (nearestGroup != null)
                 {
-                    if (maccatalystFallback != null)
-                    {
-                        object tfmObj;
-                        if (nearestGroup.Properties.TryGetValue(ManagedCodeConventions.PropertyNames.TargetFrameworkMoniker, out tfmObj))
-                        {
-                            var tfm = (NuGetFramework)tfmObj;
-                            if (tfm.Framework.Equals(FrameworkConstants.FrameworkIdentifiers.XamarinIOs, StringComparison.OrdinalIgnoreCase))
-                            {
-                                maccatalystFallback._usedXamarinIOs = true;
-                            }
-                        }
-                    }
+                    MaccatalystFallback.CheckFallback(maccatalystFallback, nearestGroup.Properties);
                     groups.Add(nearestGroup);
                 }
             }

--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -2609,6 +2609,15 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to &apos;{0}&apos; was resolved as a dependency of &apos;{1}&apos;, but the dependency is using &apos;Xamarin.iOS&apos; while &apos;{1}&apos; is using &apos;{2}&apos; as its TargetFramework. There might be compatibility issues when MacCatalyst projects depend on Xamarin.iOS projects..
+        /// </summary>
+        internal static string Warning_MacCatalystXamarinIOSCompat {
+            get {
+                return ResourceManager.GetString("Warning_MacCatalystXamarinIOSCompat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to {0} depends on {1} but {2} was not found. An approximate best match of {3} was resolved..
         /// </summary>
         internal static string Warning_MinVersionDoesNotExist {

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -1127,4 +1127,8 @@ For more information, visit https://docs.nuget.org/docs/reference/command-line-r
   <data name="VerifyCommand_NotSupported" xml:space="preserve">
     <value>Package signature validation command is not supported on this platform.</value>
   </data>
+  <data name="Warning_MacCatalystXamarinIOSCompat" xml:space="preserve">
+    <value>'{0}' was resolved as a dependency of '{1}', but the dependency is using 'Xamarin.iOS' while '{1}' is using '{2}' as its TargetFramework. There might be compatibility issues when MacCatalyst projects depend on Xamarin.iOS projects.</value>
+    <comment>0 - library/package name, 1 - VS project name, 2 - target framework</comment>
+  </data>
 </root>

--- a/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
@@ -287,6 +287,11 @@ namespace NuGet.Common
         NU1702 = 1702,
 
         /// <summary>
+        /// MacCatalyst platform fell back to xamarin.ios
+        /// </summary>
+        NU1703 = 1703,
+
+        /// <summary>
         /// Feed error converted to a warning when ignoreFailedSources is true.
         /// </summary>
         NU1801 = 1801,

--- a/src/NuGet.Core/NuGet.Common/PublicAPI/net45/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Common/PublicAPI/net45/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
+NuGet.Common.NuGetLogCode.NU1703 = 1703 -> NuGet.Common.NuGetLogCode
 NuGet.Common.TelemetryActivity.StartIndependentInterval(string propertyName) -> System.IDisposable

--- a/src/NuGet.Core/NuGet.Common/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Common/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
+NuGet.Common.NuGetLogCode.NU1703 = 1703 -> NuGet.Common.NuGetLogCode
 NuGet.Common.TelemetryActivity.StartIndependentInterval(string propertyName) -> System.IDisposable

--- a/src/NuGet.Core/NuGet.Common/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Common/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
+NuGet.Common.NuGetLogCode.NU1703 = 1703 -> NuGet.Common.NuGetLogCode
 NuGet.Common.TelemetryActivity.StartIndependentInterval(string propertyName) -> System.IDisposable

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
@@ -10001,6 +10001,64 @@ namespace NuGet.CommandLine.Test
             }
         }
 
+        [PlatformTheory(Platform.Windows)]
+        [InlineData("lib/xamarin.ios/x.dll")]
+        [InlineData("ref/xamarin.ios/x.dll")]
+        [InlineData("runtimes/win7-x64/lib/xamarin.ios/x.dll")]
+        [InlineData("runtimes/win7-x64/nativeassets/xamarin.ios/x.dll")]
+        [InlineData("build/xamarin.ios/x.targets")]
+        [InlineData("contentFiles/csharp/xamarin.ios/x.dll")]
+        [InlineData("embed/xamarin.ios/x.dll")]
+        [InlineData("buildTransitive/xamarin.ios/x.targets")]
+        public async Task RestoreNetCore_MacCatalystUsingXamarinIOS_WarnsAsync(string file)
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Set up solution, project, and packages
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+
+                var packageX = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.0"
+                };
+
+                packageX.AddFile(file);
+
+                var projectA = SimpleTestProjectContext.CreateNETCore(
+                    "a",
+                    pathContext.SolutionRoot,
+                    "net6.0-maccatalyst14.5"
+                    );
+
+                var projectB = SimpleTestProjectContext.CreateNETCore(
+                    "b",
+                    pathContext.SolutionRoot,
+                    "Xamarin.IOs"
+                    );
+
+                projectA.AddPackageToAllFrameworks(packageX);
+                projectA.AddProjectToAllFrameworks(projectB);
+                solution.Projects.Add(projectA);
+                solution.Projects.Add(projectB);
+                solution.Create(pathContext.SolutionRoot);
+
+                await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                    pathContext.PackageSource,
+                    PackageSaveMode.Defaultv3,
+                    packageX);
+
+                // Act
+                var r = Util.RestoreSolution(pathContext);
+
+                // Assert
+                r.Success.Should().BeTrue();
+                r.AllOutput.Should().Contain("WARNING: NU1703: 'x 1.0.0' was resolved as a dependency of 'a', but the dependency is using 'Xamarin.iOS' while 'a' is using 'net6.0-maccatalyst14.5' as its TargetFramework");
+                r.AllOutput.Should().Contain("WARNING: NU1703: 'b' was resolved as a dependency of 'a', but the dependency is using 'Xamarin.iOS' while 'a' is using 'net6.0-maccatalyst14.5' as its TargetFramework");
+            }
+        }
+
         [PlatformFact(Platform.Windows)]
         public async Task RestoreNetCore_WithCustomAliases_WritesConditionWithCorrectAlias()
         {


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/nuget/home/issues/10718

Regression? Last working version: N/A

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

This adds a warning when a Xamarin.iOS library is consumed by a MacCatalyst project, per https://github.com/dotnet/designs/blob/main/accepted/2021/net6.0-tfms/net6.0-tfms.md#compatibility-rules.

It's a bit hacky. Please forgive me. I tried my best lol.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [x] Documentation PR or issue filed - https://github.com/NuGet/docs.microsoft.com-nuget/issues/2468
  - **OR**
  - [ ] N/A
