### PR TITLE
Update SharpZipLib

### DIFF
--- a/build/packages.targets
+++ b/build/packages.targets
@@ -47,7 +47,7 @@
         <PackageReference Update="Microsoft.VSSDK.BuildTools" Version="17.0.1600" />
         <PackageReference Update="Microsoft.Web.Xdt" Version="$(MicrosoftWebXdtPackageVersion)" />
         <PackageReference Update="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
-        <PackageReference Update="SharpZipLib" Version="1.3.2" />
+        <PackageReference Update="SharpZipLib" Version="1.3.3" />
         <PackageReference Update="System.ComponentModel.Composition" Version="$(SystemComponentModelCompositionPackageVersion)" />
         <!--
           The Microsoft.VisualStudio.SDK metapackage brings in System.Threading.Tasks.Dataflow 4.11.1 (assembly version 4.9.5.0).

--- a/src/NuGet.Clients/NuGet.Indexing/NuGet.Indexing.csproj
+++ b/src/NuGet.Clients/NuGet.Indexing/NuGet.Indexing.csproj
@@ -18,7 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="Lucene.Net" />
-    <PackageReference Include="SharpZipLib" /> <!-- dependency of Lucene.net. Can delete when Lucene.net has an update with a newer dependency on sharpziplib -->
+    <PackageReference Include="SharpZipLib" ExcludeAssets="all" /> <!-- dependency of Lucene.net. Can delete when Lucene.net has an update with a newer dependency on sharpziplib -->
   </ItemGroup>
 
   <Import Project="$(BuildCommonDirectory)common.targets"/>


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1427

Regression? No

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Version 1.3.2 is listed as having a vulnerability: https://www.nuget.org/packages/SharpZipLib/1.3.2

We don't actually use SharpZipLib anywhere, but it's listed as a dependency on Lucene.NET, which is used by NuGet.Indexing. We exclude assets, but we have to upgrade to keep component governance happy.

## PR Checklist

- [X] PR has a meaningful title
- [X] PR has a linked issue.
- [X] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [X] Test exception: no code changes, just upgrading a dependency, which isn't even used.
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [X] N/A
