### PR TITLE
Fix PackageSaveMode nuspec always reinstalls

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/InstallCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/InstallCommand.cs
@@ -330,8 +330,14 @@ namespace NuGet.CommandLine
 
                 var packageIdentity = new PackageIdentity(packageId, version);
 
+                var PackageSaveMode = Packaging.PackageSaveMode.Defaultv2;
+                if (EffectivePackageSaveMode != Packaging.PackageSaveMode.None)
+                {
+                    PackageSaveMode = EffectivePackageSaveMode;
+                }
+
                 // Check if the package already exists or a higher version exists already.
-                var skipInstall = project.PackageExists(packageIdentity, EffectivePackageSaveMode);
+                var skipInstall = project.PackageExists(packageIdentity, PackageSaveMode);
 
                 // For SxS allow other versions to install. For non-SxS skip if a higher version exists.
                 skipInstall |= (ExcludeVersion && alreadyInstalledVersions.Any(e => e >= version));
@@ -352,16 +358,11 @@ namespace NuGet.CommandLine
                     var projectContext = new ConsoleProjectContext(Console)
                     {
                         PackageExtractionContext = new PackageExtractionContext(
-                            Packaging.PackageSaveMode.Defaultv2,
+                            PackageSaveMode,
                             PackageExtractionBehavior.XmlDocFileSaveMode,
                             clientPolicyContext,
                             Console)
                     };
-
-                    if (EffectivePackageSaveMode != Packaging.PackageSaveMode.None)
-                    {
-                        projectContext.PackageExtractionContext.PackageSaveMode = EffectivePackageSaveMode;
-                    }
 
                     resolutionContext.SourceCacheContext.NoCache = NoCache;
                     resolutionContext.SourceCacheContext.DirectDownload = DirectDownload;

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/InstallCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/InstallCommand.cs
@@ -331,7 +331,7 @@ namespace NuGet.CommandLine
                 var packageIdentity = new PackageIdentity(packageId, version);
 
                 // Check if the package already exists or a higher version exists already.
-                var skipInstall = project.PackageExists(packageIdentity);
+                var skipInstall = project.PackageExists(packageIdentity, EffectivePackageSaveMode);
 
                 // For SxS allow other versions to install. For non-SxS skip if a higher version exists.
                 skipInstall |= (ExcludeVersion && alreadyInstalledVersions.Any(e => e >= version));

--- a/src/NuGet.Core/NuGet.PackageManagement/Projects/FolderNuGetProject.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Projects/FolderNuGetProject.cs
@@ -296,7 +296,7 @@ namespace NuGet.ProjectManagement
                 if (manifestExists)
                 {
                     var reader = new NuspecReader(nuspecPath);
-                    packageExists = packageIdentity.Equals(reader.GetIdentity());
+                    manifestExists = packageIdentity.Equals(reader.GetIdentity());
                 }
             }
 

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetInstallCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetInstallCommandTest.cs
@@ -690,6 +690,7 @@ namespace NuGet.CommandLine.Test
             }
         }
 
+        [Fact]
         public void InstallCommand_PackageSaveModeNuspec()
         {
             using (var pathContext = new SimpleTestPathContext())
@@ -713,7 +714,7 @@ namespace NuGet.CommandLine.Test
                 // Assert
                 var nuspecFile = Path.Combine(
                     outputDirectory,
-                    "testPackage1.1.1.0", "testPackage1.1.1.0.nuspec");
+                    "testPackage1.1.1.0", "testPackage1.nuspec");
 
                 Assert.True(File.Exists(nuspecFile));
                 var nupkgFiles = Directory.GetFiles(outputDirectory, "*.nupkg", SearchOption.AllDirectories);
@@ -721,6 +722,7 @@ namespace NuGet.CommandLine.Test
             }
         }
 
