### PR TITLE
Change from permissive mode to fullySpecified mode for PC project package namespace

### DIFF
--- a/src/NuGet.Core/NuGet.PackageManagement/PackageDownloader.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/PackageDownloader.cs
@@ -127,7 +127,8 @@ namespace NuGet.PackageManagement
                     {
                         if (isPackageNamespaceEnabled)
                         {
-                            if (configuredPackageSources != null &&
+                            if (configuredPackageSources == null ||
+                                configuredPackageSources.Count == 0 ||
                                 !configuredPackageSources.Contains(source.PackageSource.Name, StringComparer.CurrentCultureIgnoreCase))
                             {
                                 // This package's id prefix is not defined in current package source, let's skip.

--- a/src/NuGet.Core/NuGet.PackageManagement/PackageDownloader.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/PackageDownloader.cs
@@ -129,7 +129,7 @@ namespace NuGet.PackageManagement
                         {
                             if (configuredPackageSources == null ||
                                 configuredPackageSources.Count == 0 ||
-                                !configuredPackageSources.Contains(source.PackageSource.Name, StringComparer.CurrentCultureIgnoreCase))
+                                !configuredPackageSources.Contains(source.PackageSource.Name, StringComparer.OrdinalIgnoreCase))
                             {
                                 // This package's id prefix is not defined in current package source, let's skip.
                                 continue;

--- a/src/NuGet.Core/NuGet.PackageManagement/Resolution/ResolverGather.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Resolution/ResolverGather.cs
@@ -564,7 +564,7 @@ namespace NuGet.PackageManagement
                     {
                         if (configuredPackageSources == null ||
                             configuredPackageSources.Count == 0 ||
-                            !configuredPackageSources.Contains(source.Source.PackageSource.Name, StringComparer.CurrentCultureIgnoreCase))
+                            !configuredPackageSources.Contains(source.Source.PackageSource.Name, StringComparer.OrdinalIgnoreCase))
                         {
                             // This package's id prefix is not defined in current package source, let's skip.
                             continue;

--- a/src/NuGet.Core/NuGet.PackageManagement/Resolution/ResolverGather.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Resolution/ResolverGather.cs
@@ -560,10 +560,15 @@ namespace NuGet.PackageManagement
             {
                 foreach (SourceResource source in sources)
                 {
-                    if (_areNamespacesEnabled && configuredPackageSources != null && !configuredPackageSources.Contains(source.Source.PackageSource.Name, StringComparer.CurrentCultureIgnoreCase))
+                    if (_areNamespacesEnabled)
                     {
-                        // This package's id prefix is not defined in current package source, let's skip.
-                        continue;
+                        if (configuredPackageSources == null ||
+                            configuredPackageSources.Count == 0 ||
+                            !configuredPackageSources.Contains(source.Source.PackageSource.Name, StringComparer.CurrentCultureIgnoreCase))
+                        {
+                            // This package's id prefix is not defined in current package source, let's skip.
+                            continue;
+                        }
                     }
 
                     // Keep track of the order in which these were made

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
@@ -2808,6 +2808,7 @@ EndProject";
 
                 // Assert
                 Assert.Equal(_failureCode, r.ExitCode);
+                Assert.Contains("Unable to find version '1.0.0' of package 'My.MVC.ASP'.", r.Errors);
                 Assert.Contains("Package namespace match not found for package ID 'My.MVC.ASP'", r.Output);
             }
         }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
@@ -2738,6 +2738,81 @@ EndProject";
         }
 
         [Fact]
+        public void RestoreCommand_PackageNamespace_NoNamespaceMatches()
+        {
+            // Arrange
+            var nugetexe = Util.GetNuGetExePath();
+
+            using (var workingPath = TestDirectory.Create())
+            {
+                var proj1Directory = Path.Combine(workingPath, "proj1");
+                Directory.CreateDirectory(proj1Directory);
+
+                var proj1File = Path.Combine(proj1Directory, "proj1.csproj");
+                File.WriteAllText(
+                    proj1File,
+                    @"<Project ToolsVersion='4.0' DefaultTargets='Build'
+    xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <OutputPath>out</OutputPath>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include='packages.config' />
+  </ItemGroup>
+</Project>");
+
+                var sharedRepositoryPath = Path.Combine(workingPath, "SharedRepository");
+                Directory.CreateDirectory(sharedRepositoryPath);
+                Util.CreateTestPackage("My.MVC.ASP", "1.0.0", sharedRepositoryPath);
+
+                Util.CreateFile(proj1Directory, "packages.config",
+@"<packages>
+  <package id=""My.MVC.ASP"" version=""1.0.0"" targetFramework=""net461"" />
+</packages>");
+
+                var configPath = Path.Combine(workingPath, "nuget.config");
+                SettingsTestUtils.CreateConfigurationFile(configPath, $@"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+    <packageSources>
+    <!--To inherit the global NuGet package sources remove the <clear/> line below -->
+    <clear />
+    <add key=""SharedRepository"" value=""{sharedRepositoryPath}"" />
+    </packageSources>
+    <packageNamespaces>
+        <packageSource key=""SharedRepository"">
+            <namespace id=""Contoso.MVC.ASP"" />  <!-- My.MVC.ASP doesn't match-->
+        </packageSource>
+    </packageNamespaces>
+</configuration>");
+
+                var packagePath = Path.Combine(workingPath, "packages");
+
+                string[] args = new string[]
+                    {
+                        "restore",
+                        proj1File,
+                        "-solutionDir",
+                        workingPath,
+                        "-Verbosity",
+                        "d"
+                    };
+
+                // Act
+                var r = CommandRunner.Run(
+                    nugetexe,
+                    workingPath,
+                    string.Join(" ", args),
+                    waitForExit: true);
+
+                // Assert
+                Assert.Equal(_successCode, r.ExitCode);
+                Assert.Contains("Package namespace match not found for package ID 'My.MVC.ASP'", r.Output);
+            }
+        }
+
+        [Fact]
         public void RestoreCommand_PackageNamespaceMatchesMultipleSources_Succeed()
         {
             // Arrange

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
@@ -2431,18 +2431,13 @@ EndProject";
                 var publicRepositoryPath = Path.Combine(workingPath, "PublicRepository");
                 Directory.CreateDirectory(publicRepositoryPath);
                 Util.CreateTestPackage("测试更新包", "1.0.0", publicRepositoryPath);
-                Util.CreateTestPackage("_", "1.0.0", publicRepositoryPath);
-                Util.CreateTestPackage("123123123123", "1.0.0", publicRepositoryPath);
-                Util.CreateTestPackage("jQuery", "2.1.1", publicRepositoryPath);
                 Util.CreateTestPackage("Microsoft.AspNet.Mvc", "5.2.7", publicRepositoryPath);
                 Util.CreateTestPackage("Microsoft.AspNet.WebApi.Cors", "5.2.7", publicRepositoryPath);
                 Util.CreateTestPackage("Microsoft.Extensions.Configuration.Abstractions", "5.0.0", publicRepositoryPath);
-                Util.CreateTestPackage("Microsoft.VisualStudio.Shell.Interop.9.0", "16.9.31023.347", publicRepositoryPath);
                 Util.CreateTestPackage("Moq", "4.16.1", publicRepositoryPath);
                 Util.CreateTestPackage("Moq.AutoMock", "2.3.0", publicRepositoryPath);
                 Util.CreateTestPackage("NerdBank.Algorithms", "1.0.0", publicRepositoryPath);
                 Util.CreateTestPackage("Nerdbank.GitVersioning", "1.1.64", publicRepositoryPath);
-                Util.CreateTestPackage("Newtonsoft.Json", "12.0.3", publicRepositoryPath);
                 Util.CreateTestPackage("System.Buffers", "4.5.1", publicRepositoryPath);
                 Util.CreateTestPackage("System.Memory", "4.5.4", publicRepositoryPath);
                 Util.CreateTestPackage("System.Numerics.Vectors", "4.5.0", publicRepositoryPath);
@@ -2474,21 +2469,16 @@ EndProject";
                 Util.CreateFile(proj1Directory, "packages.config",
 @"<packages>
   <package id=""测试更新包"" version=""1.0.0"" targetFramework=""net48"" />
-  <package id=""_"" version=""1.0.0"" targetFramework=""net48"" />
-  <package id=""123123123123"" version=""1.0.0"" targetFramework=""net48"" /> 
   <package id=""Castle.Core"" version=""4.4.0"" targetFramework=""net48"" />
-  <package id=""jQuery"" version=""2.1.1"" targetFramework=""net472"" />
   <package id=""Microsoft.Extensions.Primitives"" version=""5.0.0"" targetFramework=""net48"" />
   <package id=""Microsoft.Extensions.DependencyInjection.Abstractions"" version=""5.0.0"" targetFramework=""net48"" />
   <package id=""Microsoft.Extensions.Configuration"" version=""5.0.0"" targetFramework=""net48"" />
   <package id=""Microsoft.Extensions.Configuration.Abstractions"" version=""5.0.0"" targetFramework=""net48"" />
   <package id=""Microsoft.Extensions.Logging"" version=""5.0.0"" targetFramework=""net48"" />
-  <package id=""Microsoft.VisualStudio.Shell.Interop.9.0"" version=""16.9.31023.347"" targetFramework=""net48"" />
   <package id=""Moq"" version=""4.16.1"" targetFramework=""net48"" />
   <package id=""Moq.AutoMock"" version=""2.3.0"" targetFramework=""net47"" />
   <package id=""Nerdbank.GitVersioning"" version=""1.1.64"" targetFramework=""net48"" developmentDependency=""true"" />
   <package id=""NerdBank.Algorithms"" version=""1.0.0"" targetFramework=""net48"" developmentDependency=""true"" />
-  <package id=""Newtonsoft.Json"" version=""12.0.3"" targetFramework=""net48"" />
   <package id=""TestPackage.AuthorSigned"" version=""1.0.0"" targetFramework=""net48"" />
   <package id=""System.Buffers"" version=""4.5.1"" targetFramework=""net48"" />
   <package id=""System.Memory"" version=""4.5.4"" targetFramework=""net48"" />
@@ -2515,17 +2505,18 @@ EndProject";
     </packageSources>
     <packageNamespaces>
         <packageSource key=""PublicRepository"">
-            <namespace id=""Moq.*"" />
+            <namespace id=""Moq*"" />
             <namespace id=""Nerdbank.*"" />   
             <namespace id=""Microsoft.Asp.*"" />
             <namespace id=""Microsoft.AspNet.*"" />
             <namespace id=""Microsoft.Extensions.Configuration.*"" />
-            <namespace id=""System.Runtime.InteropServices.RuntimeInformation"" />            
-            <namespace id=""xunit.*"" />
+            <namespace id=""System.*"" />            
+            <namespace id=""xunit*"" />
+            <namespace id=""测试更新包"" />
         </packageSource>
         <packageSource key=""SharedRepository"">
             <namespace id=""Castle.Cor*"" /> 
-            <namespace id=""Moq.*"" />
+            <namespace id=""Moq*"" />
             <namespace id=""Microsoft.Extensions.*"" />
             <namespace id=""Microsoft.Extensions.Logging"" />
             <namespace id=""Nerd*"" />             
@@ -2697,7 +2688,6 @@ EndProject";
 
                 Util.CreateFile(proj1Directory, "packages.config",
 @"<packages>
-  <package id=""测试更新包"" version=""1.0.0"" targetFramework=""net461"" />
   <package id=""Contoso.MVC.ASP"" version=""1.0.0"" targetFramework=""net461"" />
   <package id=""Contoso.Opensource.Buffers"" version=""1.0.0"" targetFramework=""net461"" />
 </packages>");
@@ -2744,82 +2734,6 @@ EndProject";
                 // Assert
                 Assert.Equal(_successCode, r.ExitCode);
                 Assert.Contains("Package namespace matches found for package ID 'Contoso.MVC.ASP' are: 'SharedRepository'", r.Output);
-            }
-        }
-
-
-        [Fact]
-        public void RestoreCommand_PackageNamespace_NoNamespaceMatches()
-        {
-            // Arrange
-            var nugetexe = Util.GetNuGetExePath();
-
-            using (var workingPath = TestDirectory.Create())
-            {
-                var proj1Directory = Path.Combine(workingPath, "proj1");
-                Directory.CreateDirectory(proj1Directory);
-
-                var proj1File = Path.Combine(proj1Directory, "proj1.csproj");
-                File.WriteAllText(
-                    proj1File,
-                    @"<Project ToolsVersion='4.0' DefaultTargets='Build'
-    xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
-  <PropertyGroup>
-    <OutputType>Library</OutputType>
-    <OutputPath>out</OutputPath>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
-  </PropertyGroup>
-  <ItemGroup>
-    <None Include='packages.config' />
-  </ItemGroup>
-</Project>");
-
-                var sharedRepositoryPath = Path.Combine(workingPath, "SharedRepository");
-                Directory.CreateDirectory(sharedRepositoryPath);
-                Util.CreateTestPackage("My.MVC.ASP", "1.0.0", sharedRepositoryPath);
-
-                Util.CreateFile(proj1Directory, "packages.config",
-@"<packages>
-  <package id=""My.MVC.ASP"" version=""1.0.0"" targetFramework=""net461"" />
-</packages>");
-
-                var configPath = Path.Combine(workingPath, "nuget.config");
-                SettingsTestUtils.CreateConfigurationFile(configPath, $@"<?xml version=""1.0"" encoding=""utf-8""?>
-<configuration>
-    <packageSources>
-    <!--To inherit the global NuGet package sources remove the <clear/> line below -->
-    <clear />
-    <add key=""SharedRepository"" value=""{sharedRepositoryPath}"" />
-    </packageSources>
-    <packageNamespaces>
-        <packageSource key=""SharedRepository"">
-            <namespace id=""Contoso.MVC.ASP"" />  <!-- My.MVC.ASP doesn't match-->
-        </packageSource>
-    </packageNamespaces>
-</configuration>");
-
-                var packagePath = Path.Combine(workingPath, "packages");
-
-                string[] args = new string[]
-                    {
-                        "restore",
-                        proj1File,
-                        "-solutionDir",
-                        workingPath,
-                        "-Verbosity",
-                        "d"
-                    };
-
-                // Act
-                var r = CommandRunner.Run(
-                    nugetexe,
-                    workingPath,
-                    string.Join(" ", args),
-                    waitForExit: true);
-
-                // Assert
-                Assert.Equal(_successCode, r.ExitCode);
-                Assert.Contains("Package namespace match not found for package ID 'My.MVC.ASP'", r.Output);
             }
         }
 

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
@@ -2807,7 +2807,7 @@ EndProject";
                     waitForExit: true);
 
                 // Assert
-                Assert.Equal(_successCode, r.ExitCode);
+                Assert.Equal(_failureCode, r.ExitCode);
                 Assert.Contains("Package namespace match not found for package ID 'My.MVC.ASP'", r.Output);
             }
         }

--- a/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildRestoreTaskTests.cs
+++ b/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildRestoreTaskTests.cs
@@ -997,7 +997,6 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
                 {
                     writer.Write(
 @"<packages>
-  <package id=""测试更新包"" version=""1.0.0"" targetFramework=""net461"" />
   <package id=""Contoso.MVC.ASP"" version=""1.0.0"" targetFramework=""net461"" />
   <package id=""Contoso.Opensource.Buffers"" version=""1.0.0"" targetFramework=""net461"" />
 </packages>");
@@ -1005,18 +1004,6 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
 
                 var opensourceRepositoryPath = pathContext.PackageSource;
                 Directory.CreateDirectory(opensourceRepositoryPath);
-
-                var packageOpenSourceInternational = new SimpleTestPackageContext()
-                {
-                    Id = "测试更新包",
-                    Version = "1.0.0"
-                };
-                packageOpenSourceInternational.Files.Clear();
-                packageOpenSourceInternational.AddFile("lib/net461/a.dll");
-
-                await SimpleTestPackageUtility.CreateFolderFeedV3Async(
-                    opensourceRepositoryPath,
-                    packageOpenSourceInternational);
 
                 var packageOpenSourceContosoMvc = new SimpleTestPackageContext()
                 {

--- a/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildRestoreTaskTests.cs
+++ b/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildRestoreTaskTests.cs
@@ -1594,6 +1594,8 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
                 // Assert
                 Assert.Equal(1, result.ExitCode);
                 Assert.Contains("Package namespace match not found for package ID 'My.MVC.ASP'", result.Output);
+                Assert.Contains("warning : Unable to find version '1.0.0' of package 'My.MVC.ASP'.", result.Output);
+                Assert.Contains("error MSB4181: The \"RestoreTask\" task returned false but did not log an error.", result.Output);
             }
         }
 

--- a/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildRestoreTaskTests.cs
+++ b/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildRestoreTaskTests.cs
@@ -1223,7 +1223,6 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
                 {
                     writer.Write(
 @"<packages>
-  <package id=""测试更新包"" version=""1.0.0"" targetFramework=""net461"" />
   <package id=""Contoso.MVC.ASP"" version=""1.0.0"" targetFramework=""net461"" />
   <package id=""Contoso.Opensource.Buffers"" version=""1.0.0"" targetFramework=""net461"" />
 </packages>");
@@ -1231,17 +1230,6 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
 
                 var opensourceRepositoryPath = pathContext.PackageSource;
                 Directory.CreateDirectory(opensourceRepositoryPath);
-
-                var packageOpenSourceInternational = new SimpleTestPackageContext()
-                {
-                    Id = "测试更新包",
-                    Version = "1.0.0"
-                };
-                packageOpenSourceInternational.AddFile("lib/net461/a.dll");
-
-                await SimpleTestPackageUtility.CreateFolderFeedV3Async(
-                    opensourceRepositoryPath,
-                    packageOpenSourceInternational);
 
                 var packageOpenSourceContosoMvc = new SimpleTestPackageContext()
                 {
@@ -1445,7 +1433,6 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
                 {
                     writer.Write(
 @"<packages>
-  <package id=""测试更新包"" version=""1.0.0"" targetFramework=""net461"" />
   <package id=""Contoso.MVC.ASP"" version=""1.0.0"" targetFramework=""net461"" />
   <package id=""Contoso.Opensource.Buffers"" version=""1.0.0"" targetFramework=""net461"" />
 </packages>");
@@ -1453,17 +1440,6 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
 
                 var opensourceRepositoryPath = pathContext.PackageSource;
                 Directory.CreateDirectory(opensourceRepositoryPath);
-
-                var packageOpenSourceInternational = new SimpleTestPackageContext()
-                {
-                    Id = "测试更新包",
-                    Version = "1.0.0"
-                };
-                packageOpenSourceInternational.AddFile("lib/net461/a.dll");
-
-                await SimpleTestPackageUtility.CreateFolderFeedV3Async(
-                    opensourceRepositoryPath,
-                    packageOpenSourceInternational);
 
                 var packageOpenSourceContosoMvc = new SimpleTestPackageContext()
                 {
@@ -1544,102 +1520,6 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
 
                 Assert.True(result.ExitCode == 0);
                 Assert.Contains("Package namespace matches found for package ID 'Contoso.MVC.ASP' are: 'SharedRepository'", result.Output);
-            }
-        }
-
-        [PlatformFact(Platform.Windows)]
-        public async Task MsbuildRestore_PackageNamespaceLongerMatches_NoNamespaceMatchesLog()
-        {
-            // Arrange
-            using (var pathContext = new SimpleTestPathContext())
-            {
-
-                // Set up solution, project, and packages
-                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
-
-                var net461 = NuGetFramework.Parse("net461");
-
-                var projectA = new SimpleTestProjectContext(
-                    "a",
-                    ProjectStyle.PackagesConfig,
-                    pathContext.SolutionRoot);
-                projectA.Frameworks.Add(new SimpleTestProjectFrameworkContext(net461));
-                var projectAPackages = Path.Combine(pathContext.SolutionRoot, "packages");
-
-                solution.Projects.Add(projectA);
-                solution.Create(pathContext.SolutionRoot);
-
-                using (var writer = new StreamWriter(Path.Combine(Path.GetDirectoryName(projectA.ProjectPath), "packages.config")))
-                {
-                    writer.Write(
-@"<packages>
-  <package id=""My.MVC.ASP"" version=""1.0.0"" targetFramework=""net461"" />
-</packages>");
-                }
-
-                var opensourceRepositoryPath = pathContext.PackageSource;
-                Directory.CreateDirectory(opensourceRepositoryPath);
-
-                var packageOpenSourceContosoMvc = new SimpleTestPackageContext()
-                {
-                    Id = "My.MVC.ASP",  // Package Id conflict with internally created package
-                    Version = "1.0.0"
-                };
-                packageOpenSourceContosoMvc.AddFile("lib/net461/openA.dll");
-
-                await SimpleTestPackageUtility.CreateFolderFeedV3Async(
-                    opensourceRepositoryPath,
-                    packageOpenSourceContosoMvc);
-
-                var packageContosoBuffersOpenSource = new SimpleTestPackageContext()
-                {
-                    Id = "Contoso.Opensource.Buffers",
-                    Version = "1.0.0"
-                };
-                packageContosoBuffersOpenSource.AddFile("lib/net461/openA.dll");
-
-                await SimpleTestPackageUtility.CreateFolderFeedV3Async(
-                    opensourceRepositoryPath,
-                    packageContosoBuffersOpenSource);
-
-                // SimpleTestPathContext adds a NuGet.Config with a repositoryPath,
-                // so we go ahead and remove that config before running MSBuild.
-                var configPath = Path.Combine(Path.GetDirectoryName(pathContext.SolutionRoot), "NuGet.Config");
-                var configText =
-$@"<?xml version=""1.0"" encoding=""utf-8""?>
-<configuration>
-    <packageSources>
-    <!--To inherit the global NuGet package sources remove the <clear/> line below -->
-    <clear />
-    <add key=""PublicRepository"" value=""{opensourceRepositoryPath}"" />
-    </packageSources>
-    <packageNamespaces>
-        <packageSource key=""PublicRepository"">
-            <namespace id=""Contoso.MVC.ASP"" />   <!-- My.MVC.ASP doesn't match any package name spaces -->
-        </packageSource>
-    </packageNamespaces>
-</configuration>";
-
-                using (var writer = new StreamWriter(configPath))
-                {
-                    writer.Write(configText);
-                }
-
-                // Act
-                var result = _msbuildFixture.RunMsBuild(pathContext.WorkingDirectory, $"/t:restore -v:d {pathContext.SolutionRoot} /p:RestorePackagesConfig=true", ignoreExitCode: true);
-
-                // Assert
-                Assert.True(result.ExitCode == 0);
-                var contosoRestorePath = Path.Combine(projectAPackages, packageOpenSourceContosoMvc.ToString(), packageOpenSourceContosoMvc.ToString() + ".nupkg");
-                using (var nupkgReader = new PackageArchiveReader(contosoRestorePath))
-                {
-                    var allFiles = nupkgReader.GetFiles().ToList();
-                    // Assert correct package was restored.
-                    Assert.Contains("lib/net461/openA.dll", allFiles);
-                }
-
-                Assert.True(result.ExitCode == 0);
-                Assert.Contains("Package namespace match not found for package ID 'My.MVC.ASP'", result.Output);
             }
         }
 

--- a/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildRestoreTaskTests.cs
+++ b/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildRestoreTaskTests.cs
@@ -1592,16 +1592,7 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
                 var result = _msbuildFixture.RunMsBuild(pathContext.WorkingDirectory, $"/t:restore -v:d {pathContext.SolutionRoot} /p:RestorePackagesConfig=true", ignoreExitCode: true);
 
                 // Assert
-                Assert.True(result.ExitCode == 0);
-                var contosoRestorePath = Path.Combine(projectAPackages, packageOpenSourceContosoMvc.ToString(), packageOpenSourceContosoMvc.ToString() + ".nupkg");
-                using (var nupkgReader = new PackageArchiveReader(contosoRestorePath))
-                {
-                    var allFiles = nupkgReader.GetFiles().ToList();
-                    // Assert correct package was restored.
-                    Assert.Contains("lib/net461/openA.dll", allFiles);
-                }
-
-                Assert.True(result.ExitCode == 0);
+                Assert.Equal(1, result.ExitCode);
                 Assert.Contains("Package namespace match not found for package ID 'My.MVC.ASP'", result.Output);
             }
         }

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests.cs
@@ -7349,11 +7349,12 @@ namespace NuGet.Test
     </packageSources>
     <packageNamespaces>
         <packageSource key=""externalRepository"">
+            <namespace id=""Direct.*"" />
             <namespace id=""External.*"" />
             <namespace id=""Others.*"" />
         </packageSource>
         <packageSource key=""PrivateRepository"">
-            <namespace id=""Contoso.*"" />             
+            <namespace id=""Contoso.*"" />
             <namespace id=""Test.*"" />
         </packageSource>
     </packageNamespaces>
@@ -7370,7 +7371,7 @@ namespace NuGet.Test
 
                 var ExternalDirectA = new SimpleTestPackageContext()
                 {
-                    Id = directPackageIdentity.Id, // Package Id not filtered by package namespace.
+                    Id = directPackageIdentity.Id,
                     Version = "1.0.0",
                     Dependencies = new List<SimpleTestPackageContext>() { ExternalContosoA } // We set Contoso.A as dependent package.
                 };

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/ResolverGatherTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/ResolverGatherTests.cs
@@ -1571,17 +1571,15 @@ namespace NuGet.Test
             };
 
             // Act
-            HashSet<SourcePackageDependencyInfo> results = await ResolverGather.GatherAsync(context, CancellationToken.None);
-
-            List<SourcePackageDependencyInfo> check = results.OrderBy(e => e.Id).ToList();
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => ResolverGather.GatherAsync(context, CancellationToken.None));
 
             // Assert
             Assert.True(namespacesConfiguration.AreNamespacesEnabled);
             Assert.Null(configuredSources);
-            Assert.Equal(1, check.Count);
 
             // Assert log.
-            Assert.Equal($"Package namespace match not found for package ID '{packageId}' ", testNuGetProjectContext.Logs.Value[0]);
+            Assert.Contains($"Package '{packageId} 1.0.0' is not found in the following primary source(s)", exception.Message);
         }
 
         private static SourceRepository CreateTimeoutRepo(string source)


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11170

Regression? Last working version:

## Description
Change mode from permissive mode to fully specified mode for packages.config projects.
Here 
* permissive mode: When a package id needs to be downloaded, it is first compared against sources with namespaces. If any match, only those sources are used. If none of the namespaces match, then the sources without namespaces are considered, if any.
* fully specified mode: a package prefix must match one or more sources

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
