### PR TITLE
Fix IsSubSetOfWithNullCheck (#11222)

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Logging/TransitiveNoWarnUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Logging/TransitiveNoWarnUtils.cs
@@ -883,7 +883,7 @@ namespace NuGet.Commands
 
                 if (other.Count <= parent.Count)
                 {
-                    return parent.IsSubsetOf(other);
+                    return other.IsSubsetOf(parent);
                 }
 
                 return false;

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Logging/TransitiveNoWarnUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Logging/TransitiveNoWarnUtils.cs
@@ -837,27 +837,33 @@ namespace NuGet.Commands
                     var package = PackageSpecific;
                     var otherPackage = other.PackageSpecific;
 
-                    if (otherPackage == null || otherPackage.Count == 0)
+                    if (otherPackage == null)
                     {
                         return true;
                     }
 
-                    if (package == null || package.Count == 0)
+                    // To be a subset this set of package specific warnings must contain
+                    // every id and code found in other. A single miss will fail the check.
+                    foreach (var pair in otherPackage)
                     {
-                        return false;
-                    }
-
-                    if (otherPackage.Count <= package.Count)
-                    {
-                        // To be a subset this set of package specific warnings must contain
-                        // every id and code found in other. A single miss will fail the check.
-                        foreach (var pair in otherPackage)
+                        if (pair.Value == null || pair.Value.Count == 0)
                         {
-                            if (!package.TryGetValue(pair.Key, out var codes)
-                                || !codes.IsSubsetOf(pair.Value))
-                            {
-                                return false;
-                            }
+                            continue;
+                        }
+
+                        if (package == null)
+                        {
+                            return false;
+                        }
+
+                        if (!package.TryGetValue(pair.Key, out var codes))
+                        {
+                            return false;
+                        }
+
+                        if (codes == null || !pair.Value.IsSubsetOf(codes))
+                        {
+                            return false;
                         }
                     }
 

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/TransitiveNoWarnUtilsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/TransitiveNoWarnUtilsTests.cs
@@ -954,33 +954,17 @@ namespace NuGet.Commands.Test
             result.Should().Be(true);
         }
 
-        [Fact]
-        public void NodeWarningPropertiesIsSubSetOf_WithFirstProjectWideNoWarnNullAndSecondEmpty_Succeeds()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void NodeWarningPropertiesIsSubSetOf_WithNullAndEmptyProjectWideNoWarns_Succeeds(bool nullFirst)
         {
             // Arrange
             var first = new TransitiveNoWarnUtils.NodeWarningProperties(
-                null,
+                nullFirst ? null : new HashSet<NuGetLogCode>(),
                 null);
             var second = new TransitiveNoWarnUtils.NodeWarningProperties(
-                new HashSet<NuGetLogCode>(),
-                null);
-
-            // Act
-            var result = first.IsSubSetOf(second);
-
-            // Assert
-            result.Should().Be(true);
-        }
-
-        [Fact]
-        public void NodeWarningPropertiesIsSubSetOf_WithFirstProjectWideNoWarnEmptyAndSecondNull_Succeeds()
-        {
-            // Arrange
-            var first = new TransitiveNoWarnUtils.NodeWarningProperties(
-                new HashSet<NuGetLogCode>(),
-                null);
-            var second = new TransitiveNoWarnUtils.NodeWarningProperties(
-                null,
+                nullFirst ? new HashSet<NuGetLogCode>() : null,
                 null);
 
             // Act
@@ -1031,10 +1015,18 @@ namespace NuGet.Commands.Test
         [InlineData("", "NU1605, NU1604")]
         [InlineData("NU1605", "NU1604")]
         [InlineData("NU1605", "NU1605, NU1604")]
+        [InlineData("NU1604", "NU1605, NU1604")]
+        [InlineData(null, "NU1605, NU1604, NU1701")]
+        [InlineData("", "NU1605, NU1604, NU1701")]
+        [InlineData("NU1605", "NU1605, NU1604, NU1701")]
+        [InlineData("NU1604", "NU1605, NU1604, NU1701")]
+        [InlineData("NU1701", "NU1605, NU1604, NU1701")]
         [InlineData("NU1605, NU1604", "NU1701")]
         [InlineData("NU1605, NU1604", "NU1604, NU1701")]
         [InlineData("NU1605, NU1604", "NU1605, NU1701")]
         [InlineData("NU1605, NU1604", "NU1605, NU1604, NU1701")]
+        [InlineData("NU1605, NU1701", "NU1605, NU1604, NU1701")]
+        [InlineData("NU1604, NU1701", "NU1605, NU1604, NU1701")]
         public void NodeWarningPropertiesIsSubSetOf_WithSecondProjectWideNoWarnNotASubsetOfFirst_Fails(
             string firstNoWarn,
             string secondNoWarn)
@@ -1044,7 +1036,7 @@ namespace NuGet.Commands.Test
                 firstNoWarn == null ? null : MSBuildStringUtility.GetNuGetLogCodes(firstNoWarn).ToHashSet(),
                 null);
             var second = new TransitiveNoWarnUtils.NodeWarningProperties(
-                secondNoWarn == null ? null : MSBuildStringUtility.GetNuGetLogCodes(secondNoWarn).ToHashSet(),
+                MSBuildStringUtility.GetNuGetLogCodes(secondNoWarn).ToHashSet(),
                 null);
 
             // Act

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/TransitiveNoWarnUtilsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/TransitiveNoWarnUtilsTests.cs
@@ -931,15 +931,12 @@ namespace NuGet.Commands.Test
         }
 
         [Theory]
