### PR TITLE
Package Source Mapping matches found, show no logs for projects

### DIFF
--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/ResolverUtility.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/ResolverUtility.cs
@@ -241,7 +241,10 @@ namespace NuGet.DependencyResolver
         private static async Task<Tuple<LibraryRange, RemoteMatch>> ResolvePackageLibraryMatchAsync(LibraryRange libraryRange, RemoteWalkContext remoteWalkContext, CancellationToken cancellationToken)
         {
             IList<IRemoteDependencyProvider> remoteDependencyProviders = remoteWalkContext.FilterDependencyProvidersForLibrary(libraryRange);
-            LogIfPackageSourceMappingIsEnabled(libraryRange.Name, remoteWalkContext, remoteDependencyProviders);
+            if (libraryRange.TypeConstraintAllows(LibraryDependencyTarget.Package))
+            {
+                LogIfPackageSourceMappingIsEnabled(libraryRange.Name, remoteWalkContext, remoteDependencyProviders);
+            }
 
             var match = await FindPackageLibraryMatchAsync(libraryRange, NuGetFramework.AnyFramework, remoteDependencyProviders, remoteWalkContext.LocalLibraryProviders, remoteWalkContext.CacheContext, remoteWalkContext.Logger, cancellationToken);
             if (match == null)

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/ResolverUtility.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/ResolverUtility.cs
@@ -47,7 +47,11 @@ namespace NuGet.DependencyResolver
             var currentCacheContext = context.CacheContext;
 
             IList<IRemoteDependencyProvider> remoteDependencyProviders = context.FilterDependencyProvidersForLibrary(libraryRange);
-            LogIfPackageSourceMappingIsEnabled(libraryRange.Name, context, remoteDependencyProviders);
+
+            if (libraryRange.TypeConstraintAllows(LibraryDependencyTarget.Package))
+            {
+                LogIfPackageSourceMappingIsEnabled(libraryRange.Name, context, remoteDependencyProviders);
+            }
 
             // Try up to two times to get the package. The second
             // retry will refresh the cache if a package is listed 

--- a/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests/FindPackageTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests/FindPackageTests.cs
@@ -152,7 +152,7 @@ namespace NuGet.DependencyResolver.Core.Tests
             // Assert
             Assert.Equal(0, testLogger.Errors);
             testLogger.DebugMessages.TryPeek(out string message);
-            if(libraryDependencyTarget == LibraryDependencyTarget.Package)
+            if (libraryDependencyTarget == LibraryDependencyTarget.Package)
             {
                 Assert.Equal($"Package source mapping matches found for package ID '{packageX}' are: '{source}'.", message);
                 Assert.Equal(version, result.Key.Version.ToString());

--- a/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests/FindPackageTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests/FindPackageTests.cs
@@ -112,6 +112,58 @@ namespace NuGet.DependencyResolver.Core.Tests
             Assert.Equal("x", result.Key.Name);
         }
 
+        [Theory]
+        [InlineData(LibraryDependencyTarget.Package)]
+        [InlineData(LibraryDependencyTarget.Project)]
+        [InlineData(LibraryDependencyTarget.ExternalProject)]
+        [InlineData(LibraryDependencyTarget.Project | LibraryDependencyTarget.ExternalProject)]
+        public async Task FindLibraryEntryAsync_LogsOnlyPackages(LibraryDependencyTarget libraryDependencyTarget)
+        {
+            // Arrange
+            const string packageX = "x", version = "1.0.0-beta.1", source = "source";
+            var range = new LibraryRange(packageX, VersionRange.Parse(version), libraryDependencyTarget);
+            var cacheContext = new SourceCacheContext();
+            var testLogger = new TestLogger();
+            var framework = NuGetFramework.Parse("net45");
+            var token = CancellationToken.None;
+            var edge = new GraphEdge<RemoteResolveResult>(null, null, null);
+            var actualIdentity = new LibraryIdentity(packageX, NuGetVersion.Parse(version), LibraryType.Package);
+            var dependencies = new[] { new LibraryDependency() { LibraryRange = new LibraryRange("y", VersionRange.All, LibraryDependencyTarget.Package) } };
+            var dependencyInfo = LibraryDependencyInfo.Create(actualIdentity, framework, dependencies);
+
+            //package source mapping configuration
+            Dictionary<string, IReadOnlyList<string>> patterns = new();
+            patterns.Add(source, new List<string>() { packageX });
+            PackageSourceMapping sourceMappingConfiguration = new(patterns);
+            var context = new RemoteWalkContext(cacheContext, sourceMappingConfiguration, testLogger);
+
+            var remoteProvider = new Mock<IRemoteDependencyProvider>();
+            remoteProvider.Setup(e => e.FindLibraryAsync(range, It.IsAny<NuGetFramework>(), It.IsAny<SourceCacheContext>(), testLogger, token))
+                .ReturnsAsync(actualIdentity);
+            remoteProvider.SetupGet(e => e.IsHttp).Returns(true);
+            remoteProvider.SetupGet(e => e.Source).Returns(new PackageSource(source));
+            remoteProvider.Setup(e => e.GetDependenciesAsync(It.IsAny<LibraryIdentity>(), It.IsAny<NuGetFramework>(), It.IsAny<SourceCacheContext>(), testLogger, token))
+                .ReturnsAsync(dependencyInfo);
+            context.RemoteLibraryProviders.Add(remoteProvider.Object);
+
+            // Act
+            var result = await ResolverUtility.FindLibraryEntryAsync(range, framework, null, context, token);
+
+            // Assert
+            Assert.Equal(0, testLogger.Errors);
+            testLogger.DebugMessages.TryPeek(out string message);
+            if(libraryDependencyTarget == LibraryDependencyTarget.Package)
+            {
+                Assert.Equal($"Package source mapping matches found for package ID '{packageX}' are: '{source}'.", message);
+                Assert.Equal(version, result.Key.Version.ToString());
+                Assert.Equal(source, result.Data.Match.Provider.Source.Name);
+            }
+            else
+            {
+                Assert.Equal(message, null);
+            }
+        }
+
         [Fact]
         public async Task FindPackage_VerifyMissingListedPackageThrowsNotFound()
         {


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes:
https://github.com/NuGet/Home/issues/11413
Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

No logs should be displayed for Package Source Mapping matches for projects, only for packages.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [ ] N/A
