### PR TITLE
Make CI build multi-stage

### DIFF
--- a/eng/pipelines/templates/Apex_Tests_On_Windows.yml
+++ b/eng/pipelines/templates/Apex_Tests_On_Windows.yml
@@ -8,7 +8,6 @@ steps:
   inputs:
     scriptType: "inlineScript"
     inlineScript: |
-      Write-Host "##vso[build.updatebuildnumber]$env:FullVstsBuildNumber"
       Get-ChildItem Env: | Sort-Object Name | Format-Table -Wrap -AutoSize
 
 - task: DownloadBuildArtifacts@0

--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -1,13 +1,5 @@
 steps:
 - task: PowerShell@1
-  displayName: "Update Build Number"
-  inputs:
-    scriptType: "inlineScript"
-    inlineScript: |
-      Write-Host "##vso[build.updatebuildnumber]$env:FullVstsBuildNumber"
-      Get-ChildItem Env: | Sort-Object Name | Format-Table -Wrap -AutoSize
-
-- task: PowerShell@1
   inputs:
     scriptName: "$(Build.Repository.LocalPath)\\configure.ps1"
     arguments: "-Force"

--- a/eng/pipelines/templates/End_To_End_Tests_On_Windows.yml
+++ b/eng/pipelines/templates/End_To_End_Tests_On_Windows.yml
@@ -12,7 +12,6 @@ steps:
   inputs:
     scriptType: "inlineScript"
     inlineScript: |
-      Write-Host "##vso[build.updatebuildnumber]$env:FullVstsBuildNumber"
       Get-ChildItem Env: | Sort-Object Name | Format-Table -Wrap -AutoSize
 
 - task: DownloadBuildArtifacts@0

--- a/eng/pipelines/templates/Functional_Tests_On_Windows.yml
+++ b/eng/pipelines/templates/Functional_Tests_On_Windows.yml
@@ -4,7 +4,6 @@ steps:
   inputs:
     scriptType: "inlineScript"
     inlineScript: |
-      Write-Host "##vso[build.updatebuildnumber]$env:FullVstsBuildNumber"
       Get-ChildItem Env: | Sort-Object Name | Format-Table -Wrap -AutoSize
 
 - task: PowerShell@1

--- a/eng/pipelines/templates/Source_Build.yml
+++ b/eng/pipelines/templates/Source_Build.yml
@@ -1,14 +1,5 @@
 steps:
 - task: PowerShell@2
-  displayName: "Update Build Number"
-  inputs:
-    targetType: "inline"
-    script: |
-      Write-Host "##vso[build.updatebuildnumber]$env:FULLVSTSBUILDNUMBER"
-    failOnStderr: "true"
-  condition: "always()"
-
-- task: PowerShell@2
   displayName: "Build source-build"
   inputs:
     targetType: "inline"

--- a/eng/pipelines/templates/Tests_On_Linux.yml
+++ b/eng/pipelines/templates/Tests_On_Linux.yml
@@ -1,13 +1,4 @@
 steps:
-- task: PowerShell@2
-  displayName: "Update Build Number"
-  inputs:
-    targetType: "inline"
-    script: |
-      Write-Host "##vso[build.updatebuildnumber]$env:FULLVSTSBUILDNUMBER"
-    failOnStderr: "true"
-  condition: "always()"
-
 - task: ShellScript@2
   displayName: "Run Tests (continue on error)"
   continueOnError: "true"

--- a/eng/pipelines/templates/Tests_On_Mac.yml
+++ b/eng/pipelines/templates/Tests_On_Mac.yml
@@ -1,13 +1,4 @@
 steps:
-- task: PowerShell@2
-  displayName: "Update Build Number"
-  inputs:
-    targetType: "inline"
-    script: |
-      Write-Host "##vso[build.updatebuildnumber]$env:FULLVSTSBUILDNUMBER"
-    failOnStderr: "true"
-  condition: "always()"
-
 - task: DownloadBuildArtifacts@0
   displayName: "Download NuGet.CommandLine.Test artifacts"
   inputs:

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -124,7 +124,9 @@ stages:
     - template: CrossFramework_Tests_On_Windows.yml
 
 - stage: MacTests
-  dependsOn: Build_Insertable
+  dependsOn:
+  - Initialize
+  - Build_Insertable
   condition: "and(succeeded(), eq(variables['RunTestsOnMac'], 'true'))"
   jobs:
   - job: Tests_On_Mac
@@ -138,7 +140,9 @@ stages:
     - template: Tests_On_Mac.yml
 
 - stage: EndToEnd
