### PR TITLE
Add value for NU1507 warning string format item

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -473,7 +473,7 @@ namespace NuGet.Commands
             // Log a warning if there are more than one configured source and package source mapping is not enabled
             if (restoreRequest.Project.RestoreMetadata.Sources.Count > 1 && !restoreRequest.PackageSourceMapping.IsEnabled)
             {
-                await _logger.LogAsync(RestoreLogMessage.CreateWarning(NuGetLogCode.NU1507, Strings.Warning_CentralPackageVersions_MultipleSourcesWithoutPackageSourceMapping));
+                await _logger.LogAsync(RestoreLogMessage.CreateWarning(NuGetLogCode.NU1507, string.Format(CultureInfo.CurrentCulture, Strings.Warning_CentralPackageVersions_MultipleSourcesWithoutPackageSourceMapping, restoreRequest.Project.RestoreMetadata.Sources.Count)));
             }
 
             // The dependencies should not have versions explicitly defined if cpvm is enabled.

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
@@ -1680,6 +1680,7 @@ namespace NuGet.Commands.Test
                 else
                 {
                     logger.WarningMessages.Should().Contain(i => i.Contains(NuGetLogCode.NU1507.ToString()));
+                    logger.WarningMessages.Should().Contain(i => i.Contains("There are 3 package sources defined in your configuration"));
                 }
             }
         }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11709

Regression? Last working version: Not a regression

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

It looks like #4505 missed calling `string.Format` and passing the value when the warning text was changed to include a format item for the number of sources. This PR corrects that.

Note that this doesn't address all of the points in https://github.com/NuGet/Home/issues/11709, just the main one of the missing value, so I don't think completing this PR should close that one.

## PR Checklist

- [X] PR has a meaningful title
- [X] PR has a linked issue.
- [X] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->



- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [X] N/A
