### PR TITLE
msbuild Restore and Visual Studio produce different assets when assembly name if different from project name

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyPackageReferenceProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyPackageReferenceProject.cs
@@ -7,7 +7,6 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using EnvDTE;
 using Microsoft;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Threading;
@@ -132,6 +131,11 @@ namespace NuGet.PackageManagement.VisualStudio
         private async Task<string> GetSpecifiedAssemblyName()
         {
             return await _vsProjectAdapter.GetPropertyValueAsync(ProjectBuildProperties.AssemblyName);
+        }
+
+        private async Task<string> GetSpecifiedPackageId()
+        {
+            return await _vsProjectAdapter.GetPropertyValueAsync(ProjectBuildProperties.PackageId);
         }
 
         private async Task<Dictionary<string, CentralPackageVersion>> GetCentralPackageVersionsAsync()
@@ -435,11 +439,20 @@ namespace NuGet.PackageManagement.VisualStudio
 
             var projectName = _projectName ?? _projectUniqueName;
 
-            string specifiedAssemblyName = await GetSpecifiedAssemblyName();
+            string specifiedPackageId = await GetSpecifiedPackageId();
 
-            if (!string.IsNullOrWhiteSpace(specifiedAssemblyName))
+            if (!string.IsNullOrWhiteSpace(specifiedPackageId))
             {
-                projectName = specifiedAssemblyName;
+                projectName = specifiedPackageId;
+            }
+            else
+            {
+                string specifiedAssemblyName = await GetSpecifiedAssemblyName();
+
+                if (!string.IsNullOrWhiteSpace(specifiedAssemblyName))
+                {
+                    projectName = specifiedAssemblyName;
+                }
             }
 
             return new PackageSpec(tfis)

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyPackageReferenceProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyPackageReferenceProject.cs
@@ -129,6 +129,11 @@ namespace NuGet.PackageManagement.VisualStudio
             return MSBuildStringUtility.IsTrue(await _vsProjectAdapter.GetPropertyValueAsync(ProjectBuildProperties.ManagePackageVersionsCentrally));
         }
 
+        private async Task<string> GetSpecifiedAssemblyName()
+        {
+            return await _vsProjectAdapter.GetPropertyValueAsync(ProjectBuildProperties.AssemblyName);
+        }
+
         private async Task<Dictionary<string, CentralPackageVersion>> GetCentralPackageVersionsAsync()
         {
             IEnumerable<(string PackageId, string Version)> packageVersions =
@@ -429,6 +434,13 @@ namespace NuGet.PackageManagement.VisualStudio
             var tfis = new TargetFrameworkInformation[] { projectTfi };
 
             var projectName = _projectName ?? _projectUniqueName;
+
+            string specifiedAssemblyName = await GetSpecifiedAssemblyName();
+
+            if (!string.IsNullOrWhiteSpace(specifiedAssemblyName))
+            {
+                projectName = specifiedAssemblyName;
+            }
 
             return new PackageSpec(tfis)
             {

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -675,7 +675,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       If PackageId does not exist use: AssemblyName
       If AssemblyName does not exist fallback to the project file name without the extension: $(MSBuildProjectName)
 
-      For non-NETCore projects use only: $(MSBuildProjectName)
+      For non-PackageReference projects use only: $(MSBuildProjectName)
     -->
     <PropertyGroup>
       <_RestoreProjectName>$(MSBuildProjectName)</_RestoreProjectName>

--- a/src/NuGet.Core/NuGet.PackageManagement/Projects/ProjectBuildProperties.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Projects/ProjectBuildProperties.cs
@@ -52,6 +52,5 @@ namespace NuGet.ProjectManagement
         public const string RuntimeIdentifierGraphPath = nameof(RuntimeIdentifierGraphPath);
         public const string ManagePackageVersionsCentrally = nameof(ManagePackageVersionsCentrally);
         public const string AssemblyName = nameof(AssemblyName);
-
     }
 }

--- a/src/NuGet.Core/NuGet.PackageManagement/Projects/ProjectBuildProperties.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Projects/ProjectBuildProperties.cs
@@ -51,6 +51,7 @@ namespace NuGet.ProjectManagement
         public const string Clear = nameof(Clear);
         public const string RuntimeIdentifierGraphPath = nameof(RuntimeIdentifierGraphPath);
         public const string ManagePackageVersionsCentrally = nameof(ManagePackageVersionsCentrally);
