### PR TITLE
Restore errors gracefully when a source is inaccessible - Emit an error with an error code when a source is missing.

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -1033,7 +1033,7 @@ namespace NuGet.Commands
             Tuple<bool, List<RestoreTargetGraph>, RuntimeGraph> result = null;
             bool failed = false;
             using (telemetryActivity.StartIndependentInterval(CreateRestoreTargetGraphDuration))
-            { // Catch the fatal protocol exception here and create a failure assets file.
+            {
                 try
                 {
                     result = await projectRestoreCommand.TryRestoreAsync(

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -16,6 +16,7 @@ using NuGet.Frameworks;
 using NuGet.LibraryModel;
 using NuGet.Packaging.Core;
 using NuGet.ProjectModel;
+using NuGet.Protocol.Core.Types;
 using NuGet.Repositories;
 using NuGet.RuntimeModel;
 using NuGet.Versioning;
@@ -1030,24 +1031,39 @@ namespace NuGet.Commands
             var projectRestoreCommand = new ProjectRestoreCommand(projectRestoreRequest);
 
             Tuple<bool, List<RestoreTargetGraph>, RuntimeGraph> result = null;
+            bool failed = false;
             using (telemetryActivity.StartIndependentInterval(CreateRestoreTargetGraphDuration))
-            {
-                result = await projectRestoreCommand.TryRestoreAsync(
-                    projectRange,
-                    projectFrameworkRuntimePairs,
-                    userPackageFolder,
-                    fallbackPackageFolders,
-                    remoteWalker,
-                    context,
-                    forceRuntimeGraphCreation: hasSupports,
-                    token: token,
-                    telemetryActivity: telemetryActivity,
-                    telemetryPrefix: string.Empty);
+            { // Catch the fatal protocol exception here and create a failure assets file.
+                try
+                {
+                    result = await projectRestoreCommand.TryRestoreAsync(
+                        projectRange,
+                        projectFrameworkRuntimePairs,
+                        userPackageFolder,
+                        fallbackPackageFolders,
+                        remoteWalker,
+                        context,
+                        forceRuntimeGraphCreation: hasSupports,
+                        token: token,
+                        telemetryActivity: telemetryActivity,
+                        telemetryPrefix: string.Empty);
+                }
+                catch (FatalProtocolException)
+                {
+                    failed = true;
+                }
             }
 
-            var success = result.Item1;
-            allGraphs.AddRange(result.Item2);
-            _success = success;
+            if (!failed)
+            {
+                var success = result.Item1;
+                allGraphs.AddRange(result.Item2);
+                _success = success;
+            }
+            else
+            {
+                _success = false;
+            }
 
             // Calculate compatibility profiles to check by merging those defined in the project with any from the command line
             foreach (var profile in _request.Project.RuntimeGraph.Supports)

--- a/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
@@ -208,6 +208,11 @@ namespace NuGet.Common
         NU1213 = 1213,
 
         /// <summary>
+        /// Package Source is unreachable.
+        /// </summary>
+        NU1301 = 1301,
+
+        /// <summary>
         /// Package MinClientVersion did not match.
         /// </summary>
         NU1401 = 1401,

--- a/src/NuGet.Core/NuGet.Common/PublicAPI/net45/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Common/PublicAPI/net45/PublicAPI.Unshipped.txt
@@ -3,6 +3,7 @@ NuGet.Common.IPackLogMessage.Framework.set -> void
 NuGet.Common.IPackLogMessage.LibraryId.get -> string
 NuGet.Common.IPackLogMessage.LibraryId.set -> void
 NuGet.Common.NuGetLogCode.NU1013 = 1013 -> NuGet.Common.NuGetLogCode
+NuGet.Common.NuGetLogCode.NU1301 = 1301 -> NuGet.Common.NuGetLogCode
 NuGet.Common.NuGetLogCode.NU1504 = 1504 -> NuGet.Common.NuGetLogCode
 NuGet.Common.NuGetLogCode.NU5133 = 5133 -> NuGet.Common.NuGetLogCode
 NuGet.Common.PackagingLogMessage.Framework.get -> NuGet.Frameworks.NuGetFramework

--- a/src/NuGet.Core/NuGet.Common/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Common/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -3,6 +3,7 @@ NuGet.Common.IPackLogMessage.Framework.set -> void
 NuGet.Common.IPackLogMessage.LibraryId.get -> string
 NuGet.Common.IPackLogMessage.LibraryId.set -> void
 NuGet.Common.NuGetLogCode.NU1013 = 1013 -> NuGet.Common.NuGetLogCode
+NuGet.Common.NuGetLogCode.NU1301 = 1301 -> NuGet.Common.NuGetLogCode
 NuGet.Common.NuGetLogCode.NU1504 = 1504 -> NuGet.Common.NuGetLogCode
 NuGet.Common.NuGetLogCode.NU5133 = 5133 -> NuGet.Common.NuGetLogCode
 NuGet.Common.PackagingLogMessage.Framework.get -> NuGet.Frameworks.NuGetFramework

--- a/src/NuGet.Core/NuGet.Common/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Common/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -3,6 +3,7 @@ NuGet.Common.IPackLogMessage.Framework.set -> void
 NuGet.Common.IPackLogMessage.LibraryId.get -> string
 NuGet.Common.IPackLogMessage.LibraryId.set -> void
 NuGet.Common.NuGetLogCode.NU1013 = 1013 -> NuGet.Common.NuGetLogCode
+NuGet.Common.NuGetLogCode.NU1301 = 1301 -> NuGet.Common.NuGetLogCode
 NuGet.Common.NuGetLogCode.NU1504 = 1504 -> NuGet.Common.NuGetLogCode
 NuGet.Common.NuGetLogCode.NU5133 = 5133 -> NuGet.Common.NuGetLogCode
 NuGet.Common.PackagingLogMessage.Framework.get -> NuGet.Frameworks.NuGetFramework

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreLoggingTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreLoggingTests.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 using FluentAssertions;
+using NuGet.Commands.Test;
 using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Frameworks;
@@ -147,32 +148,26 @@ namespace NuGet.CommandLine.Test
             // Arrange
             using (var pathContext = new SimpleTestPathContext())
             {
-                // Set up solution, project, and packages
-                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
-
-                var netcoreapp1 = FrameworkConstants.CommonFrameworks.NetCoreApp10;
-
-                var projectA = SimpleTestProjectContext.CreateNETCore(
-                    "a",
-                    pathContext.SolutionRoot,
-                    netcoreapp1);
-
                 var packageX = new SimpleTestPackageContext("x", "1.0.0");
-
                 await SimpleTestPackageUtility.CreateFolderFeedV3Async(pathContext.PackageSource, packageX);
-                projectA.AddPackageToAllFrameworks(packageX);
-
-                solution.Projects.Add(projectA);
-                solution.Create(pathContext.SolutionRoot);
 
                 File.Delete(Path.Combine(pathContext.PackageSource, packageX.Id, packageX.Version, packageX.Id + NuGetConstants.ManifestExtension));
 
-                // Act                
-                var r = Util.RestoreSolution(pathContext, expectedExitCode: 1);
+                var logger = new TestLogger();
+                // Set-up command.
+                var request = ProjectTestHelpers.CreateRestoreRequest(
+                        ProjectTestHelpers.GetPackageSpec("Project1", pathContext.SolutionRoot, framework: "net5.0", dependencyName: packageX.Id),
+                        pathContext,
+                        logger);
+                var command = new NuGet.Commands.RestoreCommand(request);
+
+                // Act
+                var result = await command.ExecuteAsync();
 
                 // Assert
-                r.Success.Should().BeFalse();
-                r.AllOutput.Should().Contain("The package is missing the required nuspec file. Path: " + Path.Combine(pathContext.PackageSource, packageX.Id, packageX.Version));
+                result.Success.Should().BeFalse(because: logger.ShowMessages());
+                result.LockFile.LogMessages.Select(e => e.Code).Should().AllBeEquivalentTo(NuGetLogCode.NU5037);
+                logger.ShowMessages().Should().Contain("The package is missing the required nuspec file. Path: " + Path.Combine(pathContext.PackageSource, packageX.Id, packageX.Version));
             }
         }
 

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
@@ -1989,8 +1989,9 @@ namespace NuGet.Commands.FuncTest
                 var command = new RestoreCommand(request);
 
                 // Act & Assert
-                var ex = await Assert.ThrowsAsync<FatalProtocolException>(async () => await command.ExecuteAsync());
-                Assert.NotNull(ex);
+                var result = await command.ExecuteAsync();
+                result.LogMessages.Count.Should().Be(1);
+                result.LogMessages[0].Code.Equals(NuGetLogCode.NU1301);
             }
         }
 
@@ -2029,8 +2030,9 @@ namespace NuGet.Commands.FuncTest
                 var command = new RestoreCommand(request);
 
                 // Act & Assert
-                var ex = await Assert.ThrowsAsync<FatalProtocolException>(async () => await command.ExecuteAsync());
-                Assert.NotNull(ex);
+                var result = await command.ExecuteAsync();
+                result.LogMessages.Count.Should().Be(1);
+                result.LogMessages[0].Code.Equals(NuGetLogCode.NU1301);
             }
         }
 

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
@@ -3675,7 +3675,6 @@ namespace NuGet.Commands.FuncTest
             // Assert
             result.Success.Should().BeTrue(because: logger.ShowMessages());
             result.LockFile.Libraries.Should().HaveCount(1);
