### PR TITLE
Enable bulk restore coordination - don't eagerly restore projects in solution loaded scenarios, improving scenarios such as branch switching

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
@@ -304,6 +304,10 @@ namespace NuGet.PackageManagement.VisualStudio
             return true;
         }
 
+        public IReadOnlyList<object> GetAllProjectRestoreInfoSources()
+        {
+            return _projectSystemCache.GetProjectRestoreInfoSources();
+        }
 
         private static bool IsRestoredOnSolutionLoad(NuGetProject nuGetProject)
         {

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/SearchPageTelemetryEvent.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/SearchPageTelemetryEvent.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Text;
 using NuGet.Common;
 using NuGet.VisualStudio.Internal.Contracts;
+using NuGet.VisualStudio.Telemetry;
 
 namespace NuGet.PackageManagement.Telemetry
 {
@@ -28,27 +29,9 @@ namespace NuGet.PackageManagement.Telemetry
             base["PageIndex"] = pageIndex;
             base["ResultCount"] = resultCount;
             base["Duration"] = duration.TotalSeconds;
-            base["IndividualSourceDurations"] = ToJsonArray(sourceTimings);
+            base["IndividualSourceDurations"] = TelemetryUtility.ToJsonArrayOfTimingsInSeconds(sourceTimings);
             base["ResultsAggregationDuration"] = aggregationTime.TotalSeconds;
             base["LoadingStatus"] = loadingStatus.ToString();
-        }
-
-        private static string ToJsonArray(IEnumerable<TimeSpan> sourceTimings)
-        {
-            var sb = new StringBuilder();
-            sb.Append("[");
-            foreach (var item in sourceTimings)
-            {
-                sb.Append(item.TotalSeconds);
-                sb.Append(",");
-            }
-            if (sb[sb.Length - 1] == ',')
-            {
-                sb.Length--;
-            }
-            sb.Append("]");
-
-            return sb.ToString();
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/ISolutionRestoreJob.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/ISolutionRestoreJob.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.PackageManagement.VisualStudio;
@@ -29,7 +30,7 @@ namespace NuGet.SolutionRestoreManager
             SolutionRestoreRequest request,
             SolutionRestoreJobContext jobContext,
             RestoreOperationLogger logger,
-            bool isSolutionLoadRestore,
+            Dictionary<string, object> restoreStartTrackingData,
             CancellationToken token);
     }
 }

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/NuGet.SolutionRestoreManager.csproj
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/NuGet.SolutionRestoreManager.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common.legacy.props" />
   <PropertyGroup>

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreJob.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreJob.cs
@@ -58,7 +58,7 @@ namespace NuGet.SolutionRestoreManager
         private int _packageCount;
         private int _noOpProjectsCount;
         private int _upToDateProjectCount;
-        private bool _isSolutionLoadRestore;
+        private Dictionary<string, object> _trackingData;
 
         // relevant to packages.config restore only
         private int _missingPackagesCount;
@@ -122,7 +122,7 @@ namespace NuGet.SolutionRestoreManager
             SolutionRestoreRequest request,
             SolutionRestoreJobContext jobContext,
             RestoreOperationLogger logger,
