### PR TITLE
Cherry pick 820bfe9 and fix unit tests to remove references to Net472

### DIFF
--- a/src/NuGet.Core/NuGet.Frameworks/FrameworkConstants.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/FrameworkConstants.cs
@@ -16,6 +16,7 @@ namespace NuGet.Frameworks
         public static readonly Version EmptyVersion = new Version(0, 0, 0, 0);
         public static readonly Version MaxVersion = new Version(int.MaxValue, 0, 0, 0);
         public static readonly Version Version5 = new Version(5, 0, 0, 0);
+        public static readonly Version Version6 = new Version(6, 0, 0, 0);
         public static readonly Version Version10 = new Version(10, 0, 0, 0);
         public static readonly FrameworkRange DotNetAll = new FrameworkRange(
                         new NuGetFramework(FrameworkIdentifiers.NetPlatform, FrameworkConstants.EmptyVersion),
@@ -185,6 +186,7 @@ namespace NuGet.Frameworks
 
             // .NET 5.0 and later has NetCoreApp identifier
             public static readonly NuGetFramework Net50 = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version5);
+            public static readonly NuGetFramework Net60 = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version6);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Frameworks/NuGetFrameworkFactory.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/NuGetFrameworkFactory.cs
@@ -672,6 +672,12 @@ namespace NuGet.Frameworks
                 case "net50":
                     framework = FrameworkConstants.CommonFrameworks.Net50;
                     break;
+                case "netcoreapp6.0":
+                case "netcoreapp60":
+                case "net6.0":
+                case "net60":
+                    framework = FrameworkConstants.CommonFrameworks.Net60;
+                    break;
             }
 
             return framework != null;

--- a/src/NuGet.Core/NuGet.Frameworks/PublicAPI/net40/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Frameworks/PublicAPI/net40/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net60 -> NuGet.Frameworks.NuGetFramework
+static readonly NuGet.Frameworks.FrameworkConstants.Version6 -> System.Version

--- a/src/NuGet.Core/NuGet.Frameworks/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Frameworks/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net60 -> NuGet.Frameworks.NuGetFramework
+static readonly NuGet.Frameworks.FrameworkConstants.Version6 -> System.Version

--- a/src/NuGet.Core/NuGet.Frameworks/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Frameworks/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net60 -> NuGet.Frameworks.NuGetFramework
+static readonly NuGet.Frameworks.FrameworkConstants.Version6 -> System.Version

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileTarget.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileTarget.cs
@@ -31,7 +31,7 @@ namespace NuGet.ProjectModel
         /// <summary>
         /// Full framework name.
         /// </summary>
-        public string Name => GetNameString(TargetFramework.DotNetFrameworkName, RuntimeIdentifier);
+        public string Name => GetNameString(TargetFramework, RuntimeIdentifier);
 
         public bool Equals(PackagesLockFileTarget other)
         {
@@ -66,14 +66,36 @@ namespace NuGet.ProjectModel
             return combiner.CombinedHash;
         }
 
-        private static string GetNameString(string framework, string runtime)
+        private static string GetNameString(NuGetFramework framework, string runtime)
         {
-            if (!string.IsNullOrEmpty(runtime))
+            string frameworkString;
+
+            // We already shipped net5.0 being listed as .NETCoreApp,Version=5.0, so it would be a breaking change
+            // to change it. Similarly for all earlier framework identifiers.
+            // Since net5.0-windows didn't work properly, we can use the "friendly" (folder name) for net5 with a platform.
+            // For net6 and higher, always use friendly folder format, since this is the preferred customer-facing
+            // format (from dotnet/design's net5 spec).
+            // Packages lock files are checked into source control, hence customers will see it in their diffs.
+            if (string.Equals(framework.Framework, FrameworkConstants.FrameworkIdentifiers.NetCoreApp, StringComparison.OrdinalIgnoreCase)
+                && (
+                    (framework.Version.Major >= 6)
+                    || (framework.Version.Major == 5 && framework.HasPlatform)
+                   )
+                )
             {
-                return $"{framework}/{runtime}";
+                frameworkString = framework.ToString();
+            }
+            else
+            {
+                frameworkString = framework.DotNetFrameworkName;
             }
 
-            return framework;
+            if (!string.IsNullOrEmpty(runtime))
+            {
+                return $"{frameworkString}/{runtime}";
+            }
+
+            return frameworkString;
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Frameworks.Test/NuGetFrameworkParseTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Frameworks.Test/NuGetFrameworkParseTests.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections;
+using System.Collections.Generic;
 using NuGet.Frameworks;
 using Xunit;
 
@@ -423,5 +425,26 @@ namespace NuGet.Test
             // Compare the object references
             Assert.Same(framework1, framework2);
         }
