### PR TITLE
Cache global.json in NuGet SDK resolver

### DIFF
--- a/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/FileSystemInfoFullNameEqualityComparer.cs
+++ b/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/FileSystemInfoFullNameEqualityComparer.cs
@@ -1,0 +1,52 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Microsoft.Build.NuGetSdkResolver
+{
+    /// <summary>
+    /// Represents an implementation of <see cref="IEqualityComparer{T}" /> that compares <see cref="FileSystemInfo" /> objects by the value of their <see cref="FileSystemInfo.FullName" /> property.
+    /// </summary>
+    internal sealed class FileSystemInfoFullNameEqualityComparer : IEqualityComparer<FileSystemInfo>
+    {
+        /// <summary>
+        /// Gets a static singleton for the <see cref="FileSystemInfoFullNameEqualityComparer" /> class.
+        /// </summary>
+        public static FileSystemInfoFullNameEqualityComparer Instance = new FileSystemInfoFullNameEqualityComparer();
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FileSystemInfoFullNameEqualityComparer" /> class.
+        /// </summary>
+        private FileSystemInfoFullNameEqualityComparer()
+        {
+        }
+
+        /// <summary>
+        /// Determines whether the specified <see cref="FileSystemInfo" /> objects are equal by comparing their <see cref="FileSystemInfo.FullName" /> property.
+        /// </summary>
+        /// <param name="x">The first <see cref="FileSystemInfo" /> to compare.</param>
+        /// <param name="y">The second <see cref="FileSystemInfo" /> to compare.</param>
+        /// <returns><c>true</c> if the specified <see cref="FileSystemInfo" /> objects' <see cref="FileSystemInfo.FullName" /> property are equal, otherwise <c>false</c>.</returns>
+        public bool Equals(FileSystemInfo x, FileSystemInfo y)
+        {
+            return string.Equals(x.FullName, y.FullName, StringComparison.Ordinal);
+        }
+
+        /// <summary>
+        /// Returns a hash code for the specified <see cref="FileSystemInfo" /> object's <see cref="FileSystemInfo.FullName" /> property.
+        /// </summary>
+        /// <param name="obj">The <see cref="FileSystemInfo" /> for which a hash code is to be returned.</param>
+        /// <returns>A hash code for the specified <see cref="FileSystemInfo" /> object's <see cref="FileSystemInfo.FullName" /> property..</returns>
+        public int GetHashCode(FileSystemInfo obj)
+        {
+#if NETFRAMEWORK || NETSTANDARD
+            return obj.FullName.GetHashCode();
+#else
+            return obj.FullName.GetHashCode(StringComparison.Ordinal);
+#endif
+        }
+    }
+}

--- a/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/GlobalJsonReader.cs
+++ b/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/GlobalJsonReader.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -21,12 +22,21 @@ namespace Microsoft.Build.NuGetSdkResolver
         public const string MSBuildSdksPropertyName = "msbuild-sdks";
 
         /// <summary>
+        /// Represents a thread-safe cache for files based on their full path and last write time.
+        /// </summary>
+        private static readonly ConcurrentDictionary<FileInfo, (DateTime LastWriteTime, Lazy<Dictionary<string, string>> Lazy)> FileCache = new ConcurrentDictionary<FileInfo, (DateTime, Lazy<Dictionary<string, string>>)>(FileSystemInfoFullNameEqualityComparer.Instance);
+
+        /// <summary>
         /// Walks up the directory tree to find the first global.json and reads the msbuild-sdks section.
         /// </summary>
         /// <returns>A <see cref="Dictionary{String,String}"/> of MSBuild SDK versions from a global.json if found, otherwise <code>null</code>.</returns>
