### PR TITLE
Increase the time limit for Apex tests to 150 mins

### DIFF
--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -152,7 +152,7 @@ jobs:
   dependsOn:
   - Build_and_UnitTest_NonRTM
   - Initialize_Build
-  timeoutInMinutes: 120
+  timeoutInMinutes: 150
   variables:
     BuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.BuildNumber']]
     FullVstsBuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1071

Regression? Last working version:

## Description
Since the Apex test cases increases from 35 (4 skipped, so 31 actually run) to 49(4 skipped, so 45 actually run). The Apex tests run longer than before, and sometimes it timed out even if there is no hanging Apex tests.

E.g. build [6.0.0.168 ](https://github.com/NuGet/NuGet.Client/compare/dev-hengliu-CI-increaseApexTimeLimit?expand=1)passed all the 45 Apex tests but the build reached the time limit for the tasks afterwards so it still timed out.

So in this PR, we increase the time limit on Apex test from 120 mins to 150 mins.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
