### PR TITLE
Use dedicated ServiceProvider method to retrieve the IServiceProvider

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/MessageHelper.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/MessageHelper.cs
@@ -11,11 +11,10 @@ namespace NuGet.VisualStudio
 {
     public static class MessageHelper
     {
-        [SuppressMessage("Microsoft.Globalization", "CA1300:SpecifyMessageBoxOptions")]
         public static void ShowWarningMessage(string message, string title)
         {
             VsShellUtilities.ShowMessageBox(
-                ServiceLocator.GetInstance<IServiceProvider>(),
+                ServiceLocator.GetServiceProvider(),
                 message,
                 title,
                 OLEMSGICON.OLEMSGICON_WARNING,
@@ -23,11 +22,10 @@ namespace NuGet.VisualStudio
                 OLEMSGDEFBUTTON.OLEMSGDEFBUTTON_FIRST);
         }
 
-        [SuppressMessage("Microsoft.Globalization", "CA1300:SpecifyMessageBoxOptions")]
         public static void ShowInfoMessage(string message, string title)
         {
             VsShellUtilities.ShowMessageBox(
-                ServiceLocator.GetInstance<IServiceProvider>(),
+                ServiceLocator.GetServiceProvider(),
                 message,
                 title,
                 OLEMSGICON.OLEMSGICON_INFO,
@@ -43,7 +41,7 @@ namespace NuGet.VisualStudio
         public static void ShowErrorMessage(string message, string title)
         {
             VsShellUtilities.ShowMessageBox(
-                ServiceLocator.GetInstance<IServiceProvider>(),
+                ServiceLocator.GetServiceProvider(),
                 message,
                 title,
                 OLEMSGICON.OLEMSGICON_CRITICAL,
@@ -54,7 +52,7 @@ namespace NuGet.VisualStudio
         public static bool? ShowQueryMessage(string message, string title, bool showCancelButton)
         {
             int result = VsShellUtilities.ShowMessageBox(
-                ServiceLocator.GetInstance<IServiceProvider>(),
+                ServiceLocator.GetServiceProvider(),
                 message,
                 title,
                 OLEMSGICON.OLEMSGICON_QUERY,

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/ServiceLocator.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/ServiceLocator.cs
@@ -169,6 +169,11 @@ namespace NuGet.VisualStudio
             return await GetGlobalServiceFreeThreadedAsync<SComponentModel, IComponentModel>();
         }
 
+        public static IServiceProvider GetServiceProvider()
+        {
+            return NuGetUIThreadHelper.JoinableTaskFactory.Run(GetServiceProviderAsync);
+        }
+
         public static async Task<IServiceProvider> GetServiceProviderAsync()
         {
             await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11300

Regression? Last working version: Yes, 6.0.0.265, but in reality this is 6.1, because the branding change wasn't done yet. 

There's no automation avaiable to test the scenario in question, and the test team catching this is the expected outcome.

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Issue arose in https://github.com/NuGet/NuGet.Client/commit/60b3df443c2d051ac2750920008a3bb048bb918b. 

I removed the IServiceProvider check from the generic methods to avoid unnecessary UI thread switches and I had missed these calls. 

I searched for `<IServiceProvider>` and I reviewed all the ServiceLocator calls.
Unfortunately there's no easy means to change the show message right now. 

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception - Test team caught the issue. There's no means to test this through automation.
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
