### PR TITLE
Use SettingsLoadingContext in NuGetSdkResolver

### DIFF
--- a/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/NuGetSdkResolver.cs
+++ b/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/NuGetSdkResolver.cs
@@ -29,6 +29,10 @@ namespace Microsoft.Build.NuGetSdkResolver
     {
         private static readonly Lazy<bool> DisableNuGetSdkResolver = new Lazy<bool>(() => Environment.GetEnvironmentVariable("MSBUILDDISABLENUGETSDKRESOLVER") == "1");
 
+        private static readonly Lazy<object> SettingsLoadContext = new Lazy<object>(() => new SettingsLoadingContext());
+
+        private static readonly Lazy<object> MachineWideSettings = new Lazy<object>(() => new XPlatMachineWideSetting());
+
         private readonly IGlobalJsonReader _globalJsonReader;
 
         /// <summary>
@@ -127,7 +131,7 @@ namespace Microsoft.Build.NuGetSdkResolver
                 var parsedSdkVersion = (NuGetVersion)nuGetVersion;
 
                 // Load NuGet settings and a path resolver
-                ISettings settings = Settings.LoadDefaultSettings(context.ProjectFilePath);
+                ISettings settings = Settings.LoadDefaultSettings(context.ProjectFilePath, configFileName: null, MachineWideSettings.Value as IMachineWideSettings, SettingsLoadContext.Value as SettingsLoadingContext);
 
                 var fallbackPackagePathResolver = new FallbackPackagePathResolver(NuGetPathContext.Create(settings));
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11676

Regression? Last working version:

## Description
The `SettingsLoadingContext` is a file cache for `NuGet.Config` but it was never included in the NuGet-based MSBuild project SDK resolver.  This results in `NuGet.Config` being loaded once for every project in Visual Studio design-time builds which is completely unnecessary.  This change includes the `SettingsLoadingContext` when reading the settings to avoid extra reads of the file.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception - Existing tests cover this code path
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
