### PR TITLE
Service 6.2.x with Revert "Add a trailing slash on path for GeneratePathProperty (#4384)" (#4560)

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/MSBuildRestoreItemGroup.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/MSBuildRestoreItemGroup.cs
@@ -41,7 +41,7 @@ namespace NuGet.Commands
             {
                 if (Conditions.Count > 0)
                 {
-                    return string.Join(" AND ", Conditions.Select(s => s.Trim()));
+                    return " " + string.Join(" AND ", Conditions.Select(s => s.Trim())) + " ";
                 }
                 else
                 {

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/BuildAssetsUtilsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/BuildAssetsUtilsTests.cs
@@ -667,7 +667,6 @@ namespace NuGet.Commands.Test
                         }
                     }
                 }";
-
                 var projectName = "a";
                 var rootProjectsPath = pathContext.WorkingDirectory;
                 var projectDirectory = Path.Combine(rootProjectsPath, projectName);
@@ -738,15 +737,15 @@ namespace NuGet.Commands.Test
 
                 Assert.NotNull(expectedPropertyGroup);
 
-                Assert.Equal("'$(ExcludeRestorePackageImports)' != 'true'", expectedPropertyGroup.Attribute("Condition")?.Value);
+                Assert.Equal(" '$(ExcludeRestorePackageImports)' != 'true' ", expectedPropertyGroup.Attribute("Condition")?.Value);
 
                 var expectedProperty = expectedPropertyGroup.Elements().FirstOrDefault();
 
                 Assert.Equal($"Pkg{identity.Id.Replace(".", "_")}", expectedProperty.Name.LocalName);
 
-                Assert.Equal($"'$({expectedProperty.Name.LocalName})' == ''", expectedProperty.Attribute("Condition")?.Value);
+                Assert.Equal($" '$({expectedProperty.Name.LocalName})' == '' ", expectedProperty.Attribute("Condition")?.Value);
 
-                Assert.Equal($@"{packageDirectory.FullName}{Path.DirectorySeparatorChar}", expectedProperty?.Value, ignoreCase: true);
+                Assert.Equal(packageDirectory.FullName, expectedProperty?.Value, ignoreCase: true);
             }
         }
 
@@ -855,11 +854,11 @@ namespace NuGet.Commands.Test
                     Assert.NotNull(actualPropertyElement);
 
 
-                    Assert.Equal($"'$({actualPropertyElement.Name.LocalName})' == ''", actualPropertyElement.Attribute("Condition")?.Value);
+                    Assert.Equal($" '$({actualPropertyElement.Name.LocalName})' == '' ", actualPropertyElement.Attribute("Condition")?.Value);
 
-                    Assert.Equal($@"{packageDirectory.FullName}{Path.DirectorySeparatorChar}", actualPropertyElement?.Value, ignoreCase: true);
+                    Assert.Equal(packageDirectory.FullName, actualPropertyElement?.Value, ignoreCase: true);
 
-                    Assert.Equal("'$(ExcludeRestorePackageImports)' != 'true'", actualPropertyElement.Parent.Attribute("Condition")?.Value);
+                    Assert.Equal(" '$(ExcludeRestorePackageImports)' != 'true' ", actualPropertyElement.Parent.Attribute("Condition")?.Value);
                 }
                 else
                 {

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/MSBuildRestoreItemGroupTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/MSBuildRestoreItemGroupTests.cs
@@ -31,7 +31,7 @@ namespace NuGet.Commands.Test
             var condition = group.Condition;
 
             // Assert
-            Assert.Equal("'$(a)' == 'a'", condition);
+            Assert.Equal(" '$(a)' == 'a' ", condition);
         }
 
         [Fact]
@@ -46,7 +46,7 @@ namespace NuGet.Commands.Test
             var condition = group.Condition;
 
             // Assert
-            Assert.Equal("'$(b)' != 'b' AND '$(a)' == 'a'", condition);
+            Assert.Equal(" '$(b)' != 'b' AND '$(a)' == 'a' ", condition);
         }
     }
 }


### PR DESCRIPTION




<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11737

Regression? Last working version:

## Description
This reverts commit aa9721f527cb8f25d170d22b8ebaf5e1906cb7fb and is cherry-pick from dev

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
