### PR TITLE
Fix no-op restores for central package management

### DIFF
--- a/src/NuGet.Core/NuGet.ProjectModel/DependencyGraphSpec.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/DependencyGraphSpec.cs
@@ -286,7 +286,7 @@ namespace NuGet.ProjectModel
             {
                 jsonWriter.Formatting = Formatting.Indented;
 
-                Write(writer, PackageSpecWriter.Write);
+                Write(writer, hashing: false, PackageSpecWriter.Write);
             }
         }
 
@@ -295,12 +295,12 @@ namespace NuGet.ProjectModel
             using (var hashFunc = new Sha512HashFunction())
             using (var writer = new HashObjectWriter(hashFunc))
             {
-                Write(writer, PackageSpecWriter.Write);
+                Write(writer, hashing: true, PackageSpecWriter.Write);
                 return writer.GetHash();
             }
         }
 
-        private void Write(RuntimeModel.IObjectWriter writer, Action<PackageSpec, RuntimeModel.IObjectWriter> writeAction)
+        private void Write(RuntimeModel.IObjectWriter writer, bool hashing, Action<PackageSpec, RuntimeModel.IObjectWriter, bool> writeAction)
         {
             writer.WriteObjectStart();
             writer.WriteNameValue("format", Version);
@@ -324,7 +324,7 @@ namespace NuGet.ProjectModel
                 var project = pair.Value;
 
                 writer.WriteObjectStart(project.RestoreMetadata.ProjectUniqueName);
-                writeAction.Invoke(project, writer);
+                writeAction.Invoke(project, writer, hashing);
                 writer.WriteObjectEnd();
             }
 

--- a/src/NuGet.Core/NuGet.ProjectModel/DependencyGraphSpec.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/DependencyGraphSpec.cs
@@ -286,7 +286,7 @@ namespace NuGet.ProjectModel
             {
                 jsonWriter.Formatting = Formatting.Indented;
 
-                Write(writer, compressed: false, PackageSpecWriter.Write);
+                Write(writer, PackageSpecWriter.Write);
             }
         }
 
@@ -295,12 +295,12 @@ namespace NuGet.ProjectModel
             using (var hashFunc = new Sha512HashFunction())
             using (var writer = new HashObjectWriter(hashFunc))
             {
-                Write(writer, compressed: true, PackageSpecWriter.Write);
+                Write(writer, PackageSpecWriter.Write);
                 return writer.GetHash();
             }
         }
 
-        private void Write(RuntimeModel.IObjectWriter writer, bool compressed, Action<PackageSpec, RuntimeModel.IObjectWriter, bool> writeAction)
+        private void Write(RuntimeModel.IObjectWriter writer, Action<PackageSpec, RuntimeModel.IObjectWriter> writeAction)
         {
             writer.WriteObjectStart();
             writer.WriteNameValue("format", Version);
@@ -324,7 +324,7 @@ namespace NuGet.ProjectModel
                 var project = pair.Value;
 
                 writer.WriteObjectStart(project.RestoreMetadata.ProjectUniqueName);
-                writeAction.Invoke(project, writer, compressed);
+                writeAction.Invoke(project, writer);
                 writer.WriteObjectEnd();
             }
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11696

Regression? 
Last working version: dotnet 5.0.100. It has regressed because the runtime option: `UseRandomizedStringHashAlgorithm` wasn't enabled before but now it is.

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Hash calculation for no-op restore was relying on `String.GetHashCode()` method.
Unfortunately, there is a security feature (https://docs.microsoft.com/en-us/dotnet/framework/configure-apps/file-schema/runtime/userandomizedstringhashalgorithm-element#remarks) that makes string hashes calculated on a per-application domain basis. Therefore same string produces a different hash each time application is being run.
It is being fixed by replacing `String.GetHashCode()` with SHA512 calculation.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
