### PR TITLE
Add HTTPS package source feed counter for Restore

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/SourceTelemetry.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/SourceTelemetry.cs
@@ -65,7 +65,8 @@ namespace NuGet.PackageManagement.Telemetry
             var nugetOrg = HttpStyle.NotPresent;
             var vsOfflinePackages = false;
             var dotnetCuratedFeed = false;
-            var numHttpsFeeds = 0;
+            var httpsV2 = 0;
+            var httpsV3 = 0;
 
             if (packageSources != null)
             {
@@ -76,15 +77,15 @@ namespace NuGet.PackageManagement.Telemetry
                     {
                         if (source.IsHttp)
                         {
-                            if (source.IsHttps)
-                            {
-                                numHttpsFeeds++;
-                            }
-
                             if (TelemetryUtility.IsHttpV3(source))
                             {
                                 // Http V3 feed
                                 httpV3++;
+
+                                if (source.IsHttps)
+                                {
+                                    httpsV3++;
+                                }
 
                                 if (TelemetryUtility.IsNuGetOrg(source.Source))
                                 {
@@ -95,6 +96,11 @@ namespace NuGet.PackageManagement.Telemetry
                             {
                                 // Http V2 feed
                                 httpV2++;
+
+                                if (source.IsHttps)
+                                {
+                                    httpsV2++;
+                                }
 
                                 if (TelemetryUtility.IsNuGetOrg(source.Source))
                                 {
@@ -135,13 +141,14 @@ namespace NuGet.PackageManagement.Telemetry
                 vsOfflinePackages,
                 dotnetCuratedFeed,
                 protocolDiagnosticTotals,
-                numHttpsFeeds);
+                httpsV2,
+                httpsV3);
         }
 
         /// <summary>
         /// NumLocalFeeds(c:\ or \\ or file:///)
-        /// NumHTTPv2Feeds
-        /// NumHTTPv3Feeds
+        /// NumHTTPv2Feeds (includes HTTP and HTTPS)
+        /// NumHTTPv3Feeds (includes HTTP and HTTPS)
         /// NuGetOrg: [NotPresent | YesV2 | YesV3]
         /// VsOfflinePackages: [true | false]
         /// DotnetCuratedFeed: [true | false]
@@ -149,7 +156,8 @@ namespace NuGet.PackageManagement.Telemetry
         /// protocol.requests
         /// protocol.bytes
         /// protocol.duration
-        /// NumHttpsFeeds
+        /// NumHTTPSv2Feeds
+        /// NumHTTPSv3Feeds
         /// </summary>
         private class SourceSummaryTelemetryEvent : TelemetryEvent
         {
@@ -163,12 +171,15 @@ namespace NuGet.PackageManagement.Telemetry
                 bool vsOfflinePackages,
                 bool dotnetCuratedFeed,
                 PackageSourceTelemetry.Totals protocolDiagnosticTotals,
-                int numHttpsFeeds)
+                int httpsV2,
+                int httpsV3)
                 : base(eventName)
             {
                 this["NumLocalFeeds"] = local;
                 this["NumHTTPv2Feeds"] = httpV2;
                 this["NumHTTPv3Feeds"] = httpV3;
+                this["NumHTTPSv2Feeds"] = httpsV2;
+                this["NumHTTPSv3Feeds"] = httpsV3;
                 this["NuGetOrg"] = nugetOrg;
                 this["VsOfflinePackages"] = vsOfflinePackages;
                 this["DotnetCuratedFeed"] = dotnetCuratedFeed;
@@ -176,7 +187,6 @@ namespace NuGet.PackageManagement.Telemetry
                 this["protocol.requests"] = protocolDiagnosticTotals.Requests;
                 this["protocol.bytes"] = protocolDiagnosticTotals.Bytes;
                 this["protocol.duration"] = protocolDiagnosticTotals.Duration.TotalMilliseconds;
-                this["NumV2HTTPSFeeds"] = numHttpsFeeds;
             }
         }
     }

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/SourceTelemetry.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/SourceTelemetry.cs
@@ -65,7 +65,7 @@ namespace NuGet.PackageManagement.Telemetry
             var nugetOrg = HttpStyle.NotPresent;
             var vsOfflinePackages = false;
             var dotnetCuratedFeed = false;
-            bool? isHttps = null;
+            var numHttpsFeeds = 0;
 
             if (packageSources != null)
             {
@@ -76,13 +76,9 @@ namespace NuGet.PackageManagement.Telemetry
                     {
                         if (source.IsHttp)
                         {
-                            if (!isHttps.HasValue)
+                            if (source.IsHttps)
                             {
-                                isHttps = source.IsHttps;
-                            }
-                            else
-                            {
-                                isHttps = isHttps.Value && source.IsHttps;
+                                numHttpsFeeds++;
                             }
 
                             if (TelemetryUtility.IsHttpV3(source))
@@ -139,7 +135,7 @@ namespace NuGet.PackageManagement.Telemetry
                 vsOfflinePackages,
                 dotnetCuratedFeed,
                 protocolDiagnosticTotals,
-                isHttps: isHttps ?? false);
+                numHttpsFeeds);
         }
 
         /// <summary>
@@ -153,7 +149,7 @@ namespace NuGet.PackageManagement.Telemetry
         /// protocol.requests
         /// protocol.bytes
         /// protocol.duration
-        /// IsHttps [true | false]
+        /// NumHttpsFeeds
         /// </summary>
         private class SourceSummaryTelemetryEvent : TelemetryEvent
         {
@@ -167,7 +163,7 @@ namespace NuGet.PackageManagement.Telemetry
                 bool vsOfflinePackages,
                 bool dotnetCuratedFeed,
                 PackageSourceTelemetry.Totals protocolDiagnosticTotals,
-                bool isHttps)
+                int numHttpsFeeds)
                 : base(eventName)
             {
                 this["NumLocalFeeds"] = local;
@@ -180,7 +176,7 @@ namespace NuGet.PackageManagement.Telemetry
                 this["protocol.requests"] = protocolDiagnosticTotals.Requests;
                 this["protocol.bytes"] = protocolDiagnosticTotals.Bytes;
                 this["protocol.duration"] = protocolDiagnosticTotals.Duration.TotalMilliseconds;
-                this["IsHttps"] = isHttps;
+                this["NumHTTPSFeeds"] = numHttpsFeeds;
             }
         }
     }

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/SourceTelemetry.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/SourceTelemetry.cs
@@ -65,6 +65,7 @@ namespace NuGet.PackageManagement.Telemetry
             var nugetOrg = HttpStyle.NotPresent;
             var vsOfflinePackages = false;
             var dotnetCuratedFeed = false;
+            bool? isHttps = null;
 
             if (packageSources != null)
             {
@@ -75,6 +76,15 @@ namespace NuGet.PackageManagement.Telemetry
                     {
                         if (source.IsHttp)
                         {
+                            if (!isHttps.HasValue)
+                            {
+                                isHttps = source.IsHttps;
+                            }
+                            else
+                            {
+                                isHttps = isHttps.Value && source.IsHttps;
+                            }
+
                             if (TelemetryUtility.IsHttpV3(source))
                             {
                                 // Http V3 feed
@@ -128,15 +138,23 @@ namespace NuGet.PackageManagement.Telemetry
                 nugetOrg.ToString(),
                 vsOfflinePackages,
                 dotnetCuratedFeed,
-                protocolDiagnosticTotals);
+                protocolDiagnosticTotals,
+                isHttps: isHttps ?? false);
         }
 
-        // NumLocalFeeds(c:\ or \\ or file:///)
-        // NumHTTPv2Feeds
-        // NumHTTPv3Feeds
-        // NuGetOrg: [NotPresent | YesV2 | YesV3]
-        // VsOfflinePackages: [true | false]
-        // DotnetCuratedFeed: [true | false]
+        /// <summary>
+        /// NumLocalFeeds(c:\ or \\ or file:///)
+        /// NumHTTPv2Feeds
+        /// NumHTTPv3Feeds
+        /// NuGetOrg: [NotPresent | YesV2 | YesV3]
+        /// VsOfflinePackages: [true | false]
+        /// DotnetCuratedFeed: [true | false]
+        /// ParentId
+        /// protocol.requests
+        /// protocol.bytes
+        /// protocol.duration
+        /// IsHttps [true | false]
+        /// </summary>
         private class SourceSummaryTelemetryEvent : TelemetryEvent
         {
             public SourceSummaryTelemetryEvent(
@@ -148,7 +166,8 @@ namespace NuGet.PackageManagement.Telemetry
                 string nugetOrg,
                 bool vsOfflinePackages,
                 bool dotnetCuratedFeed,
-                PackageSourceTelemetry.Totals protocolDiagnosticTotals)
+                PackageSourceTelemetry.Totals protocolDiagnosticTotals,
+                bool isHttps)
                 : base(eventName)
             {
                 this["NumLocalFeeds"] = local;
@@ -161,6 +180,7 @@ namespace NuGet.PackageManagement.Telemetry
                 this["protocol.requests"] = protocolDiagnosticTotals.Requests;
                 this["protocol.bytes"] = protocolDiagnosticTotals.Bytes;
                 this["protocol.duration"] = protocolDiagnosticTotals.Duration.TotalMilliseconds;
+                this["IsHttps"] = isHttps;
             }
         }
     }

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/SourceTelemetry.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/SourceTelemetry.cs
@@ -176,7 +176,7 @@ namespace NuGet.PackageManagement.Telemetry
                 this["protocol.requests"] = protocolDiagnosticTotals.Requests;
                 this["protocol.bytes"] = protocolDiagnosticTotals.Bytes;
                 this["protocol.duration"] = protocolDiagnosticTotals.Duration.TotalMilliseconds;
