### PR TITLE
Re-enable skipped MAC test

### DIFF
--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/InstallCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/InstallCommandTests.cs
@@ -8,7 +8,6 @@ using System.Linq;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 using FluentAssertions;
-using NuGet.Common;
 using NuGet.Test.Utility;
 using Org.BouncyCastle.Crypto.Parameters;
 using Org.BouncyCastle.Security;
@@ -40,16 +39,11 @@ namespace NuGet.CommandLine.FuncTest.Commands
         public InstallCommandTests(SignCommandTestFixture fixture)
         {
             _testFixture = fixture ?? throw new ArgumentNullException(nameof(fixture));
-            // https://github.com/NuGet/Home/issues/11321
-            if (!RuntimeEnvironmentHelper.IsMacOSX)
-            {
-                _trustedTestCert = SigningTestUtility.GenerateTrustedTestCertificate();
-            }
+            _trustedTestCert = SigningTestUtility.GenerateTrustedTestCertificate();
             _nugetExePath = _testFixture.NuGetExePath;
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task Install_AuthorSignedPackage_SucceedsAsync()
         {
             // Arrange
@@ -82,8 +76,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task Install_RepoSignedPackage_SucceedsAsync()
         {
             // Arrange
@@ -116,8 +109,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task Install_UntrustedCertSignedPackage_WarnsAsync()
         {
             // Arrange
@@ -151,8 +143,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task Install_TamperedPackage_FailsAsync()
         {
             // Arrange
@@ -187,8 +178,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task Install_TamperedAndRevokedCertificateSignaturePackage_FailsAsync()
         {
             // Arrange

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/RestoreCommandSignPackagesTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/RestoreCommandSignPackagesTests.cs
@@ -41,16 +41,11 @@ namespace NuGet.CommandLine.FuncTest.Commands
         public RestoreCommandSignPackagesTests(SignCommandTestFixture fixture)
         {
             _testFixture = fixture ?? throw new ArgumentNullException(nameof(fixture));
-            // https://github.com/NuGet/Home/issues/11321
-            if (!RuntimeEnvironmentHelper.IsMacOSX)
-            {
-                _trustedTestCert = SigningTestUtility.GenerateTrustedTestCertificate();
-            }
+            _trustedTestCert = SigningTestUtility.GenerateTrustedTestCertificate();
             _nugetExePath = _testFixture.NuGetExePath;
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task Restore_TamperedPackageInPackagesConfig_FailsWithErrorAsync()
         {
             // Arrange
@@ -101,8 +96,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task Restore_TamperedPackage_FailsAsync()
         {
             // Arrange
@@ -156,8 +150,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task Restore_PackageWithCompressedSignature_WarnsAsync()
         {
             // Arrange
@@ -224,8 +217,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task Restore_PackageWithCompressedSignature_WarnAsError_FailsAndDoesNotExpandAsync()
         {
             // Arrange
@@ -303,8 +295,8 @@ namespace NuGet.CommandLine.FuncTest.Commands
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+
+        [CIOnlyFact]
         public async Task Restore_PackageWithCompressedSignature_RequireMode_FailsAndDoesNotExpandAsync()
         {
             // Arrange
@@ -382,8 +374,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [Fact]
         public void GetCertificateChain_WithUntrustedRoot_Throws()
         {
             using (var chainHolder = new X509ChainHolder())

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SignCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SignCommandTests.cs
@@ -201,8 +201,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task SignCommand_SignPackageWithValidCertChainAsync()
         {
             // Arrange

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/TrustedSignersCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/TrustedSignersCommandTests.cs
@@ -244,8 +244,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformTheory(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyTheory]
         [InlineData(true)]
         [InlineData(false)]
         public async Task TrustedSignersCommand_AddTrustedSigner_WithAuthorSignedPackage_AddsItSuccesfullyToConfigAsync(bool allowUntrustedRoot)
@@ -293,8 +292,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformTheory(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyTheory]
         [InlineData(true)]
         [InlineData(false)]
         public async Task TrustedSignersCommand_AddTrustedSigner_WithAuthorSignedPackage_AddsMultipleFilesThrows(bool allowUntrustedRoot)
@@ -336,8 +334,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformTheory(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyTheory]
         [InlineData(true, null)]
         [InlineData(true, "one;two;three")]
         [InlineData(false, null)]
@@ -397,8 +394,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformTheory(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyTheory]
         [InlineData(true, null)]
         [InlineData(true, "one;two;three")]
         [InlineData(false, null)]

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/VerifyCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/VerifyCommandTests.cs
@@ -158,8 +158,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task VerifyCommand_VerifyOnPackageSignedWithValidCertificateChainSucceedsAsync()
         {
             // Arrange
@@ -199,8 +198,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task VerifyCommand_VerifyOnPackageSignedWithAllowedCertificateSucceedsAsync()
         {
             // Arrange
@@ -242,8 +240,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task VerifyCommand_VerifyOnPackageSignedWithoutAllowedCertificateFailsAsync()
         {
             // Arrange

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetSignTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetSignTests.cs
@@ -34,8 +34,7 @@ namespace Dotnet.Integration.Test
             _signFixture = signFixture;
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [Fact]
         public async Task DotnetSign_SignPackageWithTrustedCertificate_SucceedsAsync()
         {
             // Arrange
@@ -60,8 +59,7 @@ namespace Dotnet.Integration.Test
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [Fact]
         public async Task DotnetSign_SignPackageWithTrustedCertificateWithRelativePath_SucceedsAsync()
         {
             // Arrange
@@ -86,8 +84,7 @@ namespace Dotnet.Integration.Test
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [Fact]
         public async Task DotnetSign_SignPackageWithInvalidEku_FailsAsync()
         {
             // Arrange
@@ -113,8 +110,7 @@ namespace Dotnet.Integration.Test
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [Fact]
         public async Task DotnetSign_SignPackageWithExpiredCertificate_FailsAsync()
         {
             // Arrange
@@ -140,8 +136,7 @@ namespace Dotnet.Integration.Test
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [Fact]
         public async Task DotnetSign_SignPackageWithNotYetValidCertificate_FailsAsync()
         {
             // Arrange
@@ -167,8 +162,7 @@ namespace Dotnet.Integration.Test
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [Fact]
         public async Task DotnetSign_SignPackageWithTimestamping_SucceedsAsync()
         {
             // Arrange
@@ -220,8 +214,7 @@ namespace Dotnet.Integration.Test
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [Fact]
         public async Task DotnetSign_SignPackageWithUnknownRevocationCertChain_SucceedsAsync()
         {
             // Arrange
@@ -248,8 +241,7 @@ namespace Dotnet.Integration.Test
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [Fact]
         public async Task DotnetSign_SignPackageWithOutputDirectory_SucceedsAsync()
         {
             // Arrange
@@ -280,8 +272,7 @@ namespace Dotnet.Integration.Test
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [Fact]
         public async Task DotnetSign_ResignPackageWithoutOverwrite_FailsAsync()
         {
             // Arrange
@@ -313,8 +304,7 @@ namespace Dotnet.Integration.Test
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [Fact]
         public async Task DotnetSign_ResignPackageWithOverwrite_SuccessAsync()
         {
             // Arrange
@@ -346,8 +336,7 @@ namespace Dotnet.Integration.Test
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [Fact]
         public async Task DotnetSign_SignPackageWithOverwrite_SuccessAsync()
         {
             // Arrange
@@ -372,8 +361,7 @@ namespace Dotnet.Integration.Test
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [Fact]
         public async Task DotnetSign_SignPackageWithPfxFile_SuccessAsync()
         {
             // Arrange
@@ -404,8 +392,7 @@ namespace Dotnet.Integration.Test
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [Fact]
         public async Task DotnetSign_SignPackageWithPfxFileOfRelativePath_SuccessAsync()
         {
             // Arrange
@@ -437,8 +424,7 @@ namespace Dotnet.Integration.Test
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [Fact]
         public async Task DotnetSign_SignPackageWithPfxFileWithoutPasswordAndWithNonInteractive_FailsAsync()
         {
             // Arrange
@@ -469,8 +455,7 @@ namespace Dotnet.Integration.Test
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [Fact]
         public async Task DotnetSign_SignPackageWithUntrustedSelfIssuedCertificateInCertificateStore_SuccessAsync()
         {
             // Arrange
@@ -497,8 +482,7 @@ namespace Dotnet.Integration.Test
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [Fact]
         public async Task DotnetSign_SignPackageWithUnsuportedTimestampHashAlgorithm_FailsAsync()
         {
             // Arrange

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetTrustTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetTrustTests.cs
@@ -152,8 +152,7 @@ namespace Dotnet.Integration.Test
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformTheory(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyTheory]
         [InlineData(true)]
         [InlineData(false)]
         public async Task DotnetTrust_AuthorAction_RelativePathConfileFile_Succeeds(bool allowUntrustedRoot)
@@ -216,8 +215,7 @@ namespace Dotnet.Integration.Test
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task DotnetTrust_AuthorAction_RelativePathConfileFile_WithoutExistingTrustedSignersSection_Succeeds()
         {
             // Arrange
@@ -274,8 +272,7 @@ namespace Dotnet.Integration.Test
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformTheory(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyTheory]
         [InlineData(true)]
         [InlineData(false)]
         public async Task DotnetTrust_AuthorAction_AbsolutePathConfileFile_Succeeds(bool allowUntrustedRoot)
@@ -320,8 +317,7 @@ namespace Dotnet.Integration.Test
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformTheory(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyTheory]
         [InlineData(true)]
         [InlineData(false)]
         public async Task DotnetTrust_AuthorAction_TryAddSameAuthor_Fails(bool allowUntrustedRoot)
@@ -364,8 +360,7 @@ namespace Dotnet.Integration.Test
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformTheory(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyTheory]
         [InlineData(true, null)]
         [InlineData(true, "one;two;three")]
         [InlineData(true, "one")]
@@ -423,8 +418,7 @@ namespace Dotnet.Integration.Test
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [Fact]
         public async Task DotnetTrust_RepositoryAction_TryAddSameRepository_Fails()
         {
             // Arrange
@@ -465,8 +459,7 @@ namespace Dotnet.Integration.Test
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformTheory(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyTheory]
         [InlineData(true)]
         [InlineData(false)]
         public async Task DotnetTrust_CertificateFingerPrintAction_Succeeds(bool allowUntrustedRoot)
@@ -514,8 +507,7 @@ namespace Dotnet.Integration.Test
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformTheory(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [Theory]
         [InlineData(true)]
         [InlineData(false)]
         public async Task DotnetTrust_CertificateFingerPrintAction_TryAddSameFingerPrint_Fails(bool allowUntrustedRoot)
@@ -562,8 +554,7 @@ namespace Dotnet.Integration.Test
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformTheory(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyTheory]
         [InlineData(true)]
         [InlineData(false)]
         public async Task DotnetTrust_CertificateFingerPrintAction_WithExistingSigner_AppendSucceeds(bool allowUntrustedRoot)
@@ -618,8 +609,7 @@ namespace Dotnet.Integration.Test
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task DotnetTrust_RemoveAction_Succeeds()
         {
             // Arrange
@@ -663,8 +653,7 @@ namespace Dotnet.Integration.Test
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task DotnetTrust_RemoveAction_WrongName_NoChange()
         {
             // Arrange

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/AllowListVerificationProviderTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/AllowListVerificationProviderTests.cs
@@ -31,11 +31,7 @@ namespace NuGet.Packaging.FuncTest
         public AllowListVerificationProviderTests(SigningTestFixture fixture)
         {
             _testFixture = fixture ?? throw new ArgumentNullException(nameof(fixture));
-            // https://github.com/NuGet/Home/issues/11321
-            if (!RuntimeEnvironmentHelper.IsMacOSX)
-            {
-                _trustedRepoTestCert = SigningTestUtility.GenerateTrustedTestCertificate();
-            }
+            _trustedRepoTestCert = SigningTestUtility.GenerateTrustedTestCertificate();
         }
 
         public void Dispose()
@@ -43,8 +39,7 @@ namespace NuGet.Packaging.FuncTest
             _trustedRepoTestCert.Dispose();
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task GetTrustResultAsync_AuthorSignedPackage_WithCertificateInAllowList_SuccessAsync()
         {
             // Arrange
@@ -85,8 +80,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformTheory(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyTheory]
         [MemberData(nameof(EmptyNullAndRequiredListCombinations))]
         public async Task GetTrustResultAsync_AuthorSignedPackage_RequirementsAsync(
             SignedPackageVerifierSettings verifierSettings,
@@ -134,8 +128,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task GetTrustResultAsync_AuthorSignedPackage_VerifyWithoutCertificateInAllowList_AllowUntrusted_WarnAsync()
         {
             // Arrange
@@ -181,8 +174,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task GetTrustResultAsync_AuthorSignedPackage_VerifyWithoutCertificateInAllowList_NotAllowUntrusted_ErrorAsync()
         {
             // Arrange
@@ -228,8 +220,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task GetTrustResultAsync_RepositorySignedPackage_AllowListWithAuthorTarget_AndPrimaryPlacement_ErrorAsync()
         {
             // Arrange
@@ -277,8 +268,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task GetTrustResultAsync_RepositorySignedPackage_AllowListWithRepositoryTarget_AndCounterPlacementOnly_ErrorAsync()
         {
             // Arrange
@@ -326,8 +316,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task GetTrustResultAsync_RepositorySignedPackage_AllowListWithRepositoryTarget_AndPrimaryPlacement_SuccessAsync()
         {
             // Arrange
@@ -373,8 +362,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task GetTrustResultAsync_RepositoryCountersignedPackage_AllowListWithAuthorTarget_AndPrimaryPlacement_ErrorAsync()
         {
             // Arrange
@@ -424,8 +412,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task GetTrustResultAsync_RepositoryCountersignedPackage_AllowListWithRepositoryTarget_AndPrimaryPlacementOnly_ErrorAsync()
         {
             // Arrange
@@ -475,8 +462,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task GetTrustResultAsync_RepositoryCountersignedPackage_AllowListWithRepositoryTarget_AndCounterPlacement_SuccessAsync()
         {
             // Arrange
@@ -524,8 +510,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task GetTrustResultAsync_RepositoryPrimarySignedPackage_PackageSignedWithCertFromAllowList_RequireMode_SuccessAsync()
         {
             var nupkg = new SimpleTestPackageContext();
@@ -569,8 +554,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task GetTrustResultAsync_RepositoryPrimarySignedPackage_PackageSignedWithCertNotFromAllowList_RequireMode_ErrorAsync()
         {
             var nupkg = new SimpleTestPackageContext();
@@ -621,8 +605,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task GetTrustResultAsync_RepositoryPrimarySignedPackage_PackageSignedWithCertFromAllowList_WithOwnerInOwnersList_RequireMode_SuccessAsync()
         {
             var nupkg = new SimpleTestPackageContext();
@@ -672,8 +655,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task GetTrustResultAsync_RepositoryPrimarySignedPackage_PackageSignedWithCertFromAllowList_WithOwnerNotInOwnersList_RequireMode_ErrorAsync()
         {
             var nupkg = new SimpleTestPackageContext();
@@ -724,8 +706,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task GetTrustResultAsync_RepositoryPrimarySignedPackage_PackageSignedWithCertFromAllowList_WithNoOwnersInPackage_RequireMode_ErrorAsync()
         {
             var nupkg = new SimpleTestPackageContext();
@@ -774,8 +755,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task GetTrustResultAsync_RepositoryCountersignedPackage_PackageSignedWithCertFromAllowList_WithOwnerInOwnersList_RequireMode_SuccessAsync()
         {
             var nupkg = new SimpleTestPackageContext();
@@ -827,8 +807,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task GetTrustResultAsync_RepositoryCountersignedPackage_PackageSignedWithCertFromAllowList_WithOwnerNotInOwnersList_RequireMode_ErrorAsync()
         {
             var nupkg = new SimpleTestPackageContext();
@@ -881,8 +860,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task GetTrustResultAsync_RepositoryCountersignedPackage_PackageSignedWithCertFromAllowList_WithOwnerNotInOwnersList_AuthorInList_RequireMode_SuccessAsync()
         {
             var nupkg = new SimpleTestPackageContext();
@@ -936,8 +914,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task GetTrustResultAsync_RepositoryCountersignedPackage_PackageSignedWithCertFromAllowList_WithNoOwnersInPackage_RequireMode_ErrorAsync()
         {
             var nupkg = new SimpleTestPackageContext();
@@ -988,8 +965,8 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+
+        [CIOnlyFact]
         public async Task GetTrustResultAsync_RepositoryPrimarySignedPackage_PackageSignedWithCertFromAllowList_WithEmptyOwnersList_RequireMode_SuccessAsync()
         {
             var nupkg = new SimpleTestPackageContext();
@@ -1039,8 +1016,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task GetTrustResultAsync_RepositoryPrimarySignedPackage_PackageSignedWithCertFromAllowList__WithNullOwnersList_RequireMode_SuccessAsync()
         {
             var nupkg = new SimpleTestPackageContext();

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/ClientPolicyTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/ClientPolicyTests.cs
@@ -29,11 +29,7 @@ namespace NuGet.Packaging.FuncTest
         public ClientPolicyTests(SigningTestFixture fixture)
         {
             _testFixture = fixture ?? throw new ArgumentNullException(nameof(fixture));
-            // https://github.com/NuGet/Home/issues/11321
-            if (!RuntimeEnvironmentHelper.IsMacOSX)
-            {
-                _trustedRepoTestCert = SigningTestUtility.GenerateTrustedTestCertificate();
-            }
+            _trustedRepoTestCert = SigningTestUtility.GenerateTrustedTestCertificate();
         }
 
         public void Dispose()
@@ -41,8 +37,7 @@ namespace NuGet.Packaging.FuncTest
             _trustedRepoTestCert.Dispose();
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformTheory(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyTheory]
         [InlineData(SigningTestType.Author, "accept", true, 0)]
         [InlineData(SigningTestType.Author, "require", false, 1)]
         [InlineData(SigningTestType.RepositoryPrimary, "accept", true, 0)]
@@ -97,8 +92,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformTheory(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyTheory]
         [InlineData(SigningTestType.Author, "accept", true, 0, 1)]
         [InlineData(SigningTestType.Author, "require", false, 1, 0)]
         [InlineData(SigningTestType.RepositoryPrimary, "accept", true, 0, 1)]
@@ -159,8 +153,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformTheory(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyTheory]
         [InlineData(SigningTestType.Author, SignaturePlacement.PrimarySignature, "accept")]
         [InlineData(SigningTestType.Author, SignaturePlacement.PrimarySignature, "require")]
         [InlineData(SigningTestType.RepositoryPrimary, SignaturePlacement.PrimarySignature, "accept")]
@@ -231,8 +224,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformTheory(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyTheory]
         [InlineData(SigningTestType.RepositoryPrimary, "accept")]
         [InlineData(SigningTestType.RepositoryPrimary, "require")]
         [InlineData(SigningTestType.RepositoryCountersigned, "accept")]
@@ -292,8 +284,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformTheory(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyTheory]
         [InlineData(SigningTestType.RepositoryPrimary, "accept", true, 0, 1)]
         [InlineData(SigningTestType.RepositoryPrimary, "require", false, 1, 0)]
         [InlineData(SigningTestType.RepositoryCountersigned, "accept", true, 0, 1)]
@@ -353,8 +344,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformTheory(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyTheory]
         [InlineData(SigningTestType.RepositoryPrimary, "accept", true, 0, 1)]
         [InlineData(SigningTestType.RepositoryPrimary, "require", false, 1, 0)]
         [InlineData(SigningTestType.RepositoryCountersigned, "accept", true, 0, 1)]

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/IntegrityVerificationProviderTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/IntegrityVerificationProviderTests.cs
@@ -37,11 +37,7 @@ namespace NuGet.Packaging.FuncTest
         public IntegrityVerificationProviderTests(SigningTestFixture fixture)
         {
             _testFixture = fixture ?? throw new ArgumentNullException(nameof(fixture));
-            // https://github.com/NuGet/Home/issues/11321
-            if (!RuntimeEnvironmentHelper.IsMacOSX)
-            {
-                _trustedTestCert = _testFixture.TrustedTestCertificate;
-            }
+            _trustedTestCert = _testFixture.TrustedTestCertificate;
             _trustProviders = new List<ISignatureVerificationProvider>()
             {
                 new IntegrityVerificationProvider()
@@ -63,8 +59,7 @@ namespace NuGet.Packaging.FuncTest
             return SignedPackageVerifierSettings.GetDefault(TestEnvironmentVariableReader.EmptyInstance);
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformTheory(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyTheory]
         [InlineData("command")]
         [InlineData("vs")]
         public async Task Signer_VerifyOnSignedPackageAsync(string policyString)
@@ -90,8 +85,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformTheory(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyTheory]
         [InlineData("command")]
         [InlineData("vs")]
         public async Task Signer_VerifyOnTamperedPackage_FileDeletedAsync(string policyString)
@@ -125,8 +119,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformTheory(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyTheory]
         [InlineData("command")]
         [InlineData("vs")]
         public async Task Signer_VerifyOnTamperedPackage_FileAddedAsync(string policyString)
@@ -171,8 +164,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformTheory(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyTheory]
         [InlineData("command")]
         [InlineData("vs")]
         public async Task Signer_VerifyOnTamperedPackage_FileAppendedAsync(string policyString)
@@ -216,8 +208,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformTheory(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyTheory]
         [InlineData("command")]
         [InlineData("vs")]
         public async Task Signer_VerifyOnTamperedPackage_FileTruncatedAsync(string policyString)
@@ -258,8 +249,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformTheory(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyTheory]
         [InlineData("command")]
         [InlineData("vs")]
         public async Task Signer_VerifyOnTamperedPackage_FileMetadataModifiedAsync(string policyString)
@@ -303,8 +293,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformTheory(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyTheory]
         [InlineData("command", false)]
         [InlineData("vs", true)]
         public async Task Signer_VerifyOnTamperedPackage_SignatureRemovedAsync(string policyString, bool expectedValidity)
@@ -348,8 +337,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformTheory(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyTheory]
         [InlineData("command", false)]
         [InlineData("vs", true)]
         public async Task Signer_VerifyOnTamperedPackage_SignatureTamperedAsync(string policyString, bool expectedValidity)

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/PackageSignatureVerifierTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/PackageSignatureVerifierTests.cs
@@ -59,20 +59,15 @@ namespace NuGet.Packaging.FuncTest
             public SignatureTrustAndValidityVerificationProviderTests(SigningTestFixture fixture)
             {
                 _testFixture = fixture ?? throw new ArgumentNullException(nameof(fixture));
-                // https://github.com/NuGet/Home/issues/11321
-                if (!RuntimeEnvironmentHelper.IsMacOSX)
-                {
-                    _trustedTestCert = _testFixture.TrustedTestCertificate;
-                    _untrustedTestCertificate = _testFixture.UntrustedTestCertificate;
-                }
+                _trustedTestCert = _testFixture.TrustedTestCertificate;
+                _untrustedTestCertificate = _testFixture.UntrustedTestCertificate;
                 _trustProviders = new List<ISignatureVerificationProvider>()
                 {
                     new SignatureTrustAndValidityVerificationProvider()
                 };
             }
 
-            // https://github.com/NuGet/Home/issues/11321
-            [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+            [CIOnlyFact]
             public async Task VerifySignaturesAsync_ValidCertificate_SuccessAsync()
             {
                 // Arrange
@@ -97,8 +92,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            // https://github.com/NuGet/Home/issues/11321
-            [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+            [CIOnlyFact]
             public async Task VerifySignaturesAsync_ValidCertificateAndTimestamp_SuccessAsync()
             {
                 // Arrange
@@ -128,8 +122,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            // https://github.com/NuGet/Home/issues/11321
-            [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+            [CIOnlyFact]
             public async Task VerifySignaturesAsync_ValidCertificateAndTimestampWithDifferentHashAlgorithms_SuccessAsync()
             {
                 var packageContext = new SimpleTestPackageContext();
@@ -157,8 +150,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            // https://github.com/NuGet/Home/issues/11321
-            [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+            [CIOnlyFact]
             public async Task VerifySignaturesAsync_ExpiredCertificateAndTimestamp_SuccessAsync()
             {
                 CertificateAuthority ca = await _testFixture.GetDefaultTrustedCertificateAuthorityAsync();
@@ -202,8 +194,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            // https://github.com/NuGet/Home/issues/11321
-            [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+            [CIOnlyFact]
             public async Task VerifySignaturesAsync_ExpiredCertificateAndTimestampWithTooLargeRange_FailsAsync()
             {
                 ISigningTestServer testServer = await _testFixture.GetSigningTestServerAsync();
@@ -257,8 +248,7 @@ namespace NuGet.Packaging.FuncTest
 
             // Verify a package meeting minimum signature requirements.
             // This signature is neither an author nor repository signature.
-            // https://github.com/NuGet/Home/issues/11321
-            [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+            [CIOnlyFact]
             public async Task VerifySignaturesAsync_WithBasicSignedCms_SucceedsAsync()
             {
                 var settings = new SignedPackageVerifierSettings(
@@ -307,8 +297,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            // https://github.com/NuGet/Home/issues/11321
-            [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+            [CIOnlyFact]
             public async Task VerifySignaturesAsync_SettingsRequireTimestamp_NoTimestamp_FailsAsync()
             {
                 // Arrange
@@ -349,8 +338,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            // https://github.com/NuGet/Home/issues/11321
-            [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+            [CIOnlyFact]
             public async Task VerifySignaturesAsync_SettingsNotRequireCheckCountersignature_WithValidPrimarySignatureAndInvalidCountersignature_SucceedsAsync()
             {
                 // Arrange
@@ -400,8 +388,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            // https://github.com/NuGet/Home/issues/11321
-            [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+            [CIOnlyFact]
             public async Task VerifySignaturesAsync_SettingsRequireCheckCountersignature_WithValidPrimarySignatureAndInvalidCountersignature_FailsAsync()
             {
                 // Arrange
@@ -451,8 +438,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            // https://github.com/NuGet/Home/issues/11321
-            [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+            [CIOnlyFact]
             public async Task VerifySignaturesAsync_SettingsRequireCheckCountersignature_WithValidPrimarySignatureAndValidCountersignature_SucceedsAsync()
             {
                 // Arrange
@@ -502,8 +488,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            // https://github.com/NuGet/Home/issues/11321
-            [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+            [CIOnlyFact]
             public async Task VerifySignaturesAsync_WithExpiredPrimarySignature_ValidCountersignature_AndPrimarySignatureValidAtCountersignTime_SucceedsAsync()
             {
                 // Arrange
@@ -556,8 +541,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            // https://github.com/NuGet/Home/issues/11321
-            [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+            [CIOnlyFact]
             public async Task VerifySignaturesAsync_WithExpiredAndUntrustedPrimarySignature_ValidCountersignature_AndPrimarySignatureValidAtCountersignTime_SucceedsAsync()
             {
                 var nupkg = new SimpleTestPackageContext();
@@ -605,8 +589,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            // https://github.com/NuGet/Home/issues/11321
-            [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+            [CIOnlyFact]
             public async Task VerifySignaturesAsync_WithExpiredPrimarySignature_ValidCountersignature_AndPrimarySignatureExpiredAtCountersignTime_FailsAsync()
             {
                 // Arrange
@@ -660,8 +643,8 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            // https://github.com/NuGet/Home/issues/11321
-            [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+
+            [CIOnlyFact]
             public async Task VerifySignaturesAsync_WithSignedAndCountersignedPackage_SucceedsAsync()
             {
                 // Arrange
@@ -700,8 +683,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            // https://github.com/NuGet/Home/issues/11321
-            [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+            [CIOnlyFact]
             public async Task VerifySignaturesAsync_WithSignedTimestampedCountersignedAndCountersignatureTimestampedPackage_SucceedsAsync()
             {
                 // Arrange
@@ -743,8 +725,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            // https://github.com/NuGet/Home/issues/11321
-            [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+            [CIOnlyFact]
             public async Task VerifySignaturesAsync_WithExpiredTimestamp_NotAllowIgnoreTimestamp_ShouldNotBeAnErrorAsync()
             {
                 using (var nupkgStream = new MemoryStream(GetResource("UntrustedTimestampPackage.nupkg")))
@@ -765,8 +746,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            // https://github.com/NuGet/Home/issues/11321
-            [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+            [CIOnlyFact]
             public async Task VerifySignaturesAsync_WithTimestampChainingToUntrustedRoot_NotAllowIgnoreTimestamp_FailAsync()
             {
                 using (var nupkgStream = new MemoryStream(GetResource("UntrustedTimestampPackage.nupkg")))

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/PrimarySignatureTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/PrimarySignatureTests.cs
@@ -33,17 +33,12 @@ namespace NuGet.Packaging.FuncTest
         public PrimarySignatureTests(SigningTestFixture fixture)
         {
             _testFixture = fixture ?? throw new ArgumentNullException(nameof(fixture));
-            // https://github.com/NuGet/Home/issues/11321
-            if (!RuntimeEnvironmentHelper.IsMacOSX)
-            {
-                _trustedTestCert = _testFixture.TrustedTestCertificate;
-                _trustProviders = _testFixture.TrustProviders;
-            }
+            _trustedTestCert = _testFixture.TrustedTestCertificate;
+            _trustProviders = _testFixture.TrustProviders;
             _signingSpecifications = _testFixture.SigningSpecifications;
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task Signature_HasTimestampAsync()
         {
             // Arrange
@@ -72,8 +67,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task Signature_HasNoTimestampAsync()
         {
             // Arrange
@@ -97,8 +91,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task Load_WithPrimarySignatureWithNoCertificates_ThrowsAsync()
         {
             var packageContext = new SimpleTestPackageContext();
@@ -146,8 +139,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task Load_WithReissuedSigningCertificate_ThrowsAsync()
         {
             var certificates = _testFixture.TrustedTestCertificateWithReissuedCertificate;

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/RepositoryCountersignatureTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/RepositoryCountersignatureTests.cs
@@ -43,8 +43,7 @@ namespace NuGet.Packaging.FuncTest
             Assert.Equal("primarySignature", exception.ParamName);
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [Fact]
         public async Task GetRepositoryCountersignature_WithNoCountersignatures_ReturnsNull()
         {
             using (var test = await Test.CreateWithoutRepositoryCountersignatureAsync(_fixture.TrustedTestCertificate.Source.Cert))
@@ -55,8 +54,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [Fact]
         public async Task GetRepositoryCountersignature_WithRepositoryCountersignature_ReturnsInstance()
         {
             using (var test = await Test.CreateAsync(_fixture.TrustedTestCertificate.Source.Cert))
@@ -74,8 +72,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [Fact]
         public async Task GetSignatureValue_WithSha256_ReturnsValue()
         {
             using (var test = await Test.CreateAsync(_fixture.TrustedTestCertificate.Source.Cert))

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignatureTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignatureTests.cs
@@ -37,8 +37,7 @@ namespace NuGet.Packaging.FuncTest
             _untrustedTestCertificate = _testFixture.UntrustedTestCertificate;
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task Verify_WithUntrustedSelfSignedCertificateAndNotAllowUntrusted_FailsAsync()
         {
             var settings = new SignatureVerifySettings(
@@ -64,8 +63,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task Verify_WithUntrustedSelfSignedCertificateAndAllowUntrusted_SucceedsAndWarnsAsync()
         {
             var settings = new SignatureVerifySettings(
@@ -90,8 +88,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task Verify_WithUntrustedSelfSignedCertificateAndAllowUntrustedAndNotReportUntrustedRoot_SucceedsAsync()
         {
             var settings = new SignatureVerifySettings(
@@ -116,8 +113,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task GetSigningCertificateFingerprint_WithUnsupportedHashAlgorithm_Throws()
         {
             using (var test = await VerifyTest.CreateAsync(settings: null, certificate: _untrustedTestCertificate.Cert))
@@ -127,8 +123,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task GetSigningCertificateFingerprint_SuccessfullyHashesMultipleAlgorithms()
         {
             using (var test = await VerifyTest.CreateAsync(settings: null, certificate: _untrustedTestCertificate.Cert))
@@ -147,8 +142,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [Fact]
         public async Task Timestamps_WithTwoAttributesAndOneValueEach_ReturnsTwoTimestamps()
         {
             var timestampService = await _testFixture.GetDefaultTrustedTimestampServiceAsync();
@@ -180,8 +174,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [Fact]
         public async Task Timestamps_WithOneAttributeAndTwoValues_ReturnsTwoTimestamps()
         {
             var timestampService = await _testFixture.GetDefaultTrustedTimestampServiceAsync();

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignatureTrustAndValidityVerificationProviderTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignatureTrustAndValidityVerificationProviderTests.cs
@@ -36,15 +36,10 @@ namespace NuGet.Packaging.FuncTest
         public SignatureTrustAndValidityVerificationProviderTests(SigningTestFixture fixture)
         {
             _testFixture = fixture ?? throw new ArgumentNullException(nameof(fixture));
-            // https://github.com/NuGet/Home/issues/11321
-            if (!RuntimeEnvironmentHelper.IsMacOSX)
-            {
-                _trustedTestCert = _testFixture.TrustedTestCertificate;
-            }
+            _trustedTestCert = _testFixture.TrustedTestCertificate;
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task GetTrustResultAsync_WithInvalidSignature_ThrowsAsync()
         {
             var package = new SimpleTestPackageContext();
@@ -79,8 +74,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task GetTrustResultAsync_SettingsRequireExactlyOneTimestamp_MultipleTimestamps_FailsAsync()
         {
             // Arrange
@@ -135,8 +129,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task GetTrustResultAsync_PrimarySignatureWithUntrustedRoot_EmptyAllowedUntrustedRootList_AllowUntrustedFalse_ErrorAsync()
         {
             var settings = new SignedPackageVerifierSettings(
@@ -171,8 +164,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task GetTrustResultAsync_RepositoryCountersignatureWithUntrustedRoot_EmptyAllowedUntrustedRootList_AllowUntrustedFalse_ErrorAsync()
         {
             var settings = new SignedPackageVerifierSettings(
@@ -209,8 +201,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task GetTrustResultAsync_PrimarySignatureWithUntrustedRoot_NotInAllowedUntrustedRootList_AllowUntrustedFalse_ErrorAsync()
         {
             var settings = new SignedPackageVerifierSettings(
@@ -246,8 +237,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task GetTrustResultAsync_RepositoryCountersignatureWithUntrustedRoot_NotInAllowedUntrustedRootList_AllowUntrustedFalse_ErrorAsync()
         {
             var settings = new SignedPackageVerifierSettings(
@@ -285,8 +275,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task GetTrustResultAsync_PrimarySignatureWithUntrustedRoot_InAllowedUntrustedRootList_AllowUntrustedFalse_SucceedsAsync()
         {
             var settings = new SignedPackageVerifierSettings(
@@ -324,8 +313,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task GetTrustResultAsync_RepositoryCountersignatureWithUntrustedRoot_InAllowedUntrustedRootList_AllowUntrustedFalse_SucceedsAsync()
         {
             var settings = new SignedPackageVerifierSettings(
@@ -523,8 +511,7 @@ namespace NuGet.Packaging.FuncTest
             SigningTestUtility.AssertRevocationStatusUnknown(matchingIssues, LogLevel.Information, NuGetLogCode.Undefined);
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task GetTrustResultAsync_WithTrustedButExpiredPrimaryAndTimestampCertificates_WithUnavailableRevocationInformationAndAllowUnknownRevocation_WarnsAsync()
         {
             List<SignatureLog> matchingIssues = await VerifyUnavailableRevocationInfoAsync(
@@ -546,8 +533,7 @@ namespace NuGet.Packaging.FuncTest
             SigningTestUtility.AssertRevocationStatusUnknown(matchingIssues, LogLevel.Warning, NuGetLogCode.NU3018);
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task GetTrustResultAsync_WithNoIgnoringTimestamp_TimestampWithGeneralizedTimeOutsideCertificateValidity_FailAsync()
         {
             var verificationProvider = new SignatureTrustAndValidityVerificationProvider();
@@ -592,8 +578,7 @@ namespace NuGet.Packaging.FuncTest
                 _provider = new SignatureTrustAndValidityVerificationProvider();
             }
 
-            // https://github.com/NuGet/Home/issues/11321
-            [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+            [CIOnlyFact]
             public async Task GetTrustResultAsync_WithRepositorySignedPackage_ReturnsUnknownAsync()
             {
                 var settings = new SignedPackageVerifierSettings(
@@ -621,8 +606,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            // https://github.com/NuGet/Home/issues/11321
-            [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+            [CIOnlyFact]
             public async Task GetTrustResultAsync_WithValidSignature_ReturnsValidAsync()
             {
                 var settings = new SignedPackageVerifierSettings(
@@ -652,8 +636,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            // https://github.com/NuGet/Home/issues/11321
-            [PlatformTheory(Platform.Windows, Platform.Linux, CIOnly = true)]
+            [CIOnlyTheory]
             [InlineData(true, SignatureVerificationStatus.Valid)]
             [InlineData(false, SignatureVerificationStatus.Disallowed)]
             public async Task GetTrustResultAsync_WithValidSignatureButNoTimestamp_ReturnsStatusAsync(
@@ -684,8 +667,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            // https://github.com/NuGet/Home/issues/11321
-            [PlatformTheory(Platform.Windows, Platform.Linux, CIOnly = true)]
+            [CIOnlyTheory]
             [InlineData(true, SignatureVerificationStatus.Valid)]
             [InlineData(false, SignatureVerificationStatus.Disallowed)]
             public async Task GetTrustResultAsync_WithUntrustedSignature_ReturnsStatusAsync(
@@ -806,8 +788,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            // https://github.com/NuGet/Home/issues/11321
-            [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+            [CIOnlyFact]
             public async Task GetTrustResultAsync_WithTamperedRepositoryPrimarySignedPackage_ReturnsValidAsync()
             {
                 var settings = new SignedPackageVerifierSettings(
@@ -865,8 +846,7 @@ namespace NuGet.Packaging.FuncTest
                 _provider = new SignatureTrustAndValidityVerificationProvider();
             }
 
-            // https://github.com/NuGet/Home/issues/11321
-            [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+            [CIOnlyFact]
             public async Task GetTrustResultAsync_WithAuthorSignedPackage_ReturnsUnknownAsync()
             {
                 var settings = new SignedPackageVerifierSettings(
@@ -894,8 +874,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            // https://github.com/NuGet/Home/issues/11321
-            [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+            [CIOnlyFact]
             public async Task GetTrustResultAsync_WithValidSignature_ReturnsValidAsync()
             {
                 var settings = new SignedPackageVerifierSettings(
@@ -925,8 +904,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            // https://github.com/NuGet/Home/issues/11321
-            [PlatformTheory(Platform.Windows, Platform.Linux, CIOnly = true)]
+            [CIOnlyTheory]
             [InlineData(true, SignatureVerificationStatus.Valid)]
             [InlineData(false, SignatureVerificationStatus.Disallowed)]
             public async Task GetTrustResultAsync_WithValidSignatureButNoTimestamp_ReturnsStatusAsync(
@@ -958,8 +936,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            // https://github.com/NuGet/Home/issues/11321
-            [PlatformTheory(Platform.Windows, Platform.Linux, CIOnly = true)]
+            [CIOnlyTheory]
             [InlineData(true, SignatureVerificationStatus.Valid)]
             [InlineData(false, SignatureVerificationStatus.Disallowed)]
             public async Task GetTrustResultAsync_WithUntrustedSignature_ReturnsStatusAsync(
@@ -1080,8 +1057,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            // https://github.com/NuGet/Home/issues/11321
-            [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+            [CIOnlyFact]
             public async Task GetTrustResultAsync_WithTamperedRepositoryPrimarySignedPackage_ReturnsValidAsync()
             {
                 var settings = new SignedPackageVerifierSettings(
@@ -1120,8 +1096,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            // https://github.com/NuGet/Home/issues/11321
-            [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+            [CIOnlyFact]
             public async Task GetTrustResultAsync_WithAlwaysVerifyCountersignatureBehavior_ReturnsDisallowedAsync()
             {
                 var settings = new SignedPackageVerifierSettings(
@@ -1160,8 +1135,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            // https://github.com/NuGet/Home/issues/11321
-            [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+            [CIOnlyFact]
             public async Task GetTrustResultAsync_WithExpiredSignature_ReturnsValidAsync()
             {
                 using (X509Certificate2 certificate = await GetExpiringCertificateAsync(_fixture))
@@ -1201,8 +1175,7 @@ namespace NuGet.Packaging.FuncTest
                 _provider = new SignatureTrustAndValidityVerificationProvider();
             }
 
-            // https://github.com/NuGet/Home/issues/11321
-            [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+            [CIOnlyFact]
             public async Task GetTrustResultAsync_WithAuthorSignedPackage_ReturnsUnknownAsync()
             {
                 var settings = new SignedPackageVerifierSettings(
@@ -1230,8 +1203,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            // https://github.com/NuGet/Home/issues/11321
-            [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+            [CIOnlyFact]
             public async Task GetTrustResultAsync_WithValidCountersignature_ReturnsValidAsync()
             {
                 var settings = new SignedPackageVerifierSettings(
@@ -1263,8 +1235,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            // https://github.com/NuGet/Home/issues/11321
-            [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+            [CIOnlyFact]
             public async Task GetTrustResultAsync_WithValidCountersignatureAndUntrustedPrimarySignature_ReturnsValidAsync()
             {
                 var settings = new SignedPackageVerifierSettings(
@@ -1296,8 +1267,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            // https://github.com/NuGet/Home/issues/11321
-            [PlatformTheory(Platform.Windows, Platform.Linux, CIOnly = true)]
+            [CIOnlyTheory]
             [InlineData(true, SignatureVerificationStatus.Valid)]
             [InlineData(false, SignatureVerificationStatus.Disallowed)]
             public async Task GetTrustResultAsync_WithValidCountersignatureButNoTimestamp_ReturnsStatusAsync(
@@ -1332,8 +1302,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            // https://github.com/NuGet/Home/issues/11321
-            [PlatformTheory(Platform.Windows, Platform.Linux, CIOnly = true)]
+            [CIOnlyTheory]
             [InlineData(true, SignatureVerificationStatus.Valid)]
             [InlineData(false, SignatureVerificationStatus.Disallowed)]
             public async Task GetTrustResultAsync_WithUntrustedCountersignature_ReturnsStatusAsync(
@@ -1461,8 +1430,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            // https://github.com/NuGet/Home/issues/11321
-            [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+            [CIOnlyFact]
             public async Task GetTrustResultAsync_WithTamperedRepositoryCountersignedPackage_ReturnsValidAsync()
             {
                 var settings = new SignedPackageVerifierSettings(
@@ -1503,8 +1471,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            // https://github.com/NuGet/Home/issues/11321
-            [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+            [CIOnlyFact]
             public async Task GetTrustResultAsync_WithExpiredPrimaryCertificateAndExpiredRepositoryCertificateAndValidTimestamps_ReturnsValidAsync()
             {
                 TimestampService timestampService = await _fixture.GetDefaultTrustedTimestampServiceAsync();
@@ -1530,8 +1497,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            // https://github.com/NuGet/Home/issues/11321
-            [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+            [CIOnlyFact]
             public async Task GetTrustResultAsync_WithExpiredRepositoryCertificateAndNoTimestamp_ReturnsValidAsync()
             {
                 TimestampService timestampService = await _fixture.GetDefaultTrustedTimestampServiceAsync();
@@ -1588,8 +1554,7 @@ namespace NuGet.Packaging.FuncTest
 
             // Case1: primary signature (trusted + non-expired) doesn't fall back to countersignature (trusted + non-expired).
             // The verification result is the primary signature status(valid).
-            // https://github.com/NuGet/Home/issues/11321
-            [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+            [CIOnlyFact]
             public async Task GetTrustResultAsync_WithGoodPrimarySignatureAndGoodCountersignature_NoFallbackAndReturnsValidAsync()
             {
                 using (Test test = await Test.CreateAuthorSignedRepositoryCountersignedPackageAsync(
@@ -1610,8 +1575,7 @@ namespace NuGet.Packaging.FuncTest
 
             // Case2: primary signature (trusted + non-expired) doesn't fall back to countersignature untrusted + non-expired).
             // The verification result is the primary signature status(valid).
-            // https://github.com/NuGet/Home/issues/11321
-            [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+            [CIOnlyFact]
             public async Task GetTrustResultAsync_WithGoodPrimarySignatureAndUntrustedCountersignature_NoFallbackAndReturnsValidAsync()
             {
                 using (Test test = await Test.CreateAuthorSignedRepositoryCountersignedPackageAsync(
@@ -1632,8 +1596,7 @@ namespace NuGet.Packaging.FuncTest
 
             // Case3: primary signature (untrusted + non-expired) falls back to countersignature (trusted + non-expired).
             // The verification result is the severe one of fallback status(valid) and the countersignature status(valid), so it's valid.
-            // https://github.com/NuGet/Home/issues/11321
-            [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+            [CIOnlyFact]
             public async Task GetTrustResultAsync_WithUntrustedPrimarySignatureAndGoodCountersignature_FallbackAndReturnsValidAsync()
             {
                 using (Test test = await Test.CreateAuthorSignedRepositoryCountersignedPackageAsync(
@@ -1654,8 +1617,7 @@ namespace NuGet.Packaging.FuncTest
 
             // Case4: primary signature (untrusted + non-expired) falls back to countersignature (untrusted + non-expired).
             // The verification result is the severe one of fallback status(disallowed) and the countersignature status(disallowed), so it's disallowed.
-            // https://github.com/NuGet/Home/issues/11321
-            [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+            [CIOnlyFact]
             public async Task GetTrustResultAsync_WithUntrustedPrimarySignatureAndUntrustedCountersignature_FallbackAndReturnsDisallowedAsync()
             {
                 using (Test test = await Test.CreateAuthorSignedRepositoryCountersignedPackageAsync(
@@ -1677,8 +1639,7 @@ namespace NuGet.Packaging.FuncTest
             // Case5: primary signature (trusted + expired) falls back to countersignature (trusted + non-expired).
             // And the timestamp on countersignature could fullfill the role of a trust anchor for primary signature.
             // The verification result is the severe one of fallback status(valid) and the countersignature status(valid), so it's valid.
-            // https://github.com/NuGet/Home/issues/11321
-            [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+            [CIOnlyFact]
             public async Task GetTrustResultAsync_WithExpiredPrimarySignatureAndGoodCountersignatureWithTimestamp_FallbackAndReturnsValidAsync()
             {
                 TimestampService timestampService = await _fixture.GetDefaultTrustedTimestampServiceAsync();
@@ -1705,8 +1666,7 @@ namespace NuGet.Packaging.FuncTest
 
             // Case6: primary signature (trusted + expired) falls back to countersignature (untrusted + non-expired).
             // The verification result is the severe one of fallback status(disallowed) and the countersignature status(disallowed), so it's disallowed.
-            // https://github.com/NuGet/Home/issues/11321
-            [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+            [CIOnlyFact]
             public async Task GetTrustResultAsync_WithExpiredPrimarySignatureAndUntrustedCountersignatureWithTimestamp_FallbackAndReturnsDisallowedAsync()
             {
                 TimestampService timestampService = await _fixture.GetDefaultTrustedTimestampServiceAsync();
@@ -1734,8 +1694,7 @@ namespace NuGet.Packaging.FuncTest
             // Case7: primary signature (trusted + expired) falls back to countersignature (trusted + non-expired).
             // But the timestamp on countersignature could NOT fullfill the role of a trust anchor for primary signature.
             // The verification result is the severe one of fallback status(disallowed) and the countersignature status(valid), so it's disallowed.
-            // https://github.com/NuGet/Home/issues/11321
-            [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+            [CIOnlyFact]
             public async Task GetTrustResultAsync_WithExpiredPrimarySignatureAndGoodCountersignatureWithNoTimestamp_FallbackAndReturnsDisallowedAsync()
             {
                 using (X509Certificate2 authorSigningCertificate = await GetExpiringCertificateAsync(_fixture))
@@ -1759,8 +1718,7 @@ namespace NuGet.Packaging.FuncTest
             // Case8: primary signature (trusted + expired) falls back to countersignature (trusted + expired but protected by a timestamp).
             // And the timestamp on countersignature could fullfill the role of a trust anchor for primary signature.
             // The verification result is the severe one of fallback status(valid) and the countersignature status(valid), so it's valid.
-            // https://github.com/NuGet/Home/issues/11321
-            [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+            [CIOnlyFact]
             public async Task GetTrustResultAsync_WithExpiredPrimarySignatureAndExpiredCountersignatureWithTimestamp_FallbackAndReturnsValidAsync()
             {
                 TimestampService timestampService = await _fixture.GetDefaultTrustedTimestampServiceAsync();
@@ -1790,8 +1748,7 @@ namespace NuGet.Packaging.FuncTest
             // Case9: primary signature (untrusted + expired) falls back to countersignature (trusted + non-expired).
             // But the timestamp on countersignature could NOT fullfill the role of a trust anchor for primary signature.
             // The verification result is the severe one of fallback status(disallowed) and the countersignature status(valid), so it's disallowed.
-            // https://github.com/NuGet/Home/issues/11321
-            [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+            [CIOnlyFact]
             public async Task GetTrustResultAsync_WithUntrustedExpiredPrimarySignatureAndGoodCountersignatureWithNoTimestamp_FallbackAndReturnsDisallowedAsync()
             {
                 using (X509Certificate2 authorSigningCertificate = _fixture.CreateUntrustedTestCertificateThatWillExpireSoon().Cert)
@@ -1815,8 +1772,7 @@ namespace NuGet.Packaging.FuncTest
             // Case10: primary signature (untrusted + expired) falls back to countersignature (trusted + non-expired).
             // And the timestamp on countersignature could fullfill the role of a trust anchor for primary signature.
             // The verification result is the severe one of fallback status(valid) and the countersignature status(valid), so it's valid.
-            // https://github.com/NuGet/Home/issues/11321
-            [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+            [CIOnlyFact]
             public async Task GetTrustResultAsync_WithUntrustedExpiredPrimarySignatureAndGoodCountersignatureWithTimestamp_FallbackAndReturnsValidAsync()
             {
                 TimestampService timestampService = await _fixture.GetDefaultTrustedTimestampServiceAsync();

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignatureUtilityTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignatureUtilityTests.cs
@@ -29,8 +29,7 @@ namespace NuGet.Packaging.FuncTest.SigningTests
         }
 
 #if IS_DESKTOP
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [Fact]
         public async Task GetTimestampCertificateChain_WithNoSigningCertificateUsage_Throws()
         {
             ISigningTestServer testServer = await _fixture.GetSigningTestServerAsync();
@@ -70,8 +69,7 @@ namespace NuGet.Packaging.FuncTest.SigningTests
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformTheory(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [Theory]
         [InlineData(SigningCertificateUsage.V1)]
         public async Task GetTimestampCertificateChain_WithShortEssCertIdCertificateHash_Throws(
             SigningCertificateUsage signingCertificateUsage)
@@ -114,8 +112,7 @@ namespace NuGet.Packaging.FuncTest.SigningTests
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformTheory(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [Theory]
         [InlineData(SigningCertificateUsage.V1)]
         public async Task GetTimestampCertificateChain_WithMismatchedEssCertIdCertificateHash_ReturnsChain(
             SigningCertificateUsage signingCertificateUsage)
@@ -171,8 +168,7 @@ namespace NuGet.Packaging.FuncTest.SigningTests
         }
 #endif
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformTheory(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [Theory]
         [InlineData(SigningCertificateUsage.V1)]
         [InlineData(SigningCertificateUsage.V2)]
         [InlineData(SigningCertificateUsage.V1 | SigningCertificateUsage.V2)]

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignedPackageArchiveTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignedPackageArchiveTests.cs
@@ -30,8 +30,7 @@ namespace NuGet.Packaging.FuncTest
             _fixture = fixture;
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task RemoveSignatureAsync_RemovesPackageSignatureAsync()
         {
             using (var test = await Test.CreateAsync(_fixture))
@@ -44,8 +43,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task RemoveSignatureAsync_WithCancelledToken_ThrowsAsync()
         {
             using (var test = await Test.CreateAsync(_fixture))
@@ -55,8 +53,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task RemoveSignatureAsync_WithUnsignedPackage_ThrowsAsync()
         {
             using (var test = await Test.CreateUnsignedAsync())

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignedPackageIntegrityVerificationTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignedPackageIntegrityVerificationTests.cs
@@ -38,11 +38,7 @@ namespace NuGet.Packaging.FuncTest
         public SignedPackageIntegrityVerificationTests(SigningTestFixture fixture)
         {
             _testFixture = fixture ?? throw new ArgumentNullException(nameof(fixture));
-            // https://github.com/NuGet/Home/issues/11321
-            if (!RuntimeEnvironmentHelper.IsMacOSX)
-            {
-                _trustedTestCert = _testFixture.TrustedTestCertificate;
-            }
+            _trustedTestCert = _testFixture.TrustedTestCertificate;
             _trustProviders = new List<ISignatureVerificationProvider>()
             {
                 new IntegrityVerificationProvider()
@@ -63,8 +59,7 @@ namespace NuGet.Packaging.FuncTest
                 revocationMode: RevocationMode.Online);
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task VerifyOnShiftedSignaturePackage_WhenCentralDirectoryIsLastAndFileHeaderIsLastAsync()
         {
             // Arrange
@@ -98,8 +93,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task VerifyOnShiftedSignaturePackage_WhenCentralDirectoryIsFirstAndFileHeaderIsFirstAsync()
         {
             // Arrange
@@ -126,8 +120,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task VerifyOnShiftedSignaturePackage_WhenCentralDirectoryIsLastAndFileHeaderIsFirstAsync()
         {
             // Arrange
@@ -161,8 +154,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task VerifyOnShiftedSignaturePackage_WhenCentralDirectoryIsFirstAndFileHeaderIsLastAsync()
         {
             // Arrange
@@ -196,8 +188,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task VerifyOnShiftedSignaturePackage_WhenCentralDirectoryIsMiddleAndFileHeaderIsMiddleAsync()
         {
             // Arrange
@@ -232,8 +223,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task VerifyOnInvalidSignatureFileEntry_SignatureIsCreatedUsingZipArchiveAsync()
         {
             // Arrange
@@ -272,8 +262,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task VerifyOnInvalidSignatureFileEntry_SignatureIsCreatedUsingZipArchiveAssertExceptionAsync()
         {
             // Arrange
@@ -300,8 +289,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task VerifyOnInvalidSignatureFileEntry_SignatureIsCreatedUsingZipArchiveAndCompressedAsync()
         {
             // Arrange
@@ -340,8 +328,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task VerifyOnInvalidSignatureFileEntry_SignatureIsCreatedUsingZipArchiveAndCompressedAssertExceptionAsync()
         {
             // Arrange
@@ -368,8 +355,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task VerifyOnInvalidSignatureFileEntry_SignatureCentralDirectoryHeaderHasInvalidExternalFileAttributesAsync()
         {
             var nupkg = new SimpleTestPackageContext();
@@ -398,8 +384,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task VerifyOnInvalidSignatureFileEntry_SignatureCentralDirectoryHeaderHasInvalidGeneralPurposeFlagBitsAsync()
         {
             // Arrange
@@ -443,8 +428,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task VerifyOnInvalidSignatureFileEntry_SignatureCentralDirectoryHeaderHasInvalidGeneralPurposeFlagBitsAssertExceptionAsync()
         {
             // Arrange
@@ -476,8 +460,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task VerifyOnInvalidSignatureFileEntry_SignatureCentralDirectoryHeaderHasInvalidCompressionMethodAsync()
         {
             // Arrange
@@ -509,8 +492,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task VerifyOnInvalidSignatureFileEntry_SignatureCentralDirectoryHeaderHasInvalidCompressedSizeAsync()
         {
             // Arrange
@@ -554,8 +536,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task VerifyOnInvalidSignatureFileEntry_SignatureCentralDirectoryHeaderHasInvalidCompressedSizeAssertExceptionAsync()
         {
             // Arrange
@@ -587,8 +568,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task VerifyOnInvalidSignatureFileEntry_SignatureCentralDirectoryHeaderHasInvalidUncompressedSizeAsync()
         {
             // Arrange
@@ -632,8 +612,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task VerifyOnInvalidSignatureFileEntry_SignatureCentralDirectoryHeaderHasInvalidUncompressedSizeAssertExceptionAsync()
         {
             // Arrange
@@ -665,8 +644,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task VerifyOnInvalidSignatureFileEntry_SignatureLocalFileHeaderHasInvalidGeneralPurposeFlagBitsAsync()
         {
             // Arrange
@@ -710,8 +688,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task VerifyOnInvalidSignatureFileEntry_SignatureLocalFileHeaderHasInvalidGeneralPurposeFlagBitsAssertExceptionAsync()
         {
             // Arrange
@@ -743,8 +720,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task VerifyOnInvalidSignatureFileEntry_SignatureLocalFileHeaderHasInvalidCompressionMethodAsync()
         {
             // Arrange
@@ -788,8 +764,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task VerifyOnInvalidSignatureFileEntry_SignatureLocalFileHeaderHasInvalidCompressionMethodAssertExceptionAsync()
         {
             // Arrange
@@ -821,8 +796,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task VerifyOnInvalidSignatureFileEntry_SignatureLocalFileHeaderHasInvalidCompressedSizeAsync()
         {
             // Arrange
@@ -866,8 +840,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task VerifyOnInvalidSignatureFileEntry_SignatureLocalFileHeaderHasInvalidCompressedSizeAssertExceptionAsync()
         {
             // Arrange
@@ -899,8 +872,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task VerifyOnInvalidSignatureFileEntry_SignatureLocalFileHeaderHasInvalidUncompressedSizeAsync()
         {
             // Arrange
@@ -947,8 +919,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task VerifyOnInvalidSignatureFileEntry_SignatureLocalFileHeaderHasInvalidUncompressedSizeAssertExceptionAsync()
         {
             // Arrange
@@ -979,8 +950,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task VerifyPackageContentHash_SignedPackagesAsync()
         {
             // Arrange
@@ -1014,8 +984,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task ReadSignedArchiveMetadata_InvalidSignatureFileEntry_IgnoreVerifySignatureEntry()
         {
             // Arrange

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SigningUtilityTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SigningUtilityTests.cs
@@ -27,8 +27,7 @@ namespace NuGet.Packaging.FuncTest
             _testFixture = fixture ?? throw new ArgumentNullException(nameof(fixture));
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public void Verify_WithValidInput_DoesNotThrow()
         {
             using (var certificate = new X509Certificate2(_testFixture.TrustedTestCertificate.Source.PublicCert.RawData))
@@ -38,8 +37,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task SignAsync_AddsPackageAuthorSignatureAsync()
         {
             using (var test = await Test.CreateAsync(_testFixture.TrustedTestCertificate.Source.Cert))
@@ -55,8 +53,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task SignAsync_AddsPackageRepositorySignatureAsync()
         {
             using (var test = await Test.CreateAsync(_testFixture.TrustedTestCertificate.Source.Cert))
@@ -72,8 +69,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task SignAsync_WhenRepositoryCountersigningPrimarySignature_SucceedsAsync()
         {
             using (var test = await Test.CreateAsync(_testFixture.TrustedTestCertificate.Source.Cert))
@@ -102,8 +98,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task SignAsync_WithExpiredCertificate_ThrowsAsync()
         {
             using (var test = await Test.CreateAsync(_testFixture.TrustedTestCertificateExpired.Source.Cert))
@@ -121,8 +116,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task SignAsync_WithNotYetValidCertificate_ThrowsAsync()
         {
             using (var test = await Test.CreateAsync(_testFixture.TrustedTestCertificateNotYetValid.Source.Cert))
@@ -140,8 +134,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task SignAsync_WhenRepositoryCountersigningRepositorySignedPackage_ThrowsAsync()
         {
             using (var test = await Test.CreateAsync(_testFixture.TrustedTestCertificate.Source.Cert))
@@ -171,8 +164,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task SignAsync_WhenRepositoryCountersigningRepositoryCountersignedPackage_ThrowsAsync()
         {
             using (var test = await Test.CreateAsync(_testFixture.TrustedTestCertificate.Source.Cert))

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/TimestampProviderTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/TimestampProviderTests.cs
@@ -32,15 +32,10 @@ namespace NuGet.Packaging.FuncTest
         public TimestampProviderTests(SigningTestFixture fixture)
         {
             _testFixture = fixture ?? throw new ArgumentNullException(nameof(fixture));
-            // https://github.com/NuGet/Home/issues/11321
-            if (!RuntimeEnvironmentHelper.IsMacOSX)
-            {
-                _trustedTestCert = _testFixture.TrustedTestCertificate;
-            }
+            _trustedTestCert = _testFixture.TrustedTestCertificate;
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task GetTimestampAsync_WithValidInput_ReturnsTimestampAsync()
         {
             var logger = new TestLogger();
@@ -73,8 +68,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task GetTimestampAsync_AssertCompleteChain_SuccessAsync()
         {
             var timestampService = await _testFixture.GetDefaultTrustedTimestampServiceAsync();
@@ -133,8 +127,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task GetTimestampAsync_WhenRequestNull_ThrowsAsync()
         {
             var logger = new TestLogger();
@@ -172,8 +165,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task GetTimestampAsync_WhenLoggerNull_ThrowsAsync()
         {
             var timestampService = await _testFixture.GetDefaultTrustedTimestampServiceAsync();
@@ -204,8 +196,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task GetTimestampAsync_WhenCancelled_ThrowsAsync()
         {
             var logger = new TestLogger();
@@ -236,8 +227,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task GetTimestampAsync_WhenRevocationInformationUnavailable_SuccessAsync()
         {
             var testServer = await _testFixture.GetSigningTestServerAsync();
@@ -267,8 +257,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task GetTimestampAsync_WhenTimestampSigningCertificateRevoked_ThrowsAsync()
         {
             var testServer = await _testFixture.GetSigningTestServerAsync();
@@ -292,8 +281,7 @@ namespace NuGet.Packaging.FuncTest
                 });
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task GetTimestampAsync_WithFailureReponse_ThrowsAsync()
         {
             var testServer = await _testFixture.GetSigningTestServerAsync();
@@ -315,8 +303,7 @@ namespace NuGet.Packaging.FuncTest
                 });
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task GetTimestampAsync_WhenSigningCertificateNotReturned_ThrowsAsync()
         {
             var testServer = await _testFixture.GetSigningTestServerAsync();
@@ -336,8 +323,7 @@ namespace NuGet.Packaging.FuncTest
                 });
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task GetTimestampAsync_WhenSignatureHashAlgorithmIsSha1_ThrowsAsync()
         {
             var testServer = await _testFixture.GetSigningTestServerAsync();
@@ -359,8 +345,7 @@ namespace NuGet.Packaging.FuncTest
                 });
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task GetTimestampAsync_WhenCertificateSignatureAlgorithmIsSha1_ThrowsAsync()
         {
             var testServer = await _testFixture.GetSigningTestServerAsync();
@@ -385,8 +370,7 @@ namespace NuGet.Packaging.FuncTest
                 });
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task GetTimestampAsync_TimestampGeneralizedTimeOutsideCertificateValidityPeriod_FailAsync()
         {
             // Arrange
@@ -416,8 +400,7 @@ namespace NuGet.Packaging.FuncTest
                 });
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task TimestampSignatureAsync_TimestampingPrimarySignature_SuccedsAsync()
         {
             var logger = new TestLogger();
@@ -465,8 +448,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task TimestampSignatureAsync_TimestampingCountersignature_SucceedsAsync()
         {
             var logger = new TestLogger();

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/TimestampTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/TimestampTests.cs
@@ -28,8 +28,7 @@ namespace NuGet.Packaging.FuncTest
             _trustedTestCert = _testFixture.TrustedTestCertificate;
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task Timestamp_Verify_WithOfflineRevocation_ReturnsCorrectFlagsAndLogsAsync()
         {
             var nupkg = new SimpleTestPackageContext();

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/TrustedSignerActionsProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/TrustedSignerActionsProviderTests.cs
@@ -332,8 +332,7 @@ namespace NuGet.Commands.Test
             ex.Message.Should().Be(Strings.Error_PackageNotSigned);
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task AddTrustedSignerAsync_TargetRepository_NonRepositorySignedPackage_ThrowsAsync()
         {
             // Arrange
@@ -365,8 +364,7 @@ namespace NuGet.Commands.Test
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task AddTrustedSignerAsync_NameAlreadyExists_ThrowsAsync()
         {
             // Arrange
@@ -405,8 +403,7 @@ namespace NuGet.Commands.Test
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task AddTrustedSignerAsync_ServiceIndexAlreadyExists_ThrowsAsync()
         {
             // Arrange
@@ -446,8 +443,7 @@ namespace NuGet.Commands.Test
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task AddTrustedSignerAsync_WithUnknownPrimarySignature_ThrowsAsync()
         {
             // Arrange
@@ -495,8 +491,7 @@ namespace NuGet.Commands.Test
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task AddTrustedSignerAsync_RepositorySignedPackage_AddsRepositoryCorrectlyAsync()
         {
             // Arrange
@@ -541,8 +536,7 @@ namespace NuGet.Commands.Test
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task AddTrustedSignerAsync_RepositorySignedPackage_WithOwners_AddsRepositoryCorrectlyAsync()
         {
             // Arrange
@@ -588,8 +582,7 @@ namespace NuGet.Commands.Test
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task AddTrustedSignerAsync_RepositorySignedPackage_WithAllowUntrustedRoot_AddsRepositoryCorrectlyAsync()
         {
             // Arrange
@@ -635,8 +628,7 @@ namespace NuGet.Commands.Test
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task AddTrustedSignerAsync_RepositoryCountersignedPackage_AddsRepositoryCorrectlyAsync()
         {
             // Arrange
@@ -683,8 +675,7 @@ namespace NuGet.Commands.Test
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task AddTrustedSignerAsync_RepositoryCountersignedPackage_WithOwners_AddsRepositoryCorrectlyAsync()
         {
             // Arrange
@@ -732,8 +723,7 @@ namespace NuGet.Commands.Test
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task AddTrustedSignerAsync_RepositoryCountersignedPackage_WithAllowUntrustedRoot_AddsRepositoryCorrectlyAsync()
         {
             // Arrange
@@ -781,8 +771,7 @@ namespace NuGet.Commands.Test
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task AddTrustedSignerAsync_AuthorSignedPackage_AddsAuthorCorrectlyAsync()
         {
             // Arrange
@@ -824,8 +813,7 @@ namespace NuGet.Commands.Test
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task AddTrustedSignerAsync_AuthorSignedPackage_WithAllowUntrustedRoot_AddsAuthorCorrectlyAsync()
         {
             // Arrange

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageArchiveReaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageArchiveReaderTests.cs
@@ -1843,8 +1843,7 @@ namespace NuGet.Packaging.Test
         }
 
 #if IS_SIGNING_SUPPORTED
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task GetContentHash_IsSameForUnsignedAndSignedPackageAsync()
         {
             // this test will create an unsigned package, copy it, then sign it. then compare the contentHash

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageExtractorTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageExtractorTests.cs
@@ -2048,8 +2048,7 @@ namespace NuGet.Packaging.Test
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Linux)]
+        [PlatformFact(Platform.Linux, Platform.Darwin)]
         public async Task ExtractPackageAsync_RequireMode_EmptyRepoAllowList_SuccessAsync()
         {
             using (var dir = TestDirectory.Create())
@@ -2153,8 +2152,7 @@ namespace NuGet.Packaging.Test
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Linux)]
+        [PlatformFact(Platform.Linux, Platform.Darwin)]
         public async Task ExtractPackageAsync_RequireMode_NoMatchInClientAllowList_SuccessAsync()
         {
             using (var dir = TestDirectory.Create())
@@ -2196,8 +2194,7 @@ namespace NuGet.Packaging.Test
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyFact]
         public async Task ExtractPackageAsync_RequireMode_NoMatchInClientAllowList_OptInEnvVar_Error()
         {
             // Arrange
@@ -2260,8 +2257,7 @@ namespace NuGet.Packaging.Test
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformTheory(Platform.Windows, Platform.Linux, CIOnly = true)]
+        [CIOnlyTheory]
         [MemberData(nameof(KnownClientPolicyModesList))]
         public async Task ExtractPackageAsync_RepositoryPrimarySignedPackage_PackageSignedWithCertFromRepositoryAllowList_SuccessAsync(SignatureValidationMode clientPolicyMode)
         {
@@ -2304,8 +2300,7 @@ namespace NuGet.Packaging.Test
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11321
-        [PlatformTheory(Platform.Linux)]
+        [PlatformTheory(Platform.Linux, Platform.Darwin)]
         [MemberData(nameof(KnownClientPoliciesList))]
         public async Task GetTrustResultAsync_RepositoryPrimarySignedPackage_PackageSignedWithCertNotFromRepositoryAllowList_SuccessAsync(ClientPolicyContext clientPolicy)
         {

--- a/test/TestUtilities/Test.Utility/PlatformXunitAttributes/PlatformTheoryAttribute.cs
+++ b/test/TestUtilities/Test.Utility/PlatformXunitAttributes/PlatformTheoryAttribute.cs
@@ -29,6 +29,14 @@ namespace NuGet.Test.Utility
                     skip = XunitAttributeUtility.GetMonoMessage(OnlyOnMono, SkipMono);
                 }
 
+                if (string.IsNullOrEmpty(skip))
+                {
+                    if (CIOnly && !XunitAttributeUtility.IsCI)
+                    {
+                        skip = "This test only runs on the CI. To run it locally set the env var CI=true";
+                    }
+                }
+
                 // If this is null the test will run.
                 return skip;
             }
@@ -50,6 +58,8 @@ namespace NuGet.Test.Utility
         public bool OnlyOnMono { get; set; }
 
         public bool SkipMono { get; set; }
+
+        public bool CIOnly { get; set; }
 
         /// <summary>
         /// Provide property values to use this attribute.

--- a/test/TestUtilities/Test.Utility/PlatformXunitAttributes/PlatformTheoryAttribute.cs
+++ b/test/TestUtilities/Test.Utility/PlatformXunitAttributes/PlatformTheoryAttribute.cs
@@ -29,14 +29,6 @@ namespace NuGet.Test.Utility
                     skip = XunitAttributeUtility.GetMonoMessage(OnlyOnMono, SkipMono);
                 }
 
-                if (string.IsNullOrEmpty(skip))
-                {
-                    if (CIOnly && !XunitAttributeUtility.IsCI)
-                    {
-                        skip = "This test only runs on the CI. To run it locally set the env var CI=true";
-                    }
-                }
-
                 // If this is null the test will run.
                 return skip;
             }
@@ -58,8 +50,6 @@ namespace NuGet.Test.Utility
         public bool OnlyOnMono { get; set; }
 
         public bool SkipMono { get; set; }
-
-        public bool CIOnly { get; set; }
 
         /// <summary>
         /// Provide property values to use this attribute.


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11321

Regression? Last working version:

## Description
MAC [incident ](https://portal.microsofticm.com/imp/v3/incidents/details/267776895/home) is resolved. Previously we skipped MAC tests in-order unblock process. We can re-enable them now. It's revert of https://github.com/NuGet/NuGet.Client/commit/48aa1cb1a7a4a87a6e3fae0424b96abd101a762c. But I kept changes in `test/TestUtilities/Test.Utility/PlatformXunitAttributes/PlatformTheoryAttribute.cs`, it could be useful next time.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
