### PR TITLE
Include caught exceptions when rethrowing

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/MsBuildUtility.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/MsBuildUtility.cs
@@ -420,7 +420,7 @@ namespace NuGet.CommandLine
                     solutionFile,
                     ex.Message);
 
-                throw new CommandException(message);
+                throw new CommandException(message, ex);
             }
         }
 
@@ -452,7 +452,7 @@ namespace NuGet.CommandLine
                     solutionFile,
                     exMessage);
 
-                throw new CommandException(message);
+                throw new CommandException(message, ex);
             }
         }
 


### PR DESCRIPTION
Include caught exceptions as inner exceptions when rethrowing (only in MsBuildUtility)

<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11766

Discovered these swallowed exceptions when addressing something else; wrote up this change as https://github.com/NuGet/Home/issues/11766

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
Minor edits to methods that have no existing unit tests.
  - [x] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