-                this["NumHTTPSFeeds"] = numHttpsFeeds;
+                this["NumV2HTTPSFeeds"] = numHttpsFeeds;
             }
         }
     }

--- a/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSource.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSource.cs
@@ -18,7 +18,9 @@ namespace NuGet.Configuration
         public const int DefaultProtocolVersion = 2;
 
         private readonly int _hashCode;
+
         private bool? _isHttp;
+        private bool? _isHttps;
         private bool? _isLocal;
 
         public string Name { get; private set; }
@@ -60,6 +62,9 @@ namespace NuGet.Configuration
         /// </summary>
         public int ProtocolVersion { get; set; } = DefaultProtocolVersion;
 
+        /// <summary>
+        /// Whether the source is using the HTTP protocol, including HTTPS.
+        /// </summary>
         public bool IsHttp
         {
             get
@@ -71,6 +76,22 @@ namespace NuGet.Configuration
                 }
 
                 return _isHttp.Value;
+            }
+        }
+
+        /// <summary>
+        /// Whether the source is using the HTTPS protocol.
+        /// </summary>
+        public bool IsHttps
+        {
+            get
+            {
+                if (!_isHttps.HasValue)
+                {
+                    _isHttps = Source.StartsWith("https://", StringComparison.OrdinalIgnoreCase);
+                }
+
+                return _isHttps.Value;
             }
         }
 

