### PR TITLE
Ensure tests in NUGet.Commandline.Test and MSBuild.Integration.Test don't rely on the repo root configuration.

### DIFF
--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetInstallCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetInstallCommandTest.cs
@@ -351,9 +351,6 @@ namespace NuGet.CommandLine.Test
                 var repositoryPath = Path.Combine(workingPath, "Repository");
                 var nugetexe = Util.GetNuGetExePath();
 
-                // Add a nuget.config to clear out sources and set the global packages folder
-                Util.CreateConfigForGlobalPackagesFolder(workingPath);
-
                 Directory.CreateDirectory(repositoryPath);
 
                 Util.CreateTestPackage("packageA", "1.1.0", repositoryPath);
@@ -413,9 +410,6 @@ namespace NuGet.CommandLine.Test
                 var workingPath = pathContext.WorkingDirectory;
 
                 var repositoryPath = Path.Combine(workingPath, "Repository");
-
-                // Add a nuget.config to clear out sources and set the global packages folder
-                Util.CreateConfigForGlobalPackagesFolder(workingPath);
 
                 Directory.CreateDirectory(repositoryPath);
                 Util.CreateTestPackage("packageA", "1.1.0", repositoryPath);
@@ -498,9 +492,6 @@ namespace NuGet.CommandLine.Test
                 var workingPath = pathContext.WorkingDirectory;
 
                 var repositoryPath = Path.Combine(workingPath, "Repository");
-
-                // Add a nuget.config to clear out sources and set the global packages folder
-                Util.CreateConfigForGlobalPackagesFolder(workingPath);
 
                 Directory.CreateDirectory(repositoryPath);
                 Util.CreateTestPackage("packageA", "1.1.0", repositoryPath);
@@ -595,8 +586,6 @@ namespace NuGet.CommandLine.Test
             using (var pathContext = new SimpleTestPathContext())
             {
                 var workingPath = pathContext.WorkingDirectory;
-                // Add a nuget.config to clear out sources and set the global packages folder
-                Util.CreateConfigForGlobalPackagesFolder(workingPath);
 
                 var repositoryPath = Path.Combine(workingPath, "Repository");
 
@@ -636,14 +625,11 @@ namespace NuGet.CommandLine.Test
         public void InstallCommand_FromPackagesConfigFile_SpecifyingRelativeSolutionDir()
         {
             // Arrange
-            var currentDirectory = Directory.GetCurrentDirectory();
             var nugetexe = Util.GetNuGetExePath();
 
             using (var pathContext = new SimpleTestPathContext())
             {
                 var workingPath = pathContext.WorkingDirectory;
-                // Add a nuget.config to clear out sources and set the global packages folder
-                Util.CreateConfigForGlobalPackagesFolder(workingPath);
 
                 var folderName = Path.GetFileName(workingPath);
 
@@ -1041,9 +1027,6 @@ namespace NuGet.CommandLine.Test
                 var workingPath = pathContext.WorkingDirectory;
                 var packageDirectory = pathContext.PackageSource;
 
-                // Add a nuget.config to clear out sources and set the global packages folder
-                Util.CreateConfigForGlobalPackagesFolder(workingPath);
-
                 var repositoryPath = Path.Combine(workingPath, "Repository");
                 var proj1Directory = Path.Combine(workingPath, "proj1");
 
@@ -1070,10 +1053,10 @@ namespace NuGet.CommandLine.Test
                         waitForExit: true);
 
                     // Assert
-                    Assert.Equal(0, r1.Item1);
+                    r1.Success.Should().BeTrue(because: r1.AllOutput);
 
                     // testPackage1 1.2.0 is installed
-                    Assert.True(Directory.Exists(Path.Combine(workingPath, "packages", "testPackage1.1.2.0")));
+                    Assert.True(Directory.Exists(Path.Combine(pathContext.PackagesV2, "testPackage1.1.2.0")));
                 }
             }
         }
@@ -1088,9 +1071,6 @@ namespace NuGet.CommandLine.Test
                 var workingPath = pathContext.WorkingDirectory;
                 var packageDirectory = pathContext.PackageSource;
                 var nugetexe = Util.GetNuGetExePath();
-
-                // Add a nuget.config to clear out sources and set the global packages folder
-                Util.CreateConfigForGlobalPackagesFolder(workingPath);
 
                 var packageFileName = Util.CreateTestPackage("testPackage1", "1.1.0", packageDirectory);
                 var package1 = new ZipPackage(packageFileName);
@@ -1114,7 +1094,7 @@ namespace NuGet.CommandLine.Test
                     Assert.Equal(0, r1.Item1);
 
                     // testPackage1 1.2.0-beta1 is installed
-                    Assert.True(Directory.Exists(Path.Combine(workingPath, "packages", "testPackage1.1.2.0-beta1")));
+                    Assert.True(Directory.Exists(Path.Combine(pathContext.PackagesV2, "testPackage1.1.2.0-beta1")));
                 }
             }
         }
@@ -1128,9 +1108,6 @@ namespace NuGet.CommandLine.Test
                 var workingPath = pathContext.WorkingDirectory;
                 var packageDirectory = pathContext.PackageSource;
                 var nugetexe = Util.GetNuGetExePath();
-
-                // Add a nuget.config to clear out sources and set the global packages folder
-                Util.CreateConfigForGlobalPackagesFolder(workingPath);
 
                 var packageFileName = Util.CreateTestPackage("testPackage1", "1.1.0", packageDirectory);
                 var package1 = new ZipPackage(packageFileName);
@@ -1154,7 +1131,7 @@ namespace NuGet.CommandLine.Test
                     Assert.Equal(0, r1.Item1);
 
                     // testPackage1 1.2.0-beta1 is installed
-                    Assert.True(Directory.Exists(Path.Combine(workingPath, "packages", "testPackage1.1.2.0-beta1")));
+                    Assert.True(Directory.Exists(Path.Combine(pathContext.PackagesV2, "testPackage1.1.2.0-beta1")));
                 }
             }
         }
