### PR TITLE
Adds local package source to failing tests in NuGetPackageManagerTests 

### DIFF
--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests.cs
@@ -3959,171 +3959,177 @@ namespace NuGet.Test
         }
 
         [Fact]
-        public async Task TestPacManPreviewUpdateWithAllowedVersionsConstraint()
+        public async Task TestPacManPreviewUpdateWithAllowedVersionsConstraintAsync()
         {
             // Arrange
-            var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV2OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager())
+            using var localPackageSourceDir = TestDirectory.Create();
+            using var testSolutionManager = new TestSolutionManager();
+            // create packages
+            var testPackageId = new Dictionary<string, IEnumerable<string>>
             {
-                var testSettings = NullSettings.Instance;
-                var deleteOnRestartManager = new TestDeleteOnRestartManager();
-                var token = CancellationToken.None;
-                var nuGetPackageManager = new NuGetPackageManager(
-                    sourceRepositoryProvider,
-                    testSettings,
-                    testSolutionManager,
-                    deleteOnRestartManager);
-                var packagesFolderPath = PackagesFolderPathUtility.GetPackagesFolderPath(testSolutionManager, testSettings);
+                ["new.json"] = new[] { "4.5.11", "5.0.8" },
+                ["web.Infrastructure"] = new[] { "0.0.0.1", "1.0.0.0" },
+            };
+            await SimpleTestPackageUtility.CreateFullPackagesAsync(localPackageSourceDir, testPackageId);
+            var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateSourceRepositoryProvider(new PackageSource(localPackageSourceDir));
 
-                var msBuildNuGetProject = testSolutionManager.AddNewMSBuildProject();
-                var msBuildNuGetProjectSystem = msBuildNuGetProject.ProjectSystem as TestMSBuildNuGetProjectSystem;
-                var packagesConfigPath = msBuildNuGetProject.PackagesConfigNuGetProject.FullPath;
-                var newtonsoftJsonPackageId = "newtonsoft.json";
-                var newtonsoftJsonPackageIdentity = new PackageIdentity(newtonsoftJsonPackageId, NuGetVersion.Parse("4.5.11"));
-                var primarySourceRepository = sourceRepositoryProvider.GetRepositories().Single();
-                var resolutionContext = new ResolutionContext(DependencyBehavior.Highest, false, true, VersionConstraints.None);
-                var testNuGetProjectContext = new TestNuGetProjectContext();
+            var testSettings = NullSettings.Instance;
+            var deleteOnRestartManager = new TestDeleteOnRestartManager();
+            var token = CancellationToken.None;
+            var nuGetPackageManager = new NuGetPackageManager(
+                sourceRepositoryProvider,
+                testSettings,
+                testSolutionManager,
+                deleteOnRestartManager);
+            var packagesFolderPath = PackagesFolderPathUtility.GetPackagesFolderPath(testSolutionManager, testSettings);
 
-                // Act
-                await nuGetPackageManager.InstallPackageAsync(msBuildNuGetProject, newtonsoftJsonPackageIdentity,
-                    resolutionContext, testNuGetProjectContext, primarySourceRepository, null, token);
+            var msBuildNuGetProject = testSolutionManager.AddNewMSBuildProject();
+            var msBuildNuGetProjectSystem = msBuildNuGetProject.ProjectSystem as TestMSBuildNuGetProjectSystem;
+            var packagesConfigPath = msBuildNuGetProject.PackagesConfigNuGetProject.FullPath;
+            var newtonsoftJsonPackageIdentity = new PackageIdentity("new.json", NuGetVersion.Parse("4.5.11"));
+            var primarySourceRepository = sourceRepositoryProvider.GetRepositories().Single();
+            var resolutionContext = new ResolutionContext(DependencyBehavior.Highest, false, true, VersionConstraints.None);
+            var testNuGetProjectContext = new TestNuGetProjectContext();
 
-                await nuGetPackageManager.InstallPackageAsync(msBuildNuGetProject, new PackageIdentity("Microsoft.Web.Infrastructure", new NuGetVersion("1.0.0.0")),
-                    resolutionContext, testNuGetProjectContext, primarySourceRepository, null, token);
+            // Act
+            await nuGetPackageManager.InstallPackageAsync(msBuildNuGetProject, newtonsoftJsonPackageIdentity,
+                resolutionContext, testNuGetProjectContext, primarySourceRepository, null, token);
 
