### PR TITLE
lock files support TFMs with platforms

### DIFF
--- a/src/NuGet.Core/NuGet.Frameworks/FrameworkConstants.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/FrameworkConstants.cs
@@ -16,6 +16,7 @@ namespace NuGet.Frameworks
         public static readonly Version EmptyVersion = new Version(0, 0, 0, 0);
         public static readonly Version MaxVersion = new Version(int.MaxValue, 0, 0, 0);
         public static readonly Version Version5 = new Version(5, 0, 0, 0);
+        public static readonly Version Version6 = new Version(6, 0, 0, 0);
         public static readonly Version Version10 = new Version(10, 0, 0, 0);
         public static readonly FrameworkRange DotNetAll = new FrameworkRange(
                         new NuGetFramework(FrameworkIdentifiers.NetPlatform, FrameworkConstants.EmptyVersion),
@@ -188,6 +189,7 @@ namespace NuGet.Frameworks
 
             // .NET 5.0 and later has NetCoreApp identifier
             public static readonly NuGetFramework Net50 = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version5);
+            public static readonly NuGetFramework Net60 = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version6);
 
             public static readonly NuGetFramework Native = new NuGetFramework(FrameworkIdentifiers.Native, new Version(0, 0, 0, 0));
         }

--- a/src/NuGet.Core/NuGet.Frameworks/NuGetFrameworkFactory.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/NuGetFrameworkFactory.cs
@@ -685,6 +685,12 @@ namespace NuGet.Frameworks
                 case "net50":
                     framework = FrameworkConstants.CommonFrameworks.Net50;
                     break;
+                case "netcoreapp6.0":
+                case "netcoreapp60":
+                case "net6.0":
+                case "net60":
+                    framework = FrameworkConstants.CommonFrameworks.Net60;
+                    break;
             }
 
             return framework != null;

--- a/src/NuGet.Core/NuGet.Frameworks/PublicAPI/net40/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Frameworks/PublicAPI/net40/PublicAPI.Unshipped.txt
@@ -10,3 +10,5 @@ static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Native -> N
 static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net47 -> NuGet.Frameworks.NuGetFramework
 static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net471 -> NuGet.Frameworks.NuGetFramework
 static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net472 -> NuGet.Frameworks.NuGetFramework
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net60 -> NuGet.Frameworks.NuGetFramework
+static readonly NuGet.Frameworks.FrameworkConstants.Version6 -> System.Version

--- a/src/NuGet.Core/NuGet.Frameworks/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Frameworks/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -10,3 +10,5 @@ static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Native -> N
 static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net47 -> NuGet.Frameworks.NuGetFramework
 static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net471 -> NuGet.Frameworks.NuGetFramework
 static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net472 -> NuGet.Frameworks.NuGetFramework
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net60 -> NuGet.Frameworks.NuGetFramework
+static readonly NuGet.Frameworks.FrameworkConstants.Version6 -> System.Version

--- a/src/NuGet.Core/NuGet.Frameworks/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Frameworks/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -10,3 +10,5 @@ static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Native -> N
 static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net47 -> NuGet.Frameworks.NuGetFramework
 static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net471 -> NuGet.Frameworks.NuGetFramework
 static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net472 -> NuGet.Frameworks.NuGetFramework
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net60 -> NuGet.Frameworks.NuGetFramework
+static readonly NuGet.Frameworks.FrameworkConstants.Version6 -> System.Version

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileTarget.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileTarget.cs
@@ -31,7 +31,7 @@ namespace NuGet.ProjectModel
         /// <summary>
         /// Full framework name.
         /// </summary>
-        public string Name => GetNameString(TargetFramework.DotNetFrameworkName, RuntimeIdentifier);
+        public string Name => GetNameString(TargetFramework, RuntimeIdentifier);
 
         public bool Equals(PackagesLockFileTarget other)
         {
@@ -66,14 +66,36 @@ namespace NuGet.ProjectModel
             return combiner.CombinedHash;
         }
 
