### PR TITLE
Avoids reading Deprecation Alternative Package label twice

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/DeprecationControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/DeprecationControl.xaml
@@ -64,12 +64,12 @@
             VerticalAlignment="Center">
             <TextBlock
               TextWrapping="Wrap"
-              VerticalAlignment="Center"
-              AutomationProperties.LabeledBy="{Binding ElementName=_alternatePackageLabel}">
+              VerticalAlignment="Center">
               <Hyperlink
                 ToolTip="{x:Static nuget:Resources.Deprecation_LinkTooltip}"
                 Command="{x:Static nuget:Commands.SearchPackageCommand}"
-                Style="{StaticResource HyperlinkStyleNoUri}">
+                Style="{StaticResource HyperlinkStyleNoUri}"
+                AutomationProperties.LabeledBy="{Binding ElementName=_alternatePackageLabel}">
                 <Hyperlink.CommandParameter>
                   <MultiBinding Converter="{StaticResource ParametersToHyperlinkTupleConverter}" Mode="OneWay" >
                     <Binding Path="PackageMetadata.DeprecationMetadata.AlternatePackage.PackageId" Mode="OneWay" />


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1241

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
- Avoids reading Alternative Package label twice by moving `AutomationProperties.LabeledBy` property from TextBlock to Hyperlink control.
- Narrators tend to prioritize hyperlink reading over normal text. That way, I'm telling narrator to read the hyperlink with 'Alternative package' label and not read containing TextBlock.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - ~[ ] Automated tests added~
  - [x] Test exception: Manual test pass. See below
  - ~[ ] N/A~

- **Documentation**
  - ~[ ] Documentation PR or issue filled~
  - [x] N/A: This PR does not change any current feature

## Manual Validation

### Accessibility Insights

![image](https://user-images.githubusercontent.com/1192347/136086212-8e2d8488-fbd6-4f65-9de6-a8c85bdb7b50.png)

![image](https://user-images.githubusercontent.com/1192347/136086339-7584a8c1-676f-4eda-85f2-ff76a0e6f9d5.png)


### 