### PR TITLE
Add package icon for NuGet.Localization nupkg

### DIFF
--- a/src/NuGet.Core/NuGet.Localization/NuGet.Localization.csproj
+++ b/src/NuGet.Core/NuGet.Localization/NuGet.Localization.csproj
@@ -15,7 +15,13 @@
 
   <PropertyGroup>
     <NuspecFile>NuGet.Localization.nuspec</NuspecFile>
-    <NuspecProperties>Version=$(Version);configuration=$(Configuration);LocalizationOutputDirectory=$(LocalizationOutputDirectory)</NuspecProperties>
+    <NuspecProperties>
+      Version=$(Version);
+      configuration=$(Configuration);
+      LocalizationOutputDirectory=$(LocalizationOutputDirectory);
+      PackageIcon=$(PackageIcon);
+      PackageIconPath=$(MSBuildThisFileDirectory)..\$(PackageIcon)
+    </NuspecProperties>
   </PropertyGroup>
 
   <!--

--- a/src/NuGet.Core/NuGet.Localization/NuGet.Localization.csproj
+++ b/src/NuGet.Core/NuGet.Localization/NuGet.Localization.csproj
@@ -20,7 +20,7 @@
       configuration=$(Configuration);
       LocalizationOutputDirectory=$(LocalizationOutputDirectory);
       PackageIcon=$(PackageIcon);
-      PackageIconPath=$(MSBuildThisFileDirectory)..\$(PackageIcon)
+      PackageIconPath=$([System.IO.Path]::Combine($(RepositoryRootDirectory),$(PackageIcon)))
     </NuspecProperties>
   </PropertyGroup>
 

--- a/src/NuGet.Core/NuGet.Localization/NuGet.Localization.nuspec
+++ b/src/NuGet.Core/NuGet.Localization/NuGet.Localization.nuspec
@@ -6,6 +6,7 @@
     <title>NuGet.Localization</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
+    <icon>$PackageIcon$</icon>
     <license type="expression">Apache-2.0</license>
     <projectUrl>https://aka.ms/nugetprj</projectUrl>
     <copyright>&#169; Microsoft Corporation. All rights reserved.</copyright>
@@ -18,5 +19,6 @@
 
   <files>
     <file src="$LocalizationOutputDirectory$\**\*.resources.dll" target="lib\"/>
+    <file src="$PackageIconPath$" target="\" />
   </files>
 </package>


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/10975

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
Add package icon for NuGet.Localization nupkg. I followed below steps to test this change.

1. Removed `condition` from https://github.com/NuGet/NuGet.Client/blob/dev/eng/pipelines/templates/Build_and_UnitTest.yml#L280-L285 build step in my private branch so that `nupkgs` are published for private builds
2. Browsed published nupkgs in the private build. https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=4928373&view=artifacts&pathAsName=false&type=publishedArtifacts
3. Downloaded `NuGet.Localization nupkg` from `nupkgs - nonRTM` container
4. Verified that both NuGet.Localization `nupkg` and `symbols.nupkg` have package icon.
5. Reverted the change made in step.1.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  <!-- Describe why you haven't added automation. -->
  - [x] N/A - Tested the fix manually.

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [x] N/A
