### PR TITLE
Improve message when a path contains illegal characters

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/InstallCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/InstallCommand.cs
@@ -119,7 +119,10 @@ namespace NuGet.CommandLine
                 }
                 catch (ArgumentException e)
                 {
-                    throw new ArgumentException($"Invalid Solution Directory: '{SolutionDirectory}'", e);
+                    throw new ArgumentException(string.Format(CultureInfo.CurrentCulture,
+                            LocalizedResourceManager.GetString("Error_InvalidSolutionDirectory"),
+                            SolutionDirectory),
+                        e);
                 }
 
                 var solutionSettingsFile = Path.GetFullPath(path);

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/InstallCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/InstallCommand.cs
@@ -115,7 +115,7 @@ namespace NuGet.CommandLine
                 string path;
                 try
                 {
-                    path = Path.Combine(SolutionDirectory.Trim('\"'), NuGetConstants.NuGetSolutionSettingsFolder);
+                    path = Path.Combine(SolutionDirectory, NuGetConstants.NuGetSolutionSettingsFolder);
                 }
                 catch (ArgumentException e)
                 {

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/InstallCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/InstallCommand.cs
@@ -112,7 +112,15 @@ namespace NuGet.CommandLine
             // If the SolutionDir is specified, use the .nuget directory under it to determine the solution-level settings
             if (!string.IsNullOrEmpty(SolutionDirectory))
             {
-                var path = Path.Combine(SolutionDirectory.TrimEnd(Path.DirectorySeparatorChar), NuGetConstants.NuGetSolutionSettingsFolder);
+                string path;
+                try
+                {
+                    path = Path.Combine(SolutionDirectory.TrimEnd(Path.DirectorySeparatorChar), NuGetConstants.NuGetSolutionSettingsFolder);
+                }
+                catch (ArgumentException e)
+                {
+                    throw new ArgumentException($"Invalid Solution Directory: '{SolutionDirectory}'", e);
+                }
 
                 var solutionSettingsFile = Path.GetFullPath(path);
 

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/InstallCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/InstallCommand.cs
@@ -115,7 +115,7 @@ namespace NuGet.CommandLine
                 string path;
                 try
                 {
-                    path = Path.Combine(SolutionDirectory.TrimEnd(Path.DirectorySeparatorChar), NuGetConstants.NuGetSolutionSettingsFolder);
+                    path = Path.Combine(SolutionDirectory.Trim('\"'), NuGetConstants.NuGetSolutionSettingsFolder);
                 }
                 catch (ArgumentException e)
                 {

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
@@ -885,18 +885,15 @@ namespace NuGet.CommandLine
             restoreInputs.DirectoryOfSolutionFile = Path.GetDirectoryName(solutionFileFullPath);
             restoreInputs.NameOfSolutionFile = Path.GetFileNameWithoutExtension(solutionFileFullPath);
 
+            // restore packages for the solution
+            string solutionLevelPackagesConfig;
+
             try
             {
-                // restore packages for the solution
-                var solutionLevelPackagesConfig = Path.Combine(
+                solutionLevelPackagesConfig = Path.Combine(
                     restoreInputs.DirectoryOfSolutionFile,
                     NuGetConstants.NuGetSolutionSettingsFolder,
                     Constants.PackageReferenceFile);
-
-                if (File.Exists(solutionLevelPackagesConfig))
-                {
-                    restoreInputs.PackagesConfigFiles.Add(solutionLevelPackagesConfig);
-                }
             }
             catch (ArgumentException e)
             {
@@ -904,6 +901,11 @@ namespace NuGet.CommandLine
                         LocalizedResourceManager.GetString("Error_InvalidSolutionDirectory"),
                         restoreInputs.DirectoryOfSolutionFile),
                     e);
+            }
+
+            if (File.Exists(solutionLevelPackagesConfig))
+            {
+                restoreInputs.PackagesConfigFiles.Add(solutionLevelPackagesConfig);
             }
 
             var projectFiles = MsBuildUtility.GetAllProjectFileNames(solutionFileFullPath, MsBuildDirectory.Value.Path);

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
@@ -889,7 +889,7 @@ namespace NuGet.CommandLine
             {
                 // restore packages for the solution
                 var solutionLevelPackagesConfig = Path.Combine(
-                    restoreInputs.DirectoryOfSolutionFile,
+                    restoreInputs.DirectoryOfSolutionFile.Trim('\"'),
                     NuGetConstants.NuGetSolutionSettingsFolder,
                     Constants.PackageReferenceFile);
 

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
@@ -900,7 +900,10 @@ namespace NuGet.CommandLine
             }
             catch (ArgumentException e)
             {
-                throw new ArgumentException($"Invalid Solution Directory: '{restoreInputs.DirectoryOfSolutionFile}'", e);
+                throw new ArgumentException(string.Format(CultureInfo.CurrentCulture,
+                        LocalizedResourceManager.GetString("Error_InvalidSolutionDirectory"),
+                        restoreInputs.DirectoryOfSolutionFile),
+                    e);
             }
 
             var projectFiles = MsBuildUtility.GetAllProjectFileNames(solutionFileFullPath, MsBuildDirectory.Value.Path);

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
@@ -889,7 +889,7 @@ namespace NuGet.CommandLine
             {
                 // restore packages for the solution
                 var solutionLevelPackagesConfig = Path.Combine(
-                    restoreInputs.DirectoryOfSolutionFile.Trim('\"'),
+                    restoreInputs.DirectoryOfSolutionFile,
                     NuGetConstants.NuGetSolutionSettingsFolder,
                     Constants.PackageReferenceFile);
 

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
@@ -885,15 +885,22 @@ namespace NuGet.CommandLine
             restoreInputs.DirectoryOfSolutionFile = Path.GetDirectoryName(solutionFileFullPath);
             restoreInputs.NameOfSolutionFile = Path.GetFileNameWithoutExtension(solutionFileFullPath);
 
-            // restore packages for the solution
-            var solutionLevelPackagesConfig = Path.Combine(
-                restoreInputs.DirectoryOfSolutionFile,
-                NuGetConstants.NuGetSolutionSettingsFolder,
-                Constants.PackageReferenceFile);
-
-            if (File.Exists(solutionLevelPackagesConfig))
+            try
             {
-                restoreInputs.PackagesConfigFiles.Add(solutionLevelPackagesConfig);
+                // restore packages for the solution
+                var solutionLevelPackagesConfig = Path.Combine(
+                    restoreInputs.DirectoryOfSolutionFile,
+                    NuGetConstants.NuGetSolutionSettingsFolder,
+                    Constants.PackageReferenceFile);
+
+                if (File.Exists(solutionLevelPackagesConfig))
+                {
+                    restoreInputs.PackagesConfigFiles.Add(solutionLevelPackagesConfig);
+                }
+            }
+            catch (ArgumentException e)
+            {
+                throw new ArgumentException($"Invalid Solution Directory: '{restoreInputs.DirectoryOfSolutionFile}'", e);
             }
 
             var projectFiles = MsBuildUtility.GetAllProjectFileNames(solutionFileFullPath, MsBuildDirectory.Value.Path);

--- a/src/NuGet.Clients/NuGet.CommandLine/MsBuildUtility.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/MsBuildUtility.cs
@@ -1026,7 +1026,10 @@ namespace NuGet.CommandLine
             }
             catch (ArgumentException e)
             {
-                throw new ArgumentException($"Invalid characters in one of the following paths: '{string.Join("', '", paths)}'", e);
+                throw new ArgumentException(string.Format(CultureInfo.CurrentCulture,
+                        LocalizedResourceManager.GetString("Error_InvalidCharactersInPathSegment"),
+                        string.Join("', '", paths)),
+                    e);
             }
 
         }

--- a/src/NuGet.Clients/NuGet.CommandLine/MsBuildUtility.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/MsBuildUtility.cs
@@ -439,7 +439,7 @@ namespace NuGet.CommandLine
                 var solution = new Solution(solutionFile, msbuildPath);
                 var solutionDirectory = Path.GetDirectoryName(solutionFile);
                 return solution.Projects.Where(project => !project.IsSolutionFolder)
-                    .Select(project => CombinePathWithVerboseError(solutionDirectory, project.RelativePath));
+                    .Select(project => CombinePathWithVerboseError(solutionDirectory.Trim('\"'), project.RelativePath));
             }
             catch (Exception ex)
             {
@@ -980,15 +980,9 @@ namespace NuGet.CommandLine
                 {
                     return msbuildExe;
                 }
-                else
-                {
-                    return CombinePathWithVerboseError(msbuildDirectory, "xbuild.exe");
-                }
             }
