### PR TITLE
Run Apex test in suitable version of VS

### DIFF
--- a/build/build.proj
+++ b/build/build.proj
@@ -417,6 +417,7 @@
 
     <Exec Command="$(DesktopTestCommand)"
           ContinueOnError="true"
+          EnvironmentVariables="VisualStudio.InstallationUnderTest.Path=$(VSINSTALLDIR)"
           Condition=" '$(SkipDesktopAssemblies)' != 'true' AND '$(DesktopInputTestAssemblies)' != '' ">
       <Output TaskParameter="ExitCode" PropertyName="DesktopTestErrorCode"/>
     </Exec>

--- a/scripts/e2etests/SetupFunctionalTests.ps1
+++ b/scripts/e2etests/SetupFunctionalTests.ps1
@@ -3,6 +3,7 @@ param (
     [string]$VSVersion = "17.0")
 
  . "$PSScriptRoot\Utils.ps1"
+ . "$PSScriptRoot\VSUtils.ps1"
 
 function EnableWindowsDeveloperMode()
 {
@@ -52,6 +53,15 @@ Function SuppressNuGetUI([Parameter(Mandatory = $True)] [string] $registryValueN
     }
 }
 
+function  Set-VSINSTALLDIR
+{
+    $VSInstance = Get-LatestVSInstance -VersionRange (Get-VisualStudioVersionRangeFromConfig)
+    $installationPath = $VSInstance.installationPath
+    Write-Host "Setting $$env:VSINSTALLDIR = $installationPath"
+    $env:VSINSTALLDIR = $installationPath
+    Write-Host "##vso[task.setvariable variable=VSINSTALLDIR]$installationPath"
+}
+
 trap
 {
     Write-Host $_.Exception -ForegroundColor Red
@@ -92,5 +102,6 @@ if (!(Test-Path $net35x86) -or !(Test-Path $net35x64))
 }
 
 EnableWindowsDeveloperMode
+Set-VSINSTALLDIR
 
 Write-Host 'THE END!'


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1023

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

* Create an Azure DevOps variable pointing to the VS install directory that should be used
* build\build.proj calls the xunit test runner setting the `VisualStudio.InstallationUnderTest.Path` environment variable to the VS install directory.

The `VSINSTALLDIR` variable was used because when you run `developer command prompt` or `developer powershell`, `VSINSTALLDIR` is set to the VS install directory, meaning that `msbuild build\build.proj -t:ApexTestsStandalone` will also use that version of VS. It's not the primary goal of this PR, but it's a nice bonus.

## PR Checklist

- [X] PR has a meaningful title
- [X] PR has a linked issue.
- [X] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [X] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [X] N/A