-  dependsOn: Build_Insertable
+  dependsOn:
+  - Initialize
+  - Build_Insertable
   condition: "and(succeeded(), eq(variables['RunEndToEndTests'], 'true'))"
   jobs:
   - job: End_To_End_Tests_On_Windows
@@ -160,7 +164,9 @@ stages:
     - template: End_To_End_Tests_On_Windows.yml
 
 - stage: Apex
-  dependsOn: Build_Insertable
+  dependsOn:
+  - Initialize
+  - Build_Insertable
   condition: "and(succeeded(), eq(variables['RunApexTests'], 'true'))"
   jobs:
   - job: Apex_Tests_On_Windows

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -1,201 +1,177 @@
 variables:
   DOTNET_NOLOGO: 1
 
-jobs:
-- job: Initialize_Build_SemanticVersion
-  timeoutInMinutes: 10
-  pool:
-    vmImage: windows-latest
-    demands:
-      - DotNetFramework
-      - msbuild
+stages:
+- stage: Initialize
+  jobs:
+  - job: GetSemanticVersion
+    displayName: Get NuGet.Client semantic version
+    timeoutInMinutes: 10
+    pool:
+      vmImage: windows-latest
+    steps:
+    - template: Initialize_Build_SemanticVersion.yml
 
-  steps:
-  - template: Initialize_Build_SemanticVersion.yml
+  - job: Initialize_Build
+    dependsOn: GetSemanticVersion
+    timeoutInMinutes: 10
+    variables:
+      SemanticVersion: $[dependencies.GetSemanticVersion.outputs['setsemanticversion.SemanticVersion']]
+      BuildRevision: $[counter(format('{0}.{1}', variables['SemanticVersion'], variables['build.definitionname']), 1)]
+    pool:
+      vmImage: windows-latest
+    steps:
+    - template: Initialize_Build.yml
 
-- job: Initialize_Build
-  dependsOn: Initialize_Build_SemanticVersion
-  timeoutInMinutes: 10
-  variables:
-    SemanticVersion: $[dependencies.Initialize_Build_SemanticVersion.outputs['setsemanticversion.SemanticVersion']]
-    BuildRevision: $[counter(format('{0}.{1}', variables['SemanticVersion'], variables['build.definitionname']), 1)]
+- stage: Build_Insertable
+  displayName: Build NuGet inserted into VS and .NET SDK
+  dependsOn: Initialize
+  jobs:
+  - job: Build_and_UnitTest_NonRTM
+    timeoutInMinutes: 170
+    variables:
+      BuildNumber: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.BuildNumber']]
+      FullVstsBuildNumber: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
+      VsTargetChannel: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.VsTargetChannel']]
+      VsTargetMajorVersion: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.VsTargetMajorVersion']]
+      SDKVersionForBuild: $[stageDependencies.Initialize.Initialize_Build.outputs['getSDKVersionForBuild.SDKVersionForBuild']]
+      LocalizedLanguageCount: "13"
+      BuildRTM: "false"
+    pool:
+      name: VSEngSS-MicroBuild2019
+    steps:
+    - template: Build_and_UnitTest.yml
 
-  pool:
-    vmImage: windows-latest
-    demands:
-      - DotNetFramework
-      - msbuild
+- stage: Build_For_Publishing
+  displayName: Build NuGet published to nuget.org
+  dependsOn: Initialize
+  jobs:
+  - job: Build_and_UnitTest_RTM
+    timeoutInMinutes: 170
+    variables:
+      BuildNumber: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.BuildNumber']]
+      FullVstsBuildNumber: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
+      VsTargetChannel: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.VsTargetChannel']]
+      VsTargetMajorVersion: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.VsTargetMajorVersion']]
+      SDKVersionForBuild: $[stageDependencies.Initialize.Initialize_Build.outputs['getSDKVersionForBuild.SDKVersionForBuild']]
+      LocalizedLanguageCount: "13"
+      BuildRTM: "true"
+    pool:
+      name: VSEngSS-MicroBuild2019
+    steps:
+    - template: Build_and_UnitTest.yml
 
-  steps:
-  - template: Initialize_Build.yml
+- stage: Source_Build
+  dependsOn: Build_Insertable
+  jobs:
+  - job: Build_Source_Build
+    timeoutInMinutes: 120
+    variables:
+      BuildNumber: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.BuildNumber']]
+      FullVstsBuildNumber: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
+      SDKVersionForBuild: $[stageDependencies.Initialize.Initialize_Build.outputs['getSDKVersionForBuild.SDKVersionForBuild']]
+      BuildRTM: "false"
+    pool:
+      vmImage: ubuntu-latest
+    steps:
+    - template: Source_Build.yml
 
