### PR TITLE
Add GetSolutionDirectoryAsync to IVsSolutionManager

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/NuGetPowerShellBaseCommand.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/NuGetPowerShellBaseCommand.cs
@@ -249,7 +249,7 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
 
         protected async Task CheckMissingPackagesAsync()
         {
-            var solutionDirectory = VsSolutionManager.SolutionDirectory;
+            var solutionDirectory = await VsSolutionManager.GetSolutionDirectoryAsync();
 
             var packages = await PackageRestoreManager.GetPackagesInSolutionAsync(solutionDirectory, CancellationToken.None);
             if (packages.Any(p => p.IsMissing))

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
@@ -416,25 +416,21 @@ namespace NuGet.PackageManagement.VisualStudio
             });
         }
 
-        public string SolutionDirectory
-        {
-            get
-            {
-                return NuGetUIThreadHelper.JoinableTaskFactory.Run(async delegate
-                {
-                    if (!await IsSolutionOpenAsync())
-                    {
-                        return null;
-                    }
-                    var solutionFilePath = await GetSolutionFilePathAsync();
+        public string SolutionDirectory => NuGetUIThreadHelper.JoinableTaskFactory.Run(GetSolutionDirectoryAsync);
 
-                    if (string.IsNullOrEmpty(solutionFilePath))
-                    {
-                        return null;
-                    }
-                    return Path.GetDirectoryName(solutionFilePath);
-                });
+        public async Task<string> GetSolutionDirectoryAsync()
+        {
+            if (!await IsSolutionOpenAsync())
+            {
+                return null;
             }
+            var solutionFilePath = await GetSolutionFilePathAsync();
+
+            if (string.IsNullOrEmpty(solutionFilePath))
+            {
+                return null;
+            }
+            return Path.GetDirectoryName(solutionFilePath);
         }
 
         public async Task<string> GetSolutionFilePathAsync()

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetProjectUpgraderService.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetProjectUpgraderService.cs
@@ -110,9 +110,7 @@ namespace NuGet.PackageManagement.VisualStudio
             IVsSolutionManager? solutionManager = await _state.SolutionManager.GetValueAsync(cancellationToken);
             Assumes.NotNull(solutionManager);
 
-            await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-
-            string solutionDirectory = solutionManager.SolutionDirectory;
+            string solutionDirectory = await solutionManager.GetSolutionDirectoryAsync();
 
             await TaskScheduler.Default;
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetSolutionManagerService.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetSolutionManagerService.cs
@@ -87,9 +87,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
             cancellationToken.ThrowIfCancellationRequested();
 
-            await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
-
-            return SolutionManager.SolutionDirectory;
+            return await SolutionManager.GetSolutionDirectoryAsync();
         }
 
         private static string CreateProjectActionId()

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreJob.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreJob.cs
@@ -185,12 +185,12 @@ namespace NuGet.SolutionRestoreManager
                 {
                     token.ThrowIfCancellationRequested();
 
-                    string solutionDirectory;
+                    string solutionDirectory = null;
                     bool isSolutionAvailable;
 
                     using (intervalTracker.Start(RestoreTelemetryEvent.RestoreOperationChecks))
                     {
-                        solutionDirectory = _solutionManager.SolutionDirectory;
+                        var solutionFilePath = await _solutionManager.GetSolutionDirectoryAsync();
                         isSolutionAvailable = await _solutionManager.IsSolutionAvailableAsync();
 
                         // Get the projects from the SolutionManager

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreJob.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreJob.cs
@@ -185,12 +185,12 @@ namespace NuGet.SolutionRestoreManager
                 {
                     token.ThrowIfCancellationRequested();
 
-                    string solutionDirectory = null;
+                    string solutionDirectory;
                     bool isSolutionAvailable;
 
                     using (intervalTracker.Start(RestoreTelemetryEvent.RestoreOperationChecks))
                     {
-                        var solutionFilePath = await _solutionManager.GetSolutionDirectoryAsync();
+                        solutionDirectory = await _solutionManager.GetSolutionDirectoryAsync();
                         isSolutionAvailable = await _solutionManager.IsSolutionAvailableAsync();
 
                         // Get the projects from the SolutionManager

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/IDE/IVsSolutionManager.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/IDE/IVsSolutionManager.cs
@@ -93,5 +93,8 @@ namespace NuGet.PackageManagement.VisualStudio
         Task<bool> IsSolutionOpenAsync();
 
         IReadOnlyList<object> GetAllProjectRestoreInfoSources();
+
+        Task<string> GetSolutionDirectoryAsync();
+
     }
 }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/IDE/IVsSolutionManager.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/IDE/IVsSolutionManager.cs
@@ -82,7 +82,7 @@ namespace NuGet.PackageManagement.VisualStudio
         Task<bool> IsAllProjectsNominatedAsync();
 
         /// <summary>
-        /// Retruns Solution FullName
+        /// Returns Solution FullName
         /// </summary>
         /// <returns></returns>
         Task<string> GetSolutionFilePathAsync();
@@ -92,9 +92,14 @@ namespace NuGet.PackageManagement.VisualStudio
         /// </summary>
         Task<bool> IsSolutionOpenAsync();
 
+        /// <summary>
+        /// Returns the list of project restore info sources. Empty if none are available.
+        /// </summary>
         IReadOnlyList<object> GetAllProjectRestoreInfoSources();
 
+        /// <summary>
+        /// Gets the current open solution directory. <see cref="null"/> if the there's no open solution.
+        /// </summary>
         Task<string> GetSolutionDirectoryAsync();
-
     }
 }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPackageInstallerServices.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPackageInstallerServices.cs
@@ -67,7 +67,7 @@ namespace NuGet.VisualStudio
                         // Calls may occur in the template wizard before the solution is actually created,
                         // in that case return no projects
                         if (_solutionManager != null
-                                && !string.IsNullOrEmpty(_solutionManager.SolutionDirectory))
+                                && !string.IsNullOrEmpty(await _solutionManager.GetSolutionDirectoryAsync()))
                         {
                             //switch to background thread
                             await TaskScheduler.Default;
@@ -152,7 +152,7 @@ namespace NuGet.VisualStudio
             var packages = new List<PackageReference>();
 
             if (_solutionManager != null
-                && !string.IsNullOrEmpty(_solutionManager.SolutionDirectory))
+                && !string.IsNullOrEmpty(await _solutionManager.GetSolutionDirectoryAsync()))
             {
                 var projectContext = new VSAPIProjectContext
                 {
@@ -188,7 +188,7 @@ namespace NuGet.VisualStudio
                         var packages = new List<IVsPackageMetadata>();
 
                         if (_solutionManager != null
-                            && !string.IsNullOrEmpty(_solutionManager.SolutionDirectory))
+                            && !string.IsNullOrEmpty(await _solutionManager.GetSolutionDirectoryAsync()))
                         {
                             //switch to background thread
                             await TaskScheduler.Default;

--- a/src/NuGet.Clients/NuGetConsole.Host.PowerShell/PowerShellHost.cs
+++ b/src/NuGet.Clients/NuGetConsole.Host.PowerShell/PowerShellHost.cs
@@ -416,7 +416,7 @@ namespace NuGetConsole.Host.PowerShell.Implementation
                 {
                     // if there is no solution open, we set the active directory to be user profile folder
                     var targetDir = await _solutionManager.Value.IsSolutionOpenAsync() ?
-                        _solutionManager.Value.SolutionDirectory :
+                        await _solutionManager.Value.GetSolutionDirectoryAsync() :
                         Environment.GetEnvironmentVariable("USERPROFILE");
 
                     Runspace.ChangePSDirectory(targetDir);
@@ -441,7 +441,7 @@ namespace NuGetConsole.Host.PowerShell.Implementation
                 }
 
                 var latestRestore = _latestRestore;
-                var latestSolutionDirectory = _solutionManager.Value.SolutionDirectory;
+                var latestSolutionDirectory = await _solutionManager.Value.GetSolutionDirectoryAsync();
                 if (ShouldNoOpDueToRestore(latestRestore) &&
                     ShouldNoOpDueToSolutionDirectory(latestSolutionDirectory))
                 {

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/NuGetProjectManagerServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/NuGetProjectManagerServiceTests.cs
@@ -790,6 +790,11 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             {
                 throw new NotImplementedException();
             }
+
+            public Task<string> GetSolutionDirectoryAsync()
+            {
+                return Task.FromResult(_directory.Path);
+            }
         }
     }
 }

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/Extensibility/VsPackageInstallerServicesTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/Extensibility/VsPackageInstallerServicesTests.cs
@@ -28,7 +28,7 @@ namespace NuGet.VisualStudio.Implementation.Test.Extensibility
             var telemetryProvider = new Mock<INuGetTelemetryProvider>();
 
             var assemblyDirectory = Path.GetDirectoryName(typeof(VsPackageInstallerServicesTests).Assembly.Location);
