### PR TITLE
Hides Altenative Package versions with '*' in Deprecation Details pane in PM UI

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailControlModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailControlModel.cs
@@ -3,13 +3,10 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Windows.Data;
 using System.Windows.Media.Imaging;
 using Microsoft.ServiceHub.Framework;
 using NuGet.PackageManagement.VisualStudio;
@@ -524,6 +521,11 @@ namespace NuGet.PackageManagement.UI
             if (alternatePackageMetadata == null)
             {
                 return null;
+            }
+
+            if (!VersionRange.All.Equals(alternatePackageMetadata.VersionRange))
+            {
+                return alternatePackageMetadata.PackageId;
             }
 
             var versionString = VersionRangeFormatter.Instance.Format("p", alternatePackageMetadata.VersionRange, VersionRangeFormatter.Instance);

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailControlModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailControlModel.cs
@@ -25,6 +25,9 @@ namespace NuGet.PackageManagement.UI
     /// </summary>
     public abstract class DetailControlModel : INotifyPropertyChanged, IDisposable
     {
+        private static readonly string StarAll = VersionRangeFormatter.Instance.Format("p", VersionRange.Parse("*"), VersionRangeFormatter.Instance);
+        private static readonly string StarAllFloating = VersionRangeFormatter.Instance.Format("p", VersionRange.Parse("*-*"), VersionRangeFormatter.Instance);
+
         private CancellationTokenSource _selectedVersionCancellationTokenSource = new CancellationTokenSource();
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1051:DoNotDeclareVisibleInstanceFields")]
@@ -523,12 +526,14 @@ namespace NuGet.PackageManagement.UI
                 return null;
             }
 
-            if (!VersionRange.All.Equals(alternatePackageMetadata.VersionRange))
+            // pretty print
+            string versionString = VersionRangeFormatter.Instance.Format("p", alternatePackageMetadata.VersionRange, VersionRangeFormatter.Instance);
+
+            if (StarAll.Equals(versionString, StringComparison.InvariantCultureIgnoreCase) || StarAllFloating.Equals(versionString, StringComparison.InvariantCultureIgnoreCase))
             {
                 return alternatePackageMetadata.PackageId;
             }
 
