### PR TITLE
Make EnsurePackageReferenceVersions target runs for TestablePlugin.csproj

### DIFF
--- a/build/common.targets
+++ b/build/common.targets
@@ -388,9 +388,23 @@ Condition=" ('%(Extension)' == '.dll' OR '%(Filename)' == 'NuGet.CommandLine.XPl
       Condition=" %(Reference.NuGetPackageId) == 'Newtonsoft.Json' AND %(Reference.NuGetPackageVersion) != '$(NewtonsoftJsonPackageVersion)' " />
   </Target>
 
-  <Target Name="EnsurePackageReferenceVersions">
+   <Target Name="EnsurePackageReferenceVersions">
+    <ItemGroup Condition=" '$(TargetFrameworks)' != '' ">
+      <_TargetFrameworkItems Include="$(TargetFrameworks.Split(';'))" />
+    </ItemGroup>
+    <ItemGroup Condition=" '$(TargetFrameworks)' == '' ">
+      <_TargetFrameworkItems Include="$(TargetFramework)" />
+    </ItemGroup>
+    <MSBuild
+      Projects="$(MSBuildProjectFullPath)"
+      Targets="EnsurePackageReferenceVersionsForFramework"
+      Properties="TargetFramework=%(_TargetFrameworkItems.Identity);"
+    />
+  </Target>
+
+  <Target Name="EnsurePackageReferenceVersionsForFramework">
     <Error
-      Text="%(PackageReference.Identity) should not have a version declared outside of packages.targets but found %(PackageReference.Version)"
+      Text="%(PackageReference.Identity) should not have a version declared outside of packages.targets but found '%(PackageReference.Version)'"
       Condition=" '%(PackageReference.Version)' != '' AND '%(PackageReference.IsImplicitlyDefined)' != 'true' AND '%(PackageReference.Identity)' != 'Microsoft.NET.Test.Sdk' " />
   </Target>
 

--- a/build/common.targets
+++ b/build/common.targets
@@ -403,6 +403,8 @@ Condition=" ('%(Extension)' == '.dll' OR '%(Filename)' == 'NuGet.CommandLine.XPl
   </Target>
 
   <Target Name="EnsurePackageReferenceVersionsForFramework">
+    <Message Importance="High" Text="+++++++++++++++ '$(TargetFramework)'    '$(IsCore)'"  />
+
     <Error
       Text="%(PackageReference.Identity) should not have a version declared outside of packages.targets but found '%(PackageReference.Version)'"
       Condition=" '%(PackageReference.Version)' != '' AND '%(PackageReference.IsImplicitlyDefined)' != 'true' AND '%(PackageReference.Identity)' != 'Microsoft.NET.Test.Sdk' " />

--- a/build/common.targets
+++ b/build/common.targets
@@ -403,8 +403,6 @@ Condition=" ('%(Extension)' == '.dll' OR '%(Filename)' == 'NuGet.CommandLine.XPl
   </Target>
 
   <Target Name="EnsurePackageReferenceVersionsForFramework">
-    <Message Importance="High" Text="+++++++++++++++ '$(TargetFramework)'    '$(IsCore)'"  />
-
     <Error
       Text="%(PackageReference.Identity) should not have a version declared outside of packages.targets but found '%(PackageReference.Version)'"
       Condition=" '%(PackageReference.Version)' != '' AND '%(PackageReference.IsImplicitlyDefined)' != 'true' AND '%(PackageReference.Identity)' != 'Microsoft.NET.Test.Sdk' " />

--- a/build/packages.targets
+++ b/build/packages.targets
@@ -100,6 +100,14 @@
         <PackageReference Update="Moq" Version="4.16.1" />
         <PackageReference Update="NuGet.Core" Version="$(NuGetCoreV2Version)" />
         <PackageReference Update="Portable.BouncyCastle" Version="1.8.10" />
+        <PackageReference Update="System.Collections" Version="$(SystemPackagesVersion)" />
+        <PackageReference Update="System.IO.FileSystem.Primitives" Version="$(SystemPackagesVersion)" />
+        <PackageReference Update="System.Resources.ResourceManager" Version="$(SystemPackagesVersion)" />
+        <PackageReference Update="System.Runtime.Extensions" Version="$(SystemPackagesVersion)" />
+        <PackageReference Update="System.Runtime.InteropServices" Version="$(SystemPackagesVersion)" />
+        <PackageReference Update="System.Text.Encoding.Extensions" Version="$(SystemPackagesVersion)" />
+        <PackageReference Update="System.Threading" Version="$(SystemPackagesVersion)" />
+        <PackageReference Update="System.Threading.Tasks" Version="$(SystemPackagesVersion)" />
         <PackageReference Update="xunit" Version="$(XunitVersion)" />
         <PackageReference Update="xunit.runner.visualstudio" Version="$(XunitVersion)" />
         <PackageReference Update="Xunit.StaFact" Version="0.2.9" />

--- a/test/TestExtensions/TestablePlugin/TestablePlugin.csproj
+++ b/test/TestExtensions/TestablePlugin/TestablePlugin.csproj
@@ -16,6 +16,17 @@
     <ProjectReference Include="$(NuGetCoreSrcDirectory)NuGet.Versioning\NuGet.Versioning.csproj" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(IsCore)' == 'true'">
