### PR TITLE
Replace CommandRunnerResult items with more descriptive props

### DIFF
--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Caching/NuGetExe/NuGetExe.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Caching/NuGetExe/NuGetExe.cs
@@ -34,7 +34,7 @@ namespace NuGet.CommandLine.Test.Caching
             {
                 var result = Execute(context, "locals http-cache -list", debug: false);
 
-                var stdout = result.Item2.Trim();
+                var stdout = result.Output.Trim();
 
                 // Example:
                 //   stdout = http-cache: C:\Users\jver\AppData\Local\NuGet\v3-cache
@@ -183,7 +183,7 @@ namespace NuGet.CommandLine.Test.Caching
                                 "help",
                                 waitForExit: true);
 
-                            if (helpResult.Item1 == 0)
+                            if (helpResult.ExitCode == 0)
                             {
                                 return thisPath;
                             }

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Caching/Tests/AllowsMissingPackageOnSourceTest.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Caching/Tests/AllowsMissingPackageOnSourceTest.cs
@@ -29,7 +29,7 @@ namespace NuGet.CommandLine.Test.Caching
 
             validations.Add(
                 CachingValidationType.CommandSucceeded,
-                result.Item1 == 0);
+                result.ExitCode == 0);
 
             validations.Add(
                 CachingValidationType.PackageInstalled,

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Caching/Tests/CleansUpDirectDownloadTest.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Caching/Tests/CleansUpDirectDownloadTest.cs
@@ -32,7 +32,7 @@ namespace NuGet.CommandLine.Test.Caching
 
             validations.Add(
                 CachingValidationType.CommandSucceeded,
-                result.Item1 == 0);
+                result.ExitCode == 0);
 
             validations.Add(
                 CachingValidationType.DirectDownloadFilesDoNotExist,

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Caching/Tests/PopulatesDestinationFolderTest.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Caching/Tests/PopulatesDestinationFolderTest.cs
@@ -28,7 +28,7 @@ namespace NuGet.CommandLine.Test.Caching
 
             validations.Add(
                 CachingValidationType.CommandSucceeded,
-                result.Item1 == 0);
+                result.ExitCode == 0);
 
             validations.Add(
                 CachingValidationType.PackageInstalled,

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Caching/Tests/PopulatesGlobalPackagesFolderTest.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Caching/Tests/PopulatesGlobalPackagesFolderTest.cs
@@ -28,7 +28,7 @@ namespace NuGet.CommandLine.Test.Caching
 
             validations.Add(
                 CachingValidationType.CommandSucceeded,
-                result.Item1 == 0);
+                result.ExitCode == 0);
 
             validations.Add(
                 CachingValidationType.PackageInGlobalPackagesFolder,

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Caching/Tests/ReadsFromHttpCacheTest.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Caching/Tests/ReadsFromHttpCacheTest.cs
@@ -32,7 +32,7 @@ namespace NuGet.CommandLine.Test.Caching
 
             validations.Add(
                 CachingValidationType.CommandSucceeded,
-                result.Item1 == 0);
+                result.ExitCode == 0);
 
             validations.Add(
                 CachingValidationType.PackageInstalled,

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Caching/Tests/UsesGlobalPackageFolderCopyOnEveryRunTest.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Caching/Tests/UsesGlobalPackageFolderCopyOnEveryRunTest.cs
@@ -30,7 +30,7 @@ namespace NuGet.CommandLine.Test.Caching
 
             validations.Add(
                 CachingValidationType.CommandSucceeded,
-                result.Item1 == 0);
+                result.ExitCode == 0);
 
 
             validations.Add(CachingValidationType.RestoreNoOp, result.AllOutput.Contains("No further actions are required to complete the restore"));

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Caching/Tests/UsesGlobalPackagesFolderCopyTest.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Caching/Tests/UsesGlobalPackagesFolderCopyTest.cs
@@ -30,7 +30,7 @@ namespace NuGet.CommandLine.Test.Caching
 
             validations.Add(
                 CachingValidationType.CommandSucceeded,
-                result.Item1 == 0);
+                result.ExitCode == 0);
 
             validations.Add(
                 CachingValidationType.PackageInstalled,

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Caching/Tests/WritesToHttpCacheTest.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Caching/Tests/WritesToHttpCacheTest.cs
@@ -28,7 +28,7 @@ namespace NuGet.CommandLine.Test.Caching
 
             validations.Add(
                 CachingValidationType.CommandSucceeded,
-                result.Item1 == 0);
+                result.ExitCode == 0);
 
             validations.Add(
                 CachingValidationType.PackageInHttpCache,

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/CommandRunnerTest.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/CommandRunnerTest.cs
@@ -90,10 +90,10 @@ namespace NuGet.CommandLine.FuncTest
                     waitForExit: true);
 
                 // Assert
-                Assert.Equal(0, result.Item1);
+                Assert.Equal(0, result.ExitCode);
 
                 var actualLineCount = 0;
-                using (var stringReader = new StringReader(result.Item2))
+                using (var stringReader = new StringReader(result.Output))
                 {
                     string actualLineContent;
                     while ((actualLineContent = stringReader.ReadLine()) != null)
@@ -134,8 +134,8 @@ namespace NuGet.CommandLine.FuncTest
                 waitForExit: true);
 
             // Assert
-            Assert.Equal(0, result.Item1);
-            Assert.Contains(expected, result.Item2);
+            Assert.Equal(0, result.ExitCode);
+            Assert.Contains(expected, result.Output);
         }
     }
 }

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/TrustedSignersCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/TrustedSignersCommandTests.cs
@@ -146,12 +146,12 @@ namespace NuGet.CommandLine.FuncTest.Commands
             //  Util.VerifyResultFailure(result, TrustedSignersHelpStringFragment, checkErrorMsgOnStdErr: false);
 
             Assert.True(
-                result.Item1 != 0,
-                "nuget.exe DID NOT FAIL: Ouput is " + result.Item2 + ". Error is " + result.Item3);
+                result.ExitCode != 0,
+                "nuget.exe DID NOT FAIL: Ouput is " + result.Output + ". Error is " + result.Errors);
 
             Assert.True(
-                result.Item2.Contains(_trustedSignersHelpStringFragment),
-                "Expected error is " + _trustedSignersHelpStringFragment + ". Actual error is " + result.Item3);
+                result.Output.Contains(_trustedSignersHelpStringFragment),
+                "Expected error is " + _trustedSignersHelpStringFragment + ". Actual error is " + result.Errors);
         }
 
         [Theory]

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/ExtensionsTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/ExtensionsTests.cs
@@ -21,7 +21,7 @@ namespace NuGet.CommandLine.Test
                     randomTestFolder,
                     "hello",
                     true);
-                result.Item2.Should().Be("Hello!" + Environment.NewLine);
+                result.Output.Should().Be("Hello!" + Environment.NewLine);
             }
         }
     }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NetworkCallCountTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NetworkCallCountTest.cs
@@ -121,7 +121,7 @@ namespace NuGet.CommandLine.Test
                 var allPackages = LocalFolderUtility.GetPackagesV2(packagesFolderPath, NullLogger.Instance);
 
                 // Assert
-                Assert.True(0 != r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 != r.ExitCode, r.Output + " " + r.Errors);
 
                 Assert.Equal(1, hitsByUrl["/index.json"]);
                 Assert.Equal(100, hitsByUrl2.Keys.Count(s => s.StartsWith("/nuget/Packages")));
@@ -258,7 +258,7 @@ namespace NuGet.CommandLine.Test
                 var allPackages = LocalFolderUtility.GetPackagesV2(packagesFolderPath, NullLogger.Instance);
 
                 // Assert
-                Assert.True(0 != r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 != r.ExitCode, r.Output + " " + r.Errors);
 
                 Assert.Equal(1, hitsByUrl["/index.json"]);
 
@@ -391,7 +391,7 @@ namespace NuGet.CommandLine.Test
                 var allPackages = LocalFolderUtility.GetPackagesV2(packagesFolderPath, NullLogger.Instance);
 
                 // Assert
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 Assert.Equal(testCount, allPackages.Count());
 
@@ -521,7 +521,7 @@ namespace NuGet.CommandLine.Test
                 var allPackages = LocalFolderUtility.GetPackagesV2(packagesFolderPath, NullLogger.Instance);
 
                 // Assert
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 Assert.Equal(testCount, allPackages.Count());
 
@@ -628,7 +628,7 @@ namespace NuGet.CommandLine.Test
                     .Count();
 
                 // Assert
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 Assert.Equal(3, packagesFolderCount);   // project.json packages still go here
                 Assert.Equal(6, globalFolderCount);
@@ -726,7 +726,7 @@ namespace NuGet.CommandLine.Test
                     .Count();
 
                 // Assert
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 Assert.Equal(3, packagesFolderCount);
                 Assert.Equal(6, globalFolderCount);
@@ -801,7 +801,7 @@ namespace NuGet.CommandLine.Test
                     waitForExit: true);
 
                 // Assert
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Network calls can happen multiple times here with cancelation
                 foreach (var url in hitsByUrl.Keys)
@@ -880,7 +880,7 @@ namespace NuGet.CommandLine.Test
                     waitForExit: true);
 
                 // Assert
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 foreach (var url in hitsByUrl.Keys)
                 {
@@ -953,7 +953,7 @@ namespace NuGet.CommandLine.Test
                     waitForExit: true);
 
                 // Assert
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
                 Assert.Equal(1, hitsByUrl["/index.json"]);
                 Assert.Equal(1, hitsByUrl["/reg/packagea/index.json"]);
 
@@ -1026,7 +1026,7 @@ namespace NuGet.CommandLine.Test
                     waitForExit: true);
 
                 // Assert
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 foreach (var url in hitsByUrl.Keys)
                 {
@@ -1097,7 +1097,7 @@ namespace NuGet.CommandLine.Test
                     waitForExit: true);
 
                 // Assert
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
                 Assert.Equal(1, hitsByUrl["/index.json"]);
                 Assert.Equal(1, hitsByUrl["/reg/packagea/index.json"]);
 
@@ -1170,7 +1170,7 @@ namespace NuGet.CommandLine.Test
                     waitForExit: true);
 
                 // Assert
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 Assert.Equal(1, hitsByUrl["/index.json"]);
             }
@@ -1239,7 +1239,7 @@ namespace NuGet.CommandLine.Test
                     waitForExit: true);
 
                 // Assert
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 foreach (var url in hitsByUrl.Keys)
                 {
@@ -1321,7 +1321,7 @@ namespace NuGet.CommandLine.Test
                     waitForExit: true);
 
                 // Assert
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 foreach (var url in hitsByUrl.Keys)
                 {
@@ -1389,7 +1389,7 @@ namespace NuGet.CommandLine.Test
                     waitForExit: true);
 
                 // Assert
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
                 Assert.Equal(1, hitsByUrl["/index.json"]);
 
                 // PackageE is hit twice, once from packages.config and the other from project.json.
@@ -1457,7 +1457,7 @@ namespace NuGet.CommandLine.Test
                     waitForExit: true);
 
                 // Assert
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
                 Assert.Equal(1, hitsByUrl["/index.json"]);
 
                 foreach (var url in hitsByUrl.Keys)
@@ -1523,7 +1523,7 @@ namespace NuGet.CommandLine.Test
                     waitForExit: true);
 
                 // Assert
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 foreach (var url in hitsByUrl.Keys)
                 {

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetClientCertCommandTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetClientCertCommandTests.cs
@@ -45,7 +45,7 @@ namespace NuGet.CommandLine.Test
 
                 // Assert
                 var expectedError = "Invalid combination of arguments";
-                Assert.True(result.Item2.Contains(expectedError));
+                Assert.True(result.Output.Contains(expectedError));
             }
         }
 
@@ -74,7 +74,7 @@ namespace NuGet.CommandLine.Test
 
                 // Assert
                 var expectedError = "Invalid combination of arguments";
-                Assert.True(result.Item2.Contains(expectedError));
+                Assert.True(result.Output.Contains(expectedError));
             }
         }
 
@@ -126,7 +126,7 @@ namespace NuGet.CommandLine.Test
 
                 // Assert
                 var expectedError = "Property 'PackageSource' should not be null or empty";
-                Assert.True(result.Item2.Contains(expectedError));
+                Assert.True(result.Output.Contains(expectedError));
             }
         }
 
@@ -554,7 +554,7 @@ namespace NuGet.CommandLine.Test
 
                 // Assert
                 var expectedError = "Invalid combination of arguments";
-                Assert.True(result.Item2.Contains(expectedError));
+                Assert.True(result.Output.Contains(expectedError));
             }
         }
 
@@ -587,7 +587,7 @@ namespace NuGet.CommandLine.Test
 
                 // Assert
                 var expectedError = "does not exist";
-                Assert.True(result.Item3.Contains(expectedError));
+                Assert.True(result.Errors.Contains(expectedError));
             }
         }
 
@@ -616,7 +616,7 @@ namespace NuGet.CommandLine.Test
 
                 // Assert
                 var expectedError = "Invalid combination of arguments";
-                Assert.True(result.Item2.Contains(expectedError));
+                Assert.True(result.Output.Contains(expectedError));
             }
         }
 

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetConfigCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetConfigCommandTest.cs
@@ -177,10 +177,10 @@ namespace NuGet.CommandLine.Test
                     string.Join(" ", args),
                     waitForExit: true);
 
-                var output = result.Item2;
+                var output = result.Output;
 
                 // Assert
-                Assert.Equal(0, result.Item1);
+                Assert.Equal(0, result.ExitCode);
 
                 var expectedValue = Path.Combine(Path.GetDirectoryName(configFile), "Value1")
                     + Environment.NewLine;
@@ -209,7 +209,7 @@ namespace NuGet.CommandLine.Test
                 waitForExit: true);
 
             // Assert
-            Assert.True(result.Item3.Contains("Key 'nonExistentKey' not found."));
+            Assert.True(result.Errors.Contains("Key 'nonExistentKey' not found."));
         }
 
         [Fact]
@@ -246,12 +246,12 @@ namespace NuGet.CommandLine.Test
                     string.Join(" ", args),
                     waitForExit: true);
 
-                var output = result.Item2;
+                var output = result.Output;
                 Environment.SetEnvironmentVariable("RP_ENV_VAR", string.Empty);
 
 
                 // Assert
-                Assert.Equal(0, result.Item1);
+                Assert.Equal(0, result.ExitCode);
                 Assert.Equal(expectedValue, output);
             }
         }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetDeleteCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetDeleteCommandTest.cs
@@ -38,7 +38,7 @@ namespace NuGet.CommandLine.Test
                     waitForExit: true);
 
                 // Assert
-                Assert.Equal(0, r.Item1);
+                Assert.Equal(0, r.ExitCode);
                 Assert.False(File.Exists(packageFileName));
             }
         }
@@ -66,7 +66,7 @@ namespace NuGet.CommandLine.Test
                     waitForExit: true);
 
                 // Assert
-                Assert.Equal(0, r.Item1);
+                Assert.Equal(0, r.ExitCode);
                 Assert.False(File.Exists(packageFileName));
             }
         }
@@ -96,7 +96,7 @@ namespace NuGet.CommandLine.Test
                     waitForExit: true);
 
                 // Assert
-                Assert.Equal(0, r.Item1);
+                Assert.Equal(0, r.ExitCode);
                 //The specific version folder should be gone.
                 Assert.False(Directory.Exists(packageVersionFolder.FullName));
             }
@@ -128,7 +128,7 @@ namespace NuGet.CommandLine.Test
                     waitForExit: true);
 
                 // Assert
-                Assert.Equal(0, r.Item1);
+                Assert.Equal(0, r.ExitCode);
                 Assert.False(Directory.Exists(packageVersionFolder.FullName));
             }
         }
@@ -164,7 +164,7 @@ namespace NuGet.CommandLine.Test
                     waitForExit: true);
 
                 // Assert
-                Assert.Equal(0, r.Item1);
+                Assert.Equal(0, r.ExitCode);
                 Assert.False(File.Exists(packageFileName));
             }
         }
@@ -198,7 +198,7 @@ namespace NuGet.CommandLine.Test
                     waitForExit: true);
 
                 // Assert
-                Assert.Equal(0, r.Item1);
+                Assert.Equal(0, r.ExitCode);
                 Assert.True(deleteRequestIsCalled);
             }
         }
@@ -244,8 +244,8 @@ namespace NuGet.CommandLine.Test
                 server.Stop();
 
                 // Assert
-                Assert.True(0 == result.Item1, $"{result.Item2} {result.Item3}");
-                Assert.Contains("testPackage1 1.1.0 was deleted successfully.", result.Item2);
+                Assert.True(0 == result.ExitCode, $"{result.Output} {result.Errors}");
+                Assert.Contains("testPackage1 1.1.0 was deleted successfully.", result.Output);
             }
         }
 
@@ -293,8 +293,8 @@ namespace NuGet.CommandLine.Test
                 server.Stop();
 
                 // Assert
-                Assert.True(0 == result.Item1, $"{result.Item2} {result.Item3}");
-                Assert.Contains("testPackage1 1.1.0 was deleted successfully.", result.Item2);
+                Assert.True(0 == result.ExitCode, $"{result.Output} {result.Errors}");
+                Assert.Contains("testPackage1 1.1.0 was deleted successfully.", result.Output);
             }
         }
 
@@ -373,8 +373,8 @@ namespace NuGet.CommandLine.Test
                 server.Stop();
 
                 // Assert
-                Assert.True(0 == result.Item1, $"{result.Item2} {result.Item3}");
-                Assert.Contains("testPackage1 1.1.0 was deleted successfully.", result.Item2);
+                Assert.True(0 == result.ExitCode, $"{result.Output} {result.Errors}");
+                Assert.Contains("testPackage1 1.1.0 was deleted successfully.", result.Output);
             }
         }
 
@@ -409,7 +409,7 @@ namespace NuGet.CommandLine.Test
                 {
                     if (!string.IsNullOrEmpty(serverWarning))
                     {
-                        Assert.Contains(serverWarning, r.Item2);
+                        Assert.Contains(serverWarning, r.Output);
                     }
                 }
             }
@@ -452,7 +452,7 @@ namespace NuGet.CommandLine.Test
                     waitForExit: true);
 
                 // Assert
-                Assert.Equal(0, r.Item1);
+                Assert.Equal(0, r.ExitCode);
                 Assert.True(deleteRequestIsCalled);
                 Assert.Contains("WARNING: You are running the 'delete' operation with an 'http' source", r.AllOutput);
             }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetHelpCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetHelpCommandTest.cs
@@ -34,7 +34,7 @@ namespace NuGet.CommandLine.Test
                 waitForExit: true);
 
             // Assert
-            Assert.True(0 == r.Item1, r.Item2 + Environment.NewLine + r.Item3);
+            Assert.True(0 == r.ExitCode, r.Output + Environment.NewLine + r.Errors);
         }
 
         // Tests that -ConfigFile is not included in the help message
@@ -52,8 +52,8 @@ namespace NuGet.CommandLine.Test
                 waitForExit: true);
 
             // Assert
-            Assert.Equal(0, r.Item1);
-            Assert.DoesNotContain("-ConfigFile", r.Item2, StringComparison.OrdinalIgnoreCase);
+            Assert.Equal(0, r.ExitCode);
+            Assert.DoesNotContain("-ConfigFile", r.Output, StringComparison.OrdinalIgnoreCase);
         }
 
         [Fact]

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetInitCommandTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetInitCommandTests.cs
@@ -289,7 +289,7 @@ namespace NuGet.CommandLine.Test
 
                 // Main Assert
                 Util.VerifyResultSuccess(result);
-                var output = result.Item2;
+                var output = result.Output;
                 foreach (var p in packages)
                 {
                     output.Contains(string.Format(
@@ -351,7 +351,7 @@ namespace NuGet.CommandLine.Test
                     firstPackage.ToString(),
                     testInfo.DestinationFeed));
 
-                var output = result.Item2;
+                var output = result.Output;
                 foreach (var p in packages.Skip(1))
                 {
                     output.Contains(string.Format(

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetInstallCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetInstallCommandTest.cs
@@ -952,7 +952,7 @@ namespace NuGet.CommandLine.Test
                     CultureInfo.CurrentCulture,
                     NuGetResources.RestoreCommandPackageRestoreOptOutMessage,
                     NuGetResources.PackageRestoreConsentCheckBoxText.Replace("&", ""));
-                Assert.Contains(optOutMessage.Replace("\r\n", "\n"), r.Item2.Replace("\r\n", "\n"));
+                Assert.Contains(optOutMessage.Replace("\r\n", "\n"), r.Output.Replace("\r\n", "\n"));
             }
         }
 
@@ -1013,7 +1013,7 @@ namespace NuGet.CommandLine.Test
                     CultureInfo.CurrentCulture,
                     NuGetResources.RestoreCommandPackageRestoreOptOutMessage,
                     NuGetResources.PackageRestoreConsentCheckBoxText.Replace("&", ""));
-                Assert.DoesNotContain(optOutMessage, r.Item2);
+                Assert.DoesNotContain(optOutMessage, r.Output);
             }
         }
 

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetInstallCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetInstallCommandTest.cs
@@ -365,7 +365,7 @@ namespace NuGet.CommandLine.Test
                 var r = RunInstall(pathContext, string.Empty, 0, $"-OutputDirectory outputDir -Source {repositoryPath} -ExcludeVersion");
 
                 // Assert
-                Assert.Equal(0, r.Item1);
+                Assert.Equal(0, r.ExitCode);
                 var packageADir = Path.Combine(workingPath, "outputDir", "packageA");
                 var packageBDir = Path.Combine(workingPath, "outputDir", "packageB");
                 Assert.True(Directory.Exists(packageADir));
@@ -432,7 +432,7 @@ namespace NuGet.CommandLine.Test
                 var r = RunInstall(pathContext, "", 0, args);
 
                 // Assert
-                Assert.Equal(0, r.Item1);
+                Assert.Equal(0, r.ExitCode);
                 var packageFileA = Path.Combine(workingPath, "outputDir", "packageA.1.1.0", "packageA.1.1.0.nupkg");
                 var packageFileB = Path.Combine(workingPath, "outputDir", "packageB.2.2.0", "packageB.2.2.0.nupkg");
                 Assert.True(File.Exists(packageFileA));
@@ -477,7 +477,7 @@ namespace NuGet.CommandLine.Test
                 var r = RunInstall(pathContext, "", 1, args);
 
                 // Assert
-                Assert.Equal(1, r.Item1);
+                Assert.Equal(1, r.ExitCode);
                 r.AllOutput.Should().NotContain("NU1000");
                 r.Errors.Should().Contain("Unable to find version");
             }
@@ -551,7 +551,7 @@ namespace NuGet.CommandLine.Test
                 var r = RunInstall(pathContext, packagesConfig, 0, args);
 
                 // Assert
-                Assert.Equal(0, r.Item1);
+                Assert.Equal(0, r.ExitCode);
                 var packageFileA = Path.Combine(workingPath, "outputDir", "packageA.1.1.0", "packageA.1.1.0.nupkg");
                 var packageFileB = Path.Combine(workingPath, "outputDir", "packageB.2.2.0", "packageB.2.2.0.nupkg");
                 Assert.True(File.Exists(packageFileA));
@@ -569,7 +569,7 @@ namespace NuGet.CommandLine.Test
                 var r1 = RunInstall(pathContext, packagesConfig, 0, args2);
 
                 // Assert
-                var message = r1.Item2;
+                var message = r1.Output;
                 var alreadyInstalledMessage = string.Format("All packages listed in {0} are already installed.", packagesConfig);
                 Assert.Contains(alreadyInstalledMessage, message, StringComparison.OrdinalIgnoreCase);
                 r1.ExitCode.Should().Be(0);
@@ -613,7 +613,7 @@ namespace NuGet.CommandLine.Test
                 var r = RunInstall(pathContext, "", 0, args);
 
                 // Assert
-                Assert.True(0 == r.Item1, $"{r.Item2} {r.Item3}");
+                Assert.True(0 == r.ExitCode, $"{r.Output} {r.Errors}");
                 var packageFileA = Path.Combine(workingPath, "outputDir", "packageA.1.1.0", "packageA.1.1.0.nupkg");
                 var packageFileB = Path.Combine(workingPath, "outputDir", "packageB.2.2.0", "packageB.2.2.0.nupkg");
                 Assert.True(File.Exists(packageFileA));
@@ -669,7 +669,7 @@ namespace NuGet.CommandLine.Test
                     environmentVariables: envVars);
 
                 // Assert
-                Assert.Equal(0, r.Item1);
+                Assert.Equal(0, r.ExitCode);
                 var packageFileA = Path.Combine(workingPath, "outputDir", "packageA.1.1.0", "packageA.1.1.0.nupkg");
                 var packageFileB = Path.Combine(workingPath, "outputDir", "packageB.2.2.0", "packageB.2.2.0.nupkg");
                 Assert.True(File.Exists(packageFileA));
@@ -839,12 +839,12 @@ namespace NuGet.CommandLine.Test
                 var r = RunInstall(pathContext, "testPackage1", 0, args);
 
                 // Assert
-                Assert.Equal(0, r.Item1);
+                Assert.Equal(0, r.ExitCode);
 
                 // Act (Install a second time)
                 var result = RunInstall(pathContext, "testPackage1", 0, args);
 
-                var output = result.Item2;
+                var output = result.Output;
 
                 // Assert
                 var alreadyInstalledMessage = "Package \"testPackage1.1.1.0\" is already installed.";
@@ -947,7 +947,7 @@ namespace NuGet.CommandLine.Test
                 var r = RunInstall(pathContext, configFileName, 0, " -Source " + repositoryPath + $@" -ConfigFile my.config -RequireConsent");
 
                 // Assert
