### PR TITLE
Fix GridSplitter tabstop visibility in high contrast mode

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources/Brushes.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources/Brushes.cs
@@ -156,6 +156,8 @@ namespace NuGet.PackageManagement.UI
 
         public static object ButtonFocusedStyleBrushKey { get; private set; } = SystemColors.HighlightTextBrushKey;
 
+        public static object GridSplitterFocusBrushKey { get; private set; } = SystemColors.HighlightBrushKey;
+
         public static object TabSelectedIndicatorBrushKey { get; private set; } = SystemColors.ActiveCaptionTextColor;
 
         public static object TabSelectedTextBrushKey { get; private set; } = SystemColors.ActiveCaptionTextColorKey;

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources/Resources.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources/Resources.xaml
@@ -78,6 +78,23 @@
     </Setter>
   </Style>
 
+  <Style x:Key="GridSplitterFocusVisualStyle" TargetType="{x:Type Control}">
+    <Setter Property="Background" Value="{DynamicResource {x:Static nuget:Brushes.GridSplitterFocusBrushKey}}"/>
+    <Setter Property="Foreground" Value="{DynamicResource {x:Static nuget:Brushes.UIText}}"/>
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate>
+          <Rectangle x:Name="GridSplitterFocusVisualRectangle"
+            Fill="{TemplateBinding Background}"
+            Stroke="{TemplateBinding Foreground}"
+            StrokeThickness="1"
+            StrokeDashArray="1 2"
+            SnapsToDevicePixels="true"/>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+
   <Style x:Key="MarginFocusVisualStyle" TargetType="{x:Type Control}" BasedOn="{StaticResource ControlsFocusVisualStyle}">
     <Setter Property="Margin" Value="4"/>
   </Style>
@@ -144,7 +161,7 @@
   </Style>
 
   <Style x:Key="{x:Type GridSplitter}" TargetType="{x:Type GridSplitter}" BasedOn="{StaticResource {x:Type GridSplitter}}">
-    <Setter Property="FocusVisualStyle" Value="{StaticResource ControlsFocusVisualStyle}"/>
+    <Setter Property="FocusVisualStyle" Value="{StaticResource GridSplitterFocusVisualStyle}"/>
   </Style>
 
   <Style x:Key="{x:Type ComboBox}" TargetType="{x:Type ComboBox}" BasedOn="{StaticResource {x:Static nuget:Styles.ThemedComboStyleKey}}">


### PR DESCRIPTION
## Bug
Fixes:  https://github.com/NuGet/Client.Engineering/issues/1082

Regression? No

## Description
When the grid splitter in Package Manager UI receives focus due to a tabstop, you cannot tell in high contrast mode.  This is because the visibility change is simply adding a dashed border.  This fix sets a Fill for the grid splitter to the same color as a text box's border when it receives focus.

### Normal contrast mode:

| Before | After |
| -------| ------|
|![image](https://user-images.githubusercontent.com/17556515/130652202-1e9767cb-631d-4352-874c-d757b4f0a915.png)|![image](https://user-images.githubusercontent.com/17556515/130652313-7639834e-81f5-44a2-a138-f774a8f8675f.png)|

### High Contrast White
| Before | After |
| -------| ------|
|![image](https://user-images.githubusercontent.com/17556515/130652497-3f400df1-459d-4366-be7e-781e9b0a12cb.png)|![image](https://user-images.githubusercontent.com/17556515/130652624-bb034ddc-aafd-42e7-b4cd-31701d206b7b.png)|

### High Contrast Black
| Before | After |
| -------| ------|
|![image](https://user-images.githubusercontent.com/17556515/130652789-f85f9c41-79b2-470d-a66f-cc56eb2df8e2.png)|![image](https://user-images.githubusercontent.com/17556515/130653122-e247f423-f06b-4e96-a8d5-8d7886c9e14b.png)|



## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception - Manually verified
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
