### PR TITLE
Reduce status bar spam, log only minimal message to the status bar

### DIFF
--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/Logger/NuGetFileLogger.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/Logger/NuGetFileLogger.cs
@@ -95,10 +95,13 @@ namespace NuGet.SolutionRestoreManager
 
             lock (_streamWriterLock)
             {
+                string message = logMessage;
                 if (ShouldFormatWithTime)
                 {
-                    _streamWriter.Value.WriteLine(FormatWithTime(logMessage));
+                    message = FormatWithTime(logMessage);
                 }
+                _streamWriter.Value.WriteLine(message);
+
             }
         }
 

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/Logger/NuGetFileLogger.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/Logger/NuGetFileLogger.cs
@@ -24,6 +24,8 @@ namespace NuGet.SolutionRestoreManager
 
         public bool IsEnabled { get; }
 
+        public bool ShouldFormatWithTime { get; }
+
         // The DateTimeOffset and Stopwatch ticks are not equivalent. 1/10000000 is 1 DateTime tick.
         public DateTimeOffset Now => _startTime.AddTicks(_stopwatch.ElapsedTicks * 10000000 / Stopwatch.Frequency);
 
@@ -34,11 +36,20 @@ namespace NuGet.SolutionRestoreManager
                 throw new ArgumentNullException(nameof(environmentVariableReader));
             }
 
-            _logDirectoryPath = environmentVariableReader.GetEnvironmentVariable("NUGET_SOLUTION_LOAD_LOGGING_PATH");
+            _logDirectoryPath = environmentVariableReader.GetEnvironmentVariable("NUGET_VS_RESTORE_LOGGING_PATH");
 
             if (!string.IsNullOrWhiteSpace(_logDirectoryPath))
             {
                 IsEnabled = true;
+            }
+
+            var formatWithTime = environmentVariableReader.GetEnvironmentVariable("NUGET_VS_RESTORE_FORMAT_WITH_TIME");
+
+            if (!string.IsNullOrWhiteSpace(formatWithTime))
+            {
+                _ = bool.TryParse(formatWithTime, out bool formatWithTimeOverride);
+
+                ShouldFormatWithTime = formatWithTimeOverride;
             }
 
             _startTime = DateTimeOffset.UtcNow;
@@ -84,7 +95,10 @@ namespace NuGet.SolutionRestoreManager
 
             lock (_streamWriterLock)
             {
-                _streamWriter.Value.WriteLine(FormatWithTime(logMessage));
+                if (ShouldFormatWithTime)
+                {
+                    _streamWriter.Value.WriteLine(FormatWithTime(logMessage));
+                }
             }
         }
 

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/RestoreOperationLogger.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/RestoreOperationLogger.cs
@@ -604,6 +604,8 @@ namespace NuGet.SolutionRestoreManager
 
                 _statusBar.SetText(progressMessage);
 
