### PR TITLE
Fixing install button tooltip for package item in PM UI

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageItemControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageItemControl.xaml
@@ -359,8 +359,6 @@
                       Grid.Column="2"
                       Command="{x:Static nuget:Commands.InstallPackageCommand}"
                       CommandParameter="{Binding}"
-                      ToolTip="{Binding InstalledVersionToolTip}"
-                      AutomationProperties.Name="{Binding InstalledVersionToolTip}"
                       FocusVisualStyle="{DynamicResource ControlsFocusVisualStyle}">
           <Button.Style>
             <Style TargetType="Button" BasedOn="{StaticResource buttonStyle}">
@@ -388,6 +386,20 @@
               </Style.Triggers>
             </Style>
           </Button.Style>
+          <Button.ToolTip>
+            <MultiBinding Converter="{StaticResource StringFormatConverter}">
+              <Binding Source="{x:Static nuget:Resources.ToolTip_InstallButton}" />
+              <Binding Path="Id" />
+              <Binding Path="LatestVersion" Converter="{StaticResource VersionToStringConverter}" />
+            </MultiBinding>
+          </Button.ToolTip>
+          <AutomationProperties.Name>
+            <MultiBinding Converter="{StaticResource StringFormatConverter}">
+              <Binding Source="{x:Static nuget:Resources.ToolTip_InstallButton}" />
+              <Binding Path="Id" />
+              <Binding Path="LatestVersion" Converter="{StaticResource VersionToStringConverter}" />
+            </MultiBinding>
+          </AutomationProperties.Name>
           <imaging:CrispImage Cursor="Hand" Moniker="{x:Static nuget:PackageIconMonikers.DownloadIndicator}" />
         </Button>
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11189

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

There is no tooltip for the install package in `PackageItemControl`, this is because we were using a bad property to show in the ToolTip and this property `InstalledVersionToolTip` is `null` in the Browse Tab. I used a ToolTip already defined but not used in the project and decided to show the Latest Version, that is the one being installed.

### Before
![image](https://user-images.githubusercontent.com/43253759/144687197-f364c959-0777-4c32-85d2-b71a11ae5fd0.png)

### After
![image](https://user-images.githubusercontent.com/43253759/144687261-5ae8b1ff-ad0c-4e93-9cdc-490ef3abe813.png)
![image](https://user-images.githubusercontent.com/43253759/144687284-0c2cb8a0-e431-4101-acca-60faa1e44043.png)

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [ ] N/A
