### PR TITLE
Run NuGet.Command.Functest in parallel

### DIFF
--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/NuGet.Commands.FuncTest.csproj
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/NuGet.Commands.FuncTest.csproj
@@ -6,6 +6,7 @@
     <TargetFrameworks>$(TargetFrameworksExeForSigning)</TargetFrameworks>
     <TestProjectType>functional</TestProjectType>
     <Description>Integration tests for the more involved NuGet.Commands, such as restore.</Description>
+    <UseParallelXunit>true</UseParallelXunit>
   </PropertyGroup>
 
   <ItemGroup>
@@ -21,12 +22,6 @@
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
-  <ItemGroup>
-    <None Include="xunit.runner.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
-
-  <Import Project="$(BuildCommonDirectory)common.targets"/>
+  <Import Project="$(BuildCommonDirectory)common.targets" />
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 </Project>

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/xunit.runner.json
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/xunit.runner.json
@@ -1,4 +1,0 @@
-﻿{
-  "maxParallelThreads": 1,
-  "parallelizeTestCollections": false
-}


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1286

Regression? Last working version:

## Description
Added UseParallelXunit property to NuGet.Commands.Functest project so that the tests can run in parallel using the settings defined in the shared [xunit.runner.json](https://github.com/NuGet/NuGet.Client/blob/dev/build/TestShared/xunit.runner.json) file.  I deleted xunit.runner.json file that was created under project root directory which instructed xUnit to disable parallelism.

Before: 2nd test start after 1st test end.
```
Discovering: NuGet.Commands.FuncTest
Discovered:  NuGet.Commands.FuncTest
     Starting:    NuGet.Commands.FuncTest
          NuGet.Commands.FuncTest.RestoreCommandTests.RestoreCommand_FrameworkImportRulesAreAppliedAsync [STARTING]
          NuGet.Commands.FuncTest.RestoreCommandTests.RestoreCommand_FrameworkImportRulesAreAppliedAsync [FINISHED] Time: 0.7712831s
          NuGet.Commands.FuncTest.RestoreCommandTests.RestoreCommand_RestoreInexactWithIgnoreFailingLocalSourceAsync [STARTING]
           NuGet.Commands.FuncTest.RestoreCommandTests.RestoreCommand_RestoreInexactWithIgnoreFailingLocalSourceAsync [FINISHED] Time: 0.0765266s
          NuGet.Commands.FuncTest.RestoreCommandTests.RestoreCommand_DependenciesDifferOnCaseAsync [STARTING]
          NuGet.Commands.FuncTest.RestoreCommandTests.RestoreCommand_DependenciesDifferOnCaseAsync [FINISHED] Time: 0.1014889s
```

After: From the CI logs below, xUnit started `3 tests in parallel (one test from every class file).
```
        Discovering: NuGet.Commands.FuncTest (method display = ClassAndMethod, method display options = None)
             Discovered:  NuGet.Commands.FuncTest (found 100 test cases)
                  Starting:    NuGet.Commands.FuncTest (parallel test collections = on, max threads = 8)
                         NuGet.Commands.FuncTest.RestoreCommandTests.RestoreCommand_FrameworkImportRulesAreAppliedAsync [STARTING]
                         NuGet.Commands.FuncTest.RestoreCommand_PackagesLockFileTests.RestoreCommand_PackagesLockFile_InLockedMode_WhenATargetFrameworkIsAdded_FailsWithNU1004 [STARTING]
                         NuGet.Commands.FuncTest.UWPRestoreTests.UWPRestore_ReadV1LockFile [STARTING]
                         NuGet.Commands.FuncTest.UWPRestoreTests.UWPRestore_ReadV1LockFile [FINISHED] Time: 0.0598995s
                         NuGet.Commands.FuncTest.UWPRestoreTests.UWPRestore_ModernPCL [STARTING]
                         NuGet.Commands.FuncTest.RestoreCommand_PackagesLockFileTests.RestoreCommand_PackagesLockFile_InLockedMode_WhenATargetFrameworkIsAdded_FailsWithNU1004 [FINISHED] Time: 0.5281023s
                         NuGet.Commands.FuncTest.RestoreCommand_PackagesLockFileTests.RestoreCommand_PackagesLockFile_InLockedMode_WhenADependecyIsUpdated_FailsWithNU1004 [STARTING]
                         NuGet.Commands.FuncTest.RestoreCommandTests.RestoreCommand_FrameworkImportRulesAreAppliedAsync [FINISHED] Time: 0.5355252s
                         NuGet.Commands.FuncTest.RestoreCommandTests.RestoreCommand_RestoreInexactWithIgnoreFailingLocalSourceAsync [STARTING]
                         NuGet.Commands.FuncTest.RestoreCommand_PackagesLockFileTests.RestoreCommand_PackagesLockFile_InLockedMode_WhenADependecyIsUpdated_FailsWithNU1004 [FINISHED] Time: 0.0395926s
                         NuGet.Commands.FuncTest.RestoreCommand_PackagesLockFileTests.RestoreCommand_PackagesLockFile_InLockedMode_WhenADependecyIsAdded_FailsWithNU1004 [STARTING]
                         NuGet.Commands.FuncTest.RestoreCommand_PackagesLockFileTests.RestoreCommand_PackagesLockFile_InLockedMode_WhenADependecyIsAdded_FailsWithNU1004 [FINISHED] Time: 0.04377s
                         NuGet.Commands.FuncTest.RestoreCommand_PackagesLockFileTests.RestoreCommand_PackagesLockFile_InLockedMode_WhenADependencyIsReplaced_FailsWithNU1004 [STARTING]
                         NuGet.Commands.FuncTest.RestoreCommand_PackagesLockFileTests.RestoreCommand_PackagesLockFile_InLockedMode_WhenADependencyIsReplaced_FailsWithNU1004 [FINISHED] Time: 0.075655s
                         NuGet.Commands.FuncTest.RestoreCommand_PackagesLockFileTests.RestoreCommand_PackagesLockFile_InLockedMode_WhenARuntimeIdentifierIsAdded_FailsWithNU1004 [STARTING]
                         NuGet.Commands.FuncTest.RestoreCommandTests.RestoreCommand_RestoreInexactWithIgnoreFailingLocalSourceAsync

```

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
