### PR TITLE
Cherry pick lock files support TFMs with platforms commit to service rel/16.11

### DIFF
--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -47,7 +47,7 @@ steps:
 - task: MicroBuildSwixPlugin@1
   displayName: "Install Swix Plugin"
 
-- task: ms-vseng.MicroBuildTasks.965C8DC6-1483-45C9-B384-5AC75DA1F1A4.MicroBuildOptProfPlugin@6
+- task: MicroBuildOptProfPlugin@6
   displayName: 'OptProfV2:  install the plugin'
   inputs:
     getDropNameByDrop: true
@@ -269,13 +269,13 @@ steps:
     arguments: "verify -Signatures $(Build.Repository.LocalPath)\\artifacts\\$(NupkgOutputDir)\\*.nupkg"
   condition: and(succeeded(), or(eq(variables['IsOfficialBuild'], 'true'), eq(variables['BuildRTM'], 'true')))  #skip this task for nonRTM in private build
 
-- task: ms-vseng.MicroBuildShipTasks.7c429315-71ba-4cb3-94bb-f829c95f7915.MicroBuildCodesignVerify@1
+- task: MicroBuildCodesignVerify@1
   displayName: Verify Assembly Signatures and StrongName for the nupkgs
   inputs:
     TargetFolder: '$(Build.Repository.LocalPath)\\artifacts\\$(NupkgOutputDir)'
   condition: and(succeeded(), or(eq(variables['IsOfficialBuild'], 'true'), eq(variables['BuildRTM'], 'true')))  #skip this task for nonRTM in private build
 
-- task: ms-vseng.MicroBuildShipTasks.7c429315-71ba-4cb3-94bb-f829c95f7915.MicroBuildCodesignVerify@1
+- task: MicroBuildCodesignVerify@1
   displayName: Verify Assembly Signatures and StrongName for the VSIX & exes
   inputs:
     TargetFolder: '$(Build.Repository.LocalPath)\\artifacts\\VS15'
@@ -283,7 +283,7 @@ steps:
     WhiteListPathForSigs: '$(Build.Repository.LocalPath)\\build\\ignorecodesign.csv'
   condition: and(succeeded(), or(eq(variables['IsOfficialBuild'], 'true'), eq(variables['BuildRTM'], 'true')))  #skip this task for nonRTM in private build
 
-- task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
+- task: ComponentGovernanceComponentDetection@0
   displayName: 'Component Detection'
   condition: "and(succeeded(),eq(variables['BuildRTM'], 'true'))"
 
@@ -330,7 +330,7 @@ steps:
     arguments: 'install Microsoft.DevDiv.Validation.TestPlatform.Settings.Tasks -Version 1.0.308 -Source $(VsPackageFeedUrl) -ConfigFile $(System.DefaultWorkingDirectory)\NuGet.config -OutputDirectory $(System.DefaultWorkingDirectory)\packages'
   condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
 
-- task: ms-vseng.MicroBuildTasks.0e9d0d4d-71ec-4e4e-ae40-db9896f1ae74.MicroBuildBuildVSBootstrapper@2
+- task: MicroBuildBuildVSBootstrapper@2
   displayName: 'OptProfV2:  build a Visual Studio bootstrapper'
   inputs:
     channelName: "$(VsTargetChannel)"
@@ -369,25 +369,25 @@ steps:
     msbuildArguments: '/p:OutputPath="$(Build.Repository.LocalPath)\artifacts\RunSettings" /p:TestDrop="$(TestDrop)" /p:ProfilingInputsDrop="ProfilingInputs/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildId)"'
   condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
 
-- task: ms-vscs-artifact.build-tasks.artifactDropTask-1.artifactDropTask@0
+- task: artifactDropTask@0
   displayName: 'OptProfV2:  publish the .runsettings file to artifact services'
   inputs:
     dropServiceURI: 'https://devdiv.artifacts.visualstudio.com'
     buildNumber: 'RunSettings/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildId)'
     sourcePath: 'artifacts\RunSettings'
     toLowerCase: false
-    usePat: false
+    usePat: true
     dropMetadataContainerName: RunSettings
   condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
 
