### PR TITLE
Add telemetry event when PMUI closes and properties for usage of transitive dependencies

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml
@@ -290,15 +290,18 @@
         TargetType="{x:Type Expander}"
         BasedOn="{StaticResource {x:Type Expander}}">
         <Setter Property="Header" Value="{StaticResource GroupHeaderMultiBinding}" />
+        <Setter Property="Tag" Value="{Binding Name}" /> <!-- Store unconverted enum PackageLevel-->
         <Setter Property="Foreground" Value="{DynamicResource {x:Static nuget:Brushes.UIText}}" />
-        <Setter Property="IsExpanded" Value="True" />
       </Style>
 
       <ControlTemplate
         x:Key="GroupedListItemControlTemplate"
         TargetType="{x:Type GroupItem}">
         <Expander
-          Style="{StaticResource ExpanderStyle}">
+          Style="{StaticResource ExpanderStyle}"
+          Expanded="Expander_ExpansionStateToggled"
+          Collapsed="Expander_ExpansionStateToggled"
+          IsExpanded="True">
           <ItemsPresenter />
         </Expander>
       </ControlTemplate>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
@@ -35,6 +35,7 @@ namespace NuGet.PackageManagement.UI
         private ScrollViewer _scrollViewer;
 
         public event SelectionChangedEventHandler SelectionChanged;
+        public event RoutedEventHandler GroupExpansionChanged;
 
         public delegate void UpdateButtonClickEventHandler(PackageItemViewModel[] selectedPackages);
         public event UpdateButtonClickEventHandler UpdateButtonClicked;
@@ -748,6 +749,11 @@ namespace NuGet.PackageManagement.UI
             {
                 ItemsView.GroupDescriptions.Add(new PropertyGroupDescription(nameof(PackageItemViewModel.PackageLevel)));
             }