-            result.LockFile.LogMessages.Should().HaveCount(1);
             result.LockFile.LogMessages.Select(e => e.Code).Should().AllBeEquivalentTo(NuGetLogCode.NU1801);
         }
 
@@ -3756,8 +3755,6 @@ namespace NuGet.Commands.FuncTest
 
                 // Assert
                 result.Success.Should().BeTrue(because: logger.ShowMessages());
-                result.LockFile.Libraries.Should().HaveCount(1);
-                result.LockFile.LogMessages.Should().HaveCount(1);
                 result.LockFile.LogMessages.Select(e => e.Code).Should().AllBeEquivalentTo(NuGetLogCode.NU1801);
             }
         }

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommand/FallbackFolderRestoreTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommand/FallbackFolderRestoreTests.cs
@@ -6,6 +6,8 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using FluentAssertions;
+using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Packaging;
 using NuGet.ProjectModel;
@@ -451,7 +453,9 @@ namespace NuGet.Commands.Test
 
                 // Act & Assert
                 var command = new RestoreCommand(request);
-                await Assert.ThrowsAsync<FatalProtocolException>(async () => await command.ExecuteAsync());
+                var result = await command.ExecuteAsync();
+                result.Success.Should().BeFalse();
+                result.LockFile.LogMessages.Select(e => e.Code).Should().AllBeEquivalentTo(NuGetLogCode.NU1301);
             }
         }
     }

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/SourceRepositoryDependencyProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/SourceRepositoryDependencyProviderTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using FluentAssertions;
 using Moq;
 using NuGet.Common;
 using NuGet.Configuration;
