### PR TITLE
Update Microsoft.VisualStudioEng.MicroBuild.Core to 1.0.0

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -5,7 +5,6 @@
     <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
-    <add key="microbuildtoolset" value="https://devdiv.pkgs.visualstudio.com/_packaging/microbuildtoolset/nuget/v3/index.json" />
     <add key="myget-legacy@Local" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy%40Local/nuget/v3/index.json" />
     <add key="nuget-build" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/nuget-build/nuget/v3/index.json" />
     <add key="vside_vs-impl" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl/nuget/v3/index.json" />

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -5,6 +5,7 @@
     <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
+    <add key="microbuildtoolset" value="https://devdiv.pkgs.visualstudio.com/_packaging/microbuildtoolset/nuget/v3/index.json" />
     <add key="myget-legacy@Local" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy%40Local/nuget/v3/index.json" />
     <add key="nuget-build" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/nuget-build/nuget/v3/index.json" />
     <add key="vside_vs-impl" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl/nuget/v3/index.json" />

--- a/build/bootstrap.proj
+++ b/build/bootstrap.proj
@@ -12,7 +12,6 @@
     <ItemGroup>
         <PackageDownload Include="ILMerge" version="[3.0.21]" />
         <PackageDownload Include="Lucene.Net" version="[3.0.3]" />
-        <PackageDownload Include="Microsoft.VisualStudioEng.MicroBuild.Core" version="[1.0.0]" />
         <PackageDownload Include="Microsoft.DotNet.Build.Tasks.Feed" version="[6.0.0-beta.20528.5]" />  <!-- for publishing to the .NET Core build asset registry (BAR) -->
         <PackageDownload Include="Microsoft.DotNet.Maestro.Tasks" version="[1.1.0-beta.21378.2]" />  <!-- for publishing to the .NET Core build asset registry (BAR) -->
         <PackageDownload Include="Microsoft.Web.Xdt" version="[3.0.0]" />

--- a/build/bootstrap.proj
+++ b/build/bootstrap.proj
@@ -12,6 +12,7 @@
     <ItemGroup>
         <PackageDownload Include="ILMerge" version="[3.0.21]" />
         <PackageDownload Include="Lucene.Net" version="[3.0.3]" />
+        <PackageDownload Include="Microsoft.VisualStudioEng.MicroBuild.Core" version="[1.0.0]" />
         <PackageDownload Include="Microsoft.DotNet.Build.Tasks.Feed" version="[6.0.0-beta.20528.5]" />  <!-- for publishing to the .NET Core build asset registry (BAR) -->
         <PackageDownload Include="Microsoft.DotNet.Maestro.Tasks" version="[1.1.0-beta.21378.2]" />  <!-- for publishing to the .NET Core build asset registry (BAR) -->
         <PackageDownload Include="Microsoft.Web.Xdt" version="[3.0.0]" />

--- a/build/bootstrap.proj
+++ b/build/bootstrap.proj
@@ -12,7 +12,7 @@
     <ItemGroup>
         <PackageDownload Include="ILMerge" version="[3.0.21]" />
         <PackageDownload Include="Lucene.Net" version="[3.0.3]" />
-        <PackageDownload Include="Microsoft.VisualStudioEng.MicroBuild.Core" version="[0.4.1]" />
+        <PackageDownload Include="Microsoft.VisualStudioEng.MicroBuild.Core" version="[1.0.0]" />
         <PackageDownload Include="Microsoft.DotNet.Build.Tasks.Feed" version="[6.0.0-beta.20528.5]" />  <!-- for publishing to the .NET Core build asset registry (BAR) -->
         <PackageDownload Include="Microsoft.DotNet.Maestro.Tasks" version="[1.1.0-beta.21378.2]" />  <!-- for publishing to the .NET Core build asset registry (BAR) -->
         <PackageDownload Include="Microsoft.Web.Xdt" version="[3.0.0]" />

