### PR TITLE
Use "-Channel x.0 -Quality Daily" option with dotnet-install for configure.ps1

### DIFF
--- a/build/common.ps1
+++ b/build/common.ps1
@@ -240,8 +240,8 @@ Function Install-DotnetCLI {
 
         #If "-force" is specified, or folder with specific version doesn't exist, the download command will run"
         if ($Force -or -not (Test-Path $probeDotnetPath)) {
-            Trace-Log "$DotNetInstall -Channel $($cli.Channel) -InstallDir $($cli.Root) -Version $($cli.Version) -Architecture $arch -NoPath"
-            & $DotNetInstall -Channel $cli.Channel -InstallDir $cli.Root -Version $cli.Version -Architecture $arch -NoPath
+            Trace-Log "$DotNetInstall -Channel $($cli.Channel) -Quality Daily -InstallDir $($cli.Root) -Version $($cli.Version) -Architecture $arch -NoPath"
+            & $DotNetInstall -Channel $cli.Channel -Quality Daily -InstallDir $cli.Root -Version $cli.Version -Architecture $arch -NoPath
         }
 
         if (-not (Test-Path $DotNetExe)) {
@@ -256,10 +256,10 @@ Function Install-DotnetCLI {
     }
 
     # Install the 2.x runtime because our tests target netcoreapp2x
-    Trace-Log "$DotNetInstall -Runtime dotnet -Channel 2.2 -InstallDir $CLIRoot -NoPath"
+    Trace-Log "$DotNetInstall -Runtime dotnet -Channel 2.2 -Quality Daily -InstallDir $CLIRoot -NoPath"
     # Work around the following install script bug https://github.com/dotnet/install-scripts/issues/152.
     # Start a new process to avoid the ev getting populated.
-    & powershell $DotNetInstall -Runtime dotnet -Channel 2.2 -InstallDir $CLIRoot -NoPath
+    & powershell $DotNetInstall -Runtime dotnet -Channel 2.2 -Quality Daily -InstallDir $CLIRoot -NoPath
     # Display build info
     & $DotNetExe --info
 }

--- a/build/common.ps1
+++ b/build/common.ps1
@@ -256,10 +256,10 @@ Function Install-DotnetCLI {
     }
 
     # Install the 2.x runtime because our tests target netcoreapp2x
-    Trace-Log "$DotNetInstall -Runtime dotnet -Channel 2.2 -Quality Daily -InstallDir $CLIRoot -NoPath"
+    Trace-Log "$DotNetInstall -Runtime dotnet -Channel 2.2 -InstallDir $CLIRoot -NoPath"
     # Work around the following install script bug https://github.com/dotnet/install-scripts/issues/152.
     # Start a new process to avoid the ev getting populated.
-    & powershell $DotNetInstall -Runtime dotnet -Channel 2.2 -Quality Daily -InstallDir $CLIRoot -NoPath
+    & powershell $DotNetInstall -Runtime dotnet -Channel 2.2 -InstallDir $CLIRoot -NoPath
     # Display build info
     & $DotNetExe --info
 }

--- a/build/common.ps1
+++ b/build/common.ps1
@@ -240,8 +240,17 @@ Function Install-DotnetCLI {
 
         #If "-force" is specified, or folder with specific version doesn't exist, the download command will run"
         if ($Force -or -not (Test-Path $probeDotnetPath)) {
-            Trace-Log "$DotNetInstall -Channel $($cli.Channel) -Quality Daily -InstallDir $($cli.Root) -Version $($cli.Version) -Architecture $arch -NoPath"
-            & $DotNetInstall -Channel $cli.Channel -Quality Daily -InstallDir $cli.Root -Version $cli.Version -Architecture $arch -NoPath
+            $channelMainVersion = "5"
+            foreach($channelPart in $cli.Channel.Split('/'))
+            {
+                if($channelPart -match "\d+.*")
+                {
+                    $channelMainVersion = $channelPart.Split('.')[0]
+                    Break
+                }
+            }
+            Trace-Log "$DotNetInstall -Channel $($channelMainVersion) -Quality Daily -InstallDir $($cli.Root) -Version $($cli.Version) -Architecture $arch -NoPath"
+            & $DotNetInstall -Channel $channelMainVersion -Quality Daily -InstallDir $cli.Root -Version $cli.Version -Architecture $arch -NoPath
         }
 
         if (-not (Test-Path $DotNetExe)) {

--- a/build/common.ps1
+++ b/build/common.ps1
@@ -240,7 +240,7 @@ Function Install-DotnetCLI {
 
         #If "-force" is specified, or folder with specific version doesn't exist, the download command will run"
         if ($Force -or -not (Test-Path $probeDotnetPath)) {
-            $channelMainVersion = "5"
+            $channelMainVersion = ""
             foreach($channelPart in $cli.Channel.Split('/'))
             {
                 if($channelPart -match "\d+.*")
@@ -249,6 +249,11 @@ Function Install-DotnetCLI {
                     Break
                 }
             }
+
+            if ([string]::IsNullOrEmpty($channelMainVersion)) {
+                Error-Log "Unable to detect channel version for dotnetinstall.ps1. The CLI install cannot be initiated." -Fatal
+            }
+
             Trace-Log "$DotNetInstall -Channel $($channelMainVersion) -Quality Daily -InstallDir $($cli.Root) -Version $($cli.Version) -Architecture $arch -NoPath"
             & $DotNetInstall -Channel $channelMainVersion -Quality Daily -InstallDir $cli.Root -Version $cli.Version -Architecture $arch -NoPath
         }

--- a/build/common.ps1
+++ b/build/common.ps1
@@ -243,7 +243,7 @@ Function Install-DotnetCLI {
             $channelMainVersion = ""
             foreach($channelPart in $cli.Channel.Split('/'))
             {
-                if($channelPart -match "\d+.*")
+                if ($channelPart -match "\d+.*")
                 {
                     $channelMainVersion = $channelPart.Split('.')[0]
                     Break


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/971

Regression? Last working version:

## Description
Currently when we run configure.ps1 with `dotnet-install.ps1 -Channel release/5.0.2xx` then getting warning. Instead we run with `dotnet-install.ps1 -Channel 5 -Quality Daily` as warning is suggesting.
Before: https://dev.azure.com/devdiv/DevDiv/_build/results?buildId=5249917&view=logs&j=d80b2849-30d4-52dd-74cd-d6536ba98fe0&t=b4c8a850-ec2f-53a4-6259-6271fa5e03fb&l=25
After: Now I don't see that warning anymore.
https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=5269260&view=logs&j=d80b2849-30d4-52dd-74cd-d6536ba98fe0&t=b4c8a850-ec2f-53a4-6259-6271fa5e03fb&l=20

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