+                NuGetFileLogger.DefaultInstance.Write(progressMessage);
+
                 if (totalSteps != 0)
                 {
                     _statusBar.Progress(ref _cookie, 1, "", currentStep, totalSteps);

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/RestoreOperationLogger.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/RestoreOperationLogger.cs
@@ -539,8 +539,6 @@ namespace NuGet.SolutionRestoreManager
 
                 _statusBar.SetText(progressMessage);
 
-                NuGetFileLogger.DefaultInstance.Write(progressMessage);
-
                 if (totalSteps != 0)
                 {
                     _statusBar.Progress(ref _cookie, 1, "", currentStep, totalSteps);

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/RestoreOperationLogger.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/RestoreOperationLogger.cs
@@ -219,7 +219,12 @@ namespace NuGet.SolutionRestoreManager
             // they are missing the context of the parent text above it
             return RestoreOperationProgressUI.Current != null
                 && GetMSBuildLevel(logMessage.Level) == MSBuildVerbosityLevel.Minimal
-                && logMessage.Message.Length == logMessage.Message.TrimStart().Length;
+                && !IsStringIndented(logMessage);
+
+            static bool IsStringIndented(ILogMessage logMessage)
+            {
+                return logMessage.Message.Length > 0 && char.IsWhiteSpace(logMessage.Message[0]);
+            }
         }
 
         /// <summary>

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/RestoreOperationLogger.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/RestoreOperationLogger.cs
@@ -213,12 +213,12 @@ namespace NuGet.SolutionRestoreManager
 
         private static bool ShouldReportProgress(ILogMessage logMessage)
         {
-            // Only show messages with VerbosityLevel.Normal. That is, info messages only.
+            // Only show messages with VerbosityLevel.Minimal.
             // Do not show errors, warnings, verbose or debug messages on the progress dialog
             // Avoid showing indented messages, these are typically not useful for the progress dialog since
             // they are missing the context of the parent text above it
             return RestoreOperationProgressUI.Current != null
-                && GetMSBuildLevel(logMessage.Level) == MSBuildVerbosityLevel.Normal
+                && GetMSBuildLevel(logMessage.Level) == MSBuildVerbosityLevel.Minimal
                 && logMessage.Message.Length == logMessage.Message.TrimStart().Length;
         }
 
@@ -465,71 +465,6 @@ namespace NuGet.SolutionRestoreManager
                     return LogLevel.Verbose;
                 default:
                     return LogLevel.Debug;
-            }
-        }
-
-        internal class WaitDialogProgress : RestoreOperationProgressUI
-        {
-            private readonly ThreadedWaitDialogHelper.Session _session;
-            private readonly JoinableTaskFactory _taskFactory;
-
-            private WaitDialogProgress(
-                ThreadedWaitDialogHelper.Session session,
-                JoinableTaskFactory taskFactory)
-            {
-                _session = session;
-                _taskFactory = taskFactory;
-                UserCancellationToken = _session.UserCancellationToken;
-            }
-
-            public static async Task<RestoreOperationProgressUI> StartAsync(
-                IAsyncServiceProvider asyncServiceProvider,
-                JoinableTaskFactory jtf,
-                CancellationToken token)
-            {
-                token.ThrowIfCancellationRequested();
-
-                await jtf.SwitchToMainThreadAsync(token);
-
-                var waitDialogFactory = await asyncServiceProvider.GetServiceAsync<
-                    SVsThreadedWaitDialogFactory, IVsThreadedWaitDialogFactory>();
-
-                var session = waitDialogFactory.StartWaitDialog(
-                    waitCaption: Resources.DialogTitle,
-                    initialProgress: new ThreadedWaitDialogProgressData(
-                        Resources.RestoringPackages,
-                        progressText: string.Empty,
-                        statusBarText: string.Empty,
-                        isCancelable: true,
-                        currentStep: 0,
-                        totalSteps: 0));
-
-                return new WaitDialogProgress(session, jtf);
-            }
-
-            public async override ValueTask DisposeAsync()
-            {
-                await _taskFactory.SwitchToMainThreadAsync();
-                _session.Dispose();
-            }
-
-            public override async Task ReportProgressAsync(
-                string progressMessage,
-                uint currentStep,
-                uint totalSteps)
-            {
-                await _taskFactory.SwitchToMainThreadAsync();
-
-                // When both currentStep and totalSteps are 0, we get a marquee on the dialog
-                var progressData = new ThreadedWaitDialogProgressData(
-                    progressMessage,
-                    progressText: string.Empty,
-                    statusBarText: string.Empty,
-                    isCancelable: true,
-                    currentStep: (int)currentStep,
-                    totalSteps: (int)totalSteps);
-
-                _session.Progress.Report(progressData);
             }
         }
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRunner.cs
@@ -259,7 +259,7 @@ namespace NuGet.Commands
             var log = summaryRequest.Request.Log;
 
             // Commit the result
