### PR TITLE
Warn when http sources are used in search and list

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/SearchCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/SearchCommand.cs
@@ -3,27 +3,15 @@
 
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
-using System.Diagnostics;
 using System.Globalization;
-using System.IO;
 using System.Linq;
-using System.Net.Http;
-using System.Resources;
 using System.Text;
-using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
 using NuGet.Common;
 using NuGet.Configuration;
-using NuGet.Frameworks;
-using NuGet.Packaging;
-using NuGet.Packaging.Core;
-using NuGet.Packaging.Licenses;
 using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
-using NuGet.Versioning;
 
 namespace NuGet.CommandLine
 {
@@ -80,6 +68,11 @@ namespace NuGet.CommandLine
 
             foreach (PackageSource source in listEndpoints)
             {
+                if (source.IsHttp && !source.IsHttps)
+                {
+                    logger.LogWarning(string.Format(CultureInfo.CurrentCulture, LocalizedResourceManager.GetString("Warning_HttpServerUsage"), "search", source.Source));
+                }
+
                 SourceRepository repository = Repository.Factory.GetCoreV3(source);
                 PackageSearchResource resource = await repository.GetResourceAsync<PackageSearchResource>();
 

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.Designer.cs
@@ -14647,6 +14647,15 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to You are running the &apos;{0}&apos; operation with an &apos;http&apos; source, &apos;{1}&apos;. Support for &apos;http&apos; sources will be removed in a future version..
+        /// </summary>
+        public static string Warning_HttpServerUsage {
+            get {
+                return ResourceManager.GetString("Warning_HttpServerUsage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Invalid PackageSaveMode value &apos;{0}&apos;..
         /// </summary>
         public static string Warning_InvalidPackageSaveMode {

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.Designer.cs
@@ -14647,11 +14647,21 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to You are running the &apos;{0}&apos; operation with an &apos;http&apos; source, &apos;{1}&apos;. Support for &apos;http&apos; sources will be removed in a future version..
+        ///   Looks up a localized string similar to You are running the &apos;{0}&apos; operation with an &apos;HTTP&apos; source, &apos;{1}&apos;. Non-HTTPS access will be removed in a future version. Consider migrating to an &apos;HTTPS&apos; source..
         /// </summary>
         public static string Warning_HttpServerUsage {
             get {
                 return ResourceManager.GetString("Warning_HttpServerUsage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to You are running the &apos;{0}&apos; operation with &apos;HTTP&apos; sources: {1}
+        ///Non-HTTPS access will be removed in a future version. Consider migrating to &apos;HTTPS&apos; sources..
+        /// </summary>
+        public static string Warning_HttpSources_Multiple {
+            get {
+                return ResourceManager.GetString("Warning_HttpSources_Multiple", resourceCulture);
             }
         }
         

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
@@ -5436,4 +5436,8 @@ You can set the '{1}' environment variable to 'true' to temporarily reenable thi
   <data name="Error_NuGetExeNeedsToBeUnblockedAfterDownloading" xml:space="preserve">
     <value>NuGet.exe file on path {0} needs to be unblocked after downloading.</value>
   </data>
+  <data name="Warning_HttpServerUsage" xml:space="preserve">
+    <value>You are running the '{0}' operation with an 'http' source, '{1}'. Support for 'http' sources will be removed in a future version.</value>
+    <comment>0 - The command name. Ex. Push/Delete. 1 - server uri.</comment>
+  </data>
 </root>

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
@@ -5437,7 +5437,11 @@ You can set the '{1}' environment variable to 'true' to temporarily reenable thi
     <value>NuGet.exe file on path {0} needs to be unblocked after downloading.</value>
   </data>
   <data name="Warning_HttpServerUsage" xml:space="preserve">
-    <value>You are running the '{0}' operation with an 'http' source, '{1}'. Support for 'http' sources will be removed in a future version.</value>
+    <value>You are running the '{0}' operation with an 'HTTP' source, '{1}'. Non-HTTPS access will be removed in a future version. Consider migrating to an 'HTTPS' source.</value>
     <comment>0 - The command name. Ex. Push/Delete. 1 - server uri.</comment>
+  </data>
+  <data name="Warning_HttpSources_Multiple" xml:space="preserve">
+    <value>You are running the '{0}' operation with 'HTTP' sources: {1}
+Non-HTTPS access will be removed in a future version. Consider migrating to 'HTTPS' sources.</value>
   </data>
 </root>

--- a/src/NuGet.Core/NuGet.Commands/ListCommand/ListCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/ListCommand/ListCommandRunner.cs
@@ -33,10 +33,6 @@ namespace NuGet.Commands
 
             foreach (PackageSource packageSource in listArgs.ListEndpoints)
             {
-                if (packageSource.IsHttp && !packageSource.IsHttps)
-                {
-                    listArgs.Logger.LogWarning(string.Format(CultureInfo.CurrentCulture, Strings.Warning_HttpServerUsage, "list", packageSource.Source));
-                }
                 var sourceRepository = Repository.Factory.GetCoreV3(packageSource);
                 var feed = await sourceRepository.GetResourceAsync<ListResource>(listArgs.CancellationToken);
 
@@ -53,6 +49,8 @@ namespace NuGet.Commands
                 }
             }
 
+            WarnForHTTPSources(listArgs);
+
             var allPackages = new List<IEnumerableAsync<IPackageSearchMetadata>>();
             var log = listArgs.IsDetailed ? listArgs.Logger : NullLogger.Instance;
             foreach (var feed in sourceFeeds)
@@ -64,6 +62,42 @@ namespace NuGet.Commands
             }
             ComparePackageSearchMetadata comparer = new ComparePackageSearchMetadata();
             await PrintPackages(listArgs, new AggregateEnumerableAsync<IPackageSearchMetadata>(allPackages, comparer, comparer).GetEnumeratorAsync());
+        }
+
+        private static void WarnForHTTPSources(ListArgs listArgs)
+        {
+            List<PackageSource> httpPackageSources = null;
+            foreach (PackageSource packageSource in listArgs.ListEndpoints)
+            {
+                if (packageSource.IsHttp && !packageSource.IsHttps)
+                {
+                    if (httpPackageSources == null)
+                    {
+                        httpPackageSources = new();
+                    }
+                    httpPackageSources.Add(packageSource);
+                }
+            }
+
+            if (httpPackageSources != null && httpPackageSources.Count != 0)
+            {
+                if (httpPackageSources.Count == 1)
+                {
+                    listArgs.Logger.LogWarning(
+                        string.Format(CultureInfo.CurrentCulture,
+                        Strings.Warning_HttpServerUsage,
+                        "list",
+                        httpPackageSources[0]));
+                }
+                else
+                {
+                    listArgs.Logger.LogWarning(
+                        string.Format(CultureInfo.CurrentCulture,
+                        Strings.Warning_HttpServerUsage_MultipleSources,
+                        "list",
+                        Environment.NewLine + string.Join(Environment.NewLine, httpPackageSources.Select(e => e.Name))));
+                }
+            }
         }
 
         private class ComparePackageSearchMetadata : IComparer<IPackageSearchMetadata>, IEqualityComparer<IPackageSearchMetadata>

--- a/src/NuGet.Core/NuGet.Commands/ListCommand/ListCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/ListCommand/ListCommandRunner.cs
@@ -33,6 +33,10 @@ namespace NuGet.Commands
 
             foreach (PackageSource packageSource in listArgs.ListEndpoints)
             {
+                if (packageSource.IsHttp && !packageSource.IsHttps)
+                {
+                    listArgs.Logger.LogWarning(string.Format(CultureInfo.CurrentCulture, Strings.Warning_HttpServerUsage, "list", packageSource.Source));
+                }
                 var sourceRepository = Repository.Factory.GetCoreV3(packageSource);
                 var feed = await sourceRepository.GetResourceAsync<ListResource>(listArgs.CancellationToken);
 

--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -2375,7 +2375,7 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to You are running the &apos;{0}&apos; operation with an &apos;http&apos; source, &apos;{1}&apos;. Support for &apos;http&apos; sources will be removed in a future version..
+        ///   Looks up a localized string similar to You are running the &apos;{0}&apos; operation with an &apos;HTTP&apos; source, &apos;{1}&apos;. Non-HTTPS access will be removed in a future version. Consider migrating to &apos;HTTPS&apos; sources..
         /// </summary>
         internal static string Warning_HttpServerUsage {
             get {

--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -2384,6 +2384,16 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to You are running the &apos;{0}&apos; operation with &apos;HTTP&apos; sources: {1}
+        ///Non-HTTPS access will be removed in a future version. Consider migrating to &apos;HTTPS&apos; sources..
+        /// </summary>
+        internal static string Warning_HttpServerUsage_MultipleSources {
+            get {
+                return ResourceManager.GetString("Warning_HttpServerUsage_MultipleSources", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to {0} depends on {1} but {2} was not found. An approximate best match of {3} was resolved..
         /// </summary>
         internal static string Warning_MinVersionDoesNotExist {

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -1033,7 +1033,7 @@ For more information, visit https://docs.nuget.org/docs/reference/command-line-r
     <value>This package is signed but not by a trusted signer.</value>
   </data>
   <data name="Warning_HttpServerUsage" xml:space="preserve">
-    <value>You are running the '{0}' operation with an 'HTTP' source, '{1}'. Non-HTTPS access will be removed in a future version. Consider migrating to 'HTTPS' sources.</value>
+    <value>You are running the '{0}' operation with an 'HTTP' source, '{1}'. Non-HTTPS access will be removed in a future version. Consider migrating to an 'HTTPS' source.</value>
     <comment>0 - The command name. Ex. Push/Delete. 1 - server uri.</comment>
   </data>
   <data name="Warning_HttpServerUsage_MultipleSources" xml:space="preserve">

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -1036,4 +1036,9 @@ For more information, visit https://docs.nuget.org/docs/reference/command-line-r
     <value>You are running the '{0}' operation with an 'http' source, '{1}'. Support for 'http' sources will be removed in a future version.</value>
     <comment>0 - The command name. Ex. Push/Delete. 1 - server uri.</comment>
   </data>
+  <data name="Warning_HttpServerUsage_MultipleSources" xml:space="preserve">
+    <value>You are running the '{0}' operation with 'HTTP' sources: {1}
+Non-HTTPS access will be removed in a future version. Consider migrating to 'HTTPS' sources.</value>
+    <comment>0 - operation. 1 - list of source uris</comment>
+  </data>
 </root>

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -1033,7 +1033,7 @@ For more information, visit https://docs.nuget.org/docs/reference/command-line-r
     <value>This package is signed but not by a trusted signer.</value>
   </data>
   <data name="Warning_HttpServerUsage" xml:space="preserve">
-    <value>You are running the '{0}' operation with an 'http' source, '{1}'. Support for 'http' sources will be removed in a future version.</value>
+    <value>You are running the '{0}' operation with an 'HTTP' source, '{1}'. Non-HTTPS access will be removed in a future version. Consider migrating to 'HTTPS' sources.</value>
     <comment>0 - The command name. Ex. Push/Delete. 1 - server uri.</comment>
   </data>
   <data name="Warning_HttpServerUsage_MultipleSources" xml:space="preserve">

--- a/src/NuGet.Core/NuGet.Protocol/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Strings.Designer.cs
@@ -961,7 +961,7 @@ namespace NuGet.Protocol {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to You are running the &apos;{0}&apos; operation with an &apos;http&apos; source, &apos;{1}&apos;. Support for &apos;http&apos; sources will be removed in a future version..
+        ///   Looks up a localized string similar to You are running the &apos;{0}&apos; operation with an &apos;HTTP&apos; source, &apos;{1}&apos;. Non-HTTPS access will be removed in a future version. Consider migrating to &apos;HTTPS&apos; sources..
         /// </summary>
         internal static string Warning_HttpServerUsage {
             get {

--- a/src/NuGet.Core/NuGet.Protocol/Strings.resx
+++ b/src/NuGet.Core/NuGet.Protocol/Strings.resx
@@ -479,7 +479,7 @@ The "ms" should be localized to the abbreviation for milliseconds.</comment>
     <value>String argument '{0}' cannot be null or empty</value>
   </data>
   <data name="Warning_HttpServerUsage" xml:space="preserve">
-    <value>You are running the '{0}' operation with an 'HTTP' source, '{1}'. Non-HTTPS access will be removed in a future version. Consider migrating to 'HTTPS' sources.</value>
+    <value>You are running the '{0}' operation with an 'HTTP' source, '{1}'. Non-HTTPS access will be removed in a future version. Consider migrating to an 'HTTPS' source.</value>
     <comment>0 - The command name. Ex. Push/Delete. 1 - server uri.</comment>
   </data>
 </root>

--- a/src/NuGet.Core/NuGet.Protocol/Strings.resx
+++ b/src/NuGet.Core/NuGet.Protocol/Strings.resx
@@ -479,7 +479,7 @@ The "ms" should be localized to the abbreviation for milliseconds.</comment>
     <value>String argument '{0}' cannot be null or empty</value>
   </data>
   <data name="Warning_HttpServerUsage" xml:space="preserve">
-    <value>You are running the '{0}' operation with an 'http' source, '{1}'. Support for 'http' sources will be removed in a future version.</value>
+    <value>You are running the '{0}' operation with an 'HTTP' source, '{1}'. Non-HTTPS access will be removed in a future version. Consider migrating to 'HTTPS' sources.</value>
     <comment>0 - The command name. Ex. Push/Delete. 1 - server uri.</comment>
   </data>
 </root>

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/PushCommandTest.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/PushCommandTest.cs
@@ -871,7 +871,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
 
             // Assert
             Assert.True(result.Success, result.AllOutput);
-            Assert.Contains("WARNING: You are running the 'push' operation with an 'http' source", result.AllOutput);
+            Assert.Contains("WARNING: You are running the 'push' operation with an 'HTTP' source", result.AllOutput);
         }
 
         #region Helpers

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SearchCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SearchCommandTests.cs
@@ -1,21 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Net;
-using System.Threading;
-using FluentAssertions;
 using NuGet.CommandLine.Test;
-using NuGet.Commands;
-using NuGet.Configuration;
-using NuGet.Packaging;
-using NuGet.Protocol;
-using NuGet.Protocol.Core.Types;
 using NuGet.Test.Utility;
-using Test.Utility;
 using Xunit;
 
 namespace NuGet.CommandLine.FuncTest.Commands
@@ -949,7 +936,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
         }
 
         [Fact]
-        public void SearchgCommand_WhenSearchWithHttpSource_Warns()
+        public void SearchCommand_WhenSearchWithHttpSource_Warns()
         {
             // Arrange
             string nugetexe = Util.GetNuGetExePath();
@@ -1012,6 +999,121 @@ namespace NuGet.CommandLine.FuncTest.Commands
                 waitForExit: true);
 
             server.Stop();
+
+            // Assert
+            Assert.True(result.Success, $"{result.AllOutput}");
+            Assert.Contains("No results found.", $"{result.AllOutput}");
+            Assert.DoesNotContain(">", $"{result.AllOutput}");
+            Assert.Contains("WARNING: You are running the 'search' operation with an 'HTTP' source", result.AllOutput);
+        }
+
+        [Fact]
+        public void SearchCommand_WhenSearchWithHttpSources_Warns()
+        {
+            // Arrange
+            string nugetexe = Util.GetNuGetExePath();
+
+            using MockServer server1 = new MockServer();
+            using MockServer server2 = new MockServer();
+            using SimpleTestPathContext config = new SimpleTestPathContext();
+            CommandRunner.Run(
+                nugetexe,
+                config.WorkingDirectory,
+                $"source add -name mockSource -source {server1.Uri}v3/index.json -configfile {config.NuGetConfig}",
+                waitForExit: true);
+
+            CommandRunner.Run(
+                nugetexe,
+                config.WorkingDirectory,
+                $"source add -name mockSource -source {server2.Uri}v3/index.json -configfile {config.NuGetConfig}",
+                waitForExit: true);
+
+            string index = $@"
+                {{
+                    ""version"": ""3.0.0"",
+
+                    ""resources"": [
+                    {{
+                        ""@id"": ""{server1.Uri + "search/query"}"",
+                        ""@type"": ""SearchQueryService/Versioned"",
+                        ""comment"": ""Query endpoint of NuGet Search service (primary)""
+                    }}
+                    ],
+
+                    ""@context"":
+                    {{
+                        ""@vocab"": ""http://schema.nuget.org/services#"",
+                        ""comment"": ""http://www.w3.org/2000/01/rdf-schema#comment""
+                    }}
+                }}";
+
+            server1.Get.Add("/v3/index.json", r => index);
+
+            string queryResult = $@"
+                {{
+                    ""@context"":
+                    {{
+                        ""@vocab"": ""http://schema.nuget.org/schema#"",
+                        ""@base"": ""https://api.nuget.org/v3/registration5-semver1/""
+                    }},
+                    ""totalHits"": 396,
+                    ""data"": []
+                }}";
+
+            server1.Get.Add("/search/query?q=json&skip=0&take=20&prerelease=false&semVerLevel=2.0.0", r => queryResult);
+
+            server1.Start();
+
+            string index2 = $@"
+                {{
+                    ""version"": ""3.0.0"",
+
+                    ""resources"": [
+                    {{
+                        ""@id"": ""{server2.Uri + "search/query"}"",
+                        ""@type"": ""SearchQueryService/Versioned"",
+                        ""comment"": ""Query endpoint of NuGet Search service (primary)""
+                    }}
+                    ],
+
+                    ""@context"":
+                    {{
+                        ""@vocab"": ""http://schema.nuget.org/services#"",
+                        ""comment"": ""http://www.w3.org/2000/01/rdf-schema#comment""
+                    }}
+                }}";
+
+            server2.Get.Add("/v3/index.json", r => index2);
+
+            string queryResult2 = $@"
+                {{
+                    ""@context"":
+                    {{
+                        ""@vocab"": ""http://schema.nuget.org/schema#"",
+                        ""@base"": ""https://api.nuget.org/v3/registration5-semver1/""
+                    }},
+                    ""totalHits"": 396,
+                    ""data"": []
+                }}";
+
+            server2.Get.Add("/search/query?q=json&skip=0&take=20&prerelease=false&semVerLevel=2.0.0", r => queryResult2);
+
+            server2.Start();
+            // Act
+            string[] args = new[]
+            {
+                "search",
+                "json",
+            };
+
+            CommandRunnerResult result = CommandRunner.Run(
+                nugetexe,
+                config.WorkingDirectory,
+                string.Join(" ", args),
+                waitForExit: true);
+
+            server1.Stop();
+            server2.Stop();
 
             // Assert
             Assert.True(result.Success, $"{result.AllOutput}");

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SearchCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SearchCommandTests.cs
@@ -1017,7 +1017,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
             Assert.True(result.Success, $"{result.AllOutput}");
             Assert.Contains("No results found.", $"{result.AllOutput}");
             Assert.DoesNotContain(">", $"{result.AllOutput}");
-            Assert.Contains("WARNING: You are running the 'search' operation with an 'http' source", result.AllOutput);
+            Assert.Contains("WARNING: You are running the 'search' operation with an 'HTTP' source", result.AllOutput);
         }
     }
 }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetDeleteCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetDeleteCommandTest.cs
@@ -454,7 +454,7 @@ namespace NuGet.CommandLine.Test
                 // Assert
                 Assert.Equal(0, r.ExitCode);
                 Assert.True(deleteRequestIsCalled);
-                Assert.Contains("WARNING: You are running the 'delete' operation with an 'http' source", r.AllOutput);
+                Assert.Contains("WARNING: You are running the 'delete' operation with an 'HTTP' source", r.AllOutput);
             }
         }
 

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetListCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetListCommandTest.cs
@@ -521,7 +521,7 @@ namespace NuGet.CommandLine.Test
                     // verify that the output is detailed
                     var expectedOutput = "testPackage1 1.1.0" + Environment.NewLine +
                         "testPackage2 2.1.0" + Environment.NewLine;
-                    Assert.Equal(expectedOutput, r1.Output);
+                    Assert.Equal(expectedOutput, RemoveHttpWarning(r1.Output));
 
                     Assert.Contains("$filter=IsAbsoluteLatestVersion", searchRequest);
                     Assert.Contains("searchTerm='test", searchRequest);

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetListCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetListCommandTest.cs
@@ -1187,7 +1187,7 @@ namespace NuGet.CommandLine.Test
             // verify that only package id & version is displayed
             var expectedOutput = "testPackage1 1.1.0";
             Assert.Contains(expectedOutput, result.Output);
-            Assert.Contains("WARNING: You are running the 'list' operation with an 'http' source", result.AllOutput);
+            Assert.Contains("WARNING: You are running the 'list' operation with an 'HTTP' source", result.AllOutput);
         }
     }
 }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetListCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetListCommandTest.cs
@@ -1147,5 +1147,47 @@ namespace NuGet.CommandLine.Test
                 }
             }
         }
+
+        [Fact]
+        public void ListCommand_WhenListWithHttpSource_Warns()
+        {
+            var nugetexe = Util.GetNuGetExePath();
+
+            // Arrange
+            using var packageDirectory = TestDirectory.Create();
+            using var server = new MockServer();
+            var packageFileName1 = Util.CreateTestPackage("testPackage1", "1.1.0", packageDirectory);
+
+            server.Get.Add("/nuget/$metadata", r =>
+                Util.GetMockServerResource());
+            server.Get.Add("/nuget/Search()", r =>
+                new Action<HttpListenerResponse>(response =>
+                {
+                    string searchRequest = r.Url.ToString();
+                    response.ContentType = "application/atom+xml;type=feed;charset=utf-8";
+                    string feed = server.ToODataFeed(new[] { new FileInfo(packageFileName1) }, "Search");
+                    MockServer.SetResponseContent(response, feed);
+                }));
+            server.Get.Add("/nuget", r => "OK");
+
+            server.Start();
+
+            // Act
+            var args = "list test -Source " + server.Uri + "nuget";
+            var result = CommandRunner.Run(
+                nugetexe,
+                packageDirectory,
+                args,
+                waitForExit: true);
+            server.Stop();
+
+            // Assert
+            Assert.Equal(0, result.ExitCode);
+
+            // verify that only package id & version is displayed
+            var expectedOutput = "testPackage1 1.1.0";
+            Assert.Contains(expectedOutput, result.Output);
+            Assert.Contains("WARNING: You are running the 'list' operation with an 'http' source", result.AllOutput);
+        }
     }
 }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPushCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPushCommandTest.cs
@@ -45,7 +45,7 @@ namespace NuGet.CommandLine.Test
                 Assert.True(File.Exists(Path.Combine(source, "testPackage1.1.1.0.nupkg")));
                 var output = result.Output;
                 Assert.DoesNotContain("WARNING: No API Key was provided", output);
-                Assert.DoesNotContain("WARNING: You are attempting to push to an 'http' source", output);
+                Assert.DoesNotContain("WARNING: You are attempting to push to an 'HTTP' source", output);
             }
         }
 
