### PR TITLE
Lower priority of NuGet-based MSBuild project SDK resolver to run after .NET SDK resolver

### DIFF
--- a/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/NuGetSdkResolver.cs
+++ b/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/NuGetSdkResolver.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Build.NuGetSdkResolver
         public override string Name => nameof(NuGetSdkResolver);
 
         /// <inheritdoc />
-        public override int Priority => 2500;
+        public override int Priority => 6000;
 
         /// <summary>Resolves the specified SDK reference from NuGet.</summary>
         /// <param name="sdkReference">A <see cref="T:Microsoft.Build.Framework.SdkReference" /> containing the referenced SDKs be resolved.</param>


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11566

Regression? Last working version:

## Description
Lowering the priority of the NuGet-based MSBuild project SDK resolver will allow built-in SDKs like `Microsoft.NET.Sdk` to be resolved quicker in Visual Studio and command-line builds.  This will break any customer who is overriding the built-in SDKs with a NuGet package, but we believe it's worth breaking this functionality for the benefit of performance.  At this time, there is no known customer who is doing this either.

The .NET SDK resolver's priority is 5000:
https://github.com/dotnet/sdk/blob/04d33f15114be2b5180c01124618e44e40403e44/src/Resolvers/Microsoft.DotNet.MSBuildSdkResolver/MSBuildSdkResolver.cs#L31

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
I'll need to update [this page](https://docs.microsoft.com/en-us/visualstudio/msbuild/how-to-use-project-sdk) once this is merged to reflect the new ordering.
  - [x] Documentation PR or issue filled
  - **OR**
  - [x] N/A
