### PR TITLE
Always create a ProjectRestoreMetadataFrameworkInfo for packages.config/unknown projects in Visual Studio 

### DIFF
--- a/src/NuGet.Core/NuGet.PackageManagement/Projects/MSBuildNuGetProject.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Projects/MSBuildNuGetProject.cs
@@ -678,16 +678,16 @@ namespace NuGet.ProjectManagement
                 metadata.ProjectName = ProjectSystem.ProjectName;
                 metadata.ProjectUniqueName = ProjectSystem.ProjectFileFullPath;
 
+                // Add framework group
+                var frameworkGroup = new ProjectRestoreMetadataFrameworkInfo(ProjectSystem.TargetFramework);
+                metadata.TargetFrameworks.Add(frameworkGroup);
+
                 var references = (await ProjectServices
                     .ReferencesReader
                     .GetProjectReferencesAsync(context.Logger, CancellationToken.None))
                     .ToList();
                 if (references != null && references.Count > 0)
                 {
-                    // Add framework group
-                    var frameworkGroup = new ProjectRestoreMetadataFrameworkInfo(ProjectSystem.TargetFramework);
-                    metadata.TargetFrameworks.Add(frameworkGroup);
-
                     foreach (var reference in references)
                     {
                         // This reference applies to all frameworks

--- a/test/EndToEnd/tests/BuildIntegratedTest.ps1
+++ b/test/EndToEnd/tests/BuildIntegratedTest.ps1
@@ -178,10 +178,6 @@ function Test-BuildIntegratedInstallPackageJsonNet701Beta3 {
 }
 
 function Test-BuildIntegratedProjectClosure {
-    if (!(Verify-BuildIntegratedMsBuildTask)) {
-        Write-Host "Skipping BuildIntegratedProjectClosure"
-    }
-
     # Arrange
     $project1 = New-Project BuildIntegratedClassLibrary Project1
     $project2 = New-Project BuildIntegratedClassLibrary Project2
@@ -199,10 +195,6 @@ function Test-BuildIntegratedProjectClosure {
 }
 
 function Test-BuildIntegratedProjectClosureWithLegacyProjects {
-    if (!(Verify-BuildIntegratedMsBuildTask)) {
-        Write-Host "Skipping BuildIntegratedProjectClosureWithLegacyProjects"
-    }
-
     # Arrange
     $project1 = New-Project BuildIntegratedClassLibrary Project1
     $project2 = New-ClassLibrary Project2
@@ -222,10 +214,6 @@ function Test-BuildIntegratedProjectClosureWithLegacyProjects {
 
 # Tests that packages are restored on build
 function Test-BuildIntegratedMixedLegacyProjects {
-    if (!(Verify-BuildIntegratedMsBuildTask)) {
-        Write-Host "Skipping BuildIntegratedMixedLegacyProjects"
-    }
-
     # Arrange
     $project1 = New-ClassLibrary
     $project1 | Install-Package Newtonsoft.Json -Version 5.0.6
@@ -254,10 +242,6 @@ function Test-BuildIntegratedMixedLegacyProjects {
 }
 
 function Test-BuildIntegratedMixedLegacyProjectsProjectJsonOnly {
-    if (!(Verify-BuildIntegratedMsBuildTask)) {
-        Write-Host "Skipping BuildIntegratedMixedLegacyProjects"
-    }
-
     # Arrange
     $project1 = New-ClassLibrary
     $project1 | Install-Package Newtonsoft.Json -Version 5.0.6
@@ -279,10 +263,6 @@ function Test-BuildIntegratedMixedLegacyProjectsProjectJsonOnly {
 }
 
 function Test-BuildIntegratedMixedLegacyProjectsPackagesFolderOnly {
-    if (!(Verify-BuildIntegratedMsBuildTask)) {
-        Write-Host "Skipping BuildIntegratedMixedLegacyProjects"
-    }
-
     # Arrange
     $project1 = New-ClassLibrary
     $project1 | Install-Package Newtonsoft.Json -Version 5.0.6
@@ -306,10 +286,6 @@ function Test-BuildIntegratedMixedLegacyProjectsPackagesFolderOnly {
 # Verifies that project.json that specified in project.json referenced transitively through a non-project.json project
 # are correctly pulled in.
 function Test-BuildIntegratedTransitiveProjectJsonRestores {
-    if (!(Verify-BuildIntegratedMsBuildTask)) {
-        Write-Host "Skipping BuildIntegratedMixedLegacyProjects"
-    }
-
     # Arrange
     $project1 = New-Project BuildIntegratedClassLibrary
     $project2 = New-ClassLibraryNET46
@@ -330,10 +306,6 @@ function Test-BuildIntegratedTransitiveProjectJsonRestores {
 
 # Verifies that parent projects are restored after an install
 function Test-BuildIntegratedParentProjectIsRestoredAfterInstall {
-    if (!(Verify-BuildIntegratedMsBuildTask)) {
-        Write-Host "Skipping BuildIntegratedMixedLegacyProjects"
-    }
-
     # Arrange
     $project1 = New-BuildIntegratedProj UAPApp1
     $project2 = New-BuildIntegratedProj UAPApp2
@@ -358,10 +330,6 @@ function Test-BuildIntegratedParentProjectIsRestoredAfterInstall {
 
 # Verifies that parent projects are restored after an uninstall
 function Test-BuildIntegratedParentProjectIsRestoredAfterUnInstall {
-    if (!(Verify-BuildIntegratedMsBuildTask)) {
-        Write-Host "Skipping BuildIntegratedMixedLegacyProjects"
-    }
-
     # Arrange
     $project1 = New-BuildIntegratedProj UAPApp1
     $project2 = New-BuildIntegratedProj UAPApp2
@@ -391,10 +359,6 @@ function Test-BuildIntegratedParentProjectIsRestoredAfterUnInstall {
 
 # Verifies that parent projects are restored after an update
 function Test-BuildIntegratedParentProjectIsRestoredAfterUpdate {
-    if (!(Verify-BuildIntegratedMsBuildTask)) {
-        Write-Host "Skipping BuildIntegratedMixedLegacyProjects"
-    }
-
     # Arrange
     $project1 = New-BuildIntegratedProj UAPApp1
     $project2 = New-BuildIntegratedProj UAPApp2
@@ -425,10 +389,6 @@ function Test-BuildIntegratedParentProjectIsRestoredAfterUpdate {
 # Verify that all build integrated projects are included in the closure, even when a 
 # non-build integrated project exists in between them
 function Test-BuildIntegratedParentProjectIsRestoredAfterInstallWithClassLibInTree {
-    if (!(Verify-BuildIntegratedMsBuildTask)) {
-        Write-Host "Skipping BuildIntegratedMixedLegacyProjects"
-    }
-
     # Arrange
     $project1 = New-Project BuildIntegratedClassLibrary
     $project2 = New-ClassLibraryNET46 ClassLib2
@@ -664,6 +624,25 @@ function Test-PackageReferenceProjectWithLockFile{
     
     #Assert
     Assert-PackagesLockFile $projectT
+}
+
+function Test-PackageReferenceToPackagesConfigProjectWithLockFile {
+    $project1 = New-Project PackageReferenceClassLibraryWithLockFile
+    $project2 = New-ClassLibraryNET46
+    Add-ProjectReference $project1 $project2
+
+    $project1 | Install-Package Newtonsoft.Json -Version 9.0.1
+    $project1.Save();
+    Build-Solution
+
+    $assetsFile = Get-NetCoreLockFilePath $project1
+    Remove-Item -Force $assetsFile
+
+    # Act
+    Rebuild-Solution
+
+    # Assert
+    Assert-PathExists $assetsFile
 }
 
 function BuildProjectTemplateTestCases([string[]]$ProjectTemplates) {		

--- a/test/EndToEnd/tests/BuildIntegratedTest.ps1
+++ b/test/EndToEnd/tests/BuildIntegratedTest.ps1
@@ -631,15 +631,15 @@ function Test-PackageReferenceToPackagesConfigProjectWithLockFile {
     $project2 = New-ClassLibraryNET46
     Add-ProjectReference $project1 $project2
 
-    $project1 | Install-Package Newtonsoft.Json -Version 9.0.1
     $project1.Save();
     Build-Solution
 
     $assetsFile = Get-NetCoreLockFilePath $project1
     Remove-Item -Force $assetsFile
+    $project1 | Install-Package Newtonsoft.Json -Version 9.0.1
 
     # Act
-    Rebuild-Solution
+    Build-Solution
 
     # Assert
     Assert-PathExists $assetsFile

--- a/test/EndToEnd/utility.ps1
+++ b/test/EndToEnd/utility.ps1
@@ -6,17 +6,6 @@ function Get-HostSemanticVersion {
     return [NuGet.Packaging.MinClientVersionUtility]::GetNuGetClientVersion()
 }
 
-function Verify-BuildIntegratedMsBuildTask {
-    $msBuildTaskPath = [IO.Path]::Combine(${env:ProgramFiles(x86)}, "MsBuild", "Microsoft", "NuGet", "Microsoft.NuGet.targets")
-
-    if (!(Test-Path $msBuildTaskPath)) {
-        Write-Warning "Build integrated NuGet target not found at $msBuildTaskPath"
-        return $false
-    }
-
-    return $true
-}
-
 class SkipTest : Attribute {
     SkipTest([string]$Reason) { }
     [bool] ShouldRun() { return $False }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/10924

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

NuGet constructs the restore model differently in commandline and VS. 

This ensures consistency and fixes the lock file scenario.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
