### PR TITLE
FindItems should not be marked as obsolete since it does not use yield returns in its code path

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/ContentModel/ContentItemCollection.cs
+++ b/src/NuGet.Core/NuGet.Packaging/ContentModel/ContentItemCollection.cs
@@ -45,7 +45,6 @@ namespace NuGet.ContentModel
             }
         }
 
-        [Obsolete("This method causes excessive memory usage with yield return.")]
         public IEnumerable<ContentItem> FindItems(PatternSet definition)
         {
             return FindItemsImplementation(definition, _assets);


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11487

Regression? Last working version: N/A

## Description
The FindItems method was marked as obsolete to prevent consumers from using the FindItemsImplementation that used yield returns, resulting in an overallocation of objects. Additionally, with no references to the method, it appeared to be unused. However, in PR: https://github.com/NuGet/NuGet.Client/pull/4099 the FindItemsImplementation was also fixed to not use yield returns so the memory allocation issue is not present in this method and it does not need to be obsolete. The method is also used by external sources, including dotnet. See: https://github.com/dotnet/sdk/pull/23277
https://github.com/dotnet/sdk/issues/23301

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
"Obsolete" attribute removed
  - [x] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