@@ -653,6 +654,122 @@ namespace NuGet.Commands.Test
 
                 expectedPackageDownloader.VerifyAll();
             }
+        }
+
+        [Fact]
+        public async Task FindLibraryAsync_WhenASourceIsInaccessible_AndFailuresAreNotIgnored_EveryCallLogsAnErrorMessage()
+        {
+            // Arrange
+            var cacheContext = new SourceCacheContext();
+            var expectedException = new FatalProtocolException("The source cannot be accessed");
+
+            var findResource = new Mock<FindPackageByIdResource>();
+            findResource.Setup(s => s.DoesPackageExistAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<NuGetVersion>(),
+                    It.IsAny<SourceCacheContext>(),
+                    It.IsAny<ILogger>(),
+                    It.IsAny<CancellationToken>()))
+                .Throws(expectedException);
+
+            var source = new Mock<SourceRepository>();
+            source.Setup(s => s.GetResourceAsync<FindPackageByIdResource>())
+                .ReturnsAsync(findResource.Object);
+            source.SetupGet(s => s.PackageSource)
+                .Returns(new PackageSource("http://test/index.json"));
+            var firstTestLogger = new TestLogger();
+            var secondTestLogger = new TestLogger();
+
+            var libraryRange = new LibraryRange("x", new VersionRange(new NuGetVersion(1, 0, 0)), LibraryDependencyTarget.Package);
+            var provider = new SourceRepositoryDependencyProvider(
+                source.Object,
+                firstTestLogger,
+                cacheContext,
+                ignoreFailedSources: false,
+                ignoreWarning: false);
+
+            var firstException = await Assert.ThrowsAsync<FatalProtocolException>(() => provider.FindLibraryAsync(
+                 new LibraryIdentity("x", NuGetVersion.Parse("1.0.0-beta"), LibraryType.Package),
+                 NuGetFramework.Parse("net45"),
+                 cacheContext,
+                 firstTestLogger,
+                 CancellationToken.None));
+
+            // Pre-conditions - Assert
+            firstException.Should().Be(expectedException);
+            firstTestLogger.ErrorMessages.Should().HaveCount(1);
+            firstTestLogger.ShowErrors().Should().Contain("NU1301");
+
+            // Act
+            var secondException = await Assert.ThrowsAsync<FatalProtocolException>(() => provider.FindLibraryAsync(
+                 new LibraryIdentity("x", NuGetVersion.Parse("1.0.0-beta"), LibraryType.Package),
+                 NuGetFramework.Parse("net45"),
+                 cacheContext,
+                 secondTestLogger,
+                 CancellationToken.None));
+
+            // Assert
+            secondException.Should().Be(expectedException);
+            secondTestLogger.ErrorMessages.Should().HaveCount(1);
+            secondTestLogger.ShowErrors().Should().Contain("NU1301");
+        }
+
+        [Fact]
+        public async Task FindLibraryAsync_WhenASourceIsInaccessible_AndFailuresAreIgnored_EveryCallLogsAnErrorMessage()
+        {
+            // Arrange
+            var cacheContext = new SourceCacheContext();
+            var expectedException = new FatalProtocolException("The source cannot be accessed");
+
+            var findResource = new Mock<FindPackageByIdResource>();
+            findResource.Setup(s => s.DoesPackageExistAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<NuGetVersion>(),
+                    It.IsAny<SourceCacheContext>(),
+                    It.IsAny<ILogger>(),
+                    It.IsAny<CancellationToken>()))
+                .Throws(expectedException);
+
+            var source = new Mock<SourceRepository>();
+            source.Setup(s => s.GetResourceAsync<FindPackageByIdResource>())
+                .ReturnsAsync(findResource.Object);
+            source.SetupGet(s => s.PackageSource)
+                .Returns(new PackageSource("http://test/index.json"));
+            var firstTestLogger = new TestLogger();
+            var secondTestLogger = new TestLogger();
+
+            var libraryRange = new LibraryRange("x", new VersionRange(new NuGetVersion(1, 0, 0)), LibraryDependencyTarget.Package);
+            var provider = new SourceRepositoryDependencyProvider(
+                source.Object,
+                firstTestLogger,
+                cacheContext,
+                ignoreFailedSources: true,
+                ignoreWarning: false);
+
+            var results = await provider.FindLibraryAsync(
+                 new LibraryIdentity("x", NuGetVersion.Parse("1.0.0-beta"), LibraryType.Package),
+                 NuGetFramework.Parse("net45"),
+                 cacheContext,
+                 firstTestLogger,
+                 CancellationToken.None);
+
+            // Pre-conditions - Assert
+            results.Should().Be(null);
+            firstTestLogger.WarningMessages.Should().HaveCount(1);
+            firstTestLogger.ShowWarnings().Should().Contain("NU1801");
+
+            // Act
+            results = await provider.FindLibraryAsync(
+                 new LibraryIdentity("x", NuGetVersion.Parse("1.0.0-beta"), LibraryType.Package),
+                 NuGetFramework.Parse("net45"),
+                 cacheContext,
+                 secondTestLogger,
+                 CancellationToken.None);
+
+            // Assert
+            results.Should().Be(null);
+            secondTestLogger.WarningMessages.Should().HaveCount(1);
+            secondTestLogger.ShowWarnings().Should().Contain("NU1801");
         }
 
         private sealed class SourceRepositoryDependencyProviderTest : IDisposable

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/SourceRepositoryDependencyProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/SourceRepositoryDependencyProviderTests.cs
@@ -604,7 +604,7 @@ namespace NuGet.Commands.Test
                 await test.Provider.GetPackageDownloaderAsync(
                     new PackageIdentity(id: "a", version: NuGetVersion.Parse("1.0.0")),
                     test.SourceCacheContext,
-                    NullLogger.Instance,
+                    test.Logger,
                     CancellationToken.None);
 
                 var expectedWarningCount = ignoreWarning ? 0 : 1;

