### PR TITLE
Install packages.config should honor PackageSaveMode

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/InstallCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/InstallCommand.cs
@@ -183,8 +183,14 @@ namespace NuGet.CommandLine
                 maxNumberOfParallelTasks: DisableParallelProcessing ? 1 : PackageManagementConstants.DefaultMaxDegreeOfParallelism,
                 logger: Console);
 
+            var packageSaveMode = Packaging.PackageSaveMode.Defaultv2;
+            if (EffectivePackageSaveMode != Packaging.PackageSaveMode.None)
+            {
+                packageSaveMode = EffectivePackageSaveMode;
+            }
+
             var missingPackageReferences = installedPackageReferences.Where(reference =>
-                !nuGetPackageManager.PackageExistsInPackagesFolder(reference.PackageIdentity)).Any();
+                !nuGetPackageManager.PackageExistsInPackagesFolder(reference.PackageIdentity, packageSaveMode)).Any();
 
             if (!missingPackageReferences)
             {
@@ -205,7 +211,7 @@ namespace NuGet.CommandLine
                 var projectContext = new ConsoleProjectContext(Console)
                 {
                     PackageExtractionContext = new PackageExtractionContext(
-                        Packaging.PackageSaveMode.Defaultv2,
+                        packageSaveMode,
                         PackageExtractionBehavior.XmlDocFileSaveMode,
                         clientPolicyContext,
                         Console)


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11018

Regression? Last working version: No

## Description
`nuget restore` honors `PackageSaveMode`. This PR made `nuget install` honor `PackageSaveMode` too.
1. Check whether a package with same PackageSaveMode is already installed. 
2. Install packages with specified mode.
3. Add tests. (Copied `InstallCommand_PackageSaveMode*()` with minor changes.)

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