-- task: ms-vscs-artifact.build-tasks.artifactDropTask-1.artifactDropTask@0
+- task: artifactDropTask@0
   displayName: 'OptProfV2:  publish profiling inputs to artifact services'
   inputs:
     dropServiceURI: 'https://devdiv.artifacts.visualstudio.com'
     buildNumber: 'ProfilingInputs/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildId)'
     sourcePath: '$(Build.ArtifactStagingDirectory)\OptProf\ProfilingInputs'
     toLowerCase: false
-    usePat: false
+    usePat: true
   condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
 
 - task: PublishBuildArtifacts@1
@@ -447,21 +447,15 @@ steps:
     artifactName: "symbols - $(RtmLabel)"
   condition: " and(succeeded(), eq(variables['IsOfficialBuild'], 'true')) "
 
-- task: ms-vscs-artifact.build-tasks.artifactSymbolTask-1.artifactSymbolTask@0
-  displayName: "Publish Symbols on Symweb"
-  inputs:
-    symbolServiceURI: "https://microsoft.artifacts.visualstudio.com/DefaultCollection"
-    requestName: "CollectionId/$(System.CollectionId)/ProjectId/$(System.TeamProjectId)/$(TeamName)/BuildId/$(Build.BuildId)"
-    sourcePath: "$(Build.Repository.LocalPath)\\artifacts\\symbolstoindex"
-    detailedLog: "true"
-    expirationInDays: "45"
-    usePat: "false"
-  condition: " and(succeeded(),eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true')) "
-
-- task: MicroBuildUploadVstsDropFolder@1
+- task: artifactDropTask@0
   displayName: "Upload VSTS Drop"
   inputs:
-    DropFolder: "$(Build.Repository.LocalPath)\\artifacts\\VS15"
+    dropServiceURI: 'https://devdiv.artifacts.visualstudio.com'
+    buildNumber: 'Products/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildNumber)'
+    sourcePath: "$(Build.Repository.LocalPath)\\artifacts\\$(VsixPublishDir)"
+    toLowerCase: false
+    usePat: true
+    dropMetadataContainerName: "DropMetadata-Product"
   condition: " and(succeeded(),eq(variables['BuildRTM'], 'false')) "
 
 - task: PowerShell@1

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -44,7 +44,7 @@ jobs:
     BuildRTM: "false"
 
   pool:
-    name: VSEng-MicroBuildVS2019
+    name: VSEngSS-MicroBuild2019
     demands:
       - DotNetFramework
       - msbuild
@@ -65,7 +65,7 @@ jobs:
     BuildRTM: "true"
 
   pool:
-    name: VSEng-MicroBuildVS2019
+    name: VSEngSS-MicroBuild2019
     demands:
       - DotNetFramework
       - msbuild

--- a/scripts/e2etests/Utils.ps1
+++ b/scripts/e2etests/Utils.ps1
@@ -3,7 +3,7 @@ function CleanTempFolder()
     if (Test-Path $env:temp)
     {
         Write-Host 'Deleting temp folder'
-        rmdir $env:temp -Recurse -ErrorAction SilentlyContinue
+        Get-ChildItem $env:temp | Remove-Item -Recurse -ErrorAction SilentlyContinue
         Write-Host 'Done.'
     }
 }

--- a/src/NuGet.Core/NuGet.Frameworks/FrameworkConstants.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/FrameworkConstants.cs
@@ -16,6 +16,7 @@ namespace NuGet.Frameworks
         public static readonly Version EmptyVersion = new Version(0, 0, 0, 0);
         public static readonly Version MaxVersion = new Version(int.MaxValue, 0, 0, 0);
         public static readonly Version Version5 = new Version(5, 0, 0, 0);
+        public static readonly Version Version6 = new Version(6, 0, 0, 0);
         public static readonly Version Version10 = new Version(10, 0, 0, 0);
         public static readonly FrameworkRange DotNetAll = new FrameworkRange(
                         new NuGetFramework(FrameworkIdentifiers.NetPlatform, FrameworkConstants.EmptyVersion),
@@ -185,6 +186,7 @@ namespace NuGet.Frameworks
 
             // .NET 5.0 and later has NetCoreApp identifier
             public static readonly NuGetFramework Net50 = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version5);