+        [Fact]
         public void InstallCommand_PackageSaveModeNupkg()
         {
             using (var pathContext = new SimpleTestPathContext())
@@ -743,7 +745,7 @@ namespace NuGet.CommandLine.Test
                 // Assert
                 var nupkgFile = Path.Combine(
                     outputDirectory,
-                    "testPackage1.1.1.0", "testPackage1.1.1.0.nuspec");
+                    "testPackage1.1.1.0", "testPackage1.1.1.0.nupkg");
 
                 Assert.True(File.Exists(nupkgFile));
                 var nuspecFiles = Directory.GetFiles(outputDirectory, "*.nuspec", SearchOption.AllDirectories);
@@ -751,6 +753,7 @@ namespace NuGet.CommandLine.Test
             }
         }
 
+        [Fact]
         public void InstallCommand_PackageSaveModeNuspecNupkg()
         {
             using (var pathContext = new SimpleTestPathContext())
@@ -773,8 +776,10 @@ namespace NuGet.CommandLine.Test
                 // Assert
                 var nupkgFile = Path.Combine(
                     outputDirectory,
-                    "testPackage1.1.1.0", "testPackage1.1.1.0.nuspec");
-                var nuspecFile = Path.ChangeExtension(nupkgFile, "nuspec");
+                    "testPackage1.1.1.0", "testPackage1.1.1.0.nupkg");
+                var nuspecFile = Path.Combine(
+                    outputDirectory,
+                    "testPackage1.1.1.0", "testPackage1.nuspec");
 
                 Assert.True(File.Exists(nupkgFile));
                 Assert.True(File.Exists(nuspecFile));
@@ -784,6 +789,7 @@ namespace NuGet.CommandLine.Test
         // Test that after a package is installed with -PackageSaveMode nuspec, nuget.exe
         // can detect that the package is already installed when trying to install the same
         // package.
+        [Fact]
         public void InstallCommand_PackageSaveModeNuspecReinstall()
         {
             using (var pathContext = new SimpleTestPathContext())
@@ -796,25 +802,31 @@ namespace NuGet.CommandLine.Test
                     "testPackage1", "1.1.0", source);
 
                 var args = new string[] {
+                    "-ForceEnglishOutput",
                     "-OutputDirectory", outputDirectory,
                     "-Source", source,
                     "-PackageSaveMode", "nuspec" };
-                var r = Program.Main(args);
-                Assert.Equal(0, r);
 
                 // Act
+                var r = RunInstall(pathContext, "testPackage1", 0, args);
+
+                // Assert
+                Assert.Equal(0, r.Item1);
+
+                // Act (Install a second time)
                 var result = RunInstall(pathContext, "testPackage1", 0, args);
 
                 var output = result.Item2;
 
                 // Assert
-                var expectedOutput = "'testPackage1 1.1.0' already installed." +
-                    Environment.NewLine;
-                Assert.Equal(expectedOutput, output);
+                var alreadyInstalledMessage = "Package \"testPackage1.1.1.0\" is already installed.";
+                Assert.Contains(alreadyInstalledMessage, output, StringComparison.OrdinalIgnoreCase);
+                r.ExitCode.Should().Be(0);
             }
         }
 
         // Test that PackageSaveMode specified in nuget.config file is used.
+        [Fact]
         public void InstallCommand_PackageSaveModeInConfigFile()
         {
             using (var pathContext = new SimpleTestPathContext())
@@ -847,7 +859,7 @@ namespace NuGet.CommandLine.Test
 
                 var nuspecFile = Path.Combine(
                     outputDirectory,
-                    "testPackage1.1.1.0", "testPackage1.1.1.0.nuspec");
+                    "testPackage1.1.1.0", "testPackage1.nuspec");
 
                 Assert.True(File.Exists(nuspecFile));
                 var nupkgFiles = Directory.GetFiles(outputDirectory, "*.nupkg", SearchOption.AllDirectories);


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/2402

Regression? Last working version: No

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
Check whether a package with same PackageSaveMode is already installed. That would fix the linked bug.
Enable PackageSaveMode related unit tests.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