-                Assert.Equal(0, r.Item1);
+                Assert.Equal(0, r.ExitCode);
                 var optOutMessage = string.Format(
                     CultureInfo.CurrentCulture,
                     NuGetResources.RestoreCommandPackageRestoreOptOutMessage,
@@ -1008,7 +1008,7 @@ namespace NuGet.CommandLine.Test
                 var r = RunInstall(pathContext, configFileName, 0, " -Source " + repositoryPath + $@" -ConfigFile my.config");
 
                 // Assert
-                Assert.Equal(0, r.Item1);
+                Assert.Equal(0, r.ExitCode);
                 var optOutMessage = string.Format(
                     CultureInfo.CurrentCulture,
                     NuGetResources.RestoreCommandPackageRestoreOptOutMessage,
@@ -1091,7 +1091,7 @@ namespace NuGet.CommandLine.Test
                         waitForExit: true);
 
                     // Assert
-                    Assert.Equal(0, r1.Item1);
+                    Assert.Equal(0, r1.ExitCode);
 
                     // testPackage1 1.2.0-beta1 is installed
                     Assert.True(Directory.Exists(Path.Combine(pathContext.PackagesV2, "testPackage1.1.2.0-beta1")));
@@ -1128,7 +1128,7 @@ namespace NuGet.CommandLine.Test
                         waitForExit: true);
 
                     // Assert
-                    Assert.Equal(0, r1.Item1);
+                    Assert.Equal(0, r1.ExitCode);
 
                     // testPackage1 1.2.0-beta1 is installed
                     Assert.True(Directory.Exists(Path.Combine(pathContext.PackagesV2, "testPackage1.1.2.0-beta1")));
@@ -1439,8 +1439,8 @@ namespace NuGet.CommandLine.Test
                     waitForExit: true);
 
                 // Assert
-                Assert.NotEqual(0, r.Item1);
-                Assert.Contains("Unable to resolve dependency 'non_existing'", r.Item3);
+                Assert.NotEqual(0, r.ExitCode);
+                Assert.Contains("Unable to resolve dependency 'non_existing'", r.Errors);
             }
         }
 
@@ -1869,8 +1869,8 @@ namespace NuGet.CommandLine.Test
             var r2 = RunInstall(pathContext, "Contoso.Opensource", 0, "-Version", "1.0.0", "-OutputDirectory", "outputDir", "-Verbosity", "d");
 
             // Assert
-            Assert.Equal(0, r1.Item1);
-            Assert.Equal(0, r2.Item1);
+            Assert.Equal(0, r1.ExitCode);
+            Assert.Equal(0, r2.ExitCode);
             Assert.Contains($"Package source mapping matches found for package ID 'Contoso.MVC.ASP' are: 'SharedRepository'", r1.Output);
             var packageFileContosoMVCASP = Path.Combine(workingPath, "outputDir", "Contoso.MVC.ASP.1.0.0", "Contoso.MVC.ASP.1.0.0.nupkg");
             var packageFileContosoOpensource = Path.Combine(workingPath, "outputDir", "Contoso.Opensource.1.0.0", "Contoso.Opensource.1.0.0.nupkg");
@@ -1916,7 +1916,7 @@ namespace NuGet.CommandLine.Test
             var r = RunInstall(pathContext, "Contoso.MVC.ASP", 1, "-Version", "1.0.0", "-OutputDirectory", "outputDir");
 
             // Assert
-            Assert.Equal(1, r.Item1);
+            Assert.Equal(1, r.ExitCode);
             Assert.Contains($"Package source mapping matches found for package ID 'Contoso.MVC.ASP' are: 'SharedRepository'", r.Output);
             r.AllOutput.Should().NotContain("NU1000");
             r.Errors.Should().Contain("Package 'Contoso.MVC.ASP 1.0.0' is not found in the following primary source(s):");
@@ -2052,7 +2052,7 @@ namespace NuGet.CommandLine.Test
                 environmentVariables: envVars);
 
             // Assert
-            Assert.True(expectedExitCode == r.Item1, r.Item3 + "\n\n" + r.Item2);
+            Assert.True(expectedExitCode == r.ExitCode, r.Errors + "\n\n" + r.Output);
 
             return r;
         }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetListCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetListCommandTest.cs
@@ -40,8 +40,8 @@ namespace NuGet.CommandLine.Test
                 });
 
             // Assert
-            Assert.Contains(expected, result.Item2 + " " + result.Item3);
-            Assert.NotEqual(0, result.Item1);
+            Assert.Contains(expected, result.Output + " " + result.Errors);
+            Assert.NotEqual(0, result.ExitCode);
         }
 
         [Fact]
@@ -71,8 +71,8 @@ namespace NuGet.CommandLine.Test
                 });
 
             // Assert
-            Assert.Contains(expected, result.Item2 + " " + result.Item3);
-            Assert.NotEqual(0, result.Item1);
+            Assert.Contains(expected, result.Output + " " + result.Errors);
+            Assert.NotEqual(0, result.ExitCode);
         }
 
         [Fact]
@@ -96,8 +96,8 @@ namespace NuGet.CommandLine.Test
                     waitForExit: true);
 
                 // Assert
-                Assert.Equal(0, result.Item1);
-                var output = result.Item2;
+                Assert.Equal(0, result.ExitCode);
+                var output = result.Output;
                 Assert.Equal($"testPackage1 1.1.0{Environment.NewLine}testPackage2 2.0.0{Environment.NewLine}", output);
             }
         }
@@ -122,8 +122,8 @@ namespace NuGet.CommandLine.Test
                     waitForExit: true);
 
                 // Assert
-                Assert.Equal(0, r.Item1);
-                var output = r.Item2;
+                Assert.Equal(0, r.ExitCode);
+                var output = r.Output;
                 string[] lines = output.Split(new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
 
                 Assert.Equal(5, lines.Length);
@@ -173,8 +173,8 @@ namespace NuGet.CommandLine.Test
                     waitForExit: true);
 
                 // Assert
-                Assert.Equal(0, result.Item1);
-                var output = result.Item2;
+                Assert.Equal(0, result.ExitCode);
+                var output = result.Output;
                 Assert.Equal($"testPackage1 1.1.0{Environment.NewLine}testPackage2 2.0.0{Environment.NewLine}", output);
             }
         }
@@ -222,12 +222,12 @@ namespace NuGet.CommandLine.Test
                     server.Stop();
 
                     // Assert
-                    Assert.Equal(0, result.Item1);
+                    Assert.Equal(0, result.ExitCode);
 
                     // verify that only package id & version is displayed
                     var expectedOutput = "testPackage1 1.1.0" + Environment.NewLine +
                         "testPackage2 2.1.0" + Environment.NewLine;
-                    Assert.Equal(expectedOutput, result.Item2);
+                    Assert.Equal(expectedOutput, result.Output);
 
                     Assert.Contains("$filter=IsLatestVersion", searchRequest);
                     Assert.Contains("searchTerm='test", searchRequest);
@@ -279,12 +279,12 @@ namespace NuGet.CommandLine.Test
                     server.Stop();
 
                     // Assert
-                    Assert.True(r1.Item1 == 0, r1.Item2 + " " + r1.Item3);
+                    Assert.True(r1.ExitCode == 0, r1.Output + " " + r1.Errors);
 
                     // verify that only testPackage2 is listed since the package testPackage1
                     // is not listed.
                     var expectedOutput = "testPackage2 2.1.0" + Environment.NewLine;
-                    Assert.Equal(expectedOutput, r1.Item2);
+                    Assert.Equal(expectedOutput, r1.Output);
 
                     Assert.Contains("$filter=IsLatestVersion", searchRequest);
                     Assert.Contains("searchTerm='test", searchRequest);
@@ -340,13 +340,13 @@ namespace NuGet.CommandLine.Test
                     server.Stop();
 
                     // Assert
-                    Assert.True(r1.Item1 == 0, r1.Item2 + " " + r1.Item3);
+                    Assert.True(r1.ExitCode == 0, r1.Output + " " + r1.Errors);
 
                     // verify that both testPackage1 and testPackage2 are listed.
                     var expectedOutput =
                         "testPackage1 1.1.0" + Environment.NewLine +
                         "testPackage2 2.1.0" + Environment.NewLine;
-                    Assert.Equal(expectedOutput, r1.Item2);
+                    Assert.Equal(expectedOutput, r1.Output);
 
                     Assert.Contains("$filter=IsLatestVersion", searchRequest);
                     Assert.Contains("searchTerm='test", searchRequest);
@@ -398,11 +398,11 @@ namespace NuGet.CommandLine.Test
                     server.Stop();
 
                     // Assert
-                    Assert.Equal(0, r1.Item1);
+                    Assert.Equal(0, r1.ExitCode);
 
                     // verify that the output is detailed
-                    Assert.Contains(new PackageArchiveReader(package1.OpenRead()).NuspecReader.GetDescription(), r1.Item2);
-                    Assert.Contains(new PackageArchiveReader(package2.OpenRead()).NuspecReader.GetDescription(), r1.Item2);
+                    Assert.Contains(new PackageArchiveReader(package1.OpenRead()).NuspecReader.GetDescription(), r1.Output);
+                    Assert.Contains(new PackageArchiveReader(package2.OpenRead()).NuspecReader.GetDescription(), r1.Output);
 
                     Assert.Contains("$filter=IsLatestVersion", searchRequest);
                     Assert.Contains("searchTerm='test", searchRequest);
@@ -455,12 +455,12 @@ namespace NuGet.CommandLine.Test
                     server.Stop();
 
                     // Assert
-                    Assert.Equal(0, r1.Item1);
+                    Assert.Equal(0, r1.ExitCode);
 
                     // verify that the output is detailed
                     var expectedOutput = "testPackage1 1.1.0" + Environment.NewLine +
                         "testPackage2 2.1.0" + Environment.NewLine;
-                    Assert.Equal(expectedOutput, r1.Item2);
+                    Assert.Equal(expectedOutput, r1.Output);
 
                     Assert.DoesNotContain("$filter", searchRequest);
                     Assert.Contains("searchTerm='test", searchRequest);
@@ -515,12 +515,12 @@ namespace NuGet.CommandLine.Test
                     server.Stop();
 
                     // Assert
-                    Assert.Equal(0, r1.Item1);
+                    Assert.Equal(0, r1.ExitCode);
 
                     // verify that the output is detailed
                     var expectedOutput = "testPackage1 1.1.0" + Environment.NewLine +
                         "testPackage2 2.1.0" + Environment.NewLine;
-                    Assert.Equal(expectedOutput, r1.Item2);
+                    Assert.Equal(expectedOutput, r1.Output);
 
                     Assert.Contains("$filter=IsAbsoluteLatestVersion", searchRequest);
                     Assert.Contains("searchTerm='test", searchRequest);
@@ -575,12 +575,12 @@ namespace NuGet.CommandLine.Test
                     server.Stop();
 
                     // Assert
-                    Assert.Equal(0, r1.Item1);
+                    Assert.Equal(0, r1.ExitCode);
 
                     // verify that the output is detailed
                     var expectedOutput = "testPackage1 1.1.0" + Environment.NewLine +
                         "testPackage2 2.1.0" + Environment.NewLine;
-                    r1.Item2.Should().Be(expectedOutput);
+                    r1.Output.Should().Be(expectedOutput);
 
                     Assert.DoesNotContain("$filter", searchRequest);
                     Assert.Contains("searchTerm='test", searchRequest);
@@ -675,12 +675,12 @@ namespace NuGet.CommandLine.Test
                         serverV3.Stop();
 
                         // Assert
-                        Assert.True(result.Item1 == 0, result.Item2 + " " + result.Item3);
+                        Assert.True(result.ExitCode == 0, result.Output + " " + result.Errors);
 
                         // verify that only package id & version is displayed
                         var expectedOutput = "testPackage1 1.1.0" + Environment.NewLine +
                             "testPackage2 2.1.0" + Environment.NewLine;
-                        Assert.Equal(expectedOutput, result.Item2);
+                        Assert.Equal(expectedOutput, result.Output);
 
                         Assert.Contains("$filter=IsLatestVersion", searchRequest);
                         Assert.Contains("searchTerm='test", searchRequest);
@@ -735,7 +735,7 @@ namespace NuGet.CommandLine.Test
                     serverV3.Stop();
 
                     // Assert
-                    Assert.True(result.Item1 == 0, result.Item2 + " " + result.Item3);
+                    Assert.True(result.ExitCode == 0, result.Output + " " + result.Errors);
 
                     // verify that only package id & version is displayed
                     var expectedOutput =
@@ -745,7 +745,7 @@ namespace NuGet.CommandLine.Test
                       serverV3.Uri + "index.json");
 
                     // Verify that the output contains the expected output
-                    Assert.True(result.Item2.Contains(expectedOutput));
+                    Assert.True(result.Output.Contains(expectedOutput));
                 }
             }
         }
@@ -790,11 +790,11 @@ namespace NuGet.CommandLine.Test
                     serverV3.Stop();
 
                     // Assert
-                    Assert.True(result.Item1 != 0, result.Item2 + " " + result.Item3);
+                    Assert.True(result.ExitCode != 0, result.Output + " " + result.Errors);
 
                     Assert.True(
-                        result.Item3.Contains("404 (Not Found)"),
-                        "Expected error message not found in " + result.Item3
+                        result.Errors.Contains("404 (Not Found)"),
+                        "Expected error message not found in " + result.Errors
                         );
                 }
             }
@@ -818,15 +818,15 @@ namespace NuGet.CommandLine.Test
 
                 // Assert
                 Assert.True(
-                    result.Item1 != 0,
-                    "The run did not fail as desired. Simply got this output:" + result.Item2);
+                    result.ExitCode != 0,
+                    "The run did not fail as desired. Simply got this output:" + result.Output);
 
                 Assert.True(
-                    result.Item3.Contains(
+                    result.Errors.Contains(
                         string.Format(
                             "The specified source '{0}' is invalid. Please provide a valid source.",
                             invalidInput)),
-                    "Expected error message not found in " + result.Item3
+                    "Expected error message not found in " + result.Errors
                     );
             }
         }
@@ -851,10 +851,10 @@ namespace NuGet.CommandLine.Test
 
                 // Assert
                 Assert.True(
-                    result.Item1 != 0,
-                    "The run did not fail as desired. Simply got this output:" + result.Item2);
+                    result.ExitCode != 0,
+                    "The run did not fail as desired. Simply got this output:" + result.Output);
 
-                Assert.Contains($"Unable to load the service index for source {invalidInput}.", result.Item3);
+                Assert.Contains($"Unable to load the service index for source {invalidInput}.", result.Errors);
             }
         }
 
@@ -875,13 +875,13 @@ namespace NuGet.CommandLine.Test
 
             // Assert
             Assert.True(
-                result.Item1 != 0,
-                "The run did not fail as desired. Simply got this output:" + result.Item2);
+                result.ExitCode != 0,
+                "The run did not fail as desired. Simply got this output:" + result.Output);
 
             Assert.True(
-                result.Item3.Contains(
+                result.Errors.Contains(
                     "returned an unexpected status code '404 Not Found'."),
-                "Expected error message not found in:\n " + result.Item3
+                "Expected error message not found in:\n " + result.Errors
                 );
         }
 
@@ -904,12 +904,12 @@ namespace NuGet.CommandLine.Test
 
                 // Assert
                 Assert.True(
-                    result.Item1 != 0,
-                    "The run did not fail as desired. Simply got this output:" + result.Item2);
+                    result.ExitCode != 0,
+                    "The run did not fail as desired. Simply got this output:" + result.Output);
 
                 Assert.True(
-                    result.Item3.Contains($"Unable to load the service index for source {invalidInput}."),
-                    "Expected error message not found in " + result.Item3
+                    result.Errors.Contains($"Unable to load the service index for source {invalidInput}."),
+                    "Expected error message not found in " + result.Errors
                     );
             }
         }
@@ -1037,11 +1037,11 @@ namespace NuGet.CommandLine.Test
                     serverV3.Stop();
 
                     // Assert
-                    Assert.True(0 == result.Item1, $"{result.Item2} {result.Item3}");
+                    Assert.True(0 == result.ExitCode, $"{result.Output} {result.Errors}");
                     Assert.True(serverReceiveProperAuthorizationHeader);
-                    Assert.Contains($"GET {serverV3.Uri}{listEndpoint}/Search()", result.Item2);
+                    Assert.Contains($"GET {serverV3.Uri}{listEndpoint}/Search()", result.Output);
                     // verify that only package id & version is displayed
-                    Assert.Matches(@"(?m)testPackage1\s+1\.1\.0", result.Item2);
+                    Assert.Matches(@"(?m)testPackage1\s+1\.1\.0", result.Output);
 
                 }
             }
@@ -1138,11 +1138,11 @@ namespace NuGet.CommandLine.Test
                     serverV3.Stop();
 
                     // Assert
-                    Assert.True(0 == result.Item1, $"{result.Item2} {result.Item3}");
+                    Assert.True(0 == result.ExitCode, $"{result.Output} {result.Errors}");
                     Assert.True(serverReceiveProperAuthorizationHeader);
-                    Assert.Contains($"GET {serverV3.Uri}{listEndpoint}/Search()", result.Item2);
+                    Assert.Contains($"GET {serverV3.Uri}{listEndpoint}/Search()", result.Output);
                     // verify that only package id & version is displayed
-                    Assert.Matches(@"(?m)testPackage1\s+1\.1\.0", result.Item2);
+                    Assert.Matches(@"(?m)testPackage1\s+1\.1\.0", result.Output);
 
                 }
             }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
@@ -74,7 +74,7 @@ namespace NuGet.CommandLine.Test
                     workingDirectory,
                     "pack packageA.nuspec",
                     waitForExit: true);
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
                 var path = Path.Combine(workingDirectory, "packageA.1.0.0.2.nupkg");
@@ -153,7 +153,7 @@ namespace NuGet.CommandLine.Test
                     workingDirectory,
                     "pack packageA.nuspec",
                     waitForExit: true);
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
                 var path = Path.Combine(workingDirectory, "packageA.1.0.0.2.nupkg");
@@ -207,7 +207,7 @@ namespace NuGet.CommandLine.Test
                     workingDirectory,
                     "pack packageA.nuspec",
                     waitForExit: true);
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
                 var path = Path.Combine(workingDirectory, "packageA.1.0.0.2.nupkg");
@@ -273,7 +273,7 @@ namespace NuGet.CommandLine.Test
                     workingDirectory,
                     "pack packageA.nuspec",
                     waitForExit: true);
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
                 var path = Path.Combine(workingDirectory, "packageA.1.0.0.nupkg");
@@ -321,7 +321,7 @@ namespace NuGet.CommandLine.Test
                     workingDirectory,
                     "pack packageA.nuspec",
                     waitForExit: true);
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
                 var path = Path.Combine(workingDirectory, "packageA.1.0.0.nupkg");
@@ -383,7 +383,7 @@ namespace NuGet.CommandLine.Test
                     workingDirectory,
                     "pack packageA.nuspec",
                     waitForExit: true);
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
                 var path = Path.Combine(workingDirectory, "packageA.1.0.0.nupkg");
@@ -400,7 +400,7 @@ namespace NuGet.CommandLine.Test
                     },
                     files);
 
-                Assert.False(r.Item2.Contains("Assembly outside lib folder"));
+                Assert.False(r.Output.Contains("Assembly outside lib folder"));
             }
         }
 
@@ -438,7 +438,7 @@ namespace NuGet.CommandLine.Test
                     workingDirectory,
                     "pack packageA.nuspec",
                     waitForExit: true);
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
                 var path = Path.Combine(workingDirectory, "packageA.1.0.0.nupkg");
@@ -453,7 +453,7 @@ namespace NuGet.CommandLine.Test
                     },
                     files);
 
-                Assert.False(r.Item2.Contains("Assembly outside lib folder"));
+                Assert.False(r.Output.Contains("Assembly outside lib folder"));
             }
         }
 
@@ -506,7 +506,7 @@ namespace NuGet.CommandLine.Test
                     workingDirectory,
                     "pack packageA.nuspec -symbols -SymbolPackageFormat snupkg",
                     waitForExit: true);
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
                 var path = Path.Combine(workingDirectory, "packageA.1.0.0.nupkg");
@@ -674,7 +674,7 @@ namespace NuGet.CommandLine.Test
                     workingDirectory,
                     "pack packageA.nuspec -symbols -SymbolPackageFormat snupkg",
                     waitForExit: true);
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
                 var path = Path.Combine(workingDirectory, "packageA.1.0.0.nupkg");
@@ -753,7 +753,7 @@ namespace NuGet.CommandLine.Test
                     workingDirectory,
                     "pack packageA.nuspec",
                     waitForExit: true);
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
                 var path = Path.Combine(workingDirectory, "packageA.1.0.0.nupkg");
@@ -872,7 +872,7 @@ namespace Proj2
                     proj2Directory,
                     "pack proj2.csproj -build -IncludeReferencedProjects",
                     waitForExit: true);
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
                 var package = new PackageArchiveReader(File.OpenRead(Path.Combine(proj2Directory, "proj2.0.0.0.nupkg")));
@@ -976,7 +976,7 @@ namespace Proj1
                 // Assert
                 if (packEnabled)
                 {
-                    Assert.True(0 == r.Item1, r.AllOutput);
+                    Assert.True(0 == r.ExitCode, r.AllOutput);
                     var nupkgName = Path.Combine(proj1Directory, "proj1.0.0.0.nupkg");
                     Assert.True(File.Exists(nupkgName));
                     var package = new PackageArchiveReader(File.OpenRead(nupkgName));
@@ -993,7 +993,7 @@ namespace Proj1
                 }
                 else
                 {
-                    Assert.True(1 == r.Item1, r.AllOutput);
+                    Assert.True(1 == r.ExitCode, r.AllOutput);
                     var nupkgName = Path.Combine(proj1Directory, "proj1.0.0.0.nupkg");
                     Assert.False(File.Exists(nupkgName));
 
@@ -1079,7 +1079,7 @@ namespace Proj1
                     proj1Directory,
                     "pack proj1.csproj -build ",
                     waitForExit: true);
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
                 var nupkgName = Path.Combine(proj1Directory, "proj1.0.0.0.nupkg");
@@ -1174,7 +1174,7 @@ namespace Proj2
                     proj2Directory,
                     $"pack proj2.csproj -build -IncludeReferencedProjects -symbols -SymbolPackageFormat {extension}",
                     waitForExit: true);
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
                 using (var package = new PackageArchiveReader(Path.Combine(proj2Directory, $"proj2.0.0.0.{extension}")))
@@ -1248,7 +1248,7 @@ namespace Proj2
                     projDirectory,
                     $"pack A.csproj -build -symbols -SymbolPackageFormat {extension}",
                     waitForExit: true);
-                Assert.True(result.Item1 == 0, result.Item2 + " " + result.Item3);
+                Assert.True(result.ExitCode == 0, result.Output + " " + result.Errors);
 
                 // Assert
                 using (var package = new PackageArchiveReader(Path.Combine(projDirectory, $"A.0.0.0.{extension}")))
@@ -1320,7 +1320,7 @@ public class B
                     projDirectory,
                     $"pack A.csproj -build -symbols -SymbolPackageFormat {extension}",
                     waitForExit: true);
-                Assert.True(result.Item1 == 0, result.Item2 + " " + result.Item3);
+                Assert.True(result.ExitCode == 0, result.Output + " " + result.Errors);
 
                 // Assert
                 using (var package = new PackageArchiveReader(Path.Combine(projDirectory, $"A.0.0.0.{extension}")))
@@ -1391,7 +1391,7 @@ public class B
                     projDirectory,
                     "pack A.csproj -build",
                     waitForExit: true);
-                Assert.True(result.Item1 == 0, result.Item2 + " " + result.Item3);
+                Assert.True(result.ExitCode == 0, result.Output + " " + result.Errors);
 
                 // Assert
                 var package = new PackageArchiveReader(File.OpenRead(Path.Combine(projDirectory, "A.0.0.0.nupkg")));
@@ -1488,7 +1488,7 @@ public class B
                     proj1Directory,
                     "pack proj1.csproj -build -IncludeReferencedProjects",
                     waitForExit: true);
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
                 var package = new PackageArchiveReader(File.OpenRead(Path.Combine(proj1Directory, "proj1.0.0.0.nupkg")));
@@ -1601,10 +1601,10 @@ public class B
                     proj1Directory,
                     "pack proj1.csproj -build -IncludeReferencedProjects",
                     waitForExit: true);
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
-                Assert.Contains(string.Format(NuGetResources.ProjectJsonPack_Deprecated, "proj2"), r.Item2);
-                Assert.Contains(string.Format(NuGetResources.ProjectJsonPack_Deprecated, "proj6"), r.Item2);
+                Assert.Contains(string.Format(NuGetResources.ProjectJsonPack_Deprecated, "proj2"), r.Output);
+                Assert.Contains(string.Format(NuGetResources.ProjectJsonPack_Deprecated, "proj6"), r.Output);
 
                 // Assert
                 var package = new PackageArchiveReader(File.OpenRead(Path.Combine(proj1Directory, "proj1.0.0.0.nupkg")));
@@ -1715,7 +1715,7 @@ public class B
                     proj1Directory,
                     $@"pack proj1.csproj -build -IncludeReferencedProjects  -MSBuildVersion {version}",
                     waitForExit: true);
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
                 var package = new PackageArchiveReader(File.OpenRead(Path.Combine(proj1Directory, "proj1.0.0.0.nupkg")));
@@ -1820,7 +1820,7 @@ public class B
                     proj1Directory,
                     $@"pack proj1.csproj -build -IncludeReferencedProjects  -MSBuildVersion 15.0",
                     waitForExit: true);
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
                 var package = new PackageArchiveReader(File.OpenRead(Path.Combine(proj1Directory, "proj1.0.0.0.nupkg")));
