### PR TITLE
Remove rebuild github check

### DIFF
--- a/scripts/utils/PostGitCommitStatus.ps1
+++ b/scripts/utils/PostGitCommitStatus.ps1
@@ -110,8 +110,6 @@ Function InitializeAllTestsToPending {
     {
         Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Apex Tests On Windows" -Status "success" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description "skipped"
     }
-    $rebuildUrl = "$env:VstsAzureRebuildUrl" -f "$env:BUILD_SOURCEBRANCHNAME","$env:BUILD_SOURCEVERSION"
-    Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Rebuild" -Status "success" -CommitSha $CommitSha -TargetUrl $rebuildUrl -Description "Click on details to rebuild"
 }
 
 function SetCommitStatusForTestResult {


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1145

Regression? no

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

The click to rebuild was useful before Azure DevOps added the "rebuild failed jobs" button, and when tests used to be more flaky than they are now.  However, given we can rerun just the failed jobs, without rerunning successful jobs, there's really no benefit to this link any longer.

Furthermore, when viewing a build, Azure DevOps has a big "Run new" button, which is probably more convenient since you're likely to be in Azure DevOps already, rather than going back to github and then clicking this link.

It'll also allow us to decommission the Azure Functions app and save the team some money and reduce technical debt.

## PR Checklist

- [X] PR has a meaningful title
- [X] PR has a linked issue.
- [X] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [X] N/A: Infrastructure

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [X] N/A
