### PR TITLE
Don't fail configure.ps1 when errors are handled correctly

### DIFF
--- a/build/common.ps1
+++ b/build/common.ps1
@@ -254,8 +254,8 @@ Function Install-DotnetCLI {
                 Error-Log "Unable to detect channel version for dotnetinstall.ps1. The CLI install cannot be initiated." -Fatal
             }
 
-            Trace-Log "$DotNetInstall -Channel $($channelMainVersion) -Quality Daily -InstallDir $($cli.Root) -Version $($cli.Version) -Architecture $arch -NoPath"
-            & $DotNetInstall -Channel $channelMainVersion -Quality Daily -InstallDir $cli.Root -Version $cli.Version -Architecture $arch -NoPath
+            Trace-Log "$DotNetInstall -Channel $($channelMainVersion) -InstallDir $($cli.Root) -Version $($cli.Version) -Architecture $arch -NoPath"
+            & $DotNetInstall -Channel $channelMainVersion -InstallDir $cli.Root -Version $cli.Version -Architecture $arch -NoPath
         }
 
         if (-not (Test-Path $DotNetExe)) {


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1392

Regression? no

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

The dotnet-install.ps1 script makes some HTTP calls to figure out what to download, and some of these HTTP calls fail. dotnet-install.ps1 handles this internally. It does not write to stderr, it does not use Write-Error, it does not throw an exception, when it finishes $LASTEXITCODE is zero.

However, our Invoke-BuildStep uses -ErrorVariable err to capture ALL errors, even handled errors, and then fails the build if any error has happened.

Therefore, our builds are broken because we're not handling the case when scripts handle errors correctly.

Additionally, as per https://github.com/dotnet/install-scripts/issues/246, we should not have been passing both `-Quality` and `-Version` on the command line. In fact, I think that dotnet-install.ps1 used to warn us about this, although I see from recent builds, before the script started breaking us, that it was no longer warning us.


## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [X] N/A: Infrastructure

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
