### PR TITLE
Fix deadlock when running package install.ps1

### DIFF
--- a/src/NuGet.Clients/NuGet.Console/NuGet.Console.csproj
+++ b/src/NuGet.Clients/NuGet.Console/NuGet.Console.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common.legacy.props" />
   <PropertyGroup>
@@ -62,6 +62,7 @@
     <Compile Include="Token.cs" />
     <Compile Include="TokenType.cs" />
     <Compile Include="Utils\CommandUiUtilities.cs" />
+    <Compile Include="Utils\PumpingJTF.cs" />
     <Compile Include="Xamls\ConsoleContainer.xaml.cs">
       <DependentUpon>ConsoleContainer.xaml</DependentUpon>
     </Compile>

--- a/src/NuGet.Clients/NuGet.Console/ScriptExecutor.cs
+++ b/src/NuGet.Clients/NuGet.Console/ScriptExecutor.cs
@@ -16,6 +16,7 @@ using NuGet.Packaging;
 using NuGet.Packaging.Core;
 using NuGet.ProjectManagement;
 using NuGet.VisualStudio;
+using NuGetConsole.Utils;
 using Task = System.Threading.Tasks.Task;
 
 namespace NuGetConsole
@@ -40,10 +41,13 @@ namespace NuGetConsole
         [Import]
         public IOutputConsoleProvider OutputConsoleProvider { get; set; }
 
+        private PumpingJTF _pumpingJTF;
+
         public ScriptExecutor()
         {
             Host = new AsyncLazy<IHost>(GetHostAsync, ThreadHelper.JoinableTaskFactory);
             Reset();
+            _pumpingJTF = new PumpingJTF(NuGetUIThreadHelper.JoinableTaskFactory);
         }
 
         public void Reset()
@@ -169,6 +173,11 @@ namespace NuGetConsole
             return result;
         }
 
+        public void ResetPumpingJTF()
+        {
+            _pumpingJTF = new PumpingJTF(NuGetUIThreadHelper.JoinableTaskFactory);
+        }
+
         private async Task ExecuteScriptCoreAsync(ScriptExecutionRequest request)
         {
             var console = await OutputConsoleProvider.CreatePowerShellConsoleAsync();
@@ -178,7 +187,11 @@ namespace NuGetConsole
             // to switch to powershell pipeline execution thread. In order not to block the UI thread,
             // go off the UI thread. This is important, since, switches to UI thread,
             // using SwitchToMainThreadAsync will deadlock otherwise
-            await Task.Run(() => host.Execute(console, request.BuildCommand(), request.BuildInput()));
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            _pumpingJTF.Run(async () =>
+            {
+                await Task.Run(() => host.Execute(console, request.BuildCommand(), request.BuildInput()));
+            });
         }
 
         private async Task<IHost> GetHostAsync()

--- a/src/NuGet.Clients/NuGet.Console/Utils/PumpingJTF.cs
+++ b/src/NuGet.Clients/NuGet.Console/Utils/PumpingJTF.cs
@@ -4,7 +4,7 @@
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.Threading;
 
-namespace NuGet.VisualStudio
+namespace NuGetConsole.Utils
 {
     // Note that accessing DTE objects from a background thread is a bad thing. It violates VS threading rule #1 and does not switch to main thread
     // beforing accessing a method with STA requirement. This will RPC its way into main thread and might do work that is unrelated.

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/IDE/IScriptExecutor.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/IDE/IScriptExecutor.cs
@@ -22,5 +22,7 @@ namespace NuGet.PackageManagement.VisualStudio
         bool TryMarkVisited(PackageIdentity packageIdentity, PackageInitPS1State initPS1State);
 
         Task<bool> ExecuteInitScriptAsync(PackageIdentity packageIdentity);
+
+        void ResetPumpingJTF();
     }
 }


### PR DESCRIPTION
This PR is targeting release-6.0.x. The following PR targets dev. Both PRs will be merged at the same time.

* https://github.com/NuGet/NuGet.Client/pull/4383

The differences between the two is that in 17.0 NuGet still used `ProjectServiceAccessor` and therefore needs to reset the JTF used by `ScriptExector`, but in 17.1 NuGet stopped using CPS' JTF, so that API was removed from `IScriptExecutor`.

<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11476

Regression? No

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Deadlock only happens when:
* Another VS component installs the package via NuGet's IVsPackageInstaller.
* That component calls NuGet on a background thread, but blocks the UI thread
    until NuGet finishes.
* The project uses packages.config.
* The package contains install.ps1.

All our other code switches to the UI thread as necessary, it's just running powershell scripts, which we intentionally do on the background thread, which needs the UI thread for COM RPC because of the decision to make DTE available in powershell. Therefore, move the PumpingJTF implementation to the powershell host code.

We know our implementation of PM UI and PMC don't block the UI thread, so in theory we don't even need to use PumpingJTF when packages are installed via PM UI or PMC, only when other components install via NuGet's VS extensibility APIs.  However, wiring up a boolean, or similar, so we know when it's called via extensibility vs called from our own code is not feasible. We'll just have to accept the UI thread usage for packages.config projects.

## PR Checklist

- [X] PR has a meaningful title
- [X] PR has a linked issue.
- [X] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [X] Test exception: Apex tests are slow and painful to write, and slow to execute. I don't know if it's worth the effort.
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [X] N/A
