### PR TITLE
Fix ArgumentNullException when SDK resolver is given a null project path

### DIFF
--- a/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/GlobalJsonReader.cs
+++ b/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/GlobalJsonReader.cs
@@ -28,6 +28,12 @@ namespace Microsoft.Build.NuGetSdkResolver
         /// <returns>A <see cref="Dictionary{String,String}"/> of MSBuild SDK versions from a global.json if found, otherwise <code>null</code>.</returns>
         public static Dictionary<string, string> GetMSBuildSdkVersions(SdkResolverContext context)
         {
+            if (string.IsNullOrWhiteSpace(context?.ProjectFilePath))
+            {
+                // If the ProjectFilePath is not set, an in-memory project is being evaluated and there's no way to know which directory to start looking for a global.json
+                return null;
+            }
+
             var projectDirectory = Directory.GetParent(context.ProjectFilePath);
 
             if (projectDirectory == null

--- a/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/NuGetSdkResolver.cs
+++ b/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/NuGetSdkResolver.cs
@@ -77,6 +77,15 @@ namespace Microsoft.Build.NuGetSdkResolver
                 return NuGetAbstraction.TryParseNuGetVersion(version, out parsedVersion);
             }
 
+            parsedVersion = null;
+
+            // Don't try to find versions defined in global.json if the project full path isn't set because an in-memory project is being evaluated and there's no
+            // way to be sure where to look
+            if (string.IsNullOrWhiteSpace(context?.ProjectFilePath))
+            {
+                return false;
+            }
+
             Dictionary<string, string> msbuildSdkVersions;
 
             // Get the SDK versions from a previous state, otherwise find and load global.json to get them
@@ -99,8 +108,6 @@ namespace Microsoft.Build.NuGetSdkResolver
             {
                 return NuGetAbstraction.TryParseNuGetVersion(globalJsonVersion, out parsedVersion);
             }
-
-            parsedVersion = null;
 
             return false;
         }

--- a/test/NuGet.Core.Tests/Microsoft.Build.NuGetSdkResolver.Test/GlobalJsonReader_Tests.cs
+++ b/test/NuGet.Core.Tests/Microsoft.Build.NuGetSdkResolver.Test/GlobalJsonReader_Tests.cs
@@ -74,6 +74,14 @@ namespace Microsoft.Build.NuGetSdkResolver.Test
         }
 
         [Fact]
+        public void NullProjectPath()
+        {
+            var context = new MockSdkResolverContext(projectPath: null);
+
+            GlobalJsonReader.GetMSBuildSdkVersions(context).Should().BeNull();
+        }
+
+        [Fact]
         public void SdkVersionsAreSuccessfullyLoaded()
         {
             var expectedVersions = new Dictionary<string, string>

--- a/test/NuGet.Core.Tests/Microsoft.Build.NuGetSdkResolver.Test/NuGetSdkResolver_Tests.cs
+++ b/test/NuGet.Core.Tests/Microsoft.Build.NuGetSdkResolver.Test/NuGetSdkResolver_Tests.cs
@@ -99,6 +99,28 @@ namespace Microsoft.Build.NuGetSdkResolver.Test
                 context: context);
         }
 
+        [Fact]
+        public void TryGetNuGetVersionNullProjectPath()
+        {
+            var context = new MockSdkResolverContext(projectPath: null);
+
+            VerifyTryGetNuGetVersionForSdk(
+                version: null,
+                expectedVersion: null,
+                context: context);
+        }
+
+        [Fact]
+        public void TryGetNuGetVersionNullProjectPathWithVersion()
+        {
+            var context = new MockSdkResolverContext(projectPath: null);
+
+            VerifyTryGetNuGetVersionForSdk(
+                version: "1.0.0",
+                expectedVersion: NuGetVersion.Parse("1.0.0"),
+                context: context);
+        }
+
         private void VerifyTryGetNuGetVersionForSdk(string version, NuGetVersion expectedVersion, SdkResolverContextBase context = null)
         {
             var result = NuGetSdkResolver.TryGetNuGetVersionForSdk("foo", version, context, out var parsedVersion);


### PR DESCRIPTION
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11376

Regression? No Last working version:

## Description
The SDK resolver has never handled a null project path before but a recent behavior change in MSBuild ([#6763](https://github.com/dotnet/msbuild/pull/6763)) has made this a fatal error.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
