### PR TITLE
Sort package vulnerability advisories by severity in descending order

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailControlModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailControlModel.cs
@@ -15,6 +15,7 @@ using NuGet.Versioning;
 using NuGet.VisualStudio;
 using NuGet.VisualStudio.Internal.Contracts;
 using NuGet.VisualStudio.Telemetry;
+using static Microsoft.TeamFoundation.Client.CommandLine.Options;
 using Task = System.Threading.Tasks.Task;
 
 namespace NuGet.PackageManagement.UI
@@ -415,7 +416,6 @@ namespace NuGet.PackageManagement.UI
             private set
             {
                 _packageVulnerabilities = value;
-                PackageVulnerabilityMaxSeverity = value?.Max(v => v.Severity) ?? -1;
 
                 OnPropertyChanged(nameof(PackageVulnerabilities));
                 OnPropertyChanged(nameof(IsPackageVulnerable));
@@ -423,19 +423,9 @@ namespace NuGet.PackageManagement.UI
             }
         }
 
-        private int _packageVulnerabilityMaxSeverity = -1;
         public int PackageVulnerabilityMaxSeverity
         {
-            get => _packageVulnerabilityMaxSeverity;
-            private set
-            {
-                if (_packageVulnerabilityMaxSeverity != value)
-                {
-                    _packageVulnerabilityMaxSeverity = value;
-
-                    OnPropertyChanged(nameof(PackageVulnerabilityMaxSeverity));
-                }
-            }
+            get => PackageVulnerabilities?.FirstOrDefault()?.Severity ?? -1;
         }
 
         public bool IsPackageVulnerable
@@ -509,8 +499,7 @@ namespace NuGet.PackageManagement.UI
                     PackageDeprecationReasons = newDeprecationReasons;
                     PackageDeprecationAlternatePackageText = newAlternatePackageText;
 
-                    IEnumerable<PackageVulnerabilityMetadataContextInfo> vulnerabilities = _packageMetadata?.Vulnerabilities;
-                    PackageVulnerabilities = vulnerabilities?.ToList();
+                    PackageVulnerabilities = _packageMetadata?.Vulnerabilities?.ToList();
 
                     OnPropertyChanged(nameof(PackageMetadata));
                     OnPropertyChanged(nameof(IsPackageDeprecated));

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailControlModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailControlModel.cs
@@ -15,7 +15,6 @@ using NuGet.Versioning;
 using NuGet.VisualStudio;
 using NuGet.VisualStudio.Internal.Contracts;
 using NuGet.VisualStudio.Telemetry;
-using static Microsoft.TeamFoundation.Client.CommandLine.Options;
 using Task = System.Threading.Tasks.Task;
 
 namespace NuGet.PackageManagement.UI
@@ -418,6 +417,7 @@ namespace NuGet.PackageManagement.UI
                 _packageVulnerabilities = value;
 
                 OnPropertyChanged(nameof(PackageVulnerabilities));
+                OnPropertyChanged(nameof(PackageVulnerabilityMaxSeverity));
                 OnPropertyChanged(nameof(IsPackageVulnerable));
                 OnPropertyChanged(nameof(PackageVulnerabilityCount));
             }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/PackageItemViewModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/PackageItemViewModel.cs
@@ -668,7 +668,7 @@ namespace NuGet.PackageManagement.UI
 
                 DeprecationMetadata = deprecationMetadata;
                 IsPackageDeprecated = deprecationMetadata != null;
-                VulnerabilityMaxSeverity = packageMetadata?.Vulnerabilities?.Max(v => v.Severity) ?? -1;
+                VulnerabilityMaxSeverity = packageMetadata?.Vulnerabilities?.FirstOrDefault()?.Severity ?? -1;
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/ContextInfos/PackageSearchMetadataContextInfo.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/ContextInfos/PackageSearchMetadataContextInfo.cs
@@ -73,7 +73,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
                 IsListed = packageSearchMetadata.IsListed,
                 DependencySets = packageSearchMetadata.DependencySets?.ToList(),
                 DownloadCount = packageSearchMetadata.DownloadCount,
-                Vulnerabilities = packageSearchMetadata.Vulnerabilities?.Select(vulnerability => new PackageVulnerabilityMetadataContextInfo(vulnerability.AdvisoryUrl, vulnerability.Severity)).ToArray(),
+                Vulnerabilities = packageSearchMetadata.Vulnerabilities?.Select(vulnerability => new PackageVulnerabilityMetadataContextInfo(vulnerability.AdvisoryUrl, vulnerability.Severity)).OrderByDescending(v => v.Severity).ToArray(),
             };
         }
     }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/ContextInfos/PackageSearchMetadataContextInfo.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/ContextInfos/PackageSearchMetadataContextInfo.cs