-            bool isSolutionLoadRestore,
+            Dictionary<string, object> trackingData,
             CancellationToken token)
         {
             if (request == null)
@@ -145,7 +145,7 @@ namespace NuGet.SolutionRestoreManager
             // update instance attributes with the shared context values
             _nuGetProjectContext = jobContext.NuGetProjectContext;
             _nuGetProjectContext.OperationId = request.OperationId;
-            _isSolutionLoadRestore = isSolutionLoadRestore;
+            _trackingData = trackingData;
 
             try
             {
@@ -321,7 +321,7 @@ namespace NuGet.SolutionRestoreManager
                 packagesConfigProjectsCount: projectDictionary.GetValueOrDefault(ProjectStyle.PackagesConfig, 0),
                 DateTimeOffset.Now,
                 duration,
-                isSolutionLoadRestore: _isSolutionLoadRestore,
+                _trackingData,
                 intervalTimingTracker);
 
             TelemetryActivity.EmitTelemetryEvent(restoreTelemetryEvent);

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreWorker.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreWorker.cs
@@ -530,7 +530,7 @@ namespace NuGet.SolutionRestoreManager
                                         var bulkCheckTimeout = false;
                                         for (int i = 0; i < restoreProjectInfoSources.Count && !bulkCheckTimeout; i++)
                                         {
-                                            var restoreInfoSource = (IVsProjectRestoreInfoSource)restoreProjectInfoSources[i]; 
+                                            var restoreInfoSource = (IVsProjectRestoreInfoSource)restoreProjectInfoSources[i];
                                             if (restoreInfoSource.HasPendingNomination)
                                             {
                                                 allProjectsReady = false;
@@ -546,6 +546,13 @@ namespace NuGet.SolutionRestoreManager
                                             }
                                         }
 
+                                        projectReadyCheckMeasurement.Stop();
+                                        if (projectReadyTimings == null)
+                                        {
+                                            projectReadyTimings = new();
+                                        }
+                                        projectReadyTimings.Add(projectReadyCheckMeasurement.Elapsed);
+
                                         if (allProjectsReady)
                                         {
                                             restoreReason = ImplicitRestoreReason.ProjectsReady;
@@ -556,12 +563,6 @@ namespace NuGet.SolutionRestoreManager
                                             restoreReason = ImplicitRestoreReason.ProjectsReadyCheckTimeout;
                                             break;
                                         }
-                                        projectReadyCheckMeasurement.Stop();
-                                        if (projectReadyTimings == null)
-                                        {
-                                            projectReadyTimings = new();
-                                        }
-                                        projectReadyTimings.Add(projectReadyCheckMeasurement.Elapsed);
                                     }
                                     else
                                     {

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreWorker.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreWorker.cs
@@ -416,7 +416,7 @@ namespace NuGet.SolutionRestoreManager
                             bulkRestoreCoordinationCheckStartTime: default,
                             projectsReadyCheckCount: 0,
                             projectReadyTimings: new List<TimeSpan>());
-                        var result = await ProcessRestoreRequestAsync(restoreOperation, request, new(), token);
+                        var result = await ProcessRestoreRequestAsync(restoreOperation, request, restoreTrackingData, token);
 
                         return result;
                     }

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreWorker.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreWorker.cs
@@ -412,6 +412,7 @@ namespace NuGet.SolutionRestoreManager
                             restoreReason: ImplicitRestoreReason.None,
                             requestCount: 1,
                             isBulkRestoreCoordinationEnabled: true,
+                            projectRestoreInfoSourcesCount: -1,
                             bulkRestoreCoordinationCheckStartTime: default,
                             projectsReadyCheckCount: 0,
                             projectReadyTimings: new List<TimeSpan>());

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreWorker.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreWorker.cs
@@ -408,10 +408,11 @@ namespace NuGet.SolutionRestoreManager
                     using (var restoreOperation = new BackgroundRestoreOperation())
                     {
                         await PromoteTaskToActiveAsync(restoreOperation, token);
+                        var isBulkRestoreCoordinationEnabled = _nuGetExperimentationService.Value.IsExperimentEnabled(ExperimentationConstants.BulkRestoreCoordination);
                         var restoreTrackingData = GetRestoreTrackingData(
                             restoreReason: ImplicitRestoreReason.None,
                             requestCount: 1,
-                            isBulkRestoreCoordinationEnabled: true,
+                            isBulkRestoreCoordinationEnabled: isBulkRestoreCoordinationEnabled,
                             projectRestoreInfoSourcesCount: -1,
                             bulkRestoreCoordinationCheckStartTime: default,
                             projectsReadyCheckCount: 0,
@@ -610,6 +611,7 @@ namespace NuGet.SolutionRestoreManager
                             ref _pendingRestore, new BackgroundRestoreOperation(), restoreOperation);
 
                         token.ThrowIfCancellationRequested();
+
                         Dictionary<string, object> restoreStartTrackingData = GetRestoreTrackingData(
                             restoreReason,
                             requestCount,

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreWorker.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreWorker.cs
@@ -522,7 +522,7 @@ namespace NuGet.SolutionRestoreManager
                                         }
                                         projectsReadyCheckCount++;
                                         // If we are about to start restore, we should run through all the projects to ensure there isn't a pending nomination.
-                                        var restoreProjectInfoSources = _solutionManager.Value.GetAllProjectRestoreInfoSources();
+                                        IReadOnlyList<object> restoreProjectInfoSources = _solutionManager.Value.GetAllProjectRestoreInfoSources();
                                         projectRestoreInfoSourcesCount = restoreProjectInfoSources.Count;
                                         var allProjectsReady = true;
                                         var bulkCheckTimeout = false;

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Experimentation/ExperimentationConstants.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Experimentation/ExperimentationConstants.cs
@@ -26,5 +26,6 @@ namespace NuGet.VisualStudio
 
         public static readonly ExperimentationConstants PackageManagerBackgroundColor = new("nuGetPackageManagerBackgroundColor", "NUGET_PACKAGE_MANAGER_BACKGROUND_COLOR");
         public static readonly ExperimentationConstants PackageRecommender = new("nugetrecommendpkgs", "NUGET_RECOMMEND_PACKAGES");
+        public static readonly ExperimentationConstants BulkRestoreCoordination = new("nugetBulkRestoreCoordination", "NUGET_BULK_RESTORE_COORDINATION");
     }
 }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/IDE/IVsSolutionManager.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/IDE/IVsSolutionManager.cs
