### PR TITLE
Adds AutomationProperties.Name to license term Hyperlink controls

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
@@ -1384,6 +1384,15 @@ namespace NuGet.PackageManagement.UI {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to {0} license.
+        /// </summary>
+        public static string LicenseTerm_LinkName {
+            get {
+                return ResourceManager.GetString("LicenseTerm_LinkName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Don&apos;t show again.
         /// </summary>
         public static string Link_DoNotShowAgain {

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
@@ -1031,4 +1031,8 @@ Please see https://aka.ms/troubleshoot_nuget_cache for more help.</value>
     <value>{0:G3}T</value>
     <comment>American trillions in short format notation</comment>
   </data>
+  <data name="LicenseTerm_LinkName" xml:space="preserve">
+    <value>{0} license</value>
+    <comment>{0} = license name. Examples: MIT, Apache</comment>
+  </data>
 </root>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/LicenseAcceptanceWindow.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/LicenseAcceptanceWindow.xaml
@@ -34,6 +34,7 @@
             >
                 <Hyperlink
                     AutomationProperties.AutomationId="{Binding Id, Mode=OneWay, StringFormat='LicenseTermLink_{0}'}"
+                    AutomationProperties.Name="{Binding Text, Mode=OneWay, StringFormat={x:Static nuget:Resources.LicenseTerm_LinkName}}"
                     Style="{StaticResource HyperlinkStyle}"
                     ToolTip="{Binding Link}"
                     RequestNavigate="OnViewLicenseTermsRequestNavigate"


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1236

Regression? Last working version: N/A

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

- Adds AutomationProperties.Name property to hyperlink controls in license term expression, so that Narrator can read license term hyperlink as '<<licenseTerm>> license' (in English) in License Acceptance dialog window.
- Added license name localizable String resource 


## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - [x] Test exception: Manually validated that Narrator correctly reads License term Hyperlink's
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A: No major product changes


**FastPass Validation on License Acceptance Window**

In the sample below, 'MIT' hyperlink is read by Windows Narrator as 'MIT license, hyperlink'

![image](https://user-images.githubusercontent.com/1192347/152134359-2492957d-d5ee-4201-8e11-516f2fa9bf5e.png)
