### PR TITLE
Revert breaking change when packing files and using forward slashes

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PackageBuilder.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PackageBuilder.cs
@@ -1103,8 +1103,7 @@ namespace NuGet.Packaging
         {
             exclude = exclude?.Replace('\\', Path.DirectorySeparatorChar);
 
-            // Ensure that the 'source' path uses only the OS-specific directory separating character
-            List<PhysicalPackageFile> searchFiles = ResolveSearchPattern(basePath, source.Replace('\\', Path.DirectorySeparatorChar).Replace('/', Path.DirectorySeparatorChar), destination, _includeEmptyDirectories).ToList();
+            List<PhysicalPackageFile> searchFiles = ResolveSearchPattern(basePath, source.Replace('\\', Path.DirectorySeparatorChar), destination, _includeEmptyDirectories).ToList();
 
             if (_includeEmptyDirectories)
             {

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
@@ -6318,7 +6318,7 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
             TestPackReadmeSuccess(testDir, @"docs/readme.md");
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/NuGet/Home/issues/11234")]
         public void PackCommand_PackReadme_DirSeparatorForwardSlash2_Succeeds()
         {
             var nuspec = NuspecBuilder.Create();
@@ -6372,7 +6372,7 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
             TestPackReadmeSuccess(testDir, @"docs\readme.md");
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/NuGet/Home/issues/11234")]
         public void PackCommand_PackReadme_DirSeparatorMix1_Succeeds()
         {
             var nuspec = NuspecBuilder.Create();
@@ -6426,7 +6426,7 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
             TestPackReadmeSuccess(testDir, @"docs/readme.md");
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/NuGet/Home/issues/11234")]
         public void PackCommand_PackReadme_DirSeparatorMix4_Succeeds()
         {
             var nuspec = NuspecBuilder.Create();

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageBuilderTest.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageBuilderTest.cs
@@ -383,7 +383,7 @@ namespace NuGet.Packaging.Test
             using (var directory = new TestSourcesDirectory())
             {
                 // Arrange
-                PackageBuilder builder = new PackageBuilder();
+                var builder = new PackageBuilder();
 
                 // Act
                 builder.AddFiles(directory.Path, source, destination);


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/11125

Regression? Yes Last working version: 5.9.1

## Description
Our code has different behavior if you use a back slash versus a forward slash during pack.  The feature to pack a README "fixed" this bug but regressed another.  

I've created https://github.com/NuGet/Home/issues/11234 to track the fact that the behavior is different and this PR includes a unit test to catch if we regress it again.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [x] Documentation PR or issue filled
  - **OR**
  - [ ] N/A
