### PR TITLE
Ban IAsyncProvider.GetServiceAsync, use generic extension methods to get services instead instead

### DIFF
--- a/build/BannedSymbols.txt
+++ b/build/BannedSymbols.txt
@@ -13,3 +13,6 @@ M: System.Xml.XmlReader.Create(string inputUri, System.Xml.XmlReaderSettings? se
 
 M:Microsoft.VisualStudio.Shell.VsTaskLibraryHelper.FileAndForget(System.Threading.Tasks.Task,System.String,System.String,System.Func{System.Exception,System.Boolean}); NuGet.VisualStudio.Telemetry.INuGetTelemetryProvider.PostFault, NuGet.VisualStudio.Telemetry.TelemetryUtility.PostFaultAsync or NuGet.VisualStudio.Telemetry.INuGetTelemetryProvider.PostFaultAsync
 M:Microsoft.VisualStudio.Shell.VsTaskLibraryHelper.FileAndForget(Microsoft.VisualStudio.Threading.JoinableTask,System.String,System.String,System.Func{System.Exception,System.Boolean}); NuGet.VisualStudio.Telemetry.INuGetTelemetryProvider.PostFault, NuGet.VisualStudio.Telemetry.TelemetryUtility.PostFaultAsync or NuGet.VisualStudio.Telemetry.INuGetTelemetryProvider.PostFaultAsync
+
+M:Microsoft.VisualStudio.Shell.IAsyncServiceProvider.GetServiceAsync(System.Type); Do not use this method. Use the Microsoft.VisualStudio.Shell.ServiceExtensions.GetServiceAsync for services that have UI thread affinity or that you don't know about their affinity, and use NuGet.VisualStudio.ServiceProviderExtensions.GetFreeThreadedServiceAsync<TService, TInterface> for free threaded services.
+

--- a/src/NuGet.Clients/NuGet.Console/OutputConsole/ChannelOutputConsole.cs
+++ b/src/NuGet.Clients/NuGet.Console/OutputConsole/ChannelOutputConsole.cs
@@ -6,12 +6,14 @@ using System.Collections.Generic;
 using System.IO.Pipelines;
 using System.Text;
 using System.Threading;
+using System.Xml;
 using Microsoft;
 using Microsoft.ServiceHub.Framework;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.RpcContracts.OutputChannel;
 using Microsoft.VisualStudio.Shell.ServiceBroker;
 using Microsoft.VisualStudio.Threading;
+using NuGet.VisualStudio;
 using IAsyncServiceProvider = Microsoft.VisualStudio.Shell.IAsyncServiceProvider;
 using Task = System.Threading.Tasks.Task;
 
@@ -47,7 +49,7 @@ namespace NuGetConsole
 
             _serviceBrokerClient = new AsyncLazy<ServiceBrokerClient>(async () =>
             {
-                IBrokeredServiceContainer container = (IBrokeredServiceContainer)await asyncServiceProvider.GetServiceAsync(typeof(SVsBrokeredServiceContainer));
+                IBrokeredServiceContainer container = await asyncServiceProvider.GetFreeThreadedServiceAsync<SVsBrokeredServiceContainer, IBrokeredServiceContainer>();
                 Assumes.Present(container);
                 IServiceBroker serviceBroker = container.GetFullAccessServiceBroker();
                 return new ServiceBrokerClient(serviceBroker, _joinableTaskFactory);

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/PackageSourcesOptionsControl.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/PackageSourcesOptionsControl.cs
@@ -623,7 +623,7 @@ namespace NuGet.Options
             //const int BIF_RETURNONLYFSDIRS = 0x00000001;   // For finding a folder to start document searching.
             const int BIF_BROWSEINCLUDEURLS = 0x00000080; // Allow URLs to be displayed or entered.
 
-            var uiShell = (IVsUIShell2)(await _asyncServiceProvider.GetServiceAsync(typeof(SVsUIShell)));
+            var uiShell = await _asyncServiceProvider.GetServiceAsync<SVsUIShell, IVsUIShell2>();
             Assumes.Present(uiShell);
             var rgch = new char[MaxDirectoryLength + 1];
 

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreCommand.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreCommand.cs
@@ -76,7 +76,7 @@ namespace NuGet.SolutionRestoreManager
 
             commandService.AddCommand(menuItem);
 
-            _vsMonitorSelection = await serviceProvider.GetServiceAsync(typeof(IVsMonitorSelection)) as IVsMonitorSelection;
+            _vsMonitorSelection = await serviceProvider.GetServiceAsync<IVsMonitorSelection, IVsMonitorSelection>();
             Assumes.Present(_vsMonitorSelection);
 
             // get the solution not building and not debugging cookie

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/ServiceLocator.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/ServiceLocator.cs
@@ -94,8 +94,7 @@ namespace NuGet.VisualStudio
         {
             if (PackageServiceProvider != null)
             {
-                var result = await PackageServiceProvider.GetServiceAsync(typeof(TService));
-                var service = result as TInterface;
+                TInterface service = await PackageServiceProvider.GetFreeThreadedServiceAsync<TService, TInterface>();
 
                 if (service != null)
                 {

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/ServiceProviderExtensions.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/ServiceProviderExtensions.cs
@@ -25,5 +25,13 @@ namespace NuGet.VisualStudio
         {
             return site.GetServiceAsync<SComponentModel, IComponentModel>();
         }
+
+        public static async Task<TInterface> GetFreeThreadedServiceAsync<TService, TInterface>(this IAsyncServiceProvider site) where TInterface : class
+        {
+#pragma warning disable RS0030 // Do not used banned APIs
+            return (TInterface)await site.GetServiceAsync(typeof(TService));
+#pragma warning restore RS0030 // Do not used banned APIs
+        }
     }
 }
+

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/ServiceProviderExtensions.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/ServiceProviderExtensions.cs
@@ -26,12 +26,23 @@ namespace NuGet.VisualStudio
             return site.GetServiceAsync<SComponentModel, IComponentModel>();
         }
 
+#pragma warning disable RS0030 // Do not used banned APIs
+        /// <summary>
+        /// Use this to acquire services that *do not* have UI thread dependencies.
+        /// Under the hood, this method simply justs <see cref="IAsyncServiceProvider.GetServiceAsync(Type)"/>
+        /// </summary>
+        /// <typeparam name="TService">Service type</typeparam>
+        /// <typeparam name="TInterface">Interface type</typeparam>
+        /// <param name="site">Service Provider</param>
+        /// <returns>Service from the given ServiceProvider.</returns>
         public static async Task<TInterface> GetFreeThreadedServiceAsync<TService, TInterface>(this IAsyncServiceProvider site) where TInterface : class
         {
-#pragma warning disable RS0030 // Do not used banned APIs
-            return (TInterface)await site.GetServiceAsync(typeof(TService));
-#pragma warning restore RS0030 // Do not used banned APIs
+            // Note that using Microsoft.VisualStudio.Shell.ServiceExtensions.GetServiceAsync<TService, TInterface>()
+            // is not appropriate because that method always switches to the UI thread to cast to the Interface.
+            object service = await site.GetServiceAsync(typeof(TService));
+            return service as TInterface;
         }
+#pragma warning restore RS0030 // Do not used banned APIs
     }
 }
 

--- a/src/NuGet.Clients/NuGet.VisualStudio.OnlineEnvironment.Client/SolutionExplorer/PackageManagerUICommandHandler.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.OnlineEnvironment.Client/SolutionExplorer/PackageManagerUICommandHandler.cs
@@ -102,13 +102,13 @@ namespace NuGet.VisualStudio.OnlineEnvironment.Client
 
         private void Initialize()
         {
-            _vsMonitorSelection = new AsyncLazy<vsShellInterop.IVsMonitorSelection>(
+            _vsMonitorSelection = new AsyncLazy<IVsMonitorSelection>(
                 async () =>
                 {
                     await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
                     // get the UI context cookie for the debugging mode
-                    var vsMonitorSelection = await _asyncServiceProvider.GetServiceAsync(typeof(vsShellInterop.IVsMonitorSelection)) as vsShellInterop.IVsMonitorSelection;
+                    var vsMonitorSelection = await _asyncServiceProvider.GetServiceAsync<IVsMonitorSelection, IVsMonitorSelection>();
                     Assumes.Present(vsMonitorSelection);
 
                     // get the solution not building and not debugging cookie
@@ -157,7 +157,7 @@ namespace NuGet.VisualStudio.OnlineEnvironment.Client
         {
             _initialized = true;
 
-            var componentModel = await _asyncServiceProvider.GetServiceAsync(typeof(SComponentModel)) as IComponentModel;
+            var componentModel = await _asyncServiceProvider.GetComponentModelAsync();
             Assumes.Present(componentModel);
             componentModel.DefaultCompositionService.SatisfyImportsOnce(this);
             var experimentationService = NuGetExperimentationService.Value;
@@ -165,7 +165,7 @@ namespace NuGet.VisualStudio.OnlineEnvironment.Client
 
             Brushes.LoadVsBrushes(experimentationService);
 
-            _dte = (DTE)await _asyncServiceProvider.GetServiceAsync(typeof(vsShellInterop.SDTE));
+            _dte = await _asyncServiceProvider.GetServiceAsync<SDTE, DTE>();
             Assumes.Present(_dte);
 
             _dteEvents = _dte.Events.DTEEvents;
@@ -212,7 +212,7 @@ namespace NuGet.VisualStudio.OnlineEnvironment.Client
             await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
             // Find existing hierarchy and item id of the document window if it's already registered.
-            var rdt = await _asyncServiceProvider.GetServiceAsync(typeof(IVsRunningDocumentTable)) as IVsRunningDocumentTable;
+            var rdt = await _asyncServiceProvider.GetServiceAsync<IVsRunningDocumentTable, IVsRunningDocumentTable>();
             Assumes.Present(rdt);
             IVsHierarchy hier;
             uint itemId;
@@ -260,7 +260,7 @@ namespace NuGet.VisualStudio.OnlineEnvironment.Client
 
             IVsWindowFrame windowFrame = null;
 
-            var uiShell = await _asyncServiceProvider.GetServiceAsync(typeof(SVsUIShell)) as IVsUIShell;
+            var uiShell = await _asyncServiceProvider.GetServiceAsync<SVsUIShell, IVsUIShell>();
             Assumes.Present(uiShell);
 
             uint toolWindowId;
@@ -336,7 +336,7 @@ namespace NuGet.VisualStudio.OnlineEnvironment.Client
         {
             await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
-            var uiShell = await _asyncServiceProvider.GetServiceAsync(typeof(SVsUIShell)) as IVsUIShell;
+            var uiShell = await _asyncServiceProvider.GetServiceAsync<SVsUIShell, IVsUIShell>();
             foreach (var windowFrame in VsUtility.GetDocumentWindows(uiShell))
             {
                 object property;


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/nuget/home/issues/11339

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception - No functionality change.
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
