### PR TITLE
Revert "When loading packages in PM UI, report progress to UI only when packages list is available (#4535)"

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
@@ -380,17 +380,15 @@ namespace NuGet.PackageManagement.UI
 
         private async Task WaitForCompletionAsync(IItemLoader<PackageItemViewModel> currentLoader, CancellationToken token)
         {
-            IProgress<IItemLoaderState> progress = new Progress<IItemLoaderState>(
+            var progress = new Progress<IItemLoaderState>(
                 s => HandleItemLoaderStateChange(currentLoader, s));
 
             // run to completion
             while (currentLoader.State.LoadingStatus == LoadingStatus.Loading)
             {
                 token.ThrowIfCancellationRequested();
-                await currentLoader.UpdateStateAsync(progress: null, token);//don't report progress to UI while waiting for packages list
+                await currentLoader.UpdateStateAsync(progress, token);
             }
-
-            progress.Report(currentLoader.State);
         }
 
         private async Task WaitForInitialResultsAsync(
@@ -402,10 +400,8 @@ namespace NuGet.PackageManagement.UI
                 currentLoader.State.ItemsCount == 0)
             {
                 token.ThrowIfCancellationRequested();
-                await currentLoader.UpdateStateAsync(progress: null, token);//don't report progress to UI while waiting for packages list
+                await currentLoader.UpdateStateAsync(progress, token);
             }
-
-            progress?.Report(currentLoader.State);
         }
 
         /// <summary>


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: [#1561](https://github.com/NuGet/Client.Engineering/issues/1561)

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
This reverts commit 72339786290f8ee94d0b61723d6697c472021d09. Thanks to @jebriede for reporting this issue so early because the reverted commit is not yet inserted into VS.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] N/A - This PR reverts a commit that potentially caused a regression.

- **Documentation**
  - [x] N/A
