### PR TITLE
run NuGet.Protocol.FuncTests run in parallel

### DIFF
--- a/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/NuGet.Protocol.FuncTest.csproj
+++ b/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/NuGet.Protocol.FuncTest.csproj
@@ -23,12 +23,6 @@
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
-  <ItemGroup>
-    <None Include="xunit.runner.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
-
   <PropertyGroup>
     <PostBuildEvent Condition="'$(OS)' == 'Windows_NT'">
       xcopy /diye $(ArtifactsDirectory)TestablePlugin\bin\$(Configuration)\$(TargetFramework)\* $(MSBuildProjectDirectory)\bin\$(Configuration)\$(TargetFramework)\TestablePlugin\

--- a/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/NuGet.Protocol.FuncTest.csproj
+++ b/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/NuGet.Protocol.FuncTest.csproj
@@ -6,6 +6,7 @@
     <TargetFrameworks>$(TargetFrameworksExeForSigning)</TargetFrameworks>
     <TestProjectType>functional</TestProjectType>
     <Description>Integration tests for the more involved NuGet.Protocol functionality, such as plugins.</Description>
+    <UseParallelXunit>true</UseParallelXunit>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/xunit.runner.json
+++ b/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/xunit.runner.json
@@ -1,4 +1,0 @@
-{
-  "maxParallelThreads": 1,
-  "parallelizeTestCollections": false
-}


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1288

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
Added `UseParallelXunit` property to `NuGet.Protocol.FuncTest` project so that the tests can run in parallel using the settings defined in the shared [`xunit.runner.json`](https://github.com/NuGet/NuGet.Client/blob/dev/build/TestShared/xunit.runner.json) file. I deleted `xunit.runner.json` file that was created under project root directory which instructed `xUnit` to disable parallelism. I ran 2 or 3 private builds by running tests in parallel and tests passed every time.

From the CI logs it is clear that xUnit started 7 tests in parallel.

```
 Discovering: NuGet.Protocol.FuncTest (app domain = on [shadow copy], method display = ClassAndMethod, method display options = None)
           Discovered:  NuGet.Protocol.FuncTest (found 51 test cases)
           Starting:    NuGet.Protocol.FuncTest (parallel test collections = on, max threads = 8)
             NuGet.Core.FuncTest.ResolverTests.ResolveDependenciesForVeryDeepGraph [STARTING]
             NuGet.Core.FuncTest.DownloadTimeoutStreamTests.DownloadTimeoutStream_SuccessAsync [STARTING]
             NuGet.Protocol.FuncTest.ODataServiceDocumentResourceV2Tests.ODataServiceDocumentResourceV2_Invalid [STARTING]
             NuGet.Core.FuncTest.HttpRetryHandlerTests.HttpRetryHandler_HandlesInvalidProtocol [STARTING]
             NuGet.Protocol.FuncTest.DownloadResourceV2FeedTests.DownloadResourceFromIdentityInvalidSource [STARTING]
             NuGet.Protocol.FuncTest.V2FeedParserTests.V2FeedParser_Search [STARTING]
             NuGet.Protocol.FuncTest.PluginTests.GetOrCreateAsync_SuccessfullyHandshakes [STARTING]
```

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [x] N/A