-        public static Dictionary<string, string> GetMSBuildSdkVersions(SdkResolverContext context)
+        public static Dictionary<string, string> GetMSBuildSdkVersions(SdkResolverContext context, out bool wasGlobalJsonRead, string fileName = GlobalJsonFileName)
         {
-            if (string.IsNullOrWhiteSpace(context?.ProjectFilePath))
+            bool wasRead = false;
+
+            wasGlobalJsonRead = wasRead;
+
+            if (string.IsNullOrWhiteSpace(context?.ProjectFilePath) || string.IsNullOrWhiteSpace(fileName))
             {
                 // If the ProjectFilePath is not set, an in-memory project is being evaluated and there's no way to know which directory to start looking for a global.json
                 return null;
@@ -34,46 +44,49 @@ namespace Microsoft.Build.NuGetSdkResolver
 
             DirectoryInfo projectDirectory = Directory.GetParent(context.ProjectFilePath);
 
-            if (!TryGetPathOfFileAbove(GlobalJsonFileName, projectDirectory, out FileInfo globalJsonPath))
+            if (projectDirectory == null || !TryGetPathOfFileAbove(fileName, projectDirectory, out FileInfo globalJsonPath))
             {
                 return null;
             }
 
-            string contents = File.ReadAllText(globalJsonPath.FullName);
-
-            // Look ahead in the contents to see if there is an msbuild-sdks section.  Deserializing the file requires us to load
-            // Newtonsoft.Json which is 500 KB while a global.json is usually ~100 bytes of text.
-            if (contents.IndexOf(MSBuildSdksPropertyName, StringComparison.Ordinal) == -1)
+            if (!globalJsonPath.Exists)
             {
+                FileCache.TryRemove(globalJsonPath, out var _);
+
                 return null;
             }
 
-            try
-            {
-                return Deserialize(contents);
-            }
-            catch (Exception e)
-            {
-                // Failed to parse "{0}". {1}
-                var message = string.Format(CultureInfo.CurrentCulture, Strings.FailedToParseGlobalJson, globalJsonPath, e.Message);
-                context.Logger.LogMessage(message);
-                return null;
-            }
-        }
+            // Add a new file to the cache if it doesn't exist.  If the file is already in the cache, read it again if the file has changed
+            (DateTime LastWriteTime, Lazy<Dictionary<string, string>> Lazy) result = FileCache.AddOrUpdate(
+                globalJsonPath,
+                key => (key.LastWriteTime, new Lazy<Dictionary<string, string>>(() =>
+                {
+                    wasRead = true;
 
-        /// <summary>
-        /// Deserializes a global.json and returns the MSBuild SDK versions
-        /// </summary>
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private static Dictionary<string, string> Deserialize(string value)
-        {
-            return JsonConvert.DeserializeObject<GlobalJsonFile>(value).MSBuildSdks;
-        }
+                    return ParseMSBuildSdkVersions(key, context);
+                })),
+                (key, item) =>
+                {
+                    DateTime lastWriteTime = key.LastWriteTime;
 
-        private sealed class GlobalJsonFile
-        {
-            [JsonProperty(MSBuildSdksPropertyName)]
-            public Dictionary<string, string> MSBuildSdks { get; set; }
+                    if (item.LastWriteTime < lastWriteTime)
+                    {
+                        return (lastWriteTime, new Lazy<Dictionary<string, string>>(() =>
+                        {
+                            wasRead = true;
+
+                            return ParseMSBuildSdkVersions(key, context);
+                        }));
+                    }
+
+                    return item;
+                });
+
+            Dictionary<string, string> sdkVersions = result.Lazy.Value;
+
+            wasGlobalJsonRead = wasRead;
+
+            return sdkVersions;
         }
 
         /// <summary>
@@ -113,6 +126,127 @@ namespace Microsoft.Build.NuGetSdkResolver
             while (currentDirectory != null);
 
             return false;
+        }
+
+        /// <summary>
+        /// Parses the <c>msbuild-sdks</c> section of the specified file.
+        /// </summary>
+        /// <param name="globalJsonPath"></param>
+        /// <param name="sdkResolverContext">The current <see cref="SdkResolverContext" /> to use.</param>
+        /// <returns>A <see cref="Dictionary{TKey, TValue}" /> containing MSBuild project SDK versions if any were found, otherwise <c>null</c>.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static Dictionary<string, string> ParseMSBuildSdkVersions(FileInfo globalJsonPath, SdkResolverContext sdkResolverContext)
+        {
+            // Load the file as a string and check if it has an msbuild-sdks section.  Parsing the contents requires Newtonsoft.Json.dll to be loaded which can be expensive
+            string json = File.ReadAllText(globalJsonPath.FullName);
+
+            // Look ahead in the contents to see if there is an msbuild-sdks section.  Deserializing the file requires us to load
+            // Newtonsoft.Json which is 500 KB while a global.json is usually ~100 bytes of text.
+            if (json.IndexOf(MSBuildSdksPropertyName, StringComparison.Ordinal) == -1)
+            {
+                return null;
+            }
+
+            try
+            {
+                return ParseMSBuildSdkVersionsFromJson(json);
+            }
+            catch (Exception e)
+            {
+                // Failed to parse "{0}". {1}
+                sdkResolverContext.Logger.LogMessage(string.Format(CultureInfo.CurrentCulture, Strings.FailedToParseGlobalJson, globalJsonPath, e.Message));
+
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Parses the <c>msbuild-sdks</c> section of the specified JSON string.
+        /// </summary>
+        /// <param name="json">The JSON to parse as a string.</param>
+        /// <returns>A <see cref="Dictionary{TKey, TValue}" /> containing MSBuild project SDK versions if any were found, otherwise <c>null</c>.</returns>
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static Dictionary<string, string> ParseMSBuildSdkVersionsFromJson(string json)
+        {
+            Dictionary<string, string> versionsByName = null;
+
+            using (var reader = new JsonTextReader(new StringReader(json)))
+            {
+                if (!reader.Read() || reader.TokenType != JsonToken.StartObject)
+                {
+                    return null;
+                }
+
+                while (reader.Read())
+                {
+                    if (reader.TokenType == JsonToken.PropertyName && reader.Value is string objectName && string.Equals(objectName, MSBuildSdksPropertyName, StringComparison.Ordinal) && reader.Read() && reader.TokenType == JsonToken.StartObject)
+                    {
+                        while (reader.Read() && reader.TokenType != JsonToken.EndObject)
+                        {
+                            if (reader.TokenType == JsonToken.PropertyName && reader.Value is string name && reader.Read() && reader.TokenType == JsonToken.String && reader.Value is string value)
+                            {
+                                versionsByName ??= new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+                                versionsByName[name] = value;
+
+                                continue;
+                            }
+
+                            reader.Skip();
+                        }
+
+                        return versionsByName;
+                    }
+
+                    // Skip any top-level entry that's not a property
+                    reader.Skip();
+                }
+            }
+
+            return versionsByName;
+        }
+
+        /// <summary>
+        /// An <see cref="IEqualityComparer{T}" /> that compares <see cref="FileSystemInfo" /> objects by the value of the <see cref="FileSystemInfo.FullName" /> property.
+        /// </summary>
+        private class FileSystemInfoFullNameEqualityComparer : IEqualityComparer<FileSystemInfo>
+        {
+            /// <summary>
+            /// Gets a static singleton for the <see cref="FileSystemInfoFullNameEqualityComparer" /> class.
+            /// </summary>
+            public static FileSystemInfoFullNameEqualityComparer Instance = new FileSystemInfoFullNameEqualityComparer();
+
+            /// <summary>
+            /// Initializes a new instance of the <see cref="FileSystemInfoFullNameEqualityComparer" /> class.
+            /// </summary>
+            private FileSystemInfoFullNameEqualityComparer()
+            {
+            }
+
+            /// <summary>
+            /// Determines whether the specified <see cref="FileSystemInfo" /> objects are equal by comparing their <see cref="FileSystemInfo.FullName" /> property.
+            /// </summary>
+            /// <param name="x">The first <see cref="FileSystemInfo" /> to compare.</param>
+            /// <param name="y">The second <see cref="FileSystemInfo" /> to compare.</param>
+            /// <returns><c>true</c> if the specified <see cref="FileSystemInfo" /> objects' <see cref="FileSystemInfo.FullName" /> property are equal, otherwise <c>false</c>.</returns>
+            public bool Equals(FileSystemInfo x, FileSystemInfo y)
+            {
+                return string.Equals(x.FullName, y.FullName, StringComparison.Ordinal);
+            }
+
+            /// <summary>
+            /// Returns a hash code for the specified <see cref="FileSystemInfo" /> object's <see cref="FileSystemInfo.FullName" /> property.
+            /// </summary>
+            /// <param name="obj">The <see cref="FileSystemInfo" /> for which a hash code is to be returned.</param>
+            /// <returns>A hash code for the specified <see cref="FileSystemInfo" /> object's <see cref="FileSystemInfo.FullName" /> property..</returns>
+            public int GetHashCode(FileSystemInfo obj)
+            {
+#if NETFRAMEWORK || NETSTANDARD
+                return obj.FullName.GetHashCode();
+#else
+                return obj.FullName.GetHashCode(StringComparison.Ordinal);
+#endif
+            }
         }
     }
 }

