### PR TITLE
Fix performance bottleneck

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Logging/TransitiveNoWarnUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Logging/TransitiveNoWarnUtils.cs
@@ -799,17 +799,15 @@ namespace NuGet.Commands
                 }
                 else if (thisPackages != null && otherPackages != null)
                 {
-                    packages = new Dictionary<string, HashSet<NuGetLogCode>>(StringComparer.OrdinalIgnoreCase);
+                    var sizeUpperBound = Math.Max(thisPackages.Count, otherPackages.Count);
+                    packages = new Dictionary<string, HashSet<NuGetLogCode>>(sizeUpperBound, StringComparer.OrdinalIgnoreCase);
 
-                    var allKeys = thisPackages.Keys.Concat(otherPackages.Keys)
-                        .Distinct(StringComparer.OrdinalIgnoreCase);
-
-                    foreach (var key in allKeys)
+                    foreach (var kv in thisPackages)
                     {
-                        thisPackages.TryGetValue(key, out var thisCodes);
-                        otherPackages.TryGetValue(key, out var otherCodes);
-
-                        packages.Add(key, Intersect(thisCodes, otherCodes));
+                        if (otherPackages.TryGetValue(kv.Key, out var otherCodes))
+                        {
+                            packages.Add(kv.Key, Intersect(kv.Value, otherCodes));
+                        }
                     }
                 }
 


### PR DESCRIPTION


<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes:

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Saw my nuget restores are quite slow on a mid-sized-project with the CPU pegged close to 100% on Windows.
Looking at a trace it seems like it is spending a lot of time intersecting properties from dependencies
![image](https://user-images.githubusercontent.com/5894853/153004265-4914eb70-f1e3-4ff1-9b6d-438b1d6500b2.png)
In particular a Linq execution seems to be taking a long time.

This small pr improves the intersection hopefully bringing speedups :)
All the tests seem to be passing.

## PR Checklist

- [ ] PR has a meaningful title
- [ ] PR has a linked issue.
- [ ] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [ ] N/A
