### PR TITLE
fetch MsBuild version from -MsBuildPath option if it is passed to nuget.exe restore command

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/MsBuildToolset.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/MsBuildToolset.cs
@@ -26,7 +26,7 @@ namespace NuGet.CommandLine
         /// </summary>
         public MsBuildToolset(string version, string path)
         {
-            Version = version;
+            Version = version ?? GetMsBuildVersionFromMsBuildDir(path);
             Path = path;
         }
 

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/MsBuildToolsetTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/MsBuildToolsetTest.cs
@@ -3,28 +3,25 @@
 
 using System;
 using NuGet.Common;
+using NuGet.Test.Utility;
 using Xunit;
 
 namespace NuGet.CommandLine.Test
 {
     public class MsBuildToolsetTest
     {
-        [Fact]
+        [PlatformFact(Platform.Windows)]
         public void WhenNullIsPassedForVersionParameterThenMsBuildVersionIsFetchedFromPath_Success()
         {
             //Arrange
             var msbuildPath = Util.GetMsbuildPathOnWindows();
-            if (RuntimeEnvironmentHelper.IsMono && RuntimeEnvironmentHelper.IsMacOSX)
-            {
-                msbuildPath = @"/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/msbuild/15.0/bin/";
-            }
 
             //Act
             var toolset = new MsBuildToolset(version: null, path: msbuildPath);
 
             //Assert
             Assert.Equal(msbuildPath, toolset.Path);
-            Assert.False(toolset.ParsedVersion.CompareTo(new Version(15, 5)) < 0);
+            Assert.True(toolset.ParsedVersion.CompareTo(new Version()) > 0);
         }
     }
 }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/MsBuildToolsetTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/MsBuildToolsetTest.cs
@@ -1,0 +1,30 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using NuGet.Common;
+using Xunit;
+
+namespace NuGet.CommandLine.Test
+{
+    public class MsBuildToolsetTest
+    {
+        [Fact]
+        public void WhenNullIsPassedForVersionParameterThenMsBuildVersionIsFetchedFromPath_Success()
+        {
+            //Arrange
+            var msbuildPath = Util.GetMsbuildPathOnWindows();
+            if (RuntimeEnvironmentHelper.IsMono && RuntimeEnvironmentHelper.IsMacOSX)
+            {
+                msbuildPath = @"/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/msbuild/15.0/bin/";
+            }
+
+            //Act
+            var toolset = new MsBuildToolset(version: null, path: msbuildPath);
+
+            //Assert
+            Assert.Equal(msbuildPath, toolset.Path);
+            Assert.False(toolset.ParsedVersion.CompareTo(new Version(15, 5)) < 0);
+        }
+    }
+}


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11689

Regression? Last working version: No

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
While working on https://github.com/NuGet/Home/issues/7796, I noticed that MsBuild version is not parsed correctly when `-MsBuildPath` option it is passed to nuget.exe restore command. This PR proposes simple changes to parse the version of msbuild from path option as a fallback. nuget.exe` decides whether to add `RestoreBuildInParallel="False" and RestoreUseSkipNonexistentTargets="False"` properties or not based on the MsBuild version. If the parsed version returns `0` then restore command executes a code path that is not optimized.

https://github.com/NuGet/NuGet.Client/blob/60927d634f10ccecb76f0596f3dcfe6a31d97de9/src/NuGet.Clients/NuGet.CommandLine/MsBuildUtility.cs#L270-L278

**Before fixing**: The properties `RestoreBuildInParallel="False" and RestoreUseSkipNonexistentTargets="False"` are passed to MSBuild command due to this bug. (See green color highlighting in the below image)
<img width="660" alt="image" src="https://user-images.githubusercontent.com/52756182/159793296-8b34cc80-0dd4-449e-a52e-ba93ab0bfb33.png">

**After fixing**: The said properties are not passed to the MsBuild command.
<img width="668" alt="image" src="https://user-images.githubusercontent.com/52756182/159793721-e0e13ad0-c001-4ce0-bcd2-f9b09fc3d82f.png">

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added - I didn't add function tests because I noticed couple of tests for `nuget.exe restore command` where `-MsBuildPath` option is passed. https://github.com/NuGet/NuGet.Client/blob/60927d634f10ccecb76f0596f3dcfe6a31d97de9/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs#L494-L552

- **Documentation**
  - [x] N/A