@@ -1166,17 +1143,9 @@ namespace NuGet.CommandLine.Test
         {
             using (var pathContext = new SimpleTestPathContext())
             {
-                var workingPath = pathContext.WorkingDirectory;
-                var packageDirectory = pathContext.PackageSource;
-                // Add a nuget.config to clear out sources and set the global packages folder
-                Util.CreateConfigForGlobalPackagesFolder(workingPath);
-
                 // Arrange
-                var packageFileName = Util.CreateTestPackage("testPackage1", "1.1.0", packageDirectory);
+                var packageFileName = Util.CreateTestPackage("testPackage1", "1.1.0", pathContext.PackageSource);
                 var package = new ZipPackage(packageFileName);
-
-                // Add a nuget.config to clear out sources and set the global packages folder
-                Util.CreateConfigForGlobalPackagesFolder(workingPath);
 
                 using (var server = new MockServer())
                 {
@@ -1215,12 +1184,12 @@ namespace NuGet.CommandLine.Test
                     var args = "install testPackage1 -Version 1.1.0 -Source " + server.Uri + "nuget";
                     var r1 = CommandRunner.Run(
                         nugetexe,
-                        workingPath,
+                        pathContext.WorkingDirectory,
                         args,
                         waitForExit: true);
 
                     // Assert
-                    Assert.Equal(0, r1.Item1);
+                    r1.Success.Should().BeTrue(r1.AllOutput);
                     Assert.True(getPackageByVersionIsCalled);
                     Assert.True(packageDownloadIsCalled);
                 }
@@ -1234,15 +1203,10 @@ namespace NuGet.CommandLine.Test
             {
                 var workingPath = pathContext.WorkingDirectory;
                 var packageDirectory = pathContext.PackageSource;
-                // Add a nuget.config to clear out sources and set the global packages folder
-                Util.CreateConfigForGlobalPackagesFolder(workingPath);
 
                 // Arrange
                 var packageFileName = Util.CreateTestPackage("testPackage1", "1.1.0", packageDirectory);
                 var package = new ZipPackage(packageFileName);
-
-                // Add a nuget.config to clear out sources and set the global packages folder
-                Util.CreateConfigForGlobalPackagesFolder(workingPath);
 
                 using (var server = new MockServer())
                 {
@@ -1421,12 +1385,12 @@ namespace NuGet.CommandLine.Test
 
                 var r = CommandRunner.Run(
                     nugetexe,
-                    Directory.GetCurrentDirectory(),
+                    pathContext.WorkingDirectory,
                     string.Join(" ", args),
                     waitForExit: true);
 
                 // Assert
-                Assert.Equal(0, r.Item1);
+                r.Success.Should().BeTrue(because: r.AllOutput);
                 var testTxtFile = Path.Combine(
                     outputDirectory,
                     "testPackage1.1.1.0", "content", "test1.txt");
@@ -1470,7 +1434,7 @@ namespace NuGet.CommandLine.Test
                     "install testPackage1 -OutputDirectory {0} -Source {1}", outputDirectory, source);
                 var r = CommandRunner.Run(
                     nugetexe,
-                    Directory.GetCurrentDirectory(),
+                    workingPath,
                     args,
                     waitForExit: true);
 
@@ -1489,9 +1453,10 @@ namespace NuGet.CommandLine.Test
         public void InstallCommand_DependencyResolution(string dependencyType, string requestedVersion, string expectedVersion)
         {
             var nugetexe = Util.GetNuGetExePath();
-            using (var source = TestDirectory.Create())
-            using (var outputDirectory = TestDirectory.Create())
+            using (var pathContext = new SimpleTestPathContext())
             {
+                var source = pathContext.PackageSource;
+                var outputDirectory = Path.Combine(pathContext.WorkingDirectory, "outDir");
                 // Arrange
                 Util.CreateTestPackage("depPackage", "1.1.0", source);
                 Util.CreateTestPackage("depPackage", "1.1.1", source);
@@ -1499,7 +1464,7 @@ namespace NuGet.CommandLine.Test
                 Util.CreateTestPackage("depPackage", "2.0.0", source);
 
                 var packageFileName = PackageCreater.CreatePackage(
-                    "testPackage", "1.1.0", source,
+                    "testPackage", "1.1.0", pathContext.PackageSource,
                     (builder) =>
                     {
                         if (requestedVersion == null)
@@ -1524,7 +1489,7 @@ namespace NuGet.CommandLine.Test
                 // change the path separator for mono
                 if (RuntimeEnvironmentHelper.IsMono)
                 {
-                    depPackageFile = NuGet.Common.PathUtility.GetPathWithForwardSlashes(depPackageFile);
+                    depPackageFile = Common.PathUtility.GetPathWithForwardSlashes(depPackageFile);
                 }
 
                 // Act
@@ -1543,7 +1508,7 @@ namespace NuGet.CommandLine.Test
                 }
                 var r = CommandRunner.Run(
                     nugetexe,
-                    Directory.GetCurrentDirectory(),
+                    pathContext.WorkingDirectory,
                     cmd,
                     waitForExit: true);
 

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
@@ -717,7 +717,7 @@ EndProject");
 
                 // Assert
                 Assert.Equal(_successCode, r.Item1);
-                string optOutMessage = String.Format(
+                string optOutMessage = string.Format(
                     CultureInfo.CurrentCulture,
                     NuGetResources.RestoreCommandPackageRestoreOptOutMessage,
                     NuGet.Resources.NuGetResources.PackageRestoreConsentCheckBoxText.Replace("&", ""));
@@ -757,7 +757,7 @@ EndProject");
 
                 // Assert
                 Assert.Equal(_successCode, r.Item1);
-                string optOutMessage = String.Format(
+                string optOutMessage = string.Format(
                     CultureInfo.CurrentCulture,
                     NuGetResources.RestoreCommandPackageRestoreOptOutMessage,
                     NuGet.Resources.NuGetResources.PackageRestoreConsentCheckBoxText.Replace("&", ""));
@@ -990,7 +990,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 Project(""{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}"") = ""proj1"", ""proj1\proj1.csproj"", ""{A04C59CC-7622-4223-B16B-CDF2ECAD438D}""
 EndProject");
                 Util.CreateFile(workingPath, "my.config",
-                    String.Format(CultureInfo.InvariantCulture,
+                    string.Format(CultureInfo.InvariantCulture,
 @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
     <packageSources>
@@ -1888,7 +1888,7 @@ EndProject";
             // Arrange
             var nugetexe = Util.GetNuGetExePath();
 
-            using( var pathContext = new SimpleTestPathContext())
+            using (var pathContext = new SimpleTestPathContext())
             {
                 var workingPath = pathContext.WorkingDirectory;
                 var repositoryPath = pathContext.PackageSource;

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
@@ -436,10 +436,10 @@ Microsoft Visual Studio Solution File, Format Version 12.00
             // Arrange
             var nugetexe = Util.GetNuGetExePath();
 
-            using (var workingPath = TestDirectory.Create())
+            using (var pathContext = new SimpleTestPathContext())
             {
-                var repositoryPath = Util.CreateBasicTwoProjectSolution(workingPath, proj1ConfigFileName, proj2ConfigFileName);
-
+                var workingPath = pathContext.WorkingDirectory;
+                var repositoryPath = Util.CreateBasicTwoProjectSolution(workingPath, proj1ConfigFileName, proj2ConfigFileName, redirectGlobalPackagesFolder: false);
                 // Act
                 var r = CommandRunner.Run(
                     nugetexe,
@@ -504,8 +504,9 @@ Microsoft Visual Studio Solution File, Format Version 12.00
                 msbuildPath = @"/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/msbuild/15.0/bin/";
             }
 
-            using (var workingPath = TestDirectory.Create())
+            using (var pathContext = new SimpleTestPathContext())
             {
+                var workingPath = pathContext.WorkingDirectory;
                 var repositoryPath = Util.CreateBasicTwoProjectSolution(workingPath, "packages.config", "packages.config");
 
                 // Act
@@ -518,8 +519,8 @@ Microsoft Visual Studio Solution File, Format Version 12.00
                 // Assert
                 Assert.True(_successCode == r.Item1, r.Item2);
                 Assert.True(r.Item2.Contains($"Using Msbuild from '{msbuildPath}'."));
-                var packageFileA = Path.Combine(workingPath, @"packages", "packageA.1.1.0", "packageA.1.1.0.nupkg");
-                var packageFileB = Path.Combine(workingPath, @"packages", "packageB.2.2.0", "packageB.2.2.0.nupkg");
+                var packageFileA = Path.Combine(pathContext.PackagesV2, "packageA.1.1.0", "packageA.1.1.0.nupkg");
+                var packageFileB = Path.Combine(pathContext.PackagesV2, "packageB.2.2.0", "packageB.2.2.0.nupkg");
                 Assert.True(File.Exists(packageFileA));
                 Assert.True(File.Exists(packageFileB));
             }
@@ -593,9 +594,11 @@ Microsoft Visual Studio Solution File, Format Version 12.00
             // Arrange
             var nugetexe = Util.GetNuGetExePath();
 
-            using (var workingPath = TestDirectory.Create())
+            using (var pathContext = new SimpleTestPathContext())
             {
-                var repositoryPath = Path.Combine(workingPath, "Repository");
+                var workingPath = pathContext.WorkingDirectory;
+
+                var repositoryPath = pathContext.PackageSource;
                 var proj1Directory = Path.Combine(workingPath, "proj1");
 
                 Directory.CreateDirectory(repositoryPath);
@@ -637,7 +640,7 @@ EndProject");
 
                 // Assert
                 Assert.Equal(_successCode, r.Item1);
-                var packageFileA = Path.Combine(workingPath, @"packages", "packageA.1.1.0", "packageA.1.1.0.nupkg");
+                var packageFileA = Path.Combine(pathContext.PackagesV2, "packageA.1.1.0", "packageA.1.1.0.nupkg");
                 Assert.True(File.Exists(packageFileA));
             }
         }
@@ -776,9 +779,11 @@ EndProject");
             // Arrang
             var nugetexe = Util.GetNuGetExePath();
 
-            using (var workingPath = TestDirectory.Create())
-            using (var randomTestFolder = TestDirectory.Create())
+            using (var pathContext = new SimpleTestPathContext())
             {
+                var workingPath = pathContext.WorkingDirectory;
+                var randomTestFolder = Path.Combine(pathContext.WorkingDirectory, "random");
+                Directory.CreateDirectory(randomTestFolder);
                 var repositoryPath = Util.CreateBasicTwoProjectSolution(workingPath, "packages.config", configFileName);
 
                 // Act
@@ -790,8 +795,8 @@ EndProject");
 
                 // Assert
                 Assert.Equal(_successCode, r.Item1);
-                var packageFileA = Path.Combine(workingPath, @"packages", "packageA.1.1.0", "packageA.1.1.0.nupkg");
-                var packageFileB = Path.Combine(workingPath, @"packages", "packageB.2.2.0", "packageB.2.2.0.nupkg");
+                var packageFileA = Path.Combine(pathContext.PackagesV2, "packageA.1.1.0", "packageA.1.1.0.nupkg");
+                var packageFileB = Path.Combine(pathContext.PackagesV2, "packageB.2.2.0", "packageB.2.2.0.nupkg");
                 Assert.True(File.Exists(packageFileA));
                 Assert.True(File.Exists(packageFileB));
             }
@@ -1229,9 +1234,9 @@ EndProject");
             // Arrange
             var nugetexe = Util.GetNuGetExePath();
 
-            using (var basePath = TestDirectory.Create())
+            using (var pathContext = new SimpleTestPathContext())
             {
-                var workingPath = Path.Combine(basePath, "sub1", "sub2");
+                var workingPath = Path.Combine(pathContext.WorkingDirectory, "sub1", "sub2");
 
                 Directory.CreateDirectory(workingPath);
 
@@ -1487,10 +1492,10 @@ EndProject";
         [Fact]
         public void RestoreCommand_LegacySolutionLevelPackages_SolutionDirectory()
         {
-            using (var randomRepositoryPath = TestDirectory.Create())
-            using (var randomSolutionFolder = TestDirectory.Create())
-
+            using (var pathContext = new SimpleTestPathContext())
             {
+                var randomRepositoryPath = pathContext.PackageSource;
+                var randomSolutionFolder = pathContext.SolutionRoot;
                 // Arrange
                 var nugetexe = Util.GetNuGetExePath();
                 Util.CreateTestPackage("packageA", "1.1.0", randomRepositoryPath);
@@ -1560,9 +1565,10 @@ EndProject";
         [Fact]
         public void RestoreCommand_LegacySolutionLevelPackages_SolutionFile()
         {
-            using (var randomRepositoryPath = TestDirectory.Create())
-            using (var randomSolutionFolder = TestDirectory.Create())
+            using (var pathContext = new SimpleTestPathContext())
             {
+                var randomRepositoryPath = pathContext.PackageSource;
+                var randomSolutionFolder = pathContext.SolutionRoot;
                 // Arrange
                 var nugetexe = Util.GetNuGetExePath();
                 Util.CreateTestPackage("packageA", "1.1.0", randomRepositoryPath);
@@ -1632,10 +1638,10 @@ EndProject";
         [Fact]
         public void RestoreCommand_LegacySolutionLevelPackages_NoArgument()
         {
-            using (var randomRepositoryPath = TestDirectory.Create())
-            using (var randomSolutionFolder = TestDirectory.Create())
-
+            using (var pathContext = new SimpleTestPathContext())
             {
+                var randomRepositoryPath = pathContext.PackageSource;
+                var randomSolutionFolder = pathContext.SolutionRoot;
                 // Arrange
                 var nugetexe = Util.GetNuGetExePath();
                 Util.CreateTestPackage("packageA", "1.1.0", randomRepositoryPath);
@@ -1705,9 +1711,10 @@ EndProject";
         [Fact]
         public void RestoreCommand_LegacySolutionLevelPackages_DuplicatePackageIds()
         {
-            using (var randomRepositoryPath = TestDirectory.Create())
-            using (var randomSolutionFolder = TestDirectory.Create())
+            using (var pathContext = new SimpleTestPathContext())
             {
+                var randomRepositoryPath = pathContext.PackageSource;
+                var randomSolutionFolder = pathContext.SolutionRoot;
                 // Arrange
                 var nugetexe = Util.GetNuGetExePath();
                 Util.CreateTestPackage("packageA", "1.0.0", randomRepositoryPath);
@@ -1880,10 +1887,12 @@ EndProject";
         {
             // Arrange
             var nugetexe = Util.GetNuGetExePath();
-            // Chgange here
-            using (var workingPath = TestDirectory.Create())
-            using (var repositoryPath = TestDirectory.Create())
+
+            using( var pathContext = new SimpleTestPathContext())
             {
+                var workingPath = pathContext.WorkingDirectory;
+                var repositoryPath = pathContext.PackageSource;
+
                 var entryModifiedTime = new DateTimeOffset(1985, 11, 20, 12, 0, 0, TimeSpan.FromHours(-7.0)).DateTime;
 
                 var packageFileFullPath = Util.CreateTestPackage("packageA", "1.1.0", repositoryPath);
@@ -1913,6 +1922,8 @@ EndProject";
                 var dllFileInfo = new FileInfo(dllPath);
                 Assert.True(File.Exists(dllFileInfo.FullName));
                 Assert.Equal(entryModifiedTime, dllFileInfo.LastWriteTime);
+
+                // TODO NK - 
             }
         }
 
@@ -1926,8 +1937,9 @@ EndProject";
             // Arrange
             var nugetexe = Util.GetNuGetExePath();
 
-            using (var basePath = TestDirectory.Create())
+            using (var pathContext = new SimpleTestPathContext())
             {
+                var basePath = pathContext.WorkingDirectory;
                 Directory.CreateDirectory(Path.Combine(basePath, "A"));
                 Directory.CreateDirectory(Path.Combine(basePath, "A", "A.Util"));
                 Directory.CreateDirectory(Path.Combine(basePath, "B"));
@@ -1992,14 +2004,6 @@ EndProject";
             }
 }");
 
-                Util.CreateFile(basePath, "nuget.config",
-@"<?xml version=""1.0"" encoding=""utf-8""?>
-<configuration>
-  <config>
-    <add key=""globalPackagesFolder"" value=""GlobalPackages2"" />
-  </config>
-</configuration>");
-
                 Util.CreateFile(Path.Combine(basePath, "A"), "A.sln",
                     @"
 Microsoft Visual Studio Solution File, Format Version 12.00
@@ -2040,11 +2044,12 @@ EndProject");
         {
             // Arrange
             var nugetexe = Util.GetNuGetExePath();
-            var identity = new Packaging.Core.PackageIdentity("packageA", new Versioning.NuGetVersion("1.1.0"));
+            var identity = new PackageIdentity("packageA", new NuGetVersion("1.1.0"));
 
-            using (var workingPath = TestDirectory.Create())
+            using (var pathContext = new SimpleTestPathContext())
             {
-                var repositoryPath = Path.Combine(workingPath, "Repository");
+                var repositoryPath = pathContext.PackageSource;
+                var workingPath = pathContext.WorkingDirectory;
                 Directory.CreateDirectory(repositoryPath);
                 Util.CreateTestPackage(identity.Id, identity.Version.ToNormalizedString(), repositoryPath);
                 Util.CreateFile(workingPath, "packages.config",
@@ -2076,17 +2081,11 @@ EndProject");
         {
             // Arrange
             var nugetexe = Util.GetNuGetExePath();
-            var identity = new Packaging.Core.PackageIdentity("Newtonsoft.Json", new Versioning.NuGetVersion("7.0.1"));
+            var identity = new PackageIdentity("Newtonsoft.Json", new Versioning.NuGetVersion("7.0.1"));
             var source = @"https://api.nuget.org/v3/index.json";
-            using (var workingPath = TestDirectory.Create())
+            using (var pathContext = new SimpleTestPathContext())
             {
-                // Overriding globalPackages folder
-                Util.CreateFile(workingPath, "nuget.config",
-@"<configuration>
-  <config>
-    <add key=""globalPackagesFolder"" value=""globalPackages"" />
-  </config>
-</configuration>");
+                var workingPath = pathContext.WorkingDirectory;
                 Util.CreateFile(workingPath, "packages.config",
 @"<packages>
   <package id=""" + identity.Id + @""" version=""" + identity.Version.ToNormalizedString() + @""" targetFramework=""net45"" />
@@ -2121,17 +2120,11 @@ EndProject");
         {
             // Arrange
             var nugetexe = Util.GetNuGetExePath();
-            var identity = new Packaging.Core.PackageIdentity("Newtonsoft.Json", new Versioning.NuGetVersion("7.0.1"));
+            var identity = new PackageIdentity("Newtonsoft.Json", new NuGetVersion("7.0.1"));
 
-            using (var workingPath = TestDirectory.Create())
+            using (var pathContext = new SimpleTestPathContext())
             {
-                // Overriding globalPackages folder
-                Util.CreateFile(workingPath, "nuget.config",
-@"<configuration>
-  <config>
-    <add key=""globalPackagesFolder"" value=""globalPackages"" />
-  </config>
-</configuration>");
+                var workingPath = pathContext.WorkingDirectory;
                 Util.CreateFile(workingPath, "packages.config",
 @"<packages>
   <package id=""" + identity.Id + @""" version=""" + identity.Version.ToNormalizedString() + @""" targetFramework=""net45"" />
@@ -2172,20 +2165,13 @@ EndProject");
         [Fact]
         public void RestoreCommand_ProjectContainsSolutionDirs()
         {
-            using (var randomRepositoryPath = TestDirectory.Create())
-            using (var randomSolutionFolder = TestDirectory.Create())
+            using (var pathContext = new SimpleTestPathContext())
             {
+                var randomRepositoryPath = pathContext.PackageSource;
+                var randomSolutionFolder = pathContext.SolutionRoot;
                 // Arrange
                 var nugetexe = Util.GetNuGetExePath();
                 Util.CreateTestPackage("packageA", "1.1.0", randomRepositoryPath);
-
-                Util.CreateFile(randomSolutionFolder, "nuget.config",
-$@"<?xml version=""1.0"" encoding=""utf-8""?>
-<configuration>
-  <config>
-    <add key=""globalPackagesFolder"" value=""GlobalPackages"" />
-  </config>
-</configuration>");
 
                 var solutionFile = Path.Combine(randomSolutionFolder, "A.sln");
                 var targetFile = Path.Combine(randomSolutionFolder, "MSBuild.Community.Tasks.Targets");
@@ -2239,7 +2225,7 @@ EndProject";
 
                 // Assert
                 Assert.True(_successCode == r.Item1, r.Item2 + " " + r.Item3);
-                var packageFileA = Path.Combine(randomSolutionFolder, "GlobalPackages", "packagea", "1.1.0", "packageA.1.1.0.nupkg");
+                var packageFileA = Path.Combine(pathContext.UserPackagesFolder, "packagea", "1.1.0", "packageA.1.1.0.nupkg");
                 Assert.True(File.Exists(packageFileA));
             }
         }
@@ -2247,16 +2233,15 @@ EndProject";
         [Fact]
         public void RestoreCommand_WithAuthorSignedPackage_Succeeds()
         {
-            using (var packageSourceFolder = TestDirectory.Create())
-            using (var packageDestinationFolder = TestDirectory.Create())
-            using (var projectFolder = TestDirectory.Create())
+            using (var pathContext = new SimpleTestPathContext())
             {
-                var packageFile = new FileInfo(Path.Combine(packageSourceFolder.Path, "TestPackage.AuthorSigned.1.0.0.nupkg"));
+                var packageDestinationFolder = Path.Combine(pathContext.WorkingDirectory, "outDir");
+                var packageFile = new FileInfo(Path.Combine(pathContext.PackageSource, "TestPackage.AuthorSigned.1.0.0.nupkg"));
                 var package = GetResource(packageFile.Name);
 
                 File.WriteAllBytes(packageFile.FullName, package);
 
-                var projectFile = new FileInfo(Path.Combine(projectFolder, "ClassLibrary1.csproj"));
+                var projectFile = new FileInfo(Path.Combine(pathContext.SolutionRoot, "ClassLibrary1.csproj"));
                 File.WriteAllText(
                     projectFile.FullName,
                     @"<?xml version=""1.0"" encoding=""utf-8""?>
@@ -2287,7 +2272,7 @@ EndProject";
 </Project>
                     ");
 
-                var expectedFilePath = Path.Combine(packageDestinationFolder.Path, "testpackage.authorsigned", "1.0.0", packageFile.Name);
+                var expectedFilePath = Path.Combine(packageDestinationFolder, "testpackage.authorsigned", "1.0.0", packageFile.Name);
                 var nugetExe = Util.GetNuGetExePath();
 
                 var args = new string[]
@@ -2295,16 +2280,16 @@ EndProject";
                         "restore",
                         projectFile.Name,
                         "-Source",
-                        packageSourceFolder.Path,
+                        pathContext.PackageSource,
                         "-PackagesDirectory",
-                        packageDestinationFolder.Path
+                        packageDestinationFolder
                     };
 
                 Assert.False(File.Exists(expectedFilePath));
 
                 var result = CommandRunner.Run(
                     nugetExe,
-                    projectFolder.Path,
+                    pathContext.SolutionRoot,
                     string.Join(" ", args),
                     waitForExit: true);
 
@@ -2320,9 +2305,9 @@ EndProject";
             // Arrange
             var nugetexe = Util.GetNuGetExePath();
 
-            using (var workingPath = TestDirectory.Create())
+            using (var pathContext = new SimpleTestPathContext())
             {
-                var repositoryPath = Path.Combine(workingPath, "Repository");
+                var repositoryPath = pathContext.PackageSource;
                 Directory.CreateDirectory(repositoryPath);
                 var aPackage = Util.CreateTestPackage(
                     "packageA",
@@ -2331,7 +2316,7 @@ EndProject";
                     new List<NuGetFramework> { NuGetFramework.Parse("net45") },
                     @"2.5.6/core/store/x64/netcoreapp2.0/microsoft.extensions.configuration.environmentvariables/2.0.0/lib/netstandard2.0/Microsoft.Extensions.Configuration.EnvironmentVariables.dll"
                     );
-                Util.CreateFile(workingPath, "packages.config",
+                Util.CreateFile(pathContext.WorkingDirectory, "packages.config",
 @"<packages>
   <package id=""packageA"" version=""1.0.0"" targetFramework=""net45"" />
 </packages>");
@@ -2341,13 +2326,13 @@ EndProject";
                 // Act
                 var r = CommandRunner.Run(
                     nugetexe,
-                    workingPath,
+                    pathContext.WorkingDirectory,
                     string.Join(" ", args),
                     waitForExit: true);
 
                 // Assert
                 Assert.Equal(_successCode, r.Item1);
-                var packageFileA = Path.Combine(workingPath, @"outputDir", "packageA.1.0.0", "packageA.1.0.0.nupkg");
+                var packageFileA = Path.Combine(pathContext.WorkingDirectory, @"outputDir", "packageA.1.0.0", "packageA.1.0.0.nupkg");
                 Assert.True(File.Exists(packageFileA));
             }
         }
@@ -2504,6 +2489,7 @@ EndProject";
     <add key=""signed"" value=""{signedRepository}"" />
     </packageSources>
     <packageSourceMapping>
+        <clear />
         <packageSource key=""PublicRepository"">
             <package pattern=""Moq*"" />
             <package pattern=""Nerdbank.*"" />
@@ -2547,6 +2533,7 @@ EndProject";
                     waitForExit: true);
 
                 // Assert
+                r.Success.Should().BeTrue(r.AllOutput);
                 Assert.Equal(_successCode, r.ExitCode);
                 var packageNerdBankAlgorithms = Path.Combine(packagePath, "NerdBank.Algorithms.1.0.0", "NerdBank.Algorithms.1.0.0.nupkg");
                 Assert.True(File.Exists(packageNerdBankAlgorithms));
@@ -2616,6 +2603,7 @@ EndProject";
     <add key=""SharedRepository"" value=""{sharedRepository}"" />
     </packageSources>
     <packageSourceMapping>
+        <clear />
         <packageSource key=""PublicRepository"">
             <package pattern=""Newton.*"" />
             <package pattern=""Great.*"" />
@@ -2900,8 +2888,9 @@ EndProject";
             // Arrange
             var nugetexe = Util.GetNuGetExePath();
 
-            using (var workingPath = TestDirectory.Create())
+            using (var pathContext = new SimpleTestPathContext())
             {
+                var workingPath = pathContext.SolutionRoot;
                 var proj1Directory = Path.Combine(workingPath, "proj1");
                 Directory.CreateDirectory(proj1Directory);
 
@@ -2977,8 +2966,9 @@ EndProject";
             // Arrange
             var nugetexe = Util.GetNuGetExePath();
 
-            using (var workingPath = TestDirectory.Create())
+            using (var pathContext = new SimpleTestPathContext())
             {
+                var workingPath = pathContext.SolutionRoot;
                 var proj1Directory = Path.Combine(workingPath, "proj1");
                 Directory.CreateDirectory(proj1Directory);
 

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
@@ -1922,8 +1922,6 @@ EndProject";
                 var dllFileInfo = new FileInfo(dllPath);
                 Assert.True(File.Exists(dllFileInfo.FullName));
                 Assert.Equal(entryModifiedTime, dllFileInfo.LastWriteTime);
-
-                // TODO NK - 
             }
         }
 

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
@@ -1880,7 +1880,7 @@ EndProject";
         {
             // Arrange
             var nugetexe = Util.GetNuGetExePath();
-
+            // Chgange here
             using (var workingPath = TestDirectory.Create())
             using (var repositoryPath = TestDirectory.Create())
             {

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetUpdateCommandTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetUpdateCommandTests.cs
@@ -12,6 +12,7 @@ using NuGet.Frameworks;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
 using NuGet.ProjectManagement;
+using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
 using NuGet.Test.Utility;
 using NuGet.Versioning;
@@ -25,12 +26,14 @@ namespace NuGet.CommandLine.Test
         [Fact]
         public async Task UpdateCommand_Success_Update_DeletedFile()
         {
-            using (var packagesSourceDirectory = TestDirectory.Create())
-            using (var solutionDirectory = TestDirectory.Create())
-            using (var workingPath = TestDirectory.Create())
+            using (var pathContext = new SimpleTestPathContext())
             {
+                //Arrange
+                var packagesDirectory = pathContext.PackagesV2;
+                var solutionDirectory = pathContext.SolutionRoot;
+                var packagesSourceDirectory = pathContext.PackageSource;
+                var workingPath = pathContext.WorkingDirectory;
                 var projectDirectory = Path.Combine(solutionDirectory, "proj1");
-                var packagesDirectory = Path.Combine(solutionDirectory, "packages");
 
                 var a1 = new PackageIdentity("A", new NuGetVersion("1.0.0"));
                 var a2 = new PackageIdentity("A", new NuGetVersion("2.0.0"));
@@ -135,12 +138,14 @@ namespace NuGet.CommandLine.Test
         [Fact]
         public async Task UpdateCommand_Success_References()
         {
-            using (var packagesSourceDirectory = TestDirectory.Create())
-            using (var solutionDirectory = TestDirectory.Create())
-            using (var workingPath = TestDirectory.Create())
+            using (var pathContext = new SimpleTestPathContext())
             {
+                //Arrange
+                var packagesDirectory = pathContext.PackagesV2;
+                var solutionDirectory = pathContext.SolutionRoot;
+                var packagesSourceDirectory = pathContext.PackageSource;
+                var workingPath = pathContext.WorkingDirectory;
                 var projectDirectory = Path.Combine(solutionDirectory, "proj1");
-                var packagesDirectory = Path.Combine(solutionDirectory, "packages");
 
                 var a1 = new PackageIdentity("A", new NuGetVersion("1.0.0"));
                 var a2 = new PackageIdentity("A", new NuGetVersion("2.0.0"));
@@ -215,13 +220,15 @@ namespace NuGet.CommandLine.Test
         public async Task UpdateCommand_Success_References_MultipleProjects()
         {
 
-            using (var packagesSourceDirectory = TestDirectory.Create())
-            using (var solutionDirectory = TestDirectory.Create())
-            using (var workingPath = TestDirectory.Create())
+            using (var pathContext = new SimpleTestPathContext())
             {
+                //Arrange
+                var packagesDirectory = pathContext.PackagesV2;
+                var solutionDirectory = pathContext.SolutionRoot;
+                var packagesSourceDirectory = pathContext.PackageSource;
+                var workingPath = pathContext.WorkingDirectory;
                 var projectDirectory1 = Path.Combine(solutionDirectory, "proj1");
                 var projectDirectory2 = Path.Combine(solutionDirectory, "proj2");
-                var packagesDirectory = Path.Combine(solutionDirectory, "packages");
 
                 var a1 = new PackageIdentity("A", new NuGetVersion("1.0.0"));
                 var a2 = new PackageIdentity("A", new NuGetVersion("2.0.0"));
@@ -518,12 +525,14 @@ namespace NuGet.CommandLine.Test
         [Fact]
         public async Task UpdateCommand_Success_Prerelease()
         {
-            using (var packagesSourceDirectory = TestDirectory.Create())
-            using (var solutionDirectory = TestDirectory.Create())
-            using (var workingPath = TestDirectory.Create())
+            using (var pathContext = new SimpleTestPathContext())
             {
+                //Arrange
+                var packagesDirectory = pathContext.PackagesV2;
+                var solutionDirectory = pathContext.SolutionRoot;
+                var packagesSourceDirectory = pathContext.PackageSource;
+                var workingPath = pathContext.WorkingDirectory;
                 var projectDirectory = Path.Combine(solutionDirectory, "proj1");
-                var packagesDirectory = Path.Combine(solutionDirectory, "packages");
 
                 var a1 = new PackageIdentity("A", new NuGetVersion("1.0.0"));
                 var a2 = new PackageIdentity("A", new NuGetVersion("2.0.0-BETA"));
@@ -603,12 +612,14 @@ namespace NuGet.CommandLine.Test
         [InlineData("2.0.0-BETA", "2.0.1")]
         public async Task UpdateCommand_Success_Prerelease_With_Id(string oldVersion, string newVersion)
         {
-            using (var packagesSourceDirectory = TestDirectory.Create())
-            using (var solutionDirectory = TestDirectory.Create())
-            using (var workingPath = TestDirectory.Create())
+            using (var pathContext = new SimpleTestPathContext())
             {
+                //Arrange
+                var packagesDirectory = pathContext.PackagesV2;
+                var solutionDirectory = pathContext.SolutionRoot;
+                var packagesSourceDirectory = pathContext.PackageSource;
+                var workingPath = pathContext.WorkingDirectory;
                 var projectDirectory = Path.Combine(solutionDirectory, "proj1");
-                var packagesDirectory = Path.Combine(solutionDirectory, "packages");
 
                 var a1 = new PackageIdentity("A", new NuGetVersion(oldVersion));
                 var a2 = new PackageIdentity("A", new NuGetVersion(newVersion));
@@ -686,12 +697,14 @@ namespace NuGet.CommandLine.Test
         [Fact]
         public async Task UpdateCommand_Success_Version_Upgrade()
         {
-            using (var packagesSourceDirectory = TestDirectory.Create())
-            using (var solutionDirectory = TestDirectory.Create())
-            using (var workingPath = TestDirectory.Create())
+            using (var pathContext = new SimpleTestPathContext())
             {
+                //Arrange
+                var packagesDirectory = pathContext.PackagesV2;
+                var solutionDirectory = pathContext.SolutionRoot;
+                var packagesSourceDirectory = pathContext.PackageSource;
+                var workingPath = pathContext.WorkingDirectory;
                 var projectDirectory = Path.Combine(solutionDirectory, "proj1");
-                var packagesDirectory = Path.Combine(solutionDirectory, "packages");
 
                 var a1 = new PackageIdentity("A", new NuGetVersion("1.0.0"));
                 var a2 = new PackageIdentity("A", new NuGetVersion("2.0.0"));
@@ -777,12 +790,14 @@ namespace NuGet.CommandLine.Test
         [Fact]
         public async Task UpdateCommand_Success_Version_Downgrade()
         {
-            using (var packagesSourceDirectory = TestDirectory.Create())
-            using (var solutionDirectory = TestDirectory.Create())
-            using (var workingPath = TestDirectory.Create())
+            using (var pathContext = new SimpleTestPathContext())
             {
+                //Arrange
+                var packagesDirectory = pathContext.PackagesV2;
+                var solutionDirectory = pathContext.SolutionRoot;
+                var packagesSourceDirectory = pathContext.PackageSource;
+                var workingPath = pathContext.WorkingDirectory;
                 var projectDirectory = Path.Combine(solutionDirectory, "proj1");
-                var packagesDirectory = Path.Combine(solutionDirectory, "packages");
 
                 var a1 = new PackageIdentity("A", new NuGetVersion("1.0.0"));
                 var a2 = new PackageIdentity("A", new NuGetVersion("2.0.0"));
@@ -868,12 +883,15 @@ namespace NuGet.CommandLine.Test
         [Fact]
         public async Task UpdateCommand_Success_ProjectFile_References()
         {
-            using (var packagesSourceDirectory = TestDirectory.Create())
-            using (var solutionDirectory = TestDirectory.Create())
-            using (var workingPath = TestDirectory.Create())
+            using (var pathContext = new SimpleTestPathContext())
             {
+                //Arrange
+                var packagesDirectory = pathContext.PackagesV2;
+                var solutionDirectory = pathContext.SolutionRoot;
+                var packagesSourceDirectory = pathContext.PackageSource;
+                var workingPath = pathContext.WorkingDirectory;
+
                 var projectDirectory = Path.Combine(solutionDirectory, "proj1");
-                var packagesDirectory = Path.Combine(solutionDirectory, "packages");
 
                 var a1 = new PackageIdentity("A", new NuGetVersion("1.0.0"));
                 var a2 = new PackageIdentity("A", new NuGetVersion("2.0.0"));
@@ -947,12 +965,15 @@ namespace NuGet.CommandLine.Test
         [Fact]
         public async Task UpdateCommand_Success_PackagesConfig_References()
         {
-            using (var packagesSourceDirectory = TestDirectory.Create())
-            using (var solutionDirectory = TestDirectory.Create())
-            using (var workingPath = TestDirectory.Create())
+            using (var pathContext = new SimpleTestPathContext())
             {
+                //Arrange
+                var packagesDirectory = pathContext.PackagesV2;
+                var solutionDirectory = pathContext.SolutionRoot;
+                var packagesSourceDirectory = pathContext.PackageSource;
+                var workingPath = pathContext.WorkingDirectory;
+
                 var projectDirectory = Path.Combine(solutionDirectory, "proj1");
-                var packagesDirectory = Path.Combine(solutionDirectory, "packages");
 
                 var a1 = new PackageIdentity("A", new NuGetVersion("1.0.0"));
                 var a2 = new PackageIdentity("A", new NuGetVersion("2.0.0"));
@@ -1025,15 +1046,17 @@ namespace NuGet.CommandLine.Test
             }
         }
 
-
         [Fact]
         public async Task UpdateCommand_Success_ContentFiles()
         {
             // Arrange
-            using (var packagesSourceDirectory = TestDirectory.Create())
-            using (var solutionDirectory = TestDirectory.Create())
-            using (var workingPath = TestDirectory.Create())
+            using (var pathContext = new SimpleTestPathContext())
             {
+                //Arrange
+                var workingPath = pathContext.WorkingDirectory;
+                var solutionDirectory = pathContext.SolutionRoot;
+                var packagesSourceDirectory = pathContext.PackageSource;
+
                 var projectDirectory = Path.Combine(solutionDirectory, "proj1");
                 var packagesDirectory = Path.Combine(solutionDirectory, "packages");
 
@@ -1144,9 +1167,11 @@ namespace NuGet.CommandLine.Test
         public async Task UpdateCommand_Success_CustomPackagesFolder_RelativePath()
         {
             // Arrange
-            using (var packagesSourceDirectory = TestDirectory.Create())
-            using (var solutionDirectory = TestDirectory.Create())
+            using (var pathContext = new SimpleTestPathContext())
             {
+                //Arrange
+                var solutionDirectory = pathContext.SolutionRoot;
+                var packagesSourceDirectory = pathContext.PackageSource;
                 // Use a different folder name instead of 'packages'
                 var packagesDirectory = Path.Combine(solutionDirectory, "custom-pcks");
 
@@ -1169,7 +1194,7 @@ namespace NuGet.CommandLine.Test
                     new List<PackageDependencyGroup>() { });
 
                 // Create a nuget.config file with a relative 'repositoryPath' setting
-                Util.CreateNuGetConfig(solutionDirectory, new[] { packagesSourceDirectory.Path }.ToList(), "custom-pcks");
+                Util.CreateNuGetConfig(solutionDirectory, new[] { packagesSourceDirectory }.ToList(), "custom-pcks");
 
                 var projectDirectory = Path.Combine(solutionDirectory, "proj1");
                 Directory.CreateDirectory(projectDirectory);
@@ -1239,9 +1264,11 @@ namespace NuGet.CommandLine.Test
         {
             // Arrange
             var nugetexe = Util.GetNuGetExePath();
-            using (var packagesSourceDirectory = TestDirectory.Create())
-            using (var solutionDirectory = TestDirectory.Create())
+            using (var pathContext = new SimpleTestPathContext())
             {
+                //Arrange
+                var solutionDirectory = pathContext.SolutionRoot;
+                var packagesSourceDirectory = pathContext.PackageSource;
                 var projectDirectory = Path.Combine(solutionDirectory, "proj1");
 
                 var a1 = new PackageIdentity("A", new NuGetVersion("1.0.0"));
@@ -1332,10 +1359,13 @@ namespace NuGet.CommandLine.Test
         public async Task UpdateCommand_Success_CustomPackagesFolder_AbsolutePath()
         {
             // Arrange
-            using (var packagesSourceDirectory = TestDirectory.Create())
-            using (var solutionDirectory = TestDirectory.Create())
-            using (var packagesDirectory = TestDirectory.Create())
+            using (var pathContext = new SimpleTestPathContext())
             {
+                //Arrange
+                var packagesDirectory = pathContext.PackagesV2;
+                var solutionDirectory = pathContext.SolutionRoot;
+                var packagesSourceDirectory = pathContext.PackageSource;
+
                 // Create some packages
                 var a1 = new PackageIdentity("A", new NuGetVersion("1.0.0"));
                 var a2 = new PackageIdentity("A", new NuGetVersion("2.0.0"));
@@ -1355,8 +1385,6 @@ namespace NuGet.CommandLine.Test
                     new List<PackageDependencyGroup>() { });
 
                 var projectDirectory = Path.Combine(solutionDirectory, "proj1");
-                // Create a nuget.config file that has the full absolute path to 'packagesDirectory'
-                Util.CreateNuGetConfig(solutionDirectory, new[] { packagesSourceDirectory.Path }.ToList(), packagesDirectory);
 
                 Directory.CreateDirectory(projectDirectory);
                 // create project 1
@@ -1411,7 +1439,7 @@ namespace NuGet.CommandLine.Test
 
                 // Check the custom package folder is used in the assembly reference
                 var content1 = File.ReadAllText(projectFile);
-                var customPackageFolderName = new DirectoryInfo(packagesDirectory.Path).Name;
+                var customPackageFolderName = new DirectoryInfo(packagesDirectory).Name;
                 var a1Path = Path.DirectorySeparatorChar + customPackageFolderName + Path.DirectorySeparatorChar +
                     Path.Combine("A.1.0.0", "lib", "net45", "file.dll");
                 var a2Path = Path.DirectorySeparatorChar + customPackageFolderName + Path.DirectorySeparatorChar +
@@ -1544,13 +1572,14 @@ namespace NuGet.CommandLine.Test
         [InlineData("HighestPatch", "1.0.1")]
         public async Task UpdateCommand_DependencyResolution_Success(string dependencyVersion, string expectedVersion)
         {
-            using (var packagesSourceDirectory = TestDirectory.Create())
-            using (var solutionDirectory = TestDirectory.Create())
-            using (var workingPath = TestDirectory.Create())
+            using (var pathContext = new SimpleTestPathContext())
             {
                 //Arrange
+                var workingPath = pathContext.WorkingDirectory;
+                var solutionDirectory = pathContext.SolutionRoot;
+                var packagesSourceDirectory = pathContext.PackageSource;
                 var projectDirectory = Path.Combine(solutionDirectory, "proj1");
-                var packagesDirectory = Path.Combine(solutionDirectory, "packages");
+                var packagesDirectory = pathContext.PackagesV2;
                 var nugetFramework = NuGetFramework.Parse("net45");
                 // version installed will be the 1.1.0  - Create Package a1
                 var a1PackageIdentity = new PackageIdentity("A", new NuGetVersion("1.1.0"));
@@ -1681,10 +1710,12 @@ namespace NuGet.CommandLine.Test
         [Fact]
         public async Task UpdateCommand_NF_Project_Success()
         {
-            using (TestDirectory packagesSourceDirectory = TestDirectory.Create())
-            using (TestDirectory solutionDirectory = TestDirectory.Create())
-            using (TestDirectory workingPath = TestDirectory.Create())
+            using (var pathContext = new SimpleTestPathContext())
             {
+                //Arrange
+                var workingPath = pathContext.WorkingDirectory;
+                var solutionDirectory = pathContext.SolutionRoot;
+                var packagesSourceDirectory = pathContext.PackageSource;
                 // setup directories
                 string projectDirectory1 = Path.Combine(solutionDirectory, "proj1");
                 string projectDirectory2 = Path.Combine(solutionDirectory, "proj2");
@@ -1706,8 +1737,6 @@ namespace NuGet.CommandLine.Test
                 a1Package.Files.Clear();
                 a1Package.AddFile($"lib/{a1.Id}.dll");
 
-                FileInfo a1File = await a1Package.CreateAsFileAsync(packagesSourceDirectory, a1Package.PackageName);
-
                 var a2Package = new SimpleTestPackageContext()
                 {
                     Id = a2.Id,
@@ -1715,8 +1744,6 @@ namespace NuGet.CommandLine.Test
                 };
                 a2Package.Files.Clear();
                 a2Package.AddFile($"lib/{a2.Id}.dll");
-
-                await a2Package.CreateAsFileAsync(packagesSourceDirectory, a2Package.PackageName);
 
                 var b1Package = new SimpleTestPackageContext()
                 {
@@ -1726,8 +1753,6 @@ namespace NuGet.CommandLine.Test
                 b1Package.Files.Clear();
                 b1Package.AddFile($"lib/{b1.Id}.dll");
 
-                FileInfo b1File = await a1Package.CreateAsFileAsync(packagesSourceDirectory, b1Package.PackageName);
-
                 var b2Package = new SimpleTestPackageContext()
                 {
                     Id = b2.Id,
@@ -1736,7 +1761,7 @@ namespace NuGet.CommandLine.Test
                 b2Package.Files.Clear();
                 b2Package.AddFile($"lib/{b2.Id}.dll");
 
-                await b2Package.CreateAsFileAsync(packagesSourceDirectory, b2Package.PackageName);
+                await SimpleTestPackageUtility.CreatePackagesAsync(packagesSourceDirectory, a1Package, a2Package, b1Package, b2Package);
 
                 // build list of packages (initial versions on the project files)
                 var packages = new List<(string, string)>();
@@ -1791,7 +1816,11 @@ namespace NuGet.CommandLine.Test
                 var msBuildProject1 = new MSBuildNuGetProject(projectSystem1, packagesDirectory, projectDirectory1);
                 var msBuildProject2 = new MSBuildNuGetProject(projectSystem2, packagesDirectory, projectDirectory2);
 
-                using (FileStream stream = File.OpenRead(a1File.FullName))
+                var packagesInSource = LocalFolderUtility.GetPackagesV2(pathContext.PackageSource, Common.NullLogger.Instance);
+                var a1File = packagesInSource.Single(e => e.Identity.Equals(a1Package.Identity));
+                var b1File = packagesInSource.Single(e => e.Identity.Equals(b1Package.Identity));
+
+                using (FileStream stream = File.OpenRead(a1File.Path))
                 {
                     var downloadResult = new DownloadResourceResult(stream, packagesSourceDirectory);
                     await msBuildProject1.InstallPackageAsync(
@@ -1801,7 +1830,7 @@ namespace NuGet.CommandLine.Test
                         CancellationToken.None);
                 }
 
-                using (FileStream stream = File.OpenRead(b1File.FullName))
+                using (FileStream stream = File.OpenRead(b1File.Path))
                 {
                     var downloadResult = new DownloadResourceResult(stream, packagesSourceDirectory);
                     await msBuildProject2.InstallPackageAsync(

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
@@ -5793,6 +5793,10 @@ namespace NuGet.CommandLine.Test
                 localSource.Add(new XAttribute(XName.Get("value"), pathContext.PackageSource));
                 packageSources.Add(localSource);
 
+                var packageSourceMapping = new XElement(XName.Get("packageSourceMapping"));
+                packageSourceMapping.Add(new XElement(XName.Get("clear")));
+                configuration.Add(packageSourceMapping);
+
                 File.WriteAllText(configPath, doc.ToString());
 
                 var solutionParent = Directory.GetParent(pathContext.SolutionRoot);
@@ -5820,6 +5824,8 @@ namespace NuGet.CommandLine.Test
                 disabledPackageSources.Add(disabledBrokenSource);
 
                 configuration2.Add(disabledPackageSources);
+
+                configuration2.Add(packageSourceMapping);
 
                 File.WriteAllText(configPath2, doc2.ToString());
 

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreProjectJsonTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreProjectJsonTest.cs
@@ -23,13 +23,13 @@ namespace NuGet.CommandLine.Test
         public async Task RestoreProjectJson_MinClientVersionFailAsync()
         {
             // Arrange
-            using (var workingPath = TestDirectory.Create())
+            using (var pathContext = new SimpleTestPathContext())
             {
-                var repositoryPath = Path.Combine(workingPath, "Repository");
+                var workingPath = pathContext.WorkingDirectory;
+                var repositoryPath = pathContext.PackageSource;
                 var nugetexe = Util.GetNuGetExePath();
 
                 Directory.CreateDirectory(repositoryPath);
-                Directory.CreateDirectory(Path.Combine(workingPath, ".nuget"));
 
                 var packageContext = new SimpleTestPackageContext()
                 {
@@ -40,7 +40,6 @@ namespace NuGet.CommandLine.Test
 
                 await SimpleTestPackageUtility.CreatePackagesAsync(repositoryPath, packageContext);
 
-                Util.CreateConfigForGlobalPackagesFolder(workingPath);
                 var projectJson = @"{
                                                     'dependencies': {
                                                     'packageA': '1.0.0'
@@ -1277,19 +1276,18 @@ namespace NuGet.CommandLine.Test
         public void RestoreProjectJson_FloatReleaseLabelTakesStable()
         {
             // Arrange
-            using (var workingPath = TestDirectory.Create())
+            using (var pathContext = new SimpleTestPathContext())
             {
-                var repositoryPath = Path.Combine(workingPath, "Repository");
+                var workingPath = pathContext.WorkingDirectory;
+                var repositoryPath = pathContext.PackageSource;
                 var nugetexe = Util.GetNuGetExePath();
 
                 Directory.CreateDirectory(repositoryPath);
-                Directory.CreateDirectory(Path.Combine(workingPath, ".nuget"));
                 Util.CreateTestPackage("packageA", "1.0.0", repositoryPath);
                 Util.CreateTestPackage("packageA", "2.0.0", repositoryPath);
                 Util.CreateTestPackage("packageA", "1.0.0-alpha", repositoryPath);
                 Util.CreateTestPackage("packageA", "1.0.0-beta-01", repositoryPath);
                 Util.CreateTestPackage("packageA", "1.0.0-beta-02", repositoryPath);
-                Util.CreateConfigForGlobalPackagesFolder(workingPath);
                 var projectJson = @"{
                                                     'dependencies': {
                                                     'packageA': '1.0.0-*'
@@ -1393,18 +1391,17 @@ namespace NuGet.CommandLine.Test
         public void RestoreProjectJson_RestoreFiltersToStablePackages()
         {
             // Arrange
-            using (var workingPath = TestDirectory.Create())
+            using (var pathContext = new SimpleTestPathContext())
             {
-                var repositoryPath = Path.Combine(workingPath, "Repository");
+                var workingPath = pathContext.WorkingDirectory;
+                var repositoryPath = pathContext.PackageSource;
                 var nugetexe = Util.GetNuGetExePath();
 
                 Directory.CreateDirectory(repositoryPath);
-                Directory.CreateDirectory(Path.Combine(workingPath, ".nuget"));
                 Util.CreateTestPackage("packageA", "1.0.0", repositoryPath, "win8", "packageB", "1.0.0");
                 Util.CreateTestPackage("packageB", "1.0.0-beta", repositoryPath);
                 Util.CreateTestPackage("packageB", "2.0.0-beta", repositoryPath);
                 Util.CreateTestPackage("packageB", "3.0.0", repositoryPath);
-                Util.CreateConfigForGlobalPackagesFolder(workingPath);
                 var projectJson = @"{
                                                     'dependencies': {
                                                     'packageA': '1.0.0'
@@ -2083,14 +2080,13 @@ namespace NuGet.CommandLine.Test
         public void RestoreProjectJson_GenerateTargetsFileFromNuProj()
         {
             // Arrange
-            using (var workingPath = TestDirectory.Create())
+            using (var pathContext = new SimpleTestPathContext())
             {
-                var repositoryPath = Path.Combine(workingPath, "Repository");
+                var workingPath = pathContext.WorkingDirectory;
+                var repositoryPath = pathContext.PackageSource;
                 var nugetexe = Util.GetNuGetExePath();
 
                 Directory.CreateDirectory(repositoryPath);
-                Util.CreateConfigForGlobalPackagesFolder(workingPath);
-                Directory.CreateDirectory(Path.Combine(workingPath, ".nuget"));
                 var packageA = Util.CreateTestPackageBuilder("packageA", "1.1.0-beta-01");
                 var packageB = Util.CreateTestPackageBuilder("packageB", "2.2.0-beta-02");
 

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreRetryTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreRetryTests.cs
@@ -382,7 +382,7 @@ namespace NuGet.CommandLine.Test
 
                     Assert.True(
                         File.Exists(
-                            Path.Combine(pathContext.UserPackagesFolder,"testpackage1/1.1.0/testPackage1.1.1.0.nupkg.sha512")));
+                            Path.Combine(pathContext.UserPackagesFolder, "testpackage1/1.1.0/testPackage1.1.1.0.nupkg.sha512")));
 
                     Assert.True(File.Exists(Path.Combine(workingDirectory, "project.lock.json")));
 

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreRetryTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreRetryTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.IO;
 using System.Net;
+using FluentAssertions;
 using Newtonsoft.Json.Linq;
 using NuGet.Test.Utility;
 using Xunit;
@@ -21,9 +22,10 @@ namespace NuGet.CommandLine.Test
             // Arrange
             var nugetexe = Util.GetNuGetExePath();
 
-            using (var workingDirectory = TestDirectory.Create())
-            using (var packageDirectory = TestDirectory.Create())
+            using (var pathContext = new SimpleTestPathContext())
             {
+                var workingDirectory = pathContext.WorkingDirectory;
+                var packageDirectory = pathContext.PackageSource;
                 var packageFileName = Util.CreateTestPackage("testPackage1", "1.1.0", packageDirectory);
                 var package = new ZipPackage(packageFileName);
 
@@ -116,10 +118,9 @@ namespace NuGet.CommandLine.Test
                     // Assert
                     Assert.True(Util.IsSuccess(r1), r1.Item2 + " " + r1.Item3);
 
-                    Assert.True(
-                        File.Exists(
-                            Path.Combine(workingDirectory,
-                                "packages/testpackage1.1.1.0/testpackage1.1.1.0.nupkg")));
+                    var path = Path.Combine(pathContext.PackagesV2, "testpackage1.1.1.0", "testpackage1.1.1.0.nupkg");
+
+                    File.Exists(path).Should().BeTrue($"{path} does not exist");
                 }
             }
         }
@@ -131,9 +132,10 @@ namespace NuGet.CommandLine.Test
             // Arrange
             var nugetexe = Util.GetNuGetExePath();
 
-            using (var workingDirectory = TestDirectory.Create())
-            using (var packageDirectory = TestDirectory.Create())
+            using (var pathContext = new SimpleTestPathContext())
             {
+                var workingDirectory = pathContext.WorkingDirectory;
+                var packageDirectory = pathContext.PackageSource;
                 var packageFileName = Util.CreateTestPackage("testPackage1", "1.1.0", packageDirectory);
                 var package = new ZipPackage(packageFileName);
 
@@ -146,14 +148,7 @@ namespace NuGet.CommandLine.Test
                                 }
                   }";
 
-                var config = @"<?xml version=""1.0"" encoding=""utf-8""?>
-                        <configuration>
-                          <config>
-                            <add key=""globalPackagesFolder"" value=""globalPackages"" />
-                          </config>
-                        </configuration>";
-
-                var projectFile = Util.CreateUAPProject(workingDirectory, projectJson, "a", config);
+                var projectFile = Util.CreateUAPProject(workingDirectory, projectJson, "a");
 
                 // Server setup
                 using (var server = new MockServer())
@@ -241,13 +236,13 @@ namespace NuGet.CommandLine.Test
 
                     Assert.True(
                         File.Exists(
-                            Path.Combine(workingDirectory,
-                                "globalPackages/testpackage1/1.1.0/testpackage1.1.1.0.nupkg")));
+                            Path.Combine(pathContext.UserPackagesFolder,
+                                "testpackage1/1.1.0/testpackage1.1.1.0.nupkg")));
 
                     Assert.True(
                         File.Exists(
-                            Path.Combine(workingDirectory,
-                                "globalPackages/testpackage1/1.1.0/testPackage1.1.1.0.nupkg.sha512")));
+                            Path.Combine(pathContext.UserPackagesFolder,
+                                "testpackage1/1.1.0/testPackage1.1.1.0.nupkg.sha512")));
 
                     Assert.True(File.Exists(Path.Combine(workingDirectory, "project.lock.json")));
 
@@ -267,9 +262,10 @@ namespace NuGet.CommandLine.Test
             // Arrange
             var nugetexe = Util.GetNuGetExePath();
 
-            using (var workingDirectory = TestDirectory.Create())
-            using (var packageDirectory = TestDirectory.Create())
+            using (var pathContext = new SimpleTestPathContext())
             {
+                var workingDirectory = pathContext.WorkingDirectory;
+                var packageDirectory = pathContext.PackageSource;
                 var packageFileName = Util.CreateTestPackage("testPackage1", "1.1.0", packageDirectory);
                 var package = new ZipPackage(packageFileName);
 
@@ -282,14 +278,7 @@ namespace NuGet.CommandLine.Test
                                 }
                   }";
 
-                var nugetConfigContent = @"<?xml version=""1.0"" encoding=""utf-8""?>
-                        <configuration>
-                          <config>
-                            <add key=""globalPackagesFolder"" value=""globalPackages"" />
-                          </config>
-                        </configuration>";
-
-                var projectFile = Util.CreateUAPProject(workingDirectory, projectJsonContent, "a", nugetConfigContent);
+                var projectFile = Util.CreateUAPProject(workingDirectory, projectJsonContent, "a");
 
                 // Server setup
                 var indexJson = Util.CreateIndexJson();
@@ -389,13 +378,11 @@ namespace NuGet.CommandLine.Test
 
                     Assert.True(
                         File.Exists(
-                            Path.Combine(workingDirectory,
-                                "globalPackages/testpackage1/1.1.0/testpackage1.1.1.0.nupkg")));
+                            Path.Combine(pathContext.UserPackagesFolder, "testpackage1/1.1.0/testpackage1.1.1.0.nupkg")));
 
                     Assert.True(
                         File.Exists(
-                            Path.Combine(workingDirectory,
-                                "globalPackages/testpackage1/1.1.0/testPackage1.1.1.0.nupkg.sha512")));
+                            Path.Combine(pathContext.UserPackagesFolder,"testpackage1/1.1.0/testPackage1.1.1.0.nupkg.sha512")));
 
                     Assert.True(File.Exists(Path.Combine(workingDirectory, "project.lock.json")));
 
@@ -417,9 +404,11 @@ namespace NuGet.CommandLine.Test
             // Arrange
             var nugetexe = Util.GetNuGetExePath();
 
-            using (var workingDirectory = TestDirectory.Create())
-            using (var packageDirectory = TestDirectory.Create())
+            using (var pathContext = new SimpleTestPathContext())
             {
+                var workingDirectory = pathContext.WorkingDirectory;
+                var packageDirectory = pathContext.PackageSource;
+
                 var packageFileName = Util.CreateTestPackage("testPackage1", "1.1.0", packageDirectory);
                 var package = new ZipPackage(packageFileName);
 
@@ -429,16 +418,6 @@ namespace NuGet.CommandLine.Test
                     @"<packages>
                     <package id=""testPackage1"" version=""1.1.0"" />
                   </packages>");
-
-                Util.CreateFile(
-                    workingDirectory,
-                    "nuget.config",
-                        @"<?xml version=""1.0"" encoding=""utf-8""?>
-                        <configuration>
-                            <config>
-                            <add key=""globalPackagesFolder"" value=""globalPackages"" />
-                            </config>
-                        </configuration>");
 
                 // Server setup
                 var indexJson = Util.CreateIndexJson();
@@ -580,12 +559,12 @@ namespace NuGet.CommandLine.Test
                     server.Stop();
 
                     // Assert
-                    Assert.True(Util.IsSuccess(r1), r1.Item2 + " " + r1.Item3);
+                    Assert.True(r1.Success, r1.AllOutput);
 
                     Assert.True(
                         File.Exists(
-                            Path.Combine(workingDirectory,
-                                "packages/testpackage1.1.1.0/testpackage1.1.1.0.nupkg")));
+                            Path.Combine(pathContext.PackagesV2,
+                                "testpackage1.1.1.0", "testpackage1.1.1.0.nupkg")));
 
                     // Everything should be hit 3 times
                     foreach (var url in hitsByUrl.Keys)

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Util.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Util.cs
@@ -629,6 +629,10 @@ namespace NuGet.CommandLine.Test
                 packageSources.Add(sourceEntry);
             }
 
+            var packageSourceMapping = new XElement(XName.Get("packageSourceMapping"));
+            configuration.Add(packageSourceMapping);
+            packageSourceMapping.Add(new XElement(XName.Get("clear")));
+
             Util.CreateFile(workingPath, "NuGet.Config", doc.ToString());
         }
 

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Util.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Util.cs
@@ -1065,7 +1065,7 @@ EndProject";
                  </Project>".Replace("$NAME$", projectName);
         }
 
-        public static string CreateBasicTwoProjectSolution(TestDirectory workingPath, string proj1ConfigFileName, string proj2ConfigFileName)
+        public static string CreateBasicTwoProjectSolution(TestDirectory workingPath, string proj1ConfigFileName, string proj2ConfigFileName, bool redirectGlobalPackagesFolder = true)
         {
             var repositoryPath = Path.Combine(workingPath, "Repository");
             var proj1Directory = Path.Combine(workingPath, "proj1");
@@ -1147,7 +1147,7 @@ EndProject");
 
             // If either project uses project.json, then define "globalPackagesFolder" so the package doesn't get
             // installed in the usual global packages folder.
-            if (IsProjectJson(proj1ConfigFileName) || IsProjectJson(proj2ConfigFileName))
+            if ((IsProjectJson(proj1ConfigFileName) || IsProjectJson(proj2ConfigFileName)) && redirectGlobalPackagesFolder)
             {
                 CreateFile(workingPath, "nuget.config",
 @"<?xml version=""1.0"" encoding=""utf-8""?>

--- a/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestSettingsContext.cs
+++ b/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestSettingsContext.cs
@@ -88,9 +88,11 @@ namespace NuGet.Test.Utility
             var packageSources = GetOrAddSection(doc, "packageSources");
             var disabledSources = GetOrAddSection(doc, "disabledPackageSources");
             var fallbackFolders = GetOrAddSection(doc, "fallbackPackageFolders");
+            var packageSourceMapping = GetOrAddSection(doc, "packageSourceMapping");
 
             packageSources.Add(new XElement(XName.Get("clear")));
             disabledSources.Add(new XElement(XName.Get("clear")));
+            packageSourceMapping.Add(new XElement(XName.Get("clear")));
 
             return doc;
         }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/nuget/home/issues/11444

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Self descriptive. 
This change involves a lot of TestDirectory to SimpleTestPathContext changes (which has a nuget.config file that isolates *almost* everything). 

This change unblocks https://github.com/NuGet/NuGet.Client/pull/4279.

Another big change is ensuring the default configs actually clear the package source mapping configuration.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
