### PR TITLE
Fix string comparison for floating versions in transitive lock files

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/LockFileUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/LockFileUtils.cs
@@ -1006,15 +1006,6 @@ namespace NuGet.Commands
                 // For csproj -> csproj type references where there is no range, use 1.0.0
                 range = VersionRange.Parse("1.0.0");
             }
-            else if (dependency.LibraryRange.TypeConstraintAllows(LibraryDependencyTarget.Package))
-            {
-            }
-            else
-            {
-                // For project dependencies drop the snapshot version.
-                // Ex: 1.0.0-* -> 1.0.0
-                range = range.ToNonSnapshotRange();
-            }
 
             return new PackageDependency(dependency.Name, range);
         }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/LockFileUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/LockFileUtils.cs
@@ -1006,6 +1006,9 @@ namespace NuGet.Commands
                 // For csproj -> csproj type references where there is no range, use 1.0.0
                 range = VersionRange.Parse("1.0.0");
             }
+            else if (dependency.LibraryRange.TypeConstraintAllows(LibraryDependencyTarget.Package))
+            {
+            }
             else
             {
                 // For project dependencies drop the snapshot version.

--- a/src/NuGet.Core/NuGet.ProjectModel/JsonUtility.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/JsonUtility.cs
@@ -55,7 +55,7 @@ namespace NuGet.ProjectModel
         {
             return new JProperty(
                 item.Id,
-                WriteString(item.VersionRange?.ToLegacyShortString()));
+                WriteString(item.VersionRange?.ToNonSnapshotRange().ToLegacyShortString()));
         }
 
         internal static JProperty WritePackageDependency(PackageDependency item)

--- a/src/NuGet.Core/NuGet.ProjectModel/JsonUtility.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/JsonUtility.cs
@@ -62,7 +62,7 @@ namespace NuGet.ProjectModel
         {
             return new JProperty(
                 item.Id,
-                WriteString(item.VersionRange?.OriginalString));
+                WriteString(item.VersionRange?.ToString()));
         }
 
         internal static TItem ReadProperty<TItem>(JObject jObject, string propertyName)

--- a/src/NuGet.Core/NuGet.ProjectModel/JsonUtility.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/JsonUtility.cs
@@ -51,11 +51,18 @@ namespace NuGet.ProjectModel
                 versionStr == null ? null : VersionRange.Parse(versionStr));
         }
 
+        internal static JProperty WritePackageDependencyWithLegacyString(PackageDependency item)
+        {
+            return new JProperty(
+                item.Id,
+                WriteString(item.VersionRange?.ToLegacyShortString()));
+        }
+
         internal static JProperty WritePackageDependency(PackageDependency item)
         {
             return new JProperty(
                 item.Id,
-                WriteString(item.VersionRange?.ToString()));
+                WriteString(item.VersionRange?.OriginalString));
         }
 
         internal static TItem ReadProperty<TItem>(JObject jObject, string propertyName)

--- a/src/NuGet.Core/NuGet.ProjectModel/JsonUtility.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/JsonUtility.cs
@@ -55,7 +55,7 @@ namespace NuGet.ProjectModel
         {
             return new JProperty(
                 item.Id,
-                WriteString(item.VersionRange?.ToLegacyShortString()));
+                WriteString(item.VersionRange?.ToString()));
         }
 
         internal static TItem ReadProperty<TItem>(JObject jObject, string propertyName)

