### PR TITLE
Allow null logger in ZipArchiveExtentions to fix ABI compat

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/PackageExtraction/ZipArchiveExtensions.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageExtraction/ZipArchiveExtensions.cs
@@ -96,7 +96,7 @@ namespace NuGet.Packaging
             {
                 if (entry == null) throw new ArgumentNullException(nameof(entry));
                 if (fileFullPath == null) throw new ArgumentNullException(nameof(fileFullPath));
-                if (logger == null) throw new ArgumentNullException(nameof(logger));
+                logger ??= NullLogger.Instance;
 
                 FileAttributes attr = File.GetAttributes(fileFullPath);
 

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageArchiveReaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageArchiveReaderTests.cs
@@ -1604,6 +1604,29 @@ namespace NuGet.Packaging.Test
             }
         }
 
+        /// <summary>
+        /// The NuGet Client SDK shipped many versions where PackageArchiveReader.ExtractFile would accept null
+        /// for the ILogger parameter, and would not throw. The .NET SDK make use of this and therefore throwing
+        /// ArgumentNullException is a breaking ABI change.
+        /// </summary>
+        [Fact]
+        public void ExtractFile_WithNullLogger_DoesNotThrow()
+        {
+            // Arrange
+            using (PackageReaderTest package = PackageReaderTest.Create(TestPackagesCore.GetPackageCoreReaderTestPackage()))
+            using (TestDirectory testDirectory = TestDirectory.Create())
+            {
+                string firstFile = package.Reader.GetFiles().First();
+                string destination = Path.Combine(testDirectory, firstFile);
+
+                // Act
+                package.Reader.ExtractFile(firstFile, destination, logger: null);
+
+                // Assert is just that no exception was thrown.
+            }
+
+        }
+
 #if IS_SIGNING_SUPPORTED
         [Fact]
         public async Task ValidateIntegrityAsync_WhenSignatureContentNull_Throws()


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11526

Regression? not yet shipped

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

In a previous PR, I added a null check to fix a code analyzer warning. However, it appears that the .NET SDK has been taking advantage of the fact that NuGet had never checked for null in the past, and the .NET SDK was just "lucky" that it never hit a scenario that the logger was needed (to be fair, the scenario is incredibly unlikely, to the point where I don't even know how I'd create a bug reproduction).

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception: not really changing anything meaningful.
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
