### PR TITLE
Add XMLDoc for VS extensibility APIs that are not limited to UI thread

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio/Extensibility/IVsFrameworkCompatibility.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio/Extensibility/IVsFrameworkCompatibility.cs
@@ -18,6 +18,7 @@ namespace NuGet.VisualStudio
         /// <summary>
         /// Gets all .NETStandard frameworks currently supported, in ascending order by version.
         /// </summary>
+        /// <remarks>This API is <a href="https://github.com/microsoft/vs-threading/blob/main/doc/cookbook_vs.md#how-do-i-effectively-verify-that-my-code-is-fully-free-threaded">free-threaded.</a></remarks>
         IEnumerable<FrameworkName> GetNetStandardFrameworks();
 
         /// <summary>
@@ -28,6 +29,8 @@ namespace NuGet.VisualStudio
         /// equivalent frameworks are not returned. Additionally, a framework name with version X
         /// in the result implies that framework names with versions greater than or equal to X
         /// but having the same <see cref="FrameworkName.Identifier"/> are also supported.
+        ///
+        /// <para>This API is <a href="https://github.com/microsoft/vs-threading/blob/main/doc/cookbook_vs.md#how-do-i-effectively-verify-that-my-code-is-fully-free-threaded">free-threaded.</a></para>
         /// </remarks>
         /// <param name="frameworkName">The .NETStandard version to get supporting frameworks for.</param>
         IEnumerable<FrameworkName> GetFrameworksSupportingNetStandard(FrameworkName frameworkName);
@@ -38,6 +41,7 @@ namespace NuGet.VisualStudio
         /// compatibility rules. <c>null</c> is returned of none of the frameworks
         /// are compatible.
         /// </summary>
+        /// <remarks>This API is <a href="https://github.com/microsoft/vs-threading/blob/main/doc/cookbook_vs.md#how-do-i-effectively-verify-that-my-code-is-fully-free-threaded">free-threaded.</a></remarks>
         /// <param name="targetFramework">The target framework.</param>
         /// <param name="frameworks">The list of frameworks to choose from.</param>
         /// <exception cref="ArgumentException">If any of the arguments are <c>null</c>.</exception>

--- a/src/NuGet.Clients/NuGet.VisualStudio/Extensibility/IVsFrameworkCompatibility2.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio/Extensibility/IVsFrameworkCompatibility2.cs
@@ -21,6 +21,7 @@ namespace NuGet.VisualStudio
         /// compatibility rules. <c>null</c> is returned of none of the frameworks
         /// are compatible.
         /// </summary>
+        /// <remarks>This API is <a href="https://github.com/microsoft/vs-threading/blob/main/doc/cookbook_vs.md#how-do-i-effectively-verify-that-my-code-is-fully-free-threaded">free-threaded.</a></remarks>
         /// <param name="targetFramework">The target framework.</param>
         /// <param name="fallbackTargetFrameworks">
         /// Target frameworks to use if the provided <paramref name="targetFramework"/> is not compatible.

--- a/src/NuGet.Clients/NuGet.VisualStudio/Extensibility/IVsFrameworkParser.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio/Extensibility/IVsFrameworkParser.cs
@@ -20,6 +20,7 @@ namespace NuGet.VisualStudio
         /// (e.g. ".NETFramework,Version=v4.5") into a <see cref="FrameworkName"/>
         /// instance.
         /// </summary>
+        /// <remarks>This API is <a href="https://github.com/microsoft/vs-threading/blob/main/doc/cookbook_vs.md#how-do-i-effectively-verify-that-my-code-is-fully-free-threaded">free-threaded.</a></remarks>
         /// <param name="shortOrFullName">The framework string.</param>
         /// <exception cref="ArgumentNullException">If the provided string is null.</exception>
         /// <exception cref="ArgumentException">If the provided string cannot be parsed.</exception>
@@ -33,6 +34,7 @@ namespace NuGet.VisualStudio
         /// <remarks>
         /// For example, ".NETFramework,Version=v4.5" is converted to "net45". This is the value
         /// used inside of .nupkg folder structures as well as in project.json files.
+        /// <para>This API is <a href="https://github.com/microsoft/vs-threading/blob/main/doc/cookbook_vs.md#how-do-i-effectively-verify-that-my-code-is-fully-free-threaded">free-threaded.</a></para>
         /// </remarks>
         /// <param name="frameworkName">The framework name.</param>
         /// <exception cref="ArgumentNullException">If the input is null.</exception>

