### PR TITLE
Revert "Stop using FileSystem and Common submodules (#4536)"

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,11 @@
+[submodule "submodules/FileSystem"]
+	path = submodules/FileSystem
+	url = https://github.com/NuGet/FileSystem.git
+	branch = NuGet/SubModuleIntegration
+[submodule "submodules/Common"]
+	path = submodules/Common
+	url = https://github.com/aspnet/Common.git
+	branch = NuGet/SubModuleIntegration
 [submodule "submodules/NuGet.Build.Localization"]
 	path = submodules/NuGet.Build.Localization
 	url = https://github.com/NuGet/NuGet.Build.Localization.git

--- a/build/bootstrap.proj
+++ b/build/bootstrap.proj
@@ -18,7 +18,7 @@
         <PackageDownload Include="Microsoft.Web.Xdt" version="[3.0.0]" />
         <PackageDownload Include="Newtonsoft.Json" version="[13.0.1]" />
         <PackageDownload Include="NuGet.Client.EndToEnd.TestData" version="[1.0.0]" />
-        <PackageDownload Include="NuGetValidator" version="[2.0.5]" />
+        <PackageDownload Include="NuGetValidator" version="[2.0.3]" />
     </ItemGroup>
 
 </Project>

--- a/build/packages.targets
+++ b/build/packages.targets
@@ -36,8 +36,6 @@
         <PackageReference Update="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8" />
         <PackageReference Update="Microsoft.DataAI.NuGetRecommender.Contracts" Version="2.1.0" />
         <PackageReference Update="Microsoft.Extensions.CommandLineUtils.Sources" Version="$(MicrosoftExtensionsCommandLineUtilsSourcesPackageVersion)" />
-        <PackageReference Update="Microsoft.Extensions.FileSystemGlobbing" Version="5.0.0"/>
-        <PackageReference Update="Microsoft.Extensions.FileProviders.Abstractions" Version="5.0.0" />
         <PackageReference Update="Microsoft.Internal.VisualStudio.Shell.Framework" Version="$(VSFrameworkVersion)" />
         <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.0.0" />
         <PackageReference Update="Microsoft.TeamFoundationServer.ExtendedClient" Version="$(VSServicesVersion)" />
@@ -52,7 +50,6 @@
         <PackageReference Update="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
         <PackageReference Update="SharpZipLib" Version="1.3.3" />
         <PackageReference Update="System.ComponentModel.Composition" Version="$(SystemComponentModelCompositionPackageVersion)" />
-        <PackageReference Update="System.Runtime.Serialization.Primitives" Version="$(SystemPackagesVersion)" />
         <!--
           The Microsoft.VisualStudio.SDK metapackage brings in System.Threading.Tasks.Dataflow 4.11.1 (assembly version 4.9.5.0).
           However, our MSBuild integration tests use Microsoft.Build 16.8.0, which requires System.Threading.Tasks.Dataflow 4.9.0 (assembly version 4.9.3.0).

--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -435,7 +435,7 @@ steps:
   inputs:
     artifactName: LocValidationLogs
     targetPath: "$(Build.Repository.LocalPath)\\logs\\LocalizationValidation"
-  condition: "and(succeededOrFailed(), eq(variables['BuildRTM'], 'false'))"
+  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
 
   # Use dotnet msbuild instead of MSBuild CLI.
   # Using MSBuild CLI results in an assembly binding failure for NuGet.Common.dll 4.4.0.3 because Microsoft.DotNet.Build.Tasks.Feed.dll references SleetLib.dll which references NuGet.Common 4.4.0.3.