@@ -83,7 +83,7 @@ namespace NuGet.CommandLine.Test
                 Assert.True(File.Exists(Path.Combine(source, baseFolder + packageId + ".nuspec")));
                 Assert.True(File.Exists(Path.Combine(source, baseFolder + basename + "nupkg")));
                 Assert.True(File.Exists(Path.Combine(source, baseFolder + basename + "nupkg.sha512")));
-                Assert.DoesNotContain("WARNING: You are attempting to push to an 'http' source", result.Output);
+                Assert.DoesNotContain("WARNING: You are attempting to push to an 'HTTP' source", result.Output);
             }
         }
 
@@ -2069,7 +2069,7 @@ namespace NuGet.CommandLine.Test
                             true);
             // Assert
             result.Success.Should().BeTrue(result.AllOutput);
-            result.AllOutput.Should().Contain("WARNING: You are running the 'push' operation with an 'http' source");
+            result.AllOutput.Should().Contain("WARNING: You are running the 'push' operation with an 'HTTP' source");
         }
 
         [Fact]
@@ -2117,8 +2117,8 @@ namespace NuGet.CommandLine.Test
             Assert.Contains($"Pushing testPackage1.1.1.0.symbols.nupkg to '{pushSymbolsUri}'", result.Output);
             Assert.Contains($"Created {pushSymbolsUri}", result.Output);
             Assert.Contains("Your package was pushed.", result.Output);
