### PR TITLE
Adds CollectionViewSource to sort Package Source ComboBox in PM UI

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -131,7 +131,7 @@ namespace NuGet.PackageManagement.UI
             _settingsKey = await GetSettingsKeyAsync(CancellationToken.None);
             UserSettings settings = LoadSettings();
             InitializeFilterList(settings);
-            await InitSourceRepoListAsync(settings, CancellationToken.None);
+            await InitPackageSourcesAsync(settings, CancellationToken.None);
             ApplySettings(settings, Settings);
             _initialized = true;
 
@@ -506,7 +506,7 @@ namespace NuGet.PackageManagement.UI
                 // We access UI components in these calls
                 PackageSourceMoniker prevSelectedItem = SelectedSource;
 
-                await PopulateSourceRepoListAsync(list, optionalSelectSourceName: null, cancellationToken: CancellationToken.None);
+                await PopulatePackageSourcesAsync(list, optionalSelectSourceName: null, cancellationToken: CancellationToken.None);
 
                 // force a new search explicitly only if active source has changed
                 if (prevSelectedItem == SelectedSource)
@@ -719,7 +719,7 @@ namespace NuGet.PackageManagement.UI
             }
         }
 
-        private async Task InitSourceRepoListAsync(UserSettings settings, CancellationToken cancellationToken)
+        private async Task InitPackageSourcesAsync(UserSettings settings, CancellationToken cancellationToken)
         {
             // get active source name.
             string activeSourceName;
@@ -735,10 +735,10 @@ namespace NuGet.PackageManagement.UI
                 activeSourceName = await Model.Context.SourceService.GetActivePackageSourceNameAsync(cancellationToken);
             }
 
-            await PopulateSourceRepoListAsync(activeSourceName, cancellationToken);
+            await PopulatePackageSourcesAsync(activeSourceName, cancellationToken);
         }
 
-        private ValueTask PopulateSourceRepoListAsync(IReadOnlyCollection<PackageSourceMoniker> packageSourceMonikers, string optionalSelectSourceName, CancellationToken cancellationToken)
+        private ValueTask PopulatePackageSourcesAsync(IReadOnlyCollection<PackageSourceMoniker> packageSourceMonikers, string optionalSelectSourceName, CancellationToken cancellationToken)
         {
             // init source repo list
             _topPanel.PackageSources.Clear();
@@ -768,13 +768,13 @@ namespace NuGet.PackageManagement.UI
             return new ValueTask();
         }
 
-        private async ValueTask PopulateSourceRepoListAsync(string optionalSelectSourceName, CancellationToken cancellationToken)
+        private async ValueTask PopulatePackageSourcesAsync(string optionalSelectSourceName, CancellationToken cancellationToken)
         {
             IReadOnlyCollection<PackageSourceMoniker> packageSourceMonikers = await PackageSourceMoniker.PopulateListAsync(
                 _serviceBroker,
                 cancellationToken);
 
-            await PopulateSourceRepoListAsync(packageSourceMonikers, optionalSelectSourceName, cancellationToken);
+            await PopulatePackageSourcesAsync(packageSourceMonikers, optionalSelectSourceName, cancellationToken);
         }
 
         private async ValueTask SearchPackagesAndRefreshUpdateCountAsync(bool useCacheForUpdates)

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -184,7 +184,7 @@ namespace NuGet.PackageManagement.UI
             set => _topPanel.SourceRepoList.SelectedItem = value;
         }
 
-        internal IEnumerable<PackageSourceMoniker> PackageSources => _topPanel.SourceRepoList.Items.OfType<PackageSourceMoniker>();
+        internal IEnumerable<PackageSourceMoniker> PackageSources => _topPanel.PackageSources;
 
         public bool IncludePrerelease => _topPanel.CheckboxPrerelease.IsChecked == true;
 
