### PR TITLE
Don't report downgrades for packages that are part of subgraphs that were not accepted

### DIFF
--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/GraphModel/GraphOperations.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/GraphModel/GraphOperations.cs
@@ -31,20 +31,20 @@ namespace NuGet.DependencyResolver
             root.TryResolveConflicts(result.VersionConflicts);
 
             // Remove all downgrades that didn't result in selecting the node we actually downgraded to
-            result.Downgrades.RemoveAll(d => IsIrrelevantDowngrade(d));
+            result.Downgrades.RemoveAll(d => !IsRelevantDowngrade(d));
 
             return result;
         }
 
         /// <summary>
-        /// A downgrade is relevnt if the node itself was `Accepted`.
-        /// A node that itself wasn't `Accepted`, or has a parent that wasn't accepted is irrelevant.
+        /// A downgrade is relevant if the node itself was `Accepted`.
+        /// A node that itself wasn't `Accepted`, or has a parent that wasn't accepted is not relevant.
         /// </summary>
         /// <param name="d">Downgrade result to analyze</param>
-        /// <returns>Whether the downgrade is irrelevant.</returns>
-        private static bool IsIrrelevantDowngrade(DowngradeResult<RemoteResolveResult> d)
+        /// <returns>Whether the downgrade is relevant.</returns>
+        private static bool IsRelevantDowngrade(DowngradeResult<RemoteResolveResult> d)
         {
-            return d.DowngradedTo.Disposition != Disposition.Accepted || AreAllParentsAccepted(d);
+            return d.DowngradedTo.Disposition == Disposition.Accepted && AreAllParentsAccepted(d);
 
             static bool AreAllParentsAccepted(DowngradeResult<RemoteResolveResult> d)
             {
@@ -54,11 +54,11 @@ namespace NuGet.DependencyResolver
                 {
                     if (resultToCheck.Disposition != Disposition.Accepted)
                     {
-                        return true;
+                        return false;
                     }
                     resultToCheck = resultToCheck.OuterNode;
                 }
-                return false;
+                return true;
             }
         }
 

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/GraphModel/GraphOperations.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/GraphModel/GraphOperations.cs
@@ -31,10 +31,37 @@ namespace NuGet.DependencyResolver
             root.TryResolveConflicts(result.VersionConflicts);
 
             // Remove all downgrades that didn't result in selecting the node we actually downgraded to
-            result.Downgrades.RemoveAll(d => d.DowngradedTo.Disposition != Disposition.Accepted);
+            result.Downgrades.RemoveAll(d => IsIrrelevantDowngrade(d));
 
             return result;
         }
