### PR TITLE
Reduce memory allocation by 208 MB during VS solution restore

### DIFF
--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/ResolverUtility.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/ResolverUtility.cs
@@ -31,9 +31,9 @@ namespace NuGet.DependencyResolver
             if (cache.TryGetValue(key, out var graphItem))
                 return graphItem;
 
-            _ = cache.TryAdd(key, FindLibraryEntryAsync(key.LibraryRange, framework, runtimeIdentifier, context, cancellationToken));
+            graphItem = cache.GetOrAdd(key, FindLibraryEntryAsync(key.LibraryRange, framework, runtimeIdentifier, context, cancellationToken));
 
-            return cache[key];
+            return graphItem;
         }
 
         public static async Task<GraphItem<RemoteResolveResult>> FindLibraryEntryAsync(

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/ResolverUtility.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/ResolverUtility.cs
@@ -29,8 +29,17 @@ namespace NuGet.DependencyResolver
         {
             var key = new LibraryRangeCacheKey(libraryRange, framework);
 
-            return cache.GetOrAdd(key, (cacheKey) =>
-                FindLibraryEntryAsync(cacheKey.LibraryRange, framework, runtimeIdentifier, context, cancellationToken));
+            if (!cache.TryGetValue(key, out var graphItem))
+            {
+                graphItem = FindLibraryEntryAsync(key.LibraryRange, framework, runtimeIdentifier, context, cancellationToken);
+
+                if (!cache.TryAdd(key, graphItem))
+                {
+                    graphItem = cache[key];
+                }
+            }
+
+            return graphItem;
         }
 
         public static async Task<GraphItem<RemoteResolveResult>> FindLibraryEntryAsync(

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/ResolverUtility.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/ResolverUtility.cs
@@ -28,17 +28,12 @@ namespace NuGet.DependencyResolver
         {
             var key = new LibraryRangeCacheKey(libraryRange, framework);
 
-            if (!cache.TryGetValue(key, out var graphItem))
-            {
-                graphItem = FindLibraryEntryAsync(key.LibraryRange, framework, runtimeIdentifier, context, cancellationToken);
+            if (cache.TryGetValue(key, out var graphItem))
+                return graphItem;
 
-                if (!cache.TryAdd(key, graphItem))
-                {
-                    graphItem = cache[key];
-                }
-            }
+            _ = cache.TryAdd(key, FindLibraryEntryAsync(key.LibraryRange, framework, runtimeIdentifier, context, cancellationToken));
 
-            return graphItem;
+            return cache[key];
         }
 
         public static async Task<GraphItem<RemoteResolveResult>> FindLibraryEntryAsync(

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/ResolverUtility.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/ResolverUtility.cs
@@ -9,7 +9,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Common;
-using NuGet.Configuration;
 using NuGet.Frameworks;
 using NuGet.LibraryModel;
 using NuGet.Protocol;


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1060

Regression? Last working version: No

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
Performance analyzers reported following warning 

Severity | Code | Description | File | Line | Column | Category
-- | -- | -- | -- | -- | -- | --
Warning | HAA0301 | Heap allocation   of closure Captures: framework,runtimeIdentifier,context,cancellationToken | $\src\NuGet.Core\NuGet.DependencyResolver.Core\ResolverUtility.cs | 31 | 51 | Performance

Link to source code that caused this warning. https://github.com/NuGet/NuGet.Client/blob/d70adaba77e5754ecdc41984edd21c5cecf8c2a2/src/NuGet.Core/NuGet.DependencyResolver.Core/ResolverUtility.cs#L32-L33

Looking at the PerfView trace for OrchardCore solution at https://github.com/OrchardCMS/OrchardCore/tree/d70bed827520689e1db29b1113d0fb3c4792c5f7, the current implementation caused `155 MB` of allocation during solution restore.

![image](https://user-images.githubusercontent.com/52756182/127365613-4d39b62b-d11a-452c-8c0b-ac3b288ecff9.png)

After making this change, the allocations reduced to `115 MB` there by reducing memory allocations by `40 MB`.

![image](https://user-images.githubusercontent.com/52756182/127365682-973211e4-4b66-4c34-bc82-2965c93ddd0e.png)

When I captured PerfView trace instead of restore during solution load to solution explorer -> restore nuget packages on a loaded OrchardCore solution the memory allocations reduced by `208 MB`. More details https://github.com/NuGet/NuGet.Client/pull/4170#discussion_r680266658

@jebriede - Created fixed the same issue where the code is identical to the changes proposed in this PR but in a different code path https://github.com/NuGet/NuGet.Client/pull/4095

Please let me know if there are other better ways to reduce the memory allocation.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Test exception - This method has good functional test coverage. No change to the product behavior.

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [x] N/A
