### PR TITLE
Apply arcade-powered source-build patches

### DIFF
--- a/build/common.project.props
+++ b/build/common.project.props
@@ -57,7 +57,7 @@
     <MicrosoftDotNetMaestroTasksFilePath>$(SolutionPackagesFolder)microsoft.dotnet.maestro.tasks\1.1.0-beta.21378.2\tools\netcoreapp3.1\Microsoft.DotNet.Maestro.Tasks.dll</MicrosoftDotNetMaestroTasksFilePath>
     <NoWarn>$(NoWarn);NU5105;MSB3277</NoWarn>
     <!-- additional warnings new in .NET 6 that we need to disable when building with source-build -->
-    <NoWarn Condition="'$(IsBuildOnlyXPLATProjects)' == 'true'">$(NoWarn);CS1998;CA1416</NoWarn>
+    <NoWarn Condition="'$(IsBuildOnlyXPLATProjects)' == 'true'">$(NoWarn);CS1998;CA1416;CS0618;CS1574</NoWarn>
   </PropertyGroup>
 
   <!-- Defaults -->
@@ -90,7 +90,7 @@
     <Features>strict</Features>
     <!-- Same as SDK default, but without CandidateAssemblyFiles in front, which would search in Content items -->
     <AssemblySearchPaths>{HintPathFromItem};{TargetFrameworkDirectory};{RawFileName}</AssemblySearchPaths>
-    <LangVersion>9</LangVersion>
+    <LangVersion>10</LangVersion>
   </PropertyGroup>
 
   <!-- DEBUG specific configuration settings -->

--- a/build/common.project.props
+++ b/build/common.project.props
@@ -56,6 +56,8 @@
     <MicrosoftDotNetBuildTasksFeedFilePath>$(SolutionPackagesFolder)microsoft.dotnet.build.tasks.feed\6.0.0-beta.20528.5\tools\netcoreapp2.1\Microsoft.DotNet.Build.Tasks.Feed.dll</MicrosoftDotNetBuildTasksFeedFilePath>
     <MicrosoftDotNetMaestroTasksFilePath>$(SolutionPackagesFolder)microsoft.dotnet.maestro.tasks\1.1.0-beta.21378.2\tools\netcoreapp3.1\Microsoft.DotNet.Maestro.Tasks.dll</MicrosoftDotNetMaestroTasksFilePath>
     <NoWarn>$(NoWarn);NU5105;MSB3277</NoWarn>
+    <!-- additional warnings new in .NET 6 that we need to disable when building with source-build -->
+    <NoWarn Condition="'$(IsBuildOnlyXPLATProjects)' == 'true'">$(NoWarn);CS1998;CA1416</NoWarn>
   </PropertyGroup>
 
   <!-- Defaults -->

--- a/build/common.project.props
+++ b/build/common.project.props
@@ -90,7 +90,8 @@
     <Features>strict</Features>
     <!-- Same as SDK default, but without CandidateAssemblyFiles in front, which would search in Content items -->
     <AssemblySearchPaths>{HintPathFromItem};{TargetFrameworkDirectory};{RawFileName}</AssemblySearchPaths>
-    <LangVersion>10</LangVersion>
+    <LangVersion>9</LangVersion>
+    <LangVersion Condition="'$(IsBuildOnlyXPLATProjects)' == 'true'">latest</LangVersion>
   </PropertyGroup>
 
   <!-- DEBUG specific configuration settings -->

--- a/build/common.project.props
+++ b/build/common.project.props
@@ -10,20 +10,24 @@
 
   <!-- Common -->
   <PropertyGroup>
+    <IsBuildOnlyXPLATProjects>$(DotNetBuildFromSource)</IsBuildOnlyXPLATProjects>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
     <NETFXTargetFrameworkVersion>v4.7.2</NETFXTargetFrameworkVersion>
     <NETFXTargetFramework>net472</NETFXTargetFramework>
     <NETCoreTargetFramework>netcoreapp2.1</NETCoreTargetFramework>
+    <NETCoreTargetFramework Condition="'$(IsBuildOnlyXPLATProjects)' == 'true'">net6.0</NETCoreTargetFramework>
     <NETCoreTestTargetFramework>netcoreapp5.0</NETCoreTestTargetFramework>
-    <IsBuildOnlyXPLATProjects>$(DotNetBuildFromSource)</IsBuildOnlyXPLATProjects>
     <NetStandardVersion>netstandard2.0</NetStandardVersion>
+    <NetStandardVersion Condition="'$(IsBuildOnlyXPLATProjects)' == 'true'">net6.0</NetStandardVersion>
     <TargetFrameworksExe>$(NETFXTargetFramework);$(NETCoreTargetFramework)</TargetFrameworksExe>
     <TargetFrameworksExe Condition="'$(IsBuildOnlyXPLATProjects)' == 'true' OR '$(IsXPlat)' == 'true'">$(NETCoreTargetFramework)</TargetFrameworksExe>
     <TargetFrameworksExeForSigning>$(TargetFrameworksExe);netcoreapp5.0</TargetFrameworksExeForSigning>
