### PR TITLE
Try localization resources branch without suffix before default branch

### DIFF
--- a/scripts/cibuild/ConfigureVstsBuild.ps1
+++ b/scripts/cibuild/ConfigureVstsBuild.ps1
@@ -79,6 +79,18 @@ Function Set-RtmLabel {
     Write-Host "##vso[task.setvariable variable=RtmLabel;]$label"
 }
 
+Function Get-LocBranchExists {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$branchName
+    )
+
+    Write-Host "Looking for branch '$branchName' in NuGet.Build.Localization"
+    $lsRemoteOpts = 'ls-remote', 'origin', $branchName
+    $branchExists = & git -C $NuGetLocalization $lsRemoteOpts
+    return $branchExists
+}
+
 $isRTMBuild = [boolean]::Parse($BuildRTM)
 
 Set-RtmLabel -isRTMBuild $isRTMBuild
@@ -98,17 +110,25 @@ $NuGetLocalization = Join-Path $Submodules NuGet.Build.Localization -Resolve
 
 # Check if there is a localization branch associated with this branch repo
 $currentNuGetBranch = $env:BUILD_SOURCEBRANCHNAME
-$lsRemoteOpts = 'ls-remote', 'origin', $currentNuGetBranch
-Write-Host "Looking for branch '$currentNuGetBranch' in NuGet.Build.Localization"
-$lsResult = & git -C $NuGetLocalization $lsRemoteOpts
-
-if ($lsResult)
+if (Get-LocBranchExists $currentNuGetBranch)
 {
     $NuGetLocalizationRepoBranch = $currentNuGetBranch
 }
 else
 {
-    $NuGetLocalizationRepoBranch = 'dev'
+    if ($currentNuGetBranch -like "*-MSRC") {
+        $currentNuGetBranch = $currentNuGetBranch -replace "-MSRC$", ""
+        if (Get-LocBranchExists $currentNuGetBranch) {
+            $NuGetLocalizationRepoBranch = $currentNuGetBranch
+        }
+        else
+        {
+            $NuGetLocalizationRepoBranch = "dev"
+        }
+    }
+    else {
+        $NuGetLocalizationRepoBranch = 'dev'
+    }
 }
 Write-Host "NuGet.Build.Localization Branch: $NuGetLocalizationRepoBranch"
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1614

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

The CI script tries to match the branch name being built in this NuGet.Client repo to a branch name in NuGet.Build.Localization. However, it doesn't account for internal branch names with a suffix where the branch name without the suffix should be used.

Tested by setting the `$env:BUILD_SOURCEBRANCHNAME` variable to different values, then running the script locally.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