+        }
+
+        private void Expander_ExpansionStateToggled(object sender, RoutedEventArgs e)
+        {
+            GroupExpansionChanged?.Invoke(sender, e);
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml
@@ -111,6 +111,7 @@
               x:Name="_packageList"
               AutomationProperties.Name="{x:Static nuget:Resources.Accessibility_PackagesList}"
               SelectionChanged="PackageList_SelectionChanged"
+              GroupExpansionChanged="PackageList_GroupExpansionChanged"
               UpdateButtonClicked="PackageList_UpdateButtonClicked"
               Width="{Binding ActualWidth, ElementName=_leftSide}"/>
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/NuGet.PackageManagement.VisualStudio.csproj
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/NuGet.PackageManagement.VisualStudio.csproj
@@ -48,6 +48,7 @@
     <Compile Include="Projects\IPackageReferenceProject.cs" />
     <Compile Include="Telemetry\CounterfactualLoggers.cs" />
     <Compile Include="Telemetry\PackageManagerCloseEvent.cs" />
+    <Compile Include="Telemetry\PackageManagerInstalledTabData.cs" />
     <Compile Include="Telemetry\TelemetryOnceEmitter.cs" />
     <Compile Include="Projects\PackageReferenceProject.cs" />
     <Compile Include="Projects\ProjectPackages.cs" />

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/NuGet.PackageManagement.VisualStudio.csproj
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/NuGet.PackageManagement.VisualStudio.csproj
@@ -47,6 +47,7 @@
     <Compile Include="ProjectServices\CpsProjectSystemReferenceReader.cs" />
     <Compile Include="Projects\IPackageReferenceProject.cs" />
     <Compile Include="Telemetry\CounterfactualLoggers.cs" />
+    <Compile Include="Telemetry\PackageManagerCloseEvent.cs" />
     <Compile Include="Telemetry\TelemetryOnceEmitter.cs" />
     <Compile Include="Projects\PackageReferenceProject.cs" />
     <Compile Include="Projects\ProjectPackages.cs" />

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/PackageManagerCloseEvent.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/PackageManagerCloseEvent.cs
@@ -1,0 +1,53 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Newtonsoft.Json.Serialization;
+using NuGet.Common;
+using NuGet.VisualStudio.Telemetry;
+
+namespace NuGet.PackageManagement.Telemetry
+{
+    public sealed class PackageManagerCloseEvent : TelemetryEvent
+    {
+        private const string EventName = "PMUIClose";
+
+        public PackageManagerCloseEvent(
+            Guid parentId,
+            bool isSolutionLevel,
+            string tab,
+            PackageManagerInstalledTabData installedTabData) : base(EventName)
+        {
+            base["ParentId"] = parentId.ToString();
+            base["IsSolutionLevel"] = isSolutionLevel;
+            base["Tab"] = tab;
+
+            string prefix = PackageManagerInstalledTabData.PropertyPrefix;
+            base[prefix + nameof(installedTabData.TopLevelPackageSelectedCount)] = installedTabData.TopLevelPackageSelectedCount;
+            base[prefix + nameof(installedTabData.TransitivePackageSelectedCount)] = installedTabData.TransitivePackageSelectedCount;
+            base[prefix + nameof(installedTabData.TopLevelPackagesExpandedCount)] = installedTabData.TopLevelPackagesExpandedCount;
+            base[prefix + nameof(installedTabData.TopLevelPackagesCollapsedCount)] = installedTabData.TopLevelPackagesCollapsedCount;
+            base[prefix + nameof(installedTabData.TransitivePackagesExpandedCount)] = installedTabData.TransitivePackagesExpandedCount;
+            base[prefix + nameof(installedTabData.TransitivePackagesCollapsedCount)] = installedTabData.TransitivePackagesCollapsedCount;
+        }
+    }
+
+    public class PackageManagerInstalledTabData
+    {
+        public const string PropertyPrefix = "Installed.";
+
+        public string TabName { get; }
+
+        public int TopLevelPackageSelectedCount { get; set; }
+
+        public int TransitivePackageSelectedCount { get; set; }
+
+        public int TopLevelPackagesExpandedCount { get; set; }
+
+        public int TopLevelPackagesCollapsedCount { get; set; }
+
+        public int TransitivePackagesExpandedCount { get; set; }
+
+        public int TransitivePackagesCollapsedCount { get; set; }
+    }
+}

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/PackageManagerCloseEvent.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/PackageManagerCloseEvent.cs
@@ -2,11 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using Newtonsoft.Json.Serialization;
 using NuGet.Common;
-using NuGet.VisualStudio.Telemetry;
 
-namespace NuGet.PackageManagement.Telemetry
+namespace NuGet.PackageManagement.VisualStudio
 {
     public sealed class PackageManagerCloseEvent : TelemetryEvent
     {
@@ -30,24 +28,5 @@ namespace NuGet.PackageManagement.Telemetry
             base[prefix + nameof(installedTabData.TransitivePackagesExpandedCount)] = installedTabData.TransitivePackagesExpandedCount;
             base[prefix + nameof(installedTabData.TransitivePackagesCollapsedCount)] = installedTabData.TransitivePackagesCollapsedCount;
         }
-    }
-
-    public class PackageManagerInstalledTabData
-    {
-        public const string PropertyPrefix = "Installed.";
-
-        public string TabName { get; }
-
-        public int TopLevelPackageSelectedCount { get; set; }
-
-        public int TransitivePackageSelectedCount { get; set; }
-
-        public int TopLevelPackagesExpandedCount { get; set; }
-
-        public int TopLevelPackagesCollapsedCount { get; set; }
-
-        public int TransitivePackagesExpandedCount { get; set; }
-
-        public int TransitivePackagesCollapsedCount { get; set; }
     }
 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/PackageManagerInstalledTabData.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/PackageManagerInstalledTabData.cs
@@ -1,0 +1,22 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGet.PackageManagement.VisualStudio
+{
+    public class PackageManagerInstalledTabData
+    {
+        public const string PropertyPrefix = "Installed.";
+
+        public uint TopLevelPackageSelectedCount { get; set; }
+
+        public uint TransitivePackageSelectedCount { get; set; }
+
+        public uint TopLevelPackagesExpandedCount { get; set; }
+
+        public uint TopLevelPackagesCollapsedCount { get; set; }
+
+        public uint TransitivePackagesExpandedCount { get; set; }
+
+        public uint TransitivePackagesCollapsedCount { get; set; }
+    }
+}


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1557

Regression? Last working version: N/A

## Description
Count the expanding and collapsing actions of package list grouping expanders and the package selection for top-level and transitive packages on the Installed tab and submit them as properties to a new telemetry event that is emitted when the PMUI closes.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
Counters added in UI code. Manually tested with telemetry monitor.
  - [x] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