@@ -1935,11 +1935,11 @@ public class B
                     proj1Directory,
                     $@"pack proj1.csproj -build -IncludeReferencedProjects  -MSBuildVersion {version}",
                     waitForExit: true);
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
-                Assert.Contains(string.Format(NuGetResources.ProjectJsonPack_Deprecated, "proj2"), r.Item2);
-                Assert.Contains(string.Format(NuGetResources.ProjectJsonPack_Deprecated, "proj6"), r.Item2);
+                Assert.Contains(string.Format(NuGetResources.ProjectJsonPack_Deprecated, "proj2"), r.Output);
+                Assert.Contains(string.Format(NuGetResources.ProjectJsonPack_Deprecated, "proj6"), r.Output);
 
                 var package = new PackageArchiveReader(File.OpenRead(Path.Combine(proj1Directory, "proj1.0.0.0.nupkg")));
                 var files = package.GetFiles().ToArray();
@@ -2046,11 +2046,11 @@ public class B
                     proj1Directory,
                     $@"pack proj1.csproj -build -IncludeReferencedProjects  -MSBuildVersion 15.0",
                     waitForExit: true);
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
-                Assert.Contains(string.Format(NuGetResources.ProjectJsonPack_Deprecated, "proj2"), r.Item2);
-                Assert.Contains(string.Format(NuGetResources.ProjectJsonPack_Deprecated, "proj6"), r.Item2);
+                Assert.Contains(string.Format(NuGetResources.ProjectJsonPack_Deprecated, "proj2"), r.Output);
+                Assert.Contains(string.Format(NuGetResources.ProjectJsonPack_Deprecated, "proj6"), r.Output);
 
                 var package = new PackageArchiveReader(File.OpenRead(Path.Combine(proj1Directory, "proj1.0.0.0.nupkg")));
                 var files = package.GetNonPackageDefiningFiles();
@@ -2160,7 +2160,7 @@ public class B
                     proj1Directory,
                     "pack proj1.csproj -build -IncludeReferencedProjects -Properties prefix=" + prefixTokenValue,
                     waitForExit: true);
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
                 var package = new PackageArchiveReader(File.OpenRead(Path.Combine(proj1Directory, "proj1.0.0.0.nupkg")));
@@ -2202,7 +2202,7 @@ public class B
                 var outputPackage = new PackageArchiveReader(File.OpenRead(outputPackageFileName));
 
                 // Assert
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3); // Exited successfully
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors); // Exited successfully
                 Assert.Equal(new NuGetVersion(version), outputPackage.NuspecReader.GetVersion());
             }
         }
@@ -2230,7 +2230,7 @@ public class B
                 var outputPackage = new PackageArchiveReader(File.OpenRead(outputPackageFileName));
 
                 // Assert
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3); // Exited successfully
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors); // Exited successfully
                 Assert.Equal(new NuGetVersion(semverVersion), outputPackage.NuspecReader.GetVersion());
             }
         }
@@ -2403,7 +2403,7 @@ namespace " + projectName + @"
                     proj1Directory,
                     "pack proj1.csproj -build -IncludeReferencedProjects",
                     waitForExit: true);
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
                 var package = new PackageArchiveReader(File.OpenRead(Path.Combine(proj1Directory, "proj1.0.0.0.nupkg")));
@@ -2471,14 +2471,14 @@ namespace " + projectName + @"
 
                 // Verify the nuget pack command exit code
                 Assert.NotNull(commandRunner);
-                Assert.Equal(1, commandRunner.Item1);
+                Assert.Equal(1, commandRunner.ExitCode);
 
                 var exepctedError = string.Format(
                     "Unable to output resolved nuspec file because it would overwrite the original at '{0}\\{1}'\r\n",
                     workingDirectory,
                     nuspecName);
 
-                Assert.Contains(exepctedError, commandRunner.Item3);
+                Assert.Contains(exepctedError, commandRunner.Errors);
             }
         }
 
@@ -2545,8 +2545,8 @@ namespace " + projectName + @"
                 // Verify the nuget pack command exit code
                 Assert.NotNull(commandRunner);
                 Assert.True(
-                    0 == commandRunner.Item1,
-                    string.Format("{0} {1}", commandRunner.Item2 ?? "null", commandRunner.Item3 ?? "null"));
+                    0 == commandRunner.ExitCode,
+                    string.Format("{0} {1}", commandRunner.Output ?? "null", commandRunner.Errors ?? "null"));
 
                 var nupkgPath = Path.Combine(workingDirectory, "packageA.nupkg");
 
@@ -2647,8 +2647,8 @@ namespace " + projectName + @"
                 // Verify the nuget pack command exit code
                 Assert.NotNull(commandRunner);
                 Assert.True(
-                    0 == commandRunner.Item1,
-                    string.Format("{0} {1}", commandRunner.Item2 ?? "null", commandRunner.Item3 ?? "null"));
+                    0 == commandRunner.ExitCode,
+                    string.Format("{0} {1}", commandRunner.Output ?? "null", commandRunner.Errors ?? "null"));
 
                 var nupkgPath = Path.Combine(workingDirectory, "packageA.nupkg");
 
@@ -2706,7 +2706,7 @@ namespace " + projectName + @"
                     $"pack proj1.csproj -build -IncludeReferencedProjects -outputDirectory \"{outputDirectory}\"",
                     waitForExit: true);
 
-                Assert.True(0 == r.Item1, r.Item2 + Environment.NewLine + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + Environment.NewLine + r.Errors);
 
                 // Assert
                 var package = new PackageArchiveReader(File.OpenRead(Path.Combine(outputDirectory, "proj1.0.0.0.nupkg")));
@@ -2755,7 +2755,7 @@ namespace " + projectName + @"
                     proj1Directory,
                     "pack proj1.csproj -build -IncludeReferencedProjects",
                     waitForExit: true);
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
                 var package = new PackageArchiveReader(File.OpenRead(Path.Combine(proj1Directory, "proj1.0.0.0.nupkg")));
@@ -2798,7 +2798,7 @@ namespace " + projectName + @"
                     proj1Directory,
                     "pack proj1.csproj -build -IncludeReferencedProjects",
                     waitForExit: true);
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
                 var package = new PackageArchiveReader(File.OpenRead(Path.Combine(proj1Directory, "proj1.0.0.0.nupkg")));
@@ -2927,7 +2927,7 @@ namespace Proj2
                     proj2Directory,
                     "pack proj2.csproj -p Config=Release",
                     waitForExit: true);
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
                 var package = new PackageArchiveReader(File.OpenRead(Path.Combine(proj2Directory, "proj2.0.0.0.nupkg")));
@@ -3042,7 +3042,7 @@ namespace Proj2
                     proj2Directory,
                     "pack proj2.csproj -build -IncludeReferencedProjects -p Config=Release",
                     waitForExit: true);
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
 
@@ -3103,7 +3103,7 @@ namespace Proj2
                     "pack package.nuspec",
                     waitForExit: true);
 
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
                 var package = new PackageArchiveReader(File.OpenRead(Path.Combine(projDirectory, "ExcludeBug.0.1.0.nupkg")));
@@ -3192,7 +3192,7 @@ namespace Proj1
                     proj1Directory,
                     "pack proj1.csproj -build",
                     waitForExit: true);
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
                 var package = new PackageArchiveReader(File.OpenRead(Path.Combine(proj1Directory, "proj1.0.0.0.nupkg")));
@@ -3276,7 +3276,7 @@ namespace Proj1
                     proj1Directory,
                     "pack proj1.csproj -build",
                     waitForExit: true);
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
                 var package = new PackageArchiveReader(File.OpenRead(Path.Combine(proj1Directory, "proj1.0.0.0.nupkg")));
@@ -3392,7 +3392,7 @@ namespace Proj1
                     proj1Directory,
                     "pack proj1.csproj -build -IncludeReferencedProjects",
                     waitForExit: true);
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
                 var package = new PackageArchiveReader(File.OpenRead(Path.Combine(proj1Directory, "proj1.0.0.0.nupkg")));
@@ -3504,7 +3504,7 @@ namespace Proj1
                     proj1Directory,
                     "pack proj1.csproj -build -IncludeReferencedProjects",
                     waitForExit: true);
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
                 var package = new PackageArchiveReader(File.OpenRead(Path.Combine(proj1Directory, "proj1.0.0.0.nupkg")));
@@ -3615,7 +3615,7 @@ namespace Proj1
                     proj1Directory,
                     "pack proj1.nuspec",
                     waitForExit: true);
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
                 Assert.Contains(string.Format(AnalysisResources.UnspecifiedDependencyVersionWarning, "json"), r.AllOutput);
@@ -3726,7 +3726,7 @@ namespace Proj2
                     $@"pack proj2.csproj -build -IncludeReferencedProjects -p Config=Release -msbuildversion 14",
                     waitForExit: true);
 
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
 
@@ -3851,7 +3851,7 @@ namespace Proj2
                     $@"pack proj2.csproj -build -IncludeReferencedProjects -p Config=Release -msbuildversion 15.0",
                     waitForExit: true);
 
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
 
@@ -3975,7 +3975,7 @@ namespace Proj2
                     proj2Directory,
                     @"pack proj2.csproj -build -IncludeReferencedProjects -p Config=Release -MSBuildVersion 15.1",
                     waitForExit: true);
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
 
@@ -4103,13 +4103,13 @@ namespace Proj2
                     proj2Directory,
                     $@"pack proj2.csproj -build -IncludeReferencedProjects -p Config=Release -MSBuildPath ""{msbuildPath}"" ",
                     waitForExit: true);
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
 
                 // Verify that proj1 was not built using the default config "Debug".
                 Assert.False(Directory.Exists(Path.Combine(proj1Directory, "debug_out")));
-                Assert.True(r.Item2.Contains($"Using Msbuild from '{msbuildPath}'."));
+                Assert.True(r.Output.Contains($"Using Msbuild from '{msbuildPath}'."));
 
                 var package = new PackageArchiveReader(File.OpenRead(Path.Combine(proj2Directory, "proj2.0.0.0.nupkg")));
                 var files = package.GetNonPackageDefiningFiles();
@@ -4232,14 +4232,14 @@ namespace Proj2
                     proj2Directory,
                     $@"pack proj2.csproj -build -IncludeReferencedProjects -p Config=Release -MSBuildPath ""{msbuildPath}"" -MSBuildVersion 12 ",
                     waitForExit: true);
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
 
                 // Verify that proj1 was not built using the default config "Debug".
                 Assert.False(Directory.Exists(Path.Combine(proj1Directory, "debug_out")));
-                Assert.True(r.Item2.Contains($"Using Msbuild from '{msbuildPath}'."));
-                Assert.True(r.Item2.Contains($"MsbuildPath : {msbuildPath} is using, ignore MsBuildVersion: 12."));
+                Assert.True(r.Output.Contains($"Using Msbuild from '{msbuildPath}'."));
+                Assert.True(r.Output.Contains($"MsbuildPath : {msbuildPath} is using, ignore MsBuildVersion: 12."));
 
                 var package = new PackageArchiveReader(File.OpenRead(Path.Combine(proj2Directory, "proj2.0.0.0.nupkg")));
                 var files = package.GetNonPackageDefiningFiles();
@@ -4358,11 +4358,11 @@ namespace Proj2
                     proj2Directory,
                     $@"pack proj2.csproj -build -IncludeReferencedProjects -p Config=Release -MSBuildPath ""{msbuildPath}"" ",
                     waitForExit: true);
-                Assert.True(1 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(1 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
 
-                Assert.True(r.Item3.Contains($"MSBuildPath : {msbuildPath}  doesn't not exist."));
+                Assert.True(r.Errors.Contains($"MSBuildPath : {msbuildPath}  doesn't not exist."));
             }
         }
 
@@ -4494,7 +4494,7 @@ stuff \n &lt;&lt;
                     workingDirectory,
                     "pack packageA.nuspec -verbosity detailed",
                     waitForExit: true);
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
                 var path = Path.Combine(workingDirectory, "packageA.1.0.0.nupkg");
@@ -4584,10 +4584,10 @@ stuff \n <<".Replace("\r\n", "\n");
                     proj1Directory,
                     "pack proj1.csproj -build",
                     waitForExit: true);
-                Assert.Equal(1, r.Item1);
+                Assert.Equal(1, r.ExitCode);
 
                 // Assert
-                Assert.Contains("Unable to find 'doesNotExist.1.1.0.nupkg'.", r.Item3);
+                Assert.Contains("Unable to find 'doesNotExist.1.1.0.nupkg'.", r.Errors);
             }
         }
 
@@ -4630,7 +4630,7 @@ stuff \n <<".Replace("\r\n", "\n");
                     workingDirectory,
                     "pack packageA.nuspec",
                     waitForExit: true);
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
                 var path = Path.Combine(workingDirectory, "packageA.1.0.0-beta.1.build.234.nupkg");
@@ -4706,7 +4706,7 @@ namespace Proj1
                     proj1ProjectDirectory,
                     @"pack proj1.csproj -build -IncludeReferencedProjects -Properties Configuration=Release",
                     waitForExit: true);
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
                 Assert.True(Directory.Exists(Path.Combine(proj1ProjectDirectory, "out", "Release")));
@@ -4904,7 +4904,7 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
                     workingDirectory,
                     "pack packageA.nuspec",
                     waitForExit: true);
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
                 var nupkgPath = Path.Combine(workingDirectory, $"{packageName}.{version}.nupkg");
@@ -4968,7 +4968,7 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
                     workingDirectory,
                     "pack packageA.nuspec",
                     waitForExit: true);
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
                 var nupkgPath = Path.Combine(workingDirectory, $"{packageName}.{version}.nupkg");
@@ -5034,12 +5034,12 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
                     "pack packageA.nuspec",
                     waitForExit: true);
                 // This should fail.
-                Assert.True(1 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(1 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
                 var nupkgPath = Path.Combine(workingDirectory, $"{packageName}.{version}.nupkg");
                 Assert.False(File.Exists(nupkgPath));
-                Assert.Contains($"An error occured while trying to parse the value '{licenseExpr}' of property 'license' in the manifest file.", r.Item3);
+                Assert.Contains($"An error occured while trying to parse the value '{licenseExpr}' of property 'license' in the manifest file.", r.Errors);
             }
         }
 
@@ -5082,12 +5082,12 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
                     "pack packageA.nuspec",
                     waitForExit: true);
                 // This should fail.
-                Assert.True(1 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(1 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
                 var nupkgPath = Path.Combine(workingDirectory, $"{packageName}.{version}.nupkg");
                 Assert.False(File.Exists(nupkgPath));
-                Assert.Contains($"An error occured while trying to parse the value '{licenseExpr}' of property 'license' in the manifest file.", r.Item3);
+                Assert.Contains($"An error occured while trying to parse the value '{licenseExpr}' of property 'license' in the manifest file.", r.Errors);
             }
         }
 
@@ -5130,13 +5130,13 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
                     "pack packageA.nuspec",
                     waitForExit: true);
                 // This should fail.
-                Assert.True(1 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(1 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
                 var nupkgPath = Path.Combine(workingDirectory, $"{packageName}.{version}.nupkg");
                 Assert.False(File.Exists(nupkgPath));
-                Assert.Contains($"An error occured while trying to parse the value '{licenseExpr}' of property 'license' in the manifest file.", r.Item3);
-                Assert.Contains("is not supported by this toolset. The highest supported version is", r.Item3);
+                Assert.Contains($"An error occured while trying to parse the value '{licenseExpr}' of property 'license' in the manifest file.", r.Errors);
+                Assert.Contains("is not supported by this toolset. The highest supported version is", r.Errors);
             }
         }
 
@@ -5183,7 +5183,7 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
                     workingDirectory,
                     "pack packageA.nuspec",
                     waitForExit: true);
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
                 var nupkgPath = Path.Combine(workingDirectory, $"{packageName}.{version}.nupkg");
@@ -5252,13 +5252,13 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
                     "pack packageA.nuspec",
                     waitForExit: true);
                 // This should fail.
-                Assert.True(1 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(1 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
                 var nupkgPath = Path.Combine(workingDirectory, $"{packageName}.{version}.nupkg");
                 Assert.False(File.Exists(nupkgPath));
                 // file not found.
-                Assert.Contains("NU5030", r.Item3);
+                Assert.Contains("NU5030", r.Errors);
             }
         }
 
@@ -5303,13 +5303,13 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
                     "pack packageA.nuspec",
                     waitForExit: true);
                 // This should fail.
-                Assert.True(1 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(1 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
                 var nupkgPath = Path.Combine(workingDirectory, $"{packageName}.{version}.nupkg");
                 Assert.False(File.Exists(nupkgPath));
                 // file not found.
-                Assert.Contains("NU5031", r.Item3);
+                Assert.Contains("NU5031", r.Errors);
             }
         }
 
@@ -5355,13 +5355,13 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
                     "pack packageA.nuspec",
                     waitForExit: true);
                 // This should fail.
-                Assert.True(1 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(1 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
                 var nupkgPath = Path.Combine(workingDirectory, $"{packageName}.{version}.nupkg");
                 Assert.False(File.Exists(nupkgPath));
                 // file not found.
-                Assert.Contains("Unrecognized license type", r.Item3);
+                Assert.Contains("Unrecognized license type", r.Errors);
             }
         }
 
@@ -5404,13 +5404,13 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
                     "pack packageA.nuspec",
                     waitForExit: true);
                 // This should fail.
-                Assert.True(1 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(1 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
                 var nupkgPath = Path.Combine(workingDirectory, $"{packageName}.{version}.nupkg");
                 Assert.False(File.Exists(nupkgPath));
                 // file not found.
-                Assert.Contains("The element 'license' cannot be empty", r.Item3);
+                Assert.Contains("The element 'license' cannot be empty", r.Errors);
             }
         }
 
@@ -5449,9 +5449,9 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
                     workingDirectory,
                     "pack packageA.nuspec",
                     waitForExit: true);
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
-                Assert.Contains("NU5125", r.Item2);
+                Assert.Contains("NU5125", r.Output);
 
                 // Assert
                 var nupkgPath = Path.Combine(workingDirectory, $"{packageName}.{version}.nupkg");
@@ -5515,7 +5515,7 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
                     workingDirectory,
                     "pack packageA.nuspec",
                     waitForExit: true);
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
                 var nupkgPath = Path.Combine(workingDirectory, $"{packageName}.{version}.nupkg");
@@ -5619,7 +5619,7 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
                     workingDirectory,
                     $"pack {packageName}.csproj -build -symbols -SymbolPackageFormat {extension}",
                     waitForExit: true);
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
                 var nupkgPath = Path.Combine(workingDirectory, $"{packageName}.{version}.nupkg");
@@ -5721,7 +5721,7 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
                     workingDirectory,
                     "pack packageA.nuspec",
                     waitForExit: true);
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
                 var path = Path.Combine(workingDirectory, "packageA.1.0.0.2.nupkg");
@@ -5789,7 +5789,7 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
                     workingDirectory,
                     "pack packageA.nuspec",
                     waitForExit: true);
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
                 var path = Path.Combine(workingDirectory, "packageA.1.0.0.2.nupkg");
@@ -6670,7 +6670,7 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
                         workingDirectory,
                         string.Format(command, path),
                         waitForExit: true);
-                    Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                    Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
 
                     using (var reader = new PackageArchiveReader(packagePath))
@@ -7094,7 +7094,7 @@ using System.Runtime.InteropServices;
                     projectDirectory,
                     "pack -build",
                     waitForExit: true);
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
                 var nupkgPath = Path.Combine(projectDirectory, "proj.1.0.0.nupkg");
@@ -7214,7 +7214,7 @@ using System.Runtime.InteropServices;
                     projectDirectory,
                     "pack -build",
                     waitForExit: true);
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
                 var nupkgPath = Path.Combine(projectDirectory, "proj.1.0.0.nupkg");
@@ -7260,7 +7260,7 @@ using System.Runtime.InteropServices;
                     projDirectory,
                     "pack A.csproj -build",
                     waitForExit: true);
-                Assert.True(result.Item1 == 0, result.Item2 + " " + result.Item3);
+                Assert.True(result.ExitCode == 0, result.Output + " " + result.Errors);
 
                 // Assert
                 using (var package = new PackageArchiveReader(Path.Combine(projDirectory, "A.0.0.0.nupkg")))
@@ -7331,7 +7331,7 @@ using System.Runtime.InteropServices;
                         },
                         files);
 
-                    Assert.False(packResult.Item2.Contains("Assembly outside lib folder"));
+                    Assert.False(packResult.Output.Contains("Assembly outside lib folder"));
                 }
             }
         }
@@ -7411,7 +7411,7 @@ namespace proj1
                         },
                         files);
 
-                    Assert.False(packResult.Item2.Contains("Assembly outside lib folder"));
+                    Assert.False(packResult.Output.Contains("Assembly outside lib folder"));
                 }
             }
         }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPushCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPushCommandTest.cs
@@ -41,9 +41,9 @@ namespace NuGet.CommandLine.Test
                     true);
 
                 // Assert
-                Assert.Equal(0, result.Item1);
+                Assert.Equal(0, result.ExitCode);
                 Assert.True(File.Exists(Path.Combine(source, "testPackage1.1.1.0.nupkg")));
-                var output = result.Item2;
+                var output = result.Output;
                 Assert.DoesNotContain("WARNING: No API Key was provided", output);
                 Assert.DoesNotContain("WARNING: You are attempting to push to an 'http' source", output);
             }
@@ -77,7 +77,7 @@ namespace NuGet.CommandLine.Test
                     true);
 
                 // Assert
-                Assert.Equal(0, result.Item1);
+                Assert.Equal(0, result.ExitCode);
                 var basename = string.Format("{0}.{1}.", packageId, version);
                 var baseFolder = Path.Combine(packageId, version) + Path.DirectorySeparatorChar;
                 Assert.True(File.Exists(Path.Combine(source, baseFolder + packageId + ".nuspec")));
@@ -116,9 +116,9 @@ namespace NuGet.CommandLine.Test
                     true);
 
                 // Assert
-                Assert.Equal(0, result.Item1);
+                Assert.Equal(0, result.ExitCode);
                 Assert.True(File.Exists(Path.Combine(source, "testPackage1.1.1.0.nupkg")));
-                var output = result.Item2;
+                var output = result.Output;
                 Assert.DoesNotContain("WARNING: No API Key was provided", output);
             }
         }
@@ -156,7 +156,7 @@ namespace NuGet.CommandLine.Test
                     true);
 
                 // Assert
-                Assert.Equal(0, result.Item1);
+                Assert.Equal(0, result.ExitCode);
                 Assert.True(File.Exists(Path.Combine(source, "testPackage1.1.1.0.nupkg")));
             }
         }
@@ -193,7 +193,7 @@ namespace NuGet.CommandLine.Test
                     true);
 
                 // Assert
-                Assert.Equal(0, result.Item1);
+                Assert.Equal(0, result.ExitCode);
                 Assert.True(File.Exists(Path.Combine(source, "testPackage1.1.1.0.nupkg")));
             }
         }
@@ -222,7 +222,7 @@ namespace NuGet.CommandLine.Test
                     true);
 
                 // Assert
-                Assert.Equal(0, result.Item1);
+                Assert.Equal(0, result.ExitCode);
                 Assert.True(File.Exists(Path.Combine(source, "testPackage1.1.1.0.nupkg")));
             }
         }
@@ -250,7 +250,7 @@ namespace NuGet.CommandLine.Test
                                 true);
 
                 // Assert
-                Assert.Equal(0, result.Item1);
+                Assert.Equal(0, result.ExitCode);
                 Assert.True(File.Exists(Path.Combine(source, "testPackage1.1.1.0.nupkg")));
             }
         }
@@ -291,8 +291,8 @@ namespace NuGet.CommandLine.Test
                     server.Stop();
 
                     // Assert
-                    Assert.True(0 == result.Item1, $"{result.Item2} {result.Item3}");
-                    var output = result.Item2;
+                    Assert.True(0 == result.ExitCode, $"{result.Output} {result.Errors}");
+                    var output = result.Output;
                     Assert.Contains("Your package was pushed.", output);
                     AssertFileEqual(packageFileName, outputFileName);
                 }
@@ -330,7 +330,7 @@ namespace NuGet.CommandLine.Test
                     server.Stop();
 
                     // Assert
-                    var output = result.Item2;
+                    var output = result.Output;
                     foreach (var serverWarning in serverWarnings)
                     {
                         if (!string.IsNullOrEmpty(serverWarning))
@@ -369,10 +369,10 @@ namespace NuGet.CommandLine.Test
                     waitForExit: true);
 
                 // Assert
-                Assert.Equal(0, result.Item1);
-                Assert.Contains("Your package was pushed.", result.Item2);
-                Assert.DoesNotContain("symbol", result.Item2);
-                Assert.DoesNotContain(NuGetConstants.DefaultSymbolServerUrl, result.Item2);
+                Assert.Equal(0, result.ExitCode);
+                Assert.Contains("Your package was pushed.", result.Output);
+                Assert.DoesNotContain("symbol", result.Output);
+                Assert.DoesNotContain(NuGetConstants.DefaultSymbolServerUrl, result.Output);
             }
         }
 
@@ -417,11 +417,11 @@ namespace NuGet.CommandLine.Test
 
                 // Assert
                 Assert.True(0 == result.ExitCode, result.AllOutput);
-                Assert.Contains($"Pushing testPackage1.1.1.0.nupkg to '{pushUri}'", result.Item2);
-                Assert.Contains($"Created {pushUri}", result.Item2);
-                Assert.Contains($"Pushing testPackage1.1.1.0.symbols.nupkg to '{pushSymbolsUri}'", result.Item2);
-                Assert.Contains($"Created {pushSymbolsUri}", result.Item2);
-                Assert.Contains("Your package was pushed.", result.Item2);
+                Assert.Contains($"Pushing testPackage1.1.1.0.nupkg to '{pushUri}'", result.Output);
+                Assert.Contains($"Created {pushUri}", result.Output);
+                Assert.Contains($"Pushing testPackage1.1.1.0.symbols.nupkg to '{pushSymbolsUri}'", result.Output);
+                Assert.Contains($"Created {pushSymbolsUri}", result.Output);
+                Assert.Contains("Your package was pushed.", result.Output);
             }
         }
 
