### PR TITLE
ComboBoxes in PM UI now use VS Common Control styling

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources/Brushes.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources/Brushes.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Windows;
-using System.Windows.Forms;
 using Microsoft.VisualStudio.PlatformUI;
 using Microsoft.VisualStudio.Shell;
 using NuGet.VisualStudio;
@@ -275,7 +274,7 @@ namespace NuGet.PackageManagement.UI
             ListItemBackgroundSelectedColorKey = CommonDocumentColors.ListItemBackgroundSelectedColorKey;
             ListItemTextSelectedColorKey = CommonDocumentColors.ListItemTextSelectedColorKey;
 
-            // ComboBox
+            // Brushes/Colors for ComboBox to match VS Common controls.
             ComboBoxListItemBackgroundHoverBrushKey = CommonControlsColors.ComboBoxListItemBackgroundHoverBrushKey;
             ComboBoxListItemTextBrushKey = CommonControlsColors.ComboBoxListItemTextBrushKey;
             ComboBoxListItemTextHoverBrushKey = CommonControlsColors.ComboBoxListItemTextHoverBrushKey;

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources/Brushes.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources/Brushes.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Windows;
+using System.Windows.Forms;
 using Microsoft.VisualStudio.PlatformUI;
 using Microsoft.VisualStudio.Shell;
 using NuGet.VisualStudio;
@@ -174,6 +175,14 @@ namespace NuGet.PackageManagement.UI
 
         public static object ListItemTextSelectedColorKey { get; private set; } = SystemColors.HighlightTextColorKey;
 
+        public static object ComboBoxListItemBackgroundHoverBrushKey { get; private set; } = SystemColors.HighlightBrushKey;
+
+        public static object ComboBoxListItemTextBrushKey { get; private set; } = SystemColors.ControlTextBrush;
+
+        public static object ComboBoxListItemTextHoverBrushKey { get; private set; } = SystemColors.ControlTextBrush;
+
+        public static object ComboBoxListItemBorderHoverBrushKey { get; private set; } = SystemColors.ActiveBorderBrushKey;
+
         public static void LoadVsBrushes(INuGetExperimentationService nuGetExperimentationService)
         {
             if (nuGetExperimentationService == null)
@@ -265,6 +274,12 @@ namespace NuGet.PackageManagement.UI
             // Mapping color keys directly for use to create brushes using these colors
             ListItemBackgroundSelectedColorKey = CommonDocumentColors.ListItemBackgroundSelectedColorKey;
             ListItemTextSelectedColorKey = CommonDocumentColors.ListItemTextSelectedColorKey;
+
+            // ComboBox
+            ComboBoxListItemBackgroundHoverBrushKey = CommonControlsColors.ComboBoxListItemBackgroundHoverBrushKey;
+            ComboBoxListItemTextBrushKey = CommonControlsColors.ComboBoxListItemTextBrushKey;
+            ComboBoxListItemTextHoverBrushKey = CommonControlsColors.ComboBoxListItemTextHoverBrushKey;
+            ComboBoxListItemBorderHoverBrushKey = CommonControlsColors.ComboBoxListItemBorderHoverBrushKey;
         }
 
         private static bool IsBackgroundColorFlightEnabled(INuGetExperimentationService nuGetExperimentationService) =>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources/Resources.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources/Resources.xaml
@@ -166,6 +166,47 @@
 
   <Style x:Key="{x:Type ComboBox}" TargetType="{x:Type ComboBox}" BasedOn="{StaticResource {x:Static vs:VsResourceKeys.ComboBoxStyleKey}}"/>
 
