### PR TITLE
rename packageSourceMappingConfiguration variable to packageSourceMapping

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/InstallCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/InstallCommand.cs
@@ -217,9 +217,9 @@ namespace NuGet.CommandLine
                         Console)
                 };
 
-                var packageSourceMappingConfiguration = PackageSourceMapping.GetPackageSourceMapping(Settings);
+                var packageSourceMapping = PackageSourceMapping.GetPackageSourceMapping(Settings);
 
-                var downloadContext = new PackageDownloadContext(cacheContext, installPath, DirectDownload, packageSourceMappingConfiguration)
+                var downloadContext = new PackageDownloadContext(cacheContext, installPath, DirectDownload, packageSourceMapping)
                 {
                     ClientPolicyContext = clientPolicyContext
                 };
@@ -371,9 +371,9 @@ namespace NuGet.CommandLine
                     resolutionContext.SourceCacheContext.NoCache = NoCache;
                     resolutionContext.SourceCacheContext.DirectDownload = DirectDownload;
 
-                    var packageSourceMappingConfiguration = PackageSourceMapping.GetPackageSourceMapping(Settings);
+                    var packageSourceMapping = PackageSourceMapping.GetPackageSourceMapping(Settings);
 
-                    var downloadContext = new PackageDownloadContext(resolutionContext.SourceCacheContext, installPath, DirectDownload, packageSourceMappingConfiguration)
+                    var downloadContext = new PackageDownloadContext(resolutionContext.SourceCacheContext, installPath, DirectDownload, packageSourceMapping)
                     {
                         ClientPolicyContext = clientPolicyContext
                     };

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
@@ -382,9 +382,9 @@ namespace NuGet.CommandLine
                 cacheContext.NoCache = NoCache;
                 cacheContext.DirectDownload = DirectDownload;
 
-                var packageSourceMappingConfiguration = PackageSourceMapping.GetPackageSourceMapping(Settings);
+                var packageSourceMapping = PackageSourceMapping.GetPackageSourceMapping(Settings);
 
-                var downloadContext = new PackageDownloadContext(cacheContext, packagesFolderPath, DirectDownload, packageSourceMappingConfiguration)
+                var downloadContext = new PackageDownloadContext(cacheContext, packagesFolderPath, DirectDownload, packageSourceMapping)
                 {
                     ClientPolicyContext = clientPolicyContext
                 };

--- a/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/Utility/PackageSourceMappingUtility.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/Utility/PackageSourceMappingUtility.cs
@@ -9,8 +9,8 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
     {
         public static bool IsMappingEnabled(ISettings settings)
         {
-            var packageSourceMappingConfiguration = PackageSourceMapping.GetPackageSourceMapping(settings);
-            bool isMappingEnabled = packageSourceMappingConfiguration?.IsEnabled ?? false;
+            var packageSourceMapping = PackageSourceMapping.GetPackageSourceMapping(settings);
+            bool isMappingEnabled = packageSourceMapping?.IsEnabled ?? false;
             return isMappingEnabled;
         }
     }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/UIActionEngine.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/UIActionEngine.cs
@@ -499,8 +499,8 @@ namespace NuGet.PackageManagement.UI
                         uiService.Projects,
                         cancellationToken)).ToArray();
 
