### PR TITLE
HttpRetryHandler correctly handles OperationCancelledException

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpRetryHandler.cs
+++ b/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpRetryHandler.cs
@@ -209,7 +209,7 @@ namespace NuGet.Protocol
                             success = false;
                         }
                     }
-                    catch (OperationCanceledException)
+                    catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
                     {
                         response?.Dispose();
 


### PR DESCRIPTION
The BCL (HttpClient) sometimes throws OperatingCancelledException
for timeouts, so we should only handle this exception as a cancellation
when the token is actually requesting cancellation.

<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11779

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

See commit message above

## PR Checklist

- [x] PR has a meaningful title
- [X] PR has a linked issue.
- [X] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [X] Test exception: The complexity of causing HTTP timeouts and validating retries outweighs the benefit.
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