+  <!--Copied from CommonControlsComboBoxStyle-->
+  <ControlTemplate x:Uid="ControlTemplate_1" x:Key="ComboBoxItemTemplate" TargetType="{x:Type ComboBoxItem}">
+    <Border x:Uid="Bd" Name="Bd"
+                Background="{TemplateBinding Background}"
+                BorderBrush="{TemplateBinding BorderBrush}"
+                BorderThickness="{TemplateBinding BorderThickness}"
+                Padding="{TemplateBinding Padding}"
+                SnapsToDevicePixels="true">
+      <ContentPresenter x:Uid="ContentPresenter_1" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                              VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                              SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+    </Border>
+    <ControlTemplate.Triggers>
+      <Trigger x:Uid="Trigger_1" Property="IsHighlighted" Value="true">
+        <Setter x:Uid="Setter_1" TargetName="Bd"
+                        Property="Background"
+                        Value="{DynamicResource {x:Static nuget:Brushes.ComboBoxListItemBackgroundHoverBrushKey}}"/>
+        <Setter x:Uid="Setter_2" TargetName="Bd"
+                        Property="BorderBrush"
+                        Value="{StaticResource {x:Static nuget:Brushes.ComboBoxListItemBorderHoverBrushKey}}" />
+        <Setter x:Uid="Setter_3" TargetName="Bd"
+                        Property="TextElement.Foreground"
+                        Value="{StaticResource {x:Static nuget:Brushes.ComboBoxListItemTextHoverBrushKey}}" />
+      </Trigger>
+    </ControlTemplate.Triggers>
+  </ControlTemplate>
+
+  <!--Copied from CommonControlsComboBoxStyle-->
+  <Style x:Key="CommonControlsComboBoxItem" TargetType="{x:Type ComboBoxItem}">
+    <Setter x:Uid="Setter_54" Property="BorderThickness" Value="1" />
+    <Setter x:Uid="Setter_55" Property="BorderBrush" Value="Transparent" />
+    <Setter x:Uid="Setter_56" Property="Background" Value="Transparent" />
+    <Setter x:Uid="Setter_57" Property="Foreground" Value="{StaticResource {x:Static nuget:Brushes.ComboBoxListItemTextBrushKey}}" />
+    <Setter x:Uid="Setter_58" Property="AutomationProperties.Name" Value="{Binding Text}" />
+    <Setter x:Uid="Setter_59" Property="AutomationProperties.AutomationId" Value="{Binding Text}"/>
+    <Setter x:Uid="Setter_60" Property="Template" Value="{StaticResource ComboBoxItemTemplate}" />
+    <Setter x:Uid="Setter_61" Property="Margin" Value="2,0,2,0" />
+    <Setter x:Uid="Setter_62" Property="InputMethod.IsInputMethodSuspended" Value="True"/>
+    <Setter x:Uid="Setter_63" Property="FocusVisualStyle" Value="{x:Null}"/>
+  </Style>
+
   <Style x:Key="{x:Type ScrollBar}" TargetType="{x:Type ScrollBar}" BasedOn="{StaticResource {x:Static nuget:Styles.ScrollBarStyleKey}}"/>
 
   <Style x:Key="{x:Type ScrollViewer}" TargetType="{x:Type ScrollViewer}" BasedOn="{StaticResource {x:Static nuget:Styles.ScrollViewerStyleKey}}"/>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources/Resources.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources/Resources.xaml
@@ -164,13 +164,7 @@
     <Setter Property="FocusVisualStyle" Value="{StaticResource GridSplitterFocusVisualStyle}"/>
   </Style>
 
-  <Style x:Key="{x:Type ComboBox}" TargetType="{x:Type ComboBox}" BasedOn="{StaticResource {x:Static nuget:Styles.ThemedComboStyleKey}}">
-    <Setter Property="FocusVisualStyle" Value="{StaticResource ControlsFocusVisualStyle}"/>
-  </Style>
-
-  <Style x:Key="{x:Type ComboBoxItem}" TargetType="{x:Type ComboBoxItem}" BasedOn="{StaticResource {x:Type ComboBoxItem}}">
-    <Setter Property="FocusVisualStyle" Value="{StaticResource ControlsFocusVisualStyle}"/>
-  </Style>
+  <Style x:Key="{x:Type ComboBox}" TargetType="{x:Type ComboBox}" BasedOn="{StaticResource {x:Static vs:VsResourceKeys.ComboBoxStyleKey}}"/>
 
   <Style x:Key="{x:Type ScrollBar}" TargetType="{x:Type ScrollBar}" BasedOn="{StaticResource {x:Static nuget:Styles.ScrollBarStyleKey}}"/>
 
@@ -549,52 +543,6 @@
             <Trigger Property="IsEnabled" Value="false">
               <Setter Property="Foreground" Value="{DynamicResource {x:Static nuget:Brushes.CheckBoxTextDisabledBrushKey}}"/>
             </Trigger>
