### PR TITLE
Update FluentAssertions to the latest stable version 6.6.0

### DIFF
--- a/build/packages.targets
+++ b/build/packages.targets
@@ -89,7 +89,7 @@
 
     <!-- Test and utility packages -->
     <ItemGroup>
-        <PackageReference Update="FluentAssertions" Version="5.4.1" />
+        <PackageReference Update="FluentAssertions" Version="6.6.0" />
         <PackageReference Update="Microsoft.Build.Runtime" Version="$(MicrosoftBuildPackageVersion)" />
         <PackageReference Update="Microsoft.CSharp" Version="$(SystemPackagesVersion)" />
         <PackageReference Update="Microsoft.CodeAnalysis" Version="3.0.0" />

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
@@ -1933,7 +1933,7 @@ namespace NuGet.Commands.FuncTest
         }
 
         [Fact]
-        public void RestoreCommand_PathTooLongException()
+        public async Task RestoreCommand_PathTooLongException()
         {
             // Arrange
             var sources = new List<PackageSource>
@@ -1978,7 +1978,7 @@ namespace NuGet.Commands.FuncTest
                 var command = new RestoreCommand(request);
 
                 // Act
-                new Func<Task>(async () => await command.ExecuteAsync()).Should().Throw<PathTooLongException>();
+                await ((Func<Task>)command.ExecuteAsync).Should().ThrowAsync<PathTooLongException>();
             }
         }
 
@@ -3859,7 +3859,7 @@ namespace NuGet.Commands.FuncTest
             logMessage.Message.Should().Be("You are running the 'restore' operation with an 'http' source, 'http://api.source/index.json'. Support for 'http' sources will be removed in a future version.");
         }
 
-        static TestRestoreRequest CreateRestoreRequest(PackageSpec spec, string userPackagesFolder, List<PackageSource>  sources, ILogger logger)
+        static TestRestoreRequest CreateRestoreRequest(PackageSpec spec, string userPackagesFolder, List<PackageSource> sources, ILogger logger)
         {
             var dgSpec = new DependencyGraphSpec();
             dgSpec.AddProject(spec);

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
@@ -1933,7 +1933,7 @@ namespace NuGet.Commands.FuncTest
         }
 
         [Fact]
-        public async Task RestoreCommand_PathTooLongException()
+        public async Task RestoreCommand_PathTooLongExceptionAsync()
         {
             // Arrange
             var sources = new List<PackageSource>
@@ -1978,7 +1978,7 @@ namespace NuGet.Commands.FuncTest
                 var command = new RestoreCommand(request);
 
                 // Act
-                await ((Func<Task>)command.ExecuteAsync).Should().ThrowAsync<PathTooLongException>();
+                await Assert.ThrowsAsync<PathTooLongException>(command.ExecuteAsync);
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/PackagePatternItemTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/PackagePatternItemTests.cs
@@ -56,7 +56,7 @@ namespace NuGet.Configuration.Test
             var firstPatternItem = new PackagePatternItem(first);
             var secondPatternItem = new PackagePatternItem(second);
 
-            firstPatternItem.GetHashCode().Should().Equals(secondPatternItem.GetHashCode());
+            firstPatternItem.GetHashCode().Should().Be(secondPatternItem.GetHashCode());
         }
 
         [Theory]

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/StoreClientCertItemTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/StoreClientCertItemTests.cs
@@ -65,7 +65,7 @@ namespace NuGet.Configuration.Test
         [InlineData("root", StoreName.Root)]
         [InlineData("trustedPeople", StoreName.TrustedPeople)]
         [InlineData("trustedPublisher", StoreName.TrustedPublisher)]
