### PR TITLE
Allow users to specify namespace mode using NuGet.Config file

### DIFF
--- a/src/NuGet.Core/NuGet.Configuration/PackageNamespaces/NamespaceMode.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageNamespaces/NamespaceMode.cs
@@ -1,0 +1,20 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGet.Configuration
+{
+    public enum NamespaceMode
+    {
+        /// <summary>
+        /// Relaxed mode for package namespaces.
+        /// Any package id must be in one or more matching namespace declarations.
+        /// </summary>
+        MultipleSourcesPerPackage,
+
+        /// <summary>
+        /// Strict mode for package namespaces.
+        /// No package id may match more than one feed.
+        /// </summary>
+        SingleSourcePerPackage
+    }
+}

--- a/src/NuGet.Core/NuGet.Configuration/PackageNamespaces/NamespaceMode.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageNamespaces/NamespaceMode.cs
@@ -3,13 +3,13 @@
 
 namespace NuGet.Configuration
 {
-    public enum NamespaceMode
+    internal enum NamespaceMode
     {
         /// <summary>
         /// Relaxed mode for package namespaces.
         /// Any package id must be in one or more matching namespace declarations.
         /// </summary>
-        MultipleSourcesPerPackage,
+        AtLeastOneSourcePerPackage,
 
         /// <summary>
         /// Strict mode for package namespaces.

--- a/src/NuGet.Core/NuGet.Configuration/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Configuration/PublicAPI.Unshipped.txt
@@ -1,9 +1,6 @@
 NuGet.Configuration.NamespaceItem
 NuGet.Configuration.NamespaceItem.Id.get -> string
 NuGet.Configuration.NamespaceItem.NamespaceItem(string id) -> void
-NuGet.Configuration.NamespaceMode
-NuGet.Configuration.NamespaceMode.MultipleSourcesPerPackage = 0 -> NuGet.Configuration.NamespaceMode
-NuGet.Configuration.NamespaceMode.SingleSourcePerPackage = 1 -> NuGet.Configuration.NamespaceMode
 NuGet.Configuration.PackageNamespacesConfiguration
 NuGet.Configuration.PackageNamespacesConfiguration.AreNamespacesEnabled.get -> bool
 NuGet.Configuration.PackageNamespacesConfiguration.GetConfiguredPackageSources(string term) -> System.Collections.Generic.IReadOnlyList<string>
@@ -14,7 +11,6 @@ NuGet.Configuration.PackageNamespacesSourceItem.SetKey(string value) -> void
 NuGet.Configuration.SettingElementType.Namespace = 19 -> NuGet.Configuration.SettingElementType
 NuGet.Configuration.SettingElementType.PackageNamespaces = 17 -> NuGet.Configuration.SettingElementType
 NuGet.Configuration.SettingElementType.PackageSource = 18 -> NuGet.Configuration.SettingElementType
-const NuGet.Configuration.ConfigurationConstants.NamespacesMode = "namespaceMode" -> string
 override NuGet.Configuration.NamespaceItem.Clone() -> NuGet.Configuration.SettingBase
 override NuGet.Configuration.NamespaceItem.ElementName.get -> string
 override NuGet.Configuration.NamespaceItem.Equals(object other) -> bool
@@ -26,7 +22,6 @@ override NuGet.Configuration.PackageNamespacesSourceItem.Equals(object other) ->
 override NuGet.Configuration.PackageNamespacesSourceItem.GetHashCode() -> int
 override NuGet.Configuration.PackageNamespacesSourceItem.RequiredAttributes.get -> System.Collections.Generic.IReadOnlyCollection<string>
 static NuGet.Configuration.PackageNamespacesConfiguration.GetPackageNamespacesConfiguration(NuGet.Configuration.ISettings settings) -> NuGet.Configuration.PackageNamespacesConfiguration
-static NuGet.Configuration.SettingsUtility.GetNamespaceMode(NuGet.Configuration.ISettings settings) -> NuGet.Configuration.NamespaceMode
 static readonly NuGet.Configuration.ConfigurationConstants.IdAttribute -> string
 static readonly NuGet.Configuration.ConfigurationConstants.Namespace -> string
 static readonly NuGet.Configuration.ConfigurationConstants.PackageNamespaces -> string

--- a/src/NuGet.Core/NuGet.Configuration/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Configuration/PublicAPI.Unshipped.txt
@@ -1,6 +1,9 @@
 NuGet.Configuration.NamespaceItem
 NuGet.Configuration.NamespaceItem.Id.get -> string
 NuGet.Configuration.NamespaceItem.NamespaceItem(string id) -> void
+NuGet.Configuration.NamespaceMode
+NuGet.Configuration.NamespaceMode.MultipleSourcesPerPackage = 0 -> NuGet.Configuration.NamespaceMode
+NuGet.Configuration.NamespaceMode.SingleSourcePerPackage = 1 -> NuGet.Configuration.NamespaceMode
 NuGet.Configuration.PackageNamespacesConfiguration
 NuGet.Configuration.PackageNamespacesConfiguration.AreNamespacesEnabled.get -> bool
 NuGet.Configuration.PackageNamespacesConfiguration.GetConfiguredPackageSources(string term) -> System.Collections.Generic.IReadOnlyList<string>
@@ -11,6 +14,7 @@ NuGet.Configuration.PackageNamespacesSourceItem.SetKey(string value) -> void
 NuGet.Configuration.SettingElementType.Namespace = 19 -> NuGet.Configuration.SettingElementType
 NuGet.Configuration.SettingElementType.PackageNamespaces = 17 -> NuGet.Configuration.SettingElementType
 NuGet.Configuration.SettingElementType.PackageSource = 18 -> NuGet.Configuration.SettingElementType
+const NuGet.Configuration.ConfigurationConstants.NamespacesMode = "namespaceMode" -> string
 override NuGet.Configuration.NamespaceItem.Clone() -> NuGet.Configuration.SettingBase
 override NuGet.Configuration.NamespaceItem.ElementName.get -> string
 override NuGet.Configuration.NamespaceItem.Equals(object other) -> bool
@@ -22,6 +26,7 @@ override NuGet.Configuration.PackageNamespacesSourceItem.Equals(object other) ->
 override NuGet.Configuration.PackageNamespacesSourceItem.GetHashCode() -> int
 override NuGet.Configuration.PackageNamespacesSourceItem.RequiredAttributes.get -> System.Collections.Generic.IReadOnlyCollection<string>
 static NuGet.Configuration.PackageNamespacesConfiguration.GetPackageNamespacesConfiguration(NuGet.Configuration.ISettings settings) -> NuGet.Configuration.PackageNamespacesConfiguration
+static NuGet.Configuration.SettingsUtility.GetNamespaceMode(NuGet.Configuration.ISettings settings) -> NuGet.Configuration.NamespaceMode
 static readonly NuGet.Configuration.ConfigurationConstants.IdAttribute -> string
 static readonly NuGet.Configuration.ConfigurationConstants.Namespace -> string
 static readonly NuGet.Configuration.ConfigurationConstants.PackageNamespaces -> string

--- a/src/NuGet.Core/NuGet.Configuration/Resources.Designer.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Resources.Designer.cs
@@ -97,6 +97,15 @@ namespace NuGet.Configuration {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Allowed value(s): {0}.
+        /// </summary>
+        internal static string AttributeValuesAllowed {
+            get {
+                return ResourceManager.GetString("AttributeValuesAllowed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The item passed to the Update method cannot refer to a different item than the one being updated..
         /// </summary>
         internal static string CannotUpdateDifferentItems {

--- a/src/NuGet.Core/NuGet.Configuration/Resources.resx
+++ b/src/NuGet.Core/NuGet.Configuration/Resources.resx
@@ -311,4 +311,8 @@
   <data name="Argument_Cannot_Be_Null_Empty_Or_WhiteSpaceOnly" xml:space="preserve">
     <value>Argument cannot be null, empty, or whitespace only.</value>
   </data>
+  <data name="AttributeValuesAllowed" xml:space="preserve">
+    <value>Allowed value(s): {0}</value>
+    <comment>{0} - list of allowed values for an attribute</comment>
+  </data>
 </root>

--- a/src/NuGet.Core/NuGet.Configuration/Utility/ConfigurationContants.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Utility/ConfigurationContants.cs
@@ -131,6 +131,6 @@ namespace NuGet.Configuration
 
         public static readonly string IdAttribute = "id";
 
-        public const string NamespacesMode = "namespaceMode";
+        internal const string NamespacesMode = "namespaceMode";
     }
 }

--- a/src/NuGet.Core/NuGet.Configuration/Utility/ConfigurationContants.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Utility/ConfigurationContants.cs
@@ -130,5 +130,7 @@ namespace NuGet.Configuration
         public static readonly string ValueAttribute = "value";
 
         public static readonly string IdAttribute = "id";
+
+        public const string NamespacesMode = "namespaceMode";
     }
 }

--- a/src/NuGet.Core/NuGet.Configuration/Utility/SettingsUtility.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Utility/SettingsUtility.cs
@@ -408,6 +408,23 @@ namespace NuGet.Configuration
             return RevocationMode.Online;
         }
 
+        public static NamespaceMode GetNamespaceMode(ISettings settings)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+
+            var namespacesMode = GetConfigValue(settings, ConfigurationConstants.NamespacesMode);
+
+            if (!string.IsNullOrEmpty(namespacesMode) && Enum.TryParse(namespacesMode, ignoreCase: true, result: out NamespaceMode mode))
+            {
+                return mode;
+            }
+
+            return NamespaceMode.MultipleSourcesPerPackage;
+        }
+
         /// <summary>
         /// Throw if a path is relative.
         /// </summary>

--- a/src/NuGet.Core/NuGet.Configuration/Utility/SettingsUtility.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Utility/SettingsUtility.cs
@@ -408,6 +408,14 @@ namespace NuGet.Configuration
             return RevocationMode.Online;
         }
 
