### PR TITLE
PMC initialize should cast DTE2 on main thread (in service locator)

### DIFF
--- a/src/NuGet.Clients/NuGetConsole.Host.PowerShell/RunspaceManager.cs
+++ b/src/NuGet.Clients/NuGetConsole.Host.PowerShell/RunspaceManager.cs
@@ -49,13 +49,13 @@ namespace NuGetConsole.Host.PowerShell.Implementation
             Justification = "We can't dispose it if we want to return it.")]
         private static Tuple<RunspaceDispatcher, NuGetPSHost> CreateRunspace(IConsole console, string hostName)
         {
-            DTE dte = ServiceLocator.GetInstance<DTE>();
+            DTE2 dte = ServiceLocator.GetGlobalService<DTE, DTE2>();
 
             InitialSessionState initialSessionState = InitialSessionState.CreateDefault();
             initialSessionState.Variables.Add(
                 new SessionStateVariableEntry(
                     "DTE",
-                    (DTE2)dte,
+                    dte,
                     "Visual Studio DTE automation object",
                     ScopedItemOptions.AllScope | ScopedItemOptions.Constant)
                 );


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11320

Regression? No

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Request `DTE2` from the service locator, rather than getting `DTE` and then casting on the current thread.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception
     - This is a thread timing bug when something calls a NuGet API from the UI thread before VS's NuGetPackage is initialized. To me, this feels too obscure to create a test for, as there will be a very high false-negative rate, and in the case where the scenario is hit, it's difficult to cause the test to have a failed result, rather than timeout.
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
