### PR TITLE
Avoid byte array allocations to reduce allocations by about 16% during clean restore

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging.Extraction/NuGet.Packaging.Extraction.csproj
+++ b/src/NuGet.Core/NuGet.Packaging.Extraction/NuGet.Packaging.Extraction.csproj
@@ -93,6 +93,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\NuGet.Packaging\ArrayPool.cs" Link="ArrayPool.cs" />
     <Compile Include="..\NuGet.Packaging\Core\comparers\PackageDependencyComparer.cs" Link="NuGet.Packaging\Core\comparers\PackageDependencyComparer.cs" />
     <Compile Include="..\NuGet.Packaging\Core\comparers\PackageDependencyInfoComparer.cs" Link="NuGet.Packaging\Core\comparers\PackageDependencyInfoComparer.cs" />
     <Compile Include="..\NuGet.Packaging\Core\PackageDependencyInfo.cs" Link="NuGet.Packaging\Core\PackageDependencyInfo.cs" />

--- a/src/NuGet.Core/NuGet.Packaging/ArrayPool.cs
+++ b/src/NuGet.Core/NuGet.Packaging/ArrayPool.cs
@@ -1,0 +1,124 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#if NETFRAMEWORK || NETSTANDARD2_0
+
+using System.Collections.Generic;
+
+namespace System.Buffers
+{
+    /// <summary>
+    /// Provides a resource pool that enables reusing instances of arrays.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Renting and returning buffers with an <see cref="ArrayPool{T}"/> can increase performance
+    /// in situations where arrays are created and destroyed frequently, resulting in significant
+    /// memory pressure on the garbage collector.
+    /// </para>
+    /// <para>
+    /// This class is thread-safe.  All members may be used by multiple threads concurrently.
+    /// </para>
+    /// </remarks>
+    internal class ArrayPool<T>
+    {
+        // .NET Framework/.NET Standard version of .NET Core's ArrayPool<T>, intentionally mimic'ing
+        // its API shape so that consumption of the code doesn't need to change between targets.
+
+        // Largest multiple of 4096 under default LOH threadshold
+        private const int MaxPooledArraySize = 81920;
+        private readonly SimplePool<T[]> _pool = new(() => new T[MaxPooledArraySize]);
+
+        /// <summary>
+        /// Retrieves a shared <see cref="ArrayPool{T}"/> instance.
+        /// </summary>
+        public static ArrayPool<T> Shared = new();
+
+        /// <summary>
+        /// Retrieves a buffer that is at least the requested length.
+        /// </summary>
+        /// <param name="minimumLength">The minimum length of the array needed.</param>
+        /// <returns>
+        /// An array that is at least <paramref name="minimumLength"/> in length.
+        /// </returns>
+        /// <remarks>
+        /// This buffer is loaned to the caller and should be returned to the same pool via
+        /// <see cref="Return"/> so that it may be reused in subsequent usage of <see cref="Rent"/>.
+        /// It is not a fatal error to not return a rented buffer, but failure to do so may lead to
+        /// decreased application performance, as the pool may need to create a new buffer to replace
+        /// the one lost.
+        /// </remarks>
+        public T[] Rent(int minimumLength)
+        {
+            if (minimumLength <= MaxPooledArraySize)
+            {
+                return _pool.Allocate();
+            }
+
+            return new T[minimumLength];
+        }
+
+        /// <summary>
+        /// Returns to the pool an array that was previously obtained via <see cref="Rent"/> on the same
+        /// <see cref="ArrayPool{T}"/> instance.
+        /// </summary>
+        /// <param name="array">
+        /// The buffer previously obtained from <see cref="Rent"/> to return to the pool.
+        /// </param>
+        /// <param name="clearArray">
+        /// If <c>true</c> and if the pool will store the buffer to enable subsequent reuse, <see cref="Return"/>
+        /// will clear <paramref name="array"/> of its contents so that a subsequent consumer via <see cref="Rent"/>
+        /// will not see the previous consumer's content.  If <c>false</c> or if the pool will release the buffer,
+        /// the array's contents are left unchanged.
+        /// </param>
+        /// <remarks>
+        /// Once a buffer has been returned to the pool, the caller gives up all ownership of the buffer
+        /// and must not use it. The reference returned from a given call to <see cref="Rent"/> must only be
+        /// returned via <see cref="Return"/> once.  The default <see cref="ArrayPool{T}"/>
+        /// may hold onto the returned buffer in order to rent it again, or it may release the returned buffer
+        /// if it's determined that the pool already has enough buffers stored.
+        /// </remarks>
+        public void Return(T[] array)
+        {
+            if (array.Length <= MaxPooledArraySize)
+            {
+                _pool.Free(array);
+            }
+        }
+    }
+
+    internal class SimplePool<T> where T : class
+    {
+        private readonly object _lock = new();
+        private readonly Stack<T> _values = new();
+        private readonly Func<T> _allocate;
+
+        public SimplePool(Func<T> allocate)
+        {
+            _allocate = allocate;
+        }
+
+        public T Allocate()
+        {
+            lock (_lock)
+            {
+                if (_values.Count > 0)
+                {
+                    return _values.Pop();
+                }
+
+                return _allocate();
+            }
+        }
+
+        public void Free(T value)
+        {
+            lock (_lock)
+            {
+                _values.Push(value);
+            }
+        }
+    }
+}
+
+#endif