-        // null and "" are both considered empty sets.
         [InlineData(null)]
         [InlineData("")]
         [InlineData("NU1605")]
         [InlineData("NU1605, NU1604")]
         [InlineData("NU1605, NU1604, NU1701")]
-        // TODO
-        //public void NodeWarningPropertiesIsSubSetOf_SecondProjectWideNoWarnIsEqualToFirst_Succeeds(
-        public void NodeWarningPropertiesIsSubSetOf_EqualProjectWideNoWarns_Succeeds(
+        public void NodeWarningPropertiesIsSubSetOf_WithEqualProjectWideNoWarns_Succeeds(
             string noWarn)
         {
             // Arrange
@@ -957,22 +954,33 @@ namespace NuGet.Commands.Test
             result.Should().Be(true);
         }
 
-        [Theory]
-        // null and "" are both considered empty sets.
-        [InlineData(null, "")]
-        [InlineData("", null)]
-        // TODO
-        //public void NodeWarningPropertiesIsSubSetOf_SecondProjectWideNoWarnIsEqualToFirst_Succeeds(
-        public void NodeWarningPropertiesIsSubSetOf_NullAndEmptyProjectWideNoWarns_Succeeds(
-            string firstNoWarn,
-            string secondNoWarn)
+        [Fact]
+        public void NodeWarningPropertiesIsSubSetOf_WithFirstProjectWideNoWarnNullAndSecondEmpty_Succeeds()
         {
             // Arrange
             var first = new TransitiveNoWarnUtils.NodeWarningProperties(
-                firstNoWarn == null ? null : MSBuildStringUtility.GetNuGetLogCodes(firstNoWarn).ToHashSet(),
+                null,
                 null);
             var second = new TransitiveNoWarnUtils.NodeWarningProperties(
-                secondNoWarn == null ? null : MSBuildStringUtility.GetNuGetLogCodes(secondNoWarn).ToHashSet(),
+                new HashSet<NuGetLogCode>(),
+                null);
+
+            // Act
+            var result = first.IsSubSetOf(second);
+
+            // Assert
+            result.Should().Be(true);
+        }
+
+        [Fact]
+        public void NodeWarningPropertiesIsSubSetOf_WithFirstProjectWideNoWarnEmptyAndSecondNull_Succeeds()
+        {
+            // Arrange
+            var first = new TransitiveNoWarnUtils.NodeWarningProperties(
+                new HashSet<NuGetLogCode>(),
+                null);
+            var second = new TransitiveNoWarnUtils.NodeWarningProperties(
+                null,
                 null);
 
             // Act
@@ -997,14 +1005,13 @@ namespace NuGet.Commands.Test
         [InlineData("NU1605, NU1604, NU1701", "NU1605, NU1604")]
         [InlineData("NU1605, NU1604, NU1701", "NU1605, NU1701")]
         [InlineData("NU1605, NU1604, NU1701", "NU1604, NU1701")]
-        // TODO
-        public void NodeWarningPropertiesIsSubSetOf_SecondProjectWideNoWarnIsProperSubsetOfFirst_Succeeds(
+        public void NodeWarningPropertiesIsSubSetOf_WithSecondProjectWideNoWarnAProperSubsetOfFirst_Succeeds(
             string firstNoWarn,
             string secondNoWarn)
         {
             // Arrange
             var first = new TransitiveNoWarnUtils.NodeWarningProperties(
-                firstNoWarn == null ? null : MSBuildStringUtility.GetNuGetLogCodes(firstNoWarn).ToHashSet(),
+                MSBuildStringUtility.GetNuGetLogCodes(firstNoWarn).ToHashSet(),
                 null);
             var second = new TransitiveNoWarnUtils.NodeWarningProperties(
                 secondNoWarn == null ? null : MSBuildStringUtility.GetNuGetLogCodes(secondNoWarn).ToHashSet(),
@@ -1028,7 +1035,7 @@ namespace NuGet.Commands.Test
         [InlineData("NU1605, NU1604", "NU1604, NU1701")]
         [InlineData("NU1605, NU1604", "NU1605, NU1701")]
         [InlineData("NU1605, NU1604", "NU1605, NU1604, NU1701")]
-        public void NodeWarningPropertiesIsSubSetOf_SecondProjectWideNoWarnIsNotSubsetOfFirst_Fails(
+        public void NodeWarningPropertiesIsSubSetOf_WithSecondProjectWideNoWarnNotASubsetOfFirst_Fails(
             string firstNoWarn,
             string secondNoWarn)
         {

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/TransitiveNoWarnUtilsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/TransitiveNoWarnUtilsTests.cs
@@ -932,16 +932,38 @@ namespace NuGet.Commands.Test
 
         [Theory]
         // null and "" are both considered empty sets.
-        [InlineData(null, null)]
-        [InlineData(null, "")]
-        [InlineData("", "")]
-        [InlineData("", null)]
-        [InlineData("NU1605", "NU1605")]
-        [InlineData("NU1604", "NU1604")]
-        [InlineData("NU1605, NU1604", "NU1605, NU1604")]
-        [InlineData("NU1605, NU1604, NU1701", "NU1605, NU1604, NU1701")]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("NU1605")]
+        [InlineData("NU1605, NU1604")]
+        [InlineData("NU1605, NU1604, NU1701")]
         // TODO
-        public void NodeWarningPropertiesIsSubSetOf_SecondProjectWideNoWarnIsEqualToFirst_Succeeds(
+        //public void NodeWarningPropertiesIsSubSetOf_SecondProjectWideNoWarnIsEqualToFirst_Succeeds(
+        public void NodeWarningPropertiesIsSubSetOf_EqualProjectWideNoWarns_Succeeds(
+            string noWarn)
+        {
+            // Arrange
+            var first = new TransitiveNoWarnUtils.NodeWarningProperties(
+                noWarn == null ? null : MSBuildStringUtility.GetNuGetLogCodes(noWarn).ToHashSet(),
+                null);
+            var second = new TransitiveNoWarnUtils.NodeWarningProperties(
+                noWarn == null ? null : MSBuildStringUtility.GetNuGetLogCodes(noWarn).ToHashSet(),
+                null);
+
+            // Act
+            var result = first.IsSubSetOf(second);
+
+            // Assert
+            result.Should().Be(true);
+        }
+
+        [Theory]
+        // null and "" are both considered empty sets.
+        [InlineData(null, "")]
+        [InlineData("", null)]
+        // TODO
+        //public void NodeWarningPropertiesIsSubSetOf_SecondProjectWideNoWarnIsEqualToFirst_Succeeds(
+        public void NodeWarningPropertiesIsSubSetOf_NullAndEmptyProjectWideNoWarns_Succeeds(
             string firstNoWarn,
             string secondNoWarn)
         {
@@ -1001,6 +1023,7 @@ namespace NuGet.Commands.Test
         [InlineData(null, "NU1605, NU1604")]
         [InlineData("", "NU1605, NU1604")]
         [InlineData("NU1605", "NU1604")]
+        [InlineData("NU1605", "NU1605, NU1604")]
         [InlineData("NU1605, NU1604", "NU1701")]
         [InlineData("NU1605, NU1604", "NU1604, NU1701")]
         [InlineData("NU1605, NU1604", "NU1605, NU1701")]


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11222

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

IsSubSetOfWithNullCheck is supposed to return true when `other` is
a subset of `parent`.

This fixes an issue where restore can take a long time to run on
solutions with many references and packages.

A test solution was created with 42 projects, with project n referencing
projects 1..(n-1). Each project also had a couple of package references
and a NoWarn element.

Before this change, restore ran for 5 minutes, used ~14GB of memory,
and failed with an OutOfMemoryException ("Array dimensions exceeded
supported range.")

After this change, restore completed in under 5 seconds.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
