### PR TITLE
Avoid double-checking for supported projects

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
@@ -396,11 +396,8 @@ namespace NuGet.PackageManagement.VisualStudio
 
             foreach (Project project in await EnvDTESolutionUtility.GetAllEnvDTEProjectsAsync(dte))
             {
-                if (await EnvDTEProjectUtility.IsSupportedAsync(project))
-                {
-                    isSupported = true;
-                    break;
-                }
+                isSupported = true;
+                break;
             }
 
             return isSupported;

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
@@ -690,16 +690,7 @@ namespace NuGet.PackageManagement.VisualStudio
                     {
                         var dte = await _asyncServiceProvider.GetDTEAsync();
 
-                        var supportedProjects = new List<Project>();
-                        foreach (Project project in await EnvDTESolutionUtility.GetAllEnvDTEProjectsAsync(dte))
-                        {
-                            if (await EnvDTEProjectUtility.IsSupportedAsync(project))
-                            {
-                                supportedProjects.Add(project);
-                            }
-                        }
-
-                        foreach (var project in supportedProjects)
+                        foreach (var project in await EnvDTESolutionUtility.GetAllEnvDTEProjectsAsync(dte))
                         {
                             try
                             {

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPathContextProvider.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPathContextProvider.cs
@@ -223,7 +223,7 @@ namespace NuGet.VisualStudio.Implementation.Extensibility
             await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
             DTE dte = await _asyncServiceprovider.GetDTEAsync();
-            IEnumerable<Project> supportedProjects = await GetProjectsInSolutionAsync(dte);
+            IEnumerable<Project> supportedProjects = await EnvDTESolutionUtility.GetAllEnvDTEProjectsAsync(dte);
 
             foreach (Project solutionProject in supportedProjects)
             {
@@ -367,21 +367,6 @@ namespace NuGet.VisualStudio.Implementation.Extensibility
                 pathContext.FallbackPackageFolders.Cast<string>(),
                 trie,
                 _telemetryProvider);
-        }
-
-        private async Task<IEnumerable<Project>> GetProjectsInSolutionAsync(DTE dte)
-        {
-            IEnumerable<Project> allProjects = await EnvDTESolutionUtility.GetAllEnvDTEProjectsAsync(dte);
-            var supportedProjects = new List<Project>();
-            foreach (Project project in allProjects)
-            {
-                if (await EnvDTEProjectUtility.IsSupportedAsync(project))
-                {
-                    supportedProjects.Add(project);
-                }
-            }
-
-            return supportedProjects;
         }
 
         public bool TryCreateNoSolutionContext(out IVsPathContext vsPathContext)


### PR DESCRIPTION

<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11554

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

GetAllEnvDTEProjectsAsync already checks to see if a project is supported before returning it, only for these three methods to do again. Easier read commit per commit.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