-            else
-            {
-                return CombinePathWithVerboseError(msbuildDirectory, "msbuild.exe");
-            }
+
+            return CombinePathWithVerboseError(msbuildDirectory.Trim('\"'), "msbuild.exe");
         }
 
         internal static string GetMSBuild(IEnvironmentVariableReader reader)

--- a/src/NuGet.Clients/NuGet.CommandLine/MsBuildUtility.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/MsBuildUtility.cs
@@ -439,7 +439,7 @@ namespace NuGet.CommandLine
                 var solution = new Solution(solutionFile, msbuildPath);
                 var solutionDirectory = Path.GetDirectoryName(solutionFile);
                 return solution.Projects.Where(project => !project.IsSolutionFolder)
-                    .Select(project => CombinePathWithVerboseError(solutionDirectory.Trim('\"'), project.RelativePath));
+                    .Select(project => CombinePathWithVerboseError(solutionDirectory, project.RelativePath));
             }
             catch (Exception ex)
             {
@@ -982,7 +982,7 @@ namespace NuGet.CommandLine
                 }
             }
 
-            return CombinePathWithVerboseError(msbuildDirectory.Trim('\"'), "msbuild.exe");
+            return CombinePathWithVerboseError(msbuildDirectory, "msbuild.exe");
         }
 
         internal static string GetMSBuild(IEnvironmentVariableReader reader)