--- a/build/common.project.props
+++ b/build/common.project.props
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\packages\Microsoft.VisualStudioEng.MicroBuild.Core\0.4.1\build\Microsoft.VisualStudioEng.MicroBuild.Core.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), &quot;README.md&quot;))\packages\Microsoft.VisualStudioEng.MicroBuild.Core\0.4.1\build\Microsoft.VisualStudioEng.MicroBuild.Core.props')" />
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\packages\Microsoft.VisualStudioEng.MicroBuild.Core\1.0.0\build\Microsoft.VisualStudioEng.MicroBuild.Core.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), &quot;README.md&quot;))\packages\Microsoft.VisualStudioEng.MicroBuild.Core\1.0.0\build\Microsoft.VisualStudioEng.MicroBuild.Core.props')" />
 
   <!-- Helper properties -->
   <PropertyGroup>
@@ -52,7 +52,7 @@
     <NuGetBuildLocalizationRepository>$(RepositoryRootDirectory)submodules\NuGet.Build.Localization\</NuGetBuildLocalizationRepository>
     <LocalizationRootDirectory>$(NuGetBuildLocalizationRepository)localize</LocalizationRootDirectory>
     <LocalizationWorkDirectory>$(RepositoryRootDirectory)localize</LocalizationWorkDirectory>
-    <MicroBuildDirectory>$(SolutionPackagesFolder)microsoft.visualstudioeng.microbuild.core\0.4.1\build\</MicroBuildDirectory>
+    <MicroBuildDirectory>$(SolutionPackagesFolder)microsoft.visualstudioeng.microbuild.core\1.0.0\build\</MicroBuildDirectory>
     <MicrosoftDotNetBuildTasksFeedFilePath>$(SolutionPackagesFolder)microsoft.dotnet.build.tasks.feed\6.0.0-beta.20528.5\tools\netcoreapp2.1\Microsoft.DotNet.Build.Tasks.Feed.dll</MicrosoftDotNetBuildTasksFeedFilePath>
     <MicrosoftDotNetMaestroTasksFilePath>$(SolutionPackagesFolder)microsoft.dotnet.maestro.tasks\1.1.0-beta.21378.2\tools\netcoreapp3.1\Microsoft.DotNet.Maestro.Tasks.dll</MicrosoftDotNetMaestroTasksFilePath>
     <NoWarn>$(NoWarn);NU5105;MSB3277</NoWarn>

--- a/build/common.targets
+++ b/build/common.targets
@@ -420,6 +420,6 @@ Condition=" ('%(Extension)' == '.dll' OR '%(Filename)' == 'NuGet.CommandLine.XPl
       Condition=" '%(PackageReference.Version)' != '' AND '%(PackageReference.IsImplicitlyDefined)' != 'true' AND '%(PackageReference.Identity)' != 'Microsoft.NET.Test.Sdk' " />
   </Target>
 
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\packages\Microsoft.VisualStudioEng.MicroBuild.Core\0.4.1\build\Microsoft.VisualStudioEng.MicroBuild.Core.targets" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), &quot;README.md&quot;))\packages\Microsoft.VisualStudioEng.MicroBuild.Core\0.4.1\build\Microsoft.VisualStudioEng.MicroBuild.Core.targets')" />
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\packages\Microsoft.VisualStudioEng.MicroBuild.Core\1.0.0\build\Microsoft.VisualStudioEng.MicroBuild.Core.targets" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), &quot;README.md&quot;))\packages\Microsoft.VisualStudioEng.MicroBuild.Core\1.0.0\build\Microsoft.VisualStudioEng.MicroBuild.Core.targets')" />
 
 </Project>

--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -6,13 +6,6 @@ steps:
     arguments: 'sources add -Name VS -Source https://devdiv.pkgs.visualstudio.com/_packaging/microbuildtoolset/nuget/v3/index.json -UserName $(VsPackageFeedUsername) -Password $(VsPackageFeedPassword) -ConfigFile $(System.DefaultWorkingDirectory)\NuGet.config'
   condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
 
-- task: NuGetCommand@2
-  displayName: 'Install the NuGet package for MicroBuildTasks'
-  inputs:
-    command: 'custom'
-    arguments: 'install Microsoft.VisualStudioEng.MicroBuild.Core -Version 1.0.0 -Source https://devdiv.pkgs.visualstudio.com/_packaging/microbuildtoolset/nuget/v3/index.json -ConfigFile $(System.DefaultWorkingDirectory)\NuGet.config -OutputDirectory $(System.DefaultWorkingDirectory)\packages'
-  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
-
 - task: PowerShell@1
   inputs:
     scriptName: "$(Build.Repository.LocalPath)\\configure.ps1"

