### PR TITLE
Document that PackageReaderBase.GetSupportedFrameworks supports packages.config conventions only

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/PackageReaderBase.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageReaderBase.cs
@@ -360,6 +360,10 @@ namespace NuGet.Packaging
         /// <summary>
         /// Frameworks mentioned in the package.
         /// </summary>
+        /// <remarks>
+        /// This method returns the target frameworks supported for packages.config projects.
+        /// For PackageReference compatibility, use <see cref="NuGet.Client.ManagedCodeConventions"/>
+        /// </remarks>
         public virtual IEnumerable<NuGetFramework> GetSupportedFrameworks()
         {
             var frameworks = new HashSet<NuGetFramework>(new NuGetFrameworkFullComparer());
@@ -377,6 +381,13 @@ namespace NuGet.Packaging
             return frameworks.Where(f => !f.IsUnsupported).OrderBy(f => f, new NuGetFrameworkSorter());
         }
 
+        /// <summary>
+        /// Frameworks mentioned in the package.
+        /// </summary>
+        /// <remarks>
+        /// This method returns the target frameworks supported for packages.config projects.
+        /// For PackageReference compatibility, use <see cref="NuGet.Client.ManagedCodeConventions"/>
+        /// </remarks>
         public virtual Task<IEnumerable<NuGetFramework>> GetSupportedFrameworksAsync(CancellationToken cancellationToken)
         {
             return Task.FromResult(GetSupportedFrameworks());

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginPackageReader.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginPackageReader.cs
@@ -507,15 +507,7 @@ namespace NuGet.Protocol.Plugins
             throw new NotSupportedException();
         }
 
-        /// <summary>
-        /// Asynchronously gets supported frameworks.
-        /// </summary>
-        /// <param name="cancellationToken">A cancellation token.</param>
-        /// <returns>A task that represents the asynchronous operation.
-        /// The task result (<see cref="Task{TResult}.Result" />) returns an
-        /// <see cref="IEnumerable{NuGetFramework}" />.</returns>
-        /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
-        /// is cancelled.</exception>
+        /// <inheritdoc cref="PackageReaderBase.GetSupportedFrameworksAsync(CancellationToken)"/>
         public override async Task<IEnumerable<NuGetFramework>> GetSupportedFrameworksAsync(
             CancellationToken cancellationToken)
         {


### PR DESCRIPTION

<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/10974

Regression? no

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Add XMLDoc informing that `PackageReaderBase`'s `GetSupportedFrameworks` and `GetSupportedFrameworksAsync` only return `packages.config` compatible frameworks, not `PackageReference`'s.

## PR Checklist

- [X] PR has a meaningful title
- [X] PR has a linked issue.
- [X] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [X] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [X] N/A
