### PR TITLE
Reset checkboxes in VS options when adding/removing package source

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/PackageSourcesOptionsControl.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/PackageSourcesOptionsControl.cs
@@ -147,10 +147,7 @@ namespace NuGet.Options
                 _packageSources.CurrentChanged += OnSelectedPackageSourceChanged;
                 PackageSourcesListBox.GotFocus += PackageSourcesListBox_GotFocus;
                 PackageSourcesListBox.DataSource = _packageSources;
-                for (int i = 0; i < packageSources.Count; i++)
-                {
-                    PackageSourcesListBox.SetItemChecked(i, packageSources[i].IsEnabled);
-                }
+                ResetItemsCheckedState(PackageSourcesListBox, _packageSources);
 
                 if (machineWidePackageSources.Count > 0)
                 {
@@ -158,10 +155,7 @@ namespace NuGet.Options
                     _machineWidepackageSources.CurrentChanged += OnSelectedMachineWidePackageSourceChanged;
                     MachineWidePackageSourcesListBox.GotFocus += MachineWidePackageSourcesListBox_GotFocus;
                     MachineWidePackageSourcesListBox.DataSource = _machineWidepackageSources;
-                    for (int i = 0; i < machineWidePackageSources.Count; i++)
-                    {
-                        MachineWidePackageSourcesListBox.SetItemChecked(i, machineWidePackageSources[i].IsEnabled);
-                    }
+                    ResetItemsCheckedState(MachineWidePackageSourcesListBox, _machineWidepackageSources);
                 }
                 else
                 {
@@ -189,6 +183,17 @@ namespace NuGet.Options
             {
                 MessageHelper.ShowErrorMessage(Resources.ShowError_SettingActivatedFailed, Resources.ErrorDialogBoxTitle);
                 ActivityLog.LogError(NuGetUI.LogEntrySource, ex.ToString());
+            }
+        }
+
+        private void ResetItemsCheckedState(PackageSourceCheckedListBox checkedListBox, BindingSource bindingSource)
+        {
+            var list = (IList<PackageSourceContextInfo>)bindingSource.List;
+
+            for (int i = 0; i < list.Count; i++)
+            {
+                var isEnabled = list[i].IsEnabled;
+                checkedListBox.SetItemChecked(i, isEnabled);
             }
         }
 
@@ -310,6 +315,10 @@ namespace NuGet.Options
                 return;
             }
             _packageSources.Remove(PackageSourcesListBox.SelectedItem);
+
+            // changing _packageSources appears to clear all the checked items, so now we have to reset all the checkbox states
+            ResetItemsCheckedState(PackageSourcesListBox, _packageSources);
+
             UpdateUI();
         }
 
@@ -321,6 +330,9 @@ namespace NuGet.Options
             }
 
             _packageSources.Add(CreateNewPackageSource());
+
+            // changing _packageSources appears to clear all the checked items, so now we have to reset all the checkbox states
+            ResetItemsCheckedState(PackageSourcesListBox, _packageSources);
 
             // auto-select the newly-added item
             PackageSourcesListBox.SelectedIndex = PackageSourcesListBox.Items.Count - 1;


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11521

Regression? Yes Last working version: before https://github.com/NuGet/NuGet.Client/pull/4387 (VS 17.1 preview 3)

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

WinForms appears to clear all items checked state when the binding object changes. So, adding a new item to the list, or removing a single item, it resets all items to unchecked. Therefore, we need to reset all the items checkbox status every time the list changes. 

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception: The WinForms options don't have any automated tests yet, and refactoring the entire thing (make it testable) just to add tests is out of scope for this bugfix.
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