-            Assert.Contains($"WARNING: You are running the 'push' operation with an 'http' source, '{pushUri}/'", result.AllOutput);
-            Assert.Contains($"WARNING: You are running the 'push' operation with an 'http' source, '{pushSymbolsUri}/'", result.AllOutput);
+            Assert.Contains($"WARNING: You are running the 'push' operation with an 'HTTP' source, '{pushUri}/'", result.AllOutput);
+            Assert.Contains($"WARNING: You are running the 'push' operation with an 'HTTP' source, '{pushSymbolsUri}/'", result.AllOutput);
         }
 
         [Fact]

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPushCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPushCommandTest.cs
@@ -2192,8 +2192,8 @@ namespace NuGet.CommandLine.Test
                         // Assert
                         result.Success.Should().BeTrue(result.AllOutput);
                         result.AllOutput.Should().Contain("Your package was pushed");
-                        result.AllOutput.Should().Contain($"WARNING: You are running the 'push' operation with an 'http' source, '{serverV3.Uri}index.json'");
-                        result.AllOutput.Should().Contain($"WARNING: You are running the 'push' operation with an 'http' source, '{serverV2.Uri}push/'");
+                        result.AllOutput.Should().Contain($"WARNING: You are running the 'push' operation with an 'HTTP' source, '{serverV3.Uri}index.json'");
+                        result.AllOutput.Should().Contain($"WARNING: You are running the 'push' operation with an 'HTTP' source, '{serverV2.Uri}push/'");
                         AssertFileEqual(packageFileName, outputFileName);
                     }
                 }

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
@@ -3856,7 +3856,7 @@ namespace NuGet.Commands.FuncTest
             result.LockFile.LogMessages.Should().HaveCount(1);
             IAssetsLogMessage logMessage = result.LockFile.LogMessages[0];
             logMessage.Code.Should().Be(NuGetLogCode.NU1803);
