### PR TITLE
Fix the warning icon tooltip on the installed tab by making the icon hit test visible

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerTopPanel.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerTopPanel.xaml
@@ -114,8 +114,8 @@
             </MultiBinding>
           </AutomationProperties.Name>
           <TabItem.Header>
-            <StackPanel Orientation="Horizontal" IsHitTestVisible="False" >
-              <TextBlock x:Name="textInstalled" Text="{x:Static nuget:Resources.Label_Installed}" />
+            <StackPanel Orientation="Horizontal" >
+              <TextBlock x:Name="textInstalled" Text="{x:Static nuget:Resources.Label_Installed}" IsHitTestVisible="False" />
               <imaging:CrispImage
                 Name="_warningIcon"
                 Margin="3,0"
@@ -132,8 +132,8 @@
             </MultiBinding>
           </AutomationProperties.Name>
           <TabItem.Header>
-            <StackPanel Orientation="Horizontal" IsHitTestVisible="False">
-              <TextBlock x:Name="textUpdates" Text="{x:Static nuget:Resources.Label_Updates}" />
+            <StackPanel Orientation="Horizontal">
+              <TextBlock x:Name="textUpdates" Text="{x:Static nuget:Resources.Label_Updates}" IsHitTestVisible="False" />
               <!-- the textblock that displays the count -->
               <Border
                 x:Name="_countUpdatesContainer"

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerTopPanel.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerTopPanel.xaml.cs
@@ -52,6 +52,7 @@ namespace NuGet.PackageManagement.UI
             var textConsolidate = new TextBlock();
             textConsolidate.Name = nameof(textConsolidate);
             textConsolidate.Text = Resx.Action_Consolidate;
+            textConsolidate.IsHitTestVisible = false;
             sp.Children.Add(textConsolidate);
 
             SetConsolidationAutomationProperties(tabConsolidate, count: 0);

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerTopPanel.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerTopPanel.xaml.cs
@@ -47,7 +47,6 @@ namespace NuGet.PackageManagement.UI
             var sp = new StackPanel()
             {
                 Orientation = Orientation.Horizontal,
-                IsHitTestVisible = false,
             };
 
             var textConsolidate = new TextBlock();


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/nuget/home/issues/11183

Regression? Last working version: Yes, prior to https://github.com/NuGet/NuGet.Client/pull/4210

## Description
Make the textblocks in the tab item headers be not hit testable rather than the whole stack panel that contains the textblock and an icon. The textblocks were blocking the hover action from the tab item so that was fixed in https://github.com/NuGet/NuGet.Client/pull/4210 but the fix also broke the image from being hit testable which prevents the tooltip from showing up when the mouse is over the image. By making only the textblock not hit testable, the hover behavior of the tabs is preserved from fix https://github.com/NuGet/NuGet.Client/pull/4210 but the image now has its tooltip working again too. Additionally, hovering over the image also makes the tab item hovered so it appears highlighted which is a desirable effect.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  Fix affects visual UI hover behavior. Tested manually.
  - [x] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
