### PR TITLE
Service 6.2.x with Add value for NU1507 warning string format item (#4533)

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -473,7 +473,7 @@ namespace NuGet.Commands
             // Log a warning if there are more than one configured source and package source mapping is not enabled
             if (restoreRequest.Project.RestoreMetadata.Sources.Count > 1 && !restoreRequest.PackageSourceMapping.IsEnabled)
             {
-                await _logger.LogAsync(RestoreLogMessage.CreateWarning(NuGetLogCode.NU1507, Strings.Warning_CentralPackageVersions_MultipleSourcesWithoutPackageSourceMapping));
+                await _logger.LogAsync(RestoreLogMessage.CreateWarning(NuGetLogCode.NU1507, string.Format(CultureInfo.CurrentCulture, Strings.Warning_CentralPackageVersions_MultipleSourcesWithoutPackageSourceMapping, restoreRequest.Project.RestoreMetadata.Sources.Count)));
             }
 
             // The dependencies should not have versions explicitly defined if cpvm is enabled.

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
@@ -1680,6 +1680,7 @@ namespace NuGet.Commands.Test
                 else
                 {
                     logger.WarningMessages.Should().Contain(i => i.Contains(NuGetLogCode.NU1507.ToString()));
+                    logger.WarningMessages.Should().Contain(i => i.Contains("There are 3 package sources defined in your configuration"));
                 }
             }
         }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1543

Regression? Last working version:

## Description
Cherry picked 29af687868105f782edb6e21e1103780ec78f0e7 onto `release-6.2.x`
```
D:\nuget3>git fetch origin release-6.2.x
...

D:\nuget3>git reset origin/release-6.2.x --hard
HEAD is now at eae7622b6 change IsEscrowMode to true for 6.2.0 (#4542)

D:\nuget3>git cherry-pick 29af687868105f782edb6e21e1103780ec78f0e7
Auto-merging src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
[jeffkl-cherry-pick-29af687868105f782edb6e21e1103780ec78f0e7 3e702d797] Add value for NU1507 warning string format item (#4533)
 Author: Tim Mulholland <tlmii@users.noreply.github.com>
 Date: Mon Apr 4 11:52:38 2022 -0700
 2 files changed, 2 insertions(+), 1 deletion(-)
```

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
