### PR TITLE
NuGetProjectService.GetInstalledPackagesAsync improvements

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/CpsPackageReferenceProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/CpsPackageReferenceProject.cs
@@ -68,9 +68,9 @@ namespace NuGet.PackageManagement.VisualStudio
             _unconfiguredProject = unconfiguredProject;
             ProjectServices = projectServices;
 
-            InternalMetadata.Add(NuGetProjectMetadataKeys.Name, _projectName);
-            InternalMetadata.Add(NuGetProjectMetadataKeys.UniqueName, _projectUniqueName);
-            InternalMetadata.Add(NuGetProjectMetadataKeys.FullPath, _projectFullPath);
+            InternalMetadata.Add(NuGetProjectMetadataKeys.Name, ProjectName);
+            InternalMetadata.Add(NuGetProjectMetadataKeys.UniqueName, ProjectUniqueName);
+            InternalMetadata.Add(NuGetProjectMetadataKeys.FullPath, ProjectFullPath);
             InternalMetadata.Add(NuGetProjectMetadataKeys.ProjectId, projectId);
         }
 
@@ -82,7 +82,7 @@ namespace NuGet.PackageManagement.VisualStudio
             return Task.CompletedTask;
         }
 
-        private protected override Task<string> GetAssetsFilePathAsync(bool shouldThrow)
+        protected override Task<string> GetAssetsFilePathAsync(bool shouldThrow)
         {
             var packageSpec = GetPackageSpec();
             if (packageSpec == null)
@@ -106,9 +106,9 @@ namespace NuGet.PackageManagement.VisualStudio
         private PackageSpec GetPackageSpec()
         {
             DependencyGraphSpec projectRestoreInfo;
-            if (_projectSystemCache.TryGetProjectRestoreInfo(_projectFullPath, out projectRestoreInfo, out _))
+            if (_projectSystemCache.TryGetProjectRestoreInfo(ProjectFullPath, out projectRestoreInfo, out _))
             {
-                return projectRestoreInfo.GetProjectSpec(_projectFullPath);
+                return projectRestoreInfo.GetProjectSpec(ProjectFullPath);
             }
 
             // if restore data was not found in the cache, meaning project nomination
@@ -120,7 +120,7 @@ namespace NuGet.PackageManagement.VisualStudio
         #region IDependencyGraphProject
 
 
-        public override string MSBuildProjectPath => _projectFullPath;
+        public override string MSBuildProjectPath => ProjectFullPath;
 
         public override Task<(IReadOnlyList<PackageSpec> dgSpecs, IReadOnlyList<IAssetsLogMessage> additionalMessages)> GetPackageSpecsAndAdditionalMessagesAsync(DependencyGraphCacheContext context)
         {
@@ -128,7 +128,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
             DependencyGraphSpec projectRestoreInfo;
             IReadOnlyList<IAssetsLogMessage> additionalMessages;
-            if (!_projectSystemCache.TryGetProjectRestoreInfo(_projectFullPath, out projectRestoreInfo, out additionalMessages))
+            if (!_projectSystemCache.TryGetProjectRestoreInfo(ProjectFullPath, out projectRestoreInfo, out additionalMessages))
             {
                 throw new ProjectNotNominatedException(
                     string.Format(Strings.ProjectNotLoaded_RestoreFailed, ProjectName));
@@ -336,7 +336,7 @@ namespace NuGet.PackageManagement.VisualStudio
                 {
                     throw new InvalidOperationException(string.Format(
                         Strings.UnableToGetCPSPackageInstallationService,
-                        _projectFullPath));
+                        ProjectFullPath));
                 }
 
                 foreach (var framework in installationContext.SuccessfulFrameworks)

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyPackageReferenceProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyPackageReferenceProject.cs
@@ -59,9 +59,9 @@ namespace NuGet.PackageManagement.VisualStudio
 
             ProjectStyle = ProjectStyle.PackageReference;
 
-            InternalMetadata.Add(NuGetProjectMetadataKeys.Name, _projectName);
-            InternalMetadata.Add(NuGetProjectMetadataKeys.UniqueName, _projectUniqueName);
-            InternalMetadata.Add(NuGetProjectMetadataKeys.FullPath, _projectFullPath);
+            InternalMetadata.Add(NuGetProjectMetadataKeys.Name, ProjectName);
+            InternalMetadata.Add(NuGetProjectMetadataKeys.UniqueName, ProjectUniqueName);
+            InternalMetadata.Add(NuGetProjectMetadataKeys.FullPath, ProjectFullPath);
             InternalMetadata.Add(NuGetProjectMetadataKeys.ProjectId, projectId);
 
             ProjectServices = projectServices;
@@ -89,7 +89,7 @@ namespace NuGet.PackageManagement.VisualStudio
             return NoOpRestoreUtilities.GetProjectCacheFilePath(cacheRoot: await GetMSBuildProjectExtensionsPathAsync());
         }
 
-        private protected override async Task<string> GetAssetsFilePathAsync(bool shouldThrow)
+        protected override async Task<string> GetAssetsFilePathAsync(bool shouldThrow)
         {
             var msbuildProjectExtensionsPath = await GetMSBuildProjectExtensionsPathAsync(shouldThrow);
             if (msbuildProjectExtensionsPath == null)
@@ -104,7 +104,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
         #region IDependencyGraphProject
 
-        public override string MSBuildProjectPath => _projectFullPath;
+        public override string MSBuildProjectPath => ProjectFullPath;
 
         public override async Task<(IReadOnlyList<PackageSpec> dgSpecs, IReadOnlyList<IAssetsLogMessage> additionalMessages)> GetPackageSpecsAndAdditionalMessagesAsync(DependencyGraphCacheContext context)
         {
@@ -117,7 +117,7 @@ namespace NuGet.PackageManagement.VisualStudio
                     throw new InvalidOperationException(
                         string.Format(Strings.ProjectNotLoaded_RestoreFailed, ProjectName));
                 }
-                context?.PackageSpecCache.Add(_projectFullPath, packageSpec);
+                context?.PackageSpecCache.Add(ProjectFullPath, packageSpec);
             }
 
             return (new[] { packageSpec }, null);
@@ -331,7 +331,7 @@ namespace NuGet.PackageManagement.VisualStudio
                 return SettingsUtility.GetGlobalPackagesFolder(settings);
             }
 