@@ -91,5 +91,7 @@ namespace NuGet.PackageManagement.VisualStudio
         /// Returns whether the solution is open.
         /// </summary>
         Task<bool> IsSolutionOpenAsync();
+
+        IReadOnlyList<object> GetAllProjectRestoreInfoSources();
     }
 }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/ProjectSystems/IProjectSystemCache.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/ProjectSystems/IProjectSystemCache.cs
@@ -54,7 +54,6 @@ namespace NuGet.VisualStudio
         bool TryGetProjectRestoreInfo(string name, out DependencyGraphSpec projectRestoreInfo, out IReadOnlyList<IAssetsLogMessage> nominationMessages);
 
         /// <summary>
-        /// Finds a project name by short name, unique name, unique name, or project id (guid).
         /// </summary>
         /// <param name="name">Project name, full path or unique name.</param>
         /// <param name="projectNames">Primary key if found.</param>
@@ -129,5 +128,19 @@ namespace NuGet.VisualStudio
         /// </summary>
         /// <returns><code>true</code> if the cache was dirty before and <code>false</code> otherwise</returns>
         bool TestResetDirtyFlag();
+
+        /// <summary>
+        /// Adds a project restore info source.
+        /// </summary>
+        /// <param name="projectNames">The names for the projectNames in question.</param>
+        /// <param name="restoreInfoSource">The restore info source object.</param>
+        /// <returns></returns>
+        bool AddProjectRestoreInfoSource(ProjectNames projectNames, object restoreInfoSource);
+
+        /// <summary>
+        /// Retrieves collection of all project info sources stored in the cache.
+        /// </summary>
+        /// <returns>Collection of project restore info sources.</returns>
+        IReadOnlyList<object> GetProjectRestoreInfoSources();
     }
 }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/ProjectSystems/IProjectSystemCache.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/ProjectSystems/IProjectSystemCache.cs
@@ -134,7 +134,7 @@ namespace NuGet.VisualStudio
         /// </summary>
         /// <param name="projectNames">The names for the projectNames in question.</param>
         /// <param name="restoreInfoSource">The restore info source object.</param>
-        /// <returns></returns>
+        /// <returns>True if operation succeeded.</returns>
         bool AddProjectRestoreInfoSource(ProjectNames projectNames, object restoreInfoSource);
 
         /// <summary>

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/ImplicitRestoreReason.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/ImplicitRestoreReason.cs
@@ -1,0 +1,14 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGet.VisualStudio.Telemetry
+{
+    public enum ImplicitRestoreReason
+    {
+        None, // The reason is not implicit.
+        AllProjectsNominated, // All projects have been nominated.
+        NominationsIdleTimeout, // The timeout for all nominations has been exceeded. This means that bulk restore coordination is *not* enabled.
+        ProjectsReady, // The projects ready check has been completed and no projects are reporting pending nominations.
+        ProjectsReadyCheckTimeout, // We have spent a considerable amount of time in the projects ready check.
+    }
+}

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/RestoreTelemetryEvent.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/RestoreTelemetryEvent.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using NuGet.Common;
 using NuGet.PackageManagement;
 
