### PR TITLE
Ensure the namespaces filtering is respected in packages.config package installation/updates in IVs installer API

### DIFF
--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/IVsServicesTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/IVsServicesTestCase.cs
@@ -148,8 +148,8 @@ namespace NuGet.Tests.Apex
             var packageVersionV1 = "1.0.0";
             var packageVersionV2 = "2.0.0";
 
-            await CommonUtility.CreateNetCorePackageInSourceAsync(privateRepositoryPath, packageName, packageVersionV1, "Thisisfromprivaterepo1.txt");
-            await CommonUtility.CreateNetCorePackageInSourceAsync(privateRepositoryPath, packageName, packageVersionV2, "Thisisfromprivaterepo2.txt");
+            await CommonUtility.CreateNetFrameworkPackageInSourceAsync(privateRepositoryPath, packageName, packageVersionV1, "Thisisfromprivaterepo1.txt");
+            await CommonUtility.CreateNetFrameworkPackageInSourceAsync(privateRepositoryPath, packageName, packageVersionV2, "Thisisfromprivaterepo2.txt");
 
             // Create nuget.config with Package namespace filtering rules before project is created.
             CommonUtility.CreateConfigurationFile(Path.Combine(mainDirectory, "NuGet.config"), $@"<?xml version=""1.0"" encoding=""utf-8""?>
@@ -180,7 +180,7 @@ namespace NuGet.Tests.Apex
             CommonUtility.AssertPackageInPackagesConfig(VisualStudio, projExt, packageName, XunitLogger);
 
             var packagesDirectory = Path.Combine(solutionDirectory, "packages");
-            var uniqueContentFile = Path.Combine(packagesDirectory, packageName + '.' + packageVersionV2, "lib", "net5.0", "Thisisfromprivaterepo2.txt");
+            var uniqueContentFile = Path.Combine(packagesDirectory, packageName + '.' + packageVersionV2, "lib", "net45", "Thisisfromprivaterepo2.txt");
             // Make sure version 2 is restored.
             Assert.True(File.Exists(uniqueContentFile));
         }
@@ -203,14 +203,14 @@ namespace NuGet.Tests.Apex
             var opensourceRepositoryPath = Path.Combine(mainDirectory, "OpensourceRepository");
             Directory.CreateDirectory(opensourceRepositoryPath);
 
-            await CommonUtility.CreateNetCorePackageInSourceAsync(opensourceRepositoryPath, packageName, packageVersionV1, "Thisisfromopensourcerepo1.txt");
-            await CommonUtility.CreateNetCorePackageInSourceAsync(opensourceRepositoryPath, packageName, packageVersionV2, "Thisisfromopensourcerepo2.txt");
+            await CommonUtility.CreateNetFrameworkPackageInSourceAsync(opensourceRepositoryPath, packageName, packageVersionV1, "Thisisfromopensourcerepo1.txt");
+            await CommonUtility.CreateNetFrameworkPackageInSourceAsync(opensourceRepositoryPath, packageName, packageVersionV2, "Thisisfromopensourcerepo2.txt");
 
             var privateRepositoryPath = Path.Combine(mainDirectory, "PrivateRepository");
             Directory.CreateDirectory(privateRepositoryPath);
 
-            await CommonUtility.CreateNetCorePackageInSourceAsync(privateRepositoryPath, packageName, packageVersionV1, "Thisisfromprivaterepo1.txt");
-            await CommonUtility.CreateNetCorePackageInSourceAsync(privateRepositoryPath, packageName, packageVersionV2, "Thisisfromprivaterepo2.txt");
+            await CommonUtility.CreateNetFrameworkPackageInSourceAsync(privateRepositoryPath, packageName, packageVersionV1, "Thisisfromprivaterepo1.txt");
+            await CommonUtility.CreateNetFrameworkPackageInSourceAsync(privateRepositoryPath, packageName, packageVersionV2, "Thisisfromprivaterepo2.txt");
 
             // Create nuget.config with Package namespace filtering rules before project is created.
             CommonUtility.CreateConfigurationFile(Path.Combine(mainDirectory, "NuGet.config"), $@"<?xml version=""1.0"" encoding=""utf-8""?>
@@ -245,7 +245,7 @@ namespace NuGet.Tests.Apex
             CommonUtility.AssertPackageInPackagesConfig(VisualStudio, projExt, packageName, XunitLogger);
 
             var packagesDirectory = Path.Combine(solutionDirectory, "packages");
-            var uniqueContentFile = Path.Combine(packagesDirectory, packageName + '.' + packageVersionV1, "lib", "net5.0", "Thisisfromprivaterepo1.txt");
+            var uniqueContentFile = Path.Combine(packagesDirectory, packageName + '.' + packageVersionV1, "lib", "net45", "Thisisfromprivaterepo1.txt");
             // Make sure name squatting package not restored from  opensource repository.
             Assert.True(File.Exists(uniqueContentFile));
         }