+            public static readonly NuGetFramework Net60 = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version6);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Frameworks/FrameworkConstants.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/FrameworkConstants.cs
@@ -89,6 +89,7 @@ namespace NuGet.Frameworks
             public static readonly NuGetFramework Net461 = new NuGetFramework(FrameworkIdentifiers.Net, new Version(4, 6, 1, 0));
             public static readonly NuGetFramework Net462 = new NuGetFramework(FrameworkIdentifiers.Net, new Version(4, 6, 2, 0));
             public static readonly NuGetFramework Net463 = new NuGetFramework(FrameworkIdentifiers.Net, new Version(4, 6, 3, 0));
+            public static readonly NuGetFramework Net472 = new NuGetFramework(FrameworkIdentifiers.Net, new Version(4, 7, 2, 0));
 
             public static readonly NuGetFramework NetCore45 = new NuGetFramework(FrameworkIdentifiers.NetCore, new Version(4, 5, 0, 0));
             public static readonly NuGetFramework NetCore451 = new NuGetFramework(FrameworkIdentifiers.NetCore, new Version(4, 5, 1, 0));

--- a/src/NuGet.Core/NuGet.Frameworks/NuGetFrameworkFactory.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/NuGetFrameworkFactory.cs
@@ -609,6 +609,9 @@ namespace NuGet.Frameworks
                 case "net462":
                     framework = FrameworkConstants.CommonFrameworks.Net462;
                     break;
+                case "net472":
+                    framework = FrameworkConstants.CommonFrameworks.Net472;
+                    break;
                 case "win8":
                     framework = FrameworkConstants.CommonFrameworks.Win8;
                     break;

--- a/src/NuGet.Core/NuGet.Frameworks/NuGetFrameworkFactory.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/NuGetFrameworkFactory.cs
@@ -672,6 +672,12 @@ namespace NuGet.Frameworks
                 case "net50":
                     framework = FrameworkConstants.CommonFrameworks.Net50;
                     break;
+                case "netcoreapp6.0":
+                case "netcoreapp60":
+                case "net6.0":
+                case "net60":
+                    framework = FrameworkConstants.CommonFrameworks.Net60;
+                    break;
             }
 
             return framework != null;

--- a/src/NuGet.Core/NuGet.Frameworks/PublicAPI/net40/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Frameworks/PublicAPI/net40/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net60 -> NuGet.Frameworks.NuGetFramework
+static readonly NuGet.Frameworks.FrameworkConstants.Version6 -> System.Version

--- a/src/NuGet.Core/NuGet.Frameworks/PublicAPI/net40/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Frameworks/PublicAPI/net40/PublicAPI.Unshipped.txt
@@ -1,2 +1,3 @@
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net472 -> NuGet.Frameworks.NuGetFramework
 static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net60 -> NuGet.Frameworks.NuGetFramework
 static readonly NuGet.Frameworks.FrameworkConstants.Version6 -> System.Version

--- a/src/NuGet.Core/NuGet.Frameworks/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Frameworks/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net60 -> NuGet.Frameworks.NuGetFramework
+static readonly NuGet.Frameworks.FrameworkConstants.Version6 -> System.Version

--- a/src/NuGet.Core/NuGet.Frameworks/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Frameworks/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -1,2 +1,3 @@
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net472 -> NuGet.Frameworks.NuGetFramework
 static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net60 -> NuGet.Frameworks.NuGetFramework
 static readonly NuGet.Frameworks.FrameworkConstants.Version6 -> System.Version

--- a/src/NuGet.Core/NuGet.Frameworks/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Frameworks/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net60 -> NuGet.Frameworks.NuGetFramework
+static readonly NuGet.Frameworks.FrameworkConstants.Version6 -> System.Version

--- a/src/NuGet.Core/NuGet.Frameworks/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Frameworks/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,2 +1,3 @@
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net472 -> NuGet.Frameworks.NuGetFramework
 static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net60 -> NuGet.Frameworks.NuGetFramework
 static readonly NuGet.Frameworks.FrameworkConstants.Version6 -> System.Version

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileTarget.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileTarget.cs
@@ -31,7 +31,7 @@ namespace NuGet.ProjectModel
         /// <summary>
         /// Full framework name.
         /// </summary>
