### PR TITLE
Rename packageNamespaces to packageSourceMapping, namespace to package and id to pattern

### DIFF
--- a/src/NuGet.Core/NuGet.Configuration/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Configuration/PublicAPI.Unshipped.txt
@@ -8,9 +8,9 @@ NuGet.Configuration.PackageNamespacesSourceItem
 NuGet.Configuration.PackageNamespacesSourceItem.Namespaces.get -> System.Collections.Generic.IList<NuGet.Configuration.NamespaceItem>
 NuGet.Configuration.PackageNamespacesSourceItem.PackageNamespacesSourceItem(string name, System.Collections.Generic.IEnumerable<NuGet.Configuration.NamespaceItem> namespaceItems) -> void
 NuGet.Configuration.PackageNamespacesSourceItem.SetKey(string value) -> void
-NuGet.Configuration.SettingElementType.Namespace = 19 -> NuGet.Configuration.SettingElementType
-NuGet.Configuration.SettingElementType.PackageNamespaces = 17 -> NuGet.Configuration.SettingElementType
+NuGet.Configuration.SettingElementType.Package = 19 -> NuGet.Configuration.SettingElementType
 NuGet.Configuration.SettingElementType.PackageSource = 18 -> NuGet.Configuration.SettingElementType
+NuGet.Configuration.SettingElementType.PackageSourceMapping = 17 -> NuGet.Configuration.SettingElementType
 override NuGet.Configuration.NamespaceItem.Clone() -> NuGet.Configuration.SettingBase
 override NuGet.Configuration.NamespaceItem.ElementName.get -> string
 override NuGet.Configuration.NamespaceItem.Equals(object other) -> bool

--- a/src/NuGet.Core/NuGet.Configuration/Settings/SettingElementType.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/SettingElementType.cs
@@ -45,10 +45,10 @@ namespace NuGet.Configuration
 
         /** Package Namespaces **/
 
-        PackageNamespaces,
+        PackageSourceMapping,
 
         PackageSource,
 
-        Namespace,
+        Package,
     }
 }

--- a/src/NuGet.Core/NuGet.Configuration/Settings/SettingFactory.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/SettingFactory.cs
@@ -48,7 +48,7 @@ namespace NuGet.Configuration
                         }
                         break;
 
-                    case SettingElementType.PackageNamespaces:
+                    case SettingElementType.PackageSourceMapping:
                         if (elementType == SettingElementType.PackageSource)
                         {
                             return new PackageNamespacesSourceItem(element, origin);
@@ -56,7 +56,7 @@ namespace NuGet.Configuration
                         break;
 
                     case SettingElementType.PackageSource:
-                        if (elementType == SettingElementType.Namespace)
+                        if (elementType == SettingElementType.Package)
                         {
                             return new NamespaceItem(element, origin);
                         }

--- a/src/NuGet.Core/NuGet.Configuration/Utility/ConfigurationContants.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Utility/ConfigurationContants.cs
@@ -119,7 +119,7 @@ namespace NuGet.Configuration
 
         public static readonly string TrustedSigners = "trustedSigners";
 
-        public static readonly string PackageNamespaces = "packageSourceMappings";
+        public static readonly string PackageNamespaces = "packageSourceMapping";
 
         public static readonly string UserKey = "http_proxy.user";
 

--- a/src/NuGet.Core/NuGet.Configuration/Utility/ConfigurationContants.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Utility/ConfigurationContants.cs
@@ -129,6 +129,6 @@ namespace NuGet.Configuration
 
         public static readonly string ValueAttribute = "value";
 
-        public static readonly string IdAttribute = "prefix";
+        public static readonly string IdAttribute = "pattern";
     }
 }

--- a/src/NuGet.Core/NuGet.Configuration/Utility/ConfigurationContants.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Utility/ConfigurationContants.cs
@@ -21,7 +21,7 @@ namespace NuGet.Configuration
 
         public static readonly string Certificate = "certificate";
 
-        public static readonly string Namespace = "namespace";
+        public static readonly string Namespace = "package";
 
         public static readonly string Clear = "clear";
 
@@ -119,7 +119,7 @@ namespace NuGet.Configuration
 
         public static readonly string TrustedSigners = "trustedSigners";
 
-        public static readonly string PackageNamespaces = "packageNamespaces";
+        public static readonly string PackageNamespaces = "packageSourceMappings";
 
         public static readonly string UserKey = "http_proxy.user";
 
@@ -129,6 +129,6 @@ namespace NuGet.Configuration
 
         public static readonly string ValueAttribute = "value";
 
-        public static readonly string IdAttribute = "id";
+        public static readonly string IdAttribute = "prefix";
     }
 }

--- a/test/EndToEnd/tests/PackageNameSpaceTests.ps1
+++ b/test/EndToEnd/tests/PackageNameSpaceTests.ps1
@@ -15,7 +15,7 @@ function Test-PackageNamespaceRestore-WithSingleFeed
     </packageSources>
     <packageSourceMapping>
         <packageSource key="ReadyPackages">
-            <package prefix="Soluti*" />
+            <package pattern="Soluti*" />
         </packageSource>
     </packageSourceMapping>
 </configuration>
@@ -72,7 +72,7 @@ function Test-PackageNamespaceRestore-WithMultipleFeedsWithIdenticalPackages-Res
     </packageSources>
     <packageSourceMapping>
         <packageSource key="PrivateRepository">
-            <package prefix="Contoso.MVC.*" />
+            <package pattern="Contoso.MVC.*" />
         </packageSource>
     </packageSourceMapping>
 </configuration>
@@ -133,7 +133,7 @@ function Test-VsPackageInstallerServices-PackageNamespaceInstall-WithSingleFeed-
     </packageSources>
     <packageSourceMapping>
         <packageSource key="ReadyPackages">
-            <package prefix="Soluti*" />
+            <package pattern="Soluti*" />
         </packageSource>
     </packageSourceMapping>
 </configuration>
@@ -179,7 +179,7 @@ function Test-VsPackageInstallerServices-PackageNamespaceInstall-WithSingleFeed-
     </packageSources>
     <packageSourceMapping>
         <packageSource key="SecretPackages">
-            <package prefix="Soluti*" />
+            <package pattern="Soluti*" />
         </packageSource>
     </packageSourceMapping>
 </configuration>
@@ -224,7 +224,7 @@ function Test-VsPackageInstallerServices-PackageNamespaceInstall-WithMultipleFee
     </packageSources>
     <packageSourceMapping>
         <packageSource key="PrivateRepository">
-            <package prefix="Contoso.MVC.*" />
+            <package pattern="Contoso.MVC.*" />
         </packageSource>
     </packageSourceMapping>
 </configuration>
@@ -285,7 +285,7 @@ function Test-VsPackageInstallerServices-PackageNamespaceInstall-WithMultipleFee
     </packageSources>
     <packageSourceMapping>
         <packageSource key="PrivateRepository">
-            <package prefix="Contoso.MVC.*" />
+            <package pattern="Contoso.MVC.*" />
         </packageSource>
     </packageSourceMapping>
 </configuration>
@@ -341,7 +341,7 @@ function Test-PC-PackageNamespaceInstall-Succeed
     </packageSources>
     <packageSourceMapping>
         <packageSource key="LocalRepository">
-            <package prefix="Solution*" />
+            <package pattern="Solution*" />
         </packageSource>
     </packageSourceMapping>
 </configuration>
@@ -386,7 +386,7 @@ function Test-PC-PackageNamespaceInstall-Fails
     </packageSources>
     <packageSourceMapping>
         <packageSource key="PrivateRepository">
-            <package prefix="Solution*" />
+            <package pattern="Solution*" />
         </packageSource>
     </packageSourceMapping>
 </configuration>
@@ -428,7 +428,7 @@ function Test-PC-PackageNamespaceInstall-WithCorrectSourceOption-Succeed
     </packageSources>
     <packageSourceMapping>
         <packageSource key="PrivateRepository">
-            <package prefix="Contoso.MVC.*" />
+            <package pattern="Contoso.MVC.*" />
         </packageSource>
     </packageSourceMapping>
 </configuration>
@@ -487,7 +487,7 @@ function Test-PC-PackageNamespaceInstall-WithWrongSourceOption-Fails
     </packageSources>
     <packageSourceMapping>
         <packageSource key="PrivateRepository">
-            <package prefix="Contoso.MVC.*" />
+            <package pattern="Contoso.MVC.*" />
         </packageSource>
     </packageSourceMapping>
 </configuration>
@@ -536,7 +536,7 @@ function Test-PC-PackageNamespaceUpdate-WithCorrectSourceOption-Succeed
     </packageSources>
     <packageSourceMapping>
         <packageSource key="PrivateRepository">
-            <package prefix="Contoso.MVC.*" />
+            <package pattern="Contoso.MVC.*" />
         </packageSource>
     </packageSourceMapping>
 </configuration>

--- a/test/EndToEnd/tests/PackageNameSpaceTests.ps1
+++ b/test/EndToEnd/tests/PackageNameSpaceTests.ps1
@@ -13,37 +13,37 @@ function Test-PackageNamespaceRestore-WithSingleFeed
     <clear />
     <add key="ReadyPackages" value="{0}" />
     </packageSources>
-    <packageNamespaces>
+    <packageSourceMapping>
         <packageSource key="ReadyPackages">
-            <namespace id="Soluti*" />
+            <package prefix="Soluti*" />
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMapping>
 </configuration>
 "@
-  
+
     try {
         # We have to create config file before creating solution, otherwise it's not effective for new solutions.
         $settingFileContent -f $repoDirectory | Out-File -Encoding "UTF8" $nugetConfigPath
-    
+
         $p = New-ConsoleApplication
-    
+
         $projectDirectoryPath = $p.Properties.Item("FullPath").Value
         $packagesConfigPath = Join-Path $projectDirectoryPath 'packages.config'
         $projectDirectoryPath = $p.Properties.Item("FullPath").Value
-        $solutionDirectory = Split-Path -Path $projectDirectoryPath -Parent   
+        $solutionDirectory = Split-Path -Path $projectDirectoryPath -Parent
         # Write a file to disk, but do not add it to project
         '<packages>
             <package id="SolutionLevelPkg" version="1.0.0" targetFramework="net461" />
     </packages>' | out-file $packagesConfigPath
-    
+
         # Act
         Build-Solution
-    
+
         # Assert
         $packagesFolder = Join-Path $solutionDirectory "packages"
         $solutionLevelPkgNupkgFolder = Join-Path $packagesFolder "SolutionLevelPkg.1.0.0"
         Assert-PathExists(Join-Path $solutionLevelPkgNupkgFolder "SolutionLevelPkg.1.0.0.nupkg")
-        
+
         $errorlist = Get-Errors
         Assert-AreEqual 0 $errorlist.Count
     }
@@ -70,11 +70,11 @@ function Test-PackageNamespaceRestore-WithMultipleFeedsWithIdenticalPackages-Res
     <add key="OpensourceRepository" value="{0}" />
     <add key="PrivateRepository" value="{1}" />
     </packageSources>
-    <packageNamespaces>
+    <packageSourceMapping>
         <packageSource key="PrivateRepository">
