### PR TITLE
Restores original behavior in two NuGet Plugin methods

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginPackageReader.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginPackageReader.cs
@@ -106,7 +106,7 @@ namespace NuGet.Protocol.Plugins
             var lazyCreator = _fileStreams.GetOrAdd(
                 path,
                 p => new Lazy<Task<FileStreamCreator>>(
-                    () => GetStreamInternalAsync(p, cancellationToken)));
+                    () => GetStreamInternalAsync(p)));
 
             await lazyCreator.Value;
 
@@ -1016,8 +1016,7 @@ namespace NuGet.Protocol.Plugins
         }
 
         private async Task<FileStreamCreator> GetStreamInternalAsync(
-            string pathInPackage,
-            CancellationToken cancellationToken)
+            string pathInPackage)
         {
             var packageId = _packageIdentity.Id;
             var packageVersion = _packageIdentity.Version.ToNormalizedString();
@@ -1032,7 +1031,7 @@ namespace NuGet.Protocol.Plugins
             var response = await _plugin.Connection.SendRequestAndReceiveResponseAsync<CopyFilesInPackageRequest, CopyFilesInPackageResponse>(
                 MessageMethod.CopyFilesInPackage,
                 payload,
-                cancellationToken);
+                CancellationToken.None);
 
             if (response != null)
             {

--- a/src/NuGet.Core/NuGet.Protocol/RemoteRepositories/PluginFindPackageByIdResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/RemoteRepositories/PluginFindPackageByIdResource.cs
@@ -200,7 +200,7 @@ namespace NuGet.Protocol.Core.Types
                     () => SetLogLevelAsync(logger, cancellationToken),
                     cancellationToken);
 
-                var packageInfos = await EnsurePackagesAsync(id, cacheContext, logger, cancellationToken);
+                var packageInfos = await EnsurePackagesAsync(id, cacheContext, cancellationToken);
 
                 return packageInfos.Keys;
             }
@@ -265,7 +265,7 @@ namespace NuGet.Protocol.Core.Types
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
-                var packageInfos = await EnsurePackagesAsync(id, cacheContext, logger, cancellationToken);
+                var packageInfos = await EnsurePackagesAsync(id, cacheContext, cancellationToken);
 
                 PackageInfo packageInfo;
 
@@ -360,7 +360,7 @@ namespace NuGet.Protocol.Core.Types
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
-                var packageInfos = await EnsurePackagesAsync(id, cacheContext, logger, cancellationToken);
+                var packageInfos = await EnsurePackagesAsync(id, cacheContext, cancellationToken);
 
                 return packageInfos.TryGetValue(version, out var packageInfo);
             }
@@ -378,7 +378,6 @@ namespace NuGet.Protocol.Core.Types
         private async Task<SortedDictionary<NuGetVersion, PackageInfo>> EnsurePackagesAsync(
             string id,
             SourceCacheContext cacheContext,
-            ILogger logger,
             CancellationToken cancellationToken)
         {
             AsyncLazy<SortedDictionary<NuGetVersion, PackageInfo>> result = null;
@@ -387,7 +386,6 @@ namespace NuGet.Protocol.Core.Types
                 (keyId) => new AsyncLazy<SortedDictionary<NuGetVersion, PackageInfo>>(
                     () => FindPackagesByIdAsync(
                         keyId,
-                        logger,
                         cancellationToken));
 
             if (cacheContext.RefreshMemoryCache)
@@ -406,7 +404,6 @@ namespace NuGet.Protocol.Core.Types
 
         private async Task<SortedDictionary<NuGetVersion, PackageInfo>> FindPackagesByIdAsync(
             string id,
-            ILogger logger,
             CancellationToken cancellationToken)
         {
             var uri = _packageSource.Source;
@@ -451,8 +448,6 @@ namespace NuGet.Protocol.Core.Types
                     Strings.Log_FailedToRetrievePackage,
                     id,
                     uri);
-
-                logger.LogError(message);
 
                 throw new FatalProtocolException(message, ex);
             }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1425

Regression? Last working version: N/A

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

- Removes cancellation token parameter in `GetStreamInternalAsync`, since original method does not use this token.
- Removes logger parameter in `FindPackagesByIdAsync`, since original method does not use this logger.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - ~[ ] Automated tests added~
  - [x] Test exception: Tests already cover those scenarios. Moreover, those are private methods that should not affect original behavior
  - ~[ ] N/A~

- **Documentation**
  - ~[ ] Documentation PR or issue filled~
  - [x] N/A: No major product changes.
