### PR TITLE
Make AutoCompleteResourceV3 use the supplied ILogger (if one is supplied)

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/Resources/AutoCompleteResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/AutoCompleteResourceV3.cs
@@ -51,8 +51,8 @@ namespace NuGet.Protocol
 
             var queryUri = queryUrl.Uri;
             var results = await _client.GetJObjectAsync(
-                new HttpSourceRequest(queryUri, Common.NullLogger.Instance),
-                Common.NullLogger.Instance,
+                new HttpSourceRequest(queryUri, log ?? Common.NullLogger.Instance),
+                log ?? Common.NullLogger.Instance,
                 token);
             token.ThrowIfCancellationRequested();
             if (results == null)
@@ -87,7 +87,7 @@ namespace NuGet.Protocol
             CancellationToken token)
         {
             //*TODOs : Take prerelease as parameter. Also it should return both listed and unlisted for powershell ?
-            var packages = await _regResource.GetPackageMetadata(packageId, includePrerelease, false, sourceCacheContext, Common.NullLogger.Instance, token);
+            var packages = await _regResource.GetPackageMetadata(packageId, includePrerelease, false, sourceCacheContext, log ?? Common.NullLogger.Instance, token);
             var versions = new List<NuGetVersion>();
             foreach (var package in packages)
             {

--- a/src/NuGet.Core/NuGet.Protocol/Resources/AutoCompleteResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/AutoCompleteResourceV3.cs
@@ -49,10 +49,12 @@ namespace NuGet.Protocol
 
             queryUrl.Query = queryString;
 
+            Common.ILogger logger = log ?? Common.NullLogger.Instance;
+
             var queryUri = queryUrl.Uri;
             var results = await _client.GetJObjectAsync(
-                new HttpSourceRequest(queryUri, log ?? Common.NullLogger.Instance),
-                log ?? Common.NullLogger.Instance,
+                new HttpSourceRequest(queryUri, logger),
+                logger,
                 token);
             token.ThrowIfCancellationRequested();
             if (results == null)
@@ -86,8 +88,10 @@ namespace NuGet.Protocol
             Common.ILogger log,
             CancellationToken token)
         {
+            Common.ILogger logger = log ?? Common.NullLogger.Instance;
+
             //*TODOs : Take prerelease as parameter. Also it should return both listed and unlisted for powershell ?
-            var packages = await _regResource.GetPackageMetadata(packageId, includePrerelease, false, sourceCacheContext, log ?? Common.NullLogger.Instance, token);
+            var packages = await _regResource.GetPackageMetadata(packageId, includePrerelease, false, sourceCacheContext, logger, token);
             var versions = new List<NuGetVersion>();
             foreach (var package in packages)
             {

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/AutoCompleteResourceV3Tests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/AutoCompleteResourceV3Tests.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using NuGet.Common;
 using NuGet.Packaging.Core;
 using NuGet.Protocol.Core.Types;
+using NuGet.Test.Utility;
 using NuGet.Versioning;
 using Test.Utility;
 using Xunit;
@@ -31,11 +32,14 @@ namespace NuGet.Protocol.Tests
             var repo = StaticHttpHandler.CreateSource(sourceName, Repository.Provider.GetCoreV3(), responses);
             var resource = await repo.GetResourceAsync<AutoCompleteResource>();
 
+            var logger = new TestLogger();
+
             // Act
-            var result = resource.IdStartsWith("newt", true, NullLogger.Instance, CancellationToken.None);
+            var result = resource.IdStartsWith("newt", true, logger, CancellationToken.None);
 
             // Assert
             Assert.Equal(10, result.Result.Count());
+            Assert.NotEqual(0, logger.Messages.Count);
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/PowershellAutoCompleteResourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/PowershellAutoCompleteResourceTests.cs
@@ -54,6 +54,8 @@ namespace NuGet.Protocol.Tests
             var resource = await source.GetResourceAsync<AutoCompleteResource>();
             Assert.NotNull(resource);
 
+            var logger = new TestLogger();
+
             // Act
             using (var sourceCacheContext = new SourceCacheContext())
             {
@@ -62,7 +64,7 @@ namespace NuGet.Protocol.Tests
                     "3.",
                     includePrerelease: true,
                     sourceCacheContext: sourceCacheContext,
-                    log: NullLogger.Instance,
+                    log: logger,
                     token: CancellationToken.None);
 
                 // Assert
@@ -70,6 +72,7 @@ namespace NuGet.Protocol.Tests
                 Assert.Equal(2, versions.Count());
                 Assert.Contains(new NuGetVersion("3.5.0-rc1-final"), versions);
                 Assert.Contains(new NuGetVersion("3.5.0"), versions);
+                Assert.NotEqual(0, logger.Messages.Count);
             }
         }
 
@@ -83,13 +86,16 @@ namespace NuGet.Protocol.Tests
             var resource = await source.GetResourceAsync<AutoCompleteResource>();
             Assert.NotNull(resource);
 
+            var logger = new TestLogger();
+
             // Act
             CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
-            IEnumerable<string> packages = await resource.IdStartsWith("elm", true, Common.NullLogger.Instance, cancellationTokenSource.Token);
+            IEnumerable<string> packages = await resource.IdStartsWith("elm", true, logger, cancellationTokenSource.Token);
 
             // Assert
             Assert.True(packages != null & packages.Any());
             Assert.Contains("elmah", packages);
+            Assert.NotEqual(0, logger.Messages.Count);
         }
 
         [Theory]
@@ -102,9 +108,11 @@ namespace NuGet.Protocol.Tests
             var resource = await source.GetResourceAsync<AutoCompleteResource>();
             Assert.NotNull(resource);
 
+            var logger = new TestLogger();
+
             // Act
             CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
-            Task<IEnumerable<string>> packagesTask = resource.IdStartsWith("elm", true, Common.NullLogger.Instance, cancellationTokenSource.Token);
+            Task<IEnumerable<string>> packagesTask = resource.IdStartsWith("elm", true, logger, cancellationTokenSource.Token);
             cancellationTokenSource.Cancel();
 
             // Assert
@@ -117,6 +125,7 @@ namespace NuGet.Protocol.Tests
                 Assert.Equal(e.InnerExceptions.Count(), 1);
                 Assert.True(e.InnerExceptions.Any(item => item.GetType().Equals(typeof(TaskCanceledException))));
             }
+            Assert.NotEqual(0, logger.Messages.Count);
         }
     }
 }


### PR DESCRIPTION
Otherwise fall back to NullLogger.Instance.

NuGet/Home#11272

<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11272

## Description
The supplied logger is now used (and, if `null`, then `NullLogger.Instance` is used; which appears to be the previous behaviour).
I'm not sure what the original intent was, but it looks to me like the logger can't be null because at least one of the downstream components created / called by the methods in question will actually throw an `ArgumentNullException` if passed a `null` logger.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
        _There don't appear to be any existing tests that check if supplied loggers are used, but I'm happy to write one if you feel it is necessary._
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [ ] N/A
