### PR TITLE
Fix bug when determining transitive NoWarn

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Logging/TransitiveNoWarnUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Logging/TransitiveNoWarnUtils.cs
@@ -191,7 +191,7 @@ namespace NuGet.Commands
                         // Merge the node's package specific no warn to the one in the path.
                         var mergedPackageSpecificNoWarn = MergePackageSpecificNoWarn(pathPackageSpecificNoWarn, nodePackageSpecificNoWarn);
 
-                        AddDependenciesToQueue(nodeDependencies,
+                        AddDependenciesToQueue(nodeDependencies.Where(i => !seen.ContainsKey(i.Name)),
                             queue,
                             mergedProjectWideNoWarn,
                             mergedPackageSpecificNoWarn);
@@ -228,7 +228,7 @@ namespace NuGet.Commands
                             }
                         }
 
-                        AddDependenciesToQueue(nodeDependencies,
+                        AddDependenciesToQueue(nodeDependencies.Where(i => !seen.ContainsKey(i.Name)),
                             queue,
                             pathWarningProperties.ProjectWide,
                             pathWarningProperties.PackageSpecific);


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

Fixes: https://github.com/NuGet/Home/issues/11222

Regression? No

## Description
When a set of projects has a lot of dependencies, the code that determines the NoWarn can end up searching for transitive dependencies incorrectly.  Its walking the tree and adding dependencies but only checks if they've been visited after they're added to the queue.  In one repo, this resulted in millions of searches.

The fix is to only add dependencies to the queue for processing if they have not been visited already.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  Existing tests already verify the result of this algorithm, this is just a perf optimization
  - [x] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
