### PR TITLE
Fix OptProf

### DIFF
--- a/build/OptProfV2.props
+++ b/build/OptProfV2.props
@@ -24,7 +24,7 @@
       <InstallationPath>Common7\IDE\CommonExtensions\Microsoft\NuGet\$(AssemblyName).dll</InstallationPath>
       <InstrumentationArguments>/ExeConfig:"%VisualStudio.InstallationUnderTest.Path%\Common7\IDE\vsn.exe"</InstrumentationArguments>
       <Scenarios>
-        <TestContainer Name="NuGet.Tests">
+        <TestContainer Name="NuGet.OptProf">
           <TestCase Weight="100" FullyQualifiedName="NuGet.OptProfV2Tests.IVsPackageSourceProvider_GetSources" />
           <TestCase Weight="100" FullyQualifiedName="NuGet.OptProfV2Tests.OpenSolutionAndBuild_PackageReferenceSdk" />
         </TestContainer>
@@ -41,7 +41,7 @@
       <InstallationPath>Common7\IDE\CommonExtensions\Microsoft\NuGet\$(AssemblyName).dll</InstallationPath>
       <InstrumentationArguments>/ExeConfig:"%VisualStudio.InstallationUnderTest.Path%\Common7\IDE\vsn.exe"</InstrumentationArguments>
       <Scenarios>
-        <TestContainer Name="NuGet.Tests">
+        <TestContainer Name="NuGet.OptProf">
           <TestCase Weight="100" FullyQualifiedName="NuGet.OptProfV2Tests.IVsPackageSourceProvider_GetSources" />
         </TestContainer>
       </Scenarios>

--- a/build/runsettings.proj
+++ b/build/runsettings.proj
@@ -9,7 +9,7 @@
             Projects="template.runsettingsproj"
             Properties="RunName=NuGet.OptProfV2;
             FileName=NuGet.OptProf.dll;
-            TestCaseFilter='TestCategory=OptProf';
+            TestCaseFilter=TestCategory=OptProf;
             OptProfCollector=enabled;
             IncludeProfilingInputs=true;
             VsConfigPath=tests.optprof.dev$(VsTargetMajorVersion).vsconfig;" />


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1442

Regression? Yes, since migrating Apex & E2E to Dartlab, changing the runsettingsproj in the process.

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

* Putting quotes around the test categories is what prevented tests from being discovered/running
* I changed the test project name when moving the code here, and I didn't change some of the configuration

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