@@ -17,6 +18,13 @@ namespace NuGet.VisualStudio
         public const string SolutionDependencyGraphSpecCreation = nameof(SolutionDependencyGraphSpecCreation);
         public const string PackageReferenceRestoreDuration = nameof(PackageReferenceRestoreDuration);
         public const string SolutionUpToDateCheck = nameof(SolutionUpToDateCheck);
+        public const string ImplicitRestoreReason = nameof(ImplicitRestoreReason);
+        public const string RequestCount = nameof(RequestCount);
+        public const string IsBulkFileRestoreCoordinationEnabled = nameof(IsBulkFileRestoreCoordinationEnabled);
+        public const string ProjectsReadyCheckCount = nameof(ProjectsReadyCheckCount);
+        public const string ProjectReadyCheckTimings = nameof(ProjectReadyCheckTimings);
+        public const string ProjectsReadyCheckTotalTime = nameof(ProjectsReadyCheckTotalTime);
+        public const string ProjectRestoreInfoSourcesCount = nameof(ProjectRestoreInfoSourcesCount);
 
         public RestoreTelemetryEvent(
             string operationId,
@@ -37,7 +45,7 @@ namespace NuGet.VisualStudio
             int packagesConfigProjectsCount,
             DateTimeOffset endTime,
             double duration,
-            bool isSolutionLoadRestore,
+            IDictionary<string, object> additionalTrackingData,
             IntervalTracker intervalTimingTracker) : base(RestoreActionEventName, operationId, projectIds, startTime, status, packageCount, endTime, duration)
         {
             base[nameof(OperationSource)] = source;
@@ -51,7 +59,11 @@ namespace NuGet.VisualStudio
             base[nameof(DotnetCliToolProjectsCount)] = dotnetCliToolProjectsCount;
             base[nameof(PackagesConfigProjectsCount)] = packagesConfigProjectsCount;
             base[nameof(ForceRestore)] = forceRestore;
-            base[nameof(IsSolutionLoadRestore)] = isSolutionLoadRestore;
+
+            foreach (KeyValuePair<string, object> data in additionalTrackingData)
+            {
+                base[data.Key] = data.Value;
+            }
 
             foreach (var (intervalName, intervalDuration) in intervalTimingTracker.GetIntervals())
             {

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/TelemetryUtility.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/TelemetryUtility.cs
@@ -4,7 +4,9 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Text;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
@@ -208,5 +210,34 @@ namespace NuGet.VisualStudio.Telemetry
                 return null;
             }
         });
+
+        /// <summary>
+        /// Converts a collection of timings to a json array formatted string.
+        /// Empty if the collection is null or empty.
+        /// </summary>
+        /// <param name="sourceTimings">The timings to convert.</param>
+        /// <returns>A json array of timings, returns string.empty if the collection is null or empty.</returns>
+        public static string ToJsonArrayOfTimingsInSeconds(IEnumerable<TimeSpan> sourceTimings)
+        {
+            if (sourceTimings?.Any() != true)
+            {
+                return string.Empty;
+            }
+
+            var sb = new StringBuilder();
+            sb.Append("[");
+            foreach (var item in sourceTimings)
+            {
+                sb.Append(item.TotalSeconds);
+                sb.Append(",");
+            }
+            if (sb[sb.Length - 1] == ',')
+            {
+                sb.Length--;
+            }
+            sb.Append("]");
+
+            return sb.ToString();
+        }
     }
 }

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/NuGetProjectManagerServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/NuGetProjectManagerServiceTests.cs
@@ -785,6 +785,11 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             {
                 throw new NotImplementedException();
             }
+
+            public IReadOnlyList<object> GetAllProjectRestoreInfoSources()
+            {
+                throw new NotImplementedException();
+            }
         }
     }
 }

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Telemetry/RestoreTelemetryServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Telemetry/RestoreTelemetryServiceTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using Moq;
 using NuGet.Common;
 using NuGet.VisualStudio;
@@ -61,7 +62,10 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 packagesConfigProjectsCount: 1,
                 endTime: DateTimeOffset.Now,
                 duration: 2.10,
-                isSolutionLoadRestore: true,
+                additionalTrackingData: new Dictionary<string, object>()
+                {
+                    { nameof(RestoreTelemetryEvent.IsSolutionLoadRestore), true }
+                },
                 new IntervalTracker("Activity"));
             var service = new NuGetVSTelemetryService(telemetrySession.Object);
 
