### PR TITLE
Reduce memory allocations by 13MB while opening install packages tab in solution level PM UI for OrchardCore 

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/CpsPackageReferenceProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/CpsPackageReferenceProject.cs
@@ -258,7 +258,7 @@ namespace NuGet.PackageManagement.VisualStudio
                    .GroupBy(p => p.PackageIdentity)
                    .Select(g => g.OrderBy(p => p.TargetFramework, frameworkSorter).First())
                    .ToList();
-                return new ProjectPackages(installedPackages.ToList(), transitivePackages.ToList());
+                return new ProjectPackages(installedPackages, transitivePackages);
             }
             else
             {


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1108

Regression? Last working version: No

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
Removed unnecessary calls to `.ToList()` [while fetching installed and transitive packages references](https://github.com/NuGet/NuGet.Client/blob/dbd9822255d619908ea9a51e76b8139d6397909b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/CpsPackageReferenceProject.cs#L247-L261). This simple fix `reduced memory allocations by 13 MB` for below scenario. There will be a minor perf benefit due to removal of unnecessary `.ToList()` invocations.
1. Open OrchardCore solution in VS https://github.com/OrchardCMS/OrchardCore/tree/d70bed827520689e1db29b1113d0fb3c4792c5f7
2. Wait for solution restore to complete.
2. Start PerfView trace collection
3. Right click on solution level PM UI and wait until install tab gets populated
4. Navigated to Browse tab
5. Stop PerfView trace collection

**Before fix** - The method `GetInstalledAndTransitivePackagesAsync` allocated `63 MB` memory.

![tolist-before](https://user-images.githubusercontent.com/52756182/130474865-8fc13212-84f6-4574-a6e3-e42e9aa1e590.PNG)

**After fix** - The method `GetInstalledAndTransitivePackagesAsync` allocated `50 MB` memory.

![tolist-after](https://user-images.githubusercontent.com/52756182/130475081-cb331906-5490-42fb-bc4e-fac13ee80b58.PNG)

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Test exception - No functional change to the product.

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [x] N/A
