### PR TITLE
Recalculate the Solution PMUI project list column tab ordering upon changes to column list

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/SolutionView.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/SolutionView.xaml.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Linq;
 using System.Threading;
@@ -52,6 +53,7 @@ namespace NuGet.PackageManagement.UI
             _versions.ItemContainerStyle = style;
 
             _projectList.SizeChanged += ListView_SizeChanged;
+            ((GridView)_projectList.View).Columns.CollectionChanged += Columns_CollectionChanged;
 
             //Requested Version column may not be needed, but since saved Sorting Settings are being restored at initialization time,
             //we should go ahead and create the Header column for it here with its Sort property name.
@@ -66,6 +68,22 @@ namespace NuGet.PackageManagement.UI
             };
 
             SortByColumn(_projectColumnHeader);
+        }
+
+        private void Columns_CollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+        {
+            if (sender is GridViewColumnCollection columnCollection)
+            {
+                for (int i = 0; i < columnCollection.Count; i++)
+                {
+                    if (columnCollection[i].Header is GridViewColumnHeader columnHeader)
+                    {
+                        // When the project list column header collection changes in any way, recalculate the tabindex
+                        // of each of the columns so the tab order is in the order they appear on screen.
+                        columnHeader.TabIndex = i;
+                    }
+                }
+            }
         }
 
         private void SolutionView_DataContextChanged(object sender, DependencyPropertyChangedEventArgs e)


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/nuget/client.engineering/issues/1086

Regression? Last working version: N/A

## Description
Subscribe to the collection changed event for the column header collection of the GridView that displays the project list in the solution PMUI and when any change is made to the collection, recalculate the tab order of the columns. This handles the scenario where the Version column is programmatically inserted after the UI is painted. It also handles the scenario where the columns are dragged by the user to reorder them. This was previously not working either but this fix addresses that as well.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
Code change is UI related only
  - [x] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