-                // Assert
-                // Check that the packages.config file exists after the installation
-                Assert.True(File.Exists(packagesConfigPath));
-                // Check the number of packages and packages returned by PackagesConfigProject after the installation
-                var packagesInPackagesConfig = (await msBuildNuGetProject.PackagesConfigNuGetProject.GetInstalledPackagesAsync(token)).ToList();
-                Assert.Equal(2, packagesInPackagesConfig.Count);
-                Assert.Equal(newtonsoftJsonPackageIdentity, packagesInPackagesConfig[1].PackageIdentity);
-                Assert.Equal(msBuildNuGetProject.ProjectSystem.TargetFramework, packagesInPackagesConfig[1].TargetFramework);
-                var installedPackages = await msBuildNuGetProject.GetInstalledPackagesAsync(token);
-                var newtonsoftJsonPackageReference = installedPackages.Where(pr => pr.PackageIdentity.Equals(newtonsoftJsonPackageIdentity)).FirstOrDefault();
+            await nuGetPackageManager.InstallPackageAsync(msBuildNuGetProject, new PackageIdentity("web.infrastructure", new NuGetVersion("1.0.0.0")),
+                resolutionContext, testNuGetProjectContext, primarySourceRepository, null, token);
 
-                Assert.Null(newtonsoftJsonPackageReference.AllowedVersions);
+            // Assert
+            // Check that the packages.config file exists after the installation
+            Assert.True(File.Exists(packagesConfigPath));
+            // Check the number of packages and packages returned by PackagesConfigProject after the installation
+            var packagesInPackagesConfig = (await msBuildNuGetProject.PackagesConfigNuGetProject.GetInstalledPackagesAsync(token)).ToList();
+            Assert.Equal(2, packagesInPackagesConfig.Count);
+            Assert.Contains(packagesInPackagesConfig, pr => pr.PackageIdentity.Equals(newtonsoftJsonPackageIdentity) && pr.TargetFramework == msBuildNuGetProject.ProjectSystem.TargetFramework);
+            var installedPackages = await msBuildNuGetProject.GetInstalledPackagesAsync(token);
+            var newtonsoftJsonPackageReference = installedPackages.Where(pr => pr.PackageIdentity.Equals(newtonsoftJsonPackageIdentity)).FirstOrDefault();
 
-                const string newPackagesConfig = @"<?xml version='1.0' encoding='utf-8'?>
+            Assert.Null(newtonsoftJsonPackageReference.AllowedVersions);
+
+            const string newPackagesConfig = @"<?xml version='1.0' encoding='utf-8'?>
   <packages>
-    <package id='Microsoft.Web.Infrastructure' version='1.0.0.0' targetFramework='net45' />
-    <package id='Newtonsoft.Json' version='4.5.11' allowedVersions='[4.0,5.0)' targetFramework='net45' />
+    <package id='web.Infrastructure' version='1.0.0.0' targetFramework='net45' />
+    <package id='New.Json' version='4.5.11' allowedVersions='[4.0,5.0)' targetFramework='net45' />
   </packages> ";
 
-                File.WriteAllText(packagesConfigPath, newPackagesConfig);
+            File.WriteAllText(packagesConfigPath, newPackagesConfig);
 
-                // Check that the packages.config file exists after the installation
-                Assert.True(File.Exists(packagesConfigPath));
-                // Check the number of packages and packages returned by PackagesConfigProject after the installation
-                packagesInPackagesConfig = (await msBuildNuGetProject.PackagesConfigNuGetProject.GetInstalledPackagesAsync(token)).ToList();
-                Assert.Equal(2, packagesInPackagesConfig.Count);
-                Assert.Equal(newtonsoftJsonPackageIdentity, packagesInPackagesConfig[1].PackageIdentity);
-                Assert.Equal(msBuildNuGetProject.ProjectSystem.TargetFramework, packagesInPackagesConfig[1].TargetFramework);
-                installedPackages = await msBuildNuGetProject.GetInstalledPackagesAsync(token);
-                newtonsoftJsonPackageReference = installedPackages.Where(pr => pr.PackageIdentity.Equals(newtonsoftJsonPackageIdentity)).FirstOrDefault();
+            // Check that the packages.config file exists after the installation
+            Assert.True(File.Exists(packagesConfigPath));
+            // Check the number of packages and packages returned by PackagesConfigProject after the installation
+            packagesInPackagesConfig = (await msBuildNuGetProject.PackagesConfigNuGetProject.GetInstalledPackagesAsync(token)).ToList();
+            Assert.Equal(2, packagesInPackagesConfig.Count);
+            Assert.Contains(packagesInPackagesConfig, pr => pr.PackageIdentity.Equals(newtonsoftJsonPackageIdentity) && pr.TargetFramework == msBuildNuGetProject.ProjectSystem.TargetFramework);
+            installedPackages = await msBuildNuGetProject.GetInstalledPackagesAsync(token);
+            newtonsoftJsonPackageReference = installedPackages.Where(pr => pr.PackageIdentity.Equals(newtonsoftJsonPackageIdentity)).FirstOrDefault();
 
