### PR TITLE
Fixed prerelease option when getting the latest version in list command

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackage/ListPackageCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackage/ListPackageCommandRunner.cs
@@ -607,7 +607,7 @@ namespace NuGet.CommandLine.XPlat
             using var sourceCacheContext = new SourceCacheContext();
             var packages = await packageMetadataResource.GetMetadataAsync(
                 package,
-                includePrerelease: true,
+                includePrerelease: listPackageArgs.Prerelease,
                 includeUnlisted: false,
                 sourceCacheContext: sourceCacheContext,
                 log: listPackageArgs.Logger,

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
@@ -267,7 +267,7 @@ namespace Dotnet.Integration.Test
         [PlatformTheory(Platform.Windows)]
         [InlineData("1.0.0", "", "2.1.0")]
         [InlineData("1.0.0", "--include-prerelease", "2.2.0-beta")]
-        [InlineData("1.0.0-beta", "", "2.2.0-beta")]
+        [InlineData("1.0.0-beta", "", "2.1.0")]
         [InlineData("1.0.0", "--highest-patch", "1.0.9")]
         [InlineData("1.0.0", "--highest-minor", "1.9.0")]
         [InlineData("1.0.0", "--highest-patch --include-prerelease", "1.0.10-beta")]


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11439

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
We had the prerelease option hardcoded to be true instead of using the flag `--prerelease` when getting the latest version.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
