### PR TITLE
Run LocalPackageSearchResource search in Long running thread

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/LocalRepositories/LocalPackageSearchResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LocalRepositories/LocalPackageSearchResource.cs
@@ -35,7 +35,7 @@ namespace NuGet.Protocol
             ILogger log,
             CancellationToken token)
         {
-            return await Task.Run(() =>
+            return await Task.Factory.StartNew(() =>
             {
                 // Check if source is available.
                 if (!IsLocalOrUNC(_localResource.Root))
@@ -72,7 +72,7 @@ namespace NuGet.Protocol
                 return packages
                     .Select(package => CreatePackageSearchResult(package, filters, log, token))
                     .ToArray();
-            });
+            }, token, TaskCreationOptions.LongRunning, TaskScheduler.Default);
         }
 
         /// <summary>

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/LocalResourceTests/LocalPackageSearchResourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/LocalResourceTests/LocalPackageSearchResourceTests.cs
@@ -8,7 +8,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Xml.Linq;
-using Moq;
 using NuGet.Common;
 using NuGet.Protocol.Core.Types;
 using NuGet.Test.Utility;
@@ -599,43 +598,6 @@ namespace NuGet.Protocol.Tests
                 await Assert.ThrowsAsync<TaskCanceledException>(
                     async () => await resource.SearchAsync("", null, 0, 1, NullLogger.Instance, new CancellationToken(canceled: true)));
             }
-        }
-
-        [Fact]
-        public async Task LocalPackageSearch_SearchAsync_SlowLocalRepository_WithCancellationToken_ThrowsAsync()
-        {
-            using var pathContext = new SimpleTestPathContext();
-
-            // Arrange
-            using CancellationTokenSource cts = new();
-            var localRepository = new Mock<FindLocalPackagesResourceV2>(pathContext.PackageSource);
-            localRepository.Setup(f => f.GetPackages(It.IsAny<ILogger>(), It.IsAny<CancellationToken>()))
-                   .Callback((ILogger _, CancellationToken cancellationToken) =>
-                   {
-                       Thread.Sleep(5000);
-                       cancellationToken.ThrowIfCancellationRequested();
-                   }
-                   ).Returns(Enumerable.Empty<LocalPackageInfo>);
-            LocalPackageSearchResource resource = new LocalPackageSearchResource(localRepository.Object);
-
-            // Act
-            Task delayTask = Task.Delay(TimeSpan.FromMilliseconds(500), cts.Token);
-            Task searchTask = resource.SearchAsync(searchTerm: "", filters: null, skip: 0, take: 1, log: NullLogger.Instance, token: cts.Token);
-
-            // Assert
-            // To simulate real world scenario I added delayed cancellation logic.
-            // We're expecting delay Task finish before search Task since 5000 > 500.
-            Task completed = await Task.WhenAny(searchTask, delayTask);
-            if (completed != delayTask)
-            {
-                // Search task completed before shorter delay Task which is unexpected.
-                throw new TimeoutException();
-            }
-            // Trigger cancellation after 500 milsec.
-            cts.Cancel();
-            // During execution of long search task cancellation is triggered from calling logic.
-            await Assert.ThrowsAsync<OperationCanceledException>(
-                async () => await searchTask);
         }
 
         [Theory]


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11570

Regression? Last working version:

## Description
In general Task.Run borrow thread from pre-populated Thread.Pool and it's intended for very fast operation then return. But some local V2 could be very slow due to its being UNC path over network or very large/deep layered folders. So instead of running on thread from Thread.Pool we can run it using dedicated long running thread.
I'll create another follow up PR for passing cancellation token to thread then check frequently and iterate directories one by one instead of trying to get all once.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
