### PR TITLE
Use AzDO UI for build triggers, not yaml

### DIFF
--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -1,28 +1,3 @@
-pr: none
-trigger:
-  batch: false
-  branches:
-    include:
-      - dev
-      - release-*-MSRC
-    exclude:
-      - dev-*
-
-
-# Weekly builds for supported branches, to maintain CI build health + keep OptProf training data fresh
-# Generally this means LTS versions + current GA version
-# Visual Studio support lifecycle: https://docs.microsoft.com/en-us/visualstudio/productinfo/vs-servicing
-# .NET support lifecycle: https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core
-schedules:
-- cron: "0 10 * * 0" # Every sunday at 10am UTC
-  displayName: Weekly branch build
-  branches:
-    include:
-      - release-5.11.x-MSRC # VS 16.11 and .NET 5 SDK 5.0.4xx
-      - release-6.0.x-MSRC # VS 17.0 and .NET 6 SDK 6.0.1xx
-      - release-6.1.x-MSRC # VS 17.1 and .NET 6 SDK 6.0.2xx
-  always: true
-
 parameters:
 - name: DartLabEnvironment
   displayName: DartLab Environment


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1464

Regression? no

## Description

After following up with Azure DevOps support, it turns out that Azure Pieplines uses the yaml from each branch to determine that branch's triggers and schedules. Therefore, we can't have a "centraltized, single source of truth" in the dev branch. For example, `release-6.0.x` branch's yaml is used to determine the `trigger` and `schedule` for `release-6.0.x`. This also means that if the `trigger:` section of the yaml is missing from a feature/dev branch, then it will trigger the official build for that branch. The only way to ensure that unwanted branches do not trigger official builds is to not use yaml and define the triggers and schedules in the UI.

I've already changed the triggers and schedules in the UI. This PR is just to remove unused code to reduce confusion.


## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
