### PR TITLE
Only add the `tfm_raw` properties when parsing the paths in packages.

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/ContentModel/ContentItemCollection.cs
+++ b/src/NuGet.Core/NuGet.Packaging/ContentModel/ContentItemCollection.cs
@@ -244,8 +244,9 @@ namespace NuGet.ContentModel
                 var hashCode = 0;
                 foreach (var property in obj.Properties)
                 {
-                    if (property.Key.EndsWith("_raw", StringComparison.OrdinalIgnoreCase))
+                    if (property.Key.Equals("tfm_raw", StringComparison.Ordinal))
                     {
+                        // We store the raw version of the TFM, but we don't want it to affect the result.
                         continue;
                     }
                     hashCode ^= property.Key.GetHashCode();
@@ -268,10 +269,9 @@ namespace NuGet.ContentModel
 
                 foreach (var xProperty in x.Properties)
                 {
-                    if (xProperty.Key.EndsWith("_raw", StringComparison.OrdinalIgnoreCase))
+                    if (xProperty.Key.Equals("tfm_raw", StringComparison.Ordinal))
                     {
-                        // We've started storing raw versions of each key, but
-                        // we don't want that to affect results.
+                        // We store the raw version of the TFM, but we don't want it to affect the result.
                         continue;
                     }
                     object yValue;

--- a/src/NuGet.Core/NuGet.Packaging/ContentModel/ContentItemCollection.cs
+++ b/src/NuGet.Core/NuGet.Packaging/ContentModel/ContentItemCollection.cs
@@ -4,8 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using NuGet.ContentModel.Infrastructure;
-using NuGet.Shared;
 
 namespace NuGet.ContentModel
 {

--- a/src/NuGet.Core/NuGet.Packaging/ContentModel/Infrastructure/Parser.cs
+++ b/src/NuGet.Core/NuGet.Packaging/ContentModel/Infrastructure/Parser.cs
@@ -203,7 +203,10 @@ namespace NuGet.ContentModel.Infrastructure
                                     Path = path
                                 };
                             }
-                            item.Properties.Add(_token + "_raw", substring);
+                            if (StringComparer.Ordinal.Equals(_token, "tfm"))
+                            {
+                                item.Properties.Add("tfm_raw", substring);
+                            }
                             item.Properties.Add(_token, value);
                         }
                         endIndex = delimiterIndex;


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/10969

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Stop generating raw properties for every segment, set only the tfm ones, as it's the only one that's relevant.
Avoid concatenating strings with _raw.

No functional changes here, only some perf improvements 

The dictionary change gets us from: 1,105,056,128 => 1,011,230,272, 

It's harder to reason about the improvement we get from removing the concatenation, as strings account for 20% of all allocations, and TryMatch is the biggest NuGet contributor there.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception - no functional changes, only perf.
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
