### PR TITLE
remove redundant registryKeyPath. might be a bug?

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Program.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Program.cs
@@ -396,21 +396,21 @@ namespace NuGet.CommandLine
 
         private static bool IsWindows10(ILogger logger)
         {
-            var productName = (string)RegistryKeyUtility.GetValueFromRegistryKey("ProductName", OSVersionRegistryKey, Registry.LocalMachine, logger);
+            var productName = (string)RegistryKeyUtility.GetValueFromRegistryKey("ProductName", Registry.LocalMachine, logger);
 
             return productName != null && productName.StartsWith("Windows 10");
         }
 
         private static bool IsSupportLongPathEnabled(ILogger logger)
         {
-            var longPathsEnabled = RegistryKeyUtility.GetValueFromRegistryKey("LongPathsEnabled", FilesystemRegistryKey, Registry.LocalMachine, logger);
+            var longPathsEnabled = RegistryKeyUtility.GetValueFromRegistryKey("LongPathsEnabled", Registry.LocalMachine, logger);
 
             return longPathsEnabled != null && (int)longPathsEnabled > 0;
         }
 
         private static bool IsRuntimeGreaterThanNet462(ILogger logger)
         {
-            var release = RegistryKeyUtility.GetValueFromRegistryKey("Release", DotNetSetupRegistryKey, Registry.LocalMachine, logger);
+            var release = RegistryKeyUtility.GetValueFromRegistryKey("Release", Registry.LocalMachine, logger);
 
             return release != null && (int)release >= Net462ReleasedVersion;
         }

--- a/src/NuGet.Clients/NuGet.CommandLine/RegistryKeyUtility.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/RegistryKeyUtility.cs
@@ -9,7 +9,7 @@ namespace NuGet.CommandLine
 {
     public static class RegistryKeyUtility
     {
-        public static object GetValueFromRegistryKey(string name, string registryKeyPath, RegistryKey registryKey, ILogger logger)
+        public static object GetValueFromRegistryKey(string name, RegistryKey registryKey, ILogger logger)
         {
             try
             {


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes:

Regression? Last working version:

## Description
so registryKeyPath is not used. I dont know if this is a bug?

## PR Checklist

- [x] PR has a meaningful title
- [ ] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