-    <TargetFrameworksExeForSigning Condition=" '$(IsXPlat)' == 'true' ">$(NETCoreTargetFramework);netcoreapp5.0</TargetFrameworksExeForSigning>
+    <TargetFrameworksExeForSigning Condition="'$(IsBuildOnlyXPLATProjects)' == 'true'">$(TargetFrameworksExe);net6.0</TargetFrameworksExeForSigning>
+    <TargetFrameworksExeForSigning Condition=" '$(IsXPlat)' == 'true' ">$(NETCoreTargetFramework);net6.0</TargetFrameworksExeForSigning>
     <TargetFrameworksLibrary>$(NETFXTargetFramework);$(NetStandardVersion)</TargetFrameworksLibrary>
     <TargetFrameworksLibrary Condition="'$(IsBuildOnlyXPLATProjects)' == 'true'">$(NetStandardVersion)</TargetFrameworksLibrary>
     <TargetFrameworksLibraryForSigning>$(TargetFrameworksLibrary);netcoreapp5.0</TargetFrameworksLibraryForSigning>
+    <TargetFrameworksLibraryForSigning Condition="'$(IsBuildOnlyXPLATProjects)' == 'true'">$(TargetFrameworksLibrary);net6.0</TargetFrameworksLibraryForSigning>
     <TargetFrameworksLibraryForCrossVerificationTests>$(NETFXTargetFramework);netcoreapp5.0</TargetFrameworksLibraryForCrossVerificationTests>
     <RepositoryRootDirectory>$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\</RepositoryRootDirectory>
     <BuildCommonDirectory>$(RepositoryRootDirectory)build\</BuildCommonDirectory>

--- a/build/common.project.props
+++ b/build/common.project.props
@@ -15,19 +15,19 @@
     <NETFXTargetFrameworkVersion>v4.7.2</NETFXTargetFrameworkVersion>
     <NETFXTargetFramework>net472</NETFXTargetFramework>
     <NETCoreTargetFramework>netcoreapp2.1</NETCoreTargetFramework>
-    <NETCoreTargetFramework Condition="'$(IsBuildOnlyXPLATProjects)' == 'true'">net6.0</NETCoreTargetFramework>
+    <NETCoreTargetFramework Condition="'$(DotNetBuildFromSource)' == 'true'">net6.0</NETCoreTargetFramework>
     <NETCoreTestTargetFramework>netcoreapp5.0</NETCoreTestTargetFramework>
     <NetStandardVersion>netstandard2.0</NetStandardVersion>
-    <NetStandardVersion Condition="'$(IsBuildOnlyXPLATProjects)' == 'true'">net6.0</NetStandardVersion>
+    <NetStandardVersion Condition="'$(DotNetBuildFromSource)' == 'true'">net6.0</NetStandardVersion>
     <TargetFrameworksExe>$(NETFXTargetFramework);$(NETCoreTargetFramework)</TargetFrameworksExe>
     <TargetFrameworksExe Condition="'$(IsBuildOnlyXPLATProjects)' == 'true' OR '$(IsXPlat)' == 'true'">$(NETCoreTargetFramework)</TargetFrameworksExe>
     <TargetFrameworksExeForSigning>$(TargetFrameworksExe);netcoreapp5.0</TargetFrameworksExeForSigning>
-    <TargetFrameworksExeForSigning Condition="'$(IsBuildOnlyXPLATProjects)' == 'true'">$(TargetFrameworksExe);net6.0</TargetFrameworksExeForSigning>
-    <TargetFrameworksExeForSigning Condition=" '$(IsXPlat)' == 'true' ">$(NETCoreTargetFramework);net6.0</TargetFrameworksExeForSigning>
+    <TargetFrameworksExeForSigning Condition="'$(DotNetBuildFromSource)' == 'true'">$(TargetFrameworksExe);net6.0</TargetFrameworksExeForSigning>
+    <TargetFrameworksExeForSigning Condition=" '$(IsXPlat)' == 'true' ">$(NETCoreTargetFramework);net5.0</TargetFrameworksExeForSigning>
     <TargetFrameworksLibrary>$(NETFXTargetFramework);$(NetStandardVersion)</TargetFrameworksLibrary>
     <TargetFrameworksLibrary Condition="'$(IsBuildOnlyXPLATProjects)' == 'true'">$(NetStandardVersion)</TargetFrameworksLibrary>
     <TargetFrameworksLibraryForSigning>$(TargetFrameworksLibrary);netcoreapp5.0</TargetFrameworksLibraryForSigning>
-    <TargetFrameworksLibraryForSigning Condition="'$(IsBuildOnlyXPLATProjects)' == 'true'">$(TargetFrameworksLibrary);net6.0</TargetFrameworksLibraryForSigning>
+    <TargetFrameworksLibraryForSigning Condition="'$(DotNetBuildFromSource)' == 'true'">$(TargetFrameworksLibrary);net6.0</TargetFrameworksLibraryForSigning>
     <TargetFrameworksLibraryForCrossVerificationTests>$(NETFXTargetFramework);netcoreapp5.0</TargetFrameworksLibraryForCrossVerificationTests>
     <RepositoryRootDirectory>$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\</RepositoryRootDirectory>
     <BuildCommonDirectory>$(RepositoryRootDirectory)build\</BuildCommonDirectory>