--- a/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSource.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSource.cs
@@ -71,8 +71,7 @@ namespace NuGet.Configuration
             {
                 if (!_isHttp.HasValue)
                 {
-                    _isHttp = Source.StartsWith("http://", StringComparison.OrdinalIgnoreCase) ||
-                              Source.StartsWith("https://", StringComparison.OrdinalIgnoreCase);
+                    _isHttp = IsHttps || Source.StartsWith("http://", StringComparison.OrdinalIgnoreCase);
                 }
 
                 return _isHttp.Value;
@@ -89,6 +88,10 @@ namespace NuGet.Configuration
                 if (!_isHttps.HasValue)
                 {
                     _isHttps = Source.StartsWith("https://", StringComparison.OrdinalIgnoreCase);
+                    if (_isHttps == true)
+                    {
+                        _isHttp = true;
+                    }
                 }
 
                 return _isHttps.Value;

--- a/src/NuGet.Core/NuGet.Configuration/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Configuration/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+NuGet.Configuration.PackageSource.IsHttps.get -> bool

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/SourceTelemetryTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/SourceTelemetryTests.cs
@@ -30,7 +30,8 @@ namespace NuGet.SolutionRestoreManager.Test
         private const string ProtocolRequests = "protocol.requests";
         private const string ProtocolBytes = "protocol.bytes";
         private const string ProtocolDuration = "protocol.duration";
-        private const string NumHTTPSFeeds = "NumHTTPSFeeds";
+        private const string NumV2HTTPSFeeds = "NumV2HTTPSFeeds";
+        private const string NumV3HTTPSFeeds = "NumV3HTTPSFeeds";
 
         private static readonly Guid Parent = Guid.Parse("33411664-388A-4C48-A607-A2C554171FCE");
         private static readonly PackageSourceTelemetry.Totals ProtocolDiagnosticTotals = new PackageSourceTelemetry.Totals(1, 2, TimeSpan.FromMilliseconds(3));
@@ -64,7 +65,8 @@ namespace NuGet.SolutionRestoreManager.Test
             summaryInts[NumLocalFeeds].Should().Be(0);
             summaryInts[NumHTTPv2Feeds].Should().Be(0);
             summaryInts[NumHTTPv3Feeds].Should().Be(0);
-            summaryInts[NumHTTPSFeeds].Should().Be(0);
+            summaryInts[NumV2HTTPSFeeds].Should().Be(0);
+            summaryInts[NumV3HTTPSFeeds].Should().Be(0);
             summaryStrings[ParentId].Should().Be(Parent.ToString());
             summaryStrings[NuGetOrg].Should().Be(NotPresent);
             summaryBools[VsOfflinePackages].Should().Be(false);
@@ -91,7 +93,8 @@ namespace NuGet.SolutionRestoreManager.Test
             summaryInts[NumLocalFeeds].Should().Be(0);
             summaryInts[NumHTTPv2Feeds].Should().Be(1);
             summaryInts[NumHTTPv3Feeds].Should().Be(0);
-            summaryInts[NumHTTPSFeeds].Should().Be(1);
+            summaryInts[NumV2HTTPSFeeds].Should().Be(1);
+            summaryInts[NumV3HTTPSFeeds].Should().Be(0);
             summaryStrings[ParentId].Should().Be(Parent.ToString());
             summaryStrings[NuGetOrg].Should().Be(NotPresent);
             summaryBools[VsOfflinePackages].Should().Be(false);
@@ -119,7 +122,8 @@ namespace NuGet.SolutionRestoreManager.Test
             summaryInts[NumLocalFeeds].Should().Be(2);
             summaryInts[NumHTTPv2Feeds].Should().Be(0);
             summaryInts[NumHTTPv3Feeds].Should().Be(0);
-            summaryInts[NumHTTPSFeeds].Should().Be(0);
+            summaryInts[NumV2HTTPSFeeds].Should().Be(0);
+            summaryInts[NumV3HTTPSFeeds].Should().Be(0);
             summaryStrings[ParentId].Should().Be(Parent.ToString());
             summaryStrings[NuGetOrg].Should().Be(NotPresent);
             summaryBools[VsOfflinePackages].Should().Be(true);
@@ -142,7 +146,8 @@ namespace NuGet.SolutionRestoreManager.Test
             summaryInts[NumLocalFeeds].Should().Be(0);
             summaryInts[NumHTTPv2Feeds].Should().Be(1);
             summaryInts[NumHTTPv3Feeds].Should().Be(0);
-            summaryInts[NumHTTPSFeeds].Should().Be(1);
+            summaryInts[NumV2HTTPSFeeds].Should().Be(1);
+            summaryInts[NumV3HTTPSFeeds].Should().Be(0);
             summaryStrings[ParentId].Should().Be(Parent.ToString());
             summaryStrings[NuGetOrg].Should().Be(YesV2);
             summaryBools[VsOfflinePackages].Should().Be(false);
@@ -165,7 +170,8 @@ namespace NuGet.SolutionRestoreManager.Test
             summaryInts[NumLocalFeeds].Should().Be(0);
             summaryInts[NumHTTPv2Feeds].Should().Be(1);
             summaryInts[NumHTTPv3Feeds].Should().Be(0);
-            summaryInts[NumHTTPSFeeds].Should().Be(1);
+            summaryInts[NumV2HTTPSFeeds].Should().Be(1);
+            summaryInts[NumV3HTTPSFeeds].Should().Be(0);
             summaryStrings[ParentId].Should().Be(Parent.ToString());
             summaryStrings[NuGetOrg].Should().Be(YesV2);
             summaryBools[VsOfflinePackages].Should().Be(false);
@@ -188,7 +194,8 @@ namespace NuGet.SolutionRestoreManager.Test
             summaryInts[NumLocalFeeds].Should().Be(0);
             summaryInts[NumHTTPv2Feeds].Should().Be(0);
             summaryInts[NumHTTPv3Feeds].Should().Be(1);
-            summaryInts[NumHTTPSFeeds].Should().Be(1);
+            summaryInts[NumV2HTTPSFeeds].Should().Be(0);
+            summaryInts[NumV3HTTPSFeeds].Should().Be(1);
             summaryStrings[ParentId].Should().Be(Parent.ToString());
             summaryStrings[NuGetOrg].Should().Be(YesV3);
             summaryBools[VsOfflinePackages].Should().Be(false);
@@ -211,7 +218,8 @@ namespace NuGet.SolutionRestoreManager.Test
             summaryInts[NumLocalFeeds].Should().Be(0);
             summaryInts[NumHTTPv2Feeds].Should().Be(0);
             summaryInts[NumHTTPv3Feeds].Should().Be(1);
-            summaryInts[NumHTTPSFeeds].Should().Be(1);
+            summaryInts[NumV2HTTPSFeeds].Should().Be(0);
+            summaryInts[NumV3HTTPSFeeds].Should().Be(1);
             summaryStrings[ParentId].Should().Be(Parent.ToString());
             summaryStrings[NuGetOrg].Should().Be(YesV3);
             summaryBools[VsOfflinePackages].Should().Be(false);
@@ -235,7 +243,8 @@ namespace NuGet.SolutionRestoreManager.Test
             summaryInts[NumLocalFeeds].Should().Be(0);
             summaryInts[NumHTTPv2Feeds].Should().Be(1);
             summaryInts[NumHTTPv3Feeds].Should().Be(1);
-            summaryInts[NumHTTPSFeeds].Should().Be(2);
+            summaryInts[NumV2HTTPSFeeds].Should().Be(1);
+            summaryInts[NumV3HTTPSFeeds].Should().Be(1);
             summaryStrings[ParentId].Should().Be(Parent.ToString());
             summaryStrings[NuGetOrg].Should().Be(YesV3AndV2);
             summaryBools[VsOfflinePackages].Should().Be(false);
@@ -259,7 +268,8 @@ namespace NuGet.SolutionRestoreManager.Test
             summaryInts[NumLocalFeeds].Should().Be(0);
             summaryInts[NumHTTPv2Feeds].Should().Be(1);
             summaryInts[NumHTTPv3Feeds].Should().Be(1);
-            summaryInts[NumHTTPSFeeds].Should().Be(2);
+            summaryInts[NumV2HTTPSFeeds].Should().Be(1);
+            summaryInts[NumV3HTTPSFeeds].Should().Be(1);
             summaryStrings[ParentId].Should().Be(Parent.ToString());
             summaryStrings[NuGetOrg].Should().Be(YesV3AndV2);
             summaryBools[VsOfflinePackages].Should().Be(false);
@@ -284,7 +294,8 @@ namespace NuGet.SolutionRestoreManager.Test
             summaryInts[NumLocalFeeds].Should().Be(1);
             summaryInts[NumHTTPv2Feeds].Should().Be(0);
             summaryInts[NumHTTPv3Feeds].Should().Be(0);
-            summaryInts[NumHTTPSFeeds].Should().Be(0);
+            summaryInts[NumV2HTTPSFeeds].Should().Be(0);
+            summaryInts[NumV3HTTPSFeeds].Should().Be(0);
             summaryStrings[ParentId].Should().Be(Parent.ToString());
             summaryStrings[NuGetOrg].Should().Be(NotPresent);
             summaryBools[VsOfflinePackages].Should().Be(false);
@@ -308,7 +319,8 @@ namespace NuGet.SolutionRestoreManager.Test
             summaryInts[NumLocalFeeds].Should().Be(0);
             summaryInts[NumHTTPv2Feeds].Should().Be(1);
             summaryInts[NumHTTPv3Feeds].Should().Be(1);
-            summaryInts[NumHTTPSFeeds].Should().Be(2);
+            summaryInts[NumV2HTTPSFeeds].Should().Be(1);
+            summaryInts[NumV3HTTPSFeeds].Should().Be(1);
             summaryStrings[ParentId].Should().Be(Parent.ToString());
             summaryStrings[NuGetOrg].Should().Be(NotPresent);
             summaryBools[VsOfflinePackages].Should().Be(false);
@@ -333,7 +345,8 @@ namespace NuGet.SolutionRestoreManager.Test
             summaryInts[NumLocalFeeds].Should().Be(3);
             summaryInts[NumHTTPv2Feeds].Should().Be(0);
             summaryInts[NumHTTPv3Feeds].Should().Be(0);
-            summaryInts[NumHTTPSFeeds].Should().Be(0);
+            summaryInts[NumV2HTTPSFeeds].Should().Be(0);
+            summaryInts[NumV3HTTPSFeeds].Should().Be(0);
             summaryStrings[ParentId].Should().Be(Parent.ToString());
             summaryStrings[NuGetOrg].Should().Be(NotPresent);
             summaryBools[VsOfflinePackages].Should().Be(false);
@@ -357,7 +370,8 @@ namespace NuGet.SolutionRestoreManager.Test
             summaryInts[NumLocalFeeds].Should().Be(2);
             summaryInts[NumHTTPv2Feeds].Should().Be(0);
             summaryInts[NumHTTPv3Feeds].Should().Be(0);
-            summaryInts[NumHTTPSFeeds].Should().Be(0);
+            summaryInts[NumV2HTTPSFeeds].Should().Be(0);
+            summaryInts[NumV3HTTPSFeeds].Should().Be(0);
             summaryStrings[ParentId].Should().Be(Parent.ToString());
             summaryStrings[NuGetOrg].Should().Be(NotPresent);
             summaryBools[VsOfflinePackages].Should().Be(false);
@@ -380,7 +394,8 @@ namespace NuGet.SolutionRestoreManager.Test
             summaryInts[NumLocalFeeds].Should().Be(0);
             summaryInts[NumHTTPv2Feeds].Should().Be(0);
             summaryInts[NumHTTPv3Feeds].Should().Be(1);
-            summaryInts[NumHTTPSFeeds].Should().Be(0);
+            summaryInts[NumV2HTTPSFeeds].Should().Be(0);
+            summaryInts[NumV3HTTPSFeeds].Should().Be(0);
             summaryStrings[ParentId].Should().Be(Parent.ToString());
             summaryStrings[NuGetOrg].Should().Be(NotPresent);
             summaryBools[VsOfflinePackages].Should().Be(false);
@@ -403,7 +418,8 @@ namespace NuGet.SolutionRestoreManager.Test
             summaryInts[NumLocalFeeds].Should().Be(0);
             summaryInts[NumHTTPv2Feeds].Should().Be(1);
             summaryInts[NumHTTPv3Feeds].Should().Be(0);
-            summaryInts[NumHTTPSFeeds].Should().Be(0);
+            summaryInts[NumV2HTTPSFeeds].Should().Be(0);
+            summaryInts[NumV3HTTPSFeeds].Should().Be(0);
             summaryStrings[ParentId].Should().Be(Parent.ToString());
             summaryStrings[NuGetOrg].Should().Be(NotPresent);
             summaryBools[VsOfflinePackages].Should().Be(false);
@@ -441,7 +457,8 @@ namespace NuGet.SolutionRestoreManager.Test
             summaryInts[NumLocalFeeds].Should().Be(1);
             summaryInts[NumHTTPv2Feeds].Should().Be(0);
             summaryInts[NumHTTPv3Feeds].Should().Be(3);
-            summaryInts[NumHTTPSFeeds].Should().Be(3);
+            summaryInts[NumV2HTTPSFeeds].Should().Be(0);
+            summaryInts[NumV3HTTPSFeeds].Should().Be(3);
             summaryStrings[ParentId].Should().Be(Parent.ToString());
         }
 
@@ -464,7 +481,8 @@ namespace NuGet.SolutionRestoreManager.Test
             summaryInts[NumLocalFeeds].Should().Be(1);
             summaryInts[NumHTTPv2Feeds].Should().Be(0);
             summaryInts[NumHTTPv3Feeds].Should().Be(3);
