### PR TITLE
Skip flaky test MSBuildProjectSystem_RemoveFile

### DIFF
--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/MSBuildProjectSystemTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/MSBuildProjectSystemTests.cs
@@ -65,7 +65,7 @@ namespace NuGet.CommandLine.Test
         }
 
 
-        [Fact]
+        [Fact(Skip = "https://github.com/NuGet/Home/issues/11277")]
         public void MSBuildProjectSystem_RemoveFile()
         {
             // Arrange


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1226
Fixes: https://github.com/NuGet/Home/issues/11281

Regression? Last working version: n/a

## Description
This same test is [failing](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=5272982&view=ms.vss-test-web.build-test-results-tab) many times.  [Another one](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=5270623&view=ms.vss-test-web.build-test-results-tab&runId=26569690&resultId=100465&paneView=debug). I already created follow up issue.


## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