-                    var packageSourceMappingConfiguration = PackageSourceMapping.GetPackageSourceMapping(uiService.Settings);
-                    bool isPackageSourceMappingEnabled = packageSourceMappingConfiguration?.IsEnabled ?? false;
+                    var packageSourceMapping = PackageSourceMapping.GetPackageSourceMapping(uiService.Settings);
+                    bool isPackageSourceMappingEnabled = packageSourceMapping?.IsEnabled ?? false;
                     var actionTelemetryEvent = new VSActionsTelemetryEvent(
                         uiService.ProjectContext.OperationId.ToString(),
                         projectIds,

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreJob.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreJob.cs
@@ -177,9 +177,9 @@ namespace NuGet.SolutionRestoreManager
             _packageRestoreManager.PackageRestoreFailedEvent += PackageRestoreManager_PackageRestoreFailedEvent;
 
             var sources = _sourceRepositoryProvider.GetRepositories();
-            var packageSourceMappingConfiguration = PackageSourceMapping.GetPackageSourceMapping(_settings);
+            var packageSourceMapping = PackageSourceMapping.GetPackageSourceMapping(_settings);
 
-            using (var packageSourceTelemetry = new PackageSourceTelemetry(sources, _nuGetProjectContext.OperationId, PackageSourceTelemetry.TelemetryAction.Restore, packageSourceMappingConfiguration))
+            using (var packageSourceTelemetry = new PackageSourceTelemetry(sources, _nuGetProjectContext.OperationId, PackageSourceTelemetry.TelemetryAction.Restore, packageSourceMapping))
             {
                 try
                 {
@@ -304,8 +304,8 @@ namespace NuGet.SolutionRestoreManager
                 .GroupBy(x => x.ProjectStyle)
                 .ToDictionary(x => x.Key, y => y.Count());
 
-            var packageSourceMappingConfiguration = PackageSourceMapping.GetPackageSourceMapping(_settings);
-            bool isPackageSourceMappingEnabled = packageSourceMappingConfiguration?.IsEnabled ?? false;
+            var packageSourceMapping = PackageSourceMapping.GetPackageSourceMapping(_settings);
+            bool isPackageSourceMappingEnabled = packageSourceMapping?.IsEnabled ?? false;
 
             var restoreTelemetryEvent = new RestoreTelemetryEvent(
                 _nuGetProjectContext.OperationId.ToString(),
@@ -706,9 +706,9 @@ namespace NuGet.SolutionRestoreManager
 
             using (var cacheContext = new SourceCacheContext())
             {
-                var packageSourceMappingConfiguration = PackageSourceMapping.GetPackageSourceMapping(_settings);
+                var packageSourceMapping = PackageSourceMapping.GetPackageSourceMapping(_settings);
 
-                var downloadContext = new PackageDownloadContext(cacheContext, directDownloadDirectory: null, directDownload: false, packageSourceMappingConfiguration)
+                var downloadContext = new PackageDownloadContext(cacheContext, directDownloadDirectory: null, directDownload: false, packageSourceMapping)
                 {
                     ParentId = _nuGetProjectContext.OperationId,
                     ClientPolicyContext = ClientPolicyContext.GetClientPolicy(_settings, logger)

--- a/src/NuGet.Core/NuGet.Build.Tasks/BuildTasksUtility.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/BuildTasksUtility.cs
@@ -550,9 +550,9 @@ namespace NuGet.Build.Tasks
             {
                 cacheContext.NoCache = noCache;
 
-                var packageSourceMappingConfiguration = PackageSourceMapping.GetPackageSourceMapping(settings);
+                var packageSourceMapping = PackageSourceMapping.GetPackageSourceMapping(settings);
 
-                var downloadContext = new PackageDownloadContext(cacheContext, repositoryPath, directDownload: false, packageSourceMappingConfiguration)
+                var downloadContext = new PackageDownloadContext(cacheContext, repositoryPath, directDownload: false, packageSourceMapping)
                 {
                     ClientPolicyContext = clientPolicyContext
                 };

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/DependencyGraphSpecRequestProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/DependencyGraphSpecRequestProvider.cs
@@ -159,7 +159,7 @@ namespace NuGet.Commands
             var settings = Settings.LoadImmutableSettingsGivenConfigPaths(projectPackageSpec.RestoreMetadata.ConfigFilePaths, settingsLoadingContext);
             var sources = restoreArgs.GetEffectiveSources(settings, projectPackageSpec.RestoreMetadata.Sources);
             var clientPolicyContext = ClientPolicyContext.GetClientPolicy(settings, restoreArgs.Log);
-            var packageSourceMappingConfiguration = PackageSourceMapping.GetPackageSourceMapping(settings);
+            var packageSourceMapping = PackageSourceMapping.GetPackageSourceMapping(settings);
 
             var sharedCache = _providerCache.GetOrCreate(
                 globalPath,
@@ -178,7 +178,7 @@ namespace NuGet.Commands
                 sharedCache,
                 restoreArgs.CacheContext,
                 clientPolicyContext,
-                packageSourceMappingConfiguration,
+                packageSourceMapping,
                 restoreArgs.Log,
                 _lockFileBuilderCache)
             {

--- a/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
@@ -1109,9 +1109,9 @@ namespace NuGet.PackageManagement
                     }
                 }
 
-                var packageSourceMappingConfiguration = PackageSourceMapping.GetPackageSourceMapping(Settings);
+                var packageSourceMapping = PackageSourceMapping.GetPackageSourceMapping(Settings);
 
-                var gatherContext = new GatherContext(packageSourceMappingConfiguration)
+                var gatherContext = new GatherContext(packageSourceMapping)
                 {
                     InstalledPackages = oldListOfInstalledPackages.ToList(),
                     PrimaryTargetIds = primaryTargetIds.ToList(),
@@ -1738,9 +1738,9 @@ namespace NuGet.PackageManagement
                     var primaryPackages = new List<PackageIdentity> { packageIdentity };
 
                     HashSet<SourcePackageDependencyInfo> availablePackageDependencyInfoWithSourceSet = null;
-                    var packageSourceMappingConfiguration = PackageSourceMapping.GetPackageSourceMapping(Settings);
+                    var packageSourceMapping = PackageSourceMapping.GetPackageSourceMapping(Settings);
 
-                    var gatherContext = new GatherContext(packageSourceMappingConfiguration)
+                    var gatherContext = new GatherContext(packageSourceMapping)
                     {
                         InstalledPackages = oldListOfInstalledPackages.ToList(),
                         PrimaryTargets = primaryPackages,

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceMappingConfigurationTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceMappingConfigurationTests.cs
@@ -30,10 +30,10 @@ namespace NuGet.Configuration.Test
             var settings = Settings.LoadSettingsGivenConfigPaths(new string[] { configPath1 });
 
             // Act & Assert
-            var configuration = PackageSourceMapping.GetPackageSourceMapping(settings);
-            configuration.IsEnabled.Should().BeTrue();
-            configuration.Patterns.Should().HaveCount(1);
-            KeyValuePair<string, IReadOnlyList<string>> patternsForSource = configuration.Patterns.First();
+            var packageSourceMapping = PackageSourceMapping.GetPackageSourceMapping(settings);
+            packageSourceMapping.IsEnabled.Should().BeTrue();
+            packageSourceMapping.Patterns.Should().HaveCount(1);
+            KeyValuePair<string, IReadOnlyList<string>> patternsForSource = packageSourceMapping.Patterns.First();
             patternsForSource.Key.Should().Be("nuget.org");
             patternsForSource.Value.Should().BeEquivalentTo(new string[] { "stuff" });
         }
@@ -58,14 +58,14 @@ namespace NuGet.Configuration.Test
             var settings = Settings.LoadSettingsGivenConfigPaths(new string[] { configPath1 });
 
             // Act & Assert
-            var configuration = PackageSourceMapping.GetPackageSourceMapping(settings);
-            configuration.IsEnabled.Should().BeTrue();
-            configuration.Patterns.Should().HaveCount(2);
+            var packageSourceMapping = PackageSourceMapping.GetPackageSourceMapping(settings);
+            packageSourceMapping.IsEnabled.Should().BeTrue();
+            packageSourceMapping.Patterns.Should().HaveCount(2);
 
-            IReadOnlyList<string> nugetPatterns = configuration.Patterns["nuget.org"];
+            IReadOnlyList<string> nugetPatterns = packageSourceMapping.Patterns["nuget.org"];
             nugetPatterns.Should().BeEquivalentTo(new string[] { "stuff" });
 
-            IReadOnlyList<string> contosoPattern = configuration.Patterns["contoso"];
+            IReadOnlyList<string> contosoPattern = packageSourceMapping.Patterns["contoso"];
             contosoPattern.Should().BeEquivalentTo(new string[] { "moreStuff" });
         }
     }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1219

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
Address https://github.com/NuGet/NuGet.Client/pull/4281#discussion_r717930917 comment. This PR doesn't introduce any changes to the public API. I just renamed `packageSourceMappingConfiguration` variable to `packageSourceMapping` to address the code review comment.

cc @nkolev92 

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  - [x] N/A