+        /// <summary>
+        /// Reads namespace mode from NuGet.Config
+        /// </summary>
+        /// <param name="settings"></param>
+        /// <returns>Default value if no mode configured.
+        /// Throws excetion if the mode is invalid.
+        /// Otherwise returns the namespace mode.
+        /// </returns>
         internal static NamespaceMode GetNamespaceMode(ISettings settings)
         {
             if (settings == null)
@@ -417,12 +425,26 @@ namespace NuGet.Configuration
 
             var namespacesMode = GetConfigValue(settings, ConfigurationConstants.NamespacesMode);
 
-            if (!string.IsNullOrEmpty(namespacesMode) && Enum.TryParse(namespacesMode, ignoreCase: true, result: out NamespaceMode mode))
+            if (namespacesMode is null)
+            {
+                return NamespaceMode.AtLeastOneSourcePerPackage;
+            }
+            else if (Enum.TryParse(namespacesMode, ignoreCase: true, result: out NamespaceMode mode))
             {
                 return mode;
             }
 
-            return NamespaceMode.AtLeastOneSourcePerPackage;
+            var message1 = string.Format(CultureInfo.CurrentCulture,
+                Resources.AttributeValueNotAllowed,
+                ConfigurationConstants.NamespacesMode,
+                namespacesMode,
+                ConfigurationConstants.Config);
+
+            var message2 = string.Format(CultureInfo.CurrentCulture,
+                Resources.AttributeValuesAllowed,
+                string.Join(",", Enum.GetNames(typeof(NamespaceMode))));
+
+            throw new NuGetConfigurationException(string.Concat(message1, message2));
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Configuration/Utility/SettingsUtility.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Utility/SettingsUtility.cs
@@ -408,7 +408,7 @@ namespace NuGet.Configuration
             return RevocationMode.Online;
         }
 
