### PR TITLE
Onboard API banning, add a few API that we shouldn't be using

### DIFF
--- a/build/BannedSymbols.txt
+++ b/build/BannedSymbols.txt
@@ -1,0 +1,15 @@
+# Banned APIs across the project.
+
+# Syntax:
+#
+#       E:Event
+#       M:Method
+#       F:Field
+#       P:Property
+#       T:Type
+
+M: System.Xml.XmlReader.Create(string inputUri, System.Xml.XmlReaderSettings? settings, System.Xml.XmlParserContext? inputContext); Use one of the methods with a stream instead of path string because paths get escaped.
+M: System.Xml.XmlReader.Create(string inputUri, System.Xml.XmlReaderSettings? settings); Use one of the methods with a stream instead of path string because paths get escaped.
+
+M:Microsoft.VisualStudio.Shell.VsTaskLibraryHelper.FileAndForget(System.Threading.Tasks.Task,System.String,System.String,System.Func{System.Exception,System.Boolean}); NuGet.VisualStudio.Telemetry.INuGetTelemetryProvider.PostFault, NuGet.VisualStudio.Telemetry.TelemetryUtility.PostFaultAsync or NuGet.VisualStudio.Telemetry.INuGetTelemetryProvider.PostFaultAsync
+M:Microsoft.VisualStudio.Shell.VsTaskLibraryHelper.FileAndForget(Microsoft.VisualStudio.Threading.JoinableTask,System.String,System.String,System.Func{System.Exception,System.Boolean}); NuGet.VisualStudio.Telemetry.INuGetTelemetryProvider.PostFault, NuGet.VisualStudio.Telemetry.TelemetryUtility.PostFaultAsync or NuGet.VisualStudio.Telemetry.INuGetTelemetryProvider.PostFaultAsync

--- a/build/common.project.props
+++ b/build/common.project.props
@@ -294,6 +294,11 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <AdditionalFiles Include="$(MSBuildThisFileDirectory)\BannedSymbols.txt" Condition="'$(TestProject)' != 'true'" />
   </ItemGroup>
 
   <Import Project="OptProfV2.props"/>

--- a/build/packages.targets
+++ b/build/packages.targets
@@ -31,7 +31,7 @@
         <PackageReference Update="Microsoft.Build.Locator" Version="1.4.1" />
         <PackageReference Update="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildPackageVersion)" />
         <PackageReference Update="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildPackageVersion)" />
-        <PackageReference Update="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.0.0" />
+        <PackageReference Update="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.2" />
         <PackageReference Update="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8" />
         <PackageReference Update="Microsoft.DataAI.NuGetRecommender.Contracts" Version="2.1.0" />
         <PackageReference Update="Microsoft.Extensions.CommandLineUtils" Version="1.0.1" />

--- a/build/packages.targets
+++ b/build/packages.targets
@@ -31,6 +31,7 @@
         <PackageReference Update="Microsoft.Build.Locator" Version="1.4.1" />
         <PackageReference Update="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildPackageVersion)" />
         <PackageReference Update="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildPackageVersion)" />
+        <PackageReference Update="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.0.0" />
         <PackageReference Update="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8" />
         <PackageReference Update="Microsoft.DataAI.NuGetRecommender.Contracts" Version="2.1.0" />
         <PackageReference Update="Microsoft.Extensions.CommandLineUtils" Version="1.0.1" />


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1168

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
Syntax: https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/BannedApiAnalyzers.Help.md

When certain NuGet APIs become irrelevant for whatever reason we mark them as obsolete and stop using them.
We can't really do the same for APIs we don't own. 
Sometimes, certain APIs are good, but not for our own purposes. 

This PRs adds a few of those example as a means of introducing the concept in our repo.

Note that I would eventually like to add things like `JTF.Run` here, but unfortunately that's not the case right now.

If you do have more API suggestions, I'd be happy to consider, but prefer if you would just add them in a follow up yourselves!

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
