### PR TITLE
Tests expecting NotFound response now look for generic error message

### DIFF
--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetListCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetListCommandTest.cs
@@ -921,26 +921,26 @@ namespace NuGet.CommandLine.Test
         public void ListCommand_InvalidInput_V3_NotFound(string invalidInput)
         {
             // Arrange
-            var nugetexe = Util.GetNuGetExePath();
+            string nugetexe = Util.GetNuGetExePath();
 
             // Act
             using (var pathContext = new SimpleTestPathContext())
             {
                 var args = "list test -Source " + invalidInput;
-                var result = CommandRunner.Run(
-                    nugetexe,
-                    pathContext.SolutionRoot,
-                    args,
+                CommandRunnerResult result = CommandRunner.Run(
+                    process: nugetexe,
+                    workingDirectory: pathContext.SolutionRoot,
+                    arguments: args,
                     waitForExit: true);
 
                 // Assert
-                Assert.True(
-                    result.Item1 != 0,
-                    "The run did not fail as desired. Simply got this output:" + result.Item2);
+                Assert.False(
+                    result.Success,
+                    "The run did not fail as desired. Simply got this output:" + result.Output);
 
                 Assert.True(
-                    result.Item3.Contains("400 (Bad Request)"),
-                    "Expected error message not found in " + result.Item3
+                    result.Errors.Contains("Response status code does not indicate success"),
+                    "Expected error message not found in " + result.Errors
                     );
             }
         }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPushCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPushCommandTest.cs
@@ -2007,13 +2007,13 @@ namespace NuGet.CommandLine.Test
         [InlineData("https://api.nuget.org/v4/index.json")]
         public void PushCommand_InvalidInput_V3_NotFound(string invalidInput)
         {
-            var nugetexe = Util.GetNuGetExePath();
+            string nugetexe = Util.GetNuGetExePath();
             using (var pathContext = new SimpleTestPathContext())
 
             {
                 // Arrange
-                var packagesDirectory = Path.Combine(pathContext.WorkingDirectory, "repo");
-                var packageFileName = Util.CreateTestPackage("testPackage1", "1.1.0", packagesDirectory);
+                string packagesDirectory = Path.Combine(pathContext.WorkingDirectory, "repo");
+                string packageFileName = Util.CreateTestPackage("testPackage1", "1.1.0", packagesDirectory);
 
                 // Act
                 var args = new string[]
@@ -2024,20 +2024,20 @@ namespace NuGet.CommandLine.Test
                         invalidInput
                 };
 
-                var result = CommandRunner.Run(
-                                nugetexe,
-                                pathContext.SolutionRoot,
-                                string.Join(" ", args),
-                                true);
+                CommandRunnerResult result = CommandRunner.Run(
+                                process: nugetexe,
+                                workingDirectory: pathContext.SolutionRoot,
+                                arguments: string.Join(" ", args),
+                                waitForExit: true);
 
                 // Assert
-                Assert.True(
-                    result.Item1 != 0,
-                    "The run did not fail as desired. Simply got this output:" + result.Item2);
+                Assert.False(
+                    result.Success,
+                    "The run did not fail as desired. Simply got this output:" + result.Output);
 
                 Assert.True(
-                    result.Item3.Contains("400 (Bad Request)"),
-                    "Expected error message not found in " + result.Item3
+                    result.Errors.Contains("Response status code does not indicate success"),
+                    "Expected error message not found in " + result.Errors
                     );
             }
         }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1313

Regression? Last working version: n/a

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

These tests just need to determine if an HTTP error occurred at all. A server may return a variety of specific error codes and messages, and there's no benefit to depending on that.

(Also made some coding guideline refactoring)

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added - updated a test
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
