### PR TITLE
Check for null or empty string for solution path in SDK resolver

### DIFF
--- a/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/GlobalJsonReader.cs
+++ b/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/GlobalJsonReader.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Build.NuGetSdkResolver
         public Dictionary<string, string> GetMSBuildSdkVersions(SdkResolverContext context, string fileName = GlobalJsonFileName)
         {
             // Prefer looking next to the solution file as its more likely to be closer to global.json
-            string startingPath = context?.SolutionFilePath ?? context?.ProjectFilePath;
+            string startingPath = GetStartingPath(context);
 
             // If the SolutionFilePath and ProjectFilePath are not set, an in-memory project is being evaluated and there's no way to know which directory to start looking for a global.json
             if (string.IsNullOrWhiteSpace(startingPath) || string.IsNullOrWhiteSpace(fileName))
@@ -88,6 +88,26 @@ namespace Microsoft.Build.NuGetSdkResolver
             Dictionary<string, string> sdkVersions = cacheEntry.Lazy.Value;
 
             return sdkVersions;
+        }
+
+        internal static string GetStartingPath(SdkResolverContext context)
+        {
+            if (context == null)
+            {
+                return null;
+            }
+
+            if (!string.IsNullOrWhiteSpace(context.SolutionFilePath))
+            {
+                return context.SolutionFilePath;
+            }
+
+            if (!string.IsNullOrWhiteSpace(context.ProjectFilePath))
+            {
+                return context.ProjectFilePath;
+            }
+
+            return null;
         }
 
         /// <summary>

--- a/test/NuGet.Core.Tests/Microsoft.Build.NuGetSdkResolver.Test/GlobalJsonReader_Tests.cs
+++ b/test/NuGet.Core.Tests/Microsoft.Build.NuGetSdkResolver.Test/GlobalJsonReader_Tests.cs
@@ -337,12 +337,12 @@ namespace Microsoft.Build.NuGetSdkResolver.Test
         }
 
         /// <summary>
-        /// Verifies that <see cref="GlobalJsonReader.GetMSBuildSdkVersions(Framework.SdkResolverContext)" /> returns null when the <see cref="Framework.SdkResolverContext.ProjectFilePath" /> is null.
+        /// Verifies that <see cref="GlobalJsonReader.GetMSBuildSdkVersions(Framework.SdkResolverContext)" /> returns null when the <see cref="Framework.SdkResolverContext.SolutionFilePath" /> and <see cref="Framework.SdkResolverContext.ProjectFilePath" /> is null.
         /// </summary>
         [Fact]
-        public void GetMSBuildSdkVersions_ReturnsNull_WhenProjectPathIsNull()
+        public void GetMSBuildSdkVersions_ReturnsNull_WhenSolutionFilePathAndProjectFilePathIsNull()
         {
-            var context = new MockSdkResolverContext(projectPath: null);
+            var context = new MockSdkResolverContext(projectPath: null, solutionPath: null);
 
             var globalJsonReader = new GlobalJsonReader();
 
@@ -394,6 +394,54 @@ namespace Microsoft.Build.NuGetSdkResolver.Test
 
                 wasGlobalJsonRead.Should().BeTrue();
             }
+        }
+
+        /// <summary>
+        /// Verifies that the <see cref="GlobalJsonReader.GetStartingPath(Framework.SdkResolverContext)" /> method returns the project path if the solution path is null or whitespace.
+        /// </summary>
+        /// <param name="solutionPath"></param>
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("     ")]
+        public void GetStartingPath_ReturnsProjectPath_WhenSolutionPathIsNullOrWhitespace(string solutionPath)
+        {
+            const string projectPath = "PROJECT_PATH";
+
+            var context = new MockSdkResolverContext(projectPath, solutionPath);
+
+            GlobalJsonReader.GetStartingPath(context).Should().Be(projectPath);
+        }
+
+        /// <summary>
+        /// Verifies that the <see cref="GlobalJsonReader.GetStartingPath(Framework.SdkResolverContext)" /> method returns the solution path if it is not null or whitespace.
+        /// </summary>
+        /// <param name="solutionPath"></param>
+        [Fact]
+        public void GetStartingPath_ReturnsSolutionPath_WhenSolutionPathIsNotNullOrWhitespace()
+        {
+            const string solutionPath = "SOLUTION_PATH";
+
+            var context = new MockSdkResolverContext(projectPath: null, solutionPath);
+
+            GlobalJsonReader.GetStartingPath(context).Should().Be(solutionPath);
+        }
+
+        /// <summary>
+        /// Verifies that the <see cref="GlobalJsonReader.GetStartingPath(Framework.SdkResolverContext)" /> method returns the project path if the solution path is null or whitespace.
+        /// </summary>
+        /// <param name="solutionPath"></param>
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData("", null)]
+        [InlineData("", "")]
+        [InlineData(null, "")]
+        [InlineData("     ", "     ")]
+        public void GetStartingPath_ReturnsNull_WhenSolutionPathAndProjectPathIsNullOrWhitespace(string solutionPath, string projectPath)
+        {
+            var context = new MockSdkResolverContext(projectPath, solutionPath);
+
+            GlobalJsonReader.GetStartingPath(context).Should().BeNull();
         }
 
         /// <summary>

--- a/test/NuGet.Core.Tests/Microsoft.Build.NuGetSdkResolver.Test/MockSdkResolverContext.cs
+++ b/test/NuGet.Core.Tests/Microsoft.Build.NuGetSdkResolver.Test/MockSdkResolverContext.cs
@@ -16,11 +16,12 @@ namespace Microsoft.Build.NuGetSdkResolver.Test
         /// Initializes a new instance of the <see cref="MockSdkResolverContext" /> class.
         /// </summary>
         /// <param name="projectPath">The path to the project.</param>
-        public MockSdkResolverContext(string projectPath)
+        public MockSdkResolverContext(string projectPath = null, string solutionPath = null)
         {
             Logger = MockSdkLogger;
 
             ProjectFilePath = projectPath;
+            SolutionFilePath = solutionPath;
         }
 
         /// <summary>


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11677

Regression? Last working version:

## Description
In some cases, Visual Studio will evaluate projects with an empty string for the solution path which causes the NuGet-based MSBuild project SDK resolver to not look for `global.json` when it should fall back to the project path.

This change checks for `IsNullOrWhitespace()` instead of just `null` so it can fall back to the project path.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
