### PR TITLE
Add time since last restore completed metric

### DIFF
--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreWorker.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreWorker.cs
@@ -689,9 +689,9 @@ namespace NuGet.SolutionRestoreManager
             var isSolutionLoadRestore = _isFirstRestore &&
                 request.RestoreSource == RestoreOperationSource.Implicit;
             _isFirstRestore = false;
-            string timeSinceLastRestoreCompletedTime = isSolutionLoadRestore ?
-                "0" :
-                (DateTimeOffset.UtcNow - _lastRestoreCompletedTime).TotalSeconds.ToString();
+            string timeSinceLastRestoreCompletedTime = _isFirstRestore ?
+                (DateTimeOffset.UtcNow - _lastRestoreCompletedTime).TotalSeconds.ToString() :
+                "0";
 
             restoreStartTrackingData.Add(nameof(RestoreTelemetryEvent.IsSolutionLoadRestore), isSolutionLoadRestore);
             restoreStartTrackingData.Add(nameof(RestoreTelemetryEvent.TimeSinceLastRestoreCompleted), timeSinceLastRestoreCompletedTime);

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreWorker.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreWorker.cs
@@ -688,11 +688,11 @@ namespace NuGet.SolutionRestoreManager
             // if the request is implicit & this is the first restore, assume we are restoring due to a solution load.
             var isSolutionLoadRestore = _isFirstRestore &&
                 request.RestoreSource == RestoreOperationSource.Implicit;
-            _isFirstRestore = false;
             string timeSinceLastRestoreCompletedTime = _isFirstRestore ?
-                (DateTimeOffset.UtcNow - _lastRestoreCompletedTime).TotalSeconds.ToString() :
-                "0";
+                "0" :
+                (DateTimeOffset.UtcNow - _lastRestoreCompletedTime).TotalSeconds.ToString();
 
+            _isFirstRestore = false;
             restoreStartTrackingData.Add(nameof(RestoreTelemetryEvent.IsSolutionLoadRestore), isSolutionLoadRestore);
             restoreStartTrackingData.Add(nameof(RestoreTelemetryEvent.TimeSinceLastRestoreCompleted), timeSinceLastRestoreCompletedTime);
 

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/RestoreTelemetryEvent.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/RestoreTelemetryEvent.cs
@@ -25,6 +25,7 @@ namespace NuGet.VisualStudio
         public const string ProjectReadyCheckTimings = nameof(ProjectReadyCheckTimings);
         public const string ProjectsReadyCheckTotalTime = nameof(ProjectsReadyCheckTotalTime);
         public const string ProjectRestoreInfoSourcesCount = nameof(ProjectRestoreInfoSourcesCount);
+        public const string TimeSinceLastRestoreCompleted = nameof(TimeSinceLastRestoreCompleted);
 
         public RestoreTelemetryEvent(
             string operationId,

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/RestoreTelemetryEvent.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/RestoreTelemetryEvent.cs
@@ -26,6 +26,7 @@ namespace NuGet.VisualStudio
         public const string ProjectsReadyCheckTotalTime = nameof(ProjectsReadyCheckTotalTime);
         public const string ProjectRestoreInfoSourcesCount = nameof(ProjectRestoreInfoSourcesCount);
         public const string TimeSinceLastRestoreCompleted = nameof(TimeSinceLastRestoreCompleted);
+        public const string LastRestoreOperationSource = nameof(LastRestoreOperationSource);
 
         public RestoreTelemetryEvent(
             string operationId,


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11124

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Currently during branch switch, there are frequently a lot of successive restores. In particular, one restore ends and the next one begins seconds later. 

Tracking this would give us another metric that compare pre and post bulk restore coordination behavior.

cc @jebriede 

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception - telemetry no suitable tests exist.
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
