### PR TITLE
Emit ETW intervals for better performance tracing of PM UI User Gestures

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -84,7 +84,7 @@ namespace NuGet.PackageManagement.UI
             await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
             _sinceLastRefresh = Stopwatch.StartNew();
 
-            _pmuiGestureintervalTracker = new IntervalTracker("PMUIGesture");
+            _pmuiGestureintervalTracker = new IntervalTracker("PMUIGesture", isPopulatingIntervalList: false);
 
             Model = model;
             _uiLogger = uiLogger;

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -284,13 +284,18 @@ namespace NuGet.PackageManagement.UI
             {
                 NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async () =>
                 {
-                    if (Model.IsSolution)
+                    IDisposable activity = _pmuiGestureintervalTracker.Start(nameof(OnProjectActionsExecuted));
+
+                    using (activity)
                     {
-                        await RefreshWhenNotExecutingActionAsync(RefreshOperationSource.ActionsExecuted, timeSpan);
-                    }
-                    else
-                    {
-                        await RefreshProjectAfterActionAsync(timeSpan, projectIds);
+                        if (Model.IsSolution)
+                        {
+                            await RefreshWhenNotExecutingActionAsync(RefreshOperationSource.ActionsExecuted, timeSpan);
+                        }
+                        else
+                        {
+                            await RefreshProjectAfterActionAsync(timeSpan, projectIds);
+                        }
                     }
                 }).PostOnFailure(nameof(PackageManagerControl), nameof(OnProjectActionsExecuted));
             }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -1529,8 +1529,14 @@ namespace NuGet.PackageManagement.UI
         private void ExecuteRestartSearchCommand(object sender, ExecutedRoutedEventArgs e)
         {
             EmitRefreshEvent(GetTimeSinceLastRefreshAndRestart(), RefreshOperationSource.RestartSearchCommand, RefreshOperationStatus.Success);
-            NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(() => ExecuteRestartSearchCommandAsync())
-                .PostOnFailure(nameof(PackageManagerControl), nameof(ExecuteRestartSearchCommand));
+            NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            {
+                IDisposable activity = _pmuiGestureintervalTracker.Start(nameof(ExecuteRestartSearchCommand));
+                using (activity)
+                {
+                    await ExecuteRestartSearchCommandAsync();
+                }
+            }).PostOnFailure(nameof(PackageManagerControl), nameof(ExecuteRestartSearchCommand));
         }
 
         private void ExecuteSearchPackageCommand(object sender, ExecutedRoutedEventArgs e)

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -326,9 +326,14 @@ namespace NuGet.PackageManagement.UI
             // Do not refresh if the UI is not visible. It will be refreshed later when the loaded event is called.
             if (IsVisible)
             {
-                NuGetUIThreadHelper.JoinableTaskFactory
-                    .RunAsync(() => SolutionManager_CacheUpdatedAsync(timeSpan, e))
-                    .PostOnFailure(nameof(PackageManagerControl), nameof(OnNuGetCacheUpdated));
+                NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+                {
+                    IDisposable activity = _pmuiGestureintervalTracker.Start(nameof(OnNuGetCacheUpdated));
+                    using (activity)
+                    {
+                        await SolutionManager_CacheUpdatedAsync(timeSpan, e);
+                    }
+                }).PostOnFailure(nameof(PackageManagerControl), nameof(OnNuGetCacheUpdated));
             }
             else
             {

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -63,7 +63,7 @@ namespace NuGet.PackageManagement.UI
         private string _settingsKey;
         private IServiceBroker _serviceBroker;
         private bool _disposed = false;
-        private IntervalTracker _pmuiGestureintervalTracker;
+        internal IntervalTracker _pmuiGestureintervalTracker;
 
         private PackageManagerControl()
         {
@@ -1112,7 +1112,7 @@ namespace NuGet.PackageManagement.UI
 
                 IDisposable activity = _pmuiGestureintervalTracker.Start(nameof(Filter_SelectionChanged) + "-" + _topPanel.Filter);
 
-                var selectionChangedRefreshTaskIsDisposed = false;
+                var activityIsDisposed = false;
 
                 try
                 {
@@ -1133,7 +1133,7 @@ namespace NuGet.PackageManagement.UI
                     {
                         await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
-                        selectionChangedRefreshTaskIsDisposed = true;
+                        activityIsDisposed = true;
 
                         using (activity)
                         {
@@ -1147,7 +1147,7 @@ namespace NuGet.PackageManagement.UI
                 finally
                 {
                     // If JTF threw an exception, ensure the activity is stopped.
-                    if (!selectionChangedRefreshTaskIsDisposed)
+                    if (!activityIsDisposed)
                     {
                         activity.Dispose();
                     }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -530,8 +530,14 @@ namespace NuGet.PackageManagement.UI
             _dontStartNewSearch = true;
             TimeSpan timeSpan = GetTimeSinceLastRefreshAndRestart();
 
-            NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(() => PackageSourcesChangedAsync(e, timeSpan))
-                .PostOnFailure(nameof(PackageManagerControl), nameof(PackageSourcesChanged));
+            NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            {
+                IDisposable activity = _pmuiGestureintervalTracker.Start(nameof(PackageSourcesChanged));
+                using (activity)
+                {
+                    await PackageSourcesChangedAsync(e, timeSpan);
+                }
+            }).PostOnFailure(nameof(PackageManagerControl), nameof(PackageSourcesChanged));
         }
 
         private async Task PackageSourcesChangedAsync(IReadOnlyCollection<PackageSourceContextInfo> packageSources, TimeSpan timeSpan)

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -1224,7 +1224,11 @@ namespace NuGet.PackageManagement.UI
             EmitRefreshEvent(GetTimeSinceLastRefreshAndRestart(), RefreshOperationSource.ClearSearch, RefreshOperationStatus.Success);
             NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async () =>
             {
-                await SearchPackagesAndRefreshUpdateCountAsync(useCacheForUpdates: true);
+                IDisposable activity = _pmuiGestureintervalTracker.Start(nameof(ClearSearch));
+                using (activity)
+                {
+                    await SearchPackagesAndRefreshUpdateCountAsync(useCacheForUpdates: true);
+                }
             }).PostOnFailure(nameof(PackageManagerControl), nameof(ClearSearch));
         }
 

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Telemetry/IntervalTrackerTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Telemetry/IntervalTrackerTests.cs
@@ -48,5 +48,27 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             Assert.True(allTimings.Any(e => e.Item1.Equals("second")));
             Assert.True(allTimings.Any(e => e.Item1.Equals("third")));
         }
+
+        [Fact]
+        public void IntervalTracker_WhenNotPopulatingIntervalList_ListIsEmpty()
+        {
+            var tracker = new IntervalTracker("Activity", isPopulatingIntervalList: false);
+
+            using (tracker.Start("first"))
+            {
+            }
+
+            using (tracker.Start("second"))
+            {
+            }
+
+            using (tracker.Start("third"))
+            {
+            }
+
+            var allTimings = tracker.GetIntervals().ToList();
+
+            Assert.Empty(allTimings);
+        }
     }
 }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1245

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

