### PR TITLE
Return to previous colors for Tab Count badges

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources/Brushes.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources/Brushes.cs
@@ -162,9 +162,9 @@ namespace NuGet.PackageManagement.UI
 
         public static object TabSelectedTextBrushKey { get; private set; } = SystemColors.ActiveCaptionTextColorKey;
 
-        public static object TabPopupBrushKey { get; private set; } = SystemColors.ActiveCaptionTextColor;
+        public static object TabPopupBrushKey { get; private set; } = SystemColors.HighlightBrushKey;
 
-        public static object TabPopupTextBrushKey { get; private set; } = SystemColors.HighlightTextBrush;
+        public static object TabPopupTextBrushKey { get; private set; } = SystemColors.HighlightTextBrushKey;
 
         public static object TabTextHoverBrushKey { get; private set; } = SystemColors.HotTrackBrushKey;
 
@@ -261,8 +261,6 @@ namespace NuGet.PackageManagement.UI
             TabSelectedTextBrushKey = CommonDocumentColors.InnerTabSelectedTextBrushKey; // text
             TabTextHoverBrushKey = CommonDocumentColors.InnerTabTextHoverBrushKey; //text hover
             TabTextFocusedBrushKey = CommonDocumentColors.InnerTabTextFocusedBrushKey;
-            TabPopupBrushKey = CommonControlsColors.ButtonPressedBrushKey;
-            TabPopupTextBrushKey = CommonControlsColors.ButtonPressedTextBrushKey;
 
             // Mapping color keys directly for use to create brushes using these colors
             ListItemBackgroundSelectedColorKey = CommonDocumentColors.ListItemBackgroundSelectedColorKey;


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/nuget/home/issues/10896

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
In the new dark theme, the type of buttons we're using don't pick up accent colors. After working with UX and IDE teams, it was determined there is no existing VS token for us to use here, so we are changing to a different System token which achieves the existing foreground/background colors.

* Note: Use New Dark theme
![image](https://user-images.githubusercontent.com/49205731/133517695-ebc8d5be-e88a-40b3-ac7f-3d8e2707a288.png)

### Goal (from 16.11.2 )

Dark theme:
![image](https://user-images.githubusercontent.com/49205731/133517725-cc62dc97-3006-4851-a9b3-d923ea2cf3a9.png)

Light theme:
![image](https://user-images.githubusercontent.com/49205731/133517749-509be77a-5f89-474e-8087-882e34e42b3e.png)

Blue theme:
![image](https://user-images.githubusercontent.com/49205731/133517803-90dcc619-e34a-46a4-b699-97db287dea09.png)


Blue extra contrast:
![image](https://user-images.githubusercontent.com/49205731/133517810-eeee5a9e-db53-48a0-a221-c385286ffcb8.png)


High Contrast:
![image](https://user-images.githubusercontent.com/49205731/133517813-31ca1bbf-8a35-4724-853f-5b1c73ff6597.png)

### Before PR (17.0) 

Dark theme:
![image](https://user-images.githubusercontent.com/49205731/133517856-121161bd-49bf-46d0-9c2c-f03ce8f724c5.png)


Light theme:
![image](https://user-images.githubusercontent.com/49205731/133517864-73ae7f17-ca6c-41d3-9d0c-92a67f1591d4.png)


Blue theme:
![image](https://user-images.githubusercontent.com/49205731/133517875-b9e10e04-4727-465d-bba9-ae473e01155b.png)


Blue extra contrast:
![image](https://user-images.githubusercontent.com/49205731/133517879-ce5b8940-0353-48d8-8dde-161759498ab2.png)

High contrast:
![image](https://user-images.githubusercontent.com/49205731/133517890-24d442cc-e7e7-462c-85ea-18e23d8fd83b.png)

### After PR (17.x)

Dark theme:
![image](https://user-images.githubusercontent.com/49205731/133517914-76b84429-09c2-47cf-a50e-af08b1d61c3a.png)

Light theme:
![image](https://user-images.githubusercontent.com/49205731/133517925-6314ef85-d7ef-4bcf-a0e0-a6de730200a9.png)

Blue theme:
![image](https://user-images.githubusercontent.com/49205731/133517929-9338fed0-45a2-4ae3-95bb-383e96d95de0.png)

Blue extra contrast:
![image](https://user-images.githubusercontent.com/49205731/133517936-494b1c7c-d37a-4f6e-9599-aa36be2017d8.png)

High contrast:
![image](https://user-images.githubusercontent.com/49205731/133517941-6649e5ce-dc6a-4f2d-b4e3-98c2dae64f58.png)

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception - manual - see screenshots above
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
