### PR TITLE
Add a trailing slash on path for GeneratePathProperty

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/MSBuildRestoreItemGroup.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/MSBuildRestoreItemGroup.cs
@@ -41,7 +41,7 @@ namespace NuGet.Commands
             {
                 if (Conditions.Count > 0)
                 {
-                    return " " + string.Join(" AND ", Conditions.Select(s => s.Trim())) + " ";
+                    return string.Join(" AND ", Conditions.Select(s => s.Trim()));
                 }
                 else
                 {

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
@@ -24,9 +24,6 @@ namespace NuGet.Commands
     {
         private static readonly XNamespace Namespace = XNamespace.Get("http://schemas.microsoft.com/developer/msbuild/2003");
         internal const string CrossTargetingCondition = "'$(TargetFramework)' == ''";
-        internal const string TargetFrameworkCondition = "'$(TargetFramework)' == '{0}'";
-        internal const string LanguageCondition = "'$(Language)' == '{0}'";
-        internal const string NegativeLanguageCondition = "'$(Language)' != '{0}'";
         internal const string ExcludeAllCondition = "'$(ExcludeRestorePackageImports)' != 'true'";
         public const string TargetsExtension = ".targets";
         public const string PropsExtension = ".props";
@@ -102,7 +99,7 @@ namespace NuGet.Commands
                 if (!string.IsNullOrEmpty(macroValue)
                     && path.StartsWith(macroValue, StringComparison.OrdinalIgnoreCase))
                 {
-                    path = $"$({macroName})" + $"{path.Substring(macroValue.Length)}";
+                    path = "$(" + macroName + ")" + path.Substring(macroValue.Length);
                 }
 
                 break;
@@ -167,7 +164,7 @@ namespace NuGet.Commands
 
             doc.Root.AddFirst(
                 new XElement(Namespace + "PropertyGroup",
-                            new XAttribute("Condition", $" {ExcludeAllCondition} "),
+                            new XAttribute("Condition", ExcludeAllCondition),
                             GenerateProperty("RestoreSuccess", success.ToString()),
                             GenerateProperty("RestoreTool", "NuGet"),
                             GenerateProperty("ProjectAssetsFile", assetsFilePath),
@@ -176,7 +173,7 @@ namespace NuGet.Commands
                             GenerateProperty("NuGetProjectStyle", projectStyle.ToString()),
                             GenerateProperty("NuGetToolVersion", MinClientVersionUtility.GetNuGetClientVersion().ToFullString())),
                 new XElement(Namespace + "ItemGroup",
-                            new XAttribute("Condition", $" {ExcludeAllCondition} "),
+                            new XAttribute("Condition", ExcludeAllCondition),
                             packageFolders.Select(e => GenerateItem("SourceRoot", PathUtility.EnsureTrailingSlash(e)))));
         }
 
@@ -198,7 +195,7 @@ namespace NuGet.Commands
         public static XElement GenerateProperty(string propertyName, string content)
         {
             return new XElement(Namespace + propertyName,
-                            new XAttribute("Condition", $" '$({propertyName})' == '' "),
+                            new XAttribute("Condition", "'$(" + propertyName + ")' == ''"),
                             content);
         }
 
@@ -211,14 +208,14 @@ namespace NuGet.Commands
         {
             return new XElement(Namespace + "Import",
                                 new XAttribute("Project", path),
-                                new XAttribute("Condition", $"Exists('{path}')"));
+                                new XAttribute("Condition", "Exists('" + path + "')"));
         }
 
         public static XElement GenerateContentFilesItem(string path, LockFileContentFile item, string packageId, string packageVersion)
         {
             var entry = new XElement(Namespace + item.BuildAction.Value,
                                 new XAttribute("Include", path),
-                                new XAttribute("Condition", $"Exists('{path}')"),
+                                new XAttribute("Condition", "Exists('" + path + "')"),
                                 new XElement(Namespace + "NuGetPackageId", packageId),
                                 new XElement(Namespace + "NuGetPackageVersion", packageVersion),
                                 new XElement(Namespace + "NuGetItemType", item.BuildAction),
@@ -319,7 +316,7 @@ namespace NuGet.Commands
 
             if (absolutePath.StartsWith(repositoryRoot, StringComparison.Ordinal))
             {
-                path = $"$(NuGetPackageRoot){absolutePath.Substring(repositoryRoot.Length)}";
+                path = "$(NuGetPackageRoot)" + absolutePath.Substring(repositoryRoot.Length);
             }
             else
             {
@@ -380,13 +377,13 @@ namespace NuGet.Commands
             {
                 // PackageReference style projects
                 var projFileName = Path.GetFileName(project.RestoreMetadata.ProjectPath);
-                path = Path.Combine(project.RestoreMetadata.OutputPath, $"{projFileName}.nuget.g{extension}");
+                path = Path.Combine(project.RestoreMetadata.OutputPath, projFileName + ".nuget.g" + extension);
             }
             else
             {
                 // Project.json style projects
                 var dir = Path.GetDirectoryName(project.FilePath);
-                path = Path.Combine(dir, $"{project.Name}.nuget{extension}");
+                path = Path.Combine(dir, project.Name + ".nuget" + extension);
             }
             return path;
 
@@ -396,7 +393,7 @@ namespace NuGet.Commands
         {
             var projFileName = Path.GetFileName(project.RestoreMetadata.ProjectPath);
 
-            return Path.Combine(project.RestoreMetadata.OutputPath, $"{projFileName}.nuget.g{extension}");
+            return Path.Combine(project.RestoreMetadata.OutputPath, projFileName + ".nuget.g" + extension);
         }
 
         public static List<MSBuildOutputFile> GetMSBuildOutputFiles(PackageSpec project,
@@ -448,10 +445,7 @@ namespace NuGet.Commands
 
             foreach (var ridlessTarget in ridlessTargets)
             {
-                var frameworkConditions = string.Format(
-                        CultureInfo.InvariantCulture,
-                        TargetFrameworkCondition,
-                        GetMatchingFrameworkStrings(project, ridlessTarget.TargetFramework));
+                var frameworkConditions = "'$(TargetFramework)' == '" + GetMatchingFrameworkStrings(project, ridlessTarget.TargetFramework) + "'";
 
                 // Find matching target in the original target graphs.
                 var targetGraph = targetGraphs.FirstOrDefault(e =>
@@ -622,13 +616,13 @@ namespace NuGet.Commands
                 // Must not be any of the other package languages.
                 foreach (var lang in allLanguages)
                 {
-                    yield return string.Format(CultureInfo.InvariantCulture, NegativeLanguageCondition, GetLanguage(lang));
+                    yield return "'$(Language)' != '" + GetLanguage(lang) + "'";
                 }
             }
             else
             {
                 // Must be the language.
-                yield return string.Format(CultureInfo.InvariantCulture, LanguageCondition, GetLanguage(language));
+                yield return "'$(Language)' == '" + GetLanguage(language) + "'";
             }
         }
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
@@ -762,11 +762,16 @@ namespace NuGet.Commands
 
         private static XElement GeneratePackagePathProperty(LocalPackageInfo localPackageInfo)
         {
+
 #if NETCOREAPP
-            return GenerateProperty($"Pkg{localPackageInfo.Id.Replace(".", "_", StringComparison.Ordinal)}", $"{localPackageInfo.ExpandedPath}{Path.DirectorySeparatorChar}");
+            string propertyName = "Pkg" + localPackageInfo.Id.Replace(".", "_", StringComparison.Ordinal);
 #else
-            return GenerateProperty($"Pkg{localPackageInfo.Id.Replace(".", "_")}", $"{localPackageInfo.ExpandedPath}{Path.DirectorySeparatorChar}");
+            string propertyName = "Pkg" + localPackageInfo.Id.Replace(".", "_");
 #endif
+
+            string propertyValue = localPackageInfo.ExpandedPath + Path.DirectorySeparatorChar;
+
+            return GenerateProperty(propertyName, propertyValue);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
@@ -763,9 +763,9 @@ namespace NuGet.Commands
         private static XElement GeneratePackagePathProperty(LocalPackageInfo localPackageInfo)
         {
 #if NETCOREAPP
-            return GenerateProperty($"Pkg{localPackageInfo.Id.Replace(".", "_", StringComparison.Ordinal)}", localPackageInfo.ExpandedPath);
+            return GenerateProperty($"Pkg{localPackageInfo.Id.Replace(".", "_", StringComparison.Ordinal)}", $"{localPackageInfo.ExpandedPath}{Path.DirectorySeparatorChar}");
 #else
-            return GenerateProperty($"Pkg{localPackageInfo.Id.Replace(".", "_")}", localPackageInfo.ExpandedPath);
+            return GenerateProperty($"Pkg{localPackageInfo.Id.Replace(".", "_")}", $"{localPackageInfo.ExpandedPath}{Path.DirectorySeparatorChar}");
 #endif
         }
     }

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/BuildAssetsUtilsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/BuildAssetsUtilsTests.cs
@@ -667,6 +667,7 @@ namespace NuGet.Commands.Test
                         }
                     }
                 }";
+
                 var projectName = "a";
                 var rootProjectsPath = pathContext.WorkingDirectory;
                 var projectDirectory = Path.Combine(rootProjectsPath, projectName);
@@ -737,13 +738,13 @@ namespace NuGet.Commands.Test
 
                 Assert.NotNull(expectedPropertyGroup);
 
-                Assert.Equal(" '$(ExcludeRestorePackageImports)' != 'true' ", expectedPropertyGroup.Attribute("Condition")?.Value);
+                Assert.Equal("'$(ExcludeRestorePackageImports)' != 'true'", expectedPropertyGroup.Attribute("Condition")?.Value);
 
                 var expectedProperty = expectedPropertyGroup.Elements().FirstOrDefault();
 
                 Assert.Equal($"Pkg{identity.Id.Replace(".", "_")}", expectedProperty.Name.LocalName);
 
-                Assert.Equal($" '$({expectedProperty.Name.LocalName})' == '' ", expectedProperty.Attribute("Condition")?.Value);
+                Assert.Equal($"'$({expectedProperty.Name.LocalName})' == ''", expectedProperty.Attribute("Condition")?.Value);
 
                 Assert.Equal($@"{packageDirectory.FullName}{Path.DirectorySeparatorChar}", expectedProperty?.Value, ignoreCase: true);
             }
@@ -854,11 +855,11 @@ namespace NuGet.Commands.Test
                     Assert.NotNull(actualPropertyElement);
 
 
-                    Assert.Equal($" '$({actualPropertyElement.Name.LocalName})' == '' ", actualPropertyElement.Attribute("Condition")?.Value);
+                    Assert.Equal($"'$({actualPropertyElement.Name.LocalName})' == ''", actualPropertyElement.Attribute("Condition")?.Value);
 
                     Assert.Equal($@"{packageDirectory.FullName}{Path.DirectorySeparatorChar}", actualPropertyElement?.Value, ignoreCase: true);
 
-                    Assert.Equal(" '$(ExcludeRestorePackageImports)' != 'true' ", actualPropertyElement.Parent.Attribute("Condition")?.Value);
+                    Assert.Equal("'$(ExcludeRestorePackageImports)' != 'true'", actualPropertyElement.Parent.Attribute("Condition")?.Value);
                 }
                 else
                 {

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/BuildAssetsUtilsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/BuildAssetsUtilsTests.cs
@@ -745,7 +745,7 @@ namespace NuGet.Commands.Test
 
                 Assert.Equal($" '$({expectedProperty.Name.LocalName})' == '' ", expectedProperty.Attribute("Condition")?.Value);
 
-                Assert.Equal(packageDirectory.FullName, expectedProperty?.Value, ignoreCase: true);
+                Assert.Equal($@"{packageDirectory.FullName}{Path.DirectorySeparatorChar}", expectedProperty?.Value, ignoreCase: true);
             }
         }
 
