### PR TITLE
[ArPow] Use --work-tree with git apply

### DIFF
--- a/eng/source-build/source-build.proj
+++ b/eng/source-build/source-build.proj
@@ -55,7 +55,7 @@
     </ItemGroup>
 
     <Exec
-      Command="git apply --ignore-whitespace --whitespace=nowarn &quot;%(SourceBuildPatchFile.FullPath)&quot;"
+      Command="git --work-tree=$(ProjectRoot) apply --ignore-whitespace --whitespace=nowarn &quot;%(SourceBuildPatchFile.FullPath)&quot;"
       WorkingDirectory="$(ProjectRoot)"
       Condition="'@(SourceBuildPatchFile)' != ''" />
   </Target>


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/11227

Regression? Last working version: Not a really a regression in NuGet.Client, though it is a regression from source-build 5.0.

## Description

See the issue for details about the problem and how to reproduce.

Use `git --work-tree=path apply` to ensure that `git apply` works even if the sources are copied somewhere else or the `.git` directory is removed and the code just happens to be placed somewhere under a git repository.

This is the same fix that's used everywhere else within ArPow: https://github.com/dotnet/installer/blob/74507010fafeb931a063f8649bff0b032ebc725b/src/SourceBuild/tarball/content/repos/Directory.Build.targets#L83

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception: only reproduces with ArPow tarball build, and even that, when placed in a unrelated git repository  
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