-          </ControlTemplate.Triggers>
-        </ControlTemplate>
-      </Setter.Value>
-    </Setter>
-  </Style>
-
-  <Style TargetType="{x:Type ComboBoxItem}" x:Key="ComboBoxItemStyle">
-    <Setter Property="Foreground" Value="{DynamicResource {x:Static nuget:Brushes.UIText}}"/>
-    <Setter Property="FocusVisualStyle" Value="{StaticResource ControlsFocusVisualStyle}"/>
-    <Setter Property="Template">
-      <Setter.Value>
-        <ControlTemplate TargetType="{x:Type ComboBoxItem}">
-          <Border x:Name="Bd"
-                    SnapsToDevicePixels="true"
-                    Background="{TemplateBinding Background}"
-                    BorderBrush="{TemplateBinding BorderBrush}"
-                    BorderThickness="{TemplateBinding BorderThickness}"
-                    Padding="{TemplateBinding Padding}">
-            <ContentPresenter HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
-          </Border>
-          <ControlTemplate.Triggers>
-            <MultiTrigger>
-              <MultiTrigger.Conditions>
-                <Condition Property="IsMouseOver" Value="True" />
-              </MultiTrigger.Conditions>
-              <Setter Property="Background" TargetName="Bd" Value="{DynamicResource {x:Static nuget:Brushes.ContentMouseOverBrushKey}}" />
-              <Setter Property="TextBlock.Foreground" Value="{DynamicResource {x:Static nuget:Brushes.ContentMouseOverTextBrushKey}}" />
-            </MultiTrigger>
-            <MultiTrigger>
-              <MultiTrigger.Conditions>
-                <Condition Property="Selector.IsSelectionActive" Value="False" />
-                <Condition Property="IsSelected" Value="True" />
-              </MultiTrigger.Conditions>
-              <Setter Property="Background" TargetName="Bd" Value="{DynamicResource {x:Static nuget:Brushes.ContentInactiveSelectedBrushKey}}" />
-              <Setter Property="TextBlock.Foreground" Value="{DynamicResource {x:Static nuget:Brushes.ContentInactiveSelectedTextBrushKey}}" />
-            </MultiTrigger>
-            <MultiTrigger>
-              <MultiTrigger.Conditions>
-                <Condition Property="Selector.IsSelectionActive" Value="True" />
-                <Condition Property="IsSelected" Value="True" />
-              </MultiTrigger.Conditions>
-              <Setter Property="Background" TargetName="Bd" Value="{DynamicResource {x:Static nuget:Brushes.ContentSelectedBrushKey}}" />
-              <Setter Property="TextBlock.Foreground" TargetName="Bd" Value="{DynamicResource {x:Static nuget:Brushes.ContentSelectedTextBrushKey}}" />
-            </MultiTrigger>
           </ControlTemplate.Triggers>
         </ControlTemplate>
       </Setter.Value>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources/Styles.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources/Styles.cs
