### PR TITLE
Add support for the NUGET_SCRATCH environment variable.

### DIFF
--- a/src/NuGet.Core/NuGet.Common/PathUtil/NuGetEnvironment.cs
+++ b/src/NuGet.Core/NuGet.Common/PathUtil/NuGetEnvironment.cs
@@ -79,7 +79,14 @@ namespace NuGet.Common
                     return Path.Combine(programFilesPath, "MSBuild", "14.0", "Bin", "MSBuild.exe");
 
                 case NuGetFolderPath.Temp:
-                    return Path.Combine(Path.GetTempPath(), "NuGetScratch");
+                    {
+                        var nuGetScratch = Environment.GetEnvironmentVariable("NUGET_SCRATCH");
+                        if (string.IsNullOrEmpty(nuGetScratch))
+                        {
+                            nuGetScratch = Path.Combine(Path.GetTempPath(), "NuGetScratch");
+                        }
+                        return nuGetScratch;
+                    }
 
                 default:
                     return null;


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Feature Request

Fixes: https://github.com/NuGet/Home/issues/11671

## Description
By default NuGet uses %TEMP%\NuGetScratch. Setting the NUGET_SCRATCH environment variable allows to override this default.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [x] Documentation PR or issue filled - https://github.com/NuGet/Home/issues/13567
  - **OR**
  - [ ] N/A
