### PR TITLE
Remove ToList() usage in RestoreRunnerEx.cs

### DIFF
--- a/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/RestoreRunnerEx.cs
+++ b/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/RestoreRunnerEx.cs
@@ -13,6 +13,7 @@ using NuGet.LibraryModel;
 using NuGet.ProjectModel;
 using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
+using NuGet.Shared;
 using NuGet.Versioning;
 using ILogger = NuGet.Common.ILogger;
 
@@ -50,11 +51,21 @@ namespace NuGet.Commands
 
                 var projectFullPath = Path.Combine(projectDirectory, $"{projectName}.proj");
 
-                // The package spec details what packages to restore
-                var packageSpec = new PackageSpec(TargetFrameworks.Select(i => new TargetFrameworkInformation
+                // Iterate through TargetFrameworks to generate Lists required for packageSpec
+                var tfi = new List<TargetFrameworkInformation>();
+                var otf = new List<string>();
+                foreach (var tf in TargetFrameworks)
                 {
-                    FrameworkName = i,
-                }).ToList())
+                    tfi.Add(new TargetFrameworkInformation
+                    {
+                        FrameworkName = tf
+                    });
+
+                    otf.Add(tf.ToString());
+                }
+
+                // The package spec details what packages to restore
+                var packageSpec = new PackageSpec(tfi)
                 {
                     Dependencies = new List<LibraryDependency>
                     {
@@ -80,10 +91,10 @@ namespace NuGet.Commands
                         ProjectStyle = ProjectStyle.PackageReference,
                         ProjectUniqueName = projectFullPath,
                         OutputPath = projectDirectory,
-                        OriginalTargetFrameworks = TargetFrameworks.Select(i => i.ToString()).ToList(),
+                        OriginalTargetFrameworks = otf,
                         ConfigFilePaths = settings.GetConfigFilePaths(),
                         PackagesPath = SettingsUtility.GetGlobalPackagesFolder(settings),
-                        Sources = SettingsUtility.GetEnabledSources(settings).ToList(),
+                        Sources = SettingsUtility.GetEnabledSources(settings).AsList(),
                         FallbackFolders = SettingsUtility.GetFallbackPackageFolders(settings).ToList()
                     },
                     FilePath = projectFullPath,

--- a/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/RestoreRunnerEx.cs
+++ b/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/RestoreRunnerEx.cs
@@ -52,20 +52,20 @@ namespace NuGet.Commands
                 var projectFullPath = Path.Combine(projectDirectory, $"{projectName}.proj");
 
                 // Iterate through TargetFrameworks to generate Lists required for packageSpec
-                var tfi = new List<TargetFrameworkInformation>();
-                var otf = new List<string>();
+                var frameworks = new List<TargetFrameworkInformation>(TargetFrameworks.Count);
+                var originalTargetFrameworks = new List<string>(TargetFrameworks.Count);
                 foreach (var tf in TargetFrameworks)
                 {
-                    tfi.Add(new TargetFrameworkInformation
+                    frameworks.Add(new TargetFrameworkInformation
                     {
                         FrameworkName = tf
                     });
 
-                    otf.Add(tf.ToString());
+                    originalTargetFrameworks.Add(tf.ToString());
                 }
 
                 // The package spec details what packages to restore
-                var packageSpec = new PackageSpec(tfi)
+                var packageSpec = new PackageSpec(frameworks)
                 {
                     Dependencies = new List<LibraryDependency>
                     {
@@ -91,7 +91,7 @@ namespace NuGet.Commands
                         ProjectStyle = ProjectStyle.PackageReference,
                         ProjectUniqueName = projectFullPath,
                         OutputPath = projectDirectory,
-                        OriginalTargetFrameworks = otf,
+                        OriginalTargetFrameworks = originalTargetFrameworks,
                         ConfigFilePaths = settings.GetConfigFilePaths(),
                         PackagesPath = SettingsUtility.GetGlobalPackagesFolder(settings),
                         Sources = SettingsUtility.GetEnabledSources(settings).AsList(),

--- a/src/NuGet.Core/NuGet.Configuration/Utility/SettingsUtility.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Utility/SettingsUtility.cs
@@ -289,7 +289,7 @@ namespace NuGet.Configuration
                 paths[i] = Path.GetFullPath(paths[i]);
             }
 
-            return paths;
+            return paths.AsReadOnly();
         }
 
         /// <summary>


### PR DESCRIPTION
## Description
Avoid Enumerable.ToList() when possible since it traverses the entire collection to generate the List, which can be an expensive operation.

Fixes: NuGet/Client.Engineering#1217

- Two calls are eliminated by iterating through the TargetFrameworks with a foreach loop instead of LINQ. (LINQ returns an implementation of IEnumerable that then has to be converted to a List by calling Enumerable.ToList().)
- GetEnabledSources creates a List under-the-hood. Leverage our AsList() utility method that can detect if the underlying type is a List and avoid the expensive ToList() call.
- GetFallbackPackageFolders returns a read-only List. This makes sense from a design perspective. The Fallback Package Folders, however, may change for a specific Project. Therefore, it also makes sense for the Sources collection to be of type List in ProjectRestoreMetadata. Because of this, I'm not proposing any changes to this particular usage of ToList(); the list of Fallback Package Folders should be small anyway.
- Piggy-backing a change to ensure that GetFallbackPackageFolders returns a read-only List by calling AsReadOnly()

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  - [x] Test exception: This PR does not have any functional changes. All UTs passed.
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
