### PR TITLE
Added a negligible delay between retries in a busy loop while waiting for responses from all package sources in PM UI

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/PackageItemLoader.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/PackageItemLoader.cs
@@ -202,9 +202,6 @@ namespace NuGet.PackageManagement.UI
         public async Task UpdateStateAsync(IProgress<IItemLoaderState> progress, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
-
-            progress?.Report(_state);
-
             SearchResultContextInfo searchResult = await _searchService.RefreshSearchAsync(cancellationToken);
             cancellationToken.ThrowIfCancellationRequested();
             await UpdateStateAndReportAsync(searchResult, progress, cancellationToken);

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
@@ -33,6 +33,7 @@ namespace NuGet.PackageManagement.UI
     {
         private readonly LoadingStatusIndicator _loadingStatusIndicator = new LoadingStatusIndicator();
         private ScrollViewer _scrollViewer;
+        private static TimeSpan PollingDelay = TimeSpan.FromMilliseconds(100);
 
         public event SelectionChangedEventHandler SelectionChanged;
         public event RoutedEventHandler GroupExpansionChanged;
@@ -388,6 +389,7 @@ namespace NuGet.PackageManagement.UI
             while (currentLoader.State.LoadingStatus == LoadingStatus.Loading)
             {
                 token.ThrowIfCancellationRequested();
+                await Task.Delay(PollingDelay, token);
                 await currentLoader.UpdateStateAsync(progress, token);
             }
         }
@@ -401,6 +403,7 @@ namespace NuGet.PackageManagement.UI
                 currentLoader.State.ItemsCount == 0)
             {
                 token.ThrowIfCancellationRequested();
+                await Task.Delay(PollingDelay, token);
                 await currentLoader.UpdateStateAsync(progress, token);
             }
         }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1531

[Internal Issue](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1460784)

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
While loading packages in PM UI, the current implementation is we wait on an initial response from a package source. To do that, we block the thread in a loop. But if we don't block, then an unauthenticated or slowly responding feed could cause the logic to continue and never populate the packages list.

Whenever NuGet tries to report progress, [`Progress.Report`](https://docs.microsoft.com/en-us/dotnet/api/system.progress-1.system-iprogress-t--report?view=net-6.0) method invokes handlers in a [thread pool thread](http://index/?query=system.progress&rightProject=mscorlib&file=system%5Cprogress.cs&line=92). In this case the handler is `InfiniteScrollList.HandleItemLoaderStateChange` method which switches to the main thread to update the UI. In https://github.com/NuGet/NuGet.Client/pull/1512 PR we added a loop to wait for the initial results to be available so that UI can display packages list properly. 

https://github.com/NuGet/NuGet.Client/blob/a1afdeff13fa85487e94431c461d7198084c8052/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs#L381-L406

My current understanding is that every iteration of the while loop is reporting the progress to UI even though there is no change in the state which is resulting in the creation of so many thread-pool threads and blocking majority of them for the UI thread to be available in the handler i.e., `InfiniteScrollList.HandleItemLoaderStateChange` method.

In this PR, I made few changes to add a small delay for updating the state and reporting progress to PM UI. I am working on this code path for the first time. Happy to learn from the feedback and fix the actual performance issue.

In the internal issue linked above, @davkean has following two suggestions. I think these suggestions exactly match with https://github.com/microsoft/vs-threading/blob/main/doc/threadpool_starvation.md#avoiding-thread-pool-starvation guidance.

1) `There doesn't appear to be reason to block the thread waiting for UI to be updated. I think it should be using RunAsync.` - Thanks to @donnie-msft for addressing this suggestion in https://github.com/NuGet/NuGet.Client/pull/4491

2) `Do we need 158 calls to update the UI? Unlikely, and there should only be RunAsync call at a time. ` - This is a tricky issue to fix because identifying the state change is an O(n) operation. I am bit hesitant to add state change logic because we iterate in a loop while waiting for response from various feeds. I think introducing an O(n) operation for every iteration of loop is expensive. Hence, I added a small asynchronous delay for every iteration of the loop giving a chance for VS to do other work. Thanks to @donnie-msft for brainstorming ideas with me.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception - UI related changes. Manually tested the proposed changes and didn't notice any regressions in PM UI.
- **Documentation**
  - [x] N/A