-            logMessage.Message.Should().Be("You are running the 'restore' operation with an 'http' source, 'http://api.source/index.json'. Support for 'http' sources will be removed in a future version.");
+            logMessage.Message.Should().Be("You are running the 'restore' operation with an 'HTTP' source, 'http://api.source/index.json'. Non-HTTPS access will be removed in a future version. Consider migrating to 'HTTPS' sources.");
         }
 
         static TestRestoreRequest CreateRestoreRequest(PackageSpec spec, string userPackagesFolder, List<PackageSource> sources, ILogger logger)

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
@@ -3856,7 +3856,7 @@ namespace NuGet.Commands.FuncTest
             result.LockFile.LogMessages.Should().HaveCount(1);
             IAssetsLogMessage logMessage = result.LockFile.LogMessages[0];
             logMessage.Code.Should().Be(NuGetLogCode.NU1803);
-            logMessage.Message.Should().Be("You are running the 'restore' operation with an 'HTTP' source, 'http://api.source/index.json'. Non-HTTPS access will be removed in a future version. Consider migrating to 'HTTPS' sources.");
+            logMessage.Message.Should().Be("You are running the 'restore' operation with an 'HTTP' source, 'http://api.source/index.json'. Non-HTTPS access will be removed in a future version. Consider migrating to an 'HTTPS' source.");
         }
 
         static TestRestoreRequest CreateRestoreRequest(PackageSpec spec, string userPackagesFolder, List<PackageSource> sources, ILogger logger)

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Resources/PackageUpdateResourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Resources/PackageUpdateResourceTests.cs
@@ -871,7 +871,7 @@ namespace NuGet.Protocol.Tests
             // Assert
             Assert.NotNull(sourceRequest);
             Assert.Equal(1, logger.WarningMessages.Count);
