### PR TITLE
Add extra slash for property from GeneratePathProperty

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
@@ -763,7 +763,7 @@ namespace NuGet.Commands
             string propertyName = "Pkg" + localPackageInfo.Id.Replace(".", "_");
 #endif
 
-            string propertyValue = localPackageInfo.ExpandedPath + Path.DirectorySeparatorChar;
+            string propertyValue = localPackageInfo.ExpandedPath + Path.DirectorySeparatorChar + Path.DirectorySeparatorChar;
 
             return GenerateProperty(propertyName, propertyValue);
         }

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/BuildAssetsUtilsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/BuildAssetsUtilsTests.cs
@@ -746,7 +746,7 @@ namespace NuGet.Commands.Test
 
                 Assert.Equal($"'$({expectedProperty.Name.LocalName})' == ''", expectedProperty.Attribute("Condition")?.Value);
 
-                Assert.Equal($@"{packageDirectory.FullName}{Path.DirectorySeparatorChar}", expectedProperty?.Value, ignoreCase: true);
+                Assert.Equal($@"{packageDirectory.FullName}{Path.DirectorySeparatorChar}{Path.DirectorySeparatorChar}", expectedProperty?.Value, ignoreCase: true);
             }
         }
 
@@ -857,7 +857,7 @@ namespace NuGet.Commands.Test
 
                     Assert.Equal($"'$({actualPropertyElement.Name.LocalName})' == ''", actualPropertyElement.Attribute("Condition")?.Value);
 
-                    Assert.Equal($@"{packageDirectory.FullName}{Path.DirectorySeparatorChar}", actualPropertyElement?.Value, ignoreCase: true);
+                    Assert.Equal($@"{packageDirectory.FullName}{Path.DirectorySeparatorChar}{Path.DirectorySeparatorChar}", actualPropertyElement?.Value, ignoreCase: true);
 
                     Assert.Equal("'$(ExcludeRestorePackageImports)' != 'true'", actualPropertyElement.Parent.Attribute("Condition")?.Value);
                 }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11737

Regression? Yes Last working version: VS 2022 release

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
See https://github.com/NuGet/Home/issues/8871#issuecomment-1092273688

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [ ] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [ ] N/A
