### PR TITLE
Package Signing Test Server now finds an available Port on the system

### DIFF
--- a/test/TestUtilities/Test.Utility/TestServer/PortReserver.cs
+++ b/test/TestUtilities/Test.Utility/TestServer/PortReserver.cs
@@ -25,14 +25,33 @@ namespace NuGet.Test.Server
         private static ConcurrentDictionary<string, bool> PortLock = new ConcurrentDictionary<string, bool>();
         private readonly int _basePort;
 
-        public PortReserver(int basePort = 50231)
+        /// <summary>
+        /// Initializes an instance of PortReserver.
+        /// </summary>
+        /// <param name="basePort">The base port for all request URL's. Defaults to system chosen available port,
+        /// at or below `65535`.</param>
+        /// <exception cref="ArgumentOutOfRangeException"></exception>
+        public PortReserver(int? basePort = null)
         {
-            if (basePort <= 0)
+            if (basePort is null)
+            {
+                // Port 0 means find an available port on the system.
+                var tcpListener = new TcpListener(IPAddress.Loopback, port: 0);
+                tcpListener.Start();
+                basePort = ((IPEndPoint)tcpListener.LocalEndpoint).Port;
+                tcpListener.Stop();
+            }
+            else if (basePort <= 0)
             {
                 throw new ArgumentOutOfRangeException(nameof(basePort), "The base port must be greater than zero.");
             }
 
-            _basePort = basePort;
+            if (!basePort.HasValue)
+            {
+                throw new InvalidOperationException("Unable to find a port");
+            }
+
+            _basePort = basePort.Value;
         }
 
         public async Task<T> ExecuteAsync<T>(


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1448

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

The change made to MockServer in https://github.com/NuGet/NuGet.Client/pull/4364 is being applied here to our Package Signing test server as well. Basically, ask the system for an available port, rather than using an arbitrary port.

### Example of the test failing
Test name: `Timestamp_Verify_WithOfflineRevocation_ReturnsCorrectFlagsAndLogsAsync`
Error: **System.Net.HttpListenerException : The process cannot access the file because it is being used by another process**
CI run: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=5761049&view=ms.vss-test-web.build-test-results-tab&runId=33497164&resultId=100239&paneView=debug

Trial run with this fix succeeded: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=5764276&view=results

I'm not 100% sure that this solved the flakiness, but since it's nearly identical to the `MockServer` issue, I think the code change is warranted either way.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception - I tested manually by triggering the creation of the server, stepping through the new logic. I did this by calling: `ISigningTestServer testServer = await _testFixture.GetSigningTestServerAsync();`
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