@@ -114,7 +118,10 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 packagesConfigProjectsCount: 0,
                 endTime: DateTimeOffset.Now,
                 duration: 2.10,
-                isSolutionLoadRestore: true,
+                additionalTrackingData: new Dictionary<string, object>()
+                {
+                    { nameof(RestoreTelemetryEvent.IsSolutionLoadRestore), true }
+                },
                 tracker
                 );
             var service = new NuGetVSTelemetryService(telemetrySession.Object);

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/SolutionRestoreJobTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/SolutionRestoreJobTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using Microsoft.VisualStudio.Sdk.TestFramework;
 using Microsoft.VisualStudio.Shell;
@@ -69,7 +70,7 @@ namespace NuGet.SolutionRestoreManager.Test
                 request: restoreRequest,
                 jobContext: restoreJobContext,
                 logger: logger,
-                isSolutionLoadRestore: true,
+                trackingData: new Dictionary<string, object>(),
                 token: CancellationToken.None);
 
             Assert.Equal(NuGetOperationStatus.NoOp, job.Status);
@@ -118,7 +119,7 @@ namespace NuGet.SolutionRestoreManager.Test
                 request: restoreRequest,
                 jobContext: restoreJobContext,
                 logger: logger,
-                isSolutionLoadRestore: true,
+                trackingData: new Dictionary<string, object>(),
                 token: cts.Token);
 
             Assert.Equal(NuGetOperationStatus.Cancelled, job.Status);

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/SolutionRestoreWorkerTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/SolutionRestoreWorkerTests.cs
@@ -1,0 +1,34 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using FluentAssertions;
+using Xunit;
+
+namespace NuGet.SolutionRestoreManager.Test
+{
+    public class SolutionRestoreWorkerTests
+    {
+        [Fact]
+        public void CalculateTimeoutTime_WithTimeoutLargerThanTimeElapsed_ReturnsPositiveValue()
+        {
+            var startTime = new DateTime(year: 2021, month: 7, day: 21, hour: 10, minute: 5, second: 20);
+            var currentTime = new DateTime(year: 2021, month: 7, day: 21, hour: 10, minute: 7, second: 00);
+            TimeSpan timeoutSpan = new(hours: 0, minutes: 5, seconds: 0);
+
+            var timeout = SolutionRestoreWorker.CalculateTimeoutTime(startTime: startTime, currentTime: currentTime, timeoutTime: timeoutSpan);
+            timeout.TotalMilliseconds.Should().Be(200000);
+        }
+
+        [Fact]
+        public void CalculateTimeoutTime_WithTimeElapsedLargerThanTimeout_Returns0()
+        {
+            var startTime = new DateTime(year: 2021, month: 7, day: 21, hour: 10, minute: 5, second: 20);
+            var currentTime = new DateTime(year: 2021, month: 7, day: 21, hour: 11, minute: 0, second: 00);
+            TimeSpan timeoutSpan = new(hours: 0, minutes: 5, seconds: 0);
+
+            var timeout = SolutionRestoreWorker.CalculateTimeoutTime(startTime: startTime, currentTime: currentTime, timeoutTime: timeoutSpan);
+            timeout.TotalMilliseconds.Should().Be(0);
+        }
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Common.Test/Telemetry/TelemetryUtilityTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Common.Test/Telemetry/TelemetryUtilityTests.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Linq;
+using FluentAssertions;
 using NuGet.Configuration;
 using NuGet.VisualStudio.Telemetry;
 using Xunit;
@@ -170,6 +172,32 @@ namespace NuGet.VisualStudio.Common.Test.Telemetry
             bool actualResult = TelemetryUtility.IsVsOfflineFeed(source, expectedVsOfflinePackagesPath);
 
             Assert.True(actualResult);
+        }
+
+        [Fact]
+        public void ToJsonArrayOfTimingsInSeconds_WithEmptyArray_ReturnsEmptyString()
+        {
+            TelemetryUtility.ToJsonArrayOfTimingsInSeconds(Enumerable.Empty<TimeSpan>()).Should().Be(string.Empty);
+        }
+
+        [Fact]
+        public void ToJsonArrayOfTimingsInSeconds_WithNullArgument_ReturnsEmptyString()
+        {
+            TelemetryUtility.ToJsonArrayOfTimingsInSeconds(null).Should().Be(string.Empty);
+        }
+
+        [Fact]
+        public void ToJsonArrayOfTimingsInSeconds_WithOneValue_ReturnsTimingsInSeconds()
+        {
+            TimeSpan[] values = new[] { new TimeSpan(hours: 0, minutes: 0, seconds: 5) };
+            TelemetryUtility.ToJsonArrayOfTimingsInSeconds(values).Should().Be("[5]");
+        }
+
+        [Fact]
+        public void ToJsonArrayOfTimingsInSeconds_WithMultipleValues_AppendsValuesWithComma()
+        {
+            TimeSpan[] values = new[] { new TimeSpan(hours: 0, minutes: 0, seconds: 5), new TimeSpan(days: 0, hours: 0, minutes: 1, seconds: 0, milliseconds: 500) };
+            TelemetryUtility.ToJsonArrayOfTimingsInSeconds(values).Should().Be("[5,60.5]");
         }
     }
 }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/10678

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Design at https://github.com/NuGet/Home/blob/dev/proposed/2021/BulkRestoreCoordination.md. 

