### PR TITLE
Version Combobox in PM UI displaying wrong or empty version

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailControlModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailControlModel.cs
@@ -684,7 +684,7 @@ namespace NuGet.PackageManagement.UI
                     _versions.IndexOf(SelectedVersion) > _versions.IndexOf(_versions.FirstOrDefault(v => v != null && !v.IsValidVersion))))
             {
                 // The project level is the only one that has an editable combobox and we can only see one project.
-                if (!IsSolution && _nugetProjects.First().ProjectStyle.Equals(ProjectModel.ProjectStyle.PackageReference))
+                if (!IsSolution && _nugetProjects.Count() == 1 && _nugetProjects.First().ProjectStyle.Equals(ProjectModel.ProjectStyle.PackageReference))
                 {
                     SelectVersionPackageReferenceProject(latestVersion);
                 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailControlModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailControlModel.cs
@@ -690,12 +690,12 @@ namespace NuGet.PackageManagement.UI
                 }
                 else
                 {
-                    SelectVersionNonPakageReferenceProject(latestVersion);
+                    SelectVersionNonPackageReferenceProject(latestVersion);
                 }
             }
         }
 
-        private void SelectVersionNonPakageReferenceProject(NuGetVersion latestVersion)
+        private void SelectVersionNonPackageReferenceProject(NuGetVersion latestVersion)
         {
             IEnumerable<DisplayVersion> possibleVersions = _versions.Where(v => v != null);
             if (_filter.Equals(ItemFilter.UpdatesAvailable) || _filter.Equals(ItemFilter.All))

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailControlModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailControlModel.cs
@@ -724,7 +724,7 @@ namespace NuGet.PackageManagement.UI
             else
             {
                 var installedVersion = _searchResultPackage?.AllowedVersions?.OriginalString ?? _searchResultPackage?.InstalledVersion.ToString();
-                SelectedVersion = 
+                SelectedVersion =
                     possibleVersions.FirstOrDefault(v => StringComparer.OrdinalIgnoreCase.Equals(v.Range?.OriginalString, installedVersion))
                     ?? possibleVersions.FirstOrDefault(v => v.IsValidVersion);
                 FirstDisplayedVersion = SelectedVersion;

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailControlModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailControlModel.cs
@@ -684,7 +684,7 @@ namespace NuGet.PackageManagement.UI
                     _versions.IndexOf(SelectedVersion) > _versions.IndexOf(_versions.FirstOrDefault(v => v != null && !v.IsValidVersion))))
             {
                 // The project level is the only one that has an editable combobox and we can only see one project.
-                if (!IsSolution && _nugetProjects.Count() == 1 && FirstDisplayedVersion == null && _nugetProjects.First().ProjectStyle.Equals(ProjectModel.ProjectStyle.PackageReference))
+                if (!IsSolution && _nugetProjects.Count() == 1 && _nugetProjects.First().ProjectStyle.Equals(ProjectModel.ProjectStyle.PackageReference))
                 {
                     // For the Updates and Browse tab we select the latest version, for the installed tab
                     // select the installed version by default. Otherwise, select the first version in the version list.
@@ -692,6 +692,7 @@ namespace NuGet.PackageManagement.UI
                     if (_filter.Equals(ItemFilter.UpdatesAvailable) || _filter.Equals(ItemFilter.All))
                     {
                         SelectedVersion = possibleVersions.FirstOrDefault(v => v.Range.OriginalString.Equals(latestVersion.ToString(), StringComparison.OrdinalIgnoreCase));
+                        FirstDisplayedVersion = SelectedVersion;
                         UserInput = SelectedVersion.ToString();
                     }
                     else
@@ -699,10 +700,9 @@ namespace NuGet.PackageManagement.UI
                         SelectedVersion =
                             possibleVersions.FirstOrDefault(v => StringComparer.OrdinalIgnoreCase.Equals(v.Range?.OriginalString, _searchResultPackage?.AllowedVersions?.OriginalString))
                             ?? possibleVersions.FirstOrDefault(v => v.IsValidVersion);
+                        FirstDisplayedVersion = SelectedVersion;
                         UserInput = _searchResultPackage.AllowedVersions?.OriginalString ?? SelectedVersion.ToString();
                     }
-
-                    FirstDisplayedVersion = SelectedVersion;
                 }
                 else
                 {

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailControlModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailControlModel.cs
@@ -684,33 +684,51 @@ namespace NuGet.PackageManagement.UI
                     _versions.IndexOf(SelectedVersion) > _versions.IndexOf(_versions.FirstOrDefault(v => v != null && !v.IsValidVersion))))
             {
                 // The project level is the only one that has an editable combobox and we can only see one project.
-                if (!IsSolution && _nugetProjects.Count() == 1 && _nugetProjects.First().ProjectStyle.Equals(ProjectModel.ProjectStyle.PackageReference))
+                if (!IsSolution && _nugetProjects.First().ProjectStyle.Equals(ProjectModel.ProjectStyle.PackageReference))
                 {
-                    // For the Updates and Browse tab we select the latest version, for the installed tab
-                    // select the installed version by default. Otherwise, select the first version in the version list.
-                    IEnumerable<DisplayVersion> possibleVersions = _versions.Where(v => v != null);
-                    if (_filter.Equals(ItemFilter.UpdatesAvailable) || _filter.Equals(ItemFilter.All))
-                    {
-                        SelectedVersion = possibleVersions.FirstOrDefault(v => v.Range.OriginalString.Equals(latestVersion.ToString(), StringComparison.OrdinalIgnoreCase));
-                        FirstDisplayedVersion = SelectedVersion;
-                        UserInput = SelectedVersion.ToString();
-                    }
-                    else
-                    {
-                        SelectedVersion =
-                            possibleVersions.FirstOrDefault(v => StringComparer.OrdinalIgnoreCase.Equals(v.Range?.OriginalString, _searchResultPackage?.AllowedVersions?.OriginalString))
-                            ?? possibleVersions.FirstOrDefault(v => v.IsValidVersion);
-                        FirstDisplayedVersion = SelectedVersion;
-                        UserInput = _searchResultPackage.AllowedVersions?.OriginalString ?? SelectedVersion.ToString();
-                    }
+                    SelectVersionPackageReferenceProject(latestVersion);
                 }
                 else
                 {
-                    var possibleVersions = _versions.Where(v => v != null);
-                    SelectedVersion =
-                        possibleVersions.FirstOrDefault(v => v.Version.Equals(_searchResultPackage.InstalledVersion))
-                        ?? possibleVersions.FirstOrDefault(v => v.IsValidVersion);
+                    SelectVersionNonPakageReferenceProject(latestVersion);
                 }
+            }
+        }
+
+        private void SelectVersionNonPakageReferenceProject(NuGetVersion latestVersion)
+        {
+            IEnumerable<DisplayVersion> possibleVersions = _versions.Where(v => v != null);
+            if (_filter.Equals(ItemFilter.UpdatesAvailable) || _filter.Equals(ItemFilter.All))
+            {
+                SelectedVersion = possibleVersions.FirstOrDefault(v => v.Version.Equals(latestVersion));
+            }
+            else
+            {
+                SelectedVersion =
+                    possibleVersions.FirstOrDefault(v => v.Version.Equals(_searchResultPackage.InstalledVersion))
+                    ?? possibleVersions.FirstOrDefault(v => v.IsValidVersion);
+            }
+        }
+
+        private void SelectVersionPackageReferenceProject(NuGetVersion latestVersion)
+        {
+            // For the Updates and Browse tab we select the latest version, for the installed tab
+            // select the installed version by default. Otherwise, select the first version in the version list.
+            IEnumerable<DisplayVersion> possibleVersions = _versions.Where(v => v != null);
+            if (_filter.Equals(ItemFilter.UpdatesAvailable) || _filter.Equals(ItemFilter.All))
+            {
+                SelectedVersion = possibleVersions.FirstOrDefault(v => v.Range.OriginalString.Equals(latestVersion.ToString(), StringComparison.OrdinalIgnoreCase));
+                FirstDisplayedVersion = SelectedVersion;
+                UserInput = SelectedVersion.ToString();
+            }
+            else
+            {
+                var installedVersion = _searchResultPackage?.AllowedVersions?.OriginalString ?? _searchResultPackage?.InstalledVersion.ToString();
+                SelectedVersion = 
+                    possibleVersions.FirstOrDefault(v => StringComparer.OrdinalIgnoreCase.Equals(v.Range?.OriginalString, installedVersion))
+                    ?? possibleVersions.FirstOrDefault(v => v.IsValidVersion);
+                FirstDisplayedVersion = SelectedVersion;
+                UserInput = _searchResultPackage.AllowedVersions?.OriginalString ?? SelectedVersion.ToString();
             }
         }
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/ProjectView.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/ProjectView.xaml.cs
@@ -152,7 +152,7 @@ namespace NuGet.PackageManagement.UI
         {
             if (PackageDetailControlModel.IsProjectPackageReference)
             {
-                string comboboxText = _versions.Text.Replace(" ", "");
+                string comboboxText = _versions.Text;
                 bool userTypedAVersionRange = comboboxText.StartsWith("(", StringComparison.OrdinalIgnoreCase) || comboboxText.StartsWith("[", StringComparison.OrdinalIgnoreCase);
                 IEnumerable<NuGetVersion> versions = DetailModel.Versions.Where(v => v != null).Select(v => v.Version);
 
@@ -242,17 +242,15 @@ namespace NuGet.PackageManagement.UI
             if (_versions.SelectedIndex != -1 && matchVersion?.ToString() != _versions.Items[_versions.SelectedIndex].ToString())
             {
                 _versions.SelectedIndex = -1;
-                PackageDetailControlModel.SelectedVersion = null;
             }
 
             // Automatically select the item when the input or custom range text matches it
             for (int i = 0; i < _versions.Items.Count; i++)
             {
-                var currentItem = _versions.Items[i];
+                DisplayVersion currentItem = _versions.Items[i] as DisplayVersion;
                 if (currentItem != null && (comboboxText == _versions.Items[i].ToString() || _versions.Items[i].ToString() == matchVersion?.ToString()))
                 {
                     _versions.SelectedIndex = i;
-                    PackageDetailControlModel.SelectedVersion = new DisplayVersion(userRange, matchVersion, additionalInfo: null);
                 }
             }
         }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/ProjectView.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/ProjectView.xaml.cs
@@ -250,7 +250,7 @@ namespace NuGet.PackageManagement.UI
                 DisplayVersion currentItem = _versions.Items[i] as DisplayVersion;
                 if (currentItem != null && (comboboxText == _versions.Items[i].ToString() || _versions.Items[i].ToString() == matchVersion?.ToString()))
                 {
-                    _versions.SelectedIndex = i;
+                    PackageDetailControlModel.SelectedVersion = new DisplayVersion(userRange, matchVersion, additionalInfo: null);
                 }
             }
         }

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/V3DetailControlModelTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/V3DetailControlModelTests.cs
@@ -286,7 +286,7 @@ namespace NuGet.PackageManagement.UI.Test.Models
         [InlineData("1.*", "2.10.0")]
         [InlineData("(0.1,3.4)", "2.10.0")]
         [InlineData("2.10.0", "2.10.0")]
