### PR TITLE
Make bulk restore coordination default - add feature flag support and onboard bulk restore coordination

### DIFF
--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreWorker.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreWorker.cs
@@ -74,7 +74,7 @@ namespace NuGet.SolutionRestoreManager
         private Lazy<INuGetErrorList> _errorList;
         private readonly Lazy<IOutputConsoleProvider> _outputConsoleProvider;
 
-        private Lazy<INuGetFeatureFlagService> _nugetFeatureFlagService;
+        private readonly Lazy<INuGetFeatureFlagService> _nugetFeatureFlagService;
 
         public Task<bool> CurrentRestoreOperation => _activeRestoreTask;
 
@@ -98,14 +98,14 @@ namespace NuGet.SolutionRestoreManager
             Lazy<Common.ILogger> logger,
             Lazy<INuGetErrorList> errorList,
             Lazy<IOutputConsoleProvider> outputConsoleProvider,
-            Lazy<INuGetFeatureFlagService> nuGetExperimentationService)
+            Lazy<INuGetFeatureFlagService> nugetFeatureFlagService)
             : this(AsyncServiceProvider.GlobalProvider,
                   solutionManager,
                   lockService,
                   logger,
                   errorList,
                   outputConsoleProvider,
-                  nuGetExperimentationService)
+                  nugetFeatureFlagService)
         { }
 
         public SolutionRestoreWorker(
@@ -115,7 +115,7 @@ namespace NuGet.SolutionRestoreManager
             Lazy<Common.ILogger> logger,
             Lazy<INuGetErrorList> errorList,
             Lazy<IOutputConsoleProvider> outputConsoleProvider,
-            Lazy<INuGetFeatureFlagService> nuGetExperimentationService)
+            Lazy<INuGetFeatureFlagService> nugetFeatureFlagService)
         {
             if (asyncServiceProvider == null)
             {
@@ -147,9 +147,9 @@ namespace NuGet.SolutionRestoreManager
                 throw new ArgumentNullException(nameof(outputConsoleProvider));
             }
 
-            if (nuGetExperimentationService == null)
+            if (nugetFeatureFlagService == null)
             {
-                throw new ArgumentNullException(nameof(nuGetExperimentationService));
+                throw new ArgumentNullException(nameof(nugetFeatureFlagService));
             }
 
             _asyncServiceProvider = asyncServiceProvider;
@@ -158,7 +158,7 @@ namespace NuGet.SolutionRestoreManager
             _logger = logger;
             _errorList = errorList;
             _outputConsoleProvider = outputConsoleProvider;
-            _nugetFeatureFlagService = nuGetExperimentationService;
+            _nugetFeatureFlagService = nugetFeatureFlagService;
 
             var joinableTaskContextNode = new JoinableTaskContextNode(ThreadHelper.JoinableTaskContext);
             _joinableCollection = joinableTaskContextNode.CreateCollection();

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreWorker.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreWorker.cs
@@ -10,7 +10,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft;
-using Microsoft.Internal.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.Shell;

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Services/INuGetFeatureFlagService.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Services/INuGetFeatureFlagService.cs
@@ -1,0 +1,22 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+
+namespace NuGet.VisualStudio
+{
+    /// <summary>
+    /// A service that can check whether a feature enabled through the VS Feature Flag service.
+    /// The results from the VS Feature Flag service are cached and only calculated the first time the check is performed.
+    /// This service does not listen to the updates of the VS Feature Flag service.
+    /// </summary>
+    public interface INuGetFeatureFlagService
+    {
+        /// <summary>
+        /// Determines whether a feature has been enabled.
+        /// </summary>
+        /// <param name="experimentation">The experiment info.</param>
+        /// <returns>Whether the feature is enabled.</returns>
+        Task<bool> IsFeatureEnabledAsync(NuGetFeatureFlagConstants experimentation);
+    }
+}

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Services/INuGetFeatureFlagService.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Services/INuGetFeatureFlagService.cs
@@ -15,8 +15,8 @@ namespace NuGet.VisualStudio
         /// <summary>
         /// Determines whether a feature has been enabled.
         /// </summary>
-        /// <param name="experimentation">The experiment info.</param>
+        /// <param name="featureFlag">The feature flag info.</param>
         /// <returns>Whether the feature is enabled.</returns>
-        Task<bool> IsFeatureEnabledAsync(NuGetFeatureFlagConstants experimentation);
+        Task<bool> IsFeatureEnabledAsync(NuGetFeatureFlagConstants featureFlag);
     }
 }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Services/NuGetFeatureFlagConstants.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Services/NuGetFeatureFlagConstants.cs
@@ -15,12 +15,12 @@ namespace NuGet.VisualStudio
         }
 
         /// <summary>
