### PR TITLE
Adds Transitive Package data to VSActionTelemetryEvent 

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/UIActionEngine.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/UIActionEngine.cs
@@ -322,7 +322,7 @@ namespace NuGet.PackageManagement.UI
                 int projectsCount = uiService.Projects.Count();
                 IEnumerable<IPackageReferenceContextInfo> installedPackages = null;
                 // collect the install state of the existing packages
-                foreach (IProjectContextInfo project in uiService.Projects)
+                foreach (IProjectContextInfo project in uiService.Projects) // only one project when PM UI is in project mode
                 {
                     if (projectsCount == 1 && !userAction.IsSolutionLevel && userAction.Action == NuGetProjectActionType.Install && project.ProjectStyle == ProjectModel.ProjectStyle.PackageReference && project.ProjectKind == NuGetProjectKind.PackageReference)
                     {

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/UIActionEngine.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/UIActionEngine.cs
@@ -552,7 +552,7 @@ namespace NuGet.PackageManagement.UI
                         updatedPackagesNew,
                         frameworks);
 
-                    if (!userAction.IsSolutionLevel && userAction.Action == NuGetProjectActionType.Install)
+                    if (userAction != null && !userAction.IsSolutionLevel && userAction.Action == NuGetProjectActionType.Install)
                     {
                         var selectedPackageId = VSTelemetryServiceUtility.NormalizePackageId(userAction.PackageId);
                         actionTelemetryEvent.IsSelectedPackageTransitive = transitivePackageIds?.Contains(selectedPackageId) ?? false;
@@ -619,6 +619,8 @@ namespace NuGet.PackageManagement.UI
                 actionTelemetryEvent["RecommendPackages"] = recommendPackages;
                 actionTelemetryEvent["Recommender.ModelVersion"] = recommenderVersion?.modelVersion;
                 actionTelemetryEvent["Recommender.VsixVersion"] = recommenderVersion?.vsixVersion;
+                actionTelemetryEvent.IsSolutionLevel = userAction.IsSolutionLevel;
+                actionTelemetryEvent.Tab = userAction.ActiveTab;
             }
 
             actionTelemetryEvent["TopLevelVulnerablePackagesCount"] = topLevelVulnerablePackagesCount;

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/UIActionEngine.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/UIActionEngine.cs
@@ -285,7 +285,7 @@ namespace NuGet.PackageManagement.UI
         private static void AddToExisting(IPackageReferenceContextInfo pkg, ISet<Tuple<string, string>> existingPackages)
         {
             PackageIdentity package = pkg.Identity;
-            Tuple<string, string> packageInfo = Tuple.Create(package.Id, package.Version == null ? "" : package.Version.ToNormalizedString());
+            Tuple<string, string> packageInfo = Tuple.Create(package.Id, package.Version == null ? string.Empty : package.Version.ToNormalizedString());
             if (!existingPackages.Contains(packageInfo))
             {
                 existingPackages.Add(packageInfo);

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/UIActionEngine.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/UIActionEngine.cs
@@ -331,11 +331,16 @@ namespace NuGet.PackageManagement.UI
                             existingPackages.Add(CreatePackageTuple(package));
                         }
 
-                        IEnumerable<string> transitivePackageIds = installedAndTransitives.TransitivePackages
-                            .Select(pkg => VSTelemetryServiceUtility.NormalizePackageId(pkg.Identity.Id)).Distinct();
-
+                        wasPacakgeToInstallATransitive = false;
                         string packageIdToInstall = VSTelemetryServiceUtility.NormalizePackageId(userAction.PackageId);
-                        wasPacakgeToInstallATransitive = transitivePackageIds.Contains(packageIdToInstall);
+                        foreach (IPackageReferenceContextInfo transitivePackage in installedAndTransitives.TransitivePackages)
+                        {
+                            if (packageIdToInstall == VSTelemetryServiceUtility.NormalizePackageId(transitivePackage.Identity.Id))
+                            {
+                                wasPacakgeToInstallATransitive = true;
+                                break;
+                            }
+                        }
                     }
                     else
                     {

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/UIActionEngine.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/UIActionEngine.cs
@@ -309,7 +309,7 @@ namespace NuGet.PackageManagement.UI
             List<Tuple<string, string>> addedPackages = null;
             List<Tuple<string, string>> updatedPackagesOld = null;
             List<Tuple<string, string>> updatedPackagesNew = null;
-            bool? wasPacakgeToInstallATransitive = null;
+            bool? packageToInstallWasTransitive = null;
 
             // Enable granular level telemetry events for nuget ui operation
             uiService.ProjectContext.OperationId = Guid.NewGuid();
@@ -331,13 +331,13 @@ namespace NuGet.PackageManagement.UI
                             existingPackages.Add(CreatePackageTuple(package));
                         }
 
-                        wasPacakgeToInstallATransitive = false;
+                        packageToInstallWasTransitive = false;
                         string packageIdToInstall = VSTelemetryServiceUtility.NormalizePackageId(userAction.PackageId);
                         foreach (IPackageReferenceContextInfo transitivePackage in installedAndTransitives.TransitivePackages)
                         {
                             if (packageIdToInstall == VSTelemetryServiceUtility.NormalizePackageId(transitivePackage.Identity.Id))
                             {
-                                wasPacakgeToInstallATransitive = true;
+                                packageToInstallWasTransitive = true;
                                 break;
                             }
                         }
@@ -565,9 +565,9 @@ namespace NuGet.PackageManagement.UI
                         updatedPackagesNew,
                         frameworks);
 
