### PR TITLE
Default to mmap-based I/O on Windows only

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs
@@ -217,72 +217,6 @@ namespace NuGet.Packaging
             }
         }
 
-        /// <summary>
-        /// This class literally just exists so CopyToFile gets a file size
-        /// </summary>
-        private sealed class SizedArchiveEntryStream : Stream
-        {
-            private readonly Stream _inner;
-
-            private readonly long _size;
-
-            private bool _isDisposed;
-
-            public SizedArchiveEntryStream(Stream inner, long size)
-            {
-                _inner = inner;
-                _size = size;
-            }
-
-            public override long Length { get => _size; }
-
-            public override bool CanRead => _inner.CanRead;
-
-            public override bool CanSeek => _inner.CanSeek;
-
-            public override bool CanWrite => _inner.CanWrite;
-
-            public override long Position { get => _inner.Position; set => _inner.Position = value; }
-
-            public override void Flush()
-            {
-                _inner.Flush();
-            }
-
-            public override int Read(byte[] buffer, int offset, int count)
-            {
-                return _inner.Read(buffer, offset, count);
-            }
-
-            public override long Seek(long offset, SeekOrigin origin)
-            {
-                return _inner.Seek(offset, origin);
-            }
-
-            public override void SetLength(long value)
-            {
-                _inner.SetLength(value);
-            }
-
-            public override void Write(byte[] buffer, int offset, int count)
-            {
-                _inner.Write(buffer, offset, count);
-            }
-
-            protected override void Dispose(bool disposing)
-            {
-                if (!_isDisposed)
-                {
-                    if (disposing)
-                    {
-                        _inner.Dispose();
-                    }
-
-                    _isDisposed = true;
-                }
-            }
-        }
-
         public override IEnumerable<string> CopyFiles(
             string destination,
             IEnumerable<string> packageFiles,
@@ -317,9 +251,8 @@ namespace NuGet.Packaging
                 var targetFilePath = Path.Combine(destination, normalizedPath);
 
                 using (var stream = entry.Open())
-                using (var sizedStream = new SizedArchiveEntryStream(stream, entry.Length))
                 {
-                    string copiedFile = extractFile(packageFileName, targetFilePath, sizedStream);
+                    var copiedFile = extractFile(packageFileName, targetFilePath, stream);
                     if (copiedFile != null)
                     {
                         entry.UpdateFileTimeFromEntry(copiedFile, logger);

--- a/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs
@@ -217,6 +217,72 @@ namespace NuGet.Packaging
             }
         }
 
+        /// <summary>
+        /// This class literally just exists so CopyToFile gets a file size
+        /// </summary>
+        private sealed class SizedArchiveEntryStream : Stream
+        {
+            private readonly Stream _inner;
+
+            private readonly long _size;
+
+            private bool _isDisposed;
+
+            public SizedArchiveEntryStream(Stream inner, long size)
+            {
+                _inner = inner;
+                _size = size;
+            }
+
+            public override long Length { get => _size; }
+
+            public override bool CanRead => _inner.CanRead;
+
+            public override bool CanSeek => _inner.CanSeek;
+
+            public override bool CanWrite => _inner.CanWrite;
+
+            public override long Position { get => _inner.Position; set => _inner.Position = value; }
+
+            public override void Flush()
+            {
+                _inner.Flush();
+            }
+
+            public override int Read(byte[] buffer, int offset, int count)
+            {
+                return _inner.Read(buffer, offset, count);
+            }
+
+            public override long Seek(long offset, SeekOrigin origin)
+            {
+                return _inner.Seek(offset, origin);
+            }
+
+            public override void SetLength(long value)
+            {
+                _inner.SetLength(value);
+            }
+
+            public override void Write(byte[] buffer, int offset, int count)
+            {
+                _inner.Write(buffer, offset, count);
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+                if (!_isDisposed)
+                {
+                    if (disposing)
+                    {
+                        _inner.Dispose();
+                    }
+
+                    _isDisposed = true;
+                }
+            }
+        }
+
         public override IEnumerable<string> CopyFiles(
             string destination,
             IEnumerable<string> packageFiles,
@@ -251,8 +317,9 @@ namespace NuGet.Packaging
                 var targetFilePath = Path.Combine(destination, normalizedPath);
 
                 using (var stream = entry.Open())
+                using (var sizedStream = new SizedArchiveEntryStream(stream, entry.Length))
                 {
-                    var copiedFile = extractFile(packageFileName, targetFilePath, stream);
+                    string copiedFile = extractFile(packageFileName, targetFilePath, sizedStream);
                     if (copiedFile != null)
                     {
                         entry.UpdateFileTimeFromEntry(copiedFile, logger);

--- a/src/NuGet.Core/NuGet.Packaging/PackageExtraction/StreamExtensions.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageExtraction/StreamExtensions.cs
@@ -50,7 +50,6 @@ namespace NuGet.Packaging
             while ((bytesRead = inputStream.Read(buffer, offset: 0, buffer.Length)) != 0)
             {
                 outputStream.Write(buffer, offset: 0, bytesRead);
-                inputStream.CopyTo(outputStream);
             }
 
             ArrayPool<byte>.Shared.Return(buffer);

--- a/src/NuGet.Core/NuGet.Packaging/PackageExtraction/StreamExtensions.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageExtraction/StreamExtensions.cs
@@ -1,20 +1,13 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Buffers;
 using System.IO;
-using System.IO.MemoryMappedFiles;
 
 namespace NuGet.Packaging
 {
     public static class StreamExtensions
     {
-        /**
-        Only files smaller than this value will be mmap'ed
-        */
-        private const long MAX_MMAP_SIZE = 10 * 1024 * 1024;
-
         public static string CopyToFile(this Stream inputStream, string fileFullPath)
         {
             if (Path.GetFileName(fileFullPath).Length == 0)
@@ -35,38 +28,11 @@ namespace NuGet.Packaging
                 return fileFullPath;
             }
 
-            // For files of a certain size, we can do some Cleverness and mmap
-            // them instead of writing directly to disk. This can improve
-            // performance by a lot on some operating systems and hardware,
-            // particularly Windows
-            long? size = null;
-            try
-            {
-                size = inputStream.Length;
-            }
-            catch (NotSupportedException)
-            {
-                // If we can't get Length, just move on.
-            }
             using (var outputStream = NuGetExtractionFileIO.CreateFile(fileFullPath))
             {
-                if (size > 0 && size <= MAX_MMAP_SIZE)
-                {
-                    // NOTE: Linux can't create a mmf from outputStream, so we
-                    // need to close the file (which now has the desired
-                    // perms), and then re-open it as a memory-mapped file.
-                    outputStream.Dispose();
-                    using (MemoryMappedFile mmf = MemoryMappedFile.CreateFromFile(fileFullPath, FileMode.Open, mapName: null, (long)size))
-                    using (MemoryMappedViewStream mmstream = mmf.CreateViewStream())
-                    {
-                        CopyTo(inputStream, mmstream);
-                    }
-                }
-                else
-                {
-                    CopyTo(inputStream, outputStream);
-                }
+                CopyTo(inputStream, outputStream);
             }
+
             return fileFullPath;
         }
 
@@ -84,6 +50,7 @@ namespace NuGet.Packaging
             while ((bytesRead = inputStream.Read(buffer, offset: 0, buffer.Length)) != 0)
             {
                 outputStream.Write(buffer, offset: 0, bytesRead);
+                inputStream.CopyTo(outputStream);
             }
 
             ArrayPool<byte>.Shared.Return(buffer);

--- a/src/NuGet.Core/NuGet.Packaging/PackageExtraction/StreamExtensions.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageExtraction/StreamExtensions.cs
@@ -53,11 +53,11 @@ namespace NuGet.Packaging
             // default - use memory-mapped files on Windows, but not on other systems
             private const string MMAP_VARIABLE_NAME = "NUGET_PACKAGE_EXTRACTION_USE_MMAP";
 
-            internal bool IsMMapEnabled { get; }
+            private bool _isMMapEnabled { get; }
 
             internal Testable(IEnvironmentVariableReader environmentVariableReader)
             {
-                IsMMapEnabled = environmentVariableReader.GetEnvironmentVariable(MMAP_VARIABLE_NAME) switch
+                _isMMapEnabled = environmentVariableReader.GetEnvironmentVariable(MMAP_VARIABLE_NAME) switch
                 {
                     "0" => false,
                     "1" => true,
@@ -101,7 +101,7 @@ namespace NuGet.Packaging
                     // If we can't get Length, just move on.
                 }
 
-                if (IsMMapEnabled && size > 0 && size <= MAX_MMAP_SIZE)
+                if (_isMMapEnabled && size > 0 && size <= MAX_MMAP_SIZE)
                 {
                     MmapCopy(inputStream, fileFullPath, size.Value);
                 }

--- a/src/NuGet.Core/NuGet.Packaging/PackageExtraction/StreamExtensions.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageExtraction/StreamExtensions.cs
@@ -3,11 +3,8 @@
 
 using System;
 using System.Buffers;
-using System.Diagnostics;
 using System.IO;
 using System.IO.MemoryMappedFiles;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace NuGet.Packaging
 {

--- a/src/NuGet.Core/NuGet.Packaging/PackageExtraction/StreamExtensions.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageExtraction/StreamExtensions.cs
@@ -11,92 +11,9 @@ namespace NuGet.Packaging
 {
     public static class StreamExtensions
     {
-        /**
-        Only files smaller than this value will be mmap'ed
-        */
-        private const long MAX_MMAP_SIZE = 10 * 1024 * 1024;
-
-        // Mmap can improve file writing performance, but it can make it slower too.
-        // It all depends on a particular hardware configuration, operating system or anti-virus software.
-        // From our benchmarks we concluded that mmap is a good choice for Windows,
-        // but it is not so for other systems.
-        //
-        // 1 - always use memory-mapped files
-        // 0 - never use memory-mapped files
-        // default - use memory-mapped files on Windows, but not on other systems
-        private const string MMAP_VARIABLE_NAME = "NUGET_PACKAGE_EXTRACTION_USE_MMAP";
-        private static bool IsMMapEnabled { get; }
-
-        static StreamExtensions()
-        {
-            if (string.Equals(Environment.GetEnvironmentVariable(MMAP_VARIABLE_NAME), "1", StringComparison.OrdinalIgnoreCase))
-            {
-                IsMMapEnabled = true;
-                return;
-            }
-
-            if (string.Equals(Environment.GetEnvironmentVariable(MMAP_VARIABLE_NAME), "0", StringComparison.OrdinalIgnoreCase))
-            {
-                IsMMapEnabled = false;
-                return;
-            }
-
-            IsMMapEnabled = RuntimeEnvironmentHelper.IsWindows;
-        }
-
         public static string CopyToFile(this Stream inputStream, string fileFullPath)
         {
-            if (Path.GetFileName(fileFullPath).Length == 0)
-            {
-                Directory.CreateDirectory(fileFullPath);
-                return fileFullPath;
-            }
-
-            var directory = Path.GetDirectoryName(fileFullPath);
-            if (!Directory.Exists(directory))
-            {
-                Directory.CreateDirectory(directory);
-            }
-
-            if (File.Exists(fileFullPath))
-            {
-                // Log and skip adding file
-                return fileFullPath;
-            }
-
-            // For files of a certain size, we can do some Cleverness and mmap
-            // them instead of writing directly to disk. This can improve
-            // performance by a lot on some operating systems and hardware,
-            // particularly Windows
-            long? size = null;
-            try
-            {
-                size = inputStream.Length;
-            }
-            catch (NotSupportedException)
-            {
-                // If we can't get Length, just move on.
-            }
-            using (var outputStream = NuGetExtractionFileIO.CreateFile(fileFullPath))
-            {
-                if (IsMMapEnabled && size > 0 && size <= MAX_MMAP_SIZE)
-                {
-                    // NOTE: Linux can't create a mmf from outputStream, so we
-                    // need to close the file (which now has the desired
-                    // perms), and then re-open it as a memory-mapped file.
-                    outputStream.Dispose();
-                    using (MemoryMappedFile mmf = MemoryMappedFile.CreateFromFile(fileFullPath, FileMode.Open, mapName: null, (long)size))
-                    using (MemoryMappedViewStream mmstream = mmf.CreateViewStream())
-                    {
-                        CopyTo(inputStream, mmstream);
-                    }
-                }
-                else
-                {
-                    CopyTo(inputStream, outputStream);
-                }
-            }
-            return fileFullPath;
+            return Testable.Default.CopyToFile(inputStream, fileFullPath);
         }
 
         private static void CopyTo(Stream inputStream, Stream outputStream)
@@ -119,6 +36,106 @@ namespace NuGet.Packaging
 #else
             inputStream.CopyTo(outputStream);
 #endif
+        }
+
+        internal class Testable
+        {
+            // Only files smaller than this value will be mmap'ed
+            private const long MAX_MMAP_SIZE = 10 * 1024 * 1024;
+
+            // Mmap can improve file writing performance, but it can make it slower too.
+            // It all depends on a particular hardware configuration, operating system or anti-virus software.
+            // From our benchmarks we concluded that mmap is a good choice for Windows,
+            // but it is not so for other systems.
+            //
+            // 1 - always use memory-mapped files
+            // 0 - never use memory-mapped files
+            // default - use memory-mapped files on Windows, but not on other systems
+            private const string MMAP_VARIABLE_NAME = "NUGET_PACKAGE_EXTRACTION_USE_MMAP";
+
+            internal bool IsMMapEnabled { get; }
+
+            internal Testable(IEnvironmentVariableReader environmentVariableReader)
+            {
+                IsMMapEnabled = environmentVariableReader.GetEnvironmentVariable(MMAP_VARIABLE_NAME) switch
+                {
+                    "0" => false,
+                    "1" => true,
+                    _ => RuntimeEnvironmentHelper.IsWindows
+                };
+            }
+
+            public static Testable Default { get; } = new Testable(EnvironmentVariableWrapper.Instance);
+
+            public string CopyToFile(Stream inputStream, string fileFullPath)
+            {
+                if (Path.GetFileName(fileFullPath).Length == 0)
+                {
+                    Directory.CreateDirectory(fileFullPath);
+                    return fileFullPath;
+                }
+
+                var directory = Path.GetDirectoryName(fileFullPath);
+                if (!Directory.Exists(directory))
+                {
+                    Directory.CreateDirectory(directory);
+                }
+
+                if (File.Exists(fileFullPath))
+                {
+                    // Log and skip adding file
+                    return fileFullPath;
+                }
+
+                // For files of a certain size, we can do some Cleverness and mmap
+                // them instead of writing directly to disk. This can improve
+                // performance by a lot on some operating systems and hardware,
+                // particularly Windows
+                long? size = null;
+                try
+                {
+                    size = inputStream.Length;
+                }
+                catch (NotSupportedException)
+                {
+                    // If we can't get Length, just move on.
+                }
+
+                if (IsMMapEnabled && size > 0 && size <= MAX_MMAP_SIZE)
+                {
+                    MmapCopy(inputStream, fileFullPath, size.Value);
+                }
+                else
+                {
+                    FileStreamCopy(inputStream, fileFullPath);
+                }
+
+                return fileFullPath;
+            }
+
+            internal virtual void MmapCopy(Stream inputStream, string fileFullPath, long size)
+            {
+                using (var outputStream = NuGetExtractionFileIO.CreateFile(fileFullPath))
+                {
+                    // NOTE: Linux can't create a mmf from outputStream, so we
+                    // need to close the file (which now has the desired
+                    // perms), and then re-open it as a memory-mapped file.
+                    outputStream.Dispose();
+                    using (MemoryMappedFile mmf = MemoryMappedFile.CreateFromFile(fileFullPath, FileMode.Open, mapName: null, size))
+                    using (MemoryMappedViewStream mmstream = mmf.CreateViewStream())
+                    {
+                        CopyTo(inputStream, mmstream);
+                    }
+                }
+            }
+
+            internal virtual void FileStreamCopy(Stream inputStream, string fileFullPath)
+            {
+                using (var outputStream = NuGetExtractionFileIO.CreateFile(fileFullPath))
+                {
+                    CopyTo(inputStream, outputStream);
+                }
+            }
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Packaging/PackageExtraction/StreamExtensions.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageExtraction/StreamExtensions.cs
@@ -1,13 +1,25 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Buffers;
+using System.Diagnostics;
 using System.IO;
+using System.IO.MemoryMappedFiles;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace NuGet.Packaging
 {
     public static class StreamExtensions
     {
+        /**
+        Only files smaller than this value will be mmap'ed
+        */
+        private const long MAX_MMAP_SIZE = 10 * 1024 * 1024; // 10 MB
+
+        private static bool IsMMapEnabled { get; } = string.Equals(Environment.GetEnvironmentVariable("NUGET_MMAP_PACKAGE_EXTRACTION"), "1", StringComparison.OrdinalIgnoreCase);
+
         public static string CopyToFile(this Stream inputStream, string fileFullPath)
         {
             if (Path.GetFileName(fileFullPath).Length == 0)
@@ -28,11 +40,38 @@ namespace NuGet.Packaging
                 return fileFullPath;
             }
 
+            // For files of a certain size, we can do some Cleverness and mmap
+            // them instead of writing directly to disk. This can improve
+            // performance by a lot on some operating systems and hardware,
+            // particularly Windows
+            long? size = null;
+            try
+            {
+                size = inputStream.Length;
+            }
+            catch (NotSupportedException)
+            {
+                // If we can't get Length, just move on.
+            }
             using (var outputStream = NuGetExtractionFileIO.CreateFile(fileFullPath))
             {
-                CopyTo(inputStream, outputStream);
+                if (IsMMapEnabled && size > 0 && size <= MAX_MMAP_SIZE)
+                {
+                    // NOTE: Linux can't create a mmf from outputStream, so we
+                    // need to close the file (which now has the desired
+                    // perms), and then re-open it as a memory-mapped file.
+                    outputStream.Dispose();
+                    using (MemoryMappedFile mmf = MemoryMappedFile.CreateFromFile(fileFullPath, FileMode.Open, mapName: null, (long)size))
+                    using (MemoryMappedViewStream mmstream = mmf.CreateViewStream())
+                    {
+                        CopyTo(inputStream, mmstream);
+                    }
+                }
+                else
+                {
+                    CopyTo(inputStream, outputStream);
+                }
             }
-
             return fileFullPath;
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageExtraction/StreamExtensionsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageExtraction/StreamExtensionsTests.cs
@@ -1,0 +1,41 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Moq;
+using NuGet.Common;
+using NuGet.Test.Utility;
+using Xunit;
+
+namespace NuGet.Packaging.Test.PackageExtraction
+{
+    public class StreamExtensionsTests
+    {
+        [PlatformFact(Platform.Windows)]
+        public void WriteFilesWithMMapOnWindows()
+        {
+            var environmentVariableReader = new Mock<IEnvironmentVariableReader>();
+            var uut = new NuGet.Packaging.StreamExtensions.Testable(environmentVariableReader.Object);
+            Assert.True(uut.IsMMapEnabled);
+        }
+
+        [PlatformFact(SkipPlatform = Platform.Windows)]
+        public void WriteFilesWithFileStreamOnNonWindows()
+        {
+            var environmentVariableReader = new Mock<IEnvironmentVariableReader>();
+            var uut = new NuGet.Packaging.StreamExtensions.Testable(environmentVariableReader.Object);
+            Assert.False(uut.IsMMapEnabled);
+        }
+
+        [Theory]
+        [InlineData("0", false)]
+        [InlineData("1", true)]
+        public void EnvironmentVariableIsRespected(string env, bool expected)
+        {
+            var environmentVariableReader = new Mock<IEnvironmentVariableReader>();
+            environmentVariableReader.Setup(x => x.GetEnvironmentVariable("NUGET_PACKAGE_EXTRACTION_USE_MMAP"))
+                .Returns(env);
+            var uut = new NuGet.Packaging.StreamExtensions.Testable(environmentVariableReader.Object);
+            Assert.Equal(uut.IsMMapEnabled, expected);
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageExtraction/StreamExtensionsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageExtraction/StreamExtensionsTests.cs
@@ -10,29 +10,27 @@ using Xunit;
 
 namespace NuGet.Packaging.Test.PackageExtraction
 {
-    class TestableProxy : NuGet.Packaging.StreamExtensions.Testable
-    {
-        public bool MmapCopyWasCalled { get; set; }
-        public bool FileStreamCopyWasCalled { get; set; }
-        internal TestableProxy(IEnvironmentVariableReader environmentVariableReader) : base(environmentVariableReader)
-        {
-        }
-
-        internal override void MmapCopy(Stream inputStream, string fileFullPath, long size)
-        {
-            MmapCopyWasCalled = true;
-            base.MmapCopy(inputStream, fileFullPath, size);
-        }
-
-        internal override void FileStreamCopy(Stream inputStream, string fileFullPath)
-        {
-            FileStreamCopyWasCalled = true;
-            base.FileStreamCopy(inputStream, fileFullPath);
-        }
-    }
-
     public class StreamExtensionsTests
     {
+        class TestableProxy : NuGet.Packaging.StreamExtensions.Testable
+        {
+            public bool MmapCopyWasCalled { get; set; }
+            public bool FileStreamCopyWasCalled { get; set; }
+            internal TestableProxy(IEnvironmentVariableReader environmentVariableReader) : base(environmentVariableReader)
+            {
+            }
+
+            internal override void MmapCopy(Stream inputStream, string fileFullPath, long size)
+            {
+                MmapCopyWasCalled = true;
+            }
+
+            internal override void FileStreamCopy(Stream inputStream, string fileFullPath)
+            {
+                FileStreamCopyWasCalled = true;
+            }
+        }
+
         [PlatformFact(Platform.Windows)]
         public void CopyToFile_Windows_CallsMmapCopy()
         {

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageExtraction/StreamExtensionsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageExtraction/StreamExtensionsTests.cs
@@ -12,6 +12,8 @@ namespace NuGet.Packaging.Test.PackageExtraction
 {
     public class StreamExtensionsTests
     {
+        private const string TestText = "Hello world";
+
         class TestableProxy : NuGet.Packaging.StreamExtensions.Testable
         {
             public bool MmapCopyWasCalled { get; set; }
@@ -23,11 +25,13 @@ namespace NuGet.Packaging.Test.PackageExtraction
             internal override void MmapCopy(Stream inputStream, string fileFullPath, long size)
             {
                 MmapCopyWasCalled = true;
+                base.MmapCopy(inputStream, fileFullPath, size);
             }
 
             internal override void FileStreamCopy(Stream inputStream, string fileFullPath)
             {
                 FileStreamCopyWasCalled = true;
+                base.FileStreamCopy(inputStream, fileFullPath);
             }
         }
 
@@ -39,9 +43,10 @@ namespace NuGet.Packaging.Test.PackageExtraction
                 var testPath = Path.Combine(directory, Path.GetRandomFileName());
                 var environmentVariableReader = new Mock<IEnvironmentVariableReader>();
                 var uut = new TestableProxy(environmentVariableReader.Object);
-                uut.CopyToFile(new MemoryStream(Encoding.UTF8.GetBytes("Hello world")), testPath);
+                uut.CopyToFile(new MemoryStream(Encoding.UTF8.GetBytes(TestText)), testPath);
                 Assert.True(uut.MmapCopyWasCalled);
                 Assert.False(uut.FileStreamCopyWasCalled);
+                Assert.Equal(TestText, File.ReadAllText(testPath));
             }
         }
 
@@ -53,9 +58,10 @@ namespace NuGet.Packaging.Test.PackageExtraction
                 var testPath = Path.Combine(directory, Path.GetRandomFileName());
                 var environmentVariableReader = new Mock<IEnvironmentVariableReader>();
                 var uut = new TestableProxy(environmentVariableReader.Object);
-                uut.CopyToFile(new MemoryStream(Encoding.UTF8.GetBytes("Hello world")), testPath);
+                uut.CopyToFile(new MemoryStream(Encoding.UTF8.GetBytes(TestText)), testPath);
                 Assert.False(uut.MmapCopyWasCalled);
                 Assert.True(uut.FileStreamCopyWasCalled);
+                Assert.Equal(TestText, File.ReadAllText(testPath));
             }
         }
 
@@ -71,9 +77,10 @@ namespace NuGet.Packaging.Test.PackageExtraction
                     .Returns(env);
                 var uut = new TestableProxy(environmentVariableReader.Object);
                 var testPath = Path.Combine(directory, Path.GetRandomFileName());
-                uut.CopyToFile(new MemoryStream(Encoding.UTF8.GetBytes("Hello world")), testPath);
+                uut.CopyToFile(new MemoryStream(Encoding.UTF8.GetBytes(TestText)), testPath);
                 Assert.Equal(uut.MmapCopyWasCalled, expectedMMap);
                 Assert.Equal(uut.FileStreamCopyWasCalled, !uut.MmapCopyWasCalled);
+                Assert.Equal(TestText, File.ReadAllText(testPath));
             }
         }
     }

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageExtraction/StreamExtensionsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageExtraction/StreamExtensionsTests.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.IO;
+using System.Text;
 using Moq;
 using NuGet.Common;
 using NuGet.Test.Utility;
@@ -8,34 +10,73 @@ using Xunit;
 
 namespace NuGet.Packaging.Test.PackageExtraction
 {
+    class TestableProxy : NuGet.Packaging.StreamExtensions.Testable
+    {
+        public bool MmapCopyWasCalled { get; set; }
+        public bool FileStreamCopyWasCalled { get; set; }
+        internal TestableProxy(IEnvironmentVariableReader environmentVariableReader) : base(environmentVariableReader)
+        {
+        }
+
+        internal override void MmapCopy(Stream inputStream, string fileFullPath, long size)
+        {
+            MmapCopyWasCalled = true;
+            base.MmapCopy(inputStream, fileFullPath, size);
+        }
+
+        internal override void FileStreamCopy(Stream inputStream, string fileFullPath)
+        {
+            FileStreamCopyWasCalled = true;
+            base.FileStreamCopy(inputStream, fileFullPath);
+        }
+    }
+
     public class StreamExtensionsTests
     {
         [PlatformFact(Platform.Windows)]
-        public void WriteFilesWithMMapOnWindows()
+        public void CopyToFile_Windows_CallsMmapCopy()
         {
-            var environmentVariableReader = new Mock<IEnvironmentVariableReader>();
-            var uut = new NuGet.Packaging.StreamExtensions.Testable(environmentVariableReader.Object);
-            Assert.True(uut.IsMMapEnabled);
+            using (var directory = TestDirectory.Create())
+            {
+                var testPath = Path.Combine(directory, Path.GetRandomFileName());
+                var environmentVariableReader = new Mock<IEnvironmentVariableReader>();
+                var uut = new TestableProxy(environmentVariableReader.Object);
+                uut.CopyToFile(new MemoryStream(Encoding.UTF8.GetBytes("Hello world")), testPath);
+                Assert.True(uut.MmapCopyWasCalled);
+                Assert.False(uut.FileStreamCopyWasCalled);
+            }
         }
 
         [PlatformFact(SkipPlatform = Platform.Windows)]
-        public void WriteFilesWithFileStreamOnNonWindows()
+        public void CopyToFile_NonWindows_CallsFileStreamCopy()
         {
-            var environmentVariableReader = new Mock<IEnvironmentVariableReader>();
-            var uut = new NuGet.Packaging.StreamExtensions.Testable(environmentVariableReader.Object);
-            Assert.False(uut.IsMMapEnabled);
+            using (var directory = TestDirectory.Create())
+            {
+                var testPath = Path.Combine(directory, Path.GetRandomFileName());
+                var environmentVariableReader = new Mock<IEnvironmentVariableReader>();
+                var uut = new TestableProxy(environmentVariableReader.Object);
+                uut.CopyToFile(new MemoryStream(Encoding.UTF8.GetBytes("Hello world")), testPath);
+                Assert.False(uut.MmapCopyWasCalled);
+                Assert.True(uut.FileStreamCopyWasCalled);
+            }
         }
 
         [Theory]
         [InlineData("0", false)]
         [InlineData("1", true)]
-        public void EnvironmentVariableIsRespected(string env, bool expected)
+        public void CopyToFile_EnvironmentVariable_IsRespected(string env, bool expectedMMap)
         {
-            var environmentVariableReader = new Mock<IEnvironmentVariableReader>();
-            environmentVariableReader.Setup(x => x.GetEnvironmentVariable("NUGET_PACKAGE_EXTRACTION_USE_MMAP"))
-                .Returns(env);
-            var uut = new NuGet.Packaging.StreamExtensions.Testable(environmentVariableReader.Object);
-            Assert.Equal(uut.IsMMapEnabled, expected);
+            using (var directory = TestDirectory.Create())
+            {
+                var environmentVariableReader = new Mock<IEnvironmentVariableReader>();
+                environmentVariableReader.Setup(x => x.GetEnvironmentVariable("NUGET_PACKAGE_EXTRACTION_USE_MMAP"))
+                    .Returns(env);
+                var uut = new TestableProxy(environmentVariableReader.Object);
+                var testPath = Path.Combine(directory, Path.GetRandomFileName());
+                uut.CopyToFile(new MemoryStream(Encoding.UTF8.GetBytes("Hello world")), testPath);
+                Assert.Equal(uut.MmapCopyWasCalled, expectedMMap);
+                Assert.Equal(uut.FileStreamCopyWasCalled, !uut.MmapCopyWasCalled);
+            }
         }
     }
 }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11031

Regression? Last working version: `dotnet 3.x`

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
As it was noted in the https://github.com/NuGet/Home/issues/11031, restore operations which involve downloading and installing packages into the `global-packages` folder became slow in `dotnet 5.x` (when compared to `dotnet 3.x`). 
It turns out that the problem was introduced by introducing the mmap-based package extraction (https://github.com/NuGet/NuGet.Client/pull/3524) which was supposed to make the package extraction faster. According to my testing the opposite is true and it is a better to avoid the memory mapped I/O for package extraction.

## What is the evidence ?
- `dotnet restore` is significantly faster without mmap-based file extraction, `NuGet.exe` is also faster (the effect is not so strong though but it is still visible)
- Tested with 4 different solutions
- Tested on Windows and Linux systems
- Tested on physical machine (Windows) and VMs (Windows, Linux)
- Tested with physical SSD and SSD-based ESB storage on AWS
- Results reproduced outside NuGet (Windows and Linux) with a test application https://github.com/marcin-krystianc/nuget_11031/tree/master/TestFileWriting

## Test Hardware
### AWS VM 
- m5.xlarge instance with EBS storage (General Purpose SSD - gp3 3000/125 ("non-burstable"))
- CPU Intel(R) Xeon 8259CL (4 virtual cores - "non-burstable"), 16 GB RAM
- Windows Server 2019 / Ubuntu 20.04

### Laptop
- Intel(R) Core(TM) i7-8550U CPU @ 1.80GHz (Cores 4/8)
- 16 GB RAM
- Windows 10 + Docker for testing Linux 

# Tested solutions
- [NuGet.Client](https://github.com/NuGet/NuGet.Client)
- [OrchardCore](https://github.com/OrchardCMS/OrchardCore)
- [Orleans](https://github.com/dotnet/orleans)
- [SanitisedNet471](https://github.com/marcin-krystianc/TestSolutions/tree/master/SanitisedNet471)

# Test scenarios
- To avoid a noise in the results from the HTTP traffic, all tests were run with locally defined package sources:
```
<add key="LocalNuGetPackages" value="d:\LocalNuGetPackages" />
```
- All runs were repeated multiple times (30 times) to improve confidence in the results
- Since we are interested in the package extraction process the "arctic" scenario from the [perf scripts](https://github.com/NuGet/NuGet.Client/tree/dev/scripts/perftests) was used. For tests on Linux a following command was used (perf scripts are written in PowerShell and I couldn't make them work on Linux):
```
dotnet nuget locals all --clear && \
dotnet restore -clp:PerformanceSummary -clp:summary --force /p:RestoreUseStaticGraphEvaluation=true
```

# Test results:
- clean restores ("arctic") with `dotnet restore` on Windows:
![dotnet_restore](https://user-images.githubusercontent.com/2308005/128328493-feed1403-07a7-4ee2-97f6-db7fd667ff02.png)

- clean restores ("arctic") with `NuGet.exe restore` on Windows:
![nuget_restore](https://user-images.githubusercontent.com/2308005/128328555-b052e704-6bf7-4c3b-94dc-8d3f05677dbd.png)

- clean restores with `dotnet restore` on Linux:
![dotnet_restore_linux](https://user-images.githubusercontent.com/2308005/128471811-68f0c11d-be9e-4d7d-8817-195cca0c9b61.png)

- results outside NuGet from the [test application](https://github.com/marcin-krystianc/nuget_11031/tree/master/TestFileWriting). Tables below show how much data was written after 120 seconds writing files of a particular size. On Linux the mmap-IO is slower when working with files up to 1MB. On Windows the mmap approach is particularly slow for the 1KB-1MB files.

|Windows AWS |1B |10B |100B |1KB |10KB |100KB |1MB |10MB |100MB |
|---|---|---|---|---|---|---|---|---|---|
|filestreams|174.81KB|2.63MB|26.95MB|241.69MB|2.22GB|14.09GB|15.86GB|17.54GB|14.84GB|
|memorymaps |177.63KB|2.14MB|23.06MB|57.32MB|569.08MB|4.52GB|14.56GB|14.75GB|14.55GB|

|Windows Laptop |1B |10B |100B |1KB |10KB |100KB |1MB |10MB |100MB |
|---|---|---|---|---|---|---|---|---|---|
|filestreams|204.78KB|3.59MB|39.66MB|353.12MB|3.19GB|18.15GB|33.59GB|46.75GB|32.42GB|
|memorymaps |282.23KB|3.05MB|29.10MB|172.38MB|1.51GB|7.81GB|20.08GB|33.23GB|35.74GB|

|Linux AWS |1B |10B |100B |1KB |10KB |100KB |1MB |10MB |100MB |
|---|---|---|---|---|---|---|---|---|---|
|filestreams|345.08KB|3.29MB|32.84MB|342.13MB|3.29GB|14.42GB|14.71GB|14.76GB|14.75GB|
|memorymaps |41.39KB|410.77KB|3.96MB|42.06MB|394.16MB|3.42GB|14.21GB|14.82GB|14.84GB|

# Raw data
- [results.csv](https://github.com/NuGet/NuGet.Client/files/6943836/results.csv)
- [results_windows_AWS.txt](https://github.com/NuGet/NuGet.Client/files/6943853/results_windows_AWS.txt)
- [results_windows_laptop.txt](https://github.com/NuGet/NuGet.Client/files/6943857/results_windows_laptop.txt)
- [results_linux_aws.txt](https://github.com/NuGet/NuGet.Client/files/6943863/results_linux_aws.txt)
- [dotnet_on_linux.txt](https://github.com/NuGet/NuGet.Client/files/6943866/dotnet_on_linux.txt)

# Comparison of disk and CPU utilisation
Both graphs show CPU and disk utilisation when running `dotnet nuget locals all --clear && dotnet restore` for the Orleans solution.
-   with mmap:
![0](https://user-images.githubusercontent.com/2308005/128499214-844f2867-2b06-4da8-a80d-669d6c9221f3.gif)

- without mmap:
![2](https://user-images.githubusercontent.com/2308005/128499223-97eedacd-108d-4dbe-8a9a-122c0e13e10d.gif)

It's clear from the graphs above that CPU utilisation is much higher when the regular file streams API is being used.  With mmap, the restore operation is rather I/O bound, where with file streams it becomes CPU bound. 

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A