<hr/>

Adds the bulk restore coordination feature under a feature flag to allow us to mitigate risk. This feature is *disabled* by default.
We implement the new behavior and the preserve the old behavior sxs. 

**Old behavior**

Per recent discussion and findings, increase the timeout by default. 

**New behavior** 

When all projects are nominated, we will loop through all `IVsProjectRestoreInfoSource` objects and call `HasPendingNomination`. 
If any project reports true, we will await on `WhenNominated`. We only await on one project. When we have completed one loop through all projects, if no project reported a pending nomination we continue. If not we go to the loop again. 

During this whole time we're measuring the overhead of several factors. 
* Time it takes to complete one projects ready loop. 
* How many projects ready loops have been completed. 

Per some additional discussions with the CPS team, we want add a timeout just in case something goes wrong. This allows NuGet to report telemetry about issues with the implementation. 

Any time we call `WhenNominated`, we queue a timeout task as well. If the timeout task completes first, we stop the check and run restore.  

Here's a summary of the *new metrics* we'll track and their usefulness. 

* ImplicitReasonReason - When an implicit restore happens, we don't have the details as to why that is. The available values are:  
  * None, // The reason is not implicit.
  * AllProjectsNominated, // All projects have been nominated.
  * NominationsIdleTimeout, // The timeout for all nominations has been exceeded. This means that bulk restore coordination is *not* enabled.
  * ProjectsReady, // The projects ready check has been completed and no projects are reporting pending nominations.
  * ProjectsReadyCheckTimeout, // We have spent a considerable amount of time in the projects ready check
* RequestCount - restore request count - for solution load, this should be *all SDK projects*. For non bulk coordination scenarios, this should mean 1 or in general a  lot fewer than bulk coordination scenarios.
* IsBulkFileRestoreCoordinationEnabled - self descriptive.
* ProjectsReadyCheckTotalTime - total overhead of the projects ready check time.
* ProjectsReadyCheckCount - The number of time we've done the project check loop. 1 would mean there were no pending restores. When the check count is 1, we'd expect the projectsreadychecktotaltime to be negligible.
* ProjectReadyCheckTimings - array of individual timings for investigating problem scenarios. This doesn't have significant value unless things are not going as expected. 
* RestoreProjectInfoSourcesCount - the count project info sources registered. This should *always* match the number of CPS projects. If it doesn't, either NuGet dropped a registration or project-system failed to register.

There may be additional changes to this implementation. This version doesn't necessarily contain every possibility and it won't, as we're trying to optimize a version that might be made available in preview 3.
 
**Leftover work**

* I need to do work to enable the experiment.
* Write-up on how to enable the experiment for a given user or locally. (Note that enabling it locally is finding the env var in this PR and setting the appropriate value)
* Manual tests are blocked on https://github.com/dotnet/project-system/pull/7199. Note that given that the feature is disabled, even if something is terribly wrong, it won't cause trouble.

<hr/>
cc @lifengl @ocallesp 

The implementation of the branch switching code is going to be in this PR.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added - Technically some tests are available. There's no automated tests for SolutionRestoreWorker as of now. I am consider a refactoring to enable that, as I see it a valuable investment, but there is *a lot* of overhead and a chance that the tests will be fragile due to the fact that they're timing based. 
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
