### PR TITLE
Create tracking file when user-profile nuget.config does not exist

### DIFF
--- a/src/NuGet.Core/NuGet.Configuration/PackageSource/NuGetConstants.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSource/NuGetConstants.cs
@@ -40,7 +40,7 @@ namespace NuGet.Configuration
 
         public static readonly string FeedName = "nuget.org";
 
-        public static readonly string AddV3TrackFile = "nugetorgadd.trk";
+        internal static readonly string V3TrackFile = "nugetorgadd.trk";
 
         public static readonly string DefaultConfigContent = @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>

--- a/src/NuGet.Core/NuGet.Configuration/PackageSource/NuGetConstants.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSource/NuGetConstants.cs
@@ -40,6 +40,8 @@ namespace NuGet.Configuration
 
         public static readonly string FeedName = "nuget.org";
 
+        public static readonly string AddV3TrackFile = "nugetorgadd.trk";
+
         public static readonly string DefaultConfigContent = @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
   <packageSources>

--- a/src/NuGet.Core/NuGet.Configuration/PackageSource/NuGetConstants.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSource/NuGetConstants.cs
@@ -40,7 +40,7 @@ namespace NuGet.Configuration
 
         public static readonly string FeedName = "nuget.org";
 
-        internal static readonly string V3TrackFile = "nugetorgadd.trk";
+        internal const string V3TrackFile = "nugetorgadd.trk";
 
         public static readonly string DefaultConfigContent = @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>

--- a/src/NuGet.Core/NuGet.Configuration/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Configuration/PublicAPI.Shipped.txt
@@ -494,6 +494,7 @@ static readonly NuGet.Configuration.ConfigurationConstants.UserKey -> string
 static readonly NuGet.Configuration.ConfigurationConstants.UsernameToken -> string
 static readonly NuGet.Configuration.ConfigurationConstants.ValidAuthenticationTypesToken -> string
 static readonly NuGet.Configuration.ConfigurationConstants.ValueAttribute -> string
+static readonly NuGet.Configuration.NuGetConstants.AddV3TrackFile -> string
 static readonly NuGet.Configuration.NuGetConstants.DefaultConfigContent -> string
 static readonly NuGet.Configuration.NuGetConstants.DefaultGalleryServerUrl -> string
 static readonly NuGet.Configuration.NuGetConstants.DefaultSymbolServerUrl -> string

--- a/src/NuGet.Core/NuGet.Configuration/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Configuration/PublicAPI.Shipped.txt
@@ -494,7 +494,6 @@ static readonly NuGet.Configuration.ConfigurationConstants.UserKey -> string
 static readonly NuGet.Configuration.ConfigurationConstants.UsernameToken -> string
 static readonly NuGet.Configuration.ConfigurationConstants.ValidAuthenticationTypesToken -> string
 static readonly NuGet.Configuration.ConfigurationConstants.ValueAttribute -> string
-static readonly NuGet.Configuration.NuGetConstants.AddV3TrackFile -> string
 static readonly NuGet.Configuration.NuGetConstants.DefaultConfigContent -> string
 static readonly NuGet.Configuration.NuGetConstants.DefaultGalleryServerUrl -> string
 static readonly NuGet.Configuration.NuGetConstants.DefaultSymbolServerUrl -> string

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
@@ -545,10 +545,23 @@ namespace NuGet.Configuration
                     yield break;
                 }
 
+                // If the default user config NuGet.Config does not exist, we need to create it.
                 var defaultSettingsFilePath = Path.Combine(userSettingsDir, DefaultSettingsFileName);
 
-                // ReadSettings will try to create the default config file if it doesn't exist
                 SettingsFile userSpecificSettings = ReadSettings(rootDirectory, defaultSettingsFilePath, settingsLoadingContext: settingsLoadingContext);
+                if (File.Exists(defaultSettingsFilePath) && userSpecificSettings.IsEmpty())
+                {
+                    var trackFilePath = Path.Combine(Path.GetDirectoryName(defaultSettingsFilePath), NuGetConstants.AddV3TrackFile);
+
+                    if (!File.Exists(trackFilePath))
+                    {
+                        File.Create(trackFilePath).Dispose();
+
+                        var defaultSource = new SourceItem(NuGetConstants.FeedName, NuGetConstants.V3FeedUrl, protocolVersion: "3");
+                        userSpecificSettings.AddOrUpdate(ConfigurationConstants.PackageSources, defaultSource);
+                        userSpecificSettings.SaveToDisk();
+                    }
+                }
 
                 yield return userSpecificSettings;
 

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
@@ -548,7 +548,17 @@ namespace NuGet.Configuration
                 // If the default user config NuGet.Config does not exist, we need to create it.
                 var defaultSettingsFilePath = Path.Combine(userSettingsDir, DefaultSettingsFileName);
 