-            return UriUtility.GetAbsolutePathFromFile(_projectFullPath, packagePath);
+            return UriUtility.GetAbsolutePathFromFile(ProjectFullPath, packagePath);
         }
 
         private IList<PackageSource> GetSources(ISettings settings)
@@ -352,7 +352,7 @@ namespace NuGet.PackageManagement.VisualStudio
             // Add additional sources
             sources = sources.Concat(MSBuildStringUtility.Split(_vsProjectAdapter.RestoreAdditionalProjectSources));
 
-            return sources.Select(e => new PackageSource(UriUtility.GetAbsolutePathFromFile(_projectFullPath, e))).ToList();
+            return sources.Select(e => new PackageSource(UriUtility.GetAbsolutePathFromFile(ProjectFullPath, e))).ToList();
         }
 
         private IList<string> GetFallbackFolders(ISettings settings)
@@ -373,7 +373,7 @@ namespace NuGet.PackageManagement.VisualStudio
             // Add additional fallback folders
             fallbackFolders = fallbackFolders.Concat(MSBuildStringUtility.Split(_vsProjectAdapter.RestoreAdditionalProjectFallbackFolders));
 
-            return fallbackFolders.Select(e => UriUtility.GetAbsolutePathFromFile(_projectFullPath, e)).ToList();
+            return fallbackFolders.Select(e => UriUtility.GetAbsolutePathFromFile(ProjectFullPath, e)).ToList();
         }
 
         private static bool ShouldReadFromSettings(IEnumerable<string> values)
@@ -437,7 +437,7 @@ namespace NuGet.PackageManagement.VisualStudio
             // In legacy CSProj, we only have one target framework per project
             var tfis = new TargetFrameworkInformation[] { projectTfi };
 
-            var projectName = _projectName ?? _projectUniqueName;
+            var projectName = ProjectName ?? ProjectUniqueName;
 
             string specifiedPackageId = await GetSpecifiedPackageIdAsync();
 