-- job: Build_and_UnitTest_NonRTM
-  dependsOn: Initialize_Build
-  timeoutInMinutes: 170
-  variables:
-    BuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.BuildNumber']]
-    FullVstsBuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
-    VsTargetChannel: $[dependencies.Initialize_Build.outputs['updatebuildnumber.VsTargetChannel']]
-    VsTargetMajorVersion: $[dependencies.Initialize_Build.outputs['updatebuildnumber.VsTargetMajorVersion']]
-    SDKVersionForBuild: $[dependencies.Initialize_Build.outputs['getSDKVersionForBuild.SDKVersionForBuild']]
-    LocalizedLanguageCount: "13"
-    BuildRTM: "false"
+- stage: CLI_Func_Tests
+  dependsOn: Initialize
+  jobs:
+  - job: Functional_Tests_On_Windows
+    timeoutInMinutes: 120
+    variables:
+      BuildNumber: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.BuildNumber']]
+      FullVstsBuildNumber: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
+      SDKVersionForBuild: $[stageDependencies.Initialize.Initialize_Build.outputs['getSDKVersionForBuild.SDKVersionForBuild']]
+    condition: "and(succeeded(),eq(variables['RunFunctionalTestsOnWindows'], 'true')) "
+    pool:
+      name: VSEngSS-MicroBuild2019
+    strategy:
+      matrix:
+        IsDesktop:
+          SkipCoreAssemblies: "true"
+        IsCore:
+          SkipDesktopAssemblies: "true"
+    steps:
+    - template: Functional_Tests_On_Windows.yml
 
-  pool:
-    name: VSEngSS-MicroBuild2019
-    demands:
-      - DotNetFramework
-      - msbuild
+  - job: Tests_On_Linux
+    timeoutInMinutes: 45
+    variables:
+      FULLVSTSBUILDNUMBER: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
+      SDKVersionForBuild: $[stageDependencies.Initialize.Initialize_Build.outputs['getSDKVersionForBuild.SDKVersionForBuild']]
+      MSBUILDDISABLENODEREUSE: 1
+    condition: "and(succeeded(), eq(variables['RunTestsOnLinux'], 'true'))"
+    pool:
+      vmImage: ubuntu-latest
+    steps:
+    - template: Tests_On_Linux.yml
 
-  steps:
-  - template: Build_and_UnitTest.yml
+  - job: CrossFramework_Tests_On_Windows
+    dependsOn:
+    - Initialize_Build
+    timeoutInMinutes: 30
+    variables:
+      BuildNumber: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.BuildNumber']]
+      FullVstsBuildNumber: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
+      SDKVersionForBuild: $[stageDependencies.Initialize.Initialize_Build.outputs['getSDKVersionForBuild.SDKVersionForBuild']]
+    condition: "and(succeeded(),eq(variables['RunCrossFrameworkTestsOnWindows'], 'true')) "
+    pool:
+      name: VSEngSS-MicroBuild2019
+    steps:
+    - template: CrossFramework_Tests_On_Windows.yml
 
-- job: Build_and_UnitTest_RTM
-  dependsOn: Initialize_Build
-  timeoutInMinutes: 170
-  variables:
-    BuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.BuildNumber']]
-    FullVstsBuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
-    VsTargetChannel: $[dependencies.Initialize_Build.outputs['updatebuildnumber.VsTargetChannel']]
-    VsTargetMajorVersion: $[dependencies.Initialize_Build.outputs['updatebuildnumber.VsTargetMajorVersion']]
-    SDKVersionForBuild: $[dependencies.Initialize_Build.outputs['getSDKVersionForBuild.SDKVersionForBuild']]
-    LocalizedLanguageCount: "13"
-    BuildRTM: "true"
+- stage: MacTests
+  dependsOn: Build_Insertable
+  condition: "and(succeeded(), eq(variables['RunTestsOnMac'], 'true'))"
+  jobs:
+  - job: Tests_On_Mac
+    timeoutInMinutes: 90
+    variables:
+      FULLVSTSBUILDNUMBER: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
+      SDKVersionForBuild: $[stageDependencies.Initialize.Initialize_Build.outputs['getSDKVersionForBuild.SDKVersionForBuild']]
+    pool:
+      vmImage: macos-latest
+    steps:
+    - template: Tests_On_Mac.yml
 