-                    if (wasPacakgeToInstallATransitive.HasValue)
+                    if (packageToInstallWasTransitive.HasValue)
                     {
-                        actionTelemetryEvent.IsPackageToInstallTransitive = wasPacakgeToInstallATransitive.Value;
+                        actionTelemetryEvent.PackageToInstallWasTransitive = packageToInstallWasTransitive.Value;
                     }
                     actionTelemetryEvent["InstalledPackageEnumerationTimeInMilliseconds"] = packageEnumerationTime.ElapsedMilliseconds;
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/UIActionEngine.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/UIActionEngine.cs
@@ -567,7 +567,7 @@ namespace NuGet.PackageManagement.UI
                         if (prj.ProjectKind == NuGetProjectKind.PackageReference && prj.ProjectStyle == ProjectModel.ProjectStyle.PackageReference)
                         {
                             var selectedPackageId = VSTelemetryServiceUtility.NormalizePackageId(userAction.PackageId);
-                            actionTelemetryEvent.IsSelectedPackageTransitive = transitivePackageIds?.Contains(selectedPackageId) ?? false;
+                            actionTelemetryEvent.IsPackageToInstallTransitive = transitivePackageIds?.Contains(selectedPackageId) ?? false;
                         }
                     }
                     actionTelemetryEvent["InstalledPackageEnumerationTimeInMilliseconds"] = packageEnumerationTime.ElapsedMilliseconds;

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/UserAction.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/UserAction.cs
@@ -3,12 +3,13 @@
 
 using System;
 using NuGet.Versioning;
