### PR TITLE
Update Microsoft.Build.Locator version

### DIFF
--- a/build/packages.targets
+++ b/build/packages.targets
@@ -26,7 +26,7 @@
         <PackageReference Update="MessagePack" Version="2.2.60" />
         <PackageReference Update="Microsoft.Build" Version="$(MicrosoftBuildPackageVersion)" />
         <PackageReference Update="Microsoft.Build.Framework" Version="$(MicrosoftBuildPackageVersion)" />
-        <PackageReference Update="Microsoft.Build.Locator" Version="1.2.6" />
+        <PackageReference Update="Microsoft.Build.Locator" Version="1.4.1" />
         <PackageReference Update="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildPackageVersion)" />
         <PackageReference Update="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildPackageVersion)" />
         <PackageReference Update="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8" />


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11158
Related to https://github.com/NuGet/Home/issues/11169
Regression? Last working version: n/a

## Description
Open NuGet.sln in VS, set NuGet.CommandLine.XPlat as startup project, set Debug command line parameters as package list SomeProject.csproj --deprecated (any report type should fail) and debug. You will see:

error: Could not load file or assembly 'System.Runtime.CompilerServices.Unsafe, Version=4.0.4.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' or one of its dependencies. The system cannot find the file specified.

I investigated this issue with @jeffkl and it happens to be `Microsoft.Build.Locator` issue. It's same as https://github.com/microsoft/MSBuildLocator/issues/95

After this change I manually tested above scenario works, I'll add tests with when addressing https://github.com/NuGet/Home/issues/11169

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