@@ -57,7 +57,7 @@
     <MicrosoftDotNetMaestroTasksFilePath>$(SolutionPackagesFolder)microsoft.dotnet.maestro.tasks\1.1.0-beta.21378.2\tools\netcoreapp3.1\Microsoft.DotNet.Maestro.Tasks.dll</MicrosoftDotNetMaestroTasksFilePath>
     <NoWarn>$(NoWarn);NU5105;MSB3277</NoWarn>
     <!-- additional warnings new in .NET 6 that we need to disable when building with source-build -->
-    <NoWarn Condition="'$(IsBuildOnlyXPLATProjects)' == 'true'">$(NoWarn);CS1998;CA1416;CS0618;CS1574</NoWarn>
+    <NoWarn Condition="'$(DotNetBuildFromSource)' == 'true'">$(NoWarn);CS1998;CA1416;CS0618;CS1574</NoWarn>
   </PropertyGroup>
 
   <!-- Defaults -->
@@ -91,7 +91,7 @@
     <!-- Same as SDK default, but without CandidateAssemblyFiles in front, which would search in Content items -->
     <AssemblySearchPaths>{HintPathFromItem};{TargetFrameworkDirectory};{RawFileName}</AssemblySearchPaths>
     <LangVersion>9</LangVersion>
-    <LangVersion Condition="'$(IsBuildOnlyXPLATProjects)' == 'true'">latest</LangVersion>
+    <LangVersion Condition="'$(DotNetBuildFromSource)' == 'true'">latest</LangVersion>
   </PropertyGroup>
 
   <!-- DEBUG specific configuration settings -->

--- a/build/common.project.props
+++ b/build/common.project.props
@@ -22,8 +22,8 @@
     <TargetFrameworksExe>$(NETFXTargetFramework);$(NETCoreTargetFramework)</TargetFrameworksExe>
     <TargetFrameworksExe Condition="'$(IsBuildOnlyXPLATProjects)' == 'true' OR '$(IsXPlat)' == 'true'">$(NETCoreTargetFramework)</TargetFrameworksExe>
     <TargetFrameworksExeForSigning>$(TargetFrameworksExe);netcoreapp5.0</TargetFrameworksExeForSigning>
+    <TargetFrameworksExeForSigning Condition=" '$(IsXPlat)' == 'true' ">$(NETCoreTargetFramework);netcoreapp5.0</TargetFrameworksExeForSigning>
     <TargetFrameworksExeForSigning Condition="'$(DotNetBuildFromSource)' == 'true'">$(TargetFrameworksExe);net6.0</TargetFrameworksExeForSigning>
-    <TargetFrameworksExeForSigning Condition=" '$(IsXPlat)' == 'true' ">$(NETCoreTargetFramework);net5.0</TargetFrameworksExeForSigning>
     <TargetFrameworksLibrary>$(NETFXTargetFramework);$(NetStandardVersion)</TargetFrameworksLibrary>
     <TargetFrameworksLibrary Condition="'$(IsBuildOnlyXPLATProjects)' == 'true'">$(NetStandardVersion)</TargetFrameworksLibrary>
     <TargetFrameworksLibraryForSigning>$(TargetFrameworksLibrary);netcoreapp5.0</TargetFrameworksLibraryForSigning>

--- a/build/common.targets
+++ b/build/common.targets
@@ -65,6 +65,11 @@
     <None Include="$(MSBuildThisFileDirectory)..\icon.png" Pack="true" PackagePath="\" Visible="false" />
   </ItemGroup>
 
+    <!-- Don't use PublicApiAnalyzer on source-build .NET -->
+  <PropertyGroup Condition=" '$(IsBuildOnlyXPLATProjects)' == 'true' ">
+    <UsePublicApiAnalyzer>false</UsePublicApiAnalyzer>
+  </PropertyGroup>
+
   <!-- Projects we pack become public APIs that others can use -->
   <PropertyGroup Condition=" '$(IsBuildOnlyXPLATProjects)' != 'true' and '$(PackProject)' == 'true' ">
     <UsePublicApiAnalyzer Condition=" '$(UsePublicApiAnalyzer)' == '' " >true</UsePublicApiAnalyzer>

--- a/build/common.targets
+++ b/build/common.targets
@@ -6,7 +6,7 @@
     <IsDesktop>true</IsDesktop>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" $(TargetFramework.StartsWith('netcoreapp')) OR $(TargetFramework.StartsWith('netstandard')) ">
+  <PropertyGroup Condition=" $(TargetFramework.StartsWith('netcoreapp')) OR $(TargetFramework.StartsWith('netstandard')) OR $(TargetFramework.StartsWith('net6')) ">
     <DefineConstants>$(DefineConstants);IS_CORECLR</DefineConstants>
     <IsCore>true</IsCore>
   </PropertyGroup>

--- a/build/common.targets
+++ b/build/common.targets
@@ -66,7 +66,7 @@
   </ItemGroup>
 
     <!-- Don't use PublicApiAnalyzer on source-build .NET -->
-  <PropertyGroup Condition=" '$(IsBuildOnlyXPLATProjects)' == 'true' ">
+  <PropertyGroup Condition=" '$(DotNetBuildFromSource)' == 'true' ">
     <UsePublicApiAnalyzer>false</UsePublicApiAnalyzer>
   </PropertyGroup>
 