-            Assert.Contains("You are running the 'push' operation with an 'http' source", logger.WarningMessages.First());
+            Assert.Contains("You are running the 'push' operation with an 'HTTP' source", logger.WarningMessages.First());
 
         }
 
@@ -930,7 +930,7 @@ namespace NuGet.Protocol.Tests
             Assert.NotNull(sourceRequest);
             Assert.NotNull(symbolRequest);
             Assert.Equal(1, logger.WarningMessages.Count);
-            Assert.Contains("You are running the 'push' operation with an 'http' source", logger.WarningMessages.First());
+            Assert.Contains("You are running the 'push' operation with an 'HTTP' source", logger.WarningMessages.First());
         }
 
         [Fact]
@@ -988,8 +988,8 @@ namespace NuGet.Protocol.Tests
             Assert.NotNull(sourceRequest);
             Assert.NotNull(symbolRequest);
             Assert.Equal(2, logger.WarningMessages.Count);
-            Assert.Contains("You are running the 'push' operation with an 'http' source, 'http://www.nuget.org/api/v2/'. Support for 'http' sources will be removed in a future version.", logger.WarningMessages.First());
-            Assert.Contains("You are running the 'push' operation with an 'http' source, 'http://other.smbsrc.net/api/v2/package/'. Support for 'http' sources will be removed in a future version.", logger.WarningMessages.Last());
+            Assert.Contains("You are running the 'push' operation with an 'HTTP' source, 'http://www.nuget.org/api/v2/'. Non-HTTPS access will be removed in a future version. Consider migrating to an 'HTTPS' source.", logger.WarningMessages.First());
+            Assert.Contains("You are running the 'push' operation with an 'HTTP' source, 'http://other.smbsrc.net/api/v2/package/'. Non-HTTPS access will be removed in a future version. Consider migrating to an 'HTTPS' source.", logger.WarningMessages.Last());
         }
 
         [Fact]
@@ -1030,7 +1030,7 @@ namespace NuGet.Protocol.Tests
                 Assert.NotNull(actualRequest);
                 Assert.Equal(HttpMethod.Delete, actualRequest.Method);
                 Assert.Equal(3, logger.WarningMessages.Count);
-                Assert.Contains("You are running the 'delete' operation with an 'http' source, 'http://www.nuget.org/api/v2/'. Support for 'http' sources will be removed in a future version.", logger.WarningMessages.Last());
+                Assert.Contains("You are running the 'delete' operation with an 'HTTP' source, 'http://www.nuget.org/api/v2/'. Non-HTTPS access will be removed in a future version. Consider migrating to an 'HTTPS' source.", logger.WarningMessages.Last());
             }
         }
     }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1625

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Enable warnings for nuget.exe list/search scenarios.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
