### PR TITLE
Fix package content search in Solution Explorer

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/AssetsFileDependenciesTreeSearchProvider.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/AssetsFileDependenciesTreeSearchProvider.cs
@@ -116,16 +116,25 @@ namespace NuGet.VisualStudio.SolutionExplorer
                             nuGetRestoreSnapshot.Properties.TryGetValue(NuGetRestoreRule.NuGetTargetMonikerProperty, out string nuGetTargetMoniker) &&
                             StringComparer.OrdinalIgnoreCase.Equals(nuGetTargetMoniker, tfm))
                         {
-                            // Assets file 'target' string matches the configure project's NuGetTargetMoniker property value
+                            // Assets file 'target' string matches the configured project's NuGetTargetMoniker property value
                             return configuredProject;
                         }
 
-                        if (subscriptionUpdate.CurrentState.TryGetValue(ConfigurationGeneralRule.SchemaName, out IProjectRuleSnapshot configurationGeneralSnapshot) &&
-                                 configurationGeneralSnapshot.Properties.TryGetValue(ConfigurationGeneralRule.TargetFrameworkMonikerProperty, out string targetFrameworkMoniker) &&
-                                 StringComparer.OrdinalIgnoreCase.Equals(targetFrameworkMoniker, tfm))
+                        if (subscriptionUpdate.CurrentState.TryGetValue(ConfigurationGeneralRule.SchemaName, out IProjectRuleSnapshot configurationGeneralSnapshot))
                         {
-                            // Assets file 'target' string matches the configure project's TargetFrameworkMoniker property value
-                            return configuredProject;
+                            if (configurationGeneralSnapshot.Properties.TryGetValue(ConfigurationGeneralRule.TargetFrameworkMonikerProperty, out string targetFrameworkMoniker) &&
+                                StringComparer.OrdinalIgnoreCase.Equals(targetFrameworkMoniker, tfm))
+                            {
+                                // Assets file 'target' string matches the configured project's TargetFrameworkMoniker property value
+                                return configuredProject;
+                            }
+
+                            if (configurationGeneralSnapshot.Properties.TryGetValue(ConfigurationGeneralRule.TargetFrameworkProperty, out string targetFramework) &&
+                                StringComparer.OrdinalIgnoreCase.Equals(targetFramework, tfm))
+                            {
+                                // Assets file 'target' string matches the configured project's TargetFramework property value
+                                return configuredProject;
+                            }
                         }
                     }
 

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/Rules.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/Rules.cs
@@ -10,6 +10,7 @@ namespace NuGet.VisualStudio.SolutionExplorer
         public const string SchemaName = "ConfigurationGeneral";
 
         public const string ProjectAssetsFileProperty = "ProjectAssetsFile";
+        public const string TargetFrameworkProperty = "TargetFramework";
         public const string TargetFrameworkMonikerProperty = "TargetFrameworkMoniker";
     }
 


### PR DESCRIPTION
Some time ago the target framework identifier used in the lock file was changed from form `.NETCoreApp,Version=v5.0` to `net5.0` (presumably to allow for platform suffixes such as `net5.0-android`). This broke a lookup within the dependencies tree in Solution Explorer, leading to results not being displayed.

This change allows the value to match the project's `TargetFramework` property as well, which fixes this issue on the projects I tested against.

## Given

![image](https://user-images.githubusercontent.com/350947/148169506-5a17f343-243c-4157-a12d-474982eb2c2e.png)

## Before

![image](https://user-images.githubusercontent.com/350947/148169533-4f029d0b-2d03-486d-81a3-cca60f8edcb5.png)

## After

![image](https://user-images.githubusercontent.com/350947/148169590-8762237a-9d7b-4c0c-ba98-2968162f8725.png)

<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/dotnet/project-system/issues/7834

Regression? Last working version: Yes, unknown. Some time around 16.9 I suspect.

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [ ] N/A
