### PR TITLE
Fix original target framework inference in Visual Studio restore when only the TargetFramework is not set

### DIFF
--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
@@ -300,7 +300,7 @@ namespace NuGet.SolutionRestoreManager
 
             // Initialize OTF and CT values when original value of OTF property is not provided.
             var originalTargetFrameworks = tfis
-                .Select(tfi => tfi.FrameworkName.GetShortFolderName())
+                .Select(tfi => string.IsNullOrEmpty(tfi.TargetAlias) ? tfi.FrameworkName.GetShortFolderName() : tfi.TargetAlias)
                 .ToArray();
             var crossTargeting = originalTargetFrameworks.Length > 1;
 

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
@@ -300,7 +300,7 @@ namespace NuGet.SolutionRestoreManager
 
             // Initialize OTF and CT values when original value of OTF property is not provided.
             var originalTargetFrameworks = tfis
-                .Select(tfi => string.IsNullOrEmpty(tfi.TargetAlias) ? tfi.FrameworkName.GetShortFolderName() : tfi.TargetAlias)
+                .Select(tfi => GetBestOriginalFrameworkValue(tfi))
                 .ToArray();
             var crossTargeting = originalTargetFrameworks.Length > 1;
 
@@ -355,6 +355,14 @@ namespace NuGet.SolutionRestoreManager
             };
 
             return packageSpec;
+        }
+
+        // Prefer TargetAlias if set. If not, use the framewor short name.
+        private static string GetBestOriginalFrameworkValue(TargetFrameworkInformation tfi)
+        {
+            // Validate the framework
+            string shortFolderName = tfi.FrameworkName.GetShortFolderName();
+            return !string.IsNullOrEmpty(tfi.TargetAlias) ? tfi.TargetAlias : shortFolderName;
         }
 
         private static string GetProjectOutputPath(string projectDirectory, string msbuildProjectExtensionsPath)


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11795

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Here's the commandline equivalent: https://github.com/NuGet/NuGet.Client/blob/b77d76415ce0a716398fc6d6cf62313e5d2c34b5/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs#L232-L236

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