-            solutionManager.SetupGet(sm => sm.SolutionDirectory)
+            solutionManager.Setup(s => s.GetSolutionDirectoryAsync())
                 .Throws(expectedException);
 
             // Act
@@ -58,7 +58,7 @@ namespace NuGet.VisualStudio.Implementation.Test.Extensibility
             var telemetryProvider = new Mock<INuGetTelemetryProvider>();
 
             var assemblyDirectory = Path.GetDirectoryName(typeof(VsPackageInstallerServicesTests).Assembly.Location);
-            solutionManager.SetupGet(sm => sm.SolutionDirectory)
+            solutionManager.Setup(sm => sm.GetSolutionDirectoryAsync())
                 .Throws(expectedException);
 
             var project = new Mock<EnvDTE.Project>();
@@ -92,7 +92,7 @@ namespace NuGet.VisualStudio.Implementation.Test.Extensibility
             var expectedException = new ArgumentException("Internal error");
 
             var solutionManager = new Mock<IVsSolutionManager>();
-            solutionManager.SetupGet(s => s.SolutionDirectory)
+            solutionManager.Setup(s => s.GetSolutionDirectoryAsync())
                 .Throws(expectedException);
 
             var telemetryProvider = new Mock<INuGetTelemetryProvider>();
@@ -132,7 +132,7 @@ namespace NuGet.VisualStudio.Implementation.Test.Extensibility
             var expectedException = new ArgumentException("Internal error");
 
             var solutionManager = new Mock<IVsSolutionManager>();
-            solutionManager.SetupGet(s => s.SolutionDirectory)
+            solutionManager.Setup(s => s.GetSolutionDirectoryAsync())
                 .Throws(expectedException);
 
             var telemetryProvider = new Mock<INuGetTelemetryProvider>();


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11208

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Add GetSolutionDirectoryAsync to IVsSolutionManager - the primary motivation is restore codepaths, where the threadpool thread now won't be blocked waiting on the UI thread.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