--- a/src/NuGet.Core/NuGet.Packaging/ArrayPool.cs
+++ b/src/NuGet.Core/NuGet.Packaging/ArrayPool.cs
@@ -32,7 +32,7 @@ namespace System.Buffers
         /// <summary>
         /// Retrieves a shared <see cref="ArrayPool{T}"/> instance.
         /// </summary>
-        public static ArrayPool<T> Shared = new();
+        public static readonly ArrayPool<T> Shared = new();
 
         /// <summary>
         /// Retrieves a buffer that is at least the requested length.
@@ -64,12 +64,6 @@ namespace System.Buffers
         /// </summary>
         /// <param name="array">
         /// The buffer previously obtained from <see cref="Rent"/> to return to the pool.
-        /// </param>
-        /// <param name="clearArray">
-        /// If <c>true</c> and if the pool will store the buffer to enable subsequent reuse, <see cref="Return"/>
-        /// will clear <paramref name="array"/> of its contents so that a subsequent consumer via <see cref="Rent"/>
-        /// will not see the previous consumer's content.  If <c>false</c> or if the pool will release the buffer,
-        /// the array's contents are left unchanged.
         /// </param>
         /// <remarks>
         /// Once a buffer has been returned to the pool, the caller gives up all ownership of the buffer

--- a/src/NuGet.Core/NuGet.Packaging/ArrayPool.cs
+++ b/src/NuGet.Core/NuGet.Packaging/ArrayPool.cs
@@ -29,6 +29,10 @@ namespace System.Buffers
         private const int MaxPooledArraySize = 81920;
         private readonly SimplePool<T[]> _pool = new(() => new T[MaxPooledArraySize]);
 
+        private ArrayPool()
+        {
+        }
+
         /// <summary>
         /// Retrieves a shared <see cref="ArrayPool{T}"/> instance.
         /// </summary>

--- a/src/NuGet.Core/NuGet.Packaging/PackageExtraction/StreamExtensions.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageExtraction/StreamExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Buffers;
 using System.IO;
 using System.IO.MemoryMappedFiles;
 
@@ -58,15 +59,37 @@ namespace NuGet.Packaging
                     using (MemoryMappedFile mmf = MemoryMappedFile.CreateFromFile(fileFullPath, FileMode.Open, mapName: null, (long)size))
                     using (MemoryMappedViewStream mmstream = mmf.CreateViewStream())
                     {
-                        inputStream.CopyTo(mmstream);
+                        CopyTo(inputStream, mmstream);
                     }
                 }
                 else
                 {
-                    inputStream.CopyTo(outputStream);
+                    CopyTo(inputStream, outputStream);
                 }
             }
             return fileFullPath;