-        public string Name => GetNameString(TargetFramework.DotNetFrameworkName, RuntimeIdentifier);
+        public string Name => GetNameString(TargetFramework, RuntimeIdentifier);
 
         public bool Equals(PackagesLockFileTarget other)
         {
@@ -66,14 +66,36 @@ namespace NuGet.ProjectModel
             return combiner.CombinedHash;
         }
 
-        private static string GetNameString(string framework, string runtime)
+        private static string GetNameString(NuGetFramework framework, string runtime)
         {
-            if (!string.IsNullOrEmpty(runtime))
+            string frameworkString;
+
+            // We already shipped net5.0 being listed as .NETCoreApp,Version=5.0, so it would be a breaking change
+            // to change it. Similarly for all earlier framework identifiers.
+            // Since net5.0-windows didn't work properly, we can use the "friendly" (folder name) for net5 with a platform.
+            // For net6 and higher, always use friendly folder format, since this is the preferred customer-facing
+            // format (from dotnet/design's net5 spec).
+            // Packages lock files are checked into source control, hence customers will see it in their diffs.
+            if (string.Equals(framework.Framework, FrameworkConstants.FrameworkIdentifiers.NetCoreApp, StringComparison.OrdinalIgnoreCase)
+                && (
+                    (framework.Version.Major >= 6)
+                    || (framework.Version.Major == 5 && framework.HasPlatform)
+                   )
+                )
             {
-                return $"{framework}/{runtime}";
+                frameworkString = framework.ToString();
+            }
+            else
+            {
+                frameworkString = framework.DotNetFrameworkName;
             }
 
-            return framework;
+            if (!string.IsNullOrEmpty(runtime))
+            {
+                return $"{frameworkString}/{runtime}";
+            }
+
+            return frameworkString;
         }
     }
 }

--- a/test/EndToEnd/vs.ps1
+++ b/test/EndToEnd/vs.ps1
@@ -512,7 +512,9 @@ function New-FSharpLibrary {
         [string]$SolutionFolder
     )
 
-    New-Project FSharpLibrary $ProjectName $SolutionFolder
+    $project = New-Project FSharpLibrary $ProjectName $SolutionFolder
+    Wait-OnNetCoreRestoreCompletion $project
+    return $project
 }
 
 function New-FSharpConsoleApplication {
@@ -521,7 +523,9 @@ function New-FSharpConsoleApplication {
         [string]$SolutionFolder
     )
 
-    New-Project FSharpConsoleApplication $ProjectName $SolutionFolder
+    $project = New-Project FSharpConsoleApplication $ProjectName $SolutionFolder
+    Wait-OnNetCoreRestoreCompletion $project
+    return $project
 }
 
 function New-WPFApplication {
@@ -949,7 +953,7 @@ function Get-VSFolderPath
 }
 
 function Get-MSBuildExe {
-    
-    $MSBuildRoot = Get-VSFolderPath 
+
+    $MSBuildRoot = Get-VSFolderPath
     Join-Path $MSBuildRoot "MsBuild\Current\bin\msbuild.exe"
 }

--- a/test/NuGet.Core.Tests/NuGet.Frameworks.Test/NuGetFrameworkParseTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Frameworks.Test/NuGetFrameworkParseTests.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections;
+using System.Collections.Generic;
 using NuGet.Frameworks;
 using Xunit;
 
@@ -423,5 +425,26 @@ namespace NuGet.Test
             // Compare the object references
             Assert.Same(framework1, framework2);
         }