-        private static string GetNameString(string framework, string runtime)
+        private static string GetNameString(NuGetFramework framework, string runtime)
         {
-            if (!string.IsNullOrEmpty(runtime))
+            string frameworkString;
+
+            // We already shipped net5.0 being listed as .NETCoreApp,Version=5.0, so it would be a breaking change
+            // to change it. Similarly for all earlier framework identifiers.
+            // Since net5.0-windows didn't work properly, we can use the "friendly" (folder name) for net5 with a platform.
+            // For net6 and higher, always use friendly folder format, since this is the preferred customer-facing
+            // format (from dotnet/design's net5 spec).
+            // Packages lock files are checked into source control, hence customers will see it in their diffs.
+            if (string.Equals(framework.Framework, FrameworkConstants.FrameworkIdentifiers.NetCoreApp, StringComparison.OrdinalIgnoreCase)
+                && (
+                    (framework.Version.Major >= 6)
+                    || (framework.Version.Major == 5 && framework.HasPlatform)
+                   )
+                )
             {
-                return $"{framework}/{runtime}";
+                frameworkString = framework.ToString();
+            }
+            else
+            {
+                frameworkString = framework.DotNetFrameworkName;
             }
 
-            return framework;
+            if (!string.IsNullOrEmpty(runtime))
+            {
+                return $"{frameworkString}/{runtime}";
+            }
+
+            return frameworkString;
         }
     }
 }

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
@@ -832,6 +832,33 @@ EndGlobal";
             }
         }
 
+        [PlatformFact(Platform.Windows)]
+        public void DotnetRestore_LockedMode_Net5WithAndWithoutPlatform()
+        {
+            using (var pathContext = _msbuildFixture.CreateSimpleTestPathContext())
+            {
+                // Arrange
+                string projectFileContents =
+@"<Project Sdk=""Microsoft.NET.Sdk"">
+    <PropertyGroup>
+        <TargetFrameworks>net5.0;net5.0-windows</TargetFrameworks>
+        <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
+    </PropertyGroup>
+</Project>";
+                File.WriteAllText(Path.Combine(pathContext.SolutionRoot, "a.csproj"), projectFileContents);
+
+                // Act
+                _msbuildFixture.RestoreProject(pathContext.SolutionRoot, "a", args: null);
+
+                // Assert
+                PackagesLockFile lockFile = PackagesLockFileFormat.Read(Path.Combine(pathContext.SolutionRoot, PackagesLockFileFormat.LockFileName));
+                Assert.Equal(2, lockFile.Targets.Count);
+                Assert.Contains(lockFile.Targets, target => target.TargetFramework == FrameworkConstants.CommonFrameworks.Net50);
+                var net5win7 = NuGetFramework.Parse("net5.0-windows7.0");
+                Assert.Contains(lockFile.Targets, target => target.TargetFramework == net5win7);
+            }
+        }
+
         /// <summary>
         /// Create 3 projects, each with their own nuget.config file and source.
         /// When restoring in PackageReference the settings should be found from the project folder.

--- a/test/NuGet.Core.Tests/NuGet.Frameworks.Test/NuGetFrameworkParseTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Frameworks.Test/NuGetFrameworkParseTests.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections;
+using System.Collections.Generic;
 using NuGet.Frameworks;
 using Xunit;
 
@@ -423,5 +425,26 @@ namespace NuGet.Test
             // Compare the object references
             Assert.Same(framework1, framework2);
         }