--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -3,7 +3,7 @@ steps:
   displayName: 'Add the Microbuildtoolset package source'
   inputs:
     command: 'custom'
-    arguments: 'sources add -Name VS -Source https://devdiv.pkgs.visualstudio.com/_packaging/microbuildtoolset/nuget/v3/index.json -UserName $(VsPackageFeedUsername) -Password $(VsPackageFeedPassword) -ConfigFile $(System.DefaultWorkingDirectory)\NuGet.config'
+    arguments: 'sources add -Name MicrobuildtoolsetSource -Source https://devdiv.pkgs.visualstudio.com/_packaging/microbuildtoolset/nuget/v3/index.json -UserName $(VsPackageFeedUsername) -Password $(VsPackageFeedPassword) -ConfigFile $(System.DefaultWorkingDirectory)\NuGet.config'
   condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
 
 - task: PowerShell@1

--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -6,6 +6,13 @@ steps:
     arguments: 'sources add -Name MicrobuildtoolsetSource -Source https://devdiv.pkgs.visualstudio.com/_packaging/microbuildtoolset/nuget/v3/index.json -UserName $(VsPackageFeedUsername) -Password $(VsPackageFeedPassword) -ConfigFile $(System.DefaultWorkingDirectory)\NuGet.config'
   condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
 
+- task: NuGetCommand@2
+  displayName: 'Install the NuGet package for MicroBuildTasks'
+  inputs:
+    command: 'custom'
+    arguments: 'install Microsoft.VisualStudioEng.MicroBuild.Core -Version 1.0.0 -Source https://devdiv.pkgs.visualstudio.com/_packaging/microbuildtoolset/nuget/v3/index.json -ConfigFile $(System.DefaultWorkingDirectory)\NuGet.config -OutputDirectory $(System.DefaultWorkingDirectory)\packages'
+  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
+
 - task: PowerShell@1
   inputs:
     scriptName: "$(Build.Repository.LocalPath)\\configure.ps1"

--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -6,6 +6,13 @@ steps:
     arguments: 'sources add -Name VS -Source https://devdiv.pkgs.visualstudio.com/_packaging/microbuildtoolset/nuget/v3/index.json -UserName $(VsPackageFeedUsername) -Password $(VsPackageFeedPassword) -ConfigFile $(System.DefaultWorkingDirectory)\NuGet.config'
   condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
 
+- task: NuGetCommand@2
+  displayName: 'Install the NuGet package for MicroBuildTasks'
+  inputs:
+    command: 'custom'
+    arguments: 'install Microsoft.VisualStudioEng.MicroBuild.Core -Version 1.0.0 -Source https://devdiv.pkgs.visualstudio.com/_packaging/microbuildtoolset/nuget/v3/index.json -ConfigFile $(System.DefaultWorkingDirectory)\NuGet.config -OutputDirectory $(System.DefaultWorkingDirectory)\packages'
+  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
+
 - task: PowerShell@1
   inputs:
     scriptName: "$(Build.Repository.LocalPath)\\configure.ps1"

--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -35,7 +35,7 @@ steps:
     esrpSigning: "true"
   displayName: "Install Signing Plugin"
 
-- task: MicroBuildSwixPlugin@1
+- task: ms-vseng.MicroBuildTasks.32f78468-e895-4f47-962c-58a699361df8.MicroBuildSwixPlugin@1
   displayName: "Install Swix Plugin"
 
 - task: MicroBuildOptProfPlugin@6

--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -1,4 +1,11 @@
 steps:
+- task: NuGetCommand@2
+  displayName: 'Add the Microbuildtoolset package source'
+  inputs:
+    command: 'custom'
+    arguments: 'sources add -Name VS -Source https://devdiv.pkgs.visualstudio.com/_packaging/microbuildtoolset/nuget/v3/index.json -UserName $(VsPackageFeedUsername) -Password $(VsPackageFeedPassword) -ConfigFile $(System.DefaultWorkingDirectory)\NuGet.config'
+  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
+
 - task: PowerShell@1
   inputs:
     scriptName: "$(Build.Repository.LocalPath)\\configure.ps1"
