### PR TITLE
Verify nuget.exe Authenticode while running update -self command

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/UpdateCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/UpdateCommand.cs
@@ -18,8 +18,8 @@ using NuGet.Packaging.Core;
 using NuGet.Packaging.PackageExtraction;
 using NuGet.Packaging.Signing;
 using NuGet.ProjectManagement;
-using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
+using NuGet.Protocol.Plugins;
 using NuGet.Resolver;
 using NuGet.Versioning;
 
@@ -146,7 +146,7 @@ namespace NuGet.CommandLine
                 default:
                     throw new CommandException(NuGetResources.Error_UpdateSelf_Source);
             }
-            var selfUpdater = new SelfUpdater(Console);
+            var selfUpdater = new SelfUpdater(Console, EmbeddedSignatureVerifier.Create());
             await selfUpdater.UpdateSelfAsync(Prerelease, targetSource);
         }
 

--- a/src/NuGet.Clients/NuGet.CommandLine/Common/CommandLineUtility.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Common/CommandLineUtility.cs
@@ -2,9 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Globalization;
-using System.IO;
 using System.Linq;
 using NuGet.Commands;
 using NuGet.Common;
@@ -35,6 +33,36 @@ namespace NuGet.CommandLine
                 return LocalizedResourceManager.GetString("DefaultSymbolServer") + " (" + NuGetConstants.DefaultSymbolServerUrl + ")";
             }
             return "'" + source + "'";
+        }
+
+        /// <summary>
+        /// True if the source is HTTP and has a *.nuget.org or nuget.org host.
+        /// </summary>
+        internal static bool IsNuGetOrg(PackageSource source)
+        {
+            if (source == null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+
+            if (!source.IsHttp)
+            {
+                return false;
+            }
+
+            var uri = source.TrySourceAsUri;
+            if (uri == null)
+            {
+                return false;
+            }
+
+            if (StringComparer.OrdinalIgnoreCase.Equals(uri.Host, "nuget.org")
+                || uri.Host.EndsWith(".nuget.org", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            return false;
         }
 
         public static bool IsValidConfigFileName(string fileName)

--- a/src/NuGet.Clients/NuGet.CommandLine/Common/SelfUpdater.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Common/SelfUpdater.cs
@@ -125,7 +125,7 @@ namespace NuGet.CommandLine
                         }
 
                         //Verify nuget.exe authenticode signature if nuget.org is the package source
-                        if (string.Equals(source.Source, NuGetConstants.V3FeedUrl, StringComparison.Ordinal))
+                        if (CommandLineUtility.IsNuGetOrg(source))
                         {
                             string nugetExePath = Path.Combine(tempDir, NuGetCommandLinePackageId, packageIdentity.Version.ToNormalizedString(), nugetExeInPackageFilePath);
 

--- a/src/NuGet.Clients/NuGet.CommandLine/Common/SelfUpdater.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Common/SelfUpdater.cs
@@ -105,7 +105,7 @@ namespace NuGet.CommandLine
                     {
                         DirectoryUtility.CreateSharedDirectory(tempDir);
 
-                        DownloadResourceResult downloadResourceResult = await PackageDownloader.GetDownloadResourceResultAsync(
+                        using DownloadResourceResult downloadResourceResult = await PackageDownloader.GetDownloadResourceResultAsync(
                                             sourceRepository,
                                             packageIdentity,
                                             new PackageDownloadContext(sourceCacheContext),

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.Designer.cs
@@ -2374,6 +2374,15 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Invalid NuGet.CommandLine package. Authenticode signature verification failed for NuGet.exe within the package..
+        /// </summary>
+        public static string Error_AuthenticodeVerificationFailed {
+            get {
+                return ResourceManager.GetString("Error_AuthenticodeVerificationFailed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Cannot find the specified version of msbuild: &apos;{0}&apos;.
         /// </summary>
         public static string Error_CannotFindMsbuild {

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
@@ -5433,4 +5433,7 @@ Please consider migrating '{0}' to `PackageReference` and using the pack targets
 You can set the '{1}' environment variable to 'true' to temporarily reenable this functionality.</value>
     <comment>Please do not localize `project.json` pack and `PackageReference`. 0 - path, 1 - env var name</comment>
   </data>
+  <data name="Error_AuthenticodeVerificationFailed" xml:space="preserve">
+    <value>Invalid NuGet.CommandLine package. Authenticode signature verification failed for NuGet.exe within the package.</value>
+  </data>
 </root>

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
@@ -5435,7 +5435,6 @@ You can set the '{1}' environment variable to 'true' to temporarily reenable thi
   </data>
   <data name="Error_AuthenticodeVerificationFailed" xml:space="preserve">
     <value>Invalid NuGet.CommandLine package. Authenticode signature verification failed for NuGet.exe within the package.</value>
-Write
     <comment>Please do not localize 'NuGet.Commandline', 'Authenticode' and 'NuGet.exe'</comment>
   </data>
 </root>

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
@@ -5435,5 +5435,7 @@ You can set the '{1}' environment variable to 'true' to temporarily reenable thi
   </data>
   <data name="Error_AuthenticodeVerificationFailed" xml:space="preserve">
     <value>Invalid NuGet.CommandLine package. Authenticode signature verification failed for NuGet.exe within the package.</value>
+Write
+    <comment>Please do not localize 'NuGet.Commandline', 'Authenticode' and 'NuGet.exe'</comment>
   </data>
 </root>

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/CommandLineUtilityTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/CommandLineUtilityTests.cs
@@ -1,0 +1,37 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Xunit;
+
+namespace NuGet.CommandLine.Test
+{
+    public class CommandLineUtilityTests
+    {
+        [Theory]
+        [InlineData("http://nuget.org/api/v2", true)]
+        [InlineData("http://NUGET.ORG/api/v2", true)]
+        [InlineData("https://nuget.org/api/v2", true)]
+        [InlineData("https://NUGET.ORG/api/v2", true)]
+        [InlineData("http://www.nuget.org/api/v2", true)]
+        [InlineData("http://WWW.NUGET.ORG/api/v2", true)]
+        [InlineData("https://www.nuget.org/api/v2", true)]
+        [InlineData("https://WWW.NUGET.ORG/api/v2", true)]
+        [InlineData("http://api.nuget.org/v3/index.json", true)]
+        [InlineData("http://API.NUGET.ORG/v3/index.json", true)]
+        [InlineData("https://api.nuget.org/v3/index.json", true)]
+        [InlineData("https://API.NUGET.ORG/v3/index.json", true)]
+        [InlineData("http://notnuget.org/api/v2", false)]
+        [InlineData("https://nuget.org.internal/v3/index.json", false)]
+        public void IsNuGetOrg(string sourceUrl, bool expected)
+        {
+            // Arrange
+            var source = new Configuration.PackageSource(sourceUrl);
+
+            // Act
+            var actual = CommandLineUtility.IsNuGetOrg(source);
+
+            // Assert
+            Assert.Equal(expected, actual);
+        }
+    }
+}


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Tracking: https://github.com/nuget/client.engineering/issues/1340

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
As mentioned in https://github.com/nuget/client.engineering/issues/1340#issuecomment-1011521422, added functionality to verify `nuget.exe` Authenticode signature while running `update -self` command.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [x] N/A