@@ -448,10 +448,10 @@ namespace NuGet.CommandLine.Test
                     waitForExit: true);
 
                 // Assert
-                Assert.Equal(0, result.Item1);
-                Assert.Contains($"Pushing testPackage1.1.1.0.nupkg to '{pushSource}'", result.Item2);
-                Assert.Contains($"Pushing testPackage1.1.1.0.symbols.nupkg to '{pushSymbolsSource}'", result.Item2);
-                Assert.Contains("Your package was pushed.", result.Item2);
+                Assert.Equal(0, result.ExitCode);
+                Assert.Contains($"Pushing testPackage1.1.1.0.nupkg to '{pushSource}'", result.Output);
+                Assert.Contains($"Pushing testPackage1.1.1.0.symbols.nupkg to '{pushSymbolsSource}'", result.Output);
+                Assert.Contains("Your package was pushed.", result.Output);
             }
         }
 
@@ -489,10 +489,10 @@ namespace NuGet.CommandLine.Test
                     waitForExit: true);
 
                 // Assert
-                Assert.Equal(0, result.Item1);
-                Assert.Contains($"Pushing testPackage1.1.1.0.nupkg to '{pushSource}'", result.Item2);
-                Assert.Contains($"Pushing testPackage1.1.1.0.symbols.nupkg to '{pushSymbolsSource}'", result.Item2);
-                Assert.Contains("Your package was pushed.", result.Item2);
+                Assert.Equal(0, result.ExitCode);
+                Assert.Contains($"Pushing testPackage1.1.1.0.nupkg to '{pushSource}'", result.Output);
+                Assert.Contains($"Pushing testPackage1.1.1.0.symbols.nupkg to '{pushSymbolsSource}'", result.Output);
+                Assert.Contains("Your package was pushed.", result.Output);
             }
         }
 
@@ -520,8 +520,8 @@ namespace NuGet.CommandLine.Test
                     waitForExit: true);
 
                 // Assert
-                Assert.Equal(1, result.Item1);
-                Assert.Contains("took too long", result.Item3);
+                Assert.Equal(1, result.ExitCode);
+                Assert.Contains("took too long", result.Errors);
             }
         }
 
@@ -568,8 +568,8 @@ namespace NuGet.CommandLine.Test
                     server.Stop();
 
                     // Assert
-                    var output = result.Item2;
-                    Assert.True(0 == result.Item1, result.Item2 + " " + result.Item3);
+                    var output = result.Output;
+                    Assert.True(0 == result.ExitCode, result.Output + " " + result.Errors);
                     Assert.Contains("Your package was pushed.", output);
                     AssertFileEqual(packageFileName, outputFileName);
                 }
@@ -609,8 +609,8 @@ namespace NuGet.CommandLine.Test
                     server.Stop();
 
                     // Assert
-                    Assert.NotEqual(0, result.Item1);
-                    Assert.Contains("Too many automatic redirections were attempted.", result.Item3);
+                    Assert.NotEqual(0, result.ExitCode);
+                    Assert.Contains("Too many automatic redirections were attempted.", result.Errors);
                 }
             }
         }
@@ -642,8 +642,8 @@ namespace NuGet.CommandLine.Test
                     server.Stop();
 
                     // Assert
-                    Assert.NotEqual(0, result.Item1);
-                    Assert.Contains("The remote server returned an error: (302)", result.Item3);
+                    Assert.NotEqual(0, result.ExitCode);
+                    Assert.Contains("The remote server returned an error: (302)", result.Errors);
                 }
             }
         }
@@ -685,9 +685,9 @@ namespace NuGet.CommandLine.Test
                     server.Stop();
 
                     // Assert
-                    Assert.NotEqual(0, r1.Item1);
-                    Assert.Contains("Please provide credentials for:", r1.Item2);
-                    Assert.Contains("UserName:", r1.Item2);
+                    Assert.NotEqual(0, r1.ExitCode);
+                    Assert.Contains("Please provide credentials for:", r1.Output);
+                    Assert.Contains("UserName:", r1.Output);
                 }
             }
         }
@@ -759,7 +759,7 @@ namespace NuGet.CommandLine.Test
                     server.Stop();
 
                     // Assert
-                    Assert.True(0 == r1.Item1, r1.Item2 + " " + r1.Item3);
+                    Assert.True(0 == r1.ExitCode, r1.Output + " " + r1.Errors);
 
                     // Because the credential service caches the answer and attempts
                     // to use it for token refresh the first request happens twice
@@ -839,7 +839,7 @@ namespace NuGet.CommandLine.Test
                     server.Stop();
 
                     // Assert
-                    Assert.Equal(0, r1.Item1);
+                    Assert.Equal(0, r1.ExitCode);
 
                     // Because the credential service caches the answer and attempts
                     // to use it for token refresh the first request happens twice
@@ -888,7 +888,7 @@ namespace NuGet.CommandLine.Test
                     server.Stop();
 
                     // Assert
-                    Assert.Equal(0, r1.Item1);
+                    Assert.Equal(0, r1.ExitCode);
 
                     var currentUser = WindowsIdentity.GetCurrent();
                     Assert.Equal("NTLM", putUser.Identity.AuthenticationType);
@@ -932,7 +932,7 @@ namespace NuGet.CommandLine.Test
                     server.Stop();
 
                     // Assert
-                    Assert.Equal(0, r1.Item1);
+                    Assert.Equal(0, r1.ExitCode);
 
                     var currentUser = WindowsIdentity.GetCurrent();
                     Assert.Equal("NTLM", putUser.Identity.AuthenticationType);
@@ -1001,7 +1001,7 @@ namespace NuGet.CommandLine.Test
                     server.Stop();
 
                     // Assert
-                    Assert.True(0 == r1.Item1, r1.Item2 + " " + r1.Item3);
+                    Assert.True(0 == r1.ExitCode, r1.Output + " " + r1.Errors);
                     Assert.NotEqual(0, credentialForPutRequest.Count);
                     Assert.Equal("testuser:testpassword", credentialForPutRequest[0]);
                 }
@@ -1068,7 +1068,7 @@ namespace NuGet.CommandLine.Test
                     server.Stop();
 
                     // Assert
-                    Assert.True(0 == r1.Item1, r1.Item2 + " " + r1.Item3);
+                    Assert.True(0 == r1.ExitCode, r1.Output + " " + r1.Errors);
                     Assert.NotEqual(0, credentialForPutRequest.Count);
                     Assert.Equal("testuser:testpassword", credentialForPutRequest[0]);
                 }
@@ -1199,9 +1199,9 @@ namespace NuGet.CommandLine.Test
                     server.Stop();
 
                     // Assert
-                    r1.Item1.Should().Be(1, because: r1.AllOutput);
-                    Assert.Contains("401 (Unauthorized)", r1.Item2 + " " + r1.Item3);
-                    Assert.Contains($"Credential plugin {pluginPath} handles this request, but is unable to provide credentials. Testing abort.", r1.Item2 + " " + r1.Item3);
+                    r1.ExitCode.Should().Be(1, because: r1.AllOutput);
+                    Assert.Contains("401 (Unauthorized)", r1.Output + " " + r1.Errors);
+                    Assert.Contains($"Credential plugin {pluginPath} handles this request, but is unable to provide credentials. Testing abort.", r1.Output + " " + r1.Errors);
 
                     // No requests hit server, since abort during credential acquisition
                     // and no fallback to console provider
@@ -1270,10 +1270,10 @@ namespace NuGet.CommandLine.Test
                         });
                     server.Stop();
 
-                    var output = r1.Item2 + " " + r1.Item3;
+                    var output = r1.Output + " " + r1.Errors;
 
                     // Assert
-                    Assert.True(1 == r1.Item1, output);
+                    Assert.True(1 == r1.ExitCode, output);
                     Assert.Contains("401 (Unauthorized)", output);
                     Assert.Contains($"Credential plugin {pluginPath} timed out", output);
                     // ensure the process was killed
@@ -1358,8 +1358,8 @@ namespace NuGet.CommandLine.Test
                         serverV3.Stop();
 
                         // Assert
-                        Assert.True(0 == result.Item1, result.Item2 + " " + result.Item3);
-                        var output = result.Item2;
+                        Assert.True(0 == result.ExitCode, result.Output + " " + result.Errors);
+                        var output = result.Output;
                         Assert.Contains("Your package was pushed.", output);
                         AssertFileEqual(packageFileName, outputFileName);
                     }
@@ -1413,7 +1413,7 @@ namespace NuGet.CommandLine.Test
                     serverV3.Stop();
 
                     // Assert
-                    Assert.True(1 == result.Item1, $"{result.Item2} {result.Item3}");
+                    Assert.True(1 == result.ExitCode, $"{result.Output} {result.Errors}");
 
                     var expectedOutput =
                         string.Format(
@@ -1421,7 +1421,7 @@ namespace NuGet.CommandLine.Test
                       serverV3.Uri + "index.json");
 
                     // Verify that the output contains the expected output
-                    Assert.True(result.Item3.Contains(expectedOutput));
+                    Assert.True(result.Errors.Contains(expectedOutput));
                 }
             }
         }
@@ -1480,11 +1480,11 @@ namespace NuGet.CommandLine.Test
                     serverV3.Stop();
 
                     // Assert
-                    Assert.True(result.Item1 != 0, result.Item2 + " " + result.Item3);
+                    Assert.True(result.ExitCode != 0, result.Output + " " + result.Errors);
 
                     Assert.True(
-                        result.Item3.Contains("404 (Not Found)"),
-                        "Expected error message not found in " + result.Item3
+                        result.Errors.Contains("404 (Not Found)"),
+                        "Expected error message not found in " + result.Errors
                         );
                 }
             }
@@ -1529,8 +1529,8 @@ namespace NuGet.CommandLine.Test
                     server.Stop();
 
                     // Assert
-                    Assert.True(0 == result.Item1, $"{result.Item2} {result.Item3}");
-                    Assert.Contains("Your package was pushed.", result.Item2);
+                    Assert.True(0 == result.ExitCode, $"{result.Output} {result.Errors}");
+                    Assert.Contains("Your package was pushed.", result.Output);
                     AssertFileEqual(packageFileName, outputFileName);
                 }
             }
@@ -1604,8 +1604,8 @@ namespace NuGet.CommandLine.Test
                     serverV3.Stop();
 
                     // Assert
-                    Assert.True(0 == result.Item1, $"{result.Item2} {result.Item3}");
-                    Assert.Contains("Your package was pushed.", result.Item2);
+                    Assert.True(0 == result.ExitCode, $"{result.Output} {result.Errors}");
+                    Assert.Contains("Your package was pushed.", result.Output);
                     AssertFileEqual(packageFileName, outputFileName);
                 }
             }
@@ -1692,8 +1692,8 @@ namespace NuGet.CommandLine.Test
                     serverV3.Stop();
 
                     // Assert
-                    Assert.True(0 == result.Item1, $"{result.Item2} {result.Item3}");
-                    Assert.Contains("Your package was pushed.", result.Item2);
+                    Assert.True(0 == result.ExitCode, $"{result.Output} {result.Errors}");
+                    Assert.Contains("Your package was pushed.", result.Output);
                     AssertFileEqual(packageFileName, outputFileName);
                 }
             }
@@ -1727,8 +1727,8 @@ namespace NuGet.CommandLine.Test
                                 true);
 
                 // Assert
-                Assert.True(1 == result.Item1, result.Item2 + " " + result.Item3);
-                Assert.Contains("Source parameter was not specified", result.Item3);
+                Assert.True(1 == result.ExitCode, result.Output + " " + result.Errors);
+                Assert.Contains("Source parameter was not specified", result.Errors);
             }
         }
 
@@ -1806,8 +1806,8 @@ namespace NuGet.CommandLine.Test
                     server.Stop();
 
                     // Assert
-                    Assert.True(0 == result.Item1, result.Item2 + " " + result.Item3);
-                    var output = result.Item2;
+                    Assert.True(0 == result.ExitCode, result.Output + " " + result.Errors);
+                    var output = result.Output;
                     Assert.Contains("Your package was pushed.", output);
                     AssertFileEqual(packageFileName, outputFileName);
                 }
@@ -1842,15 +1842,15 @@ namespace NuGet.CommandLine.Test
 
                 // Assert
                 Assert.True(
-                    result.Item1 != 0,
-                    "The run did not fail as desired. Simply got this output:" + result.Item2);
+                    result.ExitCode != 0,
+                    "The run did not fail as desired. Simply got this output:" + result.Output);
 
                 Assert.True(
-                    result.Item3.Contains(
+                    result.Errors.Contains(
                         string.Format(
                             "The specified source '{0}' is invalid. Provide a valid source.",
                             invalidInput)),
-                    "Expected error message not found in " + result.Item3
+                    "Expected error message not found in " + result.Errors
                     );
             }
         }
@@ -1886,23 +1886,23 @@ namespace NuGet.CommandLine.Test
 
                 // Assert
                 Assert.True(
-                    result.Item1 != 0,
-                    "The run did not fail as desired. Simply got this output:" + result.Item2);
+                    result.ExitCode != 0,
+                    "The run did not fail as desired. Simply got this output:" + result.Output);
 
                 if (RuntimeEnvironmentHelper.IsMono)
                 {
                     Assert.True(
-                        result.Item3.Contains(
+                        result.Errors.Contains(
                         "No such host is known"),
-                        "Expected error message not found in " + result.Item3
+                        "Expected error message not found in " + result.Errors
                     );
                 }
                 else
                 {
                     Assert.True(
-                        result.Item3.Contains(
+                        result.Errors.Contains(
                             "The remote name could not be resolved: 'invalid-2a0358f1-88f2-48c0-b68a-bb150cac00bd.org'"),
-                        "Expected error message not found in " + result.Item3
+                        "Expected error message not found in " + result.Errors
                     );
                 }
 
@@ -1936,10 +1936,10 @@ namespace NuGet.CommandLine.Test
 
                 // Assert
                 Assert.True(
-                    result.Item1 != 0,
-                    "The run did not fail as desired. Simply got this output:" + result.Item2);
+                    result.ExitCode != 0,
+                    "The run did not fail as desired. Simply got this output:" + result.Output);
 
-                Assert.Contains("Response status code does not indicate success: 404 (Not Found)", result.Item3);
+                Assert.Contains("Response status code does not indicate success: 404 (Not Found)", result.Errors);
 
             }
         }
@@ -1975,16 +1975,16 @@ namespace NuGet.CommandLine.Test
                 if (RuntimeEnvironmentHelper.IsMono)
                 {
                     Assert.True(
-                   result.Item3.Contains(
+                   result.Errors.Contains(
                        "No such host is known"),
-                   "Expected error message not found in " + result.Item3
+                   "Expected error message not found in " + result.Errors
                    );
                 }
                 else
                 {
                     Assert.True(
-                        result.Item3.Contains("An error occurred while sending the request."),
-                        "Expected error message not found in " + result.Item3
+                        result.Errors.Contains("An error occurred while sending the request."),
+                        "Expected error message not found in " + result.Errors
                         );
                 }
             }
@@ -2112,11 +2112,11 @@ namespace NuGet.CommandLine.Test
 
             // Assert
             result.Success.Should().BeTrue(because: result.AllOutput);
-            Assert.Contains($"Pushing testPackage1.1.1.0.nupkg to '{pushUri}'", result.Item2);
-            Assert.Contains($"Created {pushUri}", result.Item2);
-            Assert.Contains($"Pushing testPackage1.1.1.0.symbols.nupkg to '{pushSymbolsUri}'", result.Item2);
-            Assert.Contains($"Created {pushSymbolsUri}", result.Item2);
-            Assert.Contains("Your package was pushed.", result.Item2);
+            Assert.Contains($"Pushing testPackage1.1.1.0.nupkg to '{pushUri}'", result.Output);
+            Assert.Contains($"Created {pushUri}", result.Output);
+            Assert.Contains($"Pushing testPackage1.1.1.0.symbols.nupkg to '{pushSymbolsUri}'", result.Output);
+            Assert.Contains($"Created {pushSymbolsUri}", result.Output);
+            Assert.Contains("Your package was pushed.", result.Output);
             Assert.Contains($"WARNING: You are running the 'push' operation with an 'http' source, '{pushUri}/'", result.AllOutput);
             Assert.Contains($"WARNING: You are running the 'push' operation with an 'http' source, '{pushSymbolsUri}/'", result.AllOutput);
         }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
@@ -56,9 +56,9 @@ namespace NuGet.CommandLine.Test
                     waitForExit: true);
 
                 // Assert
-                Assert.NotEqual(_successCode, r.Item1);
-                var error = r.Item3;
-                Assert.Contains("Input file does not exist: bad/pat.h/myfile.blah", r.Item3, StringComparison.OrdinalIgnoreCase);
+                Assert.NotEqual(_successCode, r.ExitCode);
+                var error = r.Errors;
+                Assert.Contains("Input file does not exist: bad/pat.h/myfile.blah", r.Errors, StringComparison.OrdinalIgnoreCase);
             }
         }
 
@@ -87,9 +87,9 @@ namespace NuGet.CommandLine.Test
                     waitForExit: true);
 
                 // Assert
-                Assert.NotEqual(_successCode, r.Item1);
-                var error = r.Item3;
-                Assert.Contains("Input file does not exist:", r.Item3, StringComparison.OrdinalIgnoreCase);
+                Assert.NotEqual(_successCode, r.ExitCode);
+                var error = r.Errors;
+                Assert.Contains("Input file does not exist:", r.Errors, StringComparison.OrdinalIgnoreCase);
             }
         }
 
@@ -120,9 +120,9 @@ namespace NuGet.CommandLine.Test
                     waitForExit: true);
 
                 // Assert
-                Assert.NotEqual(_successCode, r.Item1);
-                var error = r.Item3;
-                Assert.Contains("Input file does not exist:", r.Item3, StringComparison.OrdinalIgnoreCase);
+                Assert.NotEqual(_successCode, r.ExitCode);
+                var error = r.Errors;
+                Assert.Contains("Input file does not exist:", r.Errors, StringComparison.OrdinalIgnoreCase);
             }
         }
 
@@ -151,9 +151,9 @@ namespace NuGet.CommandLine.Test
                     waitForExit: true);
 
                 // Assert
-                Assert.NotEqual(_successCode, r.Item1);
-                var error = r.Item3;
-                Assert.Contains("input file does not exist", r.Item3, StringComparison.OrdinalIgnoreCase);
+                Assert.NotEqual(_successCode, r.ExitCode);
+                var error = r.Errors;
+                Assert.Contains("input file does not exist", r.Errors, StringComparison.OrdinalIgnoreCase);
             }
         }
 
@@ -186,7 +186,7 @@ namespace NuGet.CommandLine.Test
                     waitForExit: true);
 
                 // Assert
-                Assert.Equal(_successCode, r.Item1);
+                Assert.Equal(_successCode, r.ExitCode);
                 var packageFileA = Path.Combine(workingPath, @"outputDir", "packageA.1.1.0", "packageA.1.1.0.nupkg");
                 var packageFileB = Path.Combine(workingPath, @"outputDir", "packageB.2.2.0", "packageB.2.2.0.nupkg");
                 Assert.True(File.Exists(packageFileA));
@@ -224,7 +224,7 @@ namespace NuGet.CommandLine.Test
                 // Assert
                 var packageFileA = Path.Combine(workingPath, @"outputDir", "a.1.1.0", "a.1.1.0.nupkg");
                 Assert.False(File.Exists(packageFileA));
-                Assert.Equal(_failureCode, r.Item1);
+                Assert.Equal(_failureCode, r.ExitCode);
                 Assert.Contains("The package is missing the required nuspec file.", r.AllOutput);
             }
         }
@@ -287,11 +287,11 @@ namespace NuGet.CommandLine.Test
                         waitForExit: true);
 
                     // Assert
-                    Assert.True(result.Item3 == string.Empty, $"There should not be any STDERR:{Environment.NewLine}{result.Item3}");
-                    Assert.True(result.Item2 != string.Empty, $"There should be some STDOUT.");
-                    Assert.DoesNotContain("cancel", result.Item2, StringComparison.OrdinalIgnoreCase);
-                    Assert.DoesNotContain("not found", result.Item2, StringComparison.OrdinalIgnoreCase);
-                    Assert.Equal(_successCode, result.Item1);
+                    Assert.True(result.Errors == string.Empty, $"There should not be any STDERR:{Environment.NewLine}{result.Errors}");
+                    Assert.True(result.Output != string.Empty, $"There should be some STDOUT.");
+                    Assert.DoesNotContain("cancel", result.Output, StringComparison.OrdinalIgnoreCase);
+                    Assert.DoesNotContain("not found", result.Output, StringComparison.OrdinalIgnoreCase);
+                    Assert.Equal(_successCode, result.ExitCode);
                     Assert.True(File.Exists(Path.Combine(packagesPath, @"PackageA.1.1.0", "PackageA.1.1.0.nupkg")));
                 }
             }
@@ -319,7 +319,7 @@ namespace NuGet.CommandLine.Test
                     waitForExit: true);
 
                 // Assert
-                Assert.True(_successCode == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(_successCode == r.ExitCode, r.Output + " " + r.Errors);
                 var packageFileA = Path.Combine(pathContext.PackagesV2, "packageA.1.1.0", "packageA.1.1.0.nupkg");
                 var packageFileB = Path.Combine(pathContext.PackagesV2, "packageB.2.2.0", "packageB.2.2.0.nupkg");
                 Assert.True(File.Exists(packageFileA));
@@ -385,7 +385,7 @@ namespace NuGet.CommandLine.Test
                     waitForExit: true);
 
                 // Assert
-                Assert.Equal(_successCode, r.Item1);
+                Assert.Equal(_successCode, r.ExitCode);
                 var packageFileA = Path.Combine(pathContext.PackagesV2, "packageA.1.1.0", "packageA.1.1.0.nupkg");
                 var packageFileB = Path.Combine(pathContext.PackagesV2, "packageB.2.2.0", "packageB.2.2.0.nupkg");
                 Assert.True(File.Exists(packageFileA));
@@ -419,8 +419,8 @@ Microsoft Visual Studio Solution File, Format Version 12.00
                     waitForExit: true);
 
                 // Assert
-                Assert.True(string.IsNullOrEmpty(r.Item3)); // No error
-                Assert.Contains("Nothing to do", r.Item2); // Informative message
+                Assert.True(string.IsNullOrEmpty(r.Errors)); // No error
+                Assert.Contains("Nothing to do", r.Output); // Informative message
             }
         }
 
@@ -448,16 +448,16 @@ Microsoft Visual Studio Solution File, Format Version 12.00
                     waitForExit: true);
 
                 // Assert
-                Assert.True(_successCode == r.Item1, r.Item2 + "" + r.Item3);
-                Assert.True(string.IsNullOrEmpty(r.Item3)); // No error
+                Assert.True(_successCode == r.ExitCode, r.Output + "" + r.Errors);
+                Assert.True(string.IsNullOrEmpty(r.Errors)); // No error
 
                 if (string.IsNullOrEmpty(proj1ConfigFileName) && string.IsNullOrEmpty(proj2ConfigFileName))
                 {
-                    Assert.Contains("Nothing to do", r.Item2); // Informative message
+                    Assert.Contains("Nothing to do", r.Output); // Informative message
                 }
                 else
                 {
-                    Assert.DoesNotContain("Nothing to do", r.Item2);
+                    Assert.DoesNotContain("Nothing to do", r.Output);
                 }
             }
 
@@ -483,7 +483,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
                     waitForExit: true);
 
                 // Assert
-                Assert.True(_successCode == r.Item1, $"Expected: {_successCode} - Actual: {r.Item1}{Environment.NewLine} {r.AllOutput}");
+                Assert.True(_successCode == r.ExitCode, $"Expected: {_successCode} - Actual: {r.ExitCode}{Environment.NewLine} {r.AllOutput}");
                 var packageFileA = Path.Combine(workingPath, @"packages", "packageA.1.1.0", "packageA.1.1.0.nupkg");
                 var packageFileB = Path.Combine(workingPath, @"packages", "packageB.2.2.0", "packageB.2.2.0.nupkg");
                 Assert.True(File.Exists(packageFileA));
@@ -517,8 +517,8 @@ Microsoft Visual Studio Solution File, Format Version 12.00
                     waitForExit: true);
 
                 // Assert
-                Assert.True(_successCode == r.Item1, r.Item2);
-                Assert.True(r.Item2.Contains($"Using Msbuild from '{msbuildPath}'."));
+                Assert.True(_successCode == r.ExitCode, r.Output);
+                Assert.True(r.Output.Contains($"Using Msbuild from '{msbuildPath}'."));
                 var packageFileA = Path.Combine(pathContext.PackagesV2, "packageA.1.1.0", "packageA.1.1.0.nupkg");
                 var packageFileB = Path.Combine(pathContext.PackagesV2, "packageB.2.2.0", "packageB.2.2.0.nupkg");
                 Assert.True(File.Exists(packageFileA));
@@ -545,8 +545,8 @@ Microsoft Visual Studio Solution File, Format Version 12.00
                     waitForExit: true);
 
                 // Assert
-                Assert.True(_failureCode == r.Item1, r.Item2 + " " + r.Item3);
-                Assert.True(r.Item3.Contains($"MSBuildPath : {msbuildPath}  doesn't not exist."));
+                Assert.True(_failureCode == r.ExitCode, r.Output + " " + r.Errors);
+                Assert.True(r.Errors.Contains($"MSBuildPath : {msbuildPath}  doesn't not exist."));
             }
         }
 