-                Assert.NotNull(newtonsoftJsonPackageReference.AllowedVersions);
+            Assert.NotNull(newtonsoftJsonPackageReference.AllowedVersions);
 
-                // Main Act
-                var nuGetProjectActions = (await nuGetPackageManager.PreviewUpdatePackagesAsync(
-                    new List<NuGetProject> { msBuildNuGetProject },
-                    resolutionContext,
-                    testNuGetProjectContext,
-                    sourceRepositoryProvider.GetRepositories(),
-                    sourceRepositoryProvider.GetRepositories(),
-                    token)).ToList();
+            // Main Act
+            var nuGetProjectActions = (await nuGetPackageManager.PreviewUpdatePackagesAsync(
+                new List<NuGetProject> { msBuildNuGetProject },
+                resolutionContext,
+                testNuGetProjectContext,
+                sourceRepositoryProvider.GetRepositories(),
+                sourceRepositoryProvider.GetRepositories(),
+                token)).ToList();
 
-                // Microsoft.Web.Infrastructure has no updates. However, newtonsoft.json has updates but does not satisfy the version range
-                // Hence, no nuget project actions to perform
-                Assert.Equal(0, nuGetProjectActions.Count);
-            }
+            // Microsoft.Web.Infrastructure has no updates. However, newtonsoft.json has updates but does not satisfy the version range
+            // Hence, no nuget project actions to perform
+            Assert.Equal(0, nuGetProjectActions.Count);
         }
 
         [Fact]
-        public async Task TestPacManPreviewUpdate_AllowedVersionsConstraint_RestrictHighestVersion()
+        public async Task TestPacManPreviewUpdate_AllowedVersionsConstraint_RestrictHighestVersionAsync()
         {
             // Arrange
-            var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV2OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager())
+            using var localPackageSourceDir = TestDirectory.Create();
+            using var testSolutionManager = new TestSolutionManager();
+            var testPackageId = new Dictionary<string, IEnumerable<string>>
             {
-                var testSettings = NullSettings.Instance;
-                var deleteOnRestartManager = new TestDeleteOnRestartManager();
-                var token = CancellationToken.None;
-                var nuGetPackageManager = new NuGetPackageManager(
-                    sourceRepositoryProvider,
-                    testSettings,
-                    testSolutionManager,
-                    deleteOnRestartManager);
-                var packagesFolderPath = PackagesFolderPathUtility.GetPackagesFolderPath(testSolutionManager, testSettings);
+                ["new.json"] = new[] { "4.5.11", "5.0.1" },
+                ["web.Infrastructure"] = new[] { "0.0.0.1", "1.0.0.0" },
+            };
+            await SimpleTestPackageUtility.CreateFullPackagesAsync(localPackageSourceDir, testPackageId);
+            var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateSourceRepositoryProvider(new PackageSource(localPackageSourceDir));
 