--- a/build/packages.targets
+++ b/build/packages.targets
@@ -2,6 +2,8 @@
     <PropertyGroup>
         <MicrosoftBuildPackageVersion Condition="'$(MicrosoftBuildPackageVersion)' == ''">16.8.0</MicrosoftBuildPackageVersion>
         <NewtonsoftJsonPackageVersion Condition="$(NewtonsoftJsonPackageVersion) == ''">13.0.1</NewtonsoftJsonPackageVersion>
+        <MicrosoftWebXdtPackageVersion Condition="'$(MicrosoftWebXdtPackageVersion)' == ''">3.0.0</MicrosoftWebXdtPackageVersion>
+        <SystemComponentModelCompositionPackageVersion Condition="'$(SystemComponentModelCompositionPackageVersion)' == ''">4.5.0</SystemComponentModelCompositionPackageVersion>
         <SystemPackagesVersion>4.3.0</SystemPackagesVersion>
         <VSFrameworkVersion>17.0.0-previews-1-31321-016</VSFrameworkVersion>
         <VSServicesVersion>16.153.0</VSServicesVersion>
@@ -42,10 +44,10 @@
         <PackageReference Update="Microsoft.VisualStudio.VCProjectEngine" Version="$(VSFrameworkVersion)" />
         <PackageReference Update="Microsoft.VisualStudio.Workspace.VSIntegration" Version="17.0.7-preview-0001-g5492e466a9" />
         <PackageReference Update="Microsoft.VSSDK.BuildTools" Version="17.0.1600" />
-        <PackageReference Update="Microsoft.Web.Xdt" Version="3.0.0" />
+        <PackageReference Update="Microsoft.Web.Xdt" Version="$(MicrosoftWebXdtPackageVersion)" />
         <PackageReference Update="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
         <PackageReference Update="SharpZipLib" Version="1.3.2" />
-        <PackageReference Update="System.ComponentModel.Composition" Version="4.5.0" />
+        <PackageReference Update="System.ComponentModel.Composition" Version="$(SystemComponentModelCompositionPackageVersion)" />
         <!--
           The Microsoft.VisualStudio.SDK metapackage brings in System.Threading.Tasks.Dataflow 4.11.1 (assembly version 4.9.5.0).
           However, our MSBuild integration tests use Microsoft.Build 16.8.0, which requires System.Threading.Tasks.Dataflow 4.9.0 (assembly version 4.9.3.0).

--- a/eng/source-build/build.sh
+++ b/eng/source-build/build.sh
@@ -69,5 +69,15 @@ ReadGlobalVersion Microsoft.DotNet.Arcade.Sdk
 export ARCADE_VERSION=$_ReadGlobalVersion
 ReadGlobalVersion dotnet
 export SDK_VERSION=$_ReadGlobalVersion
+
+mkdir -p cli
+curl -o cli/dotnet-install.sh -L https://dot.net/v1/dotnet-install.sh
+
+if (( $? )); then
+	echo "Could not download 'dotnet-install.sh' script. Please check your network and try again!"
+	exit 1
+fi
+chmod +x cli/dotnet-install.sh
+
 ../../cli/dotnet-install.sh -v $SDK_VERSION
 "$DOTNET" msbuild "$scriptroot/source-build.proj" /p:Configuration=$configuration /p:DotNetBuildFromSource=true /p:ArcadeBuildFromSource=true "/p:RepoRoot=$scriptroot/../../" "/bl:$scriptroot/../../artifacts/source-build/self/log/source-build.binlog" $args

--- a/eng/source-build/build.sh
+++ b/eng/source-build/build.sh
@@ -67,4 +67,7 @@ fi
 
 ReadGlobalVersion Microsoft.DotNet.Arcade.Sdk
 export ARCADE_VERSION=$_ReadGlobalVersion
+ReadGlobalVersion dotnet
+export SDK_VERSION=$_ReadGlobalVersion
+../../cli/dotnet-install.sh -v $SDK_VERSION
 "$DOTNET" msbuild "$scriptroot/source-build.proj" /p:Configuration=$configuration /p:DotNetBuildFromSource=true /p:ArcadeBuildFromSource=true "/p:RepoRoot=$scriptroot/../../" "/bl:$scriptroot/../../artifacts/source-build/self/log/source-build.binlog" $args

--- a/eng/source-build/build.sh
+++ b/eng/source-build/build.sh
@@ -80,5 +80,5 @@ if (( $? )); then
 fi
 chmod +x "$scriptroot/../../cli/dotnet-install.sh"
 
-"$scriptroot/../../cli/dotnet-install.sh" -v $SDK_VERSION
+"$scriptroot/../../cli/dotnet-install.sh" -v $SDK_VERSION -i "$scriptroot/../../cli"
 "$DOTNET" msbuild "$scriptroot/source-build.proj" /p:Configuration=$configuration /p:DotNetBuildFromSource=true /p:ArcadeBuildFromSource=true "/p:RepoRoot=$scriptroot/../../" "/bl:$scriptroot/../../artifacts/source-build/self/log/source-build.binlog" $args

--- a/eng/source-build/build.sh
+++ b/eng/source-build/build.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -x
 
 source="${BASH_SOURCE[0]}"
 scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
