### PR TITLE
Avoid double-lookup of hierarchy in ContainsFileAsync

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Utility/EnvDTEProjectUtility.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Utility/EnvDTEProjectUtility.cs
@@ -83,7 +83,6 @@ namespace NuGet.PackageManagement.VisualStudio
             }
 
             int pFound;
-            uint itemId;
 
             if (await VsHierarchyUtility.IsProjectCapabilityCompliantAsync(hierarchy))
             {
@@ -91,11 +90,11 @@ namespace NuGet.PackageManagement.VisualStudio
                 // We're checking for VSDOCUMENTPRIORITY.DP_Standard here to see if the file is included in the project.
                 // Original check (outside of if) did not have this.
                 var priority = new VSDOCUMENTPRIORITY[1];
-                var hr = vsProject.IsDocumentInProject(path, out pFound, priority, out itemId);
+                var hr = vsProject.IsDocumentInProject(path, out pFound, priority, out _);
                 return ErrorHandler.Succeeded(hr) && pFound == 1 && priority[0] >= VSDOCUMENTPRIORITY.DP_Standard;
             }
 
-            var hres = vsProject.IsDocumentInProject(path, out pFound, Array.Empty<VSDOCUMENTPRIORITY>(), out itemId);
+            var hres = vsProject.IsDocumentInProject(path, out pFound, Array.Empty<VSDOCUMENTPRIORITY>(), out _);
             return ErrorHandler.Succeeded(hres) && pFound == 1;
         }
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Utility/EnvDTEProjectUtility.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Utility/EnvDTEProjectUtility.cs
@@ -75,7 +75,8 @@ namespace NuGet.PackageManagement.VisualStudio
 
             await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
-            var vsProject = (IVsProject)(await envDTEProject.ToVsHierarchyAsync());
+            var hierarchy = await envDTEProject.ToVsHierarchyAsync();
+            var vsProject = hierarchy as IVsProject;
             if (vsProject == null)
             {
                 return false;
@@ -84,7 +85,7 @@ namespace NuGet.PackageManagement.VisualStudio
             int pFound;
             uint itemId;
 
-            if (await IsProjectCapabilityCompliantAsync(envDTEProject))
+            if (await VsHierarchyUtility.IsProjectCapabilityCompliantAsync(hierarchy))
             {
                 // REVIEW: We want to revisit this after RTM - the code in this if statement should be applied to every project type.
                 // We're checking for VSDOCUMENTPRIORITY.DP_Standard here to see if the file is included in the project.


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: 


Regression? Last working version:

## Description
This avoids a double-lookup of the hierarchy, one via ToVsHierarchyAsync and one via IsProjectCapabilityCompliantAsync.

## PR Checklist

- [X] PR has a meaningful title
- [ ] PR has a linked issue.
- [X] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [X] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [X] N/A
