### PR TITLE
Remove NuGet.SolutionRestoreManager.Interop from list

### DIFF
--- a/scripts/utils/EnsureAllPackagesExist.ps1
+++ b/scripts/utils/EnsureAllPackagesExist.ps1
@@ -10,7 +10,6 @@ Param (
 [System.Collections.ArrayList]$PackageIDListShouldExist = @(
 "NuGet.CommandLine",
 "NuGet.Indexing",
-"NuGet.SolutionRestoreManager.Interop",
 "NuGet.VisualStudio.Contracts",
 "NuGet.VisualStudio",
 "Microsoft.Build.NuGetSdkResolver",


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

Fixes: https://github.com/NuGet/Client.Engineering/issues/1096

Regression? No

## Description
Remove `NuGet.SolutionRestoreManager.Interop` from the checking list of scripts/utils/EnsureAllPackagesExist.ps1, as we no longer have/pack this project.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [ ] N/A