@@ -70,14 +71,14 @@ export ARCADE_VERSION=$_ReadGlobalVersion
 ReadGlobalVersion dotnet
 export SDK_VERSION=$_ReadGlobalVersion
 
-mkdir -p cli
-curl -o cli/dotnet-install.sh -L https://dot.net/v1/dotnet-install.sh
+mkdir -p "$scriptroot/../../cli"
+curl -o "$scriptroot/../../cli/dotnet-install.sh" -L https://dot.net/v1/dotnet-install.sh
 
 if (( $? )); then
 	echo "Could not download 'dotnet-install.sh' script. Please check your network and try again!"
 	exit 1
 fi
-chmod +x cli/dotnet-install.sh
+chmod +x "$scriptroot/../../cli/dotnet-install.sh"
 
-../../cli/dotnet-install.sh -v $SDK_VERSION
+"$scriptroot/../../cli/dotnet-install.sh" -v $SDK_VERSION
 "$DOTNET" msbuild "$scriptroot/source-build.proj" /p:Configuration=$configuration /p:DotNetBuildFromSource=true /p:ArcadeBuildFromSource=true "/p:RepoRoot=$scriptroot/../../" "/bl:$scriptroot/../../artifacts/source-build/self/log/source-build.binlog" $args

--- a/eng/source-build/global.json
+++ b/eng/source-build/global.json
@@ -1,4 +1,7 @@
 {
+  "tools": {
+    "dotnet": "6.0.100-preview.7.21379.14"
+  },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "6.0.0-beta.21309.7"
   }

--- a/eng/source-build/source-build.proj
+++ b/eng/source-build/source-build.proj
@@ -4,6 +4,8 @@
 
   <PropertyGroup>
     <ProjectRoot>$(MSBuildThisFileDirectory)../../</ProjectRoot>
+    <ArcadeDir Condition="'$(SOURCE_BUILT_SDK_DIR_ARCADE)' != ''">$(SOURCE_BUILT_SDK_DIR_ARCADE)/tools/</ArcadeDir>
+    <ArcadeDir Condition="'$(ArcadeDir)' == ''">$(NuGetPackageRoot)/microsoft.dotnet.arcade.sdk/$(ARCADE_VERSION)/tools/</ArcadeDir>
   </PropertyGroup>
 
   <Target Name="Build" DependsOnTargets="SourceBuildPostBuild">
@@ -18,14 +20,14 @@
   <Target Name="SourceBuildPostBuild" DependsOnTargets="SourceBuildInnerBuild">
     <Message Text="Running source-build PostBuild target" Importance="High" />
 
-    <MSbuild Projects="$(NuGetPackageRoot)/microsoft.dotnet.arcade.sdk/$(ARCADE_VERSION)/tools/Build.proj"
+    <MSbuild Projects="$(ArcadeDir)/Build.proj"
              Properties="_NETCORE_ENGINEERING_TELEMETRY=AfterSourceBuild;ArcadeBuildFromSource=true;Restore=true;Build=false;Pack=false;Publish=false;Rebuild=false;Test=false;IntegrationTest=false;PerformanceTest=false;PreventPrebuiltBuild=false;BaseInnerSourceBuildCommand=echo skipping internal build with args: "
              Targets="Execute"
             />
 
     <Message Text="Finished restoring Arcade" Importance="High" />
 