@@ -73,7 +73,9 @@ namespace NuGet.VisualStudio.Internal.Contracts
                 IsListed = packageSearchMetadata.IsListed,
                 DependencySets = packageSearchMetadata.DependencySets?.ToList(),
                 DownloadCount = packageSearchMetadata.DownloadCount,
-                Vulnerabilities = packageSearchMetadata.Vulnerabilities?.Select(vulnerability => new PackageVulnerabilityMetadataContextInfo(vulnerability.AdvisoryUrl, vulnerability.Severity)).OrderByDescending(v => v.Severity).ToArray(),
+                Vulnerabilities = packageSearchMetadata.Vulnerabilities?
+                    .Select(vulnerability => new PackageVulnerabilityMetadataContextInfo(vulnerability.AdvisoryUrl, vulnerability.Severity))
+                    .OrderByDescending(v => v.Severity).ToArray(),
             };
         }
     }

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/V3DetailControlModelTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/V3DetailControlModelTests.cs
@@ -132,6 +132,20 @@ namespace NuGet.PackageManagement.UI.Test.Models
         }
 
         [Fact]
+        public void PackageVulnerabilitiesWhenMetadataHasVulnerability_OrderedBySeverityDescending()
+        {
+            Assert.Collection(_testInstance.PackageVulnerabilities,
+                item =>
+                {
+                    Assert.Equal(3, item.Severity);
+                },
+                item =>
+                {
+                    Assert.Equal(2, item.Severity);
+                });
+        }
+
+        [Fact]
         public async Task SetCurrentPackageAsync_SortsVersions_ByNuGetVersionDesc()
         {
             // Arrange

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/V3DetailControlModelTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/V3DetailControlModelTests.cs
@@ -134,14 +134,12 @@ namespace NuGet.PackageManagement.UI.Test.Models
         [Fact]
         public void PackageVulnerabilities_WhenMetadataHasVulnerability_IsOrderedBySeverityDescending()
         {
-            var sortedTestVulnerabilities =
+            IEnumerable<PackageVulnerabilityMetadataContextInfo> sortedTestVulnerabilities =
                 _testData.TestData.Vulnerabilities
                 .OrderByDescending(v => v.Severity)
-                .Select(v => new Action<PackageVulnerabilityMetadataContextInfo>(
-                    (item) => Assert.Equal(v.Severity, item.Severity))
-                ).ToArray();
+                .Select(v => new PackageVulnerabilityMetadataContextInfo(v.AdvisoryUrl, v.Severity));
 
-            Assert.Collection(_testInstance.PackageVulnerabilities, sortedTestVulnerabilities);
+            Assert.Equal(sortedTestVulnerabilities, _testInstance.PackageVulnerabilities);
         }
 
         [Fact]

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/V3DetailControlModelTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/V3DetailControlModelTests.cs
@@ -132,17 +132,16 @@ namespace NuGet.PackageManagement.UI.Test.Models
         }
 
         [Fact]
-        public void PackageVulnerabilitiesWhenMetadataHasVulnerability_OrderedBySeverityDescending()
+        public void PackageVulnerabilities_WhenMetadataHasVulnerability_IsOrderedBySeverityDescending()
         {
-            Assert.Collection(_testInstance.PackageVulnerabilities,
-                item =>
-                {
-                    Assert.Equal(3, item.Severity);
-                },
-                item =>
-                {
-                    Assert.Equal(2, item.Severity);
-                });
+            var sortedTestVulnerabilities =
+                _testData.TestData.Vulnerabilities
+                .OrderByDescending(v => v.Severity)
+                .Select(v => new Action<PackageVulnerabilityMetadataContextInfo>(
+                    (item) => Assert.Equal(v.Severity, item.Severity))
+                ).ToArray();
+
+            Assert.Collection(_testInstance.PackageVulnerabilities, sortedTestVulnerabilities);
         }
 
         [Fact]


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/nuget/home/issues/11091

Regression? Last working version: N/A

## Description
Sort the list of vulnerabilities when the PackageSearchMetadataContextInfo is created so the list is cached in order and already in order whenever it is used. Since the list is in order with the highest severity vulnerability at the top, calculate the maximum severity by looking at the first vulnerability to save on computation time of checking for the max in the list.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