@@ -575,9 +575,9 @@ Microsoft Visual Studio Solution File, Format Version 12.00
                     waitForExit: true);
 
                 // Assert
-                Assert.Equal(_successCode, r.Item1);
-                Assert.True(r.Item2.Contains($"Using Msbuild from '{msbuildPath}'."));
-                Assert.True(r.Item2.Contains($"MsbuildPath : {msbuildPath} is using, ignore MsBuildVersion: 12."));
+                Assert.Equal(_successCode, r.ExitCode);
+                Assert.True(r.Output.Contains($"Using Msbuild from '{msbuildPath}'."));
+                Assert.True(r.Output.Contains($"MsbuildPath : {msbuildPath} is using, ignore MsBuildVersion: 12."));
 
                 var packageFileA = Path.Combine(workingPath, @"packages", "packageA.1.1.0", "packageA.1.1.0.nupkg");
                 var packageFileB = Path.Combine(workingPath, @"packages", "packageB.2.2.0", "packageB.2.2.0.nupkg");
@@ -639,7 +639,7 @@ EndProject");
                     waitForExit: true);
 
                 // Assert
-                Assert.Equal(_successCode, r.Item1);
+                Assert.Equal(_successCode, r.ExitCode);
                 var packageFileA = Path.Combine(pathContext.PackagesV2, "packageA.1.1.0", "packageA.1.1.0.nupkg");
                 Assert.True(File.Exists(packageFileA));
             }
@@ -678,7 +678,7 @@ EndProject");
                     waitForExit: true);
 
                 // Assert
-                Assert.True(_successCode == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(_successCode == r.ExitCode, r.Output + " " + r.Errors);
                 var packageFileA = Path.Combine(pathContext.PackagesV2, "packageA.1.1.0", "packageA.1.1.0.nupkg");
                 var packageFileB = Path.Combine(pathContext.PackagesV2, "packageB.2.2.0", "packageB.2.2.0.nupkg");
                 Assert.True(File.Exists(packageFileA));
@@ -716,12 +716,12 @@ EndProject");
                     waitForExit: true);
 
                 // Assert
-                Assert.Equal(_successCode, r.Item1);
+                Assert.Equal(_successCode, r.ExitCode);
                 string optOutMessage = string.Format(
                     CultureInfo.CurrentCulture,
                     NuGetResources.RestoreCommandPackageRestoreOptOutMessage,
                     NuGetResources.PackageRestoreConsentCheckBoxText.Replace("&", ""));
-                Assert.Contains(optOutMessage.Replace("\r\n", "\n"), r.Item2.Replace("\r\n", "\n"));
+                Assert.Contains(optOutMessage.Replace("\r\n", "\n"), r.Output.Replace("\r\n", "\n"));
                 var packageFileA = Path.Combine(workingPath, @"packages", "packageA.1.1.0", "packageA.1.1.0.nupkg");
                 var packageFileB = Path.Combine(workingPath, @"packages", "packageB.2.2.0", "packageB.2.2.0.nupkg");
                 Assert.True(File.Exists(packageFileA));
@@ -756,12 +756,12 @@ EndProject");
                     waitForExit: true);
 
                 // Assert
-                Assert.Equal(_successCode, r.Item1);
+                Assert.Equal(_successCode, r.ExitCode);
                 string optOutMessage = string.Format(
                     CultureInfo.CurrentCulture,
                     NuGetResources.RestoreCommandPackageRestoreOptOutMessage,
                     NuGetResources.PackageRestoreConsentCheckBoxText.Replace("&", ""));
-                Assert.DoesNotContain(optOutMessage, r.Item2);
+                Assert.DoesNotContain(optOutMessage, r.Output);
                 var packageFileA = Path.Combine(workingPath, @"packages", "packageA.1.1.0", "packageA.1.1.0.nupkg");
                 var packageFileB = Path.Combine(workingPath, @"packages", "packageB.2.2.0", "packageB.2.2.0.nupkg");
                 Assert.True(File.Exists(packageFileA));
@@ -794,7 +794,7 @@ EndProject");
                     waitForExit: true);
 
                 // Assert
-                Assert.Equal(_successCode, r.Item1);
+                Assert.Equal(_successCode, r.ExitCode);
                 var packageFileA = Path.Combine(pathContext.PackagesV2, "packageA.1.1.0", "packageA.1.1.0.nupkg");
                 var packageFileB = Path.Combine(pathContext.PackagesV2, "packageB.2.2.0", "packageB.2.2.0.nupkg");
                 Assert.True(File.Exists(packageFileA));
@@ -883,8 +883,8 @@ EndProject");
                     waitForExit: true);
 
                 // Assert
-                Assert.Equal(_failureCode, r.Item1);
-                Assert.Contains("This folder contains more than one solution file.", r.Item3);
+                Assert.Equal(_failureCode, r.ExitCode);
+                Assert.Contains("This folder contains more than one solution file.", r.Errors);
                 var packageFileA = Path.Combine(workingPath, @"packages", "packageA.1.1.0", "packageA.1.1.0.nupkg");
                 var packageFileB = Path.Combine(workingPath, @"packages", "packageB.2.2.0", "packageB.2.2.0.nupkg");
                 Assert.False(File.Exists(packageFileA));
@@ -956,8 +956,8 @@ EndProject");
                     waitForExit: true);
 
                 // Assert
-                Assert.Equal(_failureCode, r.Item1);
-                Assert.Contains("does not contain an msbuild solution", r.Item3);
+                Assert.Equal(_failureCode, r.ExitCode);
+                Assert.Contains("does not contain an msbuild solution", r.Errors);
                 var packageFileA = Path.Combine(workingPath, @"packages", "packageA.1.1.0", "packageA.1.1.0.nupkg");
                 var packageFileB = Path.Combine(workingPath, @"packages", "packageB.2.2.0", "packageB.2.2.0.nupkg");
                 Assert.False(File.Exists(packageFileA));
@@ -1024,7 +1024,7 @@ EndProject");
                     waitForExit: true);
 
                 // Assert
-                Assert.Equal(_successCode, r.Item1);
+                Assert.Equal(_successCode, r.ExitCode);
                 var packageFileA = Path.Combine(workingPath, @"packages", "packageA.1.1.0", "packageA.1.1.0.nupkg");
                 Assert.True(File.Exists(packageFileA));
             }
@@ -1113,7 +1113,7 @@ EndProject");
                     "restore -Source " + repositoryPath + packageSaveMode1,
                     waitForExit: true);
 
-                Assert.Equal(_successCode, r1.Item1);
+                Assert.Equal(_successCode, r1.ExitCode);
                 Assert.Equal(expectedPackageFileAExists, File.Exists(packageFileA));
                 Assert.Equal(expectedNuspecFileAExists, File.Exists(nuspecFileA));
                 Assert.Equal(expectedContentAExists, File.Exists(contentFileA));
@@ -1147,7 +1147,7 @@ EndProject");
                     "restore -Source " + repositoryPath + packageSaveMode2,
                     waitForExit: true);
 
-                Assert.Equal(_successCode, r2.Item1);
+                Assert.Equal(_successCode, r2.ExitCode);
                 Assert.Equal(expectedPackageFileAExists, File.Exists(packageFileA));
                 Assert.Equal(expectedNuspecFileAExists, File.Exists(nuspecFileA));
                 Assert.Equal(expectedContentAExists, File.Exists(contentFileA));
@@ -1291,7 +1291,7 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
                     waitForExit: true);
 
                 // Assert
-                Assert.True(_successCode == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(_successCode == r.ExitCode, r.Output + " " + r.Errors);
                 var packageFileA = Path.Combine(
                     nugetConfigDir,
                     @"..", "..", "GlobalPackages2", "packageA", "1.1.0", "packageA.1.1.0.nupkg");
@@ -1335,8 +1335,8 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
                     waitForExit: true);
 
                 // Assert
-                Assert.NotEqual(_successCode, r.Item1);
-                var error = r.Item3;
+                Assert.NotEqual(_successCode, r.ExitCode);
+                var error = r.Errors;
                 Assert.True(error.Contains("Error parsing packages.config file"));
             }
         }
@@ -1375,8 +1375,8 @@ EndProject";
                     waitForExit: true);
 
                 // Assert
-                Assert.NotEqual(_successCode, r.Item1);
-                var error = r.Item3;
+                Assert.NotEqual(_successCode, r.ExitCode);
+                var error = r.Errors;
                 Assert.True(error.Contains("Error parsing solution file"));
                 Assert.True(error.Contains("Error parsing a project section"));
             }
@@ -1415,10 +1415,10 @@ EndProject";
                     waitForExit: true,
                     environmentVariables: envVars);
 
-                var output = r.Item2 + " " + r.Item3;
+                var output = r.Output + " " + r.Errors;
 
                 // Assert
-                Assert.Equal(_failureCode, r.Item1);
+                Assert.Equal(_failureCode, r.ExitCode);
                 Assert.False(output.IndexOf("exception", StringComparison.OrdinalIgnoreCase) > -1);
                 Assert.False(output.IndexOf("exception", StringComparison.OrdinalIgnoreCase) > -1);
 
@@ -1554,7 +1554,7 @@ EndProject";
                     waitForExit: true);
 
                 // Assert
-                Assert.True(_successCode == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(_successCode == r.ExitCode, r.Output + " " + r.Errors);
                 var packageFileA = Path.Combine(randomSolutionFolder, @"packages", "packageA.1.1.0", "packageA.1.1.0.nupkg");
                 var packageFileB = Path.Combine(randomSolutionFolder, @"packages", "packageB.2.2.0", "packageB.2.2.0.nupkg");
                 Assert.True(File.Exists(packageFileA));
@@ -1627,7 +1627,7 @@ EndProject";
                     waitForExit: true);
 
                 // Assert
-                Assert.True(_successCode == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(_successCode == r.ExitCode, r.Output + " " + r.Errors);
                 var packageFileA = Path.Combine(randomSolutionFolder, @"packages", "packageA.1.1.0", "packageA.1.1.0.nupkg");
                 var packageFileB = Path.Combine(randomSolutionFolder, @"packages", "packageB.2.2.0", "packageB.2.2.0.nupkg");
                 Assert.True(File.Exists(packageFileA));
@@ -1700,7 +1700,7 @@ EndProject";
                     waitForExit: true);
 
                 // Assert
-                Assert.True(_successCode == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(_successCode == r.ExitCode, r.Output + " " + r.Errors);
                 var packageFileA = Path.Combine(randomSolutionFolder, @"packages", "packageA.1.1.0", "packageA.1.1.0.nupkg");
                 var packageFileB = Path.Combine(randomSolutionFolder, @"packages", "packageB.2.2.0", "packageB.2.2.0.nupkg");
                 Assert.True(File.Exists(packageFileA));
@@ -1783,7 +1783,7 @@ EndProject";
                     waitForExit: true);
 
                 // Assert
-                Assert.True(_successCode == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(_successCode == r.ExitCode, r.Output + " " + r.Errors);
 
                 Assert.True(File.Exists(Path.Combine(randomSolutionFolder,
                     @"packages", "packageA.1.0.0", "packageA.1.0.0.nupkg")));
@@ -1877,8 +1877,8 @@ EndProject";
                     waitForExit: true);
 
                 // Assert
-                Assert.False(_successCode == r.Item1, r.Item2 + " " + r.Item3);
-                Assert.Contains("There are duplicate packages: packageA.1.0.0, packageA.3.0.0", r.Item3);
+                Assert.False(_successCode == r.ExitCode, r.Output + " " + r.Errors);
+                Assert.Contains("There are duplicate packages: packageA.1.0.0, packageA.3.0.0", r.Errors);
             }
         }
 
@@ -1917,7 +1917,7 @@ EndProject";
                     waitForExit: true);
 
                 // Assert
-                Assert.Equal(_successCode, r.Item1);
+                Assert.Equal(_successCode, r.ExitCode);
                 var dllPath = Path.Combine(workingPath, "outputDir", "packageA.1.1.0", "lib", "net45", "A.dll");
                 var dllFileInfo = new FileInfo(dllPath);
                 Assert.True(File.Exists(dllFileInfo.FullName));
@@ -2026,7 +2026,7 @@ EndProject");
                     waitForExit: true);
 
                 // Assert
-                Assert.True(_successCode == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(_successCode == r.ExitCode, r.Output + " " + r.Errors);
                 var bProjectLockJsonFile = Path.Combine(basePath, "B", "project.lock.json");
                 Assert.True(File.Exists(bProjectLockJsonFile));
                 var bProjectLockJson = new LockFileFormat().Read(bProjectLockJsonFile);
@@ -2065,12 +2065,12 @@ EndProject");
                     waitForExit: true);
 
                 // Assert
-                Assert.Equal(_successCode, r.Item1);
+                Assert.Equal(_successCode, r.ExitCode);
                 var target = new PackagePathResolver(Path.Combine(workingPath, @"outputDir"), true);
                 var packageFilePath = target.GetInstalledPackageFilePath(identity);
 
                 Assert.True(File.Exists(packageFilePath));
-                Assert.Contains(" from source ", r.Item2); // source logging present in verbose log
+                Assert.Contains(" from source ", r.Output); // source logging present in verbose log
             }
         }
 
@@ -2099,15 +2099,15 @@ EndProject");
                     waitForExit: true);
 
                 // Assert
-                Assert.Equal(_successCode, r.Item1);
+                Assert.Equal(_successCode, r.ExitCode);
                 var target = new PackagePathResolver(Path.Combine(workingPath, @"outputDir"), true);
                 var packageFilePath = target.GetInstalledPackageFilePath(identity);
                 Assert.True(File.Exists(packageFilePath));
 
-                Assert.Contains(" from source ", r.Item2); // source logging present in verbose log
+                Assert.Contains(" from source ", r.Output); // source logging present in verbose log
 
                 // verify sorce logging reported the correct source
-                var match = Regex.Match(r.Item2, @" from source '(.*)'");
+                var match = Regex.Match(r.Output, @" from source '(.*)'");
                 Assert.True(match.Success);
                 Assert.Contains(source, match.Groups[1].Value);
             }
@@ -2147,14 +2147,14 @@ EndProject");
                     waitForExit: true);
 
                 // Assert
-                Assert.Equal(_successCode, r.Item1);
+                Assert.Equal(_successCode, r.ExitCode);
                 var target = new PackagePathResolver(Path.Combine(workingPath, @"outputDir"), true);
                 var packageFilePath = target.GetInstalledPackageFilePath(identity);
                 Assert.True(File.Exists(packageFilePath));
-                Assert.Contains(" from source ", r.Item2); // source logging present in verbose log
+                Assert.Contains(" from source ", r.Output); // source logging present in verbose log
 
                 //verify source logging reported the globalPackages folder
-                var match = Regex.Match(r.Item2, @" from source '(.*)'");
+                var match = Regex.Match(r.Output, @" from source '(.*)'");
                 Assert.True(match.Success);
                 Assert.Contains(globalPackagesFolder, match.Groups[1].Value);
             }
@@ -2222,7 +2222,7 @@ EndProject";
                     waitForExit: true);
 
                 // Assert
-                Assert.True(_successCode == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(_successCode == r.ExitCode, r.Output + " " + r.Errors);
                 var packageFileA = Path.Combine(pathContext.UserPackagesFolder, "packagea", "1.1.0", "packageA.1.1.0.nupkg");
                 Assert.True(File.Exists(packageFileA));
             }
@@ -2329,7 +2329,7 @@ EndProject";
                     waitForExit: true);
 
                 // Assert
-                Assert.Equal(_successCode, r.Item1);
+                Assert.Equal(_successCode, r.ExitCode);
                 var packageFileA = Path.Combine(pathContext.WorkingDirectory, @"outputDir", "packageA.1.0.0", "packageA.1.0.0.nupkg");
                 Assert.True(File.Exists(packageFileA));
             }
@@ -2794,7 +2794,7 @@ EndProject";
                 // Assert
                 Assert.Equal(_failureCode, r.ExitCode);
                 Assert.Contains("Package source mapping match not found for package ID 'My.MVC.ASP'", r.AllOutput);
-                Assert.Contains("Unable to find version '1.0.0' of package 'My.MVC.ASP'.", r.Item3);
+                Assert.Contains("Unable to find version '1.0.0' of package 'My.MVC.ASP'.", r.Errors);
             }
         }
 
@@ -3196,8 +3196,8 @@ EndProject";
             Assert.Contains($"Package source mapping matches found for package ID 'Contoso.MVC.ASP' are: 'SharedRepository'", r.Output);
             // Even though there is eligible source SharedRepository exist but only opensourceRepositoryPath passed as option it'll fail to restore.
             Assert.Equal(_failureCode, r.ExitCode);
-            Assert.Contains("Unable to find version '1.0.0' of package 'Contoso.Opensource'.", r.Item3);
-            Assert.Contains("Unable to find version '1.0.0' of package 'Contoso.MVC.ASP'.", r.Item3);
+            Assert.Contains("Unable to find version '1.0.0' of package 'Contoso.Opensource'.", r.Errors);
+            Assert.Contains("Unable to find version '1.0.0' of package 'Contoso.MVC.ASP'.", r.Errors);
         }
 
         [Fact]

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetSetApiKeyTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetSetApiKeyTests.cs
@@ -31,8 +31,8 @@ namespace NuGet.CommandLine.Test
                     waitForExit: true);
 
                 // Assert
-                Assert.True(0 == result.Item1, $"{result.Item2} {result.Item3}");
-                Assert.Contains($"The API Key '{testApiKey}' was saved for the NuGet gallery (https://www.nuget.org) and the symbol server (https://nuget.smbsrc.net/)", result.Item2);
+                Assert.True(0 == result.ExitCode, $"{result.Output} {result.Errors}");
+                Assert.Contains($"The API Key '{testApiKey}' was saved for the NuGet gallery (https://www.nuget.org) and the symbol server (https://nuget.smbsrc.net/)", result.Output);
 
                 var settings = Configuration.Settings.LoadDefaultSettings(
                     Path.GetDirectoryName(configFile),

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetSourcesCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetSourcesCommandTest.cs
@@ -37,7 +37,7 @@ namespace NuGet.CommandLine.Test
                 var result = CommandRunner.Run(nugetexe, workingPath, string.Join(" ", args), true);
 
                 // Assert
-                Assert.Equal(0, result.Item1);
+                Assert.Equal(0, result.ExitCode);
                 var loadedSettings = Configuration.Settings.LoadDefaultSettings(workingPath, null, null);
                 var packageSourcesSection = loadedSettings.GetSection("packageSources");
                 var sourceItem = packageSourcesSection?.GetFirstItemWithAttribute<SourceItem>("key", "test_source");
@@ -74,7 +74,7 @@ namespace NuGet.CommandLine.Test
                 var result = CommandRunner.Run(nugetexe, workingPath, string.Join(" ", args), true);
 
                 // Assert
-                Assert.True(0 == result.Item1, result.Item2 + " " + result.Item3);
+                Assert.True(0 == result.ExitCode, result.Output + " " + result.Errors);
 
                 var loadedSettings = Configuration.Settings.LoadDefaultSettings(workingPath, null, null);
 
@@ -123,7 +123,7 @@ namespace NuGet.CommandLine.Test
                 var result = CommandRunner.Run(nugetexe, workingPath, string.Join(" ", args), true);
 
                 // Assert
-                Assert.True(0 == result.Item1, result.Item2 + " " + result.Item3);
+                Assert.True(0 == result.ExitCode, result.Output + " " + result.Errors);
 
                 var loadedSettings = Configuration.Settings.LoadDefaultSettings(workingPath, null, null);
 
@@ -178,7 +178,7 @@ namespace NuGet.CommandLine.Test
                     true);
 
                 // Assert
-                Assert.Equal(0, result.Item1);
+                Assert.Equal(0, result.ExitCode);
 
                 var settings = Configuration.Settings.LoadDefaultSettings(
                     configFileDirectory,
@@ -428,7 +428,7 @@ namespace NuGet.CommandLine.Test
                 // Assert
                 Util.VerifyResultSuccess(result);
                 // Ensure that no messages are shown with Verbosity as Quiet
-                Assert.Equal(string.Empty, result.Item2);
+                Assert.Equal(string.Empty, result.Output);
                 var loadedSettings = Configuration.Settings.LoadDefaultSettings(workingPath, null, null);
                 var packageSourcesSection = loadedSettings.GetSection("packageSources");
                 var sourceItem = packageSourcesSection?.GetFirstItemWithAttribute<SourceItem>("key", "test_source");

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetSpecCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetSpecCommandTest.cs
@@ -34,7 +34,7 @@ namespace NuGet.CommandLine.Test
                     "spec",
                     waitForExit: true);
 
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 var nuspec = File.ReadAllText(Path.Combine(workingDirectory, "Package.nuspec"));
                 Assert.Equal($@"<?xml version=""1.0"" encoding=""utf-8""?>
@@ -74,7 +74,7 @@ namespace NuGet.CommandLine.Test
                     "spec Whatnot",
                     waitForExit: true);
 
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 var fileName = Path.Combine(workingDirectory, "Whatnot.nuspec");
                 Assert.True(File.Exists(fileName));
@@ -128,7 +128,7 @@ namespace NuGet.CommandLine.Test
                     "spec",
                     waitForExit: true);
 
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 var fileName = Path.Combine(workingDirectory, "Project.nuspec");
                 Assert.True(File.Exists(fileName));

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetUpdateCommandTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetUpdateCommandTests.cs
@@ -125,7 +125,7 @@ namespace NuGet.CommandLine.Test
                     string.Join(" ", args),
                     waitForExit: true);
 
-                Assert.True(r.Item1 == 0, "Output is " + r.Item2 + ". Error is " + r.Item3);
+                Assert.True(r.ExitCode == 0, "Output is " + r.Output + ". Error is " + r.Errors);
 
                 var content = File.ReadAllText(projectFile);
 
@@ -208,7 +208,7 @@ namespace NuGet.CommandLine.Test
                     string.Join(" ", args),
                     waitForExit: true);
 
-                Assert.True(r.Item1 == 0, "Output is " + r.Item2 + ". Error is " + r.Item3);
+                Assert.True(r.ExitCode == 0, "Output is " + r.Output + ". Error is " + r.Errors);
 
                 var content = File.ReadAllText(projectFile);
                 Assert.False(content.Contains(Util.GetHintPath(Path.Combine("packages", "A.1.0.0", "lib", "net45", "file.dll"))));
@@ -331,7 +331,7 @@ namespace NuGet.CommandLine.Test
                     string.Join(" ", args),
                     waitForExit: true);
 
-                Assert.True(r.Item1 == 0, "Output is " + r.Item2 + ". Error is " + r.Item3);
+                Assert.True(r.ExitCode == 0, "Output is " + r.Output + ". Error is " + r.Errors);
 
                 var content1 = File.ReadAllText(projectFile1);
                 Assert.False(content1.Contains(Util.GetHintPath(Path.Combine("packages", "A.1.0.0", "lib", "net45", "file.dll"))));
@@ -427,11 +427,11 @@ namespace NuGet.CommandLine.Test
                     waitForExit: true);
 
                 // Assert
-                Assert.True(r.Item1 == 0, "Output is " + r.Item2 + ". Error is " + r.Item3);
+                Assert.True(r.ExitCode == 0, "Output is " + r.Output + ". Error is " + r.Errors);
 
-                Assert.Contains("Scanning for projects...", r.Item2);
-                Assert.Contains($"WARNING: Found multiple project files for '{packagesConfigFile}'.", r.Item2);
-                Assert.Contains("No projects found with packages.config.", r.Item2);
+                Assert.Contains("Scanning for projects...", r.Output);
+                Assert.Contains($"WARNING: Found multiple project files for '{packagesConfigFile}'.", r.Output);
+                Assert.Contains("No projects found with packages.config.", r.Output);
 
                 var content1 = File.ReadAllText(projectFile1);
                 Assert.True(content1.Contains(Util.GetHintPath(Path.Combine("packages", "A.1.0.0", "lib", "net45", "file.dll"))));
@@ -514,7 +514,7 @@ namespace NuGet.CommandLine.Test
                     string.Join(" ", args),
                     waitForExit: true);
 
-                Assert.True(r.Item1 == 0, "Output is " + r.Item2 + ". Error is " + r.Item3);
+                Assert.True(r.ExitCode == 0, "Output is " + r.Output + ". Error is " + r.Errors);
 
                 var content = File.ReadAllText(projectFile);
                 Assert.False(content.Contains(Util.GetHintPath(Path.Combine("packages", "A.2.0.0-beta", "lib", "net45", "file.dll"))));
@@ -596,7 +596,7 @@ namespace NuGet.CommandLine.Test
                     string.Join(" ", args),
                     waitForExit: true);
 
-                Assert.True(r.Item1 == 0, "Output is " + r.Item2 + ". Error is " + r.Item3);
+                Assert.True(r.ExitCode == 0, "Output is " + r.Output + ". Error is " + r.Errors);
 
                 var content = File.ReadAllText(projectFile);
                 Assert.False(content.Contains(Util.GetHintPath(Path.Combine("packages", "A.1.0.0", "lib", "net45", "file.dll"))));
@@ -685,7 +685,7 @@ namespace NuGet.CommandLine.Test
                     string.Join(" ", args),
                     waitForExit: true);
 
-                Assert.True(r.Item1 == 0, "Output is " + r.Item2 + ". Error is " + r.Item3);
+                Assert.True(r.ExitCode == 0, "Output is " + r.Output + ". Error is " + r.Errors);
 
                 var content = File.ReadAllText(projectFile);
                 Assert.False(content.Contains(Util.GetHintPath(Path.Combine("packages", "A." + oldVersion.ToString(), "lib", "net45", "file.dll"))));
