### PR TITLE
Add basic source information in the project restore information event. 

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/RestoreTelemetryEvent.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/RestoreTelemetryEvent.cs
@@ -27,6 +27,10 @@ namespace NuGet.VisualStudio
         public const string ProjectRestoreInfoSourcesCount = nameof(ProjectRestoreInfoSourcesCount);
         public const string TimeSinceLastRestoreCompleted = nameof(TimeSinceLastRestoreCompleted);
         public const string LastRestoreOperationSource = nameof(LastRestoreOperationSource);
+        public const string NumHTTPFeeds = nameof(NumHTTPFeeds);
+        public const string NumLocalFeeds = nameof(NumLocalFeeds);
+        public const string NuGetOrg = nameof(NuGetOrg);
+        public const string VsOfflinePackages = nameof(VsOfflinePackages);
 
         public RestoreTelemetryEvent(
             string operationId,
@@ -49,7 +53,12 @@ namespace NuGet.VisualStudio
             double duration,
             IDictionary<string, object> additionalTrackingData,
             IntervalTracker intervalTimingTracker,
-            bool isPackageSourceMappingEnabled) : base(RestoreActionEventName, operationId, projectIds, startTime, status, packageCount, endTime, duration)
+            bool isPackageSourceMappingEnabled,
+            int httpFeedsCount,
+            int localFeedsCount,
+            bool hasNuGetOrg,
+            bool hasVSOfflineFeed
+            ) : base(RestoreActionEventName, operationId, projectIds, startTime, status, packageCount, endTime, duration)
         {
             base[nameof(OperationSource)] = source;
             base[nameof(NoOpProjectsCount)] = noOpProjectsCount;
@@ -63,6 +72,10 @@ namespace NuGet.VisualStudio
             base[nameof(PackagesConfigProjectsCount)] = packagesConfigProjectsCount;
             base[nameof(ForceRestore)] = forceRestore;
             base[PackageSourceMappingIsMappingEnabled] = isPackageSourceMappingEnabled;
+            base[NumHTTPFeeds] = httpFeedsCount;
+            base[NumLocalFeeds] = localFeedsCount;
+            base[NuGetOrg] = hasNuGetOrg;
+            base[VsOfflinePackages] = hasVSOfflineFeed;
 
             foreach (KeyValuePair<string, object> data in additionalTrackingData)
             {

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -49,8 +49,9 @@ namespace NuGet.Commands
         private const string IsCentralVersionManagementEnabled = nameof(IsCentralVersionManagementEnabled);
         private const string TotalUniquePackagesCount = nameof(TotalUniquePackagesCount);
         private const string NewPackagesInstalledCount = nameof(NewPackagesInstalledCount);
-        private const string RemoteProvidersCount = nameof(RemoteProvidersCount);
-        private const string LocalProvidersCount = nameof(LocalProvidersCount);
+        private const string SourcesCount = nameof(SourcesCount);
+        private const string HttpSourcesCount = nameof(HttpSourcesCount);
+        private const string LocalSourcesCount = nameof(LocalSourcesCount);
         private const string FallbackFoldersCount = nameof(FallbackFoldersCount);
 
         // no-op data names
@@ -122,10 +123,11 @@ namespace NuGet.Commands
 
                 bool isPackageSourceMappingEnabled = _request?.PackageSourceMapping.IsEnabled ?? false;
                 telemetry.TelemetryEvent[PackageSourceMappingIsMappingEnabled] = isPackageSourceMappingEnabled;
-                telemetry.TelemetryEvent[RemoteProvidersCount] = _request.DependencyProviders.RemoteProviders.Count;
-                telemetry.TelemetryEvent[LocalProvidersCount] = _request.DependencyProviders.LocalProviders.Count;
+                telemetry.TelemetryEvent[SourcesCount] = _request.DependencyProviders.RemoteProviders.Count;
+                var httpSourcesCount = _request.DependencyProviders.RemoteProviders.Where(e => e.IsHttp).Count();
+                telemetry.TelemetryEvent[HttpSourcesCount] = httpSourcesCount;
+                telemetry.TelemetryEvent[LocalSourcesCount] = _request.DependencyProviders.RemoteProviders.Count - httpSourcesCount;
                 telemetry.TelemetryEvent[FallbackFoldersCount] = _request.DependencyProviders.FallbackPackageFolders.Count;
-
 
                 _operationId = telemetry.OperationId;
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -49,6 +49,9 @@ namespace NuGet.Commands
         private const string IsCentralVersionManagementEnabled = nameof(IsCentralVersionManagementEnabled);
         private const string TotalUniquePackagesCount = nameof(TotalUniquePackagesCount);
         private const string NewPackagesInstalledCount = nameof(NewPackagesInstalledCount);
+        private const string RemoteProvidersCount = nameof(RemoteProvidersCount);
+        private const string LocalProvidersCount = nameof(LocalProvidersCount);
+        private const string FallbackFoldersCount = nameof(FallbackFoldersCount);
 
         // no-op data names
         private const string NoOpDuration = nameof(NoOpDuration);
@@ -119,6 +122,10 @@ namespace NuGet.Commands
 
                 bool isPackageSourceMappingEnabled = _request?.PackageSourceMapping.IsEnabled ?? false;
                 telemetry.TelemetryEvent[PackageSourceMappingIsMappingEnabled] = isPackageSourceMappingEnabled;
+                telemetry.TelemetryEvent[RemoteProvidersCount] = _request.DependencyProviders.RemoteProviders.Count;
+                telemetry.TelemetryEvent[LocalProvidersCount] = _request.DependencyProviders.LocalProviders.Count;
+                telemetry.TelemetryEvent[FallbackFoldersCount] = _request.DependencyProviders.FallbackPackageFolders.Count;
+
 
                 _operationId = telemetry.OperationId;
 
@@ -155,7 +162,6 @@ namespace NuGet.Commands
                         (cacheFile, noOp) = EvaluateCacheFile();
                         telemetry.TelemetryEvent[NoOpCacheFileEvaluationResult] = noOp;
                         telemetry.EndIntervalMeasure(NoOpCacheFileEvaluateDuration);
-
                         if (noOp)
                         {
                             telemetry.StartIntervalMeasure();

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Telemetry/RestoreTelemetryServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Telemetry/RestoreTelemetryServiceTests.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using Moq;
 using NuGet.Common;
-using NuGet.Configuration;
 using NuGet.VisualStudio;
 using Test.Utility;
 using Xunit;
@@ -69,7 +68,11 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                     { nameof(RestoreTelemetryEvent.IsSolutionLoadRestore), true }
                 },
                 new IntervalTracker("Activity"),
-                isPackageSourceMappingEnabled: false);
+                isPackageSourceMappingEnabled: false,
+                httpFeedsCount: 1,
+                localFeedsCount: 2,
+                hasNuGetOrg: true,
+                hasVSOfflineFeed: false);
             var service = new NuGetVSTelemetryService(telemetrySession.Object);
 
             // Act
