### PR TITLE
Log message when an experiment enabled evaluation is overridden by an environment variable

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Experimentation/NuGetExperimentationService.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Experimentation/NuGetExperimentationService.cs
@@ -5,6 +5,7 @@ using System;
 using System.ComponentModel.Composition;
 using Microsoft.VisualStudio.Experimentation;
 using NuGet.Common;
+using NuGet.VisualStudio.Telemetry;
 
 namespace NuGet.VisualStudio
 {
@@ -14,32 +15,51 @@ namespace NuGet.VisualStudio
     {
         private readonly IEnvironmentVariableReader _environmentVariableReader;
         private readonly IExperimentationService _experimentationService;
+        private readonly Lazy<IOutputConsoleProvider> _outputConsoleProvider;
 
-        public NuGetExperimentationService()
-            : this(EnvironmentVariableWrapper.Instance, ExperimentationService.Default)
+        [ImportingConstructor]
+        public NuGetExperimentationService(Lazy<IOutputConsoleProvider> _outputConsoleProvider)
+            : this(EnvironmentVariableWrapper.Instance, ExperimentationService.Default, _outputConsoleProvider)
         {
             // ensure uniqueness.
         }
 
-        internal NuGetExperimentationService(IEnvironmentVariableReader environmentVariableReader, IExperimentationService experimentationService)
+        internal NuGetExperimentationService(IEnvironmentVariableReader environmentVariableReader, IExperimentationService experimentationService, Lazy<IOutputConsoleProvider> outputConsoleProvider)
         {
             _environmentVariableReader = environmentVariableReader ?? throw new ArgumentNullException(nameof(environmentVariableReader));
             _experimentationService = experimentationService ?? throw new ArgumentNullException(nameof(experimentationService));
+            _outputConsoleProvider = outputConsoleProvider ?? throw new ArgumentNullException(nameof(outputConsoleProvider));
         }
 
         public bool IsExperimentEnabled(ExperimentationConstants experiment)
         {
             var isExpForcedEnabled = false;
             var isExpForcedDisabled = false;
-            if (!string.IsNullOrEmpty(experiment.FlightEnvironmentVariable))
+            string flightVariable = experiment.FlightEnvironmentVariable;
+
+            if (!string.IsNullOrEmpty(flightVariable))
             {
-                string envVarOverride = _environmentVariableReader.GetEnvironmentVariable(experiment.FlightEnvironmentVariable);
+                string envVarOverride = _environmentVariableReader.GetEnvironmentVariable(flightVariable);
 
                 isExpForcedDisabled = envVarOverride == "0";
                 isExpForcedEnabled = envVarOverride == "1";
+
+                if (isExpForcedDisabled || isExpForcedEnabled)
+                {
+                    LogEnvironmentVariableOverride(experiment.FlightFlag, flightVariable, envVarOverride);
+                }
             }
 
             return !isExpForcedDisabled && (isExpForcedEnabled || _experimentationService.IsCachedFlightEnabled(experiment.FlightFlag));
+        }
+
+        private void LogEnvironmentVariableOverride(string flightName, string variableName, string variableValue)
+        {
+            NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            {
+                IOutputConsole console = await _outputConsoleProvider.Value.CreatePackageManagerConsoleAsync();
+                await console.WriteLineAsync(string.Format(Resources.ExperimentVariableOverrideLogText, flightName, variableName, variableValue));
+            }).PostOnFailure(nameof(NuGetExperimentationService));
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Experimentation/NuGetExperimentationService.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Experimentation/NuGetExperimentationService.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.ComponentModel.Composition;
+using System.Globalization;
 using Microsoft.VisualStudio.Experimentation;
 using NuGet.Common;
 using NuGet.VisualStudio.Telemetry;
@@ -58,8 +59,8 @@ namespace NuGet.VisualStudio
             NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async () =>
             {
                 IOutputConsole console = await _outputConsoleProvider.Value.CreatePackageManagerConsoleAsync();
-                await console.WriteLineAsync(string.Format(Resources.ExperimentVariableOverrideLogText, flightName, variableName, variableValue));
-            }).PostOnFailure(nameof(NuGetExperimentationService));
+                await console.WriteLineAsync(string.Format(CultureInfo.CurrentUICulture, Resources.ExperimentVariableOverrideLogText, flightName, variableName, variableValue));
+            }).PostOnFailure(nameof(NuGetExperimentationService), nameof(LogEnvironmentVariableOverride));
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Resources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Resources.Designer.cs
@@ -88,6 +88,15 @@ namespace NuGet.VisualStudio {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Experiment flight &apos;{0}&apos; evaluation overridden by environment variable &apos;{1}&apos; set to &apos;{2}&apos;.
+        /// </summary>
+        internal static string ExperimentVariableOverrideLogText {
+            get {
+                return ResourceManager.GetString("ExperimentVariableOverrideLogText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to ========== Finished ==========.
         /// </summary>
         internal static string Finished {

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Resources.resx
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Resources.resx
@@ -126,6 +126,10 @@
   <data name="Argument_Must_Be_GreaterThanOrEqualTo" xml:space="preserve">
     <value>Value must be greater than or equal to {0}.</value>
   </data>
+  <data name="ExperimentVariableOverrideLogText" xml:space="preserve">
+    <value>Experiment flight '{0}' evaluation overridden by environment variable '{1}' set to '{2}'</value>
+    <comment>{0} is a flight name, {1} is a variable name, {2} is a string value of the variable</comment>
+  </data>
   <data name="Finished" xml:space="preserve">
     <value>========== Finished ==========</value>
   </data>

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/CpsPackageReferenceProjectTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/CpsPackageReferenceProjectTests.cs
@@ -51,7 +51,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             {
                 { constant.FlightFlag, true },
             };
-            var service = new NuGetExperimentationService(new TestEnvironmentVariableReader(new Dictionary<string, string>()), new TestVisualStudioExperimentalService(flightsEnabled));
+            var service = new NuGetExperimentationService(new TestEnvironmentVariableReader(new Dictionary<string, string>()), new TestVisualStudioExperimentalService(flightsEnabled), new Lazy<IOutputConsoleProvider>(() => new TestOutputConsoleProvider()));
 
             service.IsExperimentEnabled(ExperimentationConstants.TransitiveDependenciesInPMUI).Should().Be(true);
             componentModel.Setup(x => x.GetService<INuGetExperimentationService>()).Returns(service);

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/LegacyPackageReferenceProjectTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/LegacyPackageReferenceProjectTests.cs
@@ -53,7 +53,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             {
                 { constant.FlightFlag, true },
             };
-            var service = new NuGetExperimentationService(new TestEnvironmentVariableReader(new Dictionary<string, string>()), new TestVisualStudioExperimentalService(flightsEnabled));
+            var service = new NuGetExperimentationService(new TestEnvironmentVariableReader(new Dictionary<string, string>()), new TestVisualStudioExperimentalService(flightsEnabled), new Lazy<IOutputConsoleProvider>(() => new TestOutputConsoleProvider()));
 
             service.IsExperimentEnabled(constant).Should().Be(true);
             componentModel.Setup(x => x.GetService<INuGetExperimentationService>()).Returns(service);

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/NuGetPackageSearchServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/NuGetPackageSearchServiceTests.cs
@@ -68,7 +68,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 { "https://api.nuget.org/v3/registration3-gz-semver2/microsoft.extensions.logging.abstractions/index.json", ProtocolUtility.GetResource("NuGet.PackageManagement.VisualStudio.Test.compiler.resources.loggingAbstractions.json", GetType()) }
             };
             _componentModel = new Mock<IComponentModel>();
-            var expService = new NuGetExperimentationService(new TestEnvironmentVariableReader(new Dictionary<string, string>()), new TestVisualStudioExperimentalService(_experimentationFlags));
+            var expService = new NuGetExperimentationService(new TestEnvironmentVariableReader(new Dictionary<string, string>()), new TestVisualStudioExperimentalService(_experimentationFlags), new Lazy<IOutputConsoleProvider>(() => new TestOutputConsoleProvider()));
             _componentModel.Setup(x => x.GetService<INuGetExperimentationService>()).Returns(expService);
 
             globalServiceProvider.AddService(typeof(SComponentModel), _componentModel.Object);

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/NuGetProjectManagerServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/NuGetProjectManagerServiceTests.cs
@@ -75,7 +75,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             {
                 { constant.FlightFlag, true },
             };
-            var service = new NuGetExperimentationService(new TestEnvironmentVariableReader(new Dictionary<string, string>()), new TestVisualStudioExperimentalService(flightsEnabled));
+            var service = new NuGetExperimentationService(new TestEnvironmentVariableReader(new Dictionary<string, string>()), new TestVisualStudioExperimentalService(flightsEnabled), new Lazy<IOutputConsoleProvider>(() => new TestOutputConsoleProvider()));
 
             service.IsExperimentEnabled(constant).Should().Be(true);
             componentModel.Setup(x => x.GetService<INuGetExperimentationService>()).Returns(service);


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/nuget/home/issues/10758

Regression? Last working version: N/A

## Description
Wired up the Package Manager output console to the NuGetExperimentationService and when code checks if an experiment is enabled and the experiment's status is overridden by an environment variable, log a message to the console that indicates the flight name and environment variable that overrode it. This will help users who override an experiment validate that the experiment was effectively forced on or off. Updated FluentAssertions in separate PR: https://github.com/NuGet/NuGet.Client/pull/4584

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
