### PR TITLE
Create a dummy target for every tfm/rid combo when a project being restored is inconsistent in locked mode

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -261,9 +261,10 @@ namespace NuGet.Commands
                     // caller of RestoreCommand to have provided at least one AdditionalMessage in RestoreArgs.
                     // The other scenario is when the lock file is not up to date and we're running locked mode.
                     // In that case we want to write a `target` for each target framework to avoid missing target errors from the SDK build tasks.
-                    graphs = _request.Project.TargetFrameworks.Select(e =>
+                    var frameworkRuntimePair = CreateFrameworkRuntimePairs(_request.Project, RequestRuntimeUtility.GetRestoreRuntimes(_request));
+                    graphs = frameworkRuntimePair.Select(e =>
                     {
-                        return RestoreTargetGraph.Create(_request.Project.RuntimeGraph, Enumerable.Empty<GraphNode<RemoteResolveResult>>(), contextForProject, _logger, e.FrameworkName, null);
+                        return RestoreTargetGraph.Create(_request.Project.RuntimeGraph, Enumerable.Empty<GraphNode<RemoteResolveResult>>(), contextForProject, _logger, e.Framework, e.RuntimeIdentifier);
                     });
                 }
 

--- a/src/NuGet.Core/NuGet.Commands/Utility/RequestRuntimeUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/Utility/RequestRuntimeUtility.cs
@@ -3,9 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using NuGet.ProjectModel;
 
 namespace NuGet.Commands
 {

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/RestoreCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/RestoreCommandTests.cs
@@ -888,6 +888,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
                     "a",
                     pathContext.SolutionRoot,
                     net461);
+                projectA.Properties.Add("RuntimeIdentifier", "win");
 
                 var packageX = new SimpleTestPackageContext()
                 {
@@ -931,10 +932,14 @@ namespace NuGet.CommandLine.FuncTest.Commands
 
                 // Assert
                 Assert.Contains("NU1004:", result.Errors);
-                var logCodes = projectA.AssetsFile.LogMessages.Select(e => e.Code);
+                var assetsFile = projectA.AssetsFile;
+                var logCodes = assetsFile.LogMessages.Select(e => e.Code);
                 Assert.Contains(NuGetLogCode.NU1004, logCodes);
-                var ridlessMainTarget = projectA.AssetsFile.Targets.FirstOrDefault(e => string.IsNullOrEmpty(e.RuntimeIdentifier));
+                Assert.Equal(2, assetsFile.Targets.Count);
+                var ridlessMainTarget = assetsFile.Targets.FirstOrDefault(e => string.IsNullOrEmpty(e.RuntimeIdentifier));
                 Assert.Equal(net461, ridlessMainTarget.TargetFramework);
+                var ridMainTarget = assetsFile.Targets.FirstOrDefault(e => "win".Equals(e.RuntimeIdentifier));
+                Assert.Equal("win", ridMainTarget.RuntimeIdentifier);
                 Assert.True(File.Exists(projectA.PropsOutput));
                 Assert.True(File.Exists(projectA.TargetsOutput));
                 Assert.True(File.Exists(projectA.CacheFileOutputPath));


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/10590

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Follow up to https://github.com/NuGet/NuGet.Client/commit/4991066d8d78053b389b07819afba78b88e66340. 

Slightly improves the error message by allowing NU1004 to be the focus when you run `Rebuild`. 

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
