### PR TITLE
fix(docs): Remove link to closed/dead-end link in Contributing guidelines

### DIFF
--- a/docs/coding-guidelines.md
+++ b/docs/coding-guidelines.md
@@ -514,8 +514,6 @@ restoreResult.Success.Should().BeTrue(because: restoreResult.AllOutput);
 
 By default all unit test assemblies should run in parallel mode, which is the default. Unit tests shouldn't depend on any shared state, and so should generally be runnable in parallel. If the tests fail in parallel, the first thing to do is to figure out *why*; do not just disable parallel tests!
 
-Issue tracking the re-enabling of the [paralelization](https://github.com/NuGet/Home/issues/8987) in the current unit tests.
-
 For functional tests it is reasonable to disable parallel tests.
 
 ### Use only complete words or common/standard abbreviations in public APIs


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: Removed dead end link in documentation re: parallel test execution

Regression? Last working version: N/A - Docs

## Description
The provided link linked to https://github.com/NuGet/Home/issues/8987 which is a closed issue that references another issue. The second referenced issue is from Nuget/Client.Engineering which either doesn't exist or isn't public. Either way the target issue is closed so this seems like dead docs.

Started looking at this while I get familiar with the codebase/docs related to suggested feature: https://github.com/NuGet/Home/issues/11142

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [x] Documentation PR or issue filled
  - **OR**
  - [ ] N/A
