### PR TITLE
Fix VS package sources options accessibility

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/CheckedListBoxAccessibleObject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/CheckedListBoxAccessibleObject.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Windows.Forms;
-using NuGet.Configuration;
+using NuGet.VisualStudio.Internal.Contracts;
 using static System.Windows.Forms.Control;
 
 namespace NuGet.Options
@@ -31,7 +31,7 @@ namespace NuGet.Options
         {
             if (index >= 0 && index < CheckedListBox.Items.Count)
             {
-                var packageSource = (PackageSource)CheckedListBox.Items[index];
+                var packageSource = (PackageSourceContextInfo)CheckedListBox.Items[index];
                 return new CheckedListBoxItemAccessibleObject(this, packageSource.Name, index, packageSource.Source);
             }
             else

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/PackageSourceCheckedListBox.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/PackageSourceCheckedListBox.cs
@@ -62,7 +62,7 @@ namespace NuGet.Options
                     const int textMargin = 4;
 
                     // draw the enabled/disabled checkbox
-                    var checkBoxState = currentItem.IsEnabled ? CheckBoxState.CheckedNormal : CheckBoxState.UncheckedNormal;
+                    var checkBoxState = currentListBox.GetItemChecked(e.Index) ? CheckBoxState.CheckedNormal : CheckBoxState.UncheckedNormal;
                     var checkBoxSize = CheckBoxRenderer.GetGlyphSize(graphics, checkBoxState);
                     CheckBoxRenderer.DrawCheckBox(
                         graphics,

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/PackageSourcesOptionsControl.Designer.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/PackageSourcesOptionsControl.Designer.cs
@@ -1,4 +1,4 @@
-﻿using System.Windows.Forms;
+using System.Windows.Forms;
 namespace NuGet.Options
 {
     partial class PackageSourcesOptionsControl
@@ -136,7 +136,7 @@ namespace NuGet.Options
             this.PackageSourcesListBox.Name = "PackageSourcesListBox";
             this.PackageSourcesListBox.KeyUp += new System.Windows.Forms.KeyEventHandler(this.PackageSourcesListBox_KeyUp);
             this.PackageSourcesListBox.MouseMove += new System.Windows.Forms.MouseEventHandler(this.PackageSourcesListBox_MouseMove);
-            this.PackageSourcesListBox.MouseUp += new System.Windows.Forms.MouseEventHandler(this.PackageSourcesListBox_MouseUp);
+            this.PackageSourcesListBox.ItemCheck += new System.Windows.Forms.ItemCheckEventHandler(this.PackageSourcesListBox_ItemCheck);
             // 
             // tableLayoutPanel1
             // 
@@ -188,7 +188,7 @@ namespace NuGet.Options
             this.MachineWidePackageSourcesListBox.Name = "MachineWidePackageSourcesListBox";
             this.MachineWidePackageSourcesListBox.KeyUp += new System.Windows.Forms.KeyEventHandler(this.PackageSourcesListBox_KeyUp);
             this.MachineWidePackageSourcesListBox.MouseMove += new System.Windows.Forms.MouseEventHandler(this.PackageSourcesListBox_MouseMove);
-            this.MachineWidePackageSourcesListBox.MouseUp += new System.Windows.Forms.MouseEventHandler(this.PackageSourcesListBox_MouseUp);
+            this.MachineWidePackageSourcesListBox.ItemCheck += new System.Windows.Forms.ItemCheckEventHandler(this.PackageSourcesListBox_ItemCheck);
             // 
             // images32px
             // 

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/PackageSourcesOptionsControl.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/PackageSourcesOptionsControl.cs
@@ -147,6 +147,10 @@ namespace NuGet.Options
                 _packageSources.CurrentChanged += OnSelectedPackageSourceChanged;
                 PackageSourcesListBox.GotFocus += PackageSourcesListBox_GotFocus;
                 PackageSourcesListBox.DataSource = _packageSources;
+                for (int i = 0; i < packageSources.Count; i++)
+                {
+                    PackageSourcesListBox.SetItemChecked(i, packageSources[i].IsEnabled);
+                }
 
                 if (machineWidePackageSources.Count > 0)
                 {
@@ -154,6 +158,10 @@ namespace NuGet.Options
                     _machineWidepackageSources.CurrentChanged += OnSelectedMachineWidePackageSourceChanged;
                     MachineWidePackageSourcesListBox.GotFocus += MachineWidePackageSourcesListBox_GotFocus;
                     MachineWidePackageSourcesListBox.DataSource = _machineWidepackageSources;
+                    for (int i = 0; i < machineWidePackageSources.Count; i++)
+                    {
+                        MachineWidePackageSourcesListBox.SetItemChecked(i, machineWidePackageSources[i].IsEnabled);
+                    }
                 }
                 else
                 {
@@ -451,24 +459,24 @@ namespace NuGet.Options
                 CopySelectedItem((PackageSourceContextInfo)currentListBox.SelectedItem);
                 e.Handled = true;
             }
-            else if (e.KeyCode == Keys.Space)
-            {
-                TogglePackageSourceEnabled(currentListBox.SelectedIndex, currentListBox);
-                e.Handled = true;
-            }
         }
 
-        private void TogglePackageSourceEnabled(int itemIndex, PackageSourceCheckedListBox currentListBox)
+        private void PackageSourcesListBox_ItemCheck(object sender, ItemCheckEventArgs e)
         {
-            if (itemIndex < 0 || itemIndex >= currentListBox.Items.Count)
+            var checkedListBox = sender as CheckedListBox;
+            if (checkedListBox == null)
             {
                 return;
             }
 
-            var item = (PackageSourceContextInfo)currentListBox.Items[itemIndex];
-            item.IsEnabled = !item.IsEnabled;
+            if (e.Index < 0 || e.Index >= checkedListBox.Items.Count)
+            {
+                return;
+            }
 
-            currentListBox.Invalidate(GetCheckBoxRectangleForListBoxItem(currentListBox, itemIndex));
+            bool isEnabled = e.NewValue == CheckState.Checked;
+            var packageSource = (PackageSourceContextInfo)checkedListBox.Items[e.Index];
+            packageSource.IsEnabled = isEnabled;
         }
 
         private Rectangle GetCheckBoxRectangleForListBoxItem(PackageSourceCheckedListBox currentListBox, int itemIndex)
@@ -491,33 +499,6 @@ namespace NuGet.Options
         {
             Clipboard.Clear();
             Clipboard.SetText(selectedPackageSource.Source);
-        }
-
-        private void PackageSourcesListBox_MouseUp(object sender, MouseEventArgs e)
-        {
-            var currentListBox = (PackageSourceCheckedListBox)sender;
-            if (e.Button == MouseButtons.Right)
-            {
-                int itemIndexToSelect = currentListBox.IndexFromPoint(e.Location);
-                if (itemIndexToSelect >= 0 && itemIndexToSelect < currentListBox.Items.Count)
-                {
-                    currentListBox.SelectedIndex = itemIndexToSelect;
-                }
-            }
-            else if (e.Button == MouseButtons.Left)
-            {
-                var itemIndex = currentListBox.SelectedIndex;
-                if (itemIndex >= 0
-                    && itemIndex < currentListBox.Items.Count)
-                {
-                    var checkBoxRectangle = GetCheckBoxRectangleForListBoxItem(currentListBox, itemIndex);
-                    // if the mouse click position is inside the checkbox, toggle the IsEnabled property
-                    if (checkBoxRectangle.Contains(e.Location))
-                    {
-                        TogglePackageSourceEnabled(itemIndex, currentListBox);
-                    }
-                }
-            }
         }
 
         private void PackageSourcesListBox_MouseMove(object sender, MouseEventArgs e)


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11482

Regression? yes
Last working version: probably 16.8 (before https://github.com/NuGet/NuGet.Client/pull/3797 was merged)

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

* Fix typecast in CheckedListBoxAccessibleObject.cs
* Since screen CheckedListBoxAccessibleObject makes screen readers announce CheckedListBox state, not PackageSourceContextInfo.IsEnabled value, make checkbox rendering use the same state
* Change the package sources dialog to set checked state on load, and respond to check item events, instead of custom mouse/key events.

## PR Checklist

- [X] PR has a meaningful title
- [X] PR has a linked issue.
- [X] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [X] Test exception: How would we even write automated tests for screen readers?
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [X] N/A
