### PR TITLE
Fix multiple version PackageDownload reading in VS

### DIFF
--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/ProjectRestoreInfoBuilder.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/ProjectRestoreInfoBuilder.cs
@@ -173,6 +173,7 @@ namespace NuGet.SolutionRestoreManager.Test
 
             var packageDownloads = tfm
                 .DownloadDependencies
+                .GroupBy(e => e.Name)
                 .Select(ToPackageDownload);
 
             var frameworkReferences = tfm.FrameworkReferences.Select(ToFrameworkReference);
@@ -306,12 +307,14 @@ namespace NuGet.SolutionRestoreManager.Test
             return new VsReferenceItem(libraryRange.Name, properties);
         }
 
-        private static IVsReferenceItem ToPackageDownload(DownloadDependency library)
+        private static IVsReferenceItem ToPackageDownload(IGrouping<string, DownloadDependency> library)
         {
+            string versionProperty = string.Join(";", library.Select(e => e.VersionRange.OriginalString));
+
             var properties = new VsReferenceProperties(
-                new[] { new VsReferenceProperty("Version", library.VersionRange.OriginalString) }
-            );
-            return new VsReferenceItem(library.Name, properties);
+                    new[] { new VsReferenceProperty("Version", versionProperty) }
+                );
+            return new VsReferenceItem(library.Key, properties);
         }
     }
 }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11798

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

PackageDownload is supposed to allow multiple versions. https://docs.microsoft.com/en-us/nuget/consume-packages/packagedownload-functionality#packagedownload-specification

Unfortunately the test that was added when this change was initially made needed an infra change as well.

Here's the test https://github.com/NuGet/NuGet.Client/blob/a114e45c532a058746a6c31fc1a65f496d73e4fa/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsSolutionRestoreServiceTests.cs#L1406. I just alter the test infrastructure in this change.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
