### PR TITLE
Use ProjectInstance.FromFile instead of Project.FromFile + Project.CreateInstance

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs
@@ -938,12 +938,7 @@ namespace NuGet.Build.Tasks.Console
                             LoadSettings = ProjectLoadSettings.IgnoreEmptyImports | ProjectLoadSettings.IgnoreInvalidImports | ProjectLoadSettings.IgnoreMissingImports | ProjectLoadSettings.DoNotEvaluateElementsWithFalseCondition,
                             ProjectCollection = collection
                         };
-
-                        // Create a Project object which does the evaluation
-                        var project = Project.FromFile(path, projectOptions);
-
-                        // Create a ProjectInstance object which is what this factory needs to return
-                        var projectInstance = project.CreateProjectInstance(ProjectInstanceSettings.None, evaluationContext);
+                        var projectInstance = ProjectInstance.FromFile(path, projectOptions);
 
                         if (!projectInstance.Targets.ContainsKey("_IsProjectRestoreSupported") || properties.TryGetValue("TargetFramework", out var targetFramework) && string.IsNullOrWhiteSpace(targetFramework))
                         {


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/11675

Regression? Last working version:

## Description
At the time Static Graph Restore was created, there was no `ProjectInstance.FromFile` and no way to create a `ProjectInstance` with an evaluation context. This was fixed in https://github.com/dotnet/msbuild/pull/5006. So now static graph restore can use that to avoid creating the `Project` object.

This should be a perf improvement (admittedly minor).

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  - [x] N/A
