### PR TITLE
align dotnet nuget sign verbosity with that of nuget.exe

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/SignCommand/SignCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/SignCommand/SignCommandRunner.cs
@@ -45,20 +45,20 @@ namespace NuGet.Commands
 
             if (success)
             {
-                signArgs.Logger.LogInformation(Environment.NewLine);
-                signArgs.Logger.LogInformation(Strings.SignCommandDisplayCertificate);
-                signArgs.Logger.LogInformation(CertificateUtility.X509Certificate2ToString(cert, HashAlgorithmName.SHA256));
+                signArgs.Logger.LogMinimal(Environment.NewLine);
+                signArgs.Logger.LogMinimal(Strings.SignCommandDisplayCertificate);
+                signArgs.Logger.LogMinimal(CertificateUtility.X509Certificate2ToString(cert, HashAlgorithmName.SHA256));
 
                 if (!string.IsNullOrEmpty(signArgs.Timestamper))
                 {
-                    signArgs.Logger.LogInformation(Strings.SignCommandDisplayTimestamper);
-                    signArgs.Logger.LogInformation(signArgs.Timestamper);
+                    signArgs.Logger.LogMinimal(Strings.SignCommandDisplayTimestamper);
+                    signArgs.Logger.LogMinimal(signArgs.Timestamper);
                 }
 
                 if (!string.IsNullOrEmpty(signArgs.OutputDirectory))
                 {
-                    signArgs.Logger.LogInformation(Strings.SignCommandOutputPath);
-                    signArgs.Logger.LogInformation(signArgs.OutputDirectory);
+                    signArgs.Logger.LogMinimal(Strings.SignCommandOutputPath);
+                    signArgs.Logger.LogMinimal(signArgs.OutputDirectory);
                 }
 
                 using (var signRequest = new AuthorSignPackageRequest(cert, signArgs.SignatureHashAlgorithm, signArgs.TimestampHashAlgorithm))
@@ -153,7 +153,7 @@ namespace NuGet.Commands
 
             if (success)
             {
-                logger.LogInformation(Strings.SignCommandSuccess);
+                logger.LogMinimal(Strings.SignCommandSuccess);
             }
 
             return success ? 0 : 1;

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetSignTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetSignTests.cs
@@ -27,6 +27,10 @@ namespace Dotnet.Integration.Test
         private readonly string _chainBuildFailureErrorCode = NuGetLogCode.NU3018.ToString();
         private readonly string _noTimestamperWarningCode = NuGetLogCode.NU3002.ToString();
         private readonly string _timestampUnsupportedDigestAlgorithmCode = NuGetLogCode.NU3024.ToString();
+        private readonly string _signCommandDisplayCertificate = "Signing package(s) with certificate:";
+        private readonly string _signCommandDisplayTimestamper = "Timestamping package(s) with:";
+        private readonly string _signCommandOutputPath = "Signed package(s) output path:";
+        private readonly string _signCommandSuccess = "Package(s) signed successfully.";
 
         public DotnetSignTests(MsbuildIntegrationTestFixture buildFixture, SignCommandTestFixture signFixture)
         {
@@ -56,6 +60,11 @@ namespace Dotnet.Integration.Test
                 // Assert
                 result.Success.Should().BeTrue(because: result.AllOutput);
                 result.AllOutput.Should().Contain(_noTimestamperWarningCode);
+                result.AllOutput.Should().Contain(_signCommandDisplayCertificate);
+                result.AllOutput.Should().Contain(_signCommandSuccess);
+
+                string certInfo = CertificateUtility.X509Certificate2ToString(trustedCert.Source.Cert, NuGet.Common.HashAlgorithmName.SHA256);
+                result.AllOutput.Should().Contain(certInfo);
             }
         }
 
@@ -185,6 +194,13 @@ namespace Dotnet.Integration.Test
                 // Assert
                 result.Success.Should().BeTrue(because: result.AllOutput);
                 result.AllOutput.Should().NotContain(_noTimestamperWarningCode);
