### PR TITLE
Fix typo in comments in ResolverUtility.cs

### DIFF
--- a/src/NuGet.Core/NuGet.Resolver/ResolverUtility.cs
+++ b/src/NuGet.Core/NuGet.Resolver/ResolverUtility.cs
@@ -21,7 +21,7 @@ namespace NuGet.Resolver
         /// <param name="availablePackages">all packages that were available for the solution</param>
         /// <param name="packagesConfig">packages already installed in the project</param>
         /// <param name="newPackageIds">new packages that are not already installed</param>
-        /// <returns>A user friendly diagonstic message</returns>
+        /// <returns>A user friendly diagnostic message</returns>
         public static string GetDiagnosticMessage(IEnumerable<ResolverPackage> solution,
             IEnumerable<PackageDependencyInfo> availablePackages,
             IEnumerable<PackageReference> packagesConfig,


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes:

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Fix a typo, `diagonstic` => `diagnostic`

## PR Checklist

- [ ] PR has a meaningful title
- [ ] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A

