### PR TITLE
Change agent pool in release 5.11.x, and skip E2E and Apex tests

### DIFF
--- a/build/common.ps1
+++ b/build/common.ps1
@@ -199,7 +199,7 @@ Function Install-DotnetCLI {
 
         if ($Version -eq 'latest') {
 
-            # When installing latest, we firstly check the latest version from the server against what we have installed locally. This also allows us to check the SDK was correctly installed.  
+            # When installing latest, we firstly check the latest version from the server against what we have installed locally. This also allows us to check the SDK was correctly installed.
             # Get the latest specific version number for a certain channel from url like : https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/3.0.1xx/latest.version
             $latestVersionLink = "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/" + $Channel + "/latest.version"
             $latestVersionFile = Invoke-RestMethod -Method Get -Uri $latestVersionLink
@@ -237,8 +237,29 @@ Function Install-DotnetCLI {
 
         #If "-force" is specified, or folder with specific version doesn't exist, the download command will run"
         if ($Force -or -not (Test-Path $probeDotnetPath)) {
-            Trace-Log "$DotNetInstall -Channel $($cli.Channel) -InstallDir $($cli.Root) -Version $($cli.Version) -Architecture $arch -NoPath"
-            & $DotNetInstall -Channel $cli.Channel -InstallDir $cli.Root -Version $cli.Version -Architecture $arch -NoPath
+            $channelMainVersion = ""
+            foreach($channelPart in $cli.Channel.Split('/'))
+            {
+                if ($channelPart -match "\d+.*")
+                {
+                    $channelMainVersion = $channelPart.Split('.')[0]
+                    Break
+                }
+            }
+
+            if ([string]::IsNullOrEmpty($channelMainVersion)) {
+                Error-Log "Unable to detect channel version for dotnetinstall.ps1. The CLI install cannot be initiated." -Fatal
+            }
+
+            Trace-Log "$DotNetInstall -Channel $($channelMainVersion) -InstallDir $($cli.Root) -Version $($cli.Version) -Architecture $arch -NoPath"
+            # dotnet-install might make http requests that fail, but it handles those errors internally
+            # However, Invoke-BuildStep checks if any error happened, ever. Hence we need to run dotnet-install
+            # in a different process, to avoid treating their handled errors as build errors.
+            & powershell $DotNetInstall -Channel $channelMainVersion -InstallDir $cli.Root -Version $cli.Version -Architecture $arch -NoPath
+            if ($LASTEXITCODE -ne 0)
+            {
+                throw "dotnet-install.ps1 exited with non-zero exit code"
+            }
         }
 
         if (-not (Test-Path $DotNetExe)) {
@@ -254,9 +275,15 @@ Function Install-DotnetCLI {
 
     # Install the 2.x runtime because our tests target netcoreapp2x
     Trace-Log "$DotNetInstall -Runtime dotnet -Channel 2.2 -InstallDir $CLIRoot -NoPath"
-    # Work around the following install script bug https://github.com/dotnet/install-scripts/issues/152.
-    # Start a new process to avoid the ev getting populated.
+    # dotnet-install might make http requests that fail, but it handles those errors internally
+    # However, Invoke-BuildStep checks if any error happened, ever. Hence we need to run dotnet-install
+    # in a different process, to avoid treating their handled errors as build errors.
     & powershell $DotNetInstall -Runtime dotnet -Channel 2.2 -InstallDir $CLIRoot -NoPath
+    if ($LASTEXITCODE -ne 0)
+    {
+        throw "dotnet-install.ps1 exited with non-zero exit code"
+    }
+
     # Display build info
     & $DotNetExe --info
 }

--- a/build/common.ps1
+++ b/build/common.ps1
@@ -199,7 +199,7 @@ Function Install-DotnetCLI {
 
         if ($Version -eq 'latest') {
 
-            # When installing latest, we firstly check the latest version from the server against what we have installed locally. This also allows us to check the SDK was correctly installed.
+            # When installing latest, we firstly check the latest version from the server against what we have installed locally. This also allows us to check the SDK was correctly installed.  
             # Get the latest specific version number for a certain channel from url like : https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/3.0.1xx/latest.version
             $latestVersionLink = "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/" + $Channel + "/latest.version"
             $latestVersionFile = Invoke-RestMethod -Method Get -Uri $latestVersionLink
@@ -237,29 +237,8 @@ Function Install-DotnetCLI {
 
         #If "-force" is specified, or folder with specific version doesn't exist, the download command will run"
         if ($Force -or -not (Test-Path $probeDotnetPath)) {
-            $channelMainVersion = ""
-            foreach($channelPart in $cli.Channel.Split('/'))
-            {
-                if ($channelPart -match "\d+.*")
-                {
-                    $channelMainVersion = $channelPart.Split('.')[0]
-                    Break
-                }
-            }
-
-            if ([string]::IsNullOrEmpty($channelMainVersion)) {
-                Error-Log "Unable to detect channel version for dotnetinstall.ps1. The CLI install cannot be initiated." -Fatal
-            }
-
-            Trace-Log "$DotNetInstall -Channel $($channelMainVersion) -InstallDir $($cli.Root) -Version $($cli.Version) -Architecture $arch -NoPath"
-            # dotnet-install might make http requests that fail, but it handles those errors internally
-            # However, Invoke-BuildStep checks if any error happened, ever. Hence we need to run dotnet-install
-            # in a different process, to avoid treating their handled errors as build errors.
-            & powershell $DotNetInstall -Channel $channelMainVersion -InstallDir $cli.Root -Version $cli.Version -Architecture $arch -NoPath
-            if ($LASTEXITCODE -ne 0)
-            {
-                throw "dotnet-install.ps1 exited with non-zero exit code"
-            }
+            Trace-Log "$DotNetInstall -Channel $($cli.Channel) -InstallDir $($cli.Root) -Version $($cli.Version) -Architecture $arch -NoPath"
+            & $DotNetInstall -Channel $cli.Channel -InstallDir $cli.Root -Version $cli.Version -Architecture $arch -NoPath
         }
 
         if (-not (Test-Path $DotNetExe)) {
@@ -275,15 +254,9 @@ Function Install-DotnetCLI {
 
     # Install the 2.x runtime because our tests target netcoreapp2x
     Trace-Log "$DotNetInstall -Runtime dotnet -Channel 2.2 -InstallDir $CLIRoot -NoPath"
-    # dotnet-install might make http requests that fail, but it handles those errors internally
-    # However, Invoke-BuildStep checks if any error happened, ever. Hence we need to run dotnet-install
-    # in a different process, to avoid treating their handled errors as build errors.
+    # Work around the following install script bug https://github.com/dotnet/install-scripts/issues/152.
+    # Start a new process to avoid the ev getting populated.
     & powershell $DotNetInstall -Runtime dotnet -Channel 2.2 -InstallDir $CLIRoot -NoPath
-    if ($LASTEXITCODE -ne 0)
-    {
-        throw "dotnet-install.ps1 exited with non-zero exit code"
-    }
-
     # Display build info
     & $DotNetExe --info
 }

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -44,7 +44,7 @@ jobs:
     BuildRTM: "false"
 
   pool:
-    name: VSEngSS-MicroBuild2019
+    name: VSEngSS-MicroBuild2019-1ES
     demands:
       - DotNetFramework
       - msbuild
@@ -65,7 +65,7 @@ jobs:
     BuildRTM: "true"
 
   pool:
-    name: VSEngSS-MicroBuild2019
+    name: VSEngSS-MicroBuild2019-1ES
     demands:
       - DotNetFramework
       - msbuild
@@ -82,7 +82,7 @@ jobs:
     SDKVersionForBuild: $[dependencies.Initialize_Build.outputs['getSDKVersionForBuild.SDKVersionForBuild']]
   condition: "and(succeeded(),eq(variables['RunFunctionalTestsOnWindows'], 'true')) "
   pool:
-    name: VSEngSS-MicroBuild2019
+    name: VSEngSS-MicroBuild2019-1ES
     demands:
         - DotNetFramework
         - msbuild
@@ -125,46 +125,3 @@ jobs:
 
   steps:
   - template: Tests_On_Mac.yml
-
-- job: End_To_End_Tests_On_Windows
-  dependsOn:
-  - Build_and_UnitTest_NonRTM
-  - Initialize_Build
-  timeoutInMinutes: 100
-  variables:
-    FullVstsBuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
-    SDKVersionForBuild: $[dependencies.Initialize_Build.outputs['getSDKVersionForBuild.SDKVersionForBuild']]
-  condition: "and(succeeded(),eq(variables['RunEndToEndTests'], 'true')) "
-  pool:
-    name: DDNuGet-Windows
-    demands:
-    - DotNetFramework
-    - Allow_NuGet_E2E_Tests -equals true
-  strategy:
-    matrix:
-      Part1:
-        Part: "InstallPackageTest.ps1,UninstallPackageTest.ps1,UpdatePackageTest.ps1,PackageRestoreTest.ps1"
-      Part2:
-        Part: "A-TopDownloadedPackages.ps1,BuildIntegratedTest.ps1,ExecuteInitScriptTest.ps1,FindPackageTest.ps1,GetPackageTest.ps1,GetProjectTest.ps1,LegacyPackageRefProjectTest.ps1,NativeProjectTest.ps1,NetCoreProjectTest.ps1,PackTest.ps1,ProjectRetargeting.ps1,ServicesTest.ps1,Settings.ps1,SyncPackageTest.ps1,TabExpansionTest.ps1,UniversalWindowsProjectTest.ps1"
-
-  steps:
-  - template: End_To_End_Tests_On_Windows.yml
-
-- job: Apex_Tests_On_Windows
-  dependsOn:
-  - Build_and_UnitTest_NonRTM
-  - Initialize_Build
-  timeoutInMinutes: 120
-  variables:
-    BuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.BuildNumber']]
-    FullVstsBuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
-    SDKVersionForBuild: $[dependencies.Initialize_Build.outputs['getSDKVersionForBuild.SDKVersionForBuild']]
-  condition: "and(succeeded(),eq(variables['RunApexTests'], 'true')) "
-  pool:
-    name: DDNuGet-Windows
-    demands:
-    - DotNetFramework
-    - Allow_NuGet_Apex_Tests -equals true
-
-  steps:
-  - template: Apex_Tests_On_Windows.yml


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

Fixes:
https://github.com/NuGet/Client.Engineering/issues/1396

## Description
The release-5.11.x branch failed the build as:
We moved from VSEngSS-MicroBuild2019 to VSEngSS-MicroBuild2019-1ES pool
We moved from DDNuGet-Windows to Dartlab.
So,
1. Change the VSEngSS-MicroBuild2019 to VSEngSS-MicroBuild2019-1ES pool
2. Skip the E2E and Apex tests as it would take a lot of effort to get 5.11 working with Dartlab. In the past we never had the capability to run VS tests with old versions of VS, so our procedure was always to manually queue a build skipping Apex and E2E tests. (Thanks for @zivkan's suggestion!)

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
