### PR TITLE
Don't import reference assemblies for nestandard builds in NuGet.Configuration

### DIFF
--- a/src/NuGet.Core/NuGet.Configuration/NuGet.Configuration.csproj
+++ b/src/NuGet.Core/NuGet.Configuration/NuGet.Configuration.csproj
@@ -23,7 +23,7 @@
     <ProjectReference Include="$(NuGetCoreSrcDirectory)NuGet.Common\NuGet.Common.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == '$(NETFXTargetFramework)' or '$(TargetFramework)' == 'net45' or '$(TargetFramework)' == 'netstandard2.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == '$(NETFXTargetFramework)' or '$(TargetFramework)' == 'net45' ">
     <Reference Include="System.Security" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1569

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Warnings are raised: 


(ResolveAssemblyReferences target) ->
  C:\Program Files\Microsoft Visual Studio\2022\Preview\MSBuild\Current\Bin\amd64\Microsoft.Common.CurrentVersion.targets(2301,5): warning MSB3245: Could not resolve this reference. Could not locate the assembly "System.Security". Check
 to make sure the assembly exists on disk. If this reference is required by your code, you may get compilation errors. [C:\Code\NuGet.Client\src\NuGet.Core\NuGet.Configuration\NuGet.Configuration.csproj]
  C:\Program Files\Microsoft Visual Studio\2022\Preview\MSBuild\Current\Bin\amd64\Microsoft.Common.CurrentVersion.targets(2301,5): warning MSB3245: Could not resolve this reference. Could not locate the assembly "System.Xml". Check to m
ake sure the assembly exists on disk. If this reference is required by your code, you may get compilation errors. [C:\Code\NuGet.Client\src\NuGet.Core\NuGet.Configuration\NuGet.Configuration.csproj]
  C:\Program Files\Microsoft Visual Studio\2022\Preview\MSBuild\Current\Bin\amd64\Microsoft.Common.CurrentVersion.targets(2301,5): warning MSB3245: Could not resolve this reference. Could not locate the assembly "System.Xml.Linq". Check
 to make sure the assembly exists on disk. If this reference is required by your code, you may get compilation errors. [C:\Code\NuGet.Client\src\NuGet.Core\NuGet.Configuration\NuGet.Configuration.csproj]
  C:\Program Files\Microsoft Visual Studio\2022\Preview\MSBuild\Current\Bin\amd64\Microsoft.Common.CurrentVersion.targets(2301,5): warning MSB3243: No way to resolve conflict between "System.Xml, Version=4.0.0.0, Culture=neutral, Public
KeyToken=b77a5c561934e089" and "System.Xml". Choosing "System.Xml, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" arbitrarily. [C:\Code\NuGet.Client\src\NuGet.Core\NuGet.Configuration\NuGet.Configuration.csproj]
  C:\Program Files\Microsoft Visual Studio\2022\Preview\MSBuild\Current\Bin\amd64\Microsoft.Common.CurrentVersion.targets(2301,5): warning MSB3243: No way to resolve conflict between "System.Xml.Linq, Version=4.0.0.0, Culture=neutral, P
ublicKeyToken=b77a5c561934e089" and "System.Xml.Linq". Choosing "System.Xml.Linq, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" arbitrarily. [C:\Code\NuGet.Client\src\NuGet.Core\NuGet.Configuration\NuGet.Configurati
on.csproj]

    5 Warning(s)

This was mistakenly added in https://github.com/NuGet/NuGet.Client/pull/4404#discussion_r796816016

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
