### PR TITLE
Use high default assembly version in all local builds

### DIFF
--- a/build/common.project.props
+++ b/build/common.project.props
@@ -112,7 +112,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(PreReleaseVersion)' == '' ">
-    <PreReleaseVersion>0</PreReleaseVersion>
+    <PreReleaseVersion>32767</PreReleaseVersion>
   </PropertyGroup>
 
   <!--Setting the Pre-release/Build meta-data from CI if Version is set-->

--- a/build/common.ps1
+++ b/build/common.ps1
@@ -324,13 +324,6 @@ Function Test-BuildEnvironment {
     }
 }
 
-Function Get-BuildNumber() {
-    $NuGetEpoch = '2010-08-29T23:58:25-07:00' # NuGet client first commit!
-    # Build number is a 16-bit integer. The limitation is imposed by VERSIONINFO.
-    # https://msdn.microsoft.com/en-gb/library/aa381058.aspx
-    [uint16]((((Get-Date) - (Get-Date $NuGetEpoch)).TotalMinutes / 5) % [uint16]::MaxValue)
-}
-
 Function Clear-PackageCache {
     [CmdletBinding()]
     param()


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11114

Regression? No

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

* Use 32767 as assembly version 4th digit, when `BuildNumber` not passed on MSBuild command line
* Stop generating a different number when using `build.ps1`.

## PR Checklist

- [X] PR has a meaningful title
- [X] PR has a linked issue.
- [X] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [X] N/A: build script

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [X] N/A