--- a/src/NuGet.Clients/NuGet.VisualStudio/Extensibility/IVsPackageInstaller.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio/Extensibility/IVsPackageInstaller.cs
@@ -18,6 +18,7 @@ namespace NuGet.VisualStudio
         /// <summary>
         /// Installs a single package from the specified package source.
         /// </summary>
+        /// <remarks>Can be called from a background thread.</remarks>
         /// <param name="source">
         /// The package source to install the package from. This value can be <c>null</c>
         /// to indicate that the user's configured sources should be used. Otherwise,
@@ -40,6 +41,7 @@ namespace NuGet.VisualStudio
         /// <summary>
         /// Installs a single package from the specified package source.
         /// </summary>
+        /// <remarks>Can be called from a background thread.</remarks>
         /// <param name="source">
         /// The package source to install the package from. This value can be <c>null</c>
         /// to indicate that the user's configured sources should be used. Otherwise,
@@ -77,6 +79,7 @@ namespace NuGet.VisualStudio
         /// A boolean indicating if assembly references from the package should be
         /// skipped.
         /// </param>
+        [Obsolete]
         void InstallPackage(IPackageRepository repository, Project project, string packageId, string version, bool ignoreDependencies, bool skipAssemblyReferences);
 
         /// <summary>
@@ -104,6 +107,7 @@ namespace NuGet.VisualStudio
         /// <para>
         /// Dependencies are always ignored.
         /// </para>
+        /// <para>Can be called from a background thread.</para>
         /// </remarks>
         void InstallPackagesFromRegistryRepository(string keyName, bool isPreUnzipped, bool skipAssemblyReferences, Project project, IDictionary<string, string> packageVersions);
 
@@ -130,6 +134,7 @@ namespace NuGet.VisualStudio
         /// </param>
         /// <remarks>
         /// If any version of the package is already installed, no action will be taken.
+        /// <para>Can be called from a background thread.</para>
         /// </remarks>
         void InstallPackagesFromRegistryRepository(string keyName, bool isPreUnzipped, bool skipAssemblyReferences, bool ignoreDependencies, Project project, IDictionary<string, string> packageVersions);
 
@@ -155,6 +160,7 @@ namespace NuGet.VisualStudio
         /// <para>
         /// Dependencies are always ignored.
         /// </para>
+        /// <para>Can be called from a background thread.</para>
         /// </remarks>
         void InstallPackagesFromVSExtensionRepository(string extensionId, bool isPreUnzipped, bool skipAssemblyReferences, Project project, IDictionary<string, string> packageVersions);
 
@@ -178,6 +184,7 @@ namespace NuGet.VisualStudio
         /// </param>
         /// <remarks>
         /// If any version of the package is already installed, no action will be taken.
+        /// <para>Can be called from a background thread.</para>
         /// </remarks>
         void InstallPackagesFromVSExtensionRepository(string extensionId, bool isPreUnzipped, bool skipAssemblyReferences, bool ignoreDependencies, Project project, IDictionary<string, string> packageVersions);
     }

--- a/src/NuGet.Clients/NuGet.VisualStudio/Extensibility/IVsPackageInstaller2.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio/Extensibility/IVsPackageInstaller2.cs
@@ -14,6 +14,7 @@ namespace NuGet.VisualStudio
         /// <summary>
         /// Installs the latest version of a single package from the specified package source.
         /// </summary>
+        /// <remarks>Can be called from a background thread.</remarks>
         /// <param name="source">
         /// The package source to install the package from. This value can be <c>null</c>
         /// to indicate that the user's configured sources should be used. Otherwise,

--- a/src/NuGet.Clients/NuGet.VisualStudio/Extensibility/IVsPackageRestorer.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio/Extensibility/IVsPackageRestorer.cs
@@ -17,12 +17,14 @@ namespace NuGet.VisualStudio
         /// Returns a value indicating whether the user consent to download NuGet packages
         /// has been granted.
         /// </summary>
+        /// <remarks>Can be called from a background thread.</remarks>
         /// <returns>true if the user consent has been granted; otherwise, false.</returns>
         bool IsUserConsentGranted();
 
         /// <summary>
         /// Restores NuGet packages installed in the given project within the current solution.
         /// </summary>
+        /// <remarks>Can be called from a background thread.</remarks>
         /// <param name="project">The project whose NuGet packages to restore.</param>
         void RestorePackages(Project project);
     }

