### PR TITLE
Disable NuGet.Protocol.Tests.LocalPackageSearchResourceTests.LocalPackageSearch_SearchAsync_SlowLocalRepository_WithCancellationToken_ThrowsAsync 

### DIFF
--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/LocalResourceTests/LocalPackageSearchResourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/LocalResourceTests/LocalPackageSearchResourceTests.cs
@@ -601,7 +601,7 @@ namespace NuGet.Protocol.Tests
             }
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/NuGet/Home/issues/11650")]
         public async Task LocalPackageSearch_SearchAsync_SlowLocalRepository_WithCancellationToken_ThrowsAsync()
         {
             using var pathContext = new SimpleTestPathContext();


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11651

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
It's flaky and has failed 6/46 times including twice today.
https://github.com/NuGet/Home/issues/11650

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
