### PR TITLE
Fix missing install icon in package list

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/PackageItemViewModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/PackageItemViewModel.cs
@@ -139,6 +139,7 @@ namespace NuGet.PackageManagement.UI
                     OnPropertyChanged(nameof(IsNotInstalled));
                     OnPropertyChanged(nameof(IsUpdateAvailable));
                     OnPropertyChanged(nameof(LatestVersion));
+                    OnPropertyChanged(nameof(IsUninstalledAndTransitive));
 
                     // update tool tip
                     if (_latestVersion != null)

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/PackageItemViewModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/PackageItemViewModel.cs
@@ -139,7 +139,7 @@ namespace NuGet.PackageManagement.UI
                     OnPropertyChanged(nameof(IsNotInstalled));
                     OnPropertyChanged(nameof(IsUpdateAvailable));
                     OnPropertyChanged(nameof(LatestVersion));
-                    OnPropertyChanged(nameof(IsUninstalledAndTransitive));
+                    OnPropertyChanged(nameof(IsUninstalledOrTransitive));
 
                     // update tool tip
                     if (_latestVersion != null)
@@ -272,7 +272,7 @@ namespace NuGet.PackageManagement.UI
                     OnPropertyChanged(nameof(IsUpdateAvailable));
                     OnPropertyChanged(nameof(IsUninstallable));
                     OnPropertyChanged(nameof(IsNotInstalled));
-                    OnPropertyChanged(nameof(IsUninstalledAndTransitive));
+                    OnPropertyChanged(nameof(IsUninstalledOrTransitive));
                 }
             }
         }
@@ -287,7 +287,7 @@ namespace NuGet.PackageManagement.UI
             }
         }
 
-        public bool IsUninstalledAndTransitive => (Status == PackageStatus.NotInstalled && LatestVersion != null) || PackageLevel == PackageLevel.Transitive;
+        public bool IsUninstalledOrTransitive => (Status == PackageStatus.NotInstalled && LatestVersion != null) || PackageLevel == PackageLevel.Transitive;
 
         public bool IsInstalledAndTransitive => PackageLevel == PackageLevel.Transitive || InstalledVersion != null;
 
@@ -487,7 +487,7 @@ namespace NuGet.PackageManagement.UI
                 {
                     _packageLevel = value;
                     OnPropertyChanged(nameof(PackageLevel));
-                    OnPropertyChanged(nameof(IsUninstalledAndTransitive));
+                    OnPropertyChanged(nameof(IsUninstalledOrTransitive));
                     OnPropertyChanged(nameof(IsInstalledAndTransitive));
                 }
             }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageItemControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageItemControl.xaml
@@ -402,7 +402,7 @@
                     <Setter Property="Visibility" Value="Hidden" />
                   </DataTrigger.Setters>
                 </DataTrigger>
-                <DataTrigger Binding="{Binding IsUninstalledAndTransitive}" Value="false">
+                <DataTrigger Binding="{Binding IsUninstalledOrTransitive}" Value="false">
                   <DataTrigger.Setters>
                     <Setter Property="Visibility" Value="Hidden" />
                   </DataTrigger.Setters>


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/nuget/home/issues/11757

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
Missing install icon in package list for custom feed source. Adding a `OnPropertyChanged` fixes this, the problem was that `LatestVersion` was null when we checked for the icon visibility. 

I think it was a coincidence that the custom feed source that the vendors used only has 1 package available and the problem is when we only show one package.

![image](https://user-images.githubusercontent.com/43253759/165836017-8aef4173-934d-4ba2-b10d-cfa39a3273ea.png)

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception - UI fix
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [ ] N/A