-            summaryInts[NumHTTPSFeeds].Should().Be(2);
+            summaryInts[NumV2HTTPSFeeds].Should().Be(0);
+            summaryInts[NumV3HTTPSFeeds].Should().Be(2);
             summaryStrings[ParentId].Should().Be(Parent.ToString());
         }
 

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/SourceTelemetryTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/SourceTelemetryTests.cs
@@ -438,7 +438,7 @@ namespace NuGet.SolutionRestoreManager.Test
         }
 
         [Fact]
-        public void LocalAndHttpSources_WithHTTPSv3Feeds_FeedCountsAreCorrect()
+        public void LocalAndHttpSources_WithHTTPSv2Feeds_FeedCountsAreCorrect()
         {
             var sources = new List<PackageSource>()
             {

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/SourceTelemetryTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/SourceTelemetryTests.cs
@@ -30,6 +30,7 @@ namespace NuGet.SolutionRestoreManager.Test
         private const string ProtocolRequests = "protocol.requests";
         private const string ProtocolBytes = "protocol.bytes";
         private const string ProtocolDuration = "protocol.duration";
+        private const string IsHttps = "IsHttps";
 
         private static readonly Guid Parent = Guid.Parse("33411664-388A-4C48-A607-A2C554171FCE");
         private static readonly PackageSourceTelemetry.Totals ProtocolDiagnosticTotals = new PackageSourceTelemetry.Totals(1, 2, TimeSpan.FromMilliseconds(3));
@@ -67,6 +68,7 @@ namespace NuGet.SolutionRestoreManager.Test
             summaryStrings[NuGetOrg].Should().Be(NotPresent);
             summaryBools[VsOfflinePackages].Should().Be(false);
             summaryBools[DotnetCuratedFeed].Should().Be(false);
+            summaryBools[IsHttps].Should().Be(false);
         }
 
         [Theory]
@@ -93,6 +95,7 @@ namespace NuGet.SolutionRestoreManager.Test
             summaryStrings[NuGetOrg].Should().Be(NotPresent);
             summaryBools[VsOfflinePackages].Should().Be(false);
             summaryBools[DotnetCuratedFeed].Should().Be(true);
+            summaryBools[IsHttps].Should().Be(true);
         }
 
         [PlatformTheory(Platform.Windows)]
@@ -120,6 +123,7 @@ namespace NuGet.SolutionRestoreManager.Test
             summaryStrings[NuGetOrg].Should().Be(NotPresent);
             summaryBools[VsOfflinePackages].Should().Be(true);
             summaryBools[DotnetCuratedFeed].Should().Be(false);
+            summaryBools[IsHttps].Should().Be(false);
         }
 
         [Fact]
@@ -142,6 +146,7 @@ namespace NuGet.SolutionRestoreManager.Test
             summaryStrings[NuGetOrg].Should().Be(YesV2);
             summaryBools[VsOfflinePackages].Should().Be(false);
             summaryBools[DotnetCuratedFeed].Should().Be(false);
+            summaryBools[IsHttps].Should().Be(true);
         }
 
         [Fact]
@@ -164,6 +169,7 @@ namespace NuGet.SolutionRestoreManager.Test
             summaryStrings[NuGetOrg].Should().Be(YesV2);
             summaryBools[VsOfflinePackages].Should().Be(false);
             summaryBools[DotnetCuratedFeed].Should().Be(false);
+            summaryBools[IsHttps].Should().Be(true);
         }
 
         [Fact]
@@ -186,6 +192,7 @@ namespace NuGet.SolutionRestoreManager.Test
             summaryStrings[NuGetOrg].Should().Be(YesV3);
             summaryBools[VsOfflinePackages].Should().Be(false);
             summaryBools[DotnetCuratedFeed].Should().Be(false);
+            summaryBools[IsHttps].Should().Be(true);
         }
 
         [Fact]
@@ -208,6 +215,7 @@ namespace NuGet.SolutionRestoreManager.Test
             summaryStrings[NuGetOrg].Should().Be(YesV3);
             summaryBools[VsOfflinePackages].Should().Be(false);
             summaryBools[DotnetCuratedFeed].Should().Be(false);
+            summaryBools[IsHttps].Should().Be(true);
         }
 
         [Fact]
@@ -231,6 +239,7 @@ namespace NuGet.SolutionRestoreManager.Test
             summaryStrings[NuGetOrg].Should().Be(YesV3AndV2);
             summaryBools[VsOfflinePackages].Should().Be(false);
             summaryBools[DotnetCuratedFeed].Should().Be(false);
+            summaryBools[IsHttps].Should().Be(true);
         }
 
         [Fact]
@@ -254,6 +263,7 @@ namespace NuGet.SolutionRestoreManager.Test
             summaryStrings[NuGetOrg].Should().Be(YesV3AndV2);
             summaryBools[VsOfflinePackages].Should().Be(false);
             summaryBools[DotnetCuratedFeed].Should().Be(false);
+            summaryBools[IsHttps].Should().Be(true);
         }
 
         [Fact]
@@ -278,6 +288,7 @@ namespace NuGet.SolutionRestoreManager.Test
             summaryStrings[NuGetOrg].Should().Be(NotPresent);
             summaryBools[VsOfflinePackages].Should().Be(false);
             summaryBools[DotnetCuratedFeed].Should().Be(false);
+            summaryBools[IsHttps].Should().Be(false);
         }
 
         [Fact]
@@ -301,6 +312,7 @@ namespace NuGet.SolutionRestoreManager.Test
             summaryStrings[NuGetOrg].Should().Be(NotPresent);
             summaryBools[VsOfflinePackages].Should().Be(false);
             summaryBools[DotnetCuratedFeed].Should().Be(false);
+            summaryBools[IsHttps].Should().Be(true);
         }
 
         [Fact]
@@ -325,6 +337,7 @@ namespace NuGet.SolutionRestoreManager.Test
             summaryStrings[NuGetOrg].Should().Be(NotPresent);
             summaryBools[VsOfflinePackages].Should().Be(false);
             summaryBools[DotnetCuratedFeed].Should().Be(false);
+            summaryBools[IsHttps].Should().Be(false);
         }
 
         [Fact]
@@ -348,6 +361,7 @@ namespace NuGet.SolutionRestoreManager.Test
             summaryStrings[NuGetOrg].Should().Be(NotPresent);
             summaryBools[VsOfflinePackages].Should().Be(false);
             summaryBools[DotnetCuratedFeed].Should().Be(false);
+            summaryBools[IsHttps].Should().Be(false);
         }
 
         [Fact]
@@ -370,6 +384,7 @@ namespace NuGet.SolutionRestoreManager.Test
             summaryStrings[NuGetOrg].Should().Be(NotPresent);
             summaryBools[VsOfflinePackages].Should().Be(false);
             summaryBools[DotnetCuratedFeed].Should().Be(false);
+            summaryBools[IsHttps].Should().Be(false);
         }
 
         [Fact]
@@ -392,6 +407,7 @@ namespace NuGet.SolutionRestoreManager.Test
             summaryStrings[NuGetOrg].Should().Be(NotPresent);
             summaryBools[VsOfflinePackages].Should().Be(false);
             summaryBools[DotnetCuratedFeed].Should().Be(false);
+            summaryBools[IsHttps].Should().Be(false);
         }
 
         [Fact]
@@ -403,6 +419,53 @@ namespace NuGet.SolutionRestoreManager.Test
             telemetry[ProtocolRequests].Should().Be(1);
             telemetry[ProtocolBytes].Should().Be(2L);
             telemetry[ProtocolDuration].Should().Be(3.0);