+using ContractsItemFilter = NuGet.VisualStudio.Internal.Contracts.ItemFilter;
 
 namespace NuGet.PackageManagement.UI
 {
     public class UserAction
     {
-        private UserAction(NuGetProjectActionType action, string packageId, NuGetVersion packageVersion, bool isSolutionLevel)
+        private UserAction(NuGetProjectActionType action, string packageId, NuGetVersion packageVersion, bool isSolutionLevel, ContractsItemFilter activeTab)
         {
             Action = action;
 
@@ -20,26 +21,28 @@ namespace NuGet.PackageManagement.UI
             PackageId = packageId;
             Version = packageVersion;
             IsSolutionLevel = isSolutionLevel;
+            ActiveTab = activeTab;
         }
 
         public NuGetProjectActionType Action { get; private set; }
         public bool IsSolutionLevel { get; private set; }
+        public ContractsItemFilter ActiveTab { get; private set; }
         public string PackageId { get; }
         public NuGetVersion Version { get; }
 
-        public static UserAction CreateInstallAction(string packageId, NuGetVersion packageVersion, bool isSolutionLevel)
+        public static UserAction CreateInstallAction(string packageId, NuGetVersion packageVersion, bool isSolutionLevel, ContractsItemFilter activeTab)
         {
             if (packageVersion == null)
             {
                 throw new ArgumentNullException(nameof(packageVersion));
             }
 
-            return new UserAction(NuGetProjectActionType.Install, packageId, packageVersion, isSolutionLevel);
+            return new UserAction(NuGetProjectActionType.Install, packageId, packageVersion, isSolutionLevel, activeTab);
         }
 
-        public static UserAction CreateUnInstallAction(string packageId, bool isSolutionLevel)
+        public static UserAction CreateUnInstallAction(string packageId, bool isSolutionLevel, ContractsItemFilter activeTab)
         {
-            return new UserAction(NuGetProjectActionType.Uninstall, packageId, packageVersion: null, isSolutionLevel);
+            return new UserAction(NuGetProjectActionType.Uninstall, packageId, packageVersion: null, isSolutionLevel, activeTab);
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/UserAction.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/UserAction.cs
@@ -8,7 +8,7 @@ namespace NuGet.PackageManagement.UI
 {
     public class UserAction
     {
-        private UserAction(NuGetProjectActionType action, string packageId, NuGetVersion packageVersion)
+        private UserAction(NuGetProjectActionType action, string packageId, NuGetVersion packageVersion, bool isSolutionLevel)
         {
             Action = action;
 
@@ -19,27 +19,27 @@ namespace NuGet.PackageManagement.UI
 
             PackageId = packageId;
             Version = packageVersion;
+            IsSolutionLevel = isSolutionLevel;
         }
 
         public NuGetProjectActionType Action { get; private set; }
-
+        public bool IsSolutionLevel { get; private set; }
         public string PackageId { get; }
-
         public NuGetVersion Version { get; }
 
-        public static UserAction CreateInstallAction(string packageId, NuGetVersion packageVersion)
+        public static UserAction CreateInstallAction(string packageId, NuGetVersion packageVersion, bool isSolutionLevel)
         {
             if (packageVersion == null)
             {
                 throw new ArgumentNullException(nameof(packageVersion));
             }
 
-            return new UserAction(NuGetProjectActionType.Install, packageId, packageVersion);
+            return new UserAction(NuGetProjectActionType.Install, packageId, packageVersion, isSolutionLevel);
         }
 
-        public static UserAction CreateUnInstallAction(string packageId)
+        public static UserAction CreateUnInstallAction(string packageId, bool isSolutionLevel)
         {
-            return new UserAction(NuGetProjectActionType.Uninstall, packageId, packageVersion: null);
+            return new UserAction(NuGetProjectActionType.Uninstall, packageId, packageVersion: null, isSolutionLevel);
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/UserInterfaceService/INuGetUIContext.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/UserInterfaceService/INuGetUIContext.cs
@@ -8,7 +8,6 @@ using System.Threading.Tasks;
 using Microsoft.ServiceHub.Framework;
 using NuGet.PackageManagement.UI.Utility;
 using NuGet.PackageManagement.VisualStudio;
-using NuGet.VisualStudio;
 using NuGet.VisualStudio.Internal.Contracts;
 
 namespace NuGet.PackageManagement.UI

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/DetailControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/DetailControl.xaml.cs
@@ -113,7 +113,8 @@ namespace NuGet.PackageManagement.UI
                 var userAction = UserAction.CreateInstallAction(
                     model.Id,
                     model.SelectedVersion.Version,
-                    Control.Model.IsSolution);
+                    Control.Model.IsSolution,
+                    UIUtility.ToContractsItemFilter(Control._topPanel.Filter));
 
                 ExecuteUserAction(userAction, NuGetActionType.Install);
             }
@@ -125,7 +126,7 @@ namespace NuGet.PackageManagement.UI
 
             if (model != null)
             {
-                var userAction = UserAction.CreateUnInstallAction(model.Id, Control.Model.IsSolution);
+                var userAction = UserAction.CreateUnInstallAction(model.Id, Control.Model.IsSolution, UIUtility.ToContractsItemFilter(Control._topPanel.Filter));
                 ExecuteUserAction(userAction, NuGetActionType.Uninstall);
             }
         }
@@ -139,7 +140,8 @@ namespace NuGet.PackageManagement.UI
                 var userAction = UserAction.CreateInstallAction(
                     model.Id,
                     model.SelectedVersion.Version,
-                    Control.Model.IsSolution);
+                    Control.Model.IsSolution,
+                    UIUtility.ToContractsItemFilter(Control._topPanel.Filter));
 
                 ExecuteUserAction(userAction, NuGetActionType.Install);
             }
@@ -151,7 +153,7 @@ namespace NuGet.PackageManagement.UI
 
             if (model != null)
             {
-                var userAction = UserAction.CreateUnInstallAction(model.Id, Control.Model.IsSolution);
+                var userAction = UserAction.CreateUnInstallAction(model.Id, Control.Model.IsSolution, UIUtility.ToContractsItemFilter(Control._topPanel.Filter));
                 ExecuteUserAction(userAction, NuGetActionType.Uninstall);
             }
         }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/DetailControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/DetailControl.xaml.cs