### Summary:
- Using the Visual Studio Common ETW provider, emit start/stop events from every "user gesture" (eg, button click, checkbox change, selection change, search text typed).
  - Applied to 12 PM UI events (see below).
- Consuming these ETW events can be done via VS Feedback tickets where ETL files are attached. We could at least have some idea which area within PM UI appears to be unusually slow.
- Debugging NuGet.Client performance issues is another use-case for these events.

### Refactor IntervalTracker
- Added support for a tracker which does not maintain all intervals. 
- The existing tracker always accumulated intervals and emitted them as a telemetry event later. I'm not doing that with these PM UI events (for now).

### PM UI Events affected:

- **PackageManagerLoadedAsync**
- **PackageList_SelectionChanged** - select a package in packages list
- **Filter_SelectionChanged** - change Browse/Installed/Updates/Consolidate tabs
- **NuGetPackageManagerControlSearchTask** - type into the search box
- **ClearSearch** - Use the search box's clear ("X ") button
- **ExecuteRestartSearchCommand** - Press the Refresh button
- **OnProjectChanged** - affects Solution PMUI only; add/remove or load/unload projects to your solution
- **OnProjectActionsExecuted** - install/update/uninstall a package using PM UI
- **OnNuGetCacheUpdated** - fired when a project nomination happens
- **Sources_PackageSourcesChanged** - changed package source
- **SourceRepoList_SelectionChanged** - The repository list changed (that means updated in the tools -> Options -> NuGet UI)
- **CheckboxPrerelease_CheckChanged** - The checkbox for prerelease has been checked

### How to test using PerfView 

1. The following command will launch PerfView, immediately begin collecting events, focused on devenv.exe, and with the VisualStudio Common provider enabled.

`PerfView64.exe "/DataFile:PerfViewData.etl" /BufferSizeMB:256 /StackCompression /CircularMB:500 /KernelEvents:ThreadTime /TplEvents:Default -Providers:641d7f6c-481c-42e8-ab7e-d18dc5e5cb9e,*Microsoft-VisualStudio-Common /FocusProcess:"devenv.exe" collect`

2. Once you've executed your actions of interest, press "Stop collection" on the PerfView window.

3. PerfView will build a .zip file, this can take a minute or two depending on how long you recorded.

4. Open the etl.zip file within PerfView. 
5. Open the "Events" section:
![image](https://user-images.githubusercontent.com/49205731/136678325-4497e675-166f-4359-a7c1-2558c2ccf99f.png)

6. In the Events window, type "pmui" in the Event Types Filter textbox.

7. Select each event type (or ctrl+a to select all) then press Enter to view events for those type(s).

8. You should see all PM UI events recorded in this trace.
Example: 
"**Microsoft-VisualStudio-Common/vs_nuget_pmuigesture_filter_selectionchanged_installed/Start**"

All "**/Stop**" events will contain the elapsed time in milliseconds under DURATION_MSEC.

### Example Analysis: Installing a package
Installing a package, I see that the event time is about 14% less than the Output Window's "Time Elapsed".
![image](https://user-images.githubusercontent.com/49205731/136678355-f5bd2baa-7474-480f-a9c0-89f4670c0d78.png)

### Another Example with many events
![image](https://user-images.githubusercontent.com/49205731/136678296-27ca8b43-4fbe-41cc-a929-271441625afb.png)


## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added - IntervalTracker modifications are tested.
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception - New events are not tested with automation. To test, use PerfView, execute an action, and ensure a corresponding event is emitted.
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