-                var msBuildNuGetProject = testSolutionManager.AddNewMSBuildProject();
-                var msBuildNuGetProjectSystem = msBuildNuGetProject.ProjectSystem as TestMSBuildNuGetProjectSystem;
-                var packagesConfigPath = msBuildNuGetProject.PackagesConfigNuGetProject.FullPath;
-                var newtonsoftJsonPackageId = "newtonsoft.json";
-                var newtonsoftJsonPackageIdentity = new PackageIdentity(newtonsoftJsonPackageId, NuGetVersion.Parse("4.5.11"));
-                var primarySourceRepository = sourceRepositoryProvider.GetRepositories().Single();
-                var resolutionContext = new ResolutionContext(DependencyBehavior.Lowest, false, true, VersionConstraints.None);
-                var testNuGetProjectContext = new TestNuGetProjectContext();
+            var testSettings = NullSettings.Instance;
+            var deleteOnRestartManager = new TestDeleteOnRestartManager();
+            var token = CancellationToken.None;
+            var nuGetPackageManager = new NuGetPackageManager(
+                sourceRepositoryProvider,
+                testSettings,
+                testSolutionManager,
+                deleteOnRestartManager);
+            var packagesFolderPath = PackagesFolderPathUtility.GetPackagesFolderPath(testSolutionManager, testSettings);
 
-                // Act
-                await nuGetPackageManager.InstallPackageAsync(msBuildNuGetProject, newtonsoftJsonPackageIdentity,
-                    resolutionContext, testNuGetProjectContext, primarySourceRepository, null, token);
+            var msBuildNuGetProject = testSolutionManager.AddNewMSBuildProject();
+            var msBuildNuGetProjectSystem = msBuildNuGetProject.ProjectSystem as TestMSBuildNuGetProjectSystem;
+            var packagesConfigPath = msBuildNuGetProject.PackagesConfigNuGetProject.FullPath;
+            var newJsonPackageId = "newJson";
+            var newJsonPackageIdentity = new PackageIdentity("new.json", NuGetVersion.Parse("4.5.11"));
+            var primarySourceRepository = sourceRepositoryProvider.GetRepositories().Single();
+            var resolutionContext = new ResolutionContext(DependencyBehavior.Lowest, false, true, VersionConstraints.None);
+            var testNuGetProjectContext = new TestNuGetProjectContext();
 
-                await nuGetPackageManager.InstallPackageAsync(msBuildNuGetProject, new PackageIdentity("Microsoft.Web.Infrastructure", new NuGetVersion("1.0.0.0")),
-                    resolutionContext, testNuGetProjectContext, primarySourceRepository, null, token);
+            // Act
+            await nuGetPackageManager.InstallPackageAsync(msBuildNuGetProject, newJsonPackageIdentity,
+                resolutionContext, testNuGetProjectContext, primarySourceRepository, null, token);
 
-                // Assert
-                // Check that the packages.config file exists after the installation
-                Assert.True(File.Exists(packagesConfigPath));
-                // Check the number of packages and packages returned by PackagesConfigProject after the installation
-                var packagesInPackagesConfig = (await msBuildNuGetProject.PackagesConfigNuGetProject.GetInstalledPackagesAsync(token)).ToList();
-                Assert.Equal(2, packagesInPackagesConfig.Count);
-                Assert.Equal(newtonsoftJsonPackageIdentity, packagesInPackagesConfig[1].PackageIdentity);
-                Assert.Equal(msBuildNuGetProject.ProjectSystem.TargetFramework, packagesInPackagesConfig[1].TargetFramework);
-                var installedPackages = await msBuildNuGetProject.GetInstalledPackagesAsync(token);
-                var newtonsoftJsonPackageReference = installedPackages.Where(pr => pr.PackageIdentity.Equals(newtonsoftJsonPackageIdentity)).FirstOrDefault();
+            await nuGetPackageManager.InstallPackageAsync(msBuildNuGetProject, new PackageIdentity("web.infrastructure", new NuGetVersion("1.0.0.0")),
+                resolutionContext, testNuGetProjectContext, primarySourceRepository, null, token);
 
-                Assert.Null(newtonsoftJsonPackageReference.AllowedVersions);
+            // Assert
+            // Check that the packages.config file exists after the installation
+            Assert.True(File.Exists(packagesConfigPath));
+            // Check the number of packages and packages returned by PackagesConfigProject after the installation
+            var packagesInPackagesConfig = (await msBuildNuGetProject.PackagesConfigNuGetProject.GetInstalledPackagesAsync(token)).ToList();
+            Assert.Equal(2, packagesInPackagesConfig.Count);
+            Assert.Contains(packagesInPackagesConfig, pr => pr.PackageIdentity.Equals(newJsonPackageIdentity) && pr.TargetFramework == msBuildNuGetProject.ProjectSystem.TargetFramework);
+            var installedPackages = await msBuildNuGetProject.GetInstalledPackagesAsync(token);
+            var newtonsoftJsonPackageReference = installedPackages.Where(pr => pr.PackageIdentity.Equals(newJsonPackageIdentity)).FirstOrDefault();
 
