### PR TITLE
Ensure the animation is suspended when the control is not visible.

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageRestoreBar.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageRestoreBar.xaml
@@ -32,7 +32,7 @@
             
             <TextBlock x:Name="StatusMessage" Grid.Column="0" Text="{x:Static resx:Resources.AskForRestoreMessage}" TextWrapping="Wrap" TextOptions.TextFormattingMode="Display" VerticalAlignment="Center" Margin="5,0,5,0" />
             <Button x:Name="RestoreButton" VerticalAlignment="Center" Grid.Column="1" Content="{x:Static resx:Resources.RestoreButtonLabel}" Click="OnRestoreLinkClick" Margin="5,0,3,0" Padding="8,2,8,2" />
-            <ProgressBar x:Name="ProgressBar" Grid.Column="1" IsIndeterminate="True" Height="{Binding ActualHeight, ElementName=RestoreButton, Mode=OneWay}" Width="170" Margin="5,0,3,0" />
+      <ProgressBar x:Name="ProgressBar" Grid.Column="1" IsIndeterminate="{Binding RelativeSource={RelativeSource Self}, Path=IsVisible}" Height="{Binding ActualHeight, ElementName=RestoreButton, Mode=OneWay}" Width="170" Margin="5,0,3,0" />
         </Grid>
     </Border>
 </UserControl>


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11746

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

According to the internal issue, WPF has a bug where indeterminate animations are wasting cycles despite the fact that they're not visible. 

This fixes that. 

I manually validated there's no functional changes. 

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception - Perf fix. Manually validated the scenario before and after the change.
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