@@ -741,13 +741,13 @@ namespace NuGet.PackageManagement.UI
         private ValueTask PopulateSourceRepoListAsync(IReadOnlyCollection<PackageSourceMoniker> packageSourceMonikers, string optionalSelectSourceName, CancellationToken cancellationToken)
         {
             // init source repo list
-            _topPanel.SourceRepoList.Items.Clear();
+            _topPanel.PackageSources.Clear();
 
             var selectedSourceName = optionalSelectSourceName ?? SelectedSource?.SourceName;
 
             foreach (PackageSourceMoniker packageSourceMoniker in packageSourceMonikers)
             {
-                _topPanel.SourceRepoList.Items.Add(packageSourceMoniker);
+                _topPanel.PackageSources.Add(packageSourceMoniker);
             }
 
             if (selectedSourceName != null)

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerTopPanel.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerTopPanel.xaml
@@ -6,6 +6,7 @@
              xmlns:nuget="clr-namespace:NuGet.PackageManagement.UI"
              xmlns:imaging="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.Imaging"
              xmlns:catalog="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.ImageCatalog"
+             xmlns:scm="clr-namespace:System.ComponentModel;assembly=WindowsBase"
              mc:Ignorable="d"
              d:DesignHeight="100" d:DesignWidth="800">
   <UserControl.Resources>
@@ -13,6 +14,12 @@
       <ResourceDictionary.MergedDictionaries>
         <nuget:SharedResources/>
       </ResourceDictionary.MergedDictionaries>
+
+      <CollectionViewSource x:Key="cvsPackageSources">
+        <CollectionViewSource.SortDescriptions>
+          <scm:SortDescription PropertyName="SourceName" Direction="Ascending" />
+        </CollectionViewSource.SortDescriptions>
+      </CollectionViewSource>
     </ResourceDictionary>
   </UserControl.Resources>
   <Grid>
@@ -251,7 +258,8 @@
           MinHeight="22"
           AutomationProperties.Name="{x:Static nuget:Resources.Label_Repository}"
           SelectionChanged="_sourceRepoList_SelectionChanged"
-          HorizontalAlignment="Right">
+          HorizontalAlignment="Right"
+          ItemsSource="{Binding Source={StaticResource cvsPackageSources}}">
           <ComboBox.ItemTemplate>
             <DataTemplate>
               <TextBlock

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerTopPanel.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerTopPanel.xaml.cs
@@ -2,13 +2,12 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.ObjectModel;
 using System.Globalization;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Data;
-using System.Windows.Media;
-using Microsoft;
-using Microsoft.VisualStudio.PlatformUI;
+using NuGet.PackageManagement.VisualStudio;
 using Resx = NuGet.PackageManagement.UI.Resources;
 
 namespace NuGet.PackageManagement.UI
@@ -33,9 +32,16 @@ namespace NuGet.PackageManagement.UI
         public Border CountConsolidateContainer { get; private set; }
         public TextBlock CountConsolidate { get; private set; }
 
+        public ObservableCollection<PackageSourceMoniker> PackageSources { get; private set; }
+
         public PackageManagerTopPanel()
         {
             InitializeComponent();
+            PackageSources = new ObservableCollection<PackageSourceMoniker>();
+
+            var cvs = Resources["cvsPackageSources"] as CollectionViewSource;
+            cvs.Culture = CultureInfo.DefaultThreadCurrentUICulture;
+            cvs.Source = PackageSources;
         }
 
         public void CreateAndAddConsolidateTab()


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/11298

Regression? Last working version:

## Description

This PR makes package sources to be sorted according to UI locale/culture settings. 

- Adds a CollectionViewSource to PackageManagerTopPanel to sort packages sources combo box.
- Sets CollectionViewSource  Culture to current UI culture in code behind.
- Renames SourceRepoList to PackageSources where applicable.


## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - ~[ ] Automated tests added~
  - [x] Test exception: Manually tested. See images below
  - ~[ ] N/A~

- **Documentation**
  - ~[ ] Documentation PR or issue filled~
  - [x] N/A: UI change

### Validation

Package source orting in French: now it respects correct sorting, according to https://docs.microsoft.com/globalization/locale/sorting-and-string-comparison#how-do-i-verify-that-sorting-works-correctly-in-my-code

#### Before

![image](https://user-images.githubusercontent.com/1192347/135573497-09340c34-b1e2-4bb4-a1e5-f02038ad2143.png)


#### After

![image](https://user-images.githubusercontent.com/1192347/135573093-f0104a7a-4275-488d-a176-5ad8d12ba1c0.png)


### Accessiblity Insights FastPass validation

![image](https://user-images.githubusercontent.com/1192347/135574111-ffbf4751-9ac2-4a36-a364-836b7bfa0a02.png)

![image](https://user-images.githubusercontent.com/1192347/135574119-5f52e433-e3de-419c-b787-0c257bad1a2b.png)