-    <MSbuild Projects="$(NuGetPackageRoot)/microsoft.dotnet.arcade.sdk/$(ARCADE_VERSION)/tools/SourceBuild/AfterSourceBuild.proj"
+    <MSbuild Projects="$(ArcadeDir)/SourceBuild/AfterSourceBuild.proj"
              Properties="_NETCORE_ENGINEERING_TELEMETRY=AfterSourceBuild;ArcadeBuildFromSource=true;CurrentRepoSourceBuildArtifactsPackagesDir=$(ProjectRoot)artifacts/nupkgs/"
             />
 

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/GetPackOutputItemsTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/GetPackOutputItemsTask.cs
@@ -13,7 +13,7 @@ using NuGet.Versioning;
 
 namespace NuGet.Build.Tasks.Pack
 {
-    public class GetPackOutputItemsTask : Task
+    public class GetPackOutputItemsTask : Microsoft.Build.Utilities.Task
     {
         [Required]
         public string PackageId { get; set; }

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/GetProjectReferencesFromAssetsFileTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/GetProjectReferencesFromAssetsFileTask.cs
@@ -19,7 +19,7 @@ namespace NuGet.Build.Tasks.Pack
     /// This list is then later traversed to determine the version
     /// of the project reference during pack.
     /// </summary>
-    public class GetProjectReferencesFromAssetsFileTask : Task
+    public class GetProjectReferencesFromAssetsFileTask : Microsoft.Build.Utilities.Task
     {
         public string RestoreOutputAbsolutePath { get; set; }
 

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/IsPackableFalseWarningTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/IsPackableFalseWarningTask.cs
@@ -7,7 +7,7 @@ using NuGet.Common;
 
 namespace NuGet.Build.Tasks.Pack
 {
-    public class IsPackableFalseWarningTask : Task
+    public class IsPackableFalseWarningTask : Microsoft.Build.Utilities.Task
     {
         public ILogger Logger => new MSBuildLogger(Log);
         public override bool Execute()

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.csproj
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.csproj
@@ -180,10 +180,13 @@
       <PackagePathDir Condition="'$(TargetFramework)' == '$(NetStandardVersion)'">CoreCLR/</PackagePathDir>
     </PropertyGroup>
     <ItemGroup>
-      <TfmSpecificPackageFile Include="$(OutputPath)\$(ILMergeSubpath)NuGet.Build.Tasks.Pack.dll">
+      <TfmSpecificPackageFile Include="$(OutputPath)\$(ILMergeSubpath)NuGet.Build.Tasks.Pack.dll" Condition="'$(IsBuildOnlyXPLATProjects)' != 'true'">
         <PackagePath>$(PackagePathDir)</PackagePath>
       </TfmSpecificPackageFile>
       <TfmSpecificPackageFile Include="$(OutputPath)\$(ILMergeSubpath)**\NuGet*.resources.dll">
+        <PackagePath>$(PackagePathDir)</PackagePath>
+      </TfmSpecificPackageFile>
+      <TfmSpecificPackageFile Include="$(OutputPath)\$(ILMergeSubpath)NuGet*.dll" Condition="'$(IsBuildOnlyXPLATProjects)' == 'true'">
         <PackagePath>$(PackagePathDir)</PackagePath>
       </TfmSpecificPackageFile>
     </ItemGroup>    

--- a/src/NuGet.Core/NuGet.Build.Tasks/GenerateRestoreGraphFileTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/GenerateRestoreGraphFileTask.cs
@@ -17,7 +17,7 @@ namespace NuGet.Build.Tasks
     /// <summary>
     /// Represents an MSBuild task that performs a command-line based restore.
     /// </summary>
-    public sealed class GenerateRestoreGraphFileTask : Task, ICancelableTask, IDisposable
+    public sealed class GenerateRestoreGraphFileTask : Microsoft.Build.Utilities.Task, ICancelableTask, IDisposable
     {
         internal readonly CancellationTokenSource _cancellationTokenSource = new CancellationTokenSource();
 

--- a/src/NuGet.Core/NuGet.Build.Tasks/GetCentralPackageVersionsTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/GetCentralPackageVersionsTask.cs
@@ -10,7 +10,7 @@ using Newtonsoft.Json;
 
 namespace NuGet.Build.Tasks
 {
-    public class GetCentralPackageVersionsTask : Task
+    public class GetCentralPackageVersionsTask : Microsoft.Build.Utilities.Task
     {
         /// <summary>
         /// Full path to the msbuild project.

--- a/src/NuGet.Core/NuGet.Build.Tasks/GetProjectTargetFrameworksTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/GetProjectTargetFrameworksTask.cs
@@ -12,7 +12,7 @@ namespace NuGet.Build.Tasks
     /// Determine the project's targetframework(s) based
     /// on the available properties.
     /// </summary>
-    public class GetProjectTargetFrameworksTask : Task
+    public class GetProjectTargetFrameworksTask : Microsoft.Build.Utilities.Task
     {
         /// <summary>
         /// Full path to the msbuild project.

--- a/src/NuGet.Core/NuGet.Build.Tasks/GetReferenceNearestTargetFrameworkTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/GetReferenceNearestTargetFrameworkTask.cs
@@ -12,7 +12,7 @@ using NuGet.Frameworks;
 
 namespace NuGet.Build.Tasks
 {
-    public class GetReferenceNearestTargetFrameworkTask : Task
+    public class GetReferenceNearestTargetFrameworkTask : Microsoft.Build.Utilities.Task
     {
         private const string NEAREST_TARGET_FRAMEWORK = "NearestTargetFramework";
         private const string TARGET_FRAMEWORKS = "TargetFrameworks";

--- a/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreDotnetCliToolsTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreDotnetCliToolsTask.cs
@@ -14,7 +14,7 @@ using NuGet.Versioning;
 
 namespace NuGet.Build.Tasks
 {
-    public class GetRestoreDotnetCliToolsTask : Task
+    public class GetRestoreDotnetCliToolsTask : Microsoft.Build.Utilities.Task
     {
         /// <summary>
         /// Full path to the msbuild project.

--- a/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreFrameworkReferencesTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreFrameworkReferencesTask.cs
@@ -10,7 +10,7 @@ using Newtonsoft.Json;
 
 namespace NuGet.Build.Tasks
 {
-    public class GetRestoreFrameworkReferencesTask : Task
+    public class GetRestoreFrameworkReferencesTask : Microsoft.Build.Utilities.Task
     {
         /// <summary>
         /// Full path to the msbuild project.

--- a/src/NuGet.Core/NuGet.Build.Tasks/GetRestorePackageDownloadsTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/GetRestorePackageDownloadsTask.cs
@@ -10,7 +10,7 @@ using Newtonsoft.Json;
 
 namespace NuGet.Build.Tasks
 {
-    public class GetRestorePackageDownloadsTask : Task
+    public class GetRestorePackageDownloadsTask : Microsoft.Build.Utilities.Task
     {
         /// <summary>
         /// Full path to the msbuild project.

--- a/src/NuGet.Core/NuGet.Build.Tasks/GetRestorePackageReferencesTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/GetRestorePackageReferencesTask.cs
@@ -10,7 +10,7 @@ using Newtonsoft.Json;
 
 namespace NuGet.Build.Tasks
 {
-    public class GetRestorePackageReferencesTask : Task
+    public class GetRestorePackageReferencesTask : Microsoft.Build.Utilities.Task
     {
         /// <summary>
         /// Full path to the msbuild project.

--- a/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreProjectJsonPathTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreProjectJsonPathTask.cs
@@ -9,7 +9,7 @@ using NuGet.Common;
 
 namespace NuGet.Build.Tasks
 {
-    public class GetRestoreProjectJsonPathTask : Task
+    public class GetRestoreProjectJsonPathTask : Microsoft.Build.Utilities.Task
     {
         /// <summary>
         /// Full path to the msbuild project.

--- a/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreProjectReferencesTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreProjectReferencesTask.cs
@@ -11,7 +11,7 @@ using Newtonsoft.Json;
 
 namespace NuGet.Build.Tasks
 {
-    public class GetRestoreProjectReferencesTask : Task
+    public class GetRestoreProjectReferencesTask : Microsoft.Build.Utilities.Task
     {
         /// <summary>
         /// Full path to the msbuild project.

--- a/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreSettingsTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreSettingsTask.cs
@@ -17,7 +17,7 @@ namespace NuGet.Build.Tasks
     /// <summary>
     /// Get all the settings to be used for project restore.
     /// </summary>
-    public class GetRestoreSettingsTask : Task
+    public class GetRestoreSettingsTask : Microsoft.Build.Utilities.Task
     {
         [Required]
         public string ProjectUniqueName { get; set; }

--- a/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreSolutionProjectsTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreSolutionProjectsTask.cs
@@ -13,7 +13,7 @@ namespace NuGet.Build.Tasks
     /// <summary>
     /// Convert .metaproj paths to project paths.
     /// </summary>
-    public class GetRestoreSolutionProjectsTask : Task
+    public class GetRestoreSolutionProjectsTask : Microsoft.Build.Utilities.Task
     {
         private const string MetaProjExtension = ".metaproj";
 

--- a/src/NuGet.Core/NuGet.Build.Tasks/RestoreTaskEx.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/RestoreTaskEx.cs
@@ -17,7 +17,7 @@ namespace NuGet.Build.Tasks
     /// <summary>
     /// Represents an MSBuild task that performs a command-line based restore.
     /// </summary>
-    public sealed class RestoreTaskEx : Task, ICancelableTask, IDisposable
+    public sealed class RestoreTaskEx : Microsoft.Build.Utilities.Task, ICancelableTask, IDisposable
     {
         internal readonly CancellationTokenSource _cancellationTokenSource = new CancellationTokenSource();
 

--- a/src/NuGet.Core/NuGet.Build.Tasks/WarnForInvalidProjectsTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/WarnForInvalidProjectsTask.cs
@@ -10,7 +10,7 @@ using NuGet.Common;
 
 namespace NuGet.Build.Tasks
 {
-    public class WarnForInvalidProjectsTask : Task
+    public class WarnForInvalidProjectsTask : Microsoft.Build.Utilities.Task
     {
         /// <summary>
         /// All known projects.

--- a/src/NuGet.Core/NuGet.Build.Tasks/WriteRestoreGraphTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/WriteRestoreGraphTask.cs
@@ -15,7 +15,7 @@ namespace NuGet.Build.Tasks
     /// <summary>
     /// Generate dg file output.
     /// </summary>
-    public class WriteRestoreGraphTask : Task
+    public class WriteRestoreGraphTask : Microsoft.Build.Utilities.Task
     {
         /// <summary>
         /// DG file entries

--- a/src/NuGet.Core/NuGet.Frameworks/NuGet.Frameworks.csproj
+++ b/src/NuGet.Core/NuGet.Frameworks/NuGet.Frameworks.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <Description>NuGet's understanding of target frameworks.</Description>
     <TargetFrameworks Condition="'$(IsBuildOnlyXPLATProjects)' == 'true'">$(TargetFrameworksLibrary);netstandard2.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(IsBuildOnlyXPLATProjects)' != 'true'">$(TargetFrameworks);net40</TargetFrameworks>
+    <TargetFrameworks Condition="'$(IsBuildOnlyXPLATProjects)' != 'true'">$(TargetFrameworksLibrary);net40</TargetFrameworks>
     <TargetFramework />
     <NoWarn>$(NoWarn);CS1591;CS1574;CS1573</NoWarn>
     <PackProject>true</PackProject>

--- a/src/NuGet.Core/NuGet.Frameworks/NuGet.Frameworks.csproj
+++ b/src/NuGet.Core/NuGet.Frameworks/NuGet.Frameworks.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <Description>NuGet's understanding of target frameworks.</Description>
-    <TargetFrameworks>$(TargetFrameworksLibrary)</TargetFrameworks>
+    <TargetFrameworks Condition="'$(IsBuildOnlyXPLATProjects)' == 'true'">$(TargetFrameworksLibrary);netstandard2.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(IsBuildOnlyXPLATProjects)' != 'true'">$(TargetFrameworks);net40</TargetFrameworks>
     <TargetFramework />
     <NoWarn>$(NoWarn);CS1591;CS1574;CS1573</NoWarn>

--- a/src/NuGet.Core/NuGet.PackageManagement/Context/IDEExecutionContext.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Context/IDEExecutionContext.cs
@@ -8,7 +8,7 @@ using NuGet.ProjectManagement;
 
 namespace NuGet.PackageManagement
 {
-    public class IDEExecutionContext : ExecutionContext
+    public class IDEExecutionContext : NuGet.ProjectManagement.ExecutionContext
     {
         public ICommonOperations CommonOperations { get; }
 

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/NuGet.Packaging.Test.csproj
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/NuGet.Packaging.Test.csproj
@@ -6,6 +6,8 @@
     <TargetFrameworks>$(TargetFrameworksExeForSigning)</TargetFrameworks>
     <UseParallelXunit>true</UseParallelXunit>
     <Description>Unit tests for NuGet.Packaging.</Description>
+    <!-- remove warnings for obsolete types and methods: SYSLIB0023: RNGCryptoServiceProvider, SYSLIB0026: X509Certificate2() blank constructor -->
+    <NoWarn>SYSLIB0023;SYSLIB0026</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/TestUtilities/Test.Utility/ProjectManagement/TestNuGetProjectContext.cs
+++ b/test/TestUtilities/Test.Utility/ProjectManagement/TestNuGetProjectContext.cs
@@ -10,6 +10,7 @@ using NuGet.Packaging;
 using NuGet.Packaging.Core;
 using NuGet.Packaging.PackageExtraction;
 using NuGet.ProjectManagement;
+using ExecutionContext = NuGet.ProjectManagement.ExecutionContext;
 
 namespace Test.Utility
 {

--- a/test/TestUtilities/Test.Utility/ProjectManagement/TestNuGetProjectContext.cs
+++ b/test/TestUtilities/Test.Utility/ProjectManagement/TestNuGetProjectContext.cs
@@ -10,7 +10,6 @@ using NuGet.Packaging;
 using NuGet.Packaging.Core;
 using NuGet.Packaging.PackageExtraction;
 using NuGet.ProjectManagement;
-using ExecutionContext = NuGet.ProjectManagement.ExecutionContext;
 
 namespace Test.Utility
 {
@@ -64,7 +63,7 @@ namespace Test.Utility
 
         public ISourceControlManagerProvider SourceControlManagerProvider { get; set; }
 
-        public ExecutionContext ExecutionContext
+        public NuGet.ProjectManagement.ExecutionContext ExecutionContext
         {
             get { return TestExecutionContext; }
         }
@@ -102,7 +101,7 @@ namespace Test.Utility
         }
     }
 
-    public class TestExecutionContext : ExecutionContext
+    public class TestExecutionContext : NuGet.ProjectManagement.ExecutionContext
     {
         public TestExecutionContext(PackageIdentity directInstall)
         {


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11060
Fixes: https://github.com/dotnet/source-build/issues/2311

Regression? Last working version:

## Description

1.  Don't use PublicApiAnalyzer on source-build
  - We got a couple errors here about Microsoft.CodeAnalysis.PublicApiAnalyzers.DeclarePublicApiAnalyzer not being able to find src/NuGet.Core/NuGet.Common/PublicAPI/net6.0/PublicAPI.Shipped.txt.  This patch removes the analyzer for source-build scenarios, which is in keeping in general for source-build - analyzers tend to bring in weird prebuilts or trigger on errors because of source-build's different environment.
2. Update netcoreapp TFMs to 6.0
  - This is one that we're working toward not needing.  Source-build has a historical problem of only having one SDK and runtime available, and things both above and below NuGet in the source-build stack depends on only building for the one corresponding TFM.  In the long-term, we want all of these to use targeting packs and not have to change TFMs for anyone but this is the short-term fix that we've been using.  This is just updated from net5 to net6.
3. Use source-built Microsoft.Web.Xdt & System.ComponentModel.Composition
  - This is another one carried forward from 5.0.  Source-build only produces one version of each package and expects that all the repos will use them, so this lets source-build override a couple package versions that were outside the normal PackageVersions.props flow.
4. Build script changes to support ArPow from tarball.
  - This updates the source-build wrapper scripts to account for a couple issues we found bringing NuGet into the overall build.  The overall build uses some different argument passing and dotnet and Arcade paths so we needed to adjust those.
5. Upgrade to .NET 6 SDK.
  - Source-build builds with a 6.0 SDK and there are some new warnings (which become errors because of TreatWarningsAsErrors=true):
    - CS1998: This async method lacks 'await'
    - CA1416: Validate platform compatibility (some probably unreachable code isn't valid for all platforms)
  - This also updates the "if NET5" checks to "if NET5 or NET6" to account for using the 6.0 SDK.
6. Build NuGet.Frameworks for netstandard as well for VSTest.
  - VSTest depends on having netstandard2.0 bits for NuGet.Frameworks so we have to add it back in.  I tried including netstandard2.0 as a TFM to build for in patch 2, but it doesn't work for all projects so I did this targeted fix instead.  This is another one that will go away as we work toward eliminating all the TFM-finagling we currently do.
7. NuGet.Build.Tasks.Pack source-build support
  - Source-build doesn't support ILMerge so we have to include the individual DLLs in this case.  This was done in source-build 2.1 and 3.1 but lost somewhere between 5.0 and now so Michael restored this patch.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
