### PR TITLE
Fix issue where the packages list group expander wouldn't toggle when space was pressed

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
@@ -10,6 +10,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
 using System.Windows.Data;
 using System.Windows.Input;
 using System.Windows.Media;
@@ -696,10 +697,9 @@ namespace NuGet.PackageManagement.UI
 
         private void List_PreviewKeyUp(object sender, System.Windows.Input.KeyEventArgs e)
         {
-            // toggle the selection state when user presses the space bar
-            var package = _list.SelectedItem as PackageItemViewModel;
-            if (package != null && e.Key == Key.Space)
+            if (e.Key == Key.Space && e.OriginalSource is ListBoxItem && _list.SelectedItem is PackageItemViewModel package)
             {
+                // toggle the selection state when user presses the space bar
                 package.IsSelected = !package.IsSelected;
                 e.Handled = true;
             }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
@@ -10,7 +10,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Controls.Primitives;
 using System.Windows.Data;
 using System.Windows.Input;
 using System.Windows.Media;


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1532

Regression? Last working version: N/A

## Description
There is a PreviewKeyUp event handler on the packages list that is supposed to handle when a package is selected, and space is pressed, and it was interfering with space being pressed when the list group's Expander's ToggleButton was focused. Added an additional check to only run the code that handles package selection when the source is a ListBoxItem.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
Tested manually with keyboard interaction by setting focus on list group's expander, pressing space on keyboard, observing the expander toggle, then focusing a package item and pressing space and observing the code run to set the package's selection.
  - [x] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A