### PR TITLE
Remove the automation name property from the vulnerability description textblock

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/VulnerabilitiesControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/VulnerabilitiesControl.xaml
@@ -45,8 +45,7 @@
       </StackPanel>
       <TextBlock
         Margin="0,8,0,0"
-        TextWrapping="WrapWithOverflow"
-        AutomationProperties.Name="{x:Static nuget:Resources.Accessibility_VulnerabilitiesDescriptionName}">
+        TextWrapping="WrapWithOverflow">
         <TextBlock.Text>
           <MultiBinding Converter="{StaticResource StringFormatConverter}">
             <Binding Source="{x:Static nuget:Resources.Label_VulnerabilitiesDescription}" />


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/nuget/client.engineering/issues/1243

Regression? Last working version: N/A

## Description
Remove the automation name property from the vulnerability description textblock so the scan mode of screen readers properly announce the text of the textblock and not just the description of it.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
Accessibility fix. Tested using Narrator's scan mode over the vulnerabilities description text.
  - [x] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
