### PR TITLE
Address dotnet nuget push asking for unnecessary parameter

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PushCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PushCommand.cs
@@ -54,12 +54,12 @@ namespace NuGet.CommandLine.XPlat
                 var disableBuffering = push.Option(
                     "-d|--disable-buffering",
                     Strings.DisableBuffering_Description,
-                    CommandOptionType.SingleValue);
+                    CommandOptionType.NoValue);
 
                 var noSymbols = push.Option(
                     "-n|--no-symbols",
                     Strings.NoSymbols_Description,
-                    CommandOptionType.SingleValue);
+                    CommandOptionType.NoValue);
 
                 var arguments = push.Argument(
                     "[root]",


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/4864

Regression? Last working version: n/a

## Description
Currently `--no-symbols` or `--disable-buffering` options are asking for unnecessary values not actually used, so removing them to match [with doc](https://docs.microsoft.com/en-us/nuget/reference/cli-reference/cli-ref-push).

Previously :  `dotnet nuget push *.nupkg --api-key xxxxx --no-symbol 111111`
Now:  `dotnet nuget push *.nupkg --api-key xxxxx --no-symbol`
```
Debug> dotnet nuget push *.nupkg  -s https://xxxxx/v3/index.json --api-key xxxxxxxx -n
Pushing 4864.1.3.0.nupkg to 'https://xxxxx/package'...
  PUT https://xxxxxx/package/
warn : All published packages should have license information specified. Learn more: https://aka.ms/deprecateLicenseUrl.
  Created https://xxxxxxxx/package/ 6889ms
Your package was pushed.
```

Previously:  `dotnet nuget push **.nupkg -k ******* --disable-buffering 1111111`
Now: `dotnet nuget push **.nupkg -k ******* --disable-buffering`

```
dotnet nuget push *.nupkg  -s https://xxxx/index.json --api-key xxxxxxxxxx --disable-buffering
Pushing 4864.1.5.0.nupkg to 'https://xxxxxx/package'...
  PUT https://xxxxxxxxx/package/
warn : All published packages should have license information specified. Learn more: https://aka.ms/deprecateLicenseUrl.
  Created https://xxx/ 4851ms
Your package was pushed.
Pushing 4864.1.5.0.snupkg to 'xxxxx'...
  PUT https://xxxxxxx/symbolpackage/
  Created https://xxxxxx/symbolpackage/ 851ms
Your package was pushed.
```

Currently I didn't add any test because `dotnet nuget push` to server tests [are disabled(#1267)](https://github.com/NuGet/Client.Engineering/issues/1267#issuecomment-953998682) long time ago. Also `dotnet nuget push` behaves quite different between `local folder` vs `baGet` vs `server nuget.org`, so I can't simply add `push to local folder` test here.

For example if we push from location with both nupkg and snupkg using `dotnet nuget push *.nupkg`:
*  to `local folder`:  Only `.nupkg` is uploaded, always ignore `.snupkg`.
* to `baGet`: Only one is uploaded, other one is not uploaded due to `409` conflict.
* to `nuget server`: Both of them uploaded.
 
For sake of completeness push command with above options still working as expected, it'll push both `.nupkg` and `.snupkg` files to server.

```
Debug [master ≡]> dotnet nuget push *.nupkg  -s https://xxxxxx/index.json --api-key xxxxxxxxxx
Pushing 4864.1.4.0.nupkg to 'https://xxxxxxx/package'...
  PUT https://xxxxxxxx/
warn : All published packages should have license information specified. Learn more: https://aka.ms/deprecateLicenseUrl.
  Created https://xxxxxxxx/ 3582ms
Your package was pushed.
Pushing 4864.1.4.0.snupkg to 'https://xxxxxxx/symbolpackage'...
  PUT https://xxxxxxxxxx/
  Created https://xxxxxxx/symbolpackage/ 5135ms
Your package was pushed.
```

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception:  Manually test with patched sdk, dotnet push to server [is disabled](https://github.com/NuGet/Client.Engineering/issues/1267#issuecomment-953998682) for long time ago.
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
