### PR TITLE
Latest version is selected after installing a package in Browse Tab

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailControlModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailControlModel.cs
@@ -646,9 +646,16 @@ namespace NuGet.PackageManagement.UI
                 // Select the installed version by default.
                 // Otherwise, select the first version in the version list.
                 var possibleVersions = _versions.Where(v => v != null);
-                SelectedVersion =
-                    possibleVersions.FirstOrDefault(v => v.Version.Equals(_searchResultPackage.InstalledVersion))
-                    ?? possibleVersions.FirstOrDefault(v => v.IsValidVersion);
+                if (_filter != ItemFilter.All)
+                {
+                    SelectedVersion =
+                        possibleVersions.FirstOrDefault(v => v.Version.Equals(_searchResultPackage.InstalledVersion))
+                        ?? possibleVersions.FirstOrDefault(v => v.IsValidVersion);
+                }
+                else
+                {
+                    SelectedVersion = possibleVersions.FirstOrDefault(v => v.IsValidVersion);
+                }
             }
         }
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11461

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
When installing a package in the Browse the `SelectedVersion` will be updated to the installed version and will need a refresh to show the latest version, the behavior in this tab is that we always show the latest version available even if it is installed. 

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