--- a/src/NuGet.Clients/NuGet.CommandLine/MsBuildUtility.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/MsBuildUtility.cs
@@ -439,7 +439,7 @@ namespace NuGet.CommandLine
                 var solution = new Solution(solutionFile, msbuildPath);
                 var solutionDirectory = Path.GetDirectoryName(solutionFile);
                 return solution.Projects.Where(project => !project.IsSolutionFolder)
-                    .Select(project => Path.Combine(solutionDirectory, project.RelativePath));
+                    .Select(project => CombinePathWithVerboseError(solutionDirectory, project.RelativePath));
             }
             catch (Exception ex)
             {
@@ -982,12 +982,12 @@ namespace NuGet.CommandLine
                 }
                 else
                 {
-                    return Path.Combine(msbuildDirectory, "xbuild.exe");
+                    return CombinePathWithVerboseError(msbuildDirectory, "xbuild.exe");
                 }
             }
             else
             {
-                return Path.Combine(msbuildDirectory, "msbuild.exe");
+                return CombinePathWithVerboseError(msbuildDirectory, "msbuild.exe");
             }
         }
 
@@ -1007,7 +1007,7 @@ namespace NuGet.CommandLine
             {
                 foreach (var exeName in exeNames)
                 {
-                    var exePath = pathDirs.Select(dir => Path.Combine(dir.Trim('\"'), exeName)).FirstOrDefault(File.Exists);
+                    var exePath = pathDirs.Select(dir => CombinePathWithVerboseError(dir.Trim('\"'), exeName)).FirstOrDefault(File.Exists);
                     if (exePath != null)
                     {
                         return exePath;
@@ -1016,6 +1016,19 @@ namespace NuGet.CommandLine
             }
 
             return null;
+        }
+
+        internal static string CombinePathWithVerboseError(params string[] paths)
+        {
+            try
+            {
+                return Path.Combine(paths);
+            }
+            catch (ArgumentException e)
+            {
+                throw new ArgumentException($"Invalid characters in one of the following paths: '{string.Join("', '", paths)}'", e);
+            }
+
         }
 
         /// <summary>

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.Designer.cs
@@ -2833,24 +2833,6 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Ungültiger Projektordner: &apos;{0}&apos;.
-        /// </summary>
-        public static string Error_InvalidSolutionDirectory_deu {
-            get {
-                return ResourceManager.GetString("Error_InvalidSolutionDirectory_deu", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Carpeta de solución no válida: &apos;{0}&apos;.
-        /// </summary>
-        public static string Error_InvalidSolutionDirectory_esp {
-            get {
-                return ResourceManager.GetString("Error_InvalidSolutionDirectory_esp", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Source parameter was not specified..
         /// </summary>
         public static string Error_MissingSourceParameter {

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.Designer.cs
@@ -2806,11 +2806,47 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Invalid characters in one of the following path segments: &apos;{0}&apos;.
+        /// </summary>
+        public static string Error_InvalidCharactersInPathSegment {
+            get {
+                return ResourceManager.GetString("Error_InvalidCharactersInPathSegment", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Invalid MSBuild version specified: &apos;{0}&apos;.
         /// </summary>
         public static string Error_InvalidMsbuildVersion {
             get {
                 return ResourceManager.GetString("Error_InvalidMsbuildVersion", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Invalid solution directory: &apos;{0}&apos;.
+        /// </summary>
+        public static string Error_InvalidSolutionDirectory {
+            get {
+                return ResourceManager.GetString("Error_InvalidSolutionDirectory", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Ungültiger Projektordner: &apos;{0}&apos;.
+        /// </summary>
+        public static string Error_InvalidSolutionDirectory_deu {
+            get {
+                return ResourceManager.GetString("Error_InvalidSolutionDirectory_deu", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Carpeta de solución no válida: &apos;{0}&apos;.
+        /// </summary>
+        public static string Error_InvalidSolutionDirectory_esp {
+            get {
+                return ResourceManager.GetString("Error_InvalidSolutionDirectory_esp", resourceCulture);
             }
         }
         

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
@@ -4439,12 +4439,6 @@ To prevent NuGet from downloading packages during build, open the Visual Studio 
   <data name="FileConflictChoiceText_cht" xml:space="preserve">
     <value>[Y] 是  [A] 全部皆是  [N] 否  [L] 全部皆否 ?</value>
   </data>
-  <data name="Error_InvalidSolutionDirectory_deu" xml:space="preserve">
-    <value>Ungültiger Projektordner: '{0}'</value>
-  </data>
-  <data name="Error_InvalidSolutionDirectory_esp" xml:space="preserve">
-    <value>Carpeta de solución no válida: '{0}'</value>
-  </data>
   <data name="Error_MultipleSolutions_csy" xml:space="preserve">
     <value>Tato složka obsahuje více než jeden soubor řešení.</value>
   </data>

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
@@ -406,6 +406,12 @@
     <value>[Y] Yes  [A] Yes to All  [N] No  [L] No to All ?</value>
     <comment>Please do not localize the letters inside the [] brackets.</comment>
   </data>
+  <data name="Error_InvalidCharactersInPathSegment" xml:space="preserve">
+    <value>Invalid characters in one of the following path segments: '{0}'</value>
+  </data>
+  <data name="Error_InvalidSolutionDirectory" xml:space="preserve">
+    <value>Invalid solution directory: '{0}'</value>
+  </data>
   <data name="Error_MultipleSolutions" xml:space="preserve">
     <value>This folder contains more than one solution file.</value>
   </data>
@@ -4432,6 +4438,12 @@ To prevent NuGet from downloading packages during build, open the Visual Studio 
   </data>
   <data name="FileConflictChoiceText_cht" xml:space="preserve">
     <value>[Y] 是  [A] 全部皆是  [N] 否  [L] 全部皆否 ?</value>
+  </data>
+  <data name="Error_InvalidSolutionDirectory_deu" xml:space="preserve">
+    <value>Ungültiger Projektordner: '{0}'</value>
+  </data>
+  <data name="Error_InvalidSolutionDirectory_esp" xml:space="preserve">
+    <value>Carpeta de solución no válida: '{0}'</value>
   </data>
   <data name="Error_MultipleSolutions_csy" xml:space="preserve">
     <value>Tato složka obsahuje více než jeden soubor řešení.</value>

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/MSBuildUtilityTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/MSBuildUtilityTest.cs
@@ -340,7 +340,7 @@ namespace NuGet.CommandLine.Test
             Assert.Equal(Path.Combine(paths), MsBuildUtility.CombinePathWithVerboseError(paths));
         }
 
-        [Fact]
+        [PlatformFact(Platform.Windows, Platform.Linux)]
         public void CombinePathWithVerboseError_IllegalCharacters_MessageContainsBadPath()
         {
             const string badPath = @"C:\bad:>dir";

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/MSBuildUtilityTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/MSBuildUtilityTest.cs
@@ -343,7 +343,7 @@ namespace NuGet.CommandLine.Test
         [Fact]
         public void CombinePathWithVerboseError_IllegalCharacters_MessageContainsBadPath()
         {
-            const string badPath = @"C:\bad>dir";
+            const string badPath = @"C:\bad:>dir";
             var exception = Assert.Throws<ArgumentException>(() => MsBuildUtility.CombinePathWithVerboseError(badPath, "file.txt"));
             Assert.Contains(badPath, exception.Message);
         }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/MSBuildUtilityTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/MSBuildUtilityTest.cs
@@ -334,6 +334,13 @@ namespace NuGet.CommandLine.Test
         }
 
         [Fact]
+        public void CombinePathWithVerboseError_CombinesPaths()
+        {
+            var paths = new[] {"C:\\", "directory/", "\\folder", "file.txt"};
+            Assert.Equal(Path.Combine(paths), MsBuildUtility.CombinePathWithVerboseError(paths));
+        }
+
+        [Fact]
         public void CombinePathWithVerboseError_IllegalCharacters_MessageContainsBadPath()
         {
             const string badPath = @"C:\bad>dir";

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/MSBuildUtilityTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/MSBuildUtilityTest.cs
@@ -333,6 +333,14 @@ namespace NuGet.CommandLine.Test
             }
         }
 
+        [Fact]
+        public void CombinePathWithVerboseError_IllegalCharacters_MessageContainsBadPath()
+        {
+            const string badPath = @"C:\bad>dir";
+            var exception = Assert.Throws<ArgumentException>(() => MsBuildUtility.CombinePathWithVerboseError(badPath, "file.txt"));
+            Assert.Contains(badPath, exception.Message);
+        }
+
         public static class ToolsetDataSource
         {
             // Legacy toolsets

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/MSBuildUtilityTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/MSBuildUtilityTest.cs
@@ -340,7 +340,7 @@ namespace NuGet.CommandLine.Test
             Assert.Equal(Path.Combine(paths), MsBuildUtility.CombinePathWithVerboseError(paths));
         }
 
-        [PlatformFact(Platform.Windows, Platform.Linux)]
+        [PlatformFact(Platform.Windows)]
         public void CombinePathWithVerboseError_IllegalCharacters_MessageContainsBadPath()
         {
             const string badPath = @"C:\bad:>dir";


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11764

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

* When Path.Combine throws an ArgumentException, wrap it in an ArgumentException with a helpful message.

Addresses the stacks in https://github.com/NuGet/Home/issues/8373 and https://github.com/NuGet/Home/issues/11764; there may be others that these changes do not address.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
