### PR TITLE
Avoid hitting the UI thread when retrieving MEF specific services

### DIFF
--- a/src/NuGet.Clients/NuGet.Console/PowerConsoleToolWindow.cs
+++ b/src/NuGet.Clients/NuGet.Console/PowerConsoleToolWindow.cs
@@ -703,7 +703,7 @@ namespace NuGetConsole.Implementation
             {
                 if (_consoleStatus == null)
                 {
-                    _consoleStatus = ServiceLocator.GetInstance<IConsoleStatus>();
+                    _consoleStatus = ServiceLocator.GetComponentModelService<IConsoleStatus>();
                     Debug.Assert(_consoleStatus != null);
                 }
 

--- a/src/NuGet.Clients/NuGet.Console/PowerConsoleToolWindow.cs
+++ b/src/NuGet.Clients/NuGet.Console/PowerConsoleToolWindow.cs
@@ -683,7 +683,7 @@ namespace NuGetConsole.Implementation
                 {
                     _vsOutputConsole = NuGetUIThreadHelper.JoinableTaskFactory.Run(async () =>
                     {
-                        var consoleProvider = await ServiceLocator.GetInstanceAsync<IOutputConsoleProvider>();
+                        var consoleProvider = await ServiceLocator.GetComponentModelServiceAsync<IOutputConsoleProvider>();
                         if (null != consoleProvider)
                         {
                             return await consoleProvider.CreatePackageManagerConsoleAsync();

--- a/src/NuGet.Clients/NuGet.Console/Xamls/ConsoleContainer.xaml.cs
+++ b/src/NuGet.Clients/NuGet.Console/Xamls/ConsoleContainer.xaml.cs
@@ -48,9 +48,9 @@ namespace NuGetConsole
 
                             Assumes.NotNull(_solutionManager);
 
-                            var productUpdateService = ServiceLocator.GetInstance<IProductUpdateService>();
-                            var packageRestoreManager = ServiceLocator.GetInstance<IPackageRestoreManager>();
-                            var deleteOnRestartManager = ServiceLocator.GetInstance<IDeleteOnRestartManager>();
+                            var productUpdateService = ServiceLocator.GetComponentModelService<IProductUpdateService>();
+                            var packageRestoreManager = ServiceLocator.GetComponentModelService<IPackageRestoreManager>();
+                            var deleteOnRestartManager = ServiceLocator.GetComponentModelService<IDeleteOnRestartManager>();
                             var shell = ServiceLocator.GetGlobalService<SVsShell, IVsShell4>();
 
                             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();

--- a/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/Cmdlets/UninstallPackageCommand.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/Cmdlets/UninstallPackageCommand.cs
@@ -26,8 +26,8 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
 
         public UninstallPackageCommand()
         {
-            _deleteOnRestartManager = ServiceLocator.GetInstance<IDeleteOnRestartManager>();
-            _lockService = ServiceLocator.GetInstance<INuGetLockService>();
+            _deleteOnRestartManager = ServiceLocator.GetComponentModelService<IDeleteOnRestartManager>();
+            _lockService = ServiceLocator.GetComponentModelService<INuGetLockService>();
         }
 
         [Parameter(Mandatory = true, ValueFromPipelineByPropertyName = true, Position = 0)]

--- a/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/NuGetPowerShellBaseCommand.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/NuGetPowerShellBaseCommand.cs
@@ -68,14 +68,14 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
 
         protected NuGetPowerShellBaseCommand()
         {
-            _sourceRepositoryProvider = ServiceLocator.GetInstance<ISourceRepositoryProvider>();
-            ConfigSettings = ServiceLocator.GetInstance<Configuration.ISettings>();
-            VsSolutionManager = ServiceLocator.GetInstance<IVsSolutionManager>();
+            _sourceRepositoryProvider = ServiceLocator.GetComponentModelService<ISourceRepositoryProvider>();
+            ConfigSettings = ServiceLocator.GetComponentModelService<Configuration.ISettings>();
+            VsSolutionManager = ServiceLocator.GetComponentModelService<IVsSolutionManager>();
             DTE = ServiceLocator.GetInstance<DTE>();
-            SourceControlManagerProvider = ServiceLocator.GetInstance<ISourceControlManagerProvider>();
-            _commonOperations = ServiceLocator.GetInstance<ICommonOperations>();
-            PackageRestoreManager = ServiceLocator.GetInstance<IPackageRestoreManager>();
-            _deleteOnRestartManager = ServiceLocator.GetInstance<IDeleteOnRestartManager>();
+            SourceControlManagerProvider = ServiceLocator.GetComponentModelService<ISourceControlManagerProvider>();
+            _commonOperations = ServiceLocator.GetComponentModelService<ICommonOperations>();
+            PackageRestoreManager = ServiceLocator.GetComponentModelService<IPackageRestoreManager>();
+            _deleteOnRestartManager = ServiceLocator.GetComponentModelService<IDeleteOnRestartManager>();
 
             var logger = new LoggerAdapter(this);
             PackageExtractionContext = new PackageExtractionContext(

--- a/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/PackageActionBaseCommand.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/PackageActionBaseCommand.cs
@@ -29,8 +29,8 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
 
         public PackageActionBaseCommand()
         {
-            _deleteOnRestartManager = ServiceLocator.GetInstance<IDeleteOnRestartManager>();
-            _lockService = ServiceLocator.GetInstance<INuGetLockService>();
+            _deleteOnRestartManager = ServiceLocator.GetComponentModelService<IDeleteOnRestartManager>();
+            _lockService = ServiceLocator.GetComponentModelService<INuGetLockService>();
         }
 
         [Parameter(Mandatory = true, ValueFromPipelineByPropertyName = true, Position = 0)]

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/GeneralOptionControl.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/GeneralOptionControl.cs
@@ -25,8 +25,8 @@ namespace NuGet.Options
         public GeneralOptionControl()
         {
             InitializeComponent();
-            _settings = ServiceLocator.GetInstance<Configuration.ISettings>();
-            _outputConsoleLogger = ServiceLocator.GetInstance<INuGetUILogger>();
+            _settings = ServiceLocator.GetComponentModelService<ISettings>();
+            _outputConsoleLogger = ServiceLocator.GetComponentModelService<INuGetUILogger>();
             _localsCommandRunner = new LocalsCommandRunner();
             AutoScroll = true;
             Debug.Assert(_settings != null);
@@ -150,7 +150,7 @@ namespace NuGet.Options
         {
             UpdateLocalsCommandStatusText(string.Format(Resources.ShowMessage_LocalsCommandWorking), visibility: true);
             var arguments = new List<string> { "all" };
-            var settings = ServiceLocator.GetInstance<ISettings>();
+            var settings = ServiceLocator.GetComponentModelService<ISettings>();
             var logError = new LocalsArgs.Log(LogError);
             var logInformation = new LocalsArgs.Log(LogInformation);
             var localsArgs = new LocalsArgs(arguments, settings, logInformation, logError, clear: true, list: false);

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/OptionsPageBase.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/OptionsPageBase.cs
@@ -45,7 +45,7 @@ namespace NuGet.Options
             timer.Stop();
             timer.Dispose();
 
-            var optionsPageActivator = ServiceLocator.GetInstance<IOptionsPageActivator>();
+            var optionsPageActivator = ServiceLocator.GetComponentModelService<IOptionsPageActivator>();
             if (optionsPageActivator != null)
             {
                 optionsPageActivator.NotifyOptionsDialogClosed();

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -86,7 +86,7 @@ namespace NuGet.PackageManagement.UI
 
             Model = model;
             _uiLogger = uiLogger;
-            Settings = await ServiceLocator.GetInstanceAsync<ISettings>();
+            Settings = await ServiceLocator.GetComponentModelServiceAsync<ISettings>();
 
             _windowSearchHostFactory = await ServiceLocator.GetGlobalServiceAsync<SVsWindowSearchHostFactory, IVsWindowSearchHostFactory>();
             _serviceBroker = model.Context.ServiceBroker;
@@ -882,7 +882,7 @@ namespace NuGet.PackageManagement.UI
                 _recommendPackages = true;
             }
 
-            NuGetExperimentationService = await ServiceLocator.GetInstanceAsync<INuGetExperimentationService>();
+            NuGetExperimentationService = await ServiceLocator.GetComponentModelServiceAsync<INuGetExperimentationService>();
             // Check for A/B experiment here. For control group, return false instead of _recommendPackages
             if (IsRecommenderFlightEnabled(NuGetExperimentationService))
             {

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetPackageSearchService.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetPackageSearchService.cs
@@ -335,7 +335,7 @@ namespace NuGet.PackageManagement.VisualStudio
             CancellationToken cancellationToken)
         {
             var logger = new VisualStudioActivityLogger();
-            var uiLogger = ServiceLocator.GetInstance<INuGetUILogger>();
+            var uiLogger = await ServiceLocator.GetComponentModelServiceAsync<INuGetUILogger>();
             var packageFeeds = (mainFeed: (IPackageFeed?)null, recommenderFeed: (IPackageFeed?)null);
 
             if (itemFilter == ItemFilter.All && recommendPackages == false)
@@ -414,7 +414,7 @@ namespace NuGet.PackageManagement.VisualStudio
         private async Task<SourceRepository> GetPackagesFolderSourceRepositoryAsync()
         {
             IVsSolutionManager solutionManager = await _sharedServiceState.SolutionManager.GetValueAsync();
-            ISettings settings = ServiceLocator.GetInstance<ISettings>();
+            ISettings settings = await ServiceLocator.GetComponentModelServiceAsync<ISettings>();
 
             return _sharedServiceState.SourceRepositoryProvider.CreateRepository(
                 new PackageSource(PackagesFolderPathUtility.GetPackagesFolderPath(solutionManager, settings)),

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetProjectManagerService.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetProjectManagerService.cs
@@ -349,7 +349,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
                 try
                 {
-                    projectContext = await ServiceLocator.GetInstanceAsync<INuGetProjectContext>();
+                    projectContext = await ServiceLocator.GetComponentModelServiceAsync<INuGetProjectContext>();
 
                     Assumes.NotNull(projectContext);
 
@@ -418,7 +418,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
                 Assumes.NotNullOrEmpty(sourceRepositories);
 
-                INuGetProjectContext projectContext = await ServiceLocator.GetInstanceAsync<INuGetProjectContext>();
+                INuGetProjectContext projectContext = await ServiceLocator.GetComponentModelServiceAsync<INuGetProjectContext>();
                 IReadOnlyList<NuGetProject> projects = await GetProjectsAsync(projectIds, cancellationToken);
 
                 var resolutionContext = new ResolutionContext(
@@ -471,7 +471,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
             return await CatchAndRethrowExceptionAsync(async () =>
             {
-                INuGetProjectContext projectContext = await ServiceLocator.GetInstanceAsync<INuGetProjectContext>();
+                INuGetProjectContext projectContext = await ServiceLocator.GetComponentModelServiceAsync<INuGetProjectContext>();
                 IReadOnlyList<NuGetProject> projects = await GetProjectsAsync(projectIds, cancellationToken);
 
                 var projectActions = new List<ProjectAction>();
@@ -541,7 +541,7 @@ namespace NuGet.PackageManagement.VisualStudio
                     }
                 }
 
-                INuGetProjectContext projectContext = await ServiceLocator.GetInstanceAsync<INuGetProjectContext>();
+                INuGetProjectContext projectContext = await ServiceLocator.GetComponentModelServiceAsync<INuGetProjectContext>();
                 IReadOnlyList<NuGetProject> projects = await GetProjectsAsync(projectIds, cancellationToken);
 
                 var resolutionContext = new ResolutionContext(

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetProjectUpgraderService.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetProjectUpgraderService.cs
@@ -150,7 +150,7 @@ namespace NuGet.PackageManagement.VisualStudio
             NuGetPackageManager packageManager = await _state.GetPackageManagerAsync(cancellationToken);
             Assumes.NotNull(packageManager);
 
-            INuGetProjectContext projectContext = await ServiceLocator.GetInstanceAsync<INuGetProjectContext>();
+            INuGetProjectContext projectContext = await ServiceLocator.GetComponentModelServiceAsync<INuGetProjectContext>();
             Assumes.NotNull(projectContext);
 
             await packageManager.ExecuteNuGetProjectActionsAsync(
@@ -186,7 +186,7 @@ namespace NuGet.PackageManagement.VisualStudio
             NuGetPackageManager packageManager = await _state.GetPackageManagerAsync(cancellationToken);
             Assumes.NotNull(packageManager);
 
-            INuGetProjectContext projectContext = await ServiceLocator.GetInstanceAsync<INuGetProjectContext>();
+            INuGetProjectContext projectContext = await ServiceLocator.GetComponentModelServiceAsync<INuGetProjectContext>();
             Assumes.NotNull(projectContext);
 
             await packageManager.ExecuteBuildIntegratedProjectActionsAsync(

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/SharedServiceState.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/SharedServiceState.cs
@@ -27,7 +27,7 @@ namespace NuGet.PackageManagement.VisualStudio
             SourceRepositoryProvider.PackageSourceProvider.PackageSourcesChanged += PackageSourcesChanged;
 
             SolutionManager = new AsyncLazy<IVsSolutionManager>(
-                ServiceLocator.GetInstanceAsync<IVsSolutionManager>,
+                ServiceLocator.GetComponentModelServiceAsync<IVsSolutionManager>,
                 NuGetUIThreadHelper.JoinableTaskFactory);
 
             SourceRepositories = new AsyncLazy<IReadOnlyCollection<SourceRepository>>(
@@ -41,15 +41,15 @@ namespace NuGet.PackageManagement.VisualStudio
 
         public static async ValueTask<SharedServiceState> CreateAsync(CancellationToken cancellationToken)
         {
-            var sourceRepositoryProvider = await ServiceLocator.GetInstanceAsync<ISourceRepositoryProvider>();
+            var sourceRepositoryProvider = await ServiceLocator.GetComponentModelServiceAsync<ISourceRepositoryProvider>();
 
             return new SharedServiceState(sourceRepositoryProvider);
         }
 
         public async ValueTask<NuGetPackageManager> GetPackageManagerAsync(CancellationToken cancellationToken)
         {
-            IDeleteOnRestartManager deleteOnRestartManager = await ServiceLocator.GetInstanceAsync<IDeleteOnRestartManager>();
-            ISettings settings = await ServiceLocator.GetInstanceAsync<ISettings>();
+            IDeleteOnRestartManager deleteOnRestartManager = await ServiceLocator.GetComponentModelServiceAsync<IDeleteOnRestartManager>();
+            ISettings settings = await ServiceLocator.GetComponentModelServiceAsync<ISettings>();
             IVsSolutionManager solutionManager = await SolutionManager.GetValueAsync(cancellationToken);
 
             return new NuGetPackageManager(

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Utility/NuGetProjectUpgradeUtility.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Utility/NuGetProjectUpgradeUtility.cs
@@ -86,7 +86,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
         private static async Task<NuGetProject> GetNuGetProject(Project envDTEProject)
         {
-            var solutionManager = ServiceLocator.GetInstance<IVsSolutionManager>();
+            var solutionManager = await ServiceLocator.GetComponentModelServiceAsync<IVsSolutionManager>();
 
             var projectSafeName = await envDTEProject.GetCustomUniqueNameAsync();
             var nuGetProject = await solutionManager.GetNuGetProjectAsync(projectSafeName);

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Utility/ProjectRetargetingUtility.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Utility/ProjectRetargetingUtility.cs
@@ -43,7 +43,7 @@ namespace NuGet.PackageManagement.VisualStudio
             if (installedRefs != null && installedRefs.Any())
             {
                 var targetFramework = project.GetMetadata<NuGetFramework>(NuGetProjectMetadataKeys.TargetFramework);
-                return GetPackagesToBeReinstalled(targetFramework, installedRefs);
+                return await GetPackagesToBeReinstalledAsync(targetFramework, installedRefs);
             }
 
             return new List<PackageIdentity>();
@@ -55,16 +55,16 @@ namespace NuGet.PackageManagement.VisualStudio
         /// <param name="projectFramework">Current target framework of the project</param>
         /// <param name="packageReferences">List of package references in the project from which packages to be reinstalled are determined</param>
         /// <returns>List of package identities to be reinstalled</returns>
-        public static List<PackageIdentity> GetPackagesToBeReinstalled(NuGetFramework projectFramework, IEnumerable<Packaging.PackageReference> packageReferences)
+        public static async Task<List<PackageIdentity>> GetPackagesToBeReinstalledAsync(NuGetFramework projectFramework, IEnumerable<Packaging.PackageReference> packageReferences)
         {
             Debug.Assert(projectFramework != null);
             Debug.Assert(packageReferences != null);
 
             var packagesToBeReinstalled = new List<PackageIdentity>();
-            var sourceRepositoryProvider = ServiceLocator.GetInstance<ISourceRepositoryProvider>();
-            var solutionManager = ServiceLocator.GetInstance<ISolutionManager>();
-            var settings = ServiceLocator.GetInstance<Configuration.ISettings>();
-            var deleteOnRestartManager = ServiceLocator.GetInstance<IDeleteOnRestartManager>();
+            var sourceRepositoryProvider = await ServiceLocator.GetComponentModelServiceAsync<ISourceRepositoryProvider>();
+            var solutionManager = await ServiceLocator.GetComponentModelServiceAsync<ISolutionManager>();
+            var settings = await ServiceLocator.GetComponentModelServiceAsync<Configuration.ISettings>();
+            var deleteOnRestartManager = await ServiceLocator.GetComponentModelServiceAsync<IDeleteOnRestartManager>();
             var packageManager = new NuGetPackageManager(
                 sourceRepositoryProvider,
                 settings,

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Utility/SettingsHelper.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Utility/SettingsHelper.cs
@@ -24,7 +24,7 @@ namespace NuGet.PackageManagement.VisualStudio
         /// </param>
         public static void Set(string property, string value)
         {
-            var settings = ServiceLocator.GetInstance<Configuration.ISettings>();
+            var settings = ServiceLocator.GetComponentModelService<ISettings>();
             var packageRestoreConsent = new PackageRestoreConsent(settings);
             if (string.Equals(property, "PackageRestoreConsentGranted", StringComparison.OrdinalIgnoreCase))
             {
@@ -45,15 +45,6 @@ namespace NuGet.PackageManagement.VisualStudio
                     SettingsUtility.SetConfigValue(settings, property, value);
                 }
             }
-        }
-
-        /// <summary>
-        /// Gets the VsSettings singleton object.
-        /// </summary>
-        /// <returns>The VsSettings object in the system.</returns>
-        public static Configuration.ISettings GetVsSettings()
-        {
-            return ServiceLocator.GetInstance<Configuration.ISettings>();
         }
 
         /// <summary>

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Utility/SettingsHelper.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Utility/SettingsHelper.cs
@@ -48,6 +48,15 @@ namespace NuGet.PackageManagement.VisualStudio
         }
 
         /// <summary>
+        /// Gets the VsSettings singleton object.
+        /// </summary>
+        /// <returns>The VsSettings object in the system.</returns>
+        public static Configuration.ISettings GetVsSettings()
+        {
+            return ServiceLocator.GetInstance<Configuration.ISettings>();
+        }
+
+        /// <summary>
         /// Adds a new package source.
         /// </summary>
         /// <param name="name">Name of the new source.</param>

--- a/src/NuGet.Clients/NuGet.Tools/NuGetBrokeredServiceFactory.cs
+++ b/src/NuGet.Clients/NuGet.Tools/NuGetBrokeredServiceFactory.cs
@@ -203,11 +203,11 @@ namespace NuGetVSExtension
         }
         private async Task InitializeAsync()
         {
-            _lazySettings = new AsyncLazy<ISettings>(ServiceLocator.GetInstanceAsync<ISettings>, ThreadHelper.JoinableTaskFactory);
-            _lazySolutionManager = new AsyncLazy<IVsSolutionManager>(ServiceLocator.GetInstanceAsync<IVsSolutionManager>, ThreadHelper.JoinableTaskFactory);
+            _lazySettings = new AsyncLazy<ISettings>(ServiceLocator.GetComponentModelServiceAsync<ISettings>, ThreadHelper.JoinableTaskFactory);
+            _lazySolutionManager = new AsyncLazy<IVsSolutionManager>(ServiceLocator.GetComponentModelServiceAsync<IVsSolutionManager>, ThreadHelper.JoinableTaskFactory);
             _projectManagerServiceSharedState = new NuGetProjectManagerServiceState();
             _sharedServiceState = await SharedServiceState.CreateAsync(CancellationToken.None);
-            _lazyTelemetryProvider = new AsyncLazy<INuGetTelemetryProvider>(ServiceLocator.GetInstanceAsync<INuGetTelemetryProvider>, ThreadHelper.JoinableTaskFactory);
+            _lazyTelemetryProvider = new AsyncLazy<INuGetTelemetryProvider>(ServiceLocator.GetComponentModelServiceAsync<INuGetTelemetryProvider>, ThreadHelper.JoinableTaskFactory);
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/IDE/VsHierarchyUtility.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/IDE/VsHierarchyUtility.cs
@@ -118,7 +118,7 @@ namespace NuGet.VisualStudio
             // this operation needs to execute on UI thread
             await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
-            var dte = ServiceLocator.GetInstance<EnvDTE.DTE>();
+            var dte = await ServiceLocator.GetInstanceAsync<EnvDTE.DTE>();
             var projects = dte.Solution.Projects;
 
             var results = new Dictionary<string, ISet<VsHierarchyItem>>(StringComparer.OrdinalIgnoreCase);
@@ -139,7 +139,7 @@ namespace NuGet.VisualStudio
 
             await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
-            var dte = ServiceLocator.GetInstance<EnvDTE.DTE>();
+            var dte = await ServiceLocator.GetInstanceAsync<EnvDTE.DTE>();
             var projects = dte.Solution.Projects;
 
             foreach (var project in projects.Cast<EnvDTE.Project>())
@@ -157,7 +157,7 @@ namespace NuGet.VisualStudio
         private static async Task<ICollection<VsHierarchyItem>> GetExpandedProjectHierarchyItemsAsync(EnvDTE.Project project)
         {
             var projectHierarchyItem = await VsHierarchyItem.FromDteProjectAsync(project);
-            var solutionExplorerWindow = GetSolutionExplorerHierarchyWindow();
+            var solutionExplorerWindow = await GetSolutionExplorerHierarchyWindowAsync();
 
             if (solutionExplorerWindow == null)
             {
@@ -192,7 +192,7 @@ namespace NuGet.VisualStudio
         private static async Task CollapseProjectHierarchyItemsAsync(EnvDTE.Project project, ISet<VsHierarchyItem> ignoredHierarcyItems)
         {
             var projectHierarchyItem = await VsHierarchyItem.FromDteProjectAsync(project);
-            var solutionExplorerWindow = GetSolutionExplorerHierarchyWindow();
+            var solutionExplorerWindow = await GetSolutionExplorerHierarchyWindowAsync();
 
             if (solutionExplorerWindow == null)
             {
@@ -252,10 +252,11 @@ namespace NuGet.VisualStudio
             return hierarchyItem.VsHierarchy as IVsUIHierarchy;
         }
 
-        private static IVsUIHierarchyWindow GetSolutionExplorerHierarchyWindow()
+        private static async Task<IVsUIHierarchyWindow> GetSolutionExplorerHierarchyWindowAsync()
         {
+            var serviceProvider = await ServiceLocator.GetInstanceAsync<IServiceProvider>();
             return VsShellUtilities.GetUIHierarchyWindow(
-                ServiceLocator.GetInstance<IServiceProvider>(),
+                serviceProvider,
                 new Guid(VsWindowKindSolutionExplorer));
         }
     }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/ServiceLocator.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/ServiceLocator.cs
@@ -112,7 +112,7 @@ namespace NuGet.VisualStudio
                     return service;
                 }
             }
-            return Package.GetGlobalService(typeof(TService)) as TInterface;
+            return null;
         }
 
         /// <summary>

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/ServiceLocator.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/ServiceLocator.cs
@@ -52,7 +52,7 @@ namespace NuGet.VisualStudio
         /// <returns>The instance of the service request, <see langword="null"/> otherwise. </returns>
         /// <remarks>
         /// Prefer <see cref="GetComponentModelServiceAsync{TService}{TService}"/> over this requesting a MEF service.
-        /// A good rule of thumb is that only non-NuGet VS services should be retrieved this method.
+        /// A general rule is that only non-NuGet VS services should be retrieved this method.
         /// </remarks>
         public static async Task<TService> GetInstanceAsync<TService>() where TService : class
         {
@@ -112,8 +112,7 @@ namespace NuGet.VisualStudio
                     return service;
                 }
             }
-
-            return null;
+            return Package.GetGlobalService(typeof(TService)) as TInterface;
         }
 
         /// <summary>
@@ -125,7 +124,7 @@ namespace NuGet.VisualStudio
         /// <remarks>
         /// This method should only be preferred when using MEF imports is not easily achievable.
         /// Prefer this over <see cref="GetInstanceAsync{TService}"/> when the service requesting a MEF service.
-        /// A good rule of thumb is that internal NuGet services should call this method over <see cref="GetInstanceAsync{TService}"/>.
+        /// A general rule is that internal NuGet services should call this method over <see cref="GetInstanceAsync{TService}"/>.
         /// This method can be called from the UI thread, but that's unnecessary and a bad practice. Never do things that don't need the UI thread, on the UI thread.
         /// </remarks>
         public static async Task<TService> GetComponentModelServiceAsync<TService>() where TService : class

--- a/src/NuGet.Clients/NuGetConsole.Host.PowerShell/PowerShellHost.cs
+++ b/src/NuGet.Clients/NuGetConsole.Host.PowerShell/PowerShellHost.cs
@@ -106,11 +106,11 @@ namespace NuGetConsole.Host.PowerShell.Implementation
             _runspaceManager = runspaceManager;
 
             // TODO: Take these as ctor arguments
-            _sourceRepositoryProvider = ServiceLocator.GetInstance<ISourceRepositoryProvider>();
-            _solutionManager = new Lazy<IVsSolutionManager>(() => ServiceLocator.GetInstance<IVsSolutionManager>());
-            _settings = new Lazy<ISettings>(() => ServiceLocator.GetInstance<ISettings>());
-            _deleteOnRestartManager = new Lazy<IDeleteOnRestartManager>(() => ServiceLocator.GetInstance<IDeleteOnRestartManager>());
-            _scriptExecutor = new Lazy<IScriptExecutor>(() => ServiceLocator.GetInstance<IScriptExecutor>());
+            _sourceRepositoryProvider = ServiceLocator.GetComponentModelService<ISourceRepositoryProvider>();
+            _solutionManager = new Lazy<IVsSolutionManager>(() => ServiceLocator.GetComponentModelService<IVsSolutionManager>());
+            _settings = new Lazy<ISettings>(() => ServiceLocator.GetComponentModelService<ISettings>());
+            _deleteOnRestartManager = new Lazy<IDeleteOnRestartManager>(() => ServiceLocator.GetComponentModelService<IDeleteOnRestartManager>());
+            _scriptExecutor = new Lazy<IScriptExecutor>(() => ServiceLocator.GetComponentModelService<IScriptExecutor>());
 
             _dte = new Lazy<DTE>(() => ServiceLocator.GetInstance<DTE>());
             _sourceControlManagerProvider = new Lazy<ISourceControlManagerProvider>(

--- a/src/NuGet.Clients/NuGetConsole.Host.PowerShell/ProjectExtensions.cs
+++ b/src/NuGet.Clients/NuGetConsole.Host.PowerShell/ProjectExtensions.cs
@@ -38,7 +38,7 @@ namespace NuGetConsole.Host.PowerShell.Implementation
             {
                 await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
-                var solutionManager = ServiceLocator.GetInstance<IVsSolutionManager>();
+                var solutionManager = await ServiceLocator.GetComponentModelServiceAsync<IVsSolutionManager>();
                 if (solutionManager != null)
                 {
                     var project = await solutionManager.GetVsProjectAdapterAsync(projectName);
@@ -47,7 +47,7 @@ namespace NuGetConsole.Host.PowerShell.Implementation
                         throw new InvalidOperationException();
                     }
 
-                    var dte = ServiceLocator.GetInstance<EnvDTE.DTE>();
+                    var dte = await ServiceLocator.GetInstanceAsync<EnvDTE.DTE>();
                     dte.Solution.Remove(project.Project);
                 }
             });

--- a/src/NuGet.Clients/NuGetConsole.Host.PowerShell/RunspaceManager.cs
+++ b/src/NuGet.Clients/NuGetConsole.Host.PowerShell/RunspaceManager.cs
@@ -61,8 +61,8 @@ namespace NuGetConsole.Host.PowerShell.Implementation
                 );
 
             // this is used by the functional tests
-            var sourceRepositoryProvider = ServiceLocator.GetInstance<ISourceRepositoryProvider>();
-            var solutionManager = ServiceLocator.GetInstance<ISolutionManager>();
+            var sourceRepositoryProvider = ServiceLocator.GetComponentModelService<ISourceRepositoryProvider>();
+            var solutionManager = ServiceLocator.GetComponentModelService<ISolutionManager>();
             var sourceRepoTuple = Tuple.Create<string, object>("SourceRepositoryProvider", sourceRepositoryProvider);
             var solutionManagerTuple = Tuple.Create<string, object>("VsSolutionManager", solutionManager);
 

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/NuGetPackageSearchServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/NuGetPackageSearchServiceTests.cs
@@ -12,6 +12,7 @@ using Microsoft.ServiceHub.Framework.Services;
 using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.Sdk.TestFramework;
 using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Threading;
 using Moq;
 using Newtonsoft.Json;
@@ -19,7 +20,9 @@ using Newtonsoft.Json.Linq;
 using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Packaging.Core;
+using NuGet.ProjectManagement;
 using NuGet.Protocol.Core.Types;
+using NuGet.VisualStudio;
 using NuGet.VisualStudio.Internal.Contracts;
 using Test.Utility;
 using Xunit;
@@ -34,6 +37,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         private readonly IEnumerable<IPackageReferenceContextInfo> _installedPackages;
         private readonly IEnumerable<IPackageReferenceContextInfo> _transitivePackages;
         private readonly IReadOnlyCollection<IProjectContextInfo> _projects;
+        private readonly Mock<IComponentModel> _componentModel;
 
         public NuGetPackageSearchServiceTests(GlobalServiceProvider globalServiceProvider)
             : base(globalServiceProvider)
@@ -58,6 +62,8 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 { "https://api.nuget.org/v3/registration3-gz-semver2/nuget.core/index.json", ProtocolUtility.GetResource("NuGet.PackageManagement.VisualStudio.Test.compiler.resources.nugetCoreIndex.json", GetType()) },
                 { "https://api.nuget.org/v3/registration3-gz-semver2/microsoft.extensions.logging.abstractions/index.json", ProtocolUtility.GetResource("NuGet.PackageManagement.VisualStudio.Test.compiler.resources.loggingAbstractions.json", GetType()) }
             };
+            _componentModel = new Mock<IComponentModel>();
+            globalServiceProvider.AddService(typeof(SComponentModel), _componentModel.Object);
 
             _sourceRepository = StaticHttpHandler.CreateSource(testFeedUrl, Repository.Provider.GetCoreV3(), responses);
         }
@@ -290,14 +296,15 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             var settings = new Mock<ISettings>();
             var deleteOnRestartManager = new Mock<IDeleteOnRestartManager>();
 
-            var componentModel = new Mock<IComponentModel>();
+            _componentModel.Setup(x => x.GetService<IDeleteOnRestartManager>()).Returns(deleteOnRestartManager.Object);
+            _componentModel.Setup(x => x.GetService<IVsSolutionManager>()).Returns(solutionManager.Object);
+            _componentModel.Setup(x => x.GetService<ISolutionManager>()).Returns(solutionManager.Object);
+            _componentModel.Setup(x => x.GetService<ISettings>()).Returns(settings.Object);
+            _componentModel.Setup(x => x.GetService<ISourceRepositoryProvider>()).Returns(sourceRepositoryProvider.Object);
+            _componentModel.Setup(x => x.GetService<INuGetProjectContext>()).Returns(new Mock<INuGetProjectContext>().Object);
 
-            componentModel.Setup(x => x.GetService<IDeleteOnRestartManager>()).Returns(deleteOnRestartManager.Object);
-            componentModel.Setup(x => x.GetService<IVsSolutionManager>()).Returns(solutionManager.Object);
-            componentModel.Setup(x => x.GetService<ISettings>()).Returns(settings.Object);
-            componentModel.Setup(x => x.GetService<ISourceRepositoryProvider>()).Returns(sourceRepositoryProvider.Object);
-
-           AddService<SComponentModel>(Task.FromResult<object>(componentModel.Object));
+            var service = Package.GetGlobalService(typeof(SAsyncServiceProvider)) as IAsyncServiceProvider;
+            ServiceLocator.InitializePackageServiceProvider(service);
 
             var serviceActivationOptions = default(ServiceActivationOptions);
             var serviceBroker = new Mock<IServiceBroker>();

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/NuGetPackageSearchServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/NuGetPackageSearchServiceTests.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.ServiceHub.Framework;
 using Microsoft.ServiceHub.Framework.Services;
+using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.Sdk.TestFramework;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Threading;
@@ -17,10 +18,8 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using NuGet.Common;
 using NuGet.Configuration;
-using NuGet.PackageManagement.UI;
 using NuGet.Packaging.Core;
 using NuGet.Protocol.Core.Types;
-using NuGet.Versioning;
 using NuGet.VisualStudio.Internal.Contracts;
 using Test.Utility;
 using Xunit;
@@ -291,10 +290,14 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             var settings = new Mock<ISettings>();
             var deleteOnRestartManager = new Mock<IDeleteOnRestartManager>();
 
-            AddService<IDeleteOnRestartManager>(Task.FromResult<object>(deleteOnRestartManager.Object));
-            AddService<IVsSolutionManager>(Task.FromResult<object>(solutionManager.Object));
-            AddService<ISourceRepositoryProvider>(Task.FromResult<object>(sourceRepositoryProvider.Object));
-            AddService<ISettings>(Task.FromResult<object>(settings.Object));
+            var componentModel = new Mock<IComponentModel>();
+
+            componentModel.Setup(x => x.GetService<IDeleteOnRestartManager>()).Returns(deleteOnRestartManager.Object);
+            componentModel.Setup(x => x.GetService<IVsSolutionManager>()).Returns(solutionManager.Object);
+            componentModel.Setup(x => x.GetService<ISettings>()).Returns(settings.Object);
+            componentModel.Setup(x => x.GetService<ISourceRepositoryProvider>()).Returns(sourceRepositoryProvider.Object);
+
+           AddService<SComponentModel>(Task.FromResult<object>(componentModel.Object));
 
             var serviceActivationOptions = default(ServiceActivationOptions);
             var serviceBroker = new Mock<IServiceBroker>();

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/NuGetProjectManagerServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/NuGetProjectManagerServiceTests.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 using EnvDTE;
 using Microsoft.ServiceHub.Framework;
 using Microsoft.ServiceHub.Framework.Services;
+using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.ProjectSystem;
 using Microsoft.VisualStudio.ProjectSystem.References;
 using Microsoft.VisualStudio.Sdk.TestFramework;
@@ -55,6 +56,10 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             : base(globalServiceProvider)
         {
             _projectContext = new TestNuGetProjectContext();
+
+            var componentModel = new Mock<IComponentModel>();
+            componentModel.Setup(x => x.GetService<INuGetProjectContext>()).Returns(_projectContext);
+            globalServiceProvider.AddService(typeof(SComponentModel), componentModel.Object);
 
             AddService<INuGetProjectContext>(Task.FromResult<object>(_projectContext));
         }

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/NuGetProjectManagerServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/NuGetProjectManagerServiceTests.cs
@@ -59,9 +59,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
             var componentModel = new Mock<IComponentModel>();
             componentModel.Setup(x => x.GetService<INuGetProjectContext>()).Returns(_projectContext);
-            globalServiceProvider.AddService(typeof(SComponentModel), componentModel.Object);
-
-            AddService<INuGetProjectContext>(Task.FromResult<object>(_projectContext));
+            AddService<SComponentModel>(Task.FromResult((object)componentModel.Object));
         }
 
         public void Dispose()

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/SharedServiceStateTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/SharedServiceStateTests.cs
@@ -5,9 +5,12 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.Sdk.TestFramework;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
 using Moq;
 using NuGet.Configuration;
 using NuGet.Protocol.Core.Types;
+using NuGet.VisualStudio;
 using Test.Utility;
 using Xunit;
 
@@ -33,6 +36,8 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             componentModel.Setup(x => x.GetService<IVsSolutionManager>()).Returns(solutionManager.Object);
 
             globalServiceProvider.AddService(typeof(SComponentModel), componentModel.Object);
+            var service = Package.GetGlobalService(typeof(SAsyncServiceProvider)) as IAsyncServiceProvider;
+            ServiceLocator.InitializePackageServiceProvider(service);
         }
 
         [Fact]

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/SharedServiceStateTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/SharedServiceStateTests.cs
@@ -3,6 +3,7 @@
 
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.Sdk.TestFramework;
 using Moq;
 using NuGet.Configuration;
@@ -25,10 +26,13 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
             SourceRepositoryProvider sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
 
-            AddService<IDeleteOnRestartManager>(Task.FromResult<object>(Mock.Of<IDeleteOnRestartManager>()));
-            AddService<ISettings>(Task.FromResult<object>(Mock.Of<ISettings>()));
-            AddService<ISourceRepositoryProvider>(Task.FromResult<object>(sourceRepositoryProvider));
-            AddService<IVsSolutionManager>(Task.FromResult<object>(solutionManager.Object));
+            var componentModel = new Mock<IComponentModel>();
+            componentModel.Setup(x => x.GetService<IDeleteOnRestartManager>()).Returns(Mock.Of<IDeleteOnRestartManager>());
+            componentModel.Setup(x => x.GetService<ISettings>()).Returns(Mock.Of<ISettings>());
+            componentModel.Setup(x => x.GetService<ISourceRepositoryProvider>()).Returns(sourceRepositoryProvider);
+            componentModel.Setup(x => x.GetService<IVsSolutionManager>()).Returns(solutionManager.Object);
+
+            globalServiceProvider.AddService(typeof(SComponentModel), componentModel.Object);
         }
 
         [Fact]

--- a/test/NuGet.Clients.Tests/NuGet.Tools.Test/NuGetBrokeredServiceFactoryTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.Tools.Test/NuGetBrokeredServiceFactoryTests.cs
@@ -13,11 +13,14 @@ using Microsoft.ServiceHub.Framework;
 using Microsoft.ServiceHub.Framework.Services;
 using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.Sdk.TestFramework;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Shell.ServiceBroker;
 using Moq;
 using NuGet.Configuration;
 using NuGet.PackageManagement.VisualStudio;
 using NuGet.Protocol.Core.Types;
+using NuGet.VisualStudio;
 using NuGet.VisualStudio.Implementation.Extensibility;
 using NuGet.VisualStudio.Internal.Contracts;
 using NuGet.VisualStudio.Telemetry;
@@ -49,14 +52,14 @@ namespace NuGet.Tools.Test
 
             componentModel.SetupGet(x => x.DefaultCompositionService)
                 .Returns(compositionService);
-            
             componentModel.Setup(x => x.GetService<IVsSolutionManager>()).Returns(Mock.Of<IVsSolutionManager>());
             componentModel.Setup(x => x.GetService<ISettings>()).Returns(Mock.Of<ISettings>());
             componentModel.Setup(x => x.GetService<ISourceRepositoryProvider>()).Returns(sourceRepositoryProvider.Object);
             componentModel.Setup(x => x.GetService<INuGetTelemetryProvider>()).Returns(Mock.Of<INuGetTelemetryProvider>());
 
             globalServiceProvider.AddService(typeof(SComponentModel), componentModel.Object);
-
+            var service = Package.GetGlobalService(typeof(SAsyncServiceProvider)) as IAsyncServiceProvider;
+            ServiceLocator.InitializePackageServiceProvider(service);
             _serviceFactories = new Dictionary<ServiceRpcDescriptor, BrokeredServiceFactory>();
             _authorizingServiceFactories = new Dictionary<ServiceRpcDescriptor, AuthorizingBrokeredServiceFactory>();
         }

--- a/test/NuGet.Clients.Tests/NuGet.Tools.Test/NuGetBrokeredServiceFactoryTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.Tools.Test/NuGetBrokeredServiceFactoryTests.cs
@@ -43,19 +43,19 @@ namespace NuGet.Tools.Test
             var componentModel = new Mock<IComponentModel>();
             var compositionService = new MockCompositionService();
 
-            componentModel.SetupGet(x => x.DefaultCompositionService)
-                .Returns(compositionService);
-
             var sourceRepositoryProvider = new Mock<ISourceRepositoryProvider>();
-
             sourceRepositoryProvider.SetupGet(x => x.PackageSourceProvider)
                 .Returns(Mock.Of<IPackageSourceProvider>());
 
-            globalServiceProvider.AddService(typeof(IVsSolutionManager), Mock.Of<IVsSolutionManager>());
-            globalServiceProvider.AddService(typeof(ISettings), Mock.Of<ISettings>());
-            globalServiceProvider.AddService(typeof(ISourceRepositoryProvider), sourceRepositoryProvider.Object);
+            componentModel.SetupGet(x => x.DefaultCompositionService)
+                .Returns(compositionService);
+            
+            componentModel.Setup(x => x.GetService<IVsSolutionManager>()).Returns(Mock.Of<IVsSolutionManager>());
+            componentModel.Setup(x => x.GetService<ISettings>()).Returns(Mock.Of<ISettings>());
+            componentModel.Setup(x => x.GetService<ISourceRepositoryProvider>()).Returns(sourceRepositoryProvider.Object);
+            componentModel.Setup(x => x.GetService<INuGetTelemetryProvider>()).Returns(Mock.Of<INuGetTelemetryProvider>());
+
             globalServiceProvider.AddService(typeof(SComponentModel), componentModel.Object);
-            globalServiceProvider.AddService(typeof(INuGetTelemetryProvider), Mock.Of<INuGetTelemetryProvider>());
 
             _serviceFactories = new Dictionary<ServiceRpcDescriptor, BrokeredServiceFactory>();
             _authorizingServiceFactories = new Dictionary<ServiceRpcDescriptor, AuthorizingBrokeredServiceFactory>();


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/nuget/home/issues/11201

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Avoid using methods that access the UI thread when requesting services exposed via MEF, use free threaded calls instead. 

A few things that this PR does: 

* Add a public GetComponentModelServiceAsync, which is free threaded and retrieves MEF services.
* Add a public GetComponentModelService because to achieve parity to GetInstanceAsync. 
* Review all GetInstance/GetInstanceAsync calls and move them to GetComponentModelService(Async) where appropriate.

A few things that this PR doesn't do: 

* Attempt to move sync codepaths to async ones. Only a few obvious/easy ones where done. 
A review of the other codepaths will be done in https://github.com/NuGet/Home/issues/11203


## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception - No functional changes here. I also did a lot of basic tests to ensure something unexpected doesn't happen.
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [X] N/A
