### PR TITLE
Enable MSBuildProjectSystem_RemoveFile

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Common/MSBuildUser.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Common/MSBuildUser.cs
@@ -25,13 +25,20 @@ namespace NuGet.Common
         // msbuildDirectory is the directory containing the msbuild to be used. E.g. C:\Program Files (x86)\MSBuild\15.0\Bin
         public void LoadAssemblies(string msbuildDirectory)
         {
-            if (String.IsNullOrEmpty(msbuildDirectory))
+            if (string.IsNullOrEmpty(msbuildDirectory))
             {
                 throw new ArgumentNullException(nameof(msbuildDirectory));
             }
 
+            string microsoftBuildDllPath = Path.Combine(msbuildDirectory, "Microsoft.Build.dll");
+
+            if (!File.Exists(microsoftBuildDllPath))
+            {
+                throw new FileNotFoundException(message: null, microsoftBuildDllPath);
+            }
+
             _msbuildDirectory = msbuildDirectory;
-            _msbuildAssembly = Assembly.LoadFile(Path.Combine(msbuildDirectory, "Microsoft.Build.dll"));
+            _msbuildAssembly = Assembly.LoadFile(microsoftBuildDllPath);
             _frameworkAssembly = Assembly.LoadFile(Path.Combine(msbuildDirectory, "Microsoft.Build.Framework.dll"));
 
             LoadTypes();

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/MSBuildProjectSystemTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/MSBuildProjectSystemTests.cs
@@ -3,17 +3,28 @@
 
 using System;
 using System.IO;
+using System.Security;
 using System.Text;
+using System.Threading.Tasks;
 using System.Xml.Linq;
+using Moq;
 using NuGet.Common;
 using NuGet.Test.Utility;
 using Test.Utility;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace NuGet.CommandLine.Test
 {
     public class MSBuildProjectSystemTests
     {
+        private readonly ITestOutputHelper _testOutputHelper;
+
+        public MSBuildProjectSystemTests(ITestOutputHelper testOutputHelper)
+        {
+            _testOutputHelper = testOutputHelper;
+        }
+
         private class TestInfo : IDisposable
         {
             private readonly TestDirectory _projectDirectory;
@@ -22,10 +33,16 @@ namespace NuGet.CommandLine.Test
 
             public MSBuildProjectSystem MSBuildProjectSystem { get; }
 
-            public TestInfo(string projectFileContent, string projectName = "proj1")
+            public TestInfo(ITestOutputHelper testOutputHelper, string projectFileContent, string projectName = "proj1")
             {
+                var console = new Mock<IConsole>();
+
+                console.Setup(c => c.WriteLine(It.IsAny<string>(), It.IsAny<object[]>())).Callback<string, object[]>((format, args) => testOutputHelper.WriteLine(format, args));
+
+                console.SetupGet(c => c.Verbosity).Returns(Verbosity.Detailed);
+
                 _projectDirectory = TestDirectory.Create();
-                _msBuildDirectory = MsBuildUtility.GetMsBuildToolset(null, null).Path;
+                _msBuildDirectory = MsBuildUtility.GetMsBuildToolset(null, console.Object).Path;
                 _nuGetProjectContext = new TestNuGetProjectContext();
 
                 var projectFilePath = Path.Combine(_projectDirectory, projectName + ".csproj");
@@ -46,7 +63,7 @@ namespace NuGet.CommandLine.Test
         {
             // Arrange
             var projectFileContent = Util.CreateProjFileContent();
-            using (var testInfo = new TestInfo(projectFileContent))
+            using (var testInfo = new TestInfo(_testOutputHelper, projectFileContent))
             {
                 var expectedContent = "one two three";
                 using (var stream = new MemoryStream(Encoding.UTF8.GetBytes(expectedContent)))
@@ -65,7 +82,7 @@ namespace NuGet.CommandLine.Test
         }
 
 
-        [Fact(Skip = "https://github.com/NuGet/Home/issues/11277")]
+        [Fact]
         public void MSBuildProjectSystem_RemoveFile()
         {
             // Arrange
@@ -75,7 +92,7 @@ namespace NuGet.CommandLine.Test
                 references: null,
                 contentFiles: new[] { "a.js" });
 
-            using (var testInfo = new TestInfo(projectFileContent))
+            using (var testInfo = new TestInfo(_testOutputHelper, projectFileContent))
             {
                 var path = Path.Combine(testInfo.MSBuildProjectSystem.ProjectFullPath, "a.js");
                 var expectedContent = "one two three";
@@ -102,7 +119,7 @@ namespace NuGet.CommandLine.Test
                 references: null,
                 contentFiles: new[] { "a.js" });
 
-            using (var testInfo = new TestInfo(projectFileContent))
+            using (var testInfo = new TestInfo(_testOutputHelper, projectFileContent))
             {
                 var path = Path.Combine(testInfo.MSBuildProjectSystem.ProjectFullPath, "a.js");
                 var expectedContent = "one two three";
@@ -134,7 +151,7 @@ namespace NuGet.CommandLine.Test
   </Target>
 </Project>";
 
-            using (var testInfo = new TestInfo(projectFileContent))
+            using (var testInfo = new TestInfo(_testOutputHelper, projectFileContent))
             {
                 var targetFullPath = Path.Combine(testInfo.MSBuildProjectSystem.ProjectFullPath, import);
 
@@ -164,7 +181,7 @@ namespace NuGet.CommandLine.Test
   </Target>
 </Project>";
 
-            using (var testInfo = new TestInfo(projectFileContent))
+            using (var testInfo = new TestInfo(_testOutputHelper, projectFileContent))
             {
                 var targetFullPath = Path.Combine(testInfo.MSBuildProjectSystem.ProjectFullPath, import);
 


### PR DESCRIPTION



<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11277

Regression? No Last working version:

## Description
Add more logging around which MSBuild.exe was found and throw an exception if an MSBuild assembly doesn't exist.  I couldn't get the test to fail anymore.  It assumes `Microsoft.Build.dll` is next to `MSBuild.exe` which should be valid.  But at least with the additional output we should be able to troubleshoot more.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
