### PR TITLE
Fix tab stop accessibility issue in license acceptance window

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/LicenseAcceptanceWindow.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/LicenseAcceptanceWindow.xaml
@@ -88,7 +88,7 @@
                     <Run
               Text="{Binding Authors, Mode=OneTime}" />
           </TextBlock>
-          <ItemsControl ItemsSource="{Binding License}">
+          <ItemsControl ItemsSource="{Binding License}" IsTabStop="False">
             <ItemsControl.ItemsPanel>
               <ItemsPanelTemplate>
                 <WrapPanel Orientation="Horizontal" />


### PR DESCRIPTION

<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

Fixes: https://github.com/NuGet/Client.Engineering/issues/1093 (dupe)
Fixes: https://github.com/NuGet/Client.Engineering/issues/1079 

## Description
The View License hyperlink is in a content control which is also a tab stop so a user has to press Tab twice to focus the link.  This change sets the IsTabStop to False for the ItemControl to prevent this.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
