### PR TITLE
Ensure the namespaces filtering is respected in packages.config package installation/updates in PMC

### DIFF
--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Apex/ApexTestContext.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Apex/ApexTestContext.cs
@@ -22,10 +22,10 @@ namespace NuGet.Tests.Apex
 
         public NuGetApexTestService NuGetApexTestService { get; }
 
-        public ApexTestContext(VisualStudioHost visualStudio, ProjectTemplate projectTemplate, ILogger logger, bool noAutoRestore = false, bool addNetStandardFeeds = false)
+        public ApexTestContext(VisualStudioHost visualStudio, ProjectTemplate projectTemplate, ILogger logger, bool noAutoRestore = false, bool addNetStandardFeeds = false, SimpleTestPathContext simpleTestPathContext = null)
         {
             logger.LogInformation("Creating test context");
-            _pathContext = new SimpleTestPathContext();
+            _pathContext = simpleTestPathContext ?? new SimpleTestPathContext();
 
             if (noAutoRestore)
             {

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetConsoleTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetConsoleTestCase.cs
@@ -437,13 +437,12 @@ namespace NuGet.Tests.Apex
 
                 // Act
                 nugetConsole.InstallPackageFromPMC(packageName, packageVersion1);
-                nugetConsole.UpdatePackageFromPMC(packageName, packageVersion2);
 
                 // Assert
                 CommonUtility.AssertPackageInPackagesConfig(VisualStudio, testContext.Project, packageName, packageVersion2, XunitLogger);
 
                 var packagesDirectory = Path.Combine(solutionDirectory, "packages");
-                var uniqueContentFile = Path.Combine(packagesDirectory, packageName + '.' + packageVersion1, "lib", "netstandard1.0", "Thisisfromprivaterepo2.txt");
+                var uniqueContentFile = Path.Combine(packagesDirectory, packageName + '.' + packageVersion1, "lib", "netstandard1.0", "Thisisfromprivaterepo1.txt");
                 // Make sure name squatting package not restored from  opensource repository.
                 Assert.True(File.Exists(uniqueContentFile));
             }
@@ -501,12 +500,13 @@ namespace NuGet.Tests.Apex
 
                 // Act
                 nugetConsole.InstallPackageFromPMC(packageName, packageVersion1);
+                nugetConsole.UpdatePackageFromPMC(packageName, packageVersion2);
 
                 // Assert
                 CommonUtility.AssertPackageInPackagesConfig(VisualStudio, testContext.Project, packageName, packageVersion1, XunitLogger);
 
                 var packagesDirectory = Path.Combine(solutionDirectory, "packages");
-                var uniqueContentFile = Path.Combine(packagesDirectory, packageName + '.' + packageVersion1, "lib", "netstandard1.0", "Thisisfromprivaterepo1.txt");
+                var uniqueContentFile = Path.Combine(packagesDirectory, packageName + '.' + packageVersion1, "lib", "netstandard1.0", "Thisisfromprivaterepo2.txt");
                 // Make sure name squatting package not restored from  opensource repository.
                 Assert.True(File.Exists(uniqueContentFile));
             }

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetConsoleTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetConsoleTestCase.cs
@@ -294,7 +294,7 @@ namespace NuGet.Tests.Apex
 
         [NuGetWpfTheory]
         [MemberData(nameof(GetPackagesConfigTemplates))]
