### PR TITLE
Don't use DTE to get project properties when project system implements better API

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectServices/VsProjectBuildProperties.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectServices/VsProjectBuildProperties.cs
@@ -59,16 +59,6 @@ namespace NuGet.PackageManagement.VisualStudio
                 }
             }
 
-            try
-            {
-                var property = _project.Properties.Item(propertyName);
-                return property?.Value as string;
-            }
-            catch (ArgumentException)
-            {
-                // If the property doesn't exist this will throw an argument exception
-            }
-
             return null;
         }
     }

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectServices/VsProjectBuildProperties.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectServices/VsProjectBuildProperties.cs
@@ -59,6 +59,16 @@ namespace NuGet.PackageManagement.VisualStudio
                 }
             }
 
+            try
+            {
+                var property = _project.Properties.Item(propertyName);
+                return property?.Value as string;
+            }
+            catch (ArgumentException)
+            {
+                // If the property doesn't exist this will throw an argument exception
+            }
+
             return null;
         }
     }

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectServices/VsProjectBuildProperties.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectServices/VsProjectBuildProperties.cs
@@ -58,15 +58,17 @@ namespace NuGet.PackageManagement.VisualStudio
                     return output;
                 }
             }
-
-            try
+            else
             {
-                var property = _project.Properties.Item(propertyName);
-                return property?.Value as string;
-            }
-            catch (ArgumentException)
-            {
-                // If the property doesn't exist this will throw an argument exception
+                try
+                {
+                    var property = _project.Properties.Item(propertyName);
+                    return property?.Value as string;
+                }
+                catch (ArgumentException)
+                {
+                    // If the property doesn't exist this will throw an argument exception
+                }
             }
 
             return null;


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11535

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Only use `DTE.Project.Properties` when the project system doesn't implement `IVsBuildPropertyStorage`. When the better API tells us the property doesn't exist, there's no point trying again in a different way.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception
    - We already have Apex & EndToEnd tests that test various project systems: .NET Framework (non-SDK) projects, SDK/CPS projects, C++ projects, UWP projects, Web Site (no project file) projects.
    - There is no meaningful way to unit test this when the changed code is just a very thin wrapper/abstraction of Visual Studio project systems.
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