@@ -778,7 +778,7 @@ namespace NuGet.CommandLine.Test
                     string.Join(" ", args),
                     waitForExit: true);
 
-                Assert.True(r.Item1 == 0, "Output is " + r.Item2 + ". Error is " + r.Item3);
+                Assert.True(r.ExitCode == 0, "Output is " + r.Output + ". Error is " + r.Errors);
 
                 var content = File.ReadAllText(projectFile);
                 Assert.False(content.Contains(Util.GetHintPath(Path.Combine("packages", "A.1.0.0", "lib", "net45", "file.dll"))));
@@ -871,7 +871,7 @@ namespace NuGet.CommandLine.Test
                     string.Join(" ", args),
                     waitForExit: true);
 
-                Assert.True(r.Item1 == 0, "Output is " + r.Item2 + ". Error is " + r.Item3);
+                Assert.True(r.ExitCode == 0, "Output is " + r.Output + ". Error is " + r.Errors);
 
                 var content = File.ReadAllText(projectFile);
                 Assert.True(content.Contains(Util.GetHintPath(Path.Combine("packages", "A.1.0.0", "lib", "net45", "file.dll"))));
@@ -954,7 +954,7 @@ namespace NuGet.CommandLine.Test
                     string.Join(" ", args),
                     waitForExit: true);
 
-                Assert.True(r.Item1 == 0, "Output is " + r.Item2 + ". Error is " + r.Item3);
+                Assert.True(r.ExitCode == 0, "Output is " + r.Output + ". Error is " + r.Errors);
 
                 var content = File.ReadAllText(projectFile);
                 Assert.False(content.Contains(Util.GetHintPath(Path.Combine("packages", "A.1.0.0", "lib", "net45", "file.dll"))));
@@ -1037,8 +1037,8 @@ namespace NuGet.CommandLine.Test
                     string.Join(" ", args),
                     waitForExit: true);
 
-                Assert.True(r.Item1 == 0, "Output is " + r.Item2 + ". Error is " + r.Item3);
-                System.Console.WriteLine(r.Item2);
+                Assert.True(r.ExitCode == 0, "Output is " + r.Output + ". Error is " + r.Errors);
+                System.Console.WriteLine(r.Output);
 
                 var content = File.ReadAllText(projectFile);
                 Assert.False(content.Contains(Util.GetHintPath(Path.Combine("packages", "A.1.0.0", "lib", "net45", "file.dll"))));
@@ -1148,7 +1148,7 @@ namespace NuGet.CommandLine.Test
                     waitForExit: true);
 
                 // Assert
-                Assert.True(r.Item1 == 0, "Output is " + r.Item2 + ". Error is " + r.Item3);
+                Assert.True(r.ExitCode == 0, "Output is " + r.Output + ". Error is " + r.Errors);
                 Assert.False(File.Exists(test1textPath), "Content file test1.txt should not exist but does.");
                 Assert.True(File.Exists(test2textPath), "Content file test2.txt should exist but does not.");
 
@@ -1245,7 +1245,7 @@ namespace NuGet.CommandLine.Test
                     waitForExit: true);
 
                 // Should be no errors returned - used to fail as update command assumed folder was <solutiondir>\packages.
-                Assert.Empty(r.Item3);
+                Assert.Empty(r.Errors);
 
                 // Check that the new version is installed into the custom folder
                 Assert.True(Directory.Exists(Path.Combine(packagesDirectory, "A.2.0.0")));
@@ -1432,7 +1432,7 @@ namespace NuGet.CommandLine.Test
                     waitForExit: true);
 
                 // Should be no errors returned - used to fail as update command assumed folder was <solutiondir>\packages.
-                Assert.Empty(r.Item3);
+                Assert.Empty(r.Errors);
 
                 // Check that the new version is installed into the custom folder
                 Assert.True(Directory.Exists(Path.Combine(packagesDirectory, "A.2.0.0")));
@@ -1560,7 +1560,7 @@ namespace NuGet.CommandLine.Test
                     string.Join(" ", args),
                     waitForExit: true);
 
-                Assert.True(r.Item1 == 0, "Output is " + r.Item2 + ". Error is " + r.Item3);
+                Assert.True(r.ExitCode == 0, "Output is " + r.Output + ". Error is " + r.Errors);
             }
         }
 
@@ -1654,10 +1654,10 @@ namespace NuGet.CommandLine.Test
                     waitForExit: true);
 
                 //Assert
-                Assert.True(commandRunResult.Item1 == 0, "Output is " + commandRunResult.Item2 + ". Error is " + commandRunResult.Item3);
+                Assert.True(commandRunResult.ExitCode == 0, "Output is " + commandRunResult.Output + ". Error is " + commandRunResult.Errors);
                 var content = File.ReadAllText(projectFile);
                 // Assert no error
-                Assert.Equal(0, commandRunResult.Item1);
+                Assert.Equal(0, commandRunResult.ExitCode);
                 Assert.True(content.Contains(Util.GetHintPath(Path.Combine("packages", "dep." + expectedVersion, "lib", "net45", "file.dll"))));
             }
         }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetVerifyCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetVerifyCommandTest.cs
@@ -32,8 +32,8 @@ namespace NuGet.CommandLine.Test
                     true);
 
                 // Assert
-                Assert.Equal(_failureCode, result.Item1);
-                Assert.Contains("Verification type not supported.", result.Item3);
+                Assert.Equal(_failureCode, result.ExitCode);
+                Assert.Contains("Verification type not supported.", result.Errors);
             }
         }
 
@@ -61,8 +61,8 @@ namespace NuGet.CommandLine.Test
                 }
                 else
                 {
-                    Assert.Equal(_failureCode, result.Item1);
-                    Assert.Contains("File does not exist", result.Item3);
+                    Assert.Equal(_failureCode, result.ExitCode);
+                    Assert.Contains("File does not exist", result.Errors);
                 }
             }
         }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/ProjectFactoryTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/ProjectFactoryTest.cs
@@ -482,7 +482,7 @@ namespace NuGet.CommandLine
                 {
                     var files = (await package.GetPackageFilesAsync(PackageSaveMode.Files, CancellationToken.None)).ToArray();
 
-                    Assert.Equal(0, r.Item1);
+                    Assert.Equal(0, r.ExitCode);
                     Array.Sort(files);
                     Assert.Equal(
                         files,
@@ -526,7 +526,7 @@ namespace NuGet.CommandLine
                 {
                     var files = (await package.GetPackageFilesAsync(PackageSaveMode.Files, CancellationToken.None)).ToArray();
 
-                    Assert.Equal(0, r.Item1);
+                    Assert.Equal(0, r.ExitCode);
                     Array.Sort(files);
                     Assert.Equal(
                         files,
@@ -580,7 +580,7 @@ namespace NuGet.CommandLine
                 {
                     var files = (await package.GetPackageFilesAsync(PackageSaveMode.Files, CancellationToken.None)).ToArray();
 
-                    Assert.Equal(0, r.Item1);
+                    Assert.Equal(0, r.ExitCode);
                     Array.Sort(files);
                     Assert.Equal(
                         files,

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreMessageTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreMessageTest.cs
@@ -53,7 +53,7 @@ namespace NuGet.CommandLine.Test
 
                 // Act
                 var r = Util.Restore(pathContext, projectA.ProjectPath);
-                var output = r.Item2 + " " + r.Item3;
+                var output = r.Output + " " + r.Errors;
                 var reader = new LockFileFormat();
                 var lockFileObj = reader.Read(projectA.AssetsFileOutputPath);
 
@@ -93,7 +93,7 @@ namespace NuGet.CommandLine.Test
 
                 // Act
                 var r = Util.Restore(pathContext, projectA.ProjectPath);
-                var output = r.Item2 + " " + r.Item3;
+                var output = r.Output + " " + r.Errors;
                 var reader = new LockFileFormat();
                 var lockFileObj = reader.Read(projectA.AssetsFileOutputPath);
 
@@ -132,7 +132,7 @@ namespace NuGet.CommandLine.Test
 
                 // Act
                 var r = Util.Restore(pathContext, projectA.ProjectPath, expectedExitCode: 1);
-                var output = r.Item2 + " " + r.Item3;
+                var output = r.Output + " " + r.Errors;
                 var reader = new LockFileFormat();
                 var lockFileObj = reader.Read(projectA.AssetsFileOutputPath);
 
@@ -176,7 +176,7 @@ namespace NuGet.CommandLine.Test
 
                 // Act
                 var r = Util.Restore(pathContext, projectA.ProjectPath, expectedExitCode: 1);
-                var output = r.Item2 + " " + r.Item3;
+                var output = r.Output + " " + r.Errors;
 
                 // Assert
                 Assert.Contains("NU1401", output, StringComparison.OrdinalIgnoreCase);

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
@@ -467,15 +467,15 @@ namespace NuGet.CommandLine.Test
                 var r1 = Util.RestoreSolution(pathContext);
 
                 //Assert.
-                Assert.Equal(0, r1.Item1);
-                Assert.Contains("Writing cache file", r1.Item2);
+                Assert.Equal(0, r1.ExitCode);
+                Assert.Contains("Writing cache file", r1.Output);
 
                 // Act
                 var r2 = Util.RestoreSolution(pathContext);
 
                 //Assert.
-                Assert.Equal(0, r2.Item1);
-                Assert.DoesNotContain("Writing cache file", r2.Item2);
+                Assert.Equal(0, r2.ExitCode);
+                Assert.DoesNotContain("Writing cache file", r2.Output);
 
                 // create a config file
                 var projectDir = Path.GetDirectoryName(projectA.ProjectPath);
@@ -510,8 +510,8 @@ namespace NuGet.CommandLine.Test
 
 
                 //Assert.
-                Assert.Equal(0, r3.Item1);
-                Assert.Contains("Writing cache file", r3.Item2);
+                Assert.Equal(0, r3.ExitCode);
+                Assert.Contains("Writing cache file", r3.Output);
             }
         }
 
@@ -548,15 +548,15 @@ namespace NuGet.CommandLine.Test
                 var r1 = Util.RestoreSolution(pathContext);
 
                 //Assert.
-                Assert.Equal(0, r1.Item1);
-                Assert.Contains("Writing cache file", r1.Item2);
+                Assert.Equal(0, r1.ExitCode);
+                Assert.Contains("Writing cache file", r1.Output);
 
                 // Act
                 var r2 = Util.RestoreSolution(pathContext);
 
                 //Assert.
-                Assert.Equal(0, r2.Item1);
-                Assert.DoesNotContain("Writing cache file", r2.Item2);
+                Assert.Equal(0, r2.ExitCode);
+                Assert.DoesNotContain("Writing cache file", r2.Output);
 
                 // create a config file
                 var projectDir = Path.GetDirectoryName(projectA.ProjectPath);
@@ -592,8 +592,8 @@ namespace NuGet.CommandLine.Test
 
 
                 //Assert.
-                Assert.Equal(0, r3.Item1);
-                Assert.Contains("Writing cache file", r3.Item2);
+                Assert.Equal(0, r3.ExitCode);
+                Assert.Contains("Writing cache file", r3.Output);
             }
         }
 
@@ -630,15 +630,15 @@ namespace NuGet.CommandLine.Test
                 var r1 = Util.RestoreSolution(pathContext);
 
                 //Assert.
-                Assert.Equal(0, r1.Item1);
-                Assert.Contains("Writing cache file", r1.Item2);
+                Assert.Equal(0, r1.ExitCode);
+                Assert.Contains("Writing cache file", r1.Output);
 
                 // Act
                 var r2 = Util.RestoreSolution(pathContext);
 
                 //Assert.
-                Assert.Equal(0, r2.Item1);
-                Assert.DoesNotContain("Writing cache file", r2.Item2);
+                Assert.Equal(0, r2.ExitCode);
+                Assert.DoesNotContain("Writing cache file", r2.Output);
 
                 // create a config file
                 var projectDir = Path.GetDirectoryName(projectA.ProjectPath);
@@ -671,8 +671,8 @@ namespace NuGet.CommandLine.Test
 
 
                 //Assert.
-                Assert.Equal(0, r3.Item1);
-                Assert.Contains("Writing cache file", r3.Item2);
+                Assert.Equal(0, r3.ExitCode);
+                Assert.Contains("Writing cache file", r3.Output);
             }
         }
 
@@ -895,7 +895,7 @@ namespace NuGet.CommandLine.Test
                     waitForExit: true);
 
                 // Assert
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
                 Assert.True(File.Exists(projectA.AssetsFileOutputPath));
@@ -958,7 +958,7 @@ namespace NuGet.CommandLine.Test
                     waitForExit: true);
 
                 // Assert
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert correct projects were restored.
                 Assert.True(File.Exists(projectA.AssetsFileOutputPath));
@@ -1008,9 +1008,9 @@ namespace NuGet.CommandLine.Test
                 var r = Util.RestoreSolution(pathContext);
 
                 // Assert
-                Assert.True(File.Exists(projectA.AssetsFileOutputPath), r.Item2);
-                Assert.True(File.Exists(projectA.TargetsOutput), r.Item2);
-                Assert.True(File.Exists(projectA.PropsOutput), r.Item2);
+                Assert.True(File.Exists(projectA.AssetsFileOutputPath), r.Output);
+                Assert.True(File.Exists(projectA.TargetsOutput), r.Output);
+                Assert.True(File.Exists(projectA.PropsOutput), r.Output);
 
                 var assetsFile = projectA.AssetsFile;
                 Assert.Equal(2, assetsFile.Targets.Count);
@@ -1058,10 +1058,10 @@ namespace NuGet.CommandLine.Test
 
                 // Act
                 var r = Util.RestoreSolution(pathContext, expectedExitCode: 1);
-                var output = r.Item2 + " " + r.Item3;
+                var output = r.Output + " " + r.Errors;
 
                 // Assert
-                Assert.True(r.Item1 == 1);
+                Assert.True(r.ExitCode == 1);
                 Assert.Contains("no run-time assembly compatible", output);
             }
         }
@@ -1105,8 +1105,8 @@ namespace NuGet.CommandLine.Test
                 var r = Util.RestoreSolution(pathContext);
 
                 // Assert
-                Assert.True(r.Item1 == 0);
-                Assert.DoesNotContain("no run-time assembly compatible", r.Item3);
+                Assert.True(r.ExitCode == 0);
+                Assert.DoesNotContain("no run-time assembly compatible", r.Errors);
             }
         }
 
@@ -1157,10 +1157,10 @@ namespace NuGet.CommandLine.Test
 
                 // Act
                 var r = Util.RestoreSolution(pathContext, expectedExitCode: 1);
-                var output = r.Item2 + " " + r.Item3;
+                var output = r.Output + " " + r.Errors;
 
                 // Assert
-                Assert.True(r.Item1 == 1);
+                Assert.True(r.ExitCode == 1);
                 Assert.Contains("no run-time assembly compatible", output);
             }
         }
@@ -1201,9 +1201,9 @@ namespace NuGet.CommandLine.Test
                 var r = Util.RestoreSolution(pathContext);
 
                 // Assert
-                Assert.True(File.Exists(projectA.AssetsFileOutputPath), r.Item2);
-                Assert.True(File.Exists(projectA.TargetsOutput), r.Item2);
-                Assert.True(File.Exists(projectA.PropsOutput), r.Item2);
+                Assert.True(File.Exists(projectA.AssetsFileOutputPath), r.Output);
+                Assert.True(File.Exists(projectA.TargetsOutput), r.Output);
+                Assert.True(File.Exists(projectA.PropsOutput), r.Output);
 
                 var assetsFile = projectA.AssetsFile;
                 Assert.Equal(2, assetsFile.Targets.Count);
@@ -1250,9 +1250,9 @@ namespace NuGet.CommandLine.Test
                 var r = Util.RestoreSolution(pathContext);
 
                 // Assert
-                Assert.True(File.Exists(projectA.AssetsFileOutputPath), r.Item2);
-                Assert.True(File.Exists(projectA.TargetsOutput), r.Item2);
-                Assert.True(File.Exists(projectA.PropsOutput), r.Item2);
+                Assert.True(File.Exists(projectA.AssetsFileOutputPath), r.Output);
+                Assert.True(File.Exists(projectA.TargetsOutput), r.Output);
+                Assert.True(File.Exists(projectA.PropsOutput), r.Output);
 
                 var assetsFile = projectA.AssetsFile;
                 Assert.Equal(2, assetsFile.Targets.Count);
@@ -1297,7 +1297,7 @@ namespace NuGet.CommandLine.Test
 
                 // Act
                 var r = Util.RestoreSolution(pathContext);
-                var output = r.Item2 + r.Item3;
+                var output = r.Output + r.Errors;
 
                 // Assert
                 Assert.True(File.Exists(projectA.AssetsFileOutputPath), output);
@@ -1341,9 +1341,9 @@ namespace NuGet.CommandLine.Test
                 var r = Util.RestoreSolution(pathContext);
 
                 // Assert
-                Assert.True(File.Exists(projectA.AssetsFileOutputPath), r.Item2);
-                Assert.True(File.Exists(projectA.TargetsOutput), r.Item2);
-                Assert.True(File.Exists(projectA.PropsOutput), r.Item2);
+                Assert.True(File.Exists(projectA.AssetsFileOutputPath), r.Output);
+                Assert.True(File.Exists(projectA.TargetsOutput), r.Output);
+                Assert.True(File.Exists(projectA.PropsOutput), r.Output);
 
                 var assetsFile = projectA.AssetsFile;
                 Assert.Equal(3, assetsFile.Targets.Count);
@@ -1420,7 +1420,7 @@ namespace NuGet.CommandLine.Test
 
                 // Assert
                 // Version should not be used
-                Assert.False(File.Exists(path), r.Item2);
+                Assert.False(File.Exists(path), r.Output);
 
                 // Each project should have its own tool verion
                 Assert.Equal(testCount, Directory.GetDirectories(zPath).Length);
@@ -1496,8 +1496,8 @@ namespace NuGet.CommandLine.Test
 
                 // Assert
                 // Version should not be used
-                Assert.False(File.Exists(path), r.Item2);
-                Assert.False(File.Exists(cacheFile), r.Item2);
+                Assert.False(File.Exists(path), r.Output);
+                Assert.False(File.Exists(cacheFile), r.Output);
 
                 // Each project should have its own tool verion
                 Assert.Equal(testCount, Directory.GetDirectories(zPath).Length);
@@ -1507,12 +1507,12 @@ namespace NuGet.CommandLine.Test
 
                 // Assert
                 // Version should not be used
-                Assert.False(File.Exists(path), r2.Item2);
-                Assert.False(File.Exists(cacheFile), r2.Item2);
-                Assert.DoesNotContain("NU1603", r2.Item2);
+                Assert.False(File.Exists(path), r2.Output);
+                Assert.False(File.Exists(cacheFile), r2.Output);
+                Assert.DoesNotContain("NU1603", r2.Output);
                 for (var i = 1; i <= testCount; i++)
                 {
-                    Assert.Contains($"The restore inputs for 'z-netcoreapp1.0-[{i}.0.0, )' have not changed. No further actions are required to complete the restore.", r2.Item2);
+                    Assert.Contains($"The restore inputs for 'z-netcoreapp1.0-[{i}.0.0, )' have not changed. No further actions are required to complete the restore.", r2.Output);
                 }
                 // Each project should have its own tool verion
                 Assert.Equal(testCount, Directory.GetDirectories(zPath).Length);
@@ -1562,16 +1562,16 @@ namespace NuGet.CommandLine.Test
                 var r = Util.RestoreSolution(pathContext);
 
                 // Assert
-                Assert.Equal(0, r.Item1);
-                Assert.Contains("Writing cache file", r.Item2);
+                Assert.Equal(0, r.ExitCode);
+                Assert.Contains("Writing cache file", r.Output);
 
                 //re-arrange again
                 project.AddPackageToAllFrameworks(packageZ);
                 project.Save();
 
                 //assert
-                Assert.Contains("Writing cache file", r.Item2);
-                Assert.Equal(0, r.Item1);
+                Assert.Contains("Writing cache file", r.Output);
+                Assert.Equal(0, r.ExitCode);
 
 
             }
@@ -1612,8 +1612,8 @@ namespace NuGet.CommandLine.Test
 
                 // Act
                 var r = Util.RestoreSolution(pathContext);
-                Assert.Equal(0, r.Item1);
-                Assert.True(File.Exists(project.PropsOutput), r.Item2);
+                Assert.Equal(0, r.ExitCode);
+                Assert.True(File.Exists(project.PropsOutput), r.Output);
                 var propsXML = XDocument.Parse(File.ReadAllText(project.PropsOutput));
 
                 var propsItemGroups = propsXML.Root.Elements().Where(e => e.Name.LocalName == "ItemGroup").ToList();
@@ -1666,8 +1666,8 @@ namespace NuGet.CommandLine.Test
                 var r = Util.RestoreSolution(pathContext);
 
                 // Assert
-                Assert.Equal(0, r.Item1);
-                Assert.Contains("Writing cache file", r.Item2);
+                Assert.Equal(0, r.ExitCode);
+                Assert.Contains("Writing cache file", r.Output);
 
                 // build project
                 var project2 = SimpleTestProjectContext.CreateNETCore(
@@ -1684,9 +1684,9 @@ namespace NuGet.CommandLine.Test
                 var r2 = Util.RestoreSolution(pathContext);
 
                 // Assert
-                Assert.Equal(0, r2.Item1);
-                Assert.Contains("Writing cache file", r2.Item2);
-                Assert.Contains("No further actions are required to complete", r2.Item2);
+                Assert.Equal(0, r2.ExitCode);
+                Assert.Contains("Writing cache file", r2.Output);
+                Assert.Contains("No further actions are required to complete", r2.Output);
 
             }
         }
@@ -1730,8 +1730,8 @@ namespace NuGet.CommandLine.Test
                 var r = Util.RestoreSolution(pathContext);
 
                 // Assert
-                Assert.Equal(0, r.Item1);
-                Assert.Contains("Writing cache file", r.Item2);
+                Assert.Equal(0, r.ExitCode);
+                Assert.Contains("Writing cache file", r.Output);
 
                 //Setup - remove the warnings and errors
                 project.WarningsAsErrors = false;
@@ -1741,8 +1741,8 @@ namespace NuGet.CommandLine.Test
                 var r2 = Util.RestoreSolution(pathContext);
 
                 // Assert
-                Assert.Equal(0, r2.Item1);
-                Assert.Contains("No further actions are required to complete", r2.Item2);
+                Assert.Equal(0, r2.ExitCode);
+                Assert.Contains("No further actions are required to complete", r2.Output);
             }
         }
 
@@ -1800,7 +1800,7 @@ namespace NuGet.CommandLine.Test
                 var r = Util.RestoreSolution(pathContext);
 
                 // Assert
-                Assert.True(File.Exists(path), r.Item2);
+                Assert.True(File.Exists(path), r.Output);
                 Assert.Equal(1, Directory.GetDirectories(zPath).Length);
             }
         }
@@ -1858,7 +1858,7 @@ namespace NuGet.CommandLine.Test
                 var r = Util.RestoreSolution(pathContext);
 
                 // Assert
-                Assert.True(File.Exists(path), r.Item2);
+                Assert.True(File.Exists(path), r.Output);
             }
         }
 
@@ -1937,7 +1937,7 @@ namespace NuGet.CommandLine.Test
                 Assert.True(File.Exists(cachePath));
                 // This is expected, because despite the fact that both projects resolve to the same tool, the version range they request is different so they will keep overwriting each other
                 // Basically, it is impossible for both tools to no-op.
-                Assert.Contains($"Writing tool assets file to disk", r2.Item2);
+                Assert.Contains($"Writing tool assets file to disk", r2.Output);
                 r = Util.RestoreSolution(pathContext);
 
             }
@@ -2019,7 +2019,7 @@ namespace NuGet.CommandLine.Test
 
                 // This is expected, because despite the fact that both projects resolve to the same tool, the version range they request is different so they will keep overwriting each other
                 // Basically, it is impossible for both tools to no-op.
-                Assert.Contains($"Writing tool assets file to disk", r2.Item2);
+                Assert.Contains($"Writing tool assets file to disk", r2.Output);
             }
         }
 
@@ -2183,7 +2183,7 @@ namespace NuGet.CommandLine.Test
                 // Assert
                 Assert.True(File.Exists(assetsPath));
                 Assert.True(File.Exists(cachePath));
-                Assert.Contains($"The restore inputs for 'z-netcoreapp1.0-[1.0.0, )' have not changed. No further actions are required to complete the restore", r2.Item2);
+                Assert.Contains($"The restore inputs for 'z-netcoreapp1.0-[1.0.0, )' have not changed. No further actions are required to complete the restore", r2.Output);
 
                 r = Util.RestoreSolution(pathContext);
 
@@ -2248,7 +2248,7 @@ namespace NuGet.CommandLine.Test
                 var r = Util.RestoreSolution(pathContext);
 
                 // Assert
-                Assert.True(File.Exists(path), r.Item2);
+                Assert.True(File.Exists(path), r.Output);
             }
         }
 
@@ -2318,7 +2318,7 @@ namespace NuGet.CommandLine.Test
                 // Assert
                 Assert.True(File.Exists(assetsPath));
                 Assert.True(File.Exists(cachePath));
-                Assert.Contains($"The restore inputs for 'z-netcoreapp1.0-[1.0.0, )' have not changed. No further actions are required to complete the restore.", r2.Item2);
+                Assert.Contains($"The restore inputs for 'z-netcoreapp1.0-[1.0.0, )' have not changed. No further actions are required to complete the restore.", r2.Output);
 
                 r = Util.RestoreSolution(pathContext);
             }
@@ -2441,9 +2441,9 @@ namespace NuGet.CommandLine.Test
                 // Assert
                 Assert.True(File.Exists(assetsPath));
                 Assert.True(File.Exists(cachePath));
