### PR TITLE
Convert tests using TestDirectory to SimpleTestPathContext Part1

### DIFF
--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Caching/CachingTestContext.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Caching/CachingTestContext.cs
@@ -268,7 +268,7 @@ namespace NuGet.CommandLine.Test.Caching
     <clear />
   </packageSourceMapping>
 </configuration>";
-            var fileName = "nuget.config";
+            var fileName = NuGet.Configuration.Settings.DefaultSettingsFileName;
 
             File.WriteAllText(Path.Combine(workingDirectory, fileName), nugetConfigContent);
         }

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Caching/CachingTestContext.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Caching/CachingTestContext.cs
@@ -251,7 +251,26 @@ namespace NuGet.CommandLine.Test.Caching
             ProjectPath = Path.Combine(WorkingPath, "project.csproj");
 
             OutputPackagesPath = Path.Combine(WorkingPath, "packages");
+            CreateNuGetConfig(WorkingPath);
+
             Directory.CreateDirectory(OutputPackagesPath);
+        }
+
+        private void CreateNuGetConfig(string workingDirectory)
+        {
+            string nugetConfigContent =
+                @"<?xml version='1.0' encoding='utf-8'?>
+<configuration>
+  <packageSources>
+    <clear />
+  </packageSources>
+  <packageSourceMapping>
+    <clear />
+  </packageSourceMapping>
+</configuration>";
+            var fileName = "nuget.config";
+
+            File.WriteAllText(Path.Combine(workingDirectory, fileName), nugetConfigContent);
         }
 
         private string MakeTestPackage(string repositoryPath, PackageIdentity identity, string packageFileName, string contentFileName)

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreProjectJsonTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreProjectJsonTest.cs
@@ -680,8 +680,9 @@ namespace NuGet.CommandLine.Test
         public void RestoreProjectJson_RestoreFromSlnWithReferenceOutputAssemblyFalse()
         {
             // Arrange
-            using (var workingPath = TestDirectory.Create())
+            using (var pathContext = new SimpleTestPathContext())
             {
+                string workingPath = pathContext.WorkingDirectory;
                 var repositoryPath = Path.Combine(workingPath, "Repository");
                 var projectDir1 = Path.Combine(workingPath, "test1");
                 var projectDir2 = Path.Combine(workingPath, "test2");
@@ -691,7 +692,6 @@ namespace NuGet.CommandLine.Test
                 Directory.CreateDirectory(projectDir2);
                 Directory.CreateDirectory(repositoryPath);
                 Directory.CreateDirectory(Path.Combine(workingPath, ".nuget"));
-                Util.CreateConfigForGlobalPackagesFolder(workingPath);
 
                 Util.CreateFile(projectDir1, "project.json",
                                                 @"{
@@ -997,8 +997,9 @@ namespace NuGet.CommandLine.Test
         public void RestoreProjectJson_RestoreFromSlnWithUnknownProjAndCsproj()
         {
             // Arrange
-            using (var workingPath = TestDirectory.Create())
+            using (var pathContext = new SimpleTestPathContext())
             {
+                string workingPath = pathContext.WorkingDirectory;
                 var repositoryPath = Path.Combine(workingPath, "Repository");
                 var projectDir1 = Path.Combine(workingPath, "test1");
                 var projectDir2 = Path.Combine(workingPath, "test2");
@@ -1008,8 +1009,6 @@ namespace NuGet.CommandLine.Test
                 Directory.CreateDirectory(projectDir1);
                 Directory.CreateDirectory(projectDir2);
                 Directory.CreateDirectory(Path.Combine(workingPath, ".nuget"));
-
-                Util.CreateConfigForGlobalPackagesFolder(workingPath);
 
                 var packageA = Util.CreateTestPackageBuilder("packageA", "1.1.0-beta-01");
                 var libA = Util.CreatePackageFile("lib/uap/a.dll", "a");
@@ -1222,8 +1221,9 @@ namespace NuGet.CommandLine.Test
         public void RestoreProjectJson_FloatReleaseLabelHighestPrelease()
         {
             // Arrange
-            using (var workingPath = TestDirectory.Create())
+            using (var pathContext = new SimpleTestPathContext())
             {
+                string workingPath = pathContext.WorkingDirectory;
                 var repositoryPath = Path.Combine(workingPath, "Repository");
                 var nugetexe = Util.GetNuGetExePath();
 
@@ -1232,7 +1232,6 @@ namespace NuGet.CommandLine.Test
                 Util.CreateTestPackage("packageA", "1.0.0-alpha", repositoryPath);
                 Util.CreateTestPackage("packageA", "1.0.0-beta-01", repositoryPath);
                 Util.CreateTestPackage("packageA", "1.0.0-beta-02", repositoryPath);
-                Util.CreateConfigForGlobalPackagesFolder(workingPath);
                 var projectJson = @"{
                                         'dependencies': {
                                         'packageA': '1.0.0-*'
@@ -1335,8 +1334,9 @@ namespace NuGet.CommandLine.Test
         public void RestoreProjectJson_FloatIncludesStableOnly()
         {
             // Arrange
-            using (var workingPath = TestDirectory.Create())
+            using (var pathContext = new SimpleTestPathContext())
             {
+                string workingPath = pathContext.WorkingDirectory;
                 var repositoryPath = Path.Combine(workingPath, "Repository");
                 var nugetexe = Util.GetNuGetExePath();
 
@@ -1348,7 +1348,6 @@ namespace NuGet.CommandLine.Test
                 Util.CreateTestPackage("packageA", "1.1.15", repositoryPath);
                 Util.CreateTestPackage("packageA", "1.0.15-beta", repositoryPath);
                 Util.CreateTestPackage("packageA", "1.0.9-beta", repositoryPath);
-                Util.CreateConfigForGlobalPackagesFolder(workingPath);
 
                 var projectJson = @"{
                                         ""dependencies"": {
@@ -1451,8 +1450,9 @@ namespace NuGet.CommandLine.Test
         public void RestoreProjectJson_RestoreBumpsFromStableToPrereleaseWhenNeeded()
         {
             // Arrange
-            using (var workingPath = TestDirectory.Create())
+            using (var pathContext = new SimpleTestPathContext())
             {
+                string workingPath = pathContext.WorkingDirectory;
                 var repositoryPath = Path.Combine(workingPath, "Repository");
                 var nugetexe = Util.GetNuGetExePath();
 
@@ -1462,7 +1462,6 @@ namespace NuGet.CommandLine.Test
                 Util.CreateTestPackage("packageB", "1.0.0-beta", repositoryPath, "win8", "packageC", "2.0.0-beta");
                 Util.CreateTestPackage("packageC", "1.0.0", repositoryPath);
                 Util.CreateTestPackage("packageC", "2.0.0-beta", repositoryPath);
-                Util.CreateConfigForGlobalPackagesFolder(workingPath);
                 var projectJson = @"{
                                         'dependencies': {
                                         'packageA': '1.0.0',
@@ -1508,8 +1507,9 @@ namespace NuGet.CommandLine.Test
         public void RestoreProjectJson_RestoreDowngradesStableDependency()
         {
             // Arrange
-            using (var workingPath = TestDirectory.Create())
+            using (var pathContext = new SimpleTestPathContext())
             {
+                string workingPath = pathContext.WorkingDirectory;
                 var repositoryPath = Path.Combine(workingPath, "Repository");
                 var nugetexe = Util.GetNuGetExePath();
 
@@ -1519,7 +1519,6 @@ namespace NuGet.CommandLine.Test
                 Util.CreateTestPackage("packageB", "1.0.0", repositoryPath, "win8", "packageC", "[2.1.0]");
                 Util.CreateTestPackage("packageC", "3.0.0", repositoryPath);
                 Util.CreateTestPackage("packageC", "2.1.0", repositoryPath);
-                Util.CreateConfigForGlobalPackagesFolder(workingPath);
                 var projectJson = @"{
                                                     'dependencies': {
                                                     'packageA': '1.0.0',
@@ -1622,8 +1621,9 @@ namespace NuGet.CommandLine.Test
         public void RestoreProjectJson_SolutionFileWithAllProjectsInOneFolder()
         {
             // Arrange
-            using (var workingPath = TestDirectory.Create())
+            using (var pathContext = new SimpleTestPathContext())
             {
+                string workingPath = pathContext.WorkingDirectory;
                 var repositoryPath = Path.Combine(workingPath, "Repository");
                 var projectDir = Path.Combine(workingPath, "abc");
                 var nugetexe = Util.GetNuGetExePath();
@@ -1640,7 +1640,6 @@ namespace NuGet.CommandLine.Test
                 packageA.Files.Add(targetA);
                 packageA.Files.Add(libA);
 
-                Util.CreateConfigForGlobalPackagesFolder(workingPath);
                 Util.CreateTestPackage(packageA, repositoryPath);
 
                 Util.CreateFile(projectDir, "testA.project.json",
@@ -1733,7 +1732,7 @@ namespace NuGet.CommandLine.Test
                 Assert.True(File.Exists(targetFileB));
                 Assert.True(File.Exists(lockFileA));
                 Assert.True(File.Exists(lockFileB));
-                Assert.True(File.Exists(Path.Combine(workingPath, "packages/packageA.1.1.0-beta-01/packageA.1.1.0-beta-01.nupkg")));
+                Assert.True(File.Exists(Path.Combine(workingPath, "globalPackages", "packageA", "1.1.0-beta-01", "packageA.1.1.0-beta-01.nupkg")));
             }
         }
 
@@ -1741,8 +1740,9 @@ namespace NuGet.CommandLine.Test
         public void RestoreProjectJson_GenerateFilesWithProjectNameFromCSProj()
         {
             // Arrange
-            using (var workingPath = TestDirectory.Create())
+            using (var pathContext = new SimpleTestPathContext())
             {
+                string workingPath = pathContext.WorkingDirectory;
                 var repositoryPath = Path.Combine(workingPath, "Repository");
                 var nugetexe = Util.GetNuGetExePath();
 
@@ -1755,7 +1755,6 @@ namespace NuGet.CommandLine.Test
                 packageA.Files.Add(targetA);
                 packageA.Files.Add(libA);
 
-                Util.CreateConfigForGlobalPackagesFolder(workingPath);
                 Util.CreateTestPackage(packageA, repositoryPath);
 
                 Util.CreateFile(workingPath, "test.project.json",
@@ -1802,8 +1801,9 @@ namespace NuGet.CommandLine.Test
         public void RestoreProjectJson_GenerateTargetsFileFromSln()
         {
             // Arrange
-            using (var workingPath = TestDirectory.Create())
+            using (var pathContext = new SimpleTestPathContext())
             {
+                string workingPath = pathContext.WorkingDirectory;
                 var nugetexe = Util.GetNuGetExePath();
 
                 var repositoryPath = Path.Combine(workingPath, "Repository");
@@ -1813,7 +1813,6 @@ namespace NuGet.CommandLine.Test
                 Directory.CreateDirectory(projectDir);
                 Directory.CreateDirectory(Path.Combine(workingPath, ".nuget"));
 
-                Util.CreateConfigForGlobalPackagesFolder(workingPath);
                 var packageA = Util.CreateTestPackageBuilder("packageA", "1.1.0-beta-01");
                 var targetContent = "<?xml version=\"1.0\" encoding=\"utf-8\"?><Project ToolsVersion=\"12.0\" xmlns=\"http://schemas.microsoft.com/developer/msbuild/2003\"></Project>";
 
@@ -1897,13 +1896,13 @@ namespace NuGet.CommandLine.Test
         public void RestoreProjectJson_GenerateTargetsFileFromCSProj()
         {
             // Arrange
-            using (var workingPath = TestDirectory.Create())
+            using (var pathContext = new SimpleTestPathContext())
             {
+                string workingPath = pathContext.WorkingDirectory;
                 var repositoryPath = Path.Combine(workingPath, "Repository");
                 var nugetexe = Util.GetNuGetExePath();
 
                 Directory.CreateDirectory(repositoryPath);
-                Util.CreateConfigForGlobalPackagesFolder(workingPath);
                 Directory.CreateDirectory(Path.Combine(workingPath, ".nuget"));
                 var packageA = Util.CreateTestPackageBuilder("packageA", "1.1.0-beta-01");
                 var packageB = Util.CreateTestPackageBuilder("packageB", "2.2.0-beta-02");
@@ -1972,8 +1971,9 @@ namespace NuGet.CommandLine.Test
         public async Task RestoreProjectJson_GenerateTargetsForFallbackFolderAsync()
         {
             // Arrange
-            using (var workingPath = TestDirectory.Create())
+            using (var pathContext = new SimpleTestPathContext())
             {
+                string workingPath = pathContext.WorkingDirectory;
                 var repositoryPath = Path.Combine(workingPath, "Repository");
                 var globalPath = Path.Combine(workingPath, "global");
                 var fallback1 = Path.Combine(workingPath, "fallback1");
@@ -2001,6 +2001,9 @@ namespace NuGet.CommandLine.Test
         <clear />
         <add key=""a"" value=""{repositoryPath}"" />
     </packageSources>
+    <packageSourceMapping>
+      <clear />
+    </packageSourceMapping>
 </configuration>";
 
                 File.WriteAllText(Path.Combine(workingPath, "NuGet.Config"), config);
@@ -2155,8 +2158,9 @@ namespace NuGet.CommandLine.Test
         public void RestoreProjectJson_GenerateTargetsFileWithFolder()
         {
             // Arrange
-            using (var workingPath = TestDirectory.Create())
+            using (var pathContext = new SimpleTestPathContext())
             {
+                string workingPath = pathContext.WorkingDirectory;
                 var folderName = Path.GetFileName(workingPath);
 
                 var repositoryPath = Path.Combine(workingPath, "Repository");
@@ -2164,7 +2168,6 @@ namespace NuGet.CommandLine.Test
 
                 Directory.CreateDirectory(repositoryPath);
                 Directory.CreateDirectory(Path.Combine(workingPath, ".nuget"));
-                Util.CreateConfigForGlobalPackagesFolder(workingPath);
                 var packageA = Util.CreateTestPackageBuilder("packageA", "1.1.0-beta-01");
                 var packageB = Util.CreateTestPackageBuilder("packageB", "2.2.0-beta-02");
 
@@ -2230,8 +2233,9 @@ namespace NuGet.CommandLine.Test
         public void RestoreProjectJson_GenerateTargetsForRootBuildFolderIgnoreSubFolders()
         {
             // Arrange
-            using (var workingPath = TestDirectory.Create())
+            using (var pathContext = new SimpleTestPathContext())
             {
+                string workingPath = pathContext.WorkingDirectory;
                 var folderName = Path.GetFileName(workingPath);
 
                 var repositoryPath = Path.Combine(workingPath, "Repository");
@@ -2239,7 +2243,6 @@ namespace NuGet.CommandLine.Test
 
                 Directory.CreateDirectory(repositoryPath);
                 Directory.CreateDirectory(Path.Combine(workingPath, ".nuget"));
-                Util.CreateConfigForGlobalPackagesFolder(workingPath);
                 var packageA = Util.CreateTestPackageBuilder("packageA", "3.1.0");
 
                 var targetContent = "<?xml version=\"1.0\" encoding=\"utf-8\"?><Project ToolsVersion=\"12.0\" xmlns=\"http://schemas.microsoft.com/developer/msbuild/2003\"></Project>";
@@ -2300,8 +2303,9 @@ namespace NuGet.CommandLine.Test
         public void RestoreProjectJson_GenerateTargetsPersistsWithMultipleRestores()
         {
             // Arrange
-            using (var workingPath = TestDirectory.Create())
+            using (var pathContext = new SimpleTestPathContext())
             {
+                string workingPath = pathContext.WorkingDirectory;
                 var folderName = Path.GetFileName(workingPath);
 
                 var repositoryPath = Path.Combine(workingPath, "Repository");
@@ -2309,7 +2313,6 @@ namespace NuGet.CommandLine.Test
 
                 Directory.CreateDirectory(repositoryPath);
                 Directory.CreateDirectory(Path.Combine(workingPath, ".nuget"));
-                Util.CreateConfigForGlobalPackagesFolder(workingPath);
                 var packageA = Util.CreateTestPackageBuilder("packageA", "1.1.0-beta-01");
                 var packageB = Util.CreateTestPackageBuilder("packageB", "2.2.0-beta-02");
 
@@ -2414,14 +2417,14 @@ namespace NuGet.CommandLine.Test
         public void RestoreProjectJson_CorruptedLockFile()
         {
             // Arrange
-            using (var workingPath = TestDirectory.Create())
+            using (var pathContext = new SimpleTestPathContext())
             {
+                string workingPath = pathContext.WorkingDirectory;
                 var repositoryPath = Path.Combine(workingPath, "Repository");
                 var nugetexe = Util.GetNuGetExePath();
 
                 Directory.CreateDirectory(repositoryPath);
                 Directory.CreateDirectory(Path.Combine(workingPath, ".nuget"));
-                Util.CreateConfigForGlobalPackagesFolder(workingPath);
                 Util.CreateTestPackage("packageA", "1.1.0", repositoryPath);
                 Util.CreateTestPackage("packageB", "2.2.0", repositoryPath);
                 var projectJson = @"{

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetToolTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetToolTests.cs
@@ -50,8 +50,9 @@ namespace Dotnet.Integration.Test
         [PlatformFact(Platform.Windows)]
         public void DotnetToolTests_RegularDependencyPackageWithDependenciesToolRestore_ThrowsError()
         {
-            using (var testDirectory = _msbuildFixture.CreateTestDirectory())
+            using (var pathContext = new SimpleTestPathContext())
             {
+                string testDirectory = pathContext.WorkingDirectory;
                 var tfm = "netcoreapp2.0";
                 var projectName = "ToolRestoreProject";
                 var workingDirectory = Path.Combine(testDirectory, projectName);
@@ -59,7 +60,7 @@ namespace Dotnet.Integration.Test
                 var rid = "win-x86";
                 var packages = new List<PackageIdentity>() { new PackageIdentity("Newtonsoft.Json", NuGetVersion.Parse("10.0.3")) };
 
-                _msbuildFixture.CreateDotnetToolProject(testDirectory.Path, projectName, tfm, rid, packageSource, packages);
+                _msbuildFixture.CreateDotnetToolProject(testDirectory, projectName, tfm, rid, packageSource, packages);
 
                 // Act
                 var result = _msbuildFixture.RestoreToolProject(workingDirectory, projectName, string.Empty);
@@ -74,8 +75,9 @@ namespace Dotnet.Integration.Test
         [PlatformFact(Platform.Windows)]
         public async Task DotnetToolTests_BasicDotnetToolRestore_SucceedsAsync()
         {
-            using (var testDirectory = _msbuildFixture.CreateTestDirectory())
+            using (var pathContext = new SimpleTestPathContext())
             {
+                string testDirectory = pathContext.WorkingDirectory;
                 var tfm = "netcoreapp2.0";
                 var projectName = "ToolRestoreProject";
                 var workingDirectory = Path.Combine(testDirectory, projectName);
@@ -93,7 +95,7 @@ namespace Dotnet.Integration.Test
                 package.PackageTypes.Add(PackageType.DotnetTool);
                 await SimpleTestPackageUtility.CreatePackagesAsync(packageSource, package);
 
-                _msbuildFixture.CreateDotnetToolProject(testDirectory.Path, projectName, tfm, rid, packageSource, packages);
+                _msbuildFixture.CreateDotnetToolProject(testDirectory, projectName, tfm, rid, packageSource, packages);
 
                 // Act
                 var result = _msbuildFixture.RestoreToolProject(workingDirectory, projectName, string.Empty);
@@ -116,8 +118,9 @@ namespace Dotnet.Integration.Test
         [PlatformFact(Platform.Windows)]
         public async Task DotnetToolTests_MismatchedRID_FailsAsync()
         {
-            using (var testDirectory = _msbuildFixture.CreateTestDirectory())
+            using (var pathContext = new SimpleTestPathContext())
             {
+                string testDirectory = pathContext.WorkingDirectory;
                 var tfm = "netcoreapp2.0";
                 var projectName = "ToolRestoreProject";
                 var workingDirectory = Path.Combine(testDirectory, projectName);
@@ -136,7 +139,7 @@ namespace Dotnet.Integration.Test
                 package.PackageTypes.Add(PackageType.DotnetTool);
                 await SimpleTestPackageUtility.CreatePackagesAsync(packageSource, package);
 
-                _msbuildFixture.CreateDotnetToolProject(testDirectory.Path, projectName, tfm, projectRID, packageSource, packages);
+                _msbuildFixture.CreateDotnetToolProject(testDirectory, projectName, tfm, projectRID, packageSource, packages);
 
                 // Act
                 var result = _msbuildFixture.RestoreToolProject(workingDirectory, projectName, string.Empty);
@@ -150,8 +153,9 @@ namespace Dotnet.Integration.Test
         [PlatformFact(Platform.Windows)]
         public async Task DotnetToolTests_BasicDotnetToolRestore_WithJsonCompatibleAssets_SucceedsAsync()
         {
-            using (var testDirectory = _msbuildFixture.CreateTestDirectory())
+            using (var pathContext = new SimpleTestPathContext())
             {
+                string testDirectory = pathContext.WorkingDirectory;
                 var tfm = "netcoreapp2.0";
                 var projectName = "ToolRestoreProject";
                 var workingDirectory = Path.Combine(testDirectory, projectName);
@@ -171,7 +175,7 @@ namespace Dotnet.Integration.Test
                 package.PackageTypes.Add(PackageType.DotnetTool);
                 await SimpleTestPackageUtility.CreatePackagesAsync(packageSource, package);
 
-                _msbuildFixture.CreateDotnetToolProject(testDirectory.Path, projectName, tfm, rid, packageSource, packages);
+                _msbuildFixture.CreateDotnetToolProject(testDirectory, projectName, tfm, rid, packageSource, packages);
 
                 // Act
                 var result = _msbuildFixture.RestoreToolProject(workingDirectory, projectName, string.Empty);
@@ -196,8 +200,9 @@ namespace Dotnet.Integration.Test
         [InlineData("netcoreapp2.0", "any", "win-x86")]
         public async Task DotnetToolTests_PackageWithRuntimeJson_RuntimeIdentifierAny_SucceedsAsync(string tfm, string packageRID, string projectRID)
         {
-            using (var testDirectory = _msbuildFixture.CreateTestDirectory())
+            using (var pathContext = new SimpleTestPathContext())
             {
+                string testDirectory = pathContext.WorkingDirectory;
                 var projectName = "ToolRestoreProject";
                 var workingDirectory = Path.Combine(testDirectory, projectName);
                 var packageSource = Path.Combine(testDirectory, "packageSource");
@@ -215,7 +220,7 @@ namespace Dotnet.Integration.Test
                 package.PackageTypes.Add(PackageType.DotnetTool);
                 await SimpleTestPackageUtility.CreatePackagesAsync(packageSource, package);
 
-                _msbuildFixture.CreateDotnetToolProject(testDirectory.Path, projectName, tfm, projectRID, packageSource, packages);
+                _msbuildFixture.CreateDotnetToolProject(testDirectory, projectName, tfm, projectRID, packageSource, packages);
 
                 // Act
                 var result = _msbuildFixture.RestoreToolProject(workingDirectory, projectName, string.Empty);
@@ -238,8 +243,9 @@ namespace Dotnet.Integration.Test
         [PlatformFact(Platform.Windows)]
         public async Task DotnetToolTests_RegularDependencyAndToolPackageWithDependenciesToolRestore_ThrowsErrorAsync()
         {
-            using (var testDirectory = _msbuildFixture.CreateTestDirectory())
+            using (var pathContext = new SimpleTestPathContext())
             {
+                string testDirectory = pathContext.WorkingDirectory;
                 var tfm = "netcoreapp2.0";
                 var projectName = "ToolRestoreProject";
                 var workingDirectory = Path.Combine(testDirectory, projectName);
@@ -265,7 +271,7 @@ namespace Dotnet.Integration.Test
                     new PackageIdentity("Newtonsoft.Json", NuGetVersion.Parse("10.0.3"))
                 };
 
-                _msbuildFixture.CreateDotnetToolProject(testDirectory.Path, projectName, tfm, rid, packageSources, packages);
+                _msbuildFixture.CreateDotnetToolProject(testDirectory, projectName, tfm, rid, packageSources, packages);
 
                 // Act
                 var result = _msbuildFixture.RestoreToolProject(workingDirectory, projectName, string.Empty);
@@ -282,8 +288,9 @@ namespace Dotnet.Integration.Test
         [InlineData("netcoreapp1.0", "any", "win7-x64")]
         public async Task DotnetToolTests_ToolWithPlatformPackage_SucceedsAsync(string tfm, string packageRid, string projectRid)
         {
-            using (var testDirectory = _msbuildFixture.CreateTestDirectory())
+            using (var pathContext = new SimpleTestPathContext())
             {
+                string testDirectory = pathContext.WorkingDirectory;
                 var projectName = "ToolRestoreProject";
                 var workingDirectory = Path.Combine(testDirectory, projectName);
                 var packageSource = Path.Combine(testDirectory, "packageSource");
@@ -315,7 +322,7 @@ namespace Dotnet.Integration.Test
                     new PackageIdentity(packageName, packageVersion),
                 };
 
-                _msbuildFixture.CreateDotnetToolProject(testDirectory.Path, projectName, tfm, projectRid, packageSource, packages);
+                _msbuildFixture.CreateDotnetToolProject(testDirectory, projectName, tfm, projectRid, packageSource, packages);
 
                 // Act
                 var result = _msbuildFixture.RestoreToolProject(workingDirectory, projectName, string.Empty);
@@ -336,8 +343,9 @@ namespace Dotnet.Integration.Test
         [PlatformFact(Platform.Windows)]
         public async Task DotnetToolTests_ToolPackageWithIncompatibleToolsAssets_FailsAsync()
         {
-            using (var testDirectory = _msbuildFixture.CreateTestDirectory())
+            using (var pathContext = new SimpleTestPathContext())
             {
+                string testDirectory = pathContext.WorkingDirectory;
                 var tfm = "netcoreapp2.0";
                 var projectName = "ToolRestoreProject";
                 var workingDirectory = Path.Combine(testDirectory, projectName);
@@ -359,7 +367,7 @@ namespace Dotnet.Integration.Test
                 package.PackageTypes.Add(PackageType.DotnetTool);
                 await SimpleTestPackageUtility.CreatePackagesAsync(packageSource, package);
 
-                _msbuildFixture.CreateDotnetToolProject(testDirectory.Path, projectName, tfm, rid, packageSource, packages);
+                _msbuildFixture.CreateDotnetToolProject(testDirectory, projectName, tfm, rid, packageSource, packages);
 
                 // Act
                 var result = _msbuildFixture.RestoreToolProject(workingDirectory, projectName, string.Empty);
@@ -373,8 +381,9 @@ namespace Dotnet.Integration.Test
         [PlatformFact(Platform.Windows)]
         public async Task DotnetToolTests_ToolsPackageWithExtraPackageTypes_FailsAsync()
         {
-            using (var testDirectory = _msbuildFixture.CreateTestDirectory())
+            using (var pathContext = new SimpleTestPathContext())
             {
+                string testDirectory = pathContext.WorkingDirectory;
                 var tfm = "netcoreapp2.0";
                 var projectName = "ToolRestoreProject";
                 var workingDirectory = Path.Combine(testDirectory, projectName);
@@ -392,7 +401,7 @@ namespace Dotnet.Integration.Test
                 package.PackageTypes.Add(PackageType.Dependency);
                 await SimpleTestPackageUtility.CreatePackagesAsync(packageSource, package);
 
-                _msbuildFixture.CreateDotnetToolProject(testDirectory.Path, projectName, tfm, rid, packageSource, packages);
+                _msbuildFixture.CreateDotnetToolProject(testDirectory, projectName, tfm, rid, packageSource, packages);
 
                 // Act
                 var result = _msbuildFixture.RestoreToolProject(workingDirectory, projectName, string.Empty);
@@ -406,8 +415,9 @@ namespace Dotnet.Integration.Test
         [PlatformFact(Platform.Windows)]
         public async Task DotnetToolTests_BasicDotnetToolRestoreWithNestedValues_SucceedsAsync()
         {
-            using (var testDirectory = _msbuildFixture.CreateTestDirectory())
+            using (var pathContext = new SimpleTestPathContext())
             {
+                string testDirectory = pathContext.WorkingDirectory;
                 var tfm = "netcoreapp2.0";
                 var projectName = "ToolRestoreProject";
                 var workingDirectory = Path.Combine(testDirectory, projectName);
@@ -426,7 +436,7 @@ namespace Dotnet.Integration.Test
                 package.PackageTypes.Add(PackageType.DotnetTool);
                 await SimpleTestPackageUtility.CreatePackagesAsync(packageSource, package);
 
-                _msbuildFixture.CreateDotnetToolProject(testDirectory.Path, projectName, tfm, rid, packageSource, packages);
+                _msbuildFixture.CreateDotnetToolProject(testDirectory, projectName, tfm, rid, packageSource, packages);
 
                 // Act
                 var result = _msbuildFixture.RestoreToolProject(workingDirectory, projectName, string.Empty);
@@ -450,8 +460,9 @@ namespace Dotnet.Integration.Test
         [PlatformFact(Platform.Windows)]
         public async Task DotnetToolTests_AutoreferencedDependencyAndToolPackagToolRestore_SucceedsAsync()
         {
-            using (var testDirectory = _msbuildFixture.CreateTestDirectory())
+            using (var pathContext = new SimpleTestPathContext())
             {
+                string testDirectory = pathContext.WorkingDirectory;
                 var tfm = "netcoreapp2.0";
                 var projectName = "ToolRestoreProject";
                 var workingDirectory = Path.Combine(testDirectory, projectName);
@@ -478,7 +489,7 @@ namespace Dotnet.Integration.Test
                     new PackageIdentity(autoReferencePackageName, NuGetVersion.Parse("2.0.1"))
                 };
 
-                _msbuildFixture.CreateDotnetToolProject(testDirectory.Path, projectName, tfm, rid, packageSources, packages);
+                _msbuildFixture.CreateDotnetToolProject(testDirectory, projectName, tfm, rid, packageSources, packages);
 
                 var fullProjectPath = Path.Combine(workingDirectory, $"{projectName}.csproj");
                 MakePackageReferenceImplicitlyDefined(fullProjectPath, autoReferencePackageName);
@@ -501,8 +512,9 @@ namespace Dotnet.Integration.Test
         [PlatformFact(Platform.Windows)]
         public async Task DotnetToolTests_AutoreferencedDependencyRegularDependencyAndToolPackagToolRestore_ThrowsAsync()
         {
-            using (var testDirectory = _msbuildFixture.CreateTestDirectory())
+            using (var pathContext = new SimpleTestPathContext())
             {
+                string testDirectory = pathContext.WorkingDirectory;
                 var tfm = "netcoreapp2.0";
                 var projectName = "ToolRestoreProject";
                 var workingDirectory = Path.Combine(testDirectory, projectName);
@@ -530,7 +542,7 @@ namespace Dotnet.Integration.Test
                     new PackageIdentity("NuGet.Versioning", NuGetVersion.Parse("4.3.0"))
                 };
 
-                _msbuildFixture.CreateDotnetToolProject(testDirectory.Path, projectName, tfm, rid, packageSources, packages);
+                _msbuildFixture.CreateDotnetToolProject(testDirectory, projectName, tfm, rid, packageSources, packages);
 
                 var fullProjectPath = Path.Combine(workingDirectory, $"{projectName}.csproj");
                 MakePackageReferenceImplicitlyDefined(fullProjectPath, autoReferencePackageName);
@@ -551,8 +563,9 @@ namespace Dotnet.Integration.Test
         [PlatformFact(Platform.Windows)]
         public async Task DotnetToolTests_ToolPackageAndPlatformsPackageAnyRID_SucceedsAsync()
         {
-            using (var testDirectory = _msbuildFixture.CreateTestDirectory())
+            using (var pathContext = new SimpleTestPathContext())
             {
+                string testDirectory = pathContext.WorkingDirectory;
                 var tfm = "netcoreapp2.0";
                 var projectName = "ToolRestoreProject";
                 var workingDirectory = Path.Combine(testDirectory, projectName);
@@ -580,7 +593,7 @@ namespace Dotnet.Integration.Test
                     new PackageIdentity(autoReferencePackageName, NuGetVersion.Parse("2.0.1")),
                 };
 
-                _msbuildFixture.CreateDotnetToolProject(testDirectory.Path, projectName, tfm, rid, packageSources, packages);
+                _msbuildFixture.CreateDotnetToolProject(testDirectory, projectName, tfm, rid, packageSources, packages);
 
                 var fullProjectPath = Path.Combine(workingDirectory, $"{projectName}.csproj");
                 MakePackageReferenceImplicitlyDefined(fullProjectPath, autoReferencePackageName);
@@ -603,8 +616,9 @@ namespace Dotnet.Integration.Test
         [PlatformFact(Platform.Windows)]
         public async Task DotnetToolTests_IncompatibleAutorefPackageAndToolsPackageAsync()
         {
-            using (var testDirectory = _msbuildFixture.CreateTestDirectory())
+            using (var pathContext = new SimpleTestPathContext())
             {
+                string testDirectory = pathContext.WorkingDirectory;
                 var tfm = "netcoreapp1.0";
                 var incompatibletfm = "netcoreapp2.0";
                 var rid = "win-x64";
@@ -637,7 +651,7 @@ namespace Dotnet.Integration.Test
                     new PackageIdentity(autoReferencePackageName, packageVersion)
                 };
 
-                _msbuildFixture.CreateDotnetToolProject(testDirectory.Path, projectName, tfm, rid, packageSources, packages);
+                _msbuildFixture.CreateDotnetToolProject(testDirectory, projectName, tfm, rid, packageSources, packages);
 
                 var fullProjectPath = Path.Combine(workingDirectory, $"{projectName}.csproj");
                 MakePackageReferenceImplicitlyDefined(fullProjectPath, autoReferencePackageName);
@@ -661,8 +675,9 @@ namespace Dotnet.Integration.Test
         [PlatformFact(Platform.Windows)]
         public async Task DotnetToolTests_ToolRestoreWithFallback_SucceedsAsync()
         {
-            using (var testDirectory = _msbuildFixture.CreateTestDirectory())
+            using (var pathContext = new SimpleTestPathContext())
             {
+                string testDirectory = pathContext.WorkingDirectory;
                 var actualTfm = "netcoreapp2.0";
                 var fallbackTfm = "net46";
                 var projectName = "ToolRestoreProject";
@@ -683,7 +698,7 @@ namespace Dotnet.Integration.Test
                 package.PackageTypes.Add(PackageType.DotnetTool);
                 await SimpleTestPackageUtility.CreatePackagesAsync(packageSource, package);
 
-                _msbuildFixture.CreateDotnetToolProject(testDirectory.Path, projectName, actualTfm, rid, packageSource, packages);
+                _msbuildFixture.CreateDotnetToolProject(testDirectory, projectName, actualTfm, rid, packageSource, packages);
 
                 using (var stream = File.Open(Path.Combine(workingDirectory, projectName + ".csproj"), FileMode.Open, FileAccess.ReadWrite))
                 {
@@ -717,8 +732,9 @@ namespace Dotnet.Integration.Test
         [PlatformFact(Platform.Windows)]
         public async Task DotnetToolTests_ToolRestoreWithRuntimeIdentiferGraphPath_SucceedsAsync()
         {
-            using (var testDirectory = _msbuildFixture.CreateTestDirectory())
+            using (var pathContext = new SimpleTestPathContext())
             {
+                string testDirectory = pathContext.WorkingDirectory;
                 var tfm = "netcoreapp2.0";
                 var projectName = "ToolRestoreProject";
                 var workingDirectory = Path.Combine(testDirectory, projectName);
@@ -739,10 +755,10 @@ namespace Dotnet.Integration.Test
                 package.PackageTypes.Add(PackageType.DotnetTool);
                 await SimpleTestPackageUtility.CreatePackagesAsync(packageSource, package);
 
-                _msbuildFixture.CreateDotnetToolProject(testDirectory.Path, projectName, tfm, rid, packageSource, packages);
+                _msbuildFixture.CreateDotnetToolProject(testDirectory, projectName, tfm, rid, packageSource, packages);
 
                 // set up rid graph
-                var ridGraphPath = Path.Combine(testDirectory.Path, "runtime.json");
+                var ridGraphPath = Path.Combine(testDirectory, "runtime.json");
                 File.WriteAllBytes(ridGraphPath, GetTestUtilityResource("runtime.json"));
 
                 using (var stream = File.Open(Path.Combine(workingDirectory, projectName + ".csproj"), FileMode.Open, FileAccess.ReadWrite))

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
@@ -646,12 +646,16 @@ namespace Dotnet.Integration.Test
         public void PackCommand_PackProject_SupportMultipleFrameworks()
         {
             // Arrange
-            using (var testDirectory = msbuildFixture.CreateTestDirectory())
+            using (var pathContext = new SimpleTestPathContext())
             {
+                SimpleTestSettingsContext settings = pathContext.Settings;
+                settings.AddNetStandardFeeds();
+
+                string testDirectory = pathContext.WorkingDirectory;
                 var projectName = "ClassLibrary1";
                 var workingDirectory = Path.Combine(testDirectory, projectName);
                 var projectFile = Path.Combine(workingDirectory, $"{projectName}.csproj");
-                msbuildFixture.CreateDotnetNewProject(testDirectory.Path, projectName);
+                msbuildFixture.CreateDotnetNewProject(testDirectory, projectName);
 
                 using (var stream = new FileStream(projectFile, FileMode.Open, FileAccess.ReadWrite))
                 {
@@ -733,8 +737,9 @@ namespace Dotnet.Integration.Test
         public void PackProject_DependenciesWithContentFiles_NupkgExcludesContentFilesFromDependencies()
         {
             // Arrange
-            using (var testDirectory = msbuildFixture.CreateTestDirectory())
+            using (var pathContext = new SimpleTestPathContext())
             {
+                string testDirectory = pathContext.WorkingDirectory;
                 // layout
                 var topName = "top";
                 var basePackageName = "BasePackage";
@@ -2156,13 +2161,17 @@ namespace Dotnet.Integration.Test
         [InlineData("netstandard1.4;net451;netcoreapp1.0")]
         public void PackCommand_MultipleFrameworks_GeneratesPackageOnBuild(string frameworks)
         {
-            using (var testDirectory = msbuildFixture.CreateTestDirectory())
+            using (var pathContext = new SimpleTestPathContext())
             {
+                SimpleTestSettingsContext settings = pathContext.Settings;
+                settings.AddNetStandardFeeds();
+
+                string testDirectory = pathContext.WorkingDirectory;
                 var projectName = "ClassLibrary1";
                 var workingDirectory = Path.Combine(testDirectory, projectName);
                 var projectFile = Path.Combine(workingDirectory, $"{projectName}.csproj");
 
-                msbuildFixture.CreateDotnetNewProject(testDirectory.Path, projectName, " classlib");
+                msbuildFixture.CreateDotnetNewProject(testDirectory, projectName, " classlib");
 
                 using (var stream = new FileStream(projectFile, FileMode.Open, FileAccess.ReadWrite))
                 {
@@ -3882,12 +3891,16 @@ namespace ClassLibrary
         public void PackCommand_ManualAddPackage_DevelopmentDependency()
         {
             // Arrange
-            using (var testDirectory = msbuildFixture.CreateTestDirectory())
+            using (var pathContext = new SimpleTestPathContext())
             {
+                SimpleTestSettingsContext settings = pathContext.Settings;
+                settings.AddNetStandardFeeds();
+
+                string testDirectory = pathContext.WorkingDirectory;
                 var projectName = "ClassLibrary1";
                 var workingDirectory = Path.Combine(testDirectory, projectName);
                 var projectFile = Path.Combine(workingDirectory, $"{projectName}.csproj");
-                msbuildFixture.CreateDotnetNewProject(testDirectory.Path, projectName);
+                msbuildFixture.CreateDotnetNewProject(testDirectory, projectName);
 
                 using (var stream = new FileStream(projectFile, FileMode.Open, FileAccess.ReadWrite))
                 {


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11436

Regression? Last working version:

## Description
We have many tests using `TestDirectory` method which may pollute global packages folder since it doesn't clean up temporary created assets (causes flakiness). In order to onboard `PackageSourceMapping` we need to convert some to `SimpleTestPathContext` which is cleans up temporary created assets.  I believe this will reduce overall flakiness of CI test pipeline too.
Half of failing test from https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=5517484&view=results are covered here.

```
Failed tests:
NuGet.CommandLine.Test.RestoreProjectJsonTest.RestoreProjectJson_RestoreBumpsFromStableToPrereleaseWhenNeeded
NuGet.CommandLine.Test.RestoreProjectJsonTest.RestoreProjectJson_SolutionFileWithAllProjectsInOneFolder
NuGet.CommandLine.Test.RestoreProjectJsonTest.RestoreProjectJson_RestoreDowngradesStableDependency
NuGet.CommandLine.Test.RestoreProjectJsonTest.RestoreProjectJson_CorruptedLockFile
NuGet.CommandLine.Test.RestoreProjectJsonTest.RestoreProjectJson_GenerateTargetsForFallbackFolderAsync
NuGet.CommandLine.Test.RestoreProjectJsonTest.RestoreProjectJson_GenerateTargetsPersistsWithMultipleRestores
NuGet.CommandLine.Test.RestoreProjectJsonTest.RestoreProjectJson_FloatReleaseLabelHighestPrelease
NuGet.CommandLine.Test.RestoreProjectJsonTest.RestoreProjectJson_GenerateTargetsFileWithFolder
NuGet.CommandLine.Test.RestoreProjectJsonTest.RestoreProjectJson_GenerateFilesWithProjectNameFromCSProj
NuGet.CommandLine.Test.RestoreProjectJsonTest.RestoreProjectJson_RestoreFromSlnWithUnknownProjAndCsproj
NuGet.CommandLine.Test.RestoreProjectJsonTest.RestoreProjectJson_GenerateTargetsFileFromSln
NuGet.CommandLine.Test.RestoreProjectJsonTest.RestoreProjectJson_FloatIncludesStableOnly
NuGet.CommandLine.Test.RestoreProjectJsonTest.RestoreProjectJson_RestoreFromSlnWithReferenceOutputAssemblyFalse
NuGet.CommandLine.Test.RestoreProjectJsonTest.RestoreProjectJson_GenerateTargetsFileFromCSProj
NuGet.CommandLine.Test.RestoreProjectJsonTest.RestoreProjectJson_GenerateTargetsForRootBuildFolderIgnoreSubFolders
NuGet.CommandLine.Test.Caching.CachingTests.NuGetExe_Caching_PopulatesGlobalPackagesFolder
NuGet.CommandLine.Test.Caching.CachingTests.NuGetExe_Caching_UsesHttpCacheCopy
NuGet.CommandLine.Test.Caching.CachingTests.NuGetExe_Caching_UsesGlobalPackagesFolderCopy
NuGet.CommandLine.Test.Caching.CachingTests.NuGetExe_Caching_WritesToHttpCache
NuGet.CommandLine.Test.Caching.CachingTests.NuGetExe_Caching_CleansUpDirectDownload
NuGet.CommandLine.Test.Caching.CachingTests.NuGetExe_Caching_InstallsToDestinationFolder
NuGet.CommandLine.Test.Caching.CachingTests.NuGetExe_Caching_AllowsMissingPackageOnSource
NuGet.Build.Tasks.Test.GetRestoreSettingsTaskTests.TestConfigFileProbingDirectory
NuGet.Build.Tasks.Test.GetRestoreSettingsTaskTests.TestConfigFileProbingDirectoryWithSettingsLoadingContext
NuGet.Build.Tasks.Test.GetRestoreSettingsTaskTests.TestSolutionSettings
Dotnet.Integration.Test.DotnetToolTests.DotnetToolTests_ToolRestoreWithFallback_SucceedsAsync
Dotnet.Integration.Test.DotnetToolTests.DotnetToolTests_RegularDependencyAndToolPackageWithDependenciesToolRestore_ThrowsErrorAsync
Dotnet.Integration.Test.DotnetToolTests.DotnetToolTests_BasicDotnetToolRestore_WithJsonCompatibleAssets_SucceedsAsync
Dotnet.Integration.Test.DotnetToolTests.DotnetToolTests_ToolPackageAndPlatformsPackageAnyRID_SucceedsAsync
Dotnet.Integration.Test.DotnetToolTests.DotnetToolTests_PackageWithRuntimeJson_RuntimeIdentifierAny_SucceedsAsync
Dotnet.Integration.Test.DotnetToolTests.DotnetToolTests_IncompatibleAutorefPackageAndToolsPackageAsync
Dotnet.Integration.Test.DotnetToolTests.DotnetToolTests_BasicDotnetToolRestore_SucceedsAsync
Dotnet.Integration.Test.DotnetToolTests.DotnetToolTests_BasicDotnetToolRestoreWithNestedValues_SucceedsAsync
Dotnet.Integration.Test.DotnetToolTests.DotnetToolTests_MismatchedRID_FailsAsync
Dotnet.Integration.Test.DotnetToolTests.DotnetToolTests_ToolWithPlatformPackage_SucceedsAsync
Dotnet.Integration.Test.DotnetToolTests.DotnetToolTests_ToolPackageWithIncompatibleToolsAssets_FailsAsync
Dotnet.Integration.Test.DotnetToolTests.DotnetToolTests_AutoreferencedDependencyRegularDependencyAndToolPackagToolRestore_ThrowsAsync
Dotnet.Integration.Test.DotnetToolTests.DotnetToolTests_ToolsPackageWithExtraPackageTypes_FailsAsync
Dotnet.Integration.Test.DotnetToolTests.DotnetToolTests_ToolRestoreWithRuntimeIdentiferGraphPath_SucceedsAsync
Dotnet.Integration.Test.DotnetToolTests.DotnetToolTests_AutoreferencedDependencyAndToolPackagToolRestore_SucceedsAsync
Dotnet.Integration.Test.DotnetToolTests.DotnetToolTests_RegularDependencyPackageWithDependenciesToolRestore_ThrowsError
Dotnet.Integration.Test.PackCommandTests.PackCommand_MultipleFrameworks_GeneratesPackageOnBuild
Dotnet.Integration.Test.PackCommandTests.PackCommand_ManualAddPackage_DevelopmentDependency
Dotnet.Integration.Test.PackCommandTests.PackCommand_PackProject_SupportMultipleFrameworks
Dotnet.Integration.Test.PackCommandTests.PackProject_DependenciesWithContentFiles_NupkgExcludesContentFilesFromDependencies
NuGet.XPlat.FuncTest.XPlatAddPkgTests.AddPkg_UnconditionalAddIntoExeProject_Success
NuGet.XPlat.FuncTest.XPlatAddPkgTests.AddPkg_ConditionalAddTwoPackages_Success
NuGet.XPlat.FuncTest.XPlatAddPkgTests.AddPkg_ConditionalAddWithoutUserInputFramework_Success
NuGet.XPlat.FuncTest.XPlatAddPkgTests.AddPkg_UnconditionalAddPrereleaseSuccess
NuGet.XPlat.FuncTest.XPlatAddPkgTests.AddPkg_ConditionalAddWithoutVersion_Success
NuGet.XPlat.FuncTest.XPlatAddPkgTests.AddPkg_V3LocalSourceFeed_WithAbsolutePath_VersionSpecified_Success
NuGet.XPlat.FuncTest.XPlatAddPkgTests.AddPkg_DevelopmentDependency
NuGet.XPlat.FuncTest.XPlatAddPkgTests.AddPkg_UnconditionalAdd_Success
NuGet.XPlat.FuncTest.XPlatAddPkgTests.AddPkg_ConditionalAddWithUserInputFramework_Success
NuGet.XPlat.FuncTest.XPlatAddPkgTests.AddPkg_UnconditionalAddWithDotnetCliToolAndNoRestore_Success
NuGet.XPlat.FuncTest.XPlatAddPkgTests.AddPkg_UnconditionalAddWithoutVersion_Success
NuGet.XPlat.FuncTest.XPlatAddPkgTests.AddPkg_V3LocalSourceFeed_WithAbsolutePath_NoVersionSpecified_Success
NuGet.XPlat.FuncTest.XPlatAddPkgTests.AddPkg_UnconditionalAddWithNoRestore_Success
NuGet.XPlat.FuncTest.XPlatAddPkgTests.AddPkg_UnconditionalAddWithDotnetCliTool_Success
NuGet.XPlat.FuncTest.XPlatAddPkgTests.AddPkg_ConditionalWithAlias_Success
NuGet.XPlat.FuncTest.XPlatAddPkgTests.AddPkg_ConditionalAddAsUpdate_Success
NuGet.XPlat.FuncTest.XPlatAddPkgTests.AddPkg_UnconditionalAddTwoPackages_Success
NuGet.XPlat.FuncTest.XPlatAddPkgTests.AddPkg_UnconditionalAddAsUpdate_Succcess
NuGet.XPlat.FuncTest.XPlatAddPkgTests.AddPkg_UnconditionalAddWithPackageDirectory_Success
```

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