+
+        public static IEnumerable<object[]> NuGetFramework_Parse_CommonFramework_ReturnsStaticInstance_Data()
+        {
+            yield return new object[] { "net472", FrameworkConstants.CommonFrameworks.Net472 };
+            yield return new object[] { "net5.0", FrameworkConstants.CommonFrameworks.Net50 };
+            yield return new object[] { "net6.0", FrameworkConstants.CommonFrameworks.Net60 };
+
+        }
+
+        [Theory]
+        [MemberData(nameof(NuGetFramework_Parse_CommonFramework_ReturnsStaticInstance_Data))]
+        public void NuGetFramework_Parse_CommonFramework_ReturnsStaticInstance(string frameworkString, NuGetFramework frameworkObject)
+        {
+            // Act
+            NuGetFramework parsedFramework = NuGetFramework.Parse(frameworkString);
+
+            // Assert
+            Assert.Same(frameworkObject, parsedFramework);
+        }
+
+
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackagesLockFileFormatTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackagesLockFileFormatTests.cs
@@ -3,6 +3,7 @@
 
 using System.Linq;
 using Newtonsoft.Json.Linq;
+using NuGet.Frameworks;
 using Xunit;
 
 namespace NuGet.ProjectModel.Test
@@ -56,6 +57,74 @@ namespace NuGet.ProjectModel.Test
             Assert.Null(target.Dependencies[1].RequestedVersion);
             Assert.Equal("1.0.0", target.Dependencies[0].ResolvedVersion.ToNormalizedString());
             Assert.NotEmpty(target.Dependencies[1].ContentHash);
