### PR TITLE
Unskip Fsharp tests skipped due to Patch Tuesday events

### DIFF
--- a/test/EndToEnd/ProjectTemplates/FSharpConsoleApplication.zip/ConsoleApplication.fsproj
+++ b/test/EndToEnd/ProjectTemplates/FSharpConsoleApplication.zip/ConsoleApplication.fsproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
     <WarnOn>3390;$(WarnOn)</WarnOn>
+    <_NetCoreSdkIsPreview>true</_NetCoreSdkIsPreview>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/EndToEnd/ProjectTemplates/FSharpLibrary.zip/Library.fsproj
+++ b/test/EndToEnd/ProjectTemplates/FSharpLibrary.zip/Library.fsproj
@@ -4,6 +4,7 @@
     <TargetFramework>net5.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <WarnOn>3390;$(WarnOn)</WarnOn>
+    <_NetCoreSdkIsPreview>true</_NetCoreSdkIsPreview>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/EndToEnd/tests/GetPackageTest.ps1
+++ b/test/EndToEnd/tests/GetPackageTest.ps1
@@ -181,8 +181,6 @@ function Test-GetPackageForProjectReturnsCorrectPackages2 {
 }
 
 function Test-GetPackageForFSharpProjectReturnsCorrectPackages {
-    [SkipTest('https://github.com/NuGet/Home/issues/11291')]
-    param()
     # Arrange
     $p = New-FSharpConsoleApplication
     Build-Solution # wait for project nomination

--- a/test/EndToEnd/tests/GetPackageTest.ps1
+++ b/test/EndToEnd/tests/GetPackageTest.ps1
@@ -181,6 +181,7 @@ function Test-GetPackageForProjectReturnsCorrectPackages2 {
 }
 
 function Test-GetPackageForFSharpProjectReturnsCorrectPackages {
+    param()     
     # Arrange
     $p = New-FSharpConsoleApplication
     Build-Solution # wait for project nomination

--- a/test/EndToEnd/tests/InstallPackageTest.ps1
+++ b/test/EndToEnd/tests/InstallPackageTest.ps1
@@ -458,6 +458,7 @@ function Test-AddBindingRedirectToWebsiteWithNonExistingOutputPath {
 }
 
 function Test-InstallCanPipeToFSharpProjects {
+    param($context)    
     # Arrange
     $p = New-FSharpLibrary
     Build-Solution # wait for project nomination

--- a/test/EndToEnd/tests/InstallPackageTest.ps1
+++ b/test/EndToEnd/tests/InstallPackageTest.ps1
@@ -458,9 +458,6 @@ function Test-AddBindingRedirectToWebsiteWithNonExistingOutputPath {
 }
 
 function Test-InstallCanPipeToFSharpProjects {
-    [SkipTest('https://github.com/NuGet/Home/issues/11358')]
-    param($context)
-
     # Arrange
     $p = New-FSharpLibrary
     Build-Solution # wait for project nomination

--- a/test/EndToEnd/tests/UninstallPackageTest.ps1
+++ b/test/EndToEnd/tests/UninstallPackageTest.ps1
@@ -120,9 +120,6 @@ function Test-UninstallPackageWithNestedContentFiles {
 }
 
 function Test-SimpleFSharpUninstall {
-    [SkipTest('https://github.com/NuGet/Home/issues/11358')]
-    param($context)
-
     # Arrange
     $p = New-FSharpLibrary
     Build-Solution # wait for project nomination

--- a/test/EndToEnd/tests/UninstallPackageTest.ps1
+++ b/test/EndToEnd/tests/UninstallPackageTest.ps1
@@ -120,6 +120,8 @@ function Test-UninstallPackageWithNestedContentFiles {
 }
 
 function Test-SimpleFSharpUninstall {
+    param($context)
+
     # Arrange
     $p = New-FSharpLibrary
     Build-Solution # wait for project nomination

--- a/test/EndToEnd/tests/UpdatePackageTest.ps1
+++ b/test/EndToEnd/tests/UpdatePackageTest.ps1
@@ -632,7 +632,6 @@ function Test-UpdateAllPackagesInSolution {
 }
 
 function Test-UpdatePackageOnAnFSharpProjectWithMultiplePackages {
-    [SkipTest('https://github.com/NuGet/Home/issues/11358')]
     param(
         $context
     )


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11291
Fixes: https://github.com/NuGet/Home/issues/11358

Regression? Last working version: n/a

## Description
Our CI build disrupted almost monthly due to Patch Tuesday event when Fsharp publishes patched packages, but it's not propagated into our feeds. During discussing with dot.net folks recommended this `_NetCoreSdkIsPreview` flag as solution.
Once this PR merged, we need to wait few months if issue resurfaces again.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
