### PR TITLE
Plugins: Fix Log File Race

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Logging/PluginLogger.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Logging/PluginLogger.cs
@@ -104,7 +104,7 @@ namespace NuGet.Protocol.Plugins
                     processId = process.Id;
                 }
 
-                var fileName = $"NuGet_PluginLogFor_{Path.GetFileNameWithoutExtension(file.Name)}_{DateTime.UtcNow.Ticks:x}.log";
+                var fileName = $"NuGet_PluginLogFor_{Path.GetFileNameWithoutExtension(file.Name)}_{DateTime.UtcNow.Ticks:x}_{Process.GetCurrentProcess().Id}.log";
                 var filePath = Path.Combine(_logDirectoryPath, fileName);
                 var stream = File.Open(filePath, FileMode.Create, FileAccess.Write, FileShare.Read);
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11517

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Add process ID as part of plugin log file name. Avoids race condition
when two MSBuild instances are running simultaneously.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception - not easily testable at this point
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
