### PR TITLE
Minor fix for debugging doc (DOTNET_MULTILEVEL_LOOKUP)

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -139,7 +139,7 @@ If you are testing a debug build, to debug just set the environment variable def
 
 There are 2 ways to patch dotnet.exe with the latest NuGet bits.
 
-* Refer to the [PowerShell helper scripts](../scripts/nuget-debug-helpers.ps1) for a helper script to patch a zip of the SDK that can be acquired from the [dotnet installer](https://github.com/dotnet/installer/blob/master/README.md#installers-and-binaries). Note that when running you [might](https://github.com/dotnet/runtime/blob/master/docs/project/dogfooding.md) need to disable MULTI_LEVEL_LOOKUP. dotnet.exe has a special logic for the discovering the SDK, and it's possible it's discovering a different SDK from the one you patched.
+* Refer to the [PowerShell helper scripts](../scripts/nuget-debug-helpers.ps1) for a helper script to patch a zip of the SDK that can be acquired from the [dotnet installer](https://github.com/dotnet/installer/blob/master/README.md#installers-and-binaries). Note that when running you [might](https://github.com/dotnet/runtime/blob/master/docs/project/dogfooding.md) need to disable `DOTNET_MULTILEVEL_LOOKUP`. dotnet.exe has a special logic for the discovering the SDK, and it's possible it's discovering a different SDK from the one you patched.
 * Refer to [dotnet/sdk](https://github.com/dotnet/sdk) repo to build it locally and test through that. The sdk consumes NuGet through packages, use `Ctrl + F` in your trusty editor to figure out how to make those changes. Keep in mind that you might need to add a new source in their build.
 
 ### Debugging the NuGet and plugin interaction


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug
Fixes: just a minor fix for debugging doc, so there is no issue.
Regression? Last working version:

## Description
According to [doc](https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-environment-variables#dotnet_multilevel_lookup), change the environment variable from `MULTI_LEVEL_LOOKUP` to `DOTNET_MULTILEVEL_LOOKUP`.

## PR Checklist

- [x] PR has a meaningful title
- [ ] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
