### PR TITLE
Set DartLab template to a different branch to unblock Apex signing tests

### DIFF
--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -40,7 +40,7 @@ resources:
   - repository: DartLabTemplates
     type: git
     name: DartLab.Templates
-    ref: refs/heads/main
+    ref: refs/heads/dev/bradwhit/Checkpoints/PersistTags
 
 variables:
   DOTNET_NOLOGO: 1


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1623

Regression? Last working version: Around May 1st

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Set DartLab.Templates repo to a fixed branch with template fixes. I believe those fixes will be eventually merged. This PR is a temporal fix to unblock CI Apex tests.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A: Engineering change, validated with green CI run.

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A: No product change.