+
+        public static IEnumerable<object[]> NuGetFramework_Parse_CommonFramework_ReturnsStaticInstance_Data()
+        {
+            yield return new object[] { "net472", FrameworkConstants.CommonFrameworks.Net472 };
+            yield return new object[] { "net5.0", FrameworkConstants.CommonFrameworks.Net50 };
+            yield return new object[] { "net6.0", FrameworkConstants.CommonFrameworks.Net60 };
+
+        }
+
+        [Theory]
+        [MemberData(nameof(NuGetFramework_Parse_CommonFramework_ReturnsStaticInstance_Data))]
+        public void NuGetFramework_Parse_CommonFramework_ReturnsStaticInstance(string frameworkString, NuGetFramework frameworkObject)
+        {
+            // Act
+            NuGetFramework parsedFramework = NuGetFramework.Parse(frameworkString);
+
+            // Assert
+            Assert.Same(frameworkObject, parsedFramework);
+        }
+
+
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Frameworks.Test/NuGetFrameworkParseTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Frameworks.Test/NuGetFrameworkParseTests.cs
@@ -428,10 +428,8 @@ namespace NuGet.Test
 
         public static IEnumerable<object[]> NuGetFramework_Parse_CommonFramework_ReturnsStaticInstance_Data()
         {
-            yield return new object[] { "net472", FrameworkConstants.CommonFrameworks.Net472 };
             yield return new object[] { "net5.0", FrameworkConstants.CommonFrameworks.Net50 };
             yield return new object[] { "net6.0", FrameworkConstants.CommonFrameworks.Net60 };
-
         }
 
         [Theory]

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackagesLockFileFormatTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackagesLockFileFormatTests.cs
@@ -3,6 +3,7 @@
 
 using System.Linq;
 using Newtonsoft.Json.Linq;
+using NuGet.Frameworks;
 using Xunit;
 
 namespace NuGet.ProjectModel.Test
@@ -56,6 +57,74 @@ namespace NuGet.ProjectModel.Test
             Assert.Null(target.Dependencies[1].RequestedVersion);
             Assert.Equal("1.0.0", target.Dependencies[0].ResolvedVersion.ToNormalizedString());
             Assert.NotEmpty(target.Dependencies[1].ContentHash);