+                if (!File.Exists(defaultSettingsFilePath))
+                {
+                    File.WriteAllText(defaultSettingsFilePath, NuGetConstants.DefaultConfigContent);
+                    var trackFilePath = Path.Combine(Path.GetDirectoryName(defaultSettingsFilePath), NuGetConstants.AddV3TrackFile);
+                    File.Create(trackFilePath).Dispose();
+                }
+
                 SettingsFile userSpecificSettings = ReadSettings(rootDirectory, defaultSettingsFilePath, settingsLoadingContext: settingsLoadingContext);
+
+                // Handle when some other product created nuget.config using an old version of NuGet.Core.dll or NuGet.Configuration.dll that did not
+                // automatically add nuget.org as a package source.
                 if (File.Exists(defaultSettingsFilePath) && userSpecificSettings.IsEmpty())
                 {
                     var trackFilePath = Path.Combine(Path.GetDirectoryName(defaultSettingsFilePath), NuGetConstants.AddV3TrackFile);

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
@@ -344,7 +344,7 @@ namespace NuGet.Configuration
         }
 
         /// <summary>
-        /// Loads Specific NuGet.Config file. The method only loads specific config file 
+        /// Loads Specific NuGet.Config file. The method only loads specific config file
         /// which is file <paramref name="configFileName"/>from <paramref name="root"/>.
         /// </summary>
         public static ISettings LoadSpecificSettings(string root, string configFileName)
@@ -556,7 +556,7 @@ namespace NuGet.Configuration
                     }
 
                     File.WriteAllText(defaultSettingsFilePath, NuGetConstants.DefaultConfigContent);
-                    var trackFilePath = Path.Combine(Path.GetDirectoryName(defaultSettingsFilePath), NuGetConstants.AddV3TrackFile);
+                    var trackFilePath = Path.Combine(Path.GetDirectoryName(defaultSettingsFilePath), NuGetConstants.V3TrackFile);
                     File.Create(trackFilePath).Dispose();
                 }
 
