### PR TITLE
supress NU5104 for NuGet.VisualStudio

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio/NuGet.VisualStudio.csproj
+++ b/src/NuGet.Clients/NuGet.VisualStudio/NuGet.VisualStudio.csproj
@@ -4,6 +4,8 @@
 
   <PropertyGroup>
     <TargetFramework>$(NETFXTargetFramework)</TargetFramework>
+    <!-- Preview version of Microsoft.VisualStudio.ComponentModelHost causes a NU5104 warning. When upgrading to a stable version of this package, remove the below NoWarn="NU5104". -->
+    <NoWarn>$(NoWarn);NU5104</NoWarn>
     <Shipping>true</Shipping>
     <PackProject>true</PackProject>
     <IncludeInVSIX>true</IncludeInVSIX>


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

Fixes: https://github.com/NuGet/Client.Engineering/issues/1137

Regression? Last working version:

## Description
Suppress NU5104 when packing project NuGet.VisualStudio

**Running the following command to pack locally before and after this change.**
`msbuild .\build\build.proj /t:Pack /p:BuildRTM=true /p:ExcludeTestProjects=true /p:BuildNumber=1234` 
**Before this change, the output is:**
```
C:\repos\NuGet.Client\build\build.proj(221,5): error MSB4181: The "MSBuild" task returned false but did not log an error.
Done Building Project "C:\repos\NuGet.Client\build\build.proj" (Pack target(s)) -- FAILED.


Build FAILED.

"C:\repos\NuGet.Client\build\build.proj" (Pack target) (1) ->
"C:\repos\NuGet.Client\src\NuGet.Clients\NuGet.VisualStudio\NuGet.VisualStudio.csproj" (PackProjects target) (32) ->
"C:\repos\NuGet.Client\src\NuGet.Clients\NuGet.VisualStudio\NuGet.VisualStudio.csproj" (Pack target) (32:2) ->
(GenerateNuspec target) ->
  C:\Program Files\dotnet\sdk\6.0.100-preview.7.21379.14\Sdks\NuGet.Build.Tasks.Pack\build\NuGet.Build.Tasks.Pack.targets(222,5): error NU5104: A stable release of a package should not have a prerelease dependency. Either modify the ver
sion spec of dependency "Microsoft.VisualStudio.ComponentModelHost [17.0.67-g9e37b637e6, )" or update the version field in the nuspec. [C:\repos\NuGet.Client\src\NuGet.Clients\NuGet.VisualStudio\NuGet.VisualStudio.csproj]


"C:\repos\NuGet.Client\build\build.proj" (Pack target) (1) ->
(Pack target) ->
  C:\repos\NuGet.Client\build\build.proj(221,5): error MSB4181: The "MSBuild" task returned false but did not log an error.

    0 Warning(s)
    2 Error(s)
```
**After this change, the output is:**
```
Build succeeded.
    0 Warning(s)
    0 Error(s)
```
## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
