### PR TITLE
Avoid using async void in favor of async Task

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailControlModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailControlModel.cs
@@ -216,7 +216,8 @@ namespace NuGet.PackageManagement.UI
             };
 
             await CreateVersionsAsync(CancellationToken.None);
-            OnCurrentPackageChanged();
+            NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(OnCurrentPackageChanged)
+                .PostOnFailure(nameof(DetailControlModel), nameof(OnCurrentPackageChanged));
 
             var versions = await getVersionsTask;
 
@@ -234,7 +235,8 @@ namespace NuGet.PackageManagement.UI
                 .ToList();
 
             await CreateVersionsAsync(CancellationToken.None);
-            OnCurrentPackageChanged();
+            NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(OnCurrentPackageChanged)
+                .PostOnFailure(nameof(DetailControlModel), nameof(OnCurrentPackageChanged));
 
             (PackageSearchMetadataContextInfo packageSearchMetadata, PackageDeprecationMetadataContextInfo packageDeprecationMetadata) =
                 await searchResultPackage.GetDetailedPackageSearchMetadataAsync();
@@ -275,8 +277,9 @@ namespace NuGet.PackageManagement.UI
                 .PostOnFailure(nameof(DetailControlModel), nameof(DependencyBehavior_SelectedChanged));
         }
 
-        protected virtual void OnCurrentPackageChanged()
+        protected virtual Task OnCurrentPackageChanged()
         {
+            return Task.CompletedTask;
         }
 
         public virtual void OnFilterChanged(ItemFilter? previousFilter, ItemFilter currentFilter)

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageSolutionDetailControlModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageSolutionDetailControlModel.cs
@@ -474,7 +474,6 @@ namespace NuGet.PackageManagement.UI
             await BatchUpdateIsSelectedAsync(select);
         }
 
-        [SuppressMessage("Microsoft.VisualStudio.Threading.Analyzers", "VSTHRD100", Justification = "NuGet/Home#4833 Baseline")]
         protected override async Task OnCurrentPackageChanged()
         {
             if (_searchResultPackage == null)

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageSolutionDetailControlModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageSolutionDetailControlModel.cs
@@ -475,7 +475,7 @@ namespace NuGet.PackageManagement.UI
         }
 
         [SuppressMessage("Microsoft.VisualStudio.Threading.Analyzers", "VSTHRD100", Justification = "NuGet/Home#4833 Baseline")]