+
+        /// <summary>
+        /// A downgrade is relevnt if the node itself was `Accepted`.
+        /// A node that itself wasn't `Accepted`, or has a parent that wasn't accepted is irrelevant.
+        /// </summary>
+        /// <param name="d">Downgrade result to analyze</param>
+        /// <returns>Whether the downgrade is irrelevant.</returns>
+        private static bool IsIrrelevantDowngrade(DowngradeResult<RemoteResolveResult> d)
+        {
+            return d.DowngradedTo.Disposition != Disposition.Accepted || AreAllParentsAccepted(d);
+
+            static bool AreAllParentsAccepted(DowngradeResult<RemoteResolveResult> d)
+            {
+                var resultToCheck = d.DowngradedFrom.OuterNode;
+
+                while (resultToCheck != null)
+                {
+                    if (resultToCheck.Disposition != Disposition.Accepted)
+                    {
+                        return true;
+                    }
+                    resultToCheck = resultToCheck.OuterNode;
+                }
+                return false;
+            }
+        }
+
 
         private static void CheckCycleAndNearestWins(
             this GraphNode<RemoteResolveResult> root,
@@ -45,14 +72,12 @@ namespace NuGet.DependencyResolver
 
             root.ForEach((node, context) => WalkTreeCheckCycleAndNearestWins(context, node), CreateState(cycles, workingDowngrades));
 
-#if IS_DESKTOP || NETSTANDARD2_0
             // Increase List size for items to be added, if too small
             var requiredCapacity = downgrades.Count + workingDowngrades.Count;
             if (downgrades.Capacity < requiredCapacity)
             {
                 downgrades.Capacity = requiredCapacity;
             }
-#endif
             foreach (var p in workingDowngrades)
             {
                 downgrades.Add(new DowngradeResult<RemoteResolveResult>

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/GraphModel/GraphOperations.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/GraphModel/GraphOperations.cs
@@ -48,7 +48,7 @@ namespace NuGet.DependencyResolver
 
             static bool AreAllParentsAccepted(DowngradeResult<RemoteResolveResult> d)
             {
-                var resultToCheck = d.DowngradedFrom.OuterNode;
+                GraphNode<RemoteResolveResult> resultToCheck = d.DowngradedFrom.OuterNode;
 
                 while (resultToCheck != null)
                 {

--- a/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests/RemoteDependencyWalkerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests/RemoteDependencyWalkerTests.cs
@@ -1587,7 +1587,7 @@ namespace NuGet.DependencyResolver.Tests
             var provider = new DependencyProvider();
             var version100 = "1.0.0";
             var version200 = "2.0.0";
-             
+
             // A -> B 1.0.0 -> C 1.0.0(this will be rejected) -> D 2.0.0 (this will be downgraded) -> E 1.0.0
             provider.Package("A", version100)
                     .DependsOn("B", version100);

--- a/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests/RemoteDependencyWalkerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests/RemoteDependencyWalkerTests.cs
@@ -1573,7 +1573,7 @@ namespace NuGet.DependencyResolver.Tests
         /// <summary>
         /// A -> B 1.0.0 -> C 1.0.0(this will be rejected) -> D 2.0.0(this will be downgraded due to central 1.0.0) -> E 1.0.0
         ///   -> F 1.0.0 -> C 2.0.0
-        ///   -> G 1.0.0 -> H 2.0.0(this will not be rejected) -> D 1.0.0 (this will be downgraded due to central 1.0.0)
+        ///   -> G 1.0.0 -> H 2.0.0(this will not be rejected) -> D 2.0.0 (this will be downgraded due to central 1.0.0)
         ///
         ///  D has version defined centrally 1.0.0
         ///  D 1.0.0 -> I 1.0.0

--- a/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests/RemoteDependencyWalkerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests/RemoteDependencyWalkerTests.cs
@@ -5,7 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using NuGet.ContentModel;
+using FluentAssertions;
 using NuGet.Frameworks;
 using NuGet.LibraryModel;
 using NuGet.Versioning;
@@ -1572,8 +1572,8 @@ namespace NuGet.DependencyResolver.Tests
 
         /// <summary>
         /// A -> B 1.0.0 -> C 1.0.0(this will be rejected) -> D 2.0.0(this will be downgraded due to central 1.0.0) -> E 1.0.0
-        ///   -> F 1.0.0 -> C 2.0.0 -> H 2.0.0
-        ///   -> G 1.0.0 -> H 2.0.0(this will not be rejected) -> D 1.0.0
+        ///   -> F 1.0.0 -> C 2.0.0
+        ///   -> G 1.0.0 -> H 2.0.0(this will not be rejected) -> D 1.0.0 (this will be downgraded due to central 1.0.0)
         ///
         ///  D has version defined centrally 1.0.0
         ///  D 1.0.0 -> I 1.0.0
@@ -1587,7 +1587,7 @@ namespace NuGet.DependencyResolver.Tests
             var provider = new DependencyProvider();
             var version100 = "1.0.0";
             var version200 = "2.0.0";
-
+             
             // A -> B 1.0.0 -> C 1.0.0(this will be rejected) -> D 2.0.0 (this will be downgraded) -> E 1.0.0
             provider.Package("A", version100)
                     .DependsOn("B", version100);
@@ -1603,16 +1603,14 @@ namespace NuGet.DependencyResolver.Tests
                     .DependsOn("F", version100);
             provider.Package("F", version100)
                     .DependsOn("C", version200);
-            provider.Package("C", version200)
-                    .DependsOn("H", version200);
 
-            // A -> -> G 1.0.0 -> H 2.0.0(this will not be rejected) -> D 1.0.0
+            // A -> -> G 1.0.0 -> H 2.0.0(this will not be rejected) -> D 2.0.0 (this will be downgraded)
             provider.Package("A", version100)
                     .DependsOn("G", version100);
             provider.Package("G", version100)
                     .DependsOn("H", version200);
             provider.Package("H", version200)
-                    .DependsOn("D", version100);
+                    .DependsOn("D", version200);
 
             // D 1.0.0 -> I 1.0.0
             provider.Package("D", version100)
@@ -1807,6 +1805,39 @@ namespace NuGet.DependencyResolver.Tests
                 AssertPath(downgraded, "A 1.0.0", "B 1.0.0", "C 2.0.0");
                 AssertPath(downgradedBy, "A 1.0.0", "C 1.0.0");
             }
+        }
+
+
+        /// A 1.0.0 -> C 1.0.0 -> D 1.1.0
+        /// B 1.0.0 -> C 1.1.0 -> D 1.0.0
+        /// D 1.0.0
+        [Fact]
+        public async Task WalkAsync_WithDowngradeInPrunedSubgraph_DoesNotReportDowngrades()
+        {
+            var context = new TestRemoteWalkContext();
+            var provider = new DependencyProvider();
+            provider.Package("Project", "1.0")
+                    .DependsOn("A", "1.0")
+                    .DependsOn("B", "1.0")
+                    .DependsOn("D", "1.0");
+
+            provider.Package("A", "1.0")
+                    .DependsOn("C", "1.0");
+
+            provider.Package("B", "1.0")
+                    .DependsOn("C", "1.1");
+
+            provider.Package("C", "1.0")
+                    .DependsOn("D", "1.1");
+            provider.Package("C", "1.1")
+                    .DependsOn("D", "1.0");
+
+            context.LocalLibraryProviders.Add(provider);
+            var walker = new RemoteDependencyWalker(context);
+            var node = await DoWalkAsync(walker, "Project");
+
+            var result = node.Analyze();
+            result.Downgrades.Should().BeEmpty();
         }
 
         private void AssertPath<TItem>(GraphNode<TItem> node, params string[] items)


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/10972

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Say you have project A with the following 3 top level packages:

* A 1.0.0 -> C 1.0.0 -> D 1.1.0
* B 1.0.0 -> C 1.1.0 -> D 1.0.0
* D 1.0.0

A 1.0.0 is selected because it's direct. 
B 1.0.0 is selected because it's direct.
D 1.0.0 is selected because it's direct. The special thing is that there *are* D references further down in the graph. 

In the algorithm, both C 1.0.0 and C 1.1.0 graphs will be walked. 
For D 1.1.0, we detect that it's downgraded, and mark it such.
Later, when C 1.1.0 is selected, C 1.0.0 is rejected as well, all of that makes the downgrade irrelevant. 

We were already ensuring we were reporting downgrades *only* for accepted packages, but we did not consider the fact that the graph might not be pruned. 

Hey @davidfowl, given that there are not too many people familiar with the resolver code, I was hoping you can take a look. 

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
