### PR TITLE
When building a tree for package namespaces configuration remove couple of properties to reduce memory allocations.

### DIFF
--- a/src/NuGet.Core/NuGet.Configuration/PackageNamespaces/SearchNode.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageNamespaces/SearchNode.cs
@@ -9,7 +9,6 @@ namespace NuGet.Configuration
     {
         public readonly Dictionary<char, SearchNode> Children;
         public bool IsGlobbing { get; set; }
-
         public List<string> PackageSources;
 
         public SearchNode()

--- a/src/NuGet.Core/NuGet.Configuration/PackageNamespaces/SearchNode.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageNamespaces/SearchNode.cs
@@ -8,7 +8,6 @@ namespace NuGet.Configuration
     internal class SearchNode
     {
         public readonly Dictionary<char, SearchNode> Children;
-        public bool IsValueNode => !string.IsNullOrWhiteSpace(NamespaceId);
         public bool IsGlobbing { get; set; }
         public string NamespaceId { get; set; }
         public List<string> PackageSources;

--- a/src/NuGet.Core/NuGet.Configuration/PackageNamespaces/SearchNode.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageNamespaces/SearchNode.cs
@@ -9,7 +9,7 @@ namespace NuGet.Configuration
     {
         public readonly Dictionary<char, SearchNode> Children;
         public bool IsGlobbing { get; set; }
-        public string NamespaceId { get; set; }
+
         public List<string> PackageSources;
 
         public SearchNode()

--- a/src/NuGet.Core/NuGet.Configuration/PackageNamespaces/SearchTree.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageNamespaces/SearchTree.cs
@@ -66,11 +66,6 @@ namespace NuGet.Configuration
                 currentNode = currentNode.Children[c];
             }
 
-            if (string.IsNullOrEmpty(currentNode.NamespaceId))
-            {
-                currentNode.NamespaceId = namespaceId;
-            }
-
             if (currentNode.PackageSources == null)
             {
                 currentNode.PackageSources = new List<string>();
@@ -120,13 +115,7 @@ namespace NuGet.Configuration
                 }
             }
 
-            // Full term match.
-            if (i == term.Length && currentNode.IsValueNode)
-            {
-                return currentNode.PackageSources;
-            }
-
-            return longestMatchingPrefixNode?.PackageSources;
+            return currentNode.PackageSources ?? (longestMatchingPrefixNode?.PackageSources);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Configuration/PackageNamespaces/SearchTree.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageNamespaces/SearchTree.cs
@@ -115,7 +115,12 @@ namespace NuGet.Configuration
                 }
             }
 
-            return currentNode.PackageSources ?? (longestMatchingPrefixNode?.PackageSources);
+            if (i == term.Length && currentNode.PackageSources != null)
+            {
+                return currentNode.PackageSources;
+            }
+
+            return longestMatchingPrefixNode?.PackageSources;
         }
     }
 }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1025

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

## PR Checklist
@erdembayar created https://github.com/NuGet/Client.Engineering/issues/985 issue as a follow-up for https://github.com/NuGet/NuGet.Client/pull/4039#discussion_r643434207 and https://github.com/NuGet/NuGet.Client/pull/4039#discussion_r643431485. I believe the scope of https://github.com/NuGet/Client.Engineering/issues/985 is to track overall performance and telemetry (see Andy's comment on this issue) of Package Namespaces configuration algorithm. Hence, I created a child task and submitting this PR to remove `IsValueNode` and `NamespaceId` properties from `SearchTree` implementation. I thought this is the right time for creating this PR because Erick has merged https://github.com/NuGet/NuGet.Client/pull/4039 PR and `SearchTree` implementation for package namespaces is still on top of my mind.

I have beginner knowledge on https://github.com/dotnet/BenchmarkDotNet tool. I followed their quick start guide and wrote two tests (one test where the tree structure has `IsValueNode` and `NamespaceId` properties and second test don't have those properties). The tests showed a memory allocation reduction of `1KB` for `SearchTree` without above said properties and a negligible performance improvement.

``` ini
BenchmarkDotNet=v0.13.0, OS=Windows 10.0
Intel Core i7-8650U CPU 1.90GHz (Kaby Lake R), 1 CPU, 8 logical and 4 physical cores
.NET SDK=6.0.100-preview.5.21302.13
  [Host]     : .NET 6.0.0 (6.0.21.30105), X64 RyuJIT  [AttachedDebugger]
  DefaultJob : .NET 6.0.0 (6.0.21.30105), X64 RyuJIT
```
|             Method |     Mean |     Error |    StdDev |   Median |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------- |---------:|----------:|----------:|---------:|-------:|------:|------:|----------:|
|    SearchTree-With-NameSpaceId | 3.659 μs | 0.2419 μs | 0.6901 μs | 3.449 μs | 1.8539 |     - |     - |      8 KB |
| SearchTree-Without-NameSpaceId | 2.994 μs | 0.0496 μs | 0.0895 μs | 2.974 μs | 1.8005 |     - |     - |      7 KB |

When I executed [`SearchTreeTest`](https://github.com/NuGet/NuGet.Client/blob/dev/test/NuGet.Core.Tests/NuGet.Configuration.Test/SearchTreeTest.cs) locally for private branch vs dev branch I noticed a negligible performance improvement in the test execution duration.

```
> cd test\NuGet.Core.Tests\NuGet.Configuration.Test
> dotnet test .\bin\Debug\netcoreapp2.1\NuGet.Configuration.Test.dll /Tests:SearchTreeTest

Fix (private branch)  - Passed!  - Failed:     0, Passed:    52, Skipped:     0, Total:    52, Duration: 75 ms - NuGet.Configuration.Test.dll (netcoreapp2.1)
Without Fix (current dev branch)  - Passed!  - Failed:     0, Passed:    52, Skipped:     0, Total:    52, Duration: 115 ms - NuGet.Configuration.Test.dll (netcoreapp2.1)
```


- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception - Erick added lot of tests providing good test coverage for this logic.

- **Documentation**
  - [x] N/A