-        public async void IsSelectedVersionCorrect_WhenPackageStyleIsPackageReference_And_CustomVersion(string allowedVersions, string installedVersion)
+        public async void IsSelectedVersionCorrect_WhenPackageStyleIsPackageReference_And_CustomVersion_InstalledTab(string allowedVersions, string installedVersion)
         {
             // Arange project
             var mockServiceBroker = new Mock<IServiceBroker>();
@@ -363,11 +363,174 @@ namespace NuGet.PackageManagement.UI.Test.Models
         }
 
         [Theory]
+        [InlineData("*", "2.10.0")]
+        [InlineData("1.*", "2.10.0")]
+        [InlineData("(0.1,3.4)", "2.10.0")]
+        [InlineData("2.10.0", "2.10.0")]
+        public async void IsSelectedVersionCorrect_WhenPackageStyleIsPackageReference_And_CustomVersion_UpdatesTab(string allowedVersions, string installedVersion)
+        {
+            // Arange project
+            var mockServiceBroker = new Mock<IServiceBroker>();
+            var mockSearchService = new Mock<INuGetSearchService>();
+
+            var packageIdentity = new PackageIdentity("Contoso.A", NuGetVersion.Parse(installedVersion));
+
+            var installedPackages = new PackageReferenceContextInfo[]
+            {
+                PackageReferenceContextInfo.Create(
+                    new PackageReference(
+                        packageIdentity,
+                        NuGetFramework.Parse("net45"),
+                        userInstalled: true,
+                        developmentDependency: false,
+                        requireReinstallation: false,
+                        allowedVersions: VersionRange.Parse(allowedVersions)))
+            };
+
+            var projectManagerService = new Mock<INuGetProjectManagerService>();
+            projectManagerService.Setup(x => x.GetInstalledPackagesAsync(
+                    It.IsAny<IReadOnlyCollection<string>>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns(new ValueTask<IReadOnlyCollection<IPackageReferenceContextInfo>>(installedPackages));
+
+#pragma warning disable ISB001 // Dispose of proxies
+            mockServiceBroker.Setup(x => x.GetProxyAsync<INuGetProjectManagerService>(It.Is<ServiceJsonRpcDescriptor>(d => d.Moniker == NuGetServices.ProjectManagerService.Moniker), It.IsAny<ServiceActivationOptions>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(projectManagerService.Object);
+#pragma warning restore ISB001 // Dispose of proxies
+
+            var project = new Mock<IProjectContextInfo>();
+
+            project.SetupGet(p => p.ProjectKind).Returns(NuGetProjectKind.PackageReference);
+            project.SetupGet(p => p.ProjectStyle).Returns(ProjectModel.ProjectStyle.PackageReference);
+            project.SetupGet(p => p.ProjectId).Returns("ProjectId");
+
+            var model = new PackageDetailControlModel(
+                mockServiceBroker.Object,
+                solutionManager: new Mock<INuGetSolutionManagerService>().Object,
+                projects: new[] { project.Object });
+
+            // Arrange
+            var testVersions = new List<VersionInfoContextInfo>() {
+                new VersionInfoContextInfo(new NuGetVersion("2.10.1-dev-01248")),
+                new VersionInfoContextInfo(new NuGetVersion("2.10.0")),
+            };
+
+            var searchService = new Mock<IReconnectingNuGetSearchService>();
+            searchService.Setup(ss => ss.GetPackageVersionsAsync(It.IsAny<PackageIdentity>(), It.IsAny<IReadOnlyCollection<PackageSourceContextInfo>>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<IEnumerable<IProjectContextInfo>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(testVersions);
+
+            // Act
+            var vm = new PackageItemViewModel(searchService.Object)
+            {
+                Id = "Contoso.A",
+                Sources = new List<PackageSourceContextInfo> { new PackageSourceContextInfo("Contoso.A.test") },
+                InstalledVersion = NuGetVersion.Parse(installedVersion),
+                AllowedVersions = VersionRange.Parse(allowedVersions),
+                Version = NuGetVersion.Parse(installedVersion),
+            };
+
+            await model.SetCurrentPackageAsync(
+                vm,
+                ItemFilter.UpdatesAvailable,
+                () => vm);
+
+            // Assert
+            VersionRange installedVersionRange = VersionRange.Parse(allowedVersions, true);
+            NuGetVersion bestVersion = installedVersionRange.FindBestMatch(testVersions.Select(t => t.Version));
+            var displayVersion = new DisplayVersion(installedVersionRange, bestVersion, additionalInfo: null);
+
+            Assert.Equal(model.SelectedVersion.Version.ToString(), "2.10.1-dev-01248");
+            Assert.Equal(model.Versions.FirstOrDefault(), displayVersion);
+        }
+
+        [Theory]
+        [InlineData("*", "2.10.0")]
+        [InlineData("1.*", "2.10.0")]
+        [InlineData("(0.1,3.4)", "2.10.0")]
+        [InlineData("2.10.0", "2.10.0")]
+        public async void IsSelectedVersionCorrect_WhenPackageStyleIsPackageReference_And_CustomVersion_BrowseTab(string allowedVersions, string installedVersion)
+        {
+            // Arange project
+            var mockServiceBroker = new Mock<IServiceBroker>();
+            var mockSearchService = new Mock<INuGetSearchService>();
+
+            var packageIdentity = new PackageIdentity("Contoso.A", NuGetVersion.Parse(installedVersion));
+
+            var installedPackages = new PackageReferenceContextInfo[]
+            {
+                PackageReferenceContextInfo.Create(
+                    new PackageReference(
+                        packageIdentity,
+                        NuGetFramework.Parse("net45"),
+                        userInstalled: true,
+                        developmentDependency: false,
+                        requireReinstallation: false,
+                        allowedVersions: VersionRange.Parse(allowedVersions)))
+            };
+
+            var projectManagerService = new Mock<INuGetProjectManagerService>();
+            projectManagerService.Setup(x => x.GetInstalledPackagesAsync(
+                    It.IsAny<IReadOnlyCollection<string>>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns(new ValueTask<IReadOnlyCollection<IPackageReferenceContextInfo>>(installedPackages));
+
+#pragma warning disable ISB001 // Dispose of proxies
+            mockServiceBroker.Setup(x => x.GetProxyAsync<INuGetProjectManagerService>(It.Is<ServiceJsonRpcDescriptor>(d => d.Moniker == NuGetServices.ProjectManagerService.Moniker), It.IsAny<ServiceActivationOptions>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(projectManagerService.Object);
+#pragma warning restore ISB001 // Dispose of proxies
+
+            var project = new Mock<IProjectContextInfo>();
+
+            project.SetupGet(p => p.ProjectKind).Returns(NuGetProjectKind.PackageReference);
+            project.SetupGet(p => p.ProjectStyle).Returns(ProjectModel.ProjectStyle.PackageReference);
+            project.SetupGet(p => p.ProjectId).Returns("ProjectId");
+
+            var model = new PackageDetailControlModel(
+                mockServiceBroker.Object,
+                solutionManager: new Mock<INuGetSolutionManagerService>().Object,
+                projects: new[] { project.Object });
+
+            // Arrange
+            var testVersions = new List<VersionInfoContextInfo>() {
+                new VersionInfoContextInfo(new NuGetVersion("2.10.1-dev-01248")),
+                new VersionInfoContextInfo(new NuGetVersion("2.10.0")),
+            };
+
+            var searchService = new Mock<IReconnectingNuGetSearchService>();
+            searchService.Setup(ss => ss.GetPackageVersionsAsync(It.IsAny<PackageIdentity>(), It.IsAny<IReadOnlyCollection<PackageSourceContextInfo>>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<IEnumerable<IProjectContextInfo>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(testVersions);
+
+            // Act
+            var vm = new PackageItemViewModel(searchService.Object)
+            {
+                Id = "Contoso.A",
+                Sources = new List<PackageSourceContextInfo> { new PackageSourceContextInfo("Contoso.A.test") },
+                InstalledVersion = NuGetVersion.Parse(installedVersion),
+                AllowedVersions = VersionRange.Parse(allowedVersions),
+                Version = NuGetVersion.Parse(installedVersion),
+            };
+
+            await model.SetCurrentPackageAsync(
+                vm,
+                ItemFilter.All,
+                () => vm);
+
+            // Assert
+            VersionRange installedVersionRange = VersionRange.Parse(allowedVersions, true);
+            NuGetVersion bestVersion = installedVersionRange.FindBestMatch(testVersions.Select(t => t.Version));
+            var displayVersion = new DisplayVersion(installedVersionRange, bestVersion, additionalInfo: null);
+
+            Assert.Equal(model.SelectedVersion.Version.ToString(), "2.10.1-dev-01248");
+            Assert.Equal(model.Versions.FirstOrDefault(), displayVersion);
+        }
+
+
+        [Theory]
         [InlineData(NuGetProjectKind.PackagesConfig, ProjectModel.ProjectStyle.PackagesConfig, null, "2.10.0")]
         [InlineData(NuGetProjectKind.Unknown, ProjectModel.ProjectStyle.Unknown, "(0.1,3.4)", "2.10.0")]
         [InlineData(NuGetProjectKind.ProjectK, ProjectModel.ProjectStyle.ProjectJson, "(0.1,3.4)", "2.10.0")]
         [InlineData(NuGetProjectKind.Unknown, ProjectModel.ProjectStyle.DotnetCliTool, "*", "2.10.0")]
-        public async void IsSelectedVersionCorrect_WhenPackageStyleIsNotPackageReference_And_CustomVersion(NuGetProjectKind projectKind, ProjectModel.ProjectStyle projectStyle, string allowedVersions, string installedVersion)
+        public async void IsSelectedVersionCorrect_WhenPackageStyleIsNotPackageReference_And_CustomVersion_InstalledTab(NuGetProjectKind projectKind, ProjectModel.ProjectStyle projectStyle, string allowedVersions, string installedVersion)
         {
             // Arange project
             var mockServiceBroker = new Mock<IServiceBroker>();
@@ -431,12 +594,168 @@ namespace NuGet.PackageManagement.UI.Test.Models
 
             await model.SetCurrentPackageAsync(
                 vm,
-                ItemFilter.All,
+                ItemFilter.Installed,
                 () => vm);
 
             // Assert
             Assert.NotEqual(model.SelectedVersion.ToString(), allowedVersions);
             Assert.Equal(model.SelectedVersion.Version.ToString(), installedVersion);
+        }
+
+        [Theory]
+        [InlineData(NuGetProjectKind.PackagesConfig, ProjectModel.ProjectStyle.PackagesConfig, null, "2.10.0")]
+        [InlineData(NuGetProjectKind.Unknown, ProjectModel.ProjectStyle.Unknown, "(0.1,3.4)", "2.10.0")]
+        [InlineData(NuGetProjectKind.ProjectK, ProjectModel.ProjectStyle.ProjectJson, "(0.1,3.4)", "2.10.0")]
+        [InlineData(NuGetProjectKind.Unknown, ProjectModel.ProjectStyle.DotnetCliTool, "*", "2.10.0")]
+        public async void IsSelectedVersionCorrect_WhenPackageStyleIsNotPackageReference_And_CustomVersion_BrowseTab(NuGetProjectKind projectKind, ProjectModel.ProjectStyle projectStyle, string allowedVersions, string installedVersion)
+        {
+            // Arange project
+            var mockServiceBroker = new Mock<IServiceBroker>();
+            var mockSearchService = new Mock<INuGetSearchService>();
+
+            var packageIdentity = new PackageIdentity("Contoso.A", NuGetVersion.Parse(installedVersion));
+
+            var installedPackages = new PackageReferenceContextInfo[]
+            {
+                PackageReferenceContextInfo.Create(
+                    new PackageReference(
+                        packageIdentity,
+                        NuGetFramework.Parse("net45"),
+                        userInstalled: true,
+                        developmentDependency: false,
+                        requireReinstallation: false,
+                        allowedVersions: allowedVersions != null ? VersionRange.Parse(allowedVersions) : null))
+            };
+
+            var projectManagerService = new Mock<INuGetProjectManagerService>();
+            projectManagerService.Setup(x => x.GetInstalledPackagesAsync(
+                    It.IsAny<IReadOnlyCollection<string>>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns(new ValueTask<IReadOnlyCollection<IPackageReferenceContextInfo>>(installedPackages));
+
+#pragma warning disable ISB001 // Dispose of proxies
+            mockServiceBroker.Setup(x => x.GetProxyAsync<INuGetProjectManagerService>(It.Is<ServiceJsonRpcDescriptor>(d => d.Moniker == NuGetServices.ProjectManagerService.Moniker), It.IsAny<ServiceActivationOptions>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(projectManagerService.Object);
+#pragma warning restore ISB001 // Dispose of proxies
+
+            var project = new Mock<IProjectContextInfo>();
+
+            project.SetupGet(p => p.ProjectKind).Returns(projectKind);
+            project.SetupGet(p => p.ProjectStyle).Returns(projectStyle);
+            project.SetupGet(p => p.ProjectId).Returns("ProjectId");
+
+            var model = new PackageDetailControlModel(
+                mockServiceBroker.Object,
+                solutionManager: new Mock<INuGetSolutionManagerService>().Object,
+                projects: new[] { project.Object });
+
+            // Arrange
+            var testVersions = new List<VersionInfoContextInfo>() {
+                new VersionInfoContextInfo(new NuGetVersion("2.10.1")),
+                new VersionInfoContextInfo(new NuGetVersion("2.10.0")),
+            };
+
+            var searchService = new Mock<IReconnectingNuGetSearchService>();
+            searchService.Setup(ss => ss.GetPackageVersionsAsync(It.IsAny<PackageIdentity>(), It.IsAny<IReadOnlyCollection<PackageSourceContextInfo>>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<IEnumerable<IProjectContextInfo>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(testVersions);
+
+            // Act
+            var vm = new PackageItemViewModel(searchService.Object)
+            {
+                Id = "Contoso.A",
+                Sources = new List<PackageSourceContextInfo> { new PackageSourceContextInfo("Contoso.A.test") },
+                InstalledVersion = NuGetVersion.Parse(installedVersion),
+                AllowedVersions = allowedVersions != null ? VersionRange.Parse(allowedVersions) : null,
+                Version = NuGetVersion.Parse(installedVersion),
+            };
+
+            await model.SetCurrentPackageAsync(
+                vm,
+                ItemFilter.All,
+                () => vm);
+
+            // Assert
+            Assert.NotEqual(model.SelectedVersion.ToString(), allowedVersions);
+            // Browse Tab should display latest available version
+            Assert.Equal(model.SelectedVersion.Version.ToString(), "2.10.1");
+        }
+
+        [Theory]
+        [InlineData(NuGetProjectKind.PackagesConfig, ProjectModel.ProjectStyle.PackagesConfig, null, "2.10.0")]
+        [InlineData(NuGetProjectKind.Unknown, ProjectModel.ProjectStyle.Unknown, "(0.1,3.4)", "2.10.0")]
+        [InlineData(NuGetProjectKind.ProjectK, ProjectModel.ProjectStyle.ProjectJson, "(0.1,3.4)", "2.10.0")]
+        [InlineData(NuGetProjectKind.Unknown, ProjectModel.ProjectStyle.DotnetCliTool, "*", "2.10.0")]
+        public async void IsSelectedVersionCorrect_WhenPackageStyleIsNotPackageReference_And_CustomVersion_UpdatesTab(NuGetProjectKind projectKind, ProjectModel.ProjectStyle projectStyle, string allowedVersions, string installedVersion)
+        {
+            // Arange project
+            var mockServiceBroker = new Mock<IServiceBroker>();
+            var mockSearchService = new Mock<INuGetSearchService>();
+
+            var packageIdentity = new PackageIdentity("Contoso.A", NuGetVersion.Parse(installedVersion));
+
+            var installedPackages = new PackageReferenceContextInfo[]
+            {
+                PackageReferenceContextInfo.Create(
+                    new PackageReference(
+                        packageIdentity,
+                        NuGetFramework.Parse("net45"),
+                        userInstalled: true,
+                        developmentDependency: false,
+                        requireReinstallation: false,
+                        allowedVersions: allowedVersions != null ? VersionRange.Parse(allowedVersions) : null))
+            };
+
+            var projectManagerService = new Mock<INuGetProjectManagerService>();
+            projectManagerService.Setup(x => x.GetInstalledPackagesAsync(
+                    It.IsAny<IReadOnlyCollection<string>>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns(new ValueTask<IReadOnlyCollection<IPackageReferenceContextInfo>>(installedPackages));
+
+#pragma warning disable ISB001 // Dispose of proxies
+            mockServiceBroker.Setup(x => x.GetProxyAsync<INuGetProjectManagerService>(It.Is<ServiceJsonRpcDescriptor>(d => d.Moniker == NuGetServices.ProjectManagerService.Moniker), It.IsAny<ServiceActivationOptions>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(projectManagerService.Object);
+#pragma warning restore ISB001 // Dispose of proxies
+
+            var project = new Mock<IProjectContextInfo>();
+
+            project.SetupGet(p => p.ProjectKind).Returns(projectKind);
+            project.SetupGet(p => p.ProjectStyle).Returns(projectStyle);
+            project.SetupGet(p => p.ProjectId).Returns("ProjectId");
+
+            var model = new PackageDetailControlModel(
+                mockServiceBroker.Object,
+                solutionManager: new Mock<INuGetSolutionManagerService>().Object,
+                projects: new[] { project.Object });
+
+            // Arrange
+            var testVersions = new List<VersionInfoContextInfo>() {
+                new VersionInfoContextInfo(new NuGetVersion("2.10.1")),
+                new VersionInfoContextInfo(new NuGetVersion("2.10.0")),
+            };
+
+            var searchService = new Mock<IReconnectingNuGetSearchService>();
+            searchService.Setup(ss => ss.GetPackageVersionsAsync(It.IsAny<PackageIdentity>(), It.IsAny<IReadOnlyCollection<PackageSourceContextInfo>>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<IEnumerable<IProjectContextInfo>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(testVersions);
+
+            // Act
+            var vm = new PackageItemViewModel(searchService.Object)
+            {
+                Id = "Contoso.A",
+                Sources = new List<PackageSourceContextInfo> { new PackageSourceContextInfo("Contoso.A.test") },
+                InstalledVersion = NuGetVersion.Parse(installedVersion),
+                AllowedVersions = allowedVersions != null ? VersionRange.Parse(allowedVersions) : null,
+                Version = NuGetVersion.Parse(installedVersion),
+            };
+
+            await model.SetCurrentPackageAsync(
+                vm,
+                ItemFilter.UpdatesAvailable,
+                () => vm);
+
+            // Assert
+            Assert.NotEqual(model.SelectedVersion.ToString(), allowedVersions);
+            // Updates Tab should display latest available version
+            Assert.Equal(model.SelectedVersion.Version.ToString(), "2.10.1");
         }
 
         public Task<object> GetServiceAsync(Type serviceType)

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/V3DetailControlModelTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/V3DetailControlModelTests.cs
@@ -286,7 +286,7 @@ namespace NuGet.PackageManagement.UI.Test.Models
         [InlineData("1.*", "2.10.0")]
         [InlineData("(0.1,3.4)", "2.10.0")]
         [InlineData("2.10.0", "2.10.0")]
-        public async void IsSelectedVersionCorrect_WhenPackageStyleIsPackageReference_And_CustomVersion_InstalledTab(string allowedVersions, string installedVersion)
+        public async void WhenPackageStyleIsPackageReference_And_CustomVersion_InstalledTab_IsSelectedVersionCorrect(string allowedVersions, string installedVersion)
         {
             // Arange project
             var mockServiceBroker = new Mock<IServiceBroker>();
@@ -367,7 +367,7 @@ namespace NuGet.PackageManagement.UI.Test.Models
         [InlineData("1.*", "2.10.0")]
         [InlineData("(0.1,3.4)", "2.10.0")]
         [InlineData("2.10.0", "2.10.0")]
-        public async void IsSelectedVersionCorrect_WhenPackageStyleIsPackageReference_And_CustomVersion_UpdatesTab(string allowedVersions, string installedVersion)
+        public async void WhenPackageStyleIsPackageReference_And_CustomVersion_UpdatesTab_IsSelectedVersionCorrect(string allowedVersions, string installedVersion)
         {
             // Arange project
             var mockServiceBroker = new Mock<IServiceBroker>();
@@ -448,7 +448,7 @@ namespace NuGet.PackageManagement.UI.Test.Models
         [InlineData("1.*", "2.10.0")]
         [InlineData("(0.1,3.4)", "2.10.0")]
         [InlineData("2.10.0", "2.10.0")]
-        public async void IsSelectedVersionCorrect_WhenPackageStyleIsPackageReference_And_CustomVersion_BrowseTab(string allowedVersions, string installedVersion)
+        public async void WhenPackageStyleIsPackageReference_And_CustomVersion_BrowseTab_IsSelectedVersionCorrect(string allowedVersions, string installedVersion)
         {
             // Arange project
             var mockServiceBroker = new Mock<IServiceBroker>();
@@ -530,7 +530,7 @@ namespace NuGet.PackageManagement.UI.Test.Models
         [InlineData(NuGetProjectKind.Unknown, ProjectModel.ProjectStyle.Unknown, "(0.1,3.4)", "2.10.0")]
         [InlineData(NuGetProjectKind.ProjectK, ProjectModel.ProjectStyle.ProjectJson, "(0.1,3.4)", "2.10.0")]
         [InlineData(NuGetProjectKind.Unknown, ProjectModel.ProjectStyle.DotnetCliTool, "*", "2.10.0")]
-        public async void IsSelectedVersionCorrect_WhenPackageStyleIsNotPackageReference_And_CustomVersion_InstalledTab(NuGetProjectKind projectKind, ProjectModel.ProjectStyle projectStyle, string allowedVersions, string installedVersion)
+        public async void WhenPackageStyleIsNotPackageReference_And_CustomVersion_InstalledTab_IsSelectedVersionCorrect(NuGetProjectKind projectKind, ProjectModel.ProjectStyle projectStyle, string allowedVersions, string installedVersion)
         {
             // Arange project
             var mockServiceBroker = new Mock<IServiceBroker>();
@@ -607,7 +607,7 @@ namespace NuGet.PackageManagement.UI.Test.Models
         [InlineData(NuGetProjectKind.Unknown, ProjectModel.ProjectStyle.Unknown, "(0.1,3.4)", "2.10.0")]
         [InlineData(NuGetProjectKind.ProjectK, ProjectModel.ProjectStyle.ProjectJson, "(0.1,3.4)", "2.10.0")]
         [InlineData(NuGetProjectKind.Unknown, ProjectModel.ProjectStyle.DotnetCliTool, "*", "2.10.0")]
-        public async void IsSelectedVersionCorrect_WhenPackageStyleIsNotPackageReference_And_CustomVersion_BrowseTab(NuGetProjectKind projectKind, ProjectModel.ProjectStyle projectStyle, string allowedVersions, string installedVersion)
+        public async void WhenPackageStyleIsNotPackageReference_And_CustomVersion_BrowseTab_IsSelectedVersionCorrect(NuGetProjectKind projectKind, ProjectModel.ProjectStyle projectStyle, string allowedVersions, string installedVersion)
         {
             // Arange project
             var mockServiceBroker = new Mock<IServiceBroker>();
@@ -685,7 +685,7 @@ namespace NuGet.PackageManagement.UI.Test.Models
         [InlineData(NuGetProjectKind.Unknown, ProjectModel.ProjectStyle.Unknown, "(0.1,3.4)", "2.10.0")]
         [InlineData(NuGetProjectKind.ProjectK, ProjectModel.ProjectStyle.ProjectJson, "(0.1,3.4)", "2.10.0")]
         [InlineData(NuGetProjectKind.Unknown, ProjectModel.ProjectStyle.DotnetCliTool, "*", "2.10.0")]
-        public async void IsSelectedVersionCorrect_WhenPackageStyleIsNotPackageReference_And_CustomVersion_UpdatesTab(NuGetProjectKind projectKind, ProjectModel.ProjectStyle projectStyle, string allowedVersions, string installedVersion)
+        public async void WhenPackageStyleIsNotPackageReference_And_CustomVersion_UpdatesTab_IsSelectedVersionCorrect(NuGetProjectKind projectKind, ProjectModel.ProjectStyle projectStyle, string allowedVersions, string installedVersion)
         {
             // Arange project
             var mockServiceBroker = new Mock<IServiceBroker>();


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11734
Fixes: https://github.com/NuGet/Home/issues/11806
Fixes: https://github.com/NuGet/Home/issues/11802

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
This pr fixes bugs that were related, the bug was when the SelectVersion function was called, also I removed unnecessary SelectedVersion/SelectedIndex that triggered extra calculations leading to errors

Showing only 1 Version Combobox fixed (https://github.com/NuGet/Home/issues/11734):
![image](https://user-images.githubusercontent.com/43253759/168912729-151c12e1-e176-429a-9a8e-84ae0b581ab8.png)

Emprt Version Combobox fixed (https://github.com/NuGet/Home/issues/11806)
![image](https://user-images.githubusercontent.com/43253759/168913001-99cd66ea-b754-45f7-9b0c-14d10fd32ad9.png)

Display correct Version in Updates Tab (https://github.com/NuGet/Home/issues/11802)
![image](https://user-images.githubusercontent.com/43253759/168916890-ed1fa54a-b725-49bd-aa72-6aafee8a3fee.png)


## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