--- a/test/TestUtilities/Test.Utility/Commands/ProjectTestHelpers.cs
+++ b/test/TestUtilities/Test.Utility/Commands/ProjectTestHelpers.cs
@@ -373,7 +373,6 @@ namespace NuGet.Commands.Test
         private static PackageSpec GetPackageSpecWithProjectNameAndSpec(string projectName, string rootPath, string spec)
         {
             var packageSpec = JsonPackageSpecReader.GetPackageSpec(spec, projectName, Path.Combine(rootPath, projectName, projectName)).WithTestRestoreMetadata();
-            packageSpec.RestoreSettings.HideWarningsAndErrors = true; // Pretend this is running in VS and this is a .NET Core project.
             return packageSpec;
         }
 

--- a/test/TestUtilities/Test.Utility/Commands/TestRestoreRequest.cs
+++ b/test/TestUtilities/Test.Utility/Commands/TestRestoreRequest.cs
@@ -147,7 +147,7 @@ namespace NuGet.Commands.Test
             sources,
             packagesDirectory,
             fallbackPackageFolders,
-            new TestSourceCacheContext(),
+            cacheContext,
             clientPolicyContext,
             log,
             new LockFileBuilderCache())

--- a/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestSettingsContext.cs
+++ b/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestSettingsContext.cs
@@ -192,6 +192,13 @@ namespace NuGet.Test.Utility
             Save();
         }
 
+        public void AddSource(string sourceName, string sourceUri)
+        {
+            var section = GetOrAddSection(XML, "packageSources");
+            AddEntry(section, sourceName, sourceUri);
+            Save();
+        }
+
         // Simply add any text as section into nuget.config file, adding large child node into nuget.config via api is tedious.
         public static void AddSectionIntoNuGetConfig(string path, string content, string parentNode)
         {


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/7245
Fixes: https://github.com/NuGet/Home/issues/9765

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
Currently when a source is inacessible, NuGet throws an exception and fails the whole process ungracefully. 
What this means is that there'll nothing in the error list consistently (since there's no assets file write), so the experience when dealing with a failing source can be frustrating.

The change here does the following: 

* Adds NU1301 for failing sources.
* Warnings and errors are reported on a per project level, so that each project has an entry in the error list. 
* Because the warnings are reported at project level, they can be suppressed!

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [x] Documentation PR or issue filled - https://github.com/NuGet/docs.microsoft.com-nuget/issues/2686
  - **OR**
  - [ ] N/A
