### PR TITLE
Unroll LINQ calls to significantly reduce allocations

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Utility/GetPackageReferenceUtility.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Utility/GetPackageReferenceUtility.cs
@@ -110,6 +110,7 @@ namespace NuGet.PackageManagement.VisualStudio.Utility
                     if (t.TargetFramework.Equals(targetFramework) && string.IsNullOrEmpty(t.RuntimeIdentifier))
                     {
                         target = t;
+                        break;
                     }
                 }
 


### PR DESCRIPTION
This saves ~30MB of allocations when using OrchardCore.

<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11733

Regression? Last working version: Not a regression

## Description
This is a performance improvement to reduce allocations.

![image](https://user-images.githubusercontent.com/60519722/162079028-1169b0fb-4919-4cc4-8853-68d563e2c5e5.png)
![image](https://user-images.githubusercontent.com/60519722/162079101-f96686e5-aeae-4fd6-8251-960eeeaa4530.png)

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