-            var versionString = VersionRangeFormatter.Instance.Format("p", alternatePackageMetadata.VersionRange, VersionRangeFormatter.Instance);
             return $"{alternatePackageMetadata.PackageId} {versionString}";
         }
 

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/DetailControlModelTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/DetailControlModelTests.cs
@@ -1,0 +1,49 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.ServiceHub.Framework;
+using NuGet.VisualStudio.Internal.Contracts;
+using Moq;
+using Xunit;
+using NuGet.Versioning;
+
+namespace NuGet.PackageManagement.UI.Test
+{
+    public class DetailControlModelTests
+    {
+        [Theory]
+        [InlineData("*", "ANewPackage")]
+        [InlineData("*-*", "ANewPackage")]
+        [InlineData("0.0.0", "ANewPackage")]
+        [InlineData("[0.0.0,)", "ANewPackage")]
+        [InlineData("(0.0.0,)", "ANewPackage > 0.0.0")]
+        [InlineData("1.0.0", "ANewPackage >= 1.0.0")]
+        public void DeprecationAlternativePackage_WithAsterisk_ShowsNoVersionInfo(string versionRange, string expected)
+        {
+            var model = new TestDetailControlModel(
+                Mock.Of<IServiceBroker>(),
+                Enumerable.Empty<IProjectContextInfo>());
+
+            var metadata = new DetailedPackageMetadata()
+            {
+                DeprecationMetadata = new PackageDeprecationMetadataContextInfo(
+                    message: "package deprecated",
+                    reasons: new[] { "package deprecated", "legacy" },
+                    alternatePackageContextInfo: new AlternatePackageMetadataContextInfo(
+                         packageId: "ANewPackage",
+                         range: VersionRange.Parse(versionRange))
+                )
+            };
+            model.PackageMetadata = metadata;
+
+            Assert.NotNull(model.PackageDeprecationAlternatePackageText);
+            Assert.Equal(expected, model.PackageDeprecationAlternatePackageText);
+        }
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/DetailControlModelTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/DetailControlModelTests.cs
@@ -1,17 +1,12 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.ServiceHub.Framework;
-using NuGet.VisualStudio.Internal.Contracts;
 using Moq;
-using Xunit;
 using NuGet.Versioning;
+using NuGet.VisualStudio.Internal.Contracts;
+using Xunit;
 
 namespace NuGet.PackageManagement.UI.Test
 {

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/LocalDetailControlModelTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/LocalDetailControlModelTests.cs
@@ -176,6 +176,32 @@ namespace NuGet.PackageManagement.UI.Test.Models
             Assert.NotNull(model.InstalledVersion);
             Assert.True(model.IsSelectedVersionInstalled);
         }
+
+        [Theory]
+        [InlineData("*")]
+        [InlineData("*-*")]
+        [InlineData("0.0.0")]
+        [InlineData("[0.0.0,)")]
+        public void DeprecationAlternativePackage_WithAsterisk_ShowsNoVersionInfo(string versionRange)
+        {
+            var model = new PackageDetailControlModel(
+                Mock.Of<IServiceBroker>(),
+                Mock.Of<INuGetSolutionManagerService>(),
+                Enumerable.Empty<IProjectContextInfo>());
+
+            var metadata = new DetailedPackageMetadata()
+            {
+                DeprecationMetadata = new PackageDeprecationMetadataContextInfo(
+                    message: "package deprecated",
+                    reasons: new[] { "package deprecated", "legacy" },
+                    new AlternatePackageMetadataContextInfo("ANewPackage", VersionRange.Parse(versionRange))
+                    )
+            };
+            model.PackageMetadata = metadata;
+
+            Assert.NotNull(model.PackageDeprecationAlternatePackageText);
+            Assert.Equal("ANewPackage", model.PackageDeprecationAlternatePackageText);
+        }
     }
 
     public class LocalPackageSolutionDetailControlModelTests : LocalDetailControlModelTestBase

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/LocalDetailControlModelTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/LocalDetailControlModelTests.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -11,7 +10,6 @@ using Microsoft.VisualStudio.Sdk.TestFramework;
 using Microsoft.VisualStudio.Threading;
 using Moq;
 using NuGet.PackageManagement.UI.Utility;
-using NuGet.Packaging;
 using NuGet.Test.Utility;
 using NuGet.Versioning;
 using NuGet.VisualStudio;
@@ -175,32 +173,6 @@ namespace NuGet.PackageManagement.UI.Test.Models
             Assert.NotNull(model.SelectedVersion);
             Assert.NotNull(model.InstalledVersion);
             Assert.True(model.IsSelectedVersionInstalled);
-        }
-
-        [Theory]
-        [InlineData("*")]
-        [InlineData("*-*")]
-        [InlineData("0.0.0")]
-        [InlineData("[0.0.0,)")]
-        public void DeprecationAlternativePackage_WithAsterisk_ShowsNoVersionInfo(string versionRange)
-        {
-            var model = new PackageDetailControlModel(
-                Mock.Of<IServiceBroker>(),
-                Mock.Of<INuGetSolutionManagerService>(),
-                Enumerable.Empty<IProjectContextInfo>());
-
-            var metadata = new DetailedPackageMetadata()
-            {
-                DeprecationMetadata = new PackageDeprecationMetadataContextInfo(
-                    message: "package deprecated",
-                    reasons: new[] { "package deprecated", "legacy" },
-                    new AlternatePackageMetadataContextInfo("ANewPackage", VersionRange.Parse(versionRange))
-                    )
-            };
-            model.PackageMetadata = metadata;
-
-            Assert.NotNull(model.PackageDeprecationAlternatePackageText);
-            Assert.Equal("ANewPackage", model.PackageDeprecationAlternatePackageText);
         }
     }
 

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/TestDetailControlModel.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/TestDetailControlModel.cs
@@ -1,0 +1,39 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.ServiceHub.Framework;
+using NuGet.VisualStudio.Internal.Contracts;
+
+namespace NuGet.PackageManagement.UI.Test
+{
+    /// <summary>
+    /// An implementation of <see cref="DetailControlModel"/> to test its methods
+    /// </summary>
+    internal class TestDetailControlModel : DetailControlModel
+    {
+        public override bool IsSolution => throw new NotImplementedException();
+
+        public TestDetailControlModel(IServiceBroker serviceBroker, IEnumerable<IProjectContextInfo> projects) : base(serviceBroker, projects)
+        {
+        }
+
+        public override IEnumerable<IProjectContextInfo> GetSelectedProjects(UserAction action)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override Task RefreshAsync(CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException();
+        }
+
+        protected override Task CreateVersionsAsync(CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/NuGet.PackageManagement.UI.Test.csproj
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/NuGet.PackageManagement.UI.Test.csproj
@@ -40,6 +40,8 @@
     <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="MockedVS.cs" />
     <Compile Include="Models\PackageDependencySetMetadataTests.cs" />
+    <Compile Include="Models\DetailControlModelTests.cs" />
+    <Compile Include="Models\TestDetailControlModel.cs" />
     <Compile Include="Models\V3DetailControlModelTests.cs" />
     <Compile Include="Models\LocalDetailControlModelTests.cs" />
     <Compile Include="Models\PackageItemViewModelTests.cs" />


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/8795

Regression? Last working version: Probably, before: https://github.com/NuGet/NuGet.Client/pull/3079

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

According to [NuGet protocol docs](https://docs.microsoft.com/en-us/nuget/api/registration-base-url-resource#alternate-package), an `*` will be sent when any version of a given package is an alternate package.

Then, `*` is pretty-printed as '>= 0.0.0'. So, any pretty-printed version range with the same as `*` or `*-*` will not be shown. For example:

Before | After:
---|---
![Before](https://user-images.githubusercontent.com/1192347/151891101-b4f94d8f-0201-459c-8f69-b59e6cf24ce4.png) | ![After](https://user-images.githubusercontent.com/1192347/151891140-996700b8-a8ab-4615-8106-4175e8704ae4.png)


## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added: Added 1 unit test
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A: No major functional changes.

Note: during manual test, I saw empty versions drop down list, as described here: https://github.com/NuGet/NuGet.Client/pull/4355#discussion_r791130886