+        }
+
+
+        [Fact]
+        public void LocalAndHttpSources_WithAllHttps_IsHttpsIsTrue()
+        {
+            var sources = new List<PackageSource>()
+            {
+                new PackageSource(@"\\share\packages"),
+                new PackageSource("https://nugettest.org/v3/index.JSON"),
+                new PackageSource("https://tempuri.local/index.json"),
+                new PackageSource("https://nuget.org/v3/index.JSON")
+            };
+
+            var summary = SourceTelemetry.GetRestoreSourceSummaryEvent(Parent, sources, ProtocolDiagnosticTotals);
+            var summaryStrings = GetValuesAsStrings(summary);
+            var summaryInts = GetValuesAsInts(summary);
+            var summaryBools = GetValuesAsBools(summary);
+
+            summaryInts[NumLocalFeeds].Should().Be(1);
+            summaryInts[NumHTTPv2Feeds].Should().Be(0);
+            summaryInts[NumHTTPv3Feeds].Should().Be(3);
+            summaryStrings[ParentId].Should().Be(Parent.ToString());
+            summaryBools[IsHttps].Should().Be(true);
+        }
+
+        [Fact]
+        public void LocalAndHttpSources_WithAnyNonHttps_IsHttpsIsFalse()
+        {
+            var sources = new List<PackageSource>()
+            {
+                new PackageSource(@"\\share\packages"),
+                new PackageSource("https://nugettest.org/v3/index.JSON"),
+                new PackageSource("http://tempuri.local/index.json"),
+                new PackageSource("https://nuget.org/v3/index.JSON")
+            };
+
+            var summary = SourceTelemetry.GetRestoreSourceSummaryEvent(Parent, sources, ProtocolDiagnosticTotals);
+            var summaryStrings = GetValuesAsStrings(summary);
+            var summaryInts = GetValuesAsInts(summary);
+            var summaryBools = GetValuesAsBools(summary);
+
+            summaryInts[NumLocalFeeds].Should().Be(1);
+            summaryInts[NumHTTPv2Feeds].Should().Be(0);
+            summaryInts[NumHTTPv3Feeds].Should().Be(3);
+            summaryStrings[ParentId].Should().Be(Parent.ToString());
+            summaryBools[IsHttps].Should().Be(false);
         }
 
         private static Dictionary<string, string> GetValuesAsStrings(TelemetryEvent item)

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/SourceTelemetryTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/SourceTelemetryTests.cs
@@ -30,8 +30,8 @@ namespace NuGet.SolutionRestoreManager.Test
         private const string ProtocolRequests = "protocol.requests";
         private const string ProtocolBytes = "protocol.bytes";
         private const string ProtocolDuration = "protocol.duration";
-        private const string NumV2HTTPSFeeds = "NumV2HTTPSFeeds";
-        private const string NumV3HTTPSFeeds = "NumV3HTTPSFeeds";
+        private const string NumHTTPSv2Feeds = "NumHTTPSv2Feeds";
+        private const string NumHTTPSv3Feeds = "NumHTTPSv3Feeds";
 
         private static readonly Guid Parent = Guid.Parse("33411664-388A-4C48-A607-A2C554171FCE");
         private static readonly PackageSourceTelemetry.Totals ProtocolDiagnosticTotals = new PackageSourceTelemetry.Totals(1, 2, TimeSpan.FromMilliseconds(3));
@@ -65,8 +65,8 @@ namespace NuGet.SolutionRestoreManager.Test
             summaryInts[NumLocalFeeds].Should().Be(0);
             summaryInts[NumHTTPv2Feeds].Should().Be(0);
             summaryInts[NumHTTPv3Feeds].Should().Be(0);
-            summaryInts[NumV2HTTPSFeeds].Should().Be(0);
-            summaryInts[NumV3HTTPSFeeds].Should().Be(0);
+            summaryInts[NumHTTPSv2Feeds].Should().Be(0);
+            summaryInts[NumHTTPSv3Feeds].Should().Be(0);
             summaryStrings[ParentId].Should().Be(Parent.ToString());
             summaryStrings[NuGetOrg].Should().Be(NotPresent);
             summaryBools[VsOfflinePackages].Should().Be(false);
@@ -93,8 +93,8 @@ namespace NuGet.SolutionRestoreManager.Test
             summaryInts[NumLocalFeeds].Should().Be(0);
             summaryInts[NumHTTPv2Feeds].Should().Be(1);
             summaryInts[NumHTTPv3Feeds].Should().Be(0);
-            summaryInts[NumV2HTTPSFeeds].Should().Be(1);
-            summaryInts[NumV3HTTPSFeeds].Should().Be(0);
+            summaryInts[NumHTTPSv2Feeds].Should().Be(1);
+            summaryInts[NumHTTPSv3Feeds].Should().Be(0);
             summaryStrings[ParentId].Should().Be(Parent.ToString());
             summaryStrings[NuGetOrg].Should().Be(NotPresent);
             summaryBools[VsOfflinePackages].Should().Be(false);
@@ -122,8 +122,8 @@ namespace NuGet.SolutionRestoreManager.Test
             summaryInts[NumLocalFeeds].Should().Be(2);
             summaryInts[NumHTTPv2Feeds].Should().Be(0);
             summaryInts[NumHTTPv3Feeds].Should().Be(0);
-            summaryInts[NumV2HTTPSFeeds].Should().Be(0);
-            summaryInts[NumV3HTTPSFeeds].Should().Be(0);
+            summaryInts[NumHTTPSv2Feeds].Should().Be(0);
+            summaryInts[NumHTTPSv3Feeds].Should().Be(0);
             summaryStrings[ParentId].Should().Be(Parent.ToString());
             summaryStrings[NuGetOrg].Should().Be(NotPresent);
             summaryBools[VsOfflinePackages].Should().Be(true);
@@ -146,8 +146,8 @@ namespace NuGet.SolutionRestoreManager.Test
             summaryInts[NumLocalFeeds].Should().Be(0);
             summaryInts[NumHTTPv2Feeds].Should().Be(1);
             summaryInts[NumHTTPv3Feeds].Should().Be(0);
-            summaryInts[NumV2HTTPSFeeds].Should().Be(1);
-            summaryInts[NumV3HTTPSFeeds].Should().Be(0);
+            summaryInts[NumHTTPSv2Feeds].Should().Be(1);
+            summaryInts[NumHTTPSv3Feeds].Should().Be(0);
             summaryStrings[ParentId].Should().Be(Parent.ToString());
             summaryStrings[NuGetOrg].Should().Be(YesV2);
             summaryBools[VsOfflinePackages].Should().Be(false);
@@ -170,8 +170,8 @@ namespace NuGet.SolutionRestoreManager.Test
             summaryInts[NumLocalFeeds].Should().Be(0);
             summaryInts[NumHTTPv2Feeds].Should().Be(1);
             summaryInts[NumHTTPv3Feeds].Should().Be(0);
-            summaryInts[NumV2HTTPSFeeds].Should().Be(1);
-            summaryInts[NumV3HTTPSFeeds].Should().Be(0);
+            summaryInts[NumHTTPSv2Feeds].Should().Be(1);
+            summaryInts[NumHTTPSv3Feeds].Should().Be(0);
             summaryStrings[ParentId].Should().Be(Parent.ToString());
             summaryStrings[NuGetOrg].Should().Be(YesV2);
             summaryBools[VsOfflinePackages].Should().Be(false);
@@ -194,8 +194,8 @@ namespace NuGet.SolutionRestoreManager.Test
             summaryInts[NumLocalFeeds].Should().Be(0);
             summaryInts[NumHTTPv2Feeds].Should().Be(0);
             summaryInts[NumHTTPv3Feeds].Should().Be(1);
-            summaryInts[NumV2HTTPSFeeds].Should().Be(0);
-            summaryInts[NumV3HTTPSFeeds].Should().Be(1);
+            summaryInts[NumHTTPSv2Feeds].Should().Be(0);
+            summaryInts[NumHTTPSv3Feeds].Should().Be(1);
             summaryStrings[ParentId].Should().Be(Parent.ToString());
             summaryStrings[NuGetOrg].Should().Be(YesV3);
             summaryBools[VsOfflinePackages].Should().Be(false);
@@ -218,8 +218,8 @@ namespace NuGet.SolutionRestoreManager.Test
             summaryInts[NumLocalFeeds].Should().Be(0);
             summaryInts[NumHTTPv2Feeds].Should().Be(0);
             summaryInts[NumHTTPv3Feeds].Should().Be(1);
-            summaryInts[NumV2HTTPSFeeds].Should().Be(0);
-            summaryInts[NumV3HTTPSFeeds].Should().Be(1);
+            summaryInts[NumHTTPSv2Feeds].Should().Be(0);
+            summaryInts[NumHTTPSv3Feeds].Should().Be(1);
             summaryStrings[ParentId].Should().Be(Parent.ToString());
             summaryStrings[NuGetOrg].Should().Be(YesV3);
             summaryBools[VsOfflinePackages].Should().Be(false);
@@ -243,8 +243,8 @@ namespace NuGet.SolutionRestoreManager.Test
             summaryInts[NumLocalFeeds].Should().Be(0);
             summaryInts[NumHTTPv2Feeds].Should().Be(1);
             summaryInts[NumHTTPv3Feeds].Should().Be(1);