-        public void StoreClientCert_StoreName_ParsedCorrectly(string stringValue, object value)
+        public void StoreClientCert_StoreName_ParsedCorrectly(string stringValue, StoreName value)
         {
             // Arrange
             var config = $@"
@@ -104,7 +104,7 @@ namespace NuGet.Configuration.Test
         [Theory]
         [InlineData("currentUser", StoreLocation.CurrentUser)]
         [InlineData("localMachine", StoreLocation.LocalMachine)]
-        public void StoreClientCert_StoreLocation_ParsedCorrectly(string stringValue, object value)
+        public void StoreClientCert_StoreLocation_ParsedCorrectly(string stringValue, StoreLocation value)
         {
             // Arrange
             var config = $@"
@@ -156,7 +156,7 @@ namespace NuGet.Configuration.Test
         [InlineData("extension", X509FindType.FindByExtension)]
         [InlineData("keyUsage", X509FindType.FindByKeyUsage)]
         [InlineData("subjectKeyIdentifier", X509FindType.FindBySubjectKeyIdentifier)]
-        public void StoreClientCert_FindBy_ParsedCorrectly(string stringValue, object value)
+        public void StoreClientCert_FindBy_ParsedCorrectly(string stringValue, X509FindType value)
         {
             // Arrange
             var config = $@"

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/TrustedSignersProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/TrustedSignersProviderTests.cs
@@ -121,9 +121,9 @@ namespace NuGet.Packaging.Test
                 trustedSigners.Count.Should().Be(3);
                 trustedSigners.Should().BeEquivalentTo(expectedTrustedSigners,
                     options => options
-                        .Excluding(o => o.SelectedMemberPath == "[0].Origin")
-                        .Excluding(o => o.SelectedMemberPath == "[1].Origin")
-                        .Excluding(o => o.SelectedMemberPath == "[2].Origin"));
+                        .Excluding(o => o.Path == "[0].Origin")
+                        .Excluding(o => o.Path == "[1].Origin")
+                        .Excluding(o => o.Path == "[2].Origin"));
             }
         }
 
@@ -173,9 +173,9 @@ namespace NuGet.Packaging.Test
                 trustedSigners.Should().BeEquivalentTo(
                     expectedTrustedSigners,
                     options => options
-                        .Excluding(o => o.SelectedMemberPath == "[0].Origin")
-                        .Excluding(o => o.SelectedMemberPath == "[1].Origin")
-                        .Excluding(o => o.SelectedMemberPath == "[2].Origin"));
+                        .Excluding(o => o.Path == "[0].Origin")
+                        .Excluding(o => o.Path == "[1].Origin")
+                        .Excluding(o => o.Path == "[2].Origin"));
             }
         }
 
@@ -249,8 +249,8 @@ namespace NuGet.Packaging.Test
                 trustedSigners.Should().BeEquivalentTo(
                     expectedTrustedSigners,
                     options => options
-                        .Excluding(o => o.SelectedMemberPath == "[0].Origin")
-                        .Excluding(o => o.SelectedMemberPath == "[1].Origin"));
+                        .Excluding(o => o.Path == "[0].Origin")
+                        .Excluding(o => o.Path == "[1].Origin"));
             }
         }
 
@@ -299,8 +299,8 @@ namespace NuGet.Packaging.Test
                 trustedSigners.Should().BeEquivalentTo(
                     expectedTrustedSigners,
                     options => options
-                        .Excluding(o => o.SelectedMemberPath == "[0].Origin")
-                        .Excluding(o => o.SelectedMemberPath == "[1].Origin"));
+                        .Excluding(o => o.Path == "[0].Origin")
+                        .Excluding(o => o.Path == "[1].Origin"));
             }
         }
 
@@ -362,10 +362,10 @@ namespace NuGet.Packaging.Test
                 trustedSigners.Should().BeEquivalentTo(
                     expectedTrustedSigners,
                     options => options
-                        .Excluding(o => o.SelectedMemberPath == "[0].Origin")
-                        .Excluding(o => o.SelectedMemberPath == "[1].Origin")
-                        .Excluding(o => o.SelectedMemberPath == "[2].Origin")
-                        .Excluding(o => o.SelectedMemberPath == "[3].Origin"));
+                        .Excluding(o => o.Path == "[0].Origin")
+                        .Excluding(o => o.Path == "[1].Origin")
+                        .Excluding(o => o.Path == "[2].Origin")
+                        .Excluding(o => o.Path == "[3].Origin"));
             }
         }
 
@@ -413,9 +413,9 @@ namespace NuGet.Packaging.Test
                 trustedSigners.Count.Should().Be(3);
                 trustedSigners.Should().BeEquivalentTo(expectedTrustedSigners,
                     options => options
-                        .Excluding(o => o.SelectedMemberPath == "[0].Origin")
-                        .Excluding(o => o.SelectedMemberPath == "[1].Origin")
-                        .Excluding(o => o.SelectedMemberPath == "[2].Origin"));
+                        .Excluding(o => o.Path == "[0].Origin")
+                        .Excluding(o => o.Path == "[1].Origin")
+                        .Excluding(o => o.Path == "[2].Origin"));
             }
         }
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1570

Regression? Last working version: N/A

## Description
Update FluentAssertions to the latest stable version, 6.6.0, to make use of ContainMatch, NotContainMatch in future PRs, and other improvements the update provides. See: https://fluentassertions.com/upgradingtov6
Also fixed tests to adhere to the new APIs from FluentAssertions version 6+

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