+        public const string AssemblyName = nameof(AssemblyName);
 
     }
 }

--- a/src/NuGet.Core/NuGet.PackageManagement/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.PackageManagement/PublicAPI.Unshipped.txt
@@ -1,3 +1,4 @@
 NuGet.PackageManagement.GatherContext.GatherContext(NuGet.Configuration.PackageNamespacesConfiguration packageNamespacesConfiguration) -> void
 NuGet.PackageManagement.GatherContext.PackageNamespacesConfiguration.get -> NuGet.Configuration.PackageNamespacesConfiguration
+const NuGet.ProjectManagement.ProjectBuildProperties.AssemblyName = "AssemblyName" -> string
 const NuGet.ProjectManagement.ProjectBuildProperties.CLRSupport = "CLRSupport" -> string

--- a/test/EndToEnd/tests/PackageRestoreTest.ps1
+++ b/test/EndToEnd/tests/PackageRestoreTest.ps1
@@ -329,9 +329,7 @@ function Test-PackageRestore-AllSourcesAreUsed {
 }
 
 # Test that during legacy packagereference project restore, AssemblyName property is considered for asset file creation. msbuild restore already does it.
-# Highest priority: PackageId
-# If PackageId does not exist use: AssemblyName
-# If AssemblyName does not exist fallback to the project file name without the extension
+# Priority: PackageId -> AssemblyName -> Project File Name.
 function Test-VSRestore-AssemblyName-Considered-Over-ProjectFileName {
     param($context)
 
@@ -384,9 +382,7 @@ function Test-VSRestore-AssemblyName-Considered-Over-ProjectFileName {
 }
 
 # Test that during legacy packagereference project restore, PackageId property is considered for asset file creation. msbuild restore already does it.
-# Highest priority: PackageId
-# If PackageId does not exist use: AssemblyName
-# If AssemblyName does not exist fallback to the project file name without the extension
+# Priority: PackageId -> AssemblyName -> Project File Name.
 function Test-VSRestore-PackageId-Considered-Over-AssemblyName {
     param($context)
 

--- a/test/EndToEnd/tests/PackageRestoreTest.ps1
+++ b/test/EndToEnd/tests/PackageRestoreTest.ps1
@@ -359,8 +359,6 @@ function Test-VSRestore-CustomAssemblyName-Considered {
     Build-Solution  # generate asset file
     
     # Assert VS restore
-    # Make sure assembly file with correct name is created.
-    Assert-PathExists(Join-Path $debugDirectory $customAssemblyName".dll")
     $assetFilePath = Get-NetCoreLockFilePath $project
     $vsRestoredAsset = Get-Content -Raw -Path $assetFilePath
     $vsRestoredAssetJson = $vsRestoredAsset | ConvertFrom-Json

--- a/test/EndToEnd/tests/PackageRestoreTest.ps1
+++ b/test/EndToEnd/tests/PackageRestoreTest.ps1
@@ -329,7 +329,10 @@ function Test-PackageRestore-AllSourcesAreUsed {
 }
 
 # Test that during legacy packagereference project restore, AssemblyName property is considered for asset file creation. msbuild restore already does it.
-function Test-VSRestore-CustomAssemblyName-Considered {
+# Highest priority: PackageId
+# If PackageId does not exist use: AssemblyName
+# If AssemblyName does not exist fallback to the project file name without the extension
+function Test-VSRestore-AssemblyName-Considered-Over-ProjectFileName {
     param($context)
 
     # Arrange
@@ -364,11 +367,71 @@ function Test-VSRestore-CustomAssemblyName-Considered {
     $vsRestoredAssetJson = $vsRestoredAsset | ConvertFrom-Json
     $projectNameInAssetFile = $vsRestoredAssetJson.Project.Restore | Select-Object projectName
     # Assert generated asset file contains correct projectName = AssemblyName
-    Assert-True $projectNameInAssetFile.projectName -eq $customAssemblyName
+    Assert-True ($projectNameInAssetFile.projectName -eq $customAssemblyName)
 
-    # Arange MSBuild restore
+    # Arrange MSBuild restore
     # Remove VS asset file.
-    Write-Host $assetFilePath
+    Remove-Item -Force $assetFilePath
+
+    # Act MSBuild restore
+    & "$MSBuildExe" /t:restore $project.FullName
+    Assert-True ($LASTEXITCODE -eq 0)
+
+    # Main Assert
+    $msBuildRestoredAsset = Get-Content -Raw -Path $assetFilePath
+    # Assert msbuild and VS restore result in same asset file.
+    Assert-True ($vsRestoredAsset -eq $msBuildRestoredAsset)
+}
+
+# Test that during legacy packagereference project restore, PackageId property is considered for asset file creation. msbuild restore already does it.
+# Highest priority: PackageId
+# If PackageId does not exist use: AssemblyName
+# If AssemblyName does not exist fallback to the project file name without the extension
+function Test-VSRestore-PackageId-Considered-Over-AssemblyName {
+    param($context)
+
+    # Arrange
+    $customPackageId = "MySpecialPackageId"
+    $customAssemblyName = "MySpecialAssemblyName"
+    $MSBuildExe = Get-MSBuildExe    
+    $p1 = New-Project PackageReferenceClassLibrary
+    $solutionFile = Get-SolutionFullName
+    $projectDirectoryPath = $p1.Properties.Item("FullPath").Value
+    $projectPath = $p1.FullName
+    $binDirectory = Join-Path $projectDirectoryPath "bin"
+    $debugDirectory = Join-Path $binDirectory "debug"    
+    SaveAs-Solution($solutionFile)
+
+    # Change assembly name in .csproj file
+    $doc = [xml](Get-Content $projectPath)
+    $ns = New-Object System.Xml.XmlNamespaceManager($doc.NameTable)
+    $ns.AddNamespace("ns", $doc.DocumentElement.NamespaceURI)
+    $assemblyNameNode = $doc.SelectSingleNode("//ns:AssemblyName",$ns)
+    $assemblyNameNode.InnerText = $customAssemblyName
+    $node = $doc.DocumentElement.ChildNodes[1]   
+    $packageIdNode = $doc.CreateElement("PackageId",$doc.DocumentElement.NamespaceURI)
+    $packageIdInnerNode = $doc.CreateTextNode($customPackageId);
+    $packageIdNode.AppendChild($packageIdInnerNode);    
+    $node.InsertAfter($packageIdNode, $node.FirstChild)
+    $doc.Save($projectPath)
+    Close-Solution
+    Open-Solution $solutionFile    
+
+    $project = Get-Project
+
+    # Act VS restore
+    Build-Solution  # generate asset file
+    
+    # Assert VS restore
+    $assetFilePath = Get-NetCoreLockFilePath $project
+    $vsRestoredAsset = Get-Content -Raw -Path $assetFilePath
+    $vsRestoredAssetJson = $vsRestoredAsset | ConvertFrom-Json
+    $projectNameInAssetFile = $vsRestoredAssetJson.Project.Restore | Select-Object projectName
+    # Assert generated asset file contains correct projectName = AssemblyName
+    Assert-True ($projectNameInAssetFile.projectName -eq $customPackageId)
+
+    # Arrange MSBuild restore
+    # Remove VS asset file.
     Remove-Item -Force $assetFilePath
 
     # Act MSBuild restore


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/8272

Regression? Last working version: N/A
Current issue only applies to legacy packageReference packages, not sdk style.
msbuild /t:Restore and Visual Studio restore produce different assets files when assembly name <> project name.
When you perform an msbuild /restore the project.assets.json that gets generated uses the AssemblyName of the referenced class Library. However if you open up Visual Studio it will perform a restore setting this to the name of the referenced PROJECT file. This change forces a Visual Studio rebuild. 
Here is fix to for to make VS and MSbuild generate same asset file.
![image](https://user-images.githubusercontent.com/8766776/127401466-84399f58-2416-4683-8a26-33eaacf80d61.png)

## Description

## PR Checklist

- [x] PR has a meaningful title
- [ ] PR has a linked issue.
- [ ] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