-            summaryInts[NumV2HTTPSFeeds].Should().Be(1);
-            summaryInts[NumV3HTTPSFeeds].Should().Be(1);
+            summaryInts[NumHTTPSv2Feeds].Should().Be(1);
+            summaryInts[NumHTTPSv3Feeds].Should().Be(1);
             summaryStrings[ParentId].Should().Be(Parent.ToString());
             summaryStrings[NuGetOrg].Should().Be(YesV3AndV2);
             summaryBools[VsOfflinePackages].Should().Be(false);
@@ -268,8 +268,8 @@ namespace NuGet.SolutionRestoreManager.Test
             summaryInts[NumLocalFeeds].Should().Be(0);
             summaryInts[NumHTTPv2Feeds].Should().Be(1);
             summaryInts[NumHTTPv3Feeds].Should().Be(1);
-            summaryInts[NumV2HTTPSFeeds].Should().Be(1);
-            summaryInts[NumV3HTTPSFeeds].Should().Be(1);
+            summaryInts[NumHTTPSv2Feeds].Should().Be(1);
+            summaryInts[NumHTTPSv3Feeds].Should().Be(1);
             summaryStrings[ParentId].Should().Be(Parent.ToString());
             summaryStrings[NuGetOrg].Should().Be(YesV3AndV2);
             summaryBools[VsOfflinePackages].Should().Be(false);
@@ -294,8 +294,8 @@ namespace NuGet.SolutionRestoreManager.Test
             summaryInts[NumLocalFeeds].Should().Be(1);
             summaryInts[NumHTTPv2Feeds].Should().Be(0);
             summaryInts[NumHTTPv3Feeds].Should().Be(0);
-            summaryInts[NumV2HTTPSFeeds].Should().Be(0);
-            summaryInts[NumV3HTTPSFeeds].Should().Be(0);
+            summaryInts[NumHTTPSv2Feeds].Should().Be(0);
+            summaryInts[NumHTTPSv3Feeds].Should().Be(0);
             summaryStrings[ParentId].Should().Be(Parent.ToString());
             summaryStrings[NuGetOrg].Should().Be(NotPresent);
             summaryBools[VsOfflinePackages].Should().Be(false);
@@ -319,8 +319,8 @@ namespace NuGet.SolutionRestoreManager.Test
             summaryInts[NumLocalFeeds].Should().Be(0);
             summaryInts[NumHTTPv2Feeds].Should().Be(1);
             summaryInts[NumHTTPv3Feeds].Should().Be(1);
-            summaryInts[NumV2HTTPSFeeds].Should().Be(1);
-            summaryInts[NumV3HTTPSFeeds].Should().Be(1);
+            summaryInts[NumHTTPSv2Feeds].Should().Be(1);
+            summaryInts[NumHTTPSv3Feeds].Should().Be(1);
             summaryStrings[ParentId].Should().Be(Parent.ToString());
             summaryStrings[NuGetOrg].Should().Be(NotPresent);
             summaryBools[VsOfflinePackages].Should().Be(false);
@@ -345,8 +345,8 @@ namespace NuGet.SolutionRestoreManager.Test
             summaryInts[NumLocalFeeds].Should().Be(3);
             summaryInts[NumHTTPv2Feeds].Should().Be(0);
             summaryInts[NumHTTPv3Feeds].Should().Be(0);
-            summaryInts[NumV2HTTPSFeeds].Should().Be(0);
-            summaryInts[NumV3HTTPSFeeds].Should().Be(0);
+            summaryInts[NumHTTPSv2Feeds].Should().Be(0);
+            summaryInts[NumHTTPSv3Feeds].Should().Be(0);
             summaryStrings[ParentId].Should().Be(Parent.ToString());
             summaryStrings[NuGetOrg].Should().Be(NotPresent);
             summaryBools[VsOfflinePackages].Should().Be(false);
@@ -370,8 +370,8 @@ namespace NuGet.SolutionRestoreManager.Test
             summaryInts[NumLocalFeeds].Should().Be(2);
             summaryInts[NumHTTPv2Feeds].Should().Be(0);
             summaryInts[NumHTTPv3Feeds].Should().Be(0);
-            summaryInts[NumV2HTTPSFeeds].Should().Be(0);
-            summaryInts[NumV3HTTPSFeeds].Should().Be(0);
+            summaryInts[NumHTTPSv2Feeds].Should().Be(0);
+            summaryInts[NumHTTPSv3Feeds].Should().Be(0);
             summaryStrings[ParentId].Should().Be(Parent.ToString());
             summaryStrings[NuGetOrg].Should().Be(NotPresent);
             summaryBools[VsOfflinePackages].Should().Be(false);
@@ -394,8 +394,8 @@ namespace NuGet.SolutionRestoreManager.Test
             summaryInts[NumLocalFeeds].Should().Be(0);
             summaryInts[NumHTTPv2Feeds].Should().Be(0);
             summaryInts[NumHTTPv3Feeds].Should().Be(1);
-            summaryInts[NumV2HTTPSFeeds].Should().Be(0);
-            summaryInts[NumV3HTTPSFeeds].Should().Be(0);
+            summaryInts[NumHTTPSv2Feeds].Should().Be(0);
+            summaryInts[NumHTTPSv3Feeds].Should().Be(0);
             summaryStrings[ParentId].Should().Be(Parent.ToString());
             summaryStrings[NuGetOrg].Should().Be(NotPresent);
             summaryBools[VsOfflinePackages].Should().Be(false);
@@ -418,8 +418,8 @@ namespace NuGet.SolutionRestoreManager.Test
             summaryInts[NumLocalFeeds].Should().Be(0);
             summaryInts[NumHTTPv2Feeds].Should().Be(1);
             summaryInts[NumHTTPv3Feeds].Should().Be(0);
-            summaryInts[NumV2HTTPSFeeds].Should().Be(0);
-            summaryInts[NumV3HTTPSFeeds].Should().Be(0);
+            summaryInts[NumHTTPSv2Feeds].Should().Be(0);
+            summaryInts[NumHTTPSv3Feeds].Should().Be(0);
             summaryStrings[ParentId].Should().Be(Parent.ToString());
             summaryStrings[NuGetOrg].Should().Be(NotPresent);
             summaryBools[VsOfflinePackages].Should().Be(false);
@@ -437,16 +437,17 @@ namespace NuGet.SolutionRestoreManager.Test
             telemetry[ProtocolDuration].Should().Be(3.0);
         }
 
-
         [Fact]
-        public void LocalAndHttpSources_WithAllHttps_IsHttpsIsTrue()
+        public void LocalAndHttpSources_WithHTTPSv3Feeds_FeedCountsAreCorrect()
         {
             var sources = new List<PackageSource>()
             {
                 new PackageSource(@"\\share\packages"),
-                new PackageSource("https://nugettest.org/v3/index.JSON"),
-                new PackageSource("https://tempuri.local/index.json"),
-                new PackageSource("https://nuget.org/v3/index.JSON")
+                new PackageSource("http://nugettest.org/v3/index.JSON"),
+                new PackageSource("http://www.nuget.org/api/v2/curated-feeds/microsoftdotnet"), //v2
+                new PackageSource("http://tempuri.local/index.json"),
+                new PackageSource("http://nuget.org/v3/index.JSON"),
+                new PackageSource("https://www.NuGet.org/api/v2/") //v2 and HTTPS
             };
 
             var summary = SourceTelemetry.GetRestoreSourceSummaryEvent(Parent, sources, ProtocolDiagnosticTotals);
@@ -454,16 +455,26 @@ namespace NuGet.SolutionRestoreManager.Test
             var summaryInts = GetValuesAsInts(summary);
             var summaryBools = GetValuesAsBools(summary);
 
-            summaryInts[NumLocalFeeds].Should().Be(1);
-            summaryInts[NumHTTPv2Feeds].Should().Be(0);
-            summaryInts[NumHTTPv3Feeds].Should().Be(3);
-            summaryInts[NumV2HTTPSFeeds].Should().Be(0);
-            summaryInts[NumV3HTTPSFeeds].Should().Be(3);
             summaryStrings[ParentId].Should().Be(Parent.ToString());
+
+            int? numLocalFeeds = summaryInts[NumLocalFeeds];
+            int? numHTTPv2Feeds = summaryInts[NumHTTPv2Feeds];
+            int? numHTTPv3Feeds = summaryInts[NumHTTPv3Feeds];
+            int? numHTTPSv2Feeds = summaryInts[NumHTTPSv2Feeds];
+            int? numHTTPSv3Feeds = summaryInts[NumHTTPSv3Feeds];
+
+            numLocalFeeds.Should().Be(1);
+            numHTTPv2Feeds.Should().Be(2);
+            numHTTPv3Feeds.Should().Be(3);
+            numHTTPSv2Feeds.Should().Be(1);
+            numHTTPSv3Feeds.Should().Be(0);
+
+            int? totalFeeds = numLocalFeeds + numHTTPv2Feeds + numHTTPv3Feeds;
+            totalFeeds.Should().Be(sources.Count);
         }
 
         [Fact]
