### PR TITLE
Alternate Package links are visible in Light Theme when package is selected

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources/Resources.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources/Resources.xaml
@@ -665,6 +665,14 @@
 
   <Style
     TargetType="{x:Type Hyperlink}"
+    x:Key="HyperlinkStyleNoUriDeprecation">
+    <Setter Property="Foreground" Value="{Binding RelativeSource={RelativeSource AncestorType={x:Type TextBlock}}, Path=Foreground}" />
+    <Setter Property="FocusVisualStyle" Value="{StaticResource ControlsFocusVisualStyle}"/>
+    <Setter Property="TextBlock.TextDecorations" Value="Underline" />
+  </Style>
+
+  <Style
+    TargetType="{x:Type Hyperlink}"
     x:Key="HyperlinkStyle"
     BasedOn="{StaticResource HyperlinkStyleNoUri}">
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageItemDeprecationLabel.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageItemDeprecationLabel.xaml
@@ -37,7 +37,7 @@
             <Hyperlink
               ToolTip="{x:Static nuget:Resources.Deprecation_LinkTooltip}"
               Command="{x:Static nuget:Commands.SearchPackageCommand}"
-              Style="{StaticResource HyperlinkStyleNoUri}">
+              Style="{StaticResource HyperlinkStyleNoUriDeprecation}">
               <Hyperlink.CommandParameter>
                 <MultiBinding Converter="{StaticResource ParametersToHyperlinkTupleConverter}" Mode="OneWay">
                   <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="DataContext.AlternatePackage.PackageId" Mode="OneWay" />


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/nuget/client.engineering/issues/1105

Regression? Last working version: Yes < 17.0

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
Alternate package links will have a static foreground which matches the adjacent text blocks. They are permanently underlined. The fix applies to all themes.

This resolves a contrast bug with Light Theme temporarily, until we can get the binding for the hyperlink to adjust to package item Selection. Verified that other hyperlinks in details pane are still colored correctly.

![image](https://user-images.githubusercontent.com/49205731/135010798-94e41483-01ed-4a46-8572-6605cb3903bb.png)
![image](https://user-images.githubusercontent.com/49205731/135010898-4f2ba4ea-7d64-4e2f-b2fa-02802ce6a58e.png)

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception - Manually tested all themes. See screenshot.
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