-                Assert.Contains($"The restore inputs for 'x-netcoreapp1.0-[1.0.0, )' have not changed. No further actions are required to complete the restore.", r2.Item2);
-                Assert.Contains($"The restore inputs for 'a' have not changed. No further actions are required to complete the restore.", r2.Item2);
-                Assert.Contains($"The restore inputs for 'b' have not changed. No further actions are required to complete the restore.", r2.Item2);
+                Assert.Contains($"The restore inputs for 'x-netcoreapp1.0-[1.0.0, )' have not changed. No further actions are required to complete the restore.", r2.Output);
+                Assert.Contains($"The restore inputs for 'a' have not changed. No further actions are required to complete the restore.", r2.Output);
+                Assert.Contains($"The restore inputs for 'b' have not changed. No further actions are required to complete the restore.", r2.Output);
 
                 r = Util.RestoreSolution(pathContext);
             }
@@ -2493,7 +2493,7 @@ namespace NuGet.CommandLine.Test
                 var r = Util.RestoreSolution(pathContext, expectedExitCode: 0, additionalArgs: "-Recursive");
 
                 // Assert
-                Assert.True(File.Exists(path), r.Item2);
+                Assert.True(File.Exists(path), r.Output);
             }
         }
 
@@ -2541,7 +2541,7 @@ namespace NuGet.CommandLine.Test
                 var r = Util.RestoreSolution(pathContext);
 
                 // Assert
-                Assert.False(File.Exists(path), r.Item2);
+                Assert.False(File.Exists(path), r.Output);
             }
         }
         [Fact]
@@ -2679,7 +2679,7 @@ namespace NuGet.CommandLine.Test
                 var r = Util.RestoreSolution(pathContext);
 
                 // Assert
-                Assert.True(File.Exists(projectA.TargetsOutput), r.Item2);
+                Assert.True(File.Exists(projectA.TargetsOutput), r.Output);
 
                 var targetsXML = XDocument.Parse(File.ReadAllText(projectA.TargetsOutput));
                 var targetItemGroups = targetsXML.Root.Elements().Where(e => e.Name.LocalName == "ImportGroup").ToList();
@@ -2755,7 +2755,7 @@ namespace NuGet.CommandLine.Test
                 var r = Util.RestoreSolution(pathContext);
 
                 // Assert
-                Assert.True(File.Exists(projectA.TargetsOutput), r.Item2);
+                Assert.True(File.Exists(projectA.TargetsOutput), r.Output);
 
                 var targetsXML = XDocument.Parse(File.ReadAllText(projectA.TargetsOutput));
                 var targetItemGroups = targetsXML.Root.Elements().Where(e => e.Name.LocalName == "ImportGroup").ToList();
@@ -2805,7 +2805,7 @@ namespace NuGet.CommandLine.Test
                 var r = Util.RestoreSolution(pathContext);
 
                 // Assert
-                Assert.True(File.Exists(projectA.TargetsOutput), r.Item2);
+                Assert.True(File.Exists(projectA.TargetsOutput), r.Output);
 
                 var targetsXML = XDocument.Parse(File.ReadAllText(projectA.TargetsOutput));
                 var targetItemGroups = targetsXML.Root.Elements().Where(e => e.Name.LocalName == "ImportGroup").ToList();
@@ -2865,7 +2865,7 @@ namespace NuGet.CommandLine.Test
                 var r = Util.RestoreSolution(pathContext);
 
                 // Assert
-                Assert.False(File.Exists(projectA.TargetsOutput), r.Item2);
+                Assert.False(File.Exists(projectA.TargetsOutput), r.Output);
             }
         }
 
@@ -3017,14 +3017,14 @@ namespace NuGet.CommandLine.Test
                 var msbuildPropsItems = TargetsUtility.GetMSBuildPackageImports(projectA.PropsOutput);
 
                 // Assert
-                Assert.True(File.Exists(projectA.TargetsOutput), r.Item2);
+                Assert.True(File.Exists(projectA.TargetsOutput), r.Output);
                 Assert.Equal(1, msbuildTargetsItems.Count);
                 Assert.Equal(1, msbuildPropsItems.Count);
 
 
                 // Act
                 r = Util.RestoreSolution(pathContext);
-                Assert.True(File.Exists(projectA.TargetsOutput), r.Item2);
+                Assert.True(File.Exists(projectA.TargetsOutput), r.Output);
 
                 msbuildTargetsItems = TargetsUtility.GetMSBuildPackageImports(projectA.TargetsOutput);
                 msbuildPropsItems = TargetsUtility.GetMSBuildPackageImports(projectA.PropsOutput);
@@ -3032,7 +3032,7 @@ namespace NuGet.CommandLine.Test
                 Assert.Equal(1, msbuildTargetsItems.Count);
                 Assert.Equal(1, msbuildPropsItems.Count);
 
-                Assert.True(r.Item1 == 0);
+                Assert.True(r.ExitCode == 0);
             }
         }
 
@@ -3081,12 +3081,12 @@ namespace NuGet.CommandLine.Test
 
                 // Restore one
                 var r = Util.RestoreSolution(pathContext);
-                Assert.True(File.Exists(projectA.TargetsOutput), r.Item2);
+                Assert.True(File.Exists(projectA.TargetsOutput), r.Output);
 
                 // Act
                 r = Util.RestoreSolution(pathContext);
-                Assert.True(r.Item1 == 0);
-                Assert.True(File.Exists(projectA.TargetsOutput), r.Item2);
+                Assert.True(r.ExitCode == 0);
+                Assert.True(File.Exists(projectA.TargetsOutput), r.Output);
             }
         }
 
@@ -3499,7 +3499,7 @@ namespace NuGet.CommandLine.Test
                     waitForExit: true);
 
                 // Assert
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
                 var targetB = projectA.AssetsFile.Targets.Single(e => e.TargetFramework.Equals(NuGetFramework.Parse("NETCoreApp1.0"))).Libraries.SingleOrDefault(e => e.Name == "b");
@@ -3590,7 +3590,7 @@ namespace NuGet.CommandLine.Test
                     waitForExit: true);
 
                 // Assert
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
                 var assetsFile = projectA.AssetsFile;
@@ -3694,7 +3694,7 @@ namespace NuGet.CommandLine.Test
                     waitForExit: true);
 
                 // Assert
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
                 var assetsFile = projectA.AssetsFile;
@@ -3763,7 +3763,7 @@ namespace NuGet.CommandLine.Test
                     waitForExit: true);
 
                 // Assert
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
                 var targetB = projectA.AssetsFile.Targets.Single(e => e.TargetFramework.Equals(NuGetFramework.Parse("NETCoreApp1.0")) && string.IsNullOrEmpty(e.RuntimeIdentifier)).Libraries.SingleOrDefault(e => e.Name == "b");
@@ -3850,7 +3850,7 @@ namespace NuGet.CommandLine.Test
                     waitForExit: true);
 
                 // Assert
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
                 var targetB = projectA.AssetsFile.Targets.Single(e => e.TargetFramework.Equals(NuGetFramework.Parse("NETCoreApp1.0")) && string.IsNullOrEmpty(e.RuntimeIdentifier)).Libraries.SingleOrDefault(e => e.Name == "b");
@@ -3942,7 +3942,7 @@ namespace NuGet.CommandLine.Test
                     waitForExit: true);
 
                 // Assert
-                Assert.False(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.False(0 == r.ExitCode, r.Output + " " + r.Errors);
             }
         }
 
@@ -3990,9 +3990,9 @@ namespace NuGet.CommandLine.Test
 
                 // Assert
                 // Verify all files were written
-                Assert.True(File.Exists(projectA.AssetsFileOutputPath), r.Item2);
-                Assert.True(File.Exists(projectA.TargetsOutput), r.Item2);
-                Assert.True(File.Exists(projectA.PropsOutput), r.Item2);
+                Assert.True(File.Exists(projectA.AssetsFileOutputPath), r.Output);
+                Assert.True(File.Exists(projectA.TargetsOutput), r.Output);
+                Assert.True(File.Exists(projectA.PropsOutput), r.Output);
                 Assert.Equal(1, targets.Count);
             }
         }
@@ -4031,9 +4031,9 @@ namespace NuGet.CommandLine.Test
                 var r = Util.RestoreSolution(pathContext);
 
                 // Assert
-                Assert.True(File.Exists(projectA.AssetsFileOutputPath), r.Item2);
-                Assert.True(File.Exists(projectA.TargetsOutput), r.Item2);
-                Assert.True(File.Exists(projectA.PropsOutput), r.Item2);
+                Assert.True(File.Exists(projectA.AssetsFileOutputPath), r.Output);
+                Assert.True(File.Exists(projectA.TargetsOutput), r.Output);
+                Assert.True(File.Exists(projectA.PropsOutput), r.Output);
                 r.AllOutput.Should().NotContain("NU1503");
             }
         }
@@ -4165,9 +4165,9 @@ namespace NuGet.CommandLine.Test
                 var r = Util.RestoreSolution(pathContext);
 
                 // Assert
-                Assert.True(File.Exists(projectA.AssetsFileOutputPath), r.Item2);
-                Assert.True(File.Exists(projectA.TargetsOutput), r.Item2);
-                Assert.True(File.Exists(projectA.PropsOutput), r.Item2);
+                Assert.True(File.Exists(projectA.AssetsFileOutputPath), r.Output);
+                Assert.True(File.Exists(projectA.TargetsOutput), r.Output);
+                Assert.True(File.Exists(projectA.PropsOutput), r.Output);
 
                 Assert.Equal(NuGetFramework.Parse("net45"), projectA.AssetsFile.Targets.Single(e => string.IsNullOrEmpty(e.RuntimeIdentifier)).TargetFramework);
             }
@@ -5887,9 +5887,9 @@ namespace NuGet.CommandLine.Test
                 var r = Util.RestoreSolution(pathContext, 0, $"-ConfigFile {relativePathToConfig}");
 
                 // Assert
-                Assert.True(File.Exists(projectA.AssetsFileOutputPath), r.Item2);
-                Assert.True(File.Exists(projectA.TargetsOutput), r.Item2);
-                Assert.True(File.Exists(projectA.PropsOutput), r.Item2);
+                Assert.True(File.Exists(projectA.AssetsFileOutputPath), r.Output);
+                Assert.True(File.Exists(projectA.TargetsOutput), r.Output);
+                Assert.True(File.Exists(projectA.PropsOutput), r.Output);
 
                 Assert.Equal(NuGetFramework.Parse("net45"), projectA.AssetsFile.Targets.Single(e => string.IsNullOrEmpty(e.RuntimeIdentifier)).TargetFramework);
             }
@@ -5953,16 +5953,16 @@ namespace NuGet.CommandLine.Test
                 // Act && Assert
                 var r = Util.RestoreSolution(pathContext, expectedExitCode: 0);
 
-                Assert.Equal(0, r.Item1);
-                Assert.Contains("Writing cache file", r.Item2);
+                Assert.Equal(0, r.ExitCode);
+                Assert.Contains("Writing cache file", r.Output);
 
                 // Do it again, it should no-op now.
                 // Act && Assert
                 var r2 = Util.RestoreSolution(pathContext, expectedExitCode: 0);
 
-                Assert.Equal(0, r2.Item1);
-                Assert.DoesNotContain("Writing cache file", r2.Item2);
-                Assert.Contains("The restore inputs for 'parent' have not changed. No further actions are required to complete the restore.", r2.Item2);
+                Assert.Equal(0, r2.ExitCode);
+                Assert.DoesNotContain("Writing cache file", r2.Output);
+                Assert.Contains("The restore inputs for 'parent' have not changed. No further actions are required to complete the restore.", r2.Output);
             }
         }
 
@@ -6000,9 +6000,9 @@ namespace NuGet.CommandLine.Test
                 // Act && Assert
                 var r = Util.RestoreSolution(pathContext, expectedExitCode: 0);
 
-                Assert.Equal(0, r.Item1);
-                Assert.Contains("Writing cache file", r.Item2);
-                Assert.Contains("Writing assets file to disk", r.Item2);
+                Assert.Equal(0, r.ExitCode);
+                Assert.Contains("Writing cache file", r.Output);
+                Assert.Contains("Writing assets file to disk", r.Output);
 
                 // Pre-condition, Assert deleting the correct file
                 Assert.True(File.Exists(project.CacheFileOutputPath));
@@ -6010,9 +6010,9 @@ namespace NuGet.CommandLine.Test
 
                 r = Util.RestoreSolution(pathContext, expectedExitCode: 0);
 
-                Assert.Equal(0, r.Item1);
-                Assert.Contains("Writing cache file", r.Item2);
-                Assert.DoesNotContain("Writing assets file to disk", r.Item2);
+                Assert.Equal(0, r.ExitCode);
+                Assert.Contains("Writing cache file", r.Output);
+                Assert.DoesNotContain("Writing assets file to disk", r.Output);
 
 
             }
@@ -6094,22 +6094,22 @@ namespace NuGet.CommandLine.Test
 
                 // Prerequisites
                 var r1 = Util.Restore(pathContext, project.ProjectPath);
-                Assert.Equal(0, r1.Item1);
-                Assert.Contains("Writing cache file", r1.Item2);
-                Assert.Contains("Writing assets file to disk", r1.Item2);
+                Assert.Equal(0, r1.ExitCode);
+                Assert.Contains("Writing cache file", r1.Output);
+                Assert.Contains("Writing assets file to disk", r1.Output);
 
                 var r2 = Util.Restore(pathContext, secondaryProjectName);
-                Assert.Contains("Writing cache file", r2.Item2);
-                Assert.Equal(0, r2.Item1);
-                Assert.Contains("Writing assets file to disk", r2.Item2);
+                Assert.Contains("Writing cache file", r2.Output);
+                Assert.Equal(0, r2.ExitCode);
+                Assert.Contains("Writing assets file to disk", r2.Output);
 
                 // Act
                 var result = Util.Restore(pathContext, project.ProjectPath);
 
                 // Assert
-                Assert.Equal(0, result.Item1);
-                Assert.Contains("Writing cache file", result.Item2);
-                Assert.Contains("Writing assets file to disk", result.Item2);
+                Assert.Equal(0, result.ExitCode);
+                Assert.Contains("Writing cache file", result.Output);
+                Assert.Contains("Writing assets file to disk", result.Output);
             }
         }
 
@@ -6465,10 +6465,10 @@ namespace NuGet.CommandLine.Test
 
                 // Prerequisites
                 var result = Util.Restore(pathContext, project.ProjectPath, additionalArgs: "-verbosity Detailed");
-                Assert.Equal(0, result.Item1);
-                Assert.Contains("Writing cache file", result.Item2);
-                Assert.Contains("Writing assets file to disk", result.Item2);
-                Assert.Contains("Persisting dg", result.Item2);
+                Assert.Equal(0, result.ExitCode);
+                Assert.Contains("Writing cache file", result.Output);
+                Assert.Contains("Writing assets file to disk", result.Output);
+                Assert.Contains("Persisting dg", result.Output);
 
                 var dgSpecFileName = Path.Combine(Path.GetDirectoryName(project.AssetsFileOutputPath), $"{Path.GetFileName(project.ProjectPath)}.nuget.dgspec.json");
 
@@ -6480,10 +6480,10 @@ namespace NuGet.CommandLine.Test
                 result = Util.Restore(pathContext, project.ProjectPath, additionalArgs: "-verbosity Detailed");
 
                 // Assert
-                Assert.Equal(0, result.Item1);
-                Assert.DoesNotContain("Writing cache file", result.Item2);
-                Assert.DoesNotContain("Writing assets file to disk", result.Item2);
-                Assert.DoesNotContain("Persisting dg", result.Item2);
+                Assert.Equal(0, result.ExitCode);
+                Assert.DoesNotContain("Writing cache file", result.Output);
+                Assert.DoesNotContain("Writing assets file to disk", result.Output);
+                Assert.DoesNotContain("Persisting dg", result.Output);
 
                 fileInfo = new FileInfo(dgSpecFileName);
                 Assert.True(fileInfo.Exists);
@@ -6538,8 +6538,8 @@ namespace NuGet.CommandLine.Test
                 var result1 = Util.Restore(pathContext, project.ProjectPath, additionalArgs: "-verbosity Detailed");
 
                 // Assert
-                Assert.Equal(0, result1.Item1);
-                Assert.Contains("Writing packages lock file at disk.", result1.Item2);
+                Assert.Equal(0, result1.ExitCode);
+                Assert.Contains("Writing packages lock file at disk.", result1.Output);
                 Assert.True(File.Exists(packageLockFileName));
 
                 // Act
@@ -6549,9 +6549,9 @@ namespace NuGet.CommandLine.Test
                 var result2 = Util.Restore(pathContext, project.ProjectPath, additionalArgs: "-verbosity Detailed");
 
                 //Assert
-                Assert.Equal(0, result2.Item1);
-                Assert.Contains(noOpFailedMsg, result2.Item2);
-                Assert.Contains("Writing packages lock file at disk.", result2.Item2);
+                Assert.Equal(0, result2.ExitCode);
+                Assert.Contains(noOpFailedMsg, result2.Output);
+                Assert.Contains("Writing packages lock file at disk.", result2.Output);
                 Assert.True(File.Exists(packageLockFileName));
             }
         }
@@ -6605,17 +6605,17 @@ namespace NuGet.CommandLine.Test
                 var result1 = Util.Restore(pathContext, project.ProjectPath, additionalArgs: "-verbosity Detailed");
 
                 // Assert
-                Assert.Equal(0, result1.Item1);
-                Assert.Contains("Writing packages lock file at disk.", result1.Item2);
+                Assert.Equal(0, result1.ExitCode);
+                Assert.Contains("Writing packages lock file at disk.", result1.Output);
                 Assert.True(File.Exists(packageLockFileName));
 
                 // Act
                 var result2 = Util.Restore(pathContext, project.ProjectPath, additionalArgs: "-verbosity Detailed");
 
                 //Assert
-                Assert.Equal(0, result2.Item1);
-                Assert.Contains(noOpSucceedMsg, result2.Item2);
-                Assert.DoesNotContain("Writing packages lock file at disk.", result2.Item2);
+                Assert.Equal(0, result2.ExitCode);
+                Assert.Contains(noOpSucceedMsg, result2.Output);
+                Assert.DoesNotContain("Writing packages lock file at disk.", result2.Output);
                 Assert.True(File.Exists(packageLockFileName));
             }
         }
@@ -6669,8 +6669,8 @@ namespace NuGet.CommandLine.Test
                 var result1 = Util.Restore(pathContext, project.ProjectPath, additionalArgs: "-verbosity Detailed");
 
                 // Assert
-                Assert.Equal(0, result1.Item1);
-                Assert.Contains("Writing packages lock file at disk.", result1.Item2);
+                Assert.Equal(0, result1.ExitCode);
+                Assert.Contains("Writing packages lock file at disk.", result1.Output);
                 Assert.True(File.Exists(packageLockFileName));
 
                 // Act
@@ -6680,9 +6680,9 @@ namespace NuGet.CommandLine.Test
                 var result2 = Util.Restore(pathContext, project.ProjectPath, additionalArgs: "-verbosity Detailed");
 
                 //Assert
-                Assert.Equal(0, result2.Item1);
-                Assert.Contains(noOpSucceedMsg, result2.Item2);
-                Assert.DoesNotContain("Writing packages lock file at disk.", result2.Item2);
+                Assert.Equal(0, result2.ExitCode);
+                Assert.Contains(noOpSucceedMsg, result2.Output);
+                Assert.DoesNotContain("Writing packages lock file at disk.", result2.Output);
                 Assert.False(File.Exists(packageLockFileName));
             }
         }
@@ -6736,17 +6736,17 @@ namespace NuGet.CommandLine.Test
                 var result1 = Util.Restore(pathContext, project.ProjectPath, additionalArgs: "-verbosity Detailed");
 
                 // Assert
-                Assert.Equal(0, result1.Item1);
-                Assert.Contains("Writing packages lock file at disk.", result1.Item2);
+                Assert.Equal(0, result1.ExitCode);
+                Assert.Contains("Writing packages lock file at disk.", result1.Output);
                 Assert.True(File.Exists(packageLockFileName));
 
                 // Act
                 var result2 = Util.Restore(pathContext, project.ProjectPath, additionalArgs: "-verbosity Detailed");
 
                 //Assert
-                Assert.Equal(0, result2.Item1);
-                Assert.Contains(noOpSucceedMsg, result2.Item2);
-                Assert.DoesNotContain("Writing packages lock file at disk.", result2.Item2);
+                Assert.Equal(0, result2.ExitCode);
+                Assert.Contains(noOpSucceedMsg, result2.Output);
+                Assert.DoesNotContain("Writing packages lock file at disk.", result2.Output);
                 Assert.True(File.Exists(packageLockFileName));
             }
         }
@@ -7214,7 +7214,7 @@ namespace NuGet.CommandLine.Test
                 Assert.Equal("x", lockFile.PackageSpec.TargetFrameworks.Last().DownloadDependencies.First().Name);
                 var packagePath = Path.Combine(pathContext.UserPackagesFolder, packageX.Identity.Id, packageX.Version);
                 Assert.True(Directory.Exists(packagePath), $"{packageX.ToString()} is not installed");
-                Assert.Contains("Writing cache file", r.Item2);
+                Assert.Contains("Writing cache file", r.Output);
 
 
                 // Act
@@ -7223,9 +7223,9 @@ namespace NuGet.CommandLine.Test
 
                 Assert.True(Directory.Exists(packagePath), $"{packageX.ToString()} is not installed");
 
-                Assert.Equal(0, r.Item1);
-                Assert.DoesNotContain("Writing cache file", r.Item2);
-                Assert.Contains("No further actions are required to complete", r.Item2);
+                Assert.Equal(0, r.ExitCode);
+                Assert.DoesNotContain("Writing cache file", r.Output);
+                Assert.Contains("No further actions are required to complete", r.Output);
             }
         }
 
@@ -10048,8 +10048,8 @@ namespace NuGet.CommandLine.Test
 
                 // Act
                 var r = Util.RestoreSolution(pathContext);
-                Assert.Equal(0, r.Item1);
-                Assert.True(File.Exists(project.PropsOutput), r.Item2);
+                Assert.Equal(0, r.ExitCode);
+                Assert.True(File.Exists(project.PropsOutput), r.Output);
                 var propsXML = XDocument.Parse(File.ReadAllText(project.PropsOutput));
 
                 var propsItemGroups = propsXML.Root.Elements().Where(e => e.Name.LocalName == "ItemGroup").ToList();
@@ -10357,7 +10357,7 @@ namespace NuGet.CommandLine.Test
                     waitForExit: true);
 
                 // Assert
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert correct projects were restored.
                 Assert.True(File.Exists(projectA.AssetsFileOutputPath));
@@ -10663,7 +10663,7 @@ namespace NuGet.CommandLine.Test
                     waitForExit: true);
 
                 // Preconditions
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert correct projects were restored.
                 Assert.True(File.Exists(projectA.AssetsFileOutputPath));
@@ -10784,7 +10784,7 @@ namespace NuGet.CommandLine.Test
                     waitForExit: true);
 
                 // Pre-Conditions
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Change project C, bump the package Y version.
                 projectC.CleanPackagesFromAllFrameworks();

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreProjectJsonTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreProjectJsonTest.cs
@@ -68,8 +68,8 @@ namespace NuGet.CommandLine.Test
                     waitForExit: true);
 
                 // Assert
-                Assert.True(1 == r.Item1, r.Item2 + " " + r.Item3);
-                Assert.Contains("'packageA 1.0.0' package requires NuGet client version '9.9.9' or above", r.Item3);
+                Assert.True(1 == r.ExitCode, r.Output + " " + r.Errors);
+                Assert.Contains("'packageA 1.0.0' package requires NuGet client version '9.9.9' or above", r.Errors);
             }
         }
 
@@ -125,7 +125,7 @@ namespace NuGet.CommandLine.Test
                     waitForExit: true);
 
                 // Assert
-                Assert.True(1 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(1 == r.ExitCode, r.Output + " " + r.Errors);
 
                 var test1Lock = new FileInfo(Path.Combine(projectDir1, "project.lock.json"));
                 var test2Lock = new FileInfo(Path.Combine(projectDir2, "project.lock.json"));
@@ -221,7 +221,7 @@ namespace NuGet.CommandLine.Test
                     waitForExit: true);
 
                 // Assert
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 var test1Lock = new FileInfo(Path.Combine(projectDir1, "project.lock.json"));
                 var test2Lock = new FileInfo(Path.Combine(projectDir2, "project.lock.json"));
@@ -310,7 +310,7 @@ namespace NuGet.CommandLine.Test
                     waitForExit: true);
 
                 // Assert
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 var test1Lock = new FileInfo(Path.Combine(projectDir1, "project.lock.json"));
 
@@ -389,7 +389,7 @@ namespace NuGet.CommandLine.Test
                 var test1Lock = new FileInfo(Path.Combine(projectDir1, "project.lock.json"));
 
                 // Assert
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 Assert.True(test1Lock.Exists);
             }
@@ -539,7 +539,7 @@ namespace NuGet.CommandLine.Test
                 var test1Lock = new FileInfo(Path.Combine(projectDir1, "project.lock.json"));
 
                 // Assert
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 Assert.True(test1Lock.Exists);
 
@@ -651,9 +651,9 @@ namespace NuGet.CommandLine.Test
                     waitForExit: true);
 
                 // Assert
-                Assert.True(0 == r.Item1, r.Item2 + Environment.NewLine + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + Environment.NewLine + r.Errors);
 
