### PR TITLE
Un-async methods

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
@@ -590,7 +590,7 @@ namespace NuGet.PackageManagement.VisualStudio
                         AfterNuGetProjectRenamed?.Invoke(this, new NuGetProjectEventArgs(nuGetProject));
 
                     }
-                    else if (await EnvDTEProjectUtility.IsSolutionFolderAsync(envDTEProject))
+                    else if (EnvDTEProjectUtility.IsSolutionFolder(envDTEProject))
                     {
                         // In the case where a solution directory was changed, project FullNames are unchanged.
                         // We only need to invalidate the projects under the current tree so as to sync the CustomUniqueNames.

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Utility/EnvDTEProjectUtility.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Utility/EnvDTEProjectUtility.cs
@@ -45,9 +45,10 @@ namespace NuGet.PackageManagement.VisualStudio
 
         #region Get Project Information
 
-        internal static async Task<bool> IsSolutionFolderAsync(EnvDTE.Project envDTEProject)
+        internal static bool IsSolutionFolder(EnvDTE.Project envDTEProject)
         {
-            await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             return envDTEProject.Kind != null && envDTEProject.Kind.Equals(VsProjectTypes.VsProjectItemKindSolutionFolder, StringComparison.OrdinalIgnoreCase);
         }
 
@@ -442,7 +443,7 @@ namespace NuGet.PackageManagement.VisualStudio
         {
             await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
-            if (!await IsSolutionFolderAsync(envDTEProject))
+            if (!IsSolutionFolder(envDTEProject))
             {
                 return Array.Empty<EnvDTE.Project>();
             }
@@ -464,7 +465,7 @@ namespace NuGet.PackageManagement.VisualStudio
                     {
                         supportedChildProjects.Add(nestedProject);
                     }
-                    else if (await IsSolutionFolderAsync(nestedProject))
+                    else if (IsSolutionFolder(nestedProject))
                     {
                         containerProjects.Enqueue(nestedProject);
                     }

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Utility/EnvDTEProjectUtility.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Utility/EnvDTEProjectUtility.cs
@@ -85,7 +85,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
             int pFound;
 
-            if (await VsHierarchyUtility.IsProjectCapabilityCompliantAsync(hierarchy))
+            if (VsHierarchyUtility.IsProjectCapabilityCompliant(hierarchy))
             {
                 // REVIEW: We want to revisit this after RTM - the code in this if statement should be applied to every project type.
                 // We're checking for VSDOCUMENTPRIORITY.DP_Standard here to see if the file is included in the project.

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Utility/EnvDTEProjectUtility.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Utility/EnvDTEProjectUtility.cs
@@ -405,8 +405,11 @@ namespace NuGet.PackageManagement.VisualStudio
         private static async Task<bool> IsProjectCapabilityCompliantAsync(EnvDTE.Project envDTEProject)
         {
             Debug.Assert(envDTEProject != null);
+
+            await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
             var hierarchy = await envDTEProject.ToVsHierarchyAsync();
-            return await VsHierarchyUtility.IsProjectCapabilityCompliantAsync(hierarchy);
+            return VsHierarchyUtility.IsProjectCapabilityCompliant(hierarchy);
         }
 
         public async static Task<NuGetProject> GetNuGetProjectAsync(EnvDTE.Project project, ISolutionManager solutionManager)

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/IDE/VsHierarchyUtility.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/IDE/VsHierarchyUtility.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.ProjectSystem;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using NuGet.VisualStudio.Common;
@@ -18,11 +19,6 @@ namespace NuGet.VisualStudio
     public static class VsHierarchyUtility
     {
         private const string VsWindowKindSolutionExplorer = "3AE79031-E1BC-11D0-8F78-00A0C9110057";
-
-        private static readonly string[] UnsupportedProjectCapabilities = new string[]
-        {
-            "SharedAssetsProject", // This is true for shared projects in universal apps
-        };
 
         public static string GetProjectPath(IVsHierarchy project)
         {
@@ -59,7 +55,10 @@ namespace NuGet.VisualStudio
 
         public static bool HasUnsupportedProjectCapability(IVsHierarchy hierarchy)
         {
-            return UnsupportedProjectCapabilities.Any(c => hierarchy.IsCapabilityMatch(c));
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            // This is true for shared projects in universal apps
+            return hierarchy.IsCapabilityMatch(ProjectCapabilities.SharedAssetsProject);
         }
 
         public static string[] GetProjectTypeGuids(IVsHierarchy hierarchy, string defaultType = "")

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/IDE/VsHierarchyUtility.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/IDE/VsHierarchyUtility.cs
@@ -32,9 +32,11 @@ namespace NuGet.VisualStudio
             return projectPath;
         }
 
-        public static async Task<bool> IsSupportedAsync(IVsHierarchy hierarchy, string projectTypeGuid)
+        public static bool IsSupported(IVsHierarchy hierarchy, string projectTypeGuid)
         {
-            if (await IsProjectCapabilityCompliantAsync(hierarchy))
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            if (IsProjectCapabilityCompliant(hierarchy))
             {
                 return true;
             }
@@ -46,9 +48,9 @@ namespace NuGet.VisualStudio
         /// <param name="hierarchy">IVsHierarchy representing the project in the solution.</param>
         /// <returns>True if NuGet should enable this project, false if NuGet should ignore the project.</returns>
         /// <remarks>The project may be packages.config or PackageReference. This method does not tell you which.</remarks>
-        public static async Task<bool> IsProjectCapabilityCompliantAsync(IVsHierarchy hierarchy)
+        public static bool IsProjectCapabilityCompliant(IVsHierarchy hierarchy)
         {
-            await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            ThreadHelper.ThrowIfNotOnUIThread();
 
             // NOTE: (AssemblyReferences + DeclaredSourceItems + UserSourceItems) exists solely for compatibility reasons
             // with existing custom CPS-based projects that existed before "PackageReferences" capability was introduced.


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11816

Regression? Last working version:

## Description
This removes async from a few methods that are only called on the UI thread to non-async. Making these methods async has a few problems:

1) If they were actually called off the UI thread, once the switch to the UI thread has finished, these methods need to handle that the project has been unloaded. This doesn't actually happen in practice as all entry points are from the UI thread, so this prevents this from accidently been called off the UI thread in the future.
2) This results in unneeded state machines and allocations. In large solutions traces, we're seeing this adding up.
3) This forces JTF.Run usage from UI thread entry points. We're also seeing this add up.

## PR Checklist

- [ ] PR has a meaningful title
- [ ] PR has a linked issue.
- [ ] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [ ] N/A