-        public void LocalAndHttpSources_WithAnyNonHttps_IsHttpsIsFalse()
+        public void LocalAndHttpSources_WithHTTPSv3Feeds_FeedCountsAreCorrect()
         {
             var sources = new List<PackageSource>()
             {
@@ -473,17 +484,26 @@ namespace NuGet.SolutionRestoreManager.Test
                 new PackageSource("https://nuget.org/v3/index.JSON")
             };
 
-            var summary = SourceTelemetry.GetRestoreSourceSummaryEvent(Parent, sources, ProtocolDiagnosticTotals);
-            var summaryStrings = GetValuesAsStrings(summary);
-            var summaryInts = GetValuesAsInts(summary);
-            var summaryBools = GetValuesAsBools(summary);
+            TelemetryEvent summary = SourceTelemetry.GetRestoreSourceSummaryEvent(Parent, sources, ProtocolDiagnosticTotals);
+            Dictionary<string, string> summaryStrings = GetValuesAsStrings(summary);
+            Dictionary<string, int?> summaryInts = GetValuesAsInts(summary);
 
-            summaryInts[NumLocalFeeds].Should().Be(1);
-            summaryInts[NumHTTPv2Feeds].Should().Be(0);
-            summaryInts[NumHTTPv3Feeds].Should().Be(3);
-            summaryInts[NumV2HTTPSFeeds].Should().Be(0);
-            summaryInts[NumV3HTTPSFeeds].Should().Be(2);
             summaryStrings[ParentId].Should().Be(Parent.ToString());
+
+            int? numLocalFeeds = summaryInts[NumLocalFeeds];
+            int? numHTTPv2Feeds = summaryInts[NumHTTPv2Feeds];
+            int? numHTTPv3Feeds = summaryInts[NumHTTPv3Feeds];
+            int? numHTTPSv2Feeds = summaryInts[NumHTTPSv2Feeds];
+            int? numHTTPSv3Feeds = summaryInts[NumHTTPSv3Feeds];
+
+            numLocalFeeds.Should().Be(1);
+            numHTTPv2Feeds.Should().Be(0);
+            numHTTPv3Feeds.Should().Be(3);
+            numHTTPSv2Feeds.Should().Be(0);
+            numHTTPSv3Feeds.Should().Be(2);
+
+            int? totalFeeds = numLocalFeeds + numHTTPv2Feeds + numHTTPv3Feeds;
+            totalFeeds.Should().Be(sources.Count);
         }
 
         private static Dictionary<string, string> GetValuesAsStrings(TelemetryEvent item)

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/SourceTelemetryTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/SourceTelemetryTests.cs
@@ -30,7 +30,7 @@ namespace NuGet.SolutionRestoreManager.Test
         private const string ProtocolRequests = "protocol.requests";
         private const string ProtocolBytes = "protocol.bytes";
         private const string ProtocolDuration = "protocol.duration";
-        private const string IsHttps = "IsHttps";
+        private const string NumHTTPSFeeds = "NumHTTPSFeeds";
 
         private static readonly Guid Parent = Guid.Parse("33411664-388A-4C48-A607-A2C554171FCE");
         private static readonly PackageSourceTelemetry.Totals ProtocolDiagnosticTotals = new PackageSourceTelemetry.Totals(1, 2, TimeSpan.FromMilliseconds(3));
@@ -64,11 +64,11 @@ namespace NuGet.SolutionRestoreManager.Test
             summaryInts[NumLocalFeeds].Should().Be(0);
             summaryInts[NumHTTPv2Feeds].Should().Be(0);
             summaryInts[NumHTTPv3Feeds].Should().Be(0);
+            summaryInts[NumHTTPSFeeds].Should().Be(0);
             summaryStrings[ParentId].Should().Be(Parent.ToString());
             summaryStrings[NuGetOrg].Should().Be(NotPresent);
             summaryBools[VsOfflinePackages].Should().Be(false);
             summaryBools[DotnetCuratedFeed].Should().Be(false);
-            summaryBools[IsHttps].Should().Be(false);
         }
 
         [Theory]
@@ -91,11 +91,11 @@ namespace NuGet.SolutionRestoreManager.Test
             summaryInts[NumLocalFeeds].Should().Be(0);
             summaryInts[NumHTTPv2Feeds].Should().Be(1);
             summaryInts[NumHTTPv3Feeds].Should().Be(0);
+            summaryInts[NumHTTPSFeeds].Should().Be(1);
             summaryStrings[ParentId].Should().Be(Parent.ToString());
             summaryStrings[NuGetOrg].Should().Be(NotPresent);
             summaryBools[VsOfflinePackages].Should().Be(false);
             summaryBools[DotnetCuratedFeed].Should().Be(true);
-            summaryBools[IsHttps].Should().Be(true);
         }
 
         [PlatformTheory(Platform.Windows)]
@@ -119,11 +119,11 @@ namespace NuGet.SolutionRestoreManager.Test
             summaryInts[NumLocalFeeds].Should().Be(2);
             summaryInts[NumHTTPv2Feeds].Should().Be(0);
             summaryInts[NumHTTPv3Feeds].Should().Be(0);
+            summaryInts[NumHTTPSFeeds].Should().Be(0);
             summaryStrings[ParentId].Should().Be(Parent.ToString());
             summaryStrings[NuGetOrg].Should().Be(NotPresent);
             summaryBools[VsOfflinePackages].Should().Be(true);
             summaryBools[DotnetCuratedFeed].Should().Be(false);
-            summaryBools[IsHttps].Should().Be(false);
         }
 
         [Fact]
@@ -142,11 +142,11 @@ namespace NuGet.SolutionRestoreManager.Test
             summaryInts[NumLocalFeeds].Should().Be(0);
             summaryInts[NumHTTPv2Feeds].Should().Be(1);
             summaryInts[NumHTTPv3Feeds].Should().Be(0);
+            summaryInts[NumHTTPSFeeds].Should().Be(1);
             summaryStrings[ParentId].Should().Be(Parent.ToString());
             summaryStrings[NuGetOrg].Should().Be(YesV2);
             summaryBools[VsOfflinePackages].Should().Be(false);
             summaryBools[DotnetCuratedFeed].Should().Be(false);
-            summaryBools[IsHttps].Should().Be(true);
         }
 
         [Fact]
@@ -165,11 +165,11 @@ namespace NuGet.SolutionRestoreManager.Test
             summaryInts[NumLocalFeeds].Should().Be(0);
             summaryInts[NumHTTPv2Feeds].Should().Be(1);
             summaryInts[NumHTTPv3Feeds].Should().Be(0);
+            summaryInts[NumHTTPSFeeds].Should().Be(1);
             summaryStrings[ParentId].Should().Be(Parent.ToString());
             summaryStrings[NuGetOrg].Should().Be(YesV2);
             summaryBools[VsOfflinePackages].Should().Be(false);
             summaryBools[DotnetCuratedFeed].Should().Be(false);
-            summaryBools[IsHttps].Should().Be(true);
         }
 
         [Fact]
@@ -188,11 +188,11 @@ namespace NuGet.SolutionRestoreManager.Test
             summaryInts[NumLocalFeeds].Should().Be(0);
             summaryInts[NumHTTPv2Feeds].Should().Be(0);
             summaryInts[NumHTTPv3Feeds].Should().Be(1);
+            summaryInts[NumHTTPSFeeds].Should().Be(1);
             summaryStrings[ParentId].Should().Be(Parent.ToString());
             summaryStrings[NuGetOrg].Should().Be(YesV3);
             summaryBools[VsOfflinePackages].Should().Be(false);
             summaryBools[DotnetCuratedFeed].Should().Be(false);