-        protected override async void OnCurrentPackageChanged()
+        protected override async Task OnCurrentPackageChanged()
         {
             if (_searchResultPackage == null)
             {

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
@@ -29,7 +29,8 @@ namespace NuGet.CommandLine.Test
     public class NuGetRestoreCommandTest
     {
         private const int _failureCode = 1;
-        private const int _successCode = 0;
+        private const int
+            _successCode = 0;
 
         [Fact]
         public void RestoreCommand_BadInputPath()
@@ -195,7 +196,7 @@ namespace NuGet.CommandLine.Test
         }
 
         [Fact]
-        public async void RestoreCommand_MissingNuspecFileInPackage_FailsWithNU5037()
+        public async Task RestoreCommand_MissingNuspecFileInPackage_FailsWithNU5037()
         {
             // Arrange
             var nugetexe = Util.GetNuGetExePath();

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
@@ -29,8 +29,7 @@ namespace NuGet.CommandLine.Test
     public class NuGetRestoreCommandTest
     {
         private const int _failureCode = 1;
-        private const int
-            _successCode = 0;
+        private const int _successCode = 0;
 
         [Fact]
         public void RestoreCommand_BadInputPath()

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
@@ -8939,7 +8939,7 @@ namespace NuGet.CommandLine.Test
 
 
         [Fact]
-        public async void RestoreNetCore_PackagesLockFile_WithReorderedRuntimesInLockFile_PassRestore()
+        public async Task RestoreNetCore_PackagesLockFile_WithReorderedRuntimesInLockFile_PassRestore()
         {
             // A project with RestoreLockedMode should pass restore if the runtimes in the lock file have been reordered
             using (var pathContext = new SimpleTestPathContext())

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/NuGetPackageFileServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/NuGetPackageFileServiceTests.cs
@@ -52,7 +52,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         }
 
         [Fact]
-        public async void AddIconToCache_WhenAdded_IsFound()
+        public async Task AddIconToCache_WhenAdded_IsFound()
         {
             using (TestDirectory testDirectory = TestDirectory.Create())
             {
@@ -75,7 +75,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         }
 
         [Fact]
-        public async void GetPackageIconAsync_EmbeddedFromFallbackFolder_HasOnlyReadAccess()
+        public async Task GetPackageIconAsync_EmbeddedFromFallbackFolder_HasOnlyReadAccess()
         {
             // Arrange
             using (TestDirectory testDirectory = TestDirectory.Create())
@@ -112,7 +112,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         }
 
         [Fact]
-        public async void GetPackageIconAsync_EmbeddedFromFallbackFolder_DoesNotLockFile()
+        public async Task GetPackageIconAsync_EmbeddedFromFallbackFolder_DoesNotLockFile()
         {
             //Arrange
             using (TestDirectory testDirectory = TestDirectory.Create())
@@ -153,7 +153,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         }
 
         [Fact]
-        public async void GetPackageIconAsync_EmbeddedFromFallbackFolder_CanOpenReadOnlyFile()
+        public async Task GetPackageIconAsync_EmbeddedFromFallbackFolder_CanOpenReadOnlyFile()
         {
             // Arrange
             using (TestDirectory testDirectory = TestDirectory.Create())
@@ -193,7 +193,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         }
 
         [Fact]
-        public async void AddIconToCache_WhenAddedTwice_UsesSecond()
+        public async Task AddIconToCache_WhenAddedTwice_UsesSecond()
         {
             using (TestDirectory testDirectory = TestDirectory.Create())
             {
@@ -222,7 +222,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         }
 
         [Fact]
-        public async void AddIconToCache_WhenMissing_IsNotFound()
+        public async Task AddIconToCache_WhenMissing_IsNotFound()
         {
             _telemetryProvider.Setup(t => t.PostFaultAsync(It.IsAny<CacheMissException>(), typeof(NuGetPackageFileService).FullName, nameof(NuGetPackageFileService.GetPackageIconAsync), It.IsAny<IDictionary<string, object>>())).Returns(Task.CompletedTask);
             var packageFileService = new NuGetPackageFileService(
@@ -240,7 +240,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
         [Theory]
         [InlineData("icon.png", "icon.png", "icon.png", "")]
-        public async void AddLicenseToCache_WhenAdded_IsFound(
+        public async Task AddLicenseToCache_WhenAdded_IsFound(
             string iconElement,
             string iconFileLocation,
             string fileSourceElement,
@@ -280,7 +280,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
         [Theory]
         [InlineData("icon.png", "icon.png", "icon.png", "")]
-        public async void AddLicenseToCache_WhenAddedTwice_UsesSecond(
+        public async Task AddLicenseToCache_WhenAddedTwice_UsesSecond(
             string iconElement,
             string iconFileLocation,
             string fileSourceElement,
@@ -320,7 +320,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         }
 
         [Fact]
-        public async void AddLicenseToCache_WhenMissing_IsNotFound()
+        public async Task AddLicenseToCache_WhenMissing_IsNotFound()
         {
             _telemetryProvider.Setup(t => t.PostFaultAsync(It.IsAny<CacheMissException>(), typeof(NuGetPackageFileService).FullName, nameof(NuGetPackageFileService.GetEmbeddedLicenseAsync), It.IsAny<IDictionary<string, object>>())).Returns(Task.CompletedTask);
             var packageFileService = new NuGetPackageFileService(

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/LocalFolderUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/LocalFolderUtilityTests.cs
@@ -1067,7 +1067,7 @@ namespace NuGet.Protocol.Tests
         }
 
         [Fact]
-        public async void LocalFolderUtility_ResolvePackageFromPath_EmptyWhenNotFound()
+        public async Task LocalFolderUtility_ResolvePackageFromPath_EmptyWhenNotFound()
         {
             using (var root = TestDirectory.Create())
             {


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Related to: https://github.com/NuGet/Client.Engineering/issues/853

Regression? No Last working version:

## Description
We suspect that usages of `async void` is causing the xunit console to crash when unloading AppDomains.  Full investigation is available here: https://github.com/NuGet/Client.Engineering/issues/853#issuecomment-1034057186

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A - **Infrastructure**

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