-                var lines = r.Item2.Split(
+                var lines = r.Output.Split(
                                 new[] { Environment.NewLine },
                                 StringSplitOptions.RemoveEmptyEntries);
 
@@ -781,7 +781,7 @@ namespace NuGet.CommandLine.Test
                     waitForExit: true);
 
                 // Assert
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 var test1Lock = new FileInfo(Path.Combine(projectDir1, "project.lock.json"));
                 var test2Lock = new FileInfo(Path.Combine(projectDir2, "project.lock.json"));
@@ -843,9 +843,9 @@ namespace NuGet.CommandLine.Test
                 var test1Lock = new FileInfo(Path.Combine(workingPath, "project.lock.json"));
 
                 // Assert
-                Assert.True(1 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(1 == r.ExitCode, r.Output + " " + r.Errors);
                 Assert.False(test1Lock.Exists);
-                Assert.Contains("input file does not exist", r.Item3, StringComparison.OrdinalIgnoreCase);
+                Assert.Contains("input file does not exist", r.Errors, StringComparison.OrdinalIgnoreCase);
             }
         }
 
@@ -883,9 +883,9 @@ namespace NuGet.CommandLine.Test
                 var test1Lock = new FileInfo(Path.Combine(workingPath, "project.lock.json"));
 
                 // Assert
-                Assert.True(1 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(1 == r.ExitCode, r.Output + " " + r.Errors);
                 Assert.False(test1Lock.Exists);
-                Assert.Contains("input file does not exist", r.Item3, StringComparison.OrdinalIgnoreCase);
+                Assert.Contains("input file does not exist", r.Errors, StringComparison.OrdinalIgnoreCase);
             }
         }
 
@@ -935,7 +935,7 @@ namespace NuGet.CommandLine.Test
                 var test1Lock = new FileInfo(Path.Combine(projectDir1, "project.lock.json"));
 
                 // Assert
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
                 Assert.True(test1Lock.Exists);
             }
         }
@@ -986,7 +986,7 @@ namespace NuGet.CommandLine.Test
                 var test1Lock = new FileInfo(Path.Combine(projectDir1, "project.lock.json"));
 
                 // Assert
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
                 Assert.True(test1Lock.Exists);
             }
         }
@@ -1083,7 +1083,7 @@ namespace NuGet.CommandLine.Test
                     waitForExit: true);
 
                 // Assert
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 var test1Lock = new FileInfo(Path.Combine(projectDir1, "project.lock.json"));
                 var test2Lock = new FileInfo(Path.Combine(projectDir2, "project.lock.json"));
@@ -1203,7 +1203,7 @@ namespace NuGet.CommandLine.Test
                 // Assert
                 // Verify restore worked, this requires finding the packages from the repository, which is in 
                 // the solution level nuget.config.
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 var test1Lock = new FileInfo(Path.Combine(projectDir1, "project.lock.json"));
                 var test2Lock = new FileInfo(Path.Combine(projectDir2, "project.lock.json"));
@@ -1264,7 +1264,7 @@ namespace NuGet.CommandLine.Test
                 var installedA = lockFile.Targets.First().Libraries.Single(package => package.Name == "packageA");
 
                 // Assert
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
                 Assert.Equal("1.0.0-beta-02", installedA.Version.ToNormalizedString());
             }
         }
@@ -1320,7 +1320,7 @@ namespace NuGet.CommandLine.Test
                 var installedA = lockFile.Targets.First().Libraries.Single(package => package.Name == "packageA");
 
                 // Assert
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
                 Assert.Equal("1.0.0", installedA.Version.ToNormalizedString());
             }
         }
@@ -1379,7 +1379,7 @@ namespace NuGet.CommandLine.Test
                 var installedA = lockFile.Targets.First().Libraries.Single(package => package.Name == "packageA");
 
                 // Assert
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
                 Assert.Equal("1.0.10", installedA.Version.ToNormalizedString());
             }
         }
@@ -1434,7 +1434,7 @@ namespace NuGet.CommandLine.Test
                 var installedB = lockFile.Targets.First().Libraries.Where(package => package.Name == "packageB").ToList();
 
                 // Assert
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
                 Assert.Equal(1, installedB.Count);
                 Assert.Equal("3.0.0", installedB.Single().Version.ToNormalizedString());
             }
@@ -1492,7 +1492,7 @@ namespace NuGet.CommandLine.Test
                 var installedC = lockFile.Targets.First().Libraries.Single(package => package.Name == "packageC");
 
                 // Assert
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
                 Assert.Equal("2.0.0-beta", installedC.Version.ToNormalizedString());
             }
         }
@@ -1549,7 +1549,7 @@ namespace NuGet.CommandLine.Test
                 var installedC = lockFile.Targets.First().Libraries.Single(package => package.Name == "packageC");
 
                 // Assert
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
                 Assert.Equal("2.1.0", installedC.Version.ToNormalizedString());
             }
         }
@@ -1606,7 +1606,7 @@ namespace NuGet.CommandLine.Test
                 var installedC = lockFile.Targets.First().Libraries.Single(package => package.Name == "packageC");
 
                 // Assert
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
                 Assert.Equal("2.0.0-beta", installedC.Version.ToNormalizedString());
             }
         }
@@ -1717,7 +1717,7 @@ namespace NuGet.CommandLine.Test
                     waitForExit: true);
 
                 // Assert
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
                 Assert.True(File.Exists(targetFileA));
                 Assert.True(File.Exists(targetFileB));
                 Assert.True(File.Exists(lockFileA));
@@ -1778,7 +1778,7 @@ namespace NuGet.CommandLine.Test
                     waitForExit: true);
 
                 // Assert
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
                 Assert.True(File.Exists(lockFilePath));
                 Assert.True(File.Exists(targetFilePath));
             }
@@ -1866,7 +1866,7 @@ namespace NuGet.CommandLine.Test
                     waitForExit: true);
 
                 // Assert
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
                 Assert.True(File.Exists(targetFilePath));
 
                 var targetsFile = File.ReadAllText(targetFilePath);
@@ -1932,7 +1932,7 @@ namespace NuGet.CommandLine.Test
                     waitForExit: true);
 
                 // Assert
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
                 Assert.True(File.Exists(targetFilePath));
 
                 var targetsFile = File.ReadAllText(targetFilePath);
@@ -2033,7 +2033,7 @@ namespace NuGet.CommandLine.Test
                     waitForExit: true);
 
                 // Assert
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
                 Assert.True(File.Exists(targetFilePath));
 
                 var targetsFile = File.ReadAllText(targetFilePath);
@@ -2096,7 +2096,7 @@ namespace NuGet.CommandLine.Test
                     waitForExit: true);
 
                 // Assert
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
                 Assert.True(File.Exists(targetFilePath));
 
                 var targetsFile = File.ReadAllText(targetFilePath);
@@ -2160,7 +2160,7 @@ namespace NuGet.CommandLine.Test
                     waitForExit: true);
 
                 // Assert
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
                 Assert.True(File.Exists(targetFilePath));
 
                 var targetsFile = File.ReadAllText(targetFilePath);
@@ -2223,7 +2223,7 @@ namespace NuGet.CommandLine.Test
                     waitForExit: true);
 
                 // Assert
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
                 Assert.True(File.Exists(targetFilePath));
 
                 var targetsFile = File.ReadAllText(targetFilePath);
@@ -2291,7 +2291,7 @@ namespace NuGet.CommandLine.Test
                     waitForExit: true);
 
                 // Assert
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
                 Assert.True(File.Exists(targetFilePath));
 
                 using (var stream = File.OpenText(targetFilePath))
@@ -2309,7 +2309,7 @@ namespace NuGet.CommandLine.Test
                     waitForExit: true);
 
                 // Assert 2
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
                 Assert.True(File.Exists(targetFilePath));
 
                 using (var stream = File.OpenText(targetFilePath))
@@ -2327,7 +2327,7 @@ namespace NuGet.CommandLine.Test
                     waitForExit: true);
 
                 // Assert 3
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
                 Assert.True(File.Exists(targetFilePath));
 
                 using (var stream = File.OpenText(targetFilePath))
@@ -2392,7 +2392,7 @@ namespace NuGet.CommandLine.Test
 
                 // Assert
                 // If the library count can be obtained then a new lock file was created
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
                 Assert.Equal(2, lockFile.Libraries.Count);
             }
         }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreRetryTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreRetryTests.cs
@@ -117,7 +117,7 @@ namespace NuGet.CommandLine.Test
                     server.Stop();
 
                     // Assert
-                    Assert.True(r1.Success, r1.Item2 + " " + r1.Item3);
+                    Assert.True(r1.Success, r1.AllOutput);
 
                     var path = Path.Combine(pathContext.PackagesV2, "testpackage1.1.1.0", "testpackage1.1.1.0.nupkg");
 
@@ -233,7 +233,7 @@ namespace NuGet.CommandLine.Test
                     server.Stop();
 
                     // Assert
-                    Assert.True(r1.Success, r1.Item2 + " " + r1.Item3);
+                    Assert.True(r1.Success, r1.AllOutput);
 
                     Assert.True(
                         File.Exists(
@@ -375,7 +375,7 @@ namespace NuGet.CommandLine.Test
                     server.Stop();
 
                     // Assert
-                    Assert.True(r1.Success, r1.Item2 + " " + r1.Item3);
+                    Assert.True(r1.Success, r1.AllOutput);
 
                     Assert.True(
                         File.Exists(

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreUAPPackageReferenceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreUAPPackageReferenceTests.cs
@@ -288,7 +288,7 @@ namespace NuGet.CommandLine.Test
                 waitForExit: true);
 
             // Assert
-            Assert.True(exitCode == r.Item1, r.Item3 + "\n\n" + r.Item2);
+            Assert.True(exitCode == r.ExitCode, r.Errors + "\n\n" + r.Output);
 
             return r;
         }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Util.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Util.cs
@@ -87,7 +87,7 @@ namespace NuGet.CommandLine.Test
                 environmentVariables: envVars);
 
             // Assert
-            Assert.True(expectedExitCode == r.Item1, r.Item3 + "\n\n" + r.Item2);
+            Assert.True(expectedExitCode == r.ExitCode, r.Errors + "\n\n" + r.Output);
 
             return r;
         }
@@ -775,14 +775,14 @@ EndProject";
         public static void VerifyResultSuccess(CommandRunnerResult result, string expectedOutputMessage = null)
         {
             Assert.True(
-                result.Item1 == 0,
-                "nuget.exe DID NOT SUCCEED: Ouput is " + result.Item2 + ". Error is " + result.Item3);
+                result.ExitCode == 0,
+                "nuget.exe DID NOT SUCCEED: Ouput is " + result.Output + ". Error is " + result.Errors);
 
             if (!string.IsNullOrEmpty(expectedOutputMessage))
             {
                 Assert.Contains(
                     expectedOutputMessage,
-                    result.Item2);
+                    result.Output);
             }
         }
 
@@ -797,12 +797,12 @@ EndProject";
                                                string expectedErrorMessage)
         {
             Assert.True(
-                result.Item1 != 0,
-                "nuget.exe DID NOT FAIL: Ouput is " + result.Item2 + ". Error is " + result.Item3);
+                result.ExitCode != 0,
+                "nuget.exe DID NOT FAIL: Ouput is " + result.Output + ". Error is " + result.Errors);
 
             Assert.True(
-                result.Item3.Contains(expectedErrorMessage),
-                "Expected error is " + expectedErrorMessage + ". Actual error is " + result.Item3);
+                result.Errors.Contains(expectedErrorMessage),
+                "Expected error is " + expectedErrorMessage + ". Actual error is " + result.Errors);
         }
 
         public static void VerifyPackageExists(
@@ -1156,13 +1156,13 @@ EndProject");
             var mainCommand = commandSplit[0];
 
             // Assert command
-            Assert.Contains(mainCommand, result.Item3, StringComparison.InvariantCultureIgnoreCase);
+            Assert.Contains(mainCommand, result.Errors, StringComparison.InvariantCultureIgnoreCase);
             // Assert invalid argument message
             var invalidMessage = string.Format(": invalid arguments.", mainCommand);
             // Verify Exit code
             VerifyResultFailure(result, invalidMessage);
             // Verify traits of help message in stdout
-            Assert.Contains("usage:", result.Item2);
+            Assert.Contains("usage:", result.Output);
         }
 
         /// <summary>

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetSourcesTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetSourcesTests.cs
@@ -84,7 +84,7 @@ namespace Dotnet.Integration.Test
 
 
                 // Assert
-                Assert.True(result.Success, result.Output + " " + result.Errors);
+                Assert.True(result.Success, result.AllOutput);
 
                 var loadedSettings = Settings.LoadDefaultSettings(root: workingPath, configFileName: null, machineWideSettings: null);
 
@@ -133,7 +133,7 @@ namespace Dotnet.Integration.Test
                 var result = _fixture.RunDotnet(workingPath, string.Join(" ", args), ignoreExitCode: true);
 
                 // Assert
-                Assert.True(result.Success, result.Output + " " + result.Errors);
+                Assert.True(result.Success, result.AllOutput);
 
                 var loadedSettings = Settings.LoadDefaultSettings(root: workingPath, configFileName: null, machineWideSettings: null);
 

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetToolTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetToolTests.cs
@@ -42,8 +42,8 @@ namespace Dotnet.Integration.Test
                 var result = _msbuildFixture.RestoreToolProject(workingDirectory, projectName, string.Empty);
 
                 // Assert
-                Assert.True(result.Item1 == 1, result.AllOutput);
-                Assert.Contains("NU1211", result.Item2);
+                Assert.True(result.ExitCode == 1, result.AllOutput);
+                Assert.Contains("NU1211", result.Output);
             }
         }
 
@@ -66,9 +66,9 @@ namespace Dotnet.Integration.Test
                 var result = _msbuildFixture.RestoreToolProject(workingDirectory, projectName, string.Empty);
 
                 // Assert
-                Assert.True(result.Item1 == 1, result.AllOutput);
-                Assert.Contains("NU1212", result.Item2);
-                Assert.DoesNotContain("NU1211", result.Item2); // It's the correct dependency count!
+                Assert.True(result.ExitCode == 1, result.AllOutput);
+                Assert.Contains("NU1212", result.Output);
+                Assert.DoesNotContain("NU1211", result.Output); // It's the correct dependency count!
             }
         }
 
@@ -101,7 +101,7 @@ namespace Dotnet.Integration.Test
                 var result = _msbuildFixture.RestoreToolProject(workingDirectory, projectName, string.Empty);
 
                 // Assert
-                Assert.True(result.Item1 == 0, result.AllOutput);
+                Assert.True(result.ExitCode == 0, result.AllOutput);
                 Assert.True(2 == result.AllOutput.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries).Length, result.AllOutput);
                 // Verify the assets file
                 var lockFile = LockFileUtilities.GetLockFile(Path.Combine(testDirectory, projectName, "project.assets.json"), NullLogger.Instance);
@@ -145,8 +145,8 @@ namespace Dotnet.Integration.Test
                 var result = _msbuildFixture.RestoreToolProject(workingDirectory, projectName, string.Empty);
 
                 // Assert
-                Assert.True(result.Item1 == 1, result.AllOutput);
-                Assert.Contains("NU1202", result.Item2);
+                Assert.True(result.ExitCode == 1, result.AllOutput);
+                Assert.Contains("NU1202", result.Output);
             }
         }
 
@@ -181,7 +181,7 @@ namespace Dotnet.Integration.Test
                 var result = _msbuildFixture.RestoreToolProject(workingDirectory, projectName, string.Empty);
 
                 // Assert
-                Assert.True(result.Item1 == 0, result.AllOutput);
+                Assert.True(result.ExitCode == 0, result.AllOutput);
                 // Verify the assets file
                 var lockFile = LockFileUtilities.GetLockFile(Path.Combine(testDirectory, projectName, "project.assets.json"), NullLogger.Instance);
                 Assert.NotNull(lockFile);
@@ -226,7 +226,7 @@ namespace Dotnet.Integration.Test
                 var result = _msbuildFixture.RestoreToolProject(workingDirectory, projectName, string.Empty);
 
                 // Assert
-                Assert.True(result.Item1 == 0, result.AllOutput);
+                Assert.True(result.ExitCode == 0, result.AllOutput);
                 // Verify the assets file
                 var lockFile = LockFileUtilities.GetLockFile(Path.Combine(testDirectory, projectName, "project.assets.json"), NullLogger.Instance);
                 Assert.NotNull(lockFile);
@@ -277,10 +277,10 @@ namespace Dotnet.Integration.Test
                 var result = _msbuildFixture.RestoreToolProject(workingDirectory, projectName, string.Empty);
 
                 // Assert
-                Assert.True(result.Item1 == 1, result.AllOutput);
-                Assert.Contains("Invalid project-package combination for Newtonsoft.Json 10.0.3", result.Item2);
-                Assert.DoesNotContain("Invalid project-package combination for ToolPackage", result.Item2);
-                Assert.Contains("NU1211", result.Item2); //count is wrong
+                Assert.True(result.ExitCode == 1, result.AllOutput);
+                Assert.Contains("Invalid project-package combination for Newtonsoft.Json 10.0.3", result.Output);
+                Assert.DoesNotContain("Invalid project-package combination for ToolPackage", result.Output);
+                Assert.Contains("NU1211", result.Output); //count is wrong
             }
         }
 
@@ -328,7 +328,7 @@ namespace Dotnet.Integration.Test
                 var result = _msbuildFixture.RestoreToolProject(workingDirectory, projectName, string.Empty);
 
                 // Assert
-                Assert.True(result.Item1 == 0, result.AllOutput);
+                Assert.True(result.ExitCode == 0, result.AllOutput);
                 var lockFile = LockFileUtilities.GetLockFile(Path.Combine(testDirectory, projectName, "project.assets.json"), NullLogger.Instance);
                 Assert.NotNull(lockFile);
                 Assert.Equal(2, lockFile.Targets.Count);
@@ -373,7 +373,7 @@ namespace Dotnet.Integration.Test
                 var result = _msbuildFixture.RestoreToolProject(workingDirectory, projectName, string.Empty);
 
                 // Assert
-                Assert.True(result.Item1 == 1, result.AllOutput);
+                Assert.True(result.ExitCode == 1, result.AllOutput);
                 Assert.Contains("NU1202", result.AllOutput);
             }
         }
@@ -407,7 +407,7 @@ namespace Dotnet.Integration.Test
                 var result = _msbuildFixture.RestoreToolProject(workingDirectory, projectName, string.Empty);
 
                 // Assert
-                Assert.True(result.Item1 == 1, result.AllOutput);
+                Assert.True(result.ExitCode == 1, result.AllOutput);
                 Assert.Contains("NU1204", result.AllOutput);
             }
         }
@@ -442,7 +442,7 @@ namespace Dotnet.Integration.Test
                 var result = _msbuildFixture.RestoreToolProject(workingDirectory, projectName, string.Empty);
 
                 // Assert
-                Assert.True(result.Item1 == 0, result.AllOutput);
+                Assert.True(result.ExitCode == 0, result.AllOutput);
                 // Verify the assets file
                 var lockFile = LockFileUtilities.GetLockFile(Path.Combine(testDirectory, projectName, "project.assets.json"), NullLogger.Instance);
                 Assert.NotNull(lockFile);
@@ -715,7 +715,7 @@ namespace Dotnet.Integration.Test
                 var result = _msbuildFixture.RestoreToolProject(workingDirectory, projectName, string.Empty);
 
                 // Assert
-                Assert.True(result.Item1 == 0, result.AllOutput);
+                Assert.True(result.ExitCode == 0, result.AllOutput);
                 // Verify the assets file
                 var lockFile = LockFileUtilities.GetLockFile(Path.Combine(testDirectory, projectName, "project.assets.json"), NullLogger.Instance);
                 Assert.NotNull(lockFile);
@@ -776,7 +776,7 @@ namespace Dotnet.Integration.Test
                 var result = _msbuildFixture.RestoreToolProject(workingDirectory, projectName, string.Empty);
 
                 // Assert
-                Assert.True(result.Item1 == 0, result.AllOutput);
+                Assert.True(result.ExitCode == 0, result.AllOutput);
                 // Verify the assets file
                 var lockFile = LockFileUtilities.GetLockFile(Path.Combine(testDirectory, projectName, "project.assets.json"), NullLogger.Instance);
                 Assert.NotNull(lockFile);

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/MsbuildIntegrationTestFixture.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/MsbuildIntegrationTestFixture.cs
@@ -196,8 +196,8 @@ namespace Dotnet.Integration.Test
                 environmentVariables: _processEnvVars);
             if (validateSuccess)
             {
-                Assert.True(result.Item1 == 0, $"Restore failed with following log information :\n {result.AllOutput}");
-                Assert.True(result.Item3 == "", $"Restore failed with following message in error stream :\n {result.AllOutput}");
+                Assert.True(result.ExitCode == 0, $"Restore failed with following log information :\n {result.AllOutput}");
+                Assert.True(result.Errors == "", $"Restore failed with following message in error stream :\n {result.AllOutput}");
             }
         }
 
@@ -267,8 +267,8 @@ namespace Dotnet.Integration.Test
                 environmentVariables: _processEnvVars);
             if (validateSuccess)
             {
-                Assert.True(result.Item1 == 0, $"Pack failed with following log information :\n {result.AllOutput}");
-                Assert.True(result.Item3 == "", $"Pack failed with following message in error stream :\n {result.AllOutput}");
+                Assert.True(result.ExitCode == 0, $"Pack failed with following log information :\n {result.AllOutput}");
+                Assert.True(result.Errors == "", $"Pack failed with following message in error stream :\n {result.AllOutput}");
             }
             return result;
         }
@@ -300,8 +300,8 @@ namespace Dotnet.Integration.Test
                 environmentVariables: _processEnvVars);
             if (validateSuccess)
             {
-                Assert.True(result.Item1 == 0, $"Build failed with following log information :\n {result.AllOutput}");
-                Assert.True(result.Item3 == "", $"Build failed with following message in error stream :\n {result.AllOutput}");
+                Assert.True(result.ExitCode == 0, $"Build failed with following log information :\n {result.AllOutput}");
+                Assert.True(result.Errors == "", $"Build failed with following message in error stream :\n {result.AllOutput}");
             }
         }
 

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/DotnetCliUtil.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/DotnetCliUtil.cs
@@ -106,14 +106,14 @@ namespace NuGet.XPlat.FuncTest
         public static void VerifyResultSuccess(CommandRunnerResult result, string expectedOutputMessage = null)
         {
             Assert.True(
-                result.Item1 == 0,
-                $"Command DID NOT SUCCEED. Ouput is: \"{result.Item2}\". Error is: \"{result.Item3}\"");
+                result.ExitCode == 0,
+                $"Command DID NOT SUCCEED. Ouput is: \"{result.Output}\". Error is: \"{result.Errors}\"");
 
             if (!string.IsNullOrEmpty(expectedOutputMessage))
             {
                 Assert.Contains(
                     expectedOutputMessage,
-                    result.Item2);
+                    result.Output);
             }
         }
 
@@ -126,12 +126,12 @@ namespace NuGet.XPlat.FuncTest
                                                string expectedErrorMessage)
         {
             Assert.True(
-                result.Item1 != 0,
-                $"Command DID NOT FAIL. Ouput is: \"{result.Item2}\". Error is: \"{result.Item3}\"");
+                result.ExitCode != 0,
+                $"Command DID NOT FAIL. Ouput is: \"{result.Output}\". Error is: \"{result.Errors}\"");
 
             Assert.True(
-                result.Item2.Contains(expectedErrorMessage),
-                $"Expected error is: \"{expectedErrorMessage}\". Actual error is: \"{result.Item3}\". Ouput is: \"{result.Item2}\".");
+                result.Output.Contains(expectedErrorMessage),
+                $"Expected error is: \"{expectedErrorMessage}\". Actual error is: \"{result.Errors}\". Ouput is: \"{result.Output}\".");
         }
     }
 }

--- a/test/TestUtilities/Test.Utility/CommandRunnerResult.cs
+++ b/test/TestUtilities/Test.Utility/CommandRunnerResult.cs
@@ -11,48 +11,33 @@ namespace NuGet.Test.Utility
         public Process Process { get; }
 
         /// <summary>
-        /// Item 1. Multi-purpose
+        /// Refers to Exit Status Code of the command execution result
         /// </summary>
-        /// <remarks>
-        /// In occasions, it refers to Exit Status Code of the command execution result
-        /// </remarks>
-        public int Item1 { get; }
+        public int ExitCode { get; }
 
         /// <summary>
-        /// Item 2. Multi-purpose
+        /// refers to the Standard Output of the command execution
         /// </summary>
-        /// <remarks>
-        /// In occasions, it refers to the Standard Output of the command execution
-        /// </remarks>
-        public string Item2 { get; }
+        public string Output { get; }
 
         /// <summary>
-        /// Item 3. Multi-purpose
+        /// Refers to the Standard Error of the command execution
         /// </summary>
-        /// <remarks>
-        /// In occasions, it refers to the Standard Error of the command execution
-        /// </remarks>
-        public string Item3 { get; }
+        public string Errors { get; }
 
-        public int ExitCode => Item1;
-
-        public bool Success => Item1 == 0;
+        public bool Success => ExitCode == 0;
 
         /// <summary>
         /// All output messages including errors
         /// </summary>
-        public string AllOutput => Item2 + Environment.NewLine + Item3;
-
-        public string Output => Item2;
-
-        public string Errors => Item3;
+        public string AllOutput => Output + Environment.NewLine + Errors;
 
         internal CommandRunnerResult(Process process, int exitCode, string output, string error)
         {
             Process = process;
-            Item1 = exitCode;
-            Item2 = output;
-            Item3 = error;
+            ExitCode = exitCode;
+            Output = output;
+            Errors = error;
         }
     }
 }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/9190

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Note that the issue talks about an investigate task about potential differences between nuget.exe and dotnet.exe for the CommandRunner, but there is in fact no difference.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