--- a/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileFormat.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileFormat.cs
@@ -521,7 +521,7 @@ namespace NuGet.ProjectModel
             {
                 var ordered = library.Dependencies.OrderBy(dependency => dependency.Id, StringComparer.Ordinal);
 
-                json[DependenciesProperty] = JsonUtility.WriteObject(ordered, JsonUtility.WritePackageDependency);
+                json[DependenciesProperty] = JsonUtility.WriteObject(ordered, JsonUtility.WritePackageDependencyWithLegacyString);
             }
 
             if (library.FrameworkAssemblies.Count > 0)

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileFormat.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileFormat.cs
@@ -239,7 +239,8 @@ namespace NuGet.ProjectModel
             {
                 var ordered = dependency.Dependencies.OrderBy(dep => dep.Id, StringComparer.Ordinal);
 
-                json[DependenciesProperty] = JsonUtility.WriteObject(ordered, JsonUtility.WritePackageDependency);
+                json[DependenciesProperty] = JsonUtility.WriteObject(ordered, dependency.Type == PackageDependencyType.Project ?
+                    JsonUtility.WritePackageDependency : JsonUtility.WritePackageDependencyWithLegacyString);
             }
 
             return new JProperty(dependency.Id, json);

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileUtilities.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileUtilities.cs
@@ -471,7 +471,7 @@ namespace NuGet.ProjectModel
             {
                 var matchedP2PLibrary = projectDependency.Dependencies.FirstOrDefault(dep => StringComparer.OrdinalIgnoreCase.Equals(dep.Id, dependency.Name));
 
-                if (matchedP2PLibrary == null || !EqualityUtility.EqualsWithNullCheck(matchedP2PLibrary.VersionRange.MinVersion.Version, dependency.LibraryRange.VersionRange.MinVersion.Version))
+                if (matchedP2PLibrary == null || !EqualityUtility.EqualsWithNullCheck(matchedP2PLibrary.VersionRange, dependency.LibraryRange.VersionRange))
                 {
                     // P2P dependency has changed and lock file is out of sync.
                     return (true,

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileUtilities.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileUtilities.cs
@@ -471,7 +471,7 @@ namespace NuGet.ProjectModel
             {
                 var matchedP2PLibrary = projectDependency.Dependencies.FirstOrDefault(dep => StringComparer.OrdinalIgnoreCase.Equals(dep.Id, dependency.Name));
 
-                if (matchedP2PLibrary == null || !EqualityUtility.EqualsWithNullCheck(matchedP2PLibrary.VersionRange, dependency.LibraryRange.VersionRange))
+                if (matchedP2PLibrary == null || !EqualityUtility.EqualsWithNullCheck(matchedP2PLibrary.VersionRange.MinVersion.Version, dependency.LibraryRange.VersionRange.MinVersion.Version))
                 {
                     // P2P dependency has changed and lock file is out of sync.
                     return (true,

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_PackagesLockFileTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_PackagesLockFileTests.cs
@@ -677,7 +677,7 @@ namespace NuGet.Commands.FuncTest
                 // Add the dependency
                 var dependency = new LibraryDependency
                 {
-                    LibraryRange = new LibraryRange(packageA.Id, VersionRange.Parse("*"), LibraryDependencyTarget.Package)
+                    LibraryRange = new LibraryRange(packageA.Id, VersionRange.Parse("1.0.*"), LibraryDependencyTarget.Package)
                 };
 
                 childProject.TargetFrameworks.FirstOrDefault().Dependencies.Add(dependency);

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_PackagesLockFileTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_PackagesLockFileTests.cs
@@ -715,7 +715,7 @@ namespace NuGet.Commands.FuncTest
                 // Act
                 // Enable locked mode
                 parentProject.RestoreMetadata.RestoreLockProperties = new RestoreLockProperties(
-                   restorePackagesWithLockFile: "false",
+                   restorePackagesWithLockFile: "true",
                    parentProject.RestoreMetadata.RestoreLockProperties.NuGetLockFilePath,
                    restoreLockedMode: true);
 

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_PackagesLockFileTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_PackagesLockFileTests.cs
@@ -682,6 +682,12 @@ namespace NuGet.Commands.FuncTest
 
                 childProject.TargetFrameworks.FirstOrDefault().Dependencies.Add(dependency);
 
+                // Enable lock file
+                childProject.RestoreMetadata.RestoreLockProperties = new RestoreLockProperties(
+                   restorePackagesWithLockFile: "true",
+                   childProject.RestoreMetadata.RestoreLockProperties.NuGetLockFilePath,
+                   restoreLockedMode: false);
+
                 var result = await new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(childProject, pathContext, logger)).ExecuteAsync();
                 await result.CommitAsync(logger, CancellationToken.None);
                 result.Success.Should().BeTrue();
@@ -696,18 +702,23 @@ namespace NuGet.Commands.FuncTest
 
                 PackageSpecOperationsUtility.AddProjectReference(parentProject, childProject, targetFramework);
 
+                // Enable lock file
+                parentProject.RestoreMetadata.RestoreLockProperties = new RestoreLockProperties(
+                   restorePackagesWithLockFile: "true",
+                   parentProject.RestoreMetadata.RestoreLockProperties.NuGetLockFilePath,
+                   restoreLockedMode: false);
+
                 result = await new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(parentProject, allPackageSpecs, pathContext, logger)).ExecuteAsync();
                 await result.CommitAsync(logger, CancellationToken.None);
                 result.Success.Should().BeTrue();
 
+                // Act
                 // Enable locked mode
                 parentProject.RestoreMetadata.RestoreLockProperties = new RestoreLockProperties(
-                    restorePackagesWithLockFile: "true",
-                    parentProject.RestoreMetadata.RestoreLockProperties.NuGetLockFilePath,
-                    restoreLockedMode: true);
-                logger.Clear();
+                   restorePackagesWithLockFile: "false",
+                   parentProject.RestoreMetadata.RestoreLockProperties.NuGetLockFilePath,
+                   restoreLockedMode: true);
 
-                // Act.
                 result = await new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(parentProject, allPackageSpecs, pathContext, logger)).ExecuteAsync();
                 await result.CommitAsync(logger, CancellationToken.None);
 

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/LockFileFormatTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/LockFileFormatTests.cs
@@ -9,6 +9,7 @@ using Newtonsoft.Json.Linq;
 using NuGet.Common;
 using NuGet.Frameworks;
 using NuGet.LibraryModel;
+using NuGet.Packaging.Core;
 using NuGet.Versioning;
 using Xunit;
 using static NuGet.Test.Utility.TestPackagesCore;
@@ -239,6 +240,34 @@ namespace NuGet.ProjectModel.Test
             var netPlatDepGroup = lockFile.ProjectFileDependencyGroups.Last();
             Assert.Equal(NuGetFramework.Parse("dotnet").DotNetFrameworkName, netPlatDepGroup.FrameworkName);
             Assert.Empty(netPlatDepGroup.Dependencies);
+        }
+
+        [Theory]
+        [InlineData("1.0.0", "1.0.0")]
+        [InlineData("1.0.0-beta", "1.0.0-beta")]
+        [InlineData("1.0.0-*", "1.0.0")]
+        [InlineData("1.0.*", "1.0.0")]
+        [InlineData("(1.0.*, )", "(1.0.0, )")]
+        public void Test_WritePackageDependencyWithLegacyString(string version, string expectedVersion)
+        {
+            var package = new PackageDependency("a", VersionRange.Parse(version));
+            var dependency = JsonUtility.WritePackageDependencyWithLegacyString(package);
+
+            Assert.Equal(dependency.Value, expectedVersion);
+        }
+
+        [Theory]
+        [InlineData("1.0.0", "[1.0.0, )")]
+        [InlineData("1.0.0-beta", "[1.0.0-beta, )")]
+        [InlineData("1.0.0-*", "[1.0.0-*, )")]
+        [InlineData("1.0.*", "[1.0.*, )")]
+        [InlineData("(1.0.*, )", "(1.0.*, )")]
+        public void Test_WritePackageDependency(string version, string expectedVersion)
+        {
+            var package = new PackageDependency("a", VersionRange.Parse(version));
+            var dependency = JsonUtility.WritePackageDependency(package);
+
+            Assert.Equal(dependency.Value, expectedVersion);
         }
 
         [Fact]


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/8465

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
When restoring a project that has a ProjectReference in LockedMode and the package is a floating version will throw a NU1004. This is because when doing the restore we write in the lock file the minimum version of the range instead of the actual range. I changed how the comparison was made in order to always use the minimum version.

![image](https://user-images.githubusercontent.com/43253759/152731697-3dd72030-bd4d-44b1-bb14-510b24e27518.png)
![image](https://user-images.githubusercontent.com/43253759/152731719-32c08c8e-43fd-403b-8238-aa169db7d2f7.png)

## PR Checklist

- [ ] PR has a meaningful title
- [ ] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
