### PR TITLE
Disable update button when the selected value is null

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageDetailControlModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageDetailControlModel.cs
@@ -206,7 +206,7 @@ namespace NuGet.PackageManagement.UI
         {
             base.OnSelectedVersionChanged();
             OnPropertyChanged(nameof(IsSelectedVersionInstalled));
-            OnPropertyChanged(nameof(IsNotAvailableForInstall));
+            OnPropertyChanged(nameof(IsInstallorUpdateButtonEnabled));
         }
 
         public bool IsSelectedVersionInstalled
@@ -219,11 +219,11 @@ namespace NuGet.PackageManagement.UI
             }
         }
 
-        public bool IsNotAvailableForInstall
+        public bool IsInstallorUpdateButtonEnabled
         {
             get
             {
-                return SelectedVersion == null || IsSelectedVersionInstalled;
+                return SelectedVersion != null && !IsSelectedVersionInstalled;
             }
         }
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageDetailControlModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageDetailControlModel.cs
@@ -206,7 +206,7 @@ namespace NuGet.PackageManagement.UI
         {
             base.OnSelectedVersionChanged();
             OnPropertyChanged(nameof(IsSelectedVersionInstalled));
-            OnPropertyChanged(nameof(IsAvailableForInstall));
+            OnPropertyChanged(nameof(IsNotAvailableForInstall));
         }
 
         public bool IsSelectedVersionInstalled
@@ -219,7 +219,7 @@ namespace NuGet.PackageManagement.UI
             }
         }
 
-        public bool IsAvailableForInstall
+        public bool IsNotAvailableForInstall
         {
             get
             {

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageDetailControlModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageDetailControlModel.cs
@@ -206,6 +206,7 @@ namespace NuGet.PackageManagement.UI
         {
             base.OnSelectedVersionChanged();
             OnPropertyChanged(nameof(IsSelectedVersionInstalled));
+            OnPropertyChanged(nameof(IsAvailableForInstall));
         }
 
         public bool IsSelectedVersionInstalled
@@ -215,6 +216,14 @@ namespace NuGet.PackageManagement.UI
                 return SelectedVersion != null
                     && InstalledVersion != null
                     && SelectedVersion.Version == InstalledVersion;
+            }
+        }
+
+        public bool IsAvailableForInstall
+        {
+            get
+            {
+                return SelectedVersion == null || IsSelectedVersionInstalled;
             }
         }
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/ProjectView.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/ProjectView.xaml
@@ -148,7 +148,7 @@
       AutomationProperties.AutomationId="Project_Button_Update"
       Click="InstallButton_Clicked"
       Visibility="{Binding InstalledVersion, Converter={StaticResource NullToVisibilityConverter}, Mode=OneWay}"
-      IsEnabled="{Binding IsSelectedVersionInstalled, Converter={StaticResource NotNullOrTrueToBooleanConverter}}"
+      IsEnabled="{Binding IsAvailableForInstall, Converter={StaticResource NotNullOrTrueToBooleanConverter}}"
       Content="{x:Static local:Resources.Button_Update}" />
   </Grid>
 </UserControl>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/ProjectView.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/ProjectView.xaml
@@ -137,6 +137,7 @@
       AutomationProperties.AutomationId="Button_Install"
       Click="InstallButton_Clicked"
       Visibility="{Binding InstalledVersion, Converter={StaticResource InverseNullToVisibilityConverter}, Mode=OneWay}"
+      IsEnabled="{Binding IsNotAvailableForInstall, Converter={StaticResource NotNullOrTrueToBooleanConverter}, Mode=OneWay}"
       Content="{x:Static local:Resources.Button_Install}" />
 
     <Button
@@ -148,7 +149,7 @@
       AutomationProperties.AutomationId="Project_Button_Update"
       Click="InstallButton_Clicked"
       Visibility="{Binding InstalledVersion, Converter={StaticResource NullToVisibilityConverter}, Mode=OneWay}"
-      IsEnabled="{Binding IsAvailableForInstall, Converter={StaticResource NotNullOrTrueToBooleanConverter}}"
+      IsEnabled="{Binding IsNotAvailableForInstall, Converter={StaticResource NotNullOrTrueToBooleanConverter}, Mode=OneWay}"
       Content="{x:Static local:Resources.Button_Update}" />
   </Grid>
 </UserControl>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/ProjectView.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/ProjectView.xaml
@@ -137,7 +137,7 @@
       AutomationProperties.AutomationId="Button_Install"
       Click="InstallButton_Clicked"
       Visibility="{Binding InstalledVersion, Converter={StaticResource InverseNullToVisibilityConverter}, Mode=OneWay}"
-      IsEnabled="{Binding IsNotAvailableForInstall, Converter={StaticResource NotNullOrTrueToBooleanConverter}, Mode=OneWay}"
+      IsEnabled="{Binding IsInstallorUpdateButtonEnabled, Mode=OneWay}"
       Content="{x:Static local:Resources.Button_Install}" />
 
     <Button
@@ -149,7 +149,7 @@
       AutomationProperties.AutomationId="Project_Button_Update"
       Click="InstallButton_Clicked"
       Visibility="{Binding InstalledVersion, Converter={StaticResource NullToVisibilityConverter}, Mode=OneWay}"
-      IsEnabled="{Binding IsNotAvailableForInstall, Converter={StaticResource NotNullOrTrueToBooleanConverter}, Mode=OneWay}"
+      IsEnabled="{Binding IsInstallorUpdateButtonEnabled, Mode=OneWay}"
       Content="{x:Static local:Resources.Button_Update}" />
   </Grid>
 </UserControl>


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug 

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11096

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
Due to a bug in WPF dotnet/wpf#4929, NuGet sometimes allows selection of a null separator https://github.com/nuget/home/issues/11007. This pr disables the button when the SelectedVersion is null

![image](https://user-images.githubusercontent.com/43253759/142073856-c4d46c76-78a6-495c-95b2-e490cbb0505a.png)

## PR Checklist

- [ ] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [ ] N/A
