### PR TITLE
PackageRestoreBar & RestartRequestBar in PM UI now properly inform Screen Readers of visual state

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageRestoreBar.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageRestoreBar.xaml
@@ -3,10 +3,10 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              Loaded="UserControl_Loaded"
              xmlns:resx="clr-namespace:NuGet.PackageManagement.UI"
-             Visibility="{Binding Visibility, ElementName=RestoreBar}">
+             Visibility="{Binding InnerVisibility, Mode=OneWay}">
     <UserControl.Resources>
       <Storyboard x:Key="ShowSmoothly">
-        <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="RestoreBar">
+        <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="InnerVisibility" Storyboard.Target="{Binding}">
           <DiscreteObjectKeyFrame KeyTime="0:0:0.3" Value="{x:Static Visibility.Visible}"/>
         </ObjectAnimationUsingKeyFrames>
         <DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Opacity)" Storyboard.TargetName="RestoreBar">
@@ -18,12 +18,12 @@
         <DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Opacity)" Storyboard.TargetName="RestoreBar">
           <EasingDoubleKeyFrame KeyTime="0:0:0.6" Value="0"/>
         </DoubleAnimationUsingKeyFrames>
-        <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="RestoreBar">
+        <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="InnerVisibility" Storyboard.Target="{Binding}">
           <DiscreteObjectKeyFrame KeyTime="0:0:0.6" Value="{x:Static Visibility.Collapsed}"/>
         </ObjectAnimationUsingKeyFrames>
       </Storyboard>
     </UserControl.Resources>
-    <Border x:Name="RestoreBar" VerticalAlignment="Center" Visibility="Collapsed" Opacity="0" BorderThickness="0,0,0,1">
+    <Border x:Name="RestoreBar" VerticalAlignment="Center" Visibility="{Binding InnerVisibility, Mode=OneWay}" Opacity="0" BorderThickness="0,0,0,1">
         <Grid Margin="0,4,0,6">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*" />

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageRestoreBar.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageRestoreBar.xaml
@@ -2,7 +2,8 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              Loaded="UserControl_Loaded"
-             xmlns:resx="clr-namespace:NuGet.PackageManagement.UI">
+             xmlns:resx="clr-namespace:NuGet.PackageManagement.UI"
+             Visibility="{Binding Visibility, ElementName=RestoreBar}">
     <UserControl.Resources>
       <Storyboard x:Key="ShowSmoothly">
         <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="RestoreBar">

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageRestoreBar.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageRestoreBar.xaml.cs
@@ -47,8 +47,18 @@ namespace NuGet.PackageManagement.UI
 
         public Guid OperationId { get; set; }
 
+        public Visibility InnerVisibility
+        {
+            get { return (Visibility)GetValue(InnerVisibilityProperty); }
+            set { SetValue(InnerVisibilityProperty, value); }
+        }
+
+        public static readonly DependencyProperty InnerVisibilityProperty =
+            DependencyProperty.Register(nameof(InnerVisibility), typeof(Visibility), typeof(PackageRestoreBar), new PropertyMetadata(Visibility.Collapsed));
+
         public PackageRestoreBar(INuGetSolutionManagerService solutionManager, IPackageRestoreManager packageRestoreManager)
         {
+            DataContext = this;
             InitializeComponent();
             _uiDispatcher = Dispatcher.CurrentDispatcher;
             _solutionManager = solutionManager;

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/RestartRequestBar.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/RestartRequestBar.xaml
@@ -2,8 +2,8 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:resx="clr-namespace:NuGet.PackageManagement.UI"
-             Visibility="{Binding Visibility, ElementName=RestartBar}">
-    <Border x:Name="RestartBar" VerticalAlignment="Center" Visibility="Collapsed" BorderThickness="0,0,0,1">
+             Visibility="Collapsed">
+    <Border x:Name="RestartBar" VerticalAlignment="Center" BorderThickness="0,0,0,1">
         <Grid Margin="0,4,0,6">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*" />

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/RestartRequestBar.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/RestartRequestBar.xaml
@@ -1,7 +1,8 @@
-﻿  <UserControl x:Class="NuGet.PackageManagement.UI.RestartRequestBar"
+  <UserControl x:Class="NuGet.PackageManagement.UI.RestartRequestBar"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:resx="clr-namespace:NuGet.PackageManagement.UI">
+             xmlns:resx="clr-namespace:NuGet.PackageManagement.UI"
+             Visibility="{Binding Visibility, ElementName=RestartBar}">
     <Border x:Name="RestartBar" VerticalAlignment="Center" Visibility="Collapsed" BorderThickness="0,0,0,1">
         <Grid Margin="0,4,0,6">
             <Grid.ColumnDefinitions>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/RestartRequestBar.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/RestartRequestBar.xaml.cs
@@ -84,7 +84,7 @@ namespace NuGet.PackageManagement.UI
                        CultureInfo.CurrentCulture,
                        UI.Resources.RequestRestartToCompleteUninstallSinglePackage, packagesMarkedForDeletion[0]);
                     RequestRestartMessage.Text = message;
-                    RestartBar.Visibility = Visibility.Visible;
+                    Visibility = Visibility.Visible;
                 }
                 else if (count > 1)
                 {
@@ -92,11 +92,11 @@ namespace NuGet.PackageManagement.UI
                        CultureInfo.CurrentCulture,
                        UI.Resources.RequestRestartToCompleteUninstallMultiplePackages);
                     RequestRestartMessage.Text = message;
-                    RestartBar.Visibility = Visibility.Visible;
+                    Visibility = Visibility.Visible;
                 }
                 else
                 {
-                    RestartBar.Visibility = Visibility.Collapsed;
+                    Visibility = Visibility.Collapsed;
                 }
             }).PostOnFailure(nameof(RestartRequestBar));
         }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1103

Also fixes "MAS 4.2.1: An element's IsOffScreen property must be true when its clickable point is off screen".
However, after looking again at https://github.com/NuGet/Client.Engineering/issues/1102, this appears to be a report for the ListItems.


Regression? Last working version: No

## Description

The User Controls `PackageRestoreBar` & `RestartRequestBar` were remaining visible while their inner controls were made non-visible.  In that case, AccessibilityInsights reports problems with `IsOffScreen` and `BoundingRectangle` properties.

The fix is to ensure the parent UserControl's visibility is set. Since `PackageRestoreBar` uses an animation for Visibility, I added a DependencyProperty in the middle to handle the binding.

### Before/After - neither bars visible (Custom controls are visible but inners are non-visible)
![image](https://user-images.githubusercontent.com/49205731/129640165-8729b2da-2a27-4933-a3e1-5651efb648f9.png)

### Before/After - RestartBar visible (Custom control error is for non-visible PackageRestoreBar)
![image](https://user-images.githubusercontent.com/49205731/129640216-69850ac1-dcad-489f-aac9-4698943e6377.png)

### Before/After - Package Restore Bar visible (Custom control error is for non-visible PackageRestoreBar)
![image](https://user-images.githubusercontent.com/49205731/129640261-f16d6953-380e-40a2-89ad-7c9641d367c1.png)


## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception - Manually tested. See screenshots.
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [ ] N/A
