### PR TITLE
Signing:  enable X509Chain.Build(...) retry policy

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging.Extraction/NuGet.Packaging.Extraction.csproj
+++ b/src/NuGet.Core/NuGet.Packaging.Extraction/NuGet.Packaging.Extraction.csproj
@@ -177,6 +177,10 @@
     <Compile Include="..\NuGet.Packaging\Signing\Archive\Crc32.cs" Link="NuGet.Packaging\Signing\Archive\Crc32.cs" />
     <Compile Include="..\NuGet.Packaging\Signing\Archive\UnsignedPackageArchiveMetadata.cs" Link="NuGet.Packaging\Signing\Archive\UnsignedPackageArchiveMetadata.cs" />
     <Compile Include="..\NuGet.Packaging\Signing\Archive\SignedPackageArchiveMetadata.cs" Link="NuGet.Packaging\Signing\Archive\SignedPackageArchiveMetadata.cs" />
+    <Compile Include="..\NuGet.Packaging\Signing\ChainBuilding\DefaultX509ChainBuildPolicy.cs" Link="NuGet.Packaging\Signing\ChainBuilding\DefaultX509ChainBuildPolicy.cs" />
+    <Compile Include="..\NuGet.Packaging\Signing\ChainBuilding\IX509ChainBuildPolicy.cs" Link="NuGet.Packaging\Signing\ChainBuilding\IX509ChainBuildPolicy.cs" />
+    <Compile Include="..\NuGet.Packaging\Signing\ChainBuilding\RetriableX509ChainBuildPolicy.cs" Link="NuGet.Packaging\Signing\ChainBuilding\RetriableX509ChainBuildPolicy.cs" />
+    <Compile Include="..\NuGet.Packaging\Signing\ChainBuilding\X509ChainBuildPolicyFactory.cs" Link="NuGet.Packaging\Signing\ChainBuilding\X509ChainBuildPolicyFactory.cs" />
     <Compile Include="..\NuGet.Packaging\Signing\Cms\CmsFactory.cs" Link="NuGet.Packaging\Signing\Cms\CmsFactory.cs" />
     <Compile Include="..\NuGet.Packaging\Signing\Cms\ICms.cs" Link="NuGet.Packaging\Signing\Cms\ICms.cs" />
     <Compile Include="..\NuGet.Packaging\Signing\Cms\NativeCms.cs" Link="NuGet.Packaging\Signing\Cms\NativeCms.cs" />

