### PR TITLE
Local feeds no longer show a 0 Download Count

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/Model/LocalPackageSearchMetadata.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Model/LocalPackageSearchMetadata.cs
@@ -32,7 +32,7 @@ namespace NuGet.Protocol
         public string Description => _nuspec.GetDescription();
 
         /// <remarks>
-        /// Local packages always have 0 as the download count
+        /// Local package sources never provide a download count.
         /// </remarks>
         public long? DownloadCount => null;
 

--- a/src/NuGet.Core/NuGet.Protocol/Model/LocalPackageSearchMetadata.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Model/LocalPackageSearchMetadata.cs
@@ -34,7 +34,7 @@ namespace NuGet.Protocol
         /// <remarks>
         /// Local packages always have 0 as the download count
         /// </remarks>
-        public long? DownloadCount => 0;
+        public long? DownloadCount => null;
 
         public Uri IconUrl => GetIconUri();
 

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/LocalPackageSearchMetadataTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/LocalPackageSearchMetadataTests.cs
@@ -37,6 +37,22 @@ namespace NuGet.Protocol.Tests
         }
 
         [Fact]
+        public void DownloadCount_Always_Null()
+        {
+            var localPackageInfo = new LocalPackageInfo(
+                new PackageIdentity("id", NuGetVersion.Parse("1.0.0")),
+                "path",
+                new DateTime(2019, 8, 19),
+                new Lazy<NuspecReader>(() => null),
+                useFolder: false
+                );
+
+            var localPackageSearchMetadata = new LocalPackageSearchMetadata(localPackageInfo);
+
+            Assert.Null(localPackageSearchMetadata.DownloadCount);
+        }
+
+        [Fact]
         public void PackageReader_NotNull()
         {
             Assert.NotNull(_testData.TestData.PackageReader);

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/LocalResourceTests/LocalPackageMetadataResourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/LocalResourceTests/LocalPackageMetadataResourceTests.cs
@@ -300,7 +300,7 @@ namespace NuGet.Protocol.Tests
                 Assert.Equal("a,b,c", package.Authors);
                 Assert.Equal(2, package.DependencySets.Count());
                 Assert.Equal("package description", package.Description);
-                Assert.Equal(0, package.DownloadCount);
+                Assert.Equal(null, package.DownloadCount);
                 Assert.Equal(new Uri("http://nuget.org/nuget.jpg"), package.IconUrl);
                 Assert.Equal("1.0.0-alpha.1.2+5", package.Identity.Version.ToFullString());
                 Assert.Equal(new Uri("http://nuget.org/license.txt"), package.LicenseUrl);


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11012

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
Local feeds have defaulted the Download Count to 0. However, this causes hits to the Global Packages Folder to erroneously display a 0, and an unnecessary 0 to be shown when a Local package source is selected. 

This PR introduces a new bug that I believe is lower impact and less misleading than the current behavior: when a V2 feed is used, and in the details pane, the installed version is selected in the Versions dropdown, the Download Count will be hidden. (see below).

### Before/After setting count to null for local feeds.
![image](https://user-images.githubusercontent.com/49205731/134081352-00ea2a49-cffe-4046-9e29-ec0eb664a763.png)

### Before / After with nuget.org source
![image](https://user-images.githubusercontent.com/49205731/134081394-9f48447e-cdf0-4eb4-9ec1-cb534db80f64.png)

### Before / after with a V2 feed & same version selected in details (new bug w/ this PR)
![image](https://user-images.githubusercontent.com/49205731/134081490-a45fd836-7157-4992-a3c5-08b3afae4ee0.png)


## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added - Also included manual test screenshots above.
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