+        }
+
+        private static void CopyTo(Stream inputStream, Stream outputStream)
+        {
+            // .NET Framework allocates an unavoidable byte[] when using
+            // Stream.CopyTo. Reimplement it, pulling from the pool similar
+            // to .NET 5.
+
+#if NETFRAMEWORK || NETSTANDARD2_0
+            const int bufferSize = 81920; // Same as Stream.CopyTo
+            byte[] buffer = ArrayPool<byte>.Shared.Rent(bufferSize);
+
+            int bytesRead;
+            while ((bytesRead = inputStream.Read(buffer, 0, buffer.Length)) != 0)
+            {
+                outputStream.Write(buffer, 0, bytesRead);
+            }
+
+            ArrayPool<byte>.Shared.Return(buffer);
+#else
+            inputStream.CopyTo(outputStream);
+#endif
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Packaging/PackageExtraction/StreamExtensions.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageExtraction/StreamExtensions.cs
@@ -81,9 +81,9 @@ namespace NuGet.Packaging
             byte[] buffer = ArrayPool<byte>.Shared.Rent(bufferSize);
 
             int bytesRead;
-            while ((bytesRead = inputStream.Read(buffer, 0, buffer.Length)) != 0)
+            while ((bytesRead = inputStream.Read(buffer, offset: 0, buffer.Length)) != 0)
             {
-                outputStream.Write(buffer, 0, bytesRead);
+                outputStream.Write(buffer, offset: 0, bytesRead);
             }
 
             ArrayPool<byte>.Shared.Return(buffer);

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Archive/SignedPackageArchiveIOUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Archive/SignedPackageArchiveIOUtility.cs
@@ -126,14 +126,14 @@ namespace NuGet.Packaging.Signing
                 throw new ArgumentNullException(nameof(hashAlgorithm));
             }
 
-            if (count <= 0 || bytes.Length < count)
-            {
-                throw new ArgumentOutOfRangeException(nameof(count));
-            }
-
             if (bytes == null || bytes.Length == 0)
             {
                 throw new ArgumentException(Strings.ArgumentCannotBeNullOrEmpty, nameof(bytes));
+            }
+
+            if (count <= 0 || bytes.Length < count)
+            {
+                throw new ArgumentOutOfRangeException(nameof(count));
             }
 
             hashAlgorithm.TransformBlock(bytes, inputOffset: 0, count, outputBuffer: null, outputOffset: 0);
@@ -202,14 +202,14 @@ namespace NuGet.Packaging.Signing
                 throw new ArgumentNullException(nameof(hashFunc));
             }
 
-            if (count <= 0 || bytes.Length < count)
-            {
-                throw new ArgumentOutOfRangeException(nameof(count));
-            }
-
             if (bytes == null || bytes.Length == 0)
             {
                 throw new ArgumentException(Strings.ArgumentCannotBeNullOrEmpty, nameof(bytes));
+            }
+
+            if (count <= 0 || bytes.Length < count)
+            {
+                throw new ArgumentOutOfRangeException(nameof(count));
             }
 
             hashFunc.Update(bytes, offset: 0, count);

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Archive/SignedPackageArchiveIOUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Archive/SignedPackageArchiveIOUtility.cs
@@ -55,14 +55,14 @@ namespace NuGet.Packaging.Signing
 
             byte[] buffer = ArrayPool<byte>.Shared.Rent(_bufferSize);
 
-            Stream stream = reader.BaseStream;            
+            Stream stream = reader.BaseStream;
             long currentPosition;
             while ((currentPosition = stream.Position) != position)
             {
                 var bytesToRead = (int)Math.Min(position - currentPosition, buffer.Length);
 
-                var bytesRead = stream.Read(buffer, 0, bytesToRead);
-                writer.Write(buffer, 0, bytesRead);
+                int bytesRead = stream.Read(buffer, offset: 0, bytesToRead);
+                writer.Write(buffer, index: 0, bytesRead);
             }
 
             ArrayPool<byte>.Shared.Return(buffer);
@@ -101,7 +101,7 @@ namespace NuGet.Packaging.Signing
             {
                 var bytesToRead = (int)Math.Min(position - currentPosition, buffer.Length);
 
-                var bytesRead = stream.Read(buffer, 0, bytesToRead);
+                int bytesRead = stream.Read(buffer, offset: 0, bytesToRead);
                 HashBytes(hashAlgorithm, buffer, bytesRead);
             }
 
@@ -126,7 +126,12 @@ namespace NuGet.Packaging.Signing
                 throw new ArgumentNullException(nameof(hashAlgorithm));
             }
 
-            if (bytes == null || bytes.Length == 0 || count == 0)
+            if (count <= 0 || bytes.Length < count)
+            {
+                throw new ArgumentOutOfRangeException(nameof(count));
+            }
+
+            if (bytes == null || bytes.Length == 0)
             {
                 throw new ArgumentException(Strings.ArgumentCannotBeNullOrEmpty, nameof(bytes));
             }
@@ -167,7 +172,7 @@ namespace NuGet.Packaging.Signing
             {
                 var bytesToRead = (int)Math.Min(position - currentPosition, buffer.Length);
 
-                var bytesRead = stream.Read(buffer, 0, bytesToRead);
+                int bytesRead = stream.Read(buffer, offset: 0, bytesToRead);
                 HashBytes(hashFunc, buffer, bytesRead);
             }
 
