### PR TITLE
Make the performance scripts account for restore operation failures

### DIFF
--- a/scripts/perftests/PerformanceTestUtilities.ps1
+++ b/scripts/perftests/PerformanceTestUtilities.ps1
@@ -484,7 +484,7 @@ Function RunRestore(
     $logs = . $nugetClientFilePath $arguments | Out-String
     if($LASTEXITCODE -ne 0)
     { 
-        throw "The command `"$nugetClientFilePath $arguments`" finished with exit code $LASTEXITCODE" 
+        throw "The command `"$nugetClientFilePath $arguments`" finished with exit code $LASTEXITCODE.`n" + $logs
     }
 
     $totalTime = $stopwatch.Elapsed.TotalSeconds

--- a/scripts/perftests/PerformanceTestUtilities.ps1
+++ b/scripts/perftests/PerformanceTestUtilities.ps1
@@ -482,7 +482,10 @@ Function RunRestore(
     $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
 
     $logs = . $nugetClientFilePath $arguments | Out-String
-    # TODO https://github.com/NuGet/Home/issues/9968
+    if($LASTEXITCODE -ne 0)
+    { 
+        throw "The command `"$nugetClientFilePath $arguments`" finished with exit code $LASTEXITCODE" 
+    }
 
     $totalTime = $stopwatch.Elapsed.TotalSeconds
     $restoreCoreTime = ExtractRestoreElapsedTime $logs


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/9968

Regression? Last working version: No

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

The exit code of the restore operation is checked and the exception is thrown if the exit code is not 0.
The output of the failed command is also included in the exception message.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
