### PR TITLE
Set MSBUILD_EXE_PATH for functional tests

### DIFF
--- a/build/build.proj
+++ b/build/build.proj
@@ -419,7 +419,7 @@
 
     <Exec Command="$(DesktopTestCommand)"
           ContinueOnError="true"
-          EnvironmentVariables="VisualStudio.InstallationUnderTest.Path=$(VSINSTALLDIR)"
+          EnvironmentVariables="VisualStudio.InstallationUnderTest.Path=$(VSINSTALLDIR);MSBUILD_EXE_PATH=$(MSBuildBinPath)\MSBuild.exe"
           Condition=" '$(SkipDesktopAssemblies)' != 'true' AND '$(DesktopInputTestAssemblies)' != '' ">
       <Output TaskParameter="ExitCode" PropertyName="DesktopTestErrorCode"/>
     </Exec>


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1312

Regression? N/A

## Description
For some reason functional tests when calling MSBuild APIs are failing since MSBuild cannot find itself.  MSBuild uses the Visual Studio Setup Interop to query instances of Visual Studio which should work just fine.  It seems like the move to a new agent pool caused something to break, although this seems wrong since in the pipeline task `vswhere` is able to find `MSBuild.exe` just fine.  We'll need to do more investigation as to why its not working by adding more logging.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
