### PR TITLE
For C++/CLI projects, NuGet ignores the TargetPlatformMoniker

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/Utility/MSBuildProjectFrameworkUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/Utility/MSBuildProjectFrameworkUtility.cs
@@ -255,6 +255,10 @@ namespace NuGet.Commands
                     currentFrameworkString = "Silverlight,Version=v4.0,Profile=WindowsPhone71";
                     return NuGetFramework.Parse(currentFrameworkString);
                 }
+                if (isCppCli) // Don't use the platform moniker to CPP/CLI.
+                {
+                    platformMoniker = null;
+                }
                 NuGetFramework framework = NuGetFramework.ParseComponents(currentFrameworkString, platformMoniker);
 
                 if (isCppCli)

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/MSBuildProjectFrameworkUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/MSBuildProjectFrameworkUtilityTests.cs
@@ -273,6 +273,7 @@ namespace NuGet.Commands.Test
         [InlineData(@"C:\project.vcxproj", ".NETFramework,Version=v4.5", "", "", "false", "native", null)]
         [InlineData(@"C:\project.vcxproj", ".NETFramework,Version=v4.5", "", "", "NetFx", "native", null)]
         [InlineData(@"C:\project.vcxproj", ".NETCoreApp,Version=v5.0", "", "", "NetCore", "net5.0", "native")]
+        [InlineData(@"C:\project.vcxproj", ".NETCoreApp,Version=v5.0", "Windows,Version=7.0", "", "NetCore", "net5.0", "native")]
         [InlineData(@"C:\project.csproj", ".NETCoreApp,Version=v5.0", "", "", "NetCore", "net5.0", null)]
         [InlineData(@"C:\project.csproj", ".NETFramework,Version=v4.5", "", "", "NetFramework", "net45", null)]
         public void GetProjectFramework_WithCLRSupport_VariousInputs(


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11808

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Self descriptive. This was a decision reviewed with the C++ and SDK teams.

Design update at https://github.com/NuGet/Home/pull/11820. 

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