@@ -459,15 +459,15 @@ namespace NuGet.PackageManagement.VisualStudio
             {
                 Name = projectName,
                 Version = new NuGetVersion(_vsProjectAdapter.Version),
-                FilePath = _projectFullPath,
+                FilePath = ProjectFullPath,
                 RuntimeGraph = runtimeGraph,
                 RestoreMetadata = new ProjectRestoreMetadata
                 {
                     ProjectStyle = ProjectStyle.PackageReference,
                     OutputPath = await GetMSBuildProjectExtensionsPathAsync(),
-                    ProjectPath = _projectFullPath,
+                    ProjectPath = ProjectFullPath,
                     ProjectName = projectName,
-                    ProjectUniqueName = _projectFullPath,
+                    ProjectUniqueName = ProjectFullPath,
                     OriginalTargetFrameworks = tfis
                         .Select(tfi => tfi.FrameworkName.GetShortFolderName())
                         .ToList(),

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/PackageReferenceProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/PackageReferenceProject.cs
@@ -31,7 +31,7 @@ namespace NuGet.PackageManagement.VisualStudio
         {
             ProjectName = projectName;
             ProjectUniqueName = projectUniqueName;
-            MSBuildProjectPath = projectFullPath;
+            ProjectFullPath = projectFullPath;
         }
 
         public override async Task<string> GetAssetsFilePathAsync()
@@ -48,8 +48,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
         public override string ProjectName { get; }
         protected string ProjectUniqueName { get; }
-        protected string ProjectFullPath => MSBuildProjectPath;
-        public override string MSBuildProjectPath { get; }
+        protected string ProjectFullPath { get; }
 
         public override async Task<IReadOnlyList<PackageSpec>> GetPackageSpecsAsync(DependencyGraphCacheContext context)
         {

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/PackageReferenceProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/PackageReferenceProject.cs
@@ -22,10 +22,6 @@ namespace NuGet.PackageManagement.VisualStudio
     /// </summary>
     public abstract class PackageReferenceProject : BuildIntegratedNuGetProject
     {
-        private readonly protected string _projectName;
-        private readonly protected string _projectUniqueName;
-        private readonly protected string _projectFullPath;
-
         private protected DateTime _lastTimeAssetsModified;
 
         protected PackageReferenceProject(
@@ -33,9 +29,9 @@ namespace NuGet.PackageManagement.VisualStudio
             string projectUniqueName,
             string projectFullPath)
         {
-            _projectName = projectName;
-            _projectUniqueName = projectUniqueName;
-            _projectFullPath = projectFullPath;
+            ProjectName = projectName;
+            ProjectUniqueName = projectUniqueName;
+            MSBuildProjectPath = projectFullPath;
         }
 
         public override async Task<string> GetAssetsFilePathAsync()
@@ -48,9 +44,12 @@ namespace NuGet.PackageManagement.VisualStudio
             return await GetAssetsFilePathAsync(shouldThrow: false);
         }
 
-        private protected abstract Task<string> GetAssetsFilePathAsync(bool shouldThrow);
+        protected abstract Task<string> GetAssetsFilePathAsync(bool shouldThrow);
 
-        public override string ProjectName => _projectName;
+        public override string ProjectName { get; }
+        protected string ProjectUniqueName { get; }
+        protected string ProjectFullPath => MSBuildProjectPath;
+        public override string MSBuildProjectPath { get; }
 
         public override async Task<IReadOnlyList<PackageSpec>> GetPackageSpecsAsync(DependencyGraphCacheContext context)
         {

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
@@ -312,6 +312,7 @@ namespace NuGet.SolutionRestoreManager
             var packageSpec = new PackageSpec
             {
                 FilePath = projectPath,
+                Name = Path.GetFileNameWithoutExtension(projectPath),
                 RestoreMetadata = new ProjectRestoreMetadata()
                 {
                     ProjectUniqueName = projectPath,

--- a/src/NuGet.Clients/NuGet.VisualStudio.Contracts/NuGetInstalledPackage.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Contracts/NuGetInstalledPackage.cs
@@ -22,7 +22,7 @@ namespace NuGet.VisualStudio.Contracts
         /// <remarks>
         /// If the project uses packages.config, this will be the same as requested range.
         /// <para>If the project uses PackageReference, this will be the resolved version, if the project has been restored successfully.
-        /// If the project has not been restored, or the package could not be found on any package sources, this value will be null</para>
+        /// In some error conditions this may be an empty string.</para>
         /// </remarks>
         public string Version { get; }
 

--- a/src/NuGet.Clients/NuGet.VisualStudio.Contracts/NuGetInstalledPackage.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Contracts/NuGetInstalledPackage.cs
@@ -12,8 +12,8 @@ namespace NuGet.VisualStudio.Contracts
 
         /// <summary>The project's requested package range for the package.</summary>
         /// <remarks>
-        /// If the project uses packages.config, this will be same as the installed package version.
-        /// If the project uses PackageReference, this is the version string in the project file, which may not match the resolved package version, and may not be single version string.
+        /// If the project uses packages.config, this will be same as the installed package version. <br/>
+        /// If the project uses PackageReference, this is the version string in the project file, which may not match the resolved package version, and may be a range, not a single version.<br/>
         /// If the project uses PackageReference, and the package is a transitive dependency, the value will be null.
         /// </remarks>
         public string RequestedRange { get; }
@@ -21,13 +21,13 @@ namespace NuGet.VisualStudio.Contracts
         /// <summary>The installed package version</summary>
         /// <remarks>
         /// If the project uses packages.config, this will be the same as requested range.
-        /// If the project uses PackageReference, this will be the resolved version.
+        /// <para>If the project uses PackageReference, this will be the resolved version, if the project has been restored successfully.
+        /// If the project has not been restored, or the package could not be found on any package sources, this value will be null</para>
         /// </remarks>
         public string Version { get; }
 
         /// <summary>Path to the extracted package</summary>
         /// <remarks>
-        /// When Visual Studio is connected to a Codespaces or Live Share environment, the path will be for the remote envionrment, not local.
         /// This may be null if the package was not restored successfully.
         /// </remarks>
         public string InstallPath { get; }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/NuGetProjectService.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/NuGetProjectService.cs
@@ -82,10 +82,18 @@ namespace NuGet.VisualStudio.Implementation.Extensibility
             {
                 var id = packageReference.PackageIdentity.Id;
 
-                string requestedRange =
-                    packageReference.AllowedVersions?.OriginalString // most packages
-                    ?? packageReference.AllowedVersions?.ToShortString();
-                string version = packageReference.PackageIdentity.Version?.ToNormalizedString();
+                string requestedRange = null;
+                if (directDependency)
+                {
+                    requestedRange =
+                        packageReference.AllowedVersions?.OriginalString // When Version is specified
+                        ?? packageReference.AllowedVersions?.ToShortString(); // Probably only when Version is not specified in msbuild
+                }
+
+                string version =
+                    packageReference.PackageIdentity.Version?.ToNormalizedString()
+                    ?? string.Empty;
+
                 var installPath =
                     version != null
                     ? pathResolver.GetPackageDirectory(id, version)

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/NuGetProjectService.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/NuGetProjectService.cs
@@ -78,23 +78,24 @@ namespace NuGet.VisualStudio.Implementation.Extensibility
 
         private async Task<(InstalledPackageResultStatus, IReadOnlyCollection<NuGetInstalledPackage>)> GetInstalledPackagesAsync(BuildIntegratedNuGetProject project, CancellationToken cancellationToken)
         {
-            NuGetInstalledPackage ToNuGetInstalledPackage(PackageReference packageReference, FallbackPackagePathResolver pathResolver)
+            NuGetInstalledPackage ToNuGetInstalledPackage(PackageReference packageReference, FallbackPackagePathResolver pathResolver, bool directDependency)
             {
                 var id = packageReference.PackageIdentity.Id;
 
-                var versionRange = packageReference.AllowedVersions;
                 string requestedRange =
-                    packageReference.AllowedVersions.OriginalString // most packages
-                    ?? packageReference.AllowedVersions.ToShortString();
-                string version = versionRange.MinVersion.OriginalVersion ?? versionRange.MinVersion.ToNormalizedString();
-                var installPath = pathResolver.GetPackageDirectory(id, version);
-                bool directDependency = true;
+                    packageReference.AllowedVersions?.OriginalString // most packages
+                    ?? packageReference.AllowedVersions?.ToShortString();
+                string version = packageReference.PackageIdentity.Version?.ToNormalizedString();
+                var installPath =
+                    version != null
+                    ? pathResolver.GetPackageDirectory(id, version)
+                    : null;
 
                 return NuGetContractsFactory.CreateNuGetInstalledPackage(id, requestedRange, version, installPath, directDependency);
             }
 
             InstalledPackageResultStatus status;
-            IReadOnlyCollection<NuGetInstalledPackage> installedPackages;
+            List<NuGetInstalledPackage> installedPackages;
 
             (InstalledPackageResultStatus, IReadOnlyCollection<NuGetInstalledPackage>) ErrorResult(InstalledPackageResultStatus status)
             {
@@ -131,10 +132,27 @@ namespace NuGet.VisualStudio.Implementation.Extensibility
             var packagesPath = VSRestoreSettingsUtilities.GetPackagesPath(_settings, packageSpec);
             FallbackPackagePathResolver pathResolver = new FallbackPackagePathResolver(packagesPath, VSRestoreSettingsUtilities.GetFallbackFolders(_settings, packageSpec));
 
-            var packageReferences = await project.GetInstalledPackagesAsync(cancellationToken);
+            IReadOnlyCollection<PackageReference> directPackages;
+            IReadOnlyCollection<PackageReference> transitivePackages;
+            if (project is PackageReferenceProject packageReferenceProject)
+            {
+                var installed = await packageReferenceProject.GetInstalledAndTransitivePackagesAsync(cancellationToken);
+                directPackages = installed.InstalledPackages;
+                transitivePackages = installed.TransitivePackages;
+            }
+            else
+            {
+                directPackages = (await project.GetInstalledPackagesAsync(cancellationToken)).ToList();
+                transitivePackages = Array.Empty<PackageReference>();
+            }
 
-            installedPackages = packageReferences.Select(p => ToNuGetInstalledPackage(p, pathResolver))
-                .ToList();
+            installedPackages = new List<NuGetInstalledPackage>(directPackages.Count + (transitivePackages?.Count ?? 0));
+
+            installedPackages.AddRange(directPackages.Select(p => ToNuGetInstalledPackage(p, pathResolver, directDependency: true)));
+            if (transitivePackages != null)
+            {
+                installedPackages.AddRange(transitivePackages.Select(p => ToNuGetInstalledPackage(p, pathResolver, directDependency: false)));
+            }
 
             return (status, installedPackages);
         }

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/Extensibility/NuGetProjectServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/Extensibility/NuGetProjectServiceTests.cs
@@ -141,7 +141,7 @@ namespace NuGet.VisualStudio.Implementation.Test.Extensibility
                 _transitivePackages = transitivePackages;
             }
 
-            //public override string MSBuildProjectPath => throw new NotImplementedException();
+            public override string MSBuildProjectPath => ProjectFullPath;
 
             public override Task AddFileToProjectAsync(string filePath)
             {

--- a/test/TestUtilities/Test.Utility/ProjectManagement/DependencyGraphSpecTestUtilities.cs
+++ b/test/TestUtilities/Test.Utility/ProjectManagement/DependencyGraphSpecTestUtilities.cs
@@ -12,6 +12,7 @@ namespace Test.Utility.ProjectManagement
         {
             var packageSpec = new PackageSpec();
             packageSpec.FilePath = projectPath;
+            packageSpec.Name = Path.GetFileNameWithoutExtension(projectPath);
             packageSpec.RestoreMetadata = new ProjectRestoreMetadata();
             packageSpec.RestoreMetadata.ProjectUniqueName = projectPath;
             packageSpec.RestoreMetadata.ProjectStyle = ProjectStyle.PackageReference;


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/9746
Fixes: https://github.com/NuGet/Home/issues/9745

Regression? No

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

As per the two linked issues, this adds the following features:

* Return transitive packages
* Return resolved versions, not requested versions

Both of these were already documented in INuGetProjectService's contract.

The implementation re-uses the `PackageReferenceProject`'s `GetInstalledAndTransitivePackagesAsync` method, which didn't exist when the service was written originally.

Unfortunately a lot of our VS code is not designed to be easily testable, and I wasn't having luck with getting Moq to mock abstract classes, so I had to create a class that extends the abstract class in our test code. In general I'd say we should have interfaces for everything, and the abstract classes can be helpers for interface implementers to reduce boilerplate, but this would require public API changes in `NuGet.PackageManagement`, which I don't want to do for this PR.

## PR Checklist

- [X] PR has a meaningful title
- [X] PR has a linked issue.
- [X] Described changes

- **Tests**
  - [X] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [X] N/A