-        public static NamespaceMode GetNamespaceMode(ISettings settings)
+        internal static NamespaceMode GetNamespaceMode(ISettings settings)
         {
             if (settings == null)
             {
@@ -422,7 +422,7 @@ namespace NuGet.Configuration
                 return mode;
             }
 
-            return NamespaceMode.MultipleSourcesPerPackage;
+            return NamespaceMode.AtLeastOneSourcePerPackage;
         }
 
         /// <summary>

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsUtilityTests.cs
@@ -327,7 +327,7 @@ namespace NuGet.Configuration.Test
         }
 
         [Fact]
-        public void GetNamespaceModeValueForAddItem_WithValidKeyValue_Success()
+        public void GetNamespaceMode_WithValidKeyValue_Success()
         {
             // Arrange
             var nugetConfigPath = "NuGet.Config";
@@ -354,8 +354,8 @@ namespace NuGet.Configuration.Test
         [InlineData("")]
         [InlineData(null)]
         [InlineData("bad value")]
-        [InlineData("multipleSourcesPerPackage")]
-        public void GetNamespaceModeValueForAddItem_WithInValidAndDefaultKeyValueReturnsDefaultMode_Success(string namespaceMode)
+        [InlineData("atLeastOneSourcePerPackage")]
+        public void GetNamespaceMode_WithInValidOrDefaultValueReturnsDefaultMode_Success(string namespaceMode)
         {
             // Arrange
             var nugetConfigPath = "NuGet.Config";
@@ -375,7 +375,7 @@ namespace NuGet.Configuration.Test
             var result = SettingsUtility.GetNamespaceMode(settings);
 
             // Assert
-            Assert.Equal(NamespaceMode.MultipleSourcesPerPackage, result);
+            Assert.Equal(NamespaceMode.AtLeastOneSourcePerPackage, result);
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsUtilityTests.cs
@@ -347,7 +347,7 @@ namespace NuGet.Configuration.Test
             var result = SettingsUtility.GetNamespaceMode(settings);
 
             // Assert
-            result.Should().BeSameAs(NamespaceMode.SingleSourcePerPackage);
+            Assert.Equal(NamespaceMode.SingleSourcePerPackage, result);
         }
 
         [Theory]
@@ -375,7 +375,7 @@ namespace NuGet.Configuration.Test
             var result = SettingsUtility.GetNamespaceMode(settings);
 
             // Assert
-            result.Should().BeSameAs(NamespaceMode.MultipleSourcesPerPackage);
+            Assert.Equal(NamespaceMode.MultipleSourcesPerPackage, result);
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsUtilityTests.cs
@@ -316,5 +316,66 @@ namespace NuGet.Configuration.Test
             ex.Should().NotBeNull();
             ex.Should().BeOfType<ArgumentNullException>();
         }
