### PR TITLE
Fix release 5.11.x by cherry-picking engineering commits

### DIFF
--- a/build/build.proj
+++ b/build/build.proj
@@ -417,7 +417,7 @@
 
     <Exec Command="$(DesktopTestCommand)"
           ContinueOnError="true"
-          EnvironmentVariables="VisualStudio.InstallationUnderTest.Path=$(VSINSTALLDIR)"
+          EnvironmentVariables="VisualStudio.InstallationUnderTest.Path=$(VSINSTALLDIR);MSBUILD_EXE_PATH=$(MSBuildBinPath)\MSBuild.exe"
           Condition=" '$(SkipDesktopAssemblies)' != 'true' AND '$(DesktopInputTestAssemblies)' != '' ">
       <Output TaskParameter="ExitCode" PropertyName="DesktopTestErrorCode"/>
     </Exec>

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/PackageSignatureVerifierTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/PackageSignatureVerifierTests.cs
@@ -157,7 +157,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            // https://github.com/NuGet/Home/issues/11321
+            // https://github.com/NuGet/Home/issues/11459
             [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
             public async Task VerifySignaturesAsync_ExpiredCertificateAndTimestamp_SuccessAsync()
             {
@@ -202,7 +202,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            // https://github.com/NuGet/Home/issues/11321
+            // https://github.com/NuGet/Home/issues/11459
             [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
             public async Task VerifySignaturesAsync_ExpiredCertificateAndTimestampWithTooLargeRange_FailsAsync()
             {

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/TimestampTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/TimestampTests.cs
@@ -28,7 +28,7 @@ namespace NuGet.Packaging.FuncTest
             _trustedTestCert = _testFixture.TrustedTestCertificate;
         }
 
-        // https://github.com/NuGet/Home/issues/11321
+        // https://github.com/NuGet/Home/issues/11459
         [PlatformFact(Platform.Windows, Platform.Linux, CIOnly = true)]
         public async Task Timestamp_Verify_WithOfflineRevocation_ReturnsCorrectFlagsAndLogsAsync()
         {

--- a/test/TestUtilities/Test.Utility/Signing/TrustedTestCert.cs
+++ b/test/TestUtilities/Test.Utility/Signing/TrustedTestCert.cs
@@ -46,6 +46,10 @@ namespace Test.Utility.Signing
 
         private const string KeychainForMac = "/Library/Keychains/System.keychain";
 
+        //Macos-11.6 (Big Sur) has different security settings and permissions
+        //This command will bypass a popup asking for unlocking a keychain.
+        private const string BypassGUICommandForMac = "sudo security authorizationdb write com.apple.trust-settings.admin allow";
+
         public TrustedTestCert(T source,
             Func<T, X509Certificate2> getCert,
             StoreName storeName = StoreName.TrustedPeople,
@@ -123,6 +127,8 @@ namespace Test.Utility.Signing
 
             File.WriteAllBytes(certFile.FullName, TrustedCert.RawData);
 
+            RunMacCommand(BypassGUICommandForMac);
+
             string addToKeyChainCmd = $"sudo security add-trusted-cert -d -r trustRoot " +
                                       $"-k \"{KeychainForMac}\" " +
                                       $"\"{certFile.FullName}\"";
@@ -141,6 +147,7 @@ namespace Test.Utility.Signing
 
             try
             {
+                RunMacCommand(BypassGUICommandForMac);
                 RunMacCommand(removeFromKeyChainCmd);
             }
             finally


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes:
https://github.com/NuGet/Client.Engineering/issues/1303
https://github.com/NuGet/Client.Engineering/issues/1312
Fix one of the branch in https://github.com/NuGet/Client.Engineering/issues/1513
Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
Fix the release-5.11.x branch by cherry-picking previous engineering commits.
https://github.com/NuGet/NuGet.Client/pull/4371
https://github.com/NuGet/NuGet.Client/pull/4345

I bypass the Apex and E2E tests for 5.11.x branch. Pls let me know if you have any concerns.
## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
