### PR TITLE
Restore: Prefer `TargetFramework` over `TargetFrameworks` when it is specified as a global property.

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks/GetGlobalPropertyValueTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/GetGlobalPropertyValueTask.cs
@@ -1,0 +1,73 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Microsoft.Build.Framework;
+using Newtonsoft.Json;
+using NuGet.Packaging;
+using Task = Microsoft.Build.Utilities.Task;
+
+
+namespace NuGet.Build.Tasks
+{
+    public class GetGlobalPropertyValueTask : Task
+    {
+        [Required]
+        public string PropertyName { get; set; }
+
+        [Output]
+        public string GlobalPropertyValue { get; set; }
+
+        public override bool Execute()
+        {
+            var globalProperties = GetGlobalProperties();
+
+
+            if (globalProperties.TryGetValue(PropertyName, out string globalProperty))
+            {
+                GlobalPropertyValue = globalProperty;
+            }
+            return !Log.HasLoggedErrors;
+        }
+        internal Dictionary<string, string> GetGlobalProperties()
+        {
+#if IS_CORECLR
+            // MSBuild 16.5 and above has a method to get the global properties, older versions do not
+            Dictionary<string, string> msBuildGlobalProperties = BuildEngine is IBuildEngine6 buildEngine6
+                ? buildEngine6.GetGlobalProperties().ToDictionary(i => i.Key, i => i.Value, StringComparer.OrdinalIgnoreCase)
+                : new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+#else
+            var msBuildGlobalProperties = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+            // MSBuild 16.5 added a new interface, IBuildEngine6, which has a GetGlobalProperties() method.  However, we compile against
+            // Microsoft.Build.Framework version 4.0 when targeting .NET Framework, so reflection is required since type checking
+            // can't be done at compile time
+            var buildEngine6Type = typeof(IBuildEngine).Assembly.GetType("Microsoft.Build.Framework.IBuildEngine6");
+
+            if (buildEngine6Type != null)
+            {
+                var getGlobalPropertiesMethod = buildEngine6Type.GetMethod("GetGlobalProperties", BindingFlags.Instance | BindingFlags.Public);
+
+                if (getGlobalPropertiesMethod != null)
+                {
+                    try
+                    {
+                        if (getGlobalPropertiesMethod.Invoke(BuildEngine, null) is IReadOnlyDictionary<string, string> globalProperties)
+                        {
+                            msBuildGlobalProperties.AddRange(globalProperties);
+                        }
+                    }
+                    catch (Exception)
+                    {
+                        // Ignored
+                    }
+                }
+            }
+#endif
+            return msBuildGlobalProperties;
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -617,6 +617,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     _GetRestoreTargetFrameworksAsItems
     Read $(TargetFrameworks) from the project as items.
     Projects that do not have $(TargetFrameworks) will noop.
+    If $(TargetFramework) is specified globally, it'll be preferred over $(TargetFrameworks)
     ============================================================
   -->
   <Target Name="_GetRestoreTargetFrameworksAsItems"
@@ -689,8 +690,8 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <!--
     ============================================================
-    _GetRestoreSettingsCurrentProject
-    Generate items for a single framework.
+    _GetRestoreSettingsAllFrameworks
+    Generate items for all frameworks.
     ============================================================
   -->
   <Target Name="_GetRestoreSettingsAllFrameworks"
@@ -776,7 +777,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     </PropertyGroup>
 
     <!-- Determine if this will use cross targeting -->
-    <PropertyGroup Condition=" '$(PackageReferenceCompatibleProjectStyle)' == 'true' AND '$(TargetFrameworks)' != '' AND '$(_TargetFrameworkOverride)' == '' ">
+    <PropertyGroup Condition=" '$(PackageReferenceCompatibleProjectStyle)' == 'true' AND '$(TargetFrameworks)' != '' ">
       <_RestoreCrossTargeting>true</_RestoreCrossTargeting>
     </PropertyGroup>
 
@@ -902,11 +903,11 @@ Copyright (c) .NET Foundation. All rights reserved.
     Walk dependencies for all frameworks.
     ============================================================
   -->
-  <Target Name="_GenerateProjectRestoreGraphAllFrameworks"
-    Condition=" '$(TargetFrameworks)' != '' AND '$(_TargetFrameworkOverride)' == '' "
+  <!-- This should probably not check TF override -->
+<Target Name="_GenerateProjectRestoreGraphAllFrameworks"
+    Condition=" '$(TargetFrameworks)' != '' AND '$(_TargetFrameworkOverride)' == '' " 
     DependsOnTargets="_GetRestoreTargetFrameworksAsItems"
     Returns="@(_RestoreGraphEntry)">
-
     <!-- Get project and package references  -->
     <!-- Evaluate for each framework -->
     <MSBuild
@@ -928,7 +929,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     Walk dependencies with the current framework.
     ============================================================
   -->
-  <!-- probably it does not matter -->
+  <!-- probably it does not matter?  -->
   <Target Name="_GenerateProjectRestoreGraphCurrentProject"
     Condition=" '$(TargetFrameworks)' == '' OR '$(_TargetFrameworkOverride)' != '' " 
     DependsOnTargets="_GenerateProjectRestoreGraphPerFramework"
@@ -1036,6 +1037,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     _GenerateRestoreProjectPathItemsCurrentProject
     Get absolute paths for all project references.
     ============================================================
+    probably it does not matter? Do we really care for TargetFramework override? 
   -->
   <Target Name="_GenerateRestoreProjectPathItemsCurrentProject"
     Condition=" '$(TargetFrameworks)' == '' OR '$(_TargetFrameworkOverride)' != '' "

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -110,6 +110,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <UsingTask TaskName="NuGet.Build.Tasks.GetRestoreProjectStyleTask" AssemblyFile="$(RestoreTaskAssemblyFile)" />
   <UsingTask TaskName="NuGet.Build.Tasks.NuGetMessageTask" AssemblyFile="$(RestoreTaskAssemblyFile)" />
   <UsingTask TaskName="NuGet.Build.Tasks.CheckForDuplicateNuGetItemsTask" AssemblyFile="$(RestoreTaskAssemblyFile)" />
+  <UsingTask TaskName="NuGet.Build.Tasks.GetGlobalPropertyValueTask" AssemblyFile="$(RestoreTaskAssemblyFile)" />
 
   <!--
     ============================================================
@@ -234,7 +235,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <PackageVersion Remove="@(PackageVersion)" />
       <PackageVersion Include="@(DeduplicatedPackageVersions)" />
     </ItemGroup>
-    
+
   </Target>
 
   <!--
@@ -278,11 +279,11 @@ Copyright (c) .NET Foundation. All rights reserved.
     ============================================================
   -->
   <Target Name="CollectFrameworkReferences" Returns="@(_FrameworkReferenceForRestore)">
-      <ItemGroup>
-          <_FrameworkReferenceForRestore 
-            Include="@(FrameworkReference)"
-            Condition="'%(FrameworkReference.IsTransitiveFrameworkReference)' != 'true'"/>
-      </ItemGroup>
+    <ItemGroup>
+      <_FrameworkReferenceForRestore
+        Include="@(FrameworkReference)"
+        Condition="'%(FrameworkReference.IsTransitiveFrameworkReference)' != 'true'"/>
+    </ItemGroup>
   </Target>
   <!--
     ============================================================
@@ -857,7 +858,7 @@ Copyright (c) .NET Foundation. All rights reserved.
         <ConfigFilePaths>$(_OutputConfigFilePaths)</ConfigFilePaths>
         <PackagesPath>$(_OutputPackagesPath)</PackagesPath>
         <TargetFrameworks>@(_RestoreTargetFrameworksOutputFiltered)</TargetFrameworks>
-        </_RestoreGraphEntry>
+      </_RestoreGraphEntry>
     </ItemGroup>
 
     <!-- Non-NuGet type -->
@@ -907,10 +908,10 @@ Copyright (c) .NET Foundation. All rights reserved.
     ============================================================
   -->
   <!-- This should probably not check TF override -->
-<Target Name="_GenerateProjectRestoreGraphAllFrameworks"
-    Condition=" '$(TargetFrameworks)' != '' " 
-    DependsOnTargets="_GetRestoreTargetFrameworksAsItems"
-    Returns="@(_RestoreGraphEntry)">
+  <Target Name="_GenerateProjectRestoreGraphAllFrameworks"
+      Condition=" '$(TargetFrameworks)' != '' "
+      DependsOnTargets="_GetRestoreTargetFrameworksAsItems"
+      Returns="@(_RestoreGraphEntry)">
     <!-- Get project and package references  -->
     <!-- Evaluate for each framework -->
     <MSBuild
@@ -1382,22 +1383,23 @@ Copyright (c) .NET Foundation. All rights reserved.
       PropertyName="TargetFramework"
         Condition=" '$(TargetFrameworks)' != '' ">
       <Output TaskParameter="GlobalPropertyValue" PropertyName="_TargetFrameworkOverride" />
+      <Output TaskParameter="CheckCompleted" PropertyName="_TargetFrameworkOverrideCheckCompleted" />
     </GetGlobalPropertyValueTask>
-    
-    <!--<MSBuild
+
+    <MSBuild
         BuildInParallel="$(RestoreBuildInParallel)"
-        Condition=" '$(TargetFrameworks)' != '' "
+        Condition=" '$(_TargetFrameworkOverrideCheckCompleted)' != 'true' AND '$(TargetFrameworks)' != '' "
         Projects="$(MSBuildThisFileFullPath)"
         Targets="_GetTargetFrameworkOverrides">
       <Output
           TaskParameter="TargetOutputs"
           PropertyName="_TargetFrameworkOverride" />
-    </MSBuild>-->
+    </MSBuild>
 
     <!-- Only set the override if TargetFrameworks has not been overriden as well. In that case, prefer it. -->
   </Target>
 
-    <!--
+  <!--
     ============================================================
     _GetTargetFrameworkOverrides
     ============================================================
@@ -1422,7 +1424,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <_ValidProjectsForRestore Include="$(MSBuildProjectFullPath)" />
     </ItemGroup>
   </Target>
- 
+
   <!--
     ============================================================
     Import NuGet.RestoreEx.targets if the MSBuild property 'RestoreEnableStaticGraph'

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -623,9 +623,9 @@ Copyright (c) .NET Foundation. All rights reserved.
     ============================================================
   -->
   <Target Name="_GetRestoreTargetFrameworksAsItems"
-    DependsOnTargets="_GetRestoreProjectStyle"
+    DependsOnTargets="_GetRestoreProjectStyle;_GetRestoreTargetFrameworkOverride"
     Returns="@(_RestoreTargetFrameworkItems)">
-    <ItemGroup Condition=" '$(TargetFrameworks)' != '' ">
+    <ItemGroup Condition=" '$(TargetFrameworks)' != '' AND '$(_TargetFrameworkOverride)' == '' ">
       <_RestoreTargetFrameworkItems Include="$(TargetFrameworks.Split(';'))" />
     </ItemGroup>
   </Target>

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -623,8 +623,11 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Target Name="_GetRestoreTargetFrameworksAsItems"
     DependsOnTargets="_GetRestoreProjectStyle;_GetRestoreTargetFrameworkOverride"
     Returns="@(_RestoreTargetFrameworkItems)">
-    <ItemGroup Condition=" '$(TargetFrameworks)' != ''">
+    <ItemGroup Condition=" '$(TargetFrameworks)' != '' AND '$(_TargetFrameworkOverride)' == '' ">
       <_RestoreTargetFrameworkItems Include="$(TargetFrameworks.Split(';'))" />
+    </ItemGroup>
+    <ItemGroup Condition=" '$(TargetFrameworks)' != '' AND '$(_TargetFrameworkOverride)' != '' ">
+      <_RestoreTargetFrameworkItems Include="$(_TargetFrameworkOverride)" />
     </ItemGroup>
   </Target>
 
@@ -1040,7 +1043,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     probably it does not matter? Do we really care for TargetFramework override? 
   -->
   <Target Name="_GenerateRestoreProjectPathItemsCurrentProject"
-    Condition=" '$(TargetFrameworks)' == '' OR '$(_TargetFrameworkOverride)' != '' "
+    Condition=" '$(TargetFrameworks)' == '' "
     DependsOnTargets="_GenerateRestoreProjectPathItemsPerFramework"
     Returns="@(_RestoreProjectPathItems)">
   </Target>

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -1377,7 +1377,14 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Target Name="_GetRestoreTargetFrameworkOverride"
           Condition=" '$(_DisableNuGetRestoreTargetFrameworksOverride)' != 'true' "
           Returns="$(_TargetFrameworkOverride)">
-    <MSBuild
+
+    <GetGlobalPropertyValueTask
+      PropertyName="TargetFramework"
+        Condition=" '$(TargetFrameworks)' != '' ">
+      <Output TaskParameter="GlobalPropertyValue" PropertyName="_TargetFrameworkOverride" />
+    </GetGlobalPropertyValueTask>
+    
+    <!--<MSBuild
         BuildInParallel="$(RestoreBuildInParallel)"
         Condition=" '$(TargetFrameworks)' != '' "
         Projects="$(MSBuildThisFileFullPath)"
@@ -1385,10 +1392,9 @@ Copyright (c) .NET Foundation. All rights reserved.
       <Output
           TaskParameter="TargetOutputs"
           PropertyName="_TargetFrameworkOverride" />
-    </MSBuild>
+    </MSBuild>-->
 
     <!-- Only set the override if TargetFrameworks has not been overriden as well. In that case, prefer it. -->
-
   </Target>
 
     <!--

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -907,11 +907,11 @@ Copyright (c) .NET Foundation. All rights reserved.
     Walk dependencies for all frameworks.
     ============================================================
   -->
-  <!-- This should probably not check TF override -->
   <Target Name="_GenerateProjectRestoreGraphAllFrameworks"
       Condition=" '$(TargetFrameworks)' != '' "
       DependsOnTargets="_GetRestoreTargetFrameworksAsItems"
       Returns="@(_RestoreGraphEntry)">
+
     <!-- Get project and package references  -->
     <!-- Evaluate for each framework -->
     <MSBuild
@@ -1383,18 +1383,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       PropertyName="TargetFramework"
         Condition=" '$(TargetFrameworks)' != '' ">
       <Output TaskParameter="GlobalPropertyValue" PropertyName="_TargetFrameworkOverride" />
-      <Output TaskParameter="CheckCompleted" PropertyName="_TargetFrameworkOverrideCheckCompleted" />
     </GetGlobalPropertyValueTask>
-
-    <MSBuild
-        BuildInParallel="$(RestoreBuildInParallel)"
-        Condition=" '$(_TargetFrameworkOverrideCheckCompleted)' != 'true' AND '$(TargetFrameworks)' != '' "
-        Projects="$(MSBuildThisFileFullPath)"
-        Targets="_GetTargetFrameworkOverrides">
-      <Output
-          TaskParameter="TargetOutputs"
-          PropertyName="_TargetFrameworkOverride" />
-    </MSBuild>
 
     <!-- Only set the override if TargetFrameworks has not been overriden as well. In that case, prefer it. -->
   </Target>

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -1366,10 +1366,13 @@ Copyright (c) .NET Foundation. All rights reserved.
     </PropertyGroup>
   </Target>
 
+  <!--
+    ============================================================
+    _GetRestoreTargetFrameworkOverride
+    ============================================================
+  -->
   <Target Name="_GetRestoreTargetFrameworkOverride"
           Returns="$(_TargetFrameworkOverride)">
-
-    <!-- TargetFramework -->
     <MSBuild
         BuildInParallel="$(RestoreBuildInParallel)"
         Condition=" '$(TargetFrameworks)' != '' "
@@ -1384,7 +1387,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <!--
     ============================================================
-    _GetRestoreFallbackFoldersOverride
+    _GetTargetFrameworkOverrides
     ============================================================
   -->
   <Target Name="_GetTargetFrameworkOverrides"

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -589,8 +589,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <PropertyGroup>
       <_RestoreProjectFramework/>
-      <TargetFrameworkToBeUsed>$(TargetFrameworks)</TargetFrameworkToBeUsed>
-      <TargetFrameworkToBeUsed Condition=" '$(_TargetFrameworkOverride)' != '' "></TargetFrameworkToBeUsed>
+      <TargetFrameworkToBeUsed Condition=" '$(_TargetFrameworkOverride)' == '' ">$(TargetFrameworks)</TargetFrameworkToBeUsed>
     </PropertyGroup>
 
     <!-- For project.json projects target frameworks will be read from project.json. -->
@@ -853,7 +852,7 @@ Copyright (c) .NET Foundation. All rights reserved.
         <RepositoryPath>$(_OutputRepositoryPath)</RepositoryPath>
         <ConfigFilePaths>$(_OutputConfigFilePaths)</ConfigFilePaths>
         <PackagesPath>$(_OutputPackagesPath)</PackagesPath>
-        <TargetFrameworks>@(_RestoreTargetFrameworksOutputFiltered)</TargetFrameworks> <!-- what here? does it matter-->
+        <TargetFrameworks>@(_RestoreTargetFrameworksOutputFiltered)</TargetFrameworks>
         </_RestoreGraphEntry>
     </ItemGroup>
 
@@ -865,7 +864,7 @@ Copyright (c) .NET Foundation. All rights reserved.
         <ProjectPath>$(MSBuildProjectFullPath)</ProjectPath>
         <ProjectName>$(_RestoreProjectName)</ProjectName>
         <ProjectStyle>$(RestoreProjectStyle)</ProjectStyle>
-        <TargetFrameworks>@(_RestoreTargetFrameworksOutputFiltered)</TargetFrameworks> <!-- what here? does it matter-->
+        <TargetFrameworks>@(_RestoreTargetFrameworksOutputFiltered)</TargetFrameworks>
       </_RestoreGraphEntry>
     </ItemGroup>
   </Target>

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -932,9 +932,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     Walk dependencies with the current framework.
     ============================================================
   -->
-  <!-- probably it does not matter?  -->
   <Target Name="_GenerateProjectRestoreGraphCurrentProject"
-    Condition=" '$(TargetFrameworks)' == '' " 
+    Condition=" '$(TargetFrameworks)' == '' "
     DependsOnTargets="_GenerateProjectRestoreGraphPerFramework"
     Returns="@(_RestoreGraphEntry)">
   </Target>
@@ -1040,7 +1039,6 @@ Copyright (c) .NET Foundation. All rights reserved.
     _GenerateRestoreProjectPathItemsCurrentProject
     Get absolute paths for all project references.
     ============================================================
-    probably it does not matter? Do we really care for TargetFramework override? 
   -->
   <Target Name="_GenerateRestoreProjectPathItemsCurrentProject"
     Condition=" '$(TargetFrameworks)' == '' "
@@ -1377,10 +1375,23 @@ Copyright (c) .NET Foundation. All rights reserved.
     ============================================================
   -->
   <Target Name="_GetRestoreTargetFrameworkOverride"
+          Condition=" '$(_DisableNuGetRestoreTargetFrameworksOverride)' != 'true' "
           Returns="$(_TargetFrameworkOverride)">
     <MSBuild
         BuildInParallel="$(RestoreBuildInParallel)"
         Condition=" '$(TargetFrameworks)' != '' "
+        Projects="$(MSBuildThisFileFullPath)"
+        Targets="_GetTargetFrameworksOverrides">
+
+      <Output
+          TaskParameter="TargetOutputs"
+          PropertyName="_TargetFrameworksOverride" />
+    </MSBuild>
+
+    <!-- Only set the override if TargetFrameworks has not been overriden as well. In that case, prefer it. -->
+    <MSBuild
+        BuildInParallel="$(RestoreBuildInParallel)"
+        Condition=" '$(TargetFrameworks)' != '' AND $(_TargetFrameworksOverride) == '' "
         Projects="$(MSBuildThisFileFullPath)"
         Targets="_GetTargetFrameworkOverrides">
 
@@ -1388,6 +1399,7 @@ Copyright (c) .NET Foundation. All rights reserved.
           TaskParameter="TargetOutputs"
           PropertyName="_TargetFrameworkOverride" />
     </MSBuild>
+
   </Target>
 
     <!--
@@ -1399,6 +1411,18 @@ Copyright (c) .NET Foundation. All rights reserved.
           Returns="$(_TargetFrameworkOverride)">
     <PropertyGroup>
       <_TargetFrameworkOverride>$(TargetFramework)</_TargetFrameworkOverride>
+    </PropertyGroup>
+  </Target>
+
+    <!--
+    ============================================================
+    _GetTargetFrameworksOverrides
+    ============================================================
+  -->
+  <Target Name="_GetTargetFrameworksOverrides"
+          Returns="$(_TargetFrameworksOverride)">
+    <PropertyGroup>
+      <_TargetFrameworksOverride>$(TargetFrameworks)</_TargetFrameworksOverride>
     </PropertyGroup>
   </Target>
 

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -584,18 +584,22 @@ Copyright (c) .NET Foundation. All rights reserved.
     ============================================================
   -->
   <Target Name="_GetRestoreTargetFrameworksOutput"
-    DependsOnTargets="_GetRestoreProjectStyle"
+    DependsOnTargets="_GetRestoreProjectStyle;_GetRestoreTargetFrameworkOverride"
     Returns="@(_RestoreTargetFrameworksOutputFiltered)">
 
     <PropertyGroup>
       <_RestoreProjectFramework/>
+      <TargetFrameworkToBeUsed>$(TargetFrameworks)</TargetFrameworkToBeUsed>
+      <TargetFrameworkToBeUsed Condition=" '$(_TargetFrameworkOverride)' != '' ">$(_TargetFrameworkOverride)</TargetFrameworkToBeUsed>
     </PropertyGroup>
+
+    <!-- TODO NK add it here-->
 
     <!-- For project.json projects target frameworks will be read from project.json. -->
     <GetProjectTargetFrameworksTask
       Condition=" '$(RestoreProjectStyle)' != 'ProjectJson'"
       ProjectPath="$(MSBuildProjectFullPath)"
-      TargetFrameworks="$(TargetFrameworks)"
+      TargetFrameworks="$(TargetFrameworkToBeUsed)"
       TargetFramework="$(TargetFramework)"
       TargetFrameworkMoniker="$(TargetFrameworkMoniker)"
       TargetPlatformIdentifier="$(TargetPlatformIdentifier)"
@@ -1361,6 +1365,34 @@ Copyright (c) .NET Foundation. All rights reserved.
           Returns="$(_RestoreFallbackFoldersOverride)">
     <PropertyGroup>
       <_RestoreFallbackFoldersOverride>$(RestoreFallbackFolders)</_RestoreFallbackFoldersOverride>
+    </PropertyGroup>
+  </Target>
+
+  <Target Name="_GetRestoreTargetFrameworkOverride"
+          Returns="$(_TargetFrameworkOverride)">
+
+    <!-- TargetFramework -->
+    <MSBuild
+        BuildInParallel="$(RestoreBuildInParallel)"
+        Condition=" '$(TargetFrameworks)' != '' "
+        Projects="$(MSBuildThisFileFullPath)"
+        Targets="_GetTargetFrameworkOverrides">
+
+      <Output
+          TaskParameter="TargetOutputs"
+          PropertyName="_TargetFrameworkOverride" />
+    </MSBuild>
+  </Target>
+
+    <!--
+    ============================================================
+    _GetRestoreFallbackFoldersOverride
+    ============================================================
+  -->
+  <Target Name="_GetTargetFrameworkOverrides"
+          Returns="$(_TargetFrameworkOverride)">
+    <PropertyGroup>
+      <_TargetFrameworkOverride>$(TargetFramework)</_TargetFrameworkOverride>
     </PropertyGroup>
   </Target>
 

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -908,7 +908,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   -->
   <!-- This should probably not check TF override -->
 <Target Name="_GenerateProjectRestoreGraphAllFrameworks"
-    Condition=" '$(TargetFrameworks)' != '' AND '$(_TargetFrameworkOverride)' == '' " 
+    Condition=" '$(TargetFrameworks)' != '' " 
     DependsOnTargets="_GetRestoreTargetFrameworksAsItems"
     Returns="@(_RestoreGraphEntry)">
     <!-- Get project and package references  -->
@@ -934,7 +934,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   -->
   <!-- probably it does not matter?  -->
   <Target Name="_GenerateProjectRestoreGraphCurrentProject"
-    Condition=" '$(TargetFrameworks)' == '' OR '$(_TargetFrameworkOverride)' != '' " 
+    Condition=" '$(TargetFrameworks)' == '' " 
     DependsOnTargets="_GenerateProjectRestoreGraphPerFramework"
     Returns="@(_RestoreGraphEntry)">
   </Target>
@@ -1093,7 +1093,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     ============================================================
   -->
   <Target Name="_GenerateRestoreProjectPathItemsAllFrameworks"
-    Condition=" '$(TargetFrameworks)' != '' AND '$(_TargetFrameworkOverride)' == '' "
+    Condition=" '$(TargetFrameworks)' != '' "
     DependsOnTargets="_GetRestoreTargetFrameworksAsItems"
     Returns="@(_RestoreProjectPathItems)">
 

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -623,7 +623,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Target Name="_GetRestoreTargetFrameworksAsItems"
     DependsOnTargets="_GetRestoreProjectStyle;_GetRestoreTargetFrameworkOverride"
     Returns="@(_RestoreTargetFrameworkItems)">
-    <ItemGroup Condition=" '$(TargetFrameworks)' != '' AND '$(_TargetFrameworkOverride)' == '' ">
+    <ItemGroup Condition=" '$(TargetFrameworks)' != ''">
       <_RestoreTargetFrameworkItems Include="$(TargetFrameworks.Split(';'))" />
     </ItemGroup>
   </Target>

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -1381,24 +1381,13 @@ Copyright (c) .NET Foundation. All rights reserved.
         BuildInParallel="$(RestoreBuildInParallel)"
         Condition=" '$(TargetFrameworks)' != '' "
         Projects="$(MSBuildThisFileFullPath)"
-        Targets="_GetTargetFrameworksOverrides">
-
-      <Output
-          TaskParameter="TargetOutputs"
-          PropertyName="_TargetFrameworksOverride" />
-    </MSBuild>
-
-    <!-- Only set the override if TargetFrameworks has not been overriden as well. In that case, prefer it. -->
-    <MSBuild
-        BuildInParallel="$(RestoreBuildInParallel)"
-        Condition=" '$(TargetFrameworks)' != '' AND $(_TargetFrameworksOverride) == '' "
-        Projects="$(MSBuildThisFileFullPath)"
         Targets="_GetTargetFrameworkOverrides">
-
       <Output
           TaskParameter="TargetOutputs"
           PropertyName="_TargetFrameworkOverride" />
     </MSBuild>
+
+    <!-- Only set the override if TargetFrameworks has not been overriden as well. In that case, prefer it. -->
 
   </Target>
 
@@ -1410,19 +1399,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Target Name="_GetTargetFrameworkOverrides"
           Returns="$(_TargetFrameworkOverride)">
     <PropertyGroup>
-      <_TargetFrameworkOverride>$(TargetFramework)</_TargetFrameworkOverride>
-    </PropertyGroup>
-  </Target>
-
-    <!--
-    ============================================================
-    _GetTargetFrameworksOverrides
-    ============================================================
-  -->
-  <Target Name="_GetTargetFrameworksOverrides"
-          Returns="$(_TargetFrameworksOverride)">
-    <PropertyGroup>
-      <_TargetFrameworksOverride>$(TargetFrameworks)</_TargetFrameworksOverride>
+      <_TargetFrameworkOverride Condition=" '$(TargetFrameworks)' == '' ">$(TargetFramework)</_TargetFrameworkOverride>
     </PropertyGroup>
   </Target>
 

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -590,10 +590,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     <PropertyGroup>
       <_RestoreProjectFramework/>
       <TargetFrameworkToBeUsed>$(TargetFrameworks)</TargetFrameworkToBeUsed>
-      <TargetFrameworkToBeUsed Condition=" '$(_TargetFrameworkOverride)' != '' ">$(_TargetFrameworkOverride)</TargetFrameworkToBeUsed>
+      <TargetFrameworkToBeUsed Condition=" '$(_TargetFrameworkOverride)' != '' "></TargetFrameworkToBeUsed>
     </PropertyGroup>
-
-    <!-- TODO NK add it here-->
 
     <!-- For project.json projects target frameworks will be read from project.json. -->
     <GetProjectTargetFrameworksTask
@@ -779,7 +777,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     </PropertyGroup>
 
     <!-- Determine if this will use cross targeting -->
-    <PropertyGroup Condition=" '$(PackageReferenceCompatibleProjectStyle)' == 'true' AND '$(TargetFrameworks)' != '' ">
+    <PropertyGroup Condition=" '$(PackageReferenceCompatibleProjectStyle)' == 'true' AND '$(TargetFrameworks)' != '' AND '$(_TargetFrameworkOverride)' == '' ">
       <_RestoreCrossTargeting>true</_RestoreCrossTargeting>
     </PropertyGroup>
 
@@ -855,7 +853,7 @@ Copyright (c) .NET Foundation. All rights reserved.
         <RepositoryPath>$(_OutputRepositoryPath)</RepositoryPath>
         <ConfigFilePaths>$(_OutputConfigFilePaths)</ConfigFilePaths>
         <PackagesPath>$(_OutputPackagesPath)</PackagesPath>
-        <TargetFrameworks>@(_RestoreTargetFrameworksOutputFiltered)</TargetFrameworks>
+        <TargetFrameworks>@(_RestoreTargetFrameworksOutputFiltered)</TargetFrameworks> <!-- what here? does it matter-->
         </_RestoreGraphEntry>
     </ItemGroup>
 
@@ -867,7 +865,7 @@ Copyright (c) .NET Foundation. All rights reserved.
         <ProjectPath>$(MSBuildProjectFullPath)</ProjectPath>
         <ProjectName>$(_RestoreProjectName)</ProjectName>
         <ProjectStyle>$(RestoreProjectStyle)</ProjectStyle>
-        <TargetFrameworks>@(_RestoreTargetFrameworksOutputFiltered)</TargetFrameworks>
+        <TargetFrameworks>@(_RestoreTargetFrameworksOutputFiltered)</TargetFrameworks> <!-- what here? does it matter-->
       </_RestoreGraphEntry>
     </ItemGroup>
   </Target>
@@ -906,7 +904,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     ============================================================
   -->
   <Target Name="_GenerateProjectRestoreGraphAllFrameworks"
-    Condition=" '$(TargetFrameworks)' != '' "
+    Condition=" '$(TargetFrameworks)' != '' AND '$(_TargetFrameworkOverride)' == '' "
     DependsOnTargets="_GetRestoreTargetFrameworksAsItems"
     Returns="@(_RestoreGraphEntry)">
 
@@ -931,8 +929,9 @@ Copyright (c) .NET Foundation. All rights reserved.
     Walk dependencies with the current framework.
     ============================================================
   -->
+  <!-- probably it does not matter -->
   <Target Name="_GenerateProjectRestoreGraphCurrentProject"
-    Condition=" '$(TargetFrameworks)' == '' "
+    Condition=" '$(TargetFrameworks)' == '' OR '$(_TargetFrameworkOverride)' != '' " 
     DependsOnTargets="_GenerateProjectRestoreGraphPerFramework"
     Returns="@(_RestoreGraphEntry)">
   </Target>
@@ -1040,7 +1039,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     ============================================================
   -->
   <Target Name="_GenerateRestoreProjectPathItemsCurrentProject"
-    Condition=" '$(TargetFrameworks)' == '' "
+    Condition=" '$(TargetFrameworks)' == '' OR '$(_TargetFrameworkOverride)' != '' "
     DependsOnTargets="_GenerateRestoreProjectPathItemsPerFramework"
     Returns="@(_RestoreProjectPathItems)">
   </Target>
@@ -1090,7 +1089,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     ============================================================
   -->
   <Target Name="_GenerateRestoreProjectPathItemsAllFrameworks"
-    Condition=" '$(TargetFrameworks)' != '' "
+    Condition=" '$(TargetFrameworks)' != '' AND '$(_TargetFrameworkOverride)' == '' "
     DependsOnTargets="_GetRestoreTargetFrameworksAsItems"
     Returns="@(_RestoreProjectPathItems)">
 

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -589,14 +589,14 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <PropertyGroup>
       <_RestoreProjectFramework/>
-      <TargetFrameworkToBeUsed Condition=" '$(_TargetFrameworkOverride)' == '' ">$(TargetFrameworks)</TargetFrameworkToBeUsed>
+      <_TargetFrameworkToBeUsed Condition=" '$(_TargetFrameworkOverride)' == '' ">$(TargetFrameworks)</_TargetFrameworkToBeUsed>
     </PropertyGroup>
 
     <!-- For project.json projects target frameworks will be read from project.json. -->
     <GetProjectTargetFrameworksTask
       Condition=" '$(RestoreProjectStyle)' != 'ProjectJson'"
       ProjectPath="$(MSBuildProjectFullPath)"
-      TargetFrameworks="$(TargetFrameworkToBeUsed)"
+      TargetFrameworks="$(_TargetFrameworkToBeUsed)"
       TargetFramework="$(TargetFramework)"
       TargetFrameworkMoniker="$(TargetFrameworkMoniker)"
       TargetPlatformIdentifier="$(TargetPlatformIdentifier)"

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
@@ -2482,7 +2482,7 @@ EndGlobal";
             string projectFileContents =
 @"<Project Sdk=""Microsoft.NET.Sdk"">
     <PropertyGroup>
-        <TargetFrameworks>nestandard2.0;net5.0</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Condition=""'$(TargetFramework)' == 'net5.0'"" Include=""x"" Version=""1.0.0"" />
@@ -2526,7 +2526,7 @@ EndGlobal";
             string projectAFileContents =
 @$"<Project Sdk=""Microsoft.NET.Sdk"">
     <PropertyGroup>
-        <TargetFrameworks>nestandard2.0;net5.0</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
     </PropertyGroup>
     <ItemGroup>
         <ProjectReference Condition=""'$(TargetFramework)' == 'net5.0'"" Include=""..\b\b.csproj"" Version=""1.0.0"" />
@@ -2572,7 +2572,7 @@ EndGlobal";
             string projectFileContents =
 @$"<Project Sdk=""Microsoft.NET.Sdk"">
     <PropertyGroup>
-        <TargetFrameworks>nestandard2.0;net5.0</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
         <RestoreAdditionalProjectSources Condition=""'$(TargetFramework)' == 'net5.0'"">{additionalSource}</RestoreAdditionalProjectSources>
     </PropertyGroup>
     <ItemGroup>

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
@@ -2471,7 +2471,7 @@ EndGlobal";
         }
 
         [PlatformTheory(Platform.Windows)]
-        [InlineData(true)]
+        // [InlineData(true)] - Disabled static graph tests due to https://github.com/NuGet/Home/issues/11761.
         [InlineData(false)]
         public async Task DotnetRestore_WithMultiTargetingProject_WhenTargetFrameworkIsSpecifiedOnTheCommandline_RestoresForSingleFramework(bool useStaticGraphEvaluation)
         {
@@ -2510,7 +2510,7 @@ EndGlobal";
         }
 
         [PlatformTheory(Platform.Windows)]
-        [InlineData(true)]
+        // [InlineData(true)] - Disabled static graph tests due to https://github.com/NuGet/Home/issues/11761.
         [InlineData(false)]
         public async Task DotnetRestore_WithMultiTargetingProject_WhenTargetFrameworkIsSpecifiedOnTheCommandline_AndPerFrameworkProjectReferencesAreUsed_RestoresForSingleFramework(bool useStaticGraphEvaluation)
         {
@@ -2560,7 +2560,7 @@ EndGlobal";
         }
 
         [PlatformTheory(Platform.Windows)]
-        [InlineData(true)]
+        // [InlineData(true)] - Disabled static graph tests due to https://github.com/NuGet/Home/issues/11761.
         [InlineData(false)]
         public async Task DotnetRestore_WithMultiTargettingProject_WhenTargetFrameworkIsSpecifiedOnTheCommandline_PerFrameworkProjectReferencesAreUsed_RestoresForSingleFramework(bool useStaticGraphEvaluation)
         {
@@ -2605,15 +2605,5 @@ EndGlobal";
             var allTargets = File.ReadAllText(targetsFilePath);
             allTargets.Should().Contain(condition);
         }
-        //_GetRestoreSettingsCurrentProject -> Do these make a different whether it's inner or outer build? If `TargetFramework` is the thing that's set then they become functionally equivalent.
-        //_GetRestoreSettingsAllFrameworks
-
-        //_GenerateProjectRestoreGraphAllFrameworks
-        //_GenerateProjectRestoreGraphCurrentProject
-
-
-        //_GenerateRestoreProjectPathItemsCurrentProject
-        //_GenerateRestoreProjectPathItemsAllFrameworks
-
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/GetGlobalPropertyValueTaskTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/GetGlobalPropertyValueTaskTests.cs
@@ -1,0 +1,62 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using FluentAssertions;
+using Xunit;
+
+namespace NuGet.Build.Tasks.Test
+{
+    public class GetGlobalPropertyValueTaskTests
+    {
+        [Fact]
+        public void Execute_WithoutSpecialGlobalProperties_ReturnsNull()
+        {
+            // Arrange
+            var buildEngine = new TestBuildEngine();
+
+            var task = new GetGlobalPropertyValueTask()
+            {
+                BuildEngine = buildEngine,
+                PropertyName = "TargetFramework",
+            };
+
+            // Act
+            var result = task.Execute();
+
+            // Assert
+            result.Should().BeTrue();
+            task.GlobalPropertyValue.Should().Be(null);
+            task.CheckCompleted.Should().Be(true);
+        }
+
+        [Theory]
+        [InlineData("TargetFramework")]
+        [InlineData("targetframework")]
+        public void Execute_WithGlobalProperties_ReturnsValue(string requestedProperty)
+        {
+            // Arrange
+            string expectedValue = "net472";
+            Dictionary<string, string> globalProps = new()
+            {
+                { "TargetFramework", expectedValue }
+            };
+            var buildEngine = new TestBuildEngine(globalProps);
+
+            var task = new GetGlobalPropertyValueTask()
+            {
+                BuildEngine = buildEngine,
+                PropertyName = requestedProperty,
+            };
+
+            // Act
+            var result = task.Execute();
+
+            // Assert
+            result.Should().BeTrue();
+            task.GlobalPropertyValue.Should().Be(expectedValue);
+            task.CheckCompleted.Should().Be(true);
+        }
+
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/TestBuildEngine.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/TestBuildEngine.cs
@@ -24,6 +24,7 @@ namespace NuGet.Build.Tasks.Test
 
         public TestBuildEngine()
         {
+            _globalProperties = new Dictionary<string, string>();
         }
 
         public TestBuildEngine(IReadOnlyDictionary<string, string> globalProperties)


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11653

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

https://github.com/NuGet/Home/issues/11653 contains details about the scenario at hand, but the gist is that: 

> $ dotnet new maui
> $ dotnet build -f:net6.0-ios -r ios-arm64

does not work because nuget prefers TargetFrameworks over TargetFramework, so it essentially "tries" to do a restore for net6.0-android + ios-arm64 which obviously isn't something that works. 

This change allows NuGet to detect the user intent in the scenarios like the above, and *only* restore for the framework passed on the commandline. 

The change boils down to NuGet preferring the `TargetFramework` when it is specified on the commandline, as a global property. 

While working on this I discovered https://github.com/NuGet/Home/issues/11761, which basically means static graph can't support the equivalent at this point. 

Given that this change requires multiple teams to validate it's good enough, I've added a means to disable it in case something does go really wrong while we're attempting that validation. `_DisableNuGetRestoreTargetFrameworksOverride`. 

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
