### PR TITLE
When loading packages in PM UI, report progress to UI only when packages list is available

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
@@ -387,7 +387,7 @@ namespace NuGet.PackageManagement.UI
             while (currentLoader.State.LoadingStatus == LoadingStatus.Loading)
             {
                 token.ThrowIfCancellationRequested();
-                await currentLoader.UpdateStateAsync(progress: null, token);
+                await currentLoader.UpdateStateAsync(progress: null, token);//don't report progress to UI while waiting for packages list
             }
 
             progress.Report(currentLoader.State);
@@ -402,7 +402,7 @@ namespace NuGet.PackageManagement.UI
                 currentLoader.State.ItemsCount == 0)
             {
                 token.ThrowIfCancellationRequested();
-                await currentLoader.UpdateStateAsync(progress: null, token);
+                await currentLoader.UpdateStateAsync(progress: null, token);//don't report progress to UI while waiting for packages list
             }
 
             progress?.Report(currentLoader.State);

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
@@ -380,15 +380,17 @@ namespace NuGet.PackageManagement.UI
 
         private async Task WaitForCompletionAsync(IItemLoader<PackageItemViewModel> currentLoader, CancellationToken token)
         {
-            var progress = new Progress<IItemLoaderState>(
+            IProgress<IItemLoaderState> progress = new Progress<IItemLoaderState>(
                 s => HandleItemLoaderStateChange(currentLoader, s));
 
             // run to completion
             while (currentLoader.State.LoadingStatus == LoadingStatus.Loading)
             {
                 token.ThrowIfCancellationRequested();
-                await currentLoader.UpdateStateAsync(progress, token);
+                await currentLoader.UpdateStateAsync(progress: null, token);
             }
+
+            progress.Report(currentLoader.State);
         }
 
         private async Task WaitForInitialResultsAsync(
@@ -400,8 +402,10 @@ namespace NuGet.PackageManagement.UI
                 currentLoader.State.ItemsCount == 0)
             {
                 token.ThrowIfCancellationRequested();
-                await currentLoader.UpdateStateAsync(progress, token);
+                await currentLoader.UpdateStateAsync(progress: null, token);
             }
+
+            progress?.Report(currentLoader.State);
         }
 
         /// <summary>


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1531

[Internal Issue](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1460784)

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
While loading packages in PM UI, the current implementation reports progress to UI even though there is no actual change in the status. 

Whenever NuGet tries to report progress, [`Progress.Report`](https://docs.microsoft.com/en-us/dotnet/api/system.progress-1.system-iprogress-t--report?view=net-6.0) method invokes handlers in a [thread pool thread](http://index/?query=system.progress&rightProject=mscorlib&file=system%5Cprogress.cs&line=92). In this case the handler is `InfiniteScrollList.HandleItemLoaderStateChange` method which switches to the main thread to update the UI. In https://github.com/NuGet/NuGet.Client/pull/1512 PR we added a loop to wait for the initial results to be available so that UI can display packages list properly. 

https://github.com/NuGet/NuGet.Client/blob/a1afdeff13fa85487e94431c461d7198084c8052/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs#L381-L406

My current understanding is that every iteration of the while loop is reporting the progress to UI even though there is no change in the state which is resulting in the creation of so many thread-pool threads and blocking majority of them for the UI thread to be available in the handler i.e., `InfiniteScrollList.HandleItemLoaderStateChange` method.

In this PR, I made few changes to not report progress in a loop and instead report the progress to UI only when there is a change in the state. I am working on this code path for the first time. Happy to learn from the feedback and fix the actual performance issue.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception - UI related changes. Manually tested the proposed changes and didn't notice any regressions in PM UI.
- **Documentation**
  - [x] N/A
