### PR TITLE
Handle cancellation in PM UI when changing selection

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailControlModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailControlModel.cs
@@ -562,8 +562,18 @@ namespace NuGet.PackageManagement.UI
                             PackageMetadata = detailedPackageMetadata;
                         }
 
-                        NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(() => SelectedVersionChangedAsync(_searchResultPackage, _selectedVersion.Version, loadCts.Token).AsTask())
-                                                               .PostOnFailure(nameof(DetailControlModel));
+                        NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+                        {
+                            try
+                            {
+                                await SelectedVersionChangedAsync(_searchResultPackage, _selectedVersion.Version, loadCts.Token).AsTask();
+                            }
+                            catch (OperationCanceledException) when (loadCts.IsCancellationRequested)
+                            {
+                                // Expected
+                            }
+                        })
+                            .PostOnFailure(nameof(DetailControlModel));
                     }
 
                     OnPropertyChanged(nameof(SelectedVersion));

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/NuGetPackageManagerControlSearchTask.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/NuGetPackageManagerControlSearchTask.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Threading;
 using Microsoft.VisualStudio.Shell.Interop;
 using NuGet.VisualStudio;
@@ -38,8 +39,15 @@ namespace NuGet.PackageManagement.UI
                 oldCts?.Cancel();
                 oldCts?.Dispose();
 
-                await _packageManagerControl.SearchPackagesAndRefreshUpdateCountAsync(searchText: _searchQuery.SearchString, useCachedPackageMetadata: true, pSearchCallback: _searchCallback, searchTask: this);
-                SetStatus(VsSearchTaskStatus.Completed);
+                try
+                {
+                    await _packageManagerControl.SearchPackagesAndRefreshUpdateCountAsync(searchText: _searchQuery.SearchString, useCachedPackageMetadata: true, pSearchCallback: _searchCallback, searchTask: this);
+                    SetStatus(VsSearchTaskStatus.Completed);
+                }
+                catch (OperationCanceledException) when (loadCts.IsCancellationRequested)
+                {
+                    // Expected
+                }
             }).PostOnFailure(nameof(NuGetPackageManagerControlSearchTask));
         }
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Utility/NuGetSearchServiceReconnector.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Utility/NuGetSearchServiceReconnector.cs
@@ -79,8 +79,15 @@ namespace NuGet.PackageManagement.UI.Utility
 
         internal async Task AvailabilityChangedAsync()
         {
-            _service?.Dispose();
-            _service = await _serviceBroker.GetProxyAsync<INuGetSearchService>(NuGetServices.SearchService, _disposedTokenSource.Token);
+            try
+            {
+                _service?.Dispose();
+                _service = await _serviceBroker.GetProxyAsync<INuGetSearchService>(NuGetServices.SearchService, _disposedTokenSource.Token);
+            }
+            catch (OperationCanceledException) when (_disposedTokenSource.Token.IsCancellationRequested)
+            {
+                // Expected
+            }
         }
 
         public void Dispose()

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -1010,31 +1010,38 @@ namespace NuGet.PackageManagement.UI
         /// </summary>
         internal async Task UpdateDetailPaneAsync(CancellationToken cancellationToken)
         {
-            PackageItemViewModel selectedItem = _packageList.SelectedItem;
-            IReadOnlyCollection<PackageSourceContextInfo> packageSources = SelectedSource.PackageSources;
-            int selectedIndex = _packageList.SelectedIndex;
-            int recommendedCount = _packageList.PackageItems.Where(item => item.Recommended == true).Count();
-
-            if (selectedItem == null)
+            try
             {
-                _packageDetail.Visibility = Visibility.Hidden;
-            }
-            else
-            {
-                _packageDetail.Visibility = Visibility.Visible;
-                _packageDetail.DataContext = _detailModel;
+                PackageItemViewModel selectedItem = _packageList.SelectedItem;
+                IReadOnlyCollection<PackageSourceContextInfo> packageSources = SelectedSource.PackageSources;
+                int selectedIndex = _packageList.SelectedIndex;
+                int recommendedCount = _packageList.PackageItems.Where(item => item.Recommended == true).Count();
 
-                EmitSearchSelectionTelemetry(selectedItem);
-
-                await _detailModel.SetCurrentPackageAsync(selectedItem, _topPanel.Filter, () => _packageList.SelectedItem);
-                _detailModel.SetCurrentSelectionInfo(selectedIndex, recommendedCount, _recommendPackages, selectedItem.RecommenderVersion);
-
-                _packageDetail.ScrollToHome();
-
-                if (cancellationToken.IsCancellationRequested)
+                if (selectedItem == null)
                 {
-                    return;
+                    _packageDetail.Visibility = Visibility.Hidden;
                 }
+                else
+                {
+                    _packageDetail.Visibility = Visibility.Visible;
+                    _packageDetail.DataContext = _detailModel;
+
+                    EmitSearchSelectionTelemetry(selectedItem);
+
+                    await _detailModel.SetCurrentPackageAsync(selectedItem, _topPanel.Filter, () => _packageList.SelectedItem);
+                    _detailModel.SetCurrentSelectionInfo(selectedIndex, recommendedCount, _recommendPackages, selectedItem.RecommenderVersion);
+
+                    _packageDetail.ScrollToHome();
+
+                    if (cancellationToken.IsCancellationRequested)
+                    {
+                        return;
+                    }
+                }
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                // cancellation was requested, this is expected.
             }
         }
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11473

Regression? Yes. Last working version: [Probably NuGet 5.7, VS 16.7](https://github.com/NuGet/NuGet.Client/commit/e77cccfdc041872bd18a187bc46531fe24e8c8e3)

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Checked all 71 references to `PostOnFailure` and when the method used in the `jtf.RunAsync()` uses a cancellation token, handle the `OperationCancelledException` so it no longer propogates to `PostOnFailure`.

## PR Checklist

- [X] PR has a meaningful title
- [X] PR has a linked issue.
- [X] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [X] Test exception: Error handling that depends on many timing issues making it impractical to test
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [X] N/A