--- a/scripts/cibuild/BuildValidator.ps1
+++ b/scripts/cibuild/BuildValidator.ps1
@@ -38,7 +38,7 @@ param
 
 if ($BuildRTM -eq 'false')
 {
-    $NuGetValidator = [System.IO.Path]::Combine($RepoRoot, 'packages', 'nugetvalidator', '2.0.5', 'tools', 'NuGetValidator.exe')
+    $NuGetValidator = [System.IO.Path]::Combine($RepoRoot, 'packages', 'nugetvalidator', '2.0.3', 'tools', 'NuGetValidator.exe')
     $LocalizationRepository = [System.IO.Path]::Combine($RepoRoot, 'submodules', 'NuGet.Build.Localization', 'localize', 'comments', '15')
 
     if ($ValidateVsix)

--- a/setup/Microsoft.VisualStudio.NuGet.BuildTools.swr
+++ b/setup/Microsoft.VisualStudio.NuGet.BuildTools.swr
@@ -8,9 +8,6 @@ folder InstallDir:\Common7\IDE\CommonExtensions\Microsoft\NuGet
         file source=$(NuGetTargetsBasePath)NuGet.targets
         file source=$(NuGetTargetsBasePath)NuGet.props
         file source=$(NuGetTargetsBasePath)NuGet.RestoreEx.targets
-        file source=$(ReferenceOutputPath)Microsoft.Extensions.FileProviders.Abstractions.dll
-        file source=$(ReferenceOutputPath)Microsoft.Extensions.FileSystemGlobbing.dll
-        file source=$(ReferenceOutputPath)Microsoft.Extensions.Primitives.dll
         file source=$(ReferenceOutputPath)Microsoft.Web.XmlTransform.dll
         file source=$(ReferenceOutputPath)Microsoft.Build.NuGetSdkResolver.dll
         file source=$(NewtonsoftJsonPath)Newtonsoft.Json.dll

--- a/src/NuGet.Clients/NuGet.CommandLine/ilmerge.props
+++ b/src/NuGet.Clients/NuGet.CommandLine/ilmerge.props
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0">
   <ItemGroup>
-    <MergeInclude Include="$(OutputPath)Microsoft.Extensions.FileProviders.Abstractions.dll"/>
-    <MergeInclude Include="$(OutputPath)Microsoft.Extensions.FileSystemGlobbing.dll"/>
-    <MergeInclude Include="$(OutputPath)Microsoft.Extensions.Primitives.dll"/>
     <MergeInclude Include="$(OutputPath)Microsoft.Web.XmlTransform.dll"/>
     <MergeInclude Include="$(OutputPath)Newtonsoft.Json.dll"/>
     <MergeInclude Include="$(OutputPath)NuGet.Build.Tasks.dll"/>
@@ -21,13 +18,11 @@
     <MergeInclude Include="$(OutputPath)NuGet.Resolver.dll"/>
     <MergeInclude Include="$(OutputPath)NuGet.Versioning.dll"/>
     <MergeInclude Include="$(OutputPath)NuGet.Core.dll"/>
-    <MergeInclude Include="$(OutputPath)System.Memory.dll"/>
     <MergeInclude Include="$(OutputPath)System.Threading.Tasks.Dataflow.dll"/>
 
     <MergeExclude Include="$(OutputPath)Microsoft.VisualStudio.Setup.Configuration.Interop.dll"/>
     <MergeExclude Include="$(OutputPath)Microsoft.CSharp.dll"/>
     <MergeExclude Include="$(OutputPath)mscorlib.dll"/>
-    <MergeExclude Include="$(OutputPath)System.Buffers.dll"/>
     <MergeExclude Include="$(OutputPath)System.Collections.Concurrent.dll"/>
     <MergeExclude Include="$(OutputPath)System.Collections.dll"/>
     <MergeExclude Include="$(OutputPath)System.ComponentModel.Composition.dll"/>
@@ -37,10 +32,8 @@
     <MergeExclude Include="$(OutputPath)System.IO.Compression.dll"/>
     <MergeExclude Include="$(OutputPath)System.Net.Http.dll"/>
     <MergeExclude Include="$(OutputPath)System.Net.Http.WebRequest.dll"/>
-    <MergeExclude Include="$(OutputPath)System.Numerics.Vectors.dll"/>
     <MergeExclude Include="$(OutputPath)System.Runtime.dll"/>
     <MergeExclude Include="$(OutputPath)System.Runtime.Serialization.dll"/>
-    <MergeExclude Include="$(OutputPath)System.Runtime.CompilerServices.Unsafe.dll"/>
     <MergeExclude Include="$(OutputPath)System.Security.dll"/>
     <MergeExclude Include="$(OutputPath)System.ServiceModel.dll"/>
     <MergeExclude Include="$(OutputPath)System.Xml.dll"/>

--- a/src/NuGet.Clients/NuGet.MSSigning.Extensions/ilmerge.props
+++ b/src/NuGet.Clients/NuGet.MSSigning.Extensions/ilmerge.props
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0">
   <ItemGroup>
-    <MergeInclude Include="$(OutputPath)Microsoft.Extensions.FileProviders.Abstractions.dll"/>
-    <MergeInclude Include="$(OutputPath)Microsoft.Extensions.FileSystemGlobbing.dll"/>
-    <MergeInclude Include="$(OutputPath)Microsoft.Extensions.Primitives.dll"/>
     <MergeInclude Include="$(OutputPath)Microsoft.Web.XmlTransform.dll"/>
     <MergeInclude Include="$(OutputPath)Newtonsoft.Json.dll"/>
     <MergeInclude Include="$(OutputPath)NuGet.Build.Tasks.dll"/>
@@ -22,13 +19,11 @@
     <MergeInclude Include="$(OutputPath)NuGet.Versioning.dll"/>
     <MergeInclude Include="$(OutputPath)NuGet.Core.dll"/>
     <MergeInclude Include="$(OutputPath)NuGet.MSSigning.Extensions.dll"/>
-    <MergeInclude Include="$(OutputPath)System.Memory.dll"/>
     <MergeInclude Include="$(OutputPath)System.Threading.Tasks.Dataflow.dll"/>
 
     <MergeExclude Include="$(OutputPath)Microsoft.VisualStudio.Setup.Configuration.Interop.dll"/>
     <MergeExclude Include="$(OutputPath)Microsoft.CSharp.dll"/>
     <MergeExclude Include="$(OutputPath)mscorlib.dll"/>
-    <MergeExclude Include="$(OutputPath)System.Buffers.dll"/>
     <MergeExclude Include="$(OutputPath)System.Collections.Concurrent.dll"/>
     <MergeExclude Include="$(OutputPath)System.Collections.dll"/>
     <MergeExclude Include="$(OutputPath)System.ComponentModel.Composition.dll"/>
@@ -38,10 +33,8 @@
     <MergeExclude Include="$(OutputPath)System.IO.Compression.dll"/>
     <MergeExclude Include="$(OutputPath)System.Net.Http.dll"/>
     <MergeExclude Include="$(OutputPath)System.Net.Http.WebRequest.dll"/>
-    <MergeExclude Include="$(OutputPath)System.Numerics.Vectors.dll"/>
     <MergeExclude Include="$(OutputPath)System.Runtime.dll"/>
     <MergeExclude Include="$(OutputPath)System.Runtime.Serialization.dll"/>
-    <MergeExclude Include="$(OutputPath)System.Runtime.CompilerServices.Unsafe.dll"/>
     <MergeExclude Include="$(OutputPath)System.Security.dll"/>
     <MergeExclude Include="$(OutputPath)System.ServiceModel.dll"/>
     <MergeExclude Include="$(OutputPath)System.Xml.dll"/>

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/Properties/AssemblyInfo.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/Properties/AssemblyInfo.cs
@@ -21,9 +21,6 @@ using Microsoft.VisualStudio.Shell;
 [assembly: Guid("06662133-1292-4918-90f3-36c930c0b16f")]
 
 [assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\Lucene.Net.dll")]
-[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\Microsoft.Extensions.FileProviders.Abstractions.dll")]
-[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\Microsoft.Extensions.FileSystemGlobbing.dll")]
-[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\Microsoft.Extensions.Primitives.dll")]
 [assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\Newtonsoft.Json.dll")]
 [assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\NuGet.Commands.dll")]
 [assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\NuGet.Common.dll")]

--- a/src/NuGet.Clients/NuGet.Tools/Properties/AssemblyInfo.cs
+++ b/src/NuGet.Clients/NuGet.Tools/Properties/AssemblyInfo.cs
@@ -11,9 +11,6 @@ using Microsoft.VisualStudio.Shell;
 [assembly: ComVisible(false)]
 
 [assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\Lucene.Net.dll")]
-[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\Microsoft.Extensions.FileProviders.Abstractions.dll")]
-[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\Microsoft.Extensions.FileSystemGlobbing.dll")]
-[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\Microsoft.Extensions.Primitives.dll")]
 [assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\Microsoft.Web.XmlTransform.dll")]
 [assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\Newtonsoft.Json.dll")]
 [assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\NuGet.Commands.dll")]

--- a/src/NuGet.Clients/NuGet.VisualStudio.Client/.vsixinclude
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Client/.vsixinclude
@@ -34,8 +34,5 @@ NuGet.Versioning.dll
 
 # 3rd party dlls to keep
 Lucene.Net.dll
-Microsoft.Extensions.FileProviders.Abstractions.dll
-Microsoft.Extensions.FileSystemGlobbing.dll
-Microsoft.Extensions.Primitives.dll
 Microsoft.Web.XmlTransform.dll
 Newtonsoft.Json.dll

--- a/src/NuGet.Clients/NuGet.VisualStudio.Client/source.extension.vsixmanifest
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Client/source.extension.vsixmanifest
@@ -66,9 +66,6 @@
         <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="NuGet.VisualStudio.OnlineEnvironment.Client" Path="|NuGet.VisualStudio.OnlineEnvironment.Client|" />
 
         <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="File" Path="Lucene.Net.dll" AssemblyName="Lucene.Net, Version=3.0.3.0, Culture=neutral, PublicKeyToken=85089178b9ac3181" />
-        <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="File" Path="Microsoft.Extensions.FileProviders.Abstractions.dll" AssemblyName="Microsoft.Extensions.FileProviders.Abstractions, Version=5.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60" />
-        <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="File" Path="Microsoft.Extensions.FileSystemGlobbing.dll" AssemblyName="Microsoft.Extensions.FileSystemGlobbing, Version=5.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60" />
-        <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="File" Path="Microsoft.Extensions.Primitives.dll" AssemblyName="Microsoft.Extensions.Primitives, Version=5.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60" />
         <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="File" Path="Microsoft.Web.XmlTransform.dll" AssemblyName="Microsoft.Web.XmlTransform, Version=2.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
         <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="File" Path="Newtonsoft.Json.dll" AssemblyName="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed" />
     </Assets>

--- a/src/NuGet.Clients/NuGet.VisualStudio.OnlineEnvironment.Client/Properties/AssemblyInfo.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.OnlineEnvironment.Client/Properties/AssemblyInfo.cs
@@ -17,9 +17,6 @@ using Microsoft.VisualStudio.Shell;
 [assembly: ComVisible(false)]
 
 [assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\Lucene.Net.dll")]
-[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\Microsoft.Extensions.FileProviders.Abstractions.dll")]
-[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\Microsoft.Extensions.FileSystemGlobbing.dll")]
-[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\Microsoft.Extensions.Primitives.dll")]
 [assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\Microsoft.Web.XmlTransform.dll")]
 [assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\Newtonsoft.Json.dll")]
 [assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\NuGet.Commands.dll")]

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.csproj
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.csproj
@@ -113,7 +113,6 @@
         /out:$(PathToMergedNuGetPack) ^
         $(ILMergePlatformArg) ^
         /lib:$(OutputPath)publish ^
-        /allowDup ^
         /internalize ^
         /xmldocs ^
         /log:$(ILMergeResultDir)IlMergeLog.txt</IlmergeCommand>
@@ -154,7 +153,6 @@
         /out:$(PathToMergedNuGetPackResource) ^
         $(ILMergePlatformArg) ^
         /log ^
-        /allowDup ^
         /lib:$(OutputPath)\publish ^
         /internalize ^
         /xmldocs ^

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/NuGet.CommandLine.XPlat.csproj
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/NuGet.CommandLine.XPlat.csproj
@@ -20,7 +20,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.CommandLineUtils.Sources" PrivateAssets="All" />
     <PackageReference Include="System.Diagnostics.Debug" />
-    <PackageReference Include="System.Runtime.Serialization.Primitives" />
   </ItemGroup>
 
   <!-- Microsoft.Build.Locator is needed when debugging, but should not be used in the assemblies we insert.

--- a/src/NuGet.Core/NuGet.Commands/NuGet.Commands.csproj
+++ b/src/NuGet.Core/NuGet.Commands/NuGet.Commands.csproj
@@ -1,4 +1,4 @@
-﻿<Project>
+<Project>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'NuGet.sln'))\build\common.props" />
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
@@ -22,8 +22,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" />
-    <PackageReference Include="Microsoft.Extensions.FileProviders.Abstractions" />
+    <Compile Remove="..\..\..\submodules\FileSystem\src\**\AssemblyInfo.cs" />
+    <Compile Include="..\..\..\submodules\FileSystem\src\Microsoft.Extensions.FileSystemGlobbing\**\*.cs;..\..\..\submodules\FileSystem\src\Microsoft.AspNet.FileProviders.Abstractions\**\*.cs;..\..\..\submodules\FileSystem\src\Microsoft.AspNet.FileProviders.Sources\**\*.cs;..\..\..\submodules\Common\src\Microsoft.Extensions.Primitives\IChangeToken.cs" Exclude="..\..\..\submodules\FileSystem\src\**\AssemblyInfo.cs;bin\**;obj\**;**\*.xproj;packages\**" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NuGet.Core/NuGet.Commands/PublicAPI/net472/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Commands/PublicAPI/net472/PublicAPI.Shipped.txt
@@ -1,3 +1,143 @@
+Microsoft.AspNet.FileProviders.IDirectoryContents
+Microsoft.AspNet.FileProviders.IDirectoryContents.Exists.get -> bool
+Microsoft.AspNet.FileProviders.IFileInfo
+Microsoft.AspNet.FileProviders.IFileInfo.CreateReadStream() -> System.IO.Stream
+Microsoft.AspNet.FileProviders.IFileInfo.Exists.get -> bool
+Microsoft.AspNet.FileProviders.IFileInfo.IsDirectory.get -> bool
+Microsoft.AspNet.FileProviders.IFileInfo.LastModified.get -> System.DateTimeOffset
+Microsoft.AspNet.FileProviders.IFileInfo.Length.get -> long
+Microsoft.AspNet.FileProviders.IFileInfo.Name.get -> string
+Microsoft.AspNet.FileProviders.IFileInfo.PhysicalPath.get -> string
+Microsoft.AspNet.FileProviders.IFileProvider
+Microsoft.AspNet.FileProviders.IFileProvider.GetDirectoryContents(string subpath) -> Microsoft.AspNet.FileProviders.IDirectoryContents
+Microsoft.AspNet.FileProviders.IFileProvider.GetFileInfo(string subpath) -> Microsoft.AspNet.FileProviders.IFileInfo
+Microsoft.AspNet.FileProviders.IFileProvider.Watch(string filter) -> Microsoft.Extensions.Primitives.IChangeToken
+Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoBase
+Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoBase.DirectoryInfoBase() -> void
+Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoWrapper
+Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoWrapper.DirectoryInfoWrapper(System.IO.DirectoryInfo directoryInfo, bool isParentPath = false) -> void
+Microsoft.Extensions.FileSystemGlobbing.Abstractions.FileInfoBase
+Microsoft.Extensions.FileSystemGlobbing.Abstractions.FileInfoBase.FileInfoBase() -> void
+Microsoft.Extensions.FileSystemGlobbing.Abstractions.FileInfoWrapper
+Microsoft.Extensions.FileSystemGlobbing.Abstractions.FileInfoWrapper.FileInfoWrapper(System.IO.FileInfo fileInfo) -> void
+Microsoft.Extensions.FileSystemGlobbing.Abstractions.FileSystemInfoBase
+Microsoft.Extensions.FileSystemGlobbing.Abstractions.FileSystemInfoBase.FileSystemInfoBase() -> void
+Microsoft.Extensions.FileSystemGlobbing.FilePatternMatch
+Microsoft.Extensions.FileSystemGlobbing.FilePatternMatch.Equals(Microsoft.Extensions.FileSystemGlobbing.FilePatternMatch other) -> bool
+Microsoft.Extensions.FileSystemGlobbing.FilePatternMatch.FilePatternMatch(string path, string stem) -> void
+Microsoft.Extensions.FileSystemGlobbing.FilePatternMatch.Path.get -> string
+Microsoft.Extensions.FileSystemGlobbing.FilePatternMatch.Stem.get -> string
+Microsoft.Extensions.FileSystemGlobbing.Internal.ILinearPattern
+Microsoft.Extensions.FileSystemGlobbing.Internal.ILinearPattern.Segments.get -> System.Collections.Generic.IList<Microsoft.Extensions.FileSystemGlobbing.Internal.IPathSegment>
+Microsoft.Extensions.FileSystemGlobbing.Internal.IPathSegment
+Microsoft.Extensions.FileSystemGlobbing.Internal.IPathSegment.CanProduceStem.get -> bool
+Microsoft.Extensions.FileSystemGlobbing.Internal.IPathSegment.Match(string value) -> bool
+Microsoft.Extensions.FileSystemGlobbing.Internal.IPattern
+Microsoft.Extensions.FileSystemGlobbing.Internal.IPattern.CreatePatternContextForExclude() -> Microsoft.Extensions.FileSystemGlobbing.Internal.IPatternContext
+Microsoft.Extensions.FileSystemGlobbing.Internal.IPattern.CreatePatternContextForInclude() -> Microsoft.Extensions.FileSystemGlobbing.Internal.IPatternContext
+Microsoft.Extensions.FileSystemGlobbing.Internal.IPatternContext
+Microsoft.Extensions.FileSystemGlobbing.Internal.IPatternContext.Declare(System.Action<Microsoft.Extensions.FileSystemGlobbing.Internal.IPathSegment, bool> onDeclare) -> void
+Microsoft.Extensions.FileSystemGlobbing.Internal.IPatternContext.PopDirectory() -> void
+Microsoft.Extensions.FileSystemGlobbing.Internal.IPatternContext.PushDirectory(Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoBase directory) -> void
+Microsoft.Extensions.FileSystemGlobbing.Internal.IPatternContext.Test(Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoBase directory) -> bool
+Microsoft.Extensions.FileSystemGlobbing.Internal.IPatternContext.Test(Microsoft.Extensions.FileSystemGlobbing.Abstractions.FileInfoBase file) -> Microsoft.Extensions.FileSystemGlobbing.Internal.PatternTestResult
+Microsoft.Extensions.FileSystemGlobbing.Internal.IRaggedPattern
+Microsoft.Extensions.FileSystemGlobbing.Internal.IRaggedPattern.Contains.get -> System.Collections.Generic.IList<System.Collections.Generic.IList<Microsoft.Extensions.FileSystemGlobbing.Internal.IPathSegment>>
+Microsoft.Extensions.FileSystemGlobbing.Internal.IRaggedPattern.EndsWith.get -> System.Collections.Generic.IList<Microsoft.Extensions.FileSystemGlobbing.Internal.IPathSegment>
+Microsoft.Extensions.FileSystemGlobbing.Internal.IRaggedPattern.Segments.get -> System.Collections.Generic.IList<Microsoft.Extensions.FileSystemGlobbing.Internal.IPathSegment>
+Microsoft.Extensions.FileSystemGlobbing.Internal.IRaggedPattern.StartsWith.get -> System.Collections.Generic.IList<Microsoft.Extensions.FileSystemGlobbing.Internal.IPathSegment>
+Microsoft.Extensions.FileSystemGlobbing.Internal.MatcherContext
+Microsoft.Extensions.FileSystemGlobbing.Internal.MatcherContext.Execute() -> Microsoft.Extensions.FileSystemGlobbing.PatternMatchingResult
+Microsoft.Extensions.FileSystemGlobbing.Internal.MatcherContext.MatcherContext(System.Collections.Generic.IEnumerable<Microsoft.Extensions.FileSystemGlobbing.Internal.IPattern> includePatterns, System.Collections.Generic.IEnumerable<Microsoft.Extensions.FileSystemGlobbing.Internal.IPattern> excludePatterns, Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoBase directoryInfo, System.StringComparison comparison) -> void
+Microsoft.Extensions.FileSystemGlobbing.Internal.PathSegments.CurrentPathSegment
+Microsoft.Extensions.FileSystemGlobbing.Internal.PathSegments.CurrentPathSegment.CanProduceStem.get -> bool
+Microsoft.Extensions.FileSystemGlobbing.Internal.PathSegments.CurrentPathSegment.CurrentPathSegment() -> void
+Microsoft.Extensions.FileSystemGlobbing.Internal.PathSegments.CurrentPathSegment.Match(string value) -> bool
+Microsoft.Extensions.FileSystemGlobbing.Internal.PathSegments.LiteralPathSegment
+Microsoft.Extensions.FileSystemGlobbing.Internal.PathSegments.LiteralPathSegment.CanProduceStem.get -> bool
+Microsoft.Extensions.FileSystemGlobbing.Internal.PathSegments.LiteralPathSegment.LiteralPathSegment(string value, System.StringComparison comparisonType) -> void
+Microsoft.Extensions.FileSystemGlobbing.Internal.PathSegments.LiteralPathSegment.Match(string value) -> bool
+Microsoft.Extensions.FileSystemGlobbing.Internal.PathSegments.LiteralPathSegment.Value.get -> string
+Microsoft.Extensions.FileSystemGlobbing.Internal.PathSegments.ParentPathSegment
+Microsoft.Extensions.FileSystemGlobbing.Internal.PathSegments.ParentPathSegment.CanProduceStem.get -> bool
+Microsoft.Extensions.FileSystemGlobbing.Internal.PathSegments.ParentPathSegment.Match(string value) -> bool
+Microsoft.Extensions.FileSystemGlobbing.Internal.PathSegments.ParentPathSegment.ParentPathSegment() -> void
+Microsoft.Extensions.FileSystemGlobbing.Internal.PathSegments.RecursiveWildcardSegment
+Microsoft.Extensions.FileSystemGlobbing.Internal.PathSegments.RecursiveWildcardSegment.CanProduceStem.get -> bool
+Microsoft.Extensions.FileSystemGlobbing.Internal.PathSegments.RecursiveWildcardSegment.Match(string value) -> bool
+Microsoft.Extensions.FileSystemGlobbing.Internal.PathSegments.RecursiveWildcardSegment.RecursiveWildcardSegment() -> void
+Microsoft.Extensions.FileSystemGlobbing.Internal.PathSegments.WildcardPathSegment
+Microsoft.Extensions.FileSystemGlobbing.Internal.PathSegments.WildcardPathSegment.BeginsWith.get -> string
+Microsoft.Extensions.FileSystemGlobbing.Internal.PathSegments.WildcardPathSegment.CanProduceStem.get -> bool
+Microsoft.Extensions.FileSystemGlobbing.Internal.PathSegments.WildcardPathSegment.Contains.get -> System.Collections.Generic.List<string>
+Microsoft.Extensions.FileSystemGlobbing.Internal.PathSegments.WildcardPathSegment.EndsWith.get -> string
+Microsoft.Extensions.FileSystemGlobbing.Internal.PathSegments.WildcardPathSegment.Match(string value) -> bool
+Microsoft.Extensions.FileSystemGlobbing.Internal.PathSegments.WildcardPathSegment.WildcardPathSegment(string beginsWith, System.Collections.Generic.List<string> contains, string endsWith, System.StringComparison comparisonType) -> void
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContext<TFrame>
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContext<TFrame>.Frame -> TFrame
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContext<TFrame>.IsStackEmpty() -> bool
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContext<TFrame>.PatternContext() -> void
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContext<TFrame>.PopDirectory() -> void
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContext<TFrame>.PushDataFrame(TFrame frame) -> void
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextLinear
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextLinear.CalculateStem(Microsoft.Extensions.FileSystemGlobbing.Abstractions.FileInfoBase matchedFile) -> string
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextLinear.FrameData
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextLinear.FrameData.FrameData() -> void
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextLinear.FrameData.InStem -> bool
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextLinear.FrameData.IsNotApplicable -> bool
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextLinear.FrameData.SegmentIndex -> int
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextLinear.FrameData.Stem.get -> string
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextLinear.FrameData.StemItems.get -> System.Collections.Generic.IList<string>
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextLinear.IsLastSegment() -> bool
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextLinear.Pattern.get -> Microsoft.Extensions.FileSystemGlobbing.Internal.ILinearPattern
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextLinear.PatternContextLinear(Microsoft.Extensions.FileSystemGlobbing.Internal.ILinearPattern pattern) -> void
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextLinear.TestMatchingSegment(string value) -> bool
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextLinearExclude
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextLinearExclude.PatternContextLinearExclude(Microsoft.Extensions.FileSystemGlobbing.Internal.ILinearPattern pattern) -> void
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextLinearInclude
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextLinearInclude.PatternContextLinearInclude(Microsoft.Extensions.FileSystemGlobbing.Internal.ILinearPattern pattern) -> void
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextRagged
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextRagged.CalculateStem(Microsoft.Extensions.FileSystemGlobbing.Abstractions.FileInfoBase matchedFile) -> string
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextRagged.FrameData
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextRagged.FrameData.BacktrackAvailable -> int
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextRagged.FrameData.FrameData() -> void
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextRagged.FrameData.InStem -> bool
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextRagged.FrameData.IsNotApplicable -> bool
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextRagged.FrameData.SegmentGroup -> System.Collections.Generic.IList<Microsoft.Extensions.FileSystemGlobbing.Internal.IPathSegment>
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextRagged.FrameData.SegmentGroupIndex -> int
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextRagged.FrameData.SegmentIndex -> int
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextRagged.FrameData.Stem.get -> string
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextRagged.FrameData.StemItems.get -> System.Collections.Generic.IList<string>
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextRagged.IsEndingGroup() -> bool
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextRagged.IsStartingGroup() -> bool
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextRagged.Pattern.get -> Microsoft.Extensions.FileSystemGlobbing.Internal.IRaggedPattern
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextRagged.PatternContextRagged(Microsoft.Extensions.FileSystemGlobbing.Internal.IRaggedPattern pattern) -> void
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextRagged.TestMatchingGroup(Microsoft.Extensions.FileSystemGlobbing.Abstractions.FileSystemInfoBase value) -> bool
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextRagged.TestMatchingSegment(string value) -> bool
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextRaggedExclude
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextRaggedExclude.PatternContextRaggedExclude(Microsoft.Extensions.FileSystemGlobbing.Internal.IRaggedPattern pattern) -> void
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextRaggedInclude
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextRaggedInclude.PatternContextRaggedInclude(Microsoft.Extensions.FileSystemGlobbing.Internal.IRaggedPattern pattern) -> void
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternTestResult
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternTestResult.IsSuccessful.get -> bool
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternTestResult.Stem.get -> string
+Microsoft.Extensions.FileSystemGlobbing.Internal.Patterns.PatternBuilder
+Microsoft.Extensions.FileSystemGlobbing.Internal.Patterns.PatternBuilder.Build(string pattern) -> Microsoft.Extensions.FileSystemGlobbing.Internal.IPattern
+Microsoft.Extensions.FileSystemGlobbing.Internal.Patterns.PatternBuilder.ComparisonType.get -> System.StringComparison
+Microsoft.Extensions.FileSystemGlobbing.Internal.Patterns.PatternBuilder.PatternBuilder() -> void
+Microsoft.Extensions.FileSystemGlobbing.Internal.Patterns.PatternBuilder.PatternBuilder(System.StringComparison comparisonType) -> void
+Microsoft.Extensions.FileSystemGlobbing.Matcher
+Microsoft.Extensions.FileSystemGlobbing.Matcher.Matcher() -> void
+Microsoft.Extensions.FileSystemGlobbing.Matcher.Matcher(System.StringComparison comparisonType) -> void
+Microsoft.Extensions.FileSystemGlobbing.MatcherExtensions
+Microsoft.Extensions.FileSystemGlobbing.PatternMatchingResult
+Microsoft.Extensions.FileSystemGlobbing.PatternMatchingResult.Files.get -> System.Collections.Generic.IEnumerable<Microsoft.Extensions.FileSystemGlobbing.FilePatternMatch>
+Microsoft.Extensions.FileSystemGlobbing.PatternMatchingResult.Files.set -> void
+Microsoft.Extensions.FileSystemGlobbing.PatternMatchingResult.PatternMatchingResult(System.Collections.Generic.IEnumerable<Microsoft.Extensions.FileSystemGlobbing.FilePatternMatch> files) -> void
+Microsoft.Extensions.Primitives.IChangeToken
+Microsoft.Extensions.Primitives.IChangeToken.ActiveChangeCallbacks.get -> bool
+Microsoft.Extensions.Primitives.IChangeToken.HasChanged.get -> bool
+Microsoft.Extensions.Primitives.IChangeToken.RegisterChangeCallback(System.Action<object> callback, object state) -> System.IDisposable
 NuGet.Commands.AddClientCertArgs
 NuGet.Commands.AddClientCertArgs.AddClientCertArgs() -> void
 NuGet.Commands.AddClientCertArgs.Configfile.get -> string
@@ -828,8 +968,39 @@ NuGet.Commands.WarningPropertiesCollection.PackageSpecificWarningProperties.get 
 NuGet.Commands.WarningPropertiesCollection.ProjectFrameworks.get -> System.Collections.Generic.IReadOnlyList<NuGet.Frameworks.NuGetFramework>
 NuGet.Commands.WarningPropertiesCollection.ProjectWideWarningProperties.get -> NuGet.ProjectModel.WarningProperties
 NuGet.Commands.WarningPropertiesCollection.WarningPropertiesCollection(NuGet.ProjectModel.WarningProperties projectWideWarningProperties, NuGet.Commands.PackageSpecificWarningProperties packageSpecificWarningProperties, System.Collections.Generic.IReadOnlyList<NuGet.Frameworks.NuGetFramework> projectFrameworks) -> void
+abstract Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoBase.EnumerateFileSystemInfos() -> System.Collections.Generic.IEnumerable<Microsoft.Extensions.FileSystemGlobbing.Abstractions.FileSystemInfoBase>
+abstract Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoBase.GetDirectory(string path) -> Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoBase
+abstract Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoBase.GetFile(string path) -> Microsoft.Extensions.FileSystemGlobbing.Abstractions.FileInfoBase
+abstract Microsoft.Extensions.FileSystemGlobbing.Abstractions.FileSystemInfoBase.FullName.get -> string
+abstract Microsoft.Extensions.FileSystemGlobbing.Abstractions.FileSystemInfoBase.Name.get -> string
+abstract Microsoft.Extensions.FileSystemGlobbing.Abstractions.FileSystemInfoBase.ParentDirectory.get -> Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoBase
+abstract Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContext<TFrame>.PushDirectory(Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoBase directory) -> void
+abstract Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContext<TFrame>.Test(Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoBase directory) -> bool
+abstract Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContext<TFrame>.Test(Microsoft.Extensions.FileSystemGlobbing.Abstractions.FileInfoBase file) -> Microsoft.Extensions.FileSystemGlobbing.Internal.PatternTestResult
 const NuGet.Commands.BuildAssetsUtils.PropsExtension = ".props" -> string
 const NuGet.Commands.BuildAssetsUtils.TargetsExtension = ".targets" -> string
+override Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoWrapper.EnumerateFileSystemInfos() -> System.Collections.Generic.IEnumerable<Microsoft.Extensions.FileSystemGlobbing.Abstractions.FileSystemInfoBase>
+override Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoWrapper.FullName.get -> string
+override Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoWrapper.GetDirectory(string name) -> Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoBase
+override Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoWrapper.GetFile(string name) -> Microsoft.Extensions.FileSystemGlobbing.Abstractions.FileInfoBase
+override Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoWrapper.Name.get -> string
+override Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoWrapper.ParentDirectory.get -> Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoBase
+override Microsoft.Extensions.FileSystemGlobbing.Abstractions.FileInfoWrapper.FullName.get -> string
+override Microsoft.Extensions.FileSystemGlobbing.Abstractions.FileInfoWrapper.Name.get -> string
+override Microsoft.Extensions.FileSystemGlobbing.Abstractions.FileInfoWrapper.ParentDirectory.get -> Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoBase
+override Microsoft.Extensions.FileSystemGlobbing.FilePatternMatch.Equals(object obj) -> bool
+override Microsoft.Extensions.FileSystemGlobbing.FilePatternMatch.GetHashCode() -> int
+override Microsoft.Extensions.FileSystemGlobbing.Internal.PathSegments.LiteralPathSegment.Equals(object obj) -> bool
+override Microsoft.Extensions.FileSystemGlobbing.Internal.PathSegments.LiteralPathSegment.GetHashCode() -> int
+override Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextLinear.PushDirectory(Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoBase directory) -> void
+override Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextLinear.Test(Microsoft.Extensions.FileSystemGlobbing.Abstractions.FileInfoBase file) -> Microsoft.Extensions.FileSystemGlobbing.Internal.PatternTestResult
+override Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextLinearExclude.Test(Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoBase directory) -> bool
+override Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextLinearInclude.Declare(System.Action<Microsoft.Extensions.FileSystemGlobbing.Internal.IPathSegment, bool> onDeclare) -> void
+override Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextLinearInclude.Test(Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoBase directory) -> bool
+override Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextRagged.Test(Microsoft.Extensions.FileSystemGlobbing.Abstractions.FileInfoBase file) -> Microsoft.Extensions.FileSystemGlobbing.Internal.PatternTestResult
+override Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextRaggedExclude.Test(Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoBase directory) -> bool
+override Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextRaggedInclude.Declare(System.Action<Microsoft.Extensions.FileSystemGlobbing.Internal.IPathSegment, bool> onDeclare) -> void
+override Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextRaggedInclude.Test(Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoBase directory) -> bool
 override NuGet.Commands.CompatibilityIssue.ToString() -> string
 override NuGet.Commands.MSBuildItem.ToString() -> string
 override NuGet.Commands.NoOpRestoreResult.CommitAsync(NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task
@@ -852,6 +1023,11 @@ override NuGet.Commands.TransitiveNoWarnUtils.NodeWarningProperties.Equals(objec
 override NuGet.Commands.TransitiveNoWarnUtils.NodeWarningProperties.GetHashCode() -> int
 override NuGet.Commands.WarningPropertiesCollection.Equals(object obj) -> bool
 override NuGet.Commands.WarningPropertiesCollection.GetHashCode() -> int
+override sealed Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextRagged.PushDirectory(Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoBase directory) -> void
+static Microsoft.Extensions.FileSystemGlobbing.Internal.PatternTestResult.Success(string stem) -> Microsoft.Extensions.FileSystemGlobbing.Internal.PatternTestResult
+static Microsoft.Extensions.FileSystemGlobbing.MatcherExtensions.AddExcludePatterns(this Microsoft.Extensions.FileSystemGlobbing.Matcher matcher, params System.Collections.Generic.IEnumerable<string>[] excludePatternsGroups) -> void
+static Microsoft.Extensions.FileSystemGlobbing.MatcherExtensions.AddIncludePatterns(this Microsoft.Extensions.FileSystemGlobbing.Matcher matcher, params System.Collections.Generic.IEnumerable<string>[] includePatternsGroups) -> void
+static Microsoft.Extensions.FileSystemGlobbing.MatcherExtensions.GetResultsInFullPath(this Microsoft.Extensions.FileSystemGlobbing.Matcher matcher, string directoryPath) -> System.Collections.Generic.IEnumerable<string>
 static NuGet.Commands.AddClientCertRunner.Run(NuGet.Commands.AddClientCertArgs args, System.Func<NuGet.Common.ILogger> getLogger) -> void
 static NuGet.Commands.AddSourceRunner.Run(NuGet.Commands.AddSourceArgs args, System.Func<NuGet.Common.ILogger> getLogger) -> void
 static NuGet.Commands.AssetTargetFallbackUtility.ApplyFramework(NuGet.ProjectModel.TargetFrameworkInformation targetFrameworkInfo, System.Collections.Generic.IEnumerable<NuGet.Frameworks.NuGetFramework> packageTargetFallback, System.Collections.Generic.IEnumerable<NuGet.Frameworks.NuGetFramework> assetTargetFallback) -> void
@@ -996,6 +1172,8 @@ static NuGet.Commands.UpdateClientCertRunner.Run(NuGet.Commands.UpdateClientCert
 static NuGet.Commands.UpdateSourceRunner.Run(NuGet.Commands.UpdateSourceArgs args, System.Func<NuGet.Common.ILogger> getLogger) -> void
 static NuGet.Commands.WarningPropertiesCollection.ApplyProjectWideNoWarnProperties(NuGet.Common.ILogMessage message, NuGet.ProjectModel.WarningProperties warningProperties) -> bool
 static NuGet.Commands.WarningPropertiesCollection.ApplyProjectWideWarningsAsErrorProperties(NuGet.Common.ILogMessage message, NuGet.ProjectModel.WarningProperties warningProperties) -> void
+static readonly Microsoft.Extensions.FileSystemGlobbing.Internal.PathSegments.WildcardPathSegment.MatchAll -> Microsoft.Extensions.FileSystemGlobbing.Internal.PathSegments.WildcardPathSegment
+static readonly Microsoft.Extensions.FileSystemGlobbing.Internal.PatternTestResult.Failed -> Microsoft.Extensions.FileSystemGlobbing.Internal.PatternTestResult
 static readonly NuGet.Commands.AssetTargetFallbackUtility.AssetTargetFallback -> string
 static readonly NuGet.Commands.BuildAssetsUtils.MacroCandidates -> string[]
 static readonly NuGet.Commands.LockFileUtils.LIBANY -> string
@@ -1003,6 +1181,10 @@ static readonly NuGet.Commands.MSBuildRestoreItemGroup.ImportGroup -> string
 static readonly NuGet.Commands.MSBuildRestoreItemGroup.ItemGroup -> string
 static readonly NuGet.Commands.MSBuildRestoreUtility.Clear -> string
 static readonly NuGet.Commands.RestoreRequest.DefaultDegreeOfConcurrency -> int
+virtual Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContext<TFrame>.Declare(System.Action<Microsoft.Extensions.FileSystemGlobbing.Internal.IPathSegment, bool> declare) -> void
+virtual Microsoft.Extensions.FileSystemGlobbing.Matcher.AddExclude(string pattern) -> Microsoft.Extensions.FileSystemGlobbing.Matcher
+virtual Microsoft.Extensions.FileSystemGlobbing.Matcher.AddInclude(string pattern) -> Microsoft.Extensions.FileSystemGlobbing.Matcher
+virtual Microsoft.Extensions.FileSystemGlobbing.Matcher.Execute(Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoBase directoryInfo) -> Microsoft.Extensions.FileSystemGlobbing.PatternMatchingResult
 virtual NuGet.Commands.DependencyGraphFileRequestProvider.CreateRequests(string inputPath, NuGet.Commands.RestoreArgs restoreContext) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<NuGet.Commands.RestoreSummaryRequest>>
 virtual NuGet.Commands.DependencyGraphFileRequestProvider.Supports(string path) -> System.Threading.Tasks.Task<bool>
 virtual NuGet.Commands.RestoreResult.CommitAsync(NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task

--- a/src/NuGet.Core/NuGet.Commands/PublicAPI/netcoreapp5.0/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Commands/PublicAPI/netcoreapp5.0/PublicAPI.Shipped.txt
@@ -1,3 +1,143 @@
+Microsoft.AspNet.FileProviders.IDirectoryContents
+Microsoft.AspNet.FileProviders.IDirectoryContents.Exists.get -> bool
+Microsoft.AspNet.FileProviders.IFileInfo
+Microsoft.AspNet.FileProviders.IFileInfo.CreateReadStream() -> System.IO.Stream
+Microsoft.AspNet.FileProviders.IFileInfo.Exists.get -> bool
+Microsoft.AspNet.FileProviders.IFileInfo.IsDirectory.get -> bool
+Microsoft.AspNet.FileProviders.IFileInfo.LastModified.get -> System.DateTimeOffset
+Microsoft.AspNet.FileProviders.IFileInfo.Length.get -> long
+Microsoft.AspNet.FileProviders.IFileInfo.Name.get -> string
+Microsoft.AspNet.FileProviders.IFileInfo.PhysicalPath.get -> string
+Microsoft.AspNet.FileProviders.IFileProvider
+Microsoft.AspNet.FileProviders.IFileProvider.GetDirectoryContents(string subpath) -> Microsoft.AspNet.FileProviders.IDirectoryContents
+Microsoft.AspNet.FileProviders.IFileProvider.GetFileInfo(string subpath) -> Microsoft.AspNet.FileProviders.IFileInfo
+Microsoft.AspNet.FileProviders.IFileProvider.Watch(string filter) -> Microsoft.Extensions.Primitives.IChangeToken
+Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoBase
+Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoBase.DirectoryInfoBase() -> void
+Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoWrapper
+Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoWrapper.DirectoryInfoWrapper(System.IO.DirectoryInfo directoryInfo, bool isParentPath = false) -> void
+Microsoft.Extensions.FileSystemGlobbing.Abstractions.FileInfoBase
+Microsoft.Extensions.FileSystemGlobbing.Abstractions.FileInfoBase.FileInfoBase() -> void
+Microsoft.Extensions.FileSystemGlobbing.Abstractions.FileInfoWrapper
+Microsoft.Extensions.FileSystemGlobbing.Abstractions.FileInfoWrapper.FileInfoWrapper(System.IO.FileInfo fileInfo) -> void
+Microsoft.Extensions.FileSystemGlobbing.Abstractions.FileSystemInfoBase
+Microsoft.Extensions.FileSystemGlobbing.Abstractions.FileSystemInfoBase.FileSystemInfoBase() -> void
+Microsoft.Extensions.FileSystemGlobbing.FilePatternMatch
+Microsoft.Extensions.FileSystemGlobbing.FilePatternMatch.Equals(Microsoft.Extensions.FileSystemGlobbing.FilePatternMatch other) -> bool
+Microsoft.Extensions.FileSystemGlobbing.FilePatternMatch.FilePatternMatch(string path, string stem) -> void
+Microsoft.Extensions.FileSystemGlobbing.FilePatternMatch.Path.get -> string
+Microsoft.Extensions.FileSystemGlobbing.FilePatternMatch.Stem.get -> string
+Microsoft.Extensions.FileSystemGlobbing.Internal.ILinearPattern
+Microsoft.Extensions.FileSystemGlobbing.Internal.ILinearPattern.Segments.get -> System.Collections.Generic.IList<Microsoft.Extensions.FileSystemGlobbing.Internal.IPathSegment>
+Microsoft.Extensions.FileSystemGlobbing.Internal.IPathSegment
+Microsoft.Extensions.FileSystemGlobbing.Internal.IPathSegment.CanProduceStem.get -> bool
+Microsoft.Extensions.FileSystemGlobbing.Internal.IPathSegment.Match(string value) -> bool
+Microsoft.Extensions.FileSystemGlobbing.Internal.IPattern
+Microsoft.Extensions.FileSystemGlobbing.Internal.IPattern.CreatePatternContextForExclude() -> Microsoft.Extensions.FileSystemGlobbing.Internal.IPatternContext
+Microsoft.Extensions.FileSystemGlobbing.Internal.IPattern.CreatePatternContextForInclude() -> Microsoft.Extensions.FileSystemGlobbing.Internal.IPatternContext
+Microsoft.Extensions.FileSystemGlobbing.Internal.IPatternContext
+Microsoft.Extensions.FileSystemGlobbing.Internal.IPatternContext.Declare(System.Action<Microsoft.Extensions.FileSystemGlobbing.Internal.IPathSegment, bool> onDeclare) -> void
+Microsoft.Extensions.FileSystemGlobbing.Internal.IPatternContext.PopDirectory() -> void
+Microsoft.Extensions.FileSystemGlobbing.Internal.IPatternContext.PushDirectory(Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoBase directory) -> void
+Microsoft.Extensions.FileSystemGlobbing.Internal.IPatternContext.Test(Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoBase directory) -> bool
+Microsoft.Extensions.FileSystemGlobbing.Internal.IPatternContext.Test(Microsoft.Extensions.FileSystemGlobbing.Abstractions.FileInfoBase file) -> Microsoft.Extensions.FileSystemGlobbing.Internal.PatternTestResult
+Microsoft.Extensions.FileSystemGlobbing.Internal.IRaggedPattern
+Microsoft.Extensions.FileSystemGlobbing.Internal.IRaggedPattern.Contains.get -> System.Collections.Generic.IList<System.Collections.Generic.IList<Microsoft.Extensions.FileSystemGlobbing.Internal.IPathSegment>>
+Microsoft.Extensions.FileSystemGlobbing.Internal.IRaggedPattern.EndsWith.get -> System.Collections.Generic.IList<Microsoft.Extensions.FileSystemGlobbing.Internal.IPathSegment>
+Microsoft.Extensions.FileSystemGlobbing.Internal.IRaggedPattern.Segments.get -> System.Collections.Generic.IList<Microsoft.Extensions.FileSystemGlobbing.Internal.IPathSegment>
+Microsoft.Extensions.FileSystemGlobbing.Internal.IRaggedPattern.StartsWith.get -> System.Collections.Generic.IList<Microsoft.Extensions.FileSystemGlobbing.Internal.IPathSegment>
+Microsoft.Extensions.FileSystemGlobbing.Internal.MatcherContext
+Microsoft.Extensions.FileSystemGlobbing.Internal.MatcherContext.Execute() -> Microsoft.Extensions.FileSystemGlobbing.PatternMatchingResult
+Microsoft.Extensions.FileSystemGlobbing.Internal.MatcherContext.MatcherContext(System.Collections.Generic.IEnumerable<Microsoft.Extensions.FileSystemGlobbing.Internal.IPattern> includePatterns, System.Collections.Generic.IEnumerable<Microsoft.Extensions.FileSystemGlobbing.Internal.IPattern> excludePatterns, Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoBase directoryInfo, System.StringComparison comparison) -> void
+Microsoft.Extensions.FileSystemGlobbing.Internal.PathSegments.CurrentPathSegment
+Microsoft.Extensions.FileSystemGlobbing.Internal.PathSegments.CurrentPathSegment.CanProduceStem.get -> bool
+Microsoft.Extensions.FileSystemGlobbing.Internal.PathSegments.CurrentPathSegment.CurrentPathSegment() -> void
+Microsoft.Extensions.FileSystemGlobbing.Internal.PathSegments.CurrentPathSegment.Match(string value) -> bool
+Microsoft.Extensions.FileSystemGlobbing.Internal.PathSegments.LiteralPathSegment
+Microsoft.Extensions.FileSystemGlobbing.Internal.PathSegments.LiteralPathSegment.CanProduceStem.get -> bool
+Microsoft.Extensions.FileSystemGlobbing.Internal.PathSegments.LiteralPathSegment.LiteralPathSegment(string value, System.StringComparison comparisonType) -> void
+Microsoft.Extensions.FileSystemGlobbing.Internal.PathSegments.LiteralPathSegment.Match(string value) -> bool
+Microsoft.Extensions.FileSystemGlobbing.Internal.PathSegments.LiteralPathSegment.Value.get -> string
+Microsoft.Extensions.FileSystemGlobbing.Internal.PathSegments.ParentPathSegment
+Microsoft.Extensions.FileSystemGlobbing.Internal.PathSegments.ParentPathSegment.CanProduceStem.get -> bool
+Microsoft.Extensions.FileSystemGlobbing.Internal.PathSegments.ParentPathSegment.Match(string value) -> bool
+Microsoft.Extensions.FileSystemGlobbing.Internal.PathSegments.ParentPathSegment.ParentPathSegment() -> void
+Microsoft.Extensions.FileSystemGlobbing.Internal.PathSegments.RecursiveWildcardSegment
+Microsoft.Extensions.FileSystemGlobbing.Internal.PathSegments.RecursiveWildcardSegment.CanProduceStem.get -> bool
+Microsoft.Extensions.FileSystemGlobbing.Internal.PathSegments.RecursiveWildcardSegment.Match(string value) -> bool
+Microsoft.Extensions.FileSystemGlobbing.Internal.PathSegments.RecursiveWildcardSegment.RecursiveWildcardSegment() -> void
+Microsoft.Extensions.FileSystemGlobbing.Internal.PathSegments.WildcardPathSegment
+Microsoft.Extensions.FileSystemGlobbing.Internal.PathSegments.WildcardPathSegment.BeginsWith.get -> string
+Microsoft.Extensions.FileSystemGlobbing.Internal.PathSegments.WildcardPathSegment.CanProduceStem.get -> bool
+Microsoft.Extensions.FileSystemGlobbing.Internal.PathSegments.WildcardPathSegment.Contains.get -> System.Collections.Generic.List<string>
+Microsoft.Extensions.FileSystemGlobbing.Internal.PathSegments.WildcardPathSegment.EndsWith.get -> string
+Microsoft.Extensions.FileSystemGlobbing.Internal.PathSegments.WildcardPathSegment.Match(string value) -> bool
+Microsoft.Extensions.FileSystemGlobbing.Internal.PathSegments.WildcardPathSegment.WildcardPathSegment(string beginsWith, System.Collections.Generic.List<string> contains, string endsWith, System.StringComparison comparisonType) -> void
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContext<TFrame>
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContext<TFrame>.Frame -> TFrame
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContext<TFrame>.IsStackEmpty() -> bool
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContext<TFrame>.PatternContext() -> void
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContext<TFrame>.PopDirectory() -> void
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContext<TFrame>.PushDataFrame(TFrame frame) -> void
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextLinear
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextLinear.CalculateStem(Microsoft.Extensions.FileSystemGlobbing.Abstractions.FileInfoBase matchedFile) -> string
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextLinear.FrameData
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextLinear.FrameData.FrameData() -> void
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextLinear.FrameData.InStem -> bool
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextLinear.FrameData.IsNotApplicable -> bool
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextLinear.FrameData.SegmentIndex -> int
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextLinear.FrameData.Stem.get -> string
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextLinear.FrameData.StemItems.get -> System.Collections.Generic.IList<string>
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextLinear.IsLastSegment() -> bool
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextLinear.Pattern.get -> Microsoft.Extensions.FileSystemGlobbing.Internal.ILinearPattern
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextLinear.PatternContextLinear(Microsoft.Extensions.FileSystemGlobbing.Internal.ILinearPattern pattern) -> void
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextLinear.TestMatchingSegment(string value) -> bool
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextLinearExclude
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextLinearExclude.PatternContextLinearExclude(Microsoft.Extensions.FileSystemGlobbing.Internal.ILinearPattern pattern) -> void
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextLinearInclude
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextLinearInclude.PatternContextLinearInclude(Microsoft.Extensions.FileSystemGlobbing.Internal.ILinearPattern pattern) -> void
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextRagged
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextRagged.CalculateStem(Microsoft.Extensions.FileSystemGlobbing.Abstractions.FileInfoBase matchedFile) -> string
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextRagged.FrameData
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextRagged.FrameData.BacktrackAvailable -> int
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextRagged.FrameData.FrameData() -> void
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextRagged.FrameData.InStem -> bool
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextRagged.FrameData.IsNotApplicable -> bool
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextRagged.FrameData.SegmentGroup -> System.Collections.Generic.IList<Microsoft.Extensions.FileSystemGlobbing.Internal.IPathSegment>
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextRagged.FrameData.SegmentGroupIndex -> int
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextRagged.FrameData.SegmentIndex -> int
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextRagged.FrameData.Stem.get -> string
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextRagged.FrameData.StemItems.get -> System.Collections.Generic.IList<string>
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextRagged.IsEndingGroup() -> bool
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextRagged.IsStartingGroup() -> bool
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextRagged.Pattern.get -> Microsoft.Extensions.FileSystemGlobbing.Internal.IRaggedPattern
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextRagged.PatternContextRagged(Microsoft.Extensions.FileSystemGlobbing.Internal.IRaggedPattern pattern) -> void
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextRagged.TestMatchingGroup(Microsoft.Extensions.FileSystemGlobbing.Abstractions.FileSystemInfoBase value) -> bool
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextRagged.TestMatchingSegment(string value) -> bool
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextRaggedExclude
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextRaggedExclude.PatternContextRaggedExclude(Microsoft.Extensions.FileSystemGlobbing.Internal.IRaggedPattern pattern) -> void
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextRaggedInclude
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextRaggedInclude.PatternContextRaggedInclude(Microsoft.Extensions.FileSystemGlobbing.Internal.IRaggedPattern pattern) -> void
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternTestResult
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternTestResult.IsSuccessful.get -> bool
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternTestResult.Stem.get -> string
+Microsoft.Extensions.FileSystemGlobbing.Internal.Patterns.PatternBuilder
+Microsoft.Extensions.FileSystemGlobbing.Internal.Patterns.PatternBuilder.Build(string pattern) -> Microsoft.Extensions.FileSystemGlobbing.Internal.IPattern
+Microsoft.Extensions.FileSystemGlobbing.Internal.Patterns.PatternBuilder.ComparisonType.get -> System.StringComparison
+Microsoft.Extensions.FileSystemGlobbing.Internal.Patterns.PatternBuilder.PatternBuilder() -> void
+Microsoft.Extensions.FileSystemGlobbing.Internal.Patterns.PatternBuilder.PatternBuilder(System.StringComparison comparisonType) -> void
+Microsoft.Extensions.FileSystemGlobbing.Matcher
+Microsoft.Extensions.FileSystemGlobbing.Matcher.Matcher() -> void
+Microsoft.Extensions.FileSystemGlobbing.Matcher.Matcher(System.StringComparison comparisonType) -> void
+Microsoft.Extensions.FileSystemGlobbing.MatcherExtensions
+Microsoft.Extensions.FileSystemGlobbing.PatternMatchingResult
+Microsoft.Extensions.FileSystemGlobbing.PatternMatchingResult.Files.get -> System.Collections.Generic.IEnumerable<Microsoft.Extensions.FileSystemGlobbing.FilePatternMatch>
+Microsoft.Extensions.FileSystemGlobbing.PatternMatchingResult.Files.set -> void
+Microsoft.Extensions.FileSystemGlobbing.PatternMatchingResult.PatternMatchingResult(System.Collections.Generic.IEnumerable<Microsoft.Extensions.FileSystemGlobbing.FilePatternMatch> files) -> void
+Microsoft.Extensions.Primitives.IChangeToken
+Microsoft.Extensions.Primitives.IChangeToken.ActiveChangeCallbacks.get -> bool
+Microsoft.Extensions.Primitives.IChangeToken.HasChanged.get -> bool
+Microsoft.Extensions.Primitives.IChangeToken.RegisterChangeCallback(System.Action<object> callback, object state) -> System.IDisposable
 NuGet.Commands.AddClientCertArgs
 NuGet.Commands.AddClientCertArgs.AddClientCertArgs() -> void
 NuGet.Commands.AddClientCertArgs.Configfile.get -> string
@@ -827,8 +967,39 @@ NuGet.Commands.WarningPropertiesCollection.PackageSpecificWarningProperties.get 
 NuGet.Commands.WarningPropertiesCollection.ProjectFrameworks.get -> System.Collections.Generic.IReadOnlyList<NuGet.Frameworks.NuGetFramework>
 NuGet.Commands.WarningPropertiesCollection.ProjectWideWarningProperties.get -> NuGet.ProjectModel.WarningProperties
 NuGet.Commands.WarningPropertiesCollection.WarningPropertiesCollection(NuGet.ProjectModel.WarningProperties projectWideWarningProperties, NuGet.Commands.PackageSpecificWarningProperties packageSpecificWarningProperties, System.Collections.Generic.IReadOnlyList<NuGet.Frameworks.NuGetFramework> projectFrameworks) -> void
+abstract Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoBase.EnumerateFileSystemInfos() -> System.Collections.Generic.IEnumerable<Microsoft.Extensions.FileSystemGlobbing.Abstractions.FileSystemInfoBase>
+abstract Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoBase.GetDirectory(string path) -> Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoBase
+abstract Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoBase.GetFile(string path) -> Microsoft.Extensions.FileSystemGlobbing.Abstractions.FileInfoBase
+abstract Microsoft.Extensions.FileSystemGlobbing.Abstractions.FileSystemInfoBase.FullName.get -> string
+abstract Microsoft.Extensions.FileSystemGlobbing.Abstractions.FileSystemInfoBase.Name.get -> string
+abstract Microsoft.Extensions.FileSystemGlobbing.Abstractions.FileSystemInfoBase.ParentDirectory.get -> Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoBase
+abstract Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContext<TFrame>.PushDirectory(Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoBase directory) -> void
+abstract Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContext<TFrame>.Test(Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoBase directory) -> bool
+abstract Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContext<TFrame>.Test(Microsoft.Extensions.FileSystemGlobbing.Abstractions.FileInfoBase file) -> Microsoft.Extensions.FileSystemGlobbing.Internal.PatternTestResult
 const NuGet.Commands.BuildAssetsUtils.PropsExtension = ".props" -> string
 const NuGet.Commands.BuildAssetsUtils.TargetsExtension = ".targets" -> string
+override Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoWrapper.EnumerateFileSystemInfos() -> System.Collections.Generic.IEnumerable<Microsoft.Extensions.FileSystemGlobbing.Abstractions.FileSystemInfoBase>
+override Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoWrapper.FullName.get -> string
+override Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoWrapper.GetDirectory(string name) -> Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoBase
+override Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoWrapper.GetFile(string name) -> Microsoft.Extensions.FileSystemGlobbing.Abstractions.FileInfoBase
+override Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoWrapper.Name.get -> string
+override Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoWrapper.ParentDirectory.get -> Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoBase
+override Microsoft.Extensions.FileSystemGlobbing.Abstractions.FileInfoWrapper.FullName.get -> string
+override Microsoft.Extensions.FileSystemGlobbing.Abstractions.FileInfoWrapper.Name.get -> string
+override Microsoft.Extensions.FileSystemGlobbing.Abstractions.FileInfoWrapper.ParentDirectory.get -> Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoBase
+override Microsoft.Extensions.FileSystemGlobbing.FilePatternMatch.Equals(object obj) -> bool
+override Microsoft.Extensions.FileSystemGlobbing.FilePatternMatch.GetHashCode() -> int
+override Microsoft.Extensions.FileSystemGlobbing.Internal.PathSegments.LiteralPathSegment.Equals(object obj) -> bool
+override Microsoft.Extensions.FileSystemGlobbing.Internal.PathSegments.LiteralPathSegment.GetHashCode() -> int
+override Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextLinear.PushDirectory(Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoBase directory) -> void
+override Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextLinear.Test(Microsoft.Extensions.FileSystemGlobbing.Abstractions.FileInfoBase file) -> Microsoft.Extensions.FileSystemGlobbing.Internal.PatternTestResult
+override Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextLinearExclude.Test(Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoBase directory) -> bool
+override Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextLinearInclude.Declare(System.Action<Microsoft.Extensions.FileSystemGlobbing.Internal.IPathSegment, bool> onDeclare) -> void
+override Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextLinearInclude.Test(Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoBase directory) -> bool
+override Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextRagged.Test(Microsoft.Extensions.FileSystemGlobbing.Abstractions.FileInfoBase file) -> Microsoft.Extensions.FileSystemGlobbing.Internal.PatternTestResult
+override Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextRaggedExclude.Test(Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoBase directory) -> bool
+override Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextRaggedInclude.Declare(System.Action<Microsoft.Extensions.FileSystemGlobbing.Internal.IPathSegment, bool> onDeclare) -> void
+override Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextRaggedInclude.Test(Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoBase directory) -> bool
 override NuGet.Commands.CompatibilityIssue.ToString() -> string
 override NuGet.Commands.MSBuildItem.ToString() -> string
 override NuGet.Commands.NoOpRestoreResult.CommitAsync(NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task
@@ -851,6 +1022,11 @@ override NuGet.Commands.TransitiveNoWarnUtils.NodeWarningProperties.Equals(objec
 override NuGet.Commands.TransitiveNoWarnUtils.NodeWarningProperties.GetHashCode() -> int
 override NuGet.Commands.WarningPropertiesCollection.Equals(object obj) -> bool
 override NuGet.Commands.WarningPropertiesCollection.GetHashCode() -> int
+override sealed Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextRagged.PushDirectory(Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoBase directory) -> void
+static Microsoft.Extensions.FileSystemGlobbing.Internal.PatternTestResult.Success(string stem) -> Microsoft.Extensions.FileSystemGlobbing.Internal.PatternTestResult
+static Microsoft.Extensions.FileSystemGlobbing.MatcherExtensions.AddExcludePatterns(this Microsoft.Extensions.FileSystemGlobbing.Matcher matcher, params System.Collections.Generic.IEnumerable<string>[] excludePatternsGroups) -> void
+static Microsoft.Extensions.FileSystemGlobbing.MatcherExtensions.AddIncludePatterns(this Microsoft.Extensions.FileSystemGlobbing.Matcher matcher, params System.Collections.Generic.IEnumerable<string>[] includePatternsGroups) -> void
+static Microsoft.Extensions.FileSystemGlobbing.MatcherExtensions.GetResultsInFullPath(this Microsoft.Extensions.FileSystemGlobbing.Matcher matcher, string directoryPath) -> System.Collections.Generic.IEnumerable<string>
 static NuGet.Commands.AddClientCertRunner.Run(NuGet.Commands.AddClientCertArgs args, System.Func<NuGet.Common.ILogger> getLogger) -> void
 static NuGet.Commands.AddSourceRunner.Run(NuGet.Commands.AddSourceArgs args, System.Func<NuGet.Common.ILogger> getLogger) -> void
 static NuGet.Commands.AssetTargetFallbackUtility.ApplyFramework(NuGet.ProjectModel.TargetFrameworkInformation targetFrameworkInfo, System.Collections.Generic.IEnumerable<NuGet.Frameworks.NuGetFramework> packageTargetFallback, System.Collections.Generic.IEnumerable<NuGet.Frameworks.NuGetFramework> assetTargetFallback) -> void
@@ -995,6 +1171,8 @@ static NuGet.Commands.UpdateClientCertRunner.Run(NuGet.Commands.UpdateClientCert
 static NuGet.Commands.UpdateSourceRunner.Run(NuGet.Commands.UpdateSourceArgs args, System.Func<NuGet.Common.ILogger> getLogger) -> void
 static NuGet.Commands.WarningPropertiesCollection.ApplyProjectWideNoWarnProperties(NuGet.Common.ILogMessage message, NuGet.ProjectModel.WarningProperties warningProperties) -> bool
 static NuGet.Commands.WarningPropertiesCollection.ApplyProjectWideWarningsAsErrorProperties(NuGet.Common.ILogMessage message, NuGet.ProjectModel.WarningProperties warningProperties) -> void
+static readonly Microsoft.Extensions.FileSystemGlobbing.Internal.PathSegments.WildcardPathSegment.MatchAll -> Microsoft.Extensions.FileSystemGlobbing.Internal.PathSegments.WildcardPathSegment
+static readonly Microsoft.Extensions.FileSystemGlobbing.Internal.PatternTestResult.Failed -> Microsoft.Extensions.FileSystemGlobbing.Internal.PatternTestResult
 static readonly NuGet.Commands.AssetTargetFallbackUtility.AssetTargetFallback -> string
 static readonly NuGet.Commands.BuildAssetsUtils.MacroCandidates -> string[]
 static readonly NuGet.Commands.LockFileUtils.LIBANY -> string
@@ -1002,6 +1180,10 @@ static readonly NuGet.Commands.MSBuildRestoreItemGroup.ImportGroup -> string
 static readonly NuGet.Commands.MSBuildRestoreItemGroup.ItemGroup -> string
 static readonly NuGet.Commands.MSBuildRestoreUtility.Clear -> string
 static readonly NuGet.Commands.RestoreRequest.DefaultDegreeOfConcurrency -> int
+virtual Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContext<TFrame>.Declare(System.Action<Microsoft.Extensions.FileSystemGlobbing.Internal.IPathSegment, bool> declare) -> void
+virtual Microsoft.Extensions.FileSystemGlobbing.Matcher.AddExclude(string pattern) -> Microsoft.Extensions.FileSystemGlobbing.Matcher
+virtual Microsoft.Extensions.FileSystemGlobbing.Matcher.AddInclude(string pattern) -> Microsoft.Extensions.FileSystemGlobbing.Matcher
+virtual Microsoft.Extensions.FileSystemGlobbing.Matcher.Execute(Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoBase directoryInfo) -> Microsoft.Extensions.FileSystemGlobbing.PatternMatchingResult
 virtual NuGet.Commands.DependencyGraphFileRequestProvider.CreateRequests(string inputPath, NuGet.Commands.RestoreArgs restoreContext) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<NuGet.Commands.RestoreSummaryRequest>>
 virtual NuGet.Commands.DependencyGraphFileRequestProvider.Supports(string path) -> System.Threading.Tasks.Task<bool>
 virtual NuGet.Commands.RestoreResult.CommitAsync(NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task

--- a/src/NuGet.Core/NuGet.Commands/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Commands/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
@@ -1,3 +1,143 @@
+Microsoft.AspNet.FileProviders.IDirectoryContents
+Microsoft.AspNet.FileProviders.IDirectoryContents.Exists.get -> bool
+Microsoft.AspNet.FileProviders.IFileInfo
+Microsoft.AspNet.FileProviders.IFileInfo.CreateReadStream() -> System.IO.Stream
+Microsoft.AspNet.FileProviders.IFileInfo.Exists.get -> bool
+Microsoft.AspNet.FileProviders.IFileInfo.IsDirectory.get -> bool
+Microsoft.AspNet.FileProviders.IFileInfo.LastModified.get -> System.DateTimeOffset
+Microsoft.AspNet.FileProviders.IFileInfo.Length.get -> long
+Microsoft.AspNet.FileProviders.IFileInfo.Name.get -> string
+Microsoft.AspNet.FileProviders.IFileInfo.PhysicalPath.get -> string
+Microsoft.AspNet.FileProviders.IFileProvider
+Microsoft.AspNet.FileProviders.IFileProvider.GetDirectoryContents(string subpath) -> Microsoft.AspNet.FileProviders.IDirectoryContents
+Microsoft.AspNet.FileProviders.IFileProvider.GetFileInfo(string subpath) -> Microsoft.AspNet.FileProviders.IFileInfo
+Microsoft.AspNet.FileProviders.IFileProvider.Watch(string filter) -> Microsoft.Extensions.Primitives.IChangeToken
+Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoBase
+Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoBase.DirectoryInfoBase() -> void
+Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoWrapper
+Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoWrapper.DirectoryInfoWrapper(System.IO.DirectoryInfo directoryInfo, bool isParentPath = false) -> void
+Microsoft.Extensions.FileSystemGlobbing.Abstractions.FileInfoBase
+Microsoft.Extensions.FileSystemGlobbing.Abstractions.FileInfoBase.FileInfoBase() -> void
+Microsoft.Extensions.FileSystemGlobbing.Abstractions.FileInfoWrapper
+Microsoft.Extensions.FileSystemGlobbing.Abstractions.FileInfoWrapper.FileInfoWrapper(System.IO.FileInfo fileInfo) -> void
+Microsoft.Extensions.FileSystemGlobbing.Abstractions.FileSystemInfoBase
+Microsoft.Extensions.FileSystemGlobbing.Abstractions.FileSystemInfoBase.FileSystemInfoBase() -> void
+Microsoft.Extensions.FileSystemGlobbing.FilePatternMatch
+Microsoft.Extensions.FileSystemGlobbing.FilePatternMatch.Equals(Microsoft.Extensions.FileSystemGlobbing.FilePatternMatch other) -> bool
+Microsoft.Extensions.FileSystemGlobbing.FilePatternMatch.FilePatternMatch(string path, string stem) -> void
+Microsoft.Extensions.FileSystemGlobbing.FilePatternMatch.Path.get -> string
+Microsoft.Extensions.FileSystemGlobbing.FilePatternMatch.Stem.get -> string
+Microsoft.Extensions.FileSystemGlobbing.Internal.ILinearPattern
+Microsoft.Extensions.FileSystemGlobbing.Internal.ILinearPattern.Segments.get -> System.Collections.Generic.IList<Microsoft.Extensions.FileSystemGlobbing.Internal.IPathSegment>
+Microsoft.Extensions.FileSystemGlobbing.Internal.IPathSegment
+Microsoft.Extensions.FileSystemGlobbing.Internal.IPathSegment.CanProduceStem.get -> bool
+Microsoft.Extensions.FileSystemGlobbing.Internal.IPathSegment.Match(string value) -> bool
+Microsoft.Extensions.FileSystemGlobbing.Internal.IPattern
+Microsoft.Extensions.FileSystemGlobbing.Internal.IPattern.CreatePatternContextForExclude() -> Microsoft.Extensions.FileSystemGlobbing.Internal.IPatternContext
+Microsoft.Extensions.FileSystemGlobbing.Internal.IPattern.CreatePatternContextForInclude() -> Microsoft.Extensions.FileSystemGlobbing.Internal.IPatternContext
+Microsoft.Extensions.FileSystemGlobbing.Internal.IPatternContext
+Microsoft.Extensions.FileSystemGlobbing.Internal.IPatternContext.Declare(System.Action<Microsoft.Extensions.FileSystemGlobbing.Internal.IPathSegment, bool> onDeclare) -> void
+Microsoft.Extensions.FileSystemGlobbing.Internal.IPatternContext.PopDirectory() -> void
+Microsoft.Extensions.FileSystemGlobbing.Internal.IPatternContext.PushDirectory(Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoBase directory) -> void
+Microsoft.Extensions.FileSystemGlobbing.Internal.IPatternContext.Test(Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoBase directory) -> bool
+Microsoft.Extensions.FileSystemGlobbing.Internal.IPatternContext.Test(Microsoft.Extensions.FileSystemGlobbing.Abstractions.FileInfoBase file) -> Microsoft.Extensions.FileSystemGlobbing.Internal.PatternTestResult
+Microsoft.Extensions.FileSystemGlobbing.Internal.IRaggedPattern
+Microsoft.Extensions.FileSystemGlobbing.Internal.IRaggedPattern.Contains.get -> System.Collections.Generic.IList<System.Collections.Generic.IList<Microsoft.Extensions.FileSystemGlobbing.Internal.IPathSegment>>
+Microsoft.Extensions.FileSystemGlobbing.Internal.IRaggedPattern.EndsWith.get -> System.Collections.Generic.IList<Microsoft.Extensions.FileSystemGlobbing.Internal.IPathSegment>
+Microsoft.Extensions.FileSystemGlobbing.Internal.IRaggedPattern.Segments.get -> System.Collections.Generic.IList<Microsoft.Extensions.FileSystemGlobbing.Internal.IPathSegment>
+Microsoft.Extensions.FileSystemGlobbing.Internal.IRaggedPattern.StartsWith.get -> System.Collections.Generic.IList<Microsoft.Extensions.FileSystemGlobbing.Internal.IPathSegment>
+Microsoft.Extensions.FileSystemGlobbing.Internal.MatcherContext
+Microsoft.Extensions.FileSystemGlobbing.Internal.MatcherContext.Execute() -> Microsoft.Extensions.FileSystemGlobbing.PatternMatchingResult
+Microsoft.Extensions.FileSystemGlobbing.Internal.MatcherContext.MatcherContext(System.Collections.Generic.IEnumerable<Microsoft.Extensions.FileSystemGlobbing.Internal.IPattern> includePatterns, System.Collections.Generic.IEnumerable<Microsoft.Extensions.FileSystemGlobbing.Internal.IPattern> excludePatterns, Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoBase directoryInfo, System.StringComparison comparison) -> void
+Microsoft.Extensions.FileSystemGlobbing.Internal.PathSegments.CurrentPathSegment
+Microsoft.Extensions.FileSystemGlobbing.Internal.PathSegments.CurrentPathSegment.CanProduceStem.get -> bool
+Microsoft.Extensions.FileSystemGlobbing.Internal.PathSegments.CurrentPathSegment.CurrentPathSegment() -> void
+Microsoft.Extensions.FileSystemGlobbing.Internal.PathSegments.CurrentPathSegment.Match(string value) -> bool
+Microsoft.Extensions.FileSystemGlobbing.Internal.PathSegments.LiteralPathSegment
+Microsoft.Extensions.FileSystemGlobbing.Internal.PathSegments.LiteralPathSegment.CanProduceStem.get -> bool
+Microsoft.Extensions.FileSystemGlobbing.Internal.PathSegments.LiteralPathSegment.LiteralPathSegment(string value, System.StringComparison comparisonType) -> void
+Microsoft.Extensions.FileSystemGlobbing.Internal.PathSegments.LiteralPathSegment.Match(string value) -> bool
+Microsoft.Extensions.FileSystemGlobbing.Internal.PathSegments.LiteralPathSegment.Value.get -> string
+Microsoft.Extensions.FileSystemGlobbing.Internal.PathSegments.ParentPathSegment
+Microsoft.Extensions.FileSystemGlobbing.Internal.PathSegments.ParentPathSegment.CanProduceStem.get -> bool
+Microsoft.Extensions.FileSystemGlobbing.Internal.PathSegments.ParentPathSegment.Match(string value) -> bool
+Microsoft.Extensions.FileSystemGlobbing.Internal.PathSegments.ParentPathSegment.ParentPathSegment() -> void
+Microsoft.Extensions.FileSystemGlobbing.Internal.PathSegments.RecursiveWildcardSegment
+Microsoft.Extensions.FileSystemGlobbing.Internal.PathSegments.RecursiveWildcardSegment.CanProduceStem.get -> bool
+Microsoft.Extensions.FileSystemGlobbing.Internal.PathSegments.RecursiveWildcardSegment.Match(string value) -> bool
+Microsoft.Extensions.FileSystemGlobbing.Internal.PathSegments.RecursiveWildcardSegment.RecursiveWildcardSegment() -> void
+Microsoft.Extensions.FileSystemGlobbing.Internal.PathSegments.WildcardPathSegment
+Microsoft.Extensions.FileSystemGlobbing.Internal.PathSegments.WildcardPathSegment.BeginsWith.get -> string
+Microsoft.Extensions.FileSystemGlobbing.Internal.PathSegments.WildcardPathSegment.CanProduceStem.get -> bool
+Microsoft.Extensions.FileSystemGlobbing.Internal.PathSegments.WildcardPathSegment.Contains.get -> System.Collections.Generic.List<string>
+Microsoft.Extensions.FileSystemGlobbing.Internal.PathSegments.WildcardPathSegment.EndsWith.get -> string
+Microsoft.Extensions.FileSystemGlobbing.Internal.PathSegments.WildcardPathSegment.Match(string value) -> bool
+Microsoft.Extensions.FileSystemGlobbing.Internal.PathSegments.WildcardPathSegment.WildcardPathSegment(string beginsWith, System.Collections.Generic.List<string> contains, string endsWith, System.StringComparison comparisonType) -> void
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContext<TFrame>
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContext<TFrame>.Frame -> TFrame
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContext<TFrame>.IsStackEmpty() -> bool
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContext<TFrame>.PatternContext() -> void
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContext<TFrame>.PopDirectory() -> void
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContext<TFrame>.PushDataFrame(TFrame frame) -> void
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextLinear
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextLinear.CalculateStem(Microsoft.Extensions.FileSystemGlobbing.Abstractions.FileInfoBase matchedFile) -> string
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextLinear.FrameData
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextLinear.FrameData.FrameData() -> void
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextLinear.FrameData.InStem -> bool
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextLinear.FrameData.IsNotApplicable -> bool
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextLinear.FrameData.SegmentIndex -> int
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextLinear.FrameData.Stem.get -> string
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextLinear.FrameData.StemItems.get -> System.Collections.Generic.IList<string>
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextLinear.IsLastSegment() -> bool
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextLinear.Pattern.get -> Microsoft.Extensions.FileSystemGlobbing.Internal.ILinearPattern
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextLinear.PatternContextLinear(Microsoft.Extensions.FileSystemGlobbing.Internal.ILinearPattern pattern) -> void
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextLinear.TestMatchingSegment(string value) -> bool
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextLinearExclude
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextLinearExclude.PatternContextLinearExclude(Microsoft.Extensions.FileSystemGlobbing.Internal.ILinearPattern pattern) -> void
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextLinearInclude
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextLinearInclude.PatternContextLinearInclude(Microsoft.Extensions.FileSystemGlobbing.Internal.ILinearPattern pattern) -> void
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextRagged
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextRagged.CalculateStem(Microsoft.Extensions.FileSystemGlobbing.Abstractions.FileInfoBase matchedFile) -> string
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextRagged.FrameData
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextRagged.FrameData.BacktrackAvailable -> int
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextRagged.FrameData.FrameData() -> void
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextRagged.FrameData.InStem -> bool
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextRagged.FrameData.IsNotApplicable -> bool
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextRagged.FrameData.SegmentGroup -> System.Collections.Generic.IList<Microsoft.Extensions.FileSystemGlobbing.Internal.IPathSegment>
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextRagged.FrameData.SegmentGroupIndex -> int
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextRagged.FrameData.SegmentIndex -> int
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextRagged.FrameData.Stem.get -> string
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextRagged.FrameData.StemItems.get -> System.Collections.Generic.IList<string>
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextRagged.IsEndingGroup() -> bool
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextRagged.IsStartingGroup() -> bool
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextRagged.Pattern.get -> Microsoft.Extensions.FileSystemGlobbing.Internal.IRaggedPattern
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextRagged.PatternContextRagged(Microsoft.Extensions.FileSystemGlobbing.Internal.IRaggedPattern pattern) -> void
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextRagged.TestMatchingGroup(Microsoft.Extensions.FileSystemGlobbing.Abstractions.FileSystemInfoBase value) -> bool
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextRagged.TestMatchingSegment(string value) -> bool
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextRaggedExclude
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextRaggedExclude.PatternContextRaggedExclude(Microsoft.Extensions.FileSystemGlobbing.Internal.IRaggedPattern pattern) -> void
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextRaggedInclude
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextRaggedInclude.PatternContextRaggedInclude(Microsoft.Extensions.FileSystemGlobbing.Internal.IRaggedPattern pattern) -> void
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternTestResult
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternTestResult.IsSuccessful.get -> bool
+Microsoft.Extensions.FileSystemGlobbing.Internal.PatternTestResult.Stem.get -> string
+Microsoft.Extensions.FileSystemGlobbing.Internal.Patterns.PatternBuilder
+Microsoft.Extensions.FileSystemGlobbing.Internal.Patterns.PatternBuilder.Build(string pattern) -> Microsoft.Extensions.FileSystemGlobbing.Internal.IPattern
+Microsoft.Extensions.FileSystemGlobbing.Internal.Patterns.PatternBuilder.ComparisonType.get -> System.StringComparison
+Microsoft.Extensions.FileSystemGlobbing.Internal.Patterns.PatternBuilder.PatternBuilder() -> void
+Microsoft.Extensions.FileSystemGlobbing.Internal.Patterns.PatternBuilder.PatternBuilder(System.StringComparison comparisonType) -> void
+Microsoft.Extensions.FileSystemGlobbing.Matcher
+Microsoft.Extensions.FileSystemGlobbing.Matcher.Matcher() -> void
+Microsoft.Extensions.FileSystemGlobbing.Matcher.Matcher(System.StringComparison comparisonType) -> void
+Microsoft.Extensions.FileSystemGlobbing.MatcherExtensions
+Microsoft.Extensions.FileSystemGlobbing.PatternMatchingResult
+Microsoft.Extensions.FileSystemGlobbing.PatternMatchingResult.Files.get -> System.Collections.Generic.IEnumerable<Microsoft.Extensions.FileSystemGlobbing.FilePatternMatch>
+Microsoft.Extensions.FileSystemGlobbing.PatternMatchingResult.Files.set -> void
+Microsoft.Extensions.FileSystemGlobbing.PatternMatchingResult.PatternMatchingResult(System.Collections.Generic.IEnumerable<Microsoft.Extensions.FileSystemGlobbing.FilePatternMatch> files) -> void
+Microsoft.Extensions.Primitives.IChangeToken
+Microsoft.Extensions.Primitives.IChangeToken.ActiveChangeCallbacks.get -> bool
+Microsoft.Extensions.Primitives.IChangeToken.HasChanged.get -> bool
+Microsoft.Extensions.Primitives.IChangeToken.RegisterChangeCallback(System.Action<object> callback, object state) -> System.IDisposable
 NuGet.Commands.AddClientCertArgs
 NuGet.Commands.AddClientCertArgs.AddClientCertArgs() -> void
 NuGet.Commands.AddClientCertArgs.Configfile.get -> string
@@ -826,8 +966,39 @@ NuGet.Commands.WarningPropertiesCollection.PackageSpecificWarningProperties.get 
 NuGet.Commands.WarningPropertiesCollection.ProjectFrameworks.get -> System.Collections.Generic.IReadOnlyList<NuGet.Frameworks.NuGetFramework>
 NuGet.Commands.WarningPropertiesCollection.ProjectWideWarningProperties.get -> NuGet.ProjectModel.WarningProperties
 NuGet.Commands.WarningPropertiesCollection.WarningPropertiesCollection(NuGet.ProjectModel.WarningProperties projectWideWarningProperties, NuGet.Commands.PackageSpecificWarningProperties packageSpecificWarningProperties, System.Collections.Generic.IReadOnlyList<NuGet.Frameworks.NuGetFramework> projectFrameworks) -> void
+abstract Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoBase.EnumerateFileSystemInfos() -> System.Collections.Generic.IEnumerable<Microsoft.Extensions.FileSystemGlobbing.Abstractions.FileSystemInfoBase>
+abstract Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoBase.GetDirectory(string path) -> Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoBase
+abstract Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoBase.GetFile(string path) -> Microsoft.Extensions.FileSystemGlobbing.Abstractions.FileInfoBase
+abstract Microsoft.Extensions.FileSystemGlobbing.Abstractions.FileSystemInfoBase.FullName.get -> string
+abstract Microsoft.Extensions.FileSystemGlobbing.Abstractions.FileSystemInfoBase.Name.get -> string
+abstract Microsoft.Extensions.FileSystemGlobbing.Abstractions.FileSystemInfoBase.ParentDirectory.get -> Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoBase
+abstract Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContext<TFrame>.PushDirectory(Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoBase directory) -> void
+abstract Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContext<TFrame>.Test(Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoBase directory) -> bool
+abstract Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContext<TFrame>.Test(Microsoft.Extensions.FileSystemGlobbing.Abstractions.FileInfoBase file) -> Microsoft.Extensions.FileSystemGlobbing.Internal.PatternTestResult
 const NuGet.Commands.BuildAssetsUtils.PropsExtension = ".props" -> string
 const NuGet.Commands.BuildAssetsUtils.TargetsExtension = ".targets" -> string
+override Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoWrapper.EnumerateFileSystemInfos() -> System.Collections.Generic.IEnumerable<Microsoft.Extensions.FileSystemGlobbing.Abstractions.FileSystemInfoBase>
+override Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoWrapper.FullName.get -> string
+override Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoWrapper.GetDirectory(string name) -> Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoBase
+override Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoWrapper.GetFile(string name) -> Microsoft.Extensions.FileSystemGlobbing.Abstractions.FileInfoBase
+override Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoWrapper.Name.get -> string
+override Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoWrapper.ParentDirectory.get -> Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoBase
+override Microsoft.Extensions.FileSystemGlobbing.Abstractions.FileInfoWrapper.FullName.get -> string
+override Microsoft.Extensions.FileSystemGlobbing.Abstractions.FileInfoWrapper.Name.get -> string
+override Microsoft.Extensions.FileSystemGlobbing.Abstractions.FileInfoWrapper.ParentDirectory.get -> Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoBase
+override Microsoft.Extensions.FileSystemGlobbing.FilePatternMatch.Equals(object obj) -> bool
+override Microsoft.Extensions.FileSystemGlobbing.FilePatternMatch.GetHashCode() -> int
+override Microsoft.Extensions.FileSystemGlobbing.Internal.PathSegments.LiteralPathSegment.Equals(object obj) -> bool
+override Microsoft.Extensions.FileSystemGlobbing.Internal.PathSegments.LiteralPathSegment.GetHashCode() -> int
+override Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextLinear.PushDirectory(Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoBase directory) -> void
+override Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextLinear.Test(Microsoft.Extensions.FileSystemGlobbing.Abstractions.FileInfoBase file) -> Microsoft.Extensions.FileSystemGlobbing.Internal.PatternTestResult
+override Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextLinearExclude.Test(Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoBase directory) -> bool
+override Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextLinearInclude.Declare(System.Action<Microsoft.Extensions.FileSystemGlobbing.Internal.IPathSegment, bool> onDeclare) -> void
+override Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextLinearInclude.Test(Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoBase directory) -> bool
+override Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextRagged.Test(Microsoft.Extensions.FileSystemGlobbing.Abstractions.FileInfoBase file) -> Microsoft.Extensions.FileSystemGlobbing.Internal.PatternTestResult
+override Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextRaggedExclude.Test(Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoBase directory) -> bool
+override Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextRaggedInclude.Declare(System.Action<Microsoft.Extensions.FileSystemGlobbing.Internal.IPathSegment, bool> onDeclare) -> void
+override Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextRaggedInclude.Test(Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoBase directory) -> bool
 override NuGet.Commands.CompatibilityIssue.ToString() -> string
 override NuGet.Commands.MSBuildItem.ToString() -> string
 override NuGet.Commands.NoOpRestoreResult.CommitAsync(NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task
@@ -850,6 +1021,11 @@ override NuGet.Commands.TransitiveNoWarnUtils.NodeWarningProperties.Equals(objec
 override NuGet.Commands.TransitiveNoWarnUtils.NodeWarningProperties.GetHashCode() -> int
 override NuGet.Commands.WarningPropertiesCollection.Equals(object obj) -> bool
 override NuGet.Commands.WarningPropertiesCollection.GetHashCode() -> int
+override sealed Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContextRagged.PushDirectory(Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoBase directory) -> void
+static Microsoft.Extensions.FileSystemGlobbing.Internal.PatternTestResult.Success(string stem) -> Microsoft.Extensions.FileSystemGlobbing.Internal.PatternTestResult
+static Microsoft.Extensions.FileSystemGlobbing.MatcherExtensions.AddExcludePatterns(this Microsoft.Extensions.FileSystemGlobbing.Matcher matcher, params System.Collections.Generic.IEnumerable<string>[] excludePatternsGroups) -> void
+static Microsoft.Extensions.FileSystemGlobbing.MatcherExtensions.AddIncludePatterns(this Microsoft.Extensions.FileSystemGlobbing.Matcher matcher, params System.Collections.Generic.IEnumerable<string>[] includePatternsGroups) -> void
+static Microsoft.Extensions.FileSystemGlobbing.MatcherExtensions.GetResultsInFullPath(this Microsoft.Extensions.FileSystemGlobbing.Matcher matcher, string directoryPath) -> System.Collections.Generic.IEnumerable<string>
 static NuGet.Commands.AddClientCertRunner.Run(NuGet.Commands.AddClientCertArgs args, System.Func<NuGet.Common.ILogger> getLogger) -> void
 static NuGet.Commands.AddSourceRunner.Run(NuGet.Commands.AddSourceArgs args, System.Func<NuGet.Common.ILogger> getLogger) -> void
 static NuGet.Commands.AssetTargetFallbackUtility.ApplyFramework(NuGet.ProjectModel.TargetFrameworkInformation targetFrameworkInfo, System.Collections.Generic.IEnumerable<NuGet.Frameworks.NuGetFramework> packageTargetFallback, System.Collections.Generic.IEnumerable<NuGet.Frameworks.NuGetFramework> assetTargetFallback) -> void
@@ -994,6 +1170,8 @@ static NuGet.Commands.UpdateClientCertRunner.Run(NuGet.Commands.UpdateClientCert
 static NuGet.Commands.UpdateSourceRunner.Run(NuGet.Commands.UpdateSourceArgs args, System.Func<NuGet.Common.ILogger> getLogger) -> void
 static NuGet.Commands.WarningPropertiesCollection.ApplyProjectWideNoWarnProperties(NuGet.Common.ILogMessage message, NuGet.ProjectModel.WarningProperties warningProperties) -> bool
 static NuGet.Commands.WarningPropertiesCollection.ApplyProjectWideWarningsAsErrorProperties(NuGet.Common.ILogMessage message, NuGet.ProjectModel.WarningProperties warningProperties) -> void
+static readonly Microsoft.Extensions.FileSystemGlobbing.Internal.PathSegments.WildcardPathSegment.MatchAll -> Microsoft.Extensions.FileSystemGlobbing.Internal.PathSegments.WildcardPathSegment
+static readonly Microsoft.Extensions.FileSystemGlobbing.Internal.PatternTestResult.Failed -> Microsoft.Extensions.FileSystemGlobbing.Internal.PatternTestResult
 static readonly NuGet.Commands.AssetTargetFallbackUtility.AssetTargetFallback -> string
 static readonly NuGet.Commands.BuildAssetsUtils.MacroCandidates -> string[]
 static readonly NuGet.Commands.LockFileUtils.LIBANY -> string
@@ -1001,6 +1179,10 @@ static readonly NuGet.Commands.MSBuildRestoreItemGroup.ImportGroup -> string
 static readonly NuGet.Commands.MSBuildRestoreItemGroup.ItemGroup -> string
 static readonly NuGet.Commands.MSBuildRestoreUtility.Clear -> string
 static readonly NuGet.Commands.RestoreRequest.DefaultDegreeOfConcurrency -> int
+virtual Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts.PatternContext<TFrame>.Declare(System.Action<Microsoft.Extensions.FileSystemGlobbing.Internal.IPathSegment, bool> declare) -> void
+virtual Microsoft.Extensions.FileSystemGlobbing.Matcher.AddExclude(string pattern) -> Microsoft.Extensions.FileSystemGlobbing.Matcher
+virtual Microsoft.Extensions.FileSystemGlobbing.Matcher.AddInclude(string pattern) -> Microsoft.Extensions.FileSystemGlobbing.Matcher
+virtual Microsoft.Extensions.FileSystemGlobbing.Matcher.Execute(Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoBase directoryInfo) -> Microsoft.Extensions.FileSystemGlobbing.PatternMatchingResult
 virtual NuGet.Commands.DependencyGraphFileRequestProvider.CreateRequests(string inputPath, NuGet.Commands.RestoreArgs restoreContext) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<NuGet.Commands.RestoreSummaryRequest>>
 virtual NuGet.Commands.DependencyGraphFileRequestProvider.Supports(string path) -> System.Threading.Tasks.Task<bool>
 virtual NuGet.Commands.RestoreResult.CommitAsync(NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/ContentFiles/FileProviderGlobbingDirectory.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/ContentFiles/FileProviderGlobbingDirectory.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.Extensions.FileProviders;
+using Microsoft.AspNet.FileProviders;
 using Microsoft.Extensions.FileSystemGlobbing.Abstractions;
 
 // This file is based on

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/ContentFiles/FileProviderGlobbingFile.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/ContentFiles/FileProviderGlobbingFile.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using Microsoft.Extensions.FileProviders;
+using Microsoft.AspNet.FileProviders;
 using Microsoft.Extensions.FileSystemGlobbing.Abstractions;
 
 // This file is based on

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/ContentFiles/VirtualFileInfo.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/ContentFiles/VirtualFileInfo.cs
@@ -4,7 +4,7 @@
 using System;
 using System.IO;
 using System.Linq;
-using Microsoft.Extensions.FileProviders;
+using Microsoft.AspNet.FileProviders;
 
 namespace NuGet.Commands
 {

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/ContentFiles/VirtualFileProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/ContentFiles/VirtualFileProvider.cs
@@ -2,10 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.Extensions.FileProviders;
+using Microsoft.AspNet.FileProviders;
 using Microsoft.Extensions.Primitives;
 
 namespace NuGet.Commands
@@ -78,23 +77,7 @@ namespace NuGet.Commands
 
         public IChangeToken Watch(string filter)
         {
-            return NullChangeToken.Singleton;
-        }
-
-        private class EnumerableDirectoryContents : IDirectoryContents
-        {
-            private readonly IEnumerable<IFileInfo> _entries;
-
-            public EnumerableDirectoryContents(IEnumerable<IFileInfo> entries)
-            {
-                _entries = entries ?? throw new ArgumentNullException(nameof(entries));
-            }
-
-            public bool Exists => true;
-
-            public IEnumerator<IFileInfo> GetEnumerator() => _entries.GetEnumerator();
-
-            IEnumerator IEnumerable.GetEnumerator() => _entries.GetEnumerator();
+            return NoopChangeToken.Singleton;
         }
     }
 }

--- a/test/TestUtilities/Test.Utility/TestDotnetCLiUtility.cs
+++ b/test/TestUtilities/Test.Utility/TestDotnetCLiUtility.cs
@@ -233,24 +233,6 @@ SDKs found: {string.Join(", ", Directory.EnumerateDirectories(SdkDirSource).Sele
                 sourceFileName: typeof(Newtonsoft.Json.JsonSerializer).Assembly.Location,
                 destFileName: Path.Combine(pathToSdkInCli, "Newtonsoft.Json.dll"),
                 overwrite: true);
-
-            // Copy Microsoft.Extensions.FileSystemGlobbing.Abstractions.dll to the test folder as its a runtime dependency
-            File.Copy(
-                sourceFileName: typeof(Microsoft.Extensions.FileSystemGlobbing.Abstractions.FileInfoBase).Assembly.Location,
-                destFileName: Path.Combine(pathToSdkInCli, Path.GetFileName(typeof(Microsoft.Extensions.FileSystemGlobbing.Abstractions.FileInfoBase).Assembly.Location)),
-                overwrite: true);
-
-            // Copy Microsoft.Extensions.FileProviders.dll to the test folder as its a runtime dependency
-            File.Copy(
-                sourceFileName: typeof(Microsoft.Extensions.FileProviders.IFileInfo).Assembly.Location,
-                destFileName: Path.Combine(pathToSdkInCli, Path.GetFileName(typeof(Microsoft.Extensions.FileProviders.IFileInfo).Assembly.Location)),
-                overwrite: true);
-
-            // Copy Microsoft.Extensions.Primitives.dll to the test folder as its a runtime dependency
-            File.Copy(
-                sourceFileName: typeof(Microsoft.Extensions.Primitives.IChangeToken).Assembly.Location,
-                destFileName: Path.Combine(pathToSdkInCli, Path.GetFileName(typeof(Microsoft.Extensions.Primitives.IChangeToken).Assembly.Location)),
-                overwrite: true);
         }
 
         private static string GetTfmToCopy(string projectArtifactsBinFolder)
@@ -307,7 +289,7 @@ project TFMs found: {string.Join(", ", compiledTfms.Keys.Select(k => k.ToString(
                 {
                     File.Copy(sourceFileName: Path.Combine(packProjectCoreArtifactsDirectory.FullName, "ilmerge", packFileName),
                         destFileName: Path.Combine(packAssemblyDestinationDirectory, packFileName),
-                        overwrite: true);
+                        overwrite:true);
                 }
             }
             else


### PR DESCRIPTION
This reverts commit cebb6903635a0dde1059315a1363599eb5ae3099.

<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1581

Regression? Last working version:

## Description
https://github.com/NuGet/NuGet.Client/commit/cebb6903635a0dde1059315a1363599eb5ae3099 introduced NGen failure, need binding redirect to fix.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
