### PR TITLE
Cache assets file in the project context

### DIFF
--- a/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestProjectContext.cs
+++ b/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestProjectContext.cs
@@ -210,16 +210,25 @@ namespace NuGet.Test.Utility
             }
         }
 
+        private LockFile _assetsFileCache = null;
+        private DateTime _assetsFileLastModified = DateTime.MinValue;
+
         public LockFile AssetsFile
         {
             get
             {
                 var path = AssetsFileOutputPath;
-
                 if (File.Exists(path))
                 {
-                    var format = new LockFileFormat();
-                    return format.Read(path);
+                    var lastWriteTime = File.GetLastWriteTimeUtc(path);
+                    if (_assetsFileLastModified < lastWriteTime)
+                    {
+                        var format = new LockFileFormat();
+                        _assetsFileCache = format.Read(path);
+                        _assetsFileLastModified = lastWriteTime;
+                    }
+
+                    return _assetsFileCache;
                 }
 
                 return null;


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1526

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Often times projects will call `project.AssetsFile` and it will cause the lock file be read multiple times. 

After this change the execution time goes from 11.3 min to 11.2 min for RestoreNetCoreTest. 
It's not much for this test class, but this is only about half the hits. 
It's also a super cheap/easy change. 

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