-            log.LogInformation(Strings.Log_Committing);
+            log.LogVerbose(Strings.Log_Committing);
             await result.CommitAsync(log, token);
 
             if (result.Success)

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/RestoreOperationLoggerTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/RestoreOperationLoggerTests.cs
@@ -13,22 +13,6 @@ namespace NuGet.SolutionRestoreManager.Test
     public class RestoreOperationLoggerTests
     {
         [Fact]
-        public async Task WaitDialogProgress_StartAsync_CancellationTokenThrowsAsync()
-        {
-            // Prepare
-            var cts = new CancellationTokenSource();
-
-            var tsk = RestoreOperationLogger.WaitDialogProgress.StartAsync(
-                AsyncServiceProvider.GlobalProvider,
-                ThreadHelper.JoinableTaskFactory,
-                cts.Token);
-            cts.Cancel();
-
-            // Act and Assert
-            await Assert.ThrowsAsync<OperationCanceledException>(async () => await tsk);
-        }
-
-        [Fact]
         public async Task StatusBarProgress_StartAsync_CancellationTokenThrowsAsync()
         {
             // Prepare


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/4376
Fixes: https://github.com/NuGet/Home/issues/6047

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

NuGet has generally relevant logs at normal verbosity, but the logs on the status bar are *not* super thought through. 
This PR changes that. 

*Note* These are not are the final changes in this area. There are other components/APIs we can use for *reporting* progress, but that's a different change tracked in https://github.com/NuGet/Home/issues/9396. 

All the logs and tests below were performed on a solution with 1 PackageReference and 1 packages.config project each. 

Here's the before on what gets logged to the Output Window on *Normal* Verbosity. 

```console
Restoring NuGet packages...
Restoring packages for C:\Code\Temp\RestoreStatusMessages\PackageReferenceProject\PackageReferenceProject.csproj...
  GET https://api.nuget.org/v3-flatcontainer/nuget.common/index.json
  OK https://api.nuget.org/v3-flatcontainer/nuget.common/index.json 365ms
  GET https://api.nuget.org/v3-flatcontainer/nuget.common/6.0.0/nuget.common.6.0.0.nupkg
  OK https://api.nuget.org/v3-flatcontainer/nuget.common/6.0.0/nuget.common.6.0.0.nupkg 95ms
  GET https://api.nuget.org/v3-flatcontainer/nuget.frameworks/index.json
  OK https://api.nuget.org/v3-flatcontainer/nuget.frameworks/index.json 171ms
  GET https://api.nuget.org/v3-flatcontainer/nuget.frameworks/6.0.0/nuget.frameworks.6.0.0.nupkg
  OK https://api.nuget.org/v3-flatcontainer/nuget.frameworks/6.0.0/nuget.frameworks.6.0.0.nupkg 57ms
Installed NuGet.Frameworks 6.0.0 from https://api.nuget.org/v3/index.json with content hash pEWTGa8sGEbSBE7VtKBlWZafG5tWNCGPzyNL91zneWoxZubNEWK1MN5QPN3fk+cV5CaySePT5reYjCAqELn5DA==.
Installed NuGet.Common 6.0.0 from https://api.nuget.org/v3/index.json with content hash NYK9JJd60jpv+VAGuCRnnDftF9osOCCgpkyG48cDK3eTGF0P19ttROJMVULQvJw+lUp31lk9X3rDEMqADj5n3w==.
Committing restore...
Generating MSBuild file C:\Code\Temp\RestoreStatusMessages\PackageReferenceProject\obj\PackageReferenceProject.csproj.nuget.g.props.
Generating MSBuild file C:\Code\Temp\RestoreStatusMessages\PackageReferenceProject\obj\PackageReferenceProject.csproj.nuget.g.targets.
Writing assets file to disk. Path: C:\Code\Temp\RestoreStatusMessages\PackageReferenceProject\obj\project.assets.json
Restored C:\Code\Temp\RestoreStatusMessages\PackageReferenceProject\PackageReferenceProject.csproj (in 1.41 sec).
NuGet package restore finished.
Time Elapsed: 00:00:02.8708809
========== Finished ==========
```

Here's the after. 

```console
Restoring NuGet packages...
Restoring packages for C:\Code\Temp\RestoreStatusMessages\PackageReferenceProject\PackageReferenceProject.csproj...
  CACHE https://api.nuget.org/v3-flatcontainer/nuget.common/index.json
  CACHE https://api.nuget.org/v3-flatcontainer/nuget.common/6.0.0/nuget.common.6.0.0.nupkg
  CACHE https://api.nuget.org/v3-flatcontainer/nuget.frameworks/index.json
  CACHE https://api.nuget.org/v3-flatcontainer/nuget.frameworks/6.0.0/nuget.frameworks.6.0.0.nupkg
Installed NuGet.Frameworks 6.0.0 from https://api.nuget.org/v3/index.json with content hash pEWTGa8sGEbSBE7VtKBlWZafG5tWNCGPzyNL91zneWoxZubNEWK1MN5QPN3fk+cV5CaySePT5reYjCAqELn5DA==.
Installed NuGet.Common 6.0.0 from https://api.nuget.org/v3/index.json with content hash NYK9JJd60jpv+VAGuCRnnDftF9osOCCgpkyG48cDK3eTGF0P19ttROJMVULQvJw+lUp31lk9X3rDEMqADj5n3w==.
Generating MSBuild file C:\Code\Temp\RestoreStatusMessages\PackageReferenceProject\obj\PackageReferenceProject.csproj.nuget.g.props.
Generating MSBuild file C:\Code\Temp\RestoreStatusMessages\PackageReferenceProject\obj\PackageReferenceProject.csproj.nuget.g.targets.
Writing assets file to disk. Path: C:\Code\Temp\RestoreStatusMessages\PackageReferenceProject\obj\project.assets.json
Restored C:\Code\Temp\RestoreStatusMessages\PackageReferenceProject\PackageReferenceProject.csproj (in 547 ms).
NuGet package restore finished.
Time Elapsed: 00:00:01.7031949
========== Finished ==========
```

Here's my reasoning for why the *after* output is as is. 

* 1st line indicates that a restore is happening at minimal verbosity. I'd argue it's necessary. 
* Details about starting restore of the project are logged at *Normal* verbosity. This is standard behavior for operations such as restore build. All of them indicate the start and finish of the operation. 
* The `CACHE` messages were there to indicate the remote calls NuGet makes/attempts to make. They are useful for auditing. 
* Same thing applies about the individual package installation. This is a recent change. 
* Generating of the msbuild files and assets file is arguably the *least* valuable information here, but given that our logging is the same in VS and commandline (and I'd argue it should remain the same for sanity), they are relevant for auditing in commandline builds. 
* Finally the details about the project being restored and the time it took are relevant and important. These are logged at minimal verbosity. 

Here's the before and after for the Status Bar when a clean restore happens. 

Before:

```console
Restoring NuGet packages...
Restored NuGet package CsvParser.0.5.2.
Restoring NuGet packages...
Restoring packages for C:\Code\Temp\RestoreStatusMessages\PackageReferenceProject\PackageReferenceProject.csproj...
Installed NuGet.Frameworks 6.0.0 from https://api.nuget.org/v3/index.json with content hash pEWTGa8sGEbSBE7VtKBlWZafG5tWNCGPzyNL91zneWoxZubNEWK1MN5QPN3fk+cV5CaySePT5reYjCAqELn5DA==.
Installed NuGet.Common 6.0.0 from https://api.nuget.org/v3/index.json with content hash NYK9JJd60jpv+VAGuCRnnDftF9osOCCgpkyG48cDK3eTGF0P19ttROJMVULQvJw+lUp31lk9X3rDEMqADj5n3w==.
Committing restore...
Generating MSBuild file C:\Code\Temp\RestoreStatusMessages\PackageReferenceProject\obj\PackageReferenceProject.csproj.nuget.g.props.
Generating MSBuild file C:\Code\Temp\RestoreStatusMessages\PackageReferenceProject\obj\PackageReferenceProject.csproj.nuget.g.targets.
Writing assets file to disk. Path: C:\Code\Temp\RestoreStatusMessages\PackageReferenceProject\obj\project.assets.json
```

After: 

```console
Restoring NuGet packages...
Restored NuGet package CsvParser.0.5.2.
Restoring NuGet packages...
Restored C:\Code\Temp\RestoreStatusMessages\PackageReferenceProject\PackageReferenceProject.csproj (in 547 ms).
```

Note that the above version has *a lot of fluff*. 
Details about starting/ending restore and the individual packages installed + some fluff messages such as `Committing restore`  are absolutely irrelevant for the status bar. 

The new version *does* contain 2 `Restoring NuGet packages...` lines, but that's a larger refactoring that if people feel is super relevant I can create an issue for. 

Finally here are the changes for the *first* no-op restores. 

Output Window - Before: 

```console
Restoring NuGet packages...
Committing restore...
Assets file has not changed. Skipping assets file writing. Path: C:\Code\Temp\RestoreStatusMessages\PackageReferenceProject\obj\project.assets.json
Restored C:\Code\Temp\RestoreStatusMessages\PackageReferenceProject\PackageReferenceProject.csproj (in 66 ms).
NuGet package restore finished.
Time Elapsed: 00:00:00.4727655
========== Finished ==========
```

Output Window - After; 

```console
Restoring NuGet packages...
Assets file has not changed. Skipping assets file writing. Path: C:\Code\Temp\RestoreStatusMessages\PackageReferenceProject\obj\project.assets.json
Restored C:\Code\Temp\RestoreStatusMessages\PackageReferenceProject\PackageReferenceProject.csproj (in 60 ms).
NuGet package restore finished.
Time Elapsed: 00:00:00.4651742
========== Finished ==========
```

Note that details about the assets file *not* changing has been deemed relevant in the past. We can rethink that/change it, but I'm solving one problem at a time :) 


Status bar - Before

```console
Restoring NuGet packages...
Committing restore...
Assets file has not changed. Skipping assets file writing. Path: C:\Code\Temp\RestoreStatusMessages\PackageReferenceProject\obj\project.assets.json
Restored C:\Code\Temp\RestoreStatusMessages\PackageReferenceProject\PackageReferenceProject.csproj (in 66 ms).
```

Status bar - After

```
Restoring NuGet packages...
```

Now the last part is a *bit* controversial. 
No actual restore happened, and there's no indication of that in the status bar. The trikc is that once you're done with a status bar, it switches to `Ready` which is indicative of operation completion. So I propose not to complicate things by adding an extra message there. 

Finally: 

Note that every 2nd no-op logs *nothing* to the Status bar, and that's true before and after my change. 

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception - There's no means of testing this.
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
