### PR TITLE
IVsNuGetProjectUpdateEvents.StartSolutionRestore should emit project file paths

### DIFF
--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreJob.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreJob.cs
@@ -463,7 +463,7 @@ namespace NuGet.SolutionRestoreManager
 
                                 var isRestoreOriginalAction = true;
                                 var isRestoreSucceeded = true;
-                                var projectList = dgSpec.Projects.Select(e => e.Name).ToList();
+                                var projectList = dgSpec.Projects.Select(e => e.FilePath).ToList();
                                 IReadOnlyList<RestoreSummary> restoreSummaries = null;
                                 try
                                 {


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11652

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

IVsNuGetProjectUpdateEvents.StartSolutionRestore should emit project file paths, not file name

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception - Unfortunately there are no tests here, the code doesn't lend itself to too many tests.
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
