### PR TITLE
Handle duplicate runtime identifiers in csproj PR

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/VsProjectAdapter.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/VsProjectAdapter.cs
@@ -276,6 +276,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
             runtimes = runtimes
                 .Select(x => x.Trim())
+                .Distinct(StringComparer.Ordinal)
                 .Where(x => !string.IsNullOrEmpty(x));
 
             return runtimes


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/9290

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Currently when the user writes the same identifier in `RuntimeIdentifier` and `RuntimeIdentifiers` it will throw an error that there is a duplicate.  SDK projects [handle this](https://github.com/NuGet/NuGet.Client/blob/dev/src/NuGet.Clients/NuGet.SolutionRestoreManager/VSNominationUtilities.cs#L69-L79) with a `.Distict()` so I'm doing the same for this case.

For example this will throw an error:
```xml
<RuntimeIdentifier>win</RuntimeIdentifier>
<RuntimeIdentifiers>win</RuntimeIdentifiers>
```

This cannot be repro in command line, because we can only add only [RuntimeIdentifier](https://docs.microsoft.com/en-us/dotnet/core/rid-catalog) and is not being added to .csproj

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [ ] N/A
