### PR TITLE
Add a bypass GUI command when adding/deleting certificate for mac  (#…

### DIFF
--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/PackageSignatureVerifierTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/PackageSignatureVerifierTests.cs
@@ -150,7 +150,8 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            [CIOnlyFact]
+            // https://github.com/NuGet/Home/issues/11459
+            [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
             public async Task VerifySignaturesAsync_ExpiredCertificateAndTimestamp_SuccessAsync()
             {
                 CertificateAuthority ca = await _testFixture.GetDefaultTrustedCertificateAuthorityAsync();
@@ -194,7 +195,8 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            [CIOnlyFact]
+            // https://github.com/NuGet/Home/issues/11459
+            [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
             public async Task VerifySignaturesAsync_ExpiredCertificateAndTimestampWithTooLargeRange_FailsAsync()
             {
                 ISigningTestServer testServer = await _testFixture.GetSigningTestServerAsync();

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/TimestampTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/TimestampTests.cs
@@ -28,7 +28,8 @@ namespace NuGet.Packaging.FuncTest
             _trustedTestCert = _testFixture.TrustedTestCertificate;
         }
 
-        [CIOnlyFact]
+        // https://github.com/NuGet/Home/issues/11459
+        [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
         public async Task Timestamp_Verify_WithOfflineRevocation_ReturnsCorrectFlagsAndLogsAsync()
         {
             var nupkg = new SimpleTestPackageContext();

--- a/test/TestUtilities/Test.Utility/Signing/TrustedTestCert.cs
+++ b/test/TestUtilities/Test.Utility/Signing/TrustedTestCert.cs
@@ -46,6 +46,10 @@ namespace Test.Utility.Signing
 
         private const string KeychainForMac = "/Library/Keychains/System.keychain";
 
+        //Macos-11.6 (Big Sur) has different security settings and permissions
+        //This command will bypass a popup asking for unlocking a keychain.
+        private const string BypassGUICommandForMac = "sudo security authorizationdb write com.apple.trust-settings.admin allow";
+
         public TrustedTestCert(T source,
             Func<T, X509Certificate2> getCert,
             StoreName storeName = StoreName.TrustedPeople,
@@ -127,6 +131,8 @@ namespace Test.Utility.Signing
 
             File.WriteAllBytes(certFile.FullName, TrustedCert.RawData);
 
+            RunMacCommand(BypassGUICommandForMac);
+
             string addToKeyChainCmd = $"sudo security add-trusted-cert -d -r trustRoot " +
                                       $"-k \"{KeychainForMac}\" " +
                                       $"\"{certFile.FullName}\"";
@@ -145,6 +151,7 @@ namespace Test.Utility.Signing
 
             try
             {
+                RunMacCommand(BypassGUICommandForMac);
                 RunMacCommand(removeFromKeyChainCmd);
             }
             finally


### PR DESCRIPTION
…4371)

<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes:
https://github.com/nuget/client.engineering/issues/1303
Fix one of the branch in: https://github.com/NuGet/Client.Engineering/issues/1513
Regression? Last working version:

## Description
Fix release branches: 
Cherry pick https://github.com/nuget/nuget.client/pull/4371 into release-6.1.x to fix mac tests failures.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
