### PR TITLE
Move metadata to before filtering in xplat CLI

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackage/ListPackageCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackage/ListPackageCommandRunner.cs
@@ -102,6 +102,12 @@ namespace NuGet.CommandLine.XPlat
                             }
                             else
                             {
+                                if (listPackageArgs.ReportType != ReportType.Default)  // generic list package is offline -- no server lookups
+                                {
+                                    await GetRegistrationMetadataAsync(packages, listPackageArgs);
+                                    await AddLatestVersionsAsync(packages, listPackageArgs);
+                                }
+
                                 bool printPackages = FilterPackages(packages, listPackageArgs);
 
                                 // Filter packages for dedicated reports, inform user if none
@@ -119,12 +125,6 @@ namespace NuGet.CommandLine.XPlat
                                             Console.WriteLine(string.Format(Strings.ListPkg_NoVulnerablePackagesForProject, projectName));
                                             break;
                                     }
-                                }
-
-                                if (listPackageArgs.ReportType != ReportType.Default)  // generic list package is offline -- no server lookups
-                                {
-                                    await GetRegistrationMetadataAsync(packages, listPackageArgs);
-                                    await AddLatestVersionsAsync(packages, listPackageArgs);
                                 }
 
                                 printPackages = printPackages || ReportType.Default == listPackageArgs.ReportType;


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug 

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes:https://github.com/NuGet/Home/issues/10767

Regression? Last working version: N/A

## Description
(Adjustment to https://github.com/NuGet/NuGet.Client/pull/3996 - full details in that PR)

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] Note that this method is not testable, and this was a profound break. I've prototyped some refactoring here which will support tests--writing a fixture for these additional types (which could now be mocked away) will not be trivial, but will make future changes more robust: https://github.com/NuGet/NuGet.Client/compare/dev...dev-drewgil-refactorforreporttesting 

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