-                const string newPackagesConfig = @"<?xml version='1.0' encoding='utf-8'?>
+            Assert.Null(newtonsoftJsonPackageReference.AllowedVersions);
+
+            const string newPackagesConfig = @"<?xml version='1.0' encoding='utf-8'?>
   <packages>
-    <package id='Microsoft.Web.Infrastructure' version='1.0.0.0' targetFramework='net45' />
-    <package id='Newtonsoft.Json' version='4.5.11' allowedVersions='[4.0,6.0)' targetFramework='net45' />
-  </packages> ";
+    <package id='web.infrastructure' version='1.0.0.0' targetFramework='net45' />
+    <package id='new.json' version='4.5.11' allowedVersions='[4.0,6.0)' targetFramework='net45' />
+  </packages>";
 
-                File.WriteAllText(packagesConfigPath, newPackagesConfig);
+            File.WriteAllText(packagesConfigPath, newPackagesConfig);
 
-                // Check that the packages.config file exists after the installation
-                Assert.True(File.Exists(packagesConfigPath));
-                // Check the number of packages and packages returned by PackagesConfigProject after the installation
-                packagesInPackagesConfig = (await msBuildNuGetProject.PackagesConfigNuGetProject.GetInstalledPackagesAsync(token)).ToList();
-                Assert.Equal(2, packagesInPackagesConfig.Count);
-                Assert.Equal(newtonsoftJsonPackageIdentity, packagesInPackagesConfig[1].PackageIdentity);
-                Assert.Equal(msBuildNuGetProject.ProjectSystem.TargetFramework, packagesInPackagesConfig[1].TargetFramework);
-                installedPackages = await msBuildNuGetProject.GetInstalledPackagesAsync(token);
-                newtonsoftJsonPackageReference = installedPackages.Where(pr => pr.PackageIdentity.Equals(newtonsoftJsonPackageIdentity)).FirstOrDefault();
+            // Check that the packages.config file exists after the installation
+            Assert.True(File.Exists(packagesConfigPath));
+            // Check the number of packages and packages returned by PackagesConfigProject after the installation
+            packagesInPackagesConfig = (await msBuildNuGetProject.PackagesConfigNuGetProject.GetInstalledPackagesAsync(token)).ToList();
+            Assert.Equal(2, packagesInPackagesConfig.Count);
+            Assert.Contains(packagesInPackagesConfig, pr => pr.PackageIdentity.Equals(newJsonPackageIdentity) && pr.TargetFramework == msBuildNuGetProject.ProjectSystem.TargetFramework);
+            installedPackages = await msBuildNuGetProject.GetInstalledPackagesAsync(token);
+            newtonsoftJsonPackageReference = installedPackages.Where(pr => pr.PackageIdentity.Equals(newJsonPackageIdentity)).FirstOrDefault();
 
-                Assert.NotNull(newtonsoftJsonPackageReference.AllowedVersions);
+            Assert.NotNull(newtonsoftJsonPackageReference.AllowedVersions);
 
-                var newtonsoftJsonPackageIdentityAfterUpdate = new PackageIdentity(newtonsoftJsonPackageId, NuGetVersion.Parse("5.0.8"));
+            var newJsonPackageIdentityAfterUpdate = new PackageIdentity(newJsonPackageId, NuGetVersion.Parse("5.0.8"));
 
-                // Main Act
-                var nuGetProjectActions = (await nuGetPackageManager.PreviewUpdatePackagesAsync(
-                    new List<NuGetProject> { msBuildNuGetProject },
-                    resolutionContext,
-                    testNuGetProjectContext,
-                    sourceRepositoryProvider.GetRepositories(),
-                    sourceRepositoryProvider.GetRepositories(),
-                    token)).ToList();
+            // Main Act
+            var nuGetProjectActions = (await nuGetPackageManager.PreviewUpdatePackagesAsync(
+                new List<NuGetProject> { msBuildNuGetProject },
+                resolutionContext,
+                testNuGetProjectContext,
+                sourceRepositoryProvider.GetRepositories(),
+                sourceRepositoryProvider.GetRepositories(),
+                token)).ToList();
 