-        /// The value defined for the VS feature flag service.
+        /// The feature flag name defined for the VS feature flag service.
         /// </summary>
         internal string Name { get; }
 
         /// <summary>
-        /// The environment variable means of enabled this feature.
+        /// The environment variable used to override the enabled or disabled state of this feature.
         /// Might be <see cref="null"/>.
         /// </summary>
         internal string EnvironmentVariable { get; }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Services/NuGetFeatureFlagConstants.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Services/NuGetFeatureFlagConstants.cs
@@ -7,29 +7,29 @@ namespace NuGet.VisualStudio
 {
     public class NuGetFeatureFlagConstants
     {
-        internal NuGetFeatureFlagConstants(string featureFlagName, string featureEnvironmentVariable, bool defaultFeatureFlag)
+        internal NuGetFeatureFlagConstants(string name, string environmentVariable, bool defaultState)
         {
-            FeatureFlagName = featureFlagName ?? throw new ArgumentNullException(nameof(featureFlagName));
-            FeatureEnvironmentVariable = featureEnvironmentVariable;
-            DefaultFeatureFlag = defaultFeatureFlag;
+            Name = name ?? throw new ArgumentNullException(nameof(name));
+            EnvironmentVariable = environmentVariable;
+            DefaultState = defaultState;
         }
 
         /// <summary>
         /// The value defined for the VS feature flag service.
         /// </summary>
-        internal string FeatureFlagName { get; }
+        internal string Name { get; }
 
         /// <summary>
         /// The environment variable means of enabled this feature.
         /// Might be <see cref="null"/>.
         /// </summary>
-        internal string FeatureEnvironmentVariable { get; }
+        internal string EnvironmentVariable { get; }
 
         /// <summary>
         /// Default feature state, if the Feature Flag is not specified.
         /// </summary>
-        internal bool DefaultFeatureFlag { get; }
+        internal bool DefaultState { get; }
 
-        public static readonly NuGetFeatureFlagConstants BulkRestoreCoordination = new("NuGet.BulkRestoreCoordination", "NUGET_BULK_RESTORE_COORDINATION", defaultFeatureFlag: true);
+        public static readonly NuGetFeatureFlagConstants BulkRestoreCoordination = new("NuGet.BulkRestoreCoordination", "NUGET_BULK_RESTORE_COORDINATION", defaultState: true);
     }
 }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Services/NuGetFeatureFlagConstants.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Services/NuGetFeatureFlagConstants.cs
