### PR TITLE
Revert "Create tracking file when user-profile nuget.config does not exist"

### DIFF
--- a/src/NuGet.Core/NuGet.Configuration/PackageSource/NuGetConstants.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSource/NuGetConstants.cs
@@ -40,8 +40,6 @@ namespace NuGet.Configuration
 
         public static readonly string FeedName = "nuget.org";
 
-        internal const string V3TrackFile = "nugetorgadd.trk";
-
         public static readonly string DefaultConfigContent = @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
   <packageSources>

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
@@ -344,7 +344,7 @@ namespace NuGet.Configuration
         }
 
         /// <summary>
-        /// Loads Specific NuGet.Config file. The method only loads specific config file
+        /// Loads Specific NuGet.Config file. The method only loads specific config file 
         /// which is file <paramref name="configFileName"/>from <paramref name="root"/>.
         /// </summary>
         public static ISettings LoadSpecificSettings(string root, string configFileName)
@@ -545,41 +545,10 @@ namespace NuGet.Configuration
                     yield break;
                 }
 
-                string defaultSettingsFilePath = Path.Combine(userSettingsDir, DefaultSettingsFileName);
-                bool settingsFileExists = File.Exists(defaultSettingsFilePath);
+                var defaultSettingsFilePath = Path.Combine(userSettingsDir, DefaultSettingsFileName);
 
-                // If the default user config NuGet.Config does not exist, we need to create it.
-                if (!settingsFileExists)
-                {
-                    if (!Directory.Exists(userSettingsDir))
-                    {
-                        Directory.CreateDirectory(userSettingsDir);
-                    }
-
-                    // Write tracking file, so that if the customer removes nuget.org as a package source
-                    // it does not come back one more time.
-                    File.WriteAllText(defaultSettingsFilePath, NuGetConstants.DefaultConfigContent);
-                    string trackFilePath = Path.Combine(userSettingsDir, NuGetConstants.V3TrackFile);
-                    File.Create(trackFilePath).Dispose();
-                }
-
+                // ReadSettings will try to create the default config file if it doesn't exist
                 SettingsFile userSpecificSettings = ReadSettings(rootDirectory, defaultSettingsFilePath, settingsLoadingContext: settingsLoadingContext);
-
-                // Handle when some other product created nuget.config using an old version of NuGet.Core.dll or NuGet.Configuration.dll that did not
-                // automatically add nuget.org as a package source.
-                if (settingsFileExists && userSpecificSettings.IsEmpty())
-                {
-                    string trackFilePath = Path.Combine(Path.GetDirectoryName(defaultSettingsFilePath), NuGetConstants.V3TrackFile);
-
-                    if (!File.Exists(trackFilePath))
-                    {
-                        File.Create(trackFilePath).Dispose();
-
-                        SourceItem defaultSource = new(NuGetConstants.FeedName, NuGetConstants.V3FeedUrl, protocolVersion: "3");
-                        userSpecificSettings.AddOrUpdate(ConfigurationConstants.PackageSources, defaultSource);
-                        userSpecificSettings.SaveToDisk();
-                    }
-                }
 
                 yield return userSpecificSettings;
 

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
@@ -1814,7 +1814,7 @@ namespace NuGet.Configuration.Test
                 List<PackageSource> sources = LoadPackageSources(useStaticMethod, settings);
 
                 // Assert
-                Assert.Equal(1, sources.Count);
+                Assert.Equal(0, sources.Count);
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsTests.cs
@@ -2021,95 +2021,63 @@ namespace NuGet.Configuration.Test
         }
 
         [Fact]
