### PR TITLE
continueOnError Apex tests on official builds

### DIFF
--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -31,6 +31,7 @@ parameters:
 extends:
   template: templates/pipeline.yml
   parameters:
+    isOfficialBuild: true
     DartLabEnvironment: ${{parameters.DartLabEnvironment}}
     E2EPart1AgentCleanup: ${{parameters.E2EPart1AgentCleanup}}
     E2EPart2AgentCleanup: ${{parameters.E2EPart2AgentCleanup}}

--- a/eng/pipelines/templates/Apex_Tests_On_Windows.yml
+++ b/eng/pipelines/templates/Apex_Tests_On_Windows.yml
@@ -23,6 +23,9 @@ parameters:
     values:
       - delete
       - stop
+  - name: isOfficialBuild
+    type: boolean
+    default: false
 
 stages:
   - template: stages\visual-studio\single-runsettings.yml@DartLabTemplates
@@ -41,6 +44,7 @@ stages:
       dartLabEnvironment: ${{parameters.DartLabEnvironment}}
       visualStudioSigning: Test
       testMachineDeploymentJobTimeoutInMinutes: 240
+      testRunContinueOnError: ${{ parameters.isOfficialBuild }}
       testExecutionJobTimeoutInMinutes: ${{parameters.testExecutionJobTimeoutInMinutes}}
       testMachineCleanUpStrategy: ${{parameters.testMachineCleanUpStrategy}}
       testAgentElevated: true

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -1,4 +1,7 @@
 parameters:
+- name: isOfficialBuild
+  type: boolean
+  default: false
 - name: DartLabEnvironment
   displayName: DartLab Environment
   type: string

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -237,6 +237,7 @@ stages:
         value: $[stageDependencies.Build_Insertable.Build_and_UnitTest_NonRTM.outputs['vsbootstrapper.bootstrapperUrl']]
       - name: GitHubStatusName
         value: Apex Tests On Windows
+    isOfficialBuild: ${{parameters.isOfficialBuild}}
     runSettingsURI: https://vsdrop.corp.microsoft.com/file/v1/RunSettings/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildId);NuGet.Tests.Apex.runsettings
     dartLabEnvironment: ${{parameters.DartLabEnvironment}}
     testExecutionJobTimeoutInMinutes: 150


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1244

Regression? No

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

When we moved Apex tests to Dartlab, we no longer ignored test failures on official builds. After asking the Dartlab team to add this extensibility, we should use it now.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