-  pool:
-    name: VSEngSS-MicroBuild2019
-    demands:
-      - DotNetFramework
-      - msbuild
+- stage: EndToEnd
+  dependsOn: Build_Insertable
+  condition: "and(succeeded(), eq(variables['RunEndToEndTests'], 'true'))"
+  jobs:
+  - job: End_To_End_Tests_On_Windows
+    timeoutInMinutes: 100
+    variables:
+      FullVstsBuildNumber: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
+      SDKVersionForBuild: $[stageDependencies.Initialize.Initialize_Build.outputs['getSDKVersionForBuild.SDKVersionForBuild']]
+    pool:
+      name: DDNuGet-Windows
+      demands:
+      - Allow_NuGet_E2E_Tests -equals true
+    strategy:
+      matrix:
+        Part1:
+          Part: "InstallPackageTest.ps1,UninstallPackageTest.ps1,UpdatePackageTest.ps1,PackageRestoreTest.ps1"
+        Part2:
+          Part: "A-TopDownloadedPackages.ps1,BuildIntegratedTest.ps1,ExecuteInitScriptTest.ps1,FindPackageTest.ps1,GetPackageTest.ps1,GetProjectTest.ps1,LegacyPackageRefProjectTest.ps1,NativeProjectTest.ps1,NetCoreProjectTest.ps1,PackTest.ps1,ProjectRetargeting.ps1,ServicesTest.ps1,Settings.ps1,SyncPackageTest.ps1,TabExpansionTest.ps1,UniversalWindowsProjectTest.ps1"
+    steps:
+    - template: End_To_End_Tests_On_Windows.yml
 
