### PR TITLE
Packages list loading progress no longer blocks UI thread

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
@@ -407,7 +407,7 @@ namespace NuGet.PackageManagement.UI
         /// <param name="state">Progress reported by the <c>Progress</c> callback</param>
         private void HandleItemLoaderStateChange(IItemLoader<PackageItemViewModel> loader, IItemLoaderState state)
         {
-            _joinableTaskFactory.Value.Run(async () =>
+            NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async () =>
             {
                 await _joinableTaskFactory.Value.SwitchToMainThreadAsync();
 
@@ -435,7 +435,7 @@ namespace NuGet.PackageManagement.UI
                         });
                     }
                 }
-            });
+            }).PostOnFailure(nameof(InfiniteScrollList), nameof(HandleItemLoaderStateChange));
         }
 
         private Visibility EvaluateStatusBarVisibility(IItemLoader<PackageItemViewModel> loader, IItemLoaderState state)


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1479

Regression? Last working version: No

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
https://github.com/NuGet/NuGet.Client/blob/ab4f27ee10c51acfc09b1116bf6733ca099a6842/src%2FNuGet.Clients%2FNuGet.PackageManagement.UI%2FXamls%2FInfiniteScrollList.xaml.cs#L410 is in a JTF.Run where it's attempting to switch to the UI thread. This is blocking the thread pool thread until the UI responds. I've simply switched to `RunAsync` with a `PostOnFailure`.

We saw this behavior in UI delay reporting, but I have not verified that this completely fixed those delays. It just looks like a sensible, quick change to make. 

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception - If folks feel a test is warranted, I can add one. 
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
