### PR TITLE
Add counts for the package group headers and make accessible

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Converters/PackageLevelToGroupNameConverter.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Converters/PackageLevelToGroupNameConverter.cs
@@ -20,11 +20,11 @@ namespace NuGet.PackageManagement.UI
             {
                 if (pkgLevel == PackageLevel.TopLevel)
                 {
-                    return string.Format(Resources.PackageLevel_TopLevelPackageHeaderText, topLevelCount);
+                    return string.Format(CultureInfo.CurrentUICulture, Resources.PackageLevel_TopLevelPackageHeaderText, topLevelCount);
                 }
                 else if (pkgLevel == PackageLevel.Transitive)
                 {
-                    return string.Format(Resources.PackageLevel_TransitivePackageHeaderText, transitiveCount);
+                    return string.Format(CultureInfo.CurrentUICulture, Resources.PackageLevel_TransitivePackageHeaderText, transitiveCount);
                 }
             }
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Converters/PackageLevelToGroupNameConverter.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Converters/PackageLevelToGroupNameConverter.cs
@@ -8,26 +8,30 @@ using NuGet.VisualStudio;
 
 namespace NuGet.PackageManagement.UI
 {
-    internal class PackageLevelToGroupNameConverter : IValueConverter
+    internal class PackageLevelToGroupNameConverter : IMultiValueConverter
     {
-        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
         {
-            if (value is PackageLevel pkgLevel)
+            if (values != null
+                && values.Length == 3
+                && values[0] is PackageLevel pkgLevel
+                && values[1] is int topLevelCount
+                && values[2] is int transitiveCount)
             {
                 if (pkgLevel == PackageLevel.TopLevel)
                 {
-                    return Resources.PackageLevel_TopLevelPackageHeaderText;
+                    return string.Format(Resources.PackageLevel_TopLevelPackageHeaderText, topLevelCount);
                 }
                 else if (pkgLevel == PackageLevel.Transitive)
                 {
-                    return Resources.PackageLevel_TransitivePackageHeaderText;
+                    return string.Format(Resources.PackageLevel_TransitivePackageHeaderText, transitiveCount);
                 }
             }
 
             return null;
         }
 
-        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
         {
             throw new NotImplementedException();
         }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
@@ -1537,7 +1537,7 @@ namespace NuGet.PackageManagement.UI {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Top-level packages.
+        ///   Looks up a localized string similar to Top-level packages ({0}).
         /// </summary>
         public static string PackageLevel_TopLevelPackageHeaderText {
             get {
@@ -1546,7 +1546,7 @@ namespace NuGet.PackageManagement.UI {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Transitive packages.
+        ///   Looks up a localized string similar to Transitive packages ({0}).
         /// </summary>
         public static string PackageLevel_TransitivePackageHeaderText {
             get {

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
@@ -1036,10 +1036,12 @@ Please see https://aka.ms/troubleshoot_nuget_cache for more help.</value>
     <comment>{0} = license name. Examples: MIT, Apache</comment>
   </data>
   <data name="PackageLevel_TopLevelPackageHeaderText" xml:space="preserve">
-    <value>Top-level packages</value>
+    <value>Top-level packages ({0})</value>
+    <comment>{0} = number of packages</comment>
   </data>
   <data name="PackageLevel_TransitivePackageHeaderText" xml:space="preserve">
-    <value>Transitive packages</value>
+    <value>Transitive packages ({0})</value>
+    <comment>{0} = number of packages</comment>
   </data>
   <data name="ToolTip_TransitiveDependency" xml:space="preserve">
     <value>Transitively referenced version</value>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml
@@ -1,5 +1,6 @@
 <UserControl
   x:Class="NuGet.PackageManagement.UI.InfiniteScrollList"
+  x:Name="_infiniteScrollList"
   xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
   xmlns:nuget="clr-namespace:NuGet.PackageManagement.UI"
@@ -278,10 +279,17 @@
         </Grid>
       </ControlTemplate>
 
+      <MultiBinding x:Key="GroupHeaderMultiBinding" Converter="{StaticResource PackageLevelToGroupNameConverter}">
+        <Binding Path="Name" />
+        <Binding ElementName="_infiniteScrollList" Path="TopLevelPackageCount" />
+        <Binding ElementName="_infiniteScrollList" Path="TransitivePackageCount" />
+      </MultiBinding>
+
       <Style
         x:Key="ExpanderStyle"
         TargetType="{x:Type Expander}"
         BasedOn="{StaticResource {x:Type Expander}}">
+        <Setter Property="Header" Value="{StaticResource GroupHeaderMultiBinding}" />
         <Setter Property="Foreground" Value="{DynamicResource {x:Static nuget:Brushes.UIText}}" />
         <Style.Triggers>
           <DataTrigger Binding="{Binding Name}" Value="{x:Static common:PackageLevel.Transitive}">
@@ -297,16 +305,16 @@
         x:Key="GroupedListItemControlTemplate"
         TargetType="{x:Type GroupItem}">
         <Expander
-          Header="{Binding Name, Converter={StaticResource PackageLevelToGroupNameConverter}}"
           Style="{StaticResource ExpanderStyle}">
           <ItemsPresenter />
         </Expander>
       </ControlTemplate>
 
       <Style
-      x:Key="GroupedListContainerStyle"
-      TargetType="{x:Type GroupItem}">
+        x:Key="GroupedListContainerStyle"
+        TargetType="{x:Type GroupItem}">
         <Setter Property="Template" Value="{StaticResource GroupedListItemControlTemplate}" />
+        <Setter Property="AutomationProperties.Name" Value="{StaticResource GroupHeaderMultiBinding}" />
       </Style>
     </ResourceDictionary>
   </UserControl.Resources>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
@@ -141,6 +141,10 @@ namespace NuGet.PackageManagement.UI
 
         public Guid? OperationId => _loader?.State.OperationId;
 
+        public int TopLevelPackageCount { get; private set; }
+
+        public int TransitivePackageCount { get; private set; }
+
         // Load items using the specified loader
         internal async Task LoadItemsAsync(
             IPackageItemLoader loader,
@@ -492,6 +496,10 @@ namespace NuGet.PackageManagement.UI
                         Items.Add(package);
                         _selectedCount = package.IsSelected ? _selectedCount + 1 : _selectedCount;
                     }
+
+                    // update the top-level and transitive package counts
+                    TopLevelPackageCount = PackageItems.Count(p => p.PackageLevel == PackageLevel.TopLevel);
+                    TransitivePackageCount = PackageItems.Count(p => p.PackageLevel == PackageLevel.Transitive);
 
                     if (removed)
                     {

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Converters/PackageLevelToGroupNameConverterTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Converters/PackageLevelToGroupNameConverterTests.cs
@@ -11,18 +11,22 @@ namespace NuGet.PackageManagement.UI.Test.Converters
     {
         public static IEnumerable<object[]> GetConvertData()
         {
-            yield return new object[] { PackageLevel.TopLevel, Resources.PackageLevel_TopLevelPackageHeaderText };
-            yield return new object[] { PackageLevel.Transitive, Resources.PackageLevel_TransitivePackageHeaderText };
-            yield return new object[] { Resources.PackageLevel_TopLevelPackageHeaderText, null };
-            yield return new object[] { "some string", null };
-            yield return new object[] { new object(), null };
-            yield return new object[] { 12345, null };
+            yield return new object[] { new object[] { PackageLevel.TopLevel, 1, 2 }, string.Format(Resources.PackageLevel_TopLevelPackageHeaderText, 1) };
+            yield return new object[] { new object[] { PackageLevel.Transitive, 1, 2 }, string.Format(Resources.PackageLevel_TransitivePackageHeaderText, 2) };
+            yield return new object[] { new object[] { PackageLevel.TopLevel, 0, 1 }, string.Format(Resources.PackageLevel_TopLevelPackageHeaderText, 0) };
+            yield return new object[] { new object[] { PackageLevel.Transitive, 1, 0 }, string.Format(Resources.PackageLevel_TransitivePackageHeaderText, 0) };
+            yield return new object[] { new object[] { Resources.PackageLevel_TopLevelPackageHeaderText, 1, 2 }, null };
+            yield return new object[] { new object[] { "some string", 1, 2 }, null };
+            yield return new object[] { new object[] { PackageLevel.TopLevel, 1 }, null };
+            yield return new object[] { new object[] { PackageLevel.Transitive, 1 }, null };
+            yield return new object[] { new object[] { new object() }, null };
+            yield return new object[] { new object[] { 12345 }, null };
             yield return new object[] { null, null };
         }
 
         [Theory]
         [MemberData(nameof(GetConvertData))]
-        public void Convert_MultipleInputs_Succeeds(object input, object expected)
+        public void Convert_MultipleInputs_Succeeds(object[] input, object expected)
         {
             var converterToTest = new PackageLevelToGroupNameConverter();
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/nuget/home/issues/10750

Regression? Last working version: N/A

## Description
Added the number of packages in each of the package list groups: Top-level packages and Transitive packages. Ensured that the full header and its count is read with the screen reader.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added (Updated tests to reflect changes. Also ran tests with Accessibility Insights and manually tested with NVDA)
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