--- a/src/NuGet.Clients/NuGet.VisualStudio/Extensibility/IVsPackageSourceProvider.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio/Extensibility/IVsPackageSourceProvider.cs
@@ -18,6 +18,7 @@ namespace NuGet.VisualStudio
         /// <summary>
         /// Provides the list of package sources.
         /// </summary>
+        /// <remarks>Can be called from a background thread.</remarks>
         /// <param name="includeUnOfficial">Unofficial sources will be included in the results</param>
         /// <param name="includeDisabled">Disabled sources will be included in the results</param>
         /// <remarks>Does not require the UI thread.</remarks>

--- a/src/NuGet.Clients/NuGet.VisualStudio/Extensibility/IVsPackageUninstaller.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio/Extensibility/IVsPackageUninstaller.cs
@@ -17,6 +17,7 @@ namespace NuGet.VisualStudio
         /// Uninstall the specified package from a project and specify whether to uninstall its dependency packages
         /// too.
         /// </summary>
+        /// <remarks>Can be called from a background thread.</remarks>
         /// <param name="project">The project from which the package is uninstalled.</param>
         /// <param name="packageId">The package to be uninstalled</param>
         /// <param name="removeDependencies">

--- a/src/NuGet.Clients/NuGet.VisualStudio/Extensibility/IVsPathContext.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio/Extensibility/IVsPathContext.cs
@@ -25,6 +25,7 @@ namespace NuGet.VisualStudio
         /// fallback package folders are configured, an empty list is returned. The item type of this sequence is
         /// <see cref="string"/>.
         /// </summary>
+        /// <remarks>Can be called from a background thread.</remarks>
         IEnumerable FallbackPackageFolders { get; }
 
         /// <summary>

--- a/src/NuGet.Clients/NuGet.VisualStudio/Extensibility/IVsPathContextProvider.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio/Extensibility/IVsPathContextProvider.cs
@@ -15,6 +15,7 @@ namespace NuGet.VisualStudio
         /// <summary>
         /// Attempts to create an instance of <see cref="IVsPathContext"/>.
         /// </summary>
+        /// <remarks>Can be called from a background thread.</remarks>
         /// <param name="projectUniqueName">
         /// Unique identificator of the project. Should be a full path to project file.
         /// </param>

--- a/src/NuGet.Clients/NuGet.VisualStudio/Extensibility/IVsPathContextProvider2.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio/Extensibility/IVsPathContextProvider2.cs
@@ -17,6 +17,7 @@ namespace NuGet.VisualStudio
         /// <summary>
         /// Attempts to create an instance of <see cref="IVsPathContext2"/> for the solution.
         /// </summary>
+        /// <remarks>This API is free-threaded, but APIs on the returned IVsPathContext2 may not be.</remarks>
         /// <param name="context">The path context associated with this solution.</param>
         /// <returns>
         /// <code>True</code> if operation has succeeded and context was created.
@@ -30,6 +31,7 @@ namespace NuGet.VisualStudio
         /// <summary>
         /// Attempts to create an instance of <see cref="IVsPathContext2"/> for the solution.
         /// </summary>
+        /// <remarks>This API is free-threaded, but APIs on the returned IVsPathContext2 may not be.</remarks>
         /// <param name="solutionDirectory">
         /// path to the solution directory. Must be an absolute path.
         /// It will be performant to pass the solution directory if it's available.

--- a/src/NuGet.Clients/NuGet.VisualStudio/Extensibility/IVsSemanticVersionComparer.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio/Extensibility/IVsSemanticVersionComparer.cs
@@ -21,6 +21,7 @@ namespace NuGet.VisualStudio
         /// are equivalent. Returns a number greater than zero if <paramref name="versionA"/>
         /// is greater than <paramref name="versionB"/>.
         /// </summary>
+        /// <remarks>This API is free-threaded.</remarks>
         /// <param name="versionA">The first version string.</param>
         /// <param name="versionB">The second version string.</param>
         /// <exception cref="ArgumentNullException">If either version string is null.</exception>


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11021

Regression? No

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Checked all NuGet's VS extensibility APIs to check if they seemed possible to call on background threads or not. Some APIs were almost certainly free-threaded, and any that used `jtf.Run` were marked as runnable on a background thread.  Not sure if we should also mention that it will block the thread.  We already have another issue to make async versions of these APIs.

## PR Checklist

- [X] PR has a meaningful title
- [X] PR has a linked issue.
- [X] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [X] N/A: documentation

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [X] Documentation PR or issue filled: https://github.com/NuGet/docs.microsoft.com-nuget/issues/2513
  - **OR**
  - [ ] N/A
