### PR TITLE
Change official build trigger

### DIFF
--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -4,7 +4,10 @@ trigger:
   branches:
     include:
       - dev
-      - release-*
+      - release-*-MSRC
+    exclude:
+      - dev-*
+
 
 # Weekly builds for supported branches, to maintain CI build health + keep OptProf training data fresh
 # Generally this means LTS versions + current GA version
@@ -15,9 +18,9 @@ schedules:
   displayName: Weekly branch build
   branches:
     include:
-      - release-5.11.x # VS 16.11 and .NET 5 SDK 5.0.4xx
-      - release-6.0.x # VS 17.0 and .NET 6 SDK 6.0.1xx
-      - release-6.1.x # VS 17.1 and .NET 6 SDK 6.0.2xx
+      - release-5.11.x-MSRC # VS 16.11 and .NET 5 SDK 5.0.4xx
+      - release-6.0.x-MSRC # VS 17.0 and .NET 6 SDK 6.0.1xx
+      - release-6.1.x-MSRC # VS 17.1 and .NET 6 SDK 6.0.2xx
   always: true
 
 parameters:


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1438

Regression? No

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

My previous attempt in https://github.com/NuGet/NuGet.Client/pull/4451 didn't quite work out. Every commit was being built twice, due to dnceng automation that keeps the `-MSRC` branches up to date. So, let's change the trigger to only build release branch `-MSRC`, which will be the same commit as the public branch when we have no security fix pending release.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
