### PR TITLE
Add environment variable override to force disable an experiment

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Experimentation/NuGetExperimentationService.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Experimentation/NuGetExperimentationService.cs
@@ -27,19 +27,19 @@ namespace NuGet.VisualStudio
             _experimentationService = experimentationService ?? throw new ArgumentNullException(nameof(experimentationService));
         }
 
-        public bool IsExperimentEnabled(ExperimentationConstants experimentation)
+        public bool IsExperimentEnabled(ExperimentationConstants experiment)
         {
-            bool isExpForcedEnabled = false;
-            bool isExpForcedDisabled = false;
-            if (!string.IsNullOrEmpty(experimentation.FlightEnvironmentVariable))
+            var isExpForcedEnabled = false;
+            var isExpForcedDisabled = false;
+            if (!string.IsNullOrEmpty(experiment.FlightEnvironmentVariable))
             {
-                string envVarOverride = _environmentVariableReader.GetEnvironmentVariable(experimentation.FlightEnvironmentVariable);
+                string envVarOverride = _environmentVariableReader.GetEnvironmentVariable(experiment.FlightEnvironmentVariable);
 
                 isExpForcedDisabled = envVarOverride == "0";
                 isExpForcedEnabled = envVarOverride == "1";
             }
 
-            return !isExpForcedDisabled && (isExpForcedEnabled || _experimentationService.IsCachedFlightEnabled(experimentation.FlightFlag));
+            return !isExpForcedDisabled && (isExpForcedEnabled || _experimentationService.IsCachedFlightEnabled(experiment.FlightFlag));
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Experimentation/NuGetExperimentationService.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Experimentation/NuGetExperimentationService.cs
@@ -29,10 +29,17 @@ namespace NuGet.VisualStudio
 
         public bool IsExperimentEnabled(ExperimentationConstants experimentation)
         {
-            var isEnvVarEnabled = !string.IsNullOrEmpty(experimentation.FlightEnvironmentVariable)
-                && _environmentVariableReader.GetEnvironmentVariable(experimentation.FlightEnvironmentVariable) == "1";
+            bool isExpForcedEnabled = false;
+            bool isExpForcedDisabled = false;
+            if (!string.IsNullOrEmpty(experimentation.FlightEnvironmentVariable))
+            {
+                string envVarOverride = _environmentVariableReader.GetEnvironmentVariable(experimentation.FlightEnvironmentVariable);
 
-            return isEnvVarEnabled || _experimentationService.IsCachedFlightEnabled(experimentation.FlightFlag);
+                isExpForcedDisabled = envVarOverride == "0";
+                isExpForcedEnabled = envVarOverride == "1";
+            }
+
+            return !isExpForcedDisabled && (isExpForcedEnabled || _experimentationService.IsCachedFlightEnabled(experimentation.FlightFlag));
         }
     }
 }

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Common.Test/NuGetExperimentationServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Common.Test/NuGetExperimentationServiceTests.cs
@@ -35,7 +35,7 @@ namespace NuGet.VisualStudio.Common.Test
         }
 
         [Fact]
-        public void IsEnabled_WithEnabledFlight_WithEnvironmentVariable_ReturnsTrue()
+        public void IsEnabled_WithEnabledFlight_WithEnabledEnvironmentVariable_ReturnsTrue()
         {
             var constant = ExperimentationConstants.PackageManagerBackgroundColor;
             var envVars = new Dictionary<string, string>()
@@ -49,7 +49,7 @@ namespace NuGet.VisualStudio.Common.Test
         }
 
         [Theory]
-        [InlineData("0")]
+        [InlineData("2")]
         [InlineData("randomValue")]
         public void IsEnabled_WithEnvVarWithIncorrectValue_WithEnvironmentVariable__ReturnsFalse(string value)
         {
@@ -77,17 +77,19 @@ namespace NuGet.VisualStudio.Common.Test
             service.IsExperimentEnabled(ExperimentationConstants.PackageManagerBackgroundColor).Should().BeTrue();
         }
 
-        [Fact]
-        public void IsEnabled_WithEnvVarWithIncorrectValue_WithExperimentalService_ReturnsFalse()
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(false, false)]
+        public void IsEnabled_WithEnvVarNotSet_WithExperimentalService_ReturnsFlightEnabledValue(bool isFlightEnabled, bool expectedResult)
         {
             var constant = ExperimentationConstants.PackageManagerBackgroundColor;
             var flightsEnabled = new Dictionary<string, bool>()
             {
-                { constant.FlightFlag, false },
+                { constant.FlightFlag, isFlightEnabled },
             };
             var service = new NuGetExperimentationService(new TestEnvironmentVariableReader(new Dictionary<string, string>()), new TestVisualStudioExperimentalService(flightsEnabled));
 
-            service.IsExperimentEnabled(ExperimentationConstants.PackageManagerBackgroundColor).Should().BeFalse();
+            service.IsExperimentEnabled(ExperimentationConstants.PackageManagerBackgroundColor).Should().Be(expectedResult);
         }
 
         [Fact]
@@ -111,7 +113,7 @@ namespace NuGet.VisualStudio.Common.Test
         }
 
         [Fact]
-        public void IsEnabled_WithEnvVarDisabled_WithExperimentalServiceEnabled_ReturnsTrue()
+        public void IsEnabled_WithEnvVarDisabled_WithExperimentalServiceEnabled_ReturnsFalse()
         {
             var constant = ExperimentationConstants.PackageManagerBackgroundColor;
             var flightsEnabled = new Dictionary<string, bool>()
@@ -127,7 +129,7 @@ namespace NuGet.VisualStudio.Common.Test
 
             var service = new NuGetExperimentationService(envVarWrapper, new TestVisualStudioExperimentalService(flightsEnabled));
 
-            service.IsExperimentEnabled(ExperimentationConstants.PackageManagerBackgroundColor).Should().BeTrue();
+            service.IsExperimentEnabled(ExperimentationConstants.PackageManagerBackgroundColor).Should().BeFalse();
         }
 
         [Fact]


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1227

Regression? Last working version: N/A

## Description
Added logic to look for a 0 value in the environment variable associated with an experiment, and when found, force the experiment to be evaluated as disabled without checking the experimentation service. This will act as an override to allow users to test with the experiment turned off. This change retains the support for forcing the experiment to be enabled by setting the environment variable to 1. Also added and updated unit tests.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