@@ -268,14 +268,14 @@ namespace NuGet.Tests.Apex
             var opensourceRepositoryPath = Path.Combine(mainDirectory, "OpensourceRepository");
             Directory.CreateDirectory(opensourceRepositoryPath);
 
-            await CommonUtility.CreateNetCorePackageInSourceAsync(opensourceRepositoryPath, packageName, packageVersionV1, "Thisisfromopensourcerepo1.txt");
-            await CommonUtility.CreateNetCorePackageInSourceAsync(opensourceRepositoryPath, packageName, packageVersionV2, "Thisisfromopensourcerepo2.txt");
+            await CommonUtility.CreateNetFrameworkPackageInSourceAsync(opensourceRepositoryPath, packageName, packageVersionV1, "Thisisfromopensourcerepo1.txt");
+            await CommonUtility.CreateNetFrameworkPackageInSourceAsync(opensourceRepositoryPath, packageName, packageVersionV2, "Thisisfromopensourcerepo2.txt");
 
             var privateRepositoryPath = Path.Combine(mainDirectory, "PrivateRepository");
             Directory.CreateDirectory(privateRepositoryPath);
 
-            await CommonUtility.CreateNetCorePackageInSourceAsync(privateRepositoryPath, packageName, packageVersionV1, "Thisisfromprivaterepo1.txt");
-            await CommonUtility.CreateNetCorePackageInSourceAsync(privateRepositoryPath, packageName, packageVersionV2, "Thisisfromprivaterepo2.txt");
+            await CommonUtility.CreateNetFrameworkPackageInSourceAsync(privateRepositoryPath, packageName, packageVersionV1, "Thisisfromprivaterepo1.txt");
+            await CommonUtility.CreateNetFrameworkPackageInSourceAsync(privateRepositoryPath, packageName, packageVersionV2, "Thisisfromprivaterepo2.txt");
 
             // Create nuget.config with Package namespace filtering rules before project is created.
             CommonUtility.CreateConfigurationFile(Path.Combine(mainDirectory, "NuGet.config"), $@"<?xml version=""1.0"" encoding=""utf-8""?>
@@ -310,7 +310,7 @@ namespace NuGet.Tests.Apex
             CommonUtility.AssertPackageInPackagesConfig(VisualStudio, projExt, packageName, XunitLogger);
 
             var packagesDirectory = Path.Combine(solutionDirectory, "packages");
-            var uniqueContentFile = Path.Combine(packagesDirectory, packageName + '.' + packageVersionV2, "lib", "net5.0", "Thisisfromprivaterepo2.txt");
+            var uniqueContentFile = Path.Combine(packagesDirectory, packageName + '.' + packageVersionV2, "lib", "net45", "Thisisfromprivaterepo2.txt");
             // Make sure name squatting package not restored from  opensource repository.
             Assert.True(File.Exists(uniqueContentFile));
         }

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/IVsServicesTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/IVsServicesTestCase.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.IO;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.Test.Apex.VisualStudio.Solution;
 using Microsoft.VisualStudio.OLE.Interop;
@@ -79,6 +81,238 @@ namespace NuGet.Tests.Apex
                 // The global packages folder should not be the one configured by the test context!
                 userPackagesFolder.Should().NotBe(testContext.UserPackagesFolder);
             }
