### PR TITLE
Warn when http sources are used in push/delete operations

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/CommandRunners/DeleteRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/CommandRunners/DeleteRunner.cs
@@ -27,8 +27,8 @@ namespace NuGet.Commands
             ILogger logger)
         {
             source = CommandRunnerUtility.ResolveSource(sourceProvider, source);
-
-            var packageUpdateResource = await CommandRunnerUtility.GetPackageUpdateResource(sourceProvider, source);
+            PackageSource packageSource = CommandRunnerUtility.GetOrCreatePackageSource(sourceProvider, source);
+            var packageUpdateResource = await CommandRunnerUtility.GetPackageUpdateResource(sourceProvider, packageSource);
 
             await packageUpdateResource.Delete(
                 packageId,

--- a/src/NuGet.Core/NuGet.Commands/CommandRunners/DeleteRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/CommandRunners/DeleteRunner.cs
@@ -28,9 +28,11 @@ namespace NuGet.Commands
         {
             source = CommandRunnerUtility.ResolveSource(sourceProvider, source);
             PackageSource packageSource = CommandRunnerUtility.GetOrCreatePackageSource(sourceProvider, source);
-            if (packageSource.IsHttp && !packageSource.IsHttps)
+            // Only warn for V3 style sources because they have a service index which is different from the final push url.
+            if (packageSource.IsHttp && !packageSource.IsHttps &&
+                (packageSource.ProtocolVersion == 3 || packageSource.Source.EndsWith("json", StringComparison.OrdinalIgnoreCase)))
             {
-                logger.LogWarning(string.Format(CultureInfo.CurrentCulture, Strings.Push_Warning_HTTPSourceUsage, packageSource.Source));
+                logger.LogWarning(string.Format(CultureInfo.CurrentCulture, Strings.Warning_HttpServerUsage, "push", packageSource.Source));
             }
             var packageUpdateResource = await CommandRunnerUtility.GetPackageUpdateResource(sourceProvider, packageSource);
 

--- a/src/NuGet.Core/NuGet.Commands/CommandRunners/DeleteRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/CommandRunners/DeleteRunner.cs
@@ -32,7 +32,7 @@ namespace NuGet.Commands
             if (packageSource.IsHttp && !packageSource.IsHttps &&
                 (packageSource.ProtocolVersion == 3 || packageSource.Source.EndsWith("json", StringComparison.OrdinalIgnoreCase)))
             {
-                logger.LogWarning(string.Format(CultureInfo.CurrentCulture, Strings.Warning_HttpServerUsage, "push", packageSource.Source));
+                logger.LogWarning(string.Format(CultureInfo.CurrentCulture, Strings.Warning_HttpServerUsage, "delete", packageSource.Source));
             }
             var packageUpdateResource = await CommandRunnerUtility.GetPackageUpdateResource(sourceProvider, packageSource);
 

--- a/src/NuGet.Core/NuGet.Commands/CommandRunners/DeleteRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/CommandRunners/DeleteRunner.cs
@@ -2,10 +2,10 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Globalization;
 using System.Threading.Tasks;
 using NuGet.Common;
 using NuGet.Configuration;
-using NuGet.Protocol.Core.Types;
 
 namespace NuGet.Commands
 {
@@ -28,6 +28,10 @@ namespace NuGet.Commands
         {
             source = CommandRunnerUtility.ResolveSource(sourceProvider, source);
             PackageSource packageSource = CommandRunnerUtility.GetOrCreatePackageSource(sourceProvider, source);
+            if (packageSource.IsHttp && !packageSource.IsHttps)
+            {
+                logger.LogWarning(string.Format(CultureInfo.CurrentCulture, Strings.Push_Warning_HTTPSourceUsage, packageSource.Source));
+            }
             var packageUpdateResource = await CommandRunnerUtility.GetPackageUpdateResource(sourceProvider, packageSource);
 
             await packageUpdateResource.Delete(

--- a/src/NuGet.Core/NuGet.Commands/CommandRunners/PushRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/CommandRunners/PushRunner.cs
@@ -49,7 +49,7 @@ namespace NuGet.Commands
             var packageUpdateResourceScheme = packageUpdateResource.SourceUri.Scheme;
             if (packageUpdateResourceScheme.Equals("http", StringComparison.OrdinalIgnoreCase))
             {
-                logger.LogWarning(string.Format(CultureInfo.CurrentCulture, Strings.Push_Warning_HTTPSourceUsage, source));
+                logger.LogWarning(string.Format(CultureInfo.CurrentCulture, Strings.Push_Warning_HTTPSourceUsage, packageUpdateResource.SourceUri));
             }
 
             packageUpdateResource.Settings = settings;
@@ -71,7 +71,7 @@ namespace NuGet.Commands
                     var symbolsUpdateResourceScheme = symbolPackageUpdateResource.SourceUri.Scheme;
                     if (symbolsUpdateResourceScheme.Equals("http", StringComparison.OrdinalIgnoreCase))
                     {
-                        logger.LogWarning(string.Format(CultureInfo.CurrentCulture, Strings.Push_Warning_HTTPSourceUsage, source));
+                        logger.LogWarning(string.Format(CultureInfo.CurrentCulture, Strings.Push_Warning_HTTPSourceUsage, symbolPackageUpdateResource.SourceUri));
                     }
                 }
             }

--- a/src/NuGet.Core/NuGet.Commands/CommandRunners/PushRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/CommandRunners/PushRunner.cs
@@ -49,8 +49,7 @@ namespace NuGet.Commands
             var packageUpdateResourceScheme = packageUpdateResource.SourceUri.Scheme;
             if (packageUpdateResourceScheme.Equals("http", StringComparison.OrdinalIgnoreCase))
             {
-                // TODO NK - Move this into the resource.
-                logger.LogWarning($"You have specified an HTTP Source, please stop doing it. Here's the source {source}");
+                logger.LogWarning(string.Format(CultureInfo.CurrentCulture, Strings.Push_Warning_HTTPSourceUsage, source));
             }
 
             packageUpdateResource.Settings = settings;
@@ -69,12 +68,10 @@ namespace NuGet.Commands
                     symbolSource = symbolPackageUpdateResource.SourceUri.AbsoluteUri;
                     symbolApiKey = apiKey;
 
-                    // Warn for the symbol package source.
                     var symbolsUpdateResourceScheme = symbolPackageUpdateResource.SourceUri.Scheme;
                     if (symbolsUpdateResourceScheme.Equals("http", StringComparison.OrdinalIgnoreCase))
                     {
-                        // TODO NK - Move into the resource.
-                        logger.LogWarning($"You have specified an HTTP Source, please stop doing it. Here's the source {source}");
+                        logger.LogWarning(string.Format(CultureInfo.CurrentCulture, Strings.Push_Warning_HTTPSourceUsage, source));
                     }
                 }
             }

--- a/src/NuGet.Core/NuGet.Commands/CommandRunners/PushRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/CommandRunners/PushRunner.cs
@@ -71,6 +71,7 @@ namespace NuGet.Commands
                     var symbolsUpdateResourceScheme = symbolPackageUpdateResource.SourceUri.Scheme;
                     if (symbolsUpdateResourceScheme.Equals("http", StringComparison.OrdinalIgnoreCase))
                     {
+                        // TODO NK - Validate all the warnings make sense.
                         logger.LogWarning(string.Format(CultureInfo.CurrentCulture, Strings.Push_Warning_HTTPSourceUsage, symbolPackageUpdateResource.SourceUri));
                     }
                 }

--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -2375,7 +2375,7 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to You are attempting to &apos;{0}&apos; to an &apos;http&apos; source, &apos;{1}&apos;. Support for &apos;http&apos; sources will be removed in a future version..
+        ///   Looks up a localized string similar to You are running the &apos;{0}&apos; operation with an &apos;http&apos; source, &apos;{1}&apos;. Support for &apos;http&apos; sources will be removed in a future version..
         /// </summary>
         internal static string Warning_HttpServerUsage {
             get {

--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -1781,15 +1781,6 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to You are attempting to push to an &apos;http&apos; source, &apos;{0}&apos;. Support for &apos;http&apos; sources will be removed in a future version..
-        /// </summary>
-        internal static string Push_Warning_HTTPSourceUsage {
-            get {
-                return ResourceManager.GetString("Push_Warning_HTTPSourceUsage", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Registered client certificates:.
         /// </summary>
         internal static string RegsiteredClientCertificates {
@@ -2380,6 +2371,15 @@ namespace NuGet.Commands {
         internal static string Warning_FileExcludedByDefault {
             get {
                 return ResourceManager.GetString("Warning_FileExcludedByDefault", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to You are attempting to &apos;{0}&apos; to an &apos;http&apos; source, &apos;{1}&apos;. Support for &apos;http&apos; sources will be removed in a future version..
+        /// </summary>
+        internal static string Warning_HttpServerUsage {
+            get {
+                return ResourceManager.GetString("Warning_HttpServerUsage", resourceCulture);
             }
         }
         

--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -1781,6 +1781,15 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to You are attempting to push to an `http` source, &apos;{0}&apos;. Support for `http` sources will be removed in a future version..
+        /// </summary>
+        internal static string Push_Warning_HTTPSourceUsage {
+            get {
+                return ResourceManager.GetString("Push_Warning_HTTPSourceUsage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Registered client certificates:.
         /// </summary>
         internal static string RegsiteredClientCertificates {

--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -1781,7 +1781,7 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to You are attempting to push to an `http` source, &apos;{0}&apos;. Support for `http` sources will be removed in a future version..
+        ///   Looks up a localized string similar to You are attempting to push to an &apos;http&apos; source, &apos;{0}&apos;. Support for &apos;http&apos; sources will be removed in a future version..
         /// </summary>
         internal static string Push_Warning_HTTPSourceUsage {
             get {

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -1032,8 +1032,8 @@ For more information, visit https://docs.nuget.org/docs/reference/command-line-r
   <data name="Error_NoMatchingClientCertificate" xml:space="preserve">
     <value>This package is signed but not by a trusted signer.</value>
   </data>
-  <data name="Push_Warning_HTTPSourceUsage" xml:space="preserve">
-    <value>You are attempting to push to an 'http' source, '{0}'. Support for 'http' sources will be removed in a future version.</value>
-    <comment>0 - the package source url</comment>
+  <data name="Warning_HttpServerUsage" xml:space="preserve">
+    <value>You are attempting to '{0}' to an 'http' source, '{1}'. Support for 'http' sources will be removed in a future version.</value>
+    <comment>0 - The command name. Ex. Push/Delete. 1 - server uri.</comment>
   </data>
 </root>

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -1033,7 +1033,7 @@ For more information, visit https://docs.nuget.org/docs/reference/command-line-r
     <value>This package is signed but not by a trusted signer.</value>
   </data>
   <data name="Push_Warning_HTTPSourceUsage" xml:space="preserve">
-    <value>You are attempting to push to an `http` source, '{0}'. Support for `http` sources will be removed in a future version.</value>
+    <value>You are attempting to push to an 'http' source, '{0}'. Support for 'http' sources will be removed in a future version.</value>
     <comment>0 - the package source url</comment>
   </data>
 </root>

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -1033,7 +1033,7 @@ For more information, visit https://docs.nuget.org/docs/reference/command-line-r
     <value>This package is signed but not by a trusted signer.</value>
   </data>
   <data name="Warning_HttpServerUsage" xml:space="preserve">
-    <value>You are attempting to '{0}' to an 'http' source, '{1}'. Support for 'http' sources will be removed in a future version.</value>
+    <value>You are running the '{0}' operation with an 'http' source, '{1}'. Support for 'http' sources will be removed in a future version.</value>
     <comment>0 - The command name. Ex. Push/Delete. 1 - server uri.</comment>
   </data>
 </root>

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -1032,4 +1032,8 @@ For more information, visit https://docs.nuget.org/docs/reference/command-line-r
   <data name="Error_NoMatchingClientCertificate" xml:space="preserve">
     <value>This package is signed but not by a trusted signer.</value>
   </data>
+  <data name="Push_Warning_HTTPSourceUsage" xml:space="preserve">
+    <value>You are attempting to push to an `http` source, '{0}'. Support for `http` sources will be removed in a future version.</value>
+    <comment>0 - the package source url</comment>
+  </data>
 </root>

--- a/src/NuGet.Core/NuGet.Commands/Utility/CommandRunnerUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/Utility/CommandRunnerUtility.cs
@@ -67,7 +67,15 @@ namespace NuGet.Commands
             return apiKey ?? defaultApiKey;
         }
 
-        public static async Task<PackageUpdateResource> GetPackageUpdateResource(IPackageSourceProvider sourceProvider, string source)
+        public static async Task<PackageUpdateResource> GetPackageUpdateResource(IPackageSourceProvider sourceProvider, PackageSource packageSource)
+        {
+            var sourceRepositoryProvider = new CachingSourceProvider(sourceProvider);
+            var sourceRepository = sourceRepositoryProvider.CreateRepository(packageSource);
+
+            return await sourceRepository.GetResourceAsync<PackageUpdateResource>();
+        }
+
+        public static PackageSource GetOrCreatePackageSource(IPackageSourceProvider sourceProvider, string source)
         {
             // Use a loaded PackageSource if possible since it contains credential info
             PackageSource packageSource = null;
@@ -85,10 +93,7 @@ namespace NuGet.Commands
                 packageSource = new PackageSource(source);
             }
 
-            var sourceRepositoryProvider = new CachingSourceProvider(sourceProvider);
-            var sourceRepository = sourceRepositoryProvider.CreateRepository(packageSource);
-
-            return await sourceRepository.GetResourceAsync<PackageUpdateResource>();
+            return packageSource;
         }
 
         public static async Task<SymbolPackageUpdateResourceV3> GetSymbolPackageUpdateResource(IPackageSourceProvider sourceProvider, string source)

--- a/src/NuGet.Core/NuGet.Protocol/Resources/PackageUpdateResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/PackageUpdateResource.cs
@@ -3,8 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Data;
-using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -13,7 +11,6 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
 using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Packaging;
@@ -683,6 +680,10 @@ namespace NuGet.Protocol.Core.Types
             }
             else
             {
+                if (sourceUri.Scheme.Equals("http", StringComparison.OrdinalIgnoreCase))
+                {
+                    logger.LogWarning(string.Format(CultureInfo.CurrentCulture, Strings.Warning_HttpServerUsage, "delete", sourceUri));
+                }
                 await DeletePackageFromServer(source, apiKey, packageId, packageVersion, noServiceEndpoint, logger, token);
             }
         }

--- a/src/NuGet.Core/NuGet.Protocol/Resources/PackageUpdateResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/PackageUpdateResource.cs
@@ -379,7 +379,7 @@ namespace NuGet.Protocol.Core.Types
             bool useTempApiKey = IsSourceNuGetSymbolServer(source);
             HttpStatusCode? codeNotToThrow = ConvertSkipDuplicateParamToHttpStatusCode(skipDuplicate);
             bool showPushCommandPackagePushed = true;
-            if (warnForHttpSources && serviceEndpointUrl.Scheme.Equals("http", StringComparison.OrdinalIgnoreCase))
+            if (warnForHttpSources && serviceEndpointUrl.Scheme == Uri.UriSchemeHttp)
             {
                 logger.LogWarning(string.Format(CultureInfo.CurrentCulture, Strings.Warning_HttpServerUsage, "push", serviceEndpointUrl));
             }
@@ -680,7 +680,7 @@ namespace NuGet.Protocol.Core.Types
             }
             else
             {
-                if (sourceUri.Scheme.Equals("http", StringComparison.OrdinalIgnoreCase))
+                if (sourceUri.Scheme == Uri.UriSchemeHttp)
                 {
                     logger.LogWarning(string.Format(CultureInfo.CurrentCulture, Strings.Warning_HttpServerUsage, "delete", sourceUri));
                 }

--- a/src/NuGet.Core/NuGet.Protocol/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Strings.Designer.cs
@@ -961,6 +961,15 @@ namespace NuGet.Protocol {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to You are attempting to &apos;{0}&apos; to an &apos;http&apos; source, &apos;{1}&apos;. Support for &apos;http&apos; sources will be removed in a future version..
+        /// </summary>
+        internal static string Warning_HttpServerUsage {
+            get {
+                return ResourceManager.GetString("Warning_HttpServerUsage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Found symbols package &apos;{0}&apos;, but no API key was specified for the symbol server. To save an API Key, run &apos;NuGet.exe setApiKey [your API key from http://www.NuGet.org]&apos;..
         /// </summary>
         internal static string Warning_SymbolServerNotConfigured {

--- a/src/NuGet.Core/NuGet.Protocol/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Strings.Designer.cs
@@ -961,7 +961,7 @@ namespace NuGet.Protocol {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to You are attempting to &apos;{0}&apos; to an &apos;http&apos; source, &apos;{1}&apos;. Support for &apos;http&apos; sources will be removed in a future version..
+        ///   Looks up a localized string similar to You are running the &apos;{0}&apos; operation with an &apos;http&apos; source, &apos;{1}&apos;. Support for &apos;http&apos; sources will be removed in a future version..
         /// </summary>
         internal static string Warning_HttpServerUsage {
             get {

--- a/src/NuGet.Core/NuGet.Protocol/Strings.resx
+++ b/src/NuGet.Core/NuGet.Protocol/Strings.resx
@@ -478,4 +478,8 @@ The "ms" should be localized to the abbreviation for milliseconds.</comment>
   <data name="StringCannotBeNullOrEmpty" xml:space="preserve">
     <value>String argument '{0}' cannot be null or empty</value>
   </data>
+  <data name="Warning_HttpServerUsage" xml:space="preserve">
+    <value>You are attempting to '{0}' to an 'http' source, '{1}'. Support for 'http' sources will be removed in a future version.</value>
+    <comment>0 - The command name. Ex. Push/Delete. 1 - server uri.</comment>
+  </data>
 </root>

--- a/src/NuGet.Core/NuGet.Protocol/Strings.resx
+++ b/src/NuGet.Core/NuGet.Protocol/Strings.resx
@@ -479,7 +479,7 @@ The "ms" should be localized to the abbreviation for milliseconds.</comment>
     <value>String argument '{0}' cannot be null or empty</value>
   </data>
   <data name="Warning_HttpServerUsage" xml:space="preserve">
-    <value>You are attempting to '{0}' to an 'http' source, '{1}'. Support for 'http' sources will be removed in a future version.</value>
+    <value>You are running the '{0}' operation with an 'http' source, '{1}'. Support for 'http' sources will be removed in a future version.</value>
     <comment>0 - The command name. Ex. Push/Delete. 1 - server uri.</comment>
   </data>
 </root>

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/PushCommandTest.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/PushCommandTest.cs
@@ -808,7 +808,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
         /// When pushing a snupkg, a 409 Conflict is returned and any message from the server is shown appropriately.
         /// </summary>
         [Fact]
-        public void PushCommand_Server_Snupkg_ByFilename_SnupkgExists_Conflict_ServerMessage()
+        public void PushCommand_Server_Snupkg_ByFilename_SnupkgExists_Conflict_ServerMessage() // I don't know somehing like this too maybe.
         {
             // Arrange
             using (var packageDirectory = TestDirectory.Create())

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/PushCommandTest.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/PushCommandTest.cs
@@ -801,7 +801,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
         /// When pushing a snupkg, a 409 Conflict is returned and any message from the server is shown appropriately.
         /// </summary>
         [Fact]
-        public void PushCommand_Server_Snupkg_ByFilename_SnupkgExists_Conflict_ServerMessage() // I don't know somehing like this too maybe.
+        public void PushCommand_Server_Snupkg_ByFilename_SnupkgExists_Conflict_ServerMessage()
         {
             // Arrange
             using (var packageDirectory = TestDirectory.Create())

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/PushCommandTest.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/PushCommandTest.cs
@@ -871,7 +871,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
 
             // Assert
             Assert.True(result.Success, result.AllOutput);
-            Assert.Contains("WARNING: You are attempting to push to an 'http' source", result.AllOutput);
+            Assert.Contains("WARNING: You are attempting to 'push' to an 'http' source", result.AllOutput);
         }
 
         #region Helpers

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/PushCommandTest.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/PushCommandTest.cs
@@ -871,7 +871,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
 
             // Assert
             Assert.True(result.Success, result.AllOutput);
-            Assert.Contains("WARNING: You are attempting to 'push' to an 'http' source", result.AllOutput);
+            Assert.Contains("WARNING: You are running the 'push' operation with an 'http' source", result.AllOutput);
         }
 
         #region Helpers

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGet.CommandLine.Test.csproj
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGet.CommandLine.Test.csproj
@@ -1,4 +1,4 @@
-﻿<Project>
+<Project>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'NuGet.sln'))\build\common.test.props" />
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetDeleteCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetDeleteCommandTest.cs
@@ -454,7 +454,7 @@ namespace NuGet.CommandLine.Test
                 // Assert
                 Assert.Equal(0, r.Item1);
                 Assert.True(deleteRequestIsCalled);
-                Assert.Contains("WARNING: You are attempting to 'delete' to an 'http' source", r.AllOutput);
+                Assert.Contains("WARNING: You are running the 'delete' operation with an 'http' source", r.AllOutput);
             }
         }
 

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetDeleteCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetDeleteCommandTest.cs
@@ -454,7 +454,7 @@ namespace NuGet.CommandLine.Test
                 // Assert
                 Assert.Equal(0, r.Item1);
                 Assert.True(deleteRequestIsCalled);
-                Assert.Contains("WARNING: You are attempting to push to an 'http' source", r.AllOutput);
+                Assert.Contains("WARNING: You are attempting to 'delete' to an 'http' source", r.AllOutput);
             }
         }
 

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPushCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPushCommandTest.cs
@@ -2209,6 +2209,8 @@ namespace NuGet.CommandLine.Test
                         result.Success.Should().BeTrue(result.AllOutput);
                         result.AllOutput.Should().Contain("Your package was pushed");
                         result.AllOutput.Should().Contain("WARNING: You are attempting to push to an 'http' source");
+                        result.AllOutput.Should().Contain("bla bla. There should be 2 warnings. Check that both are raising it.");
+
                         AssertFileEqual(packageFileName, outputFileName);
                     }
                 }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPushCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPushCommandTest.cs
@@ -2084,7 +2084,7 @@ namespace NuGet.CommandLine.Test
                             true);
             // Assert
             result.Success.Should().BeTrue(result.AllOutput);
-            result.AllOutput.Should().Contain("WARNING: You are attempting to push to an 'http' source");
+            result.AllOutput.Should().Contain("WARNING: You are running the 'push' operation with an 'http' source");
         }
 
 
@@ -2133,8 +2133,8 @@ namespace NuGet.CommandLine.Test
             Assert.Contains($"Pushing testPackage1.1.1.0.symbols.nupkg to '{pushSymbolsUri}'", result.Item2);
             Assert.Contains($"Created {pushSymbolsUri}", result.Item2);
             Assert.Contains("Your package was pushed.", result.Item2);
-            Assert.Contains("WARNING: You are attempting to push to an 'http' source", result.AllOutput);
-            Assert.Contains("WARNING: You are attempting to push to an 'http' source. Check for the symbols warning as well.", result.AllOutput);
+            Assert.Contains($"WARNING: You are running the 'push' operation with an 'http' source, '{pushUri}/'", result.AllOutput);
+            Assert.Contains($"WARNING: You are running the 'push' operation with an 'http' source, '{pushSymbolsUri}/'", result.AllOutput);
         }
 
         [Fact]
@@ -2208,9 +2208,8 @@ namespace NuGet.CommandLine.Test
                         // Assert
                         result.Success.Should().BeTrue(result.AllOutput);
                         result.AllOutput.Should().Contain("Your package was pushed");
-                        result.AllOutput.Should().Contain("WARNING: You are attempting to push to an 'http' source");
-                        result.AllOutput.Should().Contain("bla bla. There should be 2 warnings. Check that both are raising it.");
-
+                        result.AllOutput.Should().Contain($"WARNING: You are running the 'push' operation with an 'http' source, '{serverV3.Uri}index.json'");
+                        result.AllOutput.Should().Contain($"WARNING: You are running the 'push' operation with an 'http' source, '{serverV2.Uri}push/'");
                         AssertFileEqual(packageFileName, outputFileName);
                     }
                 }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPushCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPushCommandTest.cs
@@ -2087,7 +2087,6 @@ namespace NuGet.CommandLine.Test
             result.AllOutput.Should().Contain("WARNING: You are running the 'push' operation with an 'http' source");
         }
 
-
         [Fact]
         public void PushCommand_WhenPushingToAnHttpServerWithSymbols_Warns()
         {

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/PushCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/PushCommandTests.cs
@@ -1,16 +1,10 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.IO;
-using System.IO.Compression;
 using System.Threading.Tasks;
-using NuGet.Commands;
-using NuGet.Common;
 using NuGet.Configuration;
-using NuGet.Frameworks;
-using NuGet.ProjectModel;
 using NuGet.Test.Utility;
 using Xunit;
 

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Resources/PackageUpdateResourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Resources/PackageUpdateResourceTests.cs
@@ -871,7 +871,7 @@ namespace NuGet.Protocol.Tests
             // Assert
             Assert.NotNull(sourceRequest);
             Assert.Equal(1, logger.WarningMessages.Count);
-            Assert.Contains("You are attempting to 'push' to an 'http'", logger.WarningMessages.First());
+            Assert.Contains("You are running the 'push' operation with an 'http' source", logger.WarningMessages.First());
 
         }
 
@@ -930,7 +930,7 @@ namespace NuGet.Protocol.Tests
             Assert.NotNull(sourceRequest);
             Assert.NotNull(symbolRequest);
             Assert.Equal(1, logger.WarningMessages.Count);
-            Assert.Contains("You are attempting to 'push' to an 'http'", logger.WarningMessages.First());
+            Assert.Contains("You are running the 'push' operation with an 'http' source", logger.WarningMessages.First());
         }
 
         [Fact]

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Resources/PackageUpdateResourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Resources/PackageUpdateResourceTests.cs
@@ -871,7 +871,7 @@ namespace NuGet.Protocol.Tests
             // Assert
             Assert.NotNull(sourceRequest);
             Assert.Equal(1, logger.WarningMessages.Count);
-            Assert.Equal("WARNING: Yu are calling an http source", logger.WarningMessages.First());
+            Assert.Contains("You are attempting to 'push' to an 'http'", logger.WarningMessages.First());
 
         }
 
@@ -930,7 +930,7 @@ namespace NuGet.Protocol.Tests
             Assert.NotNull(sourceRequest);
             Assert.NotNull(symbolRequest);
             Assert.Equal(1, logger.WarningMessages.Count);
-            Assert.Equal("WARNING: Yu are calling an http source", logger.WarningMessages.First());
+            Assert.Contains("You are attempting to 'push' to an 'http'", logger.WarningMessages.First());
         }
 
         [Fact]
@@ -988,7 +988,8 @@ namespace NuGet.Protocol.Tests
             Assert.NotNull(sourceRequest);
             Assert.NotNull(symbolRequest);
             Assert.Equal(2, logger.WarningMessages.Count);
-            Assert.Equal("WARNING: Yu are calling an http source", logger.WarningMessages.First());
+            Assert.Contains("You are attempting to 'push' to an 'http' source, 'http://www.nuget.org/api/v2/'. Support for 'http' sources will be removed in a future version.", logger.WarningMessages.First());
+            Assert.Contains("You are attempting to 'push' to an 'http' source, 'http://other.smbsrc.net/api/v2/package/'. Support for 'http' sources will be removed in a future version.", logger.WarningMessages.Last());
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Resources/PackageUpdateResourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Resources/PackageUpdateResourceTests.cs
@@ -16,6 +16,9 @@ using Xunit;
 
 namespace NuGet.Protocol.Tests
 {
+    // TODO NK - Add tests here.
+    // Is it easy to add http vs http here?
+    // Consider moving the warning here.
     public class PackageUpdateResourceTests
     {
         private const string ApiKeyHeader = "X-NuGet-ApiKey";


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1520

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Enable warnings for all nuget.exe and dotnet.exe push/delete scenarios. 
Note that the changes are in shared code for push and delete and not in nuget.exe/dotnet.exe specific parts.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A - This is something that will be documented as part of the wider effort.
  