### PR TITLE
StaticGraphRestore: Set LogTaskInputs to true when using a binlog

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs
@@ -871,7 +871,8 @@ namespace NuGet.Build.Tasks.Console
             string binlogParameters = Environment.GetEnvironmentVariable("RESTORE_TASK_BINLOG_PARAMETERS");
 
             // Attach the binary logger if Debug or binlog parameters were specified
-            if (Debug || !string.IsNullOrWhiteSpace(binlogParameters))
+            bool useBinlog = Debug || !string.IsNullOrWhiteSpace(binlogParameters);
+            if (useBinlog)
             {
                 loggers.Add(new BinaryLogger
                 {
@@ -911,7 +912,7 @@ namespace NuGet.Build.Tasks.Console
                 {
                     // Use the same loggers as the project collection
                     Loggers = projectCollection.Loggers,
-                    LogTaskInputs = Debug
+                    LogTaskInputs = useBinlog
                 };
 
                 // BeginBuild starts a queue which accepts build requests and applies the build parameters to all of them


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11484

Regression? Last working version: None as far as I know

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
Currently `BuildParameters.LogTaskInputs` is only set to true when debugging the console application. This changes it to set it to true any time the binlog is used.

Before:
![image](https://user-images.githubusercontent.com/6445614/148473004-96b01c0b-6b56-48d1-bd40-445520289fa0.png)

After:
![image](https://user-images.githubusercontent.com/6445614/148472887-0533fcfb-5074-4253-8ff3-6c76a9322c0e.png)


## PR Checklist

- [x ] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception - This code path is not unit tested and is under a feature flag used for debugging.
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
