### PR TITLE
fix pack issue with readmes and snupkgs

### DIFF
--- a/src/NuGet.Core/NuGet.Common/PathUtil/PathResolver.cs
+++ b/src/NuGet.Core/NuGet.Common/PathUtil/PathResolver.cs
@@ -132,7 +132,7 @@ namespace NuGet.Common
             // Append the basePath to searchPattern and get the search regex. We need to do this because the search regex is matched from line start.
             Regex searchRegex = WildcardToRegex(Path.Combine(basePath, searchPath));
 
-            // This is a hack to prevent enumerating over the entire directory tree if the only wildcard characters are the ones in the file name.
+            // This is a hack to prevent enumerating over the entire directory tree if the only wildcard characters are the ones in the file name. 
             // If the path portion of the search path does not contain any wildcard characters only iterate over the TopDirectory.
             SearchOption searchOption = SearchOption.AllDirectories;
             // (a) Path is not recursive search
@@ -211,11 +211,11 @@ namespace NuGet.Common
 
             // If the search path is relative, transfer the parent directory portion to the base path.
             // This needs to be done because the base path determines the root for our enumeration.
-            // while (searchPath.StartsWith(parentDirectoryPath, StringComparison.OrdinalIgnoreCase))
-            // {
-            //     basePath = Path.Combine(basePath, parentDirectoryPath);
-            //     searchPath = searchPath.Substring(parentDirectoryPath.Length);
-            // }
+            while (searchPath.StartsWith(parentDirectoryPath, StringComparison.OrdinalIgnoreCase))
+            {
+                basePath = Path.Combine(basePath, parentDirectoryPath);
+                searchPath = searchPath.Substring(parentDirectoryPath.Length);
+            }
 
             return Path.GetFullPath(basePath);
         }

--- a/src/NuGet.Core/NuGet.Common/PathUtil/PathResolver.cs
+++ b/src/NuGet.Core/NuGet.Common/PathUtil/PathResolver.cs
@@ -132,7 +132,7 @@ namespace NuGet.Common
             // Append the basePath to searchPattern and get the search regex. We need to do this because the search regex is matched from line start.
             Regex searchRegex = WildcardToRegex(Path.Combine(basePath, searchPath));
 
-            // This is a hack to prevent enumerating over the entire directory tree if the only wildcard characters are the ones in the file name. 
+            // This is a hack to prevent enumerating over the entire directory tree if the only wildcard characters are the ones in the file name.
             // If the path portion of the search path does not contain any wildcard characters only iterate over the TopDirectory.
             SearchOption searchOption = SearchOption.AllDirectories;
             // (a) Path is not recursive search
@@ -211,11 +211,11 @@ namespace NuGet.Common
 
             // If the search path is relative, transfer the parent directory portion to the base path.
             // This needs to be done because the base path determines the root for our enumeration.
-            while (searchPath.StartsWith(parentDirectoryPath, StringComparison.OrdinalIgnoreCase))
-            {
-                basePath = Path.Combine(basePath, parentDirectoryPath);
-                searchPath = searchPath.Substring(parentDirectoryPath.Length);
-            }
+            // while (searchPath.StartsWith(parentDirectoryPath, StringComparison.OrdinalIgnoreCase))
+            // {
+            //     basePath = Path.Combine(basePath, parentDirectoryPath);
+            //     searchPath = searchPath.Substring(parentDirectoryPath.Length);
+            // }
 
             return Path.GetFullPath(basePath);
         }

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PackageBuilder.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PackageBuilder.cs
@@ -866,7 +866,7 @@ namespace NuGet.Packaging
         /// <exception cref="PackagingException">When a validation rule is not met</exception>
         private void ValidateReadmeFile(IEnumerable<IPackageFile> files, string readmePath)
         {
-            if (!string.IsNullOrEmpty(readmePath))
+            if (!PackageTypes.Contains(PackageType.SymbolsPackage) && !string.IsNullOrEmpty(readmePath))
             {
                 // Validate readme extension
                 var extension = Path.GetExtension(readmePath);

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PackageBuilder.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PackageBuilder.cs
@@ -859,7 +859,7 @@ namespace NuGet.Packaging
         }
 
         /// <summary>
-        /// Validate that the readme file is of the correct size/type and can be opened properly.
+        /// Validate that the readme file is of the correct size/type and can be opened properly except for Symbol packages.
         /// </summary>
         /// <param name="files">Files resolved from the file entries in the nuspec</param>
         /// <param name="readmePath">readmepath found in the .nuspec</param>

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Xml/PackageMetadataXmlExtensions.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Xml/PackageMetadataXmlExtensions.cs
@@ -69,8 +69,8 @@ namespace NuGet.Packaging.Xml
                     }
                 }
                 AddElementIfNotNull(elem, ns, "licenseUrl", licenseUrlToWrite);
-
                 AddElementIfNotNull(elem, ns, "icon", metadata.Icon);
+                AddElementIfNotNull(elem, ns, "readme", metadata.Readme);
             }
             AddElementIfNotNull(elem, ns, "projectUrl", metadata.ProjectUrl);
             AddElementIfNotNull(elem, ns, "iconUrl", metadata.IconUrl);