-            <namespace id="Contoso.MVC.*" />
+            <package prefix="Contoso.MVC.*" />
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMapping>
 </configuration>
 "@
     try {
@@ -86,7 +86,7 @@ function Test-PackageNamespaceRestore-WithMultipleFeedsWithIdenticalPackages-Res
         $projectDirectoryPath = $p.Properties.Item("FullPath").Value
         $packagesConfigPath = Join-Path $projectDirectoryPath 'packages.config'
         $projectDirectoryPath = $p.Properties.Item("FullPath").Value
-        $solutionDirectory = Split-Path -Path $projectDirectoryPath -Parent   
+        $solutionDirectory = Split-Path -Path $projectDirectoryPath -Parent
         # Write a file to disk, but do not add it to project
         '<packages>
             <package id="Contoso.MVC.ASP" version="1.0.0" targetFramework="net461" />
@@ -98,7 +98,7 @@ function Test-PackageNamespaceRestore-WithMultipleFeedsWithIdenticalPackages-Res
         # Act
         Build-Solution
 
-        # Assert   
+        # Assert
         $packagesFolder = Join-Path $solutionDirectory "packages"
         $contosoNupkgFolder = Join-Path $packagesFolder "Contoso.MVC.ASP.1.0.0"
         Assert-PathExists(Join-Path $contosoNupkgFolder "Contoso.MVC.ASP.1.0.0.nupkg")
@@ -131,18 +131,18 @@ function Test-VsPackageInstallerServices-PackageNamespaceInstall-WithSingleFeed-
     <clear />
     <add key="ReadyPackages" value="{0}" />
     </packageSources>
-    <packageNamespaces>
+    <packageSourceMapping>
         <packageSource key="ReadyPackages">
-            <namespace id="Soluti*" />
+            <package prefix="Soluti*" />
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMapping>
 </configuration>
 "@
-  
+
     try {
         # We have to create config file before creating solution, otherwise it's not effective for new solutions.
         $settingFileContent -f $repoDirectory | Out-File -Encoding "UTF8" $nugetConfigPath
-    
+
         # $p = New-ConsoleApplication
         # Arrange
         $p = New-ClassLibrary
@@ -177,18 +177,18 @@ function Test-VsPackageInstallerServices-PackageNamespaceInstall-WithSingleFeed-
     <clear />
     <add key="ReadyPackages" value="{0}" />
     </packageSources>
-    <packageNamespaces>
+    <packageSourceMapping>
         <packageSource key="SecretPackages">
-            <namespace id="Soluti*" />
+            <package prefix="Soluti*" />
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMapping>
 </configuration>
 "@
-  
+
     try {
         # We have to create config file before creating solution, otherwise it's not effective for new solutions.
         $settingFileContent -f $repoDirectory | Out-File -Encoding "UTF8" $nugetConfigPath
-    
+
         # $p = New-ConsoleApplication
         # Arrange
         $p = New-ClassLibrary
@@ -222,11 +222,11 @@ function Test-VsPackageInstallerServices-PackageNamespaceInstall-WithMultipleFee
     <add key="OpensourceRepository" value="{0}" />
     <add key="PrivateRepository" value="{1}" />
     </packageSources>
-    <packageNamespaces>
+    <packageSourceMapping>
         <packageSource key="PrivateRepository">
-            <namespace id="Contoso.MVC.*" />
+            <package prefix="Contoso.MVC.*" />
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMapping>
 </configuration>
 "@
     try {
@@ -238,7 +238,7 @@ function Test-VsPackageInstallerServices-PackageNamespaceInstall-WithMultipleFee
         $projectDirectoryPath = $p.Properties.Item("FullPath").Value
         $packagesConfigPath = Join-Path $projectDirectoryPath 'packages.config'
         $projectDirectoryPath = $p.Properties.Item("FullPath").Value
-        $solutionDirectory = Split-Path -Path $projectDirectoryPath -Parent   
+        $solutionDirectory = Split-Path -Path $projectDirectoryPath -Parent
 
         CreateCustomTestPackage "Contoso.MVC.ASP" "1.0.0" $privateRepo "Thisisfromprivaterepo1.txt"
         CreateCustomTestPackage "Contoso.MVC.ASP" "2.0.0" $privateRepo "Thisisfromprivaterepo2.txt"
@@ -248,7 +248,7 @@ function Test-VsPackageInstallerServices-PackageNamespaceInstall-WithMultipleFee
         # Act
         [API.Test.InternalAPITestHook]::InstallPackageApi("Contoso.MVC.ASP", "1.0.0")
 
-        # Assert   
+        # Assert
         $packagesFolder = Join-Path $solutionDirectory "packages"
         $contosoNupkgFolder = Join-Path $packagesFolder "Contoso.MVC.ASP.1.0.0"
         Assert-PathExists(Join-Path $contosoNupkgFolder "Contoso.MVC.ASP.1.0.0.nupkg")
@@ -283,11 +283,11 @@ function Test-VsPackageInstallerServices-PackageNamespaceInstall-WithMultipleFee
     <add key="OpensourceRepository" value="{0}" />
     <add key="PrivateRepository" value="{1}" />
     </packageSources>
-    <packageNamespaces>
+    <packageSourceMapping>
         <packageSource key="PrivateRepository">
-            <namespace id="Contoso.MVC.*" />
+            <package prefix="Contoso.MVC.*" />
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMapping>
 </configuration>
 "@
     try {
@@ -299,7 +299,7 @@ function Test-VsPackageInstallerServices-PackageNamespaceInstall-WithMultipleFee
         $projectDirectoryPath = $p.Properties.Item("FullPath").Value
         $packagesConfigPath = Join-Path $projectDirectoryPath 'packages.config'
         $projectDirectoryPath = $p.Properties.Item("FullPath").Value
-        $solutionDirectory = Split-Path -Path $projectDirectoryPath -Parent   
+        $solutionDirectory = Split-Path -Path $projectDirectoryPath -Parent
 
         CreateCustomTestPackage "Contoso.MVC.ASP" "1.0.0" $privateRepo "Thisisfromprivaterepo1.txt"
         CreateCustomTestPackage "Contoso.MVC.ASP" "2.0.0" $privateRepo "Thisisfromprivaterepo2.txt"
@@ -309,7 +309,7 @@ function Test-VsPackageInstallerServices-PackageNamespaceInstall-WithMultipleFee
         # Act
         [API.Test.InternalAPITestHook]::InstallLatestPackageApi("Contoso.MVC.ASP", $false)
 
-        # Assert   
+        # Assert
         $packagesFolder = Join-Path $solutionDirectory "packages"
         $contosoNupkgFolder = Join-Path $packagesFolder "Contoso.MVC.ASP.2.0.0"
         Assert-PathExists(Join-Path $contosoNupkgFolder "Contoso.MVC.ASP.2.0.0.nupkg")
@@ -331,7 +331,7 @@ function Test-PC-PackageNamespaceInstall-Succeed
     param($context)
 
     # Arrange
-    $nugetConfigPath = Join-Path $OutputPath 'nuget.config'    
+    $nugetConfigPath = Join-Path $OutputPath 'nuget.config'
 	$settingFileContent =@"
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
@@ -339,11 +339,11 @@ function Test-PC-PackageNamespaceInstall-Succeed
     <clear />
     <add key="LocalRepository" value="{0}" />
     </packageSources>
-    <packageNamespaces>
+    <packageSourceMapping>
         <packageSource key="LocalRepository">
-            <namespace id="Solution*" />
+            <package prefix="Solution*" />
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMapping>
 </configuration>
 "@
     try {
@@ -375,7 +375,7 @@ function Test-PC-PackageNamespaceInstall-Fails
     $repoDirectory = $context.RepositoryRoot
     $privateRepo = Join-Path $repoDirectory "privateRepo"
 
-    $nugetConfigPath = Join-Path $OutputPath 'nuget.config'    
+    $nugetConfigPath = Join-Path $OutputPath 'nuget.config'
 	$settingFileContent =@"
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
@@ -384,11 +384,11 @@ function Test-PC-PackageNamespaceInstall-Fails
     <add key="LocalRepository" value="{0}" />
     <add key="PrivateRepository" value="{1}" />
     </packageSources>
-    <packageNamespaces>
+    <packageSourceMapping>
         <packageSource key="PrivateRepository">
-            <namespace id="Solution*" />
+            <package prefix="Solution*" />
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMapping>
 </configuration>
 "@
     try {
@@ -426,11 +426,11 @@ function Test-PC-PackageNamespaceInstall-WithCorrectSourceOption-Succeed
     <add key="OpensourceRepository" value="{0}" />
     <add key="PrivateRepository" value="{1}" />
     </packageSources>
-    <packageNamespaces>
+    <packageSourceMapping>
         <packageSource key="PrivateRepository">
-            <namespace id="Contoso.MVC.*" />
+            <package prefix="Contoso.MVC.*" />
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMapping>
 </configuration>
 "@
     try {
@@ -441,7 +441,7 @@ function Test-PC-PackageNamespaceInstall-WithCorrectSourceOption-Succeed
         $projectDirectoryPath = $p.Properties.Item("FullPath").Value
         $packagesConfigPath = Join-Path $projectDirectoryPath 'packages.config'
         $projectDirectoryPath = $p.Properties.Item("FullPath").Value
-        $solutionDirectory = Split-Path -Path $projectDirectoryPath -Parent   
+        $solutionDirectory = Split-Path -Path $projectDirectoryPath -Parent
 
         CreateCustomTestPackage "Contoso.MVC.ASP" "1.0.0" $privateRepo "Thisisfromprivaterepo1.txt"
         CreateCustomTestPackage "Contoso.MVC.ASP" "1.0.0" $opensourceRepo "Thisisfromopensourcerepo1.txt"
@@ -485,11 +485,11 @@ function Test-PC-PackageNamespaceInstall-WithWrongSourceOption-Fails
     <add key="OpensourceRepository" value="{0}" />
     <add key="PrivateRepository" value="{1}" />
     </packageSources>
-    <packageNamespaces>
+    <packageSourceMapping>
         <packageSource key="PrivateRepository">
-            <namespace id="Contoso.MVC.*" />
+            <package prefix="Contoso.MVC.*" />
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMapping>
 </configuration>
 "@
     try {
@@ -500,12 +500,12 @@ function Test-PC-PackageNamespaceInstall-WithWrongSourceOption-Fails
         $projectDirectoryPath = $p.Properties.Item("FullPath").Value
         $packagesConfigPath = Join-Path $projectDirectoryPath 'packages.config'
         $projectDirectoryPath = $p.Properties.Item("FullPath").Value
-        $solutionDirectory = Split-Path -Path $projectDirectoryPath -Parent   
+        $solutionDirectory = Split-Path -Path $projectDirectoryPath -Parent
 
         CreateCustomTestPackage "Contoso.MVC.ASP" "1.0.0" $privateRepo "Thisisfromprivaterepo1.txt"
         CreateCustomTestPackage "Contoso.MVC.ASP" "1.0.0" $opensourceRepo "Thisisfromopensourcerepo1.txt"
 
-        # Act & Assert   
+        # Act & Assert
         $exceptionMessage = "Package 'Contoso.MVC.ASP 1.0.0' is not found in the following primary source(s): '"+ $opensourceRepo + "'. Please verify all your online package sources are available (OR) package id, version are specified correctly."
         Assert-Throws { $p | Install-Package Contoso.MVC.ASP -Source $opensourceRepo  } $exceptionMessage
         Assert-NoPackage $p SolutionLevelPkg 1.0.0
@@ -534,11 +534,11 @@ function Test-PC-PackageNamespaceUpdate-WithCorrectSourceOption-Succeed
     <add key="OpensourceRepository" value="{0}" />
     <add key="PrivateRepository" value="{1}" />
     </packageSources>
-    <packageNamespaces>
+    <packageSourceMapping>
         <packageSource key="PrivateRepository">
-            <namespace id="Contoso.MVC.*" />
+            <package prefix="Contoso.MVC.*" />
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMapping>
 </configuration>
 "@
     try {
@@ -549,7 +549,7 @@ function Test-PC-PackageNamespaceUpdate-WithCorrectSourceOption-Succeed
         $projectDirectoryPath = $p.Properties.Item("FullPath").Value
         $packagesConfigPath = Join-Path $projectDirectoryPath 'packages.config'
         $projectDirectoryPath = $p.Properties.Item("FullPath").Value
-        $solutionDirectory = Split-Path -Path $projectDirectoryPath -Parent   
+        $solutionDirectory = Split-Path -Path $projectDirectoryPath -Parent
 
         CreateCustomTestPackage "Contoso.MVC.ASP" "1.0.0" $privateRepo "Thisisfromprivaterepo1.txt"
         CreateCustomTestPackage "Contoso.MVC.ASP" "2.0.0" $privateRepo "Thisisfromprivaterepo2.txt"
@@ -563,7 +563,7 @@ function Test-PC-PackageNamespaceUpdate-WithCorrectSourceOption-Succeed
         $p | Update-Package Contoso.MVC.ASP -Version 2.0 -Source $privateRepo
         Assert-Package $p Contoso.MVC.ASP 2.0.0
 
-        # Assert   
+        # Assert
         $packagesFolder = Join-Path $solutionDirectory "packages"
         $contosoNupkgFolder = Join-Path $packagesFolder "Contoso.MVC.ASP.2.0.0"
         Assert-PathExists(Join-Path $contosoNupkgFolder "Contoso.MVC.ASP.2.0.0.nupkg")
@@ -580,7 +580,7 @@ function Test-PC-PackageNamespaceUpdate-WithCorrectSourceOption-Succeed
     }
 }
 
-# Create a custom test package 
+# Create a custom test package
 function CreateCustomTestPackage {
     param(
         [string]$id,
@@ -593,7 +593,7 @@ function CreateCustomTestPackage {
     $builder.Authors.Add("test_author")
     $builder.Id = $id
     $builder.Version = [NuGet.Versioning.NuGetVersion]::Parse($version)
-    $builder.Description = "description" 
+    $builder.Description = "description"
 
     # add one content file
     $tempFile = [IO.Path]::GetTempFileName()
@@ -607,7 +607,7 @@ function CreateCustomTestPackage {
     {
         # add one content file
         $tempFile2 = [IO.Path]::GetTempFileName()
-        "temp2" >> $tempFile2        
+        "temp2" >> $tempFile2
         $packageFile = New-Object NuGet.Packaging.PhysicalPackageFile
         $packageFile.SourcePath = $tempFile2
         $packageFile.TargetPath = "content\$requestAdditionalContent"

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/RestoreCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/RestoreCommandTests.cs
@@ -1009,7 +1009,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
     <add key=""ExternalRepository"" value=""{externalRepositoryPath}"" />
     <add key=""ContosoRepository"" value=""{contosoRepositoryPath}"" />
     </packageSources>
-    <packageSourceMappings>
+    <packageSourceMapping>
         <packageSource key=""externalRepository"">
             <package prefix=""External.*"" />
             <package prefix=""Others.*"" />
@@ -1018,7 +1018,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
             <package prefix=""Contoso.*"" />             
             <package prefix=""Test.*"" />
         </packageSource>
-    </packageSourceMappings>
+    </packageSourceMapping>
 </configuration>");
 
                 var ContosoReal = new SimpleTestPackageContext()
@@ -1115,7 +1115,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
     <add key=""ExternalRepository"" value=""{externalRepositoryPath}"" />
     <add key=""ContosoRepository"" value=""{contosoRepositoryPath}"" />
     </packageSources>
-    <packageSourceMappings>
+    <packageSourceMapping>
         <packageSource key=""ExternalRepository"">
             <package prefix=""External.*"" />
             <package prefix=""Others.*"" />
@@ -1124,7 +1124,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
             <package prefix=""Contoso.*"" />  <!--Contoso.A package doesn't exist Contoso repository, so restore should fail-->
             <package prefix=""Test.*"" />
         </packageSource>
-    </packageSourceMappings>
+    </packageSourceMapping>
 </configuration>");
 
                 var ExternalA = new SimpleTestPackageContext()

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/RestoreCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/RestoreCommandTests.cs
@@ -1009,16 +1009,16 @@ namespace NuGet.CommandLine.FuncTest.Commands
     <add key=""ExternalRepository"" value=""{externalRepositoryPath}"" />
     <add key=""ContosoRepository"" value=""{contosoRepositoryPath}"" />
     </packageSources>
-    <packageNamespaces>
+    <packageSourceMappings>
         <packageSource key=""externalRepository"">
-            <namespace id=""External.*"" />
-            <namespace id=""Others.*"" />
+            <package prefix=""External.*"" />
+            <package prefix=""Others.*"" />
         </packageSource>
         <packageSource key=""contosoRepository"">
-            <namespace id=""Contoso.*"" />             
-            <namespace id=""Test.*"" />
+            <package prefix=""Contoso.*"" />             
+            <package prefix=""Test.*"" />
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMappings>
 </configuration>");
 
                 var ContosoReal = new SimpleTestPackageContext()
@@ -1115,16 +1115,16 @@ namespace NuGet.CommandLine.FuncTest.Commands
     <add key=""ExternalRepository"" value=""{externalRepositoryPath}"" />
     <add key=""ContosoRepository"" value=""{contosoRepositoryPath}"" />
     </packageSources>
-    <packageNamespaces>
+    <packageSourceMappings>
         <packageSource key=""ExternalRepository"">
-            <namespace id=""External.*"" />
-            <namespace id=""Others.*"" />
+            <package prefix=""External.*"" />
+            <package prefix=""Others.*"" />
         </packageSource>
         <packageSource key=""ContosoRepository"">
-            <namespace id=""Contoso.*"" />  <!--Contoso.A package doesn't exist Contoso repository, so restore should fail-->
-            <namespace id=""Test.*"" />
+            <package prefix=""Contoso.*"" />  <!--Contoso.A package doesn't exist Contoso repository, so restore should fail-->
+            <package prefix=""Test.*"" />
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMappings>
 </configuration>");
 
                 var ExternalA = new SimpleTestPackageContext()

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/RestoreCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/RestoreCommandTests.cs
@@ -1011,12 +1011,12 @@ namespace NuGet.CommandLine.FuncTest.Commands
     </packageSources>
     <packageSourceMapping>
         <packageSource key=""externalRepository"">
-            <package prefix=""External.*"" />
-            <package prefix=""Others.*"" />
+            <package pattern=""External.*"" />
+            <package pattern=""Others.*"" />
         </packageSource>
         <packageSource key=""contosoRepository"">
-            <package prefix=""Contoso.*"" />             
-            <package prefix=""Test.*"" />
+            <package pattern=""Contoso.*"" />
+            <package pattern=""Test.*"" />
         </packageSource>
     </packageSourceMapping>
 </configuration>");
@@ -1117,12 +1117,12 @@ namespace NuGet.CommandLine.FuncTest.Commands
     </packageSources>
     <packageSourceMapping>
         <packageSource key=""ExternalRepository"">
-            <package prefix=""External.*"" />
-            <package prefix=""Others.*"" />
+            <package pattern=""External.*"" />
+            <package pattern=""Others.*"" />
         </packageSource>
         <packageSource key=""ContosoRepository"">
-            <package prefix=""Contoso.*"" />  <!--Contoso.A package doesn't exist Contoso repository, so restore should fail-->
-            <package prefix=""Test.*"" />
+            <package pattern=""Contoso.*"" />  <!--Contoso.A package doesn't exist Contoso repository, so restore should fail-->
+            <package pattern=""Test.*"" />
         </packageSource>
     </packageSourceMapping>
 </configuration>");

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetInstallCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetInstallCommandTest.cs
@@ -1891,11 +1891,11 @@ namespace NuGet.CommandLine.Test
     <add key=""SharedRepository"" value=""{sharedRepositoryPath}"" />
     </packageSources>
     <packageSourceMapping>
-        <packageSource key=""PublicRepository""> 
-            <package prefix=""Contoso.Opensource"" />
+        <packageSource key=""PublicRepository"">
+            <package pattern=""Contoso.Opensource"" />
         </packageSource>
         <packageSource key=""SharedRepository"">
-            <package prefix=""Contoso.MVC.*"" />
+            <package pattern=""Contoso.MVC.*"" />
         </packageSource>
     </packageSourceMapping>
 </configuration>");
@@ -1939,11 +1939,11 @@ namespace NuGet.CommandLine.Test
     <add key=""SharedRepository"" value=""{sharedRepositoryPath}"" />
     </packageSources>
     <packageSourceMapping>
-        <packageSource key=""PublicRepository""> 
-            <package prefix=""Contoso.Opensource.*"" />
+        <packageSource key=""PublicRepository"">
+            <package pattern=""Contoso.Opensource.*"" />
         </packageSource>
         <packageSource key=""SharedRepository"">
-            <package prefix=""Contoso.MVC.*"" />
+            <package pattern=""Contoso.MVC.*"" />
         </packageSource>
     </packageSourceMapping>
 </configuration>");
@@ -1989,11 +1989,11 @@ namespace NuGet.CommandLine.Test
     <add key=""SharedRepository"" value=""{sharedRepositoryPath}"" />
     </packageSources>
     <packageSourceMapping>
-        <packageSource key=""PublicRepository""> 
-            <package prefix=""Contoso.Opensource"" />
+        <packageSource key=""PublicRepository"">
+            <package pattern=""Contoso.Opensource"" />
         </packageSource>
         <packageSource key=""SharedRepository"">
-            <package prefix=""Contoso.MVC.*"" />
+            <package pattern=""Contoso.MVC.*"" />
         </packageSource>
     </packageSourceMapping>
 </configuration>");
@@ -2041,11 +2041,11 @@ namespace NuGet.CommandLine.Test
     <add key=""SharedRepository"" value=""{sharedRepositoryPath}"" />
     </packageSources>
     <packageSourceMapping>
-        <packageSource key=""PublicRepository""> 
-            <package prefix=""Contoso.Opensource"" />
+        <packageSource key=""PublicRepository"">
+            <package pattern=""Contoso.Opensource"" />
         </packageSource>
         <packageSource key=""SharedRepository"">
-            <package prefix=""Contoso.MVC.*"" />
+            <package pattern=""Contoso.MVC.*"" />
         </packageSource>
     </packageSourceMapping>
 </configuration>");

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetInstallCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetInstallCommandTest.cs
@@ -1890,14 +1890,14 @@ namespace NuGet.CommandLine.Test
     <add key=""PublicRepository"" value=""{opensourceRepositoryPath}"" />
     <add key=""SharedRepository"" value=""{sharedRepositoryPath}"" />
     </packageSources>
-    <packageSourceMappings>
+    <packageSourceMapping>
         <packageSource key=""PublicRepository""> 
             <package prefix=""Contoso.Opensource"" />
         </packageSource>
         <packageSource key=""SharedRepository"">
             <package prefix=""Contoso.MVC.*"" />
         </packageSource>
-    </packageSourceMappings>
+    </packageSourceMapping>
 </configuration>");
 
             // Act
@@ -1938,14 +1938,14 @@ namespace NuGet.CommandLine.Test
     <add key=""PublicRepository"" value=""{opensourceRepositoryPath}"" />
     <add key=""SharedRepository"" value=""{sharedRepositoryPath}"" />
     </packageSources>
-    <packageSourceMappings>
+    <packageSourceMapping>
         <packageSource key=""PublicRepository""> 
             <package prefix=""Contoso.Opensource.*"" />
         </packageSource>
         <packageSource key=""SharedRepository"">
             <package prefix=""Contoso.MVC.*"" />
         </packageSource>
-    </packageSourceMappings>
+    </packageSourceMapping>
 </configuration>");
 
             // Act
@@ -1988,14 +1988,14 @@ namespace NuGet.CommandLine.Test
     <add key=""PublicRepository"" value=""{opensourceRepositoryPath}"" />
     <add key=""SharedRepository"" value=""{sharedRepositoryPath}"" />
     </packageSources>
-    <packageSourceMappings>
+    <packageSourceMapping>
         <packageSource key=""PublicRepository""> 
             <package prefix=""Contoso.Opensource"" />
         </packageSource>
         <packageSource key=""SharedRepository"">
             <package prefix=""Contoso.MVC.*"" />
         </packageSource>
-    </packageSourceMappings>
+    </packageSourceMapping>
 </configuration>");
 
             // Act
@@ -2040,14 +2040,14 @@ namespace NuGet.CommandLine.Test
     <add key=""PublicRepository"" value=""{opensourceRepositoryPath}"" />
     <add key=""SharedRepository"" value=""{sharedRepositoryPath}"" />
     </packageSources>
-    <packageSourceMappings>
+    <packageSourceMapping>
         <packageSource key=""PublicRepository""> 
             <package prefix=""Contoso.Opensource"" />
         </packageSource>
         <packageSource key=""SharedRepository"">
             <package prefix=""Contoso.MVC.*"" />
         </packageSource>
-    </packageSourceMappings>
+    </packageSourceMapping>
 </configuration>");
 
             // Act

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetInstallCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetInstallCommandTest.cs
@@ -1890,14 +1890,14 @@ namespace NuGet.CommandLine.Test
     <add key=""PublicRepository"" value=""{opensourceRepositoryPath}"" />
     <add key=""SharedRepository"" value=""{sharedRepositoryPath}"" />
     </packageSources>
-    <packageNamespaces>
+    <packageSourceMappings>
         <packageSource key=""PublicRepository""> 
-            <namespace id=""Contoso.Opensource"" />
+            <package prefix=""Contoso.Opensource"" />
         </packageSource>
         <packageSource key=""SharedRepository"">
-            <namespace id=""Contoso.MVC.*"" />
+            <package prefix=""Contoso.MVC.*"" />
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMappings>
 </configuration>");
 
             // Act
@@ -1938,14 +1938,14 @@ namespace NuGet.CommandLine.Test
     <add key=""PublicRepository"" value=""{opensourceRepositoryPath}"" />
     <add key=""SharedRepository"" value=""{sharedRepositoryPath}"" />
     </packageSources>
-    <packageNamespaces>
+    <packageSourceMappings>
         <packageSource key=""PublicRepository""> 
-            <namespace id=""Contoso.Opensource.*"" />
+            <package prefix=""Contoso.Opensource.*"" />
         </packageSource>
         <packageSource key=""SharedRepository"">
-            <namespace id=""Contoso.MVC.*"" />
+            <package prefix=""Contoso.MVC.*"" />
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMappings>
 </configuration>");
 
             // Act
@@ -1988,14 +1988,14 @@ namespace NuGet.CommandLine.Test
     <add key=""PublicRepository"" value=""{opensourceRepositoryPath}"" />
     <add key=""SharedRepository"" value=""{sharedRepositoryPath}"" />
     </packageSources>
-    <packageNamespaces>
+    <packageSourceMappings>
         <packageSource key=""PublicRepository""> 
-            <namespace id=""Contoso.Opensource"" />
+            <package prefix=""Contoso.Opensource"" />
         </packageSource>
         <packageSource key=""SharedRepository"">
-            <namespace id=""Contoso.MVC.*"" />
+            <package prefix=""Contoso.MVC.*"" />
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMappings>
 </configuration>");
 
             // Act
@@ -2040,14 +2040,14 @@ namespace NuGet.CommandLine.Test
     <add key=""PublicRepository"" value=""{opensourceRepositoryPath}"" />
     <add key=""SharedRepository"" value=""{sharedRepositoryPath}"" />
     </packageSources>
-    <packageNamespaces>
+    <packageSourceMappings>
         <packageSource key=""PublicRepository""> 
-            <namespace id=""Contoso.Opensource"" />
+            <package prefix=""Contoso.Opensource"" />
         </packageSource>
         <packageSource key=""SharedRepository"">
-            <namespace id=""Contoso.MVC.*"" />
+            <package prefix=""Contoso.MVC.*"" />
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMappings>
 </configuration>");
 
             // Act

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
@@ -2503,30 +2503,30 @@ EndProject";
     <add key=""SharedRepository"" value=""{sharedRepository}"" />
     <add key=""signed"" value=""{signedRepository}"" />
     </packageSources>
-    <packageNamespaces>
+    <packageSourceMappings>
         <packageSource key=""PublicRepository"">
-            <namespace id=""Moq*"" />
-            <namespace id=""Nerdbank.*"" />   
-            <namespace id=""Microsoft.Asp.*"" />
-            <namespace id=""Microsoft.AspNet.*"" />
-            <namespace id=""Microsoft.Extensions.Configuration.*"" />
-            <namespace id=""System.*"" />            
-            <namespace id=""xunit*"" />
-            <namespace id=""测试更新包"" />
+            <package prefix=""Moq*"" />
+            <package prefix=""Nerdbank.*"" />   
+            <package prefix=""Microsoft.Asp.*"" />
+            <package prefix=""Microsoft.AspNet.*"" />
+            <package prefix=""Microsoft.Extensions.Configuration.*"" />
+            <package prefix=""System.*"" />            
+            <package prefix=""xunit*"" />
+            <package prefix=""测试更新包"" />
         </packageSource>
         <packageSource key=""SharedRepository"">
-            <namespace id=""Castle.Cor*"" /> 
-            <namespace id=""Moq*"" />
-            <namespace id=""Microsoft.Extensions.*"" />
-            <namespace id=""Microsoft.Extensions.Logging"" />
-            <namespace id=""Nerd*"" />             
-            <namespace id=""Test*"" />
-            <namespace id=""xunit.extensibility.core"" />
+            <package prefix=""Castle.Cor*"" /> 
+            <package prefix=""Moq*"" />
+            <package prefix=""Microsoft.Extensions.*"" />
+            <package prefix=""Microsoft.Extensions.Logging"" />
+            <package prefix=""Nerd*"" />             
+            <package prefix=""Test*"" />
+            <package prefix=""xunit.extensibility.core"" />
         </packageSource>
         <packageSource key=""signed"">
-            <namespace id=""TestPackage.*"" />    
+            <package prefix=""TestPackage.*"" />    
         </packageSource>        
-    </packageNamespaces>
+    </packageSourceMappings>
 </configuration>");
 
                 var packagePath = Path.Combine(workingPath, "packages");
@@ -2615,16 +2615,16 @@ EndProject";
     <add key=""PublicRepository"" value=""{publicRepositoryPath}"" />
     <add key=""SharedRepository"" value=""{sharedRepository}"" />
     </packageSources>
-    <packageNamespaces>
+    <packageSourceMappings>
         <packageSource key=""PublicRepository"">
-            <namespace id=""Newton.*"" />
-            <namespace id=""Great.*"" />
-            <namespace id=""Another.*"" />   
+            <package prefix=""Newton.*"" />
+            <package prefix=""Great.*"" />
+            <package prefix=""Another.*"" />   
         </packageSource>
         <packageSource key=""SharedRepository"">
-            <namespace id=""Some.*"" /> <!--Newton.* prefix exist in other repository, not this one. -->
+            <package prefix=""Some.*"" /> <!--Newton.* prefix exist in other repository, not this one. -->
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMappings>
 </configuration>");
 
                 var packagePath = Path.Combine(workingPath, "packages");
@@ -2701,15 +2701,15 @@ EndProject";
     <add key=""PublicRepository"" value=""{opensourceRepositoryPath}"" />
     <add key=""SharedRepository"" value=""{sharedRepositoryPath}"" />
     </packageSources>
-    <packageNamespaces>
+    <packageSourceMappings>
         <packageSource key=""PublicRepository""> 
-            <namespace id=""Contoso.Opensource.*"" />
-            <namespace id=""Contoso.MVC.*"" /> 
+            <package prefix=""Contoso.Opensource.*"" />
+            <package prefix=""Contoso.MVC.*"" /> 
         </packageSource>
         <packageSource key=""SharedRepository"">
-            <namespace id=""Contoso.MVC.ASP"" />
+            <package prefix=""Contoso.MVC.ASP"" />
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMappings>
 </configuration>");
 
                 var packagePath = Path.Combine(workingPath, "packages");
@@ -2785,14 +2785,14 @@ EndProject";
     <add key=""SharedRepositoryPath1"" value=""{sharedRepositoryPath1}"" />
     <add key=""SharedRepositoryPath2"" value=""{sharedRepositoryPath2}"" />
     </packageSources>
-    <packageNamespaces>
+    <packageSourceMappings>
         <packageSource key=""SharedRepositoryPath1""> 
-            <namespace id=""Contoso.MVC.*"" /> <!--Same package namespace prefix matches both repository -->
+            <package prefix=""Contoso.MVC.*"" /> <!--Same package namespace prefix matches both repository -->
         </packageSource>
         <packageSource key=""SharedRepositoryPath2"">
-            <namespace id=""Contoso.MVC.*"" /> <!--Same package namespace prefix matches both repository -->
+            <package prefix=""Contoso.MVC.*"" /> <!--Same package namespace prefix matches both repository -->
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMappings>
 </configuration>");
 
                 var packagePath = Path.Combine(workingPath, "packages");
@@ -2867,9 +2867,9 @@ EndProject";
     <add key=""SharedRepositoryPath1"" value=""{sharedRepositoryPath1}"" />
     <add key=""SharedRepositoryPath2"" value=""{sharedRepositoryPath2}"" />
     </packageSources>
-    <packageNamespaces>
+    <packageSourceMappings>
         <!--Empty packageNamespaces -->
-    </packageNamespaces>
+    </packageSourceMappings>
 </configuration>");
 
                 var packagePath = Path.Combine(workingPath, "packages");
@@ -3012,14 +3012,14 @@ EndProject";
     <add key=""PublicRepository"" value=""{opensourceRepositoryPath}"" />
     <add key=""SharedRepository"" value=""{sharedRepositoryPath}"" />
     </packageSources>
-    <packageNamespaces>
+    <packageSourceMappings>
         <packageSource key=""PublicRepository""> 
-            <namespace id=""Contoso.Opensource.*"" />
+            <package prefix=""Contoso.Opensource.*"" />
         </packageSource>
         <packageSource key=""SharedRepository"">
-            <namespace id=""Contoso.MVC.*"" />
+            <package prefix=""Contoso.MVC.*"" />
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMappings>
 </configuration>");
 
             var packagePath = Path.Combine(workingPath, "packages");
@@ -3098,14 +3098,14 @@ EndProject";
     <add key=""PublicRepository"" value=""{opensourceRepositoryPath}"" />
     <add key=""SharedRepository"" value=""{sharedRepositoryPath}"" />
     </packageSources>
-    <packageNamespaces>
+    <packageSourceMappings>
         <packageSource key=""PublicRepository""> 
-            <namespace id=""Contoso.Opensource.*"" />
+            <package prefix=""Contoso.Opensource.*"" />
         </packageSource>
         <packageSource key=""SharedRepository"">
-            <namespace id=""Contoso.MVC.*"" />
+            <package prefix=""Contoso.MVC.*"" />
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMappings>
 </configuration>");
 
             var packagePath = Path.Combine(workingPath, "packages");
@@ -3184,11 +3184,11 @@ EndProject";
     <add key=""encyclopaedia"" value=""{sharedRepositoryPath1}"" />
     <add key=""encyclopædia"" value=""{sharedRepositoryPath2}"" />
     </packageSources>
-    <packageNamespaces>
+    <packageSourceMappings>
         <packageSource key=""encyclopædia""> 
-            <namespace id=""Contoso.MVC.*"" />
+            <package prefix=""Contoso.MVC.*"" />
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMappings>
 </configuration>");
 
                 var packagePath = Path.Combine(workingPath, "packages");

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
@@ -2503,7 +2503,7 @@ EndProject";
     <add key=""SharedRepository"" value=""{sharedRepository}"" />
     <add key=""signed"" value=""{signedRepository}"" />
     </packageSources>
-    <packageSourceMappings>
+    <packageSourceMapping>
         <packageSource key=""PublicRepository"">
             <package prefix=""Moq*"" />
             <package prefix=""Nerdbank.*"" />   
@@ -2526,7 +2526,7 @@ EndProject";
         <packageSource key=""signed"">
             <package prefix=""TestPackage.*"" />    
         </packageSource>        
-    </packageSourceMappings>
+    </packageSourceMapping>
 </configuration>");
 
                 var packagePath = Path.Combine(workingPath, "packages");
@@ -2615,7 +2615,7 @@ EndProject";
     <add key=""PublicRepository"" value=""{publicRepositoryPath}"" />
     <add key=""SharedRepository"" value=""{sharedRepository}"" />
     </packageSources>
-    <packageSourceMappings>
+    <packageSourceMapping>
         <packageSource key=""PublicRepository"">
             <package prefix=""Newton.*"" />
             <package prefix=""Great.*"" />
@@ -2624,7 +2624,7 @@ EndProject";
         <packageSource key=""SharedRepository"">
             <package prefix=""Some.*"" /> <!--Newton.* prefix exist in other repository, not this one. -->
         </packageSource>
-    </packageSourceMappings>
+    </packageSourceMapping>
 </configuration>");
 
                 var packagePath = Path.Combine(workingPath, "packages");
@@ -2701,7 +2701,7 @@ EndProject";
     <add key=""PublicRepository"" value=""{opensourceRepositoryPath}"" />
     <add key=""SharedRepository"" value=""{sharedRepositoryPath}"" />
     </packageSources>
-    <packageSourceMappings>
+    <packageSourceMapping>
         <packageSource key=""PublicRepository""> 
             <package prefix=""Contoso.Opensource.*"" />
             <package prefix=""Contoso.MVC.*"" /> 
@@ -2709,7 +2709,7 @@ EndProject";
         <packageSource key=""SharedRepository"">
             <package prefix=""Contoso.MVC.ASP"" />
         </packageSource>
-    </packageSourceMappings>
+    </packageSourceMapping>
 </configuration>");
 
                 var packagePath = Path.Combine(workingPath, "packages");
@@ -2785,14 +2785,14 @@ EndProject";
     <add key=""SharedRepositoryPath1"" value=""{sharedRepositoryPath1}"" />
     <add key=""SharedRepositoryPath2"" value=""{sharedRepositoryPath2}"" />
     </packageSources>
-    <packageSourceMappings>
+    <packageSourceMapping>
         <packageSource key=""SharedRepositoryPath1""> 
             <package prefix=""Contoso.MVC.*"" /> <!--Same package namespace prefix matches both repository -->
         </packageSource>
         <packageSource key=""SharedRepositoryPath2"">
             <package prefix=""Contoso.MVC.*"" /> <!--Same package namespace prefix matches both repository -->
         </packageSource>
-    </packageSourceMappings>
+    </packageSourceMapping>
 </configuration>");
 
                 var packagePath = Path.Combine(workingPath, "packages");
@@ -2867,9 +2867,9 @@ EndProject";
     <add key=""SharedRepositoryPath1"" value=""{sharedRepositoryPath1}"" />
     <add key=""SharedRepositoryPath2"" value=""{sharedRepositoryPath2}"" />
     </packageSources>
-    <packageSourceMappings>
+    <packageSourceMapping>
         <!--Empty packageNamespaces -->
-    </packageSourceMappings>
+    </packageSourceMapping>
 </configuration>");
 
                 var packagePath = Path.Combine(workingPath, "packages");
@@ -3012,14 +3012,14 @@ EndProject";
     <add key=""PublicRepository"" value=""{opensourceRepositoryPath}"" />
     <add key=""SharedRepository"" value=""{sharedRepositoryPath}"" />
     </packageSources>
-    <packageSourceMappings>
+    <packageSourceMapping>
         <packageSource key=""PublicRepository""> 
             <package prefix=""Contoso.Opensource.*"" />
         </packageSource>
         <packageSource key=""SharedRepository"">
             <package prefix=""Contoso.MVC.*"" />
         </packageSource>
-    </packageSourceMappings>
+    </packageSourceMapping>
 </configuration>");
 
             var packagePath = Path.Combine(workingPath, "packages");
@@ -3098,14 +3098,14 @@ EndProject";
     <add key=""PublicRepository"" value=""{opensourceRepositoryPath}"" />
     <add key=""SharedRepository"" value=""{sharedRepositoryPath}"" />
     </packageSources>
-    <packageSourceMappings>
+    <packageSourceMapping>
         <packageSource key=""PublicRepository""> 
             <package prefix=""Contoso.Opensource.*"" />
         </packageSource>
         <packageSource key=""SharedRepository"">
             <package prefix=""Contoso.MVC.*"" />
         </packageSource>
-    </packageSourceMappings>
+    </packageSourceMapping>
 </configuration>");
 
             var packagePath = Path.Combine(workingPath, "packages");
@@ -3184,11 +3184,11 @@ EndProject";
     <add key=""encyclopaedia"" value=""{sharedRepositoryPath1}"" />
     <add key=""encyclopædia"" value=""{sharedRepositoryPath2}"" />
     </packageSources>
-    <packageSourceMappings>
+    <packageSourceMapping>
         <packageSource key=""encyclopædia""> 
             <package prefix=""Contoso.MVC.*"" />
         </packageSource>
-    </packageSourceMappings>
+    </packageSourceMapping>
 </configuration>");
 
                 var packagePath = Path.Combine(workingPath, "packages");

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
@@ -2082,10 +2082,10 @@ EndProject");
             {
                 // Overriding globalPackages folder
                 Util.CreateFile(workingPath, "nuget.config",
-@"<configuration> 
-  <config> 
-    <add key=""globalPackagesFolder"" value=""globalPackages"" /> 
-  </config> 
+@"<configuration>
+  <config>
+    <add key=""globalPackagesFolder"" value=""globalPackages"" />
+  </config>
 </configuration>");
                 Util.CreateFile(workingPath, "packages.config",
 @"<packages>
@@ -2127,10 +2127,10 @@ EndProject");
             {
                 // Overriding globalPackages folder
                 Util.CreateFile(workingPath, "nuget.config",
-@"<configuration> 
-  <config> 
-    <add key=""globalPackagesFolder"" value=""globalPackages"" /> 
-  </config> 
+@"<configuration>
+  <config>
+    <add key=""globalPackagesFolder"" value=""globalPackages"" />
+  </config>
 </configuration>");
                 Util.CreateFile(workingPath, "packages.config",
 @"<packages>
@@ -2199,7 +2199,7 @@ EndProject";
                 var targetFileContents
                     = @"
 <Project xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
-<Target Name=""test"">  
+<Target Name=""test"">
     <Message Text = ""test"" />
 </Target>
 </Project>";
@@ -2374,7 +2374,7 @@ EndProject";
    <!ENTITY sayhello ""&greeting; &name;"">
 ]>
 <packages>
-    <package id=""&sayhello;"" version=""1.1.0"" targetFramework=""net45"" /> 
+    <package id=""&sayhello;"" version=""1.1.0"" targetFramework=""net45"" />
     <package id=""packageB"" version=""2.2.0"" targetFramework=""net45"" />
 </packages>");
 
@@ -2505,27 +2505,27 @@ EndProject";
     </packageSources>
     <packageSourceMapping>
         <packageSource key=""PublicRepository"">
-            <package prefix=""Moq*"" />
-            <package prefix=""Nerdbank.*"" />   
-            <package prefix=""Microsoft.Asp.*"" />
-            <package prefix=""Microsoft.AspNet.*"" />
-            <package prefix=""Microsoft.Extensions.Configuration.*"" />
-            <package prefix=""System.*"" />            
-            <package prefix=""xunit*"" />
-            <package prefix=""测试更新包"" />
+            <package pattern=""Moq*"" />
+            <package pattern=""Nerdbank.*"" />
+            <package pattern=""Microsoft.Asp.*"" />
+            <package pattern=""Microsoft.AspNet.*"" />
+            <package pattern=""Microsoft.Extensions.Configuration.*"" />
+            <package pattern=""System.*"" />
+            <package pattern=""xunit*"" />
+            <package pattern=""测试更新包"" />
         </packageSource>
         <packageSource key=""SharedRepository"">
-            <package prefix=""Castle.Cor*"" /> 
-            <package prefix=""Moq*"" />
-            <package prefix=""Microsoft.Extensions.*"" />
-            <package prefix=""Microsoft.Extensions.Logging"" />
-            <package prefix=""Nerd*"" />             
-            <package prefix=""Test*"" />
-            <package prefix=""xunit.extensibility.core"" />
+            <package pattern=""Castle.Cor*"" />
+            <package pattern=""Moq*"" />
+            <package pattern=""Microsoft.Extensions.*"" />
+            <package pattern=""Microsoft.Extensions.Logging"" />
+            <package pattern=""Nerd*"" />
+            <package pattern=""Test*"" />
+            <package pattern=""xunit.extensibility.core"" />
         </packageSource>
         <packageSource key=""signed"">
-            <package prefix=""TestPackage.*"" />    
-        </packageSource>        
+            <package pattern=""TestPackage.*"" />
+        </packageSource>
     </packageSourceMapping>
 </configuration>");
 
@@ -2617,12 +2617,12 @@ EndProject";
     </packageSources>
     <packageSourceMapping>
         <packageSource key=""PublicRepository"">
-            <package prefix=""Newton.*"" />
-            <package prefix=""Great.*"" />
-            <package prefix=""Another.*"" />   
+            <package pattern=""Newton.*"" />
+            <package pattern=""Great.*"" />
+            <package pattern=""Another.*"" />
         </packageSource>
         <packageSource key=""SharedRepository"">
-            <package prefix=""Some.*"" /> <!--Newton.* prefix exist in other repository, not this one. -->
+            <package pattern=""Some.*"" /> <!--Newton.* prefix exist in other repository, not this one. -->
         </packageSource>
     </packageSourceMapping>
 </configuration>");
@@ -2702,12 +2702,12 @@ EndProject";
     <add key=""SharedRepository"" value=""{sharedRepositoryPath}"" />
     </packageSources>
     <packageSourceMapping>
-        <packageSource key=""PublicRepository""> 
-            <package prefix=""Contoso.Opensource.*"" />
-            <package prefix=""Contoso.MVC.*"" /> 
+        <packageSource key=""PublicRepository"">
+            <package pattern=""Contoso.Opensource.*"" />
+            <package pattern=""Contoso.MVC.*"" />
         </packageSource>
         <packageSource key=""SharedRepository"">
-            <package prefix=""Contoso.MVC.ASP"" />
+            <package pattern=""Contoso.MVC.ASP"" />
         </packageSource>
     </packageSourceMapping>
 </configuration>");
@@ -2786,11 +2786,11 @@ EndProject";
     <add key=""SharedRepositoryPath2"" value=""{sharedRepositoryPath2}"" />
     </packageSources>
     <packageSourceMapping>
-        <packageSource key=""SharedRepositoryPath1""> 
-            <package prefix=""Contoso.MVC.*"" /> <!--Same package namespace prefix matches both repository -->
+        <packageSource key=""SharedRepositoryPath1"">
+            <package pattern=""Contoso.MVC.*"" /> <!--Same package namespace prefix matches both repository -->
         </packageSource>
         <packageSource key=""SharedRepositoryPath2"">
-            <package prefix=""Contoso.MVC.*"" /> <!--Same package namespace prefix matches both repository -->
+            <package pattern=""Contoso.MVC.*"" /> <!--Same package namespace prefix matches both repository -->
         </packageSource>
     </packageSourceMapping>
 </configuration>");
@@ -3013,11 +3013,11 @@ EndProject";
     <add key=""SharedRepository"" value=""{sharedRepositoryPath}"" />
     </packageSources>
     <packageSourceMapping>
-        <packageSource key=""PublicRepository""> 
-            <package prefix=""Contoso.Opensource.*"" />
+        <packageSource key=""PublicRepository"">
+            <package pattern=""Contoso.Opensource.*"" />
         </packageSource>
         <packageSource key=""SharedRepository"">
-            <package prefix=""Contoso.MVC.*"" />
+            <package pattern=""Contoso.MVC.*"" />
         </packageSource>
     </packageSourceMapping>
 </configuration>");
@@ -3099,11 +3099,11 @@ EndProject";
     <add key=""SharedRepository"" value=""{sharedRepositoryPath}"" />
     </packageSources>
     <packageSourceMapping>
-        <packageSource key=""PublicRepository""> 
-            <package prefix=""Contoso.Opensource.*"" />
+        <packageSource key=""PublicRepository"">
+            <package pattern=""Contoso.Opensource.*"" />
         </packageSource>
         <packageSource key=""SharedRepository"">
-            <package prefix=""Contoso.MVC.*"" />
+            <package pattern=""Contoso.MVC.*"" />
         </packageSource>
     </packageSourceMapping>
 </configuration>");
@@ -3185,8 +3185,8 @@ EndProject";
     <add key=""encyclopædia"" value=""{sharedRepositoryPath2}"" />
     </packageSources>
     <packageSourceMapping>
-        <packageSource key=""encyclopædia""> 
-            <package prefix=""Contoso.MVC.*"" />
+        <packageSource key=""encyclopædia"">
+            <package pattern=""Contoso.MVC.*"" />
         </packageSource>
     </packageSourceMapping>
 </configuration>");

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
@@ -10759,16 +10759,16 @@ namespace NuGet.CommandLine.Test
     <packageSources>
         <add key=""source2"" value=""{packageSource2.FullName}"" />
     </packageSources>
-        <packageNamespaces>
+        <packageSourceMappings>
             <packageSource key=""source"">
-                <namespace id=""{packageY}*"" />
-                <namespace id=""{packageZ}*"" />
+                <package prefix=""{packageY}*"" />
+                <package prefix=""{packageZ}*"" />
             </packageSource>
             <packageSource key=""source2"">
-                <namespace id=""{packageX}*"" />
-                <namespace id=""{packageK}*"" /> 
+                <package prefix=""{packageX}*"" />
+                <package prefix=""{packageK}*"" /> 
             </packageSource>
-    </packageNamespaces>
+    </packageSourceMappings>
 </configuration>
 ";
 
@@ -10834,14 +10834,14 @@ namespace NuGet.CommandLine.Test
     <packageSources>
         <add key=""source2"" value=""{packageSource2.FullName}"" />
     </packageSources>
-        <packageNamespaces>
+        <packageSourceMappings>
             <packageSource key=""source"">
-                <namespace id=""{packageY}*"" />
+                <package prefix=""{packageY}*"" />
             </packageSource>
             <packageSource key=""source2"">
-                <namespace id=""{packageX}*"" />                                                
+                <package prefix=""{packageX}*"" />                                                
             </packageSource>
-    </packageNamespaces>
+    </packageSourceMappings>
 </configuration>
 ";
 
@@ -10905,14 +10905,14 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
     <add key=""PublicRepository"" value=""{opensourceRepositoryPath}"" />
     <add key=""PrivateRepository"" value=""{privateRepositoryPath}"" />
     </packageSources>
-    <packageNamespaces>
+    <packageSourceMappings>
         <packageSource key=""PublicRepository""> 
-            <namespace id=""Contoso.Opensource.*"" />
+            <package prefix=""Contoso.Opensource.*"" />
         </packageSource>
         <packageSource key=""PrivateRepository"">
-            <namespace id=""Contoso.MVC.*"" /> <!--Contoso.MVC.ASP package exist in both repository but it'll restore from this one -->
+            <package prefix=""Contoso.MVC.*"" /> <!--Contoso.MVC.ASP package exist in both repository but it'll restore from this one -->
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMappings>
 </configuration>";
             using (var writer = new StreamWriter(configAPath))
             {
@@ -11001,14 +11001,14 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
     <add key=""PublicRepository"" value=""{opensourceRepositoryPath}"" />
     <add key=""PrivateRepository"" value=""{privateRepositoryPath}"" />
     </packageSources>
-    <packageNamespaces>
+    <packageSourceMappings>
         <packageSource key=""PublicRepository""> 
-            <namespace id=""Contoso.Opensource.*"" />
+            <package prefix=""Contoso.Opensource.*"" />
         </packageSource>
         <packageSource key=""PrivateRepository"">
-            <namespace id=""Contoso.MVC.*"" /> <!--Contoso.MVC.ASP package exist in both repository but it'll restore from this one -->
+            <package prefix=""Contoso.MVC.*"" /> <!--Contoso.MVC.ASP package exist in both repository but it'll restore from this one -->
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMappings>
 </configuration>";
             using (var writer = new StreamWriter(configAPath))
             {

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
@@ -10759,7 +10759,7 @@ namespace NuGet.CommandLine.Test
     <packageSources>
         <add key=""source2"" value=""{packageSource2.FullName}"" />
     </packageSources>
-        <packageSourceMappings>
+        <packageSourceMapping>
             <packageSource key=""source"">
                 <package prefix=""{packageY}*"" />
                 <package prefix=""{packageZ}*"" />
@@ -10768,7 +10768,7 @@ namespace NuGet.CommandLine.Test
                 <package prefix=""{packageX}*"" />
                 <package prefix=""{packageK}*"" /> 
             </packageSource>
-    </packageSourceMappings>
+    </packageSourceMapping>
 </configuration>
 ";
 
@@ -10834,14 +10834,14 @@ namespace NuGet.CommandLine.Test
     <packageSources>
         <add key=""source2"" value=""{packageSource2.FullName}"" />
     </packageSources>
-        <packageSourceMappings>
+        <packageSourceMapping>
             <packageSource key=""source"">
                 <package prefix=""{packageY}*"" />
             </packageSource>
             <packageSource key=""source2"">
                 <package prefix=""{packageX}*"" />                                                
             </packageSource>
-    </packageSourceMappings>
+    </packageSourceMapping>
 </configuration>
 ";
 
@@ -10905,14 +10905,14 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
     <add key=""PublicRepository"" value=""{opensourceRepositoryPath}"" />
     <add key=""PrivateRepository"" value=""{privateRepositoryPath}"" />
     </packageSources>
-    <packageSourceMappings>
+    <packageSourceMapping>
         <packageSource key=""PublicRepository""> 
             <package prefix=""Contoso.Opensource.*"" />
         </packageSource>
         <packageSource key=""PrivateRepository"">
             <package prefix=""Contoso.MVC.*"" /> <!--Contoso.MVC.ASP package exist in both repository but it'll restore from this one -->
         </packageSource>
-    </packageSourceMappings>
+    </packageSourceMapping>
 </configuration>";
             using (var writer = new StreamWriter(configAPath))
             {
@@ -11001,14 +11001,14 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
     <add key=""PublicRepository"" value=""{opensourceRepositoryPath}"" />
     <add key=""PrivateRepository"" value=""{privateRepositoryPath}"" />
     </packageSources>
-    <packageSourceMappings>
+    <packageSourceMapping>
         <packageSource key=""PublicRepository""> 
             <package prefix=""Contoso.Opensource.*"" />
         </packageSource>
         <packageSource key=""PrivateRepository"">
             <package prefix=""Contoso.MVC.*"" /> <!--Contoso.MVC.ASP package exist in both repository but it'll restore from this one -->
         </packageSource>
-    </packageSourceMappings>
+    </packageSourceMapping>
 </configuration>";
             using (var writer = new StreamWriter(configAPath))
             {

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
@@ -10761,12 +10761,12 @@ namespace NuGet.CommandLine.Test
     </packageSources>
         <packageSourceMapping>
             <packageSource key=""source"">
-                <package prefix=""{packageY}*"" />
-                <package prefix=""{packageZ}*"" />
+                <package pattern=""{packageY}*"" />
+                <package pattern=""{packageZ}*"" />
             </packageSource>
             <packageSource key=""source2"">
-                <package prefix=""{packageX}*"" />
-                <package prefix=""{packageK}*"" /> 
+                <package pattern=""{packageX}*"" />
+                <package pattern=""{packageK}*"" />
             </packageSource>
     </packageSourceMapping>
 </configuration>
@@ -10836,10 +10836,10 @@ namespace NuGet.CommandLine.Test
     </packageSources>
         <packageSourceMapping>
             <packageSource key=""source"">
-                <package prefix=""{packageY}*"" />
+                <package pattern=""{packageY}*"" />
             </packageSource>
             <packageSource key=""source2"">
-                <package prefix=""{packageX}*"" />                                                
+                <package pattern=""{packageX}*"" />
             </packageSource>
     </packageSourceMapping>
 </configuration>
@@ -10906,11 +10906,11 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
     <add key=""PrivateRepository"" value=""{privateRepositoryPath}"" />
     </packageSources>
     <packageSourceMapping>
-        <packageSource key=""PublicRepository""> 
-            <package prefix=""Contoso.Opensource.*"" />
+        <packageSource key=""PublicRepository"">
+            <package pattern=""Contoso.Opensource.*"" />
         </packageSource>
         <packageSource key=""PrivateRepository"">
-            <package prefix=""Contoso.MVC.*"" /> <!--Contoso.MVC.ASP package exist in both repository but it'll restore from this one -->
+            <package pattern=""Contoso.MVC.*"" /> <!--Contoso.MVC.ASP package exist in both repository but it'll restore from this one -->
         </packageSource>
     </packageSourceMapping>
 </configuration>";
@@ -11002,11 +11002,11 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
     <add key=""PrivateRepository"" value=""{privateRepositoryPath}"" />
     </packageSources>
     <packageSourceMapping>
-        <packageSource key=""PublicRepository""> 
-            <package prefix=""Contoso.Opensource.*"" />
+        <packageSource key=""PublicRepository"">
+            <package pattern=""Contoso.Opensource.*"" />
         </packageSource>
         <packageSource key=""PrivateRepository"">
-            <package prefix=""Contoso.MVC.*"" /> <!--Contoso.MVC.ASP package exist in both repository but it'll restore from this one -->
+            <package pattern=""Contoso.MVC.*"" /> <!--Contoso.MVC.ASP package exist in both repository but it'll restore from this one -->
         </packageSource>
     </packageSourceMapping>
 </configuration>";

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetAddPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetAddPackageTests.cs
@@ -269,7 +269,7 @@ namespace Dotnet.Integration.Test
     </packageSources>
         <packageSourceMapping>
             <packageSource key=""source2"">
-                <package prefix=""{packageX}*"" />
+                <package pattern=""{packageX}*"" />
             </packageSource>
     </packageSourceMapping>
 </configuration>
@@ -330,10 +330,10 @@ namespace Dotnet.Integration.Test
     </packageSources>
         <packageSourceMapping>
             <packageSource key=""source"">
-                <package prefix=""{packageZ}*"" />
+                <package pattern=""{packageZ}*"" />
             </packageSource>
             <packageSource key=""source2"">
-                <package prefix=""{packageX}*"" />
+                <package pattern=""{packageX}*"" />
             </packageSource>
     </packageSourceMapping>
 </configuration>
@@ -394,12 +394,12 @@ namespace Dotnet.Integration.Test
     </packageSources>
         <packageSourceMapping>
             <packageSource key=""source"">
-                <package prefix=""{packageZ}*"" />
-                <package prefix=""{packageX}*"" />
+                <package pattern=""{packageZ}*"" />
+                <package pattern=""{packageX}*"" />
             </packageSource>
             <packageSource key=""source2"">
-                <package prefix=""{packageZ}*"" />
-                <package prefix=""{packageX}*"" />
+                <package pattern=""{packageZ}*"" />
+                <package pattern=""{packageX}*"" />
             </packageSource>
     </packageSourceMapping>
 </configuration>
@@ -460,11 +460,11 @@ namespace Dotnet.Integration.Test
     </packageSources>
         <packageSourceMapping>
             <packageSource key=""source"">
-                <package prefix=""{packageZ}*"" />
-                <package prefix=""{packageX}*"" />
+                <package pattern=""{packageZ}*"" />
+                <package pattern=""{packageX}*"" />
             </packageSource>
             <packageSource key=""source2"">
-                <package prefix=""{packageX}*"" />
+                <package pattern=""{packageX}*"" />
             </packageSource>
     </packageSourceMapping>
 </configuration>
@@ -522,11 +522,11 @@ namespace Dotnet.Integration.Test
     </packageSources>
         <packageSourceMapping>
             <packageSource key=""source"">
-                <package prefix=""*"" />
+                <package pattern=""*"" />
             </packageSource>
             <packageSource key=""source2"">
-                <package prefix=""{packageZ}*"" />
-                <package prefix=""{packageX}*"" />
+                <package pattern=""{packageZ}*"" />
+                <package pattern=""{packageX}*"" />
             </packageSource>
     </packageSourceMapping>
 </configuration>
@@ -591,7 +591,7 @@ namespace Dotnet.Integration.Test
     </packageSources>
         <packageSourceMapping>
             <packageSource key=""source2"">
-                <package prefix=""{packageX}*"" />
+                <package pattern=""{packageX}*"" />
             </packageSource>
     </packageSourceMapping>
 </configuration>

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetAddPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetAddPackageTests.cs
@@ -267,11 +267,11 @@ namespace Dotnet.Integration.Test
     <packageSources>
         <add key=""source2"" value=""{packageSource2.FullName}"" />
     </packageSources>
-        <packageNamespaces>
+        <packageSourceMappings>
             <packageSource key=""source2"">
-                <namespace id=""{packageX}*"" />
+                <package prefix=""{packageX}*"" />
             </packageSource>
-    </packageNamespaces>
+    </packageSourceMappings>
 </configuration>
 ";
             var projectADirectory = Path.Combine(pathContext.SolutionRoot, projectA.ProjectName);
@@ -328,14 +328,14 @@ namespace Dotnet.Integration.Test
     <packageSources>
         <add key=""source2"" value=""{packageSource2.FullName}"" />
     </packageSources>
-        <packageNamespaces>
+        <packageSourceMappings>
             <packageSource key=""source"">
-                <namespace id=""{packageZ}*"" />
+                <package prefix=""{packageZ}*"" />
             </packageSource>
             <packageSource key=""source2"">
-                <namespace id=""{packageX}*"" />
+                <package prefix=""{packageX}*"" />
             </packageSource>
-    </packageNamespaces>
+    </packageSourceMappings>
 </configuration>
 ";
             var projectADirectory = Path.Combine(pathContext.SolutionRoot, projectA.ProjectName);
@@ -392,16 +392,16 @@ namespace Dotnet.Integration.Test
     <packageSources>
         <add key=""source2"" value=""{packageSource2.FullName}"" />
     </packageSources>
-        <packageNamespaces>
+        <packageSourceMappings>
             <packageSource key=""source"">
-                <namespace id=""{packageZ}*"" />
-                <namespace id=""{packageX}*"" />
+                <package prefix=""{packageZ}*"" />
+                <package prefix=""{packageX}*"" />
             </packageSource>
             <packageSource key=""source2"">
-                <namespace id=""{packageZ}*"" />
-                <namespace id=""{packageX}*"" />
+                <package prefix=""{packageZ}*"" />
+                <package prefix=""{packageX}*"" />
             </packageSource>
-    </packageNamespaces>
+    </packageSourceMappings>
 </configuration>
 ";
             var projectADirectory = Path.Combine(pathContext.SolutionRoot, projectA.ProjectName);
@@ -458,15 +458,15 @@ namespace Dotnet.Integration.Test
     <packageSources>
         <add key=""source2"" value=""{packageSource2.FullName}"" />
     </packageSources>
-        <packageNamespaces>
+        <packageSourceMappings>
             <packageSource key=""source"">
-                <namespace id=""{packageZ}*"" />
-                <namespace id=""{packageX}*"" />
+                <package prefix=""{packageZ}*"" />
+                <package prefix=""{packageX}*"" />
             </packageSource>
             <packageSource key=""source2"">
-                <namespace id=""{packageX}*"" />
+                <package prefix=""{packageX}*"" />
             </packageSource>
-    </packageNamespaces>
+    </packageSourceMappings>
 </configuration>
 ";
             var projectADirectory = Path.Combine(pathContext.SolutionRoot, projectA.ProjectName);
@@ -520,15 +520,15 @@ namespace Dotnet.Integration.Test
     <packageSources>
         <add key=""source2"" value=""{packageSource2.FullName}"" />
     </packageSources>
-        <packageNamespaces>
+        <packageSourceMappings>
             <packageSource key=""source"">
-                <namespace id=""*"" />
+                <package prefix=""*"" />
             </packageSource>
             <packageSource key=""source2"">
-                <namespace id=""{packageZ}*"" />
-                <namespace id=""{packageX}*"" />
+                <package prefix=""{packageZ}*"" />
+                <package prefix=""{packageX}*"" />
             </packageSource>
-    </packageNamespaces>
+    </packageSourceMappings>
 </configuration>
 ";
 
@@ -589,11 +589,11 @@ namespace Dotnet.Integration.Test
     <packageSources>
         <add key=""source2"" value=""{packageSource2.FullName}"" />
     </packageSources>
-        <packageNamespaces>
+        <packageSourceMappings>
             <packageSource key=""source2"">
-                <namespace id=""{packageX}*"" />
+                <package prefix=""{packageX}*"" />
             </packageSource>
-    </packageNamespaces>
+    </packageSourceMappings>
 </configuration>
 ";
             // Add RestoreSources

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetAddPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetAddPackageTests.cs
@@ -267,11 +267,11 @@ namespace Dotnet.Integration.Test
     <packageSources>
         <add key=""source2"" value=""{packageSource2.FullName}"" />
     </packageSources>
-        <packageSourceMappings>
+        <packageSourceMapping>
             <packageSource key=""source2"">
                 <package prefix=""{packageX}*"" />
             </packageSource>
-    </packageSourceMappings>
+    </packageSourceMapping>
 </configuration>
 ";
             var projectADirectory = Path.Combine(pathContext.SolutionRoot, projectA.ProjectName);
@@ -328,14 +328,14 @@ namespace Dotnet.Integration.Test
     <packageSources>
         <add key=""source2"" value=""{packageSource2.FullName}"" />
     </packageSources>
-        <packageSourceMappings>
+        <packageSourceMapping>
             <packageSource key=""source"">
                 <package prefix=""{packageZ}*"" />
             </packageSource>
             <packageSource key=""source2"">
                 <package prefix=""{packageX}*"" />
             </packageSource>
-    </packageSourceMappings>
+    </packageSourceMapping>
 </configuration>
 ";
             var projectADirectory = Path.Combine(pathContext.SolutionRoot, projectA.ProjectName);
@@ -392,7 +392,7 @@ namespace Dotnet.Integration.Test
     <packageSources>
         <add key=""source2"" value=""{packageSource2.FullName}"" />
     </packageSources>
-        <packageSourceMappings>
+        <packageSourceMapping>
             <packageSource key=""source"">
                 <package prefix=""{packageZ}*"" />
                 <package prefix=""{packageX}*"" />
@@ -401,7 +401,7 @@ namespace Dotnet.Integration.Test
                 <package prefix=""{packageZ}*"" />
                 <package prefix=""{packageX}*"" />
             </packageSource>
-    </packageSourceMappings>
+    </packageSourceMapping>
 </configuration>
 ";
             var projectADirectory = Path.Combine(pathContext.SolutionRoot, projectA.ProjectName);
@@ -458,7 +458,7 @@ namespace Dotnet.Integration.Test
     <packageSources>
         <add key=""source2"" value=""{packageSource2.FullName}"" />
     </packageSources>
-        <packageSourceMappings>
+        <packageSourceMapping>
             <packageSource key=""source"">
                 <package prefix=""{packageZ}*"" />
                 <package prefix=""{packageX}*"" />
@@ -466,7 +466,7 @@ namespace Dotnet.Integration.Test
             <packageSource key=""source2"">
                 <package prefix=""{packageX}*"" />
             </packageSource>
-    </packageSourceMappings>
+    </packageSourceMapping>
 </configuration>
 ";
             var projectADirectory = Path.Combine(pathContext.SolutionRoot, projectA.ProjectName);
@@ -520,7 +520,7 @@ namespace Dotnet.Integration.Test
     <packageSources>
         <add key=""source2"" value=""{packageSource2.FullName}"" />
     </packageSources>
-        <packageSourceMappings>
+        <packageSourceMapping>
             <packageSource key=""source"">
                 <package prefix=""*"" />
             </packageSource>
@@ -528,7 +528,7 @@ namespace Dotnet.Integration.Test
                 <package prefix=""{packageZ}*"" />
                 <package prefix=""{packageX}*"" />
             </packageSource>
-    </packageSourceMappings>
+    </packageSourceMapping>
 </configuration>
 ";
 
@@ -589,11 +589,11 @@ namespace Dotnet.Integration.Test
     <packageSources>
         <add key=""source2"" value=""{packageSource2.FullName}"" />
     </packageSources>
-        <packageSourceMappings>
+        <packageSourceMapping>
             <packageSource key=""source2"">
                 <package prefix=""{packageX}*"" />
             </packageSource>
-    </packageSourceMappings>
+    </packageSourceMapping>
 </configuration>
 ";
             // Add RestoreSources

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
@@ -1675,16 +1675,16 @@ EndGlobal";
     <packageSources>
         <add key=""source2"" value=""{packageSource2.FullName}"" />
     </packageSources>
-        <packageNamespaces>
+        <packageSourceMappings>
             <packageSource key=""source"">
-                <namespace id=""{packageY}*"" />
-                <namespace id=""{packageZ}*"" />
+                <package prefix=""{packageY}*"" />
+                <package prefix=""{packageZ}*"" />
             </packageSource>
             <packageSource key=""source2"">
-                <namespace id=""{packageX}*"" />
-                <namespace id=""{packageK}*"" /> 
+                <package prefix=""{packageX}*"" />
+                <package prefix=""{packageK}*"" /> 
             </packageSource>
-    </packageNamespaces>
+    </packageSourceMappings>
 </configuration>
 ";
             File.WriteAllText(Path.Combine(pathContext.SolutionRoot, projectA.ProjectName, "NuGet.Config"), configFile);
@@ -1754,14 +1754,14 @@ EndGlobal";
     <packageSources>
         <add key=""source2"" value=""{packageSource2.FullName}"" />
     </packageSources>
-        <packageNamespaces>
+        <packageSourceMappings>
             <packageSource key=""source"">
-                <namespace id=""{packageY}*"" />
+                <package prefix=""{packageY}*"" />
             </packageSource>
             <packageSource key=""source2"">
-                <namespace id=""{packageX}*"" />
+                <package prefix=""{packageX}*"" />
             </packageSource>
-    </packageNamespaces>
+    </packageSourceMappings>
 </configuration>
 ";
             File.WriteAllText(Path.Combine(pathContext.SolutionRoot, projectA.ProjectName, "NuGet.Config"), configFile);
@@ -1832,16 +1832,16 @@ EndGlobal";
         <add key=""source1"" value=""{pathContext.PackageSource}"" />
         <add key=""source2"" value=""{packageSource2.FullName}"" />
     </packageSources>
-        <packageNamespaces>
+        <packageSourceMappings>
             <packageSource key=""source1"">
-                <namespace id=""{packageY}*"" />
-                <namespace id=""{packageZ}*"" />
+                <package prefix=""{packageY}*"" />
+                <package prefix=""{packageZ}*"" />
             </packageSource>
             <packageSource key=""source2"">
-                <namespace id=""{packageX}*"" />
-                <namespace id=""{packageK}*"" /> 
+                <package prefix=""{packageX}*"" />
+                <package prefix=""{packageK}*"" /> 
             </packageSource>
-    </packageNamespaces>
+    </packageSourceMappings>
 </configuration>
 ";
             File.WriteAllText(Path.Combine(pathContext.SolutionRoot, projectA.ProjectName, "NuGet.Config"), configFile);
@@ -1908,14 +1908,14 @@ EndGlobal";
         <add key=""source1"" value=""{pathContext.PackageSource}"" />
         <add key=""source2"" value=""{packageSource2.FullName}"" />
     </packageSources>
-        <packageNamespaces>
+        <packageSourceMappings>
             <packageSource key=""source1"">
-                <namespace id=""{packageY}*"" />
+                <package prefix=""{packageY}*"" />
             </packageSource>
             <packageSource key=""source2"">
-                <namespace id=""{packageX}*"" />
+                <package prefix=""{packageX}*"" />
             </packageSource>
-    </packageNamespaces>
+    </packageSourceMappings>
 </configuration>
 ";
             File.WriteAllText(Path.Combine(pathContext.SolutionRoot, projectA.ProjectName, "NuGet.Config"), configFile);

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
@@ -187,7 +187,7 @@ EndGlobal";
 
                 File.WriteAllText(Path.Combine(workingDirectory, "NuGet.Config"), doc.ToString());
 
-                // Act                
+                // Act
                 var result = _msbuildFixture.RunDotnet(workingDirectory, "restore", ignoreExitCode: true);
 
                 result.AllOutput.Should().Contain($"error NU3004: Package '{packageX.Id} {packageX.Version}' from source '{pathContext.PackageSource}': signatureValidationMode is set to require, so packages are allowed only if signed by trusted signers; however, this package is unsigned.");
@@ -259,7 +259,7 @@ EndGlobal";
 
                 File.WriteAllText(Path.Combine(workingDirectory, "NuGet.Config"), doc.ToString());
 
-                // Act                
+                // Act
                 CommandRunnerResult result = _msbuildFixture.RunDotnet(workingDirectory, "restore", ignoreExitCode: true);
 
                 result.AllOutput.Should().NotContain($"error NU3004");
@@ -334,7 +334,7 @@ EndGlobal";
 
                 File.WriteAllText(Path.Combine(workingDirectory, "NuGet.Config"), doc.ToString());
 
-                // Act                
+                // Act
                 CommandRunnerResult result = _msbuildFixture.RunDotnet(
                     workingDirectory, "restore",
                     ignoreExitCode: true,
@@ -415,7 +415,7 @@ EndGlobal";
 
                 File.WriteAllText(Path.Combine(workingDirectory, "NuGet.Config"), doc.ToString());
 
-                // Act                
+                // Act
                 CommandRunnerResult result = _msbuildFixture.RunDotnet(
                     workingDirectory, "restore",
                     ignoreExitCode: true,
@@ -497,7 +497,7 @@ EndGlobal";
 
                 File.WriteAllText(Path.Combine(workingDirectory, "NuGet.Config"), doc.ToString());
 
-                // Act                
+                // Act
                 CommandRunnerResult result = _msbuildFixture.RunDotnet(
                     workingDirectory, "restore",
                     ignoreExitCode: true,
@@ -1141,7 +1141,7 @@ EndGlobal";
                 // The test depends on the presence of these packages and their versions.
                 // Change to Directory.Packages.props when new cli that supports NuGet.props will be downloaded
                 var directoryPackagesPropsName = Path.Combine(workingDirectory, $"Directory.Build.props");
-                var directoryPackagesPropsContent = @"<Project>                    
+                var directoryPackagesPropsContent = @"<Project>
                         <PropertyGroup>
                             <CentralPackageVersionsFileImported>true</CentralPackageVersionsFileImported>
                         </PropertyGroup>
@@ -1677,12 +1677,12 @@ EndGlobal";
     </packageSources>
         <packageSourceMapping>
             <packageSource key=""source"">
-                <package prefix=""{packageY}*"" />
-                <package prefix=""{packageZ}*"" />
+                <package pattern=""{packageY}*"" />
+                <package pattern=""{packageZ}*"" />
             </packageSource>
             <packageSource key=""source2"">
-                <package prefix=""{packageX}*"" />
-                <package prefix=""{packageK}*"" /> 
+                <package pattern=""{packageX}*"" />
+                <package pattern=""{packageK}*"" />
             </packageSource>
     </packageSourceMapping>
 </configuration>
@@ -1756,10 +1756,10 @@ EndGlobal";
     </packageSources>
         <packageSourceMapping>
             <packageSource key=""source"">
-                <package prefix=""{packageY}*"" />
+                <package pattern=""{packageY}*"" />
             </packageSource>
             <packageSource key=""source2"">
-                <package prefix=""{packageX}*"" />
+                <package pattern=""{packageX}*"" />
             </packageSource>
     </packageSourceMapping>
 </configuration>
@@ -1834,12 +1834,12 @@ EndGlobal";
     </packageSources>
         <packageSourceMapping>
             <packageSource key=""source1"">
-                <package prefix=""{packageY}*"" />
-                <package prefix=""{packageZ}*"" />
+                <package pattern=""{packageY}*"" />
+                <package pattern=""{packageZ}*"" />
             </packageSource>
             <packageSource key=""source2"">
-                <package prefix=""{packageX}*"" />
-                <package prefix=""{packageK}*"" /> 
+                <package pattern=""{packageX}*"" />
+                <package pattern=""{packageK}*"" />
             </packageSource>
     </packageSourceMapping>
 </configuration>
@@ -1910,10 +1910,10 @@ EndGlobal";
     </packageSources>
         <packageSourceMapping>
             <packageSource key=""source1"">
-                <package prefix=""{packageY}*"" />
+                <package pattern=""{packageY}*"" />
             </packageSource>
             <packageSource key=""source2"">
-                <package prefix=""{packageX}*"" />
+                <package pattern=""{packageX}*"" />
             </packageSource>
     </packageSourceMapping>
 </configuration>

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
@@ -1675,7 +1675,7 @@ EndGlobal";
     <packageSources>
         <add key=""source2"" value=""{packageSource2.FullName}"" />
     </packageSources>
-        <packageSourceMappings>
+        <packageSourceMapping>
             <packageSource key=""source"">
                 <package prefix=""{packageY}*"" />
                 <package prefix=""{packageZ}*"" />
@@ -1684,7 +1684,7 @@ EndGlobal";
                 <package prefix=""{packageX}*"" />
                 <package prefix=""{packageK}*"" /> 
             </packageSource>
-    </packageSourceMappings>
+    </packageSourceMapping>
 </configuration>
 ";
             File.WriteAllText(Path.Combine(pathContext.SolutionRoot, projectA.ProjectName, "NuGet.Config"), configFile);
@@ -1754,14 +1754,14 @@ EndGlobal";
     <packageSources>
         <add key=""source2"" value=""{packageSource2.FullName}"" />
     </packageSources>
-        <packageSourceMappings>
+        <packageSourceMapping>
             <packageSource key=""source"">
                 <package prefix=""{packageY}*"" />
             </packageSource>
             <packageSource key=""source2"">
                 <package prefix=""{packageX}*"" />
             </packageSource>
-    </packageSourceMappings>
+    </packageSourceMapping>
 </configuration>
 ";
             File.WriteAllText(Path.Combine(pathContext.SolutionRoot, projectA.ProjectName, "NuGet.Config"), configFile);
@@ -1832,7 +1832,7 @@ EndGlobal";
         <add key=""source1"" value=""{pathContext.PackageSource}"" />
         <add key=""source2"" value=""{packageSource2.FullName}"" />
     </packageSources>
-        <packageSourceMappings>
+        <packageSourceMapping>
             <packageSource key=""source1"">
                 <package prefix=""{packageY}*"" />
                 <package prefix=""{packageZ}*"" />
@@ -1841,7 +1841,7 @@ EndGlobal";
                 <package prefix=""{packageX}*"" />
                 <package prefix=""{packageK}*"" /> 
             </packageSource>
-    </packageSourceMappings>
+    </packageSourceMapping>
 </configuration>
 ";
             File.WriteAllText(Path.Combine(pathContext.SolutionRoot, projectA.ProjectName, "NuGet.Config"), configFile);
@@ -1908,14 +1908,14 @@ EndGlobal";
         <add key=""source1"" value=""{pathContext.PackageSource}"" />
         <add key=""source2"" value=""{packageSource2.FullName}"" />
     </packageSources>
-        <packageSourceMappings>
+        <packageSourceMapping>
             <packageSource key=""source1"">
                 <package prefix=""{packageY}*"" />
             </packageSource>
             <packageSource key=""source2"">
                 <package prefix=""{packageX}*"" />
             </packageSource>
-    </packageSourceMappings>
+    </packageSourceMapping>
 </configuration>
 ";
             File.WriteAllText(Path.Combine(pathContext.SolutionRoot, projectA.ProjectName, "NuGet.Config"), configFile);

--- a/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildRestoreTaskTests.cs
+++ b/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildRestoreTaskTests.cs
@@ -1056,14 +1056,14 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
     <add key=""PublicRepository"" value=""{opensourceRepositoryPath}"" />
     <add key=""SharedRepository"" value=""{sharedRepositoryPath}"" />
     </packageSources>
-    <packageSourceMappings>
+    <packageSourceMapping>
         <packageSource key=""PublicRepository""> 
             <package prefix=""Contoso.Opensource.*"" />
         </packageSource>
         <packageSource key=""SharedRepository"">
             <package prefix=""Contoso.MVC.*"" /> <!--Contoso.MVC.ASP package exist in both repository but it'll restore from this one -->
         </packageSource>
-    </packageSourceMappings>
+    </packageSourceMapping>
 </configuration>";
                 using (var writer = new StreamWriter(configPath))
                 {
@@ -1156,14 +1156,14 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
 <add key=""PublicRepository"" value=""{opensourceRepositoryPath}"" />
 <add key=""SharedRepository"" value=""{sharedRepositoryPath}"" />
 </packageSources>
-<packageSourceMappings>
+<packageSourceMapping>
     <packageSource key=""PublicRepository""> 
         <package prefix=""Contoso.Opensource.*"" />
     </packageSource>
     <packageSource key=""SharedRepository"">
         <package prefix=""Contoso.MVC.*"" /> <!--Contoso.MVC.ASP package doesn't exist in this repostiry, so it'll fail to restore -->
     </packageSource>
-</packageSourceMappings>
+</packageSourceMapping>
 </configuration>";
                 using (var writer = new StreamWriter(configPath))
                 {
@@ -1266,14 +1266,14 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
     <add key=""PublicRepository"" value=""{opensourceRepositoryPath}"" />
     <add key=""SharedRepository"" value=""{sharedRepositoryPath}"" />
     </packageSources>
-    <packageSourceMappings>
+    <packageSourceMapping>
         <packageSource key=""PublicRepository""> 
             <package prefix=""Contoso.O*"" />
         </packageSource>
         <packageSource key=""SharedRepository"">
             <package prefix=""Contoso.M*"" /> 
         </packageSource>
-    </packageSourceMappings>
+    </packageSourceMapping>
 </configuration>";
                 using (var writer = new StreamWriter(configPath))
                 {
@@ -1366,14 +1366,14 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
 <add key=""PublicRepository"" value=""{opensourceRepositoryPath}"" />
 <add key=""SharedRepository"" value=""{sharedRepositoryPath}"" />
 </packageSources>
-<packageSourceMappings>
+<packageSourceMapping>
     <packageSource key=""PublicRepository""> 
         <package prefix=""Contoso.O*"" />
     </packageSource>
     <packageSource key=""SharedRepository"">
         <package prefix=""Contoso.M*"" />  <!--Contoso.MVC.ASP package doesn't exist in this repostiry, so it'll fail to restore -->
     </packageSource>
-</packageSourceMappings>
+</packageSourceMapping>
 </configuration>";
                 using (var writer = new StreamWriter(configPath))
                 {
@@ -1476,7 +1476,7 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
     <add key=""PublicRepository"" value=""{opensourceRepositoryPath}"" />
     <add key=""SharedRepository"" value=""{sharedRepositoryPath}"" />
     </packageSources>
-    <packageSourceMappings>
+    <packageSourceMapping>
         <packageSource key=""PublicRepository""> 
             <package prefix=""Contoso.Opensource.*"" />
             <package prefix=""Contoso.MVC.*"" /> 
@@ -1484,7 +1484,7 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
         <packageSource key=""SharedRepository"">
             <package prefix=""Contoso.MVC.ASP"" />   <!-- Longer prefix prevails over Contoso.MVC.* -->
         </packageSource>
-    </packageSourceMappings>
+    </packageSourceMapping>
 </configuration>";
 
                 using (var writer = new StreamWriter(configPath))
@@ -1576,11 +1576,11 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
     <clear />
     <add key=""PublicRepository"" value=""{opensourceRepositoryPath}"" />
     </packageSources>
-    <packageSourceMappings>
+    <packageSourceMapping>
         <packageSource key=""PublicRepository"">
             <package prefix=""Contoso.MVC.ASP"" />   <!-- My.MVC.ASP doesn't match any package name spaces -->
         </packageSource>
-    </packageSourceMappings>
+    </packageSourceMapping>
 </configuration>";
 
                 using (var writer = new StreamWriter(configPath))
@@ -1669,14 +1669,14 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
     <add key=""SharedRepository1"" value=""{sharedRepositoryPath1}"" />
     <add key=""SharedRepository2"" value=""{sharedRepositoryPath2}"" />
     </packageSources>
-    <packageSourceMappings>
+    <packageSourceMapping>
         <packageSource key=""SharedRepository1"">
             <package prefix=""Contoso.MVC.*"" /> <!--Same package namespace prefix matches both repository -->
         </packageSource>
         <packageSource key=""SharedRepository2"">
             <package prefix=""Contoso.MVC.*"" /> <!--Same package namespace prefix matches both repository -->
         </packageSource>
-    </packageSourceMappings>
+    </packageSourceMapping>
 </configuration>";
                 using (var writer = new StreamWriter(configPath))
                 {
@@ -1818,14 +1818,14 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
     <add key=""PublicRepository"" value=""{opensourceRepositoryPath}"" />
     <add key=""PrivateRepository"" value=""{privateRepositoryPath}"" />
     </packageSources>
-    <packageSourceMappings>
+    <packageSourceMapping>
         <packageSource key=""PublicRepository""> 
             <package prefix=""Contoso.Opensource.*"" />
         </packageSource>
         <packageSource key=""PrivateRepository"">
             <package prefix=""Contoso.MVC.*"" /> <!--Contoso.MVC.ASP package exist in both repository but it'll restore from this one -->
         </packageSource>
-    </packageSourceMappings>
+    </packageSourceMapping>
 </configuration>";
             using (var writer = new StreamWriter(configAPath))
             {
@@ -1904,14 +1904,14 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
     <add key=""PublicRepository"" value=""{opensourceRepositoryPath}"" />
     <add key=""PrivateRepository"" value=""{privateRepositoryPath}"" />
     </packageSources>
-    <packageSourceMappings>
+    <packageSourceMapping>
         <packageSource key=""PublicRepository""> 
             <package prefix=""Contoso.Opensource.*"" />
         </packageSource>
         <packageSource key=""PrivateRepository"">
             <package prefix=""Contoso.MVC.*"" /> <!--Contoso.MVC.ASP package exist in both repository but it'll restore from this one -->
         </packageSource>
-    </packageSourceMappings>
+    </packageSourceMapping>
 </configuration>";
             using (var writer = new StreamWriter(configAPath))
             {

--- a/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildRestoreTaskTests.cs
+++ b/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildRestoreTaskTests.cs
@@ -1057,11 +1057,11 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
     <add key=""SharedRepository"" value=""{sharedRepositoryPath}"" />
     </packageSources>
     <packageSourceMapping>
-        <packageSource key=""PublicRepository""> 
-            <package prefix=""Contoso.Opensource.*"" />
+        <packageSource key=""PublicRepository"">
+            <package pattern=""Contoso.Opensource.*"" />
         </packageSource>
         <packageSource key=""SharedRepository"">
-            <package prefix=""Contoso.MVC.*"" /> <!--Contoso.MVC.ASP package exist in both repository but it'll restore from this one -->
+            <package pattern=""Contoso.MVC.*"" /> <!--Contoso.MVC.ASP package exist in both repository but it'll restore from this one -->
         </packageSource>
     </packageSourceMapping>
 </configuration>";
@@ -1157,11 +1157,11 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
 <add key=""SharedRepository"" value=""{sharedRepositoryPath}"" />
 </packageSources>
 <packageSourceMapping>
-    <packageSource key=""PublicRepository""> 
-        <package prefix=""Contoso.Opensource.*"" />
+    <packageSource key=""PublicRepository"">
+        <package pattern=""Contoso.Opensource.*"" />
     </packageSource>
     <packageSource key=""SharedRepository"">
-        <package prefix=""Contoso.MVC.*"" /> <!--Contoso.MVC.ASP package doesn't exist in this repostiry, so it'll fail to restore -->
+        <package pattern=""Contoso.MVC.*"" /> <!--Contoso.MVC.ASP package doesn't exist in this repostiry, so it'll fail to restore -->
     </packageSource>
 </packageSourceMapping>
 </configuration>";
@@ -1267,11 +1267,11 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
     <add key=""SharedRepository"" value=""{sharedRepositoryPath}"" />
     </packageSources>
     <packageSourceMapping>
-        <packageSource key=""PublicRepository""> 
-            <package prefix=""Contoso.O*"" />
+        <packageSource key=""PublicRepository"">
+            <package pattern=""Contoso.O*"" />
         </packageSource>
         <packageSource key=""SharedRepository"">
-            <package prefix=""Contoso.M*"" /> 
+            <package pattern=""Contoso.M*"" />
         </packageSource>
     </packageSourceMapping>
 </configuration>";
@@ -1367,11 +1367,11 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
 <add key=""SharedRepository"" value=""{sharedRepositoryPath}"" />
 </packageSources>
 <packageSourceMapping>
-    <packageSource key=""PublicRepository""> 
-        <package prefix=""Contoso.O*"" />
+    <packageSource key=""PublicRepository"">
+        <package pattern=""Contoso.O*"" />
     </packageSource>
     <packageSource key=""SharedRepository"">
-        <package prefix=""Contoso.M*"" />  <!--Contoso.MVC.ASP package doesn't exist in this repostiry, so it'll fail to restore -->
+        <package pattern=""Contoso.M*"" />  <!--Contoso.MVC.ASP package doesn't exist in this repostiry, so it'll fail to restore -->
     </packageSource>
 </packageSourceMapping>
 </configuration>";
@@ -1477,12 +1477,12 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
     <add key=""SharedRepository"" value=""{sharedRepositoryPath}"" />
     </packageSources>
     <packageSourceMapping>
-        <packageSource key=""PublicRepository""> 
-            <package prefix=""Contoso.Opensource.*"" />
-            <package prefix=""Contoso.MVC.*"" /> 
+        <packageSource key=""PublicRepository"">
+            <package pattern=""Contoso.Opensource.*"" />
+            <package pattern=""Contoso.MVC.*"" />
         </packageSource>
         <packageSource key=""SharedRepository"">
-            <package prefix=""Contoso.MVC.ASP"" />   <!-- Longer prefix prevails over Contoso.MVC.* -->
+            <package pattern=""Contoso.MVC.ASP"" />   <!-- Longer prefix prevails over Contoso.MVC.* -->
         </packageSource>
     </packageSourceMapping>
 </configuration>";
@@ -1578,7 +1578,7 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
     </packageSources>
     <packageSourceMapping>
         <packageSource key=""PublicRepository"">
-            <package prefix=""Contoso.MVC.ASP"" />   <!-- My.MVC.ASP doesn't match any package name spaces -->
+            <package pattern=""Contoso.MVC.ASP"" />   <!-- My.MVC.ASP doesn't match any package name spaces -->
         </packageSource>
     </packageSourceMapping>
 </configuration>";
@@ -1671,10 +1671,10 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
     </packageSources>
     <packageSourceMapping>
         <packageSource key=""SharedRepository1"">
-            <package prefix=""Contoso.MVC.*"" /> <!--Same package namespace prefix matches both repository -->
+            <package pattern=""Contoso.MVC.*"" /> <!--Same package namespace prefix matches both repository -->
         </packageSource>
         <packageSource key=""SharedRepository2"">
-            <package prefix=""Contoso.MVC.*"" /> <!--Same package namespace prefix matches both repository -->
+            <package pattern=""Contoso.MVC.*"" /> <!--Same package namespace prefix matches both repository -->
         </packageSource>
     </packageSourceMapping>
 </configuration>";
@@ -1819,11 +1819,11 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
     <add key=""PrivateRepository"" value=""{privateRepositoryPath}"" />
     </packageSources>
     <packageSourceMapping>
-        <packageSource key=""PublicRepository""> 
-            <package prefix=""Contoso.Opensource.*"" />
+        <packageSource key=""PublicRepository"">
+            <package pattern=""Contoso.Opensource.*"" />
         </packageSource>
         <packageSource key=""PrivateRepository"">
-            <package prefix=""Contoso.MVC.*"" /> <!--Contoso.MVC.ASP package exist in both repository but it'll restore from this one -->
+            <package pattern=""Contoso.MVC.*"" /> <!--Contoso.MVC.ASP package exist in both repository but it'll restore from this one -->
         </packageSource>
     </packageSourceMapping>
 </configuration>";
@@ -1905,11 +1905,11 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
     <add key=""PrivateRepository"" value=""{privateRepositoryPath}"" />
     </packageSources>
     <packageSourceMapping>
-        <packageSource key=""PublicRepository""> 
-            <package prefix=""Contoso.Opensource.*"" />
+        <packageSource key=""PublicRepository"">
+            <package pattern=""Contoso.Opensource.*"" />
         </packageSource>
         <packageSource key=""PrivateRepository"">
-            <package prefix=""Contoso.MVC.*"" /> <!--Contoso.MVC.ASP package exist in both repository but it'll restore from this one -->
+            <package pattern=""Contoso.MVC.*"" /> <!--Contoso.MVC.ASP package exist in both repository but it'll restore from this one -->
         </packageSource>
     </packageSourceMapping>
 </configuration>";

--- a/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildRestoreTaskTests.cs
+++ b/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildRestoreTaskTests.cs
@@ -1056,14 +1056,14 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
     <add key=""PublicRepository"" value=""{opensourceRepositoryPath}"" />
     <add key=""SharedRepository"" value=""{sharedRepositoryPath}"" />
     </packageSources>
-    <packageNamespaces>
+    <packageSourceMappings>
         <packageSource key=""PublicRepository""> 
-            <namespace id=""Contoso.Opensource.*"" />
+            <package prefix=""Contoso.Opensource.*"" />
         </packageSource>
         <packageSource key=""SharedRepository"">
-            <namespace id=""Contoso.MVC.*"" /> <!--Contoso.MVC.ASP package exist in both repository but it'll restore from this one -->
+            <package prefix=""Contoso.MVC.*"" /> <!--Contoso.MVC.ASP package exist in both repository but it'll restore from this one -->
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMappings>
 </configuration>";
                 using (var writer = new StreamWriter(configPath))
                 {
@@ -1156,14 +1156,14 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
 <add key=""PublicRepository"" value=""{opensourceRepositoryPath}"" />
 <add key=""SharedRepository"" value=""{sharedRepositoryPath}"" />
 </packageSources>
-<packageNamespaces>
+<packageSourceMappings>
     <packageSource key=""PublicRepository""> 
-        <namespace id=""Contoso.Opensource.*"" />
+        <package prefix=""Contoso.Opensource.*"" />
     </packageSource>
     <packageSource key=""SharedRepository"">
-        <namespace id=""Contoso.MVC.*"" /> <!--Contoso.MVC.ASP package doesn't exist in this repostiry, so it'll fail to restore -->
+        <package prefix=""Contoso.MVC.*"" /> <!--Contoso.MVC.ASP package doesn't exist in this repostiry, so it'll fail to restore -->
     </packageSource>
-</packageNamespaces>
+</packageSourceMappings>
 </configuration>";
                 using (var writer = new StreamWriter(configPath))
                 {
@@ -1266,14 +1266,14 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
     <add key=""PublicRepository"" value=""{opensourceRepositoryPath}"" />
     <add key=""SharedRepository"" value=""{sharedRepositoryPath}"" />
     </packageSources>
-    <packageNamespaces>
+    <packageSourceMappings>
         <packageSource key=""PublicRepository""> 
-            <namespace id=""Contoso.O*"" />
+            <package prefix=""Contoso.O*"" />
         </packageSource>
         <packageSource key=""SharedRepository"">
-            <namespace id=""Contoso.M*"" /> 
+            <package prefix=""Contoso.M*"" /> 
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMappings>
 </configuration>";
                 using (var writer = new StreamWriter(configPath))
                 {
@@ -1366,14 +1366,14 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
 <add key=""PublicRepository"" value=""{opensourceRepositoryPath}"" />
 <add key=""SharedRepository"" value=""{sharedRepositoryPath}"" />
 </packageSources>
-<packageNamespaces>
+<packageSourceMappings>
     <packageSource key=""PublicRepository""> 
-        <namespace id=""Contoso.O*"" />
+        <package prefix=""Contoso.O*"" />
     </packageSource>
     <packageSource key=""SharedRepository"">
-        <namespace id=""Contoso.M*"" />  <!--Contoso.MVC.ASP package doesn't exist in this repostiry, so it'll fail to restore -->
+        <package prefix=""Contoso.M*"" />  <!--Contoso.MVC.ASP package doesn't exist in this repostiry, so it'll fail to restore -->
     </packageSource>
-</packageNamespaces>
+</packageSourceMappings>
 </configuration>";
                 using (var writer = new StreamWriter(configPath))
                 {
@@ -1476,15 +1476,15 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
     <add key=""PublicRepository"" value=""{opensourceRepositoryPath}"" />
     <add key=""SharedRepository"" value=""{sharedRepositoryPath}"" />
     </packageSources>
-    <packageNamespaces>
+    <packageSourceMappings>
         <packageSource key=""PublicRepository""> 
-            <namespace id=""Contoso.Opensource.*"" />
-            <namespace id=""Contoso.MVC.*"" /> 
+            <package prefix=""Contoso.Opensource.*"" />
+            <package prefix=""Contoso.MVC.*"" /> 
         </packageSource>
         <packageSource key=""SharedRepository"">
-            <namespace id=""Contoso.MVC.ASP"" />   <!-- Longer prefix prevails over Contoso.MVC.* -->
+            <package prefix=""Contoso.MVC.ASP"" />   <!-- Longer prefix prevails over Contoso.MVC.* -->
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMappings>
 </configuration>";
 
                 using (var writer = new StreamWriter(configPath))
@@ -1576,11 +1576,11 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
     <clear />
     <add key=""PublicRepository"" value=""{opensourceRepositoryPath}"" />
     </packageSources>
-    <packageNamespaces>
+    <packageSourceMappings>
         <packageSource key=""PublicRepository"">
-            <namespace id=""Contoso.MVC.ASP"" />   <!-- My.MVC.ASP doesn't match any package name spaces -->
+            <package prefix=""Contoso.MVC.ASP"" />   <!-- My.MVC.ASP doesn't match any package name spaces -->
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMappings>
 </configuration>";
 
                 using (var writer = new StreamWriter(configPath))
@@ -1669,14 +1669,14 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
     <add key=""SharedRepository1"" value=""{sharedRepositoryPath1}"" />
     <add key=""SharedRepository2"" value=""{sharedRepositoryPath2}"" />
     </packageSources>
-    <packageNamespaces>
+    <packageSourceMappings>
         <packageSource key=""SharedRepository1"">
-            <namespace id=""Contoso.MVC.*"" /> <!--Same package namespace prefix matches both repository -->
+            <package prefix=""Contoso.MVC.*"" /> <!--Same package namespace prefix matches both repository -->
         </packageSource>
         <packageSource key=""SharedRepository2"">
-            <namespace id=""Contoso.MVC.*"" /> <!--Same package namespace prefix matches both repository -->
+            <package prefix=""Contoso.MVC.*"" /> <!--Same package namespace prefix matches both repository -->
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMappings>
 </configuration>";
                 using (var writer = new StreamWriter(configPath))
                 {
@@ -1818,14 +1818,14 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
     <add key=""PublicRepository"" value=""{opensourceRepositoryPath}"" />
     <add key=""PrivateRepository"" value=""{privateRepositoryPath}"" />
     </packageSources>
-    <packageNamespaces>
+    <packageSourceMappings>
         <packageSource key=""PublicRepository""> 
-            <namespace id=""Contoso.Opensource.*"" />
+            <package prefix=""Contoso.Opensource.*"" />
         </packageSource>
         <packageSource key=""PrivateRepository"">
-            <namespace id=""Contoso.MVC.*"" /> <!--Contoso.MVC.ASP package exist in both repository but it'll restore from this one -->
+            <package prefix=""Contoso.MVC.*"" /> <!--Contoso.MVC.ASP package exist in both repository but it'll restore from this one -->
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMappings>
 </configuration>";
             using (var writer = new StreamWriter(configAPath))
             {
@@ -1904,14 +1904,14 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
     <add key=""PublicRepository"" value=""{opensourceRepositoryPath}"" />
     <add key=""PrivateRepository"" value=""{privateRepositoryPath}"" />
     </packageSources>
-    <packageNamespaces>
+    <packageSourceMappings>
         <packageSource key=""PublicRepository""> 
-            <namespace id=""Contoso.Opensource.*"" />
+            <package prefix=""Contoso.Opensource.*"" />
         </packageSource>
         <packageSource key=""PrivateRepository"">
-            <namespace id=""Contoso.MVC.*"" /> <!--Contoso.MVC.ASP package exist in both repository but it'll restore from this one -->
+            <package prefix=""Contoso.MVC.*"" /> <!--Contoso.MVC.ASP package exist in both repository but it'll restore from this one -->
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMappings>
 </configuration>";
             using (var writer = new StreamWriter(configAPath))
             {

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageNamespacesConfigurationTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageNamespacesConfigurationTests.cs
@@ -23,7 +23,7 @@ namespace NuGet.Configuration.Test
     <packageSourceMapping>
         <clear />
         <packageSource key=""nuget.org"">
-            <package prefix=""stuff"" />
+            <package pattern=""stuff"" />
         </packageSource>
     </packageSourceMapping>
 </configuration>");
@@ -48,10 +48,10 @@ namespace NuGet.Configuration.Test
 <configuration>
     <packageSourceMapping>
         <packageSource key=""nuget.org"">
-            <package prefix=""stuff"" />
+            <package pattern=""stuff"" />
         </packageSource>
         <packageSource key=""contoso"">
-            <package prefix=""moreStuff"" />
+            <package pattern=""moreStuff"" />
         </packageSource>
     </packageSourceMapping>
 </configuration>");

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageNamespacesConfigurationTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageNamespacesConfigurationTests.cs
@@ -20,12 +20,12 @@ namespace NuGet.Configuration.Test
             var configPath1 = Path.Combine(mockBaseDirectory, "NuGet.Config");
             SettingsTestUtils.CreateConfigurationFile(configPath1, @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
-    <packageSourceMappings>
+    <packageSourceMapping>
         <clear />
         <packageSource key=""nuget.org"">
             <package prefix=""stuff"" />
         </packageSource>
-    </packageSourceMappings>
+    </packageSourceMapping>
 </configuration>");
             var settings = Settings.LoadSettingsGivenConfigPaths(new string[] { configPath1 });
 
@@ -46,14 +46,14 @@ namespace NuGet.Configuration.Test
             var configPath1 = Path.Combine(mockBaseDirectory, "NuGet.Config");
             SettingsTestUtils.CreateConfigurationFile(configPath1, @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
-    <packageSourceMappings>
+    <packageSourceMapping>
         <packageSource key=""nuget.org"">
             <package prefix=""stuff"" />
         </packageSource>
         <packageSource key=""contoso"">
             <package prefix=""moreStuff"" />
         </packageSource>
-    </packageSourceMappings>
+    </packageSourceMapping>
 </configuration>");
             var settings = Settings.LoadSettingsGivenConfigPaths(new string[] { configPath1 });
 

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageNamespacesConfigurationTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageNamespacesConfigurationTests.cs
@@ -20,12 +20,12 @@ namespace NuGet.Configuration.Test
             var configPath1 = Path.Combine(mockBaseDirectory, "NuGet.Config");
             SettingsTestUtils.CreateConfigurationFile(configPath1, @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
-    <packageNamespaces>
+    <packageSourceMappings>
         <clear />
         <packageSource key=""nuget.org"">
-            <namespace id=""stuff"" />
+            <package prefix=""stuff"" />
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMappings>
 </configuration>");
             var settings = Settings.LoadSettingsGivenConfigPaths(new string[] { configPath1 });
 
@@ -46,14 +46,14 @@ namespace NuGet.Configuration.Test
             var configPath1 = Path.Combine(mockBaseDirectory, "NuGet.Config");
             SettingsTestUtils.CreateConfigurationFile(configPath1, @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
-    <packageNamespaces>
+    <packageSourceMappings>
         <packageSource key=""nuget.org"">
-            <namespace id=""stuff"" />
+            <package prefix=""stuff"" />
         </packageSource>
         <packageSource key=""contoso"">
-            <namespace id=""moreStuff"" />
+            <package prefix=""moreStuff"" />
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMappings>
 </configuration>");
             var settings = Settings.LoadSettingsGivenConfigPaths(new string[] { configPath1 });
 

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageNamespacesProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageNamespacesProviderTests.cs
@@ -27,11 +27,11 @@ namespace NuGet.Configuration.Test
             var configPath1 = Path.Combine(mockBaseDirectory, "NuGet.Config");
             SettingsTestUtils.CreateConfigurationFile(configPath1, @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
-    <packageSourceMappings>
+    <packageSourceMapping>
         <packageSource key=""nuget.org"">
             <package prefix=""stuff"" />
         </packageSource>
-    </packageSourceMappings>
+    </packageSourceMapping>
 </configuration>");
 
             var settings = Settings.LoadSettingsGivenConfigPaths(new string[] { configPath1 });
@@ -54,20 +54,20 @@ namespace NuGet.Configuration.Test
             var configPath1 = Path.Combine(mockBaseDirectory, "NuGet.Config");
             SettingsTestUtils.CreateConfigurationFile(configPath1, @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
-    <packageSourceMappings>
+    <packageSourceMapping>
         <packageSource key=""nuget.org"">
             <package prefix=""stuff"" />
         </packageSource>
-    </packageSourceMappings>
+    </packageSourceMapping>
 </configuration>");
             var configPath2 = Path.Combine(mockBaseDirectory, "NuGet.Config.2");
             SettingsTestUtils.CreateConfigurationFile(configPath2, @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
-    <packageSourceMappings>
+    <packageSourceMapping>
         <packageSource key=""nuget.org"">
             <package prefix=""stuff2"" />
         </packageSource>
-    </packageSourceMappings>
+    </packageSourceMapping>
 </configuration>");
             var settings = Settings.LoadSettingsGivenConfigPaths(new string[] { configPath1, configPath2 });
 
@@ -89,20 +89,20 @@ namespace NuGet.Configuration.Test
             var configPath1 = Path.Combine(mockBaseDirectory, "NuGet.Config");
             SettingsTestUtils.CreateConfigurationFile(configPath1, @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
-    <packageSourceMappings>
+    <packageSourceMapping>
         <packageSource key=""nuget.org"">
             <package prefix=""stuff"" />
         </packageSource>
-    </packageSourceMappings>
+    </packageSourceMapping>
 </configuration>");
             var configPath2 = Path.Combine(mockBaseDirectory, "NuGet.Config.2");
             SettingsTestUtils.CreateConfigurationFile(configPath2, @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
-    <packageSourceMappings>
+    <packageSourceMapping>
         <packageSource key=""contoso"">
             <package prefix=""stuff2"" />
         </packageSource>
-    </packageSourceMappings>
+    </packageSourceMapping>
 </configuration>");
             var settings = Settings.LoadSettingsGivenConfigPaths(new string[] { configPath1, configPath2 });
 
@@ -130,21 +130,21 @@ namespace NuGet.Configuration.Test
             var configPath1 = Path.Combine(mockBaseDirectory, "NuGet.Config");
             SettingsTestUtils.CreateConfigurationFile(configPath1, @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
-    <packageSourceMappings>
+    <packageSourceMapping>
         <clear />
         <packageSource key=""nuget.org"">
             <package prefix=""stuff"" />
         </packageSource>
-    </packageSourceMappings>
+    </packageSourceMapping>
 </configuration>");
             var configPath2 = Path.Combine(mockBaseDirectory, "NuGet.Config.2");
             SettingsTestUtils.CreateConfigurationFile(configPath2, @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
-    <packageSourceMappings>
+    <packageSourceMapping>
         <packageSource key=""contoso"">
             <package prefix=""stuff2"" />
         </packageSource>
-    </packageSourceMappings>
+    </packageSourceMapping>
 </configuration>");
             var settings = Settings.LoadSettingsGivenConfigPaths(new string[] { configPath1, configPath2 });
 
@@ -167,14 +167,14 @@ namespace NuGet.Configuration.Test
             var configPath1 = Path.Combine(mockBaseDirectory, "NuGet.Config");
             SettingsTestUtils.CreateConfigurationFile(configPath1, @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
-    <packageSourceMappings>
+    <packageSourceMapping>
         <packageSource key=""nuget.org"">
             <package prefix=""stuff"" />
         </packageSource>
         <packageSource key=""contoso"">
             <package prefix=""stuff2"" />
         </packageSource>
-    </packageSourceMappings>
+    </packageSourceMapping>
 </configuration>");
             var settings = Settings.LoadSettingsGivenConfigPaths(new string[] { configPath1 });
 
@@ -187,11 +187,11 @@ namespace NuGet.Configuration.Test
             namespaceProvider.Remove(new PackageNamespacesSourceItem[] { contosoNamespace });
             var result = @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
-    <packageSourceMappings>
+    <packageSourceMapping>
         <packageSource key=""nuget.org"">
             <package prefix=""stuff"" />
         </packageSource>
-    </packageSourceMappings>
+    </packageSourceMapping>
 </configuration>";
 
             result.Replace("\r\n", "\n")
@@ -207,14 +207,14 @@ namespace NuGet.Configuration.Test
             var configPath1 = Path.Combine(mockBaseDirectory, "NuGet.Config");
             var configContent = @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
-    <packageSourceMappings>
+    <packageSourceMapping>
         <packageSource key=""nuget.org"">
             <package prefix=""stuff"" />
         </packageSource>
         <packageSource key=""contoso"">
             <package prefix=""stuff2"" />
         </packageSource>
-    </packageSourceMappings>
+    </packageSourceMapping>
 </configuration>";
             SettingsTestUtils.CreateConfigurationFile(configPath1, configContent);
             var settings = Settings.LoadSettingsGivenConfigPaths(new string[] { configPath1 });
@@ -239,20 +239,20 @@ namespace NuGet.Configuration.Test
             var configPath1 = Path.Combine(mockBaseDirectory, "NuGet.Config");
             SettingsTestUtils.CreateConfigurationFile(configPath1, @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
-    <packageSourceMappings>
+    <packageSourceMapping>
         <packageSource key=""nuget.org"">
             <package prefix=""stuff"" />
         </packageSource>
-    </packageSourceMappings>
+    </packageSourceMapping>
 </configuration>");
             var configPath2 = Path.Combine(mockBaseDirectory, "NuGet.Config.2");
             SettingsTestUtils.CreateConfigurationFile(configPath2, @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
-    <packageSourceMappings>
+    <packageSourceMapping>
         <packageSource key=""contoso"">
             <package prefix=""stuff2"" />
         </packageSource>
-    </packageSourceMappings>
+    </packageSourceMapping>
 </configuration>");
             var settings = Settings.LoadSettingsGivenConfigPaths(new string[] { configPath1, configPath2 });
 
@@ -277,20 +277,20 @@ namespace NuGet.Configuration.Test
             var configPath1 = Path.Combine(mockBaseDirectory, "NuGet.Config");
             SettingsTestUtils.CreateConfigurationFile(configPath1, @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
-    <packageSourceMappings>
+    <packageSourceMapping>
         <packageSource key=""nuget.org"">
             <package prefix=""stuff"" />
         </packageSource>
-    </packageSourceMappings>
+    </packageSourceMapping>
 </configuration>");
             var configPath2 = Path.Combine(mockBaseDirectory, "NuGet.Config.2");
             SettingsTestUtils.CreateConfigurationFile(configPath2, @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
-    <packageSourceMappings>
+    <packageSourceMapping>
         <packageSource key=""contoso"">
             <package prefix=""stuff2"" />
         </packageSource>
-    </packageSourceMappings>
+    </packageSourceMapping>
 </configuration>");
             var settings = Settings.LoadSettingsGivenConfigPaths(new string[] { configPath1, configPath2 });
 
@@ -302,12 +302,12 @@ namespace NuGet.Configuration.Test
             namespaceProvider.AddOrUpdatePackageSourceNamespace(namespaceToUpdate);
             var result = @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
-    <packageSourceMappings>
+    <packageSourceMapping>
         <packageSource key=""nuget.org"">
             <package prefix=""stuff"" />
             <package prefix=""added"" />
         </packageSource>
-    </packageSourceMappings>
+    </packageSourceMapping>
 </configuration>";
 
             result.Replace("\r\n", "\n")
@@ -323,20 +323,20 @@ namespace NuGet.Configuration.Test
             var configPath1 = Path.Combine(mockBaseDirectory, "NuGet.Config");
             SettingsTestUtils.CreateConfigurationFile(configPath1, @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
-    <packageSourceMappings>
+    <packageSourceMapping>
         <packageSource key=""nuget.org"">
             <package prefix=""stuff"" />
         </packageSource>
-    </packageSourceMappings>
+    </packageSourceMapping>
 </configuration>");
             var configPath2 = Path.Combine(mockBaseDirectory, "NuGet.Config.2");
             SettingsTestUtils.CreateConfigurationFile(configPath2, @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
-    <packageSourceMappings>
+    <packageSourceMapping>
         <packageSource key=""contoso"">
             <package prefix=""stuff2"" />
         </packageSource>
-    </packageSourceMappings>
+    </packageSourceMapping>
 </configuration>");
             var settings = Settings.LoadSettingsGivenConfigPaths(new string[] { configPath1, configPath2 });
 
@@ -347,14 +347,14 @@ namespace NuGet.Configuration.Test
 
             var result = @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
-    <packageSourceMappings>
+    <packageSourceMapping>
         <packageSource key=""contoso"">
             <package prefix=""stuff2"" />
         </packageSource>
         <packageSource key=""localSource"">
             <package prefix=""added"" />
         </packageSource>
-    </packageSourceMappings>
+    </packageSourceMapping>
 </configuration>";
 
             result.Replace("\r\n", "\n")
@@ -370,21 +370,21 @@ namespace NuGet.Configuration.Test
             var configPath1 = Path.Combine(mockBaseDirectory, "NuGet.Config");
             SettingsTestUtils.CreateConfigurationFile(configPath1, @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
-    <packageSourceMappings>
+    <packageSourceMapping>
         <clear />
         <packageSource key=""nuget.org"">
             <package prefix=""stuff"" />
         </packageSource>
-    </packageSourceMappings>
+    </packageSourceMapping>
 </configuration>");
             var configPath2 = Path.Combine(mockBaseDirectory, "NuGet.Config.2");
             SettingsTestUtils.CreateConfigurationFile(configPath2, @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
-    <packageSourceMappings>
+    <packageSourceMapping>
         <packageSource key=""contoso"">
             <package prefix=""stuff2"" />
         </packageSource>
-    </packageSourceMappings>
+    </packageSourceMapping>
 </configuration>");
             var settings = Settings.LoadSettingsGivenConfigPaths(new string[] { configPath1, configPath2 });
 
@@ -395,7 +395,7 @@ namespace NuGet.Configuration.Test
 
             var result = @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
-    <packageSourceMappings>
+    <packageSourceMapping>
         <clear />
         <packageSource key=""nuget.org"">
             <package prefix=""stuff"" />
@@ -403,7 +403,7 @@ namespace NuGet.Configuration.Test
         <packageSource key=""localSource"">
             <package prefix=""added"" />
         </packageSource>
-    </packageSourceMappings>
+    </packageSourceMapping>
 </configuration>";
 
             result.Replace("\r\n", "\n")

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageNamespacesProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageNamespacesProviderTests.cs
@@ -27,11 +27,11 @@ namespace NuGet.Configuration.Test
             var configPath1 = Path.Combine(mockBaseDirectory, "NuGet.Config");
             SettingsTestUtils.CreateConfigurationFile(configPath1, @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
-    <packageNamespaces>
+    <packageSourceMappings>
         <packageSource key=""nuget.org"">
-            <namespace id=""stuff"" />
+            <package prefix=""stuff"" />
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMappings>
 </configuration>");
 
             var settings = Settings.LoadSettingsGivenConfigPaths(new string[] { configPath1 });
@@ -54,20 +54,20 @@ namespace NuGet.Configuration.Test
             var configPath1 = Path.Combine(mockBaseDirectory, "NuGet.Config");
             SettingsTestUtils.CreateConfigurationFile(configPath1, @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
-    <packageNamespaces>
+    <packageSourceMappings>
         <packageSource key=""nuget.org"">
-            <namespace id=""stuff"" />
+            <package prefix=""stuff"" />
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMappings>
 </configuration>");
             var configPath2 = Path.Combine(mockBaseDirectory, "NuGet.Config.2");
             SettingsTestUtils.CreateConfigurationFile(configPath2, @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
-    <packageNamespaces>
+    <packageSourceMappings>
         <packageSource key=""nuget.org"">
-            <namespace id=""stuff2"" />
+            <package prefix=""stuff2"" />
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMappings>
 </configuration>");
             var settings = Settings.LoadSettingsGivenConfigPaths(new string[] { configPath1, configPath2 });
 
@@ -89,20 +89,20 @@ namespace NuGet.Configuration.Test
             var configPath1 = Path.Combine(mockBaseDirectory, "NuGet.Config");
             SettingsTestUtils.CreateConfigurationFile(configPath1, @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
-    <packageNamespaces>
+    <packageSourceMappings>
         <packageSource key=""nuget.org"">
-            <namespace id=""stuff"" />
+            <package prefix=""stuff"" />
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMappings>
 </configuration>");
             var configPath2 = Path.Combine(mockBaseDirectory, "NuGet.Config.2");
             SettingsTestUtils.CreateConfigurationFile(configPath2, @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
-    <packageNamespaces>
+    <packageSourceMappings>
         <packageSource key=""contoso"">
-            <namespace id=""stuff2"" />
+            <package prefix=""stuff2"" />
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMappings>
 </configuration>");
             var settings = Settings.LoadSettingsGivenConfigPaths(new string[] { configPath1, configPath2 });
 
@@ -130,21 +130,21 @@ namespace NuGet.Configuration.Test
             var configPath1 = Path.Combine(mockBaseDirectory, "NuGet.Config");
             SettingsTestUtils.CreateConfigurationFile(configPath1, @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
-    <packageNamespaces>
+    <packageSourceMappings>
         <clear />
         <packageSource key=""nuget.org"">
-            <namespace id=""stuff"" />
+            <package prefix=""stuff"" />
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMappings>
 </configuration>");
             var configPath2 = Path.Combine(mockBaseDirectory, "NuGet.Config.2");
             SettingsTestUtils.CreateConfigurationFile(configPath2, @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
-    <packageNamespaces>
+    <packageSourceMappings>
         <packageSource key=""contoso"">
-            <namespace id=""stuff2"" />
+            <package prefix=""stuff2"" />
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMappings>
 </configuration>");
             var settings = Settings.LoadSettingsGivenConfigPaths(new string[] { configPath1, configPath2 });
 
@@ -167,14 +167,14 @@ namespace NuGet.Configuration.Test
             var configPath1 = Path.Combine(mockBaseDirectory, "NuGet.Config");
             SettingsTestUtils.CreateConfigurationFile(configPath1, @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
-    <packageNamespaces>
+    <packageSourceMappings>
         <packageSource key=""nuget.org"">
-            <namespace id=""stuff"" />
+            <package prefix=""stuff"" />
         </packageSource>
         <packageSource key=""contoso"">
-            <namespace id=""stuff2"" />
+            <package prefix=""stuff2"" />
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMappings>
 </configuration>");
             var settings = Settings.LoadSettingsGivenConfigPaths(new string[] { configPath1 });
 
@@ -187,11 +187,11 @@ namespace NuGet.Configuration.Test
             namespaceProvider.Remove(new PackageNamespacesSourceItem[] { contosoNamespace });
             var result = @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
-    <packageNamespaces>
+    <packageSourceMappings>
         <packageSource key=""nuget.org"">
-            <namespace id=""stuff"" />
+            <package prefix=""stuff"" />
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMappings>
 </configuration>";
 
             result.Replace("\r\n", "\n")
@@ -207,14 +207,14 @@ namespace NuGet.Configuration.Test
             var configPath1 = Path.Combine(mockBaseDirectory, "NuGet.Config");
             var configContent = @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
-    <packageNamespaces>
+    <packageSourceMappings>
         <packageSource key=""nuget.org"">
-            <namespace id=""stuff"" />
+            <package prefix=""stuff"" />
         </packageSource>
         <packageSource key=""contoso"">
-            <namespace id=""stuff2"" />
+            <package prefix=""stuff2"" />
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMappings>
 </configuration>";
             SettingsTestUtils.CreateConfigurationFile(configPath1, configContent);
             var settings = Settings.LoadSettingsGivenConfigPaths(new string[] { configPath1 });
@@ -239,20 +239,20 @@ namespace NuGet.Configuration.Test
             var configPath1 = Path.Combine(mockBaseDirectory, "NuGet.Config");
             SettingsTestUtils.CreateConfigurationFile(configPath1, @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
-    <packageNamespaces>
+    <packageSourceMappings>
         <packageSource key=""nuget.org"">
-            <namespace id=""stuff"" />
+            <package prefix=""stuff"" />
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMappings>
 </configuration>");
             var configPath2 = Path.Combine(mockBaseDirectory, "NuGet.Config.2");
             SettingsTestUtils.CreateConfigurationFile(configPath2, @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
-    <packageNamespaces>
+    <packageSourceMappings>
         <packageSource key=""contoso"">
-            <namespace id=""stuff2"" />
+            <package prefix=""stuff2"" />
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMappings>
 </configuration>");
             var settings = Settings.LoadSettingsGivenConfigPaths(new string[] { configPath1, configPath2 });
 
@@ -277,20 +277,20 @@ namespace NuGet.Configuration.Test
             var configPath1 = Path.Combine(mockBaseDirectory, "NuGet.Config");
             SettingsTestUtils.CreateConfigurationFile(configPath1, @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
-    <packageNamespaces>
+    <packageSourceMappings>
         <packageSource key=""nuget.org"">
-            <namespace id=""stuff"" />
+            <package prefix=""stuff"" />
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMappings>
 </configuration>");
             var configPath2 = Path.Combine(mockBaseDirectory, "NuGet.Config.2");
             SettingsTestUtils.CreateConfigurationFile(configPath2, @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
-    <packageNamespaces>
+    <packageSourceMappings>
         <packageSource key=""contoso"">
-            <namespace id=""stuff2"" />
+            <package prefix=""stuff2"" />
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMappings>
 </configuration>");
             var settings = Settings.LoadSettingsGivenConfigPaths(new string[] { configPath1, configPath2 });
 
@@ -302,12 +302,12 @@ namespace NuGet.Configuration.Test
             namespaceProvider.AddOrUpdatePackageSourceNamespace(namespaceToUpdate);
             var result = @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
-    <packageNamespaces>
+    <packageSourceMappings>
         <packageSource key=""nuget.org"">
-            <namespace id=""stuff"" />
-            <namespace id=""added"" />
+            <package prefix=""stuff"" />
+            <package prefix=""added"" />
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMappings>
 </configuration>";
 
             result.Replace("\r\n", "\n")
@@ -323,20 +323,20 @@ namespace NuGet.Configuration.Test
             var configPath1 = Path.Combine(mockBaseDirectory, "NuGet.Config");
             SettingsTestUtils.CreateConfigurationFile(configPath1, @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
-    <packageNamespaces>
+    <packageSourceMappings>
         <packageSource key=""nuget.org"">
-            <namespace id=""stuff"" />
+            <package prefix=""stuff"" />
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMappings>
 </configuration>");
             var configPath2 = Path.Combine(mockBaseDirectory, "NuGet.Config.2");
             SettingsTestUtils.CreateConfigurationFile(configPath2, @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
-    <packageNamespaces>
+    <packageSourceMappings>
         <packageSource key=""contoso"">
-            <namespace id=""stuff2"" />
+            <package prefix=""stuff2"" />
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMappings>
 </configuration>");
             var settings = Settings.LoadSettingsGivenConfigPaths(new string[] { configPath1, configPath2 });
 
@@ -347,14 +347,14 @@ namespace NuGet.Configuration.Test
 
             var result = @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
-    <packageNamespaces>
+    <packageSourceMappings>
         <packageSource key=""contoso"">
-            <namespace id=""stuff2"" />
+            <package prefix=""stuff2"" />
         </packageSource>
         <packageSource key=""localSource"">
-            <namespace id=""added"" />
+            <package prefix=""added"" />
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMappings>
 </configuration>";
 
             result.Replace("\r\n", "\n")
@@ -370,21 +370,21 @@ namespace NuGet.Configuration.Test
             var configPath1 = Path.Combine(mockBaseDirectory, "NuGet.Config");
             SettingsTestUtils.CreateConfigurationFile(configPath1, @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
-    <packageNamespaces>
+    <packageSourceMappings>
         <clear />
         <packageSource key=""nuget.org"">
-            <namespace id=""stuff"" />
+            <package prefix=""stuff"" />
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMappings>
 </configuration>");
             var configPath2 = Path.Combine(mockBaseDirectory, "NuGet.Config.2");
             SettingsTestUtils.CreateConfigurationFile(configPath2, @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
-    <packageNamespaces>
+    <packageSourceMappings>
         <packageSource key=""contoso"">
-            <namespace id=""stuff2"" />
+            <package prefix=""stuff2"" />
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMappings>
 </configuration>");
             var settings = Settings.LoadSettingsGivenConfigPaths(new string[] { configPath1, configPath2 });
 
@@ -395,15 +395,15 @@ namespace NuGet.Configuration.Test
 
             var result = @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
-    <packageNamespaces>
+    <packageSourceMappings>
         <clear />
         <packageSource key=""nuget.org"">
-            <namespace id=""stuff"" />
+            <package prefix=""stuff"" />
         </packageSource>
         <packageSource key=""localSource"">
-            <namespace id=""added"" />
+            <package prefix=""added"" />
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMappings>
 </configuration>";
 
             result.Replace("\r\n", "\n")

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageNamespacesProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageNamespacesProviderTests.cs
@@ -29,7 +29,7 @@ namespace NuGet.Configuration.Test
 <configuration>
     <packageSourceMapping>
         <packageSource key=""nuget.org"">
-            <package prefix=""stuff"" />
+            <package pattern=""stuff"" />
         </packageSource>
     </packageSourceMapping>
 </configuration>");
@@ -56,7 +56,7 @@ namespace NuGet.Configuration.Test
 <configuration>
     <packageSourceMapping>
         <packageSource key=""nuget.org"">
-            <package prefix=""stuff"" />
+            <package pattern=""stuff"" />
         </packageSource>
     </packageSourceMapping>
 </configuration>");
@@ -65,7 +65,7 @@ namespace NuGet.Configuration.Test
 <configuration>
     <packageSourceMapping>
         <packageSource key=""nuget.org"">
-            <package prefix=""stuff2"" />
+            <package pattern=""stuff2"" />
         </packageSource>
     </packageSourceMapping>
 </configuration>");
@@ -91,7 +91,7 @@ namespace NuGet.Configuration.Test
 <configuration>
     <packageSourceMapping>
         <packageSource key=""nuget.org"">
-            <package prefix=""stuff"" />
+            <package pattern=""stuff"" />
         </packageSource>
     </packageSourceMapping>
 </configuration>");
@@ -100,7 +100,7 @@ namespace NuGet.Configuration.Test
 <configuration>
     <packageSourceMapping>
         <packageSource key=""contoso"">
-            <package prefix=""stuff2"" />
+            <package pattern=""stuff2"" />
         </packageSource>
     </packageSourceMapping>
 </configuration>");
@@ -133,7 +133,7 @@ namespace NuGet.Configuration.Test
     <packageSourceMapping>
         <clear />
         <packageSource key=""nuget.org"">
-            <package prefix=""stuff"" />
+            <package pattern=""stuff"" />
         </packageSource>
     </packageSourceMapping>
 </configuration>");
@@ -142,7 +142,7 @@ namespace NuGet.Configuration.Test
 <configuration>
     <packageSourceMapping>
         <packageSource key=""contoso"">
-            <package prefix=""stuff2"" />
+            <package pattern=""stuff2"" />
         </packageSource>
     </packageSourceMapping>
 </configuration>");
@@ -169,10 +169,10 @@ namespace NuGet.Configuration.Test
 <configuration>
     <packageSourceMapping>
         <packageSource key=""nuget.org"">
-            <package prefix=""stuff"" />
+            <package pattern=""stuff"" />
         </packageSource>
         <packageSource key=""contoso"">
-            <package prefix=""stuff2"" />
+            <package pattern=""stuff2"" />
         </packageSource>
     </packageSourceMapping>
 </configuration>");
@@ -189,7 +189,7 @@ namespace NuGet.Configuration.Test
 <configuration>
     <packageSourceMapping>
         <packageSource key=""nuget.org"">
-            <package prefix=""stuff"" />
+            <package pattern=""stuff"" />
         </packageSource>
     </packageSourceMapping>
 </configuration>";
@@ -209,10 +209,10 @@ namespace NuGet.Configuration.Test
 <configuration>
     <packageSourceMapping>
         <packageSource key=""nuget.org"">
-            <package prefix=""stuff"" />
+            <package pattern=""stuff"" />
         </packageSource>
         <packageSource key=""contoso"">
-            <package prefix=""stuff2"" />
+            <package pattern=""stuff2"" />
         </packageSource>
     </packageSourceMapping>
 </configuration>";
@@ -241,7 +241,7 @@ namespace NuGet.Configuration.Test
 <configuration>
     <packageSourceMapping>
         <packageSource key=""nuget.org"">
-            <package prefix=""stuff"" />
+            <package pattern=""stuff"" />
         </packageSource>
     </packageSourceMapping>
 </configuration>");
@@ -250,7 +250,7 @@ namespace NuGet.Configuration.Test
 <configuration>
     <packageSourceMapping>
         <packageSource key=""contoso"">
-            <package prefix=""stuff2"" />
+            <package pattern=""stuff2"" />
         </packageSource>
     </packageSourceMapping>
 </configuration>");
@@ -279,7 +279,7 @@ namespace NuGet.Configuration.Test
 <configuration>
     <packageSourceMapping>
         <packageSource key=""nuget.org"">
-            <package prefix=""stuff"" />
+            <package pattern=""stuff"" />
         </packageSource>
     </packageSourceMapping>
 </configuration>");
@@ -288,7 +288,7 @@ namespace NuGet.Configuration.Test
 <configuration>
     <packageSourceMapping>
         <packageSource key=""contoso"">
-            <package prefix=""stuff2"" />
+            <package pattern=""stuff2"" />
         </packageSource>
     </packageSourceMapping>
 </configuration>");
@@ -304,8 +304,8 @@ namespace NuGet.Configuration.Test
 <configuration>
     <packageSourceMapping>
         <packageSource key=""nuget.org"">
-            <package prefix=""stuff"" />
-            <package prefix=""added"" />
+            <package pattern=""stuff"" />
+            <package pattern=""added"" />
         </packageSource>
     </packageSourceMapping>
 </configuration>";
@@ -325,7 +325,7 @@ namespace NuGet.Configuration.Test
 <configuration>
     <packageSourceMapping>
         <packageSource key=""nuget.org"">
-            <package prefix=""stuff"" />
+            <package pattern=""stuff"" />
         </packageSource>
     </packageSourceMapping>
 </configuration>");
@@ -334,7 +334,7 @@ namespace NuGet.Configuration.Test
 <configuration>
     <packageSourceMapping>
         <packageSource key=""contoso"">
-            <package prefix=""stuff2"" />
+            <package pattern=""stuff2"" />
         </packageSource>
     </packageSourceMapping>
 </configuration>");
@@ -349,10 +349,10 @@ namespace NuGet.Configuration.Test
 <configuration>
     <packageSourceMapping>
         <packageSource key=""contoso"">
-            <package prefix=""stuff2"" />
+            <package pattern=""stuff2"" />
         </packageSource>
         <packageSource key=""localSource"">
-            <package prefix=""added"" />
+            <package pattern=""added"" />
         </packageSource>
     </packageSourceMapping>
 </configuration>";
@@ -373,7 +373,7 @@ namespace NuGet.Configuration.Test
     <packageSourceMapping>
         <clear />
         <packageSource key=""nuget.org"">
-            <package prefix=""stuff"" />
+            <package pattern=""stuff"" />
         </packageSource>
     </packageSourceMapping>
 </configuration>");
@@ -382,7 +382,7 @@ namespace NuGet.Configuration.Test
 <configuration>
     <packageSourceMapping>
         <packageSource key=""contoso"">
-            <package prefix=""stuff2"" />
+            <package pattern=""stuff2"" />
         </packageSource>
     </packageSourceMapping>
 </configuration>");
@@ -398,10 +398,10 @@ namespace NuGet.Configuration.Test
     <packageSourceMapping>
         <clear />
         <packageSource key=""nuget.org"">
-            <package prefix=""stuff"" />
+            <package pattern=""stuff"" />
         </packageSource>
         <packageSource key=""localSource"">
-            <package prefix=""added"" />
+            <package pattern=""added"" />
         </packageSource>
     </packageSourceMapping>
 </configuration>";

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/NamespaceItemTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/NamespaceItemTests.cs
@@ -127,7 +127,7 @@ namespace NuGet.Configuration.Test
 <configuration>
     <packageSourceMapping>
         <packageSource key=""nuget.org"">
-            <package prefix=""sadas"">
+            <package pattern=""sadas"">
                 <add key=""key"" value=""val"" />
             </package>
         </packageSource>
@@ -153,7 +153,7 @@ namespace NuGet.Configuration.Test
 <configuration>
     <packageSourceMapping>
         <packageSource key=""nuget.org"">
-            <package prefix=""sadas"" />
+            <package pattern=""sadas"" />
         </packageSource>
     </packageSourceMapping>
 </configuration>";
@@ -181,7 +181,7 @@ namespace NuGet.Configuration.Test
 <configuration>
     <packageSourceMapping>
         <packageSource key=""nuget.org"">
-            <package prefix=""original"" />
+            <package pattern=""original"" />
         </packageSource>
     </packageSourceMapping>
 </configuration>";
@@ -207,7 +207,7 @@ namespace NuGet.Configuration.Test
 <configuration>
     <packageSourceMapping>
         <packageSource key=""nuget.org"">
-            <package prefix=""updated"" />
+            <package pattern=""updated"" />
         </packageSource>
     </packageSourceMapping>
 </configuration>";

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/NamespaceItemTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/NamespaceItemTests.cs
@@ -101,11 +101,11 @@ namespace NuGet.Configuration.Test
             // Arrange
             var config = @"
 <configuration>
-    <packageNamespaces>
+    <packageSourceMappings>
         <packageSource key=""nuget.org"">
-            <namespace stuff=""sadas""  />
+            <package stuff=""sadas""  />
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMappings>
 </configuration>";
             var nugetConfigPath = "NuGet.Config";
             using var mockBaseDirectory = TestDirectory.Create();
@@ -116,7 +116,7 @@ namespace NuGet.Configuration.Test
 
             ex.Should().NotBeNull();
             ex.Should().BeOfType<NuGetConfigurationException>();
-            ex.Message.Should().Be(string.Format("Unable to parse config file because: Missing required attribute 'id' in element 'namespace'. Path: '{0}'.", Path.Combine(mockBaseDirectory, nugetConfigPath)));
+            ex.Message.Should().Be(string.Format("Unable to parse config file because: Missing required attribute 'prefix' in element 'namespace'. Path: '{0}'.", Path.Combine(mockBaseDirectory, nugetConfigPath)));
         }
 
         [Fact]
@@ -125,13 +125,13 @@ namespace NuGet.Configuration.Test
             // Arrange
             var config = @"
 <configuration>
-    <packageNamespaces>
+    <packageSourceMappings>
         <packageSource key=""nuget.org"">
-            <namespace id=""sadas"">
+            <package prefix=""sadas"">
                 <add key=""key"" value=""val"" />
             </namespace>
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMappings>
 </configuration>";
             var nugetConfigPath = "NuGet.Config";
             using var mockBaseDirectory = TestDirectory.Create();
@@ -142,7 +142,7 @@ namespace NuGet.Configuration.Test
 
             ex.Should().NotBeNull();
             ex.Should().BeOfType<NuGetConfigurationException>();
-            ex.Message.Should().Be(string.Format("Error parsing NuGet.Config. Element 'namespace' cannot have descendant elements. Path: '{0}'.", Path.Combine(mockBaseDirectory, nugetConfigPath)));
+            ex.Message.Should().Be(string.Format("Error parsing NuGet.Config. Element 'package' cannot have descendant elements. Path: '{0}'.", Path.Combine(mockBaseDirectory, nugetConfigPath)));
         }
 
         [Fact]
@@ -151,11 +151,11 @@ namespace NuGet.Configuration.Test
             // Arrange
             var config = @"
 <configuration>
-    <packageNamespaces>
+    <packageSourceMappings>
         <packageSource key=""nuget.org"">
-            <namespace id=""sadas"" />
+            <package prefix=""sadas"" />
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMappings>
 </configuration>";
             var nugetConfigPath = "NuGet.Config";
             using var mockBaseDirectory = TestDirectory.Create();
@@ -179,11 +179,11 @@ namespace NuGet.Configuration.Test
             // Arrange
             var config = @"
 <configuration>
-    <packageNamespaces>
+    <packageSourceMappings>
         <packageSource key=""nuget.org"">
-            <namespace id=""original"" />
+            <package prefix=""original"" />
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMappings>
 </configuration>";
             var nugetConfigPath = "NuGet.Config";
             using var mockBaseDirectory = TestDirectory.Create();
@@ -205,11 +205,11 @@ namespace NuGet.Configuration.Test
             // Assert
             var result = @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
-    <packageNamespaces>
+    <packageSourceMappings>
         <packageSource key=""nuget.org"">
-            <namespace id=""updated"" />
+            <package prefix=""updated"" />
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMappings>
 </configuration>";
 
             result.Replace("\r\n", "\n")

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/NamespaceItemTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/NamespaceItemTests.cs
@@ -116,7 +116,7 @@ namespace NuGet.Configuration.Test
 
             ex.Should().NotBeNull();
             ex.Should().BeOfType<NuGetConfigurationException>();
-            ex.Message.Should().Be(string.Format("Unable to parse config file because: Missing required attribute 'prefix' in element 'package'. Path: '{0}'.", Path.Combine(mockBaseDirectory, nugetConfigPath)));
+            ex.Message.Should().Be(string.Format("Unable to parse config file because: Missing required attribute 'pattern' in element 'package'. Path: '{0}'.", Path.Combine(mockBaseDirectory, nugetConfigPath)));
         }
 
         [Fact]

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/NamespaceItemTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/NamespaceItemTests.cs
@@ -101,11 +101,11 @@ namespace NuGet.Configuration.Test
             // Arrange
             var config = @"
 <configuration>
-    <packageSourceMappings>
+    <packageSourceMapping>
         <packageSource key=""nuget.org"">
             <package stuff=""sadas""  />
         </packageSource>
-    </packageSourceMappings>
+    </packageSourceMapping>
 </configuration>";
             var nugetConfigPath = "NuGet.Config";
             using var mockBaseDirectory = TestDirectory.Create();
@@ -125,13 +125,13 @@ namespace NuGet.Configuration.Test
             // Arrange
             var config = @"
 <configuration>
-    <packageSourceMappings>
+    <packageSourceMapping>
         <packageSource key=""nuget.org"">
             <package prefix=""sadas"">
                 <add key=""key"" value=""val"" />
             </namespace>
         </packageSource>
-    </packageSourceMappings>
+    </packageSourceMapping>
 </configuration>";
             var nugetConfigPath = "NuGet.Config";
             using var mockBaseDirectory = TestDirectory.Create();
@@ -151,11 +151,11 @@ namespace NuGet.Configuration.Test
             // Arrange
             var config = @"
 <configuration>
-    <packageSourceMappings>
+    <packageSourceMapping>
         <packageSource key=""nuget.org"">
             <package prefix=""sadas"" />
         </packageSource>
-    </packageSourceMappings>
+    </packageSourceMapping>
 </configuration>";
             var nugetConfigPath = "NuGet.Config";
             using var mockBaseDirectory = TestDirectory.Create();
@@ -179,11 +179,11 @@ namespace NuGet.Configuration.Test
             // Arrange
             var config = @"
 <configuration>
-    <packageSourceMappings>
+    <packageSourceMapping>
         <packageSource key=""nuget.org"">
             <package prefix=""original"" />
         </packageSource>
-    </packageSourceMappings>
+    </packageSourceMapping>
 </configuration>";
             var nugetConfigPath = "NuGet.Config";
             using var mockBaseDirectory = TestDirectory.Create();
@@ -205,11 +205,11 @@ namespace NuGet.Configuration.Test
             // Assert
             var result = @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
-    <packageSourceMappings>
+    <packageSourceMapping>
         <packageSource key=""nuget.org"">
             <package prefix=""updated"" />
         </packageSource>
-    </packageSourceMappings>
+    </packageSourceMapping>
 </configuration>";
 
             result.Replace("\r\n", "\n")

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/NamespaceItemTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/NamespaceItemTests.cs
@@ -92,7 +92,7 @@ namespace NuGet.Configuration.Test
         public void ElementNameGetter_ReturnsNamespace()
         {
             var original = new NamespaceItem("item");
-            original.ElementName.Should().Be("namespace");
+            original.ElementName.Should().Be("package");
         }
 
         [Fact]
@@ -116,7 +116,7 @@ namespace NuGet.Configuration.Test
 
             ex.Should().NotBeNull();
             ex.Should().BeOfType<NuGetConfigurationException>();
-            ex.Message.Should().Be(string.Format("Unable to parse config file because: Missing required attribute 'prefix' in element 'namespace'. Path: '{0}'.", Path.Combine(mockBaseDirectory, nugetConfigPath)));
+            ex.Message.Should().Be(string.Format("Unable to parse config file because: Missing required attribute 'prefix' in element 'package'. Path: '{0}'.", Path.Combine(mockBaseDirectory, nugetConfigPath)));
         }
 
         [Fact]
@@ -129,7 +129,7 @@ namespace NuGet.Configuration.Test
         <packageSource key=""nuget.org"">
             <package prefix=""sadas"">
                 <add key=""key"" value=""val"" />
-            </namespace>
+            </package>
         </packageSource>
     </packageSourceMapping>
 </configuration>";
@@ -163,7 +163,7 @@ namespace NuGet.Configuration.Test
 
             // Act and Assert
             var settingsFile = new SettingsFile(mockBaseDirectory);
-            var section = settingsFile.GetSection("packageNamespaces");
+            var section = settingsFile.GetSection("packageSourceMapping");
             section.Should().NotBeNull();
 
             section.Items.Count.Should().Be(1);
@@ -191,7 +191,7 @@ namespace NuGet.Configuration.Test
 
             // Act and Assert
             var settingsFile = new SettingsFile(mockBaseDirectory);
-            settingsFile.TryGetSection("packageNamespaces", out var section).Should().BeTrue();
+            settingsFile.TryGetSection("packageSourceMapping", out var section).Should().BeTrue();
             section.Should().NotBeNull();
 
             section.Items.Count.Should().Be(1);

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/PackageNamespacesSourceItemTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/PackageNamespacesSourceItemTests.cs
@@ -124,7 +124,7 @@ namespace NuGet.Configuration.Test
 <configuration>
     <packageSourceMapping>
         <packageSource id=""nuget.org"">
-            <package prefix=""sadas""  />
+            <package pattern=""sadas""  />
         </packageSource>
     </packageSourceMapping>
 </configuration>";
@@ -171,7 +171,7 @@ namespace NuGet.Configuration.Test
 <configuration>
     <packageSourceMapping>
         <packageSource key=""nuget.org"">
-            <package prefix=""sadas"" />
+            <package pattern=""sadas"" />
         </packageSource>
     </packageSourceMapping>
 </configuration>";
@@ -200,7 +200,7 @@ namespace NuGet.Configuration.Test
 <configuration>
     <packageSourceMapping>
         <packageSource key=""nuget.org"">
-            <package prefix=""sadas"" />
+            <package pattern=""sadas"" />
             <notANamespace id=""sadas"" />
         </packageSource>
     </packageSourceMapping>
@@ -229,7 +229,7 @@ namespace NuGet.Configuration.Test
 <configuration>
     <packageSourceMapping>
         <packageSource key=""nuget.org"">
-            <package prefix=""first"" />
+            <package pattern=""first"" />
         </packageSource>
     </packageSourceMapping>
 </configuration>";
@@ -257,8 +257,8 @@ namespace NuGet.Configuration.Test
 <configuration>
     <packageSourceMapping>
         <packageSource key=""nuget.org"">
-            <package prefix=""first"" />
-            <package prefix=""second"" />
+            <package pattern=""first"" />
+            <package pattern=""second"" />
         </packageSource>
     </packageSourceMapping>
 </configuration>";
@@ -276,8 +276,8 @@ namespace NuGet.Configuration.Test
 <configuration>
     <packageSourceMapping>
         <packageSource key=""nuget.org"">
-            <package prefix=""first"" />
-            <package prefix=""second"" />
+            <package pattern=""first"" />
+            <package pattern=""second"" />
         </packageSource>
     </packageSourceMapping>
 </configuration>";
@@ -305,7 +305,7 @@ namespace NuGet.Configuration.Test
 <configuration>
     <packageSourceMapping>
         <packageSource key=""nuget.org"">
-            <package prefix=""first"" />
+            <package pattern=""first"" />
         </packageSource>
     </packageSourceMapping>
 </configuration>";
@@ -323,7 +323,7 @@ namespace NuGet.Configuration.Test
 <configuration>
     <packageSourceMapping>
         <packageSource key=""nuget.org"">
-            <package prefix=""first"" />
+            <package pattern=""first"" />
         </packageSource>
     </packageSourceMapping>
 </configuration>";
@@ -358,8 +358,8 @@ namespace NuGet.Configuration.Test
 <configuration>
     <packageSourceMapping>
         <packageSource key=""nuget.org"">
-            <package prefix=""first"" />
-            <package prefix=""second"" />
+            <package pattern=""first"" />
+            <package pattern=""second"" />
         </packageSource>
     </packageSourceMapping>
 </configuration>";
@@ -388,8 +388,8 @@ namespace NuGet.Configuration.Test
 <configuration>
     <packageSourceMapping>
         <packageSource key=""nuget.org"">
-            <package prefix=""first"" />
-            <package prefix=""third"" />
+            <package pattern=""first"" />
+            <package pattern=""third"" />
         </packageSource>
     </packageSourceMapping>
 </configuration>";

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/PackageNamespacesSourceItemTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/PackageNamespacesSourceItemTests.cs
@@ -122,11 +122,11 @@ namespace NuGet.Configuration.Test
             // Arrange
             var config = @"
 <configuration>
-    <packageSourceMappings>
+    <packageSourceMapping>
         <packageSource id=""nuget.org"">
             <package prefix=""sadas""  />
         </packageSource>
-    </packageSourceMappings>
+    </packageSourceMapping>
 </configuration>";
             var nugetConfigPath = "NuGet.Config";
             using var mockBaseDirectory = TestDirectory.Create();
@@ -146,10 +146,10 @@ namespace NuGet.Configuration.Test
             // Arrange
             var config = @"
 <configuration>
-    <packageSourceMappings>
+    <packageSourceMapping>
         <packageSource key=""nuget.org"">
         </packageSource>
-    </packageSourceMappings>
+    </packageSourceMapping>
 </configuration>";
             var nugetConfigPath = "NuGet.Config";
             using var mockBaseDirectory = TestDirectory.Create();
@@ -169,11 +169,11 @@ namespace NuGet.Configuration.Test
             // Arrange
             var config = @"
 <configuration>
-    <packageSourceMappings>
+    <packageSourceMapping>
         <packageSource key=""nuget.org"">
             <package prefix=""sadas"" />
         </packageSource>
-    </packageSourceMappings>
+    </packageSourceMapping>
 </configuration>";
             var nugetConfigPath = "NuGet.Config";
             using var mockBaseDirectory = TestDirectory.Create();
@@ -198,12 +198,12 @@ namespace NuGet.Configuration.Test
             // Arrange
             var config = @"
 <configuration>
-    <packageSourceMappings>
+    <packageSourceMapping>
         <packageSource key=""nuget.org"">
             <package prefix=""sadas"" />
             <notANamespace id=""sadas"" />
         </packageSource>
-    </packageSourceMappings>
+    </packageSourceMapping>
 </configuration>";
             var nugetConfigPath = "NuGet.Config";
             using var mockBaseDirectory = TestDirectory.Create();
@@ -227,11 +227,11 @@ namespace NuGet.Configuration.Test
             // Arrange
             var config = @"
 <configuration>
-    <packageSourceMappings>
+    <packageSourceMapping>
         <packageSource key=""nuget.org"">
             <package prefix=""first"" />
         </packageSource>
-    </packageSourceMappings>
+    </packageSourceMapping>
 </configuration>";
             var nugetConfigPath = "NuGet.Config";
             using var mockBaseDirectory = TestDirectory.Create();
@@ -255,12 +255,12 @@ namespace NuGet.Configuration.Test
             // Assert
             var result = @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
-    <packageSourceMappings>
+    <packageSourceMapping>
         <packageSource key=""nuget.org"">
             <package prefix=""first"" />
             <package prefix=""second"" />
         </packageSource>
-    </packageSourceMappings>
+    </packageSourceMapping>
 </configuration>";
 
             result.Replace("\r\n", "\n")
@@ -274,12 +274,12 @@ namespace NuGet.Configuration.Test
             // Arrange
             var config = @"
 <configuration>
-    <packageSourceMappings>
+    <packageSourceMapping>
         <packageSource key=""nuget.org"">
             <package prefix=""first"" />
             <package prefix=""second"" />
         </packageSource>
-    </packageSourceMappings>
+    </packageSourceMapping>
 </configuration>";
             var nugetConfigPath = "NuGet.Config";
             using var mockBaseDirectory = TestDirectory.Create();
@@ -303,11 +303,11 @@ namespace NuGet.Configuration.Test
             // Assert
             var result = @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
-    <packageSourceMappings>
+    <packageSourceMapping>
         <packageSource key=""nuget.org"">
             <package prefix=""first"" />
         </packageSource>
-    </packageSourceMappings>
+    </packageSourceMapping>
 </configuration>";
 
             result.Replace("\r\n", "\n")
@@ -321,11 +321,11 @@ namespace NuGet.Configuration.Test
             // Arrange
             var config = @"
 <configuration>
-    <packageSourceMappings>
+    <packageSourceMapping>
         <packageSource key=""nuget.org"">
             <package prefix=""first"" />
         </packageSource>
-    </packageSourceMappings>
+    </packageSourceMapping>
 </configuration>";
             var nugetConfigPath = "NuGet.Config";
             using var mockBaseDirectory = TestDirectory.Create();
@@ -356,12 +356,12 @@ namespace NuGet.Configuration.Test
             // Arrange
             var config = @"
 <configuration>
-    <packageSourceMappings>
+    <packageSourceMapping>
         <packageSource key=""nuget.org"">
             <package prefix=""first"" />
             <package prefix=""second"" />
         </packageSource>
-    </packageSourceMappings>
+    </packageSourceMapping>
 </configuration>";
             var nugetConfigPath = "NuGet.Config";
             using var mockBaseDirectory = TestDirectory.Create();
@@ -386,12 +386,12 @@ namespace NuGet.Configuration.Test
             // Assert
             var result = @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
-    <packageSourceMappings>
+    <packageSourceMapping>
         <packageSource key=""nuget.org"">
             <package prefix=""first"" />
             <package prefix=""third"" />
         </packageSource>
-    </packageSourceMappings>
+    </packageSourceMapping>
 </configuration>";
 
             result.Replace("\r\n", "\n")

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/PackageNamespacesSourceItemTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/PackageNamespacesSourceItemTests.cs
@@ -181,7 +181,7 @@ namespace NuGet.Configuration.Test
 
             // Act and Assert
             var settingsFile = new SettingsFile(mockBaseDirectory);
-            var section = settingsFile.GetSection("packageNamespaces");
+            var section = settingsFile.GetSection("packageSourceMapping");
             section.Should().NotBeNull();
 
             section.Items.Count.Should().Be(1);
@@ -211,7 +211,7 @@ namespace NuGet.Configuration.Test
 
             // Act and Assert
             var settingsFile = new SettingsFile(mockBaseDirectory);
-            var section = settingsFile.GetSection("packageNamespaces");
+            var section = settingsFile.GetSection("packageSourceMapping");
             section.Should().NotBeNull();
 
             section.Items.Count.Should().Be(1);
@@ -239,7 +239,7 @@ namespace NuGet.Configuration.Test
 
             // Act and Assert
             var settingsFile = new SettingsFile(mockBaseDirectory);
-            settingsFile.TryGetSection("packageNamespaces", out var section).Should().BeTrue();
+            settingsFile.TryGetSection("packageSourceMapping", out var section).Should().BeTrue();
             section.Should().NotBeNull();
 
             section.Items.Count.Should().Be(1);
@@ -287,7 +287,7 @@ namespace NuGet.Configuration.Test
 
             // Act and Assert
             var settingsFile = new SettingsFile(mockBaseDirectory);
-            settingsFile.TryGetSection("packageNamespaces", out var section).Should().BeTrue();
+            settingsFile.TryGetSection("packageSourceMapping", out var section).Should().BeTrue();
             section.Should().NotBeNull();
 
             section.Items.Count.Should().Be(1);
@@ -333,7 +333,7 @@ namespace NuGet.Configuration.Test
 
             // Act and Assert
             var settingsFile = new SettingsFile(mockBaseDirectory);
-            settingsFile.TryGetSection("packageNamespaces", out var section).Should().BeTrue();
+            settingsFile.TryGetSection("packageSourceMapping", out var section).Should().BeTrue();
             section.Should().NotBeNull();
 
             section.Items.Count.Should().Be(1);
@@ -369,7 +369,7 @@ namespace NuGet.Configuration.Test
 
             // Act and Assert
             var settingsFile = new SettingsFile(mockBaseDirectory);
-            settingsFile.TryGetSection("packageNamespaces", out var section).Should().BeTrue();
+            settingsFile.TryGetSection("packageSourceMapping", out var section).Should().BeTrue();
             section.Should().NotBeNull();
 
             section.Items.Count.Should().Be(1);

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/PackageNamespacesSourceItemTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/PackageNamespacesSourceItemTests.cs
@@ -122,11 +122,11 @@ namespace NuGet.Configuration.Test
             // Arrange
             var config = @"
 <configuration>
-    <packageNamespaces>
+    <packageSourceMappings>
         <packageSource id=""nuget.org"">
-            <namespace id=""sadas""  />
+            <package prefix=""sadas""  />
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMappings>
 </configuration>";
             var nugetConfigPath = "NuGet.Config";
             using var mockBaseDirectory = TestDirectory.Create();
@@ -146,10 +146,10 @@ namespace NuGet.Configuration.Test
             // Arrange
             var config = @"
 <configuration>
-    <packageNamespaces>
+    <packageSourceMappings>
         <packageSource key=""nuget.org"">
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMappings>
 </configuration>";
             var nugetConfigPath = "NuGet.Config";
             using var mockBaseDirectory = TestDirectory.Create();
@@ -169,11 +169,11 @@ namespace NuGet.Configuration.Test
             // Arrange
             var config = @"
 <configuration>
-    <packageNamespaces>
+    <packageSourceMappings>
         <packageSource key=""nuget.org"">
-            <namespace id=""sadas"" />
+            <package prefix=""sadas"" />
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMappings>
 </configuration>";
             var nugetConfigPath = "NuGet.Config";
             using var mockBaseDirectory = TestDirectory.Create();
@@ -198,12 +198,12 @@ namespace NuGet.Configuration.Test
             // Arrange
             var config = @"
 <configuration>
-    <packageNamespaces>
+    <packageSourceMappings>
         <packageSource key=""nuget.org"">
-            <namespace id=""sadas"" />
+            <package prefix=""sadas"" />
             <notANamespace id=""sadas"" />
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMappings>
 </configuration>";
             var nugetConfigPath = "NuGet.Config";
             using var mockBaseDirectory = TestDirectory.Create();
@@ -227,11 +227,11 @@ namespace NuGet.Configuration.Test
             // Arrange
             var config = @"
 <configuration>
-    <packageNamespaces>
+    <packageSourceMappings>
         <packageSource key=""nuget.org"">
-            <namespace id=""first"" />
+            <package prefix=""first"" />
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMappings>
 </configuration>";
             var nugetConfigPath = "NuGet.Config";
             using var mockBaseDirectory = TestDirectory.Create();
@@ -255,12 +255,12 @@ namespace NuGet.Configuration.Test
             // Assert
             var result = @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
-    <packageNamespaces>
+    <packageSourceMappings>
         <packageSource key=""nuget.org"">
-            <namespace id=""first"" />
-            <namespace id=""second"" />
+            <package prefix=""first"" />
+            <package prefix=""second"" />
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMappings>
 </configuration>";
 
             result.Replace("\r\n", "\n")
@@ -274,12 +274,12 @@ namespace NuGet.Configuration.Test
             // Arrange
             var config = @"
 <configuration>
-    <packageNamespaces>
+    <packageSourceMappings>
         <packageSource key=""nuget.org"">
-            <namespace id=""first"" />
-            <namespace id=""second"" />
+            <package prefix=""first"" />
+            <package prefix=""second"" />
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMappings>
 </configuration>";
             var nugetConfigPath = "NuGet.Config";
             using var mockBaseDirectory = TestDirectory.Create();
@@ -303,11 +303,11 @@ namespace NuGet.Configuration.Test
             // Assert
             var result = @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
-    <packageNamespaces>
+    <packageSourceMappings>
         <packageSource key=""nuget.org"">
-            <namespace id=""first"" />
+            <package prefix=""first"" />
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMappings>
 </configuration>";
 
             result.Replace("\r\n", "\n")
@@ -321,11 +321,11 @@ namespace NuGet.Configuration.Test
             // Arrange
             var config = @"
 <configuration>
-    <packageNamespaces>
+    <packageSourceMappings>
         <packageSource key=""nuget.org"">
-            <namespace id=""first"" />
+            <package prefix=""first"" />
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMappings>
 </configuration>";
             var nugetConfigPath = "NuGet.Config";
             using var mockBaseDirectory = TestDirectory.Create();
@@ -356,12 +356,12 @@ namespace NuGet.Configuration.Test
             // Arrange
             var config = @"
 <configuration>
-    <packageNamespaces>
+    <packageSourceMappings>
         <packageSource key=""nuget.org"">
-            <namespace id=""first"" />
-            <namespace id=""second"" />
+            <package prefix=""first"" />
+            <package prefix=""second"" />
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMappings>
 </configuration>";
             var nugetConfigPath = "NuGet.Config";
             using var mockBaseDirectory = TestDirectory.Create();
@@ -386,12 +386,12 @@ namespace NuGet.Configuration.Test
             // Assert
             var result = @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
-    <packageNamespaces>
+    <packageSourceMappings>
         <packageSource key=""nuget.org"">
-            <namespace id=""first"" />
-            <namespace id=""third"" />
+            <package prefix=""first"" />
+            <package prefix=""third"" />
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMappings>
 </configuration>";
 
             result.Replace("\r\n", "\n")

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsTests.cs
@@ -2735,12 +2735,12 @@ namespace NuGet.Configuration.Test
             var nugetConfigPath = "NuGet.Config";
             var config = @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
-    <packageNamespaces>
+    <packageSourceMappings>
         <packageSource key=""nuget.org"">
             <yay/>
-            <namespace id=""stuff"" />
+            <package prefix=""stuff"" />
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMappings>
 </configuration>";
 
             using var mockBaseDirectory = TestDirectory.Create();
@@ -2754,12 +2754,12 @@ namespace NuGet.Configuration.Test
 
             var result = SettingsTestUtils.RemoveWhitespace(@"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
-    <packageNamespaces>
+    <packageSourceMappings>
         <packageSource key=""nuget.org"">
             <yay/>
-            <namespace id=""moreStuff"" />
+            <package prefix=""moreStuff"" />
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMappings>
 </configuration>");
 
             SettingsTestUtils.RemoveWhitespace(File.ReadAllText(Path.Combine(mockBaseDirectory, nugetConfigPath))).Should().Be(result);

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsTests.cs
@@ -2738,7 +2738,7 @@ namespace NuGet.Configuration.Test
     <packageSourceMapping>
         <packageSource key=""nuget.org"">
             <yay/>
-            <package prefix=""stuff"" />
+            <package pattern=""stuff"" />
         </packageSource>
     </packageSourceMapping>
 </configuration>";
@@ -2748,7 +2748,7 @@ namespace NuGet.Configuration.Test
             var settingsFile = new SettingsFile(mockBaseDirectory);
             var settings = new Settings(new SettingsFile[] { settingsFile });
 
-            // Act & 
+            // Act &
             settings.AddOrUpdate(settingsFile, "packageSourceMapping", new PackageNamespacesSourceItem("nuget.org", new List<NamespaceItem>() { new NamespaceItem("moreStuff") }));
             settings.SaveToDisk();
 
@@ -2757,7 +2757,7 @@ namespace NuGet.Configuration.Test
     <packageSourceMapping>
         <packageSource key=""nuget.org"">
             <yay/>
-            <package prefix=""moreStuff"" />
+            <package pattern=""moreStuff"" />
         </packageSource>
     </packageSourceMapping>
 </configuration>");

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsTests.cs
@@ -2749,7 +2749,7 @@ namespace NuGet.Configuration.Test
             var settings = new Settings(new SettingsFile[] { settingsFile });
 
             // Act & 
-            settings.AddOrUpdate(settingsFile, "packageNamespaces", new PackageNamespacesSourceItem("nuget.org", new List<NamespaceItem>() { new NamespaceItem("moreStuff") }));
+            settings.AddOrUpdate(settingsFile, "packageSourceMapping", new PackageNamespacesSourceItem("nuget.org", new List<NamespaceItem>() { new NamespaceItem("moreStuff") }));
             settings.SaveToDisk();
 
             var result = SettingsTestUtils.RemoveWhitespace(@"<?xml version=""1.0"" encoding=""utf-8""?>

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsTests.cs
@@ -2735,12 +2735,12 @@ namespace NuGet.Configuration.Test
             var nugetConfigPath = "NuGet.Config";
             var config = @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
-    <packageSourceMappings>
+    <packageSourceMapping>
         <packageSource key=""nuget.org"">
             <yay/>
             <package prefix=""stuff"" />
         </packageSource>
-    </packageSourceMappings>
+    </packageSourceMapping>
 </configuration>";
 
             using var mockBaseDirectory = TestDirectory.Create();
@@ -2754,12 +2754,12 @@ namespace NuGet.Configuration.Test
 
             var result = SettingsTestUtils.RemoveWhitespace(@"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
-    <packageSourceMappings>
+    <packageSourceMapping>
         <packageSource key=""nuget.org"">
             <yay/>
             <package prefix=""moreStuff"" />
         </packageSource>
-    </packageSourceMappings>
+    </packageSourceMapping>
 </configuration>");
 
             SettingsTestUtils.RemoveWhitespace(File.ReadAllText(Path.Combine(mockBaseDirectory, nugetConfigPath))).Should().Be(result);

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests.cs
@@ -7055,12 +7055,12 @@ namespace NuGet.Test
     <clear />
     <add key=""PrivateRepository"" value=""{privateRepositoryPath}"" />
     </packageSources>
-    <packageNamespaces>
+    <packageSourceMappings>
         <packageSource key=""PrivateRepository"">
-            <namespace id=""Contoso.*"" />             
-            <namespace id=""Test.*"" />
+            <package prefix=""Contoso.*"" />             
+            <package prefix=""Test.*"" />
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMappings>
 </configuration>");
                 var contosoPackageIdentity = new PackageIdentity("Contoso.A", new NuGetVersion("1.0.0"));
 
@@ -7138,16 +7138,16 @@ namespace NuGet.Test
     <add key=""ExternalRepository"" value=""{externalRepositoryPath}"" />
     <add key=""PrivateRepository"" value=""{privateRepositoryPath}"" />
     </packageSources>
-    <packageNamespaces>
+    <packageSourceMappings>
         <packageSource key=""externalRepository"">
-            <namespace id=""External.*"" />
-            <namespace id=""Others.*"" />
+            <package prefix=""External.*"" />
+            <package prefix=""Others.*"" />
         </packageSource>
         <packageSource key=""PrivateRepository"">
-            <namespace id=""Contoso.*"" />             
-            <namespace id=""Test.*"" />
+            <package prefix=""Contoso.*"" />             
+            <package prefix=""Test.*"" />
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMappings>
 </configuration>");
                 var contosoPackageIdentity = new PackageIdentity("Contoso.A", new NuGetVersion("1.0.0"));
 
@@ -7241,16 +7241,16 @@ namespace NuGet.Test
     <add key=""ExternalRepository"" value=""{externalRepositoryPath}"" />
     <add key=""PrivateRepository"" value=""{privateRepositoryPath}"" />
     </packageSources>
-    <packageNamespaces>
+    <packageSourceMappings>
         <packageSource key=""externalRepository"">
-            <namespace id=""External.*"" />
-            <namespace id=""Others.*"" />
+            <package prefix=""External.*"" />
+            <package prefix=""Others.*"" />
         </packageSource>
         <packageSource key=""PrivateRepository"">
-            <namespace id=""Contoso.*"" />             
-            <namespace id=""Test.*"" />
+            <package prefix=""Contoso.*"" />             
+            <package prefix=""Test.*"" />
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMappings>
 </configuration>");
                 var contosoPackageIdentity = new PackageIdentity("Contoso.A", new NuGetVersion("1.0.0"));
 
@@ -7347,17 +7347,17 @@ namespace NuGet.Test
     <add key=""ExternalRepository"" value=""{externalRepositoryPath}"" />
     <add key=""PrivateRepository"" value=""{privateRepositoryPath}"" />
     </packageSources>
-    <packageNamespaces>
+    <packageSourceMappings>
         <packageSource key=""externalRepository"">
-            <namespace id=""Direct.*"" />
-            <namespace id=""External.*"" />
-            <namespace id=""Others.*"" />
+            <package prefix=""Direct.*"" />
+            <package prefix=""External.*"" />
+            <package prefix=""Others.*"" />
         </packageSource>
         <packageSource key=""PrivateRepository"">
-            <namespace id=""Contoso.*"" />
-            <namespace id=""Test.*"" />
+            <package prefix=""Contoso.*"" />
+            <package prefix=""Test.*"" />
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMappings>
 </configuration>");
                 var contosoPackageIdentity = new PackageIdentity("Contoso.A", new NuGetVersion("1.0.0"));
                 var directPackageIdentity = new PackageIdentity("Direct.A", new NuGetVersion("1.0.0"));
@@ -7469,16 +7469,16 @@ namespace NuGet.Test
     <add key=""ExternalRepository"" value=""{externalRepositoryPath}"" />
     <add key=""PrivateRepository"" value=""{privateRepositoryPath}"" />
     </packageSources>
-    <packageNamespaces>
+    <packageSourceMappings>
         <packageSource key=""externalRepository"">
-            <namespace id=""External.*"" />
-            <namespace id=""Others.*"" />
+            <package prefix=""External.*"" />
+            <package prefix=""Others.*"" />
         </packageSource>
         <packageSource key=""PrivateRepository"">
-            <namespace id=""Contoso.*"" />             
-            <namespace id=""Test.*"" />
+            <package prefix=""Contoso.*"" />             
+            <package prefix=""Test.*"" />
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMappings>
 </configuration>");
                 var contosoPackageIdentity = new PackageIdentity("Contoso.A", new NuGetVersion("1.0.0"));
 
@@ -7630,16 +7630,16 @@ namespace NuGet.Test
     <add key=""ExternalRepository"" value=""{externalRepositoryPath}"" />
     <add key=""PrivateRepository"" value=""{privateRepositoryPath}"" />
     </packageSources>
-    <packageNamespaces>
+    <packageSourceMappings>
         <packageSource key=""externalRepository"">
-            <namespace id=""External.*"" />
-            <namespace id=""Others.*"" />
+            <package prefix=""External.*"" />
+            <package prefix=""Others.*"" />
         </packageSource>
         <packageSource key=""PrivateRepository"">
-            <namespace id=""Contoso.*"" />             
-            <namespace id=""Test.*"" />
+            <package prefix=""Contoso.*"" />             
+            <package prefix=""Test.*"" />
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMappings>
 </configuration>");
                 var contosoPackageIdentity = new PackageIdentity("Contoso.A", new NuGetVersion("1.0.0"));
 

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests.cs
@@ -2865,7 +2865,7 @@ namespace NuGet.Test
         [Fact]
         public async Task TestPacManPreviewInstallPackageWithNonTargetDependency()
         {
-            // Arrange            
+            // Arrange
 
             // Set up Package Source
             var packages = new List<SourcePackageDependencyInfo>
@@ -7057,8 +7057,8 @@ namespace NuGet.Test
     </packageSources>
     <packageSourceMapping>
         <packageSource key=""PrivateRepository"">
-            <package prefix=""Contoso.*"" />             
-            <package prefix=""Test.*"" />
+            <package pattern=""Contoso.*"" />
+            <package pattern=""Test.*"" />
         </packageSource>
     </packageSourceMapping>
 </configuration>");
@@ -7140,12 +7140,12 @@ namespace NuGet.Test
     </packageSources>
     <packageSourceMapping>
         <packageSource key=""externalRepository"">
-            <package prefix=""External.*"" />
-            <package prefix=""Others.*"" />
+            <package pattern=""External.*"" />
+            <package pattern=""Others.*"" />
         </packageSource>
         <packageSource key=""PrivateRepository"">
-            <package prefix=""Contoso.*"" />             
-            <package prefix=""Test.*"" />
+            <package pattern=""Contoso.*"" />
+            <package pattern=""Test.*"" />
         </packageSource>
     </packageSourceMapping>
 </configuration>");
@@ -7243,12 +7243,12 @@ namespace NuGet.Test
     </packageSources>
     <packageSourceMapping>
         <packageSource key=""externalRepository"">
-            <package prefix=""External.*"" />
-            <package prefix=""Others.*"" />
+            <package pattern=""External.*"" />
+            <package pattern=""Others.*"" />
         </packageSource>
         <packageSource key=""PrivateRepository"">
-            <package prefix=""Contoso.*"" />             
-            <package prefix=""Test.*"" />
+            <package pattern=""Contoso.*"" />
+            <package pattern=""Test.*"" />
         </packageSource>
     </packageSourceMapping>
 </configuration>");
@@ -7349,13 +7349,13 @@ namespace NuGet.Test
     </packageSources>
     <packageSourceMapping>
         <packageSource key=""externalRepository"">
-            <package prefix=""Direct.*"" />
-            <package prefix=""External.*"" />
-            <package prefix=""Others.*"" />
+            <package pattern=""Direct.*"" />
+            <package pattern=""External.*"" />
+            <package pattern=""Others.*"" />
         </packageSource>
         <packageSource key=""PrivateRepository"">
-            <package prefix=""Contoso.*"" />
-            <package prefix=""Test.*"" />
+            <package pattern=""Contoso.*"" />
+            <package pattern=""Test.*"" />
         </packageSource>
     </packageSourceMapping>
 </configuration>");
@@ -7471,12 +7471,12 @@ namespace NuGet.Test
     </packageSources>
     <packageSourceMapping>
         <packageSource key=""externalRepository"">
-            <package prefix=""External.*"" />
-            <package prefix=""Others.*"" />
+            <package pattern=""External.*"" />
+            <package pattern=""Others.*"" />
         </packageSource>
         <packageSource key=""PrivateRepository"">
-            <package prefix=""Contoso.*"" />             
-            <package prefix=""Test.*"" />
+            <package pattern=""Contoso.*"" />
+            <package pattern=""Test.*"" />
         </packageSource>
     </packageSourceMapping>
 </configuration>");
@@ -7632,12 +7632,12 @@ namespace NuGet.Test
     </packageSources>
     <packageSourceMapping>
         <packageSource key=""externalRepository"">
-            <package prefix=""External.*"" />
-            <package prefix=""Others.*"" />
+            <package pattern=""External.*"" />
+            <package pattern=""Others.*"" />
         </packageSource>
         <packageSource key=""PrivateRepository"">
-            <package prefix=""Contoso.*"" />             
-            <package prefix=""Test.*"" />
+            <package pattern=""Contoso.*"" />
+            <package pattern=""Test.*"" />
         </packageSource>
     </packageSourceMapping>
 </configuration>");

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests.cs
@@ -7055,12 +7055,12 @@ namespace NuGet.Test
     <clear />
     <add key=""PrivateRepository"" value=""{privateRepositoryPath}"" />
     </packageSources>
-    <packageSourceMappings>
+    <packageSourceMapping>
         <packageSource key=""PrivateRepository"">
             <package prefix=""Contoso.*"" />             
             <package prefix=""Test.*"" />
         </packageSource>
-    </packageSourceMappings>
+    </packageSourceMapping>
 </configuration>");
                 var contosoPackageIdentity = new PackageIdentity("Contoso.A", new NuGetVersion("1.0.0"));
 
@@ -7138,7 +7138,7 @@ namespace NuGet.Test
     <add key=""ExternalRepository"" value=""{externalRepositoryPath}"" />
     <add key=""PrivateRepository"" value=""{privateRepositoryPath}"" />
     </packageSources>
-    <packageSourceMappings>
+    <packageSourceMapping>
         <packageSource key=""externalRepository"">
             <package prefix=""External.*"" />
             <package prefix=""Others.*"" />
@@ -7147,7 +7147,7 @@ namespace NuGet.Test
             <package prefix=""Contoso.*"" />             
             <package prefix=""Test.*"" />
         </packageSource>
-    </packageSourceMappings>
+    </packageSourceMapping>
 </configuration>");
                 var contosoPackageIdentity = new PackageIdentity("Contoso.A", new NuGetVersion("1.0.0"));
 
@@ -7241,7 +7241,7 @@ namespace NuGet.Test
     <add key=""ExternalRepository"" value=""{externalRepositoryPath}"" />
     <add key=""PrivateRepository"" value=""{privateRepositoryPath}"" />
     </packageSources>
-    <packageSourceMappings>
+    <packageSourceMapping>
         <packageSource key=""externalRepository"">
             <package prefix=""External.*"" />
             <package prefix=""Others.*"" />
@@ -7250,7 +7250,7 @@ namespace NuGet.Test
             <package prefix=""Contoso.*"" />             
             <package prefix=""Test.*"" />
         </packageSource>
-    </packageSourceMappings>
+    </packageSourceMapping>
 </configuration>");
                 var contosoPackageIdentity = new PackageIdentity("Contoso.A", new NuGetVersion("1.0.0"));
 
@@ -7347,7 +7347,7 @@ namespace NuGet.Test
     <add key=""ExternalRepository"" value=""{externalRepositoryPath}"" />
     <add key=""PrivateRepository"" value=""{privateRepositoryPath}"" />
     </packageSources>
-    <packageSourceMappings>
+    <packageSourceMapping>
         <packageSource key=""externalRepository"">
             <package prefix=""Direct.*"" />
             <package prefix=""External.*"" />
@@ -7357,7 +7357,7 @@ namespace NuGet.Test
             <package prefix=""Contoso.*"" />
             <package prefix=""Test.*"" />
         </packageSource>
-    </packageSourceMappings>
+    </packageSourceMapping>
 </configuration>");
                 var contosoPackageIdentity = new PackageIdentity("Contoso.A", new NuGetVersion("1.0.0"));
                 var directPackageIdentity = new PackageIdentity("Direct.A", new NuGetVersion("1.0.0"));
@@ -7469,7 +7469,7 @@ namespace NuGet.Test
     <add key=""ExternalRepository"" value=""{externalRepositoryPath}"" />
     <add key=""PrivateRepository"" value=""{privateRepositoryPath}"" />
     </packageSources>
-    <packageSourceMappings>
+    <packageSourceMapping>
         <packageSource key=""externalRepository"">
             <package prefix=""External.*"" />
             <package prefix=""Others.*"" />
@@ -7478,7 +7478,7 @@ namespace NuGet.Test
             <package prefix=""Contoso.*"" />             
             <package prefix=""Test.*"" />
         </packageSource>
-    </packageSourceMappings>
+    </packageSourceMapping>
 </configuration>");
                 var contosoPackageIdentity = new PackageIdentity("Contoso.A", new NuGetVersion("1.0.0"));
 
@@ -7630,7 +7630,7 @@ namespace NuGet.Test
     <add key=""ExternalRepository"" value=""{externalRepositoryPath}"" />
     <add key=""PrivateRepository"" value=""{privateRepositoryPath}"" />
     </packageSources>
-    <packageSourceMappings>
+    <packageSourceMapping>
         <packageSource key=""externalRepository"">
             <package prefix=""External.*"" />
             <package prefix=""Others.*"" />
@@ -7639,7 +7639,7 @@ namespace NuGet.Test
             <package prefix=""Contoso.*"" />             
             <package prefix=""Test.*"" />
         </packageSource>
-    </packageSourceMappings>
+    </packageSourceMapping>
 </configuration>");
                 var contosoPackageIdentity = new PackageIdentity("Contoso.A", new NuGetVersion("1.0.0"));
 

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/IVsServicesTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/IVsServicesTestCase.cs
@@ -110,12 +110,12 @@ namespace NuGet.Tests.Apex
     <clear />
     <add key=""PrivateRepository"" value=""{privateRepositoryPath}"" />
     </packageSources>
-    <packageNamespaces>
+    <packageSourceMapping>
         <packageSource key=""PrivateRepository"">
-            <namespace id=""Contoso.*"" />             
-            <namespace id=""Test.*"" />
+            <package prefix=""Contoso.*"" />
+            <package prefix=""Test.*"" />
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMapping>
 </configuration>");
 
             solutionService.CreateEmptySolution("TestSolution", solutionDirectory);
@@ -159,12 +159,12 @@ namespace NuGet.Tests.Apex
     <clear />
     <add key=""PrivateRepository"" value=""{privateRepositoryPath}"" />
     </packageSources>
-    <packageNamespaces>
+    <packageSourceMapping>
         <packageSource key=""PrivateRepository"">
-            <namespace id=""Contoso.*"" />             
-            <namespace id=""Test.*"" />
+            <package prefix=""Contoso.*"" />
+            <package prefix=""Test.*"" />
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMapping>
 </configuration>");
 
             solutionService.CreateEmptySolution("TestSolution", solutionDirectory);
@@ -221,16 +221,16 @@ namespace NuGet.Tests.Apex
     <add key=""ExternalRepository"" value=""{opensourceRepositoryPath}"" />
     <add key=""PrivateRepository"" value=""{privateRepositoryPath}"" />
     </packageSources>
-    <packageNamespaces>
+    <packageSourceMapping>
         <packageSource key=""externalRepository"">
-            <namespace id=""External.*"" />
-            <namespace id=""Others.*"" />
+            <package prefix=""External.*"" />
+            <package prefix=""Others.*"" />
         </packageSource>
         <packageSource key=""PrivateRepository"">
-            <namespace id=""Contoso.*"" />             
-            <namespace id=""Test.*"" />
+            <package prefix=""Contoso.*"" />
+            <package prefix=""Test.*"" />
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMapping>
 </configuration>");
 
             solutionService.CreateEmptySolution("TestSolution", solutionDirectory);
@@ -286,16 +286,16 @@ namespace NuGet.Tests.Apex
     <add key=""ExternalRepository"" value=""{opensourceRepositoryPath}"" />
     <add key=""PrivateRepository"" value=""{privateRepositoryPath}"" />
     </packageSources>
-    <packageNamespaces>
+    <packageSourceMapping>
         <packageSource key=""externalRepository"">
-            <namespace id=""External.*"" />
-            <namespace id=""Others.*"" />
+            <package prefix=""External.*"" />
+            <package prefix=""Others.*"" />
         </packageSource>
         <packageSource key=""PrivateRepository"">
-            <namespace id=""Contoso.*"" />             
-            <namespace id=""Test.*"" />
+            <package prefix=""Contoso.*"" />
+            <package prefix=""Test.*"" />
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMapping>
 </configuration>");
 
             solutionService.CreateEmptySolution("TestSolution", solutionDirectory);

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/IVsServicesTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/IVsServicesTestCase.cs
@@ -112,8 +112,8 @@ namespace NuGet.Tests.Apex
     </packageSources>
     <packageSourceMapping>
         <packageSource key=""PrivateRepository"">
-            <package prefix=""Contoso.*"" />
-            <package prefix=""Test.*"" />
+            <package pattern=""Contoso.*"" />
+            <package pattern=""Test.*"" />
         </packageSource>
     </packageSourceMapping>
 </configuration>");
@@ -161,8 +161,8 @@ namespace NuGet.Tests.Apex
     </packageSources>
     <packageSourceMapping>
         <packageSource key=""PrivateRepository"">
-            <package prefix=""Contoso.*"" />
-            <package prefix=""Test.*"" />
+            <package pattern=""Contoso.*"" />
+            <package pattern=""Test.*"" />
         </packageSource>
     </packageSourceMapping>
 </configuration>");
@@ -223,12 +223,12 @@ namespace NuGet.Tests.Apex
     </packageSources>
     <packageSourceMapping>
         <packageSource key=""externalRepository"">
-            <package prefix=""External.*"" />
-            <package prefix=""Others.*"" />
+            <package pattern=""External.*"" />
+            <package pattern=""Others.*"" />
         </packageSource>
         <packageSource key=""PrivateRepository"">
-            <package prefix=""Contoso.*"" />
-            <package prefix=""Test.*"" />
+            <package pattern=""Contoso.*"" />
+            <package pattern=""Test.*"" />
         </packageSource>
     </packageSourceMapping>
 </configuration>");
@@ -288,12 +288,12 @@ namespace NuGet.Tests.Apex
     </packageSources>
     <packageSourceMapping>
         <packageSource key=""externalRepository"">
-            <package prefix=""External.*"" />
-            <package prefix=""Others.*"" />
+            <package pattern=""External.*"" />
+            <package pattern=""Others.*"" />
         </packageSource>
         <packageSource key=""PrivateRepository"">
-            <package prefix=""Contoso.*"" />
-            <package prefix=""Test.*"" />
+            <package pattern=""Contoso.*"" />
+            <package pattern=""Test.*"" />
         </packageSource>
     </packageSourceMapping>
 </configuration>");

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetConsoleTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetConsoleTestCase.cs
@@ -320,8 +320,8 @@ namespace NuGet.Tests.Apex
     </packageSources>
     <packageSourceMapping>
         <packageSource key=""PrivateRepository"">
-            <package prefix=""Contoso.*"" />
-            <package prefix=""Test.*"" />
+            <package pattern=""Contoso.*"" />
+            <package pattern=""Test.*"" />
         </packageSource>
     </packageSourceMapping>
 </configuration>");
@@ -367,8 +367,8 @@ namespace NuGet.Tests.Apex
     </packageSources>
     <packageSourceMapping>
         <packageSource key=""PrivateRepository"">
-            <package prefix=""Contoso.*"" />
-            <package prefix=""Test.*"" />
+            <package pattern=""Contoso.*"" />
+            <package pattern=""Test.*"" />
         </packageSource>
     </packageSourceMapping>
 </configuration>");
@@ -422,12 +422,12 @@ namespace NuGet.Tests.Apex
     </packageSources>
     <packageSourceMapping>
         <packageSource key=""externalRepository"">
-            <package prefix=""External.*"" />
-            <package prefix=""Others.*"" />
+            <package pattern=""External.*"" />
+            <package pattern=""Others.*"" />
         </packageSource>
         <packageSource key=""PrivateRepository"">
-            <package prefix=""Contoso.*"" />
-            <package prefix=""Test.*"" />
+            <package pattern=""Contoso.*"" />
+            <package pattern=""Test.*"" />
         </packageSource>
     </packageSourceMapping>
 </configuration>");
@@ -485,12 +485,12 @@ namespace NuGet.Tests.Apex
     </packageSources>
     <packageSourceMapping>
         <packageSource key=""externalRepository"">
-            <package prefix=""External.*"" />
-            <package prefix=""Others.*"" />
+            <package pattern=""External.*"" />
+            <package pattern=""Others.*"" />
         </packageSource>
         <packageSource key=""PrivateRepository"">
-            <package prefix=""Contoso.*"" />
-            <package prefix=""Test.*"" />
+            <package pattern=""Contoso.*"" />
+            <package pattern=""Test.*"" />
         </packageSource>
     </packageSourceMapping>
 </configuration>");

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetConsoleTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetConsoleTestCase.cs
@@ -318,12 +318,12 @@ namespace NuGet.Tests.Apex
     <clear />
     <add key=""PrivateRepository"" value=""{privateRepositoryPath}"" />
     </packageSources>
-    <packageNamespaces>
+    <packageSourceMapping>
         <packageSource key=""PrivateRepository"">
-            <namespace id=""Contoso.*"" />             
-            <namespace id=""Test.*"" />
+            <package prefix=""Contoso.*"" />
+            <package prefix=""Test.*"" />
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMapping>
 </configuration>");
 
             using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, XunitLogger, noAutoRestore: false, addNetStandardFeeds: false, simpleTestPathContext: simpleTestPathContext))
@@ -365,12 +365,12 @@ namespace NuGet.Tests.Apex
     <clear />
     <add key=""PrivateRepository"" value=""{privateRepositoryPath}"" />
     </packageSources>
-    <packageNamespaces>
+    <packageSourceMapping>
         <packageSource key=""PrivateRepository"">
-            <namespace id=""Contoso.*"" />             
-            <namespace id=""Test.*"" />
+            <package prefix=""Contoso.*"" />
+            <package prefix=""Test.*"" />
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMapping>
 </configuration>");
 
             using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, XunitLogger, noAutoRestore: false, addNetStandardFeeds: false, simpleTestPathContext: simpleTestPathContext))
@@ -420,16 +420,16 @@ namespace NuGet.Tests.Apex
     <add key=""ExternalRepository"" value=""{opensourceRepositoryPath}"" />
     <add key=""PrivateRepository"" value=""{privateRepositoryPath}"" />
     </packageSources>
-    <packageNamespaces>
+    <packageSourceMapping>
         <packageSource key=""externalRepository"">
-            <namespace id=""External.*"" />
-            <namespace id=""Others.*"" />
+            <package prefix=""External.*"" />
+            <package prefix=""Others.*"" />
         </packageSource>
         <packageSource key=""PrivateRepository"">
-            <namespace id=""Contoso.*"" />             
-            <namespace id=""Test.*"" />
+            <package prefix=""Contoso.*"" />
+            <package prefix=""Test.*"" />
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMapping>
 </configuration>");
 
             using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, XunitLogger, noAutoRestore: false, addNetStandardFeeds: false, simpleTestPathContext: simpleTestPathContext))
@@ -483,16 +483,16 @@ namespace NuGet.Tests.Apex
     <add key=""ExternalRepository"" value=""{opensourceRepositoryPath}"" />
     <add key=""PrivateRepository"" value=""{privateRepositoryPath}"" />
     </packageSources>
-    <packageNamespaces>
+    <packageSourceMapping>
         <packageSource key=""externalRepository"">
-            <namespace id=""External.*"" />
-            <namespace id=""Others.*"" />
+            <package prefix=""External.*"" />
+            <package prefix=""Others.*"" />
         </packageSource>
         <packageSource key=""PrivateRepository"">
-            <namespace id=""Contoso.*"" />             
-            <namespace id=""Test.*"" />
+            <package prefix=""Contoso.*"" />
+            <package prefix=""Test.*"" />
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMapping>
 </configuration>");
 
             using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, XunitLogger, noAutoRestore: false, addNetStandardFeeds: false, simpleTestPathContext: simpleTestPathContext))

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetUITestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetUITestCase.cs
@@ -183,12 +183,12 @@ namespace NuGet.Tests.Apex
     <clear />
     <add key=""PrivateRepository"" value=""{privateRepositoryPath}"" />
     </packageSources>
-    <packageNamespaces>
+    <packageSourceMapping>
         <packageSource key=""PrivateRepository"">
-            <namespace id=""Contoso.*"" />             
-            <namespace id=""Test.*"" />
+            <package prefix=""Contoso.*"" />
+            <package prefix=""Test.*"" />
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMapping>
 </configuration>");
 
             var project = solutionService.AddProject(ProjectLanguage.CSharp, ProjectTemplate.ClassLibrary, ProjectTargetFramework.V46, "TestProject");
@@ -230,12 +230,12 @@ namespace NuGet.Tests.Apex
     <clear />
     <add key=""PrivateRepository"" value=""{privateRepositoryPath}"" />
     </packageSources>
-    <packageNamespaces>
+    <packageSourceMapping>
         <packageSource key=""PrivateRepository"">
-            <namespace id=""Contoso.*"" />
-            <namespace id=""Test.*"" />
+            <package prefix=""Contoso.*"" />
+            <package prefix=""Test.*"" />
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMapping>
 </configuration>");
 
             var project = solutionService.AddProject(ProjectLanguage.CSharp, ProjectTemplate.ClassLibrary, ProjectTargetFramework.V46, "TestProject");
@@ -288,16 +288,16 @@ namespace NuGet.Tests.Apex
     <add key=""ExternalRepository"" value=""{externalRepositoryPath}"" />
     <add key=""PrivateRepository"" value=""{privateRepositoryPath}"" />
     </packageSources>
-    <packageNamespaces>
+    <packageSourceMapping>
         <packageSource key=""externalRepository"">
-            <namespace id=""External.*"" />
-            <namespace id=""Others.*"" />
+            <package prefix=""External.*"" />
+            <package prefix=""Others.*"" />
         </packageSource>
         <packageSource key=""PrivateRepository"">
-            <namespace id=""Contoso.*"" />             
-            <namespace id=""Test.*"" />
+            <package prefix=""Contoso.*"" />
+            <package prefix=""Test.*"" />
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMapping>
 //</configuration>");
 
             var project = solutionService.AddProject(ProjectLanguage.CSharp, ProjectTemplate.ClassLibrary, ProjectTargetFramework.V46, "TestProject");
@@ -345,16 +345,16 @@ namespace NuGet.Tests.Apex
     <add key=""ExternalRepository"" value=""{externalRepositoryPath}"" />
     <add key=""PrivateRepository"" value=""{privateRepositoryPath}"" />
     </packageSources>
-    <packageNamespaces>
+    <packageSourceMapping>
         <packageSource key=""externalRepository"">
-            <namespace id=""External.*"" />
-            <namespace id=""Others.*"" />
+            <package prefix=""External.*"" />
+            <package prefix=""Others.*"" />
         </packageSource>
         <packageSource key=""PrivateRepository"">
-            <namespace id=""Contoso.*"" />             
-            <namespace id=""Test.*"" />
+            <package prefix=""Contoso.*"" />
+            <package prefix=""Test.*"" />
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMapping>
 </configuration>");
 
             var project = solutionService.AddProject(ProjectLanguage.CSharp, ProjectTemplate.ClassLibrary, ProjectTargetFramework.V46, "TestProject");
@@ -368,7 +368,7 @@ namespace NuGet.Tests.Apex
             uiwindow.InstallPackageFromUI("contoso.a", "1.0.0");
 
             // Assert
-            // Even though Contoso.a exist in ExternalRepository, but PackageNamespaces filter doesn't let restore from it.
+            // Even though Contoso.a exist in ExternalRepository, but packageSourceMapping filter doesn't let restore from it.
             CommonUtility.AssertPackageNotInPackagesConfig(VisualStudio, project, "contoso.a", XunitLogger);
         }
 
@@ -399,12 +399,12 @@ namespace NuGet.Tests.Apex
     <clear />
     <add key=""PrivateRepository"" value=""{privateRepositoryPath}"" />
     </packageSources>
-    <packageNamespaces>
+    <packageSourceMapping>
         <packageSource key=""PrivateRepository"">
-            <namespace id=""Contoso.*"" />             
-            <namespace id=""Test.*"" />
+            <package prefix=""Contoso.*"" />
+            <package prefix=""Test.*"" />
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMapping>
 </configuration>");
 
             var project = solutionService.AddProject(ProjectLanguage.CSharp, ProjectTemplate.ClassLibrary, ProjectTargetFramework.V46, "TestProject");
@@ -458,16 +458,16 @@ namespace NuGet.Tests.Apex
     <add key=""ExternalRepository"" value=""{externalRepositoryPath}"" />
     <add key=""PrivateRepository"" value=""{privateRepositoryPath}"" />
     </packageSources>
-    <packageNamespaces>
+    <packageSourceMapping>
         <packageSource key=""externalRepository"">
-            <namespace id=""External.*"" />
-            <namespace id=""Others.*"" />
+            <package prefix=""External.*"" />
+            <package prefix=""Others.*"" />
         </packageSource>
         <packageSource key=""PrivateRepository"">
-            <namespace id=""Contoso.*"" />             
-            <namespace id=""Test.*"" />
+            <package prefix=""Contoso.*"" />
+            <package prefix=""Test.*"" />
         </packageSource>
-    </packageNamespaces>
+    </packageSourceMapping>
 //</configuration>");
 
             var project = solutionService.AddProject(ProjectLanguage.CSharp, ProjectTemplate.ClassLibrary, ProjectTargetFramework.V46, "TestProject");

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetUITestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetUITestCase.cs
@@ -185,8 +185,8 @@ namespace NuGet.Tests.Apex
     </packageSources>
     <packageSourceMapping>
         <packageSource key=""PrivateRepository"">
-            <package prefix=""Contoso.*"" />
-            <package prefix=""Test.*"" />
+            <package pattern=""Contoso.*"" />
+            <package pattern=""Test.*"" />
         </packageSource>
     </packageSourceMapping>
 </configuration>");
@@ -232,8 +232,8 @@ namespace NuGet.Tests.Apex
     </packageSources>
     <packageSourceMapping>
         <packageSource key=""PrivateRepository"">
-            <package prefix=""Contoso.*"" />
-            <package prefix=""Test.*"" />
+            <package pattern=""Contoso.*"" />
+            <package pattern=""Test.*"" />
         </packageSource>
     </packageSourceMapping>
 </configuration>");
@@ -290,12 +290,12 @@ namespace NuGet.Tests.Apex
     </packageSources>
     <packageSourceMapping>
         <packageSource key=""externalRepository"">
-            <package prefix=""External.*"" />
-            <package prefix=""Others.*"" />
+            <package pattern=""External.*"" />
+            <package pattern=""Others.*"" />
         </packageSource>
         <packageSource key=""PrivateRepository"">
-            <package prefix=""Contoso.*"" />
-            <package prefix=""Test.*"" />
+            <package pattern=""Contoso.*"" />
+            <package pattern=""Test.*"" />
         </packageSource>
     </packageSourceMapping>
 //</configuration>");
@@ -347,12 +347,12 @@ namespace NuGet.Tests.Apex
     </packageSources>
     <packageSourceMapping>
         <packageSource key=""externalRepository"">
-            <package prefix=""External.*"" />
-            <package prefix=""Others.*"" />
+            <package pattern=""External.*"" />
+            <package pattern=""Others.*"" />
         </packageSource>
         <packageSource key=""PrivateRepository"">
-            <package prefix=""Contoso.*"" />
-            <package prefix=""Test.*"" />
+            <package pattern=""Contoso.*"" />
+            <package pattern=""Test.*"" />
         </packageSource>
     </packageSourceMapping>
 </configuration>");
@@ -401,8 +401,8 @@ namespace NuGet.Tests.Apex
     </packageSources>
     <packageSourceMapping>
         <packageSource key=""PrivateRepository"">
-            <package prefix=""Contoso.*"" />
-            <package prefix=""Test.*"" />
+            <package pattern=""Contoso.*"" />
+            <package pattern=""Test.*"" />
         </packageSource>
     </packageSourceMapping>
 </configuration>");
@@ -460,12 +460,12 @@ namespace NuGet.Tests.Apex
     </packageSources>
     <packageSourceMapping>
         <packageSource key=""externalRepository"">
-            <package prefix=""External.*"" />
-            <package prefix=""Others.*"" />
+            <package pattern=""External.*"" />
+            <package pattern=""Others.*"" />
         </packageSource>
         <packageSource key=""PrivateRepository"">
-            <package prefix=""Contoso.*"" />
-            <package prefix=""Test.*"" />
+            <package pattern=""Contoso.*"" />
+            <package pattern=""Test.*"" />
         </packageSource>
     </packageSourceMapping>
 //</configuration>");


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11205

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Namespaces configuration currently can be configured as follows

``` xml
<packageNamespaces>
    <packageSource key="nuget.org">
      <namespace id="*" />
    </packageSource>
    <packageSource key="contoso.com">
      <namespace id="Contoso.*" />
    </packageSource>
</packageNamespaces>
```

Namespaces configuration should be as follows.

1. Rename `packageNamespaces` to `packageSourceMapping`
2. Rename `namespace` to `package`
3. Rename `id` to `pattern`

```xml
<packageSourceMapping>
    <packageSource key="nuget.org">
      <package pattern="*" />
    </packageSource>
    <packageSource key="contoso.com">
      <package pattern="Contoso.*" />
    </packageSource>
</packageSourceMapping>
```

**NOTE** - I made required changes to the product code to accept new settings. There are so many types and variables in the source code where `Namespaces`  word has been used. I will create follow-up PRs soon by renaming them, but those changes won't impact product functionality.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added - Relying on the existing tests.
  
- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [x] Documentation PR or issue filled - https://github.com/nuget/client.engineering/issues/1031