-        public async Task InstallPackageFromPMCForPC_PackageNamespace_WithSingleFeed(ProjectTemplate projectTemplate)
+        public async Task InstallPackageForPC_PackageNamespace_WithSingleFeed(ProjectTemplate projectTemplate)
         {
             // Arrange
             EnsureVisualStudioHost();
@@ -339,7 +339,7 @@ namespace NuGet.Tests.Apex
 
         [NuGetWpfTheory]
         [MemberData(nameof(GetPackagesConfigTemplates))]
-        public async Task UpdatePackageFromPMCForPC_PackageNamespace_WithSingleFeed(ProjectTemplate projectTemplate)
+        public async Task UpdatePackageForPC_PackageNamespace_WithSingleFeed(ProjectTemplate projectTemplate)
         {
             // Arrange
             EnsureVisualStudioHost();
@@ -387,7 +387,7 @@ namespace NuGet.Tests.Apex
 
         [NuGetWpfTheory]
         [MemberData(nameof(GetPackagesConfigTemplates))]
-        public async Task InstallPackageFromPMCForPC_PackageNamespace_WithMultipleFeedsWithIdenticalPackages_InstallsCorrectPackage(ProjectTemplate projectTemplate)
+        public async Task InstallPackageForPC_PackageNamespace_WithMultipleFeedsWithIdenticalPackages_InstallsCorrectPackage(ProjectTemplate projectTemplate)
         {
             // Arrange
             EnsureVisualStudioHost();
@@ -401,14 +401,14 @@ namespace NuGet.Tests.Apex
             var opensourceRepositoryPath = Path.Combine(solutionDirectory, "OpensourceRepository");
             Directory.CreateDirectory(opensourceRepositoryPath);
 
-            await CommonUtility.CreateCustomPackageInSourceAsync(opensourceRepositoryPath, packageName, packageVersion1, "Thisisfromopensourcerepo1.txt");
-            await CommonUtility.CreateCustomPackageInSourceAsync(opensourceRepositoryPath, packageName, packageVersion2, "Thisisfromopensourcerepo2.txt");
+            await CommonUtility.CreateNetCorePackageInSourceAsync(opensourceRepositoryPath, packageName, packageVersion1, "Thisisfromopensourcerepo1.txt");
+            await CommonUtility.CreateNetCorePackageInSourceAsync(opensourceRepositoryPath, packageName, packageVersion2, "Thisisfromopensourcerepo2.txt");
 
             var privateRepositoryPath = Path.Combine(solutionDirectory, "PrivateRepository");
             Directory.CreateDirectory(privateRepositoryPath);
 
-            await CommonUtility.CreateCustomPackageInSourceAsync(privateRepositoryPath, packageName, packageVersion1, "Thisisfromprivaterepo1.txt");
-            await CommonUtility.CreateCustomPackageInSourceAsync(privateRepositoryPath, packageName, packageVersion2, "Thisisfromprivaterepo2.txt");
+            await CommonUtility.CreateNetCorePackageInSourceAsync(privateRepositoryPath, packageName, packageVersion1, "Thisisfromprivaterepo1.txt");
+            await CommonUtility.CreateNetCorePackageInSourceAsync(privateRepositoryPath, packageName, packageVersion2, "Thisisfromprivaterepo2.txt");
 
             //Create nuget.config with Package namespace filtering rules.
             CommonUtility.CreateConfigurationFile(Path.Combine(solutionDirectory, "NuGet.config"), $@"<?xml version=""1.0"" encoding=""utf-8""?>
@@ -439,10 +439,10 @@ namespace NuGet.Tests.Apex
                 nugetConsole.InstallPackageFromPMC(packageName, packageVersion1);
 
                 // Assert
-                CommonUtility.AssertPackageInPackagesConfig(VisualStudio, testContext.Project, packageName, packageVersion2, XunitLogger);
+                CommonUtility.AssertPackageInPackagesConfig(VisualStudio, testContext.Project, packageName, packageVersion1, XunitLogger);
 
                 var packagesDirectory = Path.Combine(solutionDirectory, "packages");
-                var uniqueContentFile = Path.Combine(packagesDirectory, packageName + '.' + packageVersion1, "lib", "netstandard1.0", "Thisisfromprivaterepo1.txt");
+                var uniqueContentFile = Path.Combine(packagesDirectory, packageName + '.' + packageVersion1, "lib", "net5.0", "Thisisfromprivaterepo1.txt");
                 // Make sure name squatting package not restored from  opensource repository.
                 Assert.True(File.Exists(uniqueContentFile));
             }
@@ -450,7 +450,7 @@ namespace NuGet.Tests.Apex
 
         [NuGetWpfTheory]
         [MemberData(nameof(GetPackagesConfigTemplates))]
-        public async Task UpdatePackageFromPMCForPC_PackageNamespace_WithMultipleFeedsWithIdenticalPackages_UpdatesCorrectPackage(ProjectTemplate projectTemplate)
+        public async Task UpdatePackageForPC_PackageNamespace_WithMultipleFeedsWithIdenticalPackages_UpdatesCorrectPackage(ProjectTemplate projectTemplate)
         {
             // Arrange
             EnsureVisualStudioHost();
@@ -464,14 +464,14 @@ namespace NuGet.Tests.Apex
             var opensourceRepositoryPath = Path.Combine(solutionDirectory, "OpensourceRepository");
             Directory.CreateDirectory(opensourceRepositoryPath);
 
-            await CommonUtility.CreateCustomPackageInSourceAsync(opensourceRepositoryPath, packageName, packageVersion1, "Thisisfromopensourcerepo1.txt");
-            await CommonUtility.CreateCustomPackageInSourceAsync(opensourceRepositoryPath, packageName, packageVersion2, "Thisisfromopensourcerepo2.txt");
+            await CommonUtility.CreateNetCorePackageInSourceAsync(opensourceRepositoryPath, packageName, packageVersion1, "Thisisfromopensourcerepo1.txt");
+            await CommonUtility.CreateNetCorePackageInSourceAsync(opensourceRepositoryPath, packageName, packageVersion2, "Thisisfromopensourcerepo2.txt");
 
             var privateRepositoryPath = Path.Combine(solutionDirectory, "PrivateRepository");
             Directory.CreateDirectory(privateRepositoryPath);
 
-            await CommonUtility.CreateCustomPackageInSourceAsync(privateRepositoryPath, packageName, packageVersion1, "Thisisfromprivaterepo1.txt");
-            await CommonUtility.CreateCustomPackageInSourceAsync(privateRepositoryPath, packageName, packageVersion2, "Thisisfromprivaterepo2.txt");
+            await CommonUtility.CreateNetCorePackageInSourceAsync(privateRepositoryPath, packageName, packageVersion1, "Thisisfromprivaterepo1.txt");
+            await CommonUtility.CreateNetCorePackageInSourceAsync(privateRepositoryPath, packageName, packageVersion2, "Thisisfromprivaterepo2.txt");
 
             //Create nuget.config with Package namespace filtering rules.
             CommonUtility.CreateConfigurationFile(Path.Combine(solutionDirectory, "NuGet.config"), $@"<?xml version=""1.0"" encoding=""utf-8""?>
@@ -503,10 +503,10 @@ namespace NuGet.Tests.Apex
                 nugetConsole.UpdatePackageFromPMC(packageName, packageVersion2);
 
                 // Assert
-                CommonUtility.AssertPackageInPackagesConfig(VisualStudio, testContext.Project, packageName, packageVersion1, XunitLogger);
+                CommonUtility.AssertPackageInPackagesConfig(VisualStudio, testContext.Project, packageName, packageVersion2, XunitLogger);
 
                 var packagesDirectory = Path.Combine(solutionDirectory, "packages");
-                var uniqueContentFile = Path.Combine(packagesDirectory, packageName + '.' + packageVersion1, "lib", "netstandard1.0", "Thisisfromprivaterepo2.txt");
+                var uniqueContentFile = Path.Combine(packagesDirectory, packageName + '.' + packageVersion2, "lib", "net5.0", "Thisisfromprivaterepo2.txt");
                 // Make sure name squatting package not restored from  opensource repository.
                 Assert.True(File.Exists(uniqueContentFile));
             }

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetConsoleTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetConsoleTestCase.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Threading.Tasks;
 using Microsoft.Test.Apex.VisualStudio.Solution;
 using NuGet.StaFact;
+using NuGet.Test.Utility;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -288,6 +289,164 @@ namespace NuGet.Tests.Apex
 
                 nugetConsole.Clear();
                 solutionService.Save();
+            }
+        }
+
+        [NuGetWpfTheory]
+        [MemberData(nameof(GetPackagesConfigTemplates))]
+        public async Task InstallPackageFromPMCForPC_PackageNamespace_WithSingleFeed(ProjectTemplate projectTemplate)
+        {
+            // Arrange
+            EnsureVisualStudioHost();
+
+            using var simpleTestPathContext = new SimpleTestPathContext();
+            string solutionDirectory = simpleTestPathContext.SolutionRoot;
+            var privateRepositoryPath = Path.Combine(solutionDirectory, "PrivateRepository");
+            Directory.CreateDirectory(privateRepositoryPath);
+
+            var packageName = "Contoso.A";
+            var packageVersion = "1.0.0";
+
+            await CommonUtility.CreatePackageInSourceAsync(privateRepositoryPath, packageName, packageVersion);
+
+            //Create nuget.config with Package namespace filtering rules.
+            CommonUtility.CreateConfigurationFile(Path.Combine(solutionDirectory, "NuGet.config"), $@"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+    <packageSources>
+    <!--To inherit the global NuGet package sources remove the <clear/> line below -->
+    <clear />
+    <add key=""PrivateRepository"" value=""{privateRepositoryPath}"" />
+    </packageSources>
+    <packageNamespaces>
+        <packageSource key=""PrivateRepository"">
+            <namespace id=""Contoso.*"" />             
+            <namespace id=""Test.*"" />
+        </packageSource>
+    </packageNamespaces>
+//</configuration>");
+
+            using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, XunitLogger, noAutoRestore: false, addNetStandardFeeds: false, simpleTestPathContext: simpleTestPathContext))
+            {
+                var nugetConsole = GetConsole(testContext.Project);
+
+                // Act
+                nugetConsole.InstallPackageFromPMC(packageName, packageVersion);
+
+                // Assert
+                CommonUtility.AssertPackageInPackagesConfig(VisualStudio, testContext.Project, packageName, packageVersion, XunitLogger);
+            }
+        }
+
+        [NuGetWpfTheory]
+        [MemberData(nameof(GetPackagesConfigTemplates))]
+        public async Task UpdatePackageFromPMCForPC_PackageNamespace_WithSingleFeed(ProjectTemplate projectTemplate)
+        {
+            // Arrange
+            EnsureVisualStudioHost();
+
+            using var simpleTestPathContext = new SimpleTestPathContext();
+            string solutionDirectory = simpleTestPathContext.SolutionRoot;
+            var privateRepositoryPath = Path.Combine(solutionDirectory, "PrivateRepository");
+            Directory.CreateDirectory(privateRepositoryPath);
+
+            var packageName = "Contoso.A";
+            var packageVersion1 = "1.0.0";
+            var packageVersion2 = "2.0.0";
+
+            await CommonUtility.CreatePackageInSourceAsync(privateRepositoryPath, packageName, packageVersion1);
+            await CommonUtility.CreatePackageInSourceAsync(privateRepositoryPath, packageName, packageVersion2);
+
+            //Create nuget.config with Package namespace filtering rules.
+            CommonUtility.CreateConfigurationFile(Path.Combine(solutionDirectory, "NuGet.config"), $@"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+    <packageSources>
+    <!--To inherit the global NuGet package sources remove the <clear/> line below -->
+    <clear />
+    <add key=""PrivateRepository"" value=""{privateRepositoryPath}"" />
+    </packageSources>
+    <packageNamespaces>
+        <packageSource key=""PrivateRepository"">
+            <namespace id=""Contoso.*"" />             
+            <namespace id=""Test.*"" />
+        </packageSource>
+    </packageNamespaces>
+//</configuration>");
+
+            using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, XunitLogger, noAutoRestore: false, addNetStandardFeeds: false, simpleTestPathContext: simpleTestPathContext))
+            {
+                var nugetConsole = GetConsole(testContext.Project);
+
+                // Act
+                nugetConsole.InstallPackageFromPMC(packageName, packageVersion1);
+                nugetConsole.UpdatePackageFromPMC(packageName, packageVersion2);
+
+                // Assert
+                CommonUtility.AssertPackageInPackagesConfig(VisualStudio, testContext.Project, packageName, packageVersion2, XunitLogger);
+            }
+        }
+
+        [NuGetWpfTheory]
+        [MemberData(nameof(GetPackagesConfigTemplates))]
+        public async Task InstallPackageFromPMCForPC_PackageNamespace_WithMultipleFeedsWithIdenticalPackages_InstallsCorrectPackage(ProjectTemplate projectTemplate)
+        {
+            // Arrange
+            EnsureVisualStudioHost();
+            Debugger.Launch();
+            using var simpleTestPathContext = new SimpleTestPathContext();
+            string solutionDirectory = simpleTestPathContext.SolutionRoot;
+            var packageName = "Contoso.A";
+            var packageVersion1 = "1.0.0";
+            var packageVersion2 = "2.0.0";
+
+            var opensourceRepositoryPath = Path.Combine(solutionDirectory, "OpensourceRepository");
+            Directory.CreateDirectory(opensourceRepositoryPath);
+
+            await CommonUtility.CreateCustomPackageInSourceAsync(opensourceRepositoryPath, packageName, packageVersion1, "Thisisfromopensourcerepo1.txt");
+            await CommonUtility.CreateCustomPackageInSourceAsync(opensourceRepositoryPath, packageName, packageVersion2, "Thisisfromopensourcerepo2.txt");
+
+            var privateRepositoryPath = Path.Combine(solutionDirectory, "PrivateRepository");
+            Directory.CreateDirectory(privateRepositoryPath);
+
+            await CommonUtility.CreateCustomPackageInSourceAsync(privateRepositoryPath, packageName, packageVersion1, "Thisisfromprivaterepo1.txt");
+            await CommonUtility.CreateCustomPackageInSourceAsync(privateRepositoryPath, packageName, packageVersion2, "Thisisfromprivaterepo2.txt");
+
+            //Create nuget.config with Package namespace filtering rules.
+            CommonUtility.CreateConfigurationFile(Path.Combine(solutionDirectory, "NuGet.config"), $@"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+    <packageSources>
+    <!--To inherit the global NuGet package sources remove the <clear/> line below -->
+    <clear />
+    <add key=""ExternalRepository"" value=""{opensourceRepositoryPath}"" />
+    <add key=""PrivateRepository"" value=""{privateRepositoryPath}"" />
+    </packageSources>
+    <packageNamespaces>
+        <packageSource key=""externalRepository"">
+            <namespace id=""External.*"" />
+            <namespace id=""Others.*"" />
+        </packageSource>
+        <packageSource key=""PrivateRepository"">
+            <namespace id=""Contoso.*"" />             
+            <namespace id=""Test.*"" />
+        </packageSource>
+    </packageNamespaces>
+//</configuration>");
+
+            using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, XunitLogger, noAutoRestore: false, addNetStandardFeeds: false, simpleTestPathContext: simpleTestPathContext))
+            {
+                var nugetConsole = GetConsole(testContext.Project);
+
+                // Act
+                nugetConsole.InstallPackageFromPMC(packageName, packageVersion1);
+
+                // Assert
+                // Make sure name squatting package not restored from  opensource repository.
+                CommonUtility.AssertPackageNotInPackagesConfig(VisualStudio, testContext.Project, packageName, packageVersion1, XunitLogger);
+                //$packagesFolder = Join - Path $solutionDirectory "packages"
+                //$contosoNupkgFolder = Join - Path $packagesFolder "Contoso.MVC.ASP.2.0.0"
+                //Assert - PathExists(Join - Path $contosoNupkgFolder "Contoso.MVC.ASP.2.0.0.nupkg")
+                //# Make sure name squatting package from public repo not restored.
+                //$contentFolder = Join - Path $contosoNupkgFolder "content"
+                //Assert - PathExists(Join - Path $contentFolder "Thisisfromprivaterepo2.txt")
             }
         }
 

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetUITestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetUITestCase.cs
@@ -318,7 +318,6 @@ namespace NuGet.Tests.Apex
         public async Task UpdatePackageFromUI_PackageNamespace_WithSingleFeed_Succeeds()
         {
             // Arrange
-            // Arrange
             EnsureVisualStudioHost();
             var solutionService = VisualStudio.Get<SolutionService>();
             string solutionDirectory = CommonUtility.CreateSolutionDirectory(Directory.GetCurrentDirectory());

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Utility/CommonUtility.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Utility/CommonUtility.cs
@@ -78,6 +78,11 @@ namespace NuGet.Tests.Apex
             var authorSignedPackage = AuthorSignPackage(package, authorCertificate, timestampProviderUrl);
             return RepositoryCountersignPackage(authorSignedPackage, repoCertificate, v3ServiceIndexUrl, packageOwners, timestampProviderUrl);
         }
