### PR TITLE
TimeSinceLastRestore and related metrics should be added as doubles not strings

### DIFF
--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreWorker.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreWorker.cs
@@ -667,9 +667,9 @@ namespace NuGet.SolutionRestoreManager
 
         private static Dictionary<string, object> GetRestoreTrackingData(ImplicitRestoreReason restoreReason, int requestCount, bool isBulkRestoreCoordinationEnabled, int projectRestoreInfoSourcesCount, DateTime? bulkRestoreCoordinationCheckStartTime, int projectsReadyCheckCount, List<TimeSpan> projectReadyTimings)
         {
-            var bulkRestoreCoordinationTotalTime = bulkRestoreCoordinationCheckStartTime == default ?
-                "0" :
-                (DateTime.UtcNow - bulkRestoreCoordinationCheckStartTime.Value).TotalSeconds.ToString();
+            double bulkRestoreCoordinationTotalTime = bulkRestoreCoordinationCheckStartTime == default ?
+                0.0 :
+                (DateTime.UtcNow - bulkRestoreCoordinationCheckStartTime.Value).TotalSeconds;
 
             return new()
             {
@@ -692,9 +692,9 @@ namespace NuGet.SolutionRestoreManager
             // if the request is implicit & this is the first restore, assume we are restoring due to a solution load.
             var isSolutionLoadRestore = _isFirstRestore &&
                 request.RestoreSource == RestoreOperationSource.Implicit;
-            string timeSinceLastRestoreCompletedTime = _isFirstRestore ?
-                "0" :
-                (DateTimeOffset.UtcNow - _lastRestoreCompletedTime).TotalSeconds.ToString();
+            double timeSinceLastRestoreCompletedTime = _isFirstRestore ?
+                0.0 :
+                (DateTimeOffset.UtcNow - _lastRestoreCompletedTime).TotalSeconds;
             string lastRestoreOperationSourcee = _isFirstRestore ?
                 "None" :
                 _lastRestoreOperationSource.ToString();


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1282

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
Countables should go to the Measures not Properties bag. Putting doubles in the Properties bag means we have to parse back from a to string, and we'd need to be able to differentiate between different culture formatting, which is just not ideal. 

Follow up to change up the queries: https://github.com/NuGet/Client.Engineering/issues/1283

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