@@ -856,7 +856,7 @@ namespace NuGet.Commands.Test
 
                     Assert.Equal($" '$({actualPropertyElement.Name.LocalName})' == '' ", actualPropertyElement.Attribute("Condition")?.Value);
 
-                    Assert.Equal(packageDirectory.FullName, actualPropertyElement?.Value, ignoreCase: true);
+                    Assert.Equal($@"{packageDirectory.FullName}{Path.DirectorySeparatorChar}", actualPropertyElement?.Value, ignoreCase: true);
 
                     Assert.Equal(" '$(ExcludeRestorePackageImports)' != 'true' ", actualPropertyElement.Parent.Attribute("Condition")?.Value);
                 }

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/MSBuildRestoreItemGroupTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/MSBuildRestoreItemGroupTests.cs
@@ -31,7 +31,7 @@ namespace NuGet.Commands.Test
             var condition = group.Condition;
 
             // Assert
-            Assert.Equal(" '$(a)' == 'a' ", condition);
+            Assert.Equal("'$(a)' == 'a'", condition);
         }
 
         [Fact]
@@ -46,7 +46,7 @@ namespace NuGet.Commands.Test
             var condition = group.Condition;
 
             // Assert
-            Assert.Equal(" '$(b)' != 'b' AND '$(a)' == 'a' ", condition);
+            Assert.Equal("'$(b)' != 'b' AND '$(a)' == 'a'", condition);
         }
     }
 }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/8871

Regression? No Last working version:

## Description
Add a trailing directory separator character to the value of the property generated by `GeneratePathProperty`.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