+
+        public static IEnumerable<object[]> NuGetFramework_Parse_CommonFramework_ReturnsStaticInstance_Data()
+        {
+            yield return new object[] { "net472", FrameworkConstants.CommonFrameworks.Net472 };
+            yield return new object[] { "net5.0", FrameworkConstants.CommonFrameworks.Net50 };
+            yield return new object[] { "net6.0", FrameworkConstants.CommonFrameworks.Net60 };
+
+        }
+
+        [Theory]
+        [MemberData(nameof(NuGetFramework_Parse_CommonFramework_ReturnsStaticInstance_Data))]
+        public void NuGetFramework_Parse_CommonFramework_ReturnsStaticInstance(string frameworkString, NuGetFramework frameworkObject)
+        {
+            // Act
+            NuGetFramework parsedFramework = NuGetFramework.Parse(frameworkString);
+
+            // Assert
+            Assert.Same(frameworkObject, parsedFramework);
+        }
+
+
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackagesLockFileFormatTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackagesLockFileFormatTests.cs
@@ -3,6 +3,7 @@
 
 using System.Linq;
 using Newtonsoft.Json.Linq;
+using NuGet.Frameworks;
 using Xunit;
 
 namespace NuGet.ProjectModel.Test
@@ -56,6 +57,74 @@ namespace NuGet.ProjectModel.Test
             Assert.Null(target.Dependencies[1].RequestedVersion);
             Assert.Equal("1.0.0", target.Dependencies[0].ResolvedVersion.ToNormalizedString());
             Assert.NotEmpty(target.Dependencies[1].ContentHash);
