### PR TITLE
enabled new rules from FxCop Code Analyzers package

### DIFF
--- a/build/NuGet.ruleset
+++ b/build/NuGet.ruleset
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<RuleSet Name="NuGet Code Analysis Rules" ToolsVersion="16.0">
+<RuleSet Name="NuGet Code Analysis Rules" ToolsVersion="17.0">
   <Include Path="managedminimumrules.ruleset" Action="Default" />
   <Rules AnalyzerId="Microsoft.Analyzers.ManagedCodeAnalysis" RuleNamespace="Microsoft.Rules.Managed">
     <Rule Id="CA1001" Action="Warning" />
@@ -9,6 +9,14 @@
   </Rules>
   <Rules AnalyzerId="Microsoft.CodeAnalysis.CSharp.CodeStyle" RuleNamespace="Microsoft.CodeQuality.Analyzers">
     <Rule Id="IDE0055" Action="Warning" />
+  </Rules>
+  <Rules AnalyzerId="Microsoft.CodeAnalysis.NetAnalyzers" RuleNamespace="Microsoft.CodeAnalysis.NetAnalyzers">
+    <Rule Id="CA3061" Action="Warning" />
+    <Rule Id="CA3076" Action="Warning" />
+    <Rule Id="CA3077" Action="Warning" />
+    <Rule Id="CA3147" Action="Warning" />
+    <Rule Id="CA5351" Action="Warning" />
+    <Rule Id="CA5359" Action="Warning" />
   </Rules>
   <Rules AnalyzerId="Microsoft.CodeAnalysis.VersionCheckAnalyzer" RuleNamespace="Microsoft.CodeAnalysis.VersionCheckAnalyzer">
     <Rule Id="CA9999" Action="None" />
@@ -81,11 +89,17 @@
     <Rule Id="CA2241" Action="None" />
     <Rule Id="CA2242" Action="None" />
     <Rule Id="CA2243" Action="None" />
-    <Rule Id="CA3061" Action="None" />
-    <Rule Id="CA5351" Action="None" />
-    <Rule Id="CA5359" Action="None" />
+    <Rule Id="CA2301" Action="Warning" />
+    <Rule Id="CA2302" Action="Warning" />
+    <Rule Id="CA2305" Action="Warning" />
+    <Rule Id="CA2311" Action="Warning" />
+    <Rule Id="CA2312" Action="Warning" />
+    <Rule Id="CA2315" Action="Warning" />
+    <Rule Id="CA2321" Action="Warning" />
+    <Rule Id="CA2322" Action="Warning" />
+    <Rule Id="CA3001" Action="Warning" />
+    <Rule Id="CA5358" Action="Warning" />
     <Rule Id="CA5360" Action="None" />
-    <Rule Id="CA5361" Action="None" />
     <Rule Id="CA5363" Action="None" />
     <Rule Id="CA5365" Action="None" />
     <Rule Id="CA5366" Action="None" />
@@ -98,12 +112,12 @@
     <Rule Id="CA5374" Action="None" />
     <Rule Id="CA5376" Action="None" />
     <Rule Id="CA5377" Action="None" />
-    <Rule Id="CA5378" Action="None" />
     <Rule Id="CA5379" Action="None" />
     <Rule Id="CA5380" Action="None" />
     <Rule Id="CA5381" Action="None" />
     <Rule Id="CA5384" Action="None" />
     <Rule Id="CA5385" Action="None" />
+    <Rule Id="CA5386" Action="Warning" />
     <Rule Id="CA5397" Action="None" />
   </Rules>
   <Rules AnalyzerId="Microsoft.NetCore.CSharp.Analyzers" RuleNamespace="Microsoft.NetCore.CSharp.Analyzers">
@@ -116,12 +130,6 @@
   </Rules>
   <Rules AnalyzerId="Microsoft.NetFramework.Analyzers" RuleNamespace="Microsoft.NetFramework.Analyzers">
     <Rule Id="CA1058" Action="None" />
-    <Rule Id="CA2153" Action="None" />
-    <Rule Id="CA3147" Action="None" />
-  </Rules>
-  <Rules AnalyzerId="Microsoft.NetFramework.CSharp.Analyzers" RuleNamespace="Microsoft.NetFramework.CSharp.Analyzers">
-    <Rule Id="CA3076" Action="None" />
-    <Rule Id="CA3077" Action="None" />
   </Rules>
   <Rules AnalyzerId="Microsoft.VisualStudio.Threading.Analyzers" RuleNamespace="Microsoft.VisualStudio.Threading.Analyzers">
     <Rule Id="VSTHRD103" Action="Hidden" />


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/811

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
Added new rules to the Code Analyzers rulesets as documented in this [spec](https://github.com/NuGet/Client.Engineering/blob/main/designs/CI-AutomatedComplianceTools.md#net-security-analyzers). Please refer to the [this](https://github.com/NuGet/Client.Engineering/blob/main/designs/CI-AutomatedComplianceTools.md#net-security-analyzers-1) section if you are interested in knowing more about which rules are turned on in the repo.

Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  - [x] N/A