+                result.AllOutput.Should().Contain(_signCommandDisplayCertificate);
+                result.AllOutput.Should().Contain(_signCommandDisplayTimestamper);
+                result.AllOutput.Should().Contain(timestampService.Url.OriginalString);
+                result.AllOutput.Should().Contain(_signCommandSuccess);
+
+                string certInfo = CertificateUtility.X509Certificate2ToString(trustedCert.Source.Cert, NuGet.Common.HashAlgorithmName.SHA256);
+                result.AllOutput.Should().Contain(certInfo);
             }
         }
 
@@ -268,6 +284,13 @@ namespace Dotnet.Integration.Test
                 // Assert
                 result.Success.Should().BeTrue(because: result.AllOutput);
                 result.AllOutput.Should().Contain(_noTimestamperWarningCode);
+                result.AllOutput.Should().Contain(_signCommandDisplayCertificate);
+                result.AllOutput.Should().Contain(_signCommandOutputPath);
+                result.AllOutput.Should().Contain(_signCommandSuccess);
+
+                string certInfo = CertificateUtility.X509Certificate2ToString(trustedCert.Source.Cert, NuGet.Common.HashAlgorithmName.SHA256);
+                result.AllOutput.Should().Contain(certInfo);
+
                 File.Exists(signedPackagePath).Should().BeTrue();
             }
         }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

Fixes: https://github.com/nuget/home/issues/11173

Regression? Last working version:

## Description
For NuGet.exe sign command, if the package is signed successfully, the default verbosity will show the following info:
```
C:\demo> nuget sign .\test1.nupkg -CertificatePath .\1A0BA119ABDE3BC428A15672ECF8CD31B4725A6D.pfx -CertificatePassword password -Timestamper http://timestamp.entrust.net/TSS/RFC3161sha2TS -OutputDirectory .\package\Signed\


Signing package(s) with certificate:
  Subject Name: CN=Test certificate for testing NuGet package signing
  SHA1 hash: 1A0BA119ABDE3BC428A15672ECF8CD31B4725A6D
  SHA256 hash: 54D4139CC924A50E8851C1B2ACAFECB09D7C48E927778C1F325B59DEE6272BBB
  Issued by: CN=Test certificate for testing NuGet package signing
  Valid from: 8/27/2021 10:19:48 AM to 8/28/2021 10:19:48 AM

Timestamping package(s) with:
http://timestamp.entrust.net/TSS/RFC3161sha2TS
Signed package(s) output path:
.\package\Signed\
Package(s) signed successfully.
```
Before this change, dotnet nuget sign has no output in default verbosity level if it's signed successfully.
After this change, dotnet nuget sign has the same output as following:
```
C:\demo> .\PatchedSDK\dotnet.exe nuget sign .\test1.nupkg --certificate-path .\1A0BA119ABDE3BC428A15672ECF8CD31B4725A6D.pfx --certificate-password password --timestamper http://timestamp.entrust.net/TSS/RFC3161sha2TS --output .\package\Signed\

Signing package(s) with certificate:
  Subject Name: CN=Test certificate for testing NuGet package signing
  SHA1 hash: 1A0BA119ABDE3BC428A15672ECF8CD31B4725A6D
  SHA256 hash: 54D4139CC924A50E8851C1B2ACAFECB09D7C48E927778C1F325B59DEE6272BBB
  Issued by: CN=Test certificate for testing NuGet package signing
  Valid from: 8/27/2021 10:19:48 AM to 8/28/2021 10:19:48 AM
Timestamping package(s) with:
http://timestamp.entrust.net/TSS/RFC3161sha2TS
Signed package(s) output path:
.\package\Signed\
Package(s) signed successfully.
```

In this PR:
1.Make the verbosity of dotnet nuget sign command align with NuGet.exe sign command.
2.Add assertion of those messages in tests.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
