### PR TITLE
test: use new DependencyGraphSpec

### DIFF
--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
@@ -2977,7 +2977,7 @@ namespace NuGet.Commands.FuncTest
                 var newRequest = new TestRestoreRequest(spec, sources, pathContext.UserPackagesFolder, logger)
                 {
                     ProjectStyle = ProjectStyle.PackageReference,
-                    DependencyGraphSpec = dgSpec,
+                    DependencyGraphSpec = newDgSpec,
                     AllowNoOp = true,
                 };
                 var newCommand = new RestoreCommand(newRequest);


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->

Fixes: https://github.com/NuGet/Home/issues/11168

Regression? Last working version: n/a

## Description
`newDgSpec` was not used in the test so I assume this was overlooked? This PR does not change the test outcome.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
