### PR TITLE
Make the items control that contains the vulnerability advisories not be a tab stop

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/VulnerabilitiesControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/VulnerabilitiesControl.xaml
@@ -63,7 +63,8 @@
           FontWeight="Bold" />
         <ItemsControl
           ItemsSource="{Binding PackageVulnerabilities}"
-          Grid.IsSharedSizeScope="True">
+          Grid.IsSharedSizeScope="True"
+          IsTabStop="False">
           <ItemsControl.ItemTemplate>
             <DataTemplate>
               <Grid>


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1242

Regression? Last working version: N/A

## Description
Make the items control that contains the vulnerability advisories not be a tab stop so it does not get keyboard focus.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
Tab-stop issue in UI. Tested tab stops with both onscreen and regular keyboard
  - [x] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
