### PR TITLE
Await the when nominated task

### DIFF
--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreWorker.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreWorker.cs
@@ -540,7 +540,7 @@ namespace NuGet.SolutionRestoreManager
                                                 var timeoutTask = Task.Delay(timeoutTime, token);
                                                 var whenNominatedTask = restoreInfoSource.WhenNominated(token);
 
-                                                var result = Task.WhenAny(whenNominatedTask, timeoutTask);
+                                                var result = await Task.WhenAny(whenNominatedTask, timeoutTask);
                                                 if (result == timeoutTask)
                                                 {
                                                     bulkCheckTimeout = true;


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11132

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

The WhenNominated task was not awaited (WhenAny needs to be awaited), and that causes a busy spin where NuGet relies on HasPendingNomination to get the status. 

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception - Unfortunately only manual tests are possible at this point. Will add vendor tests for the future.
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