@@ -112,7 +112,8 @@ namespace NuGet.PackageManagement.UI
             {
                 var userAction = UserAction.CreateInstallAction(
                     model.Id,
-                    model.SelectedVersion.Version);
+                    model.SelectedVersion.Version,
+                    Control.Model.IsSolution);
 
                 ExecuteUserAction(userAction, NuGetActionType.Install);
             }
@@ -124,7 +125,7 @@ namespace NuGet.PackageManagement.UI
 
             if (model != null)
             {
-                var userAction = UserAction.CreateUnInstallAction(model.Id);
+                var userAction = UserAction.CreateUnInstallAction(model.Id, Control.Model.IsSolution);
                 ExecuteUserAction(userAction, NuGetActionType.Uninstall);
             }
         }
@@ -137,7 +138,8 @@ namespace NuGet.PackageManagement.UI
             {
                 var userAction = UserAction.CreateInstallAction(
                     model.Id,
-                    model.SelectedVersion.Version);
+                    model.SelectedVersion.Version,
+                    Control.Model.IsSolution);
 
                 ExecuteUserAction(userAction, NuGetActionType.Install);
             }
@@ -149,7 +151,7 @@ namespace NuGet.PackageManagement.UI
 
             if (model != null)
             {
-                var userAction = UserAction.CreateUnInstallAction(model.Id);
+                var userAction = UserAction.CreateUnInstallAction(model.Id, Control.Model.IsSolution);
                 ExecuteUserAction(userAction, NuGetActionType.Uninstall);
             }
         }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -1583,7 +1583,7 @@ namespace NuGet.PackageManagement.UI
         /// <param name="packagesInfo">Corresponding Package ViewModels from PM UI. Only needed for vulnerability telemetry counts. Can be <c>null</c></param>
         internal void InstallPackage(string packageId, NuGetVersion version, IEnumerable<PackageItemViewModel> packagesInfo)
         {
-            var action = UserAction.CreateInstallAction(packageId, version);
+            var action = UserAction.CreateInstallAction(packageId, version, Model.IsSolution);
 
             ExecuteAction(
                 () =>
@@ -1603,7 +1603,7 @@ namespace NuGet.PackageManagement.UI
         /// <param name="packagesInfo">Corresponding Package ViewModels from PM UI. Only needed for vulnerability telemetry counts. Can be <c>null</c></param>
         internal void UninstallPackage(string packageId, IEnumerable<PackageItemViewModel> packagesInfo)
         {
-            var action = UserAction.CreateUnInstallAction(packageId);
+            var action = UserAction.CreateUnInstallAction(packageId, Model.IsSolution);
 
             ExecuteAction(
                 () =>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -1583,7 +1583,7 @@ namespace NuGet.PackageManagement.UI
         /// <param name="packagesInfo">Corresponding Package ViewModels from PM UI. Only needed for vulnerability telemetry counts. Can be <c>null</c></param>
         internal void InstallPackage(string packageId, NuGetVersion version, IEnumerable<PackageItemViewModel> packagesInfo)
         {
-            var action = UserAction.CreateInstallAction(packageId, version, Model.IsSolution);
+            var action = UserAction.CreateInstallAction(packageId, version, Model.IsSolution, UIUtility.ToContractsItemFilter(_topPanel.Filter));
 
             ExecuteAction(
                 () =>
@@ -1603,7 +1603,7 @@ namespace NuGet.PackageManagement.UI
         /// <param name="packagesInfo">Corresponding Package ViewModels from PM UI. Only needed for vulnerability telemetry counts. Can be <c>null</c></param>
         internal void UninstallPackage(string packageId, IEnumerable<PackageItemViewModel> packagesInfo)
         {
-            var action = UserAction.CreateUnInstallAction(packageId, Model.IsSolution);
+            var action = UserAction.CreateUnInstallAction(packageId, Model.IsSolution, UIUtility.ToContractsItemFilter(_topPanel.Filter));
 
             ExecuteAction(
                 () =>

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/NuGet.VisualStudio.Common.csproj
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/NuGet.VisualStudio.Common.csproj
@@ -27,6 +27,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(NuGetCoreSrcDirectory)NuGet.PackageManagement\NuGet.PackageManagement.csproj" />
+    <ProjectReference Include="..\NuGet.VisualStudio.Internal.Contracts\NuGet.VisualStudio.Internal.Contracts.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="Resources.Designer.cs">

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/VSActionsTelemetryEvent.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/VSActionsTelemetryEvent.cs
@@ -10,9 +10,9 @@ namespace NuGet.VisualStudio
 {
     public class VSActionsTelemetryEvent : ActionsTelemetryEvent
     {
-        public bool IsSolutionLevel { set => this["IsSolutionLevel"] = value; }
-        public ItemFilter Tab { set => this["Tab"] = value; }
-        public bool IsPackageToInstallTransitive { set => this["IsPackageToInstallTransitive"] = value; }
+        public bool IsSolutionLevel { set => this[nameof(IsSolutionLevel)] = value; }
+        public ItemFilter Tab { set => this[nameof(Tab)] = value; }
+        public bool IsPackageToInstallTransitive { set => this[nameof(IsPackageToInstallTransitive)] = value; }
 
         public VSActionsTelemetryEvent(
            string operationId,

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/VSActionsTelemetryEvent.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/VSActionsTelemetryEvent.cs
@@ -12,7 +12,7 @@ namespace NuGet.VisualStudio
     {
         public bool IsSolutionLevel { set => this["IsSolutionLevel"] = value; }
         public ItemFilter Tab { set => this["Tab"] = value; }
-        public bool IsSelectedPackageTransitive { set => this["IsSelectedPackageTransitive"] = value; }
+        public bool IsPackageToInstallTransitive { set => this["IsPackageToInstallTransitive"] = value; }
 
         public VSActionsTelemetryEvent(
            string operationId,

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/VSActionsTelemetryEvent.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/VSActionsTelemetryEvent.cs
@@ -9,6 +9,8 @@ namespace NuGet.VisualStudio
 {
     public class VSActionsTelemetryEvent : ActionsTelemetryEvent
     {
+        public bool IsSelectedPackageTransitive { set => this["IsSelectedPackageTransitive"] = value; }
+
         public VSActionsTelemetryEvent(
            string operationId,
            string[] projectIds,

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/VSActionsTelemetryEvent.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/VSActionsTelemetryEvent.cs
@@ -4,11 +4,14 @@
 using System;
 using NuGet.Common;
 using NuGet.PackageManagement;
+using NuGet.VisualStudio.Internal.Contracts;
 
 namespace NuGet.VisualStudio
 {
     public class VSActionsTelemetryEvent : ActionsTelemetryEvent
     {
+        public bool IsSolutionLevel { set => this["IsSolutionLevel"] = value; }
+        public ItemFilter Tab { set => this["Tab"] = value; }
         public bool IsSelectedPackageTransitive { set => this["IsSelectedPackageTransitive"] = value; }
 
         public VSActionsTelemetryEvent(

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/VSActionsTelemetryEvent.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/VSActionsTelemetryEvent.cs
@@ -12,7 +12,7 @@ namespace NuGet.VisualStudio
     {
         public bool IsSolutionLevel { set => this[nameof(IsSolutionLevel)] = value; }
         public ItemFilter Tab { set => this[nameof(Tab)] = value; }
-        public bool IsPackageToInstallTransitive { set => this[nameof(IsPackageToInstallTransitive)] = value; }
+        public bool PackageToInstallWasTransitive { set => this[nameof(PackageToInstallWasTransitive)] = value; }
 
         public VSActionsTelemetryEvent(
            string operationId,

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Actions/UIActionEngineTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Actions/UIActionEngineTests.cs
@@ -12,6 +12,7 @@ using NuGet.Packaging.Core;
 using NuGet.Versioning;
 using NuGet.VisualStudio;
 using NuGet.VisualStudio.Internal.Contracts;
+using NuGet.Protocol.Core.Types;
 using Xunit;
 
 namespace NuGet.PackageManagement.UI.Test
@@ -181,8 +182,15 @@ namespace NuGet.PackageManagement.UI.Test
             Assert.Equal(3, pkgSeverities.Count());
         }
 
+        [Fact]
         public void PerformActionImplAsync_OnInstallinProject_EmitsProperty()
         {
+            var sourceProvider = new Mock<ISourceRepositoryProvider>();
+            var settings = new Mock<ISettings>();
+            var nugetPM = new NuGetPackageManager(sourceProvider, settings, "\packagesFolder");
+            var lockService = new Mock<INuGetLockService>();
+
+            var uiEngine = new UIActionEngine(sourceProvider.Object, nugetPM, lockService.Object);
             throw new NotImplementedException();
         }
 

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Actions/UIActionEngineTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Actions/UIActionEngineTests.cs
@@ -274,7 +274,7 @@ namespace NuGet.PackageManagement.UI.Test
             Assert.Equal(NuGetOperationType.Install, lastTelemetryEvent[nameof(ActionsTelemetryEvent.OperationType)]);
             Assert.Equal(isSolutionLevel, lastTelemetryEvent[nameof(VSActionsTelemetryEvent.IsSolutionLevel)]);
             Assert.Equal(activeTab, lastTelemetryEvent[nameof(VSActionsTelemetryEvent.Tab)]);
-            Assert.Equal(expectedValue, lastTelemetryEvent[nameof(VSActionsTelemetryEvent.IsPackageToInstallTransitive)]);
+            Assert.Equal(expectedValue, lastTelemetryEvent[nameof(VSActionsTelemetryEvent.PackageToInstallWasTransitive)]);
         }
 
         private sealed class PackageIdentitySubclass : PackageIdentity

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Actions/UIActionEngineTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Actions/UIActionEngineTests.cs
@@ -279,7 +279,7 @@ namespace NuGet.PackageManagement.UI.Test
             var enumerator = lastTelemetryEvent.GetEnumerator();
             while (enumerator.MoveNext())
             {
-                hasValue = enumerator.Current.Key == nameof(VSActionsTelemetryEvent.IsSelectedPackageTransitive);
+                hasValue = enumerator.Current.Key == nameof(VSActionsTelemetryEvent.IsPackageToInstallTransitive);
                 if (hasValue)
                 {
                     break;
@@ -288,7 +288,7 @@ namespace NuGet.PackageManagement.UI.Test
             Assert.Equal(containsValue, hasValue);
             if (containsValue)
             {
-                Assert.Equal(expectedValue, lastTelemetryEvent[nameof(VSActionsTelemetryEvent.IsSelectedPackageTransitive)]);
+                Assert.Equal(expectedValue, lastTelemetryEvent[nameof(VSActionsTelemetryEvent.IsPackageToInstallTransitive)]);
             }
         }
 

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Actions/UIActionEngineTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Actions/UIActionEngineTests.cs
@@ -21,7 +21,7 @@ using NuGet.Versioning;
 using NuGet.VisualStudio;
 using NuGet.VisualStudio.Internal.Contracts;
 using Xunit;
-using ContractsItemFiler = NuGet.VisualStudio.Internal.Contracts.ItemFilter;
+using ContractsItemFilter = NuGet.VisualStudio.Internal.Contracts.ItemFilter;
 
 namespace NuGet.PackageManagement.UI.Test
 {
@@ -167,7 +167,7 @@ namespace NuGet.PackageManagement.UI.Test
                 actionTelemetryEvent: actionTelemetryData,
                 continueAfterPreview: true,
                 acceptedLicense: true,
-                userAction: UserAction.CreateInstallAction("mypackageId", new NuGetVersion(1, 0, 0), It.IsAny<bool>(), It.IsAny<ContractsItemFiler>()),
+                userAction: UserAction.CreateInstallAction("mypackageId", new NuGetVersion(1, 0, 0), It.IsAny<bool>(), It.IsAny<ContractsItemFilter>()),
                 selectedIndex: 0,
                 recommendedCount: 0,
                 recommendPackages: false,
@@ -199,7 +199,7 @@ namespace NuGet.PackageManagement.UI.Test
 
         public static IEnumerable<object[]> GetInstallActionTestData()
         {
-            foreach(var activeTab in Enum.GetValues(typeof(ContractsItemFiler)))
+            foreach(var activeTab in Enum.GetValues(typeof(ContractsItemFilter)))
             {
                 yield return new object[] { activeTab, true, "transitiveA", null, }; // don't care in expectedValue in this case (solution PM UI)
                 yield return new object[] { activeTab, false, "transitiveA", true, }; // installs a package that was a transitive dependency
@@ -209,7 +209,7 @@ namespace NuGet.PackageManagement.UI.Test
 
         [Theory]
         [MemberData(nameof(GetInstallActionTestData))]
-        public async Task CreateInstallAction_OnInstallingProject_EmitsTelemetryPropertiesAsync(ContractsItemFiler activeTab, bool isSolutionLevel, string packageIdToInstall, bool? expectedValue)
+        public async Task CreateInstallAction_OnInstallingProject_EmitsPkgWasTransitiveTelemetryAndTabAndIsSolutionPropertiesAsync(ContractsItemFilter activeTab, bool isSolutionLevel, string packageIdToInstall, bool? expectedPkgWasTransitive)
         {
             // Arrange
             var telemetrySession = new Mock<ITelemetrySession>();
@@ -274,7 +274,7 @@ namespace NuGet.PackageManagement.UI.Test
             Assert.Equal(NuGetOperationType.Install, lastTelemetryEvent[nameof(ActionsTelemetryEvent.OperationType)]);
             Assert.Equal(isSolutionLevel, lastTelemetryEvent[nameof(VSActionsTelemetryEvent.IsSolutionLevel)]);
             Assert.Equal(activeTab, lastTelemetryEvent[nameof(VSActionsTelemetryEvent.Tab)]);
-            Assert.Equal(expectedValue, lastTelemetryEvent[nameof(VSActionsTelemetryEvent.PackageToInstallWasTransitive)]);
+            Assert.Equal(expectedPkgWasTransitive, lastTelemetryEvent[nameof(VSActionsTelemetryEvent.PackageToInstallWasTransitive)]);
         }
 
         private sealed class PackageIdentitySubclass : PackageIdentity

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Actions/UIActionEngineTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Actions/UIActionEngineTests.cs
@@ -151,7 +151,7 @@ namespace NuGet.PackageManagement.UI.Test
                 actionTelemetryEvent: actionTelemetryData,
                 continueAfterPreview: true,
                 acceptedLicense: true,
-                userAction: UserAction.CreateInstallAction("mypackageId", new NuGetVersion(1, 0, 0)),
+                userAction: UserAction.CreateInstallAction("mypackageId", new NuGetVersion(1, 0, 0), It.IsAny<bool>()),
                 selectedIndex: 0,
                 recommendedCount: 0,
                 recommendPackages: false,
@@ -179,6 +179,11 @@ namespace NuGet.PackageManagement.UI.Test
                 item => Assert.Equal(1, item),
                 item => Assert.Equal(3, item));
             Assert.Equal(3, pkgSeverities.Count());
+        }
+
+        public void PerformActionImplAsync_OnInstallinProject_EmitsProperty()
+        {
+            throw new NotImplementedException();
         }
 
         private sealed class PackageIdentitySubclass : PackageIdentity

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Actions/UIActionEngineTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Actions/UIActionEngineTests.cs
@@ -202,8 +202,8 @@ namespace NuGet.PackageManagement.UI.Test
             foreach(var activeTab in Enum.GetValues(typeof(ContractsItemFiler)))
             {
                 yield return new object[] { activeTab, true, "transitiveA", false, false, }; // don't care in expectedValue in this case (solution PM UI)
-                yield return new object[] { activeTab, false, "transitiveA", true, true, }; // installs a transitive package
-                yield return new object[] { activeTab, false, "anotherPackage", true, false, }; // installs a non-transitive package
+                yield return new object[] { activeTab, false, "transitiveA", true, true, }; // installs a package that was a transitive dependency
+                yield return new object[] { activeTab, false, "anotherPackage", true, false, }; // installs a package that was not a transitive dependency
             }
         }
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1497

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

- Modifies `VSActionTelemetryEvent` to add additional telemetry on Transitive Packages installed through PM UI. Transitive package Telemetry should be collected only when project PM UI is going to install a package in PackageReference project.
- Modifies `UserAction` to hold telemetry data and data from PM UI.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added: 1 new unit test added
  - ~[ ] Test exception~
  - ~[ ] N/A~

- **Documentation**
  - ~[ ] Documentation PR or issue filled~
  - [x] N/A: No product changes
