### PR TITLE
Fix spelling of Wiederherstellen 

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.Designer.cs
@@ -9729,7 +9729,7 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Der Paketordner zum Widerherstellen von NuGet-Paketen konnte nicht ermittelt werden. Bitte geben Sie &quot;-PackagesDirectory&quot; oder &quot;-SolutionDirectory&quot; an..
+        ///   Looks up a localized string similar to Der Paketordner zum Wiederherstellen von NuGet-Paketen konnte nicht ermittelt werden. Bitte geben Sie &quot;-PackagesDirectory&quot; oder &quot;-SolutionDirectory&quot; an..
         /// </summary>
         public static string RestoreCommandCannotDeterminePackagesFolder_deu {
             get {

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
@@ -4710,7 +4710,7 @@ To prevent NuGet from downloading packages during build, open the Visual Studio 
     <value>Nelze určit složku balíčků pro obnovení balíčků NuGet. Zadejte parametr -PackagesDirectory nebo -SolutionDirectory.</value>
   </data>
   <data name="RestoreCommandCannotDeterminePackagesFolder_deu" xml:space="preserve">
-    <value>Der Paketordner zum Widerherstellen von NuGet-Paketen konnte nicht ermittelt werden. Bitte geben Sie "-PackagesDirectory" oder "-SolutionDirectory" an.</value>
+    <value>Der Paketordner zum Wiederherstellen von NuGet-Paketen konnte nicht ermittelt werden. Bitte geben Sie "-PackagesDirectory" oder "-SolutionDirectory" an.</value>
   </data>
   <data name="RestoreCommandCannotDeterminePackagesFolder_esp" xml:space="preserve">
     <value>No se puede determinar la carpeta de paquetes para restaurar los paquetes NuGet. Especifique PackagesDirectory o SolutionDirectory.</value>


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11774

Fix spelling of Wiederherstellen in RestoreCommandCannotDeterminePackagesFolder_deu in NuGet.Client\src\NuGet.Clients\NuGet.CommandLine\NuGetResources.resx

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Fix the spelling of Wiederherstellen in RestoreCommandCannotDeterminePackagesFolder_deu in NuGet.Client\src\NuGet.Clients\NuGet.CommandLine\NuGetResources.resx

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
