### PR TITLE
Stop using CPS JTF

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/NuGetProjectFactory.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/NuGetProjectFactory.cs
@@ -69,13 +69,6 @@ namespace NuGet.PackageManagement.VisualStudio
 
             await _threadingService.JoinableTaskFactory.SwitchToMainThreadAsync();
 
-            if (vsProjectAdapter.VsHierarchy != null &&
-                VsHierarchyUtility.IsCPSCapabilityCompliant(vsProjectAdapter.VsHierarchy))
-            {
-                // Lazy load the CPS enabled JoinableTaskFactory for the UI.
-                NuGetUIThreadHelper.SetJoinableTaskFactoryFromService(ProjectServiceAccessor.Value as IProjectServiceAccessor);
-            }
-
             var exceptions = new List<Exception>();
             foreach (var provider in _providers)
             {
@@ -127,13 +120,6 @@ namespace NuGet.PackageManagement.VisualStudio
             if (provider == null)
             {
                 return null;
-            }
-
-            if (vsProjectAdapter.VsHierarchy != null &&
-                VsHierarchyUtility.IsCPSCapabilityCompliant(vsProjectAdapter.VsHierarchy))
-            {
-                // Lazy load the CPS enabled JoinableTaskFactory for the UI.
-                NuGetUIThreadHelper.SetJoinableTaskFactoryFromService(ProjectServiceAccessor.Value as IProjectServiceAccessor);
             }
 
             try

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/NuGetProjectFactory.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/NuGetProjectFactory.cs
@@ -24,11 +24,6 @@ namespace NuGet.PackageManagement.VisualStudio
         private readonly IVsProjectThreadingService _threadingService;
         private readonly Common.ILogger _logger;
 
-        // Reason it's lazy<object> is because we don't want to load any CPS assemblies until
-        // we're really going to use any of CPS api. Which is why we also don't use nameof or typeof apis.
-        [Import("Microsoft.VisualStudio.ProjectSystem.IProjectServiceAccessor")]
-        private Lazy<object> ProjectServiceAccessor { get; set; }
-
         [ImportingConstructor]
         public NuGetProjectFactory(
             [ImportMany(typeof(INuGetProjectProvider))]

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/NuGetUIThreadHelper.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/NuGetUIThreadHelper.cs
@@ -33,34 +33,6 @@ namespace NuGet.VisualStudio
             }
         }
 
-        /// <summary>
-        /// Retrieve the CPS enabled JoinableTaskFactory for the current version of Visual Studio.
-        /// This overrides the default VsTaskLibraryHelper.ServiceInstance JTF.
-        /// </summary>
-        public static void SetJoinableTaskFactoryFromService(IProjectServiceAccessor projectServiceAccessor)
-        {
-            if (projectServiceAccessor == null)
-            {
-                throw new ArgumentNullException(nameof(projectServiceAccessor));
-            }
-
-            if (LazyJoinableTaskFactory == null)
-            {
-                LazyJoinableTaskFactory = new Lazy<JoinableTaskFactory>(() =>
-                {
-                    // Use IProjectService for Visual Studio 2017
-                    var projectService = projectServiceAccessor.GetProjectService();
-                    return projectService.Services.ThreadingPolicy.JoinableTaskFactory;
-                },
-                // This option helps avoiding deadlocks caused by CPS trying to create ProjectServiceHost
-                // PublicationOnly mode lets parallel threads execute value factory method without
-                // being blocked on each other.
-                // It is correct behavior in this case as the value factory provides the same value
-                // each time it is called and Lazy is used just for caching the value for perf reasons.
-                LazyThreadSafetyMode.PublicationOnly);
-            }
-        }
-
         public static void SetCustomJoinableTaskFactory(JoinableTaskFactory joinableTaskFactory)
         {
             Assumes.Present(joinableTaskFactory);

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPackageInstaller.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPackageInstaller.cs
@@ -40,11 +40,6 @@ namespace NuGet.VisualStudio
         private readonly IDeleteOnRestartManager _deleteOnRestartManager;
         private readonly INuGetTelemetryProvider _telemetryProvider;
 
-        // Reason it's lazy<object> is because we don't want to load any CPS assemblies until
-        // we're really going to use any of CPS api. Which is why we also don't use nameof or typeof apis.
-        [Import("Microsoft.VisualStudio.ProjectSystem.IProjectServiceAccessor")]
-        private Lazy<object> ProjectServiceAccessor { get; set; }
-
         private JoinableTaskFactory PumpingJTF { get; set; }
 
         [ImportingConstructor]


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/8317
Fixes: https://github.com/NuGet/Home/issues/8414

Regression? no

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Remove all references to `IProjectServiceAccessor` and `NuGetUIThreadHelper.SetJoinableTaskFactoryFromService`.

Using `IProjectServiceAccessor` was the reason that NuGet's options screen didn't work in a minimal VS install. The options window caused NuGetPackage to be loaded, and our package load initializes our MEF objects, and one (or more) of the MEF objects tried to use `IProjectServiceAccessor`, which has no exports since CPS isn't installed without any workloads installed. By removing the need to get CPS's JTF, we no longer have dependencies on unavailable components when loading the options window.

## PR Checklist

- [X] PR has a meaningful title
- [X] PR has a linked issue.
- [X] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [X] Test exception
    - This is a VS service, so "external" to NuGet. Our Visual Studio E2E and Apex tests validate running in VS, so there's already some kind of test coverage.
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [X] N/A
