### PR TITLE
Test:  improve sharing of package signing test fixture instance

### DIFF
--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetAddPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetAddPackageTests.cs
@@ -15,7 +15,7 @@ using Xunit;
 
 namespace Dotnet.Integration.Test
 {
-    [Collection("Dotnet Integration Tests")]
+    [Collection(DotnetIntegrationCollection.Name)]
     public class DotnetAddPackageTests
     {
         private readonly MsbuildIntegrationTestFixture _fixture;

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
@@ -17,7 +17,7 @@ using Strings = NuGet.CommandLine.XPlat.Strings;
 
 namespace Dotnet.Integration.Test
 {
-    [Collection("Dotnet Integration Tests")]
+    [Collection(DotnetIntegrationCollection.Name)]
     public class DotnetListPackageTests
     {
         private static readonly string ProjectName = "test_project_listpkg";

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
@@ -19,7 +19,7 @@ using static NuGet.Frameworks.FrameworkConstants;
 
 namespace Dotnet.Integration.Test
 {
-    [Collection("Dotnet Integration Tests")]
+    [Collection(DotnetIntegrationCollection.Name)]
     public class DotnetRestoreTests
     {
         private const string OptInPackageVerification = "DOTNET_NUGET_SIGNATURE_VERIFICATION";

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetSignTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetSignTests.cs
@@ -15,8 +15,8 @@ using Xunit;
 
 namespace Dotnet.Integration.Test
 {
-    [Collection("Dotnet Integration Tests")]
-    public class DotnetSignTests : IClassFixture<SignCommandTestFixture>
+    [Collection(DotnetIntegrationCollection.Name)]
+    public class DotnetSignTests
     {
         private MsbuildIntegrationTestFixture _msbuildFixture;
         private SignCommandTestFixture _signFixture;

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetSourcesTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetSourcesTests.cs
@@ -11,7 +11,7 @@ using Xunit;
 
 namespace Dotnet.Integration.Test
 {
-    [Collection("Dotnet Integration Tests")]
+    [Collection(DotnetIntegrationCollection.Name)]
     public class DotnetSourcesTests
     {
         private readonly MsbuildIntegrationTestFixture _fixture;

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetToolTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetToolTests.cs
@@ -16,7 +16,7 @@ using Xunit;
 
 namespace Dotnet.Integration.Test
 {
-    [Collection("Dotnet Integration Tests")]
+    [Collection(DotnetIntegrationCollection.Name)]
     public class DotnetToolTests
     {
         private MsbuildIntegrationTestFixture _msbuildFixture;

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetTrustTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetTrustTests.cs
@@ -14,7 +14,7 @@ using Xunit;
 
 namespace Dotnet.Integration.Test
 {
-    [Collection("Dotnet Integration Tests")]
+    [Collection(DotnetIntegrationCollection.Name)]
     public class DotnetTrustTests
     {
         private const string _successfulAddTrustedSigner = "Successfully added a trusted {0} '{1}'.";

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetVerifyTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetVerifyTests.cs
@@ -14,8 +14,8 @@ using Xunit;
 
 namespace Dotnet.Integration.Test
 {
-    [Collection("Dotnet Integration Tests")]
-    public class DotnetVerifyTests : IClassFixture<SignCommandTestFixture>
+    [Collection(DotnetIntegrationCollection.Name)]
+    public class DotnetVerifyTests
     {
         private readonly string _noTimestamperWarningCode = NuGetLogCode.NU3027.ToString();
         private readonly string _primarySignatureInvalidErrorCode = NuGetLogCode.NU3018.ToString();

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
@@ -19,7 +19,7 @@ using Xunit;
 
 namespace Dotnet.Integration.Test
 {
-    [Collection("Dotnet Integration Tests")]
+    [Collection(DotnetIntegrationCollection.Name)]
     public class PackCommandTests
     {
         private MsbuildIntegrationTestFixture msbuildFixture;

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/AttributeUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/AttributeUtilityTests.cs
@@ -24,7 +24,8 @@ using DotNetUtilities = Org.BouncyCastle.Security.DotNetUtilities;
 
 namespace NuGet.Packaging.Test
 {
-    public class AttributeUtilityTests : IClassFixture<CertificatesFixture>
+    [Collection(SigningTestsCollection.Name)]
+    public class AttributeUtilityTests
     {
         private const string CommitmentTypeIdentifierProofOfDelivery = "1.2.840.113549.1.9.16.6.3";
         private const string CommitmentTypeIdentifierProofOfSender = "1.2.840.113549.1.9.16.6.4";

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/AuthorSignPackageRequestTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/AuthorSignPackageRequestTests.cs
@@ -9,7 +9,8 @@ using Xunit;
 
 namespace NuGet.Packaging.Test
 {
-    public class AuthorSignPackageRequestTests : IClassFixture<CertificatesFixture>
+    [Collection(SigningTestsCollection.Name)]
+    public class AuthorSignPackageRequestTests
     {
         private readonly CertificatesFixture _fixture;
 

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/CertificateChainUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/CertificateChainUtilityTests.cs
@@ -12,7 +12,8 @@ using Xunit;
 
 namespace NuGet.Packaging.Test
 {
-    public class CertificateChainUtilityTests : IClassFixture<CertificatesFixture>
+    [Collection(SigningTestsCollection.Name)]
+    public class CertificateChainUtilityTests
     {
         private readonly CertificatesFixture _fixture;
 

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/CertificateUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/CertificateUtilityTests.cs
@@ -13,7 +13,8 @@ using Xunit;
 
 namespace NuGet.Packaging.Test
 {
-    public class CertificateUtilityTests : IClassFixture<CertificatesFixture>
+    [Collection(SigningTestsCollection.Name)]
+    public class CertificateUtilityTests
     {
         private readonly CertificatesFixture _fixture;
 

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/ChainBuilding/DefaultX509ChainBuildPolicyTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/ChainBuilding/DefaultX509ChainBuildPolicyTests.cs
@@ -8,7 +8,8 @@ using Xunit;
 
 namespace NuGet.Packaging.Test
 {
-    public class DefaultX509ChainBuildPolicyTests : IClassFixture<CertificatesFixture>
+    [Collection(SigningTestsCollection.Name)]
+    public class DefaultX509ChainBuildPolicyTests
     {
         private readonly CertificatesFixture _fixture;
 

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/ChainBuilding/RetriableX509ChainBuildPolicyTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/ChainBuilding/RetriableX509ChainBuildPolicyTests.cs
@@ -10,7 +10,8 @@ using Xunit;
 
 namespace NuGet.Packaging.Test
 {
-    public class RetriableX509ChainBuildPolicyTests : IClassFixture<CertificatesFixture>
+    [Collection(SigningTestsCollection.Name)]
+    public class RetriableX509ChainBuildPolicyTests
     {
         private readonly CertificatesFixture _fixture;
 

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/EssCertIdTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/EssCertIdTests.cs
@@ -15,7 +15,8 @@ using EssCertId = NuGet.Packaging.Signing.EssCertId;
 
 namespace NuGet.Packaging.Test
 {
-    public class EssCertIdTests : IClassFixture<CertificatesFixture>
+    [Collection(SigningTestsCollection.Name)]
+    public class EssCertIdTests
     {
         private readonly CertificatesFixture _fixture;
 

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/EssCertIdV2Tests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/EssCertIdV2Tests.cs
@@ -20,7 +20,8 @@ using EssCertIdV2 = NuGet.Packaging.Signing.EssCertIdV2;
 
 namespace NuGet.Packaging.Test
 {
-    public class EssCertIdV2Tests : IClassFixture<CertificatesFixture>
+    [Collection(SigningTestsCollection.Name)]
+    public class EssCertIdV2Tests
     {
         private readonly CertificatesFixture _fixture;
 

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/IssuerSerialTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/IssuerSerialTests.cs
@@ -15,7 +15,8 @@ using IssuerSerial = NuGet.Packaging.Signing.IssuerSerial;
 
 namespace NuGet.Packaging.Test
 {
-    public class IssuerSerialTests : IClassFixture<CertificatesFixture>
+    [Collection(SigningTestsCollection.Name)]
+    public class IssuerSerialTests
     {
         private readonly CertificatesFixture _fixture;
 

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/PrimarySignatureTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/PrimarySignatureTests.cs
@@ -11,7 +11,8 @@ using Xunit;
 
 namespace NuGet.Packaging.Test
 {
-    public class PrimarySignatureTests : IClassFixture<CertificatesFixture>
+    [Collection(SigningTestsCollection.Name)]
+    public class PrimarySignatureTests
     {
         private const string NotExactlyOnePrimarySignature = "The package signature file does not contain exactly one primary signature.";
 

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/RepositoryCountersignatureTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/RepositoryCountersignatureTests.cs
@@ -14,7 +14,8 @@ using Xunit;
 
 namespace NuGet.Packaging.Test
 {
-    public class RepositoryCountersignatureTests : IClassFixture<CertificatesFixture>
+    [Collection(SigningTestsCollection.Name)]
+    public class RepositoryCountersignatureTests
     {
         private readonly CertificatesFixture _fixture;
 

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/RepositorySignPackageRequestTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/RepositorySignPackageRequestTests.cs
@@ -11,7 +11,8 @@ using Xunit;
 
 namespace NuGet.Packaging.Test
 {
-    public class RepositorySignPackageRequestTests : IClassFixture<CertificatesFixture>
+    [Collection(SigningTestsCollection.Name)]
+    public class RepositorySignPackageRequestTests
     {
         private readonly CertificatesFixture _fixture;
         private static readonly Uri _validV3ServiceIndexUrl = new Uri("https://test.test", UriKind.Absolute);

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/SignatureUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/SignatureUtilityTests.cs
@@ -19,7 +19,8 @@ using Xunit;
 
 namespace NuGet.Packaging.Test
 {
-    public class SignatureUtilityTests : IClassFixture<CertificatesFixture>
+    [Collection(SigningTestsCollection.Name)]
+    public class SignatureUtilityTests
     {
         private readonly CertificatesFixture _fixture;
 

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/SignedPackageArchiveUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/SignedPackageArchiveUtilityTests.cs
@@ -16,7 +16,8 @@ using Xunit;
 
 namespace NuGet.Packaging.Test
 {
-    public class SignedPackageArchiveUtilityTests : IClassFixture<CertificatesFixture>
+    [Collection(SigningTestsCollection.Name)]
+    public class SignedPackageArchiveUtilityTests
     {
         private static readonly byte[] _signatureFileName = Encoding.ASCII.GetBytes(SigningSpecifications.V1.SignaturePath);
         private readonly CertificatesFixture _fixture;

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/SigningCertificateV2Tests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/SigningCertificateV2Tests.cs
@@ -17,7 +17,8 @@ using SigningCertificateV2 = NuGet.Packaging.Signing.SigningCertificateV2;
 
 namespace NuGet.Packaging.Test
 {
-    public class SigningCertificateV2Tests : IClassFixture<CertificatesFixture>
+    [Collection(SigningTestsCollection.Name)]
+    public class SigningCertificateV2Tests
     {
         private readonly CertificatesFixture _fixture;
 

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/SigningTestsCollection.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/SigningTestsCollection.cs
@@ -3,12 +3,12 @@
 
 using Xunit;
 
-namespace Dotnet.Integration.Test
+namespace NuGet.Packaging.Test
 {
     [CollectionDefinition(Name)]
-    public class DotnetIntegrationCollection : ICollectionFixture<MsbuildIntegrationTestFixture>, ICollectionFixture<SignCommandTestFixture>
+    public sealed class SigningTestsCollection : ICollectionFixture<CertificatesFixture>
     {
-        internal const string Name = "Dotnet Integration Tests";
+        internal const string Name = "Signing tests collection";
 
         // This class has no code, and is never created. Its purpose is simply
         // to be the place to apply [CollectionDefinition] and all the

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/SigningUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/SigningUtilityTests.cs
@@ -21,7 +21,8 @@ using Xunit;
 
 namespace NuGet.Packaging.Test
 {
-    public class SigningUtilityTests : IClassFixture<CertificatesFixture>
+    [Collection(SigningTestsCollection.Name)]
+    public class SigningUtilityTests
     {
         private readonly CertificatesFixture _fixture;
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes:  https://github.com/NuGet/Home/issues/11741

Regression? No.  Last working version: N/A

## Description
This PR changes test classes to use one instance of the test fixture for the entire collection of tests.

Running all tests in the NuGet.Packaging.Test.dll assembly without this change takes ~28 s.
Running all tests in the NuGet.Packaging.Test.dll assembly without this change takes ~22 s.

That's a ~6 s (~20%) improvement in test execution time.

## PR Checklist

- [X] PR has a meaningful title
- [X] PR has a linked issue.
- [X] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [X] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [X] N/A