@@ -11,9 +11,6 @@ namespace NuGet.PackageManagement.UI
     public static class Styles
     {
         [Browsable(false)]
-        public static object ThemedComboStyleKey => VsResourceKeys.ThemedDialogComboBoxStyleKey ?? typeof(ComboBox);
-
-        [Browsable(false)]
         public static object ScrollBarStyleKey => VsResourceKeys.ScrollBarStyleKey ?? typeof(ScrollBar);
 
         [Browsable(false)]

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerTopPanel.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerTopPanel.xaml
@@ -274,6 +274,11 @@
                 Text="{Binding}" />
             </ToolTip>
           </ComboBox.ToolTip>
+          <ComboBox.ItemContainerStyle>
+            <Style TargetType="{x:Type ComboBoxItem}" BasedOn="{StaticResource CommonControlsComboBoxItem}">
+              <Setter Property="AutomationProperties.Name" Value="{Binding SourceName}"/>
+            </Style>
+          </ComboBox.ItemContainerStyle>
         </ComboBox>
         <Button
           Grid.Column="3"

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerTopPanel.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerTopPanel.xaml
@@ -274,11 +274,6 @@
                 Text="{Binding}" />
             </ToolTip>
           </ComboBox.ToolTip>
-          <ComboBox.ItemContainerStyle>
-            <Style TargetType="{x:Type ComboBoxItem}" BasedOn="{StaticResource ComboBoxItemStyle}">
-              <Setter Property="AutomationProperties.Name" Value="{Binding SourceName}"/>
-            </Style>
-          </ComboBox.ItemContainerStyle>
         </ComboBox>
         <Button
           Grid.Column="3"

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/ProjectView.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/ProjectView.xaml
@@ -101,7 +101,7 @@
       ItemsSource="{Binding Path=Versions}"
       SelectedItem="{Binding Path=SelectedVersion}">
       <ComboBox.ItemContainerStyle>
-            <Style TargetType="{x:Type ComboBoxItem}" BasedOn="{StaticResource ComboBoxItemStyle}">
+            <Style TargetType="{x:Type ComboBoxItem}">
                 <Setter Property="Foreground" Value="{DynamicResource {x:Static local:Brushes.UIText}}" />
                 <Style.Triggers>
                     <DataTrigger Binding="{Binding Path=IsValidVersion}" Value="false">

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/ProjectView.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/ProjectView.xaml
@@ -101,7 +101,7 @@
       ItemsSource="{Binding Path=Versions}"
       SelectedItem="{Binding Path=SelectedVersion}">
       <ComboBox.ItemContainerStyle>
-            <Style TargetType="{x:Type ComboBoxItem}">
+            <Style TargetType="{x:Type ComboBoxItem}" BasedOn="{StaticResource CommonControlsComboBoxItem}">
                 <Setter Property="Foreground" Value="{DynamicResource {x:Static local:Brushes.UIText}}" />
                 <Style.Triggers>
                     <DataTrigger Binding="{Binding Path=IsValidVersion}" Value="false">

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/SolutionView.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/SolutionView.xaml
@@ -399,7 +399,7 @@
         SelectedItem="{Binding Path=SelectedVersion}">
 
         <ComboBox.ItemContainerStyle>
-          <Style TargetType="{x:Type ComboBoxItem}" BasedOn="{StaticResource ComboBoxItemStyle}">
+          <Style TargetType="{x:Type ComboBoxItem}">
             <Style.Triggers>
               <DataTrigger 
                         Binding="{Binding Converter={StaticResource NotNullToBooleanConverter}}"

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/SolutionView.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/SolutionView.xaml
@@ -399,7 +399,7 @@
         SelectedItem="{Binding Path=SelectedVersion}">
 
         <ComboBox.ItemContainerStyle>
-          <Style TargetType="{x:Type ComboBoxItem}">
+          <Style TargetType="{x:Type ComboBoxItem}" BasedOn="{StaticResource CommonControlsComboBoxItem}">
             <Style.Triggers>
               <DataTrigger 
                         Binding="{Binding Converter={StaticResource NotNullToBooleanConverter}}"


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/nuget/home/issues/10978

Regression? Last working version: No

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

I'm switching the key for comboboxes to use the VS styling. This allows me to throw out some of the custom styling for ComboBoxes we had.

We would be done at this point, as I proved that this would solve this issue *if we did not override other styles*. Notice the 3 ComboBoxes in view in the screenshot below.
  - Two of them with red arrows have the same correct highlight color/border/etc. This is the result of `VsResourceKeys.ComboBoxStyleKey`
  - The erroneous color (blue arrow on right) is the Details Pane Version ComboBox
    - **Why isn't that fixed?** Since we override `ItemsContainerStyle`, I have to copy those VS styles into our repo.  There's no way to override 1 property (or more) and keep the inherited VS styling. After doing so, this looks good:

![image](https://user-images.githubusercontent.com/49205731/152048517-3d9afbe3-2f92-4b3a-97e4-6ddc619b7fdc.png)
    -  The team responsible for this styling may be able to provide a key for these items, then I can remove this styling from our repo.

![image](https://user-images.githubusercontent.com/49205731/152048565-1d59d59e-d560-4af8-a9e1-2c6393cda8c0.png)

### What's the erroneous color?
 I found out that this is quite a relic. It's the result of WPF defaulting the styling of combobox items to WPF's default ("Aero2") theme. This happens because we override part of the styling, so we lose the inheritance structure.


## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
