### PR TITLE
License Acceptance window renders on a single screen at low res

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/LicenseAcceptanceWindow.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/LicenseAcceptanceWindow.xaml
@@ -8,8 +8,6 @@
   xmlns:imaging="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.Imaging"  
   xmlns:catalog="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.ImageCatalog"  
   x:Name="_self"
-  MinWidth="450"
-  MinHeight="450"
   Width="450"
   Height="450"
   Background="{DynamicResource {x:Static nuget:Brushes.BackgroundBrushKey}}"
@@ -21,6 +19,7 @@
   Title="{x:Static nuget:Resources.WindowTitle_LicenseAcceptance}"
   d:DesignHeight="300"
   d:DesignWidth="300"
+  Loaded="LicenseAcceptanceWindow_Loaded"
   FocusManager.FocusedElement="{Binding ElementName=_acceptButton}">
   <Window.Resources>
     <ResourceDictionary>
@@ -99,82 +98,73 @@
       </DataTemplate>
     </ResourceDictionary>
   </Window.Resources>
-  <Grid>
-    <Grid.RowDefinitions>
-      <RowDefinition
+  <ScrollViewer x:Name="sv" CanContentScroll="False" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto">
+    <Grid x:Name="_licenseAcceptanceGrid" MinWidth="{Binding ElementName=sv, Path=ViewportWidth}" MinHeight="{Binding ElementName=sv, Path=ViewportHeight}"
+          Width="{Binding ElementName=sv, Path=ViewportWidth}" Height="{Binding ElementName=sv, Path=ViewportHeight}">
+      <Grid.RowDefinitions>
+        <RowDefinition
         Height="Auto" />
-      <RowDefinition
+        <RowDefinition />
+        <RowDefinition
         Height="Auto" />
-      <RowDefinition />
-      <RowDefinition
+        <RowDefinition
         Height="Auto" />
-      <RowDefinition
-        Height="Auto" />
-    </Grid.RowDefinitions>
-    <TextBlock
-      Grid.Row="0"
-      Grid.Column="0"
-      Margin="12,8,12,0"
-      x:Name="_licenseAcceptanceText"
-      AutomationProperties.Name="{Binding Text}"
-      Text="{x:Static nuget:Resources.Text_LicenseAcceptance}"
-      FontSize="{Binding ElementName=_self,Path=FontSize,Converter={StaticResource Font122PercentSizeConverter}}" />
-
-    <TextBlock
-      Grid.Row="1"
-      Grid.Column="0"
-      Margin="12,4,12,0"
-      x:Name="_licenseHeaderText"
-      AutomationProperties.Name="{Binding Text}"
-      Text="{x:Static nuget:Resources.Text_LicenseHeaderText}"
-      TextWrapping="Wrap" />
-    <ItemsControl
-      Grid.Row="2"
-      Grid.Column="0"
-      Margin="12,8"
-      MinHeight="130"
-      IsTabStop="False"
-      ItemsSource="{Binding}"
-      ItemTemplate="{StaticResource LicenseItemTemplate}">
-      <ItemsControl.Template>
-        <ControlTemplate
-          TargetType="{x:Type ItemsControl}">
-          <Border
-            BorderThickness="1"
-            BorderBrush="{DynamicResource {x:Static nuget:Brushes.BorderBrush}}">
-            <ScrollViewer
-              Padding="3"
-              CanContentScroll="True"
-              VerticalScrollBarVisibility="Visible"
-              HorizontalScrollBarVisibility="Disabled"
-              AutomationProperties.LabeledBy="{Binding ElementName=_licenseHeaderText}">
-              <ItemsPresenter></ItemsPresenter>
-            </ScrollViewer>
-          </Border>
-        </ControlTemplate>
-      </ItemsControl.Template>
-    </ItemsControl>
-
-    <TextBlock
+      </Grid.RowDefinitions>
+      <Grid Grid.Row="0" Width="{Binding Width, ElementName=_licenseAcceptanceGrid}">
+        <TextBlock
+        Margin="12,4,12,0"
+        x:Name="_licenseHeaderText"
+        AutomationProperties.Name="{Binding Text}"
+        Text="{x:Static nuget:Resources.Text_LicenseHeaderText}"
+        TextWrapping="Wrap" />
+      </Grid>
+      <Grid Grid.Row="1" Width="{Binding Width, ElementName=_licenseAcceptanceGrid}">
+        <ItemsControl
+        Margin="12,8"
+        MinHeight="116"
+        IsTabStop="False"
+        ItemsSource="{Binding}"
+        ItemTemplate="{StaticResource LicenseItemTemplate}">
+          <ItemsControl.Template>
+            <ControlTemplate
+            TargetType="{x:Type ItemsControl}">
+              <Border
+              BorderThickness="1"
+              BorderBrush="{DynamicResource {x:Static nuget:Brushes.BorderBrush}}">
+                <ScrollViewer
+                Padding="3"
+                CanContentScroll="True"
+                VerticalScrollBarVisibility="Visible"
+                HorizontalScrollBarVisibility="Disabled"
+                AutomationProperties.LabeledBy="{Binding ElementName=_licenseHeaderText}">
+                  <ItemsPresenter></ItemsPresenter>
+                </ScrollViewer>
+              </Border>
+            </ControlTemplate>
+          </ItemsControl.Template>
+        </ItemsControl>
+      </Grid>
+      <Grid Grid.Row="2" Width="{Binding Width, ElementName=_licenseAcceptanceGrid}">
+        <TextBlock
+        Margin="12,0,12,12"
+        x:Name="_licenseText"
+        Text="{x:Static nuget:Resources.Text_LicenseText}"
+        TextWrapping="Wrap" />
+      </Grid>
+      <Grid
       Grid.Row="3"