@@ -1,0 +1,35 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace NuGet.VisualStudio
+{
+    public class NuGetFeatureFlagConstants
+    {
+        internal NuGetFeatureFlagConstants(string featureFlagName, string featureEnvironmentVariable, bool defaultFeatureFlag)
+        {
+            FeatureFlagName = featureFlagName ?? throw new ArgumentNullException(nameof(featureFlagName));
+            FeatureEnvironmentVariable = featureEnvironmentVariable;
+            DefaultFeatureFlag = defaultFeatureFlag;
+        }
+
+        /// <summary>
+        /// The value defined for the VS feature flag service.
+        /// </summary>
+        internal string FeatureFlagName { get; }
+
+        /// <summary>
+        /// The environment variable means of enabled this feature.
+        /// Might be <see cref="null"/>.
+        /// </summary>
+        internal string FeatureEnvironmentVariable { get; }
+
+        /// <summary>
+        /// Default feature state, if the Feature Flag is not specified.
+        /// </summary>
+        internal bool DefaultFeatureFlag { get; }
+
+        public static readonly NuGetFeatureFlagConstants BulkRestoreCoordination = new("NuGet.BulkRestoreCoordination", "NUGET_BULK_RESTORE_COORDINATION", defaultFeatureFlag: true);
+    }
+}

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Services/NuGetFeatureFlagService.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Services/NuGetFeatureFlagService.cs
@@ -1,0 +1,66 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.Threading.Tasks;
+using Microsoft.Internal.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.Shell;
+using NuGet.Common;
+
+namespace NuGet.VisualStudio
+{
+    [Export(typeof(INuGetFeatureFlagService))]
+    [PartCreationPolicy(CreationPolicy.Shared)]
+    public class NuGetFeatureFlagService : INuGetFeatureFlagService
+    {
+        private readonly IEnvironmentVariableReader _environmentVariableReader;
+        private readonly IAsyncServiceProvider _asyncServiceProvider;
+        private readonly Microsoft.VisualStudio.Threading.AsyncLazy<IVsFeatureFlags> _ivsFeatureFlags;
+        private readonly Dictionary<string, bool> _featureFlagCache;
+
+        [ImportingConstructor]
+        public NuGetFeatureFlagService()
+            : this(EnvironmentVariableWrapper.Instance, AsyncServiceProvider.GlobalProvider)
+        {
+            // ensure uniqueness.
+        }
+
+        internal NuGetFeatureFlagService(IEnvironmentVariableReader environmentVariableReader, IAsyncServiceProvider asyncServiceProvider)
+        {
+            _environmentVariableReader = environmentVariableReader ?? throw new ArgumentNullException(nameof(environmentVariableReader));
+            _asyncServiceProvider = asyncServiceProvider ?? throw new ArgumentNullException(nameof(asyncServiceProvider));
+            _ivsFeatureFlags = new(() => _asyncServiceProvider.GetServiceAsync<SVsFeatureFlags, IVsFeatureFlags>(), NuGetUIThreadHelper.JoinableTaskFactory);
+            _featureFlagCache = new();
+        }
+
+        public async Task<bool> IsFeatureEnabledAsync(NuGetFeatureFlagConstants experiment)
+        {
+            GetEnvironmentVariablesForFeature(experiment, out bool isFeatureForcedEnabled, out bool isFeatureForcedDisabled);
+            // Perform the check from the feature flag service only once.
+            // There are events sent for targetted notification changes, but we don't listen to those at this point.
+            if (!_featureFlagCache.TryGetValue(experiment.FeatureFlagName, out bool featureEnabled))
+            {
+                var featureFlagService = await _ivsFeatureFlags.GetValueAsync();
+                await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                featureEnabled = featureFlagService.IsFeatureEnabled(experiment.FeatureFlagName, defaultValue: experiment.DefaultFeatureFlag);
+                _featureFlagCache.Add(experiment.FeatureFlagName, featureEnabled);
+            }
+            return !isFeatureForcedDisabled && (isFeatureForcedEnabled || featureEnabled);
+        }
+
+        private void GetEnvironmentVariablesForFeature(NuGetFeatureFlagConstants experiment, out bool isExpForcedEnabled, out bool isExpForcedDisabled)
+        {
+            isExpForcedEnabled = false;
+            isExpForcedDisabled = false;
+            if (!string.IsNullOrEmpty(experiment.FeatureEnvironmentVariable))
+            {
+                string envVarOverride = _environmentVariableReader.GetEnvironmentVariable(experiment.FeatureEnvironmentVariable);
+
+                isExpForcedDisabled = envVarOverride == "0";
+                isExpForcedEnabled = envVarOverride == "1";
+            }
+        }
+    }
+}

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Services/NuGetFeatureFlagService.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Services/NuGetFeatureFlagService.cs
@@ -35,31 +35,31 @@ namespace NuGet.VisualStudio
             _featureFlagCache = new();
         }
 
-        public async Task<bool> IsFeatureEnabledAsync(NuGetFeatureFlagConstants experiment)
+        public async Task<bool> IsFeatureEnabledAsync(NuGetFeatureFlagConstants featureFlag)
         {
-            GetEnvironmentVariablesForFeature(experiment, out bool isFeatureForcedEnabled, out bool isFeatureForcedDisabled);
+            GetEnvironmentVariablesForFeature(featureFlag, out bool isFeatureForcedEnabled, out bool isFeatureForcedDisabled);
             // Perform the check from the feature flag service only once.
             // There are events sent for targetted notification changes, but we don't listen to those at this point.
-            if (!_featureFlagCache.TryGetValue(experiment.FeatureFlagName, out bool featureEnabled))
+            if (!_featureFlagCache.TryGetValue(featureFlag.Name, out bool featureEnabled))
             {
                 var featureFlagService = await _ivsFeatureFlags.GetValueAsync();
                 await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-                featureEnabled = featureFlagService.IsFeatureEnabled(experiment.FeatureFlagName, defaultValue: experiment.DefaultFeatureFlag);
-                _featureFlagCache.Add(experiment.FeatureFlagName, featureEnabled);
+                featureEnabled = featureFlagService.IsFeatureEnabled(featureFlag.Name, defaultValue: featureFlag.DefaultState);
+                _featureFlagCache.Add(featureFlag.Name, featureEnabled);
             }
             return !isFeatureForcedDisabled && (isFeatureForcedEnabled || featureEnabled);
         }
 
