### PR TITLE
Stop using anonymous functions in ResolverUtility.FindLibraryByVersionAsync to reduce memory allocations

### DIFF
--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/ResolverUtility.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/ResolverUtility.cs
@@ -427,7 +427,7 @@ namespace NuGet.DependencyResolver
 
             foreach (var provider in providers)
             {
-                tasks.Add(taskWrapper(provider, libraryRange, framework, cacheContext, logger, token));
+                tasks.Add(FindLibraryFromProviderAsync(provider, libraryRange, framework, cacheContext, logger, token));
             }
 
             RemoteMatch bestMatch = null;
@@ -457,7 +457,7 @@ namespace NuGet.DependencyResolver
                 }
             }
 
-            static async Task<RemoteMatch> taskWrapper(IRemoteDependencyProvider provider, LibraryRange libraryRange,
+            static async Task<RemoteMatch> FindLibraryFromProviderAsync(IRemoteDependencyProvider provider, LibraryRange libraryRange,
                 NuGetFramework framework, SourceCacheContext cacheContext, ILogger logger, CancellationToken token)
             {
                 var library = await provider.FindLibraryAsync(libraryRange, framework, cacheContext, logger, token);

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/ResolverUtility.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/ResolverUtility.cs
@@ -374,24 +374,20 @@ namespace NuGet.DependencyResolver
                 return await FindLibraryFromSourcesAsync(
                     libraryRange,
                     providers,
-                    provider => provider.FindLibraryAsync(
-                        libraryRange,
-                        framework,
-                        cacheContext,
-                        logger,
-                        token));
+                    framework,
+                    cacheContext,
+                    logger,
+                    token);
             }
 
             // Try the non http sources first
             var nonHttpMatch = await FindLibraryFromSourcesAsync(
                 libraryRange,
                 providers.Where(p => !p.IsHttp),
-                provider => provider.FindLibraryAsync(
-                    libraryRange,
-                    framework,
-                    cacheContext,
-                    logger,
-                    token));
+                framework,
+                cacheContext,
+                logger,
+                token);
 
             // If we found an exact match then use it
             if (nonHttpMatch != null && nonHttpMatch.Library.Version.Equals(libraryRange.VersionRange.MinVersion))
@@ -403,12 +399,10 @@ namespace NuGet.DependencyResolver
             var httpMatch = await FindLibraryFromSourcesAsync(
                 libraryRange,
                 providers.Where(p => p.IsHttp),
-                provider => provider.FindLibraryAsync(
-                    libraryRange,
-                    framework,
-                    cacheContext,
-                    logger,
-                    token));
+                framework,
+                cacheContext,
+                logger,
+                token);
 
             // Pick the best match of the 2
             if (libraryRange.VersionRange.IsBetter(
@@ -424,14 +418,17 @@ namespace NuGet.DependencyResolver
         private static async Task<RemoteMatch> FindLibraryFromSourcesAsync(
             LibraryRange libraryRange,
             IEnumerable<IRemoteDependencyProvider> providers,
-            Func<IRemoteDependencyProvider, Task<LibraryIdentity>> action)
+            NuGetFramework framework,
+            SourceCacheContext cacheContext,
+            ILogger logger,
+            CancellationToken token)
         {
             var tasks = new List<Task<RemoteMatch>>();
             foreach (var provider in providers)
             {
-                Func<Task<RemoteMatch>> taskWrapper = async () =>
+                async Task<RemoteMatch> taskWrapper()
                 {
-                    var library = await action(provider);
+                    var library = await provider.FindLibraryAsync(libraryRange, framework, cacheContext, logger, token);
                     if (library != null)
                     {
                         return new RemoteMatch
@@ -442,7 +439,7 @@ namespace NuGet.DependencyResolver
                     }
 
                     return null;
-                };
+                }
 
                 tasks.Add(taskWrapper());
             }

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/ResolverUtility.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/ResolverUtility.cs
@@ -424,24 +424,10 @@ namespace NuGet.DependencyResolver
             CancellationToken token)
         {
             var tasks = new List<Task<RemoteMatch>>();
+
             foreach (var provider in providers)
             {
-                async Task<RemoteMatch> taskWrapper()
-                {
-                    var library = await provider.FindLibraryAsync(libraryRange, framework, cacheContext, logger, token);
-                    if (library != null)
-                    {
-                        return new RemoteMatch
-                        {
-                            Provider = provider,
-                            Library = library
-                        };
-                    }
-
-                    return null;
-                }
-
-                tasks.Add(taskWrapper());
+                tasks.Add(taskWrapper(provider, libraryRange, framework, cacheContext, logger, token));
             }
 
             RemoteMatch bestMatch = null;
@@ -469,6 +455,22 @@ namespace NuGet.DependencyResolver
                 {
                     bestMatch = match;
                 }
+            }
+
+            static async Task<RemoteMatch> taskWrapper(IRemoteDependencyProvider provider, LibraryRange libraryRange,
+                NuGetFramework framework, SourceCacheContext cacheContext, ILogger logger, CancellationToken token)
+            {
+                var library = await provider.FindLibraryAsync(libraryRange, framework, cacheContext, logger, token);
+                if (library != null)
+                {
+                    return new RemoteMatch
+                    {
+                        Provider = provider,
+                        Library = library
+                    };
+                }
+
+                return null;
             }
 
             return bestMatch;


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11409

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
I added a few details about the memory allocations in the linked issue. After reading [Use local function instead of lambda (IDE0039)](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0039) doc and https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/local-functions#heap-allocations, I modified the code path to use local function instead of lambda expressions. The reason I chose `static local function` is because of `If you know that your local function won't be converted to a delegate and none of the variables captured by it are captured by other lambdas or local functions that are converted to delegates, you can guarantee that your local function avoids being allocated on the heap by declaring it as a static local function. Note that this feature is available in C# 8.0 and newer. ` in the [doc](https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/local-functions#heap-allocations).

This method has **~880 MB** allocations during solution restore for OrchardCore solution https://github.com/OrchardCMS/OrchardCore/tree/75923732c36d2785cb869affb805f0ff19d1847c

![image](https://user-images.githubusercontent.com/52756182/143098452-39101c02-b521-4410-89a1-e4c76b4eeed3.png)

After code modifications the heap allocations of [ResolverUtility.FindLibraryByVersionAsync](https://github.com/NuGet/NuGet.Client/blob/a8b6b1fb3a1bccd207a83612cd0f5e1f4ff1d0b8/src/NuGet.Core/NuGet.DependencyResolver.Core/ResolverUtility.cs#L363) method have reduced by **~200 MB.** for the same solution.

![image](https://user-images.githubusercontent.com/52756182/143098346-6a4ca7e7-3ae5-40ac-95e0-82e0fc833c6d.png)

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] N/A <!-- Infrastructure, documentation etc. --> No functional change to the product.

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [x] N/A
