### PR TITLE
Move optprof tests in NuGet.Client repo

### DIFF
--- a/build/NuGet-WithApex.sln
+++ b/build/NuGet-WithApex.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.28404.58
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31602.334
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{BD1946CE-5544-4F28-A04A-9C3D51113E1A}"
 EndProject
@@ -152,8 +152,6 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGet.PackageManagement.UI"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGet.SolutionRestoreManager", "..\src\NuGet.Clients\NuGet.SolutionRestoreManager\NuGet.SolutionRestoreManager.csproj", "{06662133-1292-4918-90F3-36C930C0B16F}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NuGet.SolutionRestoreManager.Interop", "..\src\NuGet.Clients\NuGet.SolutionRestoreManager.Interop\NuGet.SolutionRestoreManager.Interop.csproj", "{4003E1AB-70DE-4B9C-8999-96160EE91D84}"
-EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGet.Tools", "..\src\NuGet.Clients\NuGet.Tools\NuGet.Tools.csproj", "{D0F9864B-D782-4471-81A2-29555E5DC0D7}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGet.VisualStudio.Client", "..\src\NuGet.Clients\NuGet.VisualStudio.Client\NuGet.VisualStudio.Client.csproj", "{3B96F91B-3B58-40ED-B06E-5CD133A79A63}"
@@ -242,6 +240,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NuGet.Tests.Apex", "..\test\NuGet.Tests.Apex\NuGet.Tests.Apex\NuGet.Tests.Apex.csproj", "{81EB90B9-7FA5-434E-8502-09A9892A0FA7}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NuGet.VisualStudio.Contracts", "..\src\NuGet.Clients\NuGet.VisualStudio.Contracts\NuGet.VisualStudio.Contracts.csproj", "{5E23CEFF-16ED-42B7-BCB9-42F14B5ACB7B}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NuGet.OptProf", "..\test\NuGet.Tests.Apex\NuGet.OptProf\NuGet.OptProf.csproj", "{402D2985-4E04-4BDA-825C-9695A9440635}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -417,10 +417,6 @@ Global
 		{06662133-1292-4918-90F3-36C930C0B16F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{06662133-1292-4918-90F3-36C930C0B16F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{06662133-1292-4918-90F3-36C930C0B16F}.Release|Any CPU.Build.0 = Release|Any CPU
-		{4003E1AB-70DE-4B9C-8999-96160EE91D84}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{4003E1AB-70DE-4B9C-8999-96160EE91D84}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{4003E1AB-70DE-4B9C-8999-96160EE91D84}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{4003E1AB-70DE-4B9C-8999-96160EE91D84}.Release|Any CPU.Build.0 = Release|Any CPU
 		{D0F9864B-D782-4471-81A2-29555E5DC0D7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{D0F9864B-D782-4471-81A2-29555E5DC0D7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D0F9864B-D782-4471-81A2-29555E5DC0D7}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -589,6 +585,10 @@ Global
 		{5E23CEFF-16ED-42B7-BCB9-42F14B5ACB7B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5E23CEFF-16ED-42B7-BCB9-42F14B5ACB7B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5E23CEFF-16ED-42B7-BCB9-42F14B5ACB7B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{402D2985-4E04-4BDA-825C-9695A9440635}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{402D2985-4E04-4BDA-825C-9695A9440635}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{402D2985-4E04-4BDA-825C-9695A9440635}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{402D2985-4E04-4BDA-825C-9695A9440635}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -646,7 +646,6 @@ Global
 		{26DC17AC-A390-4515-A2C0-07A0950036C5} = {08F523EC-3C2A-4A00-A54C-2E54C5AC856B}
 		{538ADEFD-2170-40A9-A2C5-EC8369CFE490} = {08F523EC-3C2A-4A00-A54C-2E54C5AC856B}
 		{06662133-1292-4918-90F3-36C930C0B16F} = {08F523EC-3C2A-4A00-A54C-2E54C5AC856B}
-		{4003E1AB-70DE-4B9C-8999-96160EE91D84} = {08F523EC-3C2A-4A00-A54C-2E54C5AC856B}
 		{D0F9864B-D782-4471-81A2-29555E5DC0D7} = {08F523EC-3C2A-4A00-A54C-2E54C5AC856B}
 		{3B96F91B-3B58-40ED-B06E-5CD133A79A63} = {08F523EC-3C2A-4A00-A54C-2E54C5AC856B}
 		{306CDDFA-FF0B-4299-930C-9EC6C9308160} = {08F523EC-3C2A-4A00-A54C-2E54C5AC856B}
@@ -690,6 +689,7 @@ Global
 		{DF56DB8F-F7A3-4EA6-912B-1CBC1741547F} = {8155136C-FFEA-450B-BF55-3418A6B091CC}
 		{81EB90B9-7FA5-434E-8502-09A9892A0FA7} = {8155136C-FFEA-450B-BF55-3418A6B091CC}
 		{5E23CEFF-16ED-42B7-BCB9-42F14B5ACB7B} = {08F523EC-3C2A-4A00-A54C-2E54C5AC856B}
+		{402D2985-4E04-4BDA-825C-9695A9440635} = {8155136C-FFEA-450B-BF55-3418A6B091CC}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {3747A66A-00D1-41B8-A9C5-ED0D7BEA9D25}

--- a/build/NuGet.OptProfV2.runsettingsproj
+++ b/build/NuGet.OptProfV2.runsettingsproj
@@ -29,14 +29,15 @@
   </ItemDefinitionGroup>
 
   <ItemGroup Label="Test Stores">
-    <!-- This represents the build drop that contains NuGet.Tests.dll. -->
+    <!-- This represents the build drop that contains NuGet.OptProf.dll. -->
     <TestStore Include="vstsdrop:$(TestDrop)" />
     <!-- This represents the build drop that contains profiling inputs. -->
     <TestStore Include="vstsdrop:$(ProfilingInputsDrop)" />
   </ItemGroup>
 
   <ItemGroup Label="Test Containers">
-    <TestContainer Include="NuGet.Tests.dll" />
+    <TestContainer Include="NuGet.OptProf.dll" />
+    <InstallationConfiguration Include="../.vsconfig" />
   </ItemGroup>
 
   <ItemGroup Label="Data Collectors">
@@ -204,6 +205,6 @@
     </AdditionalSettings>
   </ItemGroup>
 
-  <Import Project="$(SolutionPackagesFolder)Microsoft.DevDiv.Validation.TestPlatform.Settings.Tasks.1.0.308\build\Microsoft.DevDiv.Validation.TestPlatform.Settings.Tasks.targets" />
+  <Import Project="$(SolutionPackagesFolder)Microsoft.DevDiv.Validation.TestPlatform.Settings.Tasks.1.0.655\build\Microsoft.DevDiv.Validation.TestPlatform.Settings.Tasks.targets" />
   <Import Project="$(BuildCommonDirectory)common.targets" />
 </Project>

--- a/build/common.project.props
+++ b/build/common.project.props
@@ -243,10 +243,10 @@
   <ItemGroup Condition=" '$(IsXPlat)' != 'true' ">
     <SolutionProjects Include="$(RepositoryRootDirectory)test\*\*\*.csproj"
                       Exclude="$(RepositoryRootDirectory)test\EndToEnd\*\*.csproj;
-                               $(RepositoryRootDirectory)test\NuGet.Tests.Apex\*\NuGet.Tests.Apex.csproj"
+                               $(RepositoryRootDirectory)test\NuGet.Tests.Apex\*\*.csproj"
                       Condition=" '$(ExcludeTestProjects)' != 'true' " />
 
-    <SolutionProjects Include="$(RepositoryRootDirectory)test\NuGet.Tests.Apex\*\NuGet.Tests.Apex.csproj" Condition="'$(IncludeApex)' == 'true'" />
+    <SolutionProjects Include="$(RepositoryRootDirectory)test\NuGet.Tests.Apex\*\*.csproj" Condition="'$(IncludeApex)' == 'true'" />
     <SolutionProjects Include="$(RepositoryRootDirectory)src\*\*\*.csproj" />
 
     <SolutionProjectsWithoutVSIX Include="@(SolutionProjects)"

--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -103,7 +103,7 @@ steps:
   inputs:
     solution: "build\\build.proj"
     configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/t:RestoreVS /p:BuildNumber=$(BuildNumber) /p:BuildRTM=$(BuildRTM) /v:m"
+    msbuildArguments: "/t:RestoreVS /p:BuildNumber=$(BuildNumber) /p:BuildRTM=$(BuildRTM) /v:m /p:IncludeApex=true"
     maximumCpuCount: true
 
 - task: MSBuild@1
@@ -111,7 +111,7 @@ steps:
   inputs:
     solution: "build\\build.proj"
     configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/t:BuildNoVSIX /p:BuildRTM=$(BuildRTM) /p:BuildNumber=$(BuildNumber) /p:SkipILMergeOfNuGetExe=true /p:GitRepositoryRemoteName=github"
+    msbuildArguments: "/t:BuildNoVSIX /p:BuildRTM=$(BuildRTM) /p:BuildNumber=$(BuildNumber) /p:SkipILMergeOfNuGetExe=true /p:GitRepositoryRemoteName=github /p:IncludeApex=true"
     maximumCpuCount: true
 
 - task: MSBuild@1
@@ -317,7 +317,7 @@ steps:
   displayName: 'OptProfV2:  install the NuGet package for building .runsettingsproj file'
   inputs:
     command: 'custom'
-    arguments: 'install Microsoft.DevDiv.Validation.TestPlatform.Settings.Tasks -Version 1.0.308 -Source $(VsPackageFeedUrl) -ConfigFile $(System.DefaultWorkingDirectory)\NuGet.config -OutputDirectory $(System.DefaultWorkingDirectory)\packages'
+    arguments: 'install Microsoft.DevDiv.Validation.TestPlatform.Settings.Tasks -Version 1.0.655 -Source $(VsPackageFeedUrl) -ConfigFile $(System.DefaultWorkingDirectory)\NuGet.config -OutputDirectory $(System.DefaultWorkingDirectory)\packages'
   condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
 
 - task: MicroBuildBuildVSBootstrapper@2
@@ -338,25 +338,19 @@ steps:
     ArtifactType: Container
   condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
 
-- task: PowerShell@1
-  displayName: 'OptProfV2:  set the TestDrop environment variable'
-  inputs:
-    scriptType: 'inlineScript'
-    inlineScript: |
-      [string] $bootstrapperInfoFilePath = "$Env:BUILD_STAGINGDIRECTORY\MicroBuild\Output\BootstrapperInfo.json"
-      $json = Get-Content $bootstrapperInfoFilePath | ConvertFrom-Json
-      [string] $buildDropPath = $json.BuildDrop
-      Write-Host "Build drop:  $buildDropPath"
-      [string] $testDropPath = $buildDropPath.Replace('/Products/', '/Tests/').Substring('https://vsdrop.corp.microsoft.com/file/v1/'.Length)
-      Write-Host "Test drop:  $testDropPath"
-      Write-Host "##vso[task.setvariable variable=TestDrop]$testDropPath"
-  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
-
 - task: MSBuild@1
   displayName: 'OptProfV2:  generate a .runsettings file'
   inputs:
     solution: 'build\NuGet.OptProfV2.runsettingsproj'
-    msbuildArguments: '/p:OutputPath="$(Build.Repository.LocalPath)\artifacts\RunSettings" /p:TestDrop="$(TestDrop)" /p:ProfilingInputsDrop="ProfilingInputs/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildId)"'
+    msbuildArguments: '/p:OutputPath="$(Build.Repository.LocalPath)\artifacts\RunSettings" /p:TestDrop="RunSettings/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildId)" /p:ProfilingInputsDrop="ProfilingInputs/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildId)" /p:IncludeProfilingInputs=$(IsOfficialBuild)'
+  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
+
+- task: CopyFiles@2
+  displayName: 'OptProfV2:  copy test binaries'
+  inputs:
+    sourceFolder: 'test\NuGet.Tests.Apex\NuGet.OptProf\bin\$(BuildConfiguration)'
+    Contents: '**'
+    targetFolder: 'artifacts\RunSettings\NuGet.OptProf'
   condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
 
 - task: artifactDropTask@0
@@ -367,7 +361,7 @@ steps:
     sourcePath: 'artifacts\RunSettings'
     toLowerCase: false
     usePat: true
-    dropMetadataContainerName: RunSettings
+    dropMetadataContainerName: 'DropMetadata-RunSettings'
   condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
 
 - task: artifactDropTask@0
@@ -378,6 +372,7 @@ steps:
     sourcePath: '$(Build.ArtifactStagingDirectory)\OptProf\ProfilingInputs'
     toLowerCase: false
     usePat: true
+    dropMetadataContainerName: 'DropMetadata-ProfilingInputs'
   condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
 
 - task: PublishBuildArtifacts@1

--- a/test/NuGet.Tests.Apex/NuGet.OptProf/Assets/PackageReferenceSdk/NuGet.Config
+++ b/test/NuGet.Tests.Apex/NuGet.OptProf/Assets/PackageReferenceSdk/NuGet.Config
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+  <disabledPackageSources>
+    <clear />
+  </disabledPackageSources>
+  <packageRestore>
+    <add key="enabled" value="true" />
+    <add key="automatic" value="true" />
+  </packageRestore>
+</configuration>

--- a/test/NuGet.Tests.Apex/NuGet.OptProf/Assets/PackageReferenceSdk/PackageReferenceSdk.sln
+++ b/test/NuGet.Tests.Apex/NuGet.OptProf/Assets/PackageReferenceSdk/PackageReferenceSdk.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.28827.37
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PackageReferenceSdk", "PackageReferenceSdk\PackageReferenceSdk.csproj", "{E2C1450F-8CE3-4E82-A368-E57B4B21E88F}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{E2C1450F-8CE3-4E82-A368-E57B4B21E88F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E2C1450F-8CE3-4E82-A368-E57B4B21E88F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E2C1450F-8CE3-4E82-A368-E57B4B21E88F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E2C1450F-8CE3-4E82-A368-E57B4B21E88F}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {24E99D04-D5FB-4ED6-ACC0-9E567CE7B64F}
+	EndGlobalSection
+EndGlobal

--- a/test/NuGet.Tests.Apex/NuGet.OptProf/Assets/PackageReferenceSdk/PackageReferenceSdk/Class1.cs
+++ b/test/NuGet.Tests.Apex/NuGet.OptProf/Assets/PackageReferenceSdk/PackageReferenceSdk/Class1.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using Newtonsoft.Json.Linq;
+
+namespace PackageReferenceSdk
+{
+    public class Class1
+    {
+        internal JObject JObject { get; }
+
+        internal Class1()
+        {
+            JObject = JObject.Parse("{}");
+        }
+    }
+}

--- a/test/NuGet.Tests.Apex/NuGet.OptProf/Assets/PackageReferenceSdk/PackageReferenceSdk/PackageReferenceSdk.csproj
+++ b/test/NuGet.Tests.Apex/NuGet.OptProf/Assets/PackageReferenceSdk/PackageReferenceSdk/PackageReferenceSdk.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+  </ItemGroup>
+
+</Project>

--- a/test/NuGet.Tests.Apex/NuGet.OptProf/NuGet.OptProf.csproj
+++ b/test/NuGet.Tests.Apex/NuGet.OptProf/NuGet.OptProf.csproj
@@ -1,0 +1,39 @@
+<Project>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common.test.props" />
+  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
+
+  <PropertyGroup>
+    <TargetFramework>$(NETFXTargetFramework)</TargetFramework>
+    <NETCoreWPFProject>true</NETCoreWPFProject>
+    <IsPackable>false</IsPackable>
+    <Description>Optimization Profiling (OptProf) tests, used to generate partial ngen training data.</Description>
+    <DefaultItemExcludes>Assets/**;$(DefaultItemExcludes)</DefaultItemExcludes>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="TestIVsPackageSourceProvider.cs" />
+    <Compile Include="Tests.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="Assets\**">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Test.Apex.VisualStudio" />
+    <PackageReference Include="Microsoft.VisualStudio.Sdk" />
+    <PackageReference Include="Newtonsoft.Json" NoWarn="NU1605" />
+    <PackageReference Include="Xunit.StaFact" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\NuGet.Clients\NuGet.VisualStudio\NuGet.VisualStudio.csproj">
+      <EmbedInteropTypes>true</EmbedInteropTypes>
+    </ProjectReference>
+  </ItemGroup>
+
+  <Import Project="$(BuildCommonDirectory)common.targets" />
+  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
+</Project>

--- a/test/NuGet.Tests.Apex/NuGet.OptProf/TestIVsPackageSourceProvider.cs
+++ b/test/NuGet.Tests.Apex/NuGet.OptProf/TestIVsPackageSourceProvider.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using Microsoft.Test.Apex.VisualStudio;
+using NuGet.VisualStudio;
+
+namespace NuGet
+{
+    [Export(typeof(TestIVsPackageSourceProvider))]
+    public sealed class TestIVsPackageSourceProvider : VisualStudioTestService
+    {
+        public IEnumerable<KeyValuePair<string, string>> GetSources(bool includeUnOfficial, bool includeDisabled)
+        {
+            IVsPackageSourceProvider packageSourceProvider = VisualStudioObjectProviders.GetComponentModelService<IVsPackageSourceProvider>();
+
+            return packageSourceProvider.GetSources(includeUnOfficial, includeDisabled);
+        }
+    }
+}

--- a/test/NuGet.Tests.Apex/NuGet.OptProf/Tests.cs
+++ b/test/NuGet.Tests.Apex/NuGet.OptProf/Tests.cs
@@ -1,0 +1,239 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using Microsoft.Test.Apex;
+using Microsoft.Test.Apex.Hosts.Services;
+using Microsoft.Test.Apex.VisualStudio;
+using Microsoft.Test.Apex.VisualStudio.Shell.ToolWindows;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace NuGet
+{
+    [TestClass]
+    public class OptProfV2Tests : ApexTest
+    {
+        private static readonly Guid _packageManagerOutputWindowPaneGuid = Guid.Parse("CEC55EC8-CC51-40E7-9243-57B87A6F6BEB");
+        private const string _testCategory = "OptProf";
+        private const int _timeoutInMilliseconds = 15 * 60 * 1000; // 15 minutes
+
+        // Must be lazy because TestContext.DeploymentDirectory only returns a valid value within a test method.
+        private readonly Lazy<DirectoryInfo> _lazyAssetsDirectory;
+
+        public OptProfV2Tests()
+        {
+            _lazyAssetsDirectory = new Lazy<DirectoryInfo>(() => new DirectoryInfo(Path.Combine(TestContext.DeploymentDirectory, "Assets")));
+        }
+
+        [TestMethod]
+        [TestCategory(_testCategory)]
+        [Timeout(_timeoutInMilliseconds)]
+        [DeploymentItem(@"Assets\PackageReferenceSdk", @"Assets\PackageReferenceSdk")]
+        public void OpenSolutionAndBuild_PackageReferenceSdk()
+        {
+            FileInfo solutionFile = GetSolutionFile("PackageReferenceSdk");
+
+            OpenSolutionAndBuild(solutionFile);
+        }
+
+        [TestMethod]
+        [TestCategory(_testCategory)]
+        [Timeout(_timeoutInMilliseconds)]
+        [DeploymentItem(@"Assets\PackageReferenceSdk", @"Assets\PackageReferenceSdk")]
+        public void IVsPackageSourceProvider_GetSources()
+        {
+            FileInfo solutionFile = GetSolutionFile("PackageReferenceSdk");
+
+            UseService<TestIVsPackageSourceProvider>(solutionFile, service =>
+            {
+                IEnumerable<KeyValuePair<string, string>> sources = service.GetSources(includeUnOfficial: true, includeDisabled: true);
+
+                Assert.AreNotEqual(0, sources.Count());
+            });
+        }
+
+        private void BuildSolution(VisualStudioHost visualStudio)
+        {
+            using (Scope.Enter("Build solution."))
+            {
+                // Rebuild to ensure a clean build.
+                visualStudio.ObjectModel.Solution.BuildManager.Rebuild();
+                visualStudio.ObjectModel.Solution.BuildManager.Verify.Succeeded();
+            }
+        }
+
+        private VisualStudioHostConfiguration CreateVisualStudioHostConfiguration()
+        {
+            return new VisualStudioHostConfiguration()
+            {
+                RestoreUserSettings = false,
+                // Required in order to allow modules mapped to the test to generate IBC files.
+                InheritProcessEnvironment = true
+            };
+        }
+
+        private FileInfo GetSolutionFile(string solutionName)
+        {
+            var solutionFile = new FileInfo(Path.Combine(_lazyAssetsDirectory.Value.FullName, solutionName, $"{solutionName}.sln"));
+
+            Verify.IsTrue(solutionFile.Exists, $"Unable to find solution file {solutionFile.FullName}");
+
+            return solutionFile;
+        }
+
+        private void HandleException(VisualStudioHost visualStudio, Exception ex)
+        {
+            using (Scope.Enter("Handle exception."))
+            {
+                if (visualStudio != null && visualStudio.IsRunning)
+                {
+                    visualStudio.CaptureHostProcessDumpIfRunning(MiniDumpType.WithFullMemory);
+                    visualStudio.HostProcess.Kill();
+                }
+
+                Logger.WriteException(EntryType.Error, ex);
+                Verify.Fail("Exception encountered during test execution");
+                Assert.Fail(ex.Message);
+            }
+        }
+
+        private VisualStudioHost LaunchVisualStudio(VisualStudioHostConfiguration configuration)
+        {
+            VisualStudioHost visualStudio = Operations.CreateHost<VisualStudioHost>(configuration);
+
+            using (Scope.Enter("Launch Visual Studio."))
+            {
+                visualStudio.Start();
+            }
+
+            return visualStudio;
+        }
+
+        private void LoadSolution(VisualStudioHost visualStudio, FileInfo solutionFile)
+        {
+            using (Scope.Enter("Load solution."))
+            {
+                visualStudio.ObjectModel.Solution.WaitForFullyLoadedOnOpen = true;
+                visualStudio.ObjectModel.Solution.Open(solutionFile.FullName);
+                visualStudio.ObjectModel.Solution.Verify.HasProject();
+            }
+        }
+
+        private void OpenSolutionAndBuild(FileInfo solutionFile)
+        {
+            VisualStudioHost visualStudio = null;
+
+            try
+            {
+                VisualStudioHostConfiguration configuration = CreateVisualStudioHostConfiguration();
+
+                visualStudio = LaunchVisualStudio(configuration);
+
+                LoadSolution(visualStudio, solutionFile);
+                WaitForAutoRestoreToComplete(visualStudio, solutionFile);
+                BuildSolution(visualStudio);
+                ShutDownVisualStudio(visualStudio);
+            }
+            catch (Exception ex)
+            {
+                HandleException(visualStudio, ex);
+            }
+        }
+
+        private void ShutDownVisualStudio(VisualStudioHost visualStudio)
+        {
+            using (Scope.Enter("Close solution and shut down Visual Studio."))
+            {
+                visualStudio.ObjectModel.Solution.Close();
+                visualStudio.Stop();
+            }
+        }
+
+        private void UseService<T>(FileInfo solutionFile, Action<T> action)
+            where T : class
+        {
+            VisualStudioHost visualStudio = null;
+
+            try
+            {
+                VisualStudioHostConfiguration configuration = CreateVisualStudioHostConfiguration();
+
+                configuration.AddCompositionAssembly(Assembly.GetExecutingAssembly().Location);
+
+                visualStudio = LaunchVisualStudio(configuration);
+
+                LoadSolution(visualStudio, solutionFile);
+                WaitForAutoRestoreToComplete(visualStudio, solutionFile);
+
+                using (Scope.Enter("Get service."))
+                {
+                    var service = visualStudio.Get<T>();
+
+                    using (Scope.Enter("Verify service."))
+                    {
+                        action(service);
+                    }
+                }
+
+                ShutDownVisualStudio(visualStudio);
+            }
+            catch (Exception ex)
+            {
+                HandleException(visualStudio, ex);
+            }
+        }
+
+        private void WaitForAutoRestoreToComplete(VisualStudioHost visualStudio, FileInfo solutionFile)
+        {
+            using (Scope.Enter("Wait for auto restore completion."))
+            {
+                var assetsFile = new FileInfo(Path.Combine(solutionFile.DirectoryName, solutionFile.Directory.Name, "obj", "project.assets.json"));
+                var timeout = TimeSpan.FromMinutes(1);
+                var interval = TimeSpan.FromSeconds(5);
+
+                const string RestoreOutputCompletionMarker = "========== Finished ==========";
+
+                visualStudio.ObjectModel.Solution.WaitForIntellisenseStage(TimeSpan.FromMinutes(5));
+                visualStudio.ObjectModel.Shell.ToolWindows.OutputWindow.ToolWindow.Show();
+
+                // Wait for the assets file to be created.
+                Omni.Common.WaitFor.IsTrue(
+                    () => File.Exists(assetsFile.FullName),
+                    timeout,
+                    interval,
+                    $"An assets file was not created at '{assetsFile.FullName}'.");
+
+                // Wait for the solution restore to complete.
+                Omni.Common.WaitFor.IsTrue(
+                     () =>
+                     {
+                         if (TryGetPackageManagerOutputWindowPane(visualStudio, out OutputWindowPaneTestExtension packageManagerOutputWindowPane))
+                         {
+                             var output = packageManagerOutputWindowPane.Text;
+
+                             if (!string.IsNullOrEmpty(output))
+                             {
+                                 output = output.TrimEnd('\r', '\n');
+
+                                 return output.Contains(RestoreOutputCompletionMarker);
+                             }
+                         }
+
+                         return false;
+                     },
+                     timeout,
+                     interval,
+                     "Solution restore did not complete according to the Package Manager output window pane.");
+            }
+        }
+
+        private static bool TryGetPackageManagerOutputWindowPane(VisualStudioHost visualStudio, out OutputWindowPaneTestExtension packageManagerOutputWindowPane)
+        {
+            packageManagerOutputWindowPane = visualStudio.ObjectModel.Shell.ToolWindows.OutputWindow.GetOutputPane(_packageManagerOutputWindowPaneGuid);
+
+            return packageManagerOutputWindowPane != null;
+        }
+    }
+}


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/991

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

* Copy existing OptProf tests into NuGet.Client repo, and modify csproj to work appropriately for our repo.
* Changed runsettingsproj to change the assembly name (also helps us validate I made the changes correctly) and drop location
* Modify pipeline YAML to publish test binaries to location that the runsettings file points to.

**Note**: This test project is not run on PR. Later we'll move the tests to our existing Apex test project, so they're tested on every build, but this is just the first step.

## PR Checklist

- [X] PR has a meaningful title
- [X] PR has a linked issue.
- [X] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [X] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [X] N/A
