### PR TITLE
Use VS target version for package version of VS extensibility packages

### DIFF
--- a/build/config.props
+++ b/build/config.props
@@ -28,6 +28,9 @@
     <VsTargetBranch>main</VsTargetBranch>
     <VsTargetChannel>int.$(VsTargetBranch)</VsTargetChannel>
 
+    <!-- NuGet SDK VS package Semantic Version -->
+    <NuGetSdkVsSemanticVersion>$(VsTargetMajorVersion).$(MinorNuGetVersion).$(PatchNuGetVersion)</NuGetSdkVsSemanticVersion>
+
     <!-- This branches are used for creating insertion PRs -->
     <VsTargetBranch Condition="'$(IsEscrowMode)' == 'true'">rel/d$(VsTargetMajorVersion).$(MinorNuGetVersion)</VsTargetBranch>
     <VsTargetChannel Condition="'$(IsEscrowMode)' == 'true'">int.d$(VsTargetMajorVersion).$(MinorNuGetVersion)</VsTargetChannel>
@@ -64,6 +67,9 @@
 
   <Target Name="GetSemanticVersion">
     <Message Text="$(SemanticVersion)" Importance="High"/>
+  </Target>
+  <Target Name="GetNuGetSdkVsSemanticVersion">
+    <Message Text="$(NuGetSdkVsSemanticVersion)" Importance="High"/>
   </Target>
   <Target Name="GetVsTargetMajorVersion">
     <Message Text="$(VsTargetMajorVersion)" Importance="High"/>

--- a/scripts/cibuild/ConfigureVstsBuild.ps1
+++ b/scripts/cibuild/ConfigureVstsBuild.ps1
@@ -135,6 +135,7 @@ else
     Write-Host "##vso[task.setvariable variable=VsixPublishDir;]VS15"
     $newBuildCounter = $env:BUILD_BUILDNUMBER
     $VsTargetBranch = & dotnet msbuild $env:BUILD_REPOSITORY_LOCALPATH\build\config.props /v:m /nologo /t:GetVsTargetBranch
+    $NuGetSdkVsVersion = & dotnet msbuild $env:BUILD_REPOSITORY_LOCALPATH\build\config.props /v:m /nologo /t:NuGetSdkVsSemanticVersion
     Write-Host $VsTargetBranch
     $jsonRepresentation = @{
         BuildNumber = $newBuildCounter
@@ -143,6 +144,7 @@ else
         LocalizationRepositoryBranch = $NuGetLocalizationRepoBranch
         LocalizationRepositoryCommitHash = $LocalizationRepoCommitHash
         VsTargetBranch = $VsTargetBranch.Trim()
+        NuGetSdkVsVersion = $NuGetSdkVsVersion.Trim()
     }
 
     # First create the file locally so that we can laster publish it as a build artifact from a local source file instead of a remote source file.

--- a/scripts/cibuild/ConfigureVstsBuild.ps1
+++ b/scripts/cibuild/ConfigureVstsBuild.ps1
@@ -135,7 +135,7 @@ else
     Write-Host "##vso[task.setvariable variable=VsixPublishDir;]VS15"
     $newBuildCounter = $env:BUILD_BUILDNUMBER
     $VsTargetBranch = & dotnet msbuild $env:BUILD_REPOSITORY_LOCALPATH\build\config.props /v:m /nologo /t:GetVsTargetBranch
