### PR TITLE
Make all package list groups in the Installed tab expanded by default

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml
@@ -291,14 +291,7 @@
         BasedOn="{StaticResource {x:Type Expander}}">
         <Setter Property="Header" Value="{StaticResource GroupHeaderMultiBinding}" />
         <Setter Property="Foreground" Value="{DynamicResource {x:Static nuget:Brushes.UIText}}" />
-        <Style.Triggers>
-          <DataTrigger Binding="{Binding Name}" Value="{x:Static common:PackageLevel.Transitive}">
-            <Setter Property="IsExpanded" Value="False" />
-          </DataTrigger>
-          <DataTrigger Binding="{Binding Name}" Value="{x:Static common:PackageLevel.TopLevel}">
-            <Setter Property="IsExpanded" Value="True" />
-          </DataTrigger>
-        </Style.Triggers>
+        <Setter Property="IsExpanded" Value="True" />
       </Style>
 
       <ControlTemplate


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/nuget/client.engineering/issues/1556

Regression? Last working version: N/A

## Description
The transitive dependencies feature introduces list grouping for the packages list in the Installed tab to group by Top-Level or Transitive packages. This change makes it so both groupings are expanded by default when the list is refreshed. It will also make it so search results in both groups are expanded.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
UI change. Tested manually by loading PMUI with transitive dependencies feature on and validating that the transitive packages grouping was expanded. Also searched with text that matched a top-level and transitive dependency and validated both were expanded.
  - [x] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
