### PR TITLE
restore locked mode and force evaluate should error

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -595,12 +595,12 @@ namespace NuGet.Commands
             {
                 success = false;
 
-                // invalid input since LockedMode and RestoreForce should not be used together.
+                // invalid input since LockedMode and RestoreForceEvaluate should not be used together.
                 var message = string.Format(CultureInfo.CurrentCulture, Strings.Error_RestoreLockedModeWithForceEvaluate, packagesLockFilePath);
 
                 // directly log to the request logger when we're not going to rewrite the assets file otherwise this log will
                 // be skipped for netcore projects.
-                await _request.Log.LogAsync(RestoreLogMessage.CreateError(NuGetLogCode.NU1004, message));
+                await _request.Log.LogAsync(RestoreLogMessage.CreateError(NuGetLogCode.NU1005, message));
 
                 return (success, isLockFileValid, packagesLockFile);
             }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -590,7 +590,7 @@ namespace NuGet.Commands
             var isLockFileValid = false;
             var success = true;
 
-            var isLockedMode = _request.Project.RestoreMetadata.RestoreLockProperties.RestoreLockedMode;
+            var isLockedMode = _request.Project.RestoreMetadata?.RestoreLockProperties?.RestoreLockedMode ?? false;
             if (isLockedMode && _request.RestoreForceEvaluate)
             {
                 success = false;

--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -736,6 +736,15 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to RestoreForceEvaluate should not be used with RestoreLockedMode in the same command..
+        /// </summary>
+        internal static string Error_RestoreLockedModeWithForceEvaluate {
+            get {
+                return ResourceManager.GetString("Error_RestoreLockedModeWithForceEvaluate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The repository service index &apos;{0}&apos; is not a valid HTTPS url..
         /// </summary>
         internal static string Error_ServiceIndexShouldBeHttps {

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -1032,4 +1032,7 @@ For more information, visit https://docs.nuget.org/docs/reference/command-line-r
   <data name="Error_NoMatchingClientCertificate" xml:space="preserve">
     <value>This package is signed but not by a trusted signer.</value>
   </data>
+  <data name="Error_RestoreLockedModeWithForceEvaluate" xml:space="preserve">
+    <value>RestoreForceEvaluate should not be used with RestoreLockedMode in the same command.</value>
+  </data>
 </root>

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_PackagesLockFileTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_PackagesLockFileTests.cs
@@ -233,8 +233,8 @@ namespace NuGet.Commands.FuncTest
                 // Assert
                 result.Success.Should().BeFalse();
                 logger.ErrorMessages.Count.Should().Be(1);
-                logger.ErrorMessages.Single().Should().Contain("NU1004");
-                logger.ErrorMessages.Single().Should().Contain("The package reference a version has changed from [1.0.0, ) to [2.0.0, )");
+                logger.ErrorMessages.Single().Should().Contain("NU1005");
+                logger.ErrorMessages.Single().Should().Contain("RestoreForceEvaluate should not be used with RestoreLockedMode in the same command.");
             }
         }
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/8222

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
Using `RestoreLockedMode` and `RestoreForceEvaluate` at the same time is contradictory. 

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
