### PR TITLE
Avoid hitting the UI thread when retrieving MEF specific services

### DIFF
--- a/src/NuGet.Clients/NuGet.Console/PowerConsoleToolWindow.cs
+++ b/src/NuGet.Clients/NuGet.Console/PowerConsoleToolWindow.cs
@@ -683,7 +683,7 @@ namespace NuGetConsole.Implementation
                 {
                     _vsOutputConsole = NuGetUIThreadHelper.JoinableTaskFactory.Run(async () =>
                     {
-                        var consoleProvider = await ServiceLocator.GetInstanceAsync<IOutputConsoleProvider>();
+                        var consoleProvider = await ServiceLocator.GetComponentModelServiceAsync<IOutputConsoleProvider>();
                         if (null != consoleProvider)
                         {
                             return await consoleProvider.CreatePackageManagerConsoleAsync();
@@ -703,7 +703,7 @@ namespace NuGetConsole.Implementation
             {
                 if (_consoleStatus == null)
                 {
-                    _consoleStatus = ServiceLocator.GetInstance<IConsoleStatus>();
+                    _consoleStatus = ServiceLocator.GetComponentModelService<IConsoleStatus>();
                     Debug.Assert(_consoleStatus != null);
                 }
 

--- a/src/NuGet.Clients/NuGet.Console/Xamls/ConsoleContainer.xaml.cs
+++ b/src/NuGet.Clients/NuGet.Console/Xamls/ConsoleContainer.xaml.cs
@@ -48,9 +48,9 @@ namespace NuGetConsole
 
                             Assumes.NotNull(_solutionManager);
 
-                            var productUpdateService = ServiceLocator.GetInstance<IProductUpdateService>();
-                            var packageRestoreManager = ServiceLocator.GetInstance<IPackageRestoreManager>();
-                            var deleteOnRestartManager = ServiceLocator.GetInstance<IDeleteOnRestartManager>();
+                            var productUpdateService = ServiceLocator.GetComponentModelService<IProductUpdateService>();
+                            var packageRestoreManager = ServiceLocator.GetComponentModelService<IPackageRestoreManager>();
+                            var deleteOnRestartManager = ServiceLocator.GetComponentModelService<IDeleteOnRestartManager>();
                             var shell = ServiceLocator.GetGlobalService<SVsShell, IVsShell4>();
 
                             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();

--- a/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/Cmdlets/UninstallPackageCommand.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/Cmdlets/UninstallPackageCommand.cs
@@ -25,8 +25,8 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
 
         public UninstallPackageCommand()
         {
-            _deleteOnRestartManager = ServiceLocator.GetInstance<IDeleteOnRestartManager>();
-            _lockService = ServiceLocator.GetInstance<INuGetLockService>();
+            _deleteOnRestartManager = ServiceLocator.GetComponentModelService<IDeleteOnRestartManager>();
+            _lockService = ServiceLocator.GetComponentModelService<INuGetLockService>();
         }
 
         [Parameter(Mandatory = true, ValueFromPipelineByPropertyName = true, Position = 0)]

--- a/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/NuGetPowerShellBaseCommand.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/NuGetPowerShellBaseCommand.cs
@@ -68,14 +68,14 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
 
         protected NuGetPowerShellBaseCommand()
         {
-            _sourceRepositoryProvider = ServiceLocator.GetInstance<ISourceRepositoryProvider>();
-            ConfigSettings = ServiceLocator.GetInstance<Configuration.ISettings>();
-            VsSolutionManager = ServiceLocator.GetInstance<IVsSolutionManager>();
+            _sourceRepositoryProvider = ServiceLocator.GetComponentModelService<ISourceRepositoryProvider>();
+            ConfigSettings = ServiceLocator.GetComponentModelService<Configuration.ISettings>();
+            VsSolutionManager = ServiceLocator.GetComponentModelService<IVsSolutionManager>();
             DTE = ServiceLocator.GetInstance<DTE>();
-            SourceControlManagerProvider = ServiceLocator.GetInstance<ISourceControlManagerProvider>();
-            _commonOperations = ServiceLocator.GetInstance<ICommonOperations>();
-            PackageRestoreManager = ServiceLocator.GetInstance<IPackageRestoreManager>();
-            _deleteOnRestartManager = ServiceLocator.GetInstance<IDeleteOnRestartManager>();
+            SourceControlManagerProvider = ServiceLocator.GetComponentModelService<ISourceControlManagerProvider>();
+            _commonOperations = ServiceLocator.GetComponentModelService<ICommonOperations>();
+            PackageRestoreManager = ServiceLocator.GetComponentModelService<IPackageRestoreManager>();
+            _deleteOnRestartManager = ServiceLocator.GetComponentModelService<IDeleteOnRestartManager>();
 
             var logger = new LoggerAdapter(this);
             PackageExtractionContext = new PackageExtractionContext(

--- a/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/PackageActionBaseCommand.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/PackageActionBaseCommand.cs
@@ -29,8 +29,8 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
 
         public PackageActionBaseCommand()
         {
-            _deleteOnRestartManager = ServiceLocator.GetInstance<IDeleteOnRestartManager>();
-            _lockService = ServiceLocator.GetInstance<INuGetLockService>();
+            _deleteOnRestartManager = ServiceLocator.GetComponentModelService<IDeleteOnRestartManager>();
+            _lockService = ServiceLocator.GetComponentModelService<INuGetLockService>();
         }
 
         [Parameter(Mandatory = true, ValueFromPipelineByPropertyName = true, Position = 0)]

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/GeneralOptionControl.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/GeneralOptionControl.cs
@@ -25,8 +25,8 @@ namespace NuGet.Options
         public GeneralOptionControl()
         {
             InitializeComponent();
-            _settings = ServiceLocator.GetInstance<Configuration.ISettings>();
-            _outputConsoleLogger = ServiceLocator.GetInstance<INuGetUILogger>();
+            _settings = ServiceLocator.GetComponentModelService<ISettings>();
+            _outputConsoleLogger = ServiceLocator.GetComponentModelService<INuGetUILogger>();
             _localsCommandRunner = new LocalsCommandRunner();
             AutoScroll = true;
             Debug.Assert(_settings != null);
@@ -150,7 +150,7 @@ namespace NuGet.Options
         {
             UpdateLocalsCommandStatusText(string.Format(Resources.ShowMessage_LocalsCommandWorking), visibility: true);
             var arguments = new List<string> { "all" };
-            var settings = ServiceLocator.GetInstance<ISettings>();
+            var settings = ServiceLocator.GetComponentModelService<ISettings>();
             var logError = new LocalsArgs.Log(LogError);
             var logInformation = new LocalsArgs.Log(LogInformation);
             var localsArgs = new LocalsArgs(arguments, settings, logInformation, logError, clear: true, list: false);

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/OptionsPageBase.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/OptionsPageBase.cs
@@ -45,7 +45,7 @@ namespace NuGet.Options
             timer.Stop();
             timer.Dispose();
 
-            var optionsPageActivator = ServiceLocator.GetInstance<IOptionsPageActivator>();
+            var optionsPageActivator = ServiceLocator.GetComponentModelService<IOptionsPageActivator>();
             if (optionsPageActivator != null)
             {
                 optionsPageActivator.NotifyOptionsDialogClosed();

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -86,7 +86,7 @@ namespace NuGet.PackageManagement.UI
 
             Model = model;
             _uiLogger = uiLogger;
-            Settings = await ServiceLocator.GetInstanceAsync<ISettings>();
+            Settings = await ServiceLocator.GetComponentModelServiceAsync<ISettings>();
 
             _windowSearchHostFactory = await ServiceLocator.GetGlobalServiceAsync<SVsWindowSearchHostFactory, IVsWindowSearchHostFactory>();
             _serviceBroker = model.Context.ServiceBroker;
@@ -882,7 +882,7 @@ namespace NuGet.PackageManagement.UI
                 _recommendPackages = true;
             }
 
-            NuGetExperimentationService = await ServiceLocator.GetInstanceAsync<INuGetExperimentationService>();
+            NuGetExperimentationService = await ServiceLocator.GetComponentModelServiceAsync<INuGetExperimentationService>();
             // Check for A/B experiment here. For control group, return false instead of _recommendPackages
             if (IsRecommenderFlightEnabled(NuGetExperimentationService))
             {

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetPackageSearchService.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetPackageSearchService.cs
@@ -335,7 +335,7 @@ namespace NuGet.PackageManagement.VisualStudio
             CancellationToken cancellationToken)
         {
             var logger = new VisualStudioActivityLogger();
-            var uiLogger = ServiceLocator.GetInstance<INuGetUILogger>();
+            var uiLogger = await ServiceLocator.GetComponentModelServiceAsync<INuGetUILogger>();
             var packageFeeds = (mainFeed: (IPackageFeed?)null, recommenderFeed: (IPackageFeed?)null);
 
             if (itemFilter == ItemFilter.All && recommendPackages == false)
@@ -414,7 +414,7 @@ namespace NuGet.PackageManagement.VisualStudio
         private async Task<SourceRepository> GetPackagesFolderSourceRepositoryAsync()
         {
             IVsSolutionManager solutionManager = await _sharedServiceState.SolutionManager.GetValueAsync();
-            ISettings settings = ServiceLocator.GetInstance<ISettings>();
+            ISettings settings = await ServiceLocator.GetComponentModelServiceAsync<ISettings>();
 
             return _sharedServiceState.SourceRepositoryProvider.CreateRepository(
                 new PackageSource(PackagesFolderPathUtility.GetPackagesFolderPath(solutionManager, settings)),

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetProjectManagerService.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetProjectManagerService.cs
@@ -349,7 +349,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
                 try
                 {
-                    projectContext = await ServiceLocator.GetInstanceAsync<INuGetProjectContext>();
+                    projectContext = await ServiceLocator.GetComponentModelServiceAsync<INuGetProjectContext>();
 
                     Assumes.NotNull(projectContext);
 
@@ -418,7 +418,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
                 Assumes.NotNullOrEmpty(sourceRepositories);
 
-                INuGetProjectContext projectContext = await ServiceLocator.GetInstanceAsync<INuGetProjectContext>();
+                INuGetProjectContext projectContext = await ServiceLocator.GetComponentModelServiceAsync<INuGetProjectContext>();
                 IReadOnlyList<NuGetProject> projects = await GetProjectsAsync(projectIds, cancellationToken);
 
                 var resolutionContext = new ResolutionContext(
@@ -471,7 +471,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
             return await CatchAndRethrowExceptionAsync(async () =>
             {
-                INuGetProjectContext projectContext = await ServiceLocator.GetInstanceAsync<INuGetProjectContext>();
+                INuGetProjectContext projectContext = await ServiceLocator.GetComponentModelServiceAsync<INuGetProjectContext>();
                 IReadOnlyList<NuGetProject> projects = await GetProjectsAsync(projectIds, cancellationToken);
 
                 var projectActions = new List<ProjectAction>();
@@ -541,7 +541,7 @@ namespace NuGet.PackageManagement.VisualStudio
                     }
                 }
 
-                INuGetProjectContext projectContext = await ServiceLocator.GetInstanceAsync<INuGetProjectContext>();
+                INuGetProjectContext projectContext = await ServiceLocator.GetComponentModelServiceAsync<INuGetProjectContext>();
                 IReadOnlyList<NuGetProject> projects = await GetProjectsAsync(projectIds, cancellationToken);
 
                 var resolutionContext = new ResolutionContext(

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetProjectUpgraderService.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetProjectUpgraderService.cs
@@ -150,7 +150,7 @@ namespace NuGet.PackageManagement.VisualStudio
             NuGetPackageManager packageManager = await _state.GetPackageManagerAsync(cancellationToken);
             Assumes.NotNull(packageManager);
 
-            INuGetProjectContext projectContext = await ServiceLocator.GetInstanceAsync<INuGetProjectContext>();
+            INuGetProjectContext projectContext = await ServiceLocator.GetComponentModelServiceAsync<INuGetProjectContext>();
             Assumes.NotNull(projectContext);
 
             await packageManager.ExecuteNuGetProjectActionsAsync(
@@ -186,7 +186,7 @@ namespace NuGet.PackageManagement.VisualStudio
             NuGetPackageManager packageManager = await _state.GetPackageManagerAsync(cancellationToken);
             Assumes.NotNull(packageManager);
 
-            INuGetProjectContext projectContext = await ServiceLocator.GetInstanceAsync<INuGetProjectContext>();
+            INuGetProjectContext projectContext = await ServiceLocator.GetComponentModelServiceAsync<INuGetProjectContext>();
             Assumes.NotNull(projectContext);
 
             await packageManager.ExecuteBuildIntegratedProjectActionsAsync(

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/SharedServiceState.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/SharedServiceState.cs
@@ -27,7 +27,7 @@ namespace NuGet.PackageManagement.VisualStudio
             SourceRepositoryProvider.PackageSourceProvider.PackageSourcesChanged += PackageSourcesChanged;
 
             SolutionManager = new AsyncLazy<IVsSolutionManager>(
-                ServiceLocator.GetInstanceAsync<IVsSolutionManager>,
+                ServiceLocator.GetComponentModelServiceAsync<IVsSolutionManager>,
                 NuGetUIThreadHelper.JoinableTaskFactory);
 
             SourceRepositories = new AsyncLazy<IReadOnlyCollection<SourceRepository>>(
@@ -41,15 +41,15 @@ namespace NuGet.PackageManagement.VisualStudio
 
         public static async ValueTask<SharedServiceState> CreateAsync(CancellationToken cancellationToken)
         {
-            var sourceRepositoryProvider = await ServiceLocator.GetInstanceAsync<ISourceRepositoryProvider>();
+            var sourceRepositoryProvider = await ServiceLocator.GetComponentModelServiceAsync<ISourceRepositoryProvider>();
 
             return new SharedServiceState(sourceRepositoryProvider);
         }
 
         public async ValueTask<NuGetPackageManager> GetPackageManagerAsync(CancellationToken cancellationToken)
         {
-            IDeleteOnRestartManager deleteOnRestartManager = await ServiceLocator.GetInstanceAsync<IDeleteOnRestartManager>();
-            ISettings settings = await ServiceLocator.GetInstanceAsync<ISettings>();
+            IDeleteOnRestartManager deleteOnRestartManager = await ServiceLocator.GetComponentModelServiceAsync<IDeleteOnRestartManager>();
+            ISettings settings = await ServiceLocator.GetComponentModelServiceAsync<ISettings>();
             IVsSolutionManager solutionManager = await SolutionManager.GetValueAsync(cancellationToken);
 
             return new NuGetPackageManager(

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Utility/NuGetProjectUpgradeUtility.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Utility/NuGetProjectUpgradeUtility.cs
@@ -86,7 +86,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
         private static async Task<NuGetProject> GetNuGetProject(Project envDTEProject)
         {
-            var solutionManager = ServiceLocator.GetInstance<IVsSolutionManager>();
+            var solutionManager = await ServiceLocator.GetComponentModelServiceAsync<IVsSolutionManager>();
 
             var projectSafeName = await envDTEProject.GetCustomUniqueNameAsync();
             var nuGetProject = await solutionManager.GetNuGetProjectAsync(projectSafeName);

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Utility/ProjectRetargetingUtility.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Utility/ProjectRetargetingUtility.cs
@@ -43,7 +43,7 @@ namespace NuGet.PackageManagement.VisualStudio
             if (installedRefs != null && installedRefs.Any())
             {
                 var targetFramework = project.GetMetadata<NuGetFramework>(NuGetProjectMetadataKeys.TargetFramework);
-                return GetPackagesToBeReinstalled(targetFramework, installedRefs);
+                return await GetPackagesToBeReinstalledAsync(targetFramework, installedRefs);
             }
 
             return new List<PackageIdentity>();
@@ -55,16 +55,16 @@ namespace NuGet.PackageManagement.VisualStudio
         /// <param name="projectFramework">Current target framework of the project</param>
         /// <param name="packageReferences">List of package references in the project from which packages to be reinstalled are determined</param>
         /// <returns>List of package identities to be reinstalled</returns>
-        public static List<PackageIdentity> GetPackagesToBeReinstalled(NuGetFramework projectFramework, IEnumerable<Packaging.PackageReference> packageReferences)
+        public static async Task<List<PackageIdentity>> GetPackagesToBeReinstalledAsync(NuGetFramework projectFramework, IEnumerable<Packaging.PackageReference> packageReferences)
         {
             Debug.Assert(projectFramework != null);
             Debug.Assert(packageReferences != null);
 
             var packagesToBeReinstalled = new List<PackageIdentity>();
-            var sourceRepositoryProvider = ServiceLocator.GetInstance<ISourceRepositoryProvider>();
-            var solutionManager = ServiceLocator.GetInstance<ISolutionManager>();
-            var settings = ServiceLocator.GetInstance<Configuration.ISettings>();
-            var deleteOnRestartManager = ServiceLocator.GetInstance<IDeleteOnRestartManager>();
+            var sourceRepositoryProvider = await ServiceLocator.GetComponentModelServiceAsync<ISourceRepositoryProvider>();
+            var solutionManager = await ServiceLocator.GetComponentModelServiceAsync<ISolutionManager>();
+            var settings = await ServiceLocator.GetComponentModelServiceAsync<Configuration.ISettings>();
+            var deleteOnRestartManager = await ServiceLocator.GetComponentModelServiceAsync<IDeleteOnRestartManager>();
             var packageManager = new NuGetPackageManager(
                 sourceRepositoryProvider,
                 settings,

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Utility/SettingsHelper.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Utility/SettingsHelper.cs
@@ -24,7 +24,7 @@ namespace NuGet.PackageManagement.VisualStudio
         /// </param>
         public static void Set(string property, string value)
         {
-            var settings = ServiceLocator.GetInstance<Configuration.ISettings>();
+            var settings = ServiceLocator.GetComponentModelService<ISettings>();
             var packageRestoreConsent = new PackageRestoreConsent(settings);
             if (string.Equals(property, "PackageRestoreConsentGranted", StringComparison.OrdinalIgnoreCase))
             {

--- a/src/NuGet.Clients/NuGet.Tools/NuGetBrokeredServiceFactory.cs
+++ b/src/NuGet.Clients/NuGet.Tools/NuGetBrokeredServiceFactory.cs
@@ -203,11 +203,11 @@ namespace NuGetVSExtension
         }
         private async Task InitializeAsync()
         {
-            _lazySettings = new AsyncLazy<ISettings>(ServiceLocator.GetInstanceAsync<ISettings>, ThreadHelper.JoinableTaskFactory);
-            _lazySolutionManager = new AsyncLazy<IVsSolutionManager>(ServiceLocator.GetInstanceAsync<IVsSolutionManager>, ThreadHelper.JoinableTaskFactory);
+            _lazySettings = new AsyncLazy<ISettings>(ServiceLocator.GetComponentModelServiceAsync<ISettings>, ThreadHelper.JoinableTaskFactory);
+            _lazySolutionManager = new AsyncLazy<IVsSolutionManager>(ServiceLocator.GetComponentModelServiceAsync<IVsSolutionManager>, ThreadHelper.JoinableTaskFactory);
             _projectManagerServiceSharedState = new NuGetProjectManagerServiceState();
             _sharedServiceState = await SharedServiceState.CreateAsync(CancellationToken.None);
-            _lazyTelemetryProvider = new AsyncLazy<INuGetTelemetryProvider>(ServiceLocator.GetInstanceAsync<INuGetTelemetryProvider>, ThreadHelper.JoinableTaskFactory);
+            _lazyTelemetryProvider = new AsyncLazy<INuGetTelemetryProvider>(ServiceLocator.GetComponentModelServiceAsync<INuGetTelemetryProvider>, ThreadHelper.JoinableTaskFactory);
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/IDE/VsHierarchyUtility.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/IDE/VsHierarchyUtility.cs
@@ -118,7 +118,7 @@ namespace NuGet.VisualStudio
             // this operation needs to execute on UI thread
             await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
-            var dte = ServiceLocator.GetInstance<EnvDTE.DTE>();
+            var dte = await ServiceLocator.GetInstanceAsync<EnvDTE.DTE>();
             var projects = dte.Solution.Projects;
 
             var results = new Dictionary<string, ISet<VsHierarchyItem>>(StringComparer.OrdinalIgnoreCase);
@@ -139,7 +139,7 @@ namespace NuGet.VisualStudio
 
             await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
-            var dte = ServiceLocator.GetInstance<EnvDTE.DTE>();
+            var dte = await ServiceLocator.GetInstanceAsync<EnvDTE.DTE>();
             var projects = dte.Solution.Projects;
 
             foreach (var project in projects.Cast<EnvDTE.Project>())
@@ -157,7 +157,7 @@ namespace NuGet.VisualStudio
         private static async Task<ICollection<VsHierarchyItem>> GetExpandedProjectHierarchyItemsAsync(EnvDTE.Project project)
         {
             var projectHierarchyItem = await VsHierarchyItem.FromDteProjectAsync(project);
-            var solutionExplorerWindow = GetSolutionExplorerHierarchyWindow();
+            var solutionExplorerWindow = await GetSolutionExplorerHierarchyWindowAsync();
 
             if (solutionExplorerWindow == null)
             {
@@ -192,7 +192,7 @@ namespace NuGet.VisualStudio
         private static async Task CollapseProjectHierarchyItemsAsync(EnvDTE.Project project, ISet<VsHierarchyItem> ignoredHierarcyItems)
         {
             var projectHierarchyItem = await VsHierarchyItem.FromDteProjectAsync(project);
-            var solutionExplorerWindow = GetSolutionExplorerHierarchyWindow();
+            var solutionExplorerWindow = await GetSolutionExplorerHierarchyWindowAsync();
 
             if (solutionExplorerWindow == null)
             {
@@ -252,10 +252,11 @@ namespace NuGet.VisualStudio
             return hierarchyItem.VsHierarchy as IVsUIHierarchy;
         }
 
-        private static IVsUIHierarchyWindow GetSolutionExplorerHierarchyWindow()
+        private static async Task<IVsUIHierarchyWindow> GetSolutionExplorerHierarchyWindowAsync()
         {
+            var serviceProvider = await ServiceLocator.GetInstanceAsync<IServiceProvider>();
             return VsShellUtilities.GetUIHierarchyWindow(
-                ServiceLocator.GetInstance<IServiceProvider>(),
+                serviceProvider,
                 new Guid(VsWindowKindSolutionExplorer));
         }
     }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/ServiceLocator.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/ServiceLocator.cs
@@ -121,7 +121,8 @@ namespace NuGet.VisualStudio
                     return service;
                 }
             }
-            return null;
+
+            return await AsyncServiceProvider.GlobalProvider.GetServiceAsync<TService, TInterface>();
         }
 
         /// <summary>

--- a/src/NuGet.Clients/NuGetConsole.Host.PowerShell/PowerShellHost.cs
+++ b/src/NuGet.Clients/NuGetConsole.Host.PowerShell/PowerShellHost.cs
@@ -106,11 +106,11 @@ namespace NuGetConsole.Host.PowerShell.Implementation
             _runspaceManager = runspaceManager;
 
             // TODO: Take these as ctor arguments
-            _sourceRepositoryProvider = ServiceLocator.GetInstance<ISourceRepositoryProvider>();
-            _solutionManager = new Lazy<IVsSolutionManager>(() => ServiceLocator.GetInstance<IVsSolutionManager>());
-            _settings = new Lazy<ISettings>(() => ServiceLocator.GetInstance<ISettings>());
-            _deleteOnRestartManager = new Lazy<IDeleteOnRestartManager>(() => ServiceLocator.GetInstance<IDeleteOnRestartManager>());
-            _scriptExecutor = new Lazy<IScriptExecutor>(() => ServiceLocator.GetInstance<IScriptExecutor>());
+            _sourceRepositoryProvider = ServiceLocator.GetComponentModelService<ISourceRepositoryProvider>();
+            _solutionManager = new Lazy<IVsSolutionManager>(() => ServiceLocator.GetComponentModelService<IVsSolutionManager>());
+            _settings = new Lazy<ISettings>(() => ServiceLocator.GetComponentModelService<ISettings>());
+            _deleteOnRestartManager = new Lazy<IDeleteOnRestartManager>(() => ServiceLocator.GetComponentModelService<IDeleteOnRestartManager>());
+            _scriptExecutor = new Lazy<IScriptExecutor>(() => ServiceLocator.GetComponentModelService<IScriptExecutor>());
 
             _dte = new Lazy<DTE>(() => ServiceLocator.GetInstance<DTE>());
             _sourceControlManagerProvider = new Lazy<ISourceControlManagerProvider>(

--- a/src/NuGet.Clients/NuGetConsole.Host.PowerShell/ProjectExtensions.cs
+++ b/src/NuGet.Clients/NuGetConsole.Host.PowerShell/ProjectExtensions.cs
@@ -38,7 +38,7 @@ namespace NuGetConsole.Host.PowerShell.Implementation
             {
                 await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
-                var solutionManager = ServiceLocator.GetInstance<IVsSolutionManager>();
+                var solutionManager = await ServiceLocator.GetComponentModelServiceAsync<IVsSolutionManager>();
                 if (solutionManager != null)
                 {
                     var project = await solutionManager.GetVsProjectAdapterAsync(projectName);
@@ -47,7 +47,7 @@ namespace NuGetConsole.Host.PowerShell.Implementation
                         throw new InvalidOperationException();
                     }
 
-                    var dte = ServiceLocator.GetInstance<EnvDTE.DTE>();
+                    var dte = await ServiceLocator.GetInstanceAsync<EnvDTE.DTE>();
                     dte.Solution.Remove(project.Project);
                 }
             });

--- a/src/NuGet.Clients/NuGetConsole.Host.PowerShell/RunspaceManager.cs
+++ b/src/NuGet.Clients/NuGetConsole.Host.PowerShell/RunspaceManager.cs
@@ -61,8 +61,8 @@ namespace NuGetConsole.Host.PowerShell.Implementation
                 );
 
             // this is used by the functional tests
-            var sourceRepositoryProvider = ServiceLocator.GetInstance<ISourceRepositoryProvider>();
-            var solutionManager = ServiceLocator.GetInstance<ISolutionManager>();
+            var sourceRepositoryProvider = ServiceLocator.GetComponentModelService<ISourceRepositoryProvider>();
+            var solutionManager = ServiceLocator.GetComponentModelService<ISolutionManager>();
             var sourceRepoTuple = Tuple.Create<string, object>("SourceRepositoryProvider", sourceRepositoryProvider);
             var solutionManagerTuple = Tuple.Create<string, object>("VsSolutionManager", solutionManager);
 

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/NuGetProjectManagerServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/NuGetProjectManagerServiceTests.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 using EnvDTE;
 using Microsoft.ServiceHub.Framework;
 using Microsoft.ServiceHub.Framework.Services;
+using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.ProjectSystem;
 using Microsoft.VisualStudio.ProjectSystem.References;
 using Microsoft.VisualStudio.Sdk.TestFramework;
@@ -56,7 +57,9 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         {
             _projectContext = new TestNuGetProjectContext();
 
-            AddService<INuGetProjectContext>(Task.FromResult<object>(_projectContext));
+            var componentModel = new Mock<IComponentModel>();
+            componentModel.Setup(x => x.GetService<INuGetProjectContext>()).Returns(_projectContext);
+            AddService<SComponentModel>(Task.FromResult((object)componentModel.Object));
         }
 
         public void Dispose()


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11201

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Avoid hitting the UI thread when retrieving MEF specific services - V2!

This is a follow up to https://github.com/NuGet/NuGet.Client/commit/38f679c77284d79fe63b01ce034a227b72822d01, which was later reverted in https://github.com/NuGet/NuGet.Client/commit/fcb4b9a7fb52777ed3e740cda029f78813a988d9, because it had a regression. 

The regression was the following:
* Start VS
* Create an ASP.NET .NET Framework project.
* PowershellHost throws a null ref.
The issue is because in the ServiceLocator.GetGlobalServiceFreeThreadedAsync, I had *removed* the fallback.
The PackageServiceProvider is set when the NuGetPackage is initialized, and it seems like in the tested scenario it wasn't initialized on time, similar to https://github.com/NuGet/NuGet.Client/commit/fd6d1c07dd6fd96c3f2200b3b34212677addcedc. 


The change that *should* fix everything is https://github.com/NuGet/NuGet.Client/pull/4244/commits/a7a1f8d3f34b3c46fb0f3660401b5e1997666a2f.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