@@ -566,7 +566,7 @@ namespace NuGet.Configuration
                 // automatically add nuget.org as a package source.
                 if (File.Exists(defaultSettingsFilePath) && userSpecificSettings.IsEmpty())
                 {
-                    var trackFilePath = Path.Combine(Path.GetDirectoryName(defaultSettingsFilePath), NuGetConstants.AddV3TrackFile);
+                    var trackFilePath = Path.Combine(Path.GetDirectoryName(defaultSettingsFilePath), NuGetConstants.V3TrackFile);
 
                     if (!File.Exists(trackFilePath))
                     {

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
@@ -550,6 +550,11 @@ namespace NuGet.Configuration
 
                 if (!File.Exists(defaultSettingsFilePath))
                 {
+                    if (!Directory.Exists(userSettingsDir))
+                    {
+                        Directory.CreateDirectory(userSettingsDir);
+                    }
+
                     File.WriteAllText(defaultSettingsFilePath, NuGetConstants.DefaultConfigContent);
                     var trackFilePath = Path.Combine(Path.GetDirectoryName(defaultSettingsFilePath), NuGetConstants.AddV3TrackFile);
                     File.Create(trackFilePath).Dispose();

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
@@ -2253,7 +2253,7 @@ namespace NuGet.Configuration.Test
 
         private static void CreateSettingsFileInTestingGlobalDirectory(TestDirectory directory)
         {
-            var settingsFile = new FileInfo(Path.Combine(directory.Path, "TestingGlobalPath", "NuGet.config"));
+            var settingsFile = new FileInfo(Path.Combine(directory.Path, "TestingGlobalPath", "NuGet.Config"));
 
             settingsFile.Directory.Create();
 

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
@@ -1814,7 +1814,7 @@ namespace NuGet.Configuration.Test
                 List<PackageSource> sources = LoadPackageSources(useStaticMethod, settings);
 
                 // Assert
-                Assert.Equal(0, sources.Count);
+                Assert.Equal(1, sources.Count);
             }
         }
 
@@ -2253,7 +2253,7 @@ namespace NuGet.Configuration.Test
 
         private static void CreateSettingsFileInTestingGlobalDirectory(TestDirectory directory)
         {
-            var settingsFile = new FileInfo(Path.Combine(directory.Path, "TestingGlobalPath", "NuGet.Config"));
+            var settingsFile = new FileInfo(Path.Combine(directory.Path, "TestingGlobalPath", "NuGet.config"));
 
             settingsFile.Directory.Create();
 

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsTests.cs
@@ -2043,7 +2043,7 @@ namespace NuGet.Configuration.Test
             string expected = SettingsTestUtils.RemoveWhitespace(NuGetConstants.DefaultConfigContent);
             actual.Should().Be(expected);
 
-            // and that the tracking file exists, so that nuget.org won't be re-added if the customer removes it.
+            // Check that the tracking file exists, so that nuget.org won't be re-added if the customer removes it.
             Assert.True(File.Exists(Path.Combine(mockUserProfileDirectory, NuGetConstants.V3TrackFile)));
         }
 
@@ -2076,7 +2076,7 @@ namespace NuGet.Configuration.Test
             string expected = SettingsTestUtils.RemoveWhitespace(NuGetConstants.DefaultConfigContent);
             actual.Should().Be(expected);
 
-            // and that the tracking file exists, so that nuget.org won't be re-added if the customer removes it.
+            // Check that the tracking file exists, so that nuget.org won't be re-added if the customer removes it.
             Assert.True(File.Exists(Path.Combine(mockUserProfileDirectory, NuGetConstants.V3TrackFile)));
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsTests.cs
@@ -2021,7 +2021,7 @@ namespace NuGet.Configuration.Test
         }
 
         [Fact]
-        public void LoadSettings_EmptyUserWideConfigFile_DoNotAddNuGetOrg()
+        public void LoadSettings_AddsV3ToEmptyConfigFile_OnlyFirstTime()
         {
             using (var mockBaseDirectory = TestDirectory.Create())
             {
@@ -2042,41 +2042,37 @@ namespace NuGet.Configuration.Test
                     useTestingGlobalPath: true);
 
                 // Assert
-                var actual = SettingsTestUtils.RemoveWhitespace(File.ReadAllText(Path.Combine(mockBaseDirectory, "TestingGlobalPath", "NuGet.Config")));
-                var expected = SettingsTestUtils.RemoveWhitespace(config);
-
-                actual.Should().Be(expected);
-            }
-        }
-
-        [Fact]
-        public void LoadSettings_NonExistingUserWideConfigFile_CreateUserWideConfigFileWithNuGetOrg()
-        {
-            using (var mockBaseDirectory = TestDirectory.Create())
-            {
-                // Arrange
-                var nugetConfigPath = Path.Combine(mockBaseDirectory, "TestingGlobalPath", "NuGet.Config");
-                File.Exists(nugetConfigPath).Should().BeFalse();
-
-                // Act
-                var settings = Settings.LoadSettings(
-                    root: mockBaseDirectory,
-                    configFileName: null,
-                    machineWideSettings: null,
-                    loadUserWideSettings: true,
-                    useTestingGlobalPath: true);
-
-                // Assert
-                File.Exists(nugetConfigPath).Should().BeTrue();
-                var actual = SettingsTestUtils.RemoveWhitespace(File.ReadAllText(nugetConfigPath));
-                var expected = SettingsTestUtils.RemoveWhitespace(@"<?xml version=""1.0"" encoding=""utf-8""?>
+                var text = SettingsTestUtils.RemoveWhitespace(File.ReadAllText(Path.Combine(mockBaseDirectory, "TestingGlobalPath", "NuGet.Config")));
+                var result = SettingsTestUtils.RemoveWhitespace(@"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
     <packageSources>
         <add key=""nuget.org"" value=""https://api.nuget.org/v3/index.json"" protocolVersion=""3"" />
     </packageSources>
 </configuration>");
 
-                actual.Should().Be(expected);
+                text.Should().Be(result);
+
+                var settingsFile = new SettingsFile(Path.Combine(mockBaseDirectory, "TestingGlobalPath"));
+
+                // Act
+                var section = settingsFile.GetSection("packageSources");
+                section.Should().NotBeNull();
+                settingsFile.Remove("packageSources", section.Items.First());
+                settingsFile.SaveToDisk();
+
+                settings = Settings.LoadSettings(
+                                    root: mockBaseDirectory,
+                                    configFileName: null,
+                                    machineWideSettings: null,
+                                    loadUserWideSettings: true,
+                                    useTestingGlobalPath: true);
+                // Assert
+                text = SettingsTestUtils.RemoveWhitespace(File.ReadAllText(Path.Combine(mockBaseDirectory, "TestingGlobalPath", "NuGet.Config")));
+                result = SettingsTestUtils.RemoveWhitespace(@"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+</configuration>");
+
+                text.Should().Be(result);
             }
         }
 


### PR DESCRIPTION
Tip for reviewer: remove the first commit when viewing the diff.

<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11387

Regression? No

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

* Revert https://github.com/NuGet/NuGet.Client/pull/3907
* When default nuget.config does not exist, create both the fie with the default contents and tracking file.

## PR Checklist

- [X] PR has a meaningful title
- [X] PR has a linked issue.
- [X] Described changes

- **Tests**
  - [X] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [X] N/A
