### PR TITLE
fixes NuGet/Home #11210 `CredentialService` incorrectly sets the value of `isRetry`

### DIFF
--- a/src/NuGet.Core/NuGet.Credentials/CredentialService.cs
+++ b/src/NuGet.Core/NuGet.Credentials/CredentialService.cs
@@ -90,7 +90,7 @@ namespace NuGet.Credentials
                 cancellationToken.ThrowIfCancellationRequested();
 
                 var retryKey = RetryCacheKey(uri, type, provider);
-                var isRetry = _retryCache.ContainsKey(retryKey);
+                var isRetry = (type == CredentialRequestType.Forbidden) && _retryCache.ContainsKey(retryKey);
 
                 try
                 {


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug
fixes https://github.com/NuGet/Home/issues/11210
Related to: https://github.com/dotnet/templating/issues/4278

## Description
Fixed setting of `isRetry` value in `CredentialService`, `isRetry` should be set only when previous request fails.

This affects the UX of .NET SDK as users need to auth multiple times when doing operations with private NuGet feed.
`isRetry` should not be set on subsequent call unless the credentials are invalid.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [x] https://github.com/NuGet/docs.microsoft.com-nuget/issues/2715