@@ -34,20 +41,6 @@ steps:
     signType: "$(SigningType)"
     esrpSigning: "true"
   displayName: "Install Signing Plugin"
-
-- task: NuGetCommand@2
-  displayName: 'Add the Microbuildtoolset package source'
-  inputs:
-    command: 'custom'
-    arguments: 'sources add -Name VS -Source https://devdiv.pkgs.visualstudio.com/_packaging/microbuildtoolset/nuget/v3/index.json -UserName $(VsPackageFeedUsername) -Password $(VsPackageFeedPassword) -ConfigFile $(System.DefaultWorkingDirectory)\NuGet.config'
-  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
-
-- task: NuGetCommand@2
-  displayName: 'Install the NuGet package for MicroBuildTasks'
-  inputs:
-    command: 'custom'
-    arguments: 'install Microsoft.VisualStudioEng.MicroBuild.Core -Version 1.0.0 -Source https://devdiv.pkgs.visualstudio.com/_packaging/microbuildtoolset/nuget/v3/index.json -ConfigFile $(System.DefaultWorkingDirectory)\NuGet.config -OutputDirectory $(System.DefaultWorkingDirectory)\packages'
-  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
 
 - task: ms-vseng.MicroBuildTasks.32f78468-e895-4f47-962c-58a699361df8.MicroBuildSwixPlugin@1
   displayName: "Install Swix Plugin"

--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -1,18 +1,4 @@
 steps:
-- task: NuGetCommand@2
-  displayName: 'Add the Microbuildtoolset package source'
-  inputs:
-    command: 'custom'
-    arguments: 'sources add -Name MicrobuildtoolsetSource -Source https://devdiv.pkgs.visualstudio.com/_packaging/microbuildtoolset/nuget/v3/index.json -UserName $(VsPackageFeedUsername) -Password $(VsPackageFeedPassword) -ConfigFile $(System.DefaultWorkingDirectory)\NuGet.config'
-  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
-
-- task: NuGetCommand@2
-  displayName: 'Install the NuGet package for MicroBuildTasks'
-  inputs:
-    command: 'custom'
-    arguments: 'install Microsoft.VisualStudioEng.MicroBuild.Core -Version 1.0.0 -Source https://devdiv.pkgs.visualstudio.com/_packaging/microbuildtoolset/nuget/v3/index.json -ConfigFile $(System.DefaultWorkingDirectory)\NuGet.config -OutputDirectory $(System.DefaultWorkingDirectory)\packages'
-  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
-
 - task: PowerShell@1
   inputs:
     scriptName: "$(Build.Repository.LocalPath)\\configure.ps1"

--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -279,6 +279,20 @@ steps:
     arguments: 'install Microsoft.DevDiv.Validation.TestPlatform.Settings.Tasks -Version 1.0.655 -Source $(VsPackageFeedUrl) -ConfigFile $(System.DefaultWorkingDirectory)\NuGet.config -OutputDirectory $(System.DefaultWorkingDirectory)\packages'
   condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
 
+- task: NuGetCommand@2
+  displayName: 'Add the Microbuildtoolset package source'
+  inputs:
+    command: 'custom'
+    arguments: 'sources add -Name VS -Source https://devdiv.pkgs.visualstudio.com/_packaging/microbuildtoolset/nuget/v3/index.json -UserName $(VsPackageFeedUsername) -Password $(VsPackageFeedPassword) -ConfigFile $(System.DefaultWorkingDirectory)\NuGet.config'
+  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
+
+- task: NuGetCommand@2
+  displayName: 'Install the NuGet package for MicroBuildTasks'
+  inputs:
+    command: 'custom'
+    arguments: 'install Microsoft.VisualStudioEng.MicroBuild.Core -Version 1.0.0 -Source https://devdiv.pkgs.visualstudio.com/_packaging/microbuildtoolset/nuget/v3/index.json -ConfigFile $(System.DefaultWorkingDirectory)\NuGet.config -OutputDirectory $(System.DefaultWorkingDirectory)\packages'
+  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
+
 - task: MicroBuildBuildVSBootstrapper@2
   displayName: 'Build a Visual Studio bootstrapper'
   inputs:

--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -35,6 +35,20 @@ steps:
     esrpSigning: "true"
   displayName: "Install Signing Plugin"
 
+- task: NuGetCommand@2
+  displayName: 'Add the Microbuildtoolset package source'
+  inputs:
+    command: 'custom'
+    arguments: 'sources add -Name VS -Source https://devdiv.pkgs.visualstudio.com/_packaging/microbuildtoolset/nuget/v3/index.json -UserName $(VsPackageFeedUsername) -Password $(VsPackageFeedPassword) -ConfigFile $(System.DefaultWorkingDirectory)\NuGet.config'
+  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
+
+- task: NuGetCommand@2
+  displayName: 'Install the NuGet package for MicroBuildTasks'
+  inputs:
+    command: 'custom'
+    arguments: 'install Microsoft.VisualStudioEng.MicroBuild.Core -Version 1.0.0 -Source https://devdiv.pkgs.visualstudio.com/_packaging/microbuildtoolset/nuget/v3/index.json -ConfigFile $(System.DefaultWorkingDirectory)\NuGet.config -OutputDirectory $(System.DefaultWorkingDirectory)\packages'
+  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
+
 - task: ms-vseng.MicroBuildTasks.32f78468-e895-4f47-962c-58a699361df8.MicroBuildSwixPlugin@1
   displayName: "Install Swix Plugin"
 
@@ -277,20 +291,6 @@ steps:
   inputs:
     command: 'custom'
     arguments: 'install Microsoft.DevDiv.Validation.TestPlatform.Settings.Tasks -Version 1.0.655 -Source $(VsPackageFeedUrl) -ConfigFile $(System.DefaultWorkingDirectory)\NuGet.config -OutputDirectory $(System.DefaultWorkingDirectory)\packages'
-  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
-
-- task: NuGetCommand@2
-  displayName: 'Add the Microbuildtoolset package source'
-  inputs:
-    command: 'custom'
-    arguments: 'sources add -Name VS -Source https://devdiv.pkgs.visualstudio.com/_packaging/microbuildtoolset/nuget/v3/index.json -UserName $(VsPackageFeedUsername) -Password $(VsPackageFeedPassword) -ConfigFile $(System.DefaultWorkingDirectory)\NuGet.config'
-  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
-
-- task: NuGetCommand@2
-  displayName: 'Install the NuGet package for MicroBuildTasks'
-  inputs:
-    command: 'custom'
-    arguments: 'install Microsoft.VisualStudioEng.MicroBuild.Core -Version 1.0.0 -Source https://devdiv.pkgs.visualstudio.com/_packaging/microbuildtoolset/nuget/v3/index.json -ConfigFile $(System.DefaultWorkingDirectory)\NuGet.config -OutputDirectory $(System.DefaultWorkingDirectory)\packages'
   condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
 
 - task: MicroBuildBuildVSBootstrapper@2


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1051

Regression? Last working version: n/a

## Description

- Upgraded  Microsoft.VisualStudioEng.MicroBuild.Core package to latest 1.0.0 version.
- Updated `MicroBuildSwixPlugin@1` task to `ms-vseng.MicroBuildTasks.32f78468-e895-4f47-962c-58a699361df8.MicroBuildSwixPlugin@1` task which is same as [msbuild ](https://github.com/dotnet/msbuild/blob/e123a0c1fb4a66a3fdcfbe8a8792183f7df5cc34/.vsts-dotnet.yml#L103) and [Roslyn ](https://github.com/dotnet/roslyn-sdk/blob/aba633cc45d94819ef6595f0e9aa0a4399935fa8/.vsts-ci.yml#L42).
- But I didn't find `Microsoft.VisualStudioEng.MicroBuild.Plugins.SwixBuild` reference in our code, so nothing to upgrade, not sure if we need it. I can see [msbuild](https://github.com/dotnet/msbuild/blob/e123a0c1fb4a66a3fdcfbe8a8792183f7df5cc34/eng/Versions.props#L11) and [Roslyn ](https://github.com/dotnet/msbuild/blob/e123a0c1fb4a66a3fdcfbe8a8792183f7df5cc34/eng/Versions.props#L11) uses it.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
