### PR TITLE
Warn when http sources are used in PackageReference restore operations

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -214,6 +214,15 @@ namespace NuGet.Commands
                     _success = false;
                 }
 
+                foreach (var source in _request.Project.RestoreMetadata.Sources)
+                {
+                    if (source.IsHttp && !source.IsHttps)
+                    {
+                        await _logger.LogAsync(RestoreLogMessage.CreateWarning(NuGetLogCode.NU1803,
+                            string.Format(CultureInfo.CurrentCulture, Strings.Warning_HttpServerUsage, "restore", source.Source)));
+                    }
+                }
+
                 _success &= HasValidPlatformVersions();
 
                 // evaluate packages.lock.json file

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -214,12 +214,15 @@ namespace NuGet.Commands
                     _success = false;
                 }
 
-                foreach (var source in _request.Project.RestoreMetadata.Sources)
+                if (_request.Project?.RestoreMetadata != null)
                 {
-                    if (source.IsHttp && !source.IsHttps)
+                    foreach (var source in _request.Project.RestoreMetadata.Sources)
                     {
-                        await _logger.LogAsync(RestoreLogMessage.CreateWarning(NuGetLogCode.NU1803,
-                            string.Format(CultureInfo.CurrentCulture, Strings.Warning_HttpServerUsage, "restore", source.Source)));
+                        if (source.IsHttp && !source.IsHttps)
+                        {
+                            await _logger.LogAsync(RestoreLogMessage.CreateWarning(NuGetLogCode.NU1803,
+                                string.Format(CultureInfo.CurrentCulture, Strings.Warning_HttpServerUsage, "restore", source.Source)));
+                        }
                     }
                 }
 

--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -2375,6 +2375,15 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to You are running the &apos;{0}&apos; operation with an &apos;http&apos; source, &apos;{1}&apos;. Support for &apos;http&apos; sources will be removed in a future version..
+        /// </summary>
+        internal static string Warning_HttpServerUsage {
+            get {
+                return ResourceManager.GetString("Warning_HttpServerUsage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to {0} depends on {1} but {2} was not found. An approximate best match of {3} was resolved..
         /// </summary>
         internal static string Warning_MinVersionDoesNotExist {

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -1032,4 +1032,8 @@ For more information, visit https://docs.nuget.org/docs/reference/command-line-r
   <data name="Error_NoMatchingClientCertificate" xml:space="preserve">
     <value>This package is signed but not by a trusted signer.</value>
   </data>
+  <data name="Warning_HttpServerUsage" xml:space="preserve">
+    <value>You are running the '{0}' operation with an 'http' source, '{1}'. Support for 'http' sources will be removed in a future version.</value>
+    <comment>0 - The command name. Ex. Push/Delete. 1 - server uri.</comment>
+  </data>
 </root>

--- a/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
@@ -332,6 +332,11 @@ namespace NuGet.Common
         NU1802 = 1802,
 
         /// <summary>
+        /// HTTP Source specified, but HTTP sources will be deprecated.
+        /// </summary>
+        NU1803 = 1803,
+
+        /// <summary>
         /// Undefined signature error
         /// </summary>
         NU3000 = 3000,

--- a/src/NuGet.Core/NuGet.Common/PublicAPI/net45/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Common/PublicAPI/net45/PublicAPI.Unshipped.txt
@@ -10,6 +10,7 @@ NuGet.Common.NuGetLogCode.NU1506 = 1506 -> NuGet.Common.NuGetLogCode
 NuGet.Common.NuGetLogCode.NU1507 = 1507 -> NuGet.Common.NuGetLogCode
 NuGet.Common.NuGetLogCode.NU5133 = 5133 -> NuGet.Common.NuGetLogCode
 NuGet.Common.NuGetLogCode.NU1802 = 1802 -> NuGet.Common.NuGetLogCode
+NuGet.Common.NuGetLogCode.NU1803 = 1803 -> NuGet.Common.NuGetLogCode
 NuGet.Common.PackagingLogMessage.Framework.get -> NuGet.Frameworks.NuGetFramework
 NuGet.Common.PackagingLogMessage.Framework.set -> void
 NuGet.Common.PackagingLogMessage.LibraryId.get -> string

--- a/src/NuGet.Core/NuGet.Common/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Common/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -10,6 +10,7 @@ NuGet.Common.NuGetLogCode.NU1506 = 1506 -> NuGet.Common.NuGetLogCode
 NuGet.Common.NuGetLogCode.NU1507 = 1507 -> NuGet.Common.NuGetLogCode
 NuGet.Common.NuGetLogCode.NU5133 = 5133 -> NuGet.Common.NuGetLogCode
 NuGet.Common.NuGetLogCode.NU1802 = 1802 -> NuGet.Common.NuGetLogCode
+NuGet.Common.NuGetLogCode.NU1803 = 1803 -> NuGet.Common.NuGetLogCode
 NuGet.Common.PackagingLogMessage.Framework.get -> NuGet.Frameworks.NuGetFramework
 NuGet.Common.PackagingLogMessage.Framework.set -> void
 NuGet.Common.PackagingLogMessage.LibraryId.get -> string

--- a/src/NuGet.Core/NuGet.Common/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Common/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -10,6 +10,7 @@ NuGet.Common.NuGetLogCode.NU1506 = 1506 -> NuGet.Common.NuGetLogCode
 NuGet.Common.NuGetLogCode.NU1507 = 1507 -> NuGet.Common.NuGetLogCode
 NuGet.Common.NuGetLogCode.NU5133 = 5133 -> NuGet.Common.NuGetLogCode
 NuGet.Common.NuGetLogCode.NU1802 = 1802 -> NuGet.Common.NuGetLogCode
+NuGet.Common.NuGetLogCode.NU1803 = 1803 -> NuGet.Common.NuGetLogCode
 NuGet.Common.PackagingLogMessage.Framework.get -> NuGet.Frameworks.NuGetFramework
 NuGet.Common.PackagingLogMessage.Framework.set -> void
 NuGet.Common.PackagingLogMessage.LibraryId.get -> string


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1358

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Pretty straightforward. Contains the same warning as https://github.com/NuGet/NuGet.Client/pull/4552, but obviously with a code since it's restore.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [x] Documentation PR or issue filled https://github.com/NuGet/docs.microsoft.com-nuget/issues/2717
  - **OR**
  - [ ] N/A