+        }
+
+        [Fact]
+        public void Read_VariousTargetFrameworksAndRuntimeIdentifiers_ParsedCorrectly()
+        {
+            // Arrange
+            var lockFileContents =
+@"{
+    ""version"": 1,
+    ""dependencies"": {
+        "".NETFramework,Version=v4.7.2"": { },
+        "".NETStandard,Version=v2.0"": { },
+        "".NETCoreApp,Version=3.1"": { },
+        "".NETCoreApp,Version=3.1/win-x64"": { },
+        "".NETCoreApp,Version=5.0"": { },
+        "".NETCoreApp,Version=5.0/win-x64"": { },
+        ""net5.0-windows7.0"": { },
+        ""net5.0-windows7.0/win-x64"": { },
+        ""net6.0"": { },
+        ""net6.0/win-x64"": { },
+        ""net6.0-windows7.0"": { },
+        ""net6.0-windows7.0/win-x64"": { },
+    }
+}";
+
+            // Act
+            var lockFile = PackagesLockFileFormat.Parse(lockFileContents, "In memory");
+
+            // Assert
+            Assert.Equal(12, lockFile.Targets.Count);
+
+            Assert.Equal(FrameworkConstants.CommonFrameworks.Net472, lockFile.Targets[0].TargetFramework);
+            Assert.Null(lockFile.Targets[0].RuntimeIdentifier);
+
+            Assert.Equal(FrameworkConstants.CommonFrameworks.NetStandard20, lockFile.Targets[1].TargetFramework);
+            Assert.Null(lockFile.Targets[1].RuntimeIdentifier);
+
+            Assert.Equal(FrameworkConstants.CommonFrameworks.NetCoreApp31, lockFile.Targets[2].TargetFramework);
+            Assert.Null(lockFile.Targets[2].RuntimeIdentifier);
+
+            Assert.Equal(FrameworkConstants.CommonFrameworks.NetCoreApp31, lockFile.Targets[3].TargetFramework);
+            Assert.Equal("win-x64", lockFile.Targets[3].RuntimeIdentifier);
+
+            Assert.Equal(FrameworkConstants.CommonFrameworks.Net50, lockFile.Targets[4].TargetFramework);
+            Assert.Null(lockFile.Targets[4].RuntimeIdentifier);
+
+            Assert.Equal(FrameworkConstants.CommonFrameworks.Net50, lockFile.Targets[5].TargetFramework);
+            Assert.Equal("win-x64", lockFile.Targets[5].RuntimeIdentifier);
+
+            NuGetFramework net5win7 = NuGetFramework.Parse("net5.0-windows7.0");
+            Assert.Equal(net5win7, lockFile.Targets[6].TargetFramework);
+            Assert.Null(lockFile.Targets[6].RuntimeIdentifier);
+
+            Assert.Equal(net5win7, lockFile.Targets[7].TargetFramework);
+            Assert.Equal("win-x64", lockFile.Targets[7].RuntimeIdentifier);
+
+            Assert.Equal(FrameworkConstants.CommonFrameworks.Net60, lockFile.Targets[8].TargetFramework);
+            Assert.Null(lockFile.Targets[8].RuntimeIdentifier);
+
+            Assert.Equal(FrameworkConstants.CommonFrameworks.Net60, lockFile.Targets[9].TargetFramework);
+            Assert.Equal("win-x64", lockFile.Targets[9].RuntimeIdentifier);
+
+            NuGetFramework net6win7 = NuGetFramework.Parse("net6.0-windows7.0");
+            Assert.Equal(net6win7, lockFile.Targets[10].TargetFramework);
+            Assert.Null(lockFile.Targets[10].RuntimeIdentifier);
+
+            Assert.Equal(net6win7, lockFile.Targets[11].TargetFramework);
+            Assert.Equal("win-x64", lockFile.Targets[11].RuntimeIdentifier);
         }
 
         [Fact]

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackagesLockFileTargetTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackagesLockFileTargetTests.cs
@@ -1,0 +1,42 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using NuGet.Frameworks;
+using Xunit;
+
+namespace NuGet.ProjectModel.Test
+{
+    public class PackagesLockFileTargetTests
+    {
+        [Theory]
+        [InlineData("net472", null, ".NETFramework,Version=v4.7.2")]
+        [InlineData("netstandard2.0", null, ".NETStandard,Version=v2.0")]
+        [InlineData("netcoreapp3.1", null, ".NETCoreApp,Version=v3.1")]
+        [InlineData("netcoreapp3.1", "win-x64", ".NETCoreApp,Version=v3.1/win-x64")]
+        [InlineData("net5.0", null, ".NETCoreApp,Version=v5.0")]
+        [InlineData("net5.0", "win-x64", ".NETCoreApp,Version=v5.0/win-x64")]
+        [InlineData("net5.0-windows7.0", null, "net5.0-windows7.0")]
+        [InlineData("net5.0-windows7.0", "win-x64", "net5.0-windows7.0/win-x64")]
+        [InlineData("net6.0", null, "net6.0")]
+        [InlineData("net6.0", "win-x64", "net6.0/win-x64")]
+        [InlineData("net6.0-windows7.0", null, "net6.0-windows7.0")]
+        [InlineData("net6.0-windows7.0", "win-x64", "net6.0-windows7.0/win-x64")]
+        public void Name_DifferentTargetFrameworkAndRuntimeIdentifiers_HasExpectedValue(string targetFramework, string runtimeIdentifier, string expectedName)
+        {
+            // Arrange
+            NuGetFramework framework = NuGetFramework.Parse(targetFramework);
+
+            PackagesLockFileTarget packagesLockFileTarget = new()
+            {
+                TargetFramework = framework,
+                RuntimeIdentifier = runtimeIdentifier
+            };
+
+            // Act
+            var actualName = packagesLockFileTarget.Name;
+
+            // Assert
+            Assert.Equal(expectedName, actualName);
+        }
+    }
+}


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/10901

Regression? no, it never worked correctly.

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

In order to prevent problems if customers use different versions of the .NET SDK on CI and on their devbox, `net5.0` target frameworks will remain `.NETCoreApp,Version=v5.0` in the lock file.

However, net6.0 and above, as well as any net5.0 or higher target framework with a platform (for example `net5.0-windows`), will use the "short folder name", since that's the recommended customer visible format as per the net5 TFM spec.

## PR Checklist

- [X] PR has a meaningful title
- [X] PR has a linked issue.
- [X] Described changes

- **Tests**
  - [X] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [X] N/A
