### PR TITLE
Fix the vulnerability advisories alignment in the details pane

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/VulnerabilitiesControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/VulnerabilitiesControl.xaml
@@ -61,7 +61,8 @@
           Text="{x:Static nuget:Resources.Label_Details}"
           FontWeight="Bold" />
         <ItemsControl
-          ItemsSource="{Binding PackageVulnerabilities}">
+          ItemsSource="{Binding PackageVulnerabilities}"
+          Grid.IsSharedSizeScope="True">
           <ItemsControl.ItemTemplate>
             <DataTemplate>
               <Grid>


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11101

Regression? Last working version: N/A

## Description
Set a property on the ancestor control of the advisory grids that indicates that the grids will share a size scope. The grids already had a shared size group, but this property was missing from their common ancestor.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
UI alignment issue, change is visual
  - [x] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
