### PR TITLE
Remove the download of a custom pack targets package.

### DIFF
--- a/build/bootstrap.proj
+++ b/build/bootstrap.proj
@@ -17,7 +17,6 @@
         <PackageDownload Include="Microsoft.DotNet.Maestro.Tasks" version="[1.1.0-beta.21378.2]" />  <!-- for publishing to the .NET Core build asset registry (BAR) -->
         <PackageDownload Include="Microsoft.Web.Xdt" version="[3.0.0]" />
         <PackageDownload Include="Newtonsoft.Json" version="[13.0.1]" />
-        <PackageDownload Include="NuGet.Build.Tasks.Pack" version="[5.8.0]" />
         <PackageDownload Include="NuGet.Client.EndToEnd.TestData" version="[1.0.0]" />
         <PackageDownload Include="NuGetValidator" version="[2.0.3]" />
         <PackageDownload Include="xunit.runner.console" version="[2.4.1]" />

--- a/build/common.project.props
+++ b/build/common.project.props
@@ -43,7 +43,6 @@
     <XunitConsoleExePath>$(SolutionPackagesFolder)xunit.runner.console\2.4.1\tools\net472\xunit.console.exe</XunitConsoleExePath>
     <ILMergeExePath>$(SolutionPackagesFolder)ilmerge\3.0.21\tools\net452\ILMerge.exe</ILMergeExePath>
     <XunitXmlLoggerDirectory>$(SolutionPackagesFolder)xunitxml.testlogger\2.0.0\build\_common</XunitXmlLoggerDirectory>
-    <NuGetBuildTasksPackTargets Condition="Exists('$(SolutionPackagesFolder)nuget.build.tasks.pack\5.7.0\build\NuGet.Build.Tasks.Pack.targets')">$(SolutionPackagesFolder)nuget.build.tasks.pack\5.7.0\build\NuGet.Build.Tasks.Pack.targets</NuGetBuildTasksPackTargets>
     <EnlistmentRoot>$(RepositoryRootDirectory)</EnlistmentRoot>
     <EnlistmentRootSrc>$(RepositoryRootDirectory)src</EnlistmentRootSrc>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">$(RepositoryRootDirectory)</SolutionDir>


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/236

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

We used to do this in order to allow us to depend on future pack versions, but realistically this has had the reverse effect lately. 

Or so you would think. When the package version was moved to 5.8.0, the respective changes in the targets were not made, so this has been dead code for a while now.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
