### PR TITLE
Disable package signature verification on FreeBSD by default, as on Linux and MacOS

### DIFF
--- a/src/NuGet.Core/NuGet.Common/RuntimeEnvironmentHelper.cs
+++ b/src/NuGet.Core/NuGet.Common/RuntimeEnvironmentHelper.cs
@@ -150,6 +150,13 @@ namespace NuGet.Common
                 return true;
             }
 
+            // The OSPlatform.FreeBSD property only exists in .NET Core 3.1 and higher, whereas this project is also
+            // compiled for .NET Standard and .NET Framework, where an OSPlatform for FreeBSD must be created manually
+            if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Create("FREEBSD")))
+            {
+                return true;
+            }
+
             return false;
 #else
             var platform = (int)Environment.OSVersion.Platform;


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11481

Regression? Last working version: None

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
Disables package signature verification on FreeBSD by default, as already done for Linux and MacOS in #3979. Therefore the new property `IsFreeBSD` had to be added to the `RuntimeEnvironmentHelper` class to determine whether running on FreeBSD. This property is also used to select the more appropriate `UnixAndMonoPlatformsEmbeddedSignatureVerifier` for FreeBSD, instead of the default `FallbackEmbeddedSignatureVerifier`.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
