### PR TITLE
Remove unnecessary allocs for PackageIdentity

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/Model/PackageSearchMetadata.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Model/PackageSearchMetadata.cs
@@ -44,7 +44,20 @@ namespace NuGet.Protocol
         public Uri IconUrl { get; private set; }
 
         [JsonIgnore]
-        public PackageIdentity Identity => new PackageIdentity(PackageId, Version);
+        private PackageIdentity _packageIdentity = null;
+
+        [JsonIgnore]
+        public PackageIdentity Identity
+        {
+            get
+            {
+                if (_packageIdentity == null)
+                {
+                    _packageIdentity = new PackageIdentity(PackageId, Version);
+                }
+                return _packageIdentity;
+            }
+        }
 
         [JsonProperty(PropertyName = JsonProperties.LicenseUrl)]
         [JsonConverter(typeof(SafeUriConverter))]

--- a/src/NuGet.Core/NuGet.Protocol/Model/PackageSearchMetadata.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Model/PackageSearchMetadata.cs
@@ -43,7 +43,6 @@ namespace NuGet.Protocol
         [JsonProperty(PropertyName = JsonProperties.IconUrl)]
         public Uri IconUrl { get; private set; }
 
-        [JsonIgnore]
         private PackageIdentity _packageIdentity = null;
 
         [JsonIgnore]


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11401

Regression? Last working version:

## Description
Scenario: VS PMUI switch between `Browse` to `Update` tab observed with PerfView trace.

Currently for internal large project `PackageIdentity` object is causing up to 61% (**8.6GB**) allocation.
![image](https://user-images.githubusercontent.com/8766776/151025775-a1eda922-5b45-4c24-bc39-5095fbeee8f5.png)

Here we're fixing the issue by caching calculated package identity instead of re-allocating/re-calculating every time it's requested.
After this fix it'll reduce to less than **0.1%** or **almost nothing** for all solutions I tested.

![image](https://user-images.githubusercontent.com/8766776/151023338-6127b75a-6a7d-446e-b619-4808b12c2a3d.png)

Since it was largest item in alloc after this fix, total allocation and GC collection pause reduced too.
**Before**:
![image](https://user-images.githubusercontent.com/8766776/151024555-8dabf99d-3e05-4ebf-b0dc-e714c3161617.png)

**After**: Total allocation reduced about **7GB-8GB** and GC pause reduced by **1 sec**.
![image](https://user-images.githubusercontent.com/8766776/151025153-6f817d75-f1f1-41e9-8e03-f383940cfb43.png)

Here're more perfview measurement result before and after this change with other solutions.

Solution  | Before % | Before size | After % | After
-- | -- | -- | -- | --
Internal Large   project | 61.5 | 8.7GB | 0.1 | 5MB
Orchard | 7.3 | 40MB | 0 | 0.4MB
OrchardCore | 0.9 | 25MB | Too little, doesn't show up anymore
Orleans | 4.5 | 35MB | Too little, doesn't show up anymore
NuGet.Client | 0.7 | 126MB | Too little, doesn't show up anymore

Thank you @davkean @nkolev92 @zivkan for perfview guidance.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
