### PR TITLE
use string builder from pool to reduce string allocations in restore code path

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/LockFileBuilder.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/LockFileBuilder.cs
@@ -338,7 +338,7 @@ namespace NuGet.Commands
 
             foreach (LockFileTargetLibrary library in libraries)
             {
-                var libraryKey = library.Name + " " + library.Version;
+                var libraryKey = library.Name + library.Version;
 
                 if (libraryReferences.TryGetValue(libraryKey, out LockFileTargetLibrary existingLibrary))
                 {

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/LockFileBuilder.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/LockFileBuilder.cs
@@ -573,7 +573,7 @@ namespace NuGet.Commands
             /// </summary>
             /// <param name="x">The first <see cref="LockFileTargetLibrary" /> to compare.</param>
             /// <param name="y">The second <see cref="LockFileTargetLibrary" /> to compare.</param>
-            /// <returns><c>true</c> if the specified <see cref="LockFileTargetLibrary" /> objects' <see cref="FileSystemInfo.Name" /> and <see cref="LockFileTargetLibrary.Version" /> properties are equal, otherwise <c>false</c>.</returns>
+            /// <returns><c>true</c> if the specified <see cref="LockFileTargetLibrary" /> objects' <see cref="LockFileTargetLibrary.Name" /> and <see cref="LockFileTargetLibrary.Version" /> properties are equal, otherwise <c>false</c>.</returns>
             public bool Equals(LockFileTargetLibrary x, LockFileTargetLibrary y)
             {
                 return string.Equals(x.Name, y.Name, StringComparison.Ordinal) && x.Version.Equals(y.Version);

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/LockFileBuilder.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/LockFileBuilder.cs
@@ -12,6 +12,7 @@ using NuGet.LibraryModel;
 using NuGet.Packaging;
 using NuGet.ProjectModel;
 using NuGet.Repositories;
+using NuGet.Shared;
 using NuGetVersion = NuGet.Versioning.NuGetVersion;
 
 namespace NuGet.Commands
@@ -331,26 +332,24 @@ namespace NuGet.Commands
             return libraryReferences;
         }
 
-        private void EnsureUniqueLockFileTargetLibraries(LockFileTarget lockFileTarget)
+        private static void EnsureUniqueLockFileTargetLibraries(LockFileTarget lockFileTarget)
         {
             IList<LockFileTargetLibrary> libraries = lockFileTarget.Libraries;
-            var libraryReferences = new Dictionary<string, LockFileTargetLibrary>();
+            var libraryReferences = new Dictionary<LockFileTargetLibrary, LockFileTargetLibrary>(comparer: LockFileTargetLibraryNameAndVersionEqualityComparer.Instance);
 
             foreach (LockFileTargetLibrary library in libraries)
             {
-                var libraryKey = library.Name + library.Version;
-
-                if (libraryReferences.TryGetValue(libraryKey, out LockFileTargetLibrary existingLibrary))
+                if (libraryReferences.TryGetValue(library, out LockFileTargetLibrary existingLibrary))
                 {
                     if (RankReferences(existingLibrary.Type) > RankReferences(library.Type))
                     {
                         // Prefer project reference over package reference, so replace the the package reference.
-                        libraryReferences[libraryKey] = library;
+                        libraryReferences[library] = library;
                     }
                 }
                 else
                 {
-                    libraryReferences[libraryKey] = library;
+                    libraryReferences[library] = library;
                 }
             }
 
@@ -360,7 +359,7 @@ namespace NuGet.Commands
             }
 
             lockFileTarget.Libraries = new List<LockFileTargetLibrary>(libraryReferences.Count);
-            foreach (KeyValuePair<string, LockFileTargetLibrary> pair in libraryReferences)
+            foreach (KeyValuePair<LockFileTargetLibrary, LockFileTargetLibrary> pair in libraryReferences)
             {
                 lockFileTarget.Libraries.Add(pair.Value);
             }
@@ -550,6 +549,50 @@ namespace NuGet.Commands
         private static bool HasTools(string file)
         {
             return file.StartsWith("tools/", StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// An <see cref="IEqualityComparer{T}" /> that compares <see cref="LockFileTargetLibrary" /> objects by the value of the <see cref="LockFileTargetLibrary.Name" /> and <see cref="LockFileTargetLibrary.Version" /> properties.
+        /// </summary>
+        private class LockFileTargetLibraryNameAndVersionEqualityComparer : IEqualityComparer<LockFileTargetLibrary>
+        {
+            /// <summary>
+            /// Gets a static singleton for the <see cref="LockFileTargetLibraryNameAndVersionEqualityComparer" /> class.
+            /// </summary>
+            public static LockFileTargetLibraryNameAndVersionEqualityComparer Instance = new();
+
+            /// <summary>
+            /// Initializes a new instance of the <see cref="LockFileTargetLibraryNameAndVersionEqualityComparer" /> class.
+            /// </summary>
+            private LockFileTargetLibraryNameAndVersionEqualityComparer()
+            {
+            }
+
+            /// <summary>
+            /// Determines whether the specified <see cref="LockFileTargetLibrary" /> objects are equal by comparing their <see cref="LockFileTargetLibrary.Name" /> and <see cref="LockFileTargetLibrary.Version" /> properties.
+            /// </summary>
+            /// <param name="x">The first <see cref="LockFileTargetLibrary" /> to compare.</param>
+            /// <param name="y">The second <see cref="LockFileTargetLibrary" /> to compare.</param>
+            /// <returns><c>true</c> if the specified <see cref="LockFileTargetLibrary" /> objects' <see cref="FileSystemInfo.Name" /> and <see cref="LockFileTargetLibrary.Version" /> properties are equal, otherwise <c>false</c>.</returns>
+            public bool Equals(LockFileTargetLibrary x, LockFileTargetLibrary y)
+            {
+                return string.Equals(x.Name, y.Name, StringComparison.Ordinal) && x.Version.Equals(y.Version);
+            }
+
+            /// <summary>
+            /// Returns a hash code for the specified <see cref="LockFileTargetLibrary" /> object's <see cref="LockFileTargetLibrary.Name" /> property.
+            /// </summary>
+            /// <param name="obj">The <see cref="LockFileTargetLibrary" /> for which a hash code is to be returned.</param>
+            /// <returns>A hash code for the specified <see cref="LockFileTargetLibrary" /> object's <see cref="LockFileTargetLibrary.Name" /> and and <see cref="LockFileTargetLibrary.Version" /> properties.</returns>
+            public int GetHashCode(LockFileTargetLibrary obj)
+            {
+                var combiner = new HashCodeCombiner();
+
+                combiner.AddObject(obj.Name);
+                combiner.AddObject(obj.Version);
+
+                return combiner.CombinedHash;
+            }
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Common/PathUtil/PathUtility.cs
+++ b/src/NuGet.Core/NuGet.Common/PathUtil/PathUtility.cs
@@ -237,30 +237,39 @@ namespace NuGet.Common
                 ++index;
             }
 
-            var path = "";
-
             // check if path2 ends with a non-directory separator and if path1 has the same non-directory at the end
             if (len1 + 1 == len2 && !string.IsNullOrEmpty(path1Segments[index]) &&
                 string.Equals(path1Segments[index], path2Segments[index], compare))
             {
-                return path;
+                return string.Empty;
             }
 
+            var path = StringBuilderPool.Shared.Rent(100);
+
+            const string twoDots = "..";
             for (var i = index; len1 > i; ++i)
             {
-                path += ".." + separator;
+                path.Append(twoDots);
+                path.Append(separator);
             }
+
             for (var i = index; len2 - 1 > i; ++i)
             {
-                path += path2Segments[i] + separator;
+                path.Append(path2Segments[i]);
+                path.Append(separator);
             }
+
             // if path2 doesn't end with an empty string it means it ended with a non-directory name, so we add it back
             if (!string.IsNullOrEmpty(path2Segments[len2 - 1]))
             {
-                path += path2Segments[len2 - 1];
+                path.Append(path2Segments[len2 - 1]);
             }
 
-            return path;
+            var relativePath = path.ToString();
+
+            StringBuilderPool.Shared.Return(path);
+
+            return relativePath;
         }
 
         public static string GetAbsolutePath(string basePath, string relativePath)

--- a/src/NuGet.Core/NuGet.Common/PathUtil/PathUtility.cs
+++ b/src/NuGet.Core/NuGet.Common/PathUtil/PathUtility.cs
@@ -244,7 +244,7 @@ namespace NuGet.Common
                 return string.Empty;
             }
 
-            var path = StringBuilderPool.Shared.Rent(100);
+            var path = StringBuilderPool.Shared.Rent(256);
 
             const string twoDots = "..";
             for (var i = index; len1 > i; ++i)

--- a/src/NuGet.Core/NuGet.Packaging/PackageExtraction/PackagePathHelper.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageExtraction/PackagePathHelper.cs
@@ -65,7 +65,7 @@ namespace NuGet.Packaging
 
         private static IEnumerable<string> GetPackageFiles(string root, string filter)
         {
-            filter = filter ?? "*" + PackagingCoreConstants.NupkgExtension;
+            filter ??= "*" + PackagingCoreConstants.NupkgExtension;
             Debug.Assert(
                 filter.EndsWith(PackagingCoreConstants.NupkgExtension, StringComparison.OrdinalIgnoreCase) ||
                 filter.EndsWith(PackagingCoreConstants.NuspecExtension, StringComparison.OrdinalIgnoreCase));

--- a/src/NuGet.Core/NuGet.Packaging/PackageExtraction/PackagePathHelper.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageExtraction/PackagePathHelper.cs
@@ -65,7 +65,7 @@ namespace NuGet.Packaging
 
         private static IEnumerable<string> GetPackageFiles(string root, string filter)
         {
-            filter ??= "*" + PackagingCoreConstants.NupkgExtension;
+            filter = filter ?? "*" + PackagingCoreConstants.NupkgExtension;
             Debug.Assert(
                 filter.EndsWith(PackagingCoreConstants.NupkgExtension, StringComparison.OrdinalIgnoreCase) ||
                 filter.EndsWith(PackagingCoreConstants.NuspecExtension, StringComparison.OrdinalIgnoreCase));

--- a/src/NuGet.Core/NuGet.Protocol/RemoteRepositories/HttpFileSystemBasedFindPackageByIdResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/RemoteRepositories/HttpFileSystemBasedFindPackageByIdResource.cs
@@ -569,10 +569,27 @@ namespace NuGet.Protocol
         {
             var parsedVersion = NuGetVersion.Parse(version);
             var normalizedVersionString = parsedVersion.ToNormalizedString();
+            string idInLowerCase = id.ToLowerInvariant();
+
+            var builder = StringBuilderPool.Shared.Rent(256);
+
+            builder.Append(baseUri);
+            builder.Append(idInLowerCase);
+            builder.Append('/');
+            builder.Append(normalizedVersionString);
+            builder.Append('/');
+            builder.Append(idInLowerCase);
+            builder.Append('.');
+            builder.Append(normalizedVersionString);
+            builder.Append(".nupkg");
+            string contentUri = builder.ToString();
+
+            StringBuilderPool.Shared.Return(builder);
+
             return new PackageInfo
             {
                 Identity = new PackageIdentity(id, parsedVersion),
-                ContentUri = baseUri + id.ToLowerInvariant() + "/" + normalizedVersionString + "/" + id.ToLowerInvariant() + "." + normalizedVersionString + ".nupkg",
+                ContentUri = contentUri,
             };
         }
 

--- a/src/NuGet.Core/NuGet.Versioning/VersionRangeFactory.cs
+++ b/src/NuGet.Core/NuGet.Versioning/VersionRangeFactory.cs
@@ -199,7 +199,7 @@ namespace NuGet.Versioning
             if (!string.IsNullOrWhiteSpace(minVersionString))
             {
                 // parse the min version string
-                if (allowFloating && minVersionString.Contains("*"))
+                if (allowFloating && minVersionString.Contains('*'))
                 {
                     // single floating version
                     if (FloatRange.TryParse(minVersionString, out floatRange)


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11475

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
Leverage [StringBuilderPool](https://github.com/NuGet/NuGet.Client/blob/9a72664c07aaef63e5d23a529e34f292f96e99d7/build/Shared/StringBuilderPool.cs) functionality to reduce string allocations in restore code path. The proposed changes reduced memory allocations by `38 MB for OrchardCore solution restore scenario`.

Before - 
![image](https://user-images.githubusercontent.com/52756182/147971321-a29c1350-2391-4b39-bf1e-462b21a9b7d7.png)

After - 
![image](https://user-images.githubusercontent.com/52756182/148004965-5010cd1c-6c7b-4697-9e94-c28e33debc52.png)

Before - 
![image](https://user-images.githubusercontent.com/52756182/147971327-72904df7-cad2-45af-8220-c11aba2d16cf.png)

After - 
![image](https://user-images.githubusercontent.com/52756182/148619733-f9ffe631-b1fe-4633-8f79-671ee70b76ba.png)

Before - 
![image](https://user-images.githubusercontent.com/52756182/147971363-199ffd34-9754-4806-8c40-60c76d91179a.png)

After - 
![image](https://user-images.githubusercontent.com/52756182/148494303-8c03afff-952c-4555-9d99-a8ceeb174831.png)

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] N/A <!-- Infrastructure, documentation etc. --> No functional changes introduced in this PR.

- **Documentation**
  - [x] N/A
