### PR TITLE
Display a package's build files in Solution Explorer

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Resources/VsResources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Resources/VsResources.Designer.cs
@@ -277,6 +277,69 @@ namespace NuGet.VisualStudio.Implementation.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Build File.
+        /// </summary>
+        internal static string PackageBuildFileBrowseObjectClassName {
+            get {
+                return ResourceManager.GetString("PackageBuildFileBrowseObjectClassName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Build Files.
+        /// </summary>
+        internal static string PackageBuildFileGroupName {
+            get {
+                return ResourceManager.GetString("PackageBuildFileGroupName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The build file&apos;s name..
+        /// </summary>
+        internal static string PackageBuildFileNameDescription {
+            get {
+                return ResourceManager.GetString("PackageBuildFileNameDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Name.
+        /// </summary>
+        internal static string PackageBuildFileNameDisplayName {
+            get {
+                return ResourceManager.GetString("PackageBuildFileNameDisplayName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The build file&apos;s path..
+        /// </summary>
+        internal static string PackageBuildFilePathDescription {
+            get {
+                return ResourceManager.GetString("PackageBuildFilePathDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Path.
+        /// </summary>
+        internal static string PackageBuildFilePathDisplayName {
+            get {
+                return ResourceManager.GetString("PackageBuildFilePathDisplayName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Build Files (Multi-targeting).
+        /// </summary>
+        internal static string PackageBuildMultiTargetingFileGroupName {
+            get {
+                return ResourceManager.GetString("PackageBuildMultiTargetingFileGroupName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Compile Time Assemblies.
         /// </summary>
         internal static string PackageCompileTimeAssemblyGroupName {

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Resources/VsResources.resx
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Resources/VsResources.resx
@@ -322,6 +322,27 @@ The string representation of the user's input framework name.</comment>
   <data name="PackageFrameworkAssemblyGroupName" xml:space="preserve">
     <value>Framework Assemblies</value>
   </data>
+  <data name="PackageBuildFileGroupName" xml:space="preserve">
+    <value>Build Files</value>
+  </data>
+  <data name="PackageBuildMultiTargetingFileGroupName" xml:space="preserve">
+    <value>Build Files (Multi-targeting)</value>
+  </data>
+  <data name="PackageBuildFileBrowseObjectClassName" xml:space="preserve">
+    <value>Build File</value>
+  </data>
+  <data name="PackageBuildFileNameDisplayName" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="PackageBuildFileNameDescription" xml:space="preserve">
+    <value>The build file's name.</value>
+  </data>
+  <data name="PackageBuildFilePathDisplayName" xml:space="preserve">
+    <value>Path</value>
+  </data>
+  <data name="PackageBuildFilePathDescription" xml:space="preserve">
+    <value>The build file's path.</value>
+  </data>
   <data name="PropertyCannotBeNull" xml:space="preserve">
     <value>'{0}' cannot be null.</value>
     <comment>0 - property name</comment>

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/AssetsFileDependenciesTreeSearchProvider.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/AssetsFileDependenciesTreeSearchProvider.cs
@@ -56,7 +56,7 @@ namespace NuGet.VisualStudio.SolutionExplorer
 
             AssetsFileDependenciesSnapshot snapshot = (await dataSource.Value.GetLatestVersionAsync<AssetsFileDependenciesSnapshot>(dataSourceRegistry, cancellationToken: context.CancellationToken)).Value;
 
-            if (!(context.UnconfiguredProject.Services.ExportProvider.GetExportedValue<IActiveConfigurationGroupService>() is IActiveConfigurationGroupService3 activeConfigurationGroupService))
+            if (context.UnconfiguredProject.Services.ExportProvider.GetExportedValue<IActiveConfigurationGroupService>() is not IActiveConfigurationGroupService3 activeConfigurationGroupService)
             {
                 return;
             }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/FileOpener.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/FileOpener.cs
@@ -1,0 +1,69 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#nullable enable
+
+using System;
+using System.ComponentModel.Composition;
+using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.Composition;
+using Microsoft.VisualStudio.PlatformUI;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.TextManager.Interop;
+
+namespace NuGet.VisualStudio.SolutionExplorer
+{
+    [Export(typeof(FileOpener))]
+    internal sealed class FileOpener
+    {
+        private readonly IServiceProvider _serviceProvider;
+
+        [ImportingConstructor]
+        public FileOpener([Import(typeof(SVsServiceProvider))] IServiceProvider serviceProvider)
+        {
+            _serviceProvider = serviceProvider;
+        }
+
+        public void OpenFile(string filePath, bool isReadOnly)
+        {
+            var rdt = new RunningDocumentTable(_serviceProvider);
+
+            IVsWindowFrame? windowFrame = null;
+            try
+            {
+                // Open the document.
+                VsShellUtilities.OpenDocument(
+                    _serviceProvider,
+                    filePath,
+                    VSConstants.LOGVIEWID_Primary,
+                    out _,
+                    out _,
+                    out windowFrame);
+
+                // Set it as read only if necessary.
+                if (isReadOnly)
+                {
+                    RunningDocumentInfo rdtInfo = rdt.GetDocumentInfo(filePath);
+
+                    // Set it as read only if necessary.
+                    if (rdtInfo.DocData is IVsTextBuffer textBuffer)
+                    {
+                        textBuffer.GetStateFlags(out uint flags);
+                        textBuffer.SetStateFlags(flags | (uint)BUFFERSTATEFLAGS.BSF_USER_READONLY);
+                    }
+                }
+
+                // Show the document window
+                if (windowFrame != null)
+                {
+                    ErrorHandler.ThrowOnFailure(windowFrame.Show());
+                }
+            }
+            catch (Exception ex) when (!ex.IsCritical())
+            {
+                windowFrame?.CloseFrame(0);
+            }
+        }
+    }
+}

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/Items/AttachedItemPriority.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/Items/AttachedItemPriority.cs
@@ -23,5 +23,7 @@ namespace NuGet.VisualStudio.SolutionExplorer
         public const int CompileTimeAssemblyGroup = 400;
         public const int FrameworkAssemblyGroup = 500;
         public const int ContentFilesGroup = 600;
+        public const int PackageBuildFileGroup = 700;
+        public const int PackageBuildMultiTargetingFileGroup = 800;
     }
 }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/Items/PackageAssemblyGroupItem.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/Items/PackageAssemblyGroupItem.cs
@@ -53,6 +53,5 @@ namespace NuGet.VisualStudio.SolutionExplorer
         };
 
         public override ImageMoniker IconMoniker => KnownMonikers.ReferenceGroup;
-
     }
 }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/Items/PackageAssemblyItem.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/Items/PackageAssemblyItem.cs
@@ -35,7 +35,7 @@ namespace NuGet.VisualStudio.SolutionExplorer
             GroupType = groupType;
         }
 
-        public override object Identity => Tuple.Create(Library.Name, Path);
+        public override object Identity => Tuple.Create(Library.Name, Path, GroupType);
 
         // All siblings are assemblies, so no prioritization needed (sort alphabetically)
         public override int Priority => 0;

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/Items/PackageBuildFileGroupItem.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/Items/PackageBuildFileGroupItem.cs
@@ -1,0 +1,57 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#nullable enable
+
+using System;
+using System.ComponentModel;
+using Microsoft.VisualStudio.Imaging;
+using Microsoft.VisualStudio.Imaging.Interop;
+using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections;
+using NuGet.VisualStudio.Implementation.Resources;
+using NuGet.VisualStudio.SolutionExplorer.Models;
+
+namespace NuGet.VisualStudio.SolutionExplorer
+{
+    /// <summary>
+    /// Backing object for named group of build files (.props and .targets) within the dependencies tree.
+    /// </summary>
+    /// <remarks>
+    /// Items within this group have type <see cref="PackageBuildFileItem"/>.
+    /// </remarks>
+    internal sealed class PackageBuildFileGroupItem : RelatableItemBase
+    {
+        public AssetsFileTarget Target { get; }
+        public AssetsFileTargetLibrary Library { get; }
+        public PackageBuildFileGroupType GroupType { get; }
+
+        public PackageBuildFileGroupItem(AssetsFileTarget target, AssetsFileTargetLibrary library, PackageBuildFileGroupType groupType)
+            : base(GetGroupLabel(groupType))
+        {
+            Target = target;
+            Library = library;
+            GroupType = groupType;
+        }
+
+        private static string GetGroupLabel(PackageBuildFileGroupType groupType)
+        {
+            return groupType switch
+            {
+                PackageBuildFileGroupType.Build => VsResources.PackageBuildFileGroupName,
+                PackageBuildFileGroupType.BuildMultiTargeting => VsResources.PackageBuildMultiTargetingFileGroupName,
+                _ => throw new InvalidEnumArgumentException(nameof(groupType), (int)groupType, typeof(PackageBuildFileGroupType))
+            };
+        }
+
+        public override object Identity => Tuple.Create(GroupType, Library.Name);
+
+        public override int Priority => GroupType switch
+        {
+            PackageBuildFileGroupType.Build => AttachedItemPriority.PackageBuildFileGroup,
+            PackageBuildFileGroupType.BuildMultiTargeting => AttachedItemPriority.PackageBuildMultiTargetingFileGroup,
+            _ => throw new InvalidEnumArgumentException(nameof(GroupType), (int)GroupType, typeof(PackageBuildFileGroupType))
+        };
+
+        public override ImageMoniker IconMoniker => KnownMonikers.TargetFile;
+    }
+}

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/Items/PackageBuildFileItem.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/Items/PackageBuildFileItem.cs
@@ -1,0 +1,97 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Internal.VisualStudio.PlatformUI;
+using Microsoft.VisualStudio.Imaging;
+using Microsoft.VisualStudio.Imaging.Interop;
+using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections;
+using Microsoft.VisualStudio.Shell;
+using NuGet.VisualStudio.Implementation.Resources;
+using NuGet.VisualStudio.SolutionExplorer.Models;
+
+namespace NuGet.VisualStudio.SolutionExplorer
+{
+    /// <summary>
+    /// Backing object for a build file within a library within the dependencies tree.
+    /// </summary>
+    /// <remarks>
+    /// Items of this type are grouped within <see cref="PackageBuildFileGroupItem"/>.
+    /// </remarks>
+    internal sealed class PackageBuildFileItem : RelatableItemBase, IInvocationPattern, IInvocationController
+    {
+        private readonly FileOpener _fileOpener;
+
+        public AssetsFileTarget Target { get; }
+        public AssetsFileTargetLibrary Library { get; }
+        public string Path { get; }
+        public PackageBuildFileGroupType GroupType { get; }
+
+        public PackageBuildFileItem(AssetsFileTarget target, AssetsFileTargetLibrary library, string path, PackageBuildFileGroupType groupType, FileOpener fileOpener)
+            : base(System.IO.Path.GetFileName(path))
+        {
+            Target = target;
+            Library = library;
+            Path = path;
+            GroupType = groupType;
+            _fileOpener = fileOpener;
+        }
+
+        public string? FullPath => Target.TryResolvePackagePath(Library.Name, Library.Version, out string? fullPath)
+            ? System.IO.Path.GetFullPath(System.IO.Path.Combine(fullPath, Path))
+            : null;
+
+        public override object Identity => Tuple.Create(Library.Name, Path, GroupType);
+
+        // All siblings are build files, so no prioritization needed (sort alphabetically)
+        public override int Priority => 0;
+
+        public override ImageMoniker IconMoniker => KnownMonikers.TargetFile;
+
+        public bool CanPreview => true;
+
+        public IInvocationController InvocationController => this;
+
+        public override object? GetBrowseObject() => new BrowseObject(this);
+
+        public bool Invoke(IEnumerable<object> items, InputSource inputSource, bool preview)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            bool result = false;
+
+            foreach (object itemObject in items)
+            {
+                if (itemObject is PackageBuildFileItem { FullPath: { } path })
+                {
+                    _fileOpener.OpenFile(path, isReadOnly: true);
+                    result = true;
+                }
+            }
+
+            return result;
+        }
+
+        private sealed class BrowseObject : BrowseObjectBase
+        {
+            private readonly PackageBuildFileItem _item;
+
+            public BrowseObject(PackageBuildFileItem library) => _item = library;
+
+            public override string GetComponentName() => _item.Text;
+
+            public override string GetClassName() => VsResources.PackageBuildFileBrowseObjectClassName;
+
+            [BrowseObjectDisplayName(nameof(VsResources.PackageBuildFileNameDisplayName))]
+            [BrowseObjectDescription(nameof(VsResources.PackageBuildFileNameDescription))]
+            public string Name => _item.Text;
+
+            [BrowseObjectDisplayName(nameof(VsResources.PackageBuildFilePathDisplayName))]
+            [BrowseObjectDescription(nameof(VsResources.PackageBuildFilePathDescription))]
+            public string? Path => _item.FullPath;
+        }
+    }
+}

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/Models/AssetsFileTargetLibrary.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/Models/AssetsFileTargetLibrary.cs
@@ -58,6 +58,16 @@ namespace NuGet.VisualStudio.SolutionExplorer.Models
                 .Select(file => new AssetsFileTargetLibraryContentFile(file))
                 .ToImmutableArray();
 
+            BuildFiles = library.Build
+                .Where(file => !IsPlaceholderFile(file.Path))
+                .Select(file => file.Path)
+                .ToImmutableArray();
+
+            BuildMultiTargetingFiles = library.BuildMultiTargeting
+                .Where(file => !IsPlaceholderFile(file.Path))
+                .Select(file => file.Path)
+                .ToImmutableArray();
+
             return;
 
             static bool IsPlaceholderFile(string path)
@@ -84,6 +94,8 @@ namespace NuGet.VisualStudio.SolutionExplorer.Models
         public ImmutableArray<string> FrameworkAssemblies { get; }
         public ImmutableArray<string> CompileTimeAssemblies { get; }
         public ImmutableArray<AssetsFileTargetLibraryContentFile> ContentFiles { get; }
+        public ImmutableArray<string> BuildFiles { get; }
+        public ImmutableArray<string> BuildMultiTargetingFiles { get; }
 
         public override string ToString() => $"{Type} {Name} ({Version}) {Dependencies.Length} {(Dependencies.Length == 1 ? "dependency" : "dependencies")}";
     }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/Models/AssetsFileTargetLibraryContentFile.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/Models/AssetsFileTargetLibraryContentFile.cs
@@ -9,7 +9,7 @@ using NuGet.ProjectModel;
 namespace NuGet.VisualStudio.SolutionExplorer.Models
 {
     /// <summary>
-    /// Data about a a content file within a package in a given target, from <c>project.assets.json</c>. Immutable.
+    /// Data about a content file within a package in a given target, from <c>project.assets.json</c>. Immutable.
     /// </summary>
     internal sealed class AssetsFileTargetLibraryContentFile
     {

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/PackageAssemblyGroupType.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/PackageAssemblyGroupType.cs
@@ -11,7 +11,7 @@ namespace NuGet.VisualStudio.SolutionExplorer
     /// Enumeration of package assembly group types.
     /// </summary>
     /// <remarks>
-    /// Use by <see cref="PackageAssemblyGroupItem"/>, <see cref="PackageAssemblyItem"/> and their <see cref="IRelation"/> types.
+    /// Used by <see cref="PackageAssemblyGroupItem"/>, <see cref="PackageAssemblyItem"/> and their <see cref="IRelation"/> types.
     /// </remarks>
     internal enum PackageAssemblyGroupType
     {

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/PackageBuildFileGroupType.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/PackageBuildFileGroupType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 #nullable enable

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/PackageBuildFileGroupType.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/PackageBuildFileGroupType.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#nullable enable
+
+using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections;
+
+namespace NuGet.VisualStudio.SolutionExplorer
+{
+    /// <summary>
+    /// Enumeration of package assembly group types.
+    /// </summary>
+    /// <remarks>
+    /// Used by <see cref="PackageBuildFileGroupItem"/>, <see cref="PackageBuildFileItem"/> and their <see cref="IRelation"/> types.
+    /// </remarks>
+    internal enum PackageBuildFileGroupType
+    {
+        Build,
+        BuildMultiTargeting
+    }
+}

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/Relations/BuildFilesGroupToBuildFilesRelation.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/Relations/BuildFilesGroupToBuildFilesRelation.cs
@@ -1,0 +1,56 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.ComponentModel;
+using System.ComponentModel.Composition;
+using System.Linq;
+using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections;
+
+namespace NuGet.VisualStudio.SolutionExplorer
+{
+    [Export(typeof(IRelation))]
+    internal sealed class BuildFilesGroupToBuildFilesRelation : RelationBase<PackageBuildFileGroupItem, PackageBuildFileItem>
+    {
+        private readonly FileOpener _fileOpener;
+
+        [ImportingConstructor]
+        public BuildFilesGroupToBuildFilesRelation(FileOpener fileOpener)
+        {
+            _fileOpener = fileOpener;
+        }
+
+        protected override bool HasContainedItems(PackageBuildFileGroupItem parent)
+        {
+            return GetBuildFiles(parent).Length != 0;
+        }
+
+        protected override void UpdateContainsCollection(PackageBuildFileGroupItem parent, AggregateContainsRelationCollectionSpan span)
+        {
+            span.UpdateContainsItems(
+                GetBuildFiles(parent).OrderBy(buildFile => buildFile),
+                (buildFile, item) => StringComparer.Ordinal.Compare(buildFile, item.Path),
+                (library, item) => false,
+                buildFile => new PackageBuildFileItem(parent.Target, parent.Library, buildFile, parent.GroupType, _fileOpener));
+        }
+
+        protected override IEnumerable<PackageBuildFileGroupItem>? CreateContainedByItems(PackageBuildFileItem child)
+        {
+            yield return new PackageBuildFileGroupItem(child.Target, child.Library, child.GroupType);
+        }
+
+        private static ImmutableArray<string> GetBuildFiles(PackageBuildFileGroupItem groupItem)
+        {
+            return groupItem.GroupType switch
+            {
+                PackageBuildFileGroupType.Build => groupItem.Library.BuildFiles,
+                PackageBuildFileGroupType.BuildMultiTargeting => groupItem.Library.BuildMultiTargetingFiles,
+                _ => throw new InvalidEnumArgumentException(nameof(groupItem.GroupType), (int)groupItem.GroupType, typeof(PackageAssemblyGroupType))
+            };
+        }
+    }
+}

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/Relations/PackageToBuildFileGroupRelation.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/Relations/PackageToBuildFileGroupRelation.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 #nullable enable

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/Relations/PackageToBuildFileGroupRelation.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/Relations/PackageToBuildFileGroupRelation.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#nullable enable
+
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.Linq;
+using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections;
+using NuGet.VisualStudio.SolutionExplorer.Models;
+
+namespace NuGet.VisualStudio.SolutionExplorer
+{
+    [Export(typeof(IRelation))]
+    internal sealed class PackageToBuildFileGroupRelation : RelationBase<PackageReferenceItem, PackageBuildFileGroupItem>
+    {
+        protected override bool HasContainedItems(PackageReferenceItem parent)
+        {
+            return parent.Library.BuildFiles.Length != 0;
+        }
+
+        protected override void UpdateContainsCollection(PackageReferenceItem parent, AggregateContainsRelationCollectionSpan span)
+        {
+            span.UpdateContainsItems(
+                parent.Library.BuildFiles.Length == 0 ? Enumerable.Empty<AssetsFileTargetLibrary>() : new[] { parent.Library },
+                (library, item) => 0,
+                (library, item) => false,
+                library => new PackageBuildFileGroupItem(parent.Target, library, PackageBuildFileGroupType.Build));
+        }
+
+        protected override IEnumerable<PackageReferenceItem>? CreateContainedByItems(PackageBuildFileGroupItem child)
+        {
+            if (child.GroupType == PackageBuildFileGroupType.Build)
+            {
+                yield return new PackageReferenceItem(child.Target, child.Library);
+            }
+        }
+    }
+}

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/Relations/PackageToBuildMultiTargetingFileGroupRelation.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/Relations/PackageToBuildMultiTargetingFileGroupRelation.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 #nullable enable

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/Relations/PackageToBuildMultiTargetingFileGroupRelation.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/Relations/PackageToBuildMultiTargetingFileGroupRelation.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#nullable enable
+
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.Linq;
+using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections;
+using NuGet.VisualStudio.SolutionExplorer.Models;
+
+namespace NuGet.VisualStudio.SolutionExplorer
+{
+    [Export(typeof(IRelation))]
+    internal sealed class PackageToBuildMultiTargetingFileGroupRelation : RelationBase<PackageReferenceItem, PackageBuildFileGroupItem>
+    {
+        protected override bool HasContainedItems(PackageReferenceItem parent)
+        {
+            return parent.Library.BuildMultiTargetingFiles.Length != 0;
+        }
+
+        protected override void UpdateContainsCollection(PackageReferenceItem parent, AggregateContainsRelationCollectionSpan span)
+        {
+            span.UpdateContainsItems(
+                parent.Library.BuildMultiTargetingFiles.Length == 0 ? Enumerable.Empty<AssetsFileTargetLibrary>() : new[] { parent.Library },
+                (library, item) => 0,
+                (library, item) => false,
+                library => new PackageBuildFileGroupItem(parent.Target, library, PackageBuildFileGroupType.BuildMultiTargeting));
+        }
+
+        protected override IEnumerable<PackageReferenceItem>? CreateContainedByItems(PackageBuildFileGroupItem child)
+        {
+            if (child.GroupType == PackageBuildFileGroupType.BuildMultiTargeting)
+            {
+                yield return new PackageReferenceItem(child.Target, child.Library);
+            }
+        }
+    }
+}

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/Relations/PackageToCompileTimeAssemblyGroupRelation.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/Relations/PackageToCompileTimeAssemblyGroupRelation.cs
@@ -3,9 +3,9 @@
 
 #nullable enable
 
-using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
+using System.Linq;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections;
 using NuGet.VisualStudio.SolutionExplorer.Models;
 
@@ -22,7 +22,7 @@ namespace NuGet.VisualStudio.SolutionExplorer
         protected override void UpdateContainsCollection(PackageReferenceItem parent, AggregateContainsRelationCollectionSpan span)
         {
             span.UpdateContainsItems(
-                parent.Library.CompileTimeAssemblies.Length == 0 ? Array.Empty<AssetsFileTargetLibrary>() : new[] { parent.Library },
+                parent.Library.CompileTimeAssemblies.Length == 0 ? Enumerable.Empty<AssetsFileTargetLibrary>() : new[] { parent.Library },
                 (library, item) => 0,
                 (library, item) => false,
                 library => new PackageAssemblyGroupItem(parent.Target, library, PackageAssemblyGroupType.CompileTime));

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/Relations/PackageToContentFilesGroupRelation.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/Relations/PackageToContentFilesGroupRelation.cs
@@ -3,9 +3,9 @@
 
 #nullable enable
 
-using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
+using System.Linq;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections;
 using NuGet.VisualStudio.SolutionExplorer.Models;
 
@@ -19,7 +19,7 @@ namespace NuGet.VisualStudio.SolutionExplorer
         protected override void UpdateContainsCollection(PackageReferenceItem parent, AggregateContainsRelationCollectionSpan span)
         {
             span.UpdateContainsItems(
-                parent.Library.ContentFiles.Length == 0 ? Array.Empty<AssetsFileTargetLibrary>() : new[] { parent.Library },
+                parent.Library.ContentFiles.Length == 0 ? Enumerable.Empty<AssetsFileTargetLibrary>() : new[] { parent.Library },
                 (library, item) => 0,
                 (library, item) => false,
                 library => new PackageContentFileGroupItem(parent.Target, library));

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/Relations/PackageToFrameworkAssemblyGroupRelation.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/Relations/PackageToFrameworkAssemblyGroupRelation.cs
@@ -3,9 +3,9 @@
 
 #nullable enable
 
-using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
+using System.Linq;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections;
 using NuGet.VisualStudio.SolutionExplorer.Models;
 
@@ -19,7 +19,7 @@ namespace NuGet.VisualStudio.SolutionExplorer
         protected override void UpdateContainsCollection(PackageReferenceItem parent, AggregateContainsRelationCollectionSpan span)
         {
             span.UpdateContainsItems(
-                parent.Library.FrameworkAssemblies.Length == 0 ? Array.Empty<AssetsFileTargetLibrary>() : new[] { parent.Library },
+                parent.Library.FrameworkAssemblies.Length == 0 ? Enumerable.Empty<AssetsFileTargetLibrary>() : new[] { parent.Library },
                 (library, item) => 0,
                 (library, item) => false,
                 library => new PackageAssemblyGroupItem(parent.Target, library, PackageAssemblyGroupType.Framework));

--- a/src/NuGet.Core/NuGet.Frameworks/NuGetFramework.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/NuGetFramework.cs
@@ -148,7 +148,7 @@ namespace NuGet.Frameworks
             get { return _frameworkProfile; }
         }
 
-        /// <summary>The TargetFrameworkMoniker identifier of the current NuGetFrameowrk.</summary>
+        /// <summary>The TargetFrameworkMoniker identifier of the current NuGetFramework.</summary>
         /// <remarks>Formatted to a System.Versioning.FrameworkName</remarks>
         public string DotNetFrameworkName
         {
@@ -162,7 +162,7 @@ namespace NuGet.Frameworks
             }
         }
 
-        /// <summary>The TargetFrameworkMoniker identifier of the current NuGetFrameowrk.</summary>
+        /// <summary>The TargetFrameworkMoniker identifier of the current NuGetFramework.</summary>
         /// <remarks>Formatted to a System.Versioning.FrameworkName</remarks>
         public string GetDotNetFrameworkName(IFrameworkNameProvider mappings)
         {
@@ -193,7 +193,7 @@ namespace NuGet.Frameworks
             }
         }
 
-        /// <summary>The TargetPlatformMoniker identifier of the current NuGetFrameowrk.</summary>
+        /// <summary>The TargetPlatformMoniker identifier of the current NuGetFramework.</summary>
         /// <remarks>Similar to a System.Versioning.FrameworkName, but missing the v at the beginning of the version.</remarks>
         public string DotNetPlatformName
         {


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/dotnet/project-system/issues/7838

Regression? No.

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

This PR adds models and relations to support display of the `.props` and `.targets` files embedded within NuGet packages directly in Solution Explorer.

These files can have a significant impact upon a project's build. Previously the fact that a package brought in such customisation was largely hidden from the user. Making them more visible helps expose this property of packages, where applicable.

Double-clicking on files opens them in the editor, in a read-only buffer.

### Before

![image](https://user-images.githubusercontent.com/350947/148382855-bf1e4809-ead0-4f8e-9af9-943b3b0acf50.png)

### After

![image](https://user-images.githubusercontent.com/350947/148382911-92dc9ec4-ce14-4cd0-b8e1-f4643ac4cd61.png)

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