+        public static async Task CreateCustomPackageInSourceAsync(string packageSource, string packageName, string packageVersion, string requestAdditionalContent)
+        {
+            var package = CreateCustomPackage(packageName, packageVersion, requestAdditionalContent);
+            await SimpleTestPackageUtility.CreatePackagesAsync(packageSource, package);
+        }
 
         public static SimpleTestPackageContext AuthorSignPackage(
             SimpleTestPackageContext package,
@@ -145,6 +150,17 @@ namespace NuGet.Tests.Apex
             package.Files.Clear();
             package.AddFile("lib/net45/_._");
             package.AddFile("lib/netstandard1.0/_._");
+
+            return package;
+        }
+
+        public static SimpleTestPackageContext CreateCustomPackage(string packageName, string packageVersion, string requestAdditionalContent)
+        {
+            var package = new SimpleTestPackageContext(packageName, packageVersion);
+            package.Files.Clear();
+            package.AddFile("lib/net45/_._");
+            package.AddFile("lib/netstandard1.0/_._");
+            package.AddFile("lib/netstandard1.0/" + requestAdditionalContent);
 
             return package;
         }

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Utility/CommonUtility.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Utility/CommonUtility.cs
@@ -78,9 +78,10 @@ namespace NuGet.Tests.Apex
             var authorSignedPackage = AuthorSignPackage(package, authorCertificate, timestampProviderUrl);
             return RepositoryCountersignPackage(authorSignedPackage, repoCertificate, v3ServiceIndexUrl, packageOwners, timestampProviderUrl);
         }