-            summaryBools[IsHttps].Should().Be(true);
         }
 
         [Fact]
@@ -211,11 +211,11 @@ namespace NuGet.SolutionRestoreManager.Test
             summaryInts[NumLocalFeeds].Should().Be(0);
             summaryInts[NumHTTPv2Feeds].Should().Be(0);
             summaryInts[NumHTTPv3Feeds].Should().Be(1);
+            summaryInts[NumHTTPSFeeds].Should().Be(1);
             summaryStrings[ParentId].Should().Be(Parent.ToString());
             summaryStrings[NuGetOrg].Should().Be(YesV3);
             summaryBools[VsOfflinePackages].Should().Be(false);
             summaryBools[DotnetCuratedFeed].Should().Be(false);
-            summaryBools[IsHttps].Should().Be(true);
         }
 
         [Fact]
@@ -235,11 +235,11 @@ namespace NuGet.SolutionRestoreManager.Test
             summaryInts[NumLocalFeeds].Should().Be(0);
             summaryInts[NumHTTPv2Feeds].Should().Be(1);
             summaryInts[NumHTTPv3Feeds].Should().Be(1);
+            summaryInts[NumHTTPSFeeds].Should().Be(2);
             summaryStrings[ParentId].Should().Be(Parent.ToString());
             summaryStrings[NuGetOrg].Should().Be(YesV3AndV2);
             summaryBools[VsOfflinePackages].Should().Be(false);
             summaryBools[DotnetCuratedFeed].Should().Be(false);
-            summaryBools[IsHttps].Should().Be(true);
         }
 
         [Fact]
@@ -259,11 +259,11 @@ namespace NuGet.SolutionRestoreManager.Test
             summaryInts[NumLocalFeeds].Should().Be(0);
             summaryInts[NumHTTPv2Feeds].Should().Be(1);
             summaryInts[NumHTTPv3Feeds].Should().Be(1);
+            summaryInts[NumHTTPSFeeds].Should().Be(2);
             summaryStrings[ParentId].Should().Be(Parent.ToString());
             summaryStrings[NuGetOrg].Should().Be(YesV3AndV2);
             summaryBools[VsOfflinePackages].Should().Be(false);
             summaryBools[DotnetCuratedFeed].Should().Be(false);
-            summaryBools[IsHttps].Should().Be(true);
         }
 
         [Fact]
@@ -284,11 +284,11 @@ namespace NuGet.SolutionRestoreManager.Test
             summaryInts[NumLocalFeeds].Should().Be(1);
             summaryInts[NumHTTPv2Feeds].Should().Be(0);
             summaryInts[NumHTTPv3Feeds].Should().Be(0);
+            summaryInts[NumHTTPSFeeds].Should().Be(0);
             summaryStrings[ParentId].Should().Be(Parent.ToString());
             summaryStrings[NuGetOrg].Should().Be(NotPresent);
             summaryBools[VsOfflinePackages].Should().Be(false);
             summaryBools[DotnetCuratedFeed].Should().Be(false);
-            summaryBools[IsHttps].Should().Be(false);
         }
 
         [Fact]
@@ -308,11 +308,11 @@ namespace NuGet.SolutionRestoreManager.Test
             summaryInts[NumLocalFeeds].Should().Be(0);
             summaryInts[NumHTTPv2Feeds].Should().Be(1);
             summaryInts[NumHTTPv3Feeds].Should().Be(1);
+            summaryInts[NumHTTPSFeeds].Should().Be(2);
             summaryStrings[ParentId].Should().Be(Parent.ToString());
             summaryStrings[NuGetOrg].Should().Be(NotPresent);
             summaryBools[VsOfflinePackages].Should().Be(false);
             summaryBools[DotnetCuratedFeed].Should().Be(false);
-            summaryBools[IsHttps].Should().Be(true);
         }
 
         [Fact]
@@ -333,11 +333,11 @@ namespace NuGet.SolutionRestoreManager.Test
             summaryInts[NumLocalFeeds].Should().Be(3);
             summaryInts[NumHTTPv2Feeds].Should().Be(0);
             summaryInts[NumHTTPv3Feeds].Should().Be(0);
+            summaryInts[NumHTTPSFeeds].Should().Be(0);
             summaryStrings[ParentId].Should().Be(Parent.ToString());
             summaryStrings[NuGetOrg].Should().Be(NotPresent);
             summaryBools[VsOfflinePackages].Should().Be(false);
             summaryBools[DotnetCuratedFeed].Should().Be(false);
-            summaryBools[IsHttps].Should().Be(false);
         }
 
         [Fact]
@@ -357,11 +357,11 @@ namespace NuGet.SolutionRestoreManager.Test
             summaryInts[NumLocalFeeds].Should().Be(2);
             summaryInts[NumHTTPv2Feeds].Should().Be(0);
             summaryInts[NumHTTPv3Feeds].Should().Be(0);
+            summaryInts[NumHTTPSFeeds].Should().Be(0);
             summaryStrings[ParentId].Should().Be(Parent.ToString());
             summaryStrings[NuGetOrg].Should().Be(NotPresent);
             summaryBools[VsOfflinePackages].Should().Be(false);
             summaryBools[DotnetCuratedFeed].Should().Be(false);
-            summaryBools[IsHttps].Should().Be(false);
         }
 
         [Fact]
@@ -380,11 +380,11 @@ namespace NuGet.SolutionRestoreManager.Test
             summaryInts[NumLocalFeeds].Should().Be(0);
             summaryInts[NumHTTPv2Feeds].Should().Be(0);
             summaryInts[NumHTTPv3Feeds].Should().Be(1);
+            summaryInts[NumHTTPSFeeds].Should().Be(0);
             summaryStrings[ParentId].Should().Be(Parent.ToString());
             summaryStrings[NuGetOrg].Should().Be(NotPresent);
             summaryBools[VsOfflinePackages].Should().Be(false);
             summaryBools[DotnetCuratedFeed].Should().Be(false);
-            summaryBools[IsHttps].Should().Be(false);
         }
 
         [Fact]
@@ -403,11 +403,11 @@ namespace NuGet.SolutionRestoreManager.Test
             summaryInts[NumLocalFeeds].Should().Be(0);
             summaryInts[NumHTTPv2Feeds].Should().Be(1);
             summaryInts[NumHTTPv3Feeds].Should().Be(0);
+            summaryInts[NumHTTPSFeeds].Should().Be(0);
             summaryStrings[ParentId].Should().Be(Parent.ToString());
             summaryStrings[NuGetOrg].Should().Be(NotPresent);
             summaryBools[VsOfflinePackages].Should().Be(false);
             summaryBools[DotnetCuratedFeed].Should().Be(false);
-            summaryBools[IsHttps].Should().Be(false);
         }
 
         [Fact]
@@ -441,8 +441,8 @@ namespace NuGet.SolutionRestoreManager.Test
             summaryInts[NumLocalFeeds].Should().Be(1);
             summaryInts[NumHTTPv2Feeds].Should().Be(0);
             summaryInts[NumHTTPv3Feeds].Should().Be(3);
+            summaryInts[NumHTTPSFeeds].Should().Be(3);
             summaryStrings[ParentId].Should().Be(Parent.ToString());
-            summaryBools[IsHttps].Should().Be(true);
         }
 
         [Fact]
@@ -464,8 +464,8 @@ namespace NuGet.SolutionRestoreManager.Test
             summaryInts[NumLocalFeeds].Should().Be(1);
             summaryInts[NumHTTPv2Feeds].Should().Be(0);
             summaryInts[NumHTTPv3Feeds].Should().Be(3);
+            summaryInts[NumHTTPSFeeds].Should().Be(2);
             summaryStrings[ParentId].Should().Be(Parent.ToString());
-            summaryBools[IsHttps].Should().Be(false);
         }
 
         private static Dictionary<string, string> GetValuesAsStrings(TelemetryEvent item)


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/nuget/client.engineering/issues/1334

Regression? Last working version: No

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
For `restorepackagesourcesummary` and `searchpackagesourcesummary` events, we have been recording V2 and V3 feed counts enabled during a restore.

This PR adds a new count for HTTPS (secure) feeds.
The idea is to understand how the proportion of HTTP feeds versus HTTPS feeds over time.

We can consider similar changes to `PackageSourceDiagnostics` events in a separate PR.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