+        }
+
+        [Fact]
+        public void Read_VariousTargetFrameworksAndRuntimeIdentifiers_ParsedCorrectly()
+        {
+            // Arrange
+            var lockFileContents =
+@"{
+    ""version"": 1,
+    ""dependencies"": {
+        "".NETFramework,Version=v4.7.2"": { },
+        "".NETStandard,Version=v2.0"": { },
+        "".NETCoreApp,Version=3.1"": { },
+        "".NETCoreApp,Version=3.1/win-x64"": { },
+        "".NETCoreApp,Version=5.0"": { },
+        "".NETCoreApp,Version=5.0/win-x64"": { },
+        ""net5.0-windows7.0"": { },
+        ""net5.0-windows7.0/win-x64"": { },
+        ""net6.0"": { },
+        ""net6.0/win-x64"": { },
+        ""net6.0-windows7.0"": { },
+        ""net6.0-windows7.0/win-x64"": { },
+    }
+}";
+
+            // Act
+            var lockFile = PackagesLockFileFormat.Parse(lockFileContents, "In memory");
+
+            // Assert
+            Assert.Equal(12, lockFile.Targets.Count);
+
+            Assert.Equal(FrameworkConstants.CommonFrameworks.Net472, lockFile.Targets[0].TargetFramework);
+            Assert.Null(lockFile.Targets[0].RuntimeIdentifier);
+
+            Assert.Equal(FrameworkConstants.CommonFrameworks.NetStandard20, lockFile.Targets[1].TargetFramework);
+            Assert.Null(lockFile.Targets[1].RuntimeIdentifier);
+
+            Assert.Equal(FrameworkConstants.CommonFrameworks.NetCoreApp31, lockFile.Targets[2].TargetFramework);
+            Assert.Null(lockFile.Targets[2].RuntimeIdentifier);
+
+            Assert.Equal(FrameworkConstants.CommonFrameworks.NetCoreApp31, lockFile.Targets[3].TargetFramework);
+            Assert.Equal("win-x64", lockFile.Targets[3].RuntimeIdentifier);
+
+            Assert.Equal(FrameworkConstants.CommonFrameworks.Net50, lockFile.Targets[4].TargetFramework);
+            Assert.Null(lockFile.Targets[4].RuntimeIdentifier);
+
+            Assert.Equal(FrameworkConstants.CommonFrameworks.Net50, lockFile.Targets[5].TargetFramework);
+            Assert.Equal("win-x64", lockFile.Targets[5].RuntimeIdentifier);
+
+            NuGetFramework net5win7 = NuGetFramework.Parse("net5.0-windows7.0");
+            Assert.Equal(net5win7, lockFile.Targets[6].TargetFramework);
+            Assert.Null(lockFile.Targets[6].RuntimeIdentifier);
+
+            Assert.Equal(net5win7, lockFile.Targets[7].TargetFramework);
+            Assert.Equal("win-x64", lockFile.Targets[7].RuntimeIdentifier);
+
+            Assert.Equal(FrameworkConstants.CommonFrameworks.Net60, lockFile.Targets[8].TargetFramework);
+            Assert.Null(lockFile.Targets[8].RuntimeIdentifier);
+
+            Assert.Equal(FrameworkConstants.CommonFrameworks.Net60, lockFile.Targets[9].TargetFramework);
+            Assert.Equal("win-x64", lockFile.Targets[9].RuntimeIdentifier);
+
+            NuGetFramework net6win7 = NuGetFramework.Parse("net6.0-windows7.0");
+            Assert.Equal(net6win7, lockFile.Targets[10].TargetFramework);
+            Assert.Null(lockFile.Targets[10].RuntimeIdentifier);
+
+            Assert.Equal(net6win7, lockFile.Targets[11].TargetFramework);
+            Assert.Equal("win-x64", lockFile.Targets[11].RuntimeIdentifier);
         }
 
         [Fact]

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackagesLockFileFormatTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackagesLockFileFormatTests.cs
@@ -67,7 +67,6 @@ namespace NuGet.ProjectModel.Test
 @"{
     ""version"": 1,
     ""dependencies"": {
-        "".NETFramework,Version=v4.7.2"": { },
         "".NETStandard,Version=v2.0"": { },
         "".NETCoreApp,Version=3.1"": { },
         "".NETCoreApp,Version=3.1/win-x64"": { },
@@ -88,43 +87,40 @@ namespace NuGet.ProjectModel.Test
             // Assert
             Assert.Equal(12, lockFile.Targets.Count);
 
-            Assert.Equal(FrameworkConstants.CommonFrameworks.Net472, lockFile.Targets[0].TargetFramework);
+            Assert.Equal(FrameworkConstants.CommonFrameworks.NetStandard20, lockFile.Targets[0].TargetFramework);
             Assert.Null(lockFile.Targets[0].RuntimeIdentifier);
 
-            Assert.Equal(FrameworkConstants.CommonFrameworks.NetStandard20, lockFile.Targets[1].TargetFramework);
+            Assert.Equal(FrameworkConstants.CommonFrameworks.NetCoreApp31, lockFile.Targets[1].TargetFramework);
             Assert.Null(lockFile.Targets[1].RuntimeIdentifier);
 
             Assert.Equal(FrameworkConstants.CommonFrameworks.NetCoreApp31, lockFile.Targets[2].TargetFramework);
-            Assert.Null(lockFile.Targets[2].RuntimeIdentifier);
+            Assert.Equal("win-x64", lockFile.Targets[2].RuntimeIdentifier);
 
-            Assert.Equal(FrameworkConstants.CommonFrameworks.NetCoreApp31, lockFile.Targets[3].TargetFramework);
-            Assert.Equal("win-x64", lockFile.Targets[3].RuntimeIdentifier);
+            Assert.Equal(FrameworkConstants.CommonFrameworks.Net50, lockFile.Targets[3].TargetFramework);
+            Assert.Null(lockFile.Targets[3].RuntimeIdentifier);
 
             Assert.Equal(FrameworkConstants.CommonFrameworks.Net50, lockFile.Targets[4].TargetFramework);
-            Assert.Null(lockFile.Targets[4].RuntimeIdentifier);
-
-            Assert.Equal(FrameworkConstants.CommonFrameworks.Net50, lockFile.Targets[5].TargetFramework);
-            Assert.Equal("win-x64", lockFile.Targets[5].RuntimeIdentifier);
+            Assert.Equal("win-x64", lockFile.Targets[4].RuntimeIdentifier);
 
             NuGetFramework net5win7 = NuGetFramework.Parse("net5.0-windows7.0");
-            Assert.Equal(net5win7, lockFile.Targets[6].TargetFramework);
-            Assert.Null(lockFile.Targets[6].RuntimeIdentifier);
+            Assert.Equal(net5win7, lockFile.Targets[5].TargetFramework);
+            Assert.Null(lockFile.Targets[5].RuntimeIdentifier);
 
-            Assert.Equal(net5win7, lockFile.Targets[7].TargetFramework);
-            Assert.Equal("win-x64", lockFile.Targets[7].RuntimeIdentifier);
+            Assert.Equal(net5win7, lockFile.Targets[6].TargetFramework);
+            Assert.Equal("win-x64", lockFile.Targets[6].RuntimeIdentifier);
+
+            Assert.Equal(FrameworkConstants.CommonFrameworks.Net60, lockFile.Targets[7].TargetFramework);
+            Assert.Null(lockFile.Targets[7].RuntimeIdentifier);
 
             Assert.Equal(FrameworkConstants.CommonFrameworks.Net60, lockFile.Targets[8].TargetFramework);
-            Assert.Null(lockFile.Targets[8].RuntimeIdentifier);
-
-            Assert.Equal(FrameworkConstants.CommonFrameworks.Net60, lockFile.Targets[9].TargetFramework);
-            Assert.Equal("win-x64", lockFile.Targets[9].RuntimeIdentifier);
+            Assert.Equal("win-x64", lockFile.Targets[8].RuntimeIdentifier);
 
             NuGetFramework net6win7 = NuGetFramework.Parse("net6.0-windows7.0");
-            Assert.Equal(net6win7, lockFile.Targets[10].TargetFramework);
-            Assert.Null(lockFile.Targets[10].RuntimeIdentifier);
+            Assert.Equal(net6win7, lockFile.Targets[9].TargetFramework);
+            Assert.Null(lockFile.Targets[9].RuntimeIdentifier);
 
-            Assert.Equal(net6win7, lockFile.Targets[11].TargetFramework);
-            Assert.Equal("win-x64", lockFile.Targets[11].RuntimeIdentifier);
+            Assert.Equal(net6win7, lockFile.Targets[10].TargetFramework);
+            Assert.Equal("win-x64", lockFile.Targets[10].RuntimeIdentifier);
         }
 
         [Fact]

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackagesLockFileFormatTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackagesLockFileFormatTests.cs
@@ -85,7 +85,7 @@ namespace NuGet.ProjectModel.Test
             var lockFile = PackagesLockFileFormat.Parse(lockFileContents, "In memory");
 
             // Assert