-        private void GetEnvironmentVariablesForFeature(NuGetFeatureFlagConstants experiment, out bool isExpForcedEnabled, out bool isExpForcedDisabled)
+        private void GetEnvironmentVariablesForFeature(NuGetFeatureFlagConstants featureFlag, out bool isFeatureForcedEnabled, out bool isFeatureForcedDisabled)
         {
-            isExpForcedEnabled = false;
-            isExpForcedDisabled = false;
-            if (!string.IsNullOrEmpty(experiment.FeatureEnvironmentVariable))
+            isFeatureForcedEnabled = false;
+            isFeatureForcedDisabled = false;
+            if (!string.IsNullOrEmpty(featureFlag.EnvironmentVariable))
             {
-                string envVarOverride = _environmentVariableReader.GetEnvironmentVariable(experiment.FeatureEnvironmentVariable);
+                string envVarOverride = _environmentVariableReader.GetEnvironmentVariable(featureFlag.EnvironmentVariable);
 
-                isExpForcedDisabled = envVarOverride == "0";
-                isExpForcedEnabled = envVarOverride == "1";
+                isFeatureForcedDisabled = envVarOverride == "0";
+                isFeatureForcedEnabled = envVarOverride == "1";
             }
         }
     }

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Common.Test/MockedVS.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Common.Test/MockedVS.cs
@@ -1,0 +1,20 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.VisualStudio.Sdk.TestFramework;
+using Xunit;
+
+namespace NuGet.VisualStudio.Common.Test
+{
+    /// <summary>
+    /// Defines the "MockedVS" xunit test collection.
+    /// </summary>
+    [CollectionDefinition(Collection)]
+    public class MockedVS : ICollectionFixture<GlobalServiceProvider>, ICollectionFixture<MefHostingFixture>
+    {
+        /// <summary>
+        /// The name of the xunit test collection.
+        /// </summary>
+        public const string Collection = "MockedVS";
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Common.Test/MockedVS.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Common.Test/MockedVS.cs
@@ -9,7 +9,7 @@ namespace NuGet.VisualStudio.Common.Test
     /// <summary>
     /// Defines the "MockedVS" xunit test collection.
     /// </summary>
-    [CollectionDefinition(Collection)]
+    [CollectionDefinition(Collection, DisableParallelization = true)]
     public class MockedVS : ICollectionFixture<GlobalServiceProvider>, ICollectionFixture<MefHostingFixture>
     {
         /// <summary>

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Common.Test/NuGet.VisualStudio.Common.Test.csproj
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Common.Test/NuGet.VisualStudio.Common.Test.csproj
@@ -16,6 +16,10 @@
     <ProjectReference Include="$(TestUtilitiesDirectory)Test.Utility\Test.Utility.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.VisualStudio.Sdk.TestFramework" />
+  </ItemGroup>
+
   <Import Project="$(BuildCommonDirectory)common.targets" />
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 </Project>

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Common.Test/NuGetFeatureFlagConstantsTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Common.Test/NuGetFeatureFlagConstantsTests.cs
@@ -1,0 +1,36 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using FluentAssertions;
+using Xunit;
+
+namespace NuGet.VisualStudio.Common.Test
+{
+    public class NuGetFeatureFlagConstantsTests
+    {
+        [Fact]
+        public void Constructor_WithNullFlightFlag_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() => new NuGetFeatureFlagConstants(null, "value", defaultFeatureFlag: true));
+        }
+
+        [Fact]
+        public void Constructor_WithNullFlightExperimentalVariable_DoesNotThrow()
+        {
+            var constant = new NuGetFeatureFlagConstants("value", null, defaultFeatureFlag: true);
+
+            constant.FeatureEnvironmentVariable.Should().BeNull();
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void GeDefaultFeatureFlag_ReturnsValueThatMatchesConstructor(bool defaultFeatureFlag)
+        {
+            var constant = new NuGetFeatureFlagConstants("value", null, defaultFeatureFlag);
+
+            constant.DefaultFeatureFlag.Should().Be(defaultFeatureFlag);
+        }
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Common.Test/NuGetFeatureFlagConstantsTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Common.Test/NuGetFeatureFlagConstantsTests.cs
@@ -12,15 +12,15 @@ namespace NuGet.VisualStudio.Common.Test
         [Fact]
         public void Constructor_WithNullFlightFlag_Throws()
         {
-            Assert.Throws<ArgumentNullException>(() => new NuGetFeatureFlagConstants(null, "value", defaultFeatureFlag: true));
+            Assert.Throws<ArgumentNullException>(() => new NuGetFeatureFlagConstants(null, "value", defaultState: true));
         }
 
         [Fact]
         public void Constructor_WithNullFlightExperimentalVariable_DoesNotThrow()
         {
-            var constant = new NuGetFeatureFlagConstants("value", null, defaultFeatureFlag: true);
+            var constant = new NuGetFeatureFlagConstants("value", null, defaultState: true);
 
-            constant.FeatureEnvironmentVariable.Should().BeNull();
+            constant.EnvironmentVariable.Should().BeNull();
         }
 
         [Theory]
@@ -30,7 +30,7 @@ namespace NuGet.VisualStudio.Common.Test
         {
             var constant = new NuGetFeatureFlagConstants("value", null, defaultFeatureFlag);
 
-            constant.DefaultFeatureFlag.Should().Be(defaultFeatureFlag);
+            constant.DefaultState.Should().Be(defaultFeatureFlag);
         }
     }
 }

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Common.Test/NuGetFeatureFlagServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Common.Test/NuGetFeatureFlagServiceTests.cs
@@ -1,0 +1,206 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using FluentAssertions;
+using Microsoft.Internal.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.Sdk.TestFramework;
+using Microsoft.VisualStudio.Shell;
+using Moq;
+using NuGet.Common;
+using Test.Utility;
+using Xunit;
+using Task = System.Threading.Tasks.Task;
+
+namespace NuGet.VisualStudio.Common.Test
+{
+    [Collection(MockedVS.Collection)]
+    public class NuGetFeatureFlagServiceTests
+    {
+        private GlobalServiceProvider _globalProvider;
+
+        public NuGetFeatureFlagServiceTests(GlobalServiceProvider sp)
+        {
+            sp.Reset();
+            _globalProvider = sp;
+            NuGetUIThreadHelper.SetCustomJoinableTaskFactory(ThreadHelper.JoinableTaskFactory);
+        }
+
+        [Fact]
+        public void Constructor_WithNullWrapper_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() => new NuGetFeatureFlagService(null, AsyncServiceProvider.GlobalProvider));
+        }
+
+        [Fact]
+        public void Constructor_WithNullAsyncServiceProvider_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() => new NuGetFeatureFlagService(new TestEnvironmentVariableReader(new Dictionary<string, string>()), null));
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+
+        public async Task IsFeatureEnabledAsync_WithoutFlag_ReturnsDefaultValueFromConstant(bool featureFlagDefault)
+        {
+            var featureFlagConstant = new NuGetFeatureFlagConstants("featureFlag", "featureEnvVar", defaultFeatureFlag: featureFlagDefault);
+            var vsFeatureFlags = Mock.Of<IVsFeatureFlags>();
+
+            Mock.Get(vsFeatureFlags)
+                .Setup(x => x.IsFeatureEnabled(
+                    It.IsAny<string>(), It.IsAny<bool>()))
+                .Returns(featureFlagDefault);
+
+            _globalProvider.AddService(typeof(SVsFeatureFlags), vsFeatureFlags);
+            var service = new NuGetFeatureFlagService(new EnvironmentVariableWrapper(), AsyncServiceProvider.GlobalProvider);
+            (await service.IsFeatureEnabledAsync(featureFlagConstant)).Should().Be(featureFlagDefault);
+        }
+
+        [Fact]
+        public async Task IsFeatureEnabledAsync_WithEnabledFeatureFlagAndForcedEnabledEnvVar_ReturnsTrue()
+        {
+            var featureFlagConstant = new NuGetFeatureFlagConstants("featureFlag", "featureEnvVar", defaultFeatureFlag: false);
+            var envVars = new Dictionary<string, string>()
+            {
+                { featureFlagConstant.FeatureEnvironmentVariable, "1" },
+            };
+            var envVarWrapper = new TestEnvironmentVariableReader(envVars);
+            var vsFeatureFlags = Mock.Of<IVsFeatureFlags>();
+
+            Mock.Get(vsFeatureFlags)
+                .Setup(x => x.IsFeatureEnabled(
+                    It.IsAny<string>(), It.IsAny<bool>()))
+                .Returns(true);
+
+            _globalProvider.AddService(typeof(SVsFeatureFlags), vsFeatureFlags);
+            var service = new NuGetFeatureFlagService(envVarWrapper, AsyncServiceProvider.GlobalProvider);
+            (await service.IsFeatureEnabledAsync(featureFlagConstant)).Should().Be(true);
+
+        }
+
+        [Theory]
+        [InlineData("2")]
+        [InlineData("randomValue")]
+        public async Task IsFeatureEnabledAsync_WithEnvVarWithIncorrectValue_WithEnvironmentVariable__ReturnsFalse(string value)
+        {
+            var featureFlagConstant = new NuGetFeatureFlagConstants("featureFlag", "featureEnvVar", defaultFeatureFlag: false);
+            var envVars = new Dictionary<string, string>()
+            {
+                { featureFlagConstant.FeatureEnvironmentVariable, value },
+            };
+            var envVarWrapper = new TestEnvironmentVariableReader(envVars);
+            var vsFeatureFlags = Mock.Of<IVsFeatureFlags>();
+
+            Mock.Get(vsFeatureFlags)
+                .Setup(x => x.IsFeatureEnabled(
+                    It.IsAny<string>(), It.IsAny<bool>()))
+                .Returns(false);
+
+            _globalProvider.AddService(typeof(SVsFeatureFlags), vsFeatureFlags);
+            var service = new NuGetFeatureFlagService(envVarWrapper, AsyncServiceProvider.GlobalProvider);
+            (await service.IsFeatureEnabledAsync(featureFlagConstant)).Should().Be(false);
+        }
+
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(false, false)]
+        public async Task IsFeatureEnabledAsync_WithEnvVarNotSetWithEnabledFeatureFromWithFeatureFlagService_ReturnsExpectedResult(bool isFeatureEnabled, bool expectedResult)
+        {
+            var featureFlagConstant = new NuGetFeatureFlagConstants("featureFlag", "featureEnvVar", defaultFeatureFlag: false);
+            var envVarWrapper = new TestEnvironmentVariableReader(new Dictionary<string, string>());
+            var vsFeatureFlags = Mock.Of<IVsFeatureFlags>();
+
+            Mock.Get(vsFeatureFlags)
+                .Setup(x => x.IsFeatureEnabled(
+                    It.IsAny<string>(), It.IsAny<bool>()))
+                .Returns(isFeatureEnabled);
+
+            _globalProvider.AddService(typeof(SVsFeatureFlags), vsFeatureFlags);
+            var service = new NuGetFeatureFlagService(envVarWrapper, AsyncServiceProvider.GlobalProvider);
+            (await service.IsFeatureEnabledAsync(featureFlagConstant)).Should().Be(expectedResult);
+        }
+
+        [Fact]
+        public async Task IsFeatureEnabledAsync_WithEnvVarEnabled_WithFeatureFlagServiceDisabled_ReturnsTrue()
+        {
+            var featureFlagConstant = new NuGetFeatureFlagConstants("featureFlag", "featureEnvVar", defaultFeatureFlag: false);
+            var envVars = new Dictionary<string, string>()
+            {
+                { featureFlagConstant.FeatureEnvironmentVariable, "1" },
+            };
+            var envVarWrapper = new TestEnvironmentVariableReader(envVars);
+            var vsFeatureFlags = Mock.Of<IVsFeatureFlags>();
+
+            Mock.Get(vsFeatureFlags)
+                .Setup(x => x.IsFeatureEnabled(
+                    It.IsAny<string>(), It.IsAny<bool>()))
+                .Returns(false);
+
+            _globalProvider.AddService(typeof(SVsFeatureFlags), vsFeatureFlags);
+            var service = new NuGetFeatureFlagService(envVarWrapper, AsyncServiceProvider.GlobalProvider);
+            (await service.IsFeatureEnabledAsync(featureFlagConstant)).Should().Be(true);
+        }
+
+        [Fact]
+        public async Task IsFeatureEnabledAsync_WithEnvVarDisabled_WithFeatureFlagServiceEnabled_ReturnsFalse()
+        {
+            var featureFlagConstant = new NuGetFeatureFlagConstants("featureFlag", "featureEnvVar", defaultFeatureFlag: false);
+            var envVars = new Dictionary<string, string>()
+            {
+                { featureFlagConstant.FeatureEnvironmentVariable, "0" },
+            };
+            var envVarWrapper = new TestEnvironmentVariableReader(envVars);
+            var vsFeatureFlags = Mock.Of<IVsFeatureFlags>();
+
+            Mock.Get(vsFeatureFlags)
+                .Setup(x => x.IsFeatureEnabled(
+                    It.IsAny<string>(), It.IsAny<bool>()))
+                .Returns(true);
+
+            _globalProvider.AddService(typeof(SVsFeatureFlags), vsFeatureFlags);
+            var service = new NuGetFeatureFlagService(envVarWrapper, AsyncServiceProvider.GlobalProvider);
+            (await service.IsFeatureEnabledAsync(featureFlagConstant)).Should().Be(false);
+        }
+
+        [Fact]
+        public async Task IsFeatureEnabledAsync_WithNullEnvironmentVariableForConstant_HandlesGracefully()
+        {
+            var featureFlagConstant = new NuGetFeatureFlagConstants("featureFlag", null, defaultFeatureFlag: false);
+            var vsFeatureFlags = Mock.Of<IVsFeatureFlags>();
+
+            _globalProvider.AddService(typeof(SVsFeatureFlags), vsFeatureFlags);
+            var service = new NuGetFeatureFlagService(new EnvironmentVariableWrapper(), AsyncServiceProvider.GlobalProvider);
+            (await service.IsFeatureEnabledAsync(featureFlagConstant)).Should().Be(false);
+        }
+
+        [Fact]
+        public async Task IsFeatureEnabledAsync_MultipleFeaturesOverriddenWithDifferentEnvVars_DoNotConflict()
+        {
+            var forcedOff = new NuGetFeatureFlagConstants("TestExp1", "TEST_EXP_1", defaultFeatureFlag: false);
+            var forcedOn = new NuGetFeatureFlagConstants("TestExp2", "TEST_EXP_2", defaultFeatureFlag: false);
+            var noOverride = new NuGetFeatureFlagConstants("TestExp3", "TEST_EXP_3", defaultFeatureFlag: false);
+            var envVars = new Dictionary<string, string>()
+            {
+                { forcedOn.FeatureEnvironmentVariable, "1" },
+                { forcedOff.FeatureEnvironmentVariable, "0" },
+            };
+            var envVarWrapper = new TestEnvironmentVariableReader(envVars);
+            var vsFeatureFlags = Mock.Of<IVsFeatureFlags>();
+
+            Mock.Get(vsFeatureFlags)
+                .Setup(x => x.IsFeatureEnabled(
+                    It.IsAny<string>(), It.IsAny<bool>()))
+                .Returns(true);
+
+            _globalProvider.AddService(typeof(SVsFeatureFlags), vsFeatureFlags);
+
+            var service = new NuGetFeatureFlagService(envVarWrapper, AsyncServiceProvider.GlobalProvider);
+
+            (await service.IsFeatureEnabledAsync(forcedOff)).Should().BeFalse();
+            (await service.IsFeatureEnabledAsync(forcedOn)).Should().BeTrue();
+            (await service.IsFeatureEnabledAsync(noOverride)).Should().BeTrue();
+        }
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Common.Test/NuGetFeatureFlagServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Common.Test/NuGetFeatureFlagServiceTests.cs
@@ -45,7 +45,7 @@ namespace NuGet.VisualStudio.Common.Test
 
         public async Task IsFeatureEnabledAsync_WithoutFlag_ReturnsDefaultValueFromConstant(bool featureFlagDefault)
         {
-            var featureFlagConstant = new NuGetFeatureFlagConstants("featureFlag", "featureEnvVar", defaultFeatureFlag: featureFlagDefault);
+            var featureFlagConstant = new NuGetFeatureFlagConstants("featureFlag", "featureEnvVar", defaultState: featureFlagDefault);
             var vsFeatureFlags = Mock.Of<IVsFeatureFlags>();
 
             Mock.Get(vsFeatureFlags)
@@ -61,10 +61,10 @@ namespace NuGet.VisualStudio.Common.Test
         [Fact]
         public async Task IsFeatureEnabledAsync_WithEnabledFeatureFlagAndForcedEnabledEnvVar_ReturnsTrue()
         {
-            var featureFlagConstant = new NuGetFeatureFlagConstants("featureFlag", "featureEnvVar", defaultFeatureFlag: false);
+            var featureFlagConstant = new NuGetFeatureFlagConstants("featureFlag", "featureEnvVar", defaultState: false);
             var envVars = new Dictionary<string, string>()
             {
-                { featureFlagConstant.FeatureEnvironmentVariable, "1" },
+                { featureFlagConstant.EnvironmentVariable, "1" },
             };
             var envVarWrapper = new TestEnvironmentVariableReader(envVars);
             var vsFeatureFlags = Mock.Of<IVsFeatureFlags>();
@@ -85,10 +85,10 @@ namespace NuGet.VisualStudio.Common.Test
         [InlineData("randomValue")]
         public async Task IsFeatureEnabledAsync_WithEnvVarWithIncorrectValue_WithEnvironmentVariable__ReturnsFalse(string value)
         {
-            var featureFlagConstant = new NuGetFeatureFlagConstants("featureFlag", "featureEnvVar", defaultFeatureFlag: false);
+            var featureFlagConstant = new NuGetFeatureFlagConstants("featureFlag", "featureEnvVar", defaultState: false);
             var envVars = new Dictionary<string, string>()
             {
-                { featureFlagConstant.FeatureEnvironmentVariable, value },
+                { featureFlagConstant.EnvironmentVariable, value },
             };
             var envVarWrapper = new TestEnvironmentVariableReader(envVars);
             var vsFeatureFlags = Mock.Of<IVsFeatureFlags>();
@@ -108,7 +108,7 @@ namespace NuGet.VisualStudio.Common.Test
         [InlineData(false, false)]
         public async Task IsFeatureEnabledAsync_WithEnvVarNotSetWithEnabledFeatureFromWithFeatureFlagService_ReturnsExpectedResult(bool isFeatureEnabled, bool expectedResult)
         {
-            var featureFlagConstant = new NuGetFeatureFlagConstants("featureFlag", "featureEnvVar", defaultFeatureFlag: false);
+            var featureFlagConstant = new NuGetFeatureFlagConstants("featureFlag", "featureEnvVar", defaultState: false);
             var envVarWrapper = new TestEnvironmentVariableReader(new Dictionary<string, string>());
             var vsFeatureFlags = Mock.Of<IVsFeatureFlags>();
 
@@ -125,10 +125,10 @@ namespace NuGet.VisualStudio.Common.Test
         [Fact]
         public async Task IsFeatureEnabledAsync_WithEnvVarEnabled_WithFeatureFlagServiceDisabled_ReturnsTrue()
         {
-            var featureFlagConstant = new NuGetFeatureFlagConstants("featureFlag", "featureEnvVar", defaultFeatureFlag: false);
+            var featureFlagConstant = new NuGetFeatureFlagConstants("featureFlag", "featureEnvVar", defaultState: false);
             var envVars = new Dictionary<string, string>()
             {
-                { featureFlagConstant.FeatureEnvironmentVariable, "1" },
+                { featureFlagConstant.EnvironmentVariable, "1" },
             };
             var envVarWrapper = new TestEnvironmentVariableReader(envVars);
             var vsFeatureFlags = Mock.Of<IVsFeatureFlags>();
@@ -146,10 +146,10 @@ namespace NuGet.VisualStudio.Common.Test
         [Fact]
         public async Task IsFeatureEnabledAsync_WithEnvVarDisabled_WithFeatureFlagServiceEnabled_ReturnsFalse()
         {
-            var featureFlagConstant = new NuGetFeatureFlagConstants("featureFlag", "featureEnvVar", defaultFeatureFlag: false);
+            var featureFlagConstant = new NuGetFeatureFlagConstants("featureFlag", "featureEnvVar", defaultState: false);
             var envVars = new Dictionary<string, string>()
             {
-                { featureFlagConstant.FeatureEnvironmentVariable, "0" },
+                { featureFlagConstant.EnvironmentVariable, "0" },
             };
             var envVarWrapper = new TestEnvironmentVariableReader(envVars);
             var vsFeatureFlags = Mock.Of<IVsFeatureFlags>();
@@ -167,7 +167,7 @@ namespace NuGet.VisualStudio.Common.Test
         [Fact]
         public async Task IsFeatureEnabledAsync_WithNullEnvironmentVariableForConstant_HandlesGracefully()
         {
-            var featureFlagConstant = new NuGetFeatureFlagConstants("featureFlag", null, defaultFeatureFlag: false);
+            var featureFlagConstant = new NuGetFeatureFlagConstants("featureFlag", null, defaultState: false);
             var vsFeatureFlags = Mock.Of<IVsFeatureFlags>();
 
             _globalProvider.AddService(typeof(SVsFeatureFlags), vsFeatureFlags);
@@ -178,13 +178,13 @@ namespace NuGet.VisualStudio.Common.Test
         [Fact]
         public async Task IsFeatureEnabledAsync_MultipleFeaturesOverriddenWithDifferentEnvVars_DoNotConflict()
         {
-            var forcedOff = new NuGetFeatureFlagConstants("TestExp1", "TEST_EXP_1", defaultFeatureFlag: false);
-            var forcedOn = new NuGetFeatureFlagConstants("TestExp2", "TEST_EXP_2", defaultFeatureFlag: false);
-            var noOverride = new NuGetFeatureFlagConstants("TestExp3", "TEST_EXP_3", defaultFeatureFlag: false);
+            var forcedOff = new NuGetFeatureFlagConstants("TestExp1", "TEST_EXP_1", defaultState: false);
+            var forcedOn = new NuGetFeatureFlagConstants("TestExp2", "TEST_EXP_2", defaultState: false);
+            var noOverride = new NuGetFeatureFlagConstants("TestExp3", "TEST_EXP_3", defaultState: false);
             var envVars = new Dictionary<string, string>()
             {
-                { forcedOn.FeatureEnvironmentVariable, "1" },
-                { forcedOff.FeatureEnvironmentVariable, "0" },
+                { forcedOn.EnvironmentVariable, "1" },
+                { forcedOff.EnvironmentVariable, "0" },
             };
             var envVarWrapper = new TestEnvironmentVariableReader(envVars);
             var vsFeatureFlags = Mock.Of<IVsFeatureFlags>();


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1390

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Internal [PR](https://devdiv.visualstudio.com/DevDiv/_git/VS/pullrequest/387544)

We're going to enable a feature flag instead of an A/B experiment for bulk restore coordination. 

This adds the respective code for the feature flag service. You can refer to the internal feature flag change in [PR](https://devdiv.visualstudio.com/DevDiv/_git/VS/pullrequest/387544). 

To learn about Feature Flags, [click here](https://dev.azure.com/devdiv/DevDiv/_wiki/wikis/DevDiv.wiki/2062/Feature-Flags?anchor=creating-a-feature-flag).

You may notice, a lot of this duplicates what the experimentation service provides, and initially I wanted to add a `NuGetPreviewFeatures` services that combines a lot of the functionality, in the context that it's dealing with a gradual roll out of features, but after chatting with @jebriede, he said he'd prefer to have 2 different services.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