@@ -189,6 +194,7 @@ namespace NuGet.Packaging.Signing
         /// </summary>
         /// <param name="hashFunc">HashAlgorithm wrapper used to hash contents cross platform</param>
         /// <param name="bytes">Content to hash</param>
+        /// <param name="count">The number of bytes in the input byte array to use as data.</param>
         internal static void HashBytes(Sha512HashFunction hashFunc, byte[] bytes, int count)
         {
             if (hashFunc == null)
@@ -196,12 +202,17 @@ namespace NuGet.Packaging.Signing
                 throw new ArgumentNullException(nameof(hashFunc));
             }
 
-            if (bytes == null || bytes.Length == 0 || count == 0)
+            if (count <= 0 || bytes.Length < count)
+            {
+                throw new ArgumentOutOfRangeException(nameof(count));
+            }
+
+            if (bytes == null || bytes.Length == 0)
             {
                 throw new ArgumentException(Strings.ArgumentCannotBeNullOrEmpty, nameof(bytes));
             }
 
-            hashFunc.Update(bytes, 0, count);
+            hashFunc.Update(bytes, offset: 0, count);
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Archive/SignedPackageArchiveIOUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Archive/SignedPackageArchiveIOUtility.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
@@ -52,8 +53,9 @@ namespace NuGet.Packaging.Signing
                 throw new ArgumentOutOfRangeException(nameof(position), Strings.SignedPackageArchiveIOInvalidRead);
             }
 
-            Stream stream = reader.BaseStream;
-            byte[] buffer = new byte[_bufferSize];
+            byte[] buffer = ArrayPool<byte>.Shared.Rent(_bufferSize);
+
+            Stream stream = reader.BaseStream;            
             long currentPosition;
             while ((currentPosition = stream.Position) != position)
             {
@@ -62,6 +64,8 @@ namespace NuGet.Packaging.Signing
                 var bytesRead = stream.Read(buffer, 0, bytesToRead);
                 writer.Write(buffer, 0, bytesRead);
             }
+
+            ArrayPool<byte>.Shared.Return(buffer);
         }
 
         /// <summary>
@@ -89,8 +93,9 @@ namespace NuGet.Packaging.Signing
                 throw new ArgumentOutOfRangeException(nameof(position), Strings.SignedPackageArchiveIOInvalidRead);
             }
 
+            byte[] buffer = ArrayPool<byte>.Shared.Rent(_bufferSize);
+
             Stream stream = reader.BaseStream;
-            byte[] buffer = new byte[_bufferSize];
             long currentPosition;
             while ((currentPosition = stream.Position) != position)
             {
@@ -99,6 +104,8 @@ namespace NuGet.Packaging.Signing
                 var bytesRead = stream.Read(buffer, 0, bytesToRead);
                 HashBytes(hashAlgorithm, buffer, bytesRead);
             }
+
+            ArrayPool<byte>.Shared.Return(buffer);
         }
 
         /// <summary>
@@ -152,8 +159,9 @@ namespace NuGet.Packaging.Signing
                 throw new ArgumentOutOfRangeException(nameof(position), Strings.SignedPackageArchiveIOInvalidRead);
             }
 
+            byte[] buffer = ArrayPool<byte>.Shared.Rent(_bufferSize);
+
             Stream stream = reader.BaseStream;
-            byte[] buffer = new byte[_bufferSize];
             long currentPosition;
             while ((currentPosition = stream.Position) != position)
             {
@@ -162,6 +170,8 @@ namespace NuGet.Packaging.Signing
                 var bytesRead = stream.Read(buffer, 0, bytesToRead);
                 HashBytes(hashFunc, buffer, bytesRead);
             }
+
+            ArrayPool<byte>.Shared.Return(buffer);
         }
 
         /// <summary>


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/10988

Regression? First two allocations possibly introduced in the signed package feature.

## Description
Avoid allocating temporary byte[] instances during package verification and extractions. This should reduce allocations by about 16% (2.7 GB) in a trace from @nkolev92 based on what's in the dev branch today.

![image](https://user-images.githubusercontent.com/1103906/123933279-8fdfc380-d9d5-11eb-8f38-571889e1cd4b.png)

- Also simplified the signed package verification methods in the process. They have existing test coverage.

## PR Checklist

- [X] PR has a meaningful title
- [X] PR has a linked issue.
- [X] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [X] Test exception (perf, existing tests cover logic)
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [X] N/A

tag @nkolev92 @dtivel