--- a/src/NuGet.Core/NuGet.Packaging/Signing/ChainBuilding/DefaultX509ChainBuildPolicy.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/ChainBuilding/DefaultX509ChainBuildPolicy.cs
@@ -1,0 +1,28 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Security.Cryptography.X509Certificates;
+
+namespace NuGet.Packaging.Signing
+{
+    internal sealed class DefaultX509ChainBuildPolicy : IX509ChainBuildPolicy
+    {
+        internal static IX509ChainBuildPolicy Instance { get; } = new DefaultX509ChainBuildPolicy();
+
+        public bool Build(X509Chain chain, X509Certificate2 certificate)
+        {
+            if (chain is null)
+            {
+                throw new ArgumentNullException(nameof(chain));
+            }
+
+            if (certificate is null)
+            {
+                throw new ArgumentNullException(nameof(certificate));
+            }
+
+            return chain.Build(certificate);
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Packaging/Signing/ChainBuilding/DefaultX509ChainBuildPolicy.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/ChainBuilding/DefaultX509ChainBuildPolicy.cs
@@ -10,6 +10,8 @@ namespace NuGet.Packaging.Signing
     {
         internal static IX509ChainBuildPolicy Instance { get; } = new DefaultX509ChainBuildPolicy();
 
+        private DefaultX509ChainBuildPolicy() { }
+
         public bool Build(X509Chain chain, X509Certificate2 certificate)
         {
             if (chain is null)

--- a/src/NuGet.Core/NuGet.Packaging/Signing/ChainBuilding/IX509ChainBuildPolicy.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/ChainBuilding/IX509ChainBuildPolicy.cs
@@ -1,0 +1,16 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Security.Cryptography.X509Certificates;
+
+namespace NuGet.Packaging.Signing
+{
+    /// <summary>
+    /// Represents a wrapper around <see cref="X509Chain.Build(X509Certificate2)" /> to enable
+    /// custom behaviors (e.g.:  retry on failure).
+    /// </summary>
+    internal interface IX509ChainBuildPolicy
+    {
+        bool Build(X509Chain chain, X509Certificate2 certificate);
+    }
+}

--- a/src/NuGet.Core/NuGet.Packaging/Signing/ChainBuilding/RetriableX509ChainBuildPolicy.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/ChainBuilding/RetriableX509ChainBuildPolicy.cs
@@ -1,0 +1,77 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading;
+
+namespace NuGet.Packaging.Signing
+{
+    internal sealed class RetriableX509ChainBuildPolicy : IX509ChainBuildPolicy
+    {
+        // These properties are non-private only to facilitate testing.
+        internal int RetryCount { get; }
+        internal TimeSpan SleepInterval { get; }
+
+        internal RetriableX509ChainBuildPolicy(int retryCount, TimeSpan sleepInterval)
+        {
+            if (retryCount < 1)
+            {
+                throw new ArgumentOutOfRangeException(nameof(retryCount));
+            }
+
+            if (sleepInterval < TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(nameof(sleepInterval));
+            }
+
+            RetryCount = retryCount;
+            SleepInterval = sleepInterval;
+        }
+
+        public bool Build(X509Chain chain, X509Certificate2 certificate)
+        {
+            if (chain is null)
+            {
+                throw new ArgumentNullException(nameof(chain));
+            }
+
+            if (certificate is null)
+            {
+                throw new ArgumentNullException(nameof(certificate));
+            }
+
+            bool wasBuilt = chain.Build(certificate);
+
+            for (var i = 0; i < RetryCount; ++i)
+            {
+                if (wasBuilt)
+                {
+                    break;
+                }
+
+                bool hasUntrustedRoot = false;
+
+                foreach (X509ChainStatus chainStatus in chain.ChainStatus)
+                {
+                    if (chainStatus.Status.HasFlag(X509ChainStatusFlags.UntrustedRoot))
+                    {
+                        hasUntrustedRoot = true;
+                        break;
+                    }
+                }
+
+                if (!hasUntrustedRoot)
+                {
+                    break;
+                }
+
+                Thread.Sleep(SleepInterval);
+
+                wasBuilt = chain.Build(certificate);
+            }
+
+            return wasBuilt;
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Packaging/Signing/ChainBuilding/X509ChainBuildPolicyFactory.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/ChainBuilding/X509ChainBuildPolicyFactory.cs
@@ -1,0 +1,48 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using NuGet.Common;
+
+namespace NuGet.Packaging.Signing
+{
+    internal static class X509ChainBuildPolicyFactory
+    {
+        // These fields are non-private only to facilitate testing.
+        internal const string EnvironmentVariableName = "NUGET_EXPERIMENTAL_CHAIN_BUILD_RETRY_POLICY";
+        internal const char ValueDelimiter = ',';
+
+        internal static IX509ChainBuildPolicy Create(IEnvironmentVariableReader reader)
+        {
+            if (reader is null)
+            {
+                throw new ArgumentNullException(nameof(reader));
+            }
+
+            if (RuntimeEnvironmentHelper.IsWindows)
+            {
+                string value = reader.GetEnvironmentVariable(EnvironmentVariableName);
+
+                if (string.IsNullOrWhiteSpace(value))
+                {
+                    return DefaultX509ChainBuildPolicy.Instance;
+                }
+
+                string[] parts = value.Split(ValueDelimiter);
+
+                if (parts.Length == 2
+                    && int.TryParse(parts[0], out int retryCount)
+                    && retryCount > 0
+                    && int.TryParse(parts[1], out int sleepIntervalInMilliseconds)
+                    && sleepIntervalInMilliseconds >= 0)
+                {
+                    TimeSpan sleepInterval = TimeSpan.FromMilliseconds(sleepIntervalInMilliseconds);
+
+                    return new RetriableX509ChainBuildPolicy(retryCount, sleepInterval);
+                }
+            }
+
+            return DefaultX509ChainBuildPolicy.Instance;
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Utility/SignatureUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Utility/SignatureUtility.cs
@@ -619,13 +619,13 @@ namespace NuGet.Packaging.Signing
 
             using (var chainHolder = new X509ChainHolder())
             {
-                var chain = chainHolder.Chain;
+                X509Chain chain = chainHolder.Chain;
 
                 chain.ChainPolicy.ExtraStore.AddRange(extraStore);
 
                 chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
 
-                chain.Build(certificate);
+                CertificateChainUtility.BuildWithPolicy(chain, certificate);
 
                 if (chain.ChainStatus.Any(chainStatus =>
                     chainStatus.Status.HasFlag(X509ChainStatusFlags.Cyclic) ||

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/CertificateChainUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/CertificateChainUtilityTests.cs
@@ -188,5 +188,29 @@ namespace NuGet.Packaging.Test
                 }
             }
         }
+
+        [Fact]
+        public void BuildWithPolicy_WhenChainIsNull_Throws()
+        {
+            using (X509Certificate2 certificate = _fixture.GetDefaultCertificate())
+            {
+                ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
+                    () => CertificateChainUtility.BuildWithPolicy(chain: null, certificate));
+
+                Assert.Equal("chain", exception.ParamName);
+            }
+        }
+
+        [Fact]
+        public void BuildWithPolicy_WhenCertificateIsNull_Throws()
+        {
+            using (var chain = new X509Chain())
+            {
+                ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
+                    () => CertificateChainUtility.BuildWithPolicy(chain, certificate: null));
+
+                Assert.Equal("certificate", exception.ParamName);
+            }
+        }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/ChainBuilding/DefaultX509ChainBuildPolicyTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/ChainBuilding/DefaultX509ChainBuildPolicyTests.cs
@@ -1,0 +1,66 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Security.Cryptography.X509Certificates;
+using NuGet.Packaging.Signing;
+using Xunit;
+
+namespace NuGet.Packaging.Test
+{
+    public class DefaultX509ChainBuildPolicyTests : IClassFixture<CertificatesFixture>
+    {
+        private readonly CertificatesFixture _fixture;
+
+        public DefaultX509ChainBuildPolicyTests(CertificatesFixture fixture)
+        {
+            _fixture = fixture ?? throw new ArgumentNullException(nameof(fixture));
+        }
+
+        [Fact]
+        public void Instance_Always_IsIdempotent()
+        {
+            IX509ChainBuildPolicy instance0 = DefaultX509ChainBuildPolicy.Instance;
+            IX509ChainBuildPolicy instance1 = DefaultX509ChainBuildPolicy.Instance;
+
+            Assert.Same(instance0, instance1);
+        }
+
+        [Fact]
+        public void Build_WhenChainIsNull_Throws()
+        {
+            using (X509Certificate2 certificate = _fixture.GetDefaultCertificate())
+            {
+                ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
+                    () => DefaultX509ChainBuildPolicy.Instance.Build(chain: null, certificate));
+
+                Assert.Equal("chain", exception.ParamName);
+            }
+        }
+
+        [Fact]
+        public void Build_WhenCertificateIsNull_Throws()
+        {
+            using (var chain = new X509Chain())
+            {
+                ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
+                    () => DefaultX509ChainBuildPolicy.Instance.Build(chain, certificate: null));
+
+                Assert.Equal("certificate", exception.ParamName);
+            }
+        }
+
+        [Fact]
+        public void Build_WhenArgumentsAreValid_ReturnsExpectedResult()
+        {
+            using (var chain = new X509Chain())
+            using (X509Certificate2 expectedCertificate = _fixture.GetDefaultCertificate())
+            {
+                bool actualResult = DefaultX509ChainBuildPolicy.Instance.Build(chain, expectedCertificate);
+
+                Assert.False(actualResult);
+                Assert.Equal(X509ChainStatusFlags.UntrustedRoot, chain.ChainStatus[0].Status);
+            }
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/ChainBuilding/RetriableX509ChainBuildPolicyTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/ChainBuilding/RetriableX509ChainBuildPolicyTests.cs
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Diagnostics;
 using System.Security.Cryptography.X509Certificates;
+using Moq;
 using NuGet.Packaging.Signing;
 using NuGet.Test.Utility;
 using Xunit;
@@ -20,21 +20,36 @@ namespace NuGet.Packaging.Test
         }
 
         [PlatformFact(Platform.Windows)]
+        public void Constructor_WhenInnerPolicyIsNull_Throws()
+        {
+            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
+                () => new RetriableX509ChainBuildPolicy(innerPolicy: null, retryCount: 0, TimeSpan.MaxValue));
+
+            Assert.Equal("innerPolicy", exception.ParamName);
+        }
+
+        [PlatformFact(Platform.Windows)]
         public void Constructor_WhenRetryCountIsInvalid_Throws()
         {
+            var innerPolicy = new Mock<IX509ChainBuildPolicy>(MockBehavior.Strict);
             ArgumentOutOfRangeException exception = Assert.Throws<ArgumentOutOfRangeException>(
-                () => new RetriableX509ChainBuildPolicy(retryCount: 0, TimeSpan.MaxValue));
+                () => new RetriableX509ChainBuildPolicy(innerPolicy.Object, retryCount: 0, TimeSpan.MaxValue));
 
             Assert.Equal("retryCount", exception.ParamName);
+
+            innerPolicy.VerifyAll();
         }
 
         [PlatformFact(Platform.Windows)]
         public void Constructor_WhenSleepIntervalIsInvalid_Throws()
         {
+            var innerPolicy = new Mock<IX509ChainBuildPolicy>(MockBehavior.Strict);
             ArgumentOutOfRangeException exception = Assert.Throws<ArgumentOutOfRangeException>(
-                () => new RetriableX509ChainBuildPolicy(retryCount: 1, TimeSpan.FromSeconds(-1)));
+                () => new RetriableX509ChainBuildPolicy(innerPolicy.Object, retryCount: 1, TimeSpan.FromSeconds(-1)));
 
             Assert.Equal("sleepInterval", exception.ParamName);
+
+            innerPolicy.VerifyAll();
         }
 
         [PlatformTheory(Platform.Windows)]
@@ -44,18 +59,23 @@ namespace NuGet.Packaging.Test
             int expectedRetryCount,
             int expectedMilliseconds)
         {
+            var innerPolicy = new Mock<IX509ChainBuildPolicy>(MockBehavior.Strict);
             TimeSpan expectedSleepInterval = TimeSpan.FromSeconds(expectedMilliseconds);
 
-            var policy = new RetriableX509ChainBuildPolicy(expectedRetryCount, expectedSleepInterval);
+            var policy = new RetriableX509ChainBuildPolicy(innerPolicy.Object, expectedRetryCount, expectedSleepInterval);
 
+            Assert.Same(innerPolicy.Object, policy.InnerPolicy);
             Assert.Equal(expectedRetryCount, policy.RetryCount);
             Assert.Equal(expectedSleepInterval, policy.SleepInterval);
+
+            innerPolicy.VerifyAll();
         }
 
         [PlatformFact(Platform.Windows)]
         public void Build_WhenBuildIsNull_Throws()
         {
-            var policy = new RetriableX509ChainBuildPolicy(retryCount: 1, TimeSpan.Zero);
+            var innerPolicy = new Mock<IX509ChainBuildPolicy>(MockBehavior.Strict);
+            var policy = new RetriableX509ChainBuildPolicy(innerPolicy.Object, retryCount: 1, TimeSpan.Zero);
 
             using (X509Certificate2 certificate = _fixture.GetDefaultCertificate())
             {
@@ -63,13 +83,16 @@ namespace NuGet.Packaging.Test
                     () => policy.Build(chain: null, certificate));
 
                 Assert.Equal("chain", exception.ParamName);
+
+                innerPolicy.VerifyAll();
             }
         }
 
         [PlatformFact(Platform.Windows)]
         public void Create_WhenCertificateIsNull_Throws()
         {
-            var policy = new RetriableX509ChainBuildPolicy(retryCount: 1, TimeSpan.Zero);
+            var innerPolicy = new Mock<IX509ChainBuildPolicy>(MockBehavior.Strict);
+            var policy = new RetriableX509ChainBuildPolicy(innerPolicy.Object, retryCount: 1, TimeSpan.Zero);
 
             using (var chain = new X509Chain())
             {
@@ -77,57 +100,64 @@ namespace NuGet.Packaging.Test
                     () => policy.Build(chain, certificate: null));
 
                 Assert.Equal("certificate", exception.ParamName);
+
+                innerPolicy.VerifyAll();
             }
         }
 
         [PlatformFact(Platform.Windows)]
         public void Build_WhenArgumentsAreValidAndBuildSucceeds_DoesNotRetry()
         {
-            var policy = new RetriableX509ChainBuildPolicy(retryCount: 3, TimeSpan.FromSeconds(10));
+            var innerPolicy = new Mock<IX509ChainBuildPolicy>(MockBehavior.Strict);
+            var policy = new RetriableX509ChainBuildPolicy(innerPolicy.Object, retryCount: 3, TimeSpan.FromSeconds(10));
 
             using (var chain = new X509Chain())
-            using (X509Certificate2 certificate = GetTrustedCertificate())
+            using (X509Certificate2 certificate = _fixture.GetDefaultCertificate())
             {
-                Stopwatch stopwatch = Stopwatch.StartNew();
-
+                innerPolicy.Setup(
+                    x => x.Build(
+                        It.Is<X509Chain>(chainArg => ReferenceEquals(chainArg, chain)),
+                        It.Is<X509Certificate2>(certArg => ReferenceEquals(certArg, certificate))))
+                    .Returns(true);
                 bool actualResult = policy.Build(chain, certificate);
 
                 Assert.True(actualResult);
-                Assert.True(stopwatch.Elapsed < policy.SleepInterval);
+
+                innerPolicy.VerifyAll();
             }
         }
 
         [PlatformFact(Platform.Windows)]
         public void Build_WhenArgumentsAreValidAndBuildFailureIsRetriable_Retries()
         {
-            var policy = new RetriableX509ChainBuildPolicy(retryCount: 3, TimeSpan.FromMilliseconds(50));
+            var innerPolicy = new Mock<IX509ChainBuildPolicy>(MockBehavior.Strict);
+            var policy = new RetriableX509ChainBuildPolicy(innerPolicy.Object, retryCount: 3, TimeSpan.FromMilliseconds(50));
 
             using (var chain = new X509Chain())
             using (X509Certificate2 certificate = _fixture.GetDefaultCertificate())
             {
-                Stopwatch stopwatch = Stopwatch.StartNew();
+                innerPolicy.Setup(
+                   x => x.Build(
+                       It.Is<X509Chain>(chainArg => ReferenceEquals(chainArg, chain)),
+                       It.Is<X509Certificate2>(certArg => ReferenceEquals(certArg, certificate))))
+                   .Returns(false);
+                innerPolicy.Setup(
+                   x => x.Build(
+                       It.Is<X509Chain>(chainArg => ReferenceEquals(chainArg, chain)),
+                       It.Is<X509Certificate2>(certArg => ReferenceEquals(certArg, certificate))))
+                   .Returns(false);
+                innerPolicy.Setup(
+                    x => x.Build(
+                        It.Is<X509Chain>(chainArg => ReferenceEquals(chainArg, chain)),
+                        It.Is<X509Certificate2>(certArg => ReferenceEquals(certArg, certificate))))
+                    .Returns(true);
 
                 bool actualResult = policy.Build(chain, certificate);
 
-                Assert.False(actualResult);
-                Assert.True(stopwatch.Elapsed > TimeSpan.FromMilliseconds(policy.RetryCount * policy.SleepInterval.TotalMilliseconds));
+                Assert.True(actualResult);
+
+                innerPolicy.VerifyAll();
             }
-        }
-
-        private static X509Certificate2 GetTrustedCertificate()
-        {
-            X509Certificate2 certificate;
-
-            using (var store = new X509Store(StoreName.Root))
-            {
-                store.Open(OpenFlags.OpenExistingOnly | OpenFlags.ReadOnly);
-
-                certificate = store.Certificates[0];
-
-                store.Close();
-            }
-
-            return certificate;
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/ChainBuilding/RetriableX509ChainBuildPolicyTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/ChainBuilding/RetriableX509ChainBuildPolicyTests.cs
@@ -1,0 +1,133 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using System.Security.Cryptography.X509Certificates;
+using NuGet.Packaging.Signing;
+using NuGet.Test.Utility;
+using Xunit;
+
+namespace NuGet.Packaging.Test
+{
+    public class RetriableX509ChainBuildPolicyTests : IClassFixture<CertificatesFixture>
+    {
+        private readonly CertificatesFixture _fixture;
+
+        public RetriableX509ChainBuildPolicyTests(CertificatesFixture fixture)
+        {
+            _fixture = fixture ?? throw new ArgumentNullException(nameof(fixture));
+        }
+
+        [PlatformFact(Platform.Windows)]
+        public void Constructor_WhenRetryCountIsInvalid_Throws()
+        {
+            ArgumentOutOfRangeException exception = Assert.Throws<ArgumentOutOfRangeException>(
+                () => new RetriableX509ChainBuildPolicy(retryCount: 0, TimeSpan.MaxValue));
+
+            Assert.Equal("retryCount", exception.ParamName);
+        }
+
+        [PlatformFact(Platform.Windows)]
+        public void Constructor_WhenSleepIntervalIsInvalid_Throws()
+        {
+            ArgumentOutOfRangeException exception = Assert.Throws<ArgumentOutOfRangeException>(
+                () => new RetriableX509ChainBuildPolicy(retryCount: 1, TimeSpan.FromSeconds(-1)));
+
+            Assert.Equal("sleepInterval", exception.ParamName);
+        }
+
+        [PlatformTheory(Platform.Windows)]
+        [InlineData(1, 0)]
+        [InlineData(3, 700)]
+        public void Constructor_WhenArgumentsAreValid_InitializesProperties(
+            int expectedRetryCount,
+            int expectedMilliseconds)
+        {
+            TimeSpan expectedSleepInterval = TimeSpan.FromSeconds(expectedMilliseconds);
+
+            var policy = new RetriableX509ChainBuildPolicy(expectedRetryCount, expectedSleepInterval);
+
+            Assert.Equal(expectedRetryCount, policy.RetryCount);
+            Assert.Equal(expectedSleepInterval, policy.SleepInterval);
+        }
+
+        [PlatformFact(Platform.Windows)]
+        public void Build_WhenBuildIsNull_Throws()
+        {
+            var policy = new RetriableX509ChainBuildPolicy(retryCount: 1, TimeSpan.Zero);
+
+            using (X509Certificate2 certificate = _fixture.GetDefaultCertificate())
+            {
+                ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
+                    () => policy.Build(chain: null, certificate));
+
+                Assert.Equal("chain", exception.ParamName);
+            }
+        }
+
+        [PlatformFact(Platform.Windows)]
+        public void Create_WhenCertificateIsNull_Throws()
+        {
+            var policy = new RetriableX509ChainBuildPolicy(retryCount: 1, TimeSpan.Zero);
+
+            using (var chain = new X509Chain())
+            {
+                ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
+                    () => policy.Build(chain, certificate: null));
+
+                Assert.Equal("certificate", exception.ParamName);
+            }
+        }
+
+        [PlatformFact(Platform.Windows)]
+        public void Build_WhenArgumentsAreValidAndBuildSucceeds_DoesNotRetry()
+        {
+            var policy = new RetriableX509ChainBuildPolicy(retryCount: 3, TimeSpan.FromSeconds(10));
+
+            using (var chain = new X509Chain())
+            using (X509Certificate2 certificate = GetTrustedCertificate())
+            {
+                Stopwatch stopwatch = Stopwatch.StartNew();
+
+                bool actualResult = policy.Build(chain, certificate);
+
+                Assert.True(actualResult);
+                Assert.True(stopwatch.Elapsed < policy.SleepInterval);
+            }
+        }
+
+        [PlatformFact(Platform.Windows)]
+        public void Build_WhenArgumentsAreValidAndBuildFailureIsRetriable_Retries()
+        {
+            var policy = new RetriableX509ChainBuildPolicy(retryCount: 3, TimeSpan.FromMilliseconds(50));
+
+            using (var chain = new X509Chain())
+            using (X509Certificate2 certificate = _fixture.GetDefaultCertificate())
+            {
+                Stopwatch stopwatch = Stopwatch.StartNew();
+
+                bool actualResult = policy.Build(chain, certificate);
+
+                Assert.False(actualResult);
+                Assert.True(stopwatch.Elapsed > TimeSpan.FromMilliseconds(policy.RetryCount * policy.SleepInterval.TotalMilliseconds));
+            }
+        }
+
+        private static X509Certificate2 GetTrustedCertificate()
+        {
+            X509Certificate2 certificate;
+
+            using (var store = new X509Store(StoreName.Root))
+            {
+                store.Open(OpenFlags.OpenExistingOnly | OpenFlags.ReadOnly);
+
+                certificate = store.Certificates[0];
+
+                store.Close();
+            }
+
+            return certificate;
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/ChainBuilding/X509ChainBuildPolicyFactoryTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/ChainBuilding/X509ChainBuildPolicyFactoryTests.cs
@@ -21,6 +21,15 @@ namespace NuGet.Packaging.Test
             Assert.Equal("reader", exception.ParamName);
         }
 
+        [Fact]
+        public void Create_WhenArgumentIsValid_IsIdempotent()
+        {
+            IX509ChainBuildPolicy policy0 = X509ChainBuildPolicyFactory.Create(EnvironmentVariableWrapper.Instance);
+            IX509ChainBuildPolicy policy1 = X509ChainBuildPolicyFactory.Create(EnvironmentVariableWrapper.Instance);
+
+            Assert.Same(policy0, policy1);
+        }
+
         [PlatformTheory(Platform.Windows)]
         [InlineData(null)]
         [InlineData("")]
@@ -31,11 +40,11 @@ namespace NuGet.Packaging.Test
         [InlineData("0,1")]
         [InlineData("1,-2")]
         [InlineData("1,2,3")]
-        public void Create_OnWindowsWhenEnvironmentVariableIsInvalid_ReturnsDefaultPolicy(string value)
+        public void CreateWithoutCaching_OnWindowsWhenEnvironmentVariableIsInvalid_ReturnsDefaultPolicy(string value)
         {
             Mock<IEnvironmentVariableReader> reader = CreateMockEnvironmentVariableReader(value);
 
-            IX509ChainBuildPolicy policy = X509ChainBuildPolicyFactory.Create(reader.Object);
+            IX509ChainBuildPolicy policy = X509ChainBuildPolicyFactory.CreateWithoutCaching(reader.Object);
 
             Assert.IsType<DefaultX509ChainBuildPolicy>(policy);
 
@@ -45,11 +54,12 @@ namespace NuGet.Packaging.Test
         [PlatformTheory(Platform.Windows)]
         [InlineData("1,0")]
         [InlineData("3,7")]
-        public void Create_OnWindowsWhenEnvironmentVariableIsValid_ReturnsRetriablePolicy(string value)
+        [InlineData(" 5 , 9 ")]
+        public void CreateWithoutCaching_OnWindowsWhenEnvironmentVariableIsValid_ReturnsRetriablePolicy(string value)
         {
             Mock<IEnvironmentVariableReader> reader = CreateMockEnvironmentVariableReader(value);
 
-            IX509ChainBuildPolicy policy = X509ChainBuildPolicyFactory.Create(reader.Object);
+            IX509ChainBuildPolicy policy = X509ChainBuildPolicyFactory.CreateWithoutCaching(reader.Object);
 
             Assert.IsType<RetriableX509ChainBuildPolicy>(policy);
 
@@ -66,11 +76,11 @@ namespace NuGet.Packaging.Test
         }
 
         [PlatformFact(Platform.Linux, Platform.Darwin)]
-        public void Create_OnNonWindowsAlways_ReturnsDefaultPolicy()
+        public void CreateWithoutCaching_OnNonWindowsAlways_ReturnsDefaultPolicy()
         {
-            Mock<IEnvironmentVariableReader> reader = new Mock<IEnvironmentVariableReader>(MockBehavior.Strict);
+            var reader = new Mock<IEnvironmentVariableReader>(MockBehavior.Strict);
 
-            IX509ChainBuildPolicy policy = X509ChainBuildPolicyFactory.Create(reader.Object);
+            IX509ChainBuildPolicy policy = X509ChainBuildPolicyFactory.CreateWithoutCaching(reader.Object);
 
             Assert.IsType<DefaultX509ChainBuildPolicy>(policy);
 

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/ChainBuilding/X509ChainBuildPolicyFactoryTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/ChainBuilding/X509ChainBuildPolicyFactoryTests.cs
@@ -1,0 +1,91 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Moq;
+using NuGet.Common;
+using NuGet.Packaging.Signing;
+using NuGet.Test.Utility;
+using Xunit;
+
+namespace NuGet.Packaging.Test
+{
+    public class X509ChainBuildPolicyFactoryTests
+    {
+        [Fact]
+        public void Create_WhenArgumentIsNull_Throws()
+        {
+            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
+                () => X509ChainBuildPolicyFactory.Create(reader: null));
+
+            Assert.Equal("reader", exception.ParamName);
+        }
+
+        [PlatformTheory(Platform.Windows)]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData(" ")]
+        [InlineData(",")]
+        [InlineData("-1,2")]
+        [InlineData("0,0")]
+        [InlineData("0,1")]
+        [InlineData("1,-2")]
+        [InlineData("1,2,3")]
+        public void Create_OnWindowsWhenEnvironmentVariableIsInvalid_ReturnsDefaultPolicy(string value)
+        {
+            Mock<IEnvironmentVariableReader> reader = CreateMockEnvironmentVariableReader(value);
+
+            IX509ChainBuildPolicy policy = X509ChainBuildPolicyFactory.Create(reader.Object);
+
+            Assert.IsType<DefaultX509ChainBuildPolicy>(policy);
+
+            reader.VerifyAll();
+        }
+
+        [PlatformTheory(Platform.Windows)]
+        [InlineData("1,0")]
+        [InlineData("3,7")]
+        public void Create_OnWindowsWhenEnvironmentVariableIsValid_ReturnsRetriablePolicy(string value)
+        {
+            Mock<IEnvironmentVariableReader> reader = CreateMockEnvironmentVariableReader(value);
+
+            IX509ChainBuildPolicy policy = X509ChainBuildPolicyFactory.Create(reader.Object);
+
+            Assert.IsType<RetriableX509ChainBuildPolicy>(policy);
+
+            var retryPolicy = (RetriableX509ChainBuildPolicy)policy;
+
+            string[] parts = value.Split(X509ChainBuildPolicyFactory.ValueDelimiter);
+            int expectedRetryCount = int.Parse(parts[0]);
+            TimeSpan expectedSleepInterval = TimeSpan.FromMilliseconds(int.Parse(parts[1]));
+
+            Assert.Equal(expectedRetryCount, retryPolicy.RetryCount);
+            Assert.Equal(expectedSleepInterval, retryPolicy.SleepInterval);
+
+            reader.VerifyAll();
+        }
+
+        [PlatformFact(Platform.Linux, Platform.Darwin)]
+        public void Create_OnNonWindowsAlways_ReturnsDefaultPolicy()
+        {
+            Mock<IEnvironmentVariableReader> reader = new Mock<IEnvironmentVariableReader>(MockBehavior.Strict);
+
+            IX509ChainBuildPolicy policy = X509ChainBuildPolicyFactory.Create(reader.Object);
+
+            Assert.IsType<DefaultX509ChainBuildPolicy>(policy);
+
+            reader.VerifyAll();
+        }
+
+        private static Mock<IEnvironmentVariableReader> CreateMockEnvironmentVariableReader(
+            string variableValue)
+        {
+            var reader = new Mock<IEnvironmentVariableReader>(MockBehavior.Strict);
+
+            reader.Setup(r => r.GetEnvironmentVariable(X509ChainBuildPolicyFactory.EnvironmentVariableName))
+                .Returns(variableValue);
+
+            return reader;
+        }
+    }
+}


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes:  https://github.com/NuGet/Home/issues/11099

Regression? Last working version:  not a NuGet regression, but possibly a Windows regression

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
During X.509 certificate chain validation, Windows fetches relevant 3rd party root certificates on first use and adds them as locally trusted root certificates.  During a call to [`CertGetCertificateChain(...)`](https://docs.microsoft.com/en-us/windows/win32/api/wincrypt/nf-wincrypt-certgetcertificatechain), this network fetch is initiated with an RPC call to a Windows service.

In https://github.com/NuGet/Home/issues/11099, this RPC call sometimes fails with "The RPC server is too busy to complete this operation" (`RPC_S_SERVER_TOO_BUSY`) and the resulting failure to locally trust the root certificate results in the chain validation attempt failing with "A certification chain processed correctly but terminated in a root certificate that is not trusted by the trust provider." (`CERT_E_UNTRUSTEDROOT`).  Typically, clients handle the "RPC server is too busy" error with a retry, but `CertGetCertificateChain(...)` neither retries nor propagates up the error.  As has been noted already, retrying at another level (e.g.:  `dotnet restore`) succeeds.

This change offers users an experimental, opt-in retry on Windows, implemented within NuGet.  It is experimental because I've been unable to verify it against a repro of the failure.  To opt in, set an environment variable named `NUGET_EXPERIMENTAL_CHAIN_BUILD_RETRY_POLICY` with a value consisting of 2 comma-delimited positive integers representing retry count and sleep interval in milliseconds, respectively.  There are no default values; you'll need to pick retry values that are sensible for you.

For example:
```
set NUGET_EXPERIMENTAL_CHAIN_BUILD_RETRY_POLICY=3,1000
```
...would try up to 4 times (initial try + 3 retries) with 1 second (1,000 ms) between each try.

At best, this change is a rough workaround.  Because the real error (`RPC_S_SERVER_TOO_BUSY`) does not propagate up to NuGet, NuGet can't uniquely identify this error case, so there are some corner cases where the retry may be over-applied.  An example is an untrusted, self-issued certificate.

NuGet is not the ideal place to implement a retry, but given the practicalities of this issue, I believe this is a reasonable workaround that we can deliver faster than some alternatives.  Until we have a better understanding of the "RPC server is too busy" error, it seems unlikely that we'll get a retry implemented in Windows itself.

It would be extremely valuable if anyone using this option, let's us know what works and what doesn't.  More importantly, any further details on the root problem --- especially, tips on reproducing it ourselves --- would be appreciated.

## PR Checklist

- [X] PR has a meaningful title
- [X] PR has a linked issue.
- [X] Described changes

- **Tests**
  - [X] Automated tests added

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [X] Documentation PR or issue filled:  https://github.com/NuGet/docs.microsoft.com-nuget/issues/2530
  - **OR**
  - [ ] N/A
