### PR TITLE
Properly ignore all comments when reading global.json

### DIFF
--- a/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/GlobalJsonReader.cs
+++ b/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/GlobalJsonReader.cs
@@ -157,8 +157,6 @@ namespace Microsoft.Build.NuGetSdkResolver
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static Dictionary<string, string> ParseMSBuildSdkVersionsFromJson(string json)
         {
-            Dictionary<string, string> versionsByName = null;
-
             using (var reader = new JsonTextReader(new StringReader(json)))
             {
                 // Read to the first {
@@ -169,7 +167,7 @@ namespace Microsoft.Build.NuGetSdkResolver
                 if (reader.TokenType != JsonToken.StartObject)
                 {
                     // Return null if no { was found
-                    return versionsByName;
+                    return null;
                 }
 
                 // Read through each top-level property
@@ -178,6 +176,8 @@ namespace Microsoft.Build.NuGetSdkResolver
                     // Look for the first "msbuild-sdks" section
                     if (reader.TokenType == JsonToken.PropertyName && reader.Value is string objectName && string.Equals(objectName, MSBuildSdksPropertyName, StringComparison.Ordinal) && reader.Read() && reader.TokenType == JsonToken.StartObject)
                     {
+                        Dictionary<string, string> versionsByName = null;
+
                         // Read each token in the "msbuild-sdks" section until the end
                         while (reader.Read() && reader.TokenType != JsonToken.EndObject)
                         {
@@ -204,7 +204,8 @@ namespace Microsoft.Build.NuGetSdkResolver
                 }
             }
 
-            return versionsByName;
+            // Return null if an "msbuild-sdks" section was not found
+            return null;
         }
 
         /// <summary>

--- a/test/NuGet.Core.Tests/Microsoft.Build.NuGetSdkResolver.Test/GlobalJsonReader_Tests.cs
+++ b/test/NuGet.Core.Tests/Microsoft.Build.NuGetSdkResolver.Test/GlobalJsonReader_Tests.cs
@@ -274,14 +274,18 @@ namespace Microsoft.Build.NuGetSdkResolver.Test
         }
 
         /// <summary>
-        /// Verifies that <see cref="GlobalJsonReader.GetMSBuildSdkVersions(Framework.SdkResolverContext)" /> returns null when the specified global.json is empty or does not contain an msbuild-sdks section.
+        /// Verifies that <see cref="GlobalJsonReader.GetMSBuildSdkVersions(Framework.SdkResolverContext)" /> returns <c>null</c> when the specified global.json is empty or does not contain an msbuild-sdks section.
         /// </summary>
-        [Fact]
-        public void GetMSBuildSdkVersions_ReturnsNull_WhenGlobalJsonIsEmpty()
+        [Theory]
+        [InlineData("{ }")]
+        [InlineData("  { }  ")]
+        [InlineData("// No actual content, only a comment")]
+        [InlineData("")]
+        public void GetMSBuildSdkVersions_ReturnsNull_WhenGlobalJsonIsEmpty(string contents)
         {
             using (var testDirectory = TestDirectory.Create())
             {
-                File.WriteAllText(Path.Combine(testDirectory.Path, GlobalJsonReader.GlobalJsonFileName), @" { } ");
+                File.WriteAllText(Path.Combine(testDirectory.Path, GlobalJsonReader.GlobalJsonFileName), contents);
 
                 var context = new MockSdkResolverContext(testDirectory);
 
@@ -301,7 +305,7 @@ namespace Microsoft.Build.NuGetSdkResolver.Test
         }
 
         /// <summary>
-        /// Verifies that <see cref="GlobalJsonReader.GetMSBuildSdkVersions(Framework.SdkResolverContext)" /> returns null when the specified global.json contains valid JSON but the msbuild-sdks section isn't correctly declared.
+        /// Verifies that <see cref="GlobalJsonReader.GetMSBuildSdkVersions(Framework.SdkResolverContext)" /> returns <c>null</c> when the specified global.json contains valid JSON but the msbuild-sdks section isn't correctly declared.
         /// </summary>
         [Theory]
         [InlineData("1")] // A number value
@@ -337,7 +341,7 @@ namespace Microsoft.Build.NuGetSdkResolver.Test
         }
 
         /// <summary>
-        /// Verifies that <see cref="GlobalJsonReader.GetMSBuildSdkVersions(Framework.SdkResolverContext)" /> returns null when the <see cref="Framework.SdkResolverContext.SolutionFilePath" /> and <see cref="Framework.SdkResolverContext.ProjectFilePath" /> is null.
+        /// Verifies that <see cref="GlobalJsonReader.GetMSBuildSdkVersions(Framework.SdkResolverContext)" /> returns <c>null</c> when the <see cref="Framework.SdkResolverContext.SolutionFilePath" /> and <see cref="Framework.SdkResolverContext.ProjectFilePath" /> is null.
         /// </summary>
         [Fact]
         public void GetMSBuildSdkVersions_ReturnsNull_WhenSolutionFilePathAndProjectFilePathIsNull()

--- a/test/NuGet.Core.Tests/Microsoft.Build.NuGetSdkResolver.Test/GlobalJsonReader_Tests.cs
+++ b/test/NuGet.Core.Tests/Microsoft.Build.NuGetSdkResolver.Test/GlobalJsonReader_Tests.cs
@@ -368,13 +368,35 @@ namespace Microsoft.Build.NuGetSdkResolver.Test
             {
                 File.WriteAllText(
                     Path.Combine(testDirectory, GlobalJsonReader.GlobalJsonFileName),
-                    @"{
-  // This is a comment
-  ""msbuild-sdks"": {
+                    @"// Comment before content
+// Comment before content
+{ // Comment on same line as token
+// Comment after start token
+// Comment after start token
+  ""unrelated-section-before"" : {
+    // Comment in unrelated section
+    // Comment in unrelated section
+    ""property1"": ""value1""
+  }, // comment after token, whitespace below is intentional
+
+  ""msbuild-sdks"": {  // Comment after token
     /* This is another comment */
-    ""Sdk1"": ""1.0.0""
-  }
-}");
+    // Comment before value
+    ""Sdk1"": ""1.0.0"", // Comment after value
+    // Comment between value
+    // Comment between value
+    ""Sdk2"": ""2.0.0"" // Comment after value
+    // Comment after value
+    // Comment after value
+  }, // Comment after end token
+  ""unrelated-section-after"" : {
+    // Comment in unrelated section
+    // Comment in unrelated section
+    ""property1"": ""value1""
+  }, // comment after token
+} // Comment after end token
+// Comment at end of file
+// Comment at end of file");
 
                 var context = new MockSdkResolverContext(testDirectory);
 
@@ -389,7 +411,8 @@ namespace Microsoft.Build.NuGetSdkResolver.Test
 
                 globalJsonReader.GetMSBuildSdkVersions(context).Should().BeEquivalentTo(new Dictionary<string, string>
                 {
-                    ["Sdk1"] = "1.0.0"
+                    ["Sdk1"] = "1.0.0",
+                    ["Sdk2"] = "2.0.0"
                 });
 
                 wasGlobalJsonRead.Should().BeTrue();


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11784

Regression? Yes Last working version: 17.1 / 6.1

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
The code was expecting the first object to be a curly brace (`{`) and a leading comment would make the parser think the JSON was invalid.  Instead, the code now reads until it finds the first `{` and then looks for the `msbuild-sdks` section.  If no curly brace is found, the code will return `null`.
## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