+    <PackageReference Include="System.Collections" Version="$(SystemPackagesVersion)" />
+    <PackageReference Include="System.IO.FileSystem.Primitives" Version="$(SystemPackagesVersion)" />
+    <PackageReference Include="System.Resources.ResourceManager" Version="$(SystemPackagesVersion)" />
+    <PackageReference Include="System.Runtime.Extensions" Version="$(SystemPackagesVersion)" />
+    <PackageReference Include="System.Runtime.InteropServices" Version="$(SystemPackagesVersion)" />
+    <PackageReference Include="System.Text.Encoding.Extensions" Version="$(SystemPackagesVersion)" />
+    <PackageReference Include="System.Threading" Version="$(SystemPackagesVersion)" />
+    <PackageReference Include="System.Threading.Tasks" Version="$(SystemPackagesVersion)" />
+  </ItemGroup>
+
   <Import Project="$(BuildCommonDirectory)common.targets"/>
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 </Project>

--- a/test/TestExtensions/TestablePlugin/TestablePlugin.csproj
+++ b/test/TestExtensions/TestablePlugin/TestablePlugin.csproj
@@ -17,14 +17,14 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(IsCore)' == 'true'">
-    <PackageReference Include="System.Collections" Version="$(SystemPackagesVersion)" />
-    <PackageReference Include="System.IO.FileSystem.Primitives" Version="$(SystemPackagesVersion)" />
-    <PackageReference Include="System.Resources.ResourceManager" Version="$(SystemPackagesVersion)" />
-    <PackageReference Include="System.Runtime.Extensions" Version="$(SystemPackagesVersion)" />
-    <PackageReference Include="System.Runtime.InteropServices" Version="$(SystemPackagesVersion)" />
-    <PackageReference Include="System.Text.Encoding.Extensions" Version="$(SystemPackagesVersion)" />
-    <PackageReference Include="System.Threading" Version="$(SystemPackagesVersion)" />
-    <PackageReference Include="System.Threading.Tasks" Version="$(SystemPackagesVersion)" />
+    <PackageReference Include="System.Collections" />
+    <PackageReference Include="System.IO.FileSystem.Primitives" />
+    <PackageReference Include="System.Resources.ResourceManager" />
+    <PackageReference Include="System.Runtime.Extensions" />
+    <PackageReference Include="System.Runtime.InteropServices" />
+    <PackageReference Include="System.Text.Encoding.Extensions" />
+    <PackageReference Include="System.Threading" />
+    <PackageReference Include="System.Threading.Tasks" />
   </ItemGroup>
 
   <Import Project="$(BuildCommonDirectory)common.targets"/>

--- a/test/TestExtensions/TestablePlugin/TestablePlugin.csproj
+++ b/test/TestExtensions/TestablePlugin/TestablePlugin.csproj
@@ -16,17 +16,6 @@
     <ProjectReference Include="$(NuGetCoreSrcDirectory)NuGet.Versioning\NuGet.Versioning.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(IsCore)' == 'true'">
-    <PackageReference Include="System.Collections" Version="$(SystemPackagesVersion)" />
-    <PackageReference Include="System.IO.FileSystem.Primitives" Version="$(SystemPackagesVersion)" />
-    <PackageReference Include="System.Resources.ResourceManager" Version="$(SystemPackagesVersion)" />
-    <PackageReference Include="System.Runtime.Extensions" Version="$(SystemPackagesVersion)" />
-    <PackageReference Include="System.Runtime.InteropServices" Version="$(SystemPackagesVersion)" />
-    <PackageReference Include="System.Text.Encoding.Extensions" Version="$(SystemPackagesVersion)" />
-    <PackageReference Include="System.Threading" Version="$(SystemPackagesVersion)" />
-    <PackageReference Include="System.Threading.Tasks" Version="$(SystemPackagesVersion)" />
-  </ItemGroup>
-
   <Import Project="$(BuildCommonDirectory)common.targets"/>
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 </Project>


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/nuget/home/issues/9790

Regression? Last working version: n/a

## Description
Investigated why [EnsurePackageReferenceVersions](https://github.com/NuGet/NuGet.Client/blob/3ec538cb909cf5b9b0f663ef6f7a6891406d21aa/build/common.targets#L391-L395) (it ensures we don't specify versions in individual projects) target didn't fail when the version  is specified for packageReferences in [TestablePlugin.csproj](https://github.com/NuGet/NuGet.Client/blob/3ec538cb909cf5b9b0f663ef6f7a6891406d21aa/test/TestExtensions/TestablePlugin/TestablePlugin.csproj#L19-L28). 
Upon inspecting binlog I found it's not running due at least 2 conditions are not met (both have to meet in order to target to run), it looks this packageReferences have no use in this test project, so we can remove.
![image](https://user-images.githubusercontent.com/8766776/127597697-7df133ab-d4d1-49b2-b837-8d47040a232f.png)

1. First when  I checked that with binlog, $(IsCore) is not set to `true` when when it's multitargetting.
2. $SystemPackagesVersion not set any value. 

Since it's not used I just decided to remove  unused packageReferences  from [TestablePlugin.csproj](https://github.com/NuGet/NuGet.Client/blob/3ec538cb909cf5b9b0f663ef6f7a6891406d21aa/test/TestExtensions/TestablePlugin/TestablePlugin.csproj#L19-L28)
Also don't see any other places where `"$(SystemPackagesVersion)"` used for package references, except for `packages.targets`.

## PR Checklist

- [x] PR has a meaningful title
- [ ] PR has a linked issue.
- [ ] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