-    $NuGetSdkVsVersion = & dotnet msbuild $env:BUILD_REPOSITORY_LOCALPATH\build\config.props /v:m /nologo /t:NuGetSdkVsSemanticVersion
+    $NuGetSdkVsVersion = & dotnet msbuild $env:BUILD_REPOSITORY_LOCALPATH\build\config.props /v:m /nologo /t:GetNuGetSdkVsSemanticVersion
     Write-Host $VsTargetBranch
     $jsonRepresentation = @{
         BuildNumber = $newBuildCounter

--- a/src/NuGet.Clients/NuGet.VisualStudio.Contracts/NuGet.VisualStudio.Contracts.csproj
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Contracts/NuGet.VisualStudio.Contracts.csproj
@@ -14,7 +14,7 @@
     <RootNamespace>NuGet.VisualStudio.Contracts</RootNamespace>
     <Description>RPC contracts for NuGet's Visual Studio Service Broker extensibility APIs.</Description>
     <!-- VS Extensibility APIs should use package version corresponding to VS version it targets, to reduce confusion. Also keep assembly version stable to minimize binding redirect issues. -->
-    <Version>$(NuGetSdkVsSemanticVersion)$(PreReleaseInformationVersion)</Version>
+    <PackageVersion>$(NuGetSdkVsSemanticVersion)$(PreReleaseInformationVersion)</PackageVersion>
     <AssemblyVersion>$(NuGetSdkVsSemanticVersion).0</AssemblyVersion>
   </PropertyGroup>
 

--- a/src/NuGet.Clients/NuGet.VisualStudio.Contracts/NuGet.VisualStudio.Contracts.csproj
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Contracts/NuGet.VisualStudio.Contracts.csproj
@@ -13,6 +13,9 @@
     <IncludeNuGetSharedFiles>true</IncludeNuGetSharedFiles>
     <RootNamespace>NuGet.VisualStudio.Contracts</RootNamespace>
     <Description>RPC contracts for NuGet's Visual Studio Service Broker extensibility APIs.</Description>
+    <!-- VS Extensibility APIs should use package version corresponding to VS version it targets, to reduce confusion. Also keep assembly version stable to minimize binding redirect issues. -->
+    <Version>$(NuGetSdkVsSemanticVersion)$(PreReleaseInformationVersion)</Version>
+    <AssemblyVersion>$(NuGetSdkVsSemanticVersion).0</AssemblyVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NuGet.Clients/NuGet.VisualStudio.Interop/NuGet.VisualStudio.Interop.csproj
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Interop/NuGet.VisualStudio.Interop.csproj
@@ -4,7 +4,6 @@
   <PropertyGroup>
     <TargetFramework>$(NETFXTargetFramework)</TargetFramework>
     <Shipping>true</Shipping>
-    <Pack>true</Pack>
     <IncludeInVsix>true</IncludeInVsix>
     <Description>NuGet's Visual Studio client Template Wizard interop implementation.</Description>
     <RootNamespace>NuGet.VisualStudio</RootNamespace>

--- a/src/NuGet.Clients/NuGet.VisualStudio/NuGet.VisualStudio.csproj
+++ b/src/NuGet.Clients/NuGet.VisualStudio/NuGet.VisualStudio.csproj
@@ -10,7 +10,7 @@
     <PackProject>true</PackProject>
     <IncludeInVSIX>true</IncludeInVSIX>
     <!-- VS Extensibility APIs should use package version corresponding to VS version it targets, to reduce confusion. Also keep assembly version stable to minimize binding redirect issues. -->
-    <Version>$(NuGetSdkVsSemanticVersion)$(PreReleaseInformationVersion)</Version>
+    <PackageVersion>$(NuGetSdkVsSemanticVersion)$(PreReleaseInformationVersion)</PackageVersion>
     <AssemblyVersion>$(NuGetSdkVsSemanticVersion).0</AssemblyVersion>
   </PropertyGroup>
 

--- a/src/NuGet.Clients/NuGet.VisualStudio/NuGet.VisualStudio.csproj
+++ b/src/NuGet.Clients/NuGet.VisualStudio/NuGet.VisualStudio.csproj
@@ -9,6 +9,9 @@
     <Shipping>true</Shipping>
     <PackProject>true</PackProject>
     <IncludeInVSIX>true</IncludeInVSIX>
+    <!-- VS Extensibility APIs should use package version corresponding to VS version it targets, to reduce confusion. Also keep assembly version stable to minimize binding redirect issues. -->
+    <Version>$(NuGetSdkVsSemanticVersion)$(PreReleaseInformationVersion)</Version>
+    <AssemblyVersion>$(NuGetSdkVsSemanticVersion).0</AssemblyVersion>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Also make use same assembly version for all builds, so there are no
binding redirect issues when nupkgs published to nuget.org are a
different build number to what was inserted into VS.

<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11394
Related: https://github.com/NuGet/Home/issues/11367

Regression? No

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

The reported problem was due to the fact that our assembly versions include the build number, which increments every build, and the packages we published to nuget.org were a higher build number than what was inserted into VS.  Our vsix adds binding redirects for our VS extensibility API packages/assemblies, but since the version we shipped in dev17.0.0 is lower than the assembly version we published to nuget.org, the binding redirect didn't apply.

So, the main goal of this PR is to ensure that the last digit of the assembly version is always zero, so it will no longer matter which specific builds of NuGet we insert into VS or publish to nuget.org. It'll all work out.

Our VS insertions require us to set the assembly version, so an extra parameter was added to `buildInfo.json`, so we can update the insertion pipeline to handle this correctly.

Finally, a secondary goal of this PR is to align the NuGet.VisualStudio and NuGet.VisualStudio.Contracts packages with the major and minor versions of Visual Studio that this build of NuGet is targeting, to make it easier for customers to know which version of the packages they should use, depending on which version of Visual Studio they are building their extension for. I'm going to go into more detail in a comment to this PR.

## PR Checklist

- [X] PR has a meaningful title
- [ ] PR has a linked issue.
- [X] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [X] N/A: No product changes, just assembly and package versions.

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [X] Documentation PR or issue filled: https://github.com/NuGet/docs.microsoft.com-nuget/issues/2582
  - **OR**
  - [ ] N/A