+        }
+
+        [Fact]
+        public void Read_VariousTargetFrameworksAndRuntimeIdentifiers_ParsedCorrectly()
+        {
+            // Arrange
+            var lockFileContents =
+@"{
+    ""version"": 1,
+    ""dependencies"": {
+        "".NETFramework,Version=v4.7.2"": { },
+        "".NETStandard,Version=v2.0"": { },
+        "".NETCoreApp,Version=3.1"": { },
+        "".NETCoreApp,Version=3.1/win-x64"": { },
+        "".NETCoreApp,Version=5.0"": { },
+        "".NETCoreApp,Version=5.0/win-x64"": { },
+        ""net5.0-windows7.0"": { },
+        ""net5.0-windows7.0/win-x64"": { },
+        ""net6.0"": { },
+        ""net6.0/win-x64"": { },
+        ""net6.0-windows7.0"": { },
+        ""net6.0-windows7.0/win-x64"": { },
+    }
+}";
+
+            // Act
+            var lockFile = PackagesLockFileFormat.Parse(lockFileContents, "In memory");
+
+            // Assert
+            Assert.Equal(12, lockFile.Targets.Count);
+
+            Assert.Equal(FrameworkConstants.CommonFrameworks.Net472, lockFile.Targets[0].TargetFramework);
+            Assert.Null(lockFile.Targets[0].RuntimeIdentifier);
+
+            Assert.Equal(FrameworkConstants.CommonFrameworks.NetStandard20, lockFile.Targets[1].TargetFramework);
+            Assert.Null(lockFile.Targets[1].RuntimeIdentifier);
+
+            Assert.Equal(FrameworkConstants.CommonFrameworks.NetCoreApp31, lockFile.Targets[2].TargetFramework);
+            Assert.Null(lockFile.Targets[2].RuntimeIdentifier);
+
+            Assert.Equal(FrameworkConstants.CommonFrameworks.NetCoreApp31, lockFile.Targets[3].TargetFramework);
+            Assert.Equal("win-x64", lockFile.Targets[3].RuntimeIdentifier);
+
+            Assert.Equal(FrameworkConstants.CommonFrameworks.Net50, lockFile.Targets[4].TargetFramework);
+            Assert.Null(lockFile.Targets[4].RuntimeIdentifier);
+
+            Assert.Equal(FrameworkConstants.CommonFrameworks.Net50, lockFile.Targets[5].TargetFramework);
+            Assert.Equal("win-x64", lockFile.Targets[5].RuntimeIdentifier);
+
+            NuGetFramework net5win7 = NuGetFramework.Parse("net5.0-windows7.0");
+            Assert.Equal(net5win7, lockFile.Targets[6].TargetFramework);
+            Assert.Null(lockFile.Targets[6].RuntimeIdentifier);
+
+            Assert.Equal(net5win7, lockFile.Targets[7].TargetFramework);
+            Assert.Equal("win-x64", lockFile.Targets[7].RuntimeIdentifier);
+
+            Assert.Equal(FrameworkConstants.CommonFrameworks.Net60, lockFile.Targets[8].TargetFramework);
+            Assert.Null(lockFile.Targets[8].RuntimeIdentifier);
+
+            Assert.Equal(FrameworkConstants.CommonFrameworks.Net60, lockFile.Targets[9].TargetFramework);
+            Assert.Equal("win-x64", lockFile.Targets[9].RuntimeIdentifier);
+
+            NuGetFramework net6win7 = NuGetFramework.Parse("net6.0-windows7.0");
+            Assert.Equal(net6win7, lockFile.Targets[10].TargetFramework);
+            Assert.Null(lockFile.Targets[10].RuntimeIdentifier);
+
+            Assert.Equal(net6win7, lockFile.Targets[11].TargetFramework);
+            Assert.Equal("win-x64", lockFile.Targets[11].RuntimeIdentifier);
         }
 
         [Fact]

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackagesLockFileTargetTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackagesLockFileTargetTests.cs
@@ -1,0 +1,42 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using NuGet.Frameworks;
+using Xunit;
+
+namespace NuGet.ProjectModel.Test
+{
+    public class PackagesLockFileTargetTests
+    {
+        [Theory]
+        [InlineData("net472", null, ".NETFramework,Version=v4.7.2")]
+        [InlineData("netstandard2.0", null, ".NETStandard,Version=v2.0")]
+        [InlineData("netcoreapp3.1", null, ".NETCoreApp,Version=v3.1")]
+        [InlineData("netcoreapp3.1", "win-x64", ".NETCoreApp,Version=v3.1/win-x64")]
+        [InlineData("net5.0", null, ".NETCoreApp,Version=v5.0")]
+        [InlineData("net5.0", "win-x64", ".NETCoreApp,Version=v5.0/win-x64")]
+        [InlineData("net5.0-windows7.0", null, "net5.0-windows7.0")]
+        [InlineData("net5.0-windows7.0", "win-x64", "net5.0-windows7.0/win-x64")]
+        [InlineData("net6.0", null, "net6.0")]
+        [InlineData("net6.0", "win-x64", "net6.0/win-x64")]
+        [InlineData("net6.0-windows7.0", null, "net6.0-windows7.0")]
+        [InlineData("net6.0-windows7.0", "win-x64", "net6.0-windows7.0/win-x64")]
+        public void Name_DifferentTargetFrameworkAndRuntimeIdentifiers_HasExpectedValue(string targetFramework, string runtimeIdentifier, string expectedName)
+        {
+            // Arrange
+            NuGetFramework framework = NuGetFramework.Parse(targetFramework);
+
+            PackagesLockFileTarget packagesLockFileTarget = new()
+            {
+                TargetFramework = framework,
+                RuntimeIdentifier = runtimeIdentifier
+            };
+
+            // Act
+            var actualName = packagesLockFileTarget.Name;
+
+            // Assert
+            Assert.Equal(expectedName, actualName);
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackagesLockFileTargetTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackagesLockFileTargetTests.cs
@@ -26,7 +26,7 @@ namespace NuGet.ProjectModel.Test
             // Arrange
             NuGetFramework framework = NuGetFramework.Parse(targetFramework);
 
-            PackagesLockFileTarget packagesLockFileTarget = new()
+            PackagesLockFileTarget packagesLockFileTarget = new PackagesLockFileTarget()
             {
                 TargetFramework = framework,
                 RuntimeIdentifier = runtimeIdentifier

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Resources/PackageUpdateResourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Resources/PackageUpdateResourceTests.cs
@@ -223,7 +223,7 @@ namespace NuGet.Protocol.Tests
             }
         }
 
-        [Theory]
+        [Theory(Skip = "https://github.com/NuGet/Home/issues/10706")]
         [InlineData("https://nuget.smbsrc.net/")]
         [InlineData("http://nuget.smbsrc.net/")]
         [InlineData("https://nuget.smbsrc.net")]


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: Associated with https://github.com/NuGet/Client.Engineering/issues/1110

Regression? Last working version: No

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
Cherry pick 820bfe9 and few other commits related to CI for green build. Added `net472` in `FrameworkConstants` as it was used in tests.

All the CI checks passed for this PR - https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=5160229&view=results

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  - [x] N/A