-        public void LoadSettings_UserSettingsFolderDoesNotExist_DefaultNuGetConfigAndTrackingFilesCreated()
+        public void LoadSettings_EmptyUserWideConfigFile_DoNotAddNuGetOrg()
         {
-            // Arrange
-            using TestDirectory mockSolutionDirectory = TestDirectory.Create();
-            // Settings.LoadSettings' useTestingGlobalPath will use a subdirectory, instead of machine configuration, to allow for testing.
-            string mockUserProfileDirectory = Path.Combine(mockSolutionDirectory, "TestingGlobalPath");
-
-            // Act
-            ISettings settings = Settings.LoadSettings(
-                root: mockSolutionDirectory,
-                configFileName: null,
-                machineWideSettings: null,
-                loadUserWideSettings: true,
-                useTestingGlobalPath: true);
-
-            // Assert
-
-            // Check that the config file has the expected contents
-            string actual = SettingsTestUtils.RemoveWhitespace(File.ReadAllText(Path.Combine(mockUserProfileDirectory, "NuGet.Config")));
-            string expected = SettingsTestUtils.RemoveWhitespace(NuGetConstants.DefaultConfigContent);
-            actual.Should().Be(expected);
-
-            // Check that the tracking file exists, so that nuget.org won't be re-added if the customer removes it.
-            Assert.True(File.Exists(Path.Combine(mockUserProfileDirectory, NuGetConstants.V3TrackFile)));
-        }
-
-        [Fact]
-        public void LoadSettings_UserNuGetConfigIsEmptyWithoutTrackingFile_NuGetOrgSourceAddedAndTrackingFileCreated()
-        {
-            // Arrange
-            using TestDirectory mockSolutionDirectory = TestDirectory.Create();
-            // Settings.LoadSettings' useTestingGlobalPath will use a subdirectory, instead of machine configuration, to allow for testing.
-            string mockUserProfileDirectory = Path.Combine(mockSolutionDirectory, "TestingGlobalPath");
-
-            string emptyConfig = @"<?xml version=""1.0"" encoding=""utf-8""?>
+            using (var mockBaseDirectory = TestDirectory.Create())
+            {
+                // Arrange
+                var config = @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
 </configuration>";
 
-            string nugetConfigPath = "NuGet.Config";
-            SettingsTestUtils.CreateConfigurationFile(nugetConfigPath, mockUserProfileDirectory, emptyConfig);
+                var nugetConfigPath = "NuGet.Config";
+                SettingsTestUtils.CreateConfigurationFile(nugetConfigPath, Path.Combine(mockBaseDirectory, "TestingGlobalPath"), config);
 
-            // Act
-            ISettings settings = Settings.LoadSettings(
-                root: mockSolutionDirectory,
-                configFileName: null,
-                machineWideSettings: null,
-                loadUserWideSettings: true,
-                useTestingGlobalPath: true);
+                // Act
+                var settings = Settings.LoadSettings(
+                    root: mockBaseDirectory,
+                    configFileName: null,
+                    machineWideSettings: null,
+                    loadUserWideSettings: true,
+                    useTestingGlobalPath: true);
 
-            // Assert
-            // Check that the config file has the expected contents
-            string actual = SettingsTestUtils.RemoveWhitespace(File.ReadAllText(Path.Combine(mockUserProfileDirectory, "NuGet.Config")));
-            string expected = SettingsTestUtils.RemoveWhitespace(NuGetConstants.DefaultConfigContent);
-            actual.Should().Be(expected);
+                // Assert
+                var actual = SettingsTestUtils.RemoveWhitespace(File.ReadAllText(Path.Combine(mockBaseDirectory, "TestingGlobalPath", "NuGet.Config")));
+                var expected = SettingsTestUtils.RemoveWhitespace(config);
 
-            // Check that the tracking file exists, so that nuget.org won't be re-added if the customer removes it.
-            Assert.True(File.Exists(Path.Combine(mockUserProfileDirectory, NuGetConstants.V3TrackFile)));
+                actual.Should().Be(expected);
+            }
         }
 
         [Fact]
-        public void LoadSettings_UserNuGetConfigIsEmptyAndTrackingFileExists_ConfigFileNotModified()
+        public void LoadSettings_NonExistingUserWideConfigFile_CreateUserWideConfigFileWithNuGetOrg()
         {
-            // Arrange
-            using TestDirectory mockSolutionDirectory = TestDirectory.Create();
-            // Settings.LoadSettings' useTestingGlobalPath will use a subdirectory, instead of machine configuration, to allow for testing.
-            string mockUserProfileDirectory = Path.Combine(mockSolutionDirectory, "TestingGlobalPath");
+            using (var mockBaseDirectory = TestDirectory.Create())
+            {
+                // Arrange
+                var nugetConfigPath = Path.Combine(mockBaseDirectory, "TestingGlobalPath", "NuGet.Config");
+                File.Exists(nugetConfigPath).Should().BeFalse();
 
-            string emptyConfig = @"<?xml version=""1.0"" encoding=""utf-8""?>
+                // Act
+                var settings = Settings.LoadSettings(
+                    root: mockBaseDirectory,
+                    configFileName: null,
+                    machineWideSettings: null,
+                    loadUserWideSettings: true,
+                    useTestingGlobalPath: true);
+
+                // Assert
+                File.Exists(nugetConfigPath).Should().BeTrue();
+                var actual = SettingsTestUtils.RemoveWhitespace(File.ReadAllText(nugetConfigPath));
+                var expected = SettingsTestUtils.RemoveWhitespace(@"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
-</configuration>";
+    <packageSources>
+        <add key=""nuget.org"" value=""https://api.nuget.org/v3/index.json"" protocolVersion=""3"" />
+    </packageSources>
+</configuration>");
 
-            string nugetConfigPath = "NuGet.Config";
-            SettingsTestUtils.CreateConfigurationFile(nugetConfigPath, mockUserProfileDirectory, emptyConfig);
-
-            File.WriteAllText(Path.Combine(mockUserProfileDirectory, NuGetConstants.V3TrackFile), string.Empty);
-
-            // Act
-            ISettings settings = Settings.LoadSettings(
-                root: mockSolutionDirectory,
-                configFileName: null,
-                machineWideSettings: null,
-                loadUserWideSettings: true,
-                useTestingGlobalPath: true);
-
-            // Assert
-            // Check that the config file has the expected contents
-            string actual = SettingsTestUtils.RemoveWhitespace(File.ReadAllText(Path.Combine(mockUserProfileDirectory, "NuGet.Config")));
-            string expected = SettingsTestUtils.RemoveWhitespace(emptyConfig);
-            actual.Should().Be(expected);
+                actual.Should().Be(expected);
+            }
         }
 
         [Theory]


### PR DESCRIPTION

This reverts commit 35617e6430d1cfa5e4d25f2f9f4fab635833d178.

<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11616

Regression? Yes Last working version: NuGet 6.0

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Revert https://github.com/NuGet/NuGet.Client/pull/4338

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