+
+        [Fact]
+        public void GetNamespaceMode_WithNullSettings_Throws()
+        {
+            var ex = Record.Exception(() => SettingsUtility.GetNamespaceMode(settings: null));
+
+            ex.Should().NotBeNull();
+            ex.Should().BeOfType<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void GetNamespaceModeValueForAddItem_WithValidKeyValue_Success()
+        {
+            // Arrange
+            var nugetConfigPath = "NuGet.Config";
+            var config = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+    <config>
+        <add key=""namespaceMode"" value=""singleSourcePerPackage"" />
+    </config>
+</configuration>";
+
+            using var mockBaseDirectory = TestDirectory.Create();
+
+            SettingsTestUtils.CreateConfigurationFile(nugetConfigPath, mockBaseDirectory, config);
+            var settings = new Settings(mockBaseDirectory);
+
+            // Act
+            var result = SettingsUtility.GetNamespaceMode(settings);
+
+            // Assert
+            result.Should().BeSameAs(NamespaceMode.SingleSourcePerPackage);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData(null)]
+        [InlineData("bad value")]
+        [InlineData("multipleSourcesPerPackage")]
+        public void GetNamespaceModeValueForAddItem_WithInValidAndDefaultKeyValueReturnsDefaultMode_Success(string namespaceMode)
+        {
+            // Arrange
+            var nugetConfigPath = "NuGet.Config";
+            var config = $@"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+    <config>
+        <add key=""namespaceMode"" value= ""{namespaceMode}"" />
+    </config>
+</configuration>";
+
+            using var mockBaseDirectory = TestDirectory.Create();
+
+            SettingsTestUtils.CreateConfigurationFile(nugetConfigPath, mockBaseDirectory, config);
+            var settings = new Settings(mockBaseDirectory);
+
+            // Act
+            var result = SettingsUtility.GetNamespaceMode(settings);
+
+            // Assert
+            result.Should().BeSameAs(NamespaceMode.MultipleSourcesPerPackage);
+        }
     }
 }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/nuget/home/issues/11150

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

As per [spec](https://github.com/NuGet/Home/blob/dev/proposed/2021/PackageNamespaces.md#explanation), Users can configure package namespaces mode in the NuGet.Config file for different source pinning behaviors. There are following modes as per spec.
- `fullySpecified` - Any package id must be in one or more matching namespace declarations
- `singleSource` - No package id may match more than one feed (based on precedence rules)

**Note:** These names are subjective to change soon. To keep things moving in parallel, in this PR I added `singleSourcePerPackage` and `atLeastOneSourcePerPackage` modes. I will create follow-up pull requests to make use of namespace modes in `PackageReference`, `PackageDownload` and `Packages.Config` scenarios.

Sample `NuGet.Config` file with namespace mode added is shown below.

``` xml
<?xml version="1.0" encoding="utf-8"?>
<configuration>
    <config>
        <add key="namespaceMode" value= "singleSourcePerPackage" />
    </config>
</configuration>
```
Users can also use the following `nuget.exe` command to add `namespaceMode` to the `NuGet.Config` file

`> nuget.exe config -Set namespacesMode=singleSourcePerPackage -configfile <PATH TO CONFIG FILE>`
https://docs.microsoft.com/en-us/nuget/reference/cli-reference/cli-ref-config

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [x] Documentation PR or issue filled - https://github.com/nuget/client.engineering/issues/1031