+        }
+
+        [StaFact]
+        public async Task SimpleInstallFromIVsInstaller_PackageNamespace_WithSingleFeed()
+        {
+            // Arrange
+            EnsureVisualStudioHost();
+            var dte = VisualStudio.Dte;
+            string mainDirectory = CommonUtility.CreateSolutionDirectory(Directory.GetCurrentDirectory());
+            string solutionDirectory = Path.Combine(mainDirectory, "Solution");
+            var solutionService = VisualStudio.Get<SolutionService>();
+            var nugetTestService = GetNuGetTestService();
+
+            var privateRepositoryPath = Path.Combine(mainDirectory, "PrivateRepository");
+            Directory.CreateDirectory(privateRepositoryPath);
+
+            var packageName = "Contoso.A";
+            var packageVersion = "1.0.0";
+
+            await CommonUtility.CreatePackageInSourceAsync(privateRepositoryPath, packageName, packageVersion);
+
+            // Create nuget.config with Package namespace filtering rules before project is created.
+            CommonUtility.CreateConfigurationFile(Path.Combine(mainDirectory, "NuGet.config"), $@"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+    <packageSources>
+    <!--To inherit the global NuGet package sources remove the <clear/> line below -->
+    <clear />
+    <add key=""PrivateRepository"" value=""{privateRepositoryPath}"" />
+    </packageSources>
+    <packageNamespaces>
+        <packageSource key=""PrivateRepository"">
+            <namespace id=""Contoso.*"" />             
+            <namespace id=""Test.*"" />
+        </packageSource>
+    </packageNamespaces>
+</configuration>");
+
+            solutionService.CreateEmptySolution("TestSolution", solutionDirectory);
+            var projExt = solutionService.AddProject(ProjectLanguage.CSharp, ProjectTemplate.ClassLibrary, ProjectTargetFramework.V46, "TestProject");
+            solutionService.SaveAll();
+            var project = dte.Solution.Projects.Item(1);
+
+            // Act
+            nugetTestService.InstallPackage(project.UniqueName, "contoso.a");
+
+            // Assert
+            CommonUtility.AssertPackageInPackagesConfig(VisualStudio, projExt, packageName, XunitLogger);
+        }
+
+        [StaFact]
+        public async Task SimpleUpdateFromIVsInstaller_PackageNamespace_WithSingleFeed()
+        {
+            // Arrange
+            EnsureVisualStudioHost();
+            var dte = VisualStudio.Dte;
+            string mainDirectory = CommonUtility.CreateSolutionDirectory(Directory.GetCurrentDirectory());
+            string solutionDirectory = Path.Combine(mainDirectory, "Solution");
+            var solutionService = VisualStudio.Get<SolutionService>();
+            var nugetTestService = GetNuGetTestService();
+
+            var privateRepositoryPath = Path.Combine(mainDirectory, "PrivateRepository");
+            Directory.CreateDirectory(privateRepositoryPath);
+
+            var packageName = "Contoso.A";
+            var packageVersionV1 = "1.0.0";
+            var packageVersionV2 = "2.0.0";
+
+            await CommonUtility.CreateNetCorePackageInSourceAsync(privateRepositoryPath, packageName, packageVersionV1, "Thisisfromprivaterepo1.txt");
+            await CommonUtility.CreateNetCorePackageInSourceAsync(privateRepositoryPath, packageName, packageVersionV2, "Thisisfromprivaterepo2.txt");
+
+            // Create nuget.config with Package namespace filtering rules before project is created.
+            CommonUtility.CreateConfigurationFile(Path.Combine(mainDirectory, "NuGet.config"), $@"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+    <packageSources>
+    <!--To inherit the global NuGet package sources remove the <clear/> line below -->
+    <clear />
+    <add key=""PrivateRepository"" value=""{privateRepositoryPath}"" />
+    </packageSources>
+    <packageNamespaces>
+        <packageSource key=""PrivateRepository"">
+            <namespace id=""Contoso.*"" />             
+            <namespace id=""Test.*"" />
+        </packageSource>
+    </packageNamespaces>
+</configuration>");
+
+            solutionService.CreateEmptySolution("TestSolution", solutionDirectory);
+            var projExt = solutionService.AddProject(ProjectLanguage.CSharp, ProjectTemplate.ClassLibrary, ProjectTargetFramework.V46, "TestProject");
+            solutionService.SaveAll();
+            var project = dte.Solution.Projects.Item(1);
+
+            // Act
+            nugetTestService.InstallPackage(project.UniqueName, "contoso.a", "1.0.0");
+            nugetTestService.InstallPackage(project.UniqueName, "contoso.a", "2.0.0");
+
+            // Assert
+            CommonUtility.AssertPackageInPackagesConfig(VisualStudio, projExt, packageName, XunitLogger);
+
+            var packagesDirectory = Path.Combine(solutionDirectory, "packages");
+            var uniqueContentFile = Path.Combine(packagesDirectory, packageName + '.' + packageVersionV2, "lib", "net5.0", "Thisisfromprivaterepo2.txt");
+            // Make sure version 2 is restored.
+            Assert.True(File.Exists(uniqueContentFile));
+        }
+
+        [StaFact]
+        public async Task SimpleInstallFromIVsInstaller_PackageNamespace_WithMultipleFeedsWithIdenticalPackages_InstallsCorrectPackage()
+        {
+            // Arrange
+            EnsureVisualStudioHost();
+            var dte = VisualStudio.Dte;
+            string mainDirectory = CommonUtility.CreateSolutionDirectory(Directory.GetCurrentDirectory());
+            string solutionDirectory = Path.Combine(mainDirectory, "Solution");
+            var solutionService = VisualStudio.Get<SolutionService>();
+            var nugetTestService = GetNuGetTestService();
+
+            var packageName = "Contoso.A";
+            var packageVersionV1 = "1.0.0";
+            var packageVersionV2 = "2.0.0";
+
+            var opensourceRepositoryPath = Path.Combine(mainDirectory, "OpensourceRepository");
+            Directory.CreateDirectory(opensourceRepositoryPath);
+
+            await CommonUtility.CreateNetCorePackageInSourceAsync(opensourceRepositoryPath, packageName, packageVersionV1, "Thisisfromopensourcerepo1.txt");
+            await CommonUtility.CreateNetCorePackageInSourceAsync(opensourceRepositoryPath, packageName, packageVersionV2, "Thisisfromopensourcerepo2.txt");
+
+            var privateRepositoryPath = Path.Combine(mainDirectory, "PrivateRepository");
+            Directory.CreateDirectory(privateRepositoryPath);
+
+            await CommonUtility.CreateNetCorePackageInSourceAsync(privateRepositoryPath, packageName, packageVersionV1, "Thisisfromprivaterepo1.txt");
+            await CommonUtility.CreateNetCorePackageInSourceAsync(privateRepositoryPath, packageName, packageVersionV2, "Thisisfromprivaterepo2.txt");
+
+            // Create nuget.config with Package namespace filtering rules before project is created.
+            CommonUtility.CreateConfigurationFile(Path.Combine(mainDirectory, "NuGet.config"), $@"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+    <packageSources>
+    <!--To inherit the global NuGet package sources remove the <clear/> line below -->
+    <clear />
+    <add key=""ExternalRepository"" value=""{opensourceRepositoryPath}"" />
+    <add key=""PrivateRepository"" value=""{privateRepositoryPath}"" />
+    </packageSources>
+    <packageNamespaces>
+        <packageSource key=""externalRepository"">
+            <namespace id=""External.*"" />
+            <namespace id=""Others.*"" />
+        </packageSource>
+        <packageSource key=""PrivateRepository"">
+            <namespace id=""Contoso.*"" />             
+            <namespace id=""Test.*"" />
+        </packageSource>
+    </packageNamespaces>
+</configuration>");
+
+            solutionService.CreateEmptySolution("TestSolution", solutionDirectory);
+            var projExt = solutionService.AddProject(ProjectLanguage.CSharp, ProjectTemplate.ClassLibrary, ProjectTargetFramework.V46, "TestProject");
+            solutionService.SaveAll();
+            var project = dte.Solution.Projects.Item(1);
+
+            // Act
+            nugetTestService.InstallPackage(project.UniqueName, "contoso.a", "1.0.0");
+
+            // Assert
+            CommonUtility.AssertPackageInPackagesConfig(VisualStudio, projExt, packageName, XunitLogger);
+
+            var packagesDirectory = Path.Combine(solutionDirectory, "packages");
+            var uniqueContentFile = Path.Combine(packagesDirectory, packageName + '.' + packageVersionV1, "lib", "net5.0", "Thisisfromprivaterepo1.txt");
+            // Make sure name squatting package not restored from  opensource repository.
+            Assert.True(File.Exists(uniqueContentFile));
+        }
+
+        [StaFact]
+        public async Task SimpleUpdateFromIVsInstaller_PackageNamespace_WithMultipleFeedsWithIdenticalPackages_UpdatesCorrectPackage()
+        {
+            // Arrange
+            EnsureVisualStudioHost();
+            var dte = VisualStudio.Dte;
+            string mainDirectory = CommonUtility.CreateSolutionDirectory(Directory.GetCurrentDirectory());
+            string solutionDirectory = Path.Combine(mainDirectory, "Solution");
+            var solutionService = VisualStudio.Get<SolutionService>();
+            var nugetTestService = GetNuGetTestService();
+
+            var packageName = "Contoso.A";
+            var packageVersionV1 = "1.0.0";
+            var packageVersionV2 = "2.0.0";
+
+            var opensourceRepositoryPath = Path.Combine(mainDirectory, "OpensourceRepository");
+            Directory.CreateDirectory(opensourceRepositoryPath);
+
+            await CommonUtility.CreateNetCorePackageInSourceAsync(opensourceRepositoryPath, packageName, packageVersionV1, "Thisisfromopensourcerepo1.txt");
+            await CommonUtility.CreateNetCorePackageInSourceAsync(opensourceRepositoryPath, packageName, packageVersionV2, "Thisisfromopensourcerepo2.txt");
+
+            var privateRepositoryPath = Path.Combine(mainDirectory, "PrivateRepository");
+            Directory.CreateDirectory(privateRepositoryPath);
+
+            await CommonUtility.CreateNetCorePackageInSourceAsync(privateRepositoryPath, packageName, packageVersionV1, "Thisisfromprivaterepo1.txt");
+            await CommonUtility.CreateNetCorePackageInSourceAsync(privateRepositoryPath, packageName, packageVersionV2, "Thisisfromprivaterepo2.txt");
+
+            // Create nuget.config with Package namespace filtering rules before project is created.
+            CommonUtility.CreateConfigurationFile(Path.Combine(mainDirectory, "NuGet.config"), $@"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+    <packageSources>
+    <!--To inherit the global NuGet package sources remove the <clear/> line below -->
+    <clear />
+    <add key=""ExternalRepository"" value=""{opensourceRepositoryPath}"" />
+    <add key=""PrivateRepository"" value=""{privateRepositoryPath}"" />
+    </packageSources>
+    <packageNamespaces>
+        <packageSource key=""externalRepository"">
+            <namespace id=""External.*"" />
+            <namespace id=""Others.*"" />
+        </packageSource>
+        <packageSource key=""PrivateRepository"">
+            <namespace id=""Contoso.*"" />             
+            <namespace id=""Test.*"" />
+        </packageSource>
+    </packageNamespaces>
+</configuration>");
+
+            solutionService.CreateEmptySolution("TestSolution", solutionDirectory);
+            var projExt = solutionService.AddProject(ProjectLanguage.CSharp, ProjectTemplate.ClassLibrary, ProjectTargetFramework.V46, "TestProject");
+            solutionService.SaveAll();
+            var project = dte.Solution.Projects.Item(1);
+
+            // Act
+            nugetTestService.InstallPackage(project.UniqueName, "contoso.a", "1.0.0");
+            nugetTestService.InstallPackage(project.UniqueName, "contoso.a", "2.0.0");
+            // Assert
+            CommonUtility.AssertPackageInPackagesConfig(VisualStudio, projExt, packageName, XunitLogger);
+
+            var packagesDirectory = Path.Combine(solutionDirectory, "packages");
+            var uniqueContentFile = Path.Combine(packagesDirectory, packageName + '.' + packageVersionV2, "lib", "net5.0", "Thisisfromprivaterepo2.txt");
+            // Make sure name squatting package not restored from  opensource repository.
+            Assert.True(File.Exists(uniqueContentFile));
         }
     }
 }

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetConsoleTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetConsoleTestCase.cs
@@ -323,7 +323,7 @@ namespace NuGet.Tests.Apex
             <namespace id=""Test.*"" />
         </packageSource>
     </packageNamespaces>
-//</configuration>");
+</configuration>");
 
             using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, XunitLogger, noAutoRestore: false, addNetStandardFeeds: false, simpleTestPathContext: simpleTestPathContext))
             {
@@ -370,7 +370,7 @@ namespace NuGet.Tests.Apex
             <namespace id=""Test.*"" />
         </packageSource>
     </packageNamespaces>
-//</configuration>");
+</configuration>");
 
             using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, XunitLogger, noAutoRestore: false, addNetStandardFeeds: false, simpleTestPathContext: simpleTestPathContext))
             {
@@ -429,7 +429,7 @@ namespace NuGet.Tests.Apex
             <namespace id=""Test.*"" />
         </packageSource>
     </packageNamespaces>
-//</configuration>");
+</configuration>");
 
             using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, XunitLogger, noAutoRestore: false, addNetStandardFeeds: false, simpleTestPathContext: simpleTestPathContext))
             {
@@ -492,7 +492,7 @@ namespace NuGet.Tests.Apex
             <namespace id=""Test.*"" />
         </packageSource>
     </packageNamespaces>
-//</configuration>");
+</configuration>");
 
             using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, XunitLogger, noAutoRestore: false, addNetStandardFeeds: false, simpleTestPathContext: simpleTestPathContext))
             {

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetConsoleTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetConsoleTestCase.cs
@@ -401,14 +401,14 @@ namespace NuGet.Tests.Apex
             var opensourceRepositoryPath = Path.Combine(solutionDirectory, "OpensourceRepository");
             Directory.CreateDirectory(opensourceRepositoryPath);
 
-            await CommonUtility.CreateNetCorePackageInSourceAsync(opensourceRepositoryPath, packageName, packageVersion1, "Thisisfromopensourcerepo1.txt");
-            await CommonUtility.CreateNetCorePackageInSourceAsync(opensourceRepositoryPath, packageName, packageVersion2, "Thisisfromopensourcerepo2.txt");
+            await CommonUtility.CreateNetFrameworkPackageInSourceAsync(opensourceRepositoryPath, packageName, packageVersion1, "Thisisfromopensourcerepo1.txt");
+            await CommonUtility.CreateNetFrameworkPackageInSourceAsync(opensourceRepositoryPath, packageName, packageVersion2, "Thisisfromopensourcerepo2.txt");
 
             var privateRepositoryPath = Path.Combine(solutionDirectory, "PrivateRepository");
             Directory.CreateDirectory(privateRepositoryPath);
 
-            await CommonUtility.CreateNetCorePackageInSourceAsync(privateRepositoryPath, packageName, packageVersion1, "Thisisfromprivaterepo1.txt");
-            await CommonUtility.CreateNetCorePackageInSourceAsync(privateRepositoryPath, packageName, packageVersion2, "Thisisfromprivaterepo2.txt");
+            await CommonUtility.CreateNetFrameworkPackageInSourceAsync(privateRepositoryPath, packageName, packageVersion1, "Thisisfromprivaterepo1.txt");
+            await CommonUtility.CreateNetFrameworkPackageInSourceAsync(privateRepositoryPath, packageName, packageVersion2, "Thisisfromprivaterepo2.txt");
 
             //Create nuget.config with Package namespace filtering rules.
             CommonUtility.CreateConfigurationFile(Path.Combine(solutionDirectory, "NuGet.config"), $@"<?xml version=""1.0"" encoding=""utf-8""?>
@@ -442,7 +442,7 @@ namespace NuGet.Tests.Apex
                 CommonUtility.AssertPackageInPackagesConfig(VisualStudio, testContext.Project, packageName, packageVersion1, XunitLogger);
 
                 var packagesDirectory = Path.Combine(solutionDirectory, "packages");
-                var uniqueContentFile = Path.Combine(packagesDirectory, packageName + '.' + packageVersion1, "lib", "net5.0", "Thisisfromprivaterepo1.txt");
+                var uniqueContentFile = Path.Combine(packagesDirectory, packageName + '.' + packageVersion1, "lib", "net45", "Thisisfromprivaterepo1.txt");
                 // Make sure name squatting package not restored from  opensource repository.
                 Assert.True(File.Exists(uniqueContentFile));
             }
@@ -464,14 +464,14 @@ namespace NuGet.Tests.Apex
             var opensourceRepositoryPath = Path.Combine(solutionDirectory, "OpensourceRepository");
             Directory.CreateDirectory(opensourceRepositoryPath);
 
-            await CommonUtility.CreateNetCorePackageInSourceAsync(opensourceRepositoryPath, packageName, packageVersion1, "Thisisfromopensourcerepo1.txt");
-            await CommonUtility.CreateNetCorePackageInSourceAsync(opensourceRepositoryPath, packageName, packageVersion2, "Thisisfromopensourcerepo2.txt");
+            await CommonUtility.CreateNetFrameworkPackageInSourceAsync(opensourceRepositoryPath, packageName, packageVersion1, "Thisisfromopensourcerepo1.txt");
+            await CommonUtility.CreateNetFrameworkPackageInSourceAsync(opensourceRepositoryPath, packageName, packageVersion2, "Thisisfromopensourcerepo2.txt");
 
             var privateRepositoryPath = Path.Combine(solutionDirectory, "PrivateRepository");
             Directory.CreateDirectory(privateRepositoryPath);
 
-            await CommonUtility.CreateNetCorePackageInSourceAsync(privateRepositoryPath, packageName, packageVersion1, "Thisisfromprivaterepo1.txt");
-            await CommonUtility.CreateNetCorePackageInSourceAsync(privateRepositoryPath, packageName, packageVersion2, "Thisisfromprivaterepo2.txt");
+            await CommonUtility.CreateNetFrameworkPackageInSourceAsync(privateRepositoryPath, packageName, packageVersion1, "Thisisfromprivaterepo1.txt");
+            await CommonUtility.CreateNetFrameworkPackageInSourceAsync(privateRepositoryPath, packageName, packageVersion2, "Thisisfromprivaterepo2.txt");
 
             //Create nuget.config with Package namespace filtering rules.
             CommonUtility.CreateConfigurationFile(Path.Combine(solutionDirectory, "NuGet.config"), $@"<?xml version=""1.0"" encoding=""utf-8""?>
@@ -506,7 +506,7 @@ namespace NuGet.Tests.Apex
                 CommonUtility.AssertPackageInPackagesConfig(VisualStudio, testContext.Project, packageName, packageVersion2, XunitLogger);
 
                 var packagesDirectory = Path.Combine(solutionDirectory, "packages");
-                var uniqueContentFile = Path.Combine(packagesDirectory, packageName + '.' + packageVersion2, "lib", "net5.0", "Thisisfromprivaterepo2.txt");
+                var uniqueContentFile = Path.Combine(packagesDirectory, packageName + '.' + packageVersion2, "lib", "net45", "Thisisfromprivaterepo2.txt");
                 // Make sure name squatting package not restored from  opensource repository.
                 Assert.True(File.Exists(uniqueContentFile));
             }

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetUITestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetUITestCase.cs
@@ -189,7 +189,7 @@ namespace NuGet.Tests.Apex
             <namespace id=""Test.*"" />
         </packageSource>
     </packageNamespaces>
-//</configuration>");
+</configuration>");
 
             var project = solutionService.AddProject(ProjectLanguage.CSharp, ProjectTemplate.ClassLibrary, ProjectTargetFramework.V46, "TestProject");
             VisualStudio.ClearOutputWindow();
@@ -236,7 +236,7 @@ namespace NuGet.Tests.Apex
             <namespace id=""Test.*"" />
         </packageSource>
     </packageNamespaces>
-//</configuration>");
+</configuration>");
 
             var project = solutionService.AddProject(ProjectLanguage.CSharp, ProjectTemplate.ClassLibrary, ProjectTargetFramework.V46, "TestProject");
             var nuProject = solutionService.AddProject(ProjectLanguage.CSharp, ProjectTemplate.ClassLibrary, ProjectTargetFramework.V46, "NuProject");
@@ -297,7 +297,7 @@ namespace NuGet.Tests.Apex
             <namespace id=""Test.*"" />
         </packageSource>
     </packageNamespaces>
-//</configuration>");
+</configuration>");
 
             var project = solutionService.AddProject(ProjectLanguage.CSharp, ProjectTemplate.ClassLibrary, ProjectTargetFramework.V46, "TestProject");
             VisualStudio.ClearOutputWindow();
@@ -347,7 +347,7 @@ namespace NuGet.Tests.Apex
             <namespace id=""Test.*"" />
         </packageSource>
     </packageNamespaces>
-//</configuration>");
+</configuration>");
 
             var project = solutionService.AddProject(ProjectLanguage.CSharp, ProjectTemplate.ClassLibrary, ProjectTargetFramework.V46, "TestProject");
             VisualStudio.ClearOutputWindow();

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Utility/CommonUtility.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Utility/CommonUtility.cs
@@ -79,9 +79,9 @@ namespace NuGet.Tests.Apex
             return RepositoryCountersignPackage(authorSignedPackage, repoCertificate, v3ServiceIndexUrl, packageOwners, timestampProviderUrl);
         }
 
-        public static async Task CreateNetCorePackageInSourceAsync(string packageSource, string packageName, string packageVersion, string requestAdditionalContent = null)
+        public static async Task CreateNetFrameworkPackageInSourceAsync(string packageSource, string packageName, string packageVersion, string requestAdditionalContent = null)
         {
-            var package = CreateNetCorePackage(packageName, packageVersion, requestAdditionalContent);
+            var package = CreatePackage(packageName, packageVersion, requestAdditionalContent);
             await SimpleTestPackageUtility.CreatePackagesAsync(packageSource, package);
         }
 
@@ -145,25 +145,16 @@ namespace NuGet.Tests.Apex
             return package;
         }
 
-        public static SimpleTestPackageContext CreatePackage(string packageName, string packageVersion)
+        public static SimpleTestPackageContext CreatePackage(string packageName, string packageVersion, string requestAdditionalContent = null)
         {
             var package = new SimpleTestPackageContext(packageName, packageVersion);
             package.Files.Clear();
             package.AddFile("lib/net45/_._");
             package.AddFile("lib/netstandard1.0/_._");
 
-            return package;
-        }
-
-        public static SimpleTestPackageContext CreateNetCorePackage(string packageName, string packageVersion, string requestAdditionalContent)
-        {
-            var package = new SimpleTestPackageContext(packageName, packageVersion);
-            package.Files.Clear();
-            package.AddFile("lib/net5.0/_._");
-
-            if(!string.IsNullOrWhiteSpace(requestAdditionalContent))
+            if (!string.IsNullOrWhiteSpace(requestAdditionalContent))
             {
-                package.AddFile("lib/net5.0/" + requestAdditionalContent);
+                package.AddFile("lib/net45/" + requestAdditionalContent);
             }
 
             return package;


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11002

Regression? Last working version: n/a

## Description
This change ensuring that the namespaces are respected during package installation in [IVs installer API](https://github.com/NuGet/Home/issues/10738#issuecomment-869887550). If there is same package Id exist in 2 repositories then it only request it from one it specified in namespace filter, previously we try to fetch from all possible repositories and install one from fastest which may not be what user really wanted.

This PR is continuation of https://github.com/NuGet/NuGet.Client/pull/4140.

I didn't manually test it exact way how Roslyn works, but I did add new unit tests for `InstallPackageApi`, `InstallLatestPackageApi` apis so I believe it should cover the scenario.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [ ] N/A