-      Grid.Column="0"
-      Margin="12,0,12,12"
-      x:Name="_licenseText"
-      Text="{x:Static nuget:Resources.Text_LicenseText}"
-      TextWrapping="Wrap" />
-    <Grid
-      Grid.Row="5"
-      Grid.Column="0"
+      Width="{Binding ActualWidth, ElementName=_licenseAcceptanceGrid}"
+      Margin="0,0,12,0"
       HorizontalAlignment="Right">
-      <Grid.ColumnDefinitions>
-        <ColumnDefinition />
-        <ColumnDefinition
+        <Grid.ColumnDefinitions>
+          <ColumnDefinition />
+          <ColumnDefinition
             Width="auto" />
-        <ColumnDefinition
+          <ColumnDefinition
             Width="auto" />
-      </Grid.ColumnDefinitions>
+        </Grid.ColumnDefinitions>
 
-      <Button
+        <Button
           Name="_acceptButton"
           Grid.Column="1"
           MinWidth="86"
@@ -183,7 +173,7 @@
           Content="{x:Static nuget:Resources.Button_IAccept}"
           AutomationProperties.AutomationId="AcceptButton"
           Click="OnAcceptButtonClick" />
-      <Button
+        <Button
           Grid.Column="2"
           MinWidth="86"
           MinHeight="24"
@@ -191,6 +181,7 @@
           Content="{x:Static nuget:Resources.Button_IDecline}"
           AutomationProperties.AutomationId="DeclineButton"
           Click="OnDeclineButtonClick" />
+      </Grid>
     </Grid>
-  </Grid>
+  </ScrollViewer>
 </nuget:VsDialogWindow>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/LicenseAcceptanceWindow.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/LicenseAcceptanceWindow.xaml.cs
@@ -1,9 +1,12 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Windows;
 using System.Windows.Documents;
+using System.Windows.Forms;
 using System.Windows.Input;
+using System.Windows.Media;
 using NuGet.VisualStudio;
 using NuGet.VisualStudio.Telemetry;
 
@@ -60,7 +63,7 @@ namespace NuGet.PackageManagement.UI
             DialogResult = true;
         }
 
-        private void OnButtonKeyDown(object sender, KeyEventArgs e)
+        private void OnButtonKeyDown(object sender, System.Windows.Input.KeyEventArgs e)
         {
             if (e.Key == Key.A)
             {
@@ -71,6 +74,25 @@ namespace NuGet.PackageManagement.UI
             {
                 DialogResult = false;
             }
+        }
+
+        private void LicenseAcceptanceWindow_Loaded(object sender, RoutedEventArgs e)
+        {
+            var screen = Screen.FromPoint(new System.Drawing.Point((int)Left, (int)Top));
+            var dpiScale = VisualTreeHelper.GetDpi(this);
+
+            double screenWidth = screen.WorkingArea.Width / dpiScale.DpiScaleX;
+            double screenHeight = screen.WorkingArea.Height / dpiScale.DpiScaleY;
+
+            int desiredLength = 450;
+            int heightPadding = 25; // Make window height at least this much smaller than the screen height.
+            Height = Math.Min(desiredLength, screenHeight - heightPadding);
+            MaxHeight = screenHeight;
+            MinHeight = Height;
+
+            Width = Math.Min(desiredLength, screenWidth);
+            MaxWidth = screenWidth;
+            MinWidth = Width;
         }
     }
 }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1134
Fixes: https://github.com/NuGet/Home/issues/8162

Regression? Last working version: No

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

- Determine screen the license window will appear on, and constrain its dimensions to that window.
  - Using Windows.Forms structures to do this for now. The logic feels a bit hacky, and will follow-up with WPF experts to see if anything better can be done. For now, we need to unblock accessibility of this window.
- The dimensions of 450x450 are maintained, unless the screen has less space available.
- Minimum of 1280x720 (vs system requirement) plus 200% DPI scaling (accessibility requirement) will now render the entire window.

#### Recommended resolution on test machine (3240x2160 at 200% scaling) (before/after)
![image](https://user-images.githubusercontent.com/49205731/132740720-4bf4c4ce-55d3-4a87-b625-7445b0a1d907.png)


#### Repro resolution (from original bug) 1366x768 200% scaling
![image](https://user-images.githubusercontent.com/49205731/132741000-eaf89d66-58f7-433c-b3e6-4d97ddebf473.png)

#### Minimum VS System Requirement resolution (1280x720) & DPI scaling of 200%
Before:
![image](https://user-images.githubusercontent.com/49205731/132741196-84b44aed-390c-4b4f-b67f-d1758c4164d0.png)

After:
![image](https://user-images.githubusercontent.com/49205731/132741240-526c8fca-d7dd-4c13-b98a-9f942616c1d9.png)


## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception - Manually tested, see screenshots.
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
