### PR TITLE
Use IBuildDependencyProjectReferencesService to read projects references for CPS based packages.config projects

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/NuGet.PackageManagement.VisualStudio.csproj
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/NuGet.PackageManagement.VisualStudio.csproj
@@ -43,6 +43,7 @@
     <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="PackageFeeds\PackageSourceMoniker.cs" />
     <Compile Include="PackageFeeds\RecommenderPackageFeed.cs" />
+    <Compile Include="ProjectServices\CpsProjectSystemReferenceReader.cs" />
     <Compile Include="Projects\PackageReferenceProject.cs" />
     <Compile Include="Projects\ProjectPackages.cs" />
     <Compile Include="Services\ISharedServiceState.cs" />
@@ -66,7 +67,7 @@
     <Compile Include="Common\PackageCollectionItem.cs" />
     <Compile Include="Common\PackageCollectionItemExtensions.cs" />
     <Compile Include="PackageFeeds\LoadingStatusExtensionMethods.cs" />
-    <Compile Include="ProjectServices\NetCoreProjectSystemServices.cs" />
+    <Compile Include="ProjectServices\CpsProjectSystemServices.cs" />
     <Compile Include="ProjectServices\VsCoreProjectSystemReferenceReader.cs" />
     <Compile Include="ProjectSystems\VsCoreProjectSystem.cs" />
     <Compile Include="Projects\VsMSBuildProjectSystemServices.cs" />

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectServices/CpsProjectSystemReferenceReader.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectServices/CpsProjectSystemReferenceReader.cs
@@ -57,7 +57,7 @@ namespace NuGet.PackageManagement.VisualStudio
             Common.ILogger logger, CancellationToken _)
         {
             var unconfiguredProject = await _unconfiguredProject.GetValueAsync();
-            IBuildDependencyProjectReferencesService service = (await unconfiguredProject.GetSuggestedConfiguredProjectAsync())?.Services.ProjectReferences;
+            IBuildDependencyProjectReferencesService service = (await unconfiguredProject?.GetSuggestedConfiguredProjectAsync())?.Services.ProjectReferences;
 
             if (service == null)
             {

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectServices/CpsProjectSystemReferenceReader.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectServices/CpsProjectSystemReferenceReader.cs
@@ -57,12 +57,13 @@ namespace NuGet.PackageManagement.VisualStudio
             Common.ILogger logger, CancellationToken _)
         {
             var unconfiguredProject = await _unconfiguredProject.GetValueAsync();
-            IBuildDependencyProjectReferencesService service = (await unconfiguredProject?.GetSuggestedConfiguredProjectAsync())?.Services.ProjectReferences;
+            IBuildDependencyProjectReferencesService service = await GetProjectReferencesService(unconfiguredProject);
 
             if (service == null)
             {
                 return Enumerable.Empty<ProjectRestoreReference>();
             }
+
             var results = new List<ProjectRestoreReference>();
             var hasMissingReferences = false;
 
@@ -103,6 +104,26 @@ namespace NuGet.PackageManagement.VisualStudio
             }
 
             return results;
+        }
+
+        /// <summary>
+        /// Gets the project reference service for the suggested configured project if available, <see langword="null"/> otherwise.
+        /// </summary>
+        private static async Task<IBuildDependencyProjectReferencesService> GetProjectReferencesService(UnconfiguredProject unconfiguredProject)
+        {
+            IBuildDependencyProjectReferencesService service = null;
+
+            if (unconfiguredProject != null)
+            {
+                ConfiguredProject configuredProject = await unconfiguredProject.GetSuggestedConfiguredProjectAsync();
+
+                if (configuredProject != null)
+                {
+                    service = configuredProject.Services.ProjectReferences;
+                }
+            }
+
+            return service;
         }
 
         public Task<IEnumerable<LibraryDependency>> GetPackageReferencesAsync(

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectServices/CpsProjectSystemReferenceReader.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectServices/CpsProjectSystemReferenceReader.cs
@@ -1,0 +1,114 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft;
+using Microsoft.VisualStudio.ProjectSystem;
+using Microsoft.VisualStudio.ProjectSystem.Properties;
+using Microsoft.VisualStudio.ProjectSystem.References;
+using Microsoft.VisualStudio.Threading;
+using NuGet.Frameworks;
+using NuGet.LibraryModel;
+using NuGet.ProjectManagement;
+using NuGet.ProjectModel;
+using NuGet.VisualStudio;
+
+namespace NuGet.PackageManagement.VisualStudio
+{
+    /// <summary>
+    /// Reference reader implementation for the core project system in the integrated development environment (IDE).
+    /// </summary>
+    internal class CpsProjectSystemReferenceReader
+        : IProjectSystemReferencesReader
+    {
+        private readonly IVsProjectAdapter _vsProjectAdapter;
+        private readonly IVsProjectThreadingService _threadingService;
+        private readonly AsyncLazy<ConfiguredProject> _configuredProject;
+
+        public CpsProjectSystemReferenceReader(
+            IVsProjectAdapter vsProjectAdapter,
+            IVsProjectThreadingService threadingService)
+        {
+            Assumes.Present(vsProjectAdapter);
+            Assumes.Present(threadingService);
+
+            _vsProjectAdapter = vsProjectAdapter;
+            _threadingService = threadingService;
+            _configuredProject = new AsyncLazy<ConfiguredProject>(async () =>
+            {
+                await _threadingService.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+                var context = _vsProjectAdapter.Project as IVsBrowseObjectContext;
+                if (context == null)
+                {
+                    // VC implements this on their DTE.Project.Object
+                    context = _vsProjectAdapter.Project.Object as IVsBrowseObjectContext;
+                }
+                return context?.ConfiguredProject;
+            }, threadingService.JoinableTaskFactory);
+        }
+
+        public async Task<IEnumerable<ProjectRestoreReference>> GetProjectReferencesAsync(
+            Common.ILogger logger, CancellationToken _)
+        {
+            var project = await _configuredProject.GetValueAsync();
+            IBuildDependencyProjectReferencesService service = project.Services.ProjectReferences;
+
+            if (service == null)
+            {
+                return Enumerable.Empty<ProjectRestoreReference>();
+            }
+            var results = new List<ProjectRestoreReference>();
+            var hasMissingReferences = false;
+
+            foreach (IUnresolvedBuildDependencyProjectReference projectReference in await service.GetUnresolvedReferencesAsync())
+            {
+                try
+                {
+                    if (!await projectReference.GetReferenceOutputAssemblyAsync())
+                    {
+                        string childProjectPath = await projectReference.GetFullPathAsync();
+                        var projectRestoreReference = new ProjectRestoreReference()
+                        {
+                            ProjectPath = childProjectPath,
+                            ProjectUniqueName = childProjectPath
+                        };
+
+                        results.Add(projectRestoreReference);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    hasMissingReferences = true;
+                    logger.LogDebug(ex.ToString());
+                }
+            }
+
+            if (hasMissingReferences)
+            {
+                // Log a generic message once per project if any items could not be resolved.
+                // In most cases this can be ignored, but in the rare case where the unresolved
+                // item is actually a project the restore result will be incomplete.
+                var message = string.Format(
+                    CultureInfo.CurrentCulture,
+                    Strings.UnresolvedItemDuringProjectClosureWalk,
+                    _vsProjectAdapter.UniqueName);
+
+                logger.LogVerbose(message);
+            }
+
+            return results;
+        }
+
+        public Task<IEnumerable<LibraryDependency>> GetPackageReferencesAsync(
+            NuGetFramework targetFramework, CancellationToken _)
+        {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectServices/CpsProjectSystemReferenceReader.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectServices/CpsProjectSystemReferenceReader.cs
@@ -72,7 +72,7 @@ namespace NuGet.PackageManagement.VisualStudio
                 {
                     if (await projectReference.GetReferenceOutputAssemblyAsync())
                     {
-                        string childProjectPath = await projectReference.GetFullPathAsync();
+                        string childProjectPath = projectReference.EvaluatedIncludeAsFullPath;
                         var projectRestoreReference = new ProjectRestoreReference()
                         {
                             ProjectPath = childProjectPath,

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectServices/CpsProjectSystemReferenceReader.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectServices/CpsProjectSystemReferenceReader.cs
@@ -70,7 +70,7 @@ namespace NuGet.PackageManagement.VisualStudio
             {
                 try
                 {
-                    if (!await projectReference.GetReferenceOutputAssemblyAsync())
+                    if (await projectReference.GetReferenceOutputAssemblyAsync())
                     {
                         string childProjectPath = await projectReference.GetFullPathAsync();
                         var projectRestoreReference = new ProjectRestoreReference()

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectServices/CpsProjectSystemServices.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectServices/CpsProjectSystemServices.cs
@@ -11,10 +11,10 @@ namespace NuGet.PackageManagement.VisualStudio
     /// <summary>
     /// Represent net core project systems in visual studio.
     /// </summary>
-    internal class NetCoreProjectSystemServices :
+    internal class CpsProjectSystemServices :
         INuGetProjectServices
     {
-        public NetCoreProjectSystemServices(
+        public CpsProjectSystemServices(
             IVsProjectAdapter vsProjectAdapter,
             Lazy<IScriptExecutor> scriptExecutor)
         {

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/CpsPackageReferenceProjectProvider.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/CpsPackageReferenceProjectProvider.cs
@@ -88,7 +88,7 @@ namespace NuGet.PackageManagement.VisualStudio
             var fullProjectPath = vsProject.FullProjectPath;
             var unconfiguredProject = GetUnconfiguredProject(vsProject.Project);
 
-            var projectServices = new NetCoreProjectSystemServices(vsProject, _scriptExecutor);
+            var projectServices = new CpsProjectSystemServices(vsProject, _scriptExecutor);
 
             return new CpsPackageReferenceProject(
                 vsProject.ProjectName,

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/VsMSBuildProjectSystemServices.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/VsMSBuildProjectSystemServices.cs
@@ -64,7 +64,9 @@ namespace NuGet.PackageManagement.VisualStudio
             _vsProjectSystem = vsProjectSystem;
             _threadingService = threadingService;
 
-            ReferencesReader = new VsCoreProjectSystemReferenceReader(vsProjectAdapter, threadingService);
+            ReferencesReader = vsProjectSystem is CpsProjectSystem ?
+                new CpsProjectSystemReferenceReader(vsProjectAdapter, _threadingService) :
+                new VsCoreProjectSystemReferenceReader(vsProjectAdapter, _threadingService);
             ScriptService = new VsProjectScriptHostService(vsProjectAdapter, scriptExecutor);
         }
     }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11162

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
There's a restore time UI delay: 

UIDelay: nuget.packagemanagement.visualstudio.dll!NuGet.PackageManagement.VisualStudio.VsCoreProjectSystemReferenceReader+<GetProjectReferencesAsync>d__

It happens when mixed solutions are used, ones that have PackageReference projects & legacy managed projects & native projects. 

The walk that we run in https://github.com/NuGet/NuGet.Client/blob/c1a0597e5498bcf3bf0938b3dd0170edbf0b2d20/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectServices/VsCoreProjectSystemReferenceReader.cs#L54 is inefficient and in some cases, such as the native case, it might even trigger a design time build. 

The fix is to use a CPS specific API which is free threaded. 
Note that there's currently a bug with this API: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1374627, which is being fixed as we speak.

Second part of this UI delay will be fixed in https://github.com/NuGet/Home/issues/11163.

cc @lifengl @davkean

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception - There's no functional changes, but unfortunately there are no tests for the overall scenario. Given that this is a VS only scenario, and we have seen *a lot* of APEX flakiness, I decided to instead a manual test. https://github.com/nkolev92/CpsReferencesReaderTest. It's really against what I think we should be doing, but I see this as a pragmatic solution at this point. 
  Finally there's a bug, which means it'll be a while until we can add an E2E/Apex test: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1374627
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