@@ -80,7 +80,6 @@ namespace NuGet.Packaging.Xml
             AddElementIfNotNull(elem, ns, "copyright", metadata.Copyright);
             AddElementIfNotNull(elem, ns, "language", metadata.Language);
             AddElementIfNotNull(elem, ns, "tags", metadata.Tags);
-            AddElementIfNotNull(elem, ns, "readme", metadata.Readme);
             if (metadata.Serviceable)
             {
                 elem.Add(new XElement(ns + "serviceable", metadata.Serviceable));

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
@@ -5443,8 +5443,9 @@ namespace ClassLibrary
         [PlatformFact(Platform.Windows)]
         public void PackCommand_PackageReadmeFile_BasicFunc_WithSymbol_Succeeds()
         {
-            var testDirBuilder = TestDirectoryBuilder.Create();
-            var projectBuilder = ProjectFileBuilder.Create();
+            // Arrange
+            TestDirectoryBuilder testDirBuilder = TestDirectoryBuilder.Create();
+            ProjectFileBuilder projectBuilder = ProjectFileBuilder.Create();
 
             testDirBuilder
                 .WithFile("test\\readme.md", 10)
@@ -5465,23 +5466,26 @@ namespace ClassLibrary
                 .WithItem(itemType: "None", itemPath: "folder\\**", packagePath: "media", pack: "true")
                 .WithItem(itemType: "None", itemPath: "utils\\*", packagePath: "utils", pack: "true");
 
+            // Act
             using (var srcDir = msbuildFixture.Build(testDirBuilder))
             {
                 projectBuilder.Build(msbuildFixture, srcDir.Path);
-                var result = msbuildFixture.PackProject(projectBuilder.ProjectFolder, projectBuilder.ProjectName, string.Empty);
+                msbuildFixture.PackProject(projectBuilder.ProjectFolder, projectBuilder.ProjectName, string.Empty);
 
+                // Assert
                 // Validate embedded readme in package
                 ValidatePackReadme(projectBuilder);
 
                 // Validate that other content is also included
-                var nupkgPath = Path.Combine(projectBuilder.ProjectFolder, "bin", "Debug", $"{projectBuilder.ProjectName}.1.0.0.nupkg");
+                string nupkgPath = Path.Combine(projectBuilder.ProjectFolder, "bin", "Debug", $"{projectBuilder.ProjectName}.1.0.0.nupkg");
                 using (var nupkgReader = new PackageArchiveReader(nupkgPath))
                 {
                     Assert.NotNull(nupkgReader.GetEntry("content/other/files.txt"));
                     Assert.NotNull(nupkgReader.GetEntry("utils/sources.txt"));
                     Assert.NotNull(nupkgReader.GetEntry("media/nested/sample.txt"));
                 }
-                var snupkgPath = Path.Combine(projectBuilder.ProjectFolder, "bin", "Debug", $"{projectBuilder.ProjectName}.1.0.0.snupkg");
+
+                string snupkgPath = Path.Combine(projectBuilder.ProjectFolder, "bin", "Debug", $"{projectBuilder.ProjectName}.1.0.0.snupkg");
                 Assert.True(File.Exists(snupkgPath), "No snupkg was produced");
             }
         }

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
@@ -5480,10 +5480,9 @@ namespace ClassLibrary
                     Assert.NotNull(nupkgReader.GetEntry("content/other/files.txt"));
                     Assert.NotNull(nupkgReader.GetEntry("utils/sources.txt"));
                     Assert.NotNull(nupkgReader.GetEntry("media/nested/sample.txt"));
-                    Assert.NotNull(nupkgReader.GetEntry("readme.md"));
                 }
                 var snupkgPath = Path.Combine(projectBuilder.ProjectFolder, "bin", "Debug", $"{projectBuilder.ProjectName}.1.0.0.snupkg");
-                Assert.True(File.Exists(snupkgPath));
+                Assert.True(File.Exists(snupkgPath), "No snupkg was produced");
             }
         }
 

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
@@ -5467,7 +5467,7 @@ namespace ClassLibrary
                 .WithItem(itemType: "None", itemPath: "utils\\*", packagePath: "utils", pack: "true");
 
             // Act
-            using (var srcDir = msbuildFixture.Build(testDirBuilder))
+            using (TestDirectory srcDir = msbuildFixture.Build(testDirBuilder))
             {
                 projectBuilder.Build(msbuildFixture, srcDir.Path);
                 msbuildFixture.PackProject(projectBuilder.ProjectFolder, projectBuilder.ProjectName, string.Empty);


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/10791

Regression? No

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
According to [NuGet.org symbol package constraints](https://docs.microsoft.com/en-us/nuget/create-packages/symbol-packages-snupkg#nugetorg-symbol-package-constraints), the symbol package should not have the readme file.
So this PR:
1) skip validation of readme file if the package is a symbol package
2) add a test for packing snupkgs with readme file, and verify it's successfully created the snupkgs.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
