### PR TITLE
Do not delete `ilmerge\NuGet.Build.Tasks.Pack.dll` when running integration tests

### DIFF
--- a/test/TestUtilities/Test.Utility/TestDotnetCLiUtility.cs
+++ b/test/TestUtilities/Test.Utility/TestDotnetCLiUtility.cs
@@ -287,9 +287,9 @@ project TFMs found: {string.Join(", ", compiledTfms.Keys.Select(k => k.ToString(
                 DateTime ilMergedPackAssemblyCreationDate = File.GetCreationTimeUtc(Path.Combine(ilMergedPackDirectoryPath, packFileName));
                 if (ilMergedPackAssemblyCreationDate > packAssemblyCreationDate)
                 {
-                    FileUtility.Replace(
-                        sourceFileName: Path.Combine(packProjectCoreArtifactsDirectory.FullName, "ilmerge", packFileName),
-                        destFileName: Path.Combine(packAssemblyDestinationDirectory, packFileName));
+                    File.Copy(sourceFileName: Path.Combine(packProjectCoreArtifactsDirectory.FullName, "ilmerge", packFileName),
+                        destFileName: Path.Combine(packAssemblyDestinationDirectory, packFileName),
+                        overwrite:true);
                 }
             }
             else


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes:https://github.com/NuGet/Home/issues/11454

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

- `FileUtility.Replace` removes a file from source location
- `File.Copy` does not remove a file from source location

`FileUtility.Replace` - has extra retry logic, but in this particular case, it is not necessary. Each time integration tests are run, `NuGet.Build.Tasks.Pack.dll` is copied into a new location so there is no chance for the destination file being locked.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [ ] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