-                // Microsoft.Web.Infrastructure has no updates. However, newtonsoft.json has updates but should pick it as per the version constraint
-                // Hence, 4.5.11 will be uninstalled and 5.0.8 will be installed
-                Assert.Equal(2, nuGetProjectActions.Count);
-
-                var newtonsoftJsonAction = nuGetProjectActions.Where(a => a.PackageIdentity.Equals(newtonsoftJsonPackageIdentityAfterUpdate)).FirstOrDefault();
-
-                Assert.NotNull(newtonsoftJsonAction);
-            }
+            // Microsoft.Web.Infrastructure has no updates. However, newtonsoft.json has updates but should pick it as per the version constraint
+            // Hence, 4.5.11 will be uninstalled and 5.0.8 will be installed
+            Assert.Equal(2, nuGetProjectActions.Count);
+            var newtonsoftJsonAction = nuGetProjectActions.Where(a => a.PackageIdentity.Equals(newJsonPackageIdentityAfterUpdate)).FirstOrDefault();
+            Assert.NotNull(newtonsoftJsonAction);
         }
 
         [Fact]

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests.cs
@@ -4129,7 +4129,7 @@ namespace NuGet.Test
             // web.infrastructure has no updates. However, new.json has updates but should pick it as per the version constraint
             // Hence, 4.5.11 will be uninstalled and 5.0.8 will be installed
             Assert.Equal(2, nuGetProjectActions.Count());
-            Assert.Contains(nuGetProjectActions, pr => pr.PackageIdentity.Equals(newtonsoftJsonPackageReference));
+            Assert.Contains(nuGetProjectActions, pr => pr.PackageIdentity.Equals(newJsonPackageIdentityAfterUpdate));
         }
 
         [Fact]

--- a/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestPackageUtility.cs
+++ b/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestPackageUtility.cs
@@ -19,13 +19,32 @@ using NuGet.Packaging;
 using NuGet.Packaging.Core;
 using NuGet.Packaging.PackageExtraction;
 using NuGet.Packaging.Signing;
-using NuGet.Shared;
 using NuGet.Versioning;
 
 namespace NuGet.Test.Utility
 {
     public static class SimpleTestPackageUtility
     {
+        public static async Task CreateFullPackagesAsync(string repositoryDir, IDictionary<string, IEnumerable<string>> packages)
+        {
+            if (packages == null)
+            {
+                throw new ArgumentNullException(nameof(packages));
+            }
+            if (repositoryDir == null)
+            {
+                throw new ArgumentNullException(nameof(repositoryDir));
+            }
+
+            foreach (KeyValuePair<string, IEnumerable<string>> package in packages)
+            {
+                foreach (string pkgVersion in package.Value)
+                {
+                    await CreateFullPackageAsync(repositoryDir, package.Key, pkgVersion);
+                }
+            }
+        }
+
         /// <summary>
         /// Creates a net45 package containing lib, build, native, tools, and contentFiles
         /// </summary>

--- a/test/TestUtilities/Test.Utility/SourceRepository/TestSourceRepositoryUtility.cs
+++ b/test/TestUtilities/Test.Utility/SourceRepository/TestSourceRepositoryUtility.cs
@@ -42,6 +42,15 @@ namespace Test.Utility
             return CreateSourceRepositoryProvider(new List<PackageSource> { V2PackageSource });
         }
 
+        public static SourceRepositoryProvider CreateSourceRepositoryProvider(PackageSource packageSource)
+        {
+            if (packageSource == null)
+            {
+                throw new ArgumentNullException(nameof(packageSource));
+            }
+            return CreateSourceRepositoryProvider(new[] { packageSource });
+        }
+
         public static SourceRepositoryProvider CreateSourceRepositoryProvider(IEnumerable<PackageSource> packageSources)
         {
             var thisUtility = new TestSourceRepositoryUtility();


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11739

Regression? Last working version: 6.3.0.10

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

- Fixes tests:
  * TestPacManPreviewUpdateWithAllowedVersionsConstraintAsync
  * TestPacManPreviewUpdate_AllowedVersionsConstraint_RestrictHighestVersionAsync

- Runs two tests with a local package source with synthetic packages
- Simplified `using` constructs. Recommended hiding whitespace changes for better PR review experience
- Changes some assertions to improve readability

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception: Test fix on actual tests
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A: No product changes.
