### PR TITLE
Re-enable skipped F# tests

### DIFF
--- a/test/EndToEnd/tests/GetPackageTest.ps1
+++ b/test/EndToEnd/tests/GetPackageTest.ps1
@@ -181,7 +181,6 @@ function Test-GetPackageForProjectReturnsCorrectPackages2 {
 }
 
 function Test-GetPackageForFSharpProjectReturnsCorrectPackages {
-    [SkipTest('https://github.com/dotnet/fsharp/issues/12835')]
     param()     
     # Arrange
     $p = New-FSharpConsoleApplication

--- a/test/EndToEnd/tests/InstallPackageTest.ps1
+++ b/test/EndToEnd/tests/InstallPackageTest.ps1
@@ -458,7 +458,6 @@ function Test-AddBindingRedirectToWebsiteWithNonExistingOutputPath {
 }
 
 function Test-InstallCanPipeToFSharpProjects {
-    [SkipTest('https://github.com/dotnet/fsharp/issues/12835')]
     param($context)    
     # Arrange
     $p = New-FSharpLibrary

--- a/test/EndToEnd/tests/UninstallPackageTest.ps1
+++ b/test/EndToEnd/tests/UninstallPackageTest.ps1
@@ -120,7 +120,6 @@ function Test-UninstallPackageWithNestedContentFiles {
 }
 
 function Test-SimpleFSharpUninstall {
-    [SkipTest('https://github.com/dotnet/fsharp/issues/12835')]
     param($context)
 
     # Arrange

--- a/test/EndToEnd/tests/UpdatePackageTest.ps1
+++ b/test/EndToEnd/tests/UpdatePackageTest.ps1
@@ -632,7 +632,6 @@ function Test-UpdateAllPackagesInSolution {
 }
 
 function Test-UpdatePackageOnAnFSharpProjectWithMultiplePackages {
-    [SkipTest('https://github.com/dotnet/fsharp/issues/12835')]
     param(
         $context
     )


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11672

Regression? Last working version:

## Description
I was told fix on F# side is more stable than last time and encouraged me try again. Let's finger's crossed and wait for next patch Tuesday.


## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