-        public static async Task CreateCustomPackageInSourceAsync(string packageSource, string packageName, string packageVersion, string requestAdditionalContent)
+
+        public static async Task CreateNetCorePackageInSourceAsync(string packageSource, string packageName, string packageVersion, string requestAdditionalContent = null)
         {
-            var package = CreateCustomPackage(packageName, packageVersion, requestAdditionalContent);
+            var package = CreateNetCorePackage(packageName, packageVersion, requestAdditionalContent);
             await SimpleTestPackageUtility.CreatePackagesAsync(packageSource, package);
         }
 
@@ -154,13 +155,16 @@ namespace NuGet.Tests.Apex
             return package;
         }
 
-        public static SimpleTestPackageContext CreateCustomPackage(string packageName, string packageVersion, string requestAdditionalContent)
+        public static SimpleTestPackageContext CreateNetCorePackage(string packageName, string packageVersion, string requestAdditionalContent)
         {
             var package = new SimpleTestPackageContext(packageName, packageVersion);
             package.Files.Clear();
-            package.AddFile("lib/net45/_._");
-            package.AddFile("lib/netstandard1.0/_._");
-            package.AddFile("lib/netstandard1.0/" + requestAdditionalContent);
+            package.AddFile("lib/net5.0/_._");
+
+            if(!string.IsNullOrWhiteSpace(requestAdditionalContent))
+            {
+                package.AddFile("lib/net5.0/" + requestAdditionalContent);
+            }
 
             return package;
         }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11001

Regression? Last working version: N/A

## Description
This change ensuring that the namespaces are respected during package installation in PMC. If there is same package Id exist in 2 repositories then it only request it from one it specified in namespace filter, previously we try to fetch from all possible repositories and install one from fastest which may not be what user really wanted.

This PR is continuation of https://github.com/NuGet/NuGet.Client/pull/4140.

Please note: init.ps1 is might not respect package namespace filtering, because technically any powershell command could be inside it and it can do pretty much anything including direct downloading assets from web.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
