### PR TITLE
Remove wrappers that hide JTF.Run calls in IVsProjectThreadingService

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectServices/VsCoreProjectSystemReferenceReader.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectServices/VsCoreProjectSystemReferenceReader.cs
@@ -10,6 +10,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft;
 using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using NuGet.Frameworks;
 using NuGet.LibraryModel;
@@ -128,7 +129,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
         private IEnumerable<Reference> GetVSProjectReferences()
         {
-            _threadingService.ThrowIfNotOnUIThread();
+            ThreadHelper.ThrowIfNotOnUIThread();
 
             var langProject = _vsProjectAdapter.Project.Object as VSProject;
             if (langProject != null)
@@ -146,7 +147,7 @@ namespace NuGet.PackageManagement.VisualStudio
             IVsEnumHierarchyItemsFactory itemsFactory,
             Common.ILogger logger)
         {
-            _threadingService.ThrowIfNotOnUIThread();
+            ThreadHelper.ThrowIfNotOnUIThread();
 
             var excludedReferences = new List<string>();
 
@@ -208,7 +209,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
         private bool IsProjectReference(Reference3 reference, Common.ILogger logger)
         {
-            _threadingService.ThrowIfNotOnUIThread();
+            ThreadHelper.ThrowIfNotOnUIThread();
 
             try
             {
@@ -225,7 +226,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
         private bool IsReferenceResolved(Reference3 reference, Common.ILogger logger)
         {
-            _threadingService.ThrowIfNotOnUIThread();
+            ThreadHelper.ThrowIfNotOnUIThread();
 
             try
             {

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectServices/VsManagedLanguagesProjectSystemServices.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectServices/VsManagedLanguagesProjectSystemServices.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft;
+using Microsoft.VisualStudio.Shell;
 using NuGet.Commands;
 using NuGet.Common;
 using NuGet.Frameworks;
@@ -82,7 +83,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
             _asVSProject4 = new Lazy<VSProject4>(() =>
             {
-                _threadingService.ThrowIfNotOnUIThread();
+                ThreadHelper.ThrowIfNotOnUIThread();
                 return vsProjectAdapter.Project.Object as VSProject4;
             });
 
@@ -297,7 +298,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
         private void AddOrUpdatePackageReference(string packageName, VersionRange packageVersion, string[] metadataElements, string[] metadataValues)
         {
-            _threadingService.ThrowIfNotOnUIThread();
+            ThreadHelper.ThrowIfNotOnUIThread();
 
             // Note that API behavior is:
             // - specify a metadata element name with a value => add/replace that metadata item on the package reference

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectServices/VsProjectBuildProperties.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectServices/VsProjectBuildProperties.cs
@@ -35,7 +35,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
         public string GetPropertyValue(string propertyName)
         {
-            return _threadingService.ExecuteSynchronously(() => GetPropertyValueAsync(propertyName));
+            return _threadingService.JoinableTaskFactory.Run(() => GetPropertyValueAsync(propertyName));
         }
 
         public async Task<string> GetPropertyValueAsync(string propertyName)

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/VsMSBuildProjectSystemServices.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/VsMSBuildProjectSystemServices.cs
@@ -39,7 +39,7 @@ namespace NuGet.PackageManagement.VisualStudio
         {
             get
             {
-                return _threadingService.ExecuteSynchronously(async () =>
+                return _threadingService.JoinableTaskFactory.Run(async () =>
                 {
                     await _threadingService.JoinableTaskFactory.SwitchToMainThreadAsync();
                     return _vsProjectAdapter.Project.Object is VSLangProj150.VSProject4;

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/VsProjectAdapter.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/VsProjectAdapter.cs
@@ -159,7 +159,7 @@ namespace NuGet.PackageManagement.VisualStudio
         {
             get
             {
-                _threadingService.ThrowIfNotOnUIThread();
+                ThreadHelper.ThrowIfNotOnUIThread();
 
                 var packageVersion = BuildProperties.GetPropertyValue(ProjectBuildProperties.PackageVersion);
 
@@ -245,7 +245,7 @@ namespace NuGet.PackageManagement.VisualStudio
                 return EnvDTEProjectUtility.GetReferencedProjects(Project)
                     .Select(p =>
                     {
-                        _threadingService.ThrowIfNotOnUIThread();
+                        ThreadHelper.ThrowIfNotOnUIThread();
                         return p.UniqueName;
                     });
             }

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/VsProjectAdapterProvider.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/VsProjectAdapterProvider.cs
@@ -43,7 +43,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
         public IVsProjectAdapter CreateAdapterForFullyLoadedProject(EnvDTE.Project dteProject)
         {
-            return _threadingService.ExecuteSynchronously(
+            return _threadingService.JoinableTaskFactory.Run(
                 () => CreateAdapterForFullyLoadedProjectAsync(dteProject));
         }
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/DefaultProjectThreadingService.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/DefaultProjectThreadingService.cs
@@ -1,13 +1,9 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.ComponentModel.Composition;
-using System.Threading.Tasks;
-using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Threading;
 using NuGet.VisualStudio;
-using Task = System.Threading.Tasks.Task;
 
 namespace NuGet.PackageManagement.VisualStudio
 {
@@ -15,20 +11,5 @@ namespace NuGet.PackageManagement.VisualStudio
     internal class DefaultProjectThreadingService : IVsProjectThreadingService
     {
         public JoinableTaskFactory JoinableTaskFactory => NuGetUIThreadHelper.JoinableTaskFactory;
-
-        public void ExecuteSynchronously(Func<Task> asyncAction)
-        {
-            NuGetUIThreadHelper.JoinableTaskFactory.Run(asyncAction);
-        }
-
-        public T ExecuteSynchronously<T>(Func<Task<T>> asyncMethod)
-        {
-            return NuGetUIThreadHelper.JoinableTaskFactory.Run(asyncMethod);
-        }
-
-        public void ThrowIfNotOnUIThread(string callerMemberName)
-        {
-            ThreadHelper.ThrowIfNotOnUIThread(callerMemberName);
-        }
     }
 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/IVsProjectThreadingService.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/IVsProjectThreadingService.cs
@@ -1,22 +1,12 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using System.Runtime.CompilerServices;
-using System.Threading.Tasks;
 using Microsoft.VisualStudio.Threading;
-using Task = System.Threading.Tasks.Task;
 
 namespace NuGet.PackageManagement.VisualStudio
 {
     public interface IVsProjectThreadingService
     {
         JoinableTaskFactory JoinableTaskFactory { get; }
-
-        void ExecuteSynchronously(Func<Task> asyncAction);
-
-        T ExecuteSynchronously<T>(Func<Task<T>> asyncAction);
-
-        void ThrowIfNotOnUIThread([CallerMemberName] string callerMemberName = "");
     }
 }

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/LegacyPackageReferenceProjectTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/LegacyPackageReferenceProjectTests.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading;
-using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.VisualStudio.Sdk.TestFramework;
 using Microsoft.VisualStudio.Shell;
@@ -1471,20 +1470,5 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         }
 
         public JoinableTaskFactory JoinableTaskFactory { get; }
-
-        public void ExecuteSynchronously(Func<System.Threading.Tasks.Task> asyncAction)
-        {
-            JoinableTaskFactory.Run(asyncAction);
-        }
-
-        public T ExecuteSynchronously<T>(Func<Task<T>> asyncAction)
-        {
-            return JoinableTaskFactory.Run(asyncAction);
-        }
-
-        public void ThrowIfNotOnUIThread(string callerMemberName)
-        {
-            ThreadHelper.ThrowIfNotOnUIThread(callerMemberName);
-        }
     }
 }

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/TestUtilities/TestProjectThreadingService.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/TestUtilities/TestProjectThreadingService.cs
@@ -1,9 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using System.Runtime.CompilerServices;
-using System.Threading.Tasks;
 using Microsoft.VisualStudio.Threading;
 using NuGet.PackageManagement.VisualStudio;
 
@@ -21,23 +18,5 @@ namespace NuGet.VisualStudio.Implementation.Test.TestUtilities
         }
 
         public JoinableTaskFactory JoinableTaskFactory => _context.Factory;
-
-        public void ExecuteSynchronously(Func<Task> asyncAction)
-        {
-            JoinableTaskFactory.Run(asyncAction);
-        }
-
-        public T ExecuteSynchronously<T>(Func<Task<T>> asyncAction)
-        {
-            return JoinableTaskFactory.Run(asyncAction);
-        }
-
-        public void ThrowIfNotOnUIThread([CallerMemberName] string callerMemberName = "")
-        {
-            if (!_context.IsOnMainThread)
-            {
-                throw new Exception();
-            }
-        }
     }
 }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11211

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
JTF.Run is an anti-pattern, but sometimes necessary in our code for various reasons.

This issue tracks removing some of those wrappers in IVSProjectThreadingService, thus making it super obvious that you are using JTF.Run and that it's bad.

It also allows analyzers to better warn about those usages

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