-            Assert.Equal(12, lockFile.Targets.Count);
+            Assert.Equal(11, lockFile.Targets.Count);
 
             Assert.Equal(FrameworkConstants.CommonFrameworks.NetStandard20, lockFile.Targets[0].TargetFramework);
             Assert.Null(lockFile.Targets[0].RuntimeIdentifier);

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackagesLockFileTargetTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackagesLockFileTargetTests.cs
@@ -1,0 +1,42 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using NuGet.Frameworks;
+using Xunit;
+
+namespace NuGet.ProjectModel.Test
+{
+    public class PackagesLockFileTargetTests
+    {
+        [Theory]
+        [InlineData("net472", null, ".NETFramework,Version=v4.7.2")]
+        [InlineData("netstandard2.0", null, ".NETStandard,Version=v2.0")]
+        [InlineData("netcoreapp3.1", null, ".NETCoreApp,Version=v3.1")]
+        [InlineData("netcoreapp3.1", "win-x64", ".NETCoreApp,Version=v3.1/win-x64")]
+        [InlineData("net5.0", null, ".NETCoreApp,Version=v5.0")]
+        [InlineData("net5.0", "win-x64", ".NETCoreApp,Version=v5.0/win-x64")]
+        [InlineData("net5.0-windows7.0", null, "net5.0-windows7.0")]
+        [InlineData("net5.0-windows7.0", "win-x64", "net5.0-windows7.0/win-x64")]
+        [InlineData("net6.0", null, "net6.0")]
+        [InlineData("net6.0", "win-x64", "net6.0/win-x64")]
+        [InlineData("net6.0-windows7.0", null, "net6.0-windows7.0")]
+        [InlineData("net6.0-windows7.0", "win-x64", "net6.0-windows7.0/win-x64")]
+        public void Name_DifferentTargetFrameworkAndRuntimeIdentifiers_HasExpectedValue(string targetFramework, string runtimeIdentifier, string expectedName)
+        {
+            // Arrange
+            NuGetFramework framework = NuGetFramework.Parse(targetFramework);
+
+            PackagesLockFileTarget packagesLockFileTarget = new()
+            {
+                TargetFramework = framework,
+                RuntimeIdentifier = runtimeIdentifier
+            };
+
+            // Act
+            var actualName = packagesLockFileTarget.Name;
+
+            // Assert
+            Assert.Equal(expectedName, actualName);
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackagesLockFileTargetTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackagesLockFileTargetTests.cs
@@ -26,7 +26,7 @@ namespace NuGet.ProjectModel.Test
             // Arrange
             NuGetFramework framework = NuGetFramework.Parse(targetFramework);
 
-            PackagesLockFileTarget packagesLockFileTarget = new()
+            var packagesLockFileTarget = new PackagesLockFileTarget()
             {
                 TargetFramework = framework,
                 RuntimeIdentifier = runtimeIdentifier

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackagesLockFileTargetTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackagesLockFileTargetTests.cs
@@ -9,7 +9,6 @@ namespace NuGet.ProjectModel.Test
     public class PackagesLockFileTargetTests
     {
         [Theory]
-        [InlineData("net472", null, ".NETFramework,Version=v4.7.2")]
         [InlineData("netstandard2.0", null, ".NETStandard,Version=v2.0")]
         [InlineData("netcoreapp3.1", null, ".NETCoreApp,Version=v3.1")]
         [InlineData("netcoreapp3.1", "win-x64", ".NETCoreApp,Version=v3.1/win-x64")]


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: Associated with https://github.com/NuGet/Client.Engineering/issues/1110

Regression? Last working version: N/A

## Description
Cherry pick 820bfe9 and fix unit tests to remove from unit tests all references to Net472 because it is not available in the commit being cherry-picked

## PR Checklist

- [x] PR has a meaningful title
- [ ] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
