### PR TITLE
Revert "Unskip Fsharp tests skipped due to Patch Tuesday events (#4459)"

### DIFF
--- a/test/EndToEnd/ProjectTemplates/FSharpConsoleApplication.zip/ConsoleApplication.fsproj
+++ b/test/EndToEnd/ProjectTemplates/FSharpConsoleApplication.zip/ConsoleApplication.fsproj
@@ -4,7 +4,6 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
     <WarnOn>3390;$(WarnOn)</WarnOn>
-    <_NetCoreSdkIsPreview>true</_NetCoreSdkIsPreview>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/EndToEnd/ProjectTemplates/FSharpLibrary.zip/Library.fsproj
+++ b/test/EndToEnd/ProjectTemplates/FSharpLibrary.zip/Library.fsproj
@@ -4,7 +4,6 @@
     <TargetFramework>net5.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <WarnOn>3390;$(WarnOn)</WarnOn>
-    <_NetCoreSdkIsPreview>true</_NetCoreSdkIsPreview>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/EndToEnd/tests/GetPackageTest.ps1
+++ b/test/EndToEnd/tests/GetPackageTest.ps1
@@ -181,7 +181,8 @@ function Test-GetPackageForProjectReturnsCorrectPackages2 {
 }
 
 function Test-GetPackageForFSharpProjectReturnsCorrectPackages {
-    param()     
+    [SkipTest('https://github.com/NuGet/Home/issues/11291')]
+    param()
     # Arrange
     $p = New-FSharpConsoleApplication
     Build-Solution # wait for project nomination

--- a/test/EndToEnd/tests/InstallPackageTest.ps1
+++ b/test/EndToEnd/tests/InstallPackageTest.ps1
@@ -458,7 +458,9 @@ function Test-AddBindingRedirectToWebsiteWithNonExistingOutputPath {
 }
 
 function Test-InstallCanPipeToFSharpProjects {
-    param($context)    
+    [SkipTest('https://github.com/NuGet/Home/issues/11358')]
+    param($context)
+
     # Arrange
     $p = New-FSharpLibrary
     Build-Solution # wait for project nomination

--- a/test/EndToEnd/tests/UninstallPackageTest.ps1
+++ b/test/EndToEnd/tests/UninstallPackageTest.ps1
@@ -120,6 +120,7 @@ function Test-UninstallPackageWithNestedContentFiles {
 }
 
 function Test-SimpleFSharpUninstall {
+    [SkipTest('https://github.com/NuGet/Home/issues/11358')]
     param($context)
 
     # Arrange

--- a/test/EndToEnd/tests/UpdatePackageTest.ps1
+++ b/test/EndToEnd/tests/UpdatePackageTest.ps1
@@ -632,6 +632,7 @@ function Test-UpdateAllPackagesInSolution {
 }
 
 function Test-UpdatePackageOnAnFSharpProjectWithMultiplePackages {
+    [SkipTest('https://github.com/NuGet/Home/issues/11358')]
     param(
         $context
     )


### PR DESCRIPTION
This reverts commit 4ed05177c6222d32ad55d612d2202aa9c6a1f2a6.

<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: 

Regression? Last working version: N/A

## Description
The FSharp tests are failing again due to open issue: https://github.com/dotnet/fsharp/issues/12835. This will revert the change we made recently to unskip the tests that were failing so they are skipped again as this is currently blocking all open PRs from passing automated tests.

## PR Checklist

- [x] PR has a meaningful title
- [ ] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