-  steps:
-  - template: Build_and_UnitTest.yml
-
-- job: Functional_Tests_On_Windows
-  dependsOn: Initialize_Build
-  timeoutInMinutes: 120
-  variables:
-    BuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.BuildNumber']]
-    FullVstsBuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
-    SDKVersionForBuild: $[dependencies.Initialize_Build.outputs['getSDKVersionForBuild.SDKVersionForBuild']]
-  condition: "and(succeeded(),eq(variables['RunFunctionalTestsOnWindows'], 'true')) "
-  pool:
-    name: VSEngSS-MicroBuild2019
-    demands:
-        - DotNetFramework
-        - msbuild
-  strategy:
-    matrix:
-      IsDesktop:
-        SkipCoreAssemblies: "true"
-      IsCore:
-        SkipDesktopAssemblies: "true"
-
-  steps:
-  - template: Functional_Tests_On_Windows.yml
-
-- job: CrossFramework_Tests_On_Windows
-  dependsOn:
-  - Initialize_Build
-  timeoutInMinutes: 30
-  variables:
-    BuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.BuildNumber']]
-    FullVstsBuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
-    SDKVersionForBuild: $[dependencies.Initialize_Build.outputs['getSDKVersionForBuild.SDKVersionForBuild']]
-  condition: "and(succeeded(),eq(variables['RunCrossFrameworkTestsOnWindows'], 'true')) "
-  pool:
-    name: VSEngSS-MicroBuild2019
-    demands:
-        - DotNetFramework
-        - msbuild
-
-  steps:
-  - template: CrossFramework_Tests_On_Windows.yml
-
-- job: Tests_On_Linux
-  dependsOn: Initialize_Build
-  timeoutInMinutes: 45
-  variables:
-    FULLVSTSBUILDNUMBER: $[dependencies.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
-    SDKVersionForBuild: $[dependencies.Initialize_Build.outputs['getSDKVersionForBuild.SDKVersionForBuild']]
-    MSBUILDDISABLENODEREUSE: 1
-  condition: "and(succeeded(),eq(variables['RunTestsOnLinux'], 'true')) "
-  pool:
-    vmImage: ubuntu-latest
-    demands: sh
-
-  steps:
-  - template: Tests_On_Linux.yml
-
-- job: Tests_On_Mac
-  dependsOn:
-  - Build_and_UnitTest_NonRTM
-  - Initialize_Build
-  timeoutInMinutes: 90
-  variables:
-    FULLVSTSBUILDNUMBER: $[dependencies.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
-    SDKVersionForBuild: $[dependencies.Initialize_Build.outputs['getSDKVersionForBuild.SDKVersionForBuild']]
-  condition: "and(succeeded(),eq(variables['RunTestsOnMac'], 'true')) "
-  pool:
-    vmImage: macos-latest
-
-  steps:
-  - template: Tests_On_Mac.yml
-
-- job: End_To_End_Tests_On_Windows
-  dependsOn:
-  - Build_and_UnitTest_NonRTM
-  - Initialize_Build
-  timeoutInMinutes: 100
-  variables:
-    FullVstsBuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
-    SDKVersionForBuild: $[dependencies.Initialize_Build.outputs['getSDKVersionForBuild.SDKVersionForBuild']]
-  condition: "and(succeeded(),eq(variables['RunEndToEndTests'], 'true')) "
-  pool:
-    name: DDNuGet-Windows
-    demands:
-    - DotNetFramework
-    - Allow_NuGet_E2E_Tests -equals true
-  strategy:
-    matrix:
-      Part1:
-        Part: "InstallPackageTest.ps1,UninstallPackageTest.ps1,UpdatePackageTest.ps1,PackageRestoreTest.ps1"
-      Part2:
-        Part: "A-TopDownloadedPackages.ps1,BuildIntegratedTest.ps1,ExecuteInitScriptTest.ps1,FindPackageTest.ps1,GetPackageTest.ps1,GetProjectTest.ps1,LegacyPackageRefProjectTest.ps1,NativeProjectTest.ps1,NetCoreProjectTest.ps1,PackTest.ps1,ProjectRetargeting.ps1,ServicesTest.ps1,Settings.ps1,SyncPackageTest.ps1,TabExpansionTest.ps1,UniversalWindowsProjectTest.ps1"
-
-  steps:
-  - template: End_To_End_Tests_On_Windows.yml
-
-- job: Apex_Tests_On_Windows
-  dependsOn:
-  - Build_and_UnitTest_NonRTM
-  - Initialize_Build
-  timeoutInMinutes: 150
-  variables:
-    BuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.BuildNumber']]
-    FullVstsBuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
-    SDKVersionForBuild: $[dependencies.Initialize_Build.outputs['getSDKVersionForBuild.SDKVersionForBuild']]
-  condition: "and(succeeded(),eq(variables['RunApexTests'], 'true')) "
-  pool:
-    name: DDNuGet-Windows
-    demands:
-    - DotNetFramework
-    - Allow_NuGet_Apex_Tests -equals true
-
-  steps:
-  - template: Apex_Tests_On_Windows.yml
-
-- job: Source_Build
-  dependsOn:
-  - Initialize_Build
-  timeoutInMinutes: 120
-  variables:
-    BuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.BuildNumber']]
-    FullVstsBuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
-    SDKVersionForBuild: $[dependencies.Initialize_Build.outputs['getSDKVersionForBuild.SDKVersionForBuild']]
-    BuildRTM: "false"
-  pool:
-    vmImage: ubuntu-latest
-    demands: sh
-  steps:
-  - template: Source_Build.yml
+- stage: Apex
+  dependsOn: Build_Insertable
+  condition: "and(succeeded(), eq(variables['RunApexTests'], 'true'))"
+  jobs:
+  - job: Apex_Tests_On_Windows
+    timeoutInMinutes: 150
+    variables:
+      BuildNumber: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.BuildNumber']]
+      FullVstsBuildNumber: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
+      SDKVersionForBuild: $[stageDependencies.Initialize.Initialize_Build.outputs['getSDKVersionForBuild.SDKVersionForBuild']]
+    pool:
+      name: DDNuGet-Windows
+      demands:
+      - Allow_NuGet_Apex_Tests -equals true
+    steps:
+    - template: Apex_Tests_On_Windows.yml

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -62,7 +62,7 @@ stages:
     - template: Build_and_UnitTest.yml
 
 - stage: Source_Build
-  dependsOn: Build_Insertable
+  dependsOn: Initialize
   jobs:
   - job: Build_Source_Build
     timeoutInMinutes: 120
@@ -110,8 +110,6 @@ stages:
     - template: Tests_On_Linux.yml
 
   - job: CrossFramework_Tests_On_Windows
-    dependsOn:
-    - Initialize_Build
     timeoutInMinutes: 30
     variables:
       BuildNumber: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.BuildNumber']]


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1089

Regression? No

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

When viewing diff for `pipeline.yml`, make sure you enable "hide whitespace changes" in GitHub's diff options.

* Removed "update build number" from all jobs that are not the initialize_build job
* Made most jobs their own stage, although I did put windows func tests and linux tests in a single stage.
  * Build RTM and NonRTM are in different stages because E2E, Apex and Mac tests dependsOn the NonRTM build. If both build jobs were in the same stage, then the other stages won't start until all jobs in the stage are complete. Also if the RTM build failed, then the stage will be in a failed state, and none of the other stages will run. This way, they still run even if RTM build fails.

## PR Checklist

- [X] PR has a meaningful title
- [X] PR has a linked issue.
- [X] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [X] N/A: Infrastructure

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [X] N/A
