### PR TITLE
Showing warning icon in Installed tab when installed packages have vulnerability

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
@@ -1006,6 +1006,24 @@ namespace NuGet.PackageManagement.UI {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to You have {0} vulnerable package(s) and {1} deprecated package(s) installed..
+        /// </summary>
+        public static string Label_Installed_VulnerableAndDeprecatedWarning {
+            get {
+                return ResourceManager.GetString("Label_Installed_VulnerableAndDeprecatedWarning", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to You have {0} vulnerable package(s) installed..
+        /// </summary>
+        public static string Label_Installed_VulnerableWarning {
+            get {
+                return ResourceManager.GetString("Label_Installed_VulnerableWarning", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Installed:.
         /// </summary>
         public static string Label_InstalledColon {

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
@@ -967,4 +967,12 @@ Please see https://aka.ms/troubleshoot_nuget_cache for more help.</value>
   <data name="VulnerabilitySeverity_Moderate" xml:space="preserve">
     <value>Moderate</value>
   </data>
+  <data name="Label_Installed_VulnerableAndDeprecatedWarning" xml:space="preserve">
+    <value>You have {0} vulnerable package(s) and {1} deprecated package(s) installed.</value>
+    <comment>{0} and {1} are numbers of installed packages</comment>
+  </data>
+  <data name="Label_Installed_VulnerableWarning" xml:space="preserve">
+    <value>You have {0} vulnerable package(s) installed.</value>
+    <comment>{0} is the number of installed packages</comment>
+  </data>
 </root>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerTopPanel.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerTopPanel.xaml.cs
@@ -107,22 +107,45 @@ namespace NuGet.PackageManagement.UI
             tabConsolidate.SetValue(System.Windows.Automation.AutomationProperties.NameProperty, automationString);
         }
 
-        public void UpdateDeprecationStatusOnInstalledTab(int installedDeprecatedPackagesCount)
+        public void UpdateWarningStatusOnInstalledTab(int installedVulnerablePackagesCount, int installedDeprecatedPackagesCount)
         {
+            bool hasInstalledVulnerablePackages = installedVulnerablePackagesCount > 0;
             bool hasInstalledDeprecatedPackages = installedDeprecatedPackagesCount > 0;
-            if (hasInstalledDeprecatedPackages)
-            {
-                _warningIcon.Visibility = Visibility.Visible;
-                _warningIcon.ToolTip = string.Format(
-                    CultureInfo.CurrentCulture,
-                    NuGet.PackageManagement.UI.Resources.Label_Installed_DeprecatedWarning,
-                    installedDeprecatedPackagesCount);
-            }
-            else
+            bool warningIconShouldBeVisible = hasInstalledVulnerablePackages || hasInstalledDeprecatedPackages;
+
+            if (!warningIconShouldBeVisible)
             {
                 _warningIcon.Visibility = Visibility.Collapsed;
                 _warningIcon.ToolTip = null;
+                return;
             }
+
+            string warningTooltip = null;
+            if (hasInstalledVulnerablePackages && hasInstalledDeprecatedPackages)
+            {
+                warningTooltip = string.Format(
+                    CultureInfo.CurrentCulture,
+                    Resx.Label_Installed_VulnerableAndDeprecatedWarning,
+                    installedVulnerablePackagesCount,
+                    installedDeprecatedPackagesCount);
+            }
+            else if (hasInstalledVulnerablePackages)
+            {
+                warningTooltip = string.Format(
+                    CultureInfo.CurrentCulture,
+                    Resx.Label_Installed_VulnerableWarning,
+                    installedVulnerablePackagesCount);
+            }
+            else if (hasInstalledDeprecatedPackages)
+            {
+                warningTooltip = string.Format(
+                    CultureInfo.CurrentCulture,
+                    Resx.Label_Installed_DeprecatedWarning,
+                    installedDeprecatedPackagesCount);
+            }
+
+            _warningIcon.Visibility = Visibility.Visible;
+            _warningIcon.ToolTip = warningTooltip;
         }
 
         public void UpdateCountOnConsolidateTab(int count)


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/10982

Regression? Last working version: N/A

## Description
Modified the code that counts the deprecated packages for the installed tab warning icon to count vulnerable packages too and use that information to show a warning in the Installed tab when one or more packages is vulnerable or deprecated, or both, along with a tooltip that displays how many packages are vulnerable, deprecated, or both.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
Modified existing code in code-behind. Performed manual testing with 0 installed packages, multiple installed packages without vulnerabilities or deprecation, 1 vulnerable package, multiple vulnerable packages, 1 vulnerable and 1 deprecated, 1 deprecated, multiple deprecated, and multiple deprecated and multiple vulnerable with and without packages that have either vulnerabilities or deprecation.
  - [x] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