@@ -131,7 +134,11 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                     { nameof(RestoreTelemetryEvent.IsSolutionLoadRestore), true }
                 },
                 tracker,
-                isPackageSourceMappingEnabled: isPackageSourceMappingEnabled);
+                isPackageSourceMappingEnabled: isPackageSourceMappingEnabled,
+                httpFeedsCount: 1,
+                localFeedsCount: 2,
+                hasNuGetOrg: true,
+                hasVSOfflineFeed: false);
             var service = new NuGetVSTelemetryService(telemetrySession.Object);
 
             // Act
@@ -141,7 +148,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
             Assert.NotNull(lastTelemetryEvent);
             Assert.Equal(RestoreTelemetryEvent.RestoreActionEventName, lastTelemetryEvent.Name);
-            Assert.Equal(23, lastTelemetryEvent.Count);
+            Assert.Equal(27, lastTelemetryEvent.Count);
 
             Assert.Equal(restoreTelemetryData.OperationSource.ToString(), lastTelemetryEvent["OperationSource"].ToString());
 
@@ -154,7 +161,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         {
             Assert.NotNull(actual);
             Assert.Equal(RestoreTelemetryEvent.RestoreActionEventName, actual.Name);
-            Assert.Equal(21, actual.Count);
+            Assert.Equal(25, actual.Count);
 
             Assert.Equal(expected.OperationSource.ToString(), actual["OperationSource"].ToString());
 
@@ -169,6 +176,14 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             Assert.Equal(expected.UnknownProjectsCount, (int)actual["UnknownProjectsCount"]);
             Assert.Equal(expected.LegacyPackageReferenceProjectsCount, (int)actual["LegacyPackageReferenceProjectsCount"]);
             Assert.Equal(expected.CpsPackageReferenceProjectsCount, (int)actual["CpsPackageReferenceProjectsCount"]);
+            Assert.Equal(expected[RestoreTelemetryEvent.NumHTTPFeeds], (int)actual["NumHTTPFeeds"]);
+            Assert.Equal(expected[RestoreTelemetryEvent.NumLocalFeeds], (int)actual["NumLocalFeeds"]);
+            Assert.Equal(expected[RestoreTelemetryEvent.NuGetOrg], (bool)actual["NuGetOrg"]);
+            Assert.Equal(expected[RestoreTelemetryEvent.VsOfflinePackages], (bool)actual["VsOfflinePackages"]);
+            Assert.Equal(1, (int)actual["NumHTTPFeeds"]);
+            Assert.Equal(2, (int)actual["NumLocalFeeds"]);
+            Assert.Equal(true, (bool)actual["NuGetOrg"]);
+            Assert.Equal(false, (bool)actual["VsOfflinePackages"]);
             AssertProjectsCount(expected);
 
             TestTelemetryUtility.VerifyTelemetryEventData(operationId, expected, actual);

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
@@ -12,7 +12,6 @@ using FluentAssertions;
 using Moq;
 using NuGet.Common;
 using NuGet.Configuration;
-using NuGet.Configuration.Test;
 using NuGet.DependencyResolver;
 using NuGet.Frameworks;
 using NuGet.LibraryModel;
@@ -2104,7 +2103,7 @@ namespace NuGet.Commands.Test
 
             var projectInformationEvent = telemetryEvents.Single(e => e.Name.Equals("ProjectRestoreInformation"));
 
-            projectInformationEvent.Count.Should().Be(24);
+            projectInformationEvent.Count.Should().Be(28);
             projectInformationEvent["RestoreSuccess"].Should().Be(true);
             projectInformationEvent["NoOpResult"].Should().Be(false);
             projectInformationEvent["IsCentralVersionManagementEnabled"].Should().Be(false);
@@ -2129,6 +2128,10 @@ namespace NuGet.Commands.Test
             projectInformationEvent["OperationId"].Should().NotBeNull();
             projectInformationEvent["Duration"].Should().NotBeNull();
             projectInformationEvent["PackageSourceMapping.IsMappingEnabled"].Should().Be(false);
+            projectInformationEvent["SourcesCount"].Should().Be(1);
+            projectInformationEvent["HttpSourcesCount"].Should().Be(0);
+            projectInformationEvent["LocalSourcesCount"].Should().Be(1);
+            projectInformationEvent["FallbackFoldersCount"].Should().Be(0);
         }
 
         [Fact]
