### PR TITLE
Fix BuildTools vsix hash in vsman file

### DIFF
--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -215,7 +215,7 @@ steps:
   inputs:
     solution: "setup/Microsoft.VisualStudio.NuGet.BuildTools.vsmanproj"
     configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/p:BuildNumber=$(BuildNumber) /p:ManifestDirPath=$(Build.ArtifactStagingDirectory)/sbom"
+    msbuildArguments: "/p:BuildNumber=$(BuildNumber) /p:IsVsixBuild=true"
   condition: " and(succeeded(), eq(variables['BuildRTM'], 'false'))"
 
 - task: MSBuild@1
@@ -260,6 +260,14 @@ steps:
     solution: "setup\\Microsoft.VisualStudio.NuGet.Core.vsmanproj"
     configuration: "$(BuildConfiguration)"
     msbuildArguments: "/p:ManifestDirPath=$(Build.ArtifactStagingDirectory)/sbom"
+  condition: " and(succeeded(),eq(variables['BuildRTM'], 'false')) "
+
+- task: MSBuild@1
+  displayName: "Generate VSMAN file for Build Tools VSIX"
+  inputs:
+    solution: "setup\\Microsoft.VisualStudio.NuGet.BuildTools.vsmanproj"
+    configuration: "$(BuildConfiguration)"
+    msbuildArguments: "/p:IsVsixBuild=false /p:ManifestDirPath=$(Build.ArtifactStagingDirectory)/sbom"
   condition: " and(succeeded(),eq(variables['BuildRTM'], 'false')) "
 
 - task: PowerShell@1

--- a/setup/Microsoft.VisualStudio.NuGet.BuildTools.vsmanproj
+++ b/setup/Microsoft.VisualStudio.NuGet.BuildTools.vsmanproj
@@ -12,7 +12,7 @@
     <OutputPath>$(VsixPublishDestination)</OutputPath>
   </PropertyGroup>
 
-  <PropertyGroup>
+  <PropertyGroup Condition=" '$(IsVsixBuild)' == 'true' ">
     <IsPackage>true</IsPackage>
     <FinalizeValidate>false</FinalizeValidate>
     <ValidateManifest>false</ValidateManifest>
@@ -20,11 +20,11 @@
     <MicroBuild_SigningEnabled>false</MicroBuild_SigningEnabled>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition=" '$(IsVsixBuild)' == 'true' ">
     <ProjectReference Include="Microsoft.VisualStudio.NuGet.BuildTools.swixproj" SkipGetTargetFrameworkProperties="true" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition=" '$(IsVsixBuild)' != 'true' ">
     <MergeManifest Include="$(VsixPublishDestination)$(MSBuildProjectName).json"
       SBOMFileLocation="$(ManifestDirPath)_manifest\spdx_2.2\manifest.spdx.json"
       />


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: [#1491](https://github.com/NuGet/Client.Engineering/issues/1491)

Regression? Yes Last working version: before https://github.com/NuGet/NuGet.Client/pull/4468

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

In https://github.com/NuGet/NuGet.Client/pull/4468 I changed the BuildTools install files from: 1. create vsix 2. sign vsix 3. create vsman.  To: 1. create vsix 1.b create vsman 2. sign vsix.

Since the vsman, which captures the hash of the vsix, happens before the vsix is signed, the hash changes and the vsman is invalid.  This PR brings back the original order.


## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
