### PR TITLE
Generate SBOM in builds

### DIFF
--- a/eng/common/README.md
+++ b/eng/common/README.md
@@ -1,3 +1,28 @@
-NuGet does not use Arcade, but this is the folder that Arcade normally maintains. See: https://github.com/dotnet/arcade/blob/main/eng/common/README.md
+# Don't touch this folder
 
-This is us dipping our toe into Arcade, and reusing small bits and pieces without going all-in.
+                uuuuuuuuuuuuuuuuuuuu
+              u" uuuuuuuuuuuuuuuuuu "u
+            u" u$$$$$$$$$$$$$$$$$$$$u "u
+          u" u$$$$$$$$$$$$$$$$$$$$$$$$u "u
+        u" u$$$$$$$$$$$$$$$$$$$$$$$$$$$$u "u
+      u" u$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$u "u
+    u" u$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$u "u
+    $ $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$ $
+    $ $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$ $
+    $ $$$" ... "$...  ...$" ... "$$$  ... "$$$ $
+    $ $$$u `"$$$$$$$  $$$  $$$$$  $$  $$$  $$$ $
+    $ $$$$$$uu "$$$$  $$$  $$$$$  $$  """ u$$$ $
+    $ $$$""$$$  $$$$  $$$u "$$$" u$$  $$$$$$$$ $
+    $ $$$$....,$$$$$..$$$$$....,$$$$..$$$$$$$$ $
+    $ $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$ $
+    "u "$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$" u"
+      "u "$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$" u"
+        "u "$$$$$$$$$$$$$$$$$$$$$$$$$$$$" u"
+          "u "$$$$$$$$$$$$$$$$$$$$$$$$" u"
+            "u "$$$$$$$$$$$$$$$$$$$$" u"
+              "u """""""""""""""""" u"
+                """"""""""""""""""""
+
+!!! Changes made in this directory are subject to being overwritten by automation !!!
+
+The files in this directory are shared by all Arcade repos and managed by automation. If you need to make changes to these files, open an issue or submit a pull request to https://github.com/dotnet/arcade first.

--- a/eng/common/README.md
+++ b/eng/common/README.md
@@ -1,0 +1,3 @@
+NuGet does not use Arcade, but this is the folder that Arcade normally maintains. See: https://github.com/dotnet/arcade/blob/main/eng/common/README.md
+
+This is us dipping our toe into Arcade, and reusing small bits and pieces without going all-in.

--- a/eng/common/generate-sbom-prep.ps1
+++ b/eng/common/generate-sbom-prep.ps1
@@ -1,0 +1,19 @@
+Param(
+    [Parameter(Mandatory=$true)][string] $ManifestDirPath    # Manifest directory where sbom will be placed
+)
+
+Write-Host "Creating dir $ManifestDirPath"
+# create directory for sbom manifest to be placed
+if (!(Test-Path -path $ManifestDirPath))
+{
+  New-Item -ItemType Directory -path $ManifestDirPath
+  Write-Host "Successfully created directory $ManifestDirPath"
+}
+else{
+  Write-PipelineTelemetryError -category 'Build'  "Unable to create sbom folder."
+}
+
+Write-Host "Updating artifact name"
+$artifact_name = "${env:SYSTEM_STAGENAME}_${env:AGENT_JOBNAME}_SBOM" -replace '["/:<>\\|?@*"() ]', '_'
+Write-Host "Artifact name $artifact_name"
+Write-Host "##vso[task.setvariable variable=ARTIFACT_NAME]$artifact_name"

--- a/eng/common/generate-sbom-prep.sh
+++ b/eng/common/generate-sbom-prep.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+source="${BASH_SOURCE[0]}"
+
+manifest_dir=$1
+
+if [ ! -d "$manifest_dir" ] ; then
+  mkdir -p "$manifest_dir"
+  echo "Sbom directory created." $manifest_dir
+else
+  Write-PipelineTelemetryError -category 'Build'  "Unable to create sbom folder."
+fi
+
+artifact_name=$SYSTEM_STAGENAME"_"$AGENT_JOBNAME"_SBOM"
+echo "Artifact name before : "$artifact_name
+# replace all special characters with _, some builds use special characters like : in Agent.Jobname, that is not a permissible name while uploading artifacts.
+safe_artifact_name="${artifact_name//["/:<>\\|?@*$" ]/_}"
+echo "Artifact name after : "$safe_artifact_name
+export ARTIFACT_NAME=$safe_artifact_name
+echo "##vso[task.setvariable variable=ARTIFACT_NAME]$safe_artifact_name"
+
+exit 0

--- a/eng/common/templates/steps/generate-sbom.yml
+++ b/eng/common/templates/steps/generate-sbom.yml
@@ -1,0 +1,43 @@
+# BuildDropPath - The root folder of the drop directory for which the manifest file will be generated.
+# PackageName - The name of the package this SBOM represents.
+# PackageVersion - The version of the package this SBOM represents.
+# ManifestDirPath - The path of the directory where the generated manifest files will be placed
+
+parameters:
+  PackageVersion: 7.0.0
+  BuildDropPath: '$(Build.SourcesDirectory)/artifacts'
+  PackageName: '.NET'
+  ManifestDirPath: $(Build.ArtifactStagingDirectory)/sbom
+  sbomContinueOnError: true
+
+steps:
+- task: PowerShell@2
+  displayName: Prep for SBOM generation in (Non-linux)
+  condition: or(eq(variables['Agent.Os'], 'Windows_NT'), eq(variables['Agent.Os'], 'Darwin'))
+  inputs:
+    filePath: ./eng/common/generate-sbom-prep.ps1
+    arguments: ${{parameters.manifestDirPath}}
+
+# Chmodding is a workaround for https://github.com/dotnet/arcade/issues/8461
+- script: |
+    chmod +x ./eng/common/generate-sbom-prep.sh
+    ./eng/common/generate-sbom-prep.sh ${{parameters.manifestDirPath}}
+  displayName: Prep for SBOM generation in (Linux)
+  condition: eq(variables['Agent.Os'], 'Linux')
+  continueOnError: ${{ parameters.sbomContinueOnError }}
+
+- task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+  displayName: 'Generate SBOM manifest'
+  continueOnError: ${{ parameters.sbomContinueOnError }}
+  inputs:
+      PackageName: ${{ parameters.packageName }}
+      BuildDropPath: ${{ parameters.buildDropPath }}
+      PackageVersion: ${{ parameters.packageVersion }}
+      ManifestDirPath: ${{ parameters.manifestDirPath }}
+
+- task: PublishPipelineArtifact@1
+  displayName: Publish SBOM manifest
+  continueOnError: ${{parameters.sbomContinueOnError}}
+  inputs:
+    targetPath: '${{parameters.manifestDirPath}}'
+    artifactName: $(ARTIFACT_NAME)

--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -205,7 +205,7 @@ steps:
   condition: "and(succeeded(),eq(variables['BuildRTM'], 'false'))"
 
 - ${{ if not(parameters.BuildRTM)}}:
-  - template: eng\common\templates\steps\generate-sbom.yml
+  - template: \eng\common\templates\steps\generate-sbom.yml
     parameters:
       PackageName: 'NuGet.Client'
       PackageVersion: "$(SemanticVersion)"

--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -261,13 +261,6 @@ steps:
     configuration: "$(BuildConfiguration)"
   condition: " and(succeeded(),eq(variables['BuildRTM'], 'false')) "
 
-- task: MSBuild@1
-  displayName: "Generate VSMAN file for Build Tools VSIX"
-  inputs:
-    solution: "setup\\Microsoft.VisualStudio.NuGet.BuildTools.vsmanproj"
-    configuration: "$(BuildConfiguration)"
-  condition: " and(succeeded(),eq(variables['BuildRTM'], 'false')) "
-
 - task: PowerShell@1
   displayName: "Create EndToEnd Test Package"
   inputs:

--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -204,7 +204,7 @@ steps:
     maximumCpuCount: true
   condition: "and(succeeded(),eq(variables['BuildRTM'], 'false'))"
 
-- ${{ if not(parameters.BuildRTM)}}
+- ${{ if not(parameters.BuildRTM)}}:
   - template: eng\common\templates\steps\generate-sbom.yml
     parameters:
       PackageName: 'NuGet.Client'

--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -1,3 +1,7 @@
+parameters:
+- name: isOfficialBuild
+  type: boolean
+
 steps:
 - task: PowerShell@1
   inputs:
@@ -35,7 +39,7 @@ steps:
     esrpSigning: "true"
   displayName: "Install Signing Plugin"
 
-- task: ms-vseng.MicroBuildTasks.32f78468-e895-4f47-962c-58a699361df8.MicroBuildSwixPlugin@1
+- task: MicroBuildSwixPlugin@4
   displayName: "Install Swix Plugin"
 
 - task: MicroBuildOptProfPlugin@6
@@ -199,6 +203,12 @@ steps:
     msbuildArguments: "/t:BuildVSIX /p:BuildRTM=$(BuildRTM) /p:ExcludeTestProjects=$(BuildRTM) /p:IsCIBuild=true"
     maximumCpuCount: true
   condition: "and(succeeded(),eq(variables['BuildRTM'], 'false'))"
+
+- task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+  displayName: 'Generate SBOM For Insertion'
+  inputs:
+    BuildDropPath: '$(Build.Repository.LocalPath)\\artifacts\\VS15'
+  condition: " and(succeeded(),eq(variables['BuildRTM'], 'false')) "
 
 - task: MSBuild@1
   displayName: "Generate Build Tools package"

--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -1,5 +1,5 @@
 parameters:
-- name: isOfficialBuild
+- name: BuildRTM
   type: boolean
 
 steps:
@@ -204,18 +204,18 @@ steps:
     maximumCpuCount: true
   condition: "and(succeeded(),eq(variables['BuildRTM'], 'false'))"
 
-- task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
-  displayName: 'Generate SBOM For Insertion'
-  inputs:
-    BuildDropPath: '$(Build.Repository.LocalPath)\\artifacts\\VS15'
-  condition: " and(succeeded(),eq(variables['BuildRTM'], 'false')) "
+- ${{ if not(parameters.BuildRTM)}}
+  - template: eng\common\templates\steps\generate-sbom.yml
+    parameters:
+      PackageName: 'NuGet.Client'
+      PackageVersion: "$(SemanticVersion)"
 
 - task: MSBuild@1
   displayName: "Generate Build Tools package"
   inputs:
     solution: "setup/Microsoft.VisualStudio.NuGet.BuildTools.vsmanproj"
     configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/p:BuildNumber=$(BuildNumber) /p:IsVsixBuild=true"
+    msbuildArguments: "/p:BuildNumber=$(BuildNumber) /p:ManifestDirPath=$(Build.ArtifactStagingDirectory)/sbom"
   condition: " and(succeeded(), eq(variables['BuildRTM'], 'false'))"
 
 - task: MSBuild@1
@@ -259,6 +259,7 @@ steps:
   inputs:
     solution: "setup\\Microsoft.VisualStudio.NuGet.Core.vsmanproj"
     configuration: "$(BuildConfiguration)"
+    msbuildArguments: "/p:ManifestDirPath=$(Build.ArtifactStagingDirectory)/sbom"
   condition: " and(succeeded(),eq(variables['BuildRTM'], 'false')) "
 
 - task: PowerShell@1

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -95,12 +95,13 @@ stages:
       SDKVersionForBuild: $[stageDependencies.Initialize.Initialize_Build.outputs['getSDKVersionForBuild.SDKVersionForBuild']]
       LocalizedLanguageCount: "13"
       BuildRTM: "false"
+      SemanticVersion: $[stageDependencies.Initialize.GetSemanticVersion.outputs['setsemanticversion.SemanticVersion']]
     pool:
       name: VSEngSS-MicroBuild2019-1ES
     steps:
     - template: Build_and_UnitTest.yml
       parameters:
-        isOfficialBuild: ${{ parameters.isOfficialBuild }}
+        BuildRTM: false
 
 - stage: Build_For_Publishing
   displayName: Build NuGet published to nuget.org
@@ -121,7 +122,7 @@ stages:
     steps:
     - template: Build_and_UnitTest.yml
       parameters:
-        isOfficialBuild: ${{ parameters.isOfficialBuild }}
+        BuildRTM: true
 
 - stage: Source_Build
   dependsOn: Initialize

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -99,6 +99,8 @@ stages:
       name: VSEngSS-MicroBuild2019-1ES
     steps:
     - template: Build_and_UnitTest.yml
+      parameters:
+        isOfficialBuild: ${{ parameters.isOfficialBuild }}
 
 - stage: Build_For_Publishing
   displayName: Build NuGet published to nuget.org
@@ -118,6 +120,8 @@ stages:
       name: VSEngSS-MicroBuild2019-1ES
     steps:
     - template: Build_and_UnitTest.yml
+      parameters:
+        isOfficialBuild: ${{ parameters.isOfficialBuild }}
 
 - stage: Source_Build
   dependsOn: Initialize

--- a/setup/Microsoft.VisualStudio.NuGet.BuildTools.swixproj
+++ b/setup/Microsoft.VisualStudio.NuGet.BuildTools.swixproj
@@ -35,7 +35,6 @@
   <Target Name="CopyToDropFolder" AfterTargets="Build">
     <Copy SourceFiles="$(OutputPath)$(MSBuildProjectName).vsix" DestinationFolder="$(VsixPublishDestination)" />
     <Copy SourceFiles="$(OutputPath)$(MSBuildProjectName).json" DestinationFolder="$(VsixPublishDestination)" />
-    <Copy SourceFiles="$(OutputPath)$(MSBuildProjectName).vsman" DestinationFolder="$(VsixPublishDestination)" />
   </Target>
 
   <!-- MicroBuild plugin fails if GetNativeManifest is not found for some reason -->

--- a/setup/Microsoft.VisualStudio.NuGet.BuildTools.swixproj
+++ b/setup/Microsoft.VisualStudio.NuGet.BuildTools.swixproj
@@ -19,8 +19,7 @@
     <NuGetTargetsBasePath>$(RepositoryRootDirectory)src\NuGet.Core\NuGet.Build.Tasks\</NuGetTargetsBasePath>
     <XmlTransformPath>$(ArtifactsDirectory)microsoft.web.xdt\3.0.0\lib\net40\</XmlTransformPath>
     <NewtonsoftJsonPath>$(SolutionPackagesFolder)newtonsoft.json\13.0.1\lib\net45\</NewtonsoftJsonPath>
-
-</PropertyGroup>
+  </PropertyGroup>
 
   <PropertyGroup>
     <!-- Variables added here will be usable in the swr file.  This is a semi colon delimited
@@ -32,6 +31,12 @@
   <ItemGroup>
     <Package Include="Microsoft.VisualStudio.NuGet.BuildTools.swr" />
   </ItemGroup>
+
+  <Target Name="CopyToDropFolder" AfterTargets="Build">
+    <Copy SourceFiles="$(OutputPath)$(MSBuildProjectName).vsix" DestinationFolder="$(VsixPublishDestination)" />
+    <Copy SourceFiles="$(OutputPath)$(MSBuildProjectName).json" DestinationFolder="$(VsixPublishDestination)" />
+    <Copy SourceFiles="$(OutputPath)$(MSBuildProjectName).vsman" DestinationFolder="$(VsixPublishDestination)" />
+  </Target>
 
   <!-- MicroBuild plugin fails if GetNativeManifest is not found for some reason -->
   <Target Name="GetNativeManifest" />

--- a/setup/Microsoft.VisualStudio.NuGet.BuildTools.vsmanproj
+++ b/setup/Microsoft.VisualStudio.NuGet.BuildTools.vsmanproj
@@ -26,7 +26,7 @@
 
   <ItemGroup>
     <MergeManifest Include="$(VsixPublishDestination)$(MSBuildProjectName).json"
-      SBOMFileLocation="$(VsixPublishDestination)_manifest\spdx_2.2\manifest.spdx.json"
+      SBOMFileLocation="$(ManifestDirPath)_manifest\spdx_2.2\manifest.spdx.json"
       />
   </ItemGroup>
 

--- a/setup/Microsoft.VisualStudio.NuGet.BuildTools.vsmanproj
+++ b/setup/Microsoft.VisualStudio.NuGet.BuildTools.vsmanproj
@@ -10,10 +10,10 @@
     <BuildNumber>$(SemanticVersion).$(BuildNumber)</BuildNumber>
     <TargetName>$(MSBuildProjectName)</TargetName>
     <DropFolder>$(VsixPublishDestination)</DropFolder>
-    <OutputPath Condition="'$(IsVsixBuild)' != 'true'">$(DropFolder)</OutputPath>
+    <OutputPath>$(DropFolder)</OutputPath>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(IsVsixBuild)' == 'true'">
+  <PropertyGroup>
     <IsPackage>true</IsPackage>
     <FinalizeValidate>false</FinalizeValidate>
     <ValidateManifest>false</ValidateManifest>
@@ -21,7 +21,7 @@
     <MicroBuild_SigningEnabled>false</MicroBuild_SigningEnabled>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(IsVsixBuild)' == 'true'">
+  <ItemGroup>
     <ProjectReference Include="Microsoft.VisualStudio.NuGet.BuildTools.swixproj" SkipGetTargetFrameworkProperties="true" />
   </ItemGroup>
 
@@ -31,7 +31,7 @@
       />
   </ItemGroup>
 
-  <Target Name="CopyToDropFolder" AfterTargets="Build" Condition="'$(IsVsixBuild)' == 'true'">
+  <Target Name="CopyToDropFolder" AfterTargets="Build">
     <Copy SourceFiles="$(OutputPath)$(MSBuildProjectName).vsix" DestinationFolder="$(DropFolder)" />
     <Copy SourceFiles="$(OutputPath)$(MSBuildProjectName).json" DestinationFolder="$(DropFolder)" />
   </Target>

--- a/setup/Microsoft.VisualStudio.NuGet.BuildTools.vsmanproj
+++ b/setup/Microsoft.VisualStudio.NuGet.BuildTools.vsmanproj
@@ -9,6 +9,7 @@
     <FinalizeSkipLayout>true</FinalizeSkipLayout>
     <BuildNumber>$(SemanticVersion).$(BuildNumber)</BuildNumber>
     <TargetName>$(MSBuildProjectName)</TargetName>
+    <OutputPath>$(VsixPublishDestination)</OutputPath>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/setup/Microsoft.VisualStudio.NuGet.BuildTools.vsmanproj
+++ b/setup/Microsoft.VisualStudio.NuGet.BuildTools.vsmanproj
@@ -9,8 +9,6 @@
     <FinalizeSkipLayout>true</FinalizeSkipLayout>
     <BuildNumber>$(SemanticVersion).$(BuildNumber)</BuildNumber>
     <TargetName>$(MSBuildProjectName)</TargetName>
-    <DropFolder>$(VsixPublishDestination)</DropFolder>
-    <OutputPath>$(DropFolder)</OutputPath>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -26,15 +24,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <MergeManifest Include="$(OutputPath)$(MSBuildProjectName).json"
+    <MergeManifest Include="$(VsixPublishDestination)$(MSBuildProjectName).json"
       SBOMFileLocation="$(VsixPublishDestination)_manifest\spdx_2.2\manifest.spdx.json"
       />
   </ItemGroup>
-
-  <Target Name="CopyToDropFolder" AfterTargets="Build">
-    <Copy SourceFiles="$(OutputPath)$(MSBuildProjectName).vsix" DestinationFolder="$(DropFolder)" />
-    <Copy SourceFiles="$(OutputPath)$(MSBuildProjectName).json" DestinationFolder="$(DropFolder)" />
-  </Target>
 
   <Import Project="$(MicroBuildDirectory)Microsoft.VisualStudioEng.MicroBuild.Core.targets" />
 

--- a/setup/Microsoft.VisualStudio.NuGet.BuildTools.vsmanproj
+++ b/setup/Microsoft.VisualStudio.NuGet.BuildTools.vsmanproj
@@ -26,7 +26,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <MergeManifest Include="$(OutputPath)$(MSBuildProjectName).json" />
+    <MergeManifest Include="$(OutputPath)$(MSBuildProjectName).json"
+      SBOMFileLocation="$(VsixPublishDestination)_manifest\spdx_2.2\manifest.spdx.json"
+      />
   </ItemGroup>
 
   <Target Name="CopyToDropFolder" AfterTargets="Build" Condition="'$(IsVsixBuild)' == 'true'">

--- a/setup/Microsoft.VisualStudio.NuGet.Core.vsmanproj
+++ b/setup/Microsoft.VisualStudio.NuGet.Core.vsmanproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <MergeManifest Include="$(VsixPublishDestination)Microsoft.VisualStudio.NuGet.Core.json"
-      SBOMFileLocation="$(VsixPublishDestination)_manifest\spdx_2.2\manifest.spdx.json"
+      SBOMFileLocation="$(ManifestDirPath)_manifest\spdx_2.2\manifest.spdx.json"
       />
   </ItemGroup>
 

--- a/setup/Microsoft.VisualStudio.NuGet.Core.vsmanproj
+++ b/setup/Microsoft.VisualStudio.NuGet.Core.vsmanproj
@@ -12,7 +12,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <MergeManifest Include="$(VsixPublishDestination)Microsoft.VisualStudio.NuGet.Core.json" />
+    <MergeManifest Include="$(VsixPublishDestination)Microsoft.VisualStudio.NuGet.Core.json"
+      SBOMFileLocation="$(VsixPublishDestination)_manifest\spdx_2.2\manifest.spdx.json"
+      />
   </ItemGroup>
 
   <Import Project="$(MicroBuildDirectory)Microsoft.VisualStudioEng.MicroBuild.Core.targets"/>


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1418

Regression? No

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

To comply with new compliance requirements. SBOM = Software Bill Of Materials.

* Copy Arcade yaml, and use from our Build_And_UnitTest job
* Update MicroBuild swixproj plugin, and tell it where to find the SBOM
* Change BuildTools vsix/vsman to generate in a single pass, rather than two.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