@@ -2184,7 +2187,7 @@ namespace NuGet.Commands.Test
 
             var projectInformationEvent = telemetryEvents.Single(e => e.Name.Equals("ProjectRestoreInformation"));
 
-            projectInformationEvent.Count.Should().Be(16);
+            projectInformationEvent.Count.Should().Be(20);
             projectInformationEvent["RestoreSuccess"].Should().Be(true);
             projectInformationEvent["NoOpResult"].Should().Be(true);
             projectInformationEvent["IsCentralVersionManagementEnabled"].Should().Be(false);
@@ -2201,9 +2204,13 @@ namespace NuGet.Commands.Test
             projectInformationEvent["NoOpRestoreOutputEvaluationDuration"].Should().NotBeNull();
             projectInformationEvent["NoOpReplayLogsDuration"].Should().NotBeNull();
             projectInformationEvent["PackageSourceMapping.IsMappingEnabled"].Should().Be(false);
-        }
+            projectInformationEvent["SourcesCount"].Should().Be(1);
+            projectInformationEvent["HttpSourcesCount"].Should().Be(0);
+            projectInformationEvent["LocalSourcesCount"].Should().Be(1);
+            projectInformationEvent["FallbackFoldersCount"].Should().Be(0);
+    }
 
-        [Fact]
+    [Fact]
         public async Task ExecuteAsync_WithPartiallyPopulatedGlobalPackagesFolder_PopulatesNewlyInstalledPackagesTelemetry()
         {
             // Arrange
@@ -2258,7 +2265,7 @@ namespace NuGet.Commands.Test
 
             var projectInformationEvent = telemetryEvents.Single(e => e.Name.Equals("ProjectRestoreInformation"));
 
-            projectInformationEvent.Count.Should().Be(24);
+            projectInformationEvent.Count.Should().Be(28);
             projectInformationEvent["RestoreSuccess"].Should().Be(true);
             projectInformationEvent["NoOpResult"].Should().Be(false);
             projectInformationEvent["TotalUniquePackagesCount"].Should().Be(2);


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/nuget/client.engineering/issues/1259

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

This PR adds basic source information in the project restore information and restore information events to allow us to reason better about the source mapping eligibility of projects and repos. 

Note that while this does duplicate the data from events such as source summary, it is a minimal amount of data, and it significantly makes the querying easier, and the dashboards workable. 

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
