### PR TITLE
switch to main thread only when needed while loading packages in PM UI

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
@@ -413,10 +413,10 @@ namespace NuGet.PackageManagement.UI
         {
             NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async () =>
             {
-                await _joinableTaskFactory.Value.SwitchToMainThreadAsync();
-
                 if (loader == _loader)
                 {
+                    await _joinableTaskFactory.Value.SwitchToMainThreadAsync();
+
                     _loadingStatusBar.UpdateLoadingState(state);
 
                     // decide when to show status bar


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1511

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
In https://github.com/NuGet/NuGet.Client/pull/4491 PR, We modified code to use `JTF.RunAsync` instead of `JTF.Run` to avoid blocking UI thread while loading packages in PM UI. I noticed that code switches to the UI thread a bit early. This PR proposes a simple change to switch to the UI thread only if the required conditions are met.

https://github.com/NuGet/NuGet.Client/blob/e682eec55dca2c0a515c4b8f4c926f6673f2e876/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs#L416-L420

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Test exception - No functional changes to the product. I did manual testing installing the VSIX and didn't notice any breaking changes due to this fix.

- **Documentation**
  - [x]  N/A
