### PR TITLE
Avoid unnecessarily resizing dictionary while calculating project closure

### DIFF
--- a/build/Shared/SharedExtensions.cs
+++ b/build/Shared/SharedExtensions.cs
@@ -9,6 +9,33 @@ namespace NuGet.Shared
 {
     internal static class Extensions
     {
+        /// <inheritdoc cref="Enumerable.ToDictionary{TSource, TKey, TElement}(IEnumerable{TSource}, Func{TSource, TKey}, Func{TSource, TElement}, IEqualityComparer{TKey})"/>.
+        public static Dictionary<TKey, TElement> ToDictionary<TSource, TKey, TElement>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, int capacity, IEqualityComparer<TKey> comparer)
+        {
+            if (source == null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+
+            if (keySelector == null)
+            {
+                throw new ArgumentNullException(nameof(keySelector));
+            }
+
+            if (elementSelector == null)
+            {
+                throw new ArgumentNullException(nameof(elementSelector));
+            }
+
+            var d = new Dictionary<TKey, TElement>(capacity, comparer);
+            foreach (TSource element in source)
+            {
+                d.Add(keySelector(element), elementSelector(element));
+            }
+
+            return d;
+        }
+
         /// <summary>
         /// Return the enumerable as a List of T, copying if required. Optimized for common case where it is an List of T.
         /// Avoid mutating the return value.

--- a/src/NuGet.Core/NuGet.ProjectModel/DependencyGraphSpec.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/DependencyGraphSpec.cs
@@ -10,6 +10,7 @@ using Newtonsoft.Json.Linq;
 using NuGet.Common;
 using NuGet.LibraryModel;
 using NuGet.Packaging;
+using NuGet.Shared;
 using NuGet.Versioning;
 
 namespace NuGet.ProjectModel
@@ -164,7 +165,7 @@ namespace NuGet.ProjectModel
             }
 
             var projectsByUniqueName = _projects
-                .ToDictionary(t => t.Value.RestoreMetadata.ProjectUniqueName, t => t.Value, PathUtility.GetStringComparerBasedOnOS());
+                .ToDictionary(t => t.Value.RestoreMetadata.ProjectUniqueName, t => t.Value, _projects.Count, PathUtility.GetStringComparerBasedOnOS());
 
             var closure = new List<PackageSpec>();
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug
Fixes: n/a

Regression? Last working version: n/a

## Description
ToDictionary does not let you specify an underlying starting capacity. This causes it to inherit the default size and unnecessarily resize itself multiple times in a large solution. Added a version of ToDictionary that lets you specify a default.

This was allocating 0.5% (150 MB) opening a 1000 project solution.

![image](https://user-images.githubusercontent.com/1103906/123744536-423e5a80-d8f2-11eb-9f16-a5b91b1d3b54.png)

## PR Checklist

- [X] PR has a meaningful title
- [ ] PR has a linked issue.
- [X] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [X] Test exception (perf)
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [ ] N/A
