### PR TITLE
Fix SimpleBindingRedirectsClassLibraryReference test

### DIFF
--- a/test/EndToEnd/tests/InstallPackageTest.ps1
+++ b/test/EndToEnd/tests/InstallPackageTest.ps1
@@ -765,15 +765,14 @@ function Test-SimpleBindingRedirectsClassLibraryUpdatePackage {
 }
 
 function Test-SimpleBindingRedirectsClassLibraryReference {
-    [SkipTest('https://github.com/NuGet/Home/issues/10890')]
     param(
         $context
     )
     # Arrange
     $a = New-WebApplication
     $b = New-WebSite
-    $d = New-ClassLibrary
-    $e = New-ClassLibrary
+    $d = New-ClassLibraryNET46
+    $e = New-ClassLibraryNET46
 
     Add-ProjectReference $a $d
     Add-ProjectReference $b $e


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/10890

Regression? Last working version:

## Description
Fix binding redirect test disabled during move to 64bit VS effort. 

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [ ] N/A