--- a/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/GlobalJsonReader.cs
+++ b/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/GlobalJsonReader.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Build.NuGetSdkResolver
     /// Represents an implementation of <see cref="IGlobalJsonReader" /> that reads MSBuild project SDK related sections from a global.json.
     /// <seealso href="https://docs.microsoft.com/en-us/dotnet/core/tools/global-json?#msbuild-sdks" />
     /// </summary>
-    internal sealed partial class GlobalJsonReader : IGlobalJsonReader
+    internal sealed class GlobalJsonReader : IGlobalJsonReader
     {
         /// <summary>
         /// The default name of the file containing configuration information.

--- a/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/GlobalJsonReader.cs
+++ b/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/GlobalJsonReader.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Build.NuGetSdkResolver
         /// <summary>
         /// Occurs when a file is read.
         /// </summary>
-        public event EventHandler FileRead;
+        public event EventHandler<string> FileRead;
 
         /// <inheritdoc cref="IGlobalJsonReader.GetMSBuildSdkVersions(SdkResolverContext, string)" />
         public Dictionary<string, string> GetMSBuildSdkVersions(SdkResolverContext context, string fileName = GlobalJsonFileName)
@@ -181,9 +181,9 @@ namespace Microsoft.Build.NuGetSdkResolver
         /// <param name="filePath">The full path to file that was read.</param>
         private void OnFileRead(string filePath)
         {
-            EventHandler fileReadEventHandler = FileRead;
+            EventHandler<string> fileReadEventHandler = FileRead;
 
-            fileReadEventHandler?.Invoke(filePath, EventArgs.Empty);
+            fileReadEventHandler?.Invoke(this, filePath);
         }
 
         /// <summary>

--- a/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/IGlobalJsonReader.cs
+++ b/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/IGlobalJsonReader.cs
@@ -1,0 +1,22 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Microsoft.Build.Framework;
+
+namespace Microsoft.Build.NuGetSdkResolver
+{
+    /// <summary>
+    /// Represents an interface for a class that reads global.json.
+    /// </summary>
+    internal interface IGlobalJsonReader
+    {
+        /// <summary>
+        /// Walks up the directory tree to find the first global.json and reads the msbuild-sdks section.
+        /// </summary>
+        /// <param name="context">An <see cref="SdkResolverContext" /> to use when locating the file.</param>
+        /// <param name="fileName">An optional file name to search for, the default is global.json.</param>
+        /// <returns>A <see cref="Dictionary{String,String}" /> of MSBuild SDK versions from a global.json if found, otherwise <c>null</c>.</returns>
+        Dictionary<string, string> GetMSBuildSdkVersions(SdkResolverContext context, string fileName = GlobalJsonReader.GlobalJsonFileName);
+    }
+}

--- a/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/NuGetSdkLogger.cs
+++ b/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/NuGetSdkLogger.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Build.NuGetSdkResolver
     /// An implementation of <see cref="ILogger" /> that logs messages to an <see cref="SdkLogger" />.
     /// </summary>
     /// <inheritdoc />
-    internal class NuGetSdkLogger : ILogger
+    internal sealed class NuGetSdkLogger : ILogger
     {
         /// <summary>
         /// A collection of errors that have been logged.

--- a/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/NuGetSdkResolver.cs
+++ b/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/NuGetSdkResolver.cs
@@ -85,20 +85,7 @@ namespace Microsoft.Build.NuGetSdkResolver
                 return false;
             }
 
-            Dictionary<string, string> msbuildSdkVersions;
-
-            // Get the SDK versions from a previous state, otherwise find and load global.json to get them
-            if (context.State is Dictionary<string, string> dictionary)
-            {
-                msbuildSdkVersions = dictionary;
-            }
-            else
-            {
-                msbuildSdkVersions = GlobalJsonReader.GetMSBuildSdkVersions(context);
-
-                // Save the SDK versions in case this resolver is called again for another SDK in the same build
-                context.State = msbuildSdkVersions;
-            }
+            Dictionary<string, string> msbuildSdkVersions = GlobalJsonReader.GetMSBuildSdkVersions(context, out bool _);
 
             // Check if global.json specified a version for this SDK and make sure its a version compatible with NuGet
             if (msbuildSdkVersions != null && msbuildSdkVersions.TryGetValue(id, out var globalJsonVersion) &&

--- a/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/NuGetSdkResolver.cs
+++ b/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/NuGetSdkResolver.cs
@@ -29,6 +29,25 @@ namespace Microsoft.Build.NuGetSdkResolver
     {
         private static readonly Lazy<bool> DisableNuGetSdkResolver = new Lazy<bool>(() => Environment.GetEnvironmentVariable("MSBUILDDISABLENUGETSDKRESOLVER") == "1");
 
+        private readonly IGlobalJsonReader _globalJsonReader;
+
+        /// <summary>
+        /// Initializes a new instance of the NuGetSdkResolver class.
+        /// </summary>
+        public NuGetSdkResolver()
+            : this(new GlobalJsonReader())
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the NuGetSdkResolver class with the specified <see cref="IGlobalJsonReader" />.
+        /// </summary>
+        /// <param name="globalJsonReader">An <see cref="IGlobalJsonReader" /> to use when reading a global.json file.</param>
+        internal NuGetSdkResolver(IGlobalJsonReader globalJsonReader)
+        {
+            _globalJsonReader = globalJsonReader;
+        }
+
         /// <inheritdoc />
         public override string Name => nameof(NuGetSdkResolver);
 
@@ -41,7 +60,7 @@ namespace Microsoft.Build.NuGetSdkResolver
         /// <param name="factory">Factory class to create an <see cref="T:Microsoft.Build.Framework.SdkResult" /></param>
         /// <returns>
         ///     An <see cref="T:Microsoft.Build.Framework.SdkResult" /> containing the resolved SDKs or associated error / reason
-        ///     the SDK could not be resolved.  Return <code>null</code> if the resolver is not
+        ///     the SDK could not be resolved.  Return <c>null</c> if the resolver is not
         ///     applicable for a particular <see cref="T:Microsoft.Build.Framework.SdkReference" />.
         /// </returns>
         public override SdkResult Resolve(SdkReference sdkReference, SdkResolverContext resolverContext, SdkResultFactory factory)
@@ -67,8 +86,7 @@ namespace Microsoft.Build.NuGetSdkResolver
         /// This method should not consume any NuGet classes directly to avoid loading additional assemblies when they are not needed.  This method
         /// returns an object so that NuGetVersion is not consumed directly.
         /// </summary>
-        internal static bool TryGetNuGetVersionForSdk(string id, string version, SdkResolverContext context,
-            out object parsedVersion)
+        internal bool TryGetNuGetVersionForSdk(string id, string version, SdkResolverContext context, out object parsedVersion)
         {
             if (!string.IsNullOrWhiteSpace(version))
             {
@@ -85,7 +103,7 @@ namespace Microsoft.Build.NuGetSdkResolver
                 return false;
             }
 
-            Dictionary<string, string> msbuildSdkVersions = GlobalJsonReader.GetMSBuildSdkVersions(context, out bool _);
+            Dictionary<string, string> msbuildSdkVersions = _globalJsonReader.GetMSBuildSdkVersions(context);
 
             // Check if global.json specified a version for this SDK and make sure its a version compatible with NuGet
             if (msbuildSdkVersions != null && msbuildSdkVersions.TryGetValue(id, out var globalJsonVersion) &&

--- a/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/Strings.Designer.cs
+++ b/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/Strings.Designer.cs
@@ -10,7 +10,6 @@
 
 namespace Microsoft.Build.NuGetSdkResolver {
     using System;
-    using System.Reflection;
     
     
     /// <summary>
@@ -20,7 +19,7 @@ namespace Microsoft.Build.NuGetSdkResolver {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Strings {
@@ -40,7 +39,7 @@ namespace Microsoft.Build.NuGetSdkResolver {
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Microsoft.Build.NuGetSdkResolver.Strings", typeof(Strings).GetTypeInfo().Assembly);
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Microsoft.Build.NuGetSdkResolver.Strings", typeof(Strings).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
@@ -71,11 +70,29 @@ namespace Microsoft.Build.NuGetSdkResolver {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Failed to determine path to global.json from path &quot;{0}&quot;. {1}.
+        /// </summary>
+        internal static string FailedToFindPathToGlobalJson {
+            get {
+                return ResourceManager.GetString("FailedToFindPathToGlobalJson", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Failed to parse &quot;{0}&quot;. {1}.
         /// </summary>
         internal static string FailedToParseGlobalJson {
             get {
                 return ResourceManager.GetString("FailedToParseGlobalJson", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to read file &quot;{0}&quot;. {1}.
+        /// </summary>
+        internal static string FailedToReadGlobalJson {
+            get {
+                return ResourceManager.GetString("FailedToReadGlobalJson", resourceCulture);
             }
         }
         

--- a/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/Strings.resx
+++ b/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/Strings.resx
@@ -120,8 +120,14 @@
   <data name="CouldNotFindInstalledPackage" xml:space="preserve">
     <value>Failed to resolve SDK '{0}'. A package was successfully restored but the package could not be located.</value>
   </data>
+  <data name="FailedToFindPathToGlobalJson" xml:space="preserve">
+    <value>Failed to determine path to global.json from path "{0}". {1}</value>
+  </data>
   <data name="FailedToParseGlobalJson" xml:space="preserve">
     <value>Failed to parse "{0}". {1}</value>
+  </data>
+  <data name="FailedToReadGlobalJson" xml:space="preserve">
+    <value>Failed to read file "{0}". {1}</value>
   </data>
   <data name="PackageWasNotInstalled" xml:space="preserve">
     <value>Failed to resolve SDK '{0}'. Package restore was successful but a package with the ID of "{1}" was not installed.</value>

--- a/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/Strings.resx
+++ b/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/Strings.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -119,17 +119,22 @@
   </resheader>
   <data name="CouldNotFindInstalledPackage" xml:space="preserve">
     <value>Failed to resolve SDK '{0}'. A package was successfully restored but the package could not be located.</value>
+    <comment>{0} is the name of an MSBuild project SDK.</comment>
   </data>
   <data name="FailedToFindPathToGlobalJson" xml:space="preserve">
     <value>Failed to determine path to global.json from path "{0}". {1}</value>
+    <comment>{0} is the path to the file used to start looking for global.json and {1} is the exception message that occurred.</comment>
   </data>
   <data name="FailedToParseGlobalJson" xml:space="preserve">
     <value>Failed to parse "{0}". {1}</value>
+    <comment>{0} is the path to the global.json file that was attempted to be parsed and {1} is the exception message that occurred.</comment>
   </data>
   <data name="FailedToReadGlobalJson" xml:space="preserve">
     <value>Failed to read file "{0}". {1}</value>
+    <comment>{0} is the path to the global.json file that was attempted to be read and {1} is the exception message that occurred.</comment>
   </data>
   <data name="PackageWasNotInstalled" xml:space="preserve">
     <value>Failed to resolve SDK '{0}'. Package restore was successful but a package with the ID of "{1}" was not installed.</value>
+    <comment>{0} is name of an MSBuild project SDK and {1} is package ID that was installed.</comment>
   </data>
 </root>

--- a/test/NuGet.Core.Tests/Microsoft.Build.NuGetSdkResolver.Test/GlobalJsonReader_Tests.cs
+++ b/test/NuGet.Core.Tests/Microsoft.Build.NuGetSdkResolver.Test/GlobalJsonReader_Tests.cs
@@ -51,9 +51,9 @@ namespace Microsoft.Build.NuGetSdkResolver.Test
 
                 string actualGlobalJsonPath = null;
 
-                globalJsonReader.FileRead += (sender, args) =>
+                globalJsonReader.FileRead += (_, globalJsonPath) =>
                 {
-                    actualGlobalJsonPath = sender as string;
+                    actualGlobalJsonPath = globalJsonPath;
                 };
 
                 globalJsonReader.GetMSBuildSdkVersions(context).Should().Equal(expectedVersions);
@@ -98,9 +98,9 @@ namespace Microsoft.Build.NuGetSdkResolver.Test
 
                 string actualGlobalJsonPath = null;
 
-                globalJsonReader.FileRead += (sender, args) =>
+                globalJsonReader.FileRead += (_, globalJsonPath) =>
                 {
-                    actualGlobalJsonPath = sender as string;
+                    actualGlobalJsonPath = globalJsonPath;
                 };
 
                 globalJsonReader.GetMSBuildSdkVersions(context).Should().BeEquivalentTo(expectedVersions);
@@ -131,9 +131,9 @@ namespace Microsoft.Build.NuGetSdkResolver.Test
 
                 string actualGlobalJsonPath = null;
 
-                globalJsonReader.FileRead += (sender, args) =>
+                globalJsonReader.FileRead += (_, globalJsonPath) =>
                 {
-                    actualGlobalJsonPath = sender as string;
+                    actualGlobalJsonPath = globalJsonPath;
                 };
 
                 globalJsonReader.GetMSBuildSdkVersions(context).Should().BeNull();
@@ -168,9 +168,9 @@ namespace Microsoft.Build.NuGetSdkResolver.Test
 
                 string actualGlobalJsonPath = null;
 
-                globalJsonReader.FileRead += (sender, args) =>
+                globalJsonReader.FileRead += (_, globalJsonPath) =>
                 {
-                    actualGlobalJsonPath = sender as string;
+                    actualGlobalJsonPath = globalJsonPath;
                 };
 
                 globalJsonReader.GetMSBuildSdkVersions(context).Should().Equal(expectedVersions);
@@ -201,17 +201,15 @@ namespace Microsoft.Build.NuGetSdkResolver.Test
 
                 Dictionary<string, int> globalJsonReadCountByPath = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
 
-                globalJsonReader.FileRead += (sender, args) =>
+                globalJsonReader.FileRead += (_, globalJsonPath) =>
                 {
-                    string globalJsonPath = sender as string;
-
                     if (globalJsonReadCountByPath.ContainsKey(globalJsonPath))
                     {
-                        globalJsonReadCountByPath[sender as string]++;
+                        globalJsonReadCountByPath[globalJsonPath]++;
                     }
                     else
                     {
-                        globalJsonReadCountByPath[sender as string] = 1;
+                        globalJsonReadCountByPath[globalJsonPath] = 1;
                     }
                 };
 

--- a/test/NuGet.Core.Tests/Microsoft.Build.NuGetSdkResolver.Test/MockGlobalJsonReader.cs
+++ b/test/NuGet.Core.Tests/Microsoft.Build.NuGetSdkResolver.Test/MockGlobalJsonReader.cs
@@ -1,0 +1,26 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Microsoft.Build.Framework;
+
+namespace Microsoft.Build.NuGetSdkResolver.Test
+{
+    /// <summary>
+    /// Represents a mock implementation of <see cref="IGlobalJsonReader" />.
+    /// </summary>
+    internal class MockGlobalJsonReader : IGlobalJsonReader
+    {
+        private readonly Dictionary<string, string> _sdkVersions;
+
+        public MockGlobalJsonReader(Dictionary<string, string> sdkVersions)
+        {
+            _sdkVersions = sdkVersions;
+        }
+
+        public Dictionary<string, string> GetMSBuildSdkVersions(SdkResolverContext context, string fileName = "global.json")
+        {
+            return _sdkVersions;
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/Microsoft.Build.NuGetSdkResolver.Test/NuGetSdkResolver_Tests.cs
+++ b/test/NuGet.Core.Tests/Microsoft.Build.NuGetSdkResolver.Test/NuGetSdkResolver_Tests.cs
@@ -183,26 +183,6 @@ namespace Microsoft.Build.NuGetSdkResolver.Test
                 sdkResolverContext);
         }
 
-        /// <summary>
-        /// Verifies that <see cref="NuGetSdkResolver.TryGetNuGetVersionForSdk(string, string, SdkResolverContextBase, out object)" /> uses the saved state from a previous call when passed in via the <see cref="SdkResolverContext" />.
-        /// </summary>
-        [Fact]
-        public void TryGetNuGetVersionForSdk_WhenStateIsNotNull_StateIsUsed()
-        {
-            var sdkResolverContext = new MockSdkResolverContext(ProjectName)
-            {
-                State = new Dictionary<string, string>
-                {
-                    [PackageA] = "1.2.3"
-                }
-            };
-
-            VerifyTryGetNuGetVersionForSdk(
-                version: null,
-                expectedVersion: NuGetVersion.Parse("1.2.3"),
-                sdkResolverContext);
-        }
-
         private void VerifyTryGetNuGetVersionForSdk(string version, NuGetVersion expectedVersion, SdkResolverContext context)
         {
             var result = NuGetSdkResolver.TryGetNuGetVersionForSdk(PackageA, version, context, out var parsedVersion);

--- a/test/NuGet.Core.Tests/Microsoft.Build.NuGetSdkResolver.Test/NuGetSdkResolver_Tests.cs
+++ b/test/NuGet.Core.Tests/Microsoft.Build.NuGetSdkResolver.Test/NuGetSdkResolver_Tests.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.IO;
 using FluentAssertions;
 using Microsoft.Build.Framework;
+using Moq;
 using NuGet.Packaging;
 using NuGet.Test.Utility;
 using NuGet.Versioning;
@@ -85,7 +86,7 @@ namespace Microsoft.Build.NuGetSdkResolver.Test
         [Fact]
         public void TryGetNuGetVersionForSdk_WhenGlobalJsonExists_UsesVersionsFromGlobalJson()
         {
-            var expectedVersions = new Dictionary<string, string>
+            var allVersions = new Dictionary<string, string>
             {
                 [PackageA] = "5.11.77",
                 [PackageB] = "2.0.0"
@@ -93,13 +94,12 @@ namespace Microsoft.Build.NuGetSdkResolver.Test
 
             using (var testDirectory = TestDirectory.Create())
             {
-                GlobalJsonReaderTests.WriteGlobalJson(testDirectory, expectedVersions);
-
                 var sdkResolverContext = new MockSdkResolverContext(testDirectory);
 
                 VerifyTryGetNuGetVersionForSdk(
+                    allVersions,
                     version: null,
-                    expectedVersion: NuGetVersion.Parse(expectedVersions[PackageA]),
+                    expectedVersion: NuGetVersion.Parse(allVersions[PackageA]),
                     sdkResolverContext);
             }
         }
@@ -110,15 +110,15 @@ namespace Microsoft.Build.NuGetSdkResolver.Test
         [Fact]
         public void TryGetNuGetVersionForSdk_WhenInvalidVersionInGlobalJson_ReturnsNull()
         {
-            var sdkResolverContext = new MockSdkResolverContext(ProjectName)
+            var allVersions = new Dictionary<string, string>
             {
-                State = new Dictionary<string, string>
-                {
-                    [PackageA] = "InvalidVersion"
-                }
+                [PackageA] = "InvalidVersion"
             };
 
+            var sdkResolverContext = new MockSdkResolverContext(ProjectName);
+
             VerifyTryGetNuGetVersionForSdk(
+                allVersions,
                 version: null,
                 expectedVersion: null,
                 sdkResolverContext);
@@ -133,6 +133,7 @@ namespace Microsoft.Build.NuGetSdkResolver.Test
             var sdkResolverContext = new MockSdkResolverContext(ProjectName);
 
             VerifyTryGetNuGetVersionForSdk(
+                allVersions: null,
                 version: "InvalidVersion",
                 expectedVersion: null,
                 sdkResolverContext);
@@ -147,6 +148,7 @@ namespace Microsoft.Build.NuGetSdkResolver.Test
             var sdkResolverContext = new MockSdkResolverContext(projectPath: null);
 
             VerifyTryGetNuGetVersionForSdk(
+                allVersions: null,
                 version: "1.0.0",
                 expectedVersion: NuGetVersion.Parse("1.0.0"),
                 sdkResolverContext);
@@ -161,6 +163,7 @@ namespace Microsoft.Build.NuGetSdkResolver.Test
             var sdkResolverContext = new MockSdkResolverContext(projectPath: null);
 
             VerifyTryGetNuGetVersionForSdk(
+                allVersions: null,
                 version: null,
                 expectedVersion: null,
                 sdkResolverContext);
@@ -178,14 +181,19 @@ namespace Microsoft.Build.NuGetSdkResolver.Test
             };
 
             VerifyTryGetNuGetVersionForSdk(
+                allVersions: null,
                 version: null,
                 expectedVersion: null,
                 sdkResolverContext);
         }
 
-        private void VerifyTryGetNuGetVersionForSdk(string version, NuGetVersion expectedVersion, SdkResolverContext context)
+        private void VerifyTryGetNuGetVersionForSdk(Dictionary<string, string> allVersions, string version, NuGetVersion expectedVersion, SdkResolverContext context)
         {
-            var result = NuGetSdkResolver.TryGetNuGetVersionForSdk(PackageA, version, context, out var parsedVersion);
+            var globalJsonReader = new MockGlobalJsonReader(allVersions);
+
+            var sdkResolver = new NuGetSdkResolver(globalJsonReader);
+
+            var result = sdkResolver.TryGetNuGetVersionForSdk(PackageA, version, context, out var parsedVersion);
 
             if (expectedVersion != null)
             {


### PR DESCRIPTION


<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11450

Regression? No

## Description
The MSBuild SDK resolver APIs provide some state but it is not thread-safe.  This results in the NuGet SDK resolver loading and parsing global.json N times in Visual Studio, once for solution load and once for every design time build.

This change introduces a file cache based on path and last write time that is thread-safe.

I also changed how global.json is parsed to help speed up the process.

Related to https://github.com/NuGet/Home/issues/11443 and https://github.com/NuGet/Home/issues/11441

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
