### PR TITLE
Draft of Consuming pdb in package reference

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/LockFileUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/LockFileUtils.cs
@@ -691,6 +691,11 @@ namespace NuGet.Commands
                         {
                             newItem.Properties["locale"] = (string)locale;
                         }
+                        object related;
+                        if (item.Properties.TryGetValue("related", out related))
+                        {
+                            newItem.Properties["related"] = (string)related;
+                        }
                         additionalAction?.Invoke(newItem);
                         yield return newItem;
                     }

--- a/src/NuGet.Core/NuGet.Packaging/ContentModel/ContentItemCollection.cs
+++ b/src/NuGet.Core/NuGet.Packaging/ContentModel/ContentItemCollection.cs
@@ -314,7 +314,7 @@ namespace NuGet.ContentModel
             else
             {
                 relatedFileExtensionList.Sort();
-                string relatedFileExtensionsProperty = String.Join(";", relatedFileExtensionList.ToArray());
+                string relatedFileExtensionsProperty = String.Join(";", relatedFileExtensionList);
                 return relatedFileExtensionsProperty;
             }
         }

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
@@ -1754,7 +1754,7 @@ EndGlobal";
                 await SimpleTestPackageUtility.CreateFolderFeedV3Async(pathContext.PackageSource, packageContext);
 
                 var directoryPackagesPropsContent =
-                    @"<Project>                    
+                    @"<Project>
                         <ItemGroup>
                             <PackageVersion Include=""X"" Version=""[1.0.0]"" />
                             <PackageVersion Include=""X"" Version=""[2.0.0]"" />
@@ -2309,7 +2309,7 @@ EndGlobal";
                 await SimpleTestPackageUtility.CreateFolderFeedV3Async(pathContext.PackageSource, packageContext);
 
                 var directoryPackagesPropsContent =
-                    @"<Project>                    
+                    @"<Project>
                         <ItemGroup>
                             <PackageVersion Include=""X"" Version=""[1.0.0]"" />
                             <PackageVersion Include=""X"" Version=""[2.0.0]"" />
@@ -2395,6 +2395,96 @@ EndGlobal";
             }
         }
 
+        [Fact]
+        public async Task WhenPackageReferrenceHasRelatedFiles_RelatedPropertyIsApplied_Success()
+        {
+            using var pathContext = _msbuildFixture.CreateSimpleTestPathContext();
+
+            // Set up solution, and project
+            // projectA -> projectB -> packageX -> packageY
+            var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+            var framework = "net5.0";
+            var projectA = SimpleTestProjectContext.CreateNETCore(
+               "projectA",
+               pathContext.SolutionRoot,
+               framework);
+
+            var projectB = SimpleTestProjectContext.CreateNETCore(
+               "projectB",
+               pathContext.SolutionRoot,
+               framework);
+
+            projectB.Properties.Add("Configuration", "Debug");
+
+            projectA.AddProjectToAllFrameworks(projectB);
+
+            var packageX = new SimpleTestPackageContext("packageX", "1.0.0");
+            packageX.Files.Clear();
+            packageX.AddFile($"lib/net5.0/X.dll");
+            packageX.AddFile($"lib/net5.0/X.xml");
+
+            var packageY = new SimpleTestPackageContext("packageY", "1.0.0");
+            packageY.Files.Clear();
+            // Compile
+            packageY.AddFile("ref/net5.0/Y.dll");
+            packageY.AddFile("ref/net5.0/Y.xml");
+            // Runtime
+            packageY.AddFile("lib/net5.0/Y.dll");
+            packageY.AddFile("lib/net5.0/Y.pdb");
+            packageY.AddFile("lib/net5.0/Y.xml");
+            // Embed
+            packageY.AddFile("embed/net5.0/Y.dll");
+            packageY.AddFile("embed/net5.0/Y.pdb");
+
+            packageX.Dependencies.Add(packageY);
+            await SimpleTestPackageUtility.CreatePackagesAsync(pathContext.PackageSource, packageX, packageY);
+            projectB.AddPackageToAllFrameworks(packageX);
+
+            solution.Projects.Add(projectA);
+            solution.Projects.Add(projectB);
+            solution.Create(pathContext.SolutionRoot);
+
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                    pathContext.PackageSource,
+                    PackageSaveMode.Defaultv3,
+                    packageX,
+                    packageY);
+
+            //Act
+            var result = _msbuildFixture.RunDotnet(pathContext.WorkingDirectory, $"restore {projectA.ProjectPath} -v n", ignoreExitCode: true);
+
+            // Assert
+            result.Success.Should().BeTrue(because: result.AllOutput);
+
+            var assetsFile = projectA.AssetsFile;
+            Assert.NotNull(assetsFile);
+            var targets = assetsFile.GetTarget(framework, null);
+
+            // packageX (top-level package reference): "related" property is applied correctly for Compile & Runtime
+            var packageXLib = targets.Libraries.Single(x => x.Name.Equals("packageX"));
+            var packageXCompile = packageXLib.CompileTimeAssemblies;
+            AssertRelatedProperty(packageXCompile, $"lib/net5.0/X.dll", ".xml");
+            var packageXRuntime = packageXLib.RuntimeAssemblies;
+            AssertRelatedProperty(packageXRuntime, $"lib/net5.0/X.dll", ".xml");
+
+            // packageY (transitive package reference): "related" property is applied for Compile, Runtime and Embeded.
+            var packageYLib = targets.Libraries.Single(x => x.Name.Equals("packageY"));
+            var packageYCompile = packageYLib.CompileTimeAssemblies;
+            AssertRelatedProperty(packageYCompile, $"ref/net5.0/Y.dll", ".xml");
+            var packageYRuntime = packageYLib.RuntimeAssemblies;
+            AssertRelatedProperty(packageYRuntime, $"lib/net5.0/Y.dll", ".pdb;.xml");
+            var packageYEmbed = packageYLib.EmbedAssemblies;
+            AssertRelatedProperty(packageYEmbed, $"embed/net5.0/Y.dll", ".pdb");
+
+            // projectB (project reference): "related" property is NOT applied for Compile or Runtime.
+            var projectBLib = targets.Libraries.Single(x => x.Name.Equals("projectB"));
+            var projectBCompile = projectBLib.CompileTimeAssemblies;
+            AssertRelatedProperty(projectBCompile, $"bin/placeholder/projectB.dll", null);
+            var projectBRuntime = projectBLib.RuntimeAssemblies;
+            AssertRelatedProperty(projectBRuntime, $"bin/placeholder/projectB.dll", null);
+
+        }
+
         private static SimpleTestPackageContext CreateNetstandardCompatiblePackage(string id, string version)
         {
             var pkgX = new SimpleTestPackageContext(id, version);
@@ -2467,6 +2557,19 @@ EndGlobal";
                 // Ensure restore no-ops
                 result.ExitCode.Should().Be(0, because: result.AllOutput);
                 result.AllOutput.Should().Contain("All projects are up-to-date for restore.");
+            }
+        }
+
+        private void AssertRelatedProperty(IList<LockFileItem> items, string path, string related)
+        {
+            var item = items.Single(i => i.Path.Equals(path));
+            if (related == null)
+            {
+                Assert.False(item.Properties.ContainsKey("related"));
+            }
+            else
+            {
+                Assert.Equal(related, item.Properties["related"]);
             }
         }
     }

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/compiler/resources/uwpBlankAppV1.json
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/compiler/resources/uwpBlankAppV1.json
@@ -22,7 +22,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/Microsoft.CSharp.dll": {}
+          "ref/netcore50/Microsoft.CSharp.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/Microsoft.CSharp.dll": {}
@@ -99,12 +101,18 @@
           "ref/netcore50/System.Numerics.dll": {},
           "ref/netcore50/System.Runtime.Serialization.dll": {},
           "ref/netcore50/System.ServiceModel.Web.dll": {},
-          "ref/netcore50/System.ServiceModel.dll": {},
+          "ref/netcore50/System.ServiceModel.dll": {
+            "related": ".Web.dll"
+          },
           "ref/netcore50/System.Windows.dll": {},
           "ref/netcore50/System.Xml.Linq.dll": {},
           "ref/netcore50/System.Xml.Serialization.dll": {},
-          "ref/netcore50/System.Xml.dll": {},
-          "ref/netcore50/System.dll": {},
+          "ref/netcore50/System.Xml.dll": {
+            "related": ".Linq.dll;.Serialization.dll"
+          },
+          "ref/netcore50/System.dll": {
+            "related": ".ComponentModel.DataAnnotations.dll;.Core.dll;.Net.dll;.Numerics.dll;.Runtime.Serialization.dll;.ServiceModel.dll;.ServiceModel.Web.dll;.Windows.dll;.Xml.dll;.Xml.Linq.dll;.Xml.Serialization.dll"
+          },
           "ref/netcore50/mscorlib.dll": {}
         },
         "runtime": {
@@ -114,12 +122,18 @@
           "lib/netcore50/System.Numerics.dll": {},
           "lib/netcore50/System.Runtime.Serialization.dll": {},
           "lib/netcore50/System.ServiceModel.Web.dll": {},
-          "lib/netcore50/System.ServiceModel.dll": {},
+          "lib/netcore50/System.ServiceModel.dll": {
+            "related": ".Web.dll"
+          },
           "lib/netcore50/System.Windows.dll": {},
           "lib/netcore50/System.Xml.Linq.dll": {},
           "lib/netcore50/System.Xml.Serialization.dll": {},
-          "lib/netcore50/System.Xml.dll": {},
-          "lib/netcore50/System.dll": {}
+          "lib/netcore50/System.Xml.dll": {
+            "related": ".Linq.dll;.Serialization.dll"
+          },
+          "lib/netcore50/System.dll": {
+            "related": ".ComponentModel.DataAnnotations.dll;.Core.dll;.Net.dll;.Numerics.dll;.Runtime.Serialization.dll;.ServiceModel.dll;.ServiceModel.Web.dll;.Windows.dll;.Xml.dll;.Xml.Linq.dll;.Xml.Serialization.dll"
+          }
         },
         "runtimeTargets": {
           "runtimes/aot/lib/netcore50/System.ComponentModel.DataAnnotations.dll": {
@@ -236,7 +250,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/Microsoft.VisualBasic.dll": {}
+          "ref/netcore50/Microsoft.VisualBasic.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/Microsoft.VisualBasic.dll": {}
@@ -248,7 +264,9 @@
           "System.Runtime.InteropServices": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/Microsoft.Win32.Primitives.dll": {}
+          "ref/dotnet/Microsoft.Win32.Primitives.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/Microsoft.Win32.Primitives.dll": {}
@@ -262,7 +280,9 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.AppContext.dll": {}
+          "ref/dotnet/System.AppContext.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.AppContext.dll": {}
@@ -277,7 +297,9 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Collections.dll": {}
+          "ref/dotnet/System.Collections.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Collections.dll": {}
@@ -302,7 +324,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Collections.Concurrent.dll": {}
+          "ref/dotnet/System.Collections.Concurrent.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Collections.Concurrent.dll": {}
@@ -320,10 +344,14 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "lib/dotnet/System.Collections.Immutable.dll": {}
+          "lib/dotnet/System.Collections.Immutable.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
-          "lib/dotnet/System.Collections.Immutable.dll": {}
+          "lib/dotnet/System.Collections.Immutable.dll": {
+            "related": ".xml"
+          }
         }
       },
       "System.Collections.NonGeneric/4.0.0": {
@@ -336,7 +364,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Collections.NonGeneric.dll": {}
+          "ref/dotnet/System.Collections.NonGeneric.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Collections.NonGeneric.dll": {}
@@ -353,7 +383,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Collections.Specialized.dll": {}
+          "ref/dotnet/System.Collections.Specialized.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Collections.Specialized.dll": {}
@@ -364,7 +396,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.ComponentModel.dll": {}
+          "ref/netcore50/System.ComponentModel.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.ComponentModel.dll": {}
@@ -385,7 +419,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.ComponentModel.Annotations.dll": {}
+          "ref/dotnet/System.ComponentModel.Annotations.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.ComponentModel.Annotations.dll": {}
@@ -399,7 +435,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.ComponentModel.EventBasedAsync.dll": {}
+          "ref/dotnet/System.ComponentModel.EventBasedAsync.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.ComponentModel.EventBasedAsync.dll": {}
@@ -418,7 +456,9 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Data.Common.dll": {}
+          "ref/dotnet/System.Data.Common.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Data.Common.dll": {}
@@ -426,7 +466,9 @@
       },
       "System.Diagnostics.Contracts/4.0.0": {
         "compile": {
-          "ref/netcore50/System.Diagnostics.Contracts.dll": {}
+          "ref/netcore50/System.Diagnostics.Contracts.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Diagnostics.Contracts.dll": {}
@@ -443,7 +485,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Diagnostics.Debug.dll": {}
+          "ref/dotnet/System.Diagnostics.Debug.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Diagnostics.Debug.dll": {}
@@ -460,7 +504,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Diagnostics.StackTrace.dll": {}
+          "ref/dotnet/System.Diagnostics.StackTrace.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Diagnostics.StackTrace.dll": {}
@@ -474,7 +520,9 @@
       },
       "System.Diagnostics.Tools/4.0.0": {
         "compile": {
-          "ref/netcore50/System.Diagnostics.Tools.dll": {}
+          "ref/netcore50/System.Diagnostics.Tools.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Diagnostics.Tools.dll": {}
@@ -500,7 +548,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Diagnostics.Tracing.dll": {}
+          "ref/dotnet/System.Diagnostics.Tracing.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Diagnostics.Tracing.dll": {}
@@ -528,7 +578,9 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Dynamic.Runtime.dll": {}
+          "ref/dotnet/System.Dynamic.Runtime.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Dynamic.Runtime.dll": {}
@@ -545,7 +597,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Globalization.dll": {}
+          "ref/dotnet/System.Globalization.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Globalization.dll": {}
@@ -563,7 +617,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Globalization.Calendars.dll": {}
+          "ref/dotnet/System.Globalization.Calendars.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Globalization.Calendars.dll": {}
@@ -584,7 +640,9 @@
           "System.Runtime.InteropServices": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Globalization.Extensions.dll": {}
+          "ref/dotnet/System.Globalization.Extensions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Globalization.Extensions.dll": {}
@@ -600,7 +658,9 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.IO.dll": {}
+          "ref/dotnet/System.IO.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.IO.dll": {}
@@ -625,7 +685,9 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "ref/netcore50/System.IO.Compression.dll": {}
+          "ref/netcore50/System.IO.Compression.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.IO.Compression.dll": {}
@@ -643,7 +705,9 @@
           "System.Text.Encoding": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.IO.Compression.ZipFile.dll": {}
+          "ref/dotnet/System.IO.Compression.ZipFile.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.IO.Compression.ZipFile.dll": {}
@@ -668,7 +732,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.IO.FileSystem.dll": {}
+          "ref/dotnet/System.IO.FileSystem.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.IO.FileSystem.dll": {}
@@ -679,7 +745,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.IO.FileSystem.Primitives.dll": {}
+          "ref/dotnet/System.IO.FileSystem.Primitives.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.IO.FileSystem.Primitives.dll": {}
@@ -698,7 +766,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.IO.IsolatedStorage.dll": {}
+          "ref/dotnet/System.IO.IsolatedStorage.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.IO.IsolatedStorage.dll": {}
@@ -715,7 +785,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.IO.UnmanagedMemoryStream.dll": {}
+          "ref/dotnet/System.IO.UnmanagedMemoryStream.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.IO.UnmanagedMemoryStream.dll": {}
@@ -730,7 +802,9 @@
           "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Linq.dll": {}
+          "ref/netcore50/System.Linq.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Linq.dll": {}
@@ -753,7 +827,9 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Linq.Expressions.dll": {}
+          "ref/dotnet/System.Linq.Expressions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Linq.Expressions.dll": {}
@@ -779,7 +855,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Linq.Parallel.dll": {}
+          "ref/netcore50/System.Linq.Parallel.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Linq.Parallel.dll": {}
@@ -796,7 +874,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.Linq.Queryable.dll": {}
+          "ref/netcore50/System.Linq.Queryable.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Linq.Queryable.dll": {}
@@ -820,7 +900,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Net.Http.dll": {}
+          "ref/netcore50/System.Net.Http.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Net.Http.dll": {}
@@ -832,7 +914,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.Net.Http.Rtc.dll": {}
+          "ref/netcore50/System.Net.Http.Rtc.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Net.Http.Rtc.dll": {}
@@ -845,7 +929,9 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "ref/netcore50/System.Net.NetworkInformation.dll": {}
+          "ref/netcore50/System.Net.NetworkInformation.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Net.NetworkInformation.dll": {}
@@ -857,7 +943,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Net.Primitives.dll": {}
+          "ref/dotnet/System.Net.Primitives.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Net.Primitives.dll": {}
@@ -877,7 +965,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Net.Requests.dll": {}
+          "ref/dotnet/System.Net.Requests.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Net.Requests.dll": {}
@@ -889,7 +979,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Net.Sockets.dll": {}
+          "ref/dotnet/System.Net.Sockets.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Net.Sockets.dll": {}
@@ -903,7 +995,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Net.WebHeaderCollection.dll": {}
+          "ref/dotnet/System.Net.WebHeaderCollection.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Net.WebHeaderCollection.dll": {}
@@ -945,7 +1039,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.ObjectModel.dll": {}
+          "ref/dotnet/System.ObjectModel.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.ObjectModel.dll": {}
@@ -1081,7 +1177,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Reflection.dll": {}
+          "ref/dotnet/System.Reflection.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Reflection.dll": {}
@@ -1100,7 +1198,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.Reflection.Context.dll": {}
+          "ref/netcore50/System.Reflection.Context.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Reflection.Context.dll": {}
@@ -1118,7 +1218,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Reflection.DispatchProxy.dll": {}
+          "ref/dotnet/System.Reflection.DispatchProxy.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Reflection.DispatchProxy.dll": {}
@@ -1141,7 +1243,9 @@
           "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Reflection.Extensions.dll": {}
+          "ref/netcore50/System.Reflection.Extensions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Reflection.Extensions.dll": {}
@@ -1171,10 +1275,14 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "lib/dotnet/System.Reflection.Metadata.dll": {}
+          "lib/dotnet/System.Reflection.Metadata.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
-          "lib/dotnet/System.Reflection.Metadata.dll": {}
+          "lib/dotnet/System.Reflection.Metadata.dll": {
+            "related": ".xml"
+          }
         }
       },
       "System.Reflection.Primitives/4.0.0": {
@@ -1183,7 +1291,9 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "ref/netcore50/System.Reflection.Primitives.dll": {}
+          "ref/netcore50/System.Reflection.Primitives.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Reflection.Primitives.dll": {}
@@ -1207,7 +1317,9 @@
           "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Reflection.TypeExtensions.dll": {}
+          "ref/dotnet/System.Reflection.TypeExtensions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Reflection.TypeExtensions.dll": {}
@@ -1226,7 +1338,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.Resources.ResourceManager.dll": {}
+          "ref/netcore50/System.Resources.ResourceManager.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Resources.ResourceManager.dll": {}
@@ -1243,7 +1357,9 @@
           "System.Private.Uri": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Runtime.dll": {}
+          "ref/dotnet/System.Runtime.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.dll": {}
@@ -1260,7 +1376,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Runtime.Extensions.dll": {}
+          "ref/dotnet/System.Runtime.Extensions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.Extensions.dll": {}
@@ -1277,7 +1395,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Runtime.Handles.dll": {}
+          "ref/dotnet/System.Runtime.Handles.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.Handles.dll": {}
@@ -1297,7 +1417,9 @@
           "System.Runtime.Handles": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Runtime.InteropServices.dll": {}
+          "ref/dotnet/System.Runtime.InteropServices.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.InteropServices.dll": {}
@@ -1311,7 +1433,9 @@
       },
       "System.Runtime.InteropServices.WindowsRuntime/4.0.0": {
         "compile": {
-          "ref/netcore50/System.Runtime.InteropServices.WindowsRuntime.dll": {}
+          "ref/netcore50/System.Runtime.InteropServices.WindowsRuntime.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.InteropServices.WindowsRuntime.dll": {}
@@ -1331,7 +1455,9 @@
           "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Runtime.Numerics.dll": {}
+          "ref/netcore50/System.Runtime.Numerics.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.Numerics.dll": {}
@@ -1342,7 +1468,9 @@
           "System.Private.DataContractSerialization": "4.0.0"
         },
         "compile": {
-          "ref/netcore50/System.Runtime.Serialization.Json.dll": {}
+          "ref/netcore50/System.Runtime.Serialization.Json.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.Serialization.Json.dll": {}
@@ -1360,7 +1488,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Runtime.Serialization.Primitives.dll": {}
+          "ref/dotnet/System.Runtime.Serialization.Primitives.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Runtime.Serialization.Primitives.dll": {}
@@ -1372,7 +1502,9 @@
           "System.Runtime.Serialization.Primitives": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Runtime.Serialization.Xml.dll": {}
+          "ref/dotnet/System.Runtime.Serialization.Xml.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.Serialization.Xml.dll": {}
@@ -1398,7 +1530,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Runtime.WindowsRuntime.dll": {}
+          "ref/netcore50/System.Runtime.WindowsRuntime.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.WindowsRuntime.dll": {}
@@ -1419,7 +1553,9 @@
           "System.Runtime.WindowsRuntime": "4.0.0"
         },
         "compile": {
-          "ref/netcore50/System.Runtime.WindowsRuntime.UI.Xaml.dll": {}
+          "ref/netcore50/System.Runtime.WindowsRuntime.UI.Xaml.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.WindowsRuntime.UI.Xaml.dll": {}
@@ -1437,7 +1573,9 @@
           "System.Security.Principal": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Security.Claims.dll": {}
+          "ref/dotnet/System.Security.Claims.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Security.Claims.dll": {}
@@ -1448,7 +1586,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/netcore50/System.Security.Principal.dll": {}
+          "ref/netcore50/System.Security.Principal.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Security.Principal.dll": {}
@@ -1460,7 +1600,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.ServiceModel.Duplex.dll": {}
+          "ref/netcore50/System.ServiceModel.Duplex.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.ServiceModel.Duplex.dll": {}
@@ -1472,7 +1614,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.ServiceModel.Http.dll": {}
+          "ref/dotnet/System.ServiceModel.Http.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.ServiceModel.Http.dll": {}
@@ -1484,7 +1628,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.ServiceModel.NetTcp.dll": {}
+          "ref/netcore50/System.ServiceModel.NetTcp.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.ServiceModel.NetTcp.dll": {}
@@ -1496,7 +1642,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.ServiceModel.Primitives.dll": {}
+          "ref/netcore50/System.ServiceModel.Primitives.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.ServiceModel.Primitives.dll": {}
@@ -1508,7 +1656,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.ServiceModel.Security.dll": {}
+          "ref/netcore50/System.ServiceModel.Security.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.ServiceModel.Security.dll": {}
@@ -1519,7 +1669,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Text.Encoding.dll": {}
+          "ref/dotnet/System.Text.Encoding.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Text.Encoding.dll": {}
@@ -1546,7 +1698,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Text.Encoding.CodePages.dll": {}
+          "ref/dotnet/System.Text.Encoding.CodePages.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Text.Encoding.CodePages.dll": {}
@@ -1558,7 +1712,9 @@
           "System.Text.Encoding": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Text.Encoding.Extensions.dll": {}
+          "ref/dotnet/System.Text.Encoding.Extensions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Text.Encoding.Extensions.dll": {}
@@ -1580,7 +1736,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Text.RegularExpressions.dll": {}
+          "ref/dotnet/System.Text.RegularExpressions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Text.RegularExpressions.dll": {}
@@ -1592,7 +1750,9 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Threading.dll": {}
+          "ref/dotnet/System.Threading.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Threading.dll": {}
@@ -1614,7 +1774,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Threading.Overlapped.dll": {}
+          "ref/dotnet/System.Threading.Overlapped.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Threading.Overlapped.dll": {}
@@ -1625,7 +1787,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Threading.Tasks.dll": {}
+          "ref/dotnet/System.Threading.Tasks.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Threading.Tasks.dll": {}
@@ -1652,10 +1816,14 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "lib/dotnet/System.Threading.Tasks.Dataflow.dll": {}
+          "lib/dotnet/System.Threading.Tasks.Dataflow.dll": {
+            "related": ".XML"
+          }
         },
         "runtime": {
-          "lib/dotnet/System.Threading.Tasks.Dataflow.dll": {}
+          "lib/dotnet/System.Threading.Tasks.Dataflow.dll": {
+            "related": ".XML"
+          }
         }
       },
       "System.Threading.Tasks.Parallel/4.0.0": {
@@ -1670,7 +1838,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Threading.Tasks.Parallel.dll": {}
+          "ref/netcore50/System.Threading.Tasks.Parallel.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Threading.Tasks.Parallel.dll": {}
@@ -1678,7 +1848,9 @@
       },
       "System.Threading.Timer/4.0.0": {
         "compile": {
-          "ref/netcore50/System.Threading.Timer.dll": {}
+          "ref/netcore50/System.Threading.Timer.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Threading.Timer.dll": {}
@@ -1708,7 +1880,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Xml.ReaderWriter.dll": {}
+          "ref/dotnet/System.Xml.ReaderWriter.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Xml.ReaderWriter.dll": {}
@@ -1729,7 +1903,9 @@
           "System.Xml.ReaderWriter": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Xml.XDocument.dll": {}
+          "ref/dotnet/System.Xml.XDocument.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Xml.XDocument.dll": {}
@@ -1749,7 +1925,9 @@
           "System.Xml.ReaderWriter": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Xml.XmlDocument.dll": {}
+          "ref/dotnet/System.Xml.XmlDocument.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Xml.XmlDocument.dll": {}
@@ -1775,7 +1953,9 @@
           "System.Xml.XmlDocument": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Xml.XmlSerializer.dll": {}
+          "ref/dotnet/System.Xml.XmlSerializer.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Xml.XmlSerializer.dll": {}
@@ -1809,7 +1989,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/Microsoft.CSharp.dll": {}
+          "ref/netcore50/Microsoft.CSharp.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/Microsoft.CSharp.dll": {}
@@ -1886,12 +2068,18 @@
           "ref/netcore50/System.Numerics.dll": {},
           "ref/netcore50/System.Runtime.Serialization.dll": {},
           "ref/netcore50/System.ServiceModel.Web.dll": {},
-          "ref/netcore50/System.ServiceModel.dll": {},
+          "ref/netcore50/System.ServiceModel.dll": {
+            "related": ".Web.dll"
+          },
           "ref/netcore50/System.Windows.dll": {},
           "ref/netcore50/System.Xml.Linq.dll": {},
           "ref/netcore50/System.Xml.Serialization.dll": {},
-          "ref/netcore50/System.Xml.dll": {},
-          "ref/netcore50/System.dll": {},
+          "ref/netcore50/System.Xml.dll": {
+            "related": ".Linq.dll;.Serialization.dll"
+          },
+          "ref/netcore50/System.dll": {
+            "related": ".ComponentModel.DataAnnotations.dll;.Core.dll;.Net.dll;.Numerics.dll;.Runtime.Serialization.dll;.ServiceModel.dll;.ServiceModel.Web.dll;.Windows.dll;.Xml.dll;.Xml.Linq.dll;.Xml.Serialization.dll"
+          },
           "ref/netcore50/mscorlib.dll": {}
         },
         "runtime": {
@@ -1901,12 +2089,18 @@
           "lib/netcore50/System.Numerics.dll": {},
           "lib/netcore50/System.Runtime.Serialization.dll": {},
           "lib/netcore50/System.ServiceModel.Web.dll": {},
-          "lib/netcore50/System.ServiceModel.dll": {},
+          "lib/netcore50/System.ServiceModel.dll": {
+            "related": ".Web.dll"
+          },
           "lib/netcore50/System.Windows.dll": {},
           "lib/netcore50/System.Xml.Linq.dll": {},
           "lib/netcore50/System.Xml.Serialization.dll": {},
-          "lib/netcore50/System.Xml.dll": {},
-          "lib/netcore50/System.dll": {}
+          "lib/netcore50/System.Xml.dll": {
+            "related": ".Linq.dll;.Serialization.dll"
+          },
+          "lib/netcore50/System.dll": {
+            "related": ".ComponentModel.DataAnnotations.dll;.Core.dll;.Net.dll;.Numerics.dll;.Runtime.Serialization.dll;.ServiceModel.dll;.ServiceModel.Web.dll;.Windows.dll;.Xml.dll;.Xml.Linq.dll;.Xml.Serialization.dll"
+          }
         }
       },
       "Microsoft.NETCore.Runtime/1.0.0": {
@@ -2016,7 +2210,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/Microsoft.VisualBasic.dll": {}
+          "ref/netcore50/Microsoft.VisualBasic.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/Microsoft.VisualBasic.dll": {}
@@ -2028,7 +2224,9 @@
           "System.Runtime.InteropServices": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/Microsoft.Win32.Primitives.dll": {}
+          "ref/dotnet/Microsoft.Win32.Primitives.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/Microsoft.Win32.Primitives.dll": {}
@@ -2042,7 +2240,9 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.AppContext.dll": {}
+          "ref/dotnet/System.AppContext.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.AppContext.dll": {}
@@ -2057,7 +2257,9 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Collections.dll": {}
+          "ref/dotnet/System.Collections.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Collections.dll": {}
@@ -2076,7 +2278,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Collections.Concurrent.dll": {}
+          "ref/dotnet/System.Collections.Concurrent.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Collections.Concurrent.dll": {}
@@ -2094,10 +2298,14 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "lib/dotnet/System.Collections.Immutable.dll": {}
+          "lib/dotnet/System.Collections.Immutable.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
-          "lib/dotnet/System.Collections.Immutable.dll": {}
+          "lib/dotnet/System.Collections.Immutable.dll": {
+            "related": ".xml"
+          }
         }
       },
       "System.Collections.NonGeneric/4.0.0": {
@@ -2110,7 +2318,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Collections.NonGeneric.dll": {}
+          "ref/dotnet/System.Collections.NonGeneric.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Collections.NonGeneric.dll": {}
@@ -2127,7 +2337,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Collections.Specialized.dll": {}
+          "ref/dotnet/System.Collections.Specialized.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Collections.Specialized.dll": {}
@@ -2138,7 +2350,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.ComponentModel.dll": {}
+          "ref/netcore50/System.ComponentModel.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.ComponentModel.dll": {}
@@ -2159,7 +2373,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.ComponentModel.Annotations.dll": {}
+          "ref/dotnet/System.ComponentModel.Annotations.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.ComponentModel.Annotations.dll": {}
@@ -2173,7 +2389,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.ComponentModel.EventBasedAsync.dll": {}
+          "ref/dotnet/System.ComponentModel.EventBasedAsync.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.ComponentModel.EventBasedAsync.dll": {}
@@ -2192,7 +2410,9 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Data.Common.dll": {}
+          "ref/dotnet/System.Data.Common.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Data.Common.dll": {}
@@ -2200,7 +2420,9 @@
       },
       "System.Diagnostics.Contracts/4.0.0": {
         "compile": {
-          "ref/netcore50/System.Diagnostics.Contracts.dll": {}
+          "ref/netcore50/System.Diagnostics.Contracts.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Diagnostics.Contracts.dll": {}
@@ -2211,7 +2433,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Diagnostics.Debug.dll": {}
+          "ref/dotnet/System.Diagnostics.Debug.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Diagnostics.Debug.dll": {}
@@ -2222,7 +2446,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Diagnostics.StackTrace.dll": {}
+          "ref/dotnet/System.Diagnostics.StackTrace.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Diagnostics.StackTrace.dll": {}
@@ -2230,7 +2456,9 @@
       },
       "System.Diagnostics.Tools/4.0.0": {
         "compile": {
-          "ref/netcore50/System.Diagnostics.Tools.dll": {}
+          "ref/netcore50/System.Diagnostics.Tools.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Diagnostics.Tools.dll": {}
@@ -2250,7 +2478,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Diagnostics.Tracing.dll": {}
+          "ref/dotnet/System.Diagnostics.Tracing.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Diagnostics.Tracing.dll": {}
@@ -2274,7 +2504,9 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Dynamic.Runtime.dll": {}
+          "ref/dotnet/System.Dynamic.Runtime.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Dynamic.Runtime.dll": {}
@@ -2285,7 +2517,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Globalization.dll": {}
+          "ref/dotnet/System.Globalization.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Globalization.dll": {}
@@ -2297,7 +2531,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Globalization.Calendars.dll": {}
+          "ref/dotnet/System.Globalization.Calendars.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Globalization.Calendars.dll": {}
@@ -2312,7 +2548,9 @@
           "System.Runtime.InteropServices": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Globalization.Extensions.dll": {}
+          "ref/dotnet/System.Globalization.Extensions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Globalization.Extensions.dll": {}
@@ -2328,7 +2566,9 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.IO.dll": {}
+          "ref/dotnet/System.IO.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.IO.dll": {}
@@ -2348,7 +2588,9 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "ref/netcore50/System.IO.Compression.dll": {}
+          "ref/netcore50/System.IO.Compression.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.IO.Compression.dll": {}
@@ -2371,7 +2613,9 @@
           "System.Text.Encoding": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.IO.Compression.ZipFile.dll": {}
+          "ref/dotnet/System.IO.Compression.ZipFile.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.IO.Compression.ZipFile.dll": {}
@@ -2396,7 +2640,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.IO.FileSystem.dll": {}
+          "ref/dotnet/System.IO.FileSystem.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.IO.FileSystem.dll": {}
@@ -2407,7 +2653,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.IO.FileSystem.Primitives.dll": {}
+          "ref/dotnet/System.IO.FileSystem.Primitives.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.IO.FileSystem.Primitives.dll": {}
@@ -2426,7 +2674,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.IO.IsolatedStorage.dll": {}
+          "ref/dotnet/System.IO.IsolatedStorage.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.IO.IsolatedStorage.dll": {}
@@ -2443,7 +2693,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.IO.UnmanagedMemoryStream.dll": {}
+          "ref/dotnet/System.IO.UnmanagedMemoryStream.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.IO.UnmanagedMemoryStream.dll": {}
@@ -2458,7 +2710,9 @@
           "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Linq.dll": {}
+          "ref/netcore50/System.Linq.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Linq.dll": {}
@@ -2483,7 +2737,9 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Linq.Expressions.dll": {}
+          "ref/dotnet/System.Linq.Expressions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Linq.Expressions.dll": {}
@@ -2503,7 +2759,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Linq.Parallel.dll": {}
+          "ref/netcore50/System.Linq.Parallel.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Linq.Parallel.dll": {}
@@ -2520,7 +2778,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.Linq.Queryable.dll": {}
+          "ref/netcore50/System.Linq.Queryable.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Linq.Queryable.dll": {}
@@ -2544,7 +2804,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Net.Http.dll": {}
+          "ref/netcore50/System.Net.Http.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Net.Http.dll": {}
@@ -2556,7 +2818,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.Net.Http.Rtc.dll": {}
+          "ref/netcore50/System.Net.Http.Rtc.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Net.Http.Rtc.dll": {}
@@ -2569,7 +2833,9 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "ref/netcore50/System.Net.NetworkInformation.dll": {}
+          "ref/netcore50/System.Net.NetworkInformation.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Net.NetworkInformation.dll": {}
@@ -2581,7 +2847,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Net.Primitives.dll": {}
+          "ref/dotnet/System.Net.Primitives.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Net.Primitives.dll": {}
@@ -2601,7 +2869,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Net.Requests.dll": {}
+          "ref/dotnet/System.Net.Requests.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Net.Requests.dll": {}
@@ -2613,7 +2883,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Net.Sockets.dll": {}
+          "ref/dotnet/System.Net.Sockets.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Net.Sockets.dll": {}
@@ -2627,7 +2899,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Net.WebHeaderCollection.dll": {}
+          "ref/dotnet/System.Net.WebHeaderCollection.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Net.WebHeaderCollection.dll": {}
@@ -2669,7 +2943,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.ObjectModel.dll": {}
+          "ref/dotnet/System.ObjectModel.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.ObjectModel.dll": {}
@@ -2795,7 +3071,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Reflection.dll": {}
+          "ref/dotnet/System.Reflection.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Reflection.dll": {}
@@ -2808,7 +3086,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.Reflection.Context.dll": {}
+          "ref/netcore50/System.Reflection.Context.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Reflection.Context.dll": {}
@@ -2828,7 +3108,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Reflection.DispatchProxy.dll": {}
+          "ref/dotnet/System.Reflection.DispatchProxy.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Reflection.DispatchProxy.dll": {}
@@ -2843,7 +3125,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Reflection.Emit.dll": {}
+          "ref/dotnet/System.Reflection.Emit.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Reflection.Emit.dll": {}
@@ -2856,7 +3140,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Reflection.Emit.ILGeneration.dll": {}
+          "ref/dotnet/System.Reflection.Emit.ILGeneration.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Reflection.Emit.ILGeneration.dll": {}
@@ -2870,7 +3156,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Reflection.Emit.Lightweight.dll": {}
+          "ref/dotnet/System.Reflection.Emit.Lightweight.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Reflection.Emit.Lightweight.dll": {}
@@ -2887,7 +3175,9 @@
           "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Reflection.Extensions.dll": {}
+          "ref/netcore50/System.Reflection.Extensions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Reflection.Extensions.dll": {}
@@ -2911,10 +3201,14 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "lib/dotnet/System.Reflection.Metadata.dll": {}
+          "lib/dotnet/System.Reflection.Metadata.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
-          "lib/dotnet/System.Reflection.Metadata.dll": {}
+          "lib/dotnet/System.Reflection.Metadata.dll": {
+            "related": ".xml"
+          }
         }
       },
       "System.Reflection.Primitives/4.0.0": {
@@ -2923,7 +3217,9 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "ref/netcore50/System.Reflection.Primitives.dll": {}
+          "ref/netcore50/System.Reflection.Primitives.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Reflection.Primitives.dll": {}
@@ -2941,7 +3237,9 @@
           "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Reflection.TypeExtensions.dll": {}
+          "ref/dotnet/System.Reflection.TypeExtensions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Reflection.TypeExtensions.dll": {}
@@ -2954,7 +3252,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.Resources.ResourceManager.dll": {}
+          "ref/netcore50/System.Resources.ResourceManager.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Resources.ResourceManager.dll": {}
@@ -2965,7 +3265,9 @@
           "System.Private.Uri": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Runtime.dll": {}
+          "ref/dotnet/System.Runtime.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.dll": {}
@@ -2976,7 +3278,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Runtime.Extensions.dll": {}
+          "ref/dotnet/System.Runtime.Extensions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.Extensions.dll": {}
@@ -2987,7 +3291,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Runtime.Handles.dll": {}
+          "ref/dotnet/System.Runtime.Handles.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.Handles.dll": {}
@@ -3001,7 +3307,9 @@
           "System.Runtime.Handles": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Runtime.InteropServices.dll": {}
+          "ref/dotnet/System.Runtime.InteropServices.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.InteropServices.dll": {}
@@ -3009,7 +3317,9 @@
       },
       "System.Runtime.InteropServices.WindowsRuntime/4.0.0": {
         "compile": {
-          "ref/netcore50/System.Runtime.InteropServices.WindowsRuntime.dll": {}
+          "ref/netcore50/System.Runtime.InteropServices.WindowsRuntime.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.InteropServices.WindowsRuntime.dll": {}
@@ -3023,7 +3333,9 @@
           "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Runtime.Numerics.dll": {}
+          "ref/netcore50/System.Runtime.Numerics.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.Numerics.dll": {}
@@ -3034,7 +3346,9 @@
           "System.Private.DataContractSerialization": "4.0.0"
         },
         "compile": {
-          "ref/netcore50/System.Runtime.Serialization.Json.dll": {}
+          "ref/netcore50/System.Runtime.Serialization.Json.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.Serialization.Json.dll": {}
@@ -3046,7 +3360,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Runtime.Serialization.Primitives.dll": {}
+          "ref/dotnet/System.Runtime.Serialization.Primitives.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Runtime.Serialization.Primitives.dll": {}
@@ -3058,7 +3374,9 @@
           "System.Runtime.Serialization.Primitives": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Runtime.Serialization.Xml.dll": {}
+          "ref/dotnet/System.Runtime.Serialization.Xml.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.Serialization.Xml.dll": {}
@@ -3078,7 +3396,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Runtime.WindowsRuntime.dll": {}
+          "ref/netcore50/System.Runtime.WindowsRuntime.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.WindowsRuntime.dll": {}
@@ -3093,7 +3413,9 @@
           "System.Runtime.WindowsRuntime": "4.0.0"
         },
         "compile": {
-          "ref/netcore50/System.Runtime.WindowsRuntime.UI.Xaml.dll": {}
+          "ref/netcore50/System.Runtime.WindowsRuntime.UI.Xaml.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.WindowsRuntime.UI.Xaml.dll": {}
@@ -3111,7 +3433,9 @@
           "System.Security.Principal": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Security.Claims.dll": {}
+          "ref/dotnet/System.Security.Claims.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Security.Claims.dll": {}
@@ -3122,7 +3446,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/netcore50/System.Security.Principal.dll": {}
+          "ref/netcore50/System.Security.Principal.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Security.Principal.dll": {}
@@ -3134,7 +3460,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.ServiceModel.Duplex.dll": {}
+          "ref/netcore50/System.ServiceModel.Duplex.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.ServiceModel.Duplex.dll": {}
@@ -3146,7 +3474,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.ServiceModel.Http.dll": {}
+          "ref/dotnet/System.ServiceModel.Http.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.ServiceModel.Http.dll": {}
@@ -3158,7 +3488,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.ServiceModel.NetTcp.dll": {}
+          "ref/netcore50/System.ServiceModel.NetTcp.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.ServiceModel.NetTcp.dll": {}
@@ -3170,7 +3502,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.ServiceModel.Primitives.dll": {}
+          "ref/netcore50/System.ServiceModel.Primitives.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.ServiceModel.Primitives.dll": {}
@@ -3182,7 +3516,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.ServiceModel.Security.dll": {}
+          "ref/netcore50/System.ServiceModel.Security.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.ServiceModel.Security.dll": {}
@@ -3193,7 +3529,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Text.Encoding.dll": {}
+          "ref/dotnet/System.Text.Encoding.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Text.Encoding.dll": {}
@@ -3214,7 +3552,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Text.Encoding.CodePages.dll": {}
+          "ref/dotnet/System.Text.Encoding.CodePages.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Text.Encoding.CodePages.dll": {}
@@ -3226,7 +3566,9 @@
           "System.Text.Encoding": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Text.Encoding.Extensions.dll": {}
+          "ref/dotnet/System.Text.Encoding.Extensions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Text.Encoding.Extensions.dll": {}
@@ -3242,7 +3584,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Text.RegularExpressions.dll": {}
+          "ref/dotnet/System.Text.RegularExpressions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Text.RegularExpressions.dll": {}
@@ -3254,7 +3598,9 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Threading.dll": {}
+          "ref/dotnet/System.Threading.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Threading.dll": {}
@@ -3270,7 +3616,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Threading.Overlapped.dll": {}
+          "ref/dotnet/System.Threading.Overlapped.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Threading.Overlapped.dll": {}
@@ -3281,7 +3629,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Threading.Tasks.dll": {}
+          "ref/dotnet/System.Threading.Tasks.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Threading.Tasks.dll": {}
@@ -3302,10 +3652,14 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "lib/dotnet/System.Threading.Tasks.Dataflow.dll": {}
+          "lib/dotnet/System.Threading.Tasks.Dataflow.dll": {
+            "related": ".XML"
+          }
         },
         "runtime": {
-          "lib/dotnet/System.Threading.Tasks.Dataflow.dll": {}
+          "lib/dotnet/System.Threading.Tasks.Dataflow.dll": {
+            "related": ".XML"
+          }
         }
       },
       "System.Threading.Tasks.Parallel/4.0.0": {
@@ -3320,7 +3674,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Threading.Tasks.Parallel.dll": {}
+          "ref/netcore50/System.Threading.Tasks.Parallel.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Threading.Tasks.Parallel.dll": {}
@@ -3328,7 +3684,9 @@
       },
       "System.Threading.Timer/4.0.0": {
         "compile": {
-          "ref/netcore50/System.Threading.Timer.dll": {}
+          "ref/netcore50/System.Threading.Timer.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Threading.Timer.dll": {}
@@ -3352,7 +3710,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Xml.ReaderWriter.dll": {}
+          "ref/dotnet/System.Xml.ReaderWriter.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Xml.ReaderWriter.dll": {}
@@ -3373,7 +3733,9 @@
           "System.Xml.ReaderWriter": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Xml.XDocument.dll": {}
+          "ref/dotnet/System.Xml.XDocument.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Xml.XDocument.dll": {}
@@ -3393,7 +3755,9 @@
           "System.Xml.ReaderWriter": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Xml.XmlDocument.dll": {}
+          "ref/dotnet/System.Xml.XmlDocument.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Xml.XmlDocument.dll": {}
@@ -3421,7 +3785,9 @@
           "System.Xml.XmlDocument": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Xml.XmlSerializer.dll": {}
+          "ref/dotnet/System.Xml.XmlSerializer.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Xml.XmlSerializer.dll": {}
@@ -3449,7 +3815,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/Microsoft.CSharp.dll": {}
+          "ref/netcore50/Microsoft.CSharp.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/Microsoft.CSharp.dll": {}
@@ -3526,12 +3894,18 @@
           "ref/netcore50/System.Numerics.dll": {},
           "ref/netcore50/System.Runtime.Serialization.dll": {},
           "ref/netcore50/System.ServiceModel.Web.dll": {},
-          "ref/netcore50/System.ServiceModel.dll": {},
+          "ref/netcore50/System.ServiceModel.dll": {
+            "related": ".Web.dll"
+          },
           "ref/netcore50/System.Windows.dll": {},
           "ref/netcore50/System.Xml.Linq.dll": {},
           "ref/netcore50/System.Xml.Serialization.dll": {},
-          "ref/netcore50/System.Xml.dll": {},
-          "ref/netcore50/System.dll": {},
+          "ref/netcore50/System.Xml.dll": {
+            "related": ".Linq.dll;.Serialization.dll"
+          },
+          "ref/netcore50/System.dll": {
+            "related": ".ComponentModel.DataAnnotations.dll;.Core.dll;.Net.dll;.Numerics.dll;.Runtime.Serialization.dll;.ServiceModel.dll;.ServiceModel.Web.dll;.Windows.dll;.Xml.dll;.Xml.Linq.dll;.Xml.Serialization.dll"
+          },
           "ref/netcore50/mscorlib.dll": {}
         },
         "runtime": {
@@ -3541,12 +3915,18 @@
           "runtimes/aot/lib/netcore50/System.Numerics.dll": {},
           "runtimes/aot/lib/netcore50/System.Runtime.Serialization.dll": {},
           "runtimes/aot/lib/netcore50/System.ServiceModel.Web.dll": {},
-          "runtimes/aot/lib/netcore50/System.ServiceModel.dll": {},
+          "runtimes/aot/lib/netcore50/System.ServiceModel.dll": {
+            "related": ".Web.dll"
+          },
           "runtimes/aot/lib/netcore50/System.Windows.dll": {},
           "runtimes/aot/lib/netcore50/System.Xml.Linq.dll": {},
           "runtimes/aot/lib/netcore50/System.Xml.Serialization.dll": {},
-          "runtimes/aot/lib/netcore50/System.Xml.dll": {},
-          "runtimes/aot/lib/netcore50/System.dll": {},
+          "runtimes/aot/lib/netcore50/System.Xml.dll": {
+            "related": ".Linq.dll;.Serialization.dll"
+          },
+          "runtimes/aot/lib/netcore50/System.dll": {
+            "related": ".ComponentModel.DataAnnotations.dll;.Core.dll;.Net.dll;.Numerics.dll;.Runtime.Serialization.dll;.ServiceModel.dll;.ServiceModel.Web.dll;.Windows.dll;.Xml.dll;.Xml.Linq.dll;.Xml.Serialization.dll"
+          },
           "runtimes/aot/lib/netcore50/mscorlib.dll": {}
         }
       },
@@ -3642,7 +4022,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/Microsoft.VisualBasic.dll": {}
+          "ref/netcore50/Microsoft.VisualBasic.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/Microsoft.VisualBasic.dll": {}
@@ -3654,7 +4036,9 @@
           "System.Runtime.InteropServices": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/Microsoft.Win32.Primitives.dll": {}
+          "ref/dotnet/Microsoft.Win32.Primitives.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/Microsoft.Win32.Primitives.dll": {}
@@ -3668,7 +4052,9 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.AppContext.dll": {}
+          "ref/dotnet/System.AppContext.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.AppContext.dll": {}
@@ -3683,7 +4069,9 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Collections.dll": {}
+          "ref/dotnet/System.Collections.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Collections.dll": {}
@@ -3702,7 +4090,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Collections.Concurrent.dll": {}
+          "ref/dotnet/System.Collections.Concurrent.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Collections.Concurrent.dll": {}
@@ -3720,10 +4110,14 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "lib/dotnet/System.Collections.Immutable.dll": {}
+          "lib/dotnet/System.Collections.Immutable.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
-          "lib/dotnet/System.Collections.Immutable.dll": {}
+          "lib/dotnet/System.Collections.Immutable.dll": {
+            "related": ".xml"
+          }
         }
       },
       "System.Collections.NonGeneric/4.0.0": {
@@ -3736,7 +4130,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Collections.NonGeneric.dll": {}
+          "ref/dotnet/System.Collections.NonGeneric.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Collections.NonGeneric.dll": {}
@@ -3753,7 +4149,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Collections.Specialized.dll": {}
+          "ref/dotnet/System.Collections.Specialized.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Collections.Specialized.dll": {}
@@ -3764,7 +4162,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.ComponentModel.dll": {}
+          "ref/netcore50/System.ComponentModel.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.ComponentModel.dll": {}
@@ -3785,7 +4185,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.ComponentModel.Annotations.dll": {}
+          "ref/dotnet/System.ComponentModel.Annotations.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.ComponentModel.Annotations.dll": {}
@@ -3799,7 +4201,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.ComponentModel.EventBasedAsync.dll": {}
+          "ref/dotnet/System.ComponentModel.EventBasedAsync.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.ComponentModel.EventBasedAsync.dll": {}
@@ -3818,7 +4222,9 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Data.Common.dll": {}
+          "ref/dotnet/System.Data.Common.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Data.Common.dll": {}
@@ -3826,7 +4232,9 @@
       },
       "System.Diagnostics.Contracts/4.0.0": {
         "compile": {
-          "ref/netcore50/System.Diagnostics.Contracts.dll": {}
+          "ref/netcore50/System.Diagnostics.Contracts.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Contracts.dll": {}
@@ -3837,7 +4245,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Diagnostics.Debug.dll": {}
+          "ref/dotnet/System.Diagnostics.Debug.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Debug.dll": {}
@@ -3848,7 +4258,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Diagnostics.StackTrace.dll": {}
+          "ref/dotnet/System.Diagnostics.StackTrace.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Diagnostics.StackTrace.dll": {}
@@ -3856,7 +4268,9 @@
       },
       "System.Diagnostics.Tools/4.0.0": {
         "compile": {
-          "ref/netcore50/System.Diagnostics.Tools.dll": {}
+          "ref/netcore50/System.Diagnostics.Tools.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tools.dll": {}
@@ -3876,7 +4290,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Diagnostics.Tracing.dll": {}
+          "ref/dotnet/System.Diagnostics.Tracing.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tracing.dll": {}
@@ -3898,7 +4314,9 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Dynamic.Runtime.dll": {}
+          "ref/dotnet/System.Dynamic.Runtime.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Dynamic.Runtime.dll": {}
@@ -3909,7 +4327,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Globalization.dll": {}
+          "ref/dotnet/System.Globalization.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Globalization.dll": {}
@@ -3921,7 +4341,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Globalization.Calendars.dll": {}
+          "ref/dotnet/System.Globalization.Calendars.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Globalization.Calendars.dll": {}
@@ -3936,7 +4358,9 @@
           "System.Runtime.InteropServices": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Globalization.Extensions.dll": {}
+          "ref/dotnet/System.Globalization.Extensions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Globalization.Extensions.dll": {}
@@ -3952,7 +4376,9 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.IO.dll": {}
+          "ref/dotnet/System.IO.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.IO.dll": {}
@@ -3972,7 +4398,9 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "ref/netcore50/System.IO.Compression.dll": {}
+          "ref/netcore50/System.IO.Compression.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.IO.Compression.dll": {}
@@ -3995,7 +4423,9 @@
           "System.Text.Encoding": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.IO.Compression.ZipFile.dll": {}
+          "ref/dotnet/System.IO.Compression.ZipFile.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.IO.Compression.ZipFile.dll": {}
@@ -4020,7 +4450,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.IO.FileSystem.dll": {}
+          "ref/dotnet/System.IO.FileSystem.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.IO.FileSystem.dll": {}
@@ -4031,7 +4463,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.IO.FileSystem.Primitives.dll": {}
+          "ref/dotnet/System.IO.FileSystem.Primitives.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.IO.FileSystem.Primitives.dll": {}
@@ -4050,7 +4484,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.IO.IsolatedStorage.dll": {}
+          "ref/dotnet/System.IO.IsolatedStorage.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.IO.IsolatedStorage.dll": {}
@@ -4067,7 +4503,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.IO.UnmanagedMemoryStream.dll": {}
+          "ref/dotnet/System.IO.UnmanagedMemoryStream.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.IO.UnmanagedMemoryStream.dll": {}
@@ -4082,7 +4520,9 @@
           "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Linq.dll": {}
+          "ref/netcore50/System.Linq.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Linq.dll": {}
@@ -4105,7 +4545,9 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Linq.Expressions.dll": {}
+          "ref/dotnet/System.Linq.Expressions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Linq.Expressions.dll": {}
@@ -4125,7 +4567,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Linq.Parallel.dll": {}
+          "ref/netcore50/System.Linq.Parallel.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Linq.Parallel.dll": {}
@@ -4142,7 +4586,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.Linq.Queryable.dll": {}
+          "ref/netcore50/System.Linq.Queryable.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Linq.Queryable.dll": {}
@@ -4166,7 +4612,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Net.Http.dll": {}
+          "ref/netcore50/System.Net.Http.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Net.Http.dll": {}
@@ -4178,7 +4626,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.Net.Http.Rtc.dll": {}
+          "ref/netcore50/System.Net.Http.Rtc.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Net.Http.Rtc.dll": {}
@@ -4191,7 +4641,9 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "ref/netcore50/System.Net.NetworkInformation.dll": {}
+          "ref/netcore50/System.Net.NetworkInformation.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Net.NetworkInformation.dll": {}
@@ -4203,7 +4655,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Net.Primitives.dll": {}
+          "ref/dotnet/System.Net.Primitives.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Net.Primitives.dll": {}
@@ -4223,7 +4677,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Net.Requests.dll": {}
+          "ref/dotnet/System.Net.Requests.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Net.Requests.dll": {}
@@ -4235,7 +4691,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Net.Sockets.dll": {}
+          "ref/dotnet/System.Net.Sockets.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Net.Sockets.dll": {}
@@ -4249,7 +4707,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Net.WebHeaderCollection.dll": {}
+          "ref/dotnet/System.Net.WebHeaderCollection.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Net.WebHeaderCollection.dll": {}
@@ -4291,7 +4751,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.ObjectModel.dll": {}
+          "ref/dotnet/System.ObjectModel.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.ObjectModel.dll": {}
@@ -4415,7 +4877,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Reflection.dll": {}
+          "ref/dotnet/System.Reflection.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Reflection.dll": {}
@@ -4428,7 +4892,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.Reflection.Context.dll": {}
+          "ref/netcore50/System.Reflection.Context.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Reflection.Context.dll": {}
@@ -4446,7 +4912,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Reflection.DispatchProxy.dll": {}
+          "ref/dotnet/System.Reflection.DispatchProxy.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Reflection.DispatchProxy.dll": {}
@@ -4461,7 +4929,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Reflection.Emit.dll": {}
+          "ref/dotnet/System.Reflection.Emit.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Reflection.Emit.dll": {}
@@ -4474,7 +4944,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Reflection.Emit.ILGeneration.dll": {}
+          "ref/dotnet/System.Reflection.Emit.ILGeneration.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Reflection.Emit.ILGeneration.dll": {}
@@ -4491,7 +4963,9 @@
           "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Reflection.Extensions.dll": {}
+          "ref/netcore50/System.Reflection.Extensions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Reflection.Extensions.dll": {}
@@ -4515,10 +4989,14 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "lib/dotnet/System.Reflection.Metadata.dll": {}
+          "lib/dotnet/System.Reflection.Metadata.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
-          "lib/dotnet/System.Reflection.Metadata.dll": {}
+          "lib/dotnet/System.Reflection.Metadata.dll": {
+            "related": ".xml"
+          }
         }
       },
       "System.Reflection.Primitives/4.0.0": {
@@ -4527,7 +5005,9 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "ref/netcore50/System.Reflection.Primitives.dll": {}
+          "ref/netcore50/System.Reflection.Primitives.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Reflection.Primitives.dll": {}
@@ -4545,7 +5025,9 @@
           "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Reflection.TypeExtensions.dll": {}
+          "ref/dotnet/System.Reflection.TypeExtensions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Reflection.TypeExtensions.dll": {}
@@ -4558,7 +5040,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.Resources.ResourceManager.dll": {}
+          "ref/netcore50/System.Resources.ResourceManager.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Resources.ResourceManager.dll": {}
@@ -4569,7 +5053,9 @@
           "System.Private.Uri": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Runtime.dll": {}
+          "ref/dotnet/System.Runtime.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Runtime.dll": {}
@@ -4580,7 +5066,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Runtime.Extensions.dll": {}
+          "ref/dotnet/System.Runtime.Extensions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Runtime.Extensions.dll": {}
@@ -4591,7 +5079,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Runtime.Handles.dll": {}
+          "ref/dotnet/System.Runtime.Handles.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Runtime.Handles.dll": {}
@@ -4605,7 +5095,9 @@
           "System.Runtime.Handles": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Runtime.InteropServices.dll": {}
+          "ref/dotnet/System.Runtime.InteropServices.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Runtime.InteropServices.dll": {}
@@ -4613,7 +5105,9 @@
       },
       "System.Runtime.InteropServices.WindowsRuntime/4.0.0": {
         "compile": {
-          "ref/netcore50/System.Runtime.InteropServices.WindowsRuntime.dll": {}
+          "ref/netcore50/System.Runtime.InteropServices.WindowsRuntime.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Runtime.InteropServices.WindowsRuntime.dll": {}
@@ -4627,7 +5121,9 @@
           "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Runtime.Numerics.dll": {}
+          "ref/netcore50/System.Runtime.Numerics.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.Numerics.dll": {}
@@ -4638,7 +5134,9 @@
           "System.Private.DataContractSerialization": "4.0.0"
         },
         "compile": {
-          "ref/netcore50/System.Runtime.Serialization.Json.dll": {}
+          "ref/netcore50/System.Runtime.Serialization.Json.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Runtime.Serialization.Json.dll": {}
@@ -4650,7 +5148,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Runtime.Serialization.Primitives.dll": {}
+          "ref/dotnet/System.Runtime.Serialization.Primitives.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Runtime.Serialization.Primitives.dll": {}
@@ -4662,7 +5162,9 @@
           "System.Runtime.Serialization.Primitives": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Runtime.Serialization.Xml.dll": {}
+          "ref/dotnet/System.Runtime.Serialization.Xml.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Runtime.Serialization.Xml.dll": {}
@@ -4682,7 +5184,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Runtime.WindowsRuntime.dll": {}
+          "ref/netcore50/System.Runtime.WindowsRuntime.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Runtime.WindowsRuntime.dll": {}
@@ -4697,7 +5201,9 @@
           "System.Runtime.WindowsRuntime": "4.0.0"
         },
         "compile": {
-          "ref/netcore50/System.Runtime.WindowsRuntime.UI.Xaml.dll": {}
+          "ref/netcore50/System.Runtime.WindowsRuntime.UI.Xaml.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.WindowsRuntime.UI.Xaml.dll": {}
@@ -4715,7 +5221,9 @@
           "System.Security.Principal": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Security.Claims.dll": {}
+          "ref/dotnet/System.Security.Claims.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Security.Claims.dll": {}
@@ -4726,7 +5234,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/netcore50/System.Security.Principal.dll": {}
+          "ref/netcore50/System.Security.Principal.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Security.Principal.dll": {}
@@ -4738,7 +5248,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.ServiceModel.Duplex.dll": {}
+          "ref/netcore50/System.ServiceModel.Duplex.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.ServiceModel.Duplex.dll": {}
@@ -4750,7 +5262,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.ServiceModel.Http.dll": {}
+          "ref/dotnet/System.ServiceModel.Http.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.ServiceModel.Http.dll": {}
@@ -4762,7 +5276,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.ServiceModel.NetTcp.dll": {}
+          "ref/netcore50/System.ServiceModel.NetTcp.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.ServiceModel.NetTcp.dll": {}
@@ -4774,7 +5290,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.ServiceModel.Primitives.dll": {}
+          "ref/netcore50/System.ServiceModel.Primitives.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.ServiceModel.Primitives.dll": {}
@@ -4786,7 +5304,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.ServiceModel.Security.dll": {}
+          "ref/netcore50/System.ServiceModel.Security.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.ServiceModel.Security.dll": {}
@@ -4797,7 +5317,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Text.Encoding.dll": {}
+          "ref/dotnet/System.Text.Encoding.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.dll": {}
@@ -4818,7 +5340,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Text.Encoding.CodePages.dll": {}
+          "ref/dotnet/System.Text.Encoding.CodePages.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Text.Encoding.CodePages.dll": {}
@@ -4830,7 +5354,9 @@
           "System.Text.Encoding": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Text.Encoding.Extensions.dll": {}
+          "ref/dotnet/System.Text.Encoding.Extensions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.Extensions.dll": {}
@@ -4846,7 +5372,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Text.RegularExpressions.dll": {}
+          "ref/dotnet/System.Text.RegularExpressions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Text.RegularExpressions.dll": {}
@@ -4858,7 +5386,9 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Threading.dll": {}
+          "ref/dotnet/System.Threading.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Threading.dll": {}
@@ -4874,7 +5404,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Threading.Overlapped.dll": {}
+          "ref/dotnet/System.Threading.Overlapped.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Threading.Overlapped.dll": {}
@@ -4885,7 +5417,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Threading.Tasks.dll": {}
+          "ref/dotnet/System.Threading.Tasks.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Threading.Tasks.dll": {}
@@ -4906,10 +5440,14 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "lib/dotnet/System.Threading.Tasks.Dataflow.dll": {}
+          "lib/dotnet/System.Threading.Tasks.Dataflow.dll": {
+            "related": ".XML"
+          }
         },
         "runtime": {
-          "lib/dotnet/System.Threading.Tasks.Dataflow.dll": {}
+          "lib/dotnet/System.Threading.Tasks.Dataflow.dll": {
+            "related": ".XML"
+          }
         }
       },
       "System.Threading.Tasks.Parallel/4.0.0": {
@@ -4924,7 +5462,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Threading.Tasks.Parallel.dll": {}
+          "ref/netcore50/System.Threading.Tasks.Parallel.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Threading.Tasks.Parallel.dll": {}
@@ -4932,7 +5472,9 @@
       },
       "System.Threading.Timer/4.0.0": {
         "compile": {
-          "ref/netcore50/System.Threading.Timer.dll": {}
+          "ref/netcore50/System.Threading.Timer.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Threading.Timer.dll": {}
@@ -4956,7 +5498,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Xml.ReaderWriter.dll": {}
+          "ref/dotnet/System.Xml.ReaderWriter.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Xml.ReaderWriter.dll": {}
@@ -4977,7 +5521,9 @@
           "System.Xml.ReaderWriter": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Xml.XDocument.dll": {}
+          "ref/dotnet/System.Xml.XDocument.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Xml.XDocument.dll": {}
@@ -4997,7 +5543,9 @@
           "System.Xml.ReaderWriter": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Xml.XmlDocument.dll": {}
+          "ref/dotnet/System.Xml.XmlDocument.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Xml.XmlDocument.dll": {}
@@ -5025,7 +5573,9 @@
           "System.Xml.XmlDocument": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Xml.XmlSerializer.dll": {}
+          "ref/dotnet/System.Xml.XmlSerializer.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Xml.XmlSerializer.dll": {}
@@ -5053,7 +5603,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/Microsoft.CSharp.dll": {}
+          "ref/netcore50/Microsoft.CSharp.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/Microsoft.CSharp.dll": {}
@@ -5130,12 +5682,18 @@
           "ref/netcore50/System.Numerics.dll": {},
           "ref/netcore50/System.Runtime.Serialization.dll": {},
           "ref/netcore50/System.ServiceModel.Web.dll": {},
-          "ref/netcore50/System.ServiceModel.dll": {},
+          "ref/netcore50/System.ServiceModel.dll": {
+            "related": ".Web.dll"
+          },
           "ref/netcore50/System.Windows.dll": {},
           "ref/netcore50/System.Xml.Linq.dll": {},
           "ref/netcore50/System.Xml.Serialization.dll": {},
-          "ref/netcore50/System.Xml.dll": {},
-          "ref/netcore50/System.dll": {},
+          "ref/netcore50/System.Xml.dll": {
+            "related": ".Linq.dll;.Serialization.dll"
+          },
+          "ref/netcore50/System.dll": {
+            "related": ".ComponentModel.DataAnnotations.dll;.Core.dll;.Net.dll;.Numerics.dll;.Runtime.Serialization.dll;.ServiceModel.dll;.ServiceModel.Web.dll;.Windows.dll;.Xml.dll;.Xml.Linq.dll;.Xml.Serialization.dll"
+          },
           "ref/netcore50/mscorlib.dll": {}
         },
         "runtime": {
@@ -5145,12 +5703,18 @@
           "lib/netcore50/System.Numerics.dll": {},
           "lib/netcore50/System.Runtime.Serialization.dll": {},
           "lib/netcore50/System.ServiceModel.Web.dll": {},
-          "lib/netcore50/System.ServiceModel.dll": {},
+          "lib/netcore50/System.ServiceModel.dll": {
+            "related": ".Web.dll"
+          },
           "lib/netcore50/System.Windows.dll": {},
           "lib/netcore50/System.Xml.Linq.dll": {},
           "lib/netcore50/System.Xml.Serialization.dll": {},
-          "lib/netcore50/System.Xml.dll": {},
-          "lib/netcore50/System.dll": {}
+          "lib/netcore50/System.Xml.dll": {
+            "related": ".Linq.dll;.Serialization.dll"
+          },
+          "lib/netcore50/System.dll": {
+            "related": ".ComponentModel.DataAnnotations.dll;.Core.dll;.Net.dll;.Numerics.dll;.Runtime.Serialization.dll;.ServiceModel.dll;.ServiceModel.Web.dll;.Windows.dll;.Xml.dll;.Xml.Linq.dll;.Xml.Serialization.dll"
+          }
         }
       },
       "Microsoft.NETCore.Runtime/1.0.0": {
@@ -5266,7 +5830,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/Microsoft.VisualBasic.dll": {}
+          "ref/netcore50/Microsoft.VisualBasic.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/Microsoft.VisualBasic.dll": {}
@@ -5278,7 +5844,9 @@
           "System.Runtime.InteropServices": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/Microsoft.Win32.Primitives.dll": {}
+          "ref/dotnet/Microsoft.Win32.Primitives.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/Microsoft.Win32.Primitives.dll": {}
@@ -5292,7 +5860,9 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.AppContext.dll": {}
+          "ref/dotnet/System.AppContext.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.AppContext.dll": {}
@@ -5307,7 +5877,9 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Collections.dll": {}
+          "ref/dotnet/System.Collections.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Collections.dll": {}
@@ -5326,7 +5898,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Collections.Concurrent.dll": {}
+          "ref/dotnet/System.Collections.Concurrent.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Collections.Concurrent.dll": {}
@@ -5344,10 +5918,14 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "lib/dotnet/System.Collections.Immutable.dll": {}
+          "lib/dotnet/System.Collections.Immutable.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
-          "lib/dotnet/System.Collections.Immutable.dll": {}
+          "lib/dotnet/System.Collections.Immutable.dll": {
+            "related": ".xml"
+          }
         }
       },
       "System.Collections.NonGeneric/4.0.0": {
@@ -5360,7 +5938,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Collections.NonGeneric.dll": {}
+          "ref/dotnet/System.Collections.NonGeneric.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Collections.NonGeneric.dll": {}
@@ -5377,7 +5957,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Collections.Specialized.dll": {}
+          "ref/dotnet/System.Collections.Specialized.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Collections.Specialized.dll": {}
@@ -5388,7 +5970,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.ComponentModel.dll": {}
+          "ref/netcore50/System.ComponentModel.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.ComponentModel.dll": {}
@@ -5409,7 +5993,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.ComponentModel.Annotations.dll": {}
+          "ref/dotnet/System.ComponentModel.Annotations.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.ComponentModel.Annotations.dll": {}
@@ -5423,7 +6009,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.ComponentModel.EventBasedAsync.dll": {}
+          "ref/dotnet/System.ComponentModel.EventBasedAsync.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.ComponentModel.EventBasedAsync.dll": {}
@@ -5442,7 +6030,9 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Data.Common.dll": {}
+          "ref/dotnet/System.Data.Common.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Data.Common.dll": {}
@@ -5450,7 +6040,9 @@
       },
       "System.Diagnostics.Contracts/4.0.0": {
         "compile": {
-          "ref/netcore50/System.Diagnostics.Contracts.dll": {}
+          "ref/netcore50/System.Diagnostics.Contracts.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Diagnostics.Contracts.dll": {}
@@ -5461,7 +6053,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Diagnostics.Debug.dll": {}
+          "ref/dotnet/System.Diagnostics.Debug.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Diagnostics.Debug.dll": {}
@@ -5472,7 +6066,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Diagnostics.StackTrace.dll": {}
+          "ref/dotnet/System.Diagnostics.StackTrace.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Diagnostics.StackTrace.dll": {}
@@ -5480,7 +6076,9 @@
       },
       "System.Diagnostics.Tools/4.0.0": {
         "compile": {
-          "ref/netcore50/System.Diagnostics.Tools.dll": {}
+          "ref/netcore50/System.Diagnostics.Tools.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Diagnostics.Tools.dll": {}
@@ -5500,7 +6098,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Diagnostics.Tracing.dll": {}
+          "ref/dotnet/System.Diagnostics.Tracing.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Diagnostics.Tracing.dll": {}
@@ -5524,7 +6124,9 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Dynamic.Runtime.dll": {}
+          "ref/dotnet/System.Dynamic.Runtime.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Dynamic.Runtime.dll": {}
@@ -5535,7 +6137,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Globalization.dll": {}
+          "ref/dotnet/System.Globalization.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Globalization.dll": {}
@@ -5547,7 +6151,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Globalization.Calendars.dll": {}
+          "ref/dotnet/System.Globalization.Calendars.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Globalization.Calendars.dll": {}
@@ -5562,7 +6168,9 @@
           "System.Runtime.InteropServices": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Globalization.Extensions.dll": {}
+          "ref/dotnet/System.Globalization.Extensions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Globalization.Extensions.dll": {}
@@ -5578,7 +6186,9 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.IO.dll": {}
+          "ref/dotnet/System.IO.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.IO.dll": {}
@@ -5598,7 +6208,9 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "ref/netcore50/System.IO.Compression.dll": {}
+          "ref/netcore50/System.IO.Compression.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.IO.Compression.dll": {}
@@ -5621,7 +6233,9 @@
           "System.Text.Encoding": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.IO.Compression.ZipFile.dll": {}
+          "ref/dotnet/System.IO.Compression.ZipFile.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.IO.Compression.ZipFile.dll": {}
@@ -5646,7 +6260,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.IO.FileSystem.dll": {}
+          "ref/dotnet/System.IO.FileSystem.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.IO.FileSystem.dll": {}
@@ -5657,7 +6273,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.IO.FileSystem.Primitives.dll": {}
+          "ref/dotnet/System.IO.FileSystem.Primitives.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.IO.FileSystem.Primitives.dll": {}
@@ -5676,7 +6294,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.IO.IsolatedStorage.dll": {}
+          "ref/dotnet/System.IO.IsolatedStorage.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.IO.IsolatedStorage.dll": {}
@@ -5693,7 +6313,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.IO.UnmanagedMemoryStream.dll": {}
+          "ref/dotnet/System.IO.UnmanagedMemoryStream.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.IO.UnmanagedMemoryStream.dll": {}
@@ -5708,7 +6330,9 @@
           "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Linq.dll": {}
+          "ref/netcore50/System.Linq.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Linq.dll": {}
@@ -5733,7 +6357,9 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Linq.Expressions.dll": {}
+          "ref/dotnet/System.Linq.Expressions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Linq.Expressions.dll": {}
@@ -5753,7 +6379,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Linq.Parallel.dll": {}
+          "ref/netcore50/System.Linq.Parallel.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Linq.Parallel.dll": {}
@@ -5770,7 +6398,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.Linq.Queryable.dll": {}
+          "ref/netcore50/System.Linq.Queryable.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Linq.Queryable.dll": {}
@@ -5794,7 +6424,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Net.Http.dll": {}
+          "ref/netcore50/System.Net.Http.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Net.Http.dll": {}
@@ -5806,7 +6438,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.Net.Http.Rtc.dll": {}
+          "ref/netcore50/System.Net.Http.Rtc.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Net.Http.Rtc.dll": {}
@@ -5819,7 +6453,9 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "ref/netcore50/System.Net.NetworkInformation.dll": {}
+          "ref/netcore50/System.Net.NetworkInformation.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Net.NetworkInformation.dll": {}
@@ -5831,7 +6467,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Net.Primitives.dll": {}
+          "ref/dotnet/System.Net.Primitives.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Net.Primitives.dll": {}
@@ -5851,7 +6489,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Net.Requests.dll": {}
+          "ref/dotnet/System.Net.Requests.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Net.Requests.dll": {}
@@ -5863,7 +6503,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Net.Sockets.dll": {}
+          "ref/dotnet/System.Net.Sockets.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Net.Sockets.dll": {}
@@ -5877,7 +6519,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Net.WebHeaderCollection.dll": {}
+          "ref/dotnet/System.Net.WebHeaderCollection.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Net.WebHeaderCollection.dll": {}
@@ -5919,7 +6563,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.ObjectModel.dll": {}
+          "ref/dotnet/System.ObjectModel.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.ObjectModel.dll": {}
@@ -6045,7 +6691,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Reflection.dll": {}
+          "ref/dotnet/System.Reflection.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Reflection.dll": {}
@@ -6058,7 +6706,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.Reflection.Context.dll": {}
+          "ref/netcore50/System.Reflection.Context.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Reflection.Context.dll": {}
@@ -6078,7 +6728,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Reflection.DispatchProxy.dll": {}
+          "ref/dotnet/System.Reflection.DispatchProxy.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Reflection.DispatchProxy.dll": {}
@@ -6093,7 +6745,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Reflection.Emit.dll": {}
+          "ref/dotnet/System.Reflection.Emit.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Reflection.Emit.dll": {}
@@ -6106,7 +6760,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Reflection.Emit.ILGeneration.dll": {}
+          "ref/dotnet/System.Reflection.Emit.ILGeneration.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Reflection.Emit.ILGeneration.dll": {}
@@ -6120,7 +6776,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Reflection.Emit.Lightweight.dll": {}
+          "ref/dotnet/System.Reflection.Emit.Lightweight.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Reflection.Emit.Lightweight.dll": {}
@@ -6137,7 +6795,9 @@
           "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Reflection.Extensions.dll": {}
+          "ref/netcore50/System.Reflection.Extensions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Reflection.Extensions.dll": {}
@@ -6161,10 +6821,14 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "lib/dotnet/System.Reflection.Metadata.dll": {}
+          "lib/dotnet/System.Reflection.Metadata.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
-          "lib/dotnet/System.Reflection.Metadata.dll": {}
+          "lib/dotnet/System.Reflection.Metadata.dll": {
+            "related": ".xml"
+          }
         }
       },
       "System.Reflection.Primitives/4.0.0": {
@@ -6173,7 +6837,9 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "ref/netcore50/System.Reflection.Primitives.dll": {}
+          "ref/netcore50/System.Reflection.Primitives.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Reflection.Primitives.dll": {}
@@ -6191,7 +6857,9 @@
           "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Reflection.TypeExtensions.dll": {}
+          "ref/dotnet/System.Reflection.TypeExtensions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Reflection.TypeExtensions.dll": {}
@@ -6204,7 +6872,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.Resources.ResourceManager.dll": {}
+          "ref/netcore50/System.Resources.ResourceManager.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Resources.ResourceManager.dll": {}
@@ -6215,7 +6885,9 @@
           "System.Private.Uri": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Runtime.dll": {}
+          "ref/dotnet/System.Runtime.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.dll": {}
@@ -6226,7 +6898,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Runtime.Extensions.dll": {}
+          "ref/dotnet/System.Runtime.Extensions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.Extensions.dll": {}
@@ -6237,7 +6911,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Runtime.Handles.dll": {}
+          "ref/dotnet/System.Runtime.Handles.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.Handles.dll": {}
@@ -6251,7 +6927,9 @@
           "System.Runtime.Handles": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Runtime.InteropServices.dll": {}
+          "ref/dotnet/System.Runtime.InteropServices.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.InteropServices.dll": {}
@@ -6259,7 +6937,9 @@
       },
       "System.Runtime.InteropServices.WindowsRuntime/4.0.0": {
         "compile": {
-          "ref/netcore50/System.Runtime.InteropServices.WindowsRuntime.dll": {}
+          "ref/netcore50/System.Runtime.InteropServices.WindowsRuntime.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.InteropServices.WindowsRuntime.dll": {}
@@ -6273,7 +6953,9 @@
           "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Runtime.Numerics.dll": {}
+          "ref/netcore50/System.Runtime.Numerics.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.Numerics.dll": {}
@@ -6284,7 +6966,9 @@
           "System.Private.DataContractSerialization": "4.0.0"
         },
         "compile": {
-          "ref/netcore50/System.Runtime.Serialization.Json.dll": {}
+          "ref/netcore50/System.Runtime.Serialization.Json.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.Serialization.Json.dll": {}
@@ -6296,7 +6980,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Runtime.Serialization.Primitives.dll": {}
+          "ref/dotnet/System.Runtime.Serialization.Primitives.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Runtime.Serialization.Primitives.dll": {}
@@ -6308,7 +6994,9 @@
           "System.Runtime.Serialization.Primitives": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Runtime.Serialization.Xml.dll": {}
+          "ref/dotnet/System.Runtime.Serialization.Xml.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.Serialization.Xml.dll": {}
@@ -6328,7 +7016,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Runtime.WindowsRuntime.dll": {}
+          "ref/netcore50/System.Runtime.WindowsRuntime.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.WindowsRuntime.dll": {}
@@ -6343,7 +7033,9 @@
           "System.Runtime.WindowsRuntime": "4.0.0"
         },
         "compile": {
-          "ref/netcore50/System.Runtime.WindowsRuntime.UI.Xaml.dll": {}
+          "ref/netcore50/System.Runtime.WindowsRuntime.UI.Xaml.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.WindowsRuntime.UI.Xaml.dll": {}
@@ -6361,7 +7053,9 @@
           "System.Security.Principal": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Security.Claims.dll": {}
+          "ref/dotnet/System.Security.Claims.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Security.Claims.dll": {}
@@ -6372,7 +7066,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/netcore50/System.Security.Principal.dll": {}
+          "ref/netcore50/System.Security.Principal.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Security.Principal.dll": {}
@@ -6384,7 +7080,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.ServiceModel.Duplex.dll": {}
+          "ref/netcore50/System.ServiceModel.Duplex.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.ServiceModel.Duplex.dll": {}
@@ -6396,7 +7094,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.ServiceModel.Http.dll": {}
+          "ref/dotnet/System.ServiceModel.Http.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.ServiceModel.Http.dll": {}
@@ -6408,7 +7108,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.ServiceModel.NetTcp.dll": {}
+          "ref/netcore50/System.ServiceModel.NetTcp.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.ServiceModel.NetTcp.dll": {}
@@ -6420,7 +7122,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.ServiceModel.Primitives.dll": {}
+          "ref/netcore50/System.ServiceModel.Primitives.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.ServiceModel.Primitives.dll": {}
@@ -6432,7 +7136,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.ServiceModel.Security.dll": {}
+          "ref/netcore50/System.ServiceModel.Security.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.ServiceModel.Security.dll": {}
@@ -6443,7 +7149,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Text.Encoding.dll": {}
+          "ref/dotnet/System.Text.Encoding.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Text.Encoding.dll": {}
@@ -6464,7 +7172,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Text.Encoding.CodePages.dll": {}
+          "ref/dotnet/System.Text.Encoding.CodePages.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Text.Encoding.CodePages.dll": {}
@@ -6476,7 +7186,9 @@
           "System.Text.Encoding": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Text.Encoding.Extensions.dll": {}
+          "ref/dotnet/System.Text.Encoding.Extensions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Text.Encoding.Extensions.dll": {}
@@ -6492,7 +7204,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Text.RegularExpressions.dll": {}
+          "ref/dotnet/System.Text.RegularExpressions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Text.RegularExpressions.dll": {}
@@ -6504,7 +7218,9 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Threading.dll": {}
+          "ref/dotnet/System.Threading.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Threading.dll": {}
@@ -6520,7 +7236,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Threading.Overlapped.dll": {}
+          "ref/dotnet/System.Threading.Overlapped.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Threading.Overlapped.dll": {}
@@ -6531,7 +7249,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Threading.Tasks.dll": {}
+          "ref/dotnet/System.Threading.Tasks.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Threading.Tasks.dll": {}
@@ -6552,10 +7272,14 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "lib/dotnet/System.Threading.Tasks.Dataflow.dll": {}
+          "lib/dotnet/System.Threading.Tasks.Dataflow.dll": {
+            "related": ".XML"
+          }
         },
         "runtime": {
-          "lib/dotnet/System.Threading.Tasks.Dataflow.dll": {}
+          "lib/dotnet/System.Threading.Tasks.Dataflow.dll": {
+            "related": ".XML"
+          }
         }
       },
       "System.Threading.Tasks.Parallel/4.0.0": {
@@ -6570,7 +7294,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Threading.Tasks.Parallel.dll": {}
+          "ref/netcore50/System.Threading.Tasks.Parallel.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Threading.Tasks.Parallel.dll": {}
@@ -6578,7 +7304,9 @@
       },
       "System.Threading.Timer/4.0.0": {
         "compile": {
-          "ref/netcore50/System.Threading.Timer.dll": {}
+          "ref/netcore50/System.Threading.Timer.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Threading.Timer.dll": {}
@@ -6602,7 +7330,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Xml.ReaderWriter.dll": {}
+          "ref/dotnet/System.Xml.ReaderWriter.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Xml.ReaderWriter.dll": {}
@@ -6623,7 +7353,9 @@
           "System.Xml.ReaderWriter": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Xml.XDocument.dll": {}
+          "ref/dotnet/System.Xml.XDocument.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Xml.XDocument.dll": {}
@@ -6643,7 +7375,9 @@
           "System.Xml.ReaderWriter": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Xml.XmlDocument.dll": {}
+          "ref/dotnet/System.Xml.XmlDocument.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Xml.XmlDocument.dll": {}
@@ -6671,7 +7405,9 @@
           "System.Xml.XmlDocument": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Xml.XmlSerializer.dll": {}
+          "ref/dotnet/System.Xml.XmlSerializer.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Xml.XmlSerializer.dll": {}
@@ -6699,7 +7435,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/Microsoft.CSharp.dll": {}
+          "ref/netcore50/Microsoft.CSharp.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/Microsoft.CSharp.dll": {}
@@ -6776,12 +7514,18 @@
           "ref/netcore50/System.Numerics.dll": {},
           "ref/netcore50/System.Runtime.Serialization.dll": {},
           "ref/netcore50/System.ServiceModel.Web.dll": {},
-          "ref/netcore50/System.ServiceModel.dll": {},
+          "ref/netcore50/System.ServiceModel.dll": {
+            "related": ".Web.dll"
+          },
           "ref/netcore50/System.Windows.dll": {},
           "ref/netcore50/System.Xml.Linq.dll": {},
           "ref/netcore50/System.Xml.Serialization.dll": {},
-          "ref/netcore50/System.Xml.dll": {},
-          "ref/netcore50/System.dll": {},
+          "ref/netcore50/System.Xml.dll": {
+            "related": ".Linq.dll;.Serialization.dll"
+          },
+          "ref/netcore50/System.dll": {
+            "related": ".ComponentModel.DataAnnotations.dll;.Core.dll;.Net.dll;.Numerics.dll;.Runtime.Serialization.dll;.ServiceModel.dll;.ServiceModel.Web.dll;.Windows.dll;.Xml.dll;.Xml.Linq.dll;.Xml.Serialization.dll"
+          },
           "ref/netcore50/mscorlib.dll": {}
         },
         "runtime": {
@@ -6791,12 +7535,18 @@
           "runtimes/aot/lib/netcore50/System.Numerics.dll": {},
           "runtimes/aot/lib/netcore50/System.Runtime.Serialization.dll": {},
           "runtimes/aot/lib/netcore50/System.ServiceModel.Web.dll": {},
-          "runtimes/aot/lib/netcore50/System.ServiceModel.dll": {},
+          "runtimes/aot/lib/netcore50/System.ServiceModel.dll": {
+            "related": ".Web.dll"
+          },
           "runtimes/aot/lib/netcore50/System.Windows.dll": {},
           "runtimes/aot/lib/netcore50/System.Xml.Linq.dll": {},
           "runtimes/aot/lib/netcore50/System.Xml.Serialization.dll": {},
-          "runtimes/aot/lib/netcore50/System.Xml.dll": {},
-          "runtimes/aot/lib/netcore50/System.dll": {},
+          "runtimes/aot/lib/netcore50/System.Xml.dll": {
+            "related": ".Linq.dll;.Serialization.dll"
+          },
+          "runtimes/aot/lib/netcore50/System.dll": {
+            "related": ".ComponentModel.DataAnnotations.dll;.Core.dll;.Net.dll;.Numerics.dll;.Runtime.Serialization.dll;.ServiceModel.dll;.ServiceModel.Web.dll;.Windows.dll;.Xml.dll;.Xml.Linq.dll;.Xml.Serialization.dll"
+          },
           "runtimes/aot/lib/netcore50/mscorlib.dll": {}
         }
       },
@@ -6892,7 +7642,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/Microsoft.VisualBasic.dll": {}
+          "ref/netcore50/Microsoft.VisualBasic.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/Microsoft.VisualBasic.dll": {}
@@ -6904,7 +7656,9 @@
           "System.Runtime.InteropServices": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/Microsoft.Win32.Primitives.dll": {}
+          "ref/dotnet/Microsoft.Win32.Primitives.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/Microsoft.Win32.Primitives.dll": {}
@@ -6918,7 +7672,9 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.AppContext.dll": {}
+          "ref/dotnet/System.AppContext.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.AppContext.dll": {}
@@ -6933,7 +7689,9 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Collections.dll": {}
+          "ref/dotnet/System.Collections.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Collections.dll": {}
@@ -6952,7 +7710,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Collections.Concurrent.dll": {}
+          "ref/dotnet/System.Collections.Concurrent.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Collections.Concurrent.dll": {}
@@ -6970,10 +7730,14 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "lib/dotnet/System.Collections.Immutable.dll": {}
+          "lib/dotnet/System.Collections.Immutable.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
-          "lib/dotnet/System.Collections.Immutable.dll": {}
+          "lib/dotnet/System.Collections.Immutable.dll": {
+            "related": ".xml"
+          }
         }
       },
       "System.Collections.NonGeneric/4.0.0": {
@@ -6986,7 +7750,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Collections.NonGeneric.dll": {}
+          "ref/dotnet/System.Collections.NonGeneric.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Collections.NonGeneric.dll": {}
@@ -7003,7 +7769,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Collections.Specialized.dll": {}
+          "ref/dotnet/System.Collections.Specialized.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Collections.Specialized.dll": {}
@@ -7014,7 +7782,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.ComponentModel.dll": {}
+          "ref/netcore50/System.ComponentModel.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.ComponentModel.dll": {}
@@ -7035,7 +7805,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.ComponentModel.Annotations.dll": {}
+          "ref/dotnet/System.ComponentModel.Annotations.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.ComponentModel.Annotations.dll": {}
@@ -7049,7 +7821,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.ComponentModel.EventBasedAsync.dll": {}
+          "ref/dotnet/System.ComponentModel.EventBasedAsync.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.ComponentModel.EventBasedAsync.dll": {}
@@ -7068,7 +7842,9 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Data.Common.dll": {}
+          "ref/dotnet/System.Data.Common.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Data.Common.dll": {}
@@ -7076,7 +7852,9 @@
       },
       "System.Diagnostics.Contracts/4.0.0": {
         "compile": {
-          "ref/netcore50/System.Diagnostics.Contracts.dll": {}
+          "ref/netcore50/System.Diagnostics.Contracts.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Contracts.dll": {}
@@ -7087,7 +7865,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Diagnostics.Debug.dll": {}
+          "ref/dotnet/System.Diagnostics.Debug.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Debug.dll": {}
@@ -7098,7 +7878,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Diagnostics.StackTrace.dll": {}
+          "ref/dotnet/System.Diagnostics.StackTrace.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Diagnostics.StackTrace.dll": {}
@@ -7106,7 +7888,9 @@
       },
       "System.Diagnostics.Tools/4.0.0": {
         "compile": {
-          "ref/netcore50/System.Diagnostics.Tools.dll": {}
+          "ref/netcore50/System.Diagnostics.Tools.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tools.dll": {}
@@ -7126,7 +7910,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Diagnostics.Tracing.dll": {}
+          "ref/dotnet/System.Diagnostics.Tracing.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tracing.dll": {}
@@ -7148,7 +7934,9 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Dynamic.Runtime.dll": {}
+          "ref/dotnet/System.Dynamic.Runtime.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Dynamic.Runtime.dll": {}
@@ -7159,7 +7947,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Globalization.dll": {}
+          "ref/dotnet/System.Globalization.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Globalization.dll": {}
@@ -7171,7 +7961,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Globalization.Calendars.dll": {}
+          "ref/dotnet/System.Globalization.Calendars.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Globalization.Calendars.dll": {}
@@ -7186,7 +7978,9 @@
           "System.Runtime.InteropServices": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Globalization.Extensions.dll": {}
+          "ref/dotnet/System.Globalization.Extensions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Globalization.Extensions.dll": {}
@@ -7202,7 +7996,9 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.IO.dll": {}
+          "ref/dotnet/System.IO.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.IO.dll": {}
@@ -7222,7 +8018,9 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "ref/netcore50/System.IO.Compression.dll": {}
+          "ref/netcore50/System.IO.Compression.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.IO.Compression.dll": {}
@@ -7245,7 +8043,9 @@
           "System.Text.Encoding": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.IO.Compression.ZipFile.dll": {}
+          "ref/dotnet/System.IO.Compression.ZipFile.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.IO.Compression.ZipFile.dll": {}
@@ -7270,7 +8070,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.IO.FileSystem.dll": {}
+          "ref/dotnet/System.IO.FileSystem.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.IO.FileSystem.dll": {}
@@ -7281,7 +8083,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.IO.FileSystem.Primitives.dll": {}
+          "ref/dotnet/System.IO.FileSystem.Primitives.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.IO.FileSystem.Primitives.dll": {}
@@ -7300,7 +8104,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.IO.IsolatedStorage.dll": {}
+          "ref/dotnet/System.IO.IsolatedStorage.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.IO.IsolatedStorage.dll": {}
@@ -7317,7 +8123,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.IO.UnmanagedMemoryStream.dll": {}
+          "ref/dotnet/System.IO.UnmanagedMemoryStream.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.IO.UnmanagedMemoryStream.dll": {}
@@ -7332,7 +8140,9 @@
           "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Linq.dll": {}
+          "ref/netcore50/System.Linq.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Linq.dll": {}
@@ -7355,7 +8165,9 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Linq.Expressions.dll": {}
+          "ref/dotnet/System.Linq.Expressions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Linq.Expressions.dll": {}
@@ -7375,7 +8187,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Linq.Parallel.dll": {}
+          "ref/netcore50/System.Linq.Parallel.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Linq.Parallel.dll": {}
@@ -7392,7 +8206,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.Linq.Queryable.dll": {}
+          "ref/netcore50/System.Linq.Queryable.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Linq.Queryable.dll": {}
@@ -7416,7 +8232,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Net.Http.dll": {}
+          "ref/netcore50/System.Net.Http.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Net.Http.dll": {}
@@ -7428,7 +8246,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.Net.Http.Rtc.dll": {}
+          "ref/netcore50/System.Net.Http.Rtc.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Net.Http.Rtc.dll": {}
@@ -7441,7 +8261,9 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "ref/netcore50/System.Net.NetworkInformation.dll": {}
+          "ref/netcore50/System.Net.NetworkInformation.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Net.NetworkInformation.dll": {}
@@ -7453,7 +8275,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Net.Primitives.dll": {}
+          "ref/dotnet/System.Net.Primitives.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Net.Primitives.dll": {}
@@ -7473,7 +8297,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Net.Requests.dll": {}
+          "ref/dotnet/System.Net.Requests.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Net.Requests.dll": {}
@@ -7485,7 +8311,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Net.Sockets.dll": {}
+          "ref/dotnet/System.Net.Sockets.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Net.Sockets.dll": {}
@@ -7499,7 +8327,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Net.WebHeaderCollection.dll": {}
+          "ref/dotnet/System.Net.WebHeaderCollection.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Net.WebHeaderCollection.dll": {}
@@ -7541,7 +8371,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.ObjectModel.dll": {}
+          "ref/dotnet/System.ObjectModel.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.ObjectModel.dll": {}
@@ -7665,7 +8497,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Reflection.dll": {}
+          "ref/dotnet/System.Reflection.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Reflection.dll": {}
@@ -7678,7 +8512,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.Reflection.Context.dll": {}
+          "ref/netcore50/System.Reflection.Context.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Reflection.Context.dll": {}
@@ -7696,7 +8532,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Reflection.DispatchProxy.dll": {}
+          "ref/dotnet/System.Reflection.DispatchProxy.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Reflection.DispatchProxy.dll": {}
@@ -7711,7 +8549,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Reflection.Emit.dll": {}
+          "ref/dotnet/System.Reflection.Emit.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Reflection.Emit.dll": {}
@@ -7724,7 +8564,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Reflection.Emit.ILGeneration.dll": {}
+          "ref/dotnet/System.Reflection.Emit.ILGeneration.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Reflection.Emit.ILGeneration.dll": {}
@@ -7741,7 +8583,9 @@
           "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Reflection.Extensions.dll": {}
+          "ref/netcore50/System.Reflection.Extensions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Reflection.Extensions.dll": {}
@@ -7765,10 +8609,14 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "lib/dotnet/System.Reflection.Metadata.dll": {}
+          "lib/dotnet/System.Reflection.Metadata.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
-          "lib/dotnet/System.Reflection.Metadata.dll": {}
+          "lib/dotnet/System.Reflection.Metadata.dll": {
+            "related": ".xml"
+          }
         }
       },
       "System.Reflection.Primitives/4.0.0": {
@@ -7777,7 +8625,9 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "ref/netcore50/System.Reflection.Primitives.dll": {}
+          "ref/netcore50/System.Reflection.Primitives.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Reflection.Primitives.dll": {}
@@ -7795,7 +8645,9 @@
           "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Reflection.TypeExtensions.dll": {}
+          "ref/dotnet/System.Reflection.TypeExtensions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Reflection.TypeExtensions.dll": {}
@@ -7808,7 +8660,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.Resources.ResourceManager.dll": {}
+          "ref/netcore50/System.Resources.ResourceManager.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Resources.ResourceManager.dll": {}
@@ -7819,7 +8673,9 @@
           "System.Private.Uri": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Runtime.dll": {}
+          "ref/dotnet/System.Runtime.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Runtime.dll": {}
@@ -7830,7 +8686,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Runtime.Extensions.dll": {}
+          "ref/dotnet/System.Runtime.Extensions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Runtime.Extensions.dll": {}
@@ -7841,7 +8699,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Runtime.Handles.dll": {}
+          "ref/dotnet/System.Runtime.Handles.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Runtime.Handles.dll": {}
@@ -7855,7 +8715,9 @@
           "System.Runtime.Handles": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Runtime.InteropServices.dll": {}
+          "ref/dotnet/System.Runtime.InteropServices.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Runtime.InteropServices.dll": {}
@@ -7863,7 +8725,9 @@
       },
       "System.Runtime.InteropServices.WindowsRuntime/4.0.0": {
         "compile": {
-          "ref/netcore50/System.Runtime.InteropServices.WindowsRuntime.dll": {}
+          "ref/netcore50/System.Runtime.InteropServices.WindowsRuntime.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Runtime.InteropServices.WindowsRuntime.dll": {}
@@ -7877,7 +8741,9 @@
           "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Runtime.Numerics.dll": {}
+          "ref/netcore50/System.Runtime.Numerics.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.Numerics.dll": {}
@@ -7888,7 +8754,9 @@
           "System.Private.DataContractSerialization": "4.0.0"
         },
         "compile": {
-          "ref/netcore50/System.Runtime.Serialization.Json.dll": {}
+          "ref/netcore50/System.Runtime.Serialization.Json.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Runtime.Serialization.Json.dll": {}
@@ -7900,7 +8768,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Runtime.Serialization.Primitives.dll": {}
+          "ref/dotnet/System.Runtime.Serialization.Primitives.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Runtime.Serialization.Primitives.dll": {}
@@ -7912,7 +8782,9 @@
           "System.Runtime.Serialization.Primitives": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Runtime.Serialization.Xml.dll": {}
+          "ref/dotnet/System.Runtime.Serialization.Xml.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Runtime.Serialization.Xml.dll": {}
@@ -7932,7 +8804,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Runtime.WindowsRuntime.dll": {}
+          "ref/netcore50/System.Runtime.WindowsRuntime.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Runtime.WindowsRuntime.dll": {}
@@ -7947,7 +8821,9 @@
           "System.Runtime.WindowsRuntime": "4.0.0"
         },
         "compile": {
-          "ref/netcore50/System.Runtime.WindowsRuntime.UI.Xaml.dll": {}
+          "ref/netcore50/System.Runtime.WindowsRuntime.UI.Xaml.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.WindowsRuntime.UI.Xaml.dll": {}
@@ -7965,7 +8841,9 @@
           "System.Security.Principal": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Security.Claims.dll": {}
+          "ref/dotnet/System.Security.Claims.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Security.Claims.dll": {}
@@ -7976,7 +8854,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/netcore50/System.Security.Principal.dll": {}
+          "ref/netcore50/System.Security.Principal.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Security.Principal.dll": {}
@@ -7988,7 +8868,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.ServiceModel.Duplex.dll": {}
+          "ref/netcore50/System.ServiceModel.Duplex.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.ServiceModel.Duplex.dll": {}
@@ -8000,7 +8882,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.ServiceModel.Http.dll": {}
+          "ref/dotnet/System.ServiceModel.Http.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.ServiceModel.Http.dll": {}
@@ -8012,7 +8896,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.ServiceModel.NetTcp.dll": {}
+          "ref/netcore50/System.ServiceModel.NetTcp.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.ServiceModel.NetTcp.dll": {}
@@ -8024,7 +8910,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.ServiceModel.Primitives.dll": {}
+          "ref/netcore50/System.ServiceModel.Primitives.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.ServiceModel.Primitives.dll": {}
@@ -8036,7 +8924,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.ServiceModel.Security.dll": {}
+          "ref/netcore50/System.ServiceModel.Security.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.ServiceModel.Security.dll": {}
@@ -8047,7 +8937,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Text.Encoding.dll": {}
+          "ref/dotnet/System.Text.Encoding.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.dll": {}
@@ -8068,7 +8960,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Text.Encoding.CodePages.dll": {}
+          "ref/dotnet/System.Text.Encoding.CodePages.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Text.Encoding.CodePages.dll": {}
@@ -8080,7 +8974,9 @@
           "System.Text.Encoding": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Text.Encoding.Extensions.dll": {}
+          "ref/dotnet/System.Text.Encoding.Extensions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.Extensions.dll": {}
@@ -8096,7 +8992,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Text.RegularExpressions.dll": {}
+          "ref/dotnet/System.Text.RegularExpressions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Text.RegularExpressions.dll": {}
@@ -8108,7 +9006,9 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Threading.dll": {}
+          "ref/dotnet/System.Threading.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Threading.dll": {}
@@ -8124,7 +9024,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Threading.Overlapped.dll": {}
+          "ref/dotnet/System.Threading.Overlapped.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Threading.Overlapped.dll": {}
@@ -8135,7 +9037,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Threading.Tasks.dll": {}
+          "ref/dotnet/System.Threading.Tasks.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Threading.Tasks.dll": {}
@@ -8156,10 +9060,14 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "lib/dotnet/System.Threading.Tasks.Dataflow.dll": {}
+          "lib/dotnet/System.Threading.Tasks.Dataflow.dll": {
+            "related": ".XML"
+          }
         },
         "runtime": {
-          "lib/dotnet/System.Threading.Tasks.Dataflow.dll": {}
+          "lib/dotnet/System.Threading.Tasks.Dataflow.dll": {
+            "related": ".XML"
+          }
         }
       },
       "System.Threading.Tasks.Parallel/4.0.0": {
@@ -8174,7 +9082,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Threading.Tasks.Parallel.dll": {}
+          "ref/netcore50/System.Threading.Tasks.Parallel.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Threading.Tasks.Parallel.dll": {}
@@ -8182,7 +9092,9 @@
       },
       "System.Threading.Timer/4.0.0": {
         "compile": {
-          "ref/netcore50/System.Threading.Timer.dll": {}
+          "ref/netcore50/System.Threading.Timer.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Threading.Timer.dll": {}
@@ -8206,7 +9118,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Xml.ReaderWriter.dll": {}
+          "ref/dotnet/System.Xml.ReaderWriter.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Xml.ReaderWriter.dll": {}
@@ -8227,7 +9141,9 @@
           "System.Xml.ReaderWriter": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Xml.XDocument.dll": {}
+          "ref/dotnet/System.Xml.XDocument.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Xml.XDocument.dll": {}
@@ -8247,7 +9163,9 @@
           "System.Xml.ReaderWriter": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Xml.XmlDocument.dll": {}
+          "ref/dotnet/System.Xml.XmlDocument.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Xml.XmlDocument.dll": {}
@@ -8275,7 +9193,9 @@
           "System.Xml.XmlDocument": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Xml.XmlSerializer.dll": {}
+          "ref/dotnet/System.Xml.XmlSerializer.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Xml.XmlSerializer.dll": {}
@@ -8303,7 +9223,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/Microsoft.CSharp.dll": {}
+          "ref/netcore50/Microsoft.CSharp.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/Microsoft.CSharp.dll": {}
@@ -8380,12 +9302,18 @@
           "ref/netcore50/System.Numerics.dll": {},
           "ref/netcore50/System.Runtime.Serialization.dll": {},
           "ref/netcore50/System.ServiceModel.Web.dll": {},
-          "ref/netcore50/System.ServiceModel.dll": {},
+          "ref/netcore50/System.ServiceModel.dll": {
+            "related": ".Web.dll"
+          },
           "ref/netcore50/System.Windows.dll": {},
           "ref/netcore50/System.Xml.Linq.dll": {},
           "ref/netcore50/System.Xml.Serialization.dll": {},
-          "ref/netcore50/System.Xml.dll": {},
-          "ref/netcore50/System.dll": {},
+          "ref/netcore50/System.Xml.dll": {
+            "related": ".Linq.dll;.Serialization.dll"
+          },
+          "ref/netcore50/System.dll": {
+            "related": ".ComponentModel.DataAnnotations.dll;.Core.dll;.Net.dll;.Numerics.dll;.Runtime.Serialization.dll;.ServiceModel.dll;.ServiceModel.Web.dll;.Windows.dll;.Xml.dll;.Xml.Linq.dll;.Xml.Serialization.dll"
+          },
           "ref/netcore50/mscorlib.dll": {}
         },
         "runtime": {
@@ -8395,12 +9323,18 @@
           "lib/netcore50/System.Numerics.dll": {},
           "lib/netcore50/System.Runtime.Serialization.dll": {},
           "lib/netcore50/System.ServiceModel.Web.dll": {},
-          "lib/netcore50/System.ServiceModel.dll": {},
+          "lib/netcore50/System.ServiceModel.dll": {
+            "related": ".Web.dll"
+          },
           "lib/netcore50/System.Windows.dll": {},
           "lib/netcore50/System.Xml.Linq.dll": {},
           "lib/netcore50/System.Xml.Serialization.dll": {},
-          "lib/netcore50/System.Xml.dll": {},
-          "lib/netcore50/System.dll": {}
+          "lib/netcore50/System.Xml.dll": {
+            "related": ".Linq.dll;.Serialization.dll"
+          },
+          "lib/netcore50/System.dll": {
+            "related": ".ComponentModel.DataAnnotations.dll;.Core.dll;.Net.dll;.Numerics.dll;.Runtime.Serialization.dll;.ServiceModel.dll;.ServiceModel.Web.dll;.Windows.dll;.Xml.dll;.Xml.Linq.dll;.Xml.Serialization.dll"
+          }
         }
       },
       "Microsoft.NETCore.Runtime/1.0.0": {
@@ -8516,7 +9450,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/Microsoft.VisualBasic.dll": {}
+          "ref/netcore50/Microsoft.VisualBasic.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/Microsoft.VisualBasic.dll": {}
@@ -8528,7 +9464,9 @@
           "System.Runtime.InteropServices": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/Microsoft.Win32.Primitives.dll": {}
+          "ref/dotnet/Microsoft.Win32.Primitives.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/Microsoft.Win32.Primitives.dll": {}
@@ -8542,7 +9480,9 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.AppContext.dll": {}
+          "ref/dotnet/System.AppContext.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.AppContext.dll": {}
@@ -8557,7 +9497,9 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Collections.dll": {}
+          "ref/dotnet/System.Collections.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Collections.dll": {}
@@ -8576,7 +9518,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Collections.Concurrent.dll": {}
+          "ref/dotnet/System.Collections.Concurrent.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Collections.Concurrent.dll": {}
@@ -8594,10 +9538,14 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "lib/dotnet/System.Collections.Immutable.dll": {}
+          "lib/dotnet/System.Collections.Immutable.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
-          "lib/dotnet/System.Collections.Immutable.dll": {}
+          "lib/dotnet/System.Collections.Immutable.dll": {
+            "related": ".xml"
+          }
         }
       },
       "System.Collections.NonGeneric/4.0.0": {
@@ -8610,7 +9558,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Collections.NonGeneric.dll": {}
+          "ref/dotnet/System.Collections.NonGeneric.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Collections.NonGeneric.dll": {}
@@ -8627,7 +9577,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Collections.Specialized.dll": {}
+          "ref/dotnet/System.Collections.Specialized.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Collections.Specialized.dll": {}
@@ -8638,7 +9590,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.ComponentModel.dll": {}
+          "ref/netcore50/System.ComponentModel.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.ComponentModel.dll": {}
@@ -8659,7 +9613,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.ComponentModel.Annotations.dll": {}
+          "ref/dotnet/System.ComponentModel.Annotations.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.ComponentModel.Annotations.dll": {}
@@ -8673,7 +9629,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.ComponentModel.EventBasedAsync.dll": {}
+          "ref/dotnet/System.ComponentModel.EventBasedAsync.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.ComponentModel.EventBasedAsync.dll": {}
@@ -8692,7 +9650,9 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Data.Common.dll": {}
+          "ref/dotnet/System.Data.Common.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Data.Common.dll": {}
@@ -8700,7 +9660,9 @@
       },
       "System.Diagnostics.Contracts/4.0.0": {
         "compile": {
-          "ref/netcore50/System.Diagnostics.Contracts.dll": {}
+          "ref/netcore50/System.Diagnostics.Contracts.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Diagnostics.Contracts.dll": {}
@@ -8711,7 +9673,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Diagnostics.Debug.dll": {}
+          "ref/dotnet/System.Diagnostics.Debug.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Diagnostics.Debug.dll": {}
@@ -8722,7 +9686,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Diagnostics.StackTrace.dll": {}
+          "ref/dotnet/System.Diagnostics.StackTrace.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Diagnostics.StackTrace.dll": {}
@@ -8730,7 +9696,9 @@
       },
       "System.Diagnostics.Tools/4.0.0": {
         "compile": {
-          "ref/netcore50/System.Diagnostics.Tools.dll": {}
+          "ref/netcore50/System.Diagnostics.Tools.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Diagnostics.Tools.dll": {}
@@ -8750,7 +9718,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Diagnostics.Tracing.dll": {}
+          "ref/dotnet/System.Diagnostics.Tracing.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Diagnostics.Tracing.dll": {}
@@ -8774,7 +9744,9 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Dynamic.Runtime.dll": {}
+          "ref/dotnet/System.Dynamic.Runtime.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Dynamic.Runtime.dll": {}
@@ -8785,7 +9757,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Globalization.dll": {}
+          "ref/dotnet/System.Globalization.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Globalization.dll": {}
@@ -8797,7 +9771,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Globalization.Calendars.dll": {}
+          "ref/dotnet/System.Globalization.Calendars.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Globalization.Calendars.dll": {}
@@ -8812,7 +9788,9 @@
           "System.Runtime.InteropServices": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Globalization.Extensions.dll": {}
+          "ref/dotnet/System.Globalization.Extensions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Globalization.Extensions.dll": {}
@@ -8828,7 +9806,9 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.IO.dll": {}
+          "ref/dotnet/System.IO.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.IO.dll": {}
@@ -8848,7 +9828,9 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "ref/netcore50/System.IO.Compression.dll": {}
+          "ref/netcore50/System.IO.Compression.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.IO.Compression.dll": {}
@@ -8871,7 +9853,9 @@
           "System.Text.Encoding": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.IO.Compression.ZipFile.dll": {}
+          "ref/dotnet/System.IO.Compression.ZipFile.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.IO.Compression.ZipFile.dll": {}
@@ -8896,7 +9880,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.IO.FileSystem.dll": {}
+          "ref/dotnet/System.IO.FileSystem.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.IO.FileSystem.dll": {}
@@ -8907,7 +9893,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.IO.FileSystem.Primitives.dll": {}
+          "ref/dotnet/System.IO.FileSystem.Primitives.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.IO.FileSystem.Primitives.dll": {}
@@ -8926,7 +9914,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.IO.IsolatedStorage.dll": {}
+          "ref/dotnet/System.IO.IsolatedStorage.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.IO.IsolatedStorage.dll": {}
@@ -8943,7 +9933,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.IO.UnmanagedMemoryStream.dll": {}
+          "ref/dotnet/System.IO.UnmanagedMemoryStream.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.IO.UnmanagedMemoryStream.dll": {}
@@ -8958,7 +9950,9 @@
           "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Linq.dll": {}
+          "ref/netcore50/System.Linq.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Linq.dll": {}
@@ -8983,7 +9977,9 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Linq.Expressions.dll": {}
+          "ref/dotnet/System.Linq.Expressions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Linq.Expressions.dll": {}
@@ -9003,7 +9999,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Linq.Parallel.dll": {}
+          "ref/netcore50/System.Linq.Parallel.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Linq.Parallel.dll": {}
@@ -9020,7 +10018,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.Linq.Queryable.dll": {}
+          "ref/netcore50/System.Linq.Queryable.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Linq.Queryable.dll": {}
@@ -9044,7 +10044,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Net.Http.dll": {}
+          "ref/netcore50/System.Net.Http.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Net.Http.dll": {}
@@ -9056,7 +10058,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.Net.Http.Rtc.dll": {}
+          "ref/netcore50/System.Net.Http.Rtc.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Net.Http.Rtc.dll": {}
@@ -9069,7 +10073,9 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "ref/netcore50/System.Net.NetworkInformation.dll": {}
+          "ref/netcore50/System.Net.NetworkInformation.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Net.NetworkInformation.dll": {}
@@ -9081,7 +10087,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Net.Primitives.dll": {}
+          "ref/dotnet/System.Net.Primitives.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Net.Primitives.dll": {}
@@ -9101,7 +10109,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Net.Requests.dll": {}
+          "ref/dotnet/System.Net.Requests.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Net.Requests.dll": {}
@@ -9113,7 +10123,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Net.Sockets.dll": {}
+          "ref/dotnet/System.Net.Sockets.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Net.Sockets.dll": {}
@@ -9127,7 +10139,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Net.WebHeaderCollection.dll": {}
+          "ref/dotnet/System.Net.WebHeaderCollection.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Net.WebHeaderCollection.dll": {}
@@ -9169,7 +10183,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.ObjectModel.dll": {}
+          "ref/dotnet/System.ObjectModel.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.ObjectModel.dll": {}
@@ -9295,7 +10311,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Reflection.dll": {}
+          "ref/dotnet/System.Reflection.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Reflection.dll": {}
@@ -9308,7 +10326,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.Reflection.Context.dll": {}
+          "ref/netcore50/System.Reflection.Context.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Reflection.Context.dll": {}
@@ -9328,7 +10348,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Reflection.DispatchProxy.dll": {}
+          "ref/dotnet/System.Reflection.DispatchProxy.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Reflection.DispatchProxy.dll": {}
@@ -9343,7 +10365,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Reflection.Emit.dll": {}
+          "ref/dotnet/System.Reflection.Emit.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Reflection.Emit.dll": {}
@@ -9356,7 +10380,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Reflection.Emit.ILGeneration.dll": {}
+          "ref/dotnet/System.Reflection.Emit.ILGeneration.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Reflection.Emit.ILGeneration.dll": {}
@@ -9370,7 +10396,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Reflection.Emit.Lightweight.dll": {}
+          "ref/dotnet/System.Reflection.Emit.Lightweight.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Reflection.Emit.Lightweight.dll": {}
@@ -9387,7 +10415,9 @@
           "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Reflection.Extensions.dll": {}
+          "ref/netcore50/System.Reflection.Extensions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Reflection.Extensions.dll": {}
@@ -9411,10 +10441,14 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "lib/dotnet/System.Reflection.Metadata.dll": {}
+          "lib/dotnet/System.Reflection.Metadata.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
-          "lib/dotnet/System.Reflection.Metadata.dll": {}
+          "lib/dotnet/System.Reflection.Metadata.dll": {
+            "related": ".xml"
+          }
         }
       },
       "System.Reflection.Primitives/4.0.0": {
@@ -9423,7 +10457,9 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "ref/netcore50/System.Reflection.Primitives.dll": {}
+          "ref/netcore50/System.Reflection.Primitives.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Reflection.Primitives.dll": {}
@@ -9441,7 +10477,9 @@
           "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Reflection.TypeExtensions.dll": {}
+          "ref/dotnet/System.Reflection.TypeExtensions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Reflection.TypeExtensions.dll": {}
@@ -9454,7 +10492,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.Resources.ResourceManager.dll": {}
+          "ref/netcore50/System.Resources.ResourceManager.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Resources.ResourceManager.dll": {}
@@ -9465,7 +10505,9 @@
           "System.Private.Uri": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Runtime.dll": {}
+          "ref/dotnet/System.Runtime.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.dll": {}
@@ -9476,7 +10518,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Runtime.Extensions.dll": {}
+          "ref/dotnet/System.Runtime.Extensions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.Extensions.dll": {}
@@ -9487,7 +10531,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Runtime.Handles.dll": {}
+          "ref/dotnet/System.Runtime.Handles.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.Handles.dll": {}
@@ -9501,7 +10547,9 @@
           "System.Runtime.Handles": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Runtime.InteropServices.dll": {}
+          "ref/dotnet/System.Runtime.InteropServices.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.InteropServices.dll": {}
@@ -9509,7 +10557,9 @@
       },
       "System.Runtime.InteropServices.WindowsRuntime/4.0.0": {
         "compile": {
-          "ref/netcore50/System.Runtime.InteropServices.WindowsRuntime.dll": {}
+          "ref/netcore50/System.Runtime.InteropServices.WindowsRuntime.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.InteropServices.WindowsRuntime.dll": {}
@@ -9523,7 +10573,9 @@
           "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Runtime.Numerics.dll": {}
+          "ref/netcore50/System.Runtime.Numerics.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.Numerics.dll": {}
@@ -9534,7 +10586,9 @@
           "System.Private.DataContractSerialization": "4.0.0"
         },
         "compile": {
-          "ref/netcore50/System.Runtime.Serialization.Json.dll": {}
+          "ref/netcore50/System.Runtime.Serialization.Json.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.Serialization.Json.dll": {}
@@ -9546,7 +10600,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Runtime.Serialization.Primitives.dll": {}
+          "ref/dotnet/System.Runtime.Serialization.Primitives.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Runtime.Serialization.Primitives.dll": {}
@@ -9558,7 +10614,9 @@
           "System.Runtime.Serialization.Primitives": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Runtime.Serialization.Xml.dll": {}
+          "ref/dotnet/System.Runtime.Serialization.Xml.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.Serialization.Xml.dll": {}
@@ -9578,7 +10636,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Runtime.WindowsRuntime.dll": {}
+          "ref/netcore50/System.Runtime.WindowsRuntime.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.WindowsRuntime.dll": {}
@@ -9593,7 +10653,9 @@
           "System.Runtime.WindowsRuntime": "4.0.0"
         },
         "compile": {
-          "ref/netcore50/System.Runtime.WindowsRuntime.UI.Xaml.dll": {}
+          "ref/netcore50/System.Runtime.WindowsRuntime.UI.Xaml.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.WindowsRuntime.UI.Xaml.dll": {}
@@ -9611,7 +10673,9 @@
           "System.Security.Principal": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Security.Claims.dll": {}
+          "ref/dotnet/System.Security.Claims.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Security.Claims.dll": {}
@@ -9622,7 +10686,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/netcore50/System.Security.Principal.dll": {}
+          "ref/netcore50/System.Security.Principal.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Security.Principal.dll": {}
@@ -9634,7 +10700,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.ServiceModel.Duplex.dll": {}
+          "ref/netcore50/System.ServiceModel.Duplex.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.ServiceModel.Duplex.dll": {}
@@ -9646,7 +10714,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.ServiceModel.Http.dll": {}
+          "ref/dotnet/System.ServiceModel.Http.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.ServiceModel.Http.dll": {}
@@ -9658,7 +10728,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.ServiceModel.NetTcp.dll": {}
+          "ref/netcore50/System.ServiceModel.NetTcp.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.ServiceModel.NetTcp.dll": {}
@@ -9670,7 +10742,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.ServiceModel.Primitives.dll": {}
+          "ref/netcore50/System.ServiceModel.Primitives.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.ServiceModel.Primitives.dll": {}
@@ -9682,7 +10756,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.ServiceModel.Security.dll": {}
+          "ref/netcore50/System.ServiceModel.Security.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.ServiceModel.Security.dll": {}
@@ -9693,7 +10769,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Text.Encoding.dll": {}
+          "ref/dotnet/System.Text.Encoding.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Text.Encoding.dll": {}
@@ -9714,7 +10792,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Text.Encoding.CodePages.dll": {}
+          "ref/dotnet/System.Text.Encoding.CodePages.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Text.Encoding.CodePages.dll": {}
@@ -9726,7 +10806,9 @@
           "System.Text.Encoding": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Text.Encoding.Extensions.dll": {}
+          "ref/dotnet/System.Text.Encoding.Extensions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Text.Encoding.Extensions.dll": {}
@@ -9742,7 +10824,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Text.RegularExpressions.dll": {}
+          "ref/dotnet/System.Text.RegularExpressions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Text.RegularExpressions.dll": {}
@@ -9754,7 +10838,9 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Threading.dll": {}
+          "ref/dotnet/System.Threading.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Threading.dll": {}
@@ -9770,7 +10856,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Threading.Overlapped.dll": {}
+          "ref/dotnet/System.Threading.Overlapped.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Threading.Overlapped.dll": {}
@@ -9781,7 +10869,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Threading.Tasks.dll": {}
+          "ref/dotnet/System.Threading.Tasks.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Threading.Tasks.dll": {}
@@ -9802,10 +10892,14 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "lib/dotnet/System.Threading.Tasks.Dataflow.dll": {}
+          "lib/dotnet/System.Threading.Tasks.Dataflow.dll": {
+            "related": ".XML"
+          }
         },
         "runtime": {
-          "lib/dotnet/System.Threading.Tasks.Dataflow.dll": {}
+          "lib/dotnet/System.Threading.Tasks.Dataflow.dll": {
+            "related": ".XML"
+          }
         }
       },
       "System.Threading.Tasks.Parallel/4.0.0": {
@@ -9820,7 +10914,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Threading.Tasks.Parallel.dll": {}
+          "ref/netcore50/System.Threading.Tasks.Parallel.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Threading.Tasks.Parallel.dll": {}
@@ -9828,7 +10924,9 @@
       },
       "System.Threading.Timer/4.0.0": {
         "compile": {
-          "ref/netcore50/System.Threading.Timer.dll": {}
+          "ref/netcore50/System.Threading.Timer.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Threading.Timer.dll": {}
@@ -9852,7 +10950,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Xml.ReaderWriter.dll": {}
+          "ref/dotnet/System.Xml.ReaderWriter.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Xml.ReaderWriter.dll": {}
@@ -9873,7 +10973,9 @@
           "System.Xml.ReaderWriter": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Xml.XDocument.dll": {}
+          "ref/dotnet/System.Xml.XDocument.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Xml.XDocument.dll": {}
@@ -9893,7 +10995,9 @@
           "System.Xml.ReaderWriter": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Xml.XmlDocument.dll": {}
+          "ref/dotnet/System.Xml.XmlDocument.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Xml.XmlDocument.dll": {}
@@ -9921,7 +11025,9 @@
           "System.Xml.XmlDocument": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Xml.XmlSerializer.dll": {}
+          "ref/dotnet/System.Xml.XmlSerializer.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Xml.XmlSerializer.dll": {}
@@ -9949,7 +11055,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/Microsoft.CSharp.dll": {}
+          "ref/netcore50/Microsoft.CSharp.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/Microsoft.CSharp.dll": {}
@@ -10026,12 +11134,18 @@
           "ref/netcore50/System.Numerics.dll": {},
           "ref/netcore50/System.Runtime.Serialization.dll": {},
           "ref/netcore50/System.ServiceModel.Web.dll": {},
-          "ref/netcore50/System.ServiceModel.dll": {},
+          "ref/netcore50/System.ServiceModel.dll": {
+            "related": ".Web.dll"
+          },
           "ref/netcore50/System.Windows.dll": {},
           "ref/netcore50/System.Xml.Linq.dll": {},
           "ref/netcore50/System.Xml.Serialization.dll": {},
-          "ref/netcore50/System.Xml.dll": {},
-          "ref/netcore50/System.dll": {},
+          "ref/netcore50/System.Xml.dll": {
+            "related": ".Linq.dll;.Serialization.dll"
+          },
+          "ref/netcore50/System.dll": {
+            "related": ".ComponentModel.DataAnnotations.dll;.Core.dll;.Net.dll;.Numerics.dll;.Runtime.Serialization.dll;.ServiceModel.dll;.ServiceModel.Web.dll;.Windows.dll;.Xml.dll;.Xml.Linq.dll;.Xml.Serialization.dll"
+          },
           "ref/netcore50/mscorlib.dll": {}
         },
         "runtime": {
@@ -10041,12 +11155,18 @@
           "runtimes/aot/lib/netcore50/System.Numerics.dll": {},
           "runtimes/aot/lib/netcore50/System.Runtime.Serialization.dll": {},
           "runtimes/aot/lib/netcore50/System.ServiceModel.Web.dll": {},
-          "runtimes/aot/lib/netcore50/System.ServiceModel.dll": {},
+          "runtimes/aot/lib/netcore50/System.ServiceModel.dll": {
+            "related": ".Web.dll"
+          },
           "runtimes/aot/lib/netcore50/System.Windows.dll": {},
           "runtimes/aot/lib/netcore50/System.Xml.Linq.dll": {},
           "runtimes/aot/lib/netcore50/System.Xml.Serialization.dll": {},
-          "runtimes/aot/lib/netcore50/System.Xml.dll": {},
-          "runtimes/aot/lib/netcore50/System.dll": {},
+          "runtimes/aot/lib/netcore50/System.Xml.dll": {
+            "related": ".Linq.dll;.Serialization.dll"
+          },
+          "runtimes/aot/lib/netcore50/System.dll": {
+            "related": ".ComponentModel.DataAnnotations.dll;.Core.dll;.Net.dll;.Numerics.dll;.Runtime.Serialization.dll;.ServiceModel.dll;.ServiceModel.Web.dll;.Windows.dll;.Xml.dll;.Xml.Linq.dll;.Xml.Serialization.dll"
+          },
           "runtimes/aot/lib/netcore50/mscorlib.dll": {}
         }
       },
@@ -10142,7 +11262,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/Microsoft.VisualBasic.dll": {}
+          "ref/netcore50/Microsoft.VisualBasic.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/Microsoft.VisualBasic.dll": {}
@@ -10154,7 +11276,9 @@
           "System.Runtime.InteropServices": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/Microsoft.Win32.Primitives.dll": {}
+          "ref/dotnet/Microsoft.Win32.Primitives.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/Microsoft.Win32.Primitives.dll": {}
@@ -10168,7 +11292,9 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.AppContext.dll": {}
+          "ref/dotnet/System.AppContext.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.AppContext.dll": {}
@@ -10183,7 +11309,9 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Collections.dll": {}
+          "ref/dotnet/System.Collections.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Collections.dll": {}
@@ -10202,7 +11330,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Collections.Concurrent.dll": {}
+          "ref/dotnet/System.Collections.Concurrent.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Collections.Concurrent.dll": {}
@@ -10220,10 +11350,14 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "lib/dotnet/System.Collections.Immutable.dll": {}
+          "lib/dotnet/System.Collections.Immutable.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
-          "lib/dotnet/System.Collections.Immutable.dll": {}
+          "lib/dotnet/System.Collections.Immutable.dll": {
+            "related": ".xml"
+          }
         }
       },
       "System.Collections.NonGeneric/4.0.0": {
@@ -10236,7 +11370,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Collections.NonGeneric.dll": {}
+          "ref/dotnet/System.Collections.NonGeneric.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Collections.NonGeneric.dll": {}
@@ -10253,7 +11389,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Collections.Specialized.dll": {}
+          "ref/dotnet/System.Collections.Specialized.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Collections.Specialized.dll": {}
@@ -10264,7 +11402,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.ComponentModel.dll": {}
+          "ref/netcore50/System.ComponentModel.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.ComponentModel.dll": {}
@@ -10285,7 +11425,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.ComponentModel.Annotations.dll": {}
+          "ref/dotnet/System.ComponentModel.Annotations.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.ComponentModel.Annotations.dll": {}
@@ -10299,7 +11441,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.ComponentModel.EventBasedAsync.dll": {}
+          "ref/dotnet/System.ComponentModel.EventBasedAsync.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.ComponentModel.EventBasedAsync.dll": {}
@@ -10318,7 +11462,9 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Data.Common.dll": {}
+          "ref/dotnet/System.Data.Common.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Data.Common.dll": {}
@@ -10326,7 +11472,9 @@
       },
       "System.Diagnostics.Contracts/4.0.0": {
         "compile": {
-          "ref/netcore50/System.Diagnostics.Contracts.dll": {}
+          "ref/netcore50/System.Diagnostics.Contracts.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Contracts.dll": {}
@@ -10337,7 +11485,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Diagnostics.Debug.dll": {}
+          "ref/dotnet/System.Diagnostics.Debug.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Debug.dll": {}
@@ -10348,7 +11498,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Diagnostics.StackTrace.dll": {}
+          "ref/dotnet/System.Diagnostics.StackTrace.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Diagnostics.StackTrace.dll": {}
@@ -10356,7 +11508,9 @@
       },
       "System.Diagnostics.Tools/4.0.0": {
         "compile": {
-          "ref/netcore50/System.Diagnostics.Tools.dll": {}
+          "ref/netcore50/System.Diagnostics.Tools.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tools.dll": {}
@@ -10376,7 +11530,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Diagnostics.Tracing.dll": {}
+          "ref/dotnet/System.Diagnostics.Tracing.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tracing.dll": {}
@@ -10398,7 +11554,9 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Dynamic.Runtime.dll": {}
+          "ref/dotnet/System.Dynamic.Runtime.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Dynamic.Runtime.dll": {}
@@ -10409,7 +11567,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Globalization.dll": {}
+          "ref/dotnet/System.Globalization.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Globalization.dll": {}
@@ -10421,7 +11581,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Globalization.Calendars.dll": {}
+          "ref/dotnet/System.Globalization.Calendars.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Globalization.Calendars.dll": {}
@@ -10436,7 +11598,9 @@
           "System.Runtime.InteropServices": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Globalization.Extensions.dll": {}
+          "ref/dotnet/System.Globalization.Extensions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Globalization.Extensions.dll": {}
@@ -10452,7 +11616,9 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.IO.dll": {}
+          "ref/dotnet/System.IO.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.IO.dll": {}
@@ -10472,7 +11638,9 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "ref/netcore50/System.IO.Compression.dll": {}
+          "ref/netcore50/System.IO.Compression.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.IO.Compression.dll": {}
@@ -10495,7 +11663,9 @@
           "System.Text.Encoding": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.IO.Compression.ZipFile.dll": {}
+          "ref/dotnet/System.IO.Compression.ZipFile.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.IO.Compression.ZipFile.dll": {}
@@ -10520,7 +11690,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.IO.FileSystem.dll": {}
+          "ref/dotnet/System.IO.FileSystem.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.IO.FileSystem.dll": {}
@@ -10531,7 +11703,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.IO.FileSystem.Primitives.dll": {}
+          "ref/dotnet/System.IO.FileSystem.Primitives.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.IO.FileSystem.Primitives.dll": {}
@@ -10550,7 +11724,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.IO.IsolatedStorage.dll": {}
+          "ref/dotnet/System.IO.IsolatedStorage.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.IO.IsolatedStorage.dll": {}
@@ -10567,7 +11743,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.IO.UnmanagedMemoryStream.dll": {}
+          "ref/dotnet/System.IO.UnmanagedMemoryStream.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.IO.UnmanagedMemoryStream.dll": {}
@@ -10582,7 +11760,9 @@
           "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Linq.dll": {}
+          "ref/netcore50/System.Linq.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Linq.dll": {}
@@ -10605,7 +11785,9 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Linq.Expressions.dll": {}
+          "ref/dotnet/System.Linq.Expressions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Linq.Expressions.dll": {}
@@ -10625,7 +11807,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Linq.Parallel.dll": {}
+          "ref/netcore50/System.Linq.Parallel.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Linq.Parallel.dll": {}
@@ -10642,7 +11826,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.Linq.Queryable.dll": {}
+          "ref/netcore50/System.Linq.Queryable.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Linq.Queryable.dll": {}
@@ -10666,7 +11852,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Net.Http.dll": {}
+          "ref/netcore50/System.Net.Http.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Net.Http.dll": {}
@@ -10678,7 +11866,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.Net.Http.Rtc.dll": {}
+          "ref/netcore50/System.Net.Http.Rtc.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Net.Http.Rtc.dll": {}
@@ -10691,7 +11881,9 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "ref/netcore50/System.Net.NetworkInformation.dll": {}
+          "ref/netcore50/System.Net.NetworkInformation.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Net.NetworkInformation.dll": {}
@@ -10703,7 +11895,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Net.Primitives.dll": {}
+          "ref/dotnet/System.Net.Primitives.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Net.Primitives.dll": {}
@@ -10723,7 +11917,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Net.Requests.dll": {}
+          "ref/dotnet/System.Net.Requests.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Net.Requests.dll": {}
@@ -10735,7 +11931,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Net.Sockets.dll": {}
+          "ref/dotnet/System.Net.Sockets.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Net.Sockets.dll": {}
@@ -10749,7 +11947,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Net.WebHeaderCollection.dll": {}
+          "ref/dotnet/System.Net.WebHeaderCollection.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Net.WebHeaderCollection.dll": {}
@@ -10791,7 +11991,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.ObjectModel.dll": {}
+          "ref/dotnet/System.ObjectModel.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.ObjectModel.dll": {}
@@ -10915,7 +12117,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Reflection.dll": {}
+          "ref/dotnet/System.Reflection.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Reflection.dll": {}
@@ -10928,7 +12132,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.Reflection.Context.dll": {}
+          "ref/netcore50/System.Reflection.Context.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Reflection.Context.dll": {}
@@ -10946,7 +12152,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Reflection.DispatchProxy.dll": {}
+          "ref/dotnet/System.Reflection.DispatchProxy.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Reflection.DispatchProxy.dll": {}
@@ -10961,7 +12169,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Reflection.Emit.dll": {}
+          "ref/dotnet/System.Reflection.Emit.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Reflection.Emit.dll": {}
@@ -10974,7 +12184,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Reflection.Emit.ILGeneration.dll": {}
+          "ref/dotnet/System.Reflection.Emit.ILGeneration.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Reflection.Emit.ILGeneration.dll": {}
@@ -10991,7 +12203,9 @@
           "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Reflection.Extensions.dll": {}
+          "ref/netcore50/System.Reflection.Extensions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Reflection.Extensions.dll": {}
@@ -11015,10 +12229,14 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "lib/dotnet/System.Reflection.Metadata.dll": {}
+          "lib/dotnet/System.Reflection.Metadata.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
-          "lib/dotnet/System.Reflection.Metadata.dll": {}
+          "lib/dotnet/System.Reflection.Metadata.dll": {
+            "related": ".xml"
+          }
         }
       },
       "System.Reflection.Primitives/4.0.0": {
@@ -11027,7 +12245,9 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "ref/netcore50/System.Reflection.Primitives.dll": {}
+          "ref/netcore50/System.Reflection.Primitives.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Reflection.Primitives.dll": {}
@@ -11045,7 +12265,9 @@
           "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Reflection.TypeExtensions.dll": {}
+          "ref/dotnet/System.Reflection.TypeExtensions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Reflection.TypeExtensions.dll": {}
@@ -11058,7 +12280,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.Resources.ResourceManager.dll": {}
+          "ref/netcore50/System.Resources.ResourceManager.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Resources.ResourceManager.dll": {}
@@ -11069,7 +12293,9 @@
           "System.Private.Uri": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Runtime.dll": {}
+          "ref/dotnet/System.Runtime.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Runtime.dll": {}
@@ -11080,7 +12306,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Runtime.Extensions.dll": {}
+          "ref/dotnet/System.Runtime.Extensions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Runtime.Extensions.dll": {}
@@ -11091,7 +12319,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Runtime.Handles.dll": {}
+          "ref/dotnet/System.Runtime.Handles.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Runtime.Handles.dll": {}
@@ -11105,7 +12335,9 @@
           "System.Runtime.Handles": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Runtime.InteropServices.dll": {}
+          "ref/dotnet/System.Runtime.InteropServices.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Runtime.InteropServices.dll": {}
@@ -11113,7 +12345,9 @@
       },
       "System.Runtime.InteropServices.WindowsRuntime/4.0.0": {
         "compile": {
-          "ref/netcore50/System.Runtime.InteropServices.WindowsRuntime.dll": {}
+          "ref/netcore50/System.Runtime.InteropServices.WindowsRuntime.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Runtime.InteropServices.WindowsRuntime.dll": {}
@@ -11127,7 +12361,9 @@
           "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Runtime.Numerics.dll": {}
+          "ref/netcore50/System.Runtime.Numerics.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.Numerics.dll": {}
@@ -11138,7 +12374,9 @@
           "System.Private.DataContractSerialization": "4.0.0"
         },
         "compile": {
-          "ref/netcore50/System.Runtime.Serialization.Json.dll": {}
+          "ref/netcore50/System.Runtime.Serialization.Json.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Runtime.Serialization.Json.dll": {}
@@ -11150,7 +12388,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Runtime.Serialization.Primitives.dll": {}
+          "ref/dotnet/System.Runtime.Serialization.Primitives.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Runtime.Serialization.Primitives.dll": {}
@@ -11162,7 +12402,9 @@
           "System.Runtime.Serialization.Primitives": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Runtime.Serialization.Xml.dll": {}
+          "ref/dotnet/System.Runtime.Serialization.Xml.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Runtime.Serialization.Xml.dll": {}
@@ -11182,7 +12424,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Runtime.WindowsRuntime.dll": {}
+          "ref/netcore50/System.Runtime.WindowsRuntime.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Runtime.WindowsRuntime.dll": {}
@@ -11197,7 +12441,9 @@
           "System.Runtime.WindowsRuntime": "4.0.0"
         },
         "compile": {
-          "ref/netcore50/System.Runtime.WindowsRuntime.UI.Xaml.dll": {}
+          "ref/netcore50/System.Runtime.WindowsRuntime.UI.Xaml.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.WindowsRuntime.UI.Xaml.dll": {}
@@ -11215,7 +12461,9 @@
           "System.Security.Principal": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Security.Claims.dll": {}
+          "ref/dotnet/System.Security.Claims.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Security.Claims.dll": {}
@@ -11226,7 +12474,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/netcore50/System.Security.Principal.dll": {}
+          "ref/netcore50/System.Security.Principal.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Security.Principal.dll": {}
@@ -11238,7 +12488,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.ServiceModel.Duplex.dll": {}
+          "ref/netcore50/System.ServiceModel.Duplex.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.ServiceModel.Duplex.dll": {}
@@ -11250,7 +12502,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.ServiceModel.Http.dll": {}
+          "ref/dotnet/System.ServiceModel.Http.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.ServiceModel.Http.dll": {}
@@ -11262,7 +12516,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.ServiceModel.NetTcp.dll": {}
+          "ref/netcore50/System.ServiceModel.NetTcp.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.ServiceModel.NetTcp.dll": {}
@@ -11274,7 +12530,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.ServiceModel.Primitives.dll": {}
+          "ref/netcore50/System.ServiceModel.Primitives.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.ServiceModel.Primitives.dll": {}
@@ -11286,7 +12544,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.ServiceModel.Security.dll": {}
+          "ref/netcore50/System.ServiceModel.Security.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.ServiceModel.Security.dll": {}
@@ -11297,7 +12557,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Text.Encoding.dll": {}
+          "ref/dotnet/System.Text.Encoding.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.dll": {}
@@ -11318,7 +12580,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Text.Encoding.CodePages.dll": {}
+          "ref/dotnet/System.Text.Encoding.CodePages.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Text.Encoding.CodePages.dll": {}
@@ -11330,7 +12594,9 @@
           "System.Text.Encoding": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Text.Encoding.Extensions.dll": {}
+          "ref/dotnet/System.Text.Encoding.Extensions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.Extensions.dll": {}
@@ -11346,7 +12612,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Text.RegularExpressions.dll": {}
+          "ref/dotnet/System.Text.RegularExpressions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Text.RegularExpressions.dll": {}
@@ -11358,7 +12626,9 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Threading.dll": {}
+          "ref/dotnet/System.Threading.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Threading.dll": {}
@@ -11374,7 +12644,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Threading.Overlapped.dll": {}
+          "ref/dotnet/System.Threading.Overlapped.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Threading.Overlapped.dll": {}
@@ -11385,7 +12657,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Threading.Tasks.dll": {}
+          "ref/dotnet/System.Threading.Tasks.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Threading.Tasks.dll": {}
@@ -11406,10 +12680,14 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "lib/dotnet/System.Threading.Tasks.Dataflow.dll": {}
+          "lib/dotnet/System.Threading.Tasks.Dataflow.dll": {
+            "related": ".XML"
+          }
         },
         "runtime": {
-          "lib/dotnet/System.Threading.Tasks.Dataflow.dll": {}
+          "lib/dotnet/System.Threading.Tasks.Dataflow.dll": {
+            "related": ".XML"
+          }
         }
       },
       "System.Threading.Tasks.Parallel/4.0.0": {
@@ -11424,7 +12702,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Threading.Tasks.Parallel.dll": {}
+          "ref/netcore50/System.Threading.Tasks.Parallel.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Threading.Tasks.Parallel.dll": {}
@@ -11432,7 +12712,9 @@
       },
       "System.Threading.Timer/4.0.0": {
         "compile": {
-          "ref/netcore50/System.Threading.Timer.dll": {}
+          "ref/netcore50/System.Threading.Timer.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Threading.Timer.dll": {}
@@ -11456,7 +12738,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Xml.ReaderWriter.dll": {}
+          "ref/dotnet/System.Xml.ReaderWriter.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Xml.ReaderWriter.dll": {}
@@ -11477,7 +12761,9 @@
           "System.Xml.ReaderWriter": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Xml.XDocument.dll": {}
+          "ref/dotnet/System.Xml.XDocument.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Xml.XDocument.dll": {}
@@ -11497,7 +12783,9 @@
           "System.Xml.ReaderWriter": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Xml.XmlDocument.dll": {}
+          "ref/dotnet/System.Xml.XmlDocument.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Xml.XmlDocument.dll": {}
@@ -11525,7 +12813,9 @@
           "System.Xml.XmlDocument": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Xml.XmlSerializer.dll": {}
+          "ref/dotnet/System.Xml.XmlSerializer.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Xml.XmlSerializer.dll": {}

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/compiler/resources/uwpBlankAppV2.json
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/compiler/resources/uwpBlankAppV2.json
@@ -23,7 +23,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/Microsoft.CSharp.dll": {}
+          "ref/netcore50/Microsoft.CSharp.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/Microsoft.CSharp.dll": {}
@@ -104,12 +106,18 @@
           "ref/netcore50/System.Numerics.dll": {},
           "ref/netcore50/System.Runtime.Serialization.dll": {},
           "ref/netcore50/System.ServiceModel.Web.dll": {},
-          "ref/netcore50/System.ServiceModel.dll": {},
+          "ref/netcore50/System.ServiceModel.dll": {
+            "related": ".Web.dll"
+          },
           "ref/netcore50/System.Windows.dll": {},
           "ref/netcore50/System.Xml.Linq.dll": {},
           "ref/netcore50/System.Xml.Serialization.dll": {},
-          "ref/netcore50/System.Xml.dll": {},
-          "ref/netcore50/System.dll": {},
+          "ref/netcore50/System.Xml.dll": {
+            "related": ".Linq.dll;.Serialization.dll"
+          },
+          "ref/netcore50/System.dll": {
+            "related": ".ComponentModel.DataAnnotations.dll;.Core.dll;.Net.dll;.Numerics.dll;.Runtime.Serialization.dll;.ServiceModel.dll;.ServiceModel.Web.dll;.Windows.dll;.Xml.dll;.Xml.Linq.dll;.Xml.Serialization.dll"
+          },
           "ref/netcore50/mscorlib.dll": {}
         },
         "runtime": {
@@ -119,12 +127,18 @@
           "lib/netcore50/System.Numerics.dll": {},
           "lib/netcore50/System.Runtime.Serialization.dll": {},
           "lib/netcore50/System.ServiceModel.Web.dll": {},
-          "lib/netcore50/System.ServiceModel.dll": {},
+          "lib/netcore50/System.ServiceModel.dll": {
+            "related": ".Web.dll"
+          },
           "lib/netcore50/System.Windows.dll": {},
           "lib/netcore50/System.Xml.Linq.dll": {},
           "lib/netcore50/System.Xml.Serialization.dll": {},
-          "lib/netcore50/System.Xml.dll": {},
-          "lib/netcore50/System.dll": {}
+          "lib/netcore50/System.Xml.dll": {
+            "related": ".Linq.dll;.Serialization.dll"
+          },
+          "lib/netcore50/System.dll": {
+            "related": ".ComponentModel.DataAnnotations.dll;.Core.dll;.Net.dll;.Numerics.dll;.Runtime.Serialization.dll;.ServiceModel.dll;.ServiceModel.Web.dll;.Windows.dll;.Xml.dll;.Xml.Linq.dll;.Xml.Serialization.dll"
+          }
         },
         "runtimeTargets": {
           "runtimes/aot/lib/netcore50/System.ComponentModel.DataAnnotations.dll": {
@@ -248,7 +262,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/Microsoft.VisualBasic.dll": {}
+          "ref/netcore50/Microsoft.VisualBasic.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/Microsoft.VisualBasic.dll": {}
@@ -261,7 +277,9 @@
           "System.Runtime.InteropServices": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/Microsoft.Win32.Primitives.dll": {}
+          "ref/dotnet/Microsoft.Win32.Primitives.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/Microsoft.Win32.Primitives.dll": {}
@@ -276,7 +294,9 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.AppContext.dll": {}
+          "ref/dotnet/System.AppContext.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.AppContext.dll": {}
@@ -292,7 +312,9 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Collections.dll": {}
+          "ref/dotnet/System.Collections.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Collections.dll": {}
@@ -318,7 +340,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Collections.Concurrent.dll": {}
+          "ref/dotnet/System.Collections.Concurrent.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Collections.Concurrent.dll": {}
@@ -337,10 +361,14 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "lib/dotnet/System.Collections.Immutable.dll": {}
+          "lib/dotnet/System.Collections.Immutable.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
-          "lib/dotnet/System.Collections.Immutable.dll": {}
+          "lib/dotnet/System.Collections.Immutable.dll": {
+            "related": ".xml"
+          }
         }
       },
       "System.Collections.NonGeneric/4.0.0": {
@@ -354,7 +382,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Collections.NonGeneric.dll": {}
+          "ref/dotnet/System.Collections.NonGeneric.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Collections.NonGeneric.dll": {}
@@ -372,7 +402,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Collections.Specialized.dll": {}
+          "ref/dotnet/System.Collections.Specialized.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Collections.Specialized.dll": {}
@@ -384,7 +416,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.ComponentModel.dll": {}
+          "ref/netcore50/System.ComponentModel.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.ComponentModel.dll": {}
@@ -406,7 +440,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.ComponentModel.Annotations.dll": {}
+          "ref/dotnet/System.ComponentModel.Annotations.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.ComponentModel.Annotations.dll": {}
@@ -421,7 +457,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.ComponentModel.EventBasedAsync.dll": {}
+          "ref/dotnet/System.ComponentModel.EventBasedAsync.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.ComponentModel.EventBasedAsync.dll": {}
@@ -441,7 +479,9 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Data.Common.dll": {}
+          "ref/dotnet/System.Data.Common.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Data.Common.dll": {}
@@ -450,7 +490,9 @@
       "System.Diagnostics.Contracts/4.0.0": {
         "type": "package",
         "compile": {
-          "ref/netcore50/System.Diagnostics.Contracts.dll": {}
+          "ref/netcore50/System.Diagnostics.Contracts.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Diagnostics.Contracts.dll": {}
@@ -468,7 +510,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Diagnostics.Debug.dll": {}
+          "ref/dotnet/System.Diagnostics.Debug.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Diagnostics.Debug.dll": {}
@@ -486,7 +530,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Diagnostics.StackTrace.dll": {}
+          "ref/dotnet/System.Diagnostics.StackTrace.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Diagnostics.StackTrace.dll": {}
@@ -501,7 +547,9 @@
       "System.Diagnostics.Tools/4.0.0": {
         "type": "package",
         "compile": {
-          "ref/netcore50/System.Diagnostics.Tools.dll": {}
+          "ref/netcore50/System.Diagnostics.Tools.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Diagnostics.Tools.dll": {}
@@ -528,7 +576,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Diagnostics.Tracing.dll": {}
+          "ref/dotnet/System.Diagnostics.Tracing.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Diagnostics.Tracing.dll": {}
@@ -557,7 +607,9 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Dynamic.Runtime.dll": {}
+          "ref/dotnet/System.Dynamic.Runtime.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Dynamic.Runtime.dll": {}
@@ -575,7 +627,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Globalization.dll": {}
+          "ref/dotnet/System.Globalization.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Globalization.dll": {}
@@ -594,7 +648,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Globalization.Calendars.dll": {}
+          "ref/dotnet/System.Globalization.Calendars.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Globalization.Calendars.dll": {}
@@ -616,7 +672,9 @@
           "System.Runtime.InteropServices": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Globalization.Extensions.dll": {}
+          "ref/dotnet/System.Globalization.Extensions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Globalization.Extensions.dll": {}
@@ -633,7 +691,9 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.IO.dll": {}
+          "ref/dotnet/System.IO.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.IO.dll": {}
@@ -659,7 +719,9 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "ref/netcore50/System.IO.Compression.dll": {}
+          "ref/netcore50/System.IO.Compression.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.IO.Compression.dll": {}
@@ -678,7 +740,9 @@
           "System.Text.Encoding": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.IO.Compression.ZipFile.dll": {}
+          "ref/dotnet/System.IO.Compression.ZipFile.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.IO.Compression.ZipFile.dll": {}
@@ -704,7 +768,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.IO.FileSystem.dll": {}
+          "ref/dotnet/System.IO.FileSystem.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.IO.FileSystem.dll": {}
@@ -716,7 +782,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.IO.FileSystem.Primitives.dll": {}
+          "ref/dotnet/System.IO.FileSystem.Primitives.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.IO.FileSystem.Primitives.dll": {}
@@ -736,7 +804,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.IO.IsolatedStorage.dll": {}
+          "ref/dotnet/System.IO.IsolatedStorage.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.IO.IsolatedStorage.dll": {}
@@ -754,7 +824,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.IO.UnmanagedMemoryStream.dll": {}
+          "ref/dotnet/System.IO.UnmanagedMemoryStream.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.IO.UnmanagedMemoryStream.dll": {}
@@ -770,7 +842,9 @@
           "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Linq.dll": {}
+          "ref/netcore50/System.Linq.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Linq.dll": {}
@@ -794,7 +868,9 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Linq.Expressions.dll": {}
+          "ref/dotnet/System.Linq.Expressions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Linq.Expressions.dll": {}
@@ -821,7 +897,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Linq.Parallel.dll": {}
+          "ref/netcore50/System.Linq.Parallel.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Linq.Parallel.dll": {}
@@ -839,7 +917,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.Linq.Queryable.dll": {}
+          "ref/netcore50/System.Linq.Queryable.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Linq.Queryable.dll": {}
@@ -864,7 +944,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Net.Http.dll": {}
+          "ref/netcore50/System.Net.Http.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Net.Http.dll": {}
@@ -877,7 +959,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.Net.Http.Rtc.dll": {}
+          "ref/netcore50/System.Net.Http.Rtc.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Net.Http.Rtc.dll": {}
@@ -891,7 +975,9 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "ref/netcore50/System.Net.NetworkInformation.dll": {}
+          "ref/netcore50/System.Net.NetworkInformation.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Net.NetworkInformation.dll": {}
@@ -904,7 +990,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Net.Primitives.dll": {}
+          "ref/dotnet/System.Net.Primitives.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Net.Primitives.dll": {}
@@ -925,7 +1013,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Net.Requests.dll": {}
+          "ref/dotnet/System.Net.Requests.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Net.Requests.dll": {}
@@ -938,7 +1028,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Net.Sockets.dll": {}
+          "ref/dotnet/System.Net.Sockets.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Net.Sockets.dll": {}
@@ -953,7 +1045,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Net.WebHeaderCollection.dll": {}
+          "ref/dotnet/System.Net.WebHeaderCollection.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Net.WebHeaderCollection.dll": {}
@@ -998,7 +1092,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.ObjectModel.dll": {}
+          "ref/dotnet/System.ObjectModel.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.ObjectModel.dll": {}
@@ -1139,7 +1235,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Reflection.dll": {}
+          "ref/dotnet/System.Reflection.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Reflection.dll": {}
@@ -1159,7 +1257,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.Reflection.Context.dll": {}
+          "ref/netcore50/System.Reflection.Context.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Reflection.Context.dll": {}
@@ -1178,7 +1278,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Reflection.DispatchProxy.dll": {}
+          "ref/dotnet/System.Reflection.DispatchProxy.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Reflection.DispatchProxy.dll": {}
@@ -1202,7 +1304,9 @@
           "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Reflection.Extensions.dll": {}
+          "ref/netcore50/System.Reflection.Extensions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Reflection.Extensions.dll": {}
@@ -1233,10 +1337,14 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "lib/dotnet/System.Reflection.Metadata.dll": {}
+          "lib/dotnet/System.Reflection.Metadata.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
-          "lib/dotnet/System.Reflection.Metadata.dll": {}
+          "lib/dotnet/System.Reflection.Metadata.dll": {
+            "related": ".xml"
+          }
         }
       },
       "System.Reflection.Primitives/4.0.0": {
@@ -1246,7 +1354,9 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "ref/netcore50/System.Reflection.Primitives.dll": {}
+          "ref/netcore50/System.Reflection.Primitives.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Reflection.Primitives.dll": {}
@@ -1271,7 +1381,9 @@
           "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Reflection.TypeExtensions.dll": {}
+          "ref/dotnet/System.Reflection.TypeExtensions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Reflection.TypeExtensions.dll": {}
@@ -1291,7 +1403,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.Resources.ResourceManager.dll": {}
+          "ref/netcore50/System.Resources.ResourceManager.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Resources.ResourceManager.dll": {}
@@ -1309,7 +1423,9 @@
           "System.Private.Uri": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Runtime.dll": {}
+          "ref/dotnet/System.Runtime.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.dll": {}
@@ -1327,7 +1443,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Runtime.Extensions.dll": {}
+          "ref/dotnet/System.Runtime.Extensions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.Extensions.dll": {}
@@ -1345,7 +1463,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Runtime.Handles.dll": {}
+          "ref/dotnet/System.Runtime.Handles.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.Handles.dll": {}
@@ -1366,7 +1486,9 @@
           "System.Runtime.Handles": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Runtime.InteropServices.dll": {}
+          "ref/dotnet/System.Runtime.InteropServices.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.InteropServices.dll": {}
@@ -1381,7 +1503,9 @@
       "System.Runtime.InteropServices.WindowsRuntime/4.0.0": {
         "type": "package",
         "compile": {
-          "ref/netcore50/System.Runtime.InteropServices.WindowsRuntime.dll": {}
+          "ref/netcore50/System.Runtime.InteropServices.WindowsRuntime.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.InteropServices.WindowsRuntime.dll": {}
@@ -1402,7 +1526,9 @@
           "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Runtime.Numerics.dll": {}
+          "ref/netcore50/System.Runtime.Numerics.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.Numerics.dll": {}
@@ -1414,7 +1540,9 @@
           "System.Private.DataContractSerialization": "4.0.0"
         },
         "compile": {
-          "ref/netcore50/System.Runtime.Serialization.Json.dll": {}
+          "ref/netcore50/System.Runtime.Serialization.Json.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.Serialization.Json.dll": {}
@@ -1433,7 +1561,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Runtime.Serialization.Primitives.dll": {}
+          "ref/dotnet/System.Runtime.Serialization.Primitives.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Runtime.Serialization.Primitives.dll": {}
@@ -1446,7 +1576,9 @@
           "System.Runtime.Serialization.Primitives": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Runtime.Serialization.Xml.dll": {}
+          "ref/dotnet/System.Runtime.Serialization.Xml.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.Serialization.Xml.dll": {}
@@ -1473,7 +1605,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Runtime.WindowsRuntime.dll": {}
+          "ref/netcore50/System.Runtime.WindowsRuntime.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.WindowsRuntime.dll": {}
@@ -1495,7 +1629,9 @@
           "System.Runtime.WindowsRuntime": "4.0.0"
         },
         "compile": {
-          "ref/netcore50/System.Runtime.WindowsRuntime.UI.Xaml.dll": {}
+          "ref/netcore50/System.Runtime.WindowsRuntime.UI.Xaml.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.WindowsRuntime.UI.Xaml.dll": {}
@@ -1514,7 +1650,9 @@
           "System.Security.Principal": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Security.Claims.dll": {}
+          "ref/dotnet/System.Security.Claims.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Security.Claims.dll": {}
@@ -1526,7 +1664,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/netcore50/System.Security.Principal.dll": {}
+          "ref/netcore50/System.Security.Principal.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Security.Principal.dll": {}
@@ -1539,7 +1679,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.ServiceModel.Duplex.dll": {}
+          "ref/netcore50/System.ServiceModel.Duplex.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.ServiceModel.Duplex.dll": {}
@@ -1552,7 +1694,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.ServiceModel.Http.dll": {}
+          "ref/dotnet/System.ServiceModel.Http.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.ServiceModel.Http.dll": {}
@@ -1565,7 +1709,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.ServiceModel.NetTcp.dll": {}
+          "ref/netcore50/System.ServiceModel.NetTcp.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.ServiceModel.NetTcp.dll": {}
@@ -1578,7 +1724,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.ServiceModel.Primitives.dll": {}
+          "ref/netcore50/System.ServiceModel.Primitives.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.ServiceModel.Primitives.dll": {}
@@ -1591,7 +1739,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.ServiceModel.Security.dll": {}
+          "ref/netcore50/System.ServiceModel.Security.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.ServiceModel.Security.dll": {}
@@ -1603,7 +1753,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Text.Encoding.dll": {}
+          "ref/dotnet/System.Text.Encoding.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Text.Encoding.dll": {}
@@ -1631,7 +1783,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Text.Encoding.CodePages.dll": {}
+          "ref/dotnet/System.Text.Encoding.CodePages.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Text.Encoding.CodePages.dll": {}
@@ -1644,7 +1798,9 @@
           "System.Text.Encoding": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Text.Encoding.Extensions.dll": {}
+          "ref/dotnet/System.Text.Encoding.Extensions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Text.Encoding.Extensions.dll": {}
@@ -1667,7 +1823,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Text.RegularExpressions.dll": {}
+          "ref/dotnet/System.Text.RegularExpressions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Text.RegularExpressions.dll": {}
@@ -1680,7 +1838,9 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Threading.dll": {}
+          "ref/dotnet/System.Threading.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Threading.dll": {}
@@ -1703,7 +1863,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Threading.Overlapped.dll": {}
+          "ref/dotnet/System.Threading.Overlapped.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Threading.Overlapped.dll": {}
@@ -1715,7 +1877,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Threading.Tasks.dll": {}
+          "ref/dotnet/System.Threading.Tasks.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Threading.Tasks.dll": {}
@@ -1743,10 +1907,14 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "lib/dotnet/System.Threading.Tasks.Dataflow.dll": {}
+          "lib/dotnet/System.Threading.Tasks.Dataflow.dll": {
+            "related": ".XML"
+          }
         },
         "runtime": {
-          "lib/dotnet/System.Threading.Tasks.Dataflow.dll": {}
+          "lib/dotnet/System.Threading.Tasks.Dataflow.dll": {
+            "related": ".XML"
+          }
         }
       },
       "System.Threading.Tasks.Parallel/4.0.0": {
@@ -1762,7 +1930,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Threading.Tasks.Parallel.dll": {}
+          "ref/netcore50/System.Threading.Tasks.Parallel.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Threading.Tasks.Parallel.dll": {}
@@ -1771,7 +1941,9 @@
       "System.Threading.Timer/4.0.0": {
         "type": "package",
         "compile": {
-          "ref/netcore50/System.Threading.Timer.dll": {}
+          "ref/netcore50/System.Threading.Timer.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Threading.Timer.dll": {}
@@ -1802,7 +1974,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Xml.ReaderWriter.dll": {}
+          "ref/dotnet/System.Xml.ReaderWriter.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Xml.ReaderWriter.dll": {}
@@ -1824,7 +1998,9 @@
           "System.Xml.ReaderWriter": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Xml.XDocument.dll": {}
+          "ref/dotnet/System.Xml.XDocument.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Xml.XDocument.dll": {}
@@ -1845,7 +2021,9 @@
           "System.Xml.ReaderWriter": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Xml.XmlDocument.dll": {}
+          "ref/dotnet/System.Xml.XmlDocument.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Xml.XmlDocument.dll": {}
@@ -1872,7 +2050,9 @@
           "System.Xml.XmlDocument": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Xml.XmlSerializer.dll": {}
+          "ref/dotnet/System.Xml.XmlSerializer.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Xml.XmlSerializer.dll": {}
@@ -1907,7 +2087,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/Microsoft.CSharp.dll": {}
+          "ref/netcore50/Microsoft.CSharp.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/Microsoft.CSharp.dll": {}
@@ -1988,12 +2170,18 @@
           "ref/netcore50/System.Numerics.dll": {},
           "ref/netcore50/System.Runtime.Serialization.dll": {},
           "ref/netcore50/System.ServiceModel.Web.dll": {},
-          "ref/netcore50/System.ServiceModel.dll": {},
+          "ref/netcore50/System.ServiceModel.dll": {
+            "related": ".Web.dll"
+          },
           "ref/netcore50/System.Windows.dll": {},
           "ref/netcore50/System.Xml.Linq.dll": {},
           "ref/netcore50/System.Xml.Serialization.dll": {},
-          "ref/netcore50/System.Xml.dll": {},
-          "ref/netcore50/System.dll": {},
+          "ref/netcore50/System.Xml.dll": {
+            "related": ".Linq.dll;.Serialization.dll"
+          },
+          "ref/netcore50/System.dll": {
+            "related": ".ComponentModel.DataAnnotations.dll;.Core.dll;.Net.dll;.Numerics.dll;.Runtime.Serialization.dll;.ServiceModel.dll;.ServiceModel.Web.dll;.Windows.dll;.Xml.dll;.Xml.Linq.dll;.Xml.Serialization.dll"
+          },
           "ref/netcore50/mscorlib.dll": {}
         },
         "runtime": {
@@ -2003,12 +2191,18 @@
           "lib/netcore50/System.Numerics.dll": {},
           "lib/netcore50/System.Runtime.Serialization.dll": {},
           "lib/netcore50/System.ServiceModel.Web.dll": {},
-          "lib/netcore50/System.ServiceModel.dll": {},
+          "lib/netcore50/System.ServiceModel.dll": {
+            "related": ".Web.dll"
+          },
           "lib/netcore50/System.Windows.dll": {},
           "lib/netcore50/System.Xml.Linq.dll": {},
           "lib/netcore50/System.Xml.Serialization.dll": {},
-          "lib/netcore50/System.Xml.dll": {},
-          "lib/netcore50/System.dll": {}
+          "lib/netcore50/System.Xml.dll": {
+            "related": ".Linq.dll;.Serialization.dll"
+          },
+          "lib/netcore50/System.dll": {
+            "related": ".ComponentModel.DataAnnotations.dll;.Core.dll;.Net.dll;.Numerics.dll;.Runtime.Serialization.dll;.ServiceModel.dll;.ServiceModel.Web.dll;.Windows.dll;.Xml.dll;.Xml.Linq.dll;.Xml.Serialization.dll"
+          }
         }
       },
       "Microsoft.NETCore.Runtime/1.0.0": {
@@ -2125,7 +2319,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/Microsoft.VisualBasic.dll": {}
+          "ref/netcore50/Microsoft.VisualBasic.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/Microsoft.VisualBasic.dll": {}
@@ -2138,7 +2334,9 @@
           "System.Runtime.InteropServices": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/Microsoft.Win32.Primitives.dll": {}
+          "ref/dotnet/Microsoft.Win32.Primitives.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/Microsoft.Win32.Primitives.dll": {}
@@ -2153,7 +2351,9 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.AppContext.dll": {}
+          "ref/dotnet/System.AppContext.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.AppContext.dll": {}
@@ -2169,7 +2369,9 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Collections.dll": {}
+          "ref/dotnet/System.Collections.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Collections.dll": {}
@@ -2189,7 +2391,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Collections.Concurrent.dll": {}
+          "ref/dotnet/System.Collections.Concurrent.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Collections.Concurrent.dll": {}
@@ -2208,10 +2412,14 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "lib/dotnet/System.Collections.Immutable.dll": {}
+          "lib/dotnet/System.Collections.Immutable.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
-          "lib/dotnet/System.Collections.Immutable.dll": {}
+          "lib/dotnet/System.Collections.Immutable.dll": {
+            "related": ".xml"
+          }
         }
       },
       "System.Collections.NonGeneric/4.0.0": {
@@ -2225,7 +2433,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Collections.NonGeneric.dll": {}
+          "ref/dotnet/System.Collections.NonGeneric.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Collections.NonGeneric.dll": {}
@@ -2243,7 +2453,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Collections.Specialized.dll": {}
+          "ref/dotnet/System.Collections.Specialized.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Collections.Specialized.dll": {}
@@ -2255,7 +2467,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.ComponentModel.dll": {}
+          "ref/netcore50/System.ComponentModel.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.ComponentModel.dll": {}
@@ -2277,7 +2491,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.ComponentModel.Annotations.dll": {}
+          "ref/dotnet/System.ComponentModel.Annotations.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.ComponentModel.Annotations.dll": {}
@@ -2292,7 +2508,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.ComponentModel.EventBasedAsync.dll": {}
+          "ref/dotnet/System.ComponentModel.EventBasedAsync.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.ComponentModel.EventBasedAsync.dll": {}
@@ -2312,7 +2530,9 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Data.Common.dll": {}
+          "ref/dotnet/System.Data.Common.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Data.Common.dll": {}
@@ -2321,7 +2541,9 @@
       "System.Diagnostics.Contracts/4.0.0": {
         "type": "package",
         "compile": {
-          "ref/netcore50/System.Diagnostics.Contracts.dll": {}
+          "ref/netcore50/System.Diagnostics.Contracts.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Diagnostics.Contracts.dll": {}
@@ -2333,7 +2555,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Diagnostics.Debug.dll": {}
+          "ref/dotnet/System.Diagnostics.Debug.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Diagnostics.Debug.dll": {}
@@ -2345,7 +2569,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Diagnostics.StackTrace.dll": {}
+          "ref/dotnet/System.Diagnostics.StackTrace.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Diagnostics.StackTrace.dll": {}
@@ -2354,7 +2580,9 @@
       "System.Diagnostics.Tools/4.0.0": {
         "type": "package",
         "compile": {
-          "ref/netcore50/System.Diagnostics.Tools.dll": {}
+          "ref/netcore50/System.Diagnostics.Tools.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Diagnostics.Tools.dll": {}
@@ -2375,7 +2603,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Diagnostics.Tracing.dll": {}
+          "ref/dotnet/System.Diagnostics.Tracing.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Diagnostics.Tracing.dll": {}
@@ -2400,7 +2630,9 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Dynamic.Runtime.dll": {}
+          "ref/dotnet/System.Dynamic.Runtime.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Dynamic.Runtime.dll": {}
@@ -2412,7 +2644,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Globalization.dll": {}
+          "ref/dotnet/System.Globalization.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Globalization.dll": {}
@@ -2425,7 +2659,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Globalization.Calendars.dll": {}
+          "ref/dotnet/System.Globalization.Calendars.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Globalization.Calendars.dll": {}
@@ -2441,7 +2677,9 @@
           "System.Runtime.InteropServices": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Globalization.Extensions.dll": {}
+          "ref/dotnet/System.Globalization.Extensions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Globalization.Extensions.dll": {}
@@ -2458,7 +2696,9 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.IO.dll": {}
+          "ref/dotnet/System.IO.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.IO.dll": {}
@@ -2479,7 +2719,9 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "ref/netcore50/System.IO.Compression.dll": {}
+          "ref/netcore50/System.IO.Compression.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.IO.Compression.dll": {}
@@ -2504,7 +2746,9 @@
           "System.Text.Encoding": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.IO.Compression.ZipFile.dll": {}
+          "ref/dotnet/System.IO.Compression.ZipFile.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.IO.Compression.ZipFile.dll": {}
@@ -2530,7 +2774,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.IO.FileSystem.dll": {}
+          "ref/dotnet/System.IO.FileSystem.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.IO.FileSystem.dll": {}
@@ -2542,7 +2788,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.IO.FileSystem.Primitives.dll": {}
+          "ref/dotnet/System.IO.FileSystem.Primitives.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.IO.FileSystem.Primitives.dll": {}
@@ -2562,7 +2810,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.IO.IsolatedStorage.dll": {}
+          "ref/dotnet/System.IO.IsolatedStorage.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.IO.IsolatedStorage.dll": {}
@@ -2580,7 +2830,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.IO.UnmanagedMemoryStream.dll": {}
+          "ref/dotnet/System.IO.UnmanagedMemoryStream.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.IO.UnmanagedMemoryStream.dll": {}
@@ -2596,7 +2848,9 @@
           "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Linq.dll": {}
+          "ref/netcore50/System.Linq.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Linq.dll": {}
@@ -2622,7 +2876,9 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Linq.Expressions.dll": {}
+          "ref/dotnet/System.Linq.Expressions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Linq.Expressions.dll": {}
@@ -2643,7 +2899,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Linq.Parallel.dll": {}
+          "ref/netcore50/System.Linq.Parallel.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Linq.Parallel.dll": {}
@@ -2661,7 +2919,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.Linq.Queryable.dll": {}
+          "ref/netcore50/System.Linq.Queryable.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Linq.Queryable.dll": {}
@@ -2686,7 +2946,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Net.Http.dll": {}
+          "ref/netcore50/System.Net.Http.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Net.Http.dll": {}
@@ -2699,7 +2961,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.Net.Http.Rtc.dll": {}
+          "ref/netcore50/System.Net.Http.Rtc.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Net.Http.Rtc.dll": {}
@@ -2713,7 +2977,9 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "ref/netcore50/System.Net.NetworkInformation.dll": {}
+          "ref/netcore50/System.Net.NetworkInformation.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Net.NetworkInformation.dll": {}
@@ -2726,7 +2992,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Net.Primitives.dll": {}
+          "ref/dotnet/System.Net.Primitives.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Net.Primitives.dll": {}
@@ -2747,7 +3015,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Net.Requests.dll": {}
+          "ref/dotnet/System.Net.Requests.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Net.Requests.dll": {}
@@ -2760,7 +3030,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Net.Sockets.dll": {}
+          "ref/dotnet/System.Net.Sockets.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Net.Sockets.dll": {}
@@ -2775,7 +3047,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Net.WebHeaderCollection.dll": {}
+          "ref/dotnet/System.Net.WebHeaderCollection.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Net.WebHeaderCollection.dll": {}
@@ -2820,7 +3094,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.ObjectModel.dll": {}
+          "ref/dotnet/System.ObjectModel.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.ObjectModel.dll": {}
@@ -2951,7 +3227,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Reflection.dll": {}
+          "ref/dotnet/System.Reflection.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Reflection.dll": {}
@@ -2965,7 +3243,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.Reflection.Context.dll": {}
+          "ref/netcore50/System.Reflection.Context.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Reflection.Context.dll": {}
@@ -2986,7 +3266,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Reflection.DispatchProxy.dll": {}
+          "ref/dotnet/System.Reflection.DispatchProxy.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Reflection.DispatchProxy.dll": {}
@@ -3002,7 +3284,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Reflection.Emit.dll": {}
+          "ref/dotnet/System.Reflection.Emit.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Reflection.Emit.dll": {}
@@ -3016,7 +3300,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Reflection.Emit.ILGeneration.dll": {}
+          "ref/dotnet/System.Reflection.Emit.ILGeneration.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Reflection.Emit.ILGeneration.dll": {}
@@ -3031,7 +3317,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Reflection.Emit.Lightweight.dll": {}
+          "ref/dotnet/System.Reflection.Emit.Lightweight.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Reflection.Emit.Lightweight.dll": {}
@@ -3049,7 +3337,9 @@
           "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Reflection.Extensions.dll": {}
+          "ref/netcore50/System.Reflection.Extensions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Reflection.Extensions.dll": {}
@@ -3074,10 +3364,14 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "lib/dotnet/System.Reflection.Metadata.dll": {}
+          "lib/dotnet/System.Reflection.Metadata.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
-          "lib/dotnet/System.Reflection.Metadata.dll": {}
+          "lib/dotnet/System.Reflection.Metadata.dll": {
+            "related": ".xml"
+          }
         }
       },
       "System.Reflection.Primitives/4.0.0": {
@@ -3087,7 +3381,9 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "ref/netcore50/System.Reflection.Primitives.dll": {}
+          "ref/netcore50/System.Reflection.Primitives.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Reflection.Primitives.dll": {}
@@ -3106,7 +3402,9 @@
           "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Reflection.TypeExtensions.dll": {}
+          "ref/dotnet/System.Reflection.TypeExtensions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Reflection.TypeExtensions.dll": {}
@@ -3120,7 +3418,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.Resources.ResourceManager.dll": {}
+          "ref/netcore50/System.Resources.ResourceManager.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Resources.ResourceManager.dll": {}
@@ -3132,7 +3432,9 @@
           "System.Private.Uri": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Runtime.dll": {}
+          "ref/dotnet/System.Runtime.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.dll": {}
@@ -3144,7 +3446,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Runtime.Extensions.dll": {}
+          "ref/dotnet/System.Runtime.Extensions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.Extensions.dll": {}
@@ -3156,7 +3460,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Runtime.Handles.dll": {}
+          "ref/dotnet/System.Runtime.Handles.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.Handles.dll": {}
@@ -3171,7 +3477,9 @@
           "System.Runtime.Handles": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Runtime.InteropServices.dll": {}
+          "ref/dotnet/System.Runtime.InteropServices.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.InteropServices.dll": {}
@@ -3180,7 +3488,9 @@
       "System.Runtime.InteropServices.WindowsRuntime/4.0.0": {
         "type": "package",
         "compile": {
-          "ref/netcore50/System.Runtime.InteropServices.WindowsRuntime.dll": {}
+          "ref/netcore50/System.Runtime.InteropServices.WindowsRuntime.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.InteropServices.WindowsRuntime.dll": {}
@@ -3195,7 +3505,9 @@
           "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Runtime.Numerics.dll": {}
+          "ref/netcore50/System.Runtime.Numerics.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.Numerics.dll": {}
@@ -3207,7 +3519,9 @@
           "System.Private.DataContractSerialization": "4.0.0"
         },
         "compile": {
-          "ref/netcore50/System.Runtime.Serialization.Json.dll": {}
+          "ref/netcore50/System.Runtime.Serialization.Json.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.Serialization.Json.dll": {}
@@ -3220,7 +3534,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Runtime.Serialization.Primitives.dll": {}
+          "ref/dotnet/System.Runtime.Serialization.Primitives.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Runtime.Serialization.Primitives.dll": {}
@@ -3233,7 +3549,9 @@
           "System.Runtime.Serialization.Primitives": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Runtime.Serialization.Xml.dll": {}
+          "ref/dotnet/System.Runtime.Serialization.Xml.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.Serialization.Xml.dll": {}
@@ -3254,7 +3572,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Runtime.WindowsRuntime.dll": {}
+          "ref/netcore50/System.Runtime.WindowsRuntime.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.WindowsRuntime.dll": {}
@@ -3270,7 +3590,9 @@
           "System.Runtime.WindowsRuntime": "4.0.0"
         },
         "compile": {
-          "ref/netcore50/System.Runtime.WindowsRuntime.UI.Xaml.dll": {}
+          "ref/netcore50/System.Runtime.WindowsRuntime.UI.Xaml.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.WindowsRuntime.UI.Xaml.dll": {}
@@ -3289,7 +3611,9 @@
           "System.Security.Principal": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Security.Claims.dll": {}
+          "ref/dotnet/System.Security.Claims.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Security.Claims.dll": {}
@@ -3301,7 +3625,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/netcore50/System.Security.Principal.dll": {}
+          "ref/netcore50/System.Security.Principal.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Security.Principal.dll": {}
@@ -3314,7 +3640,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.ServiceModel.Duplex.dll": {}
+          "ref/netcore50/System.ServiceModel.Duplex.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.ServiceModel.Duplex.dll": {}
@@ -3327,7 +3655,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.ServiceModel.Http.dll": {}
+          "ref/dotnet/System.ServiceModel.Http.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.ServiceModel.Http.dll": {}
@@ -3340,7 +3670,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.ServiceModel.NetTcp.dll": {}
+          "ref/netcore50/System.ServiceModel.NetTcp.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.ServiceModel.NetTcp.dll": {}
@@ -3353,7 +3685,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.ServiceModel.Primitives.dll": {}
+          "ref/netcore50/System.ServiceModel.Primitives.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.ServiceModel.Primitives.dll": {}
@@ -3366,7 +3700,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.ServiceModel.Security.dll": {}
+          "ref/netcore50/System.ServiceModel.Security.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.ServiceModel.Security.dll": {}
@@ -3378,7 +3714,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Text.Encoding.dll": {}
+          "ref/dotnet/System.Text.Encoding.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Text.Encoding.dll": {}
@@ -3400,7 +3738,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Text.Encoding.CodePages.dll": {}
+          "ref/dotnet/System.Text.Encoding.CodePages.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Text.Encoding.CodePages.dll": {}
@@ -3413,7 +3753,9 @@
           "System.Text.Encoding": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Text.Encoding.Extensions.dll": {}
+          "ref/dotnet/System.Text.Encoding.Extensions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Text.Encoding.Extensions.dll": {}
@@ -3430,7 +3772,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Text.RegularExpressions.dll": {}
+          "ref/dotnet/System.Text.RegularExpressions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Text.RegularExpressions.dll": {}
@@ -3443,7 +3787,9 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Threading.dll": {}
+          "ref/dotnet/System.Threading.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Threading.dll": {}
@@ -3460,7 +3806,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Threading.Overlapped.dll": {}
+          "ref/dotnet/System.Threading.Overlapped.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Threading.Overlapped.dll": {}
@@ -3472,7 +3820,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Threading.Tasks.dll": {}
+          "ref/dotnet/System.Threading.Tasks.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Threading.Tasks.dll": {}
@@ -3494,10 +3844,14 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "lib/dotnet/System.Threading.Tasks.Dataflow.dll": {}
+          "lib/dotnet/System.Threading.Tasks.Dataflow.dll": {
+            "related": ".XML"
+          }
         },
         "runtime": {
-          "lib/dotnet/System.Threading.Tasks.Dataflow.dll": {}
+          "lib/dotnet/System.Threading.Tasks.Dataflow.dll": {
+            "related": ".XML"
+          }
         }
       },
       "System.Threading.Tasks.Parallel/4.0.0": {
@@ -3513,7 +3867,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Threading.Tasks.Parallel.dll": {}
+          "ref/netcore50/System.Threading.Tasks.Parallel.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Threading.Tasks.Parallel.dll": {}
@@ -3522,7 +3878,9 @@
       "System.Threading.Timer/4.0.0": {
         "type": "package",
         "compile": {
-          "ref/netcore50/System.Threading.Timer.dll": {}
+          "ref/netcore50/System.Threading.Timer.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Threading.Timer.dll": {}
@@ -3547,7 +3905,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Xml.ReaderWriter.dll": {}
+          "ref/dotnet/System.Xml.ReaderWriter.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Xml.ReaderWriter.dll": {}
@@ -3569,7 +3929,9 @@
           "System.Xml.ReaderWriter": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Xml.XDocument.dll": {}
+          "ref/dotnet/System.Xml.XDocument.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Xml.XDocument.dll": {}
@@ -3590,7 +3952,9 @@
           "System.Xml.ReaderWriter": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Xml.XmlDocument.dll": {}
+          "ref/dotnet/System.Xml.XmlDocument.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Xml.XmlDocument.dll": {}
@@ -3619,7 +3983,9 @@
           "System.Xml.XmlDocument": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Xml.XmlSerializer.dll": {}
+          "ref/dotnet/System.Xml.XmlSerializer.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Xml.XmlSerializer.dll": {}
@@ -3648,7 +4014,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/Microsoft.CSharp.dll": {}
+          "ref/netcore50/Microsoft.CSharp.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/Microsoft.CSharp.dll": {}
@@ -3729,12 +4097,18 @@
           "ref/netcore50/System.Numerics.dll": {},
           "ref/netcore50/System.Runtime.Serialization.dll": {},
           "ref/netcore50/System.ServiceModel.Web.dll": {},
-          "ref/netcore50/System.ServiceModel.dll": {},
+          "ref/netcore50/System.ServiceModel.dll": {
+            "related": ".Web.dll"
+          },
           "ref/netcore50/System.Windows.dll": {},
           "ref/netcore50/System.Xml.Linq.dll": {},
           "ref/netcore50/System.Xml.Serialization.dll": {},
-          "ref/netcore50/System.Xml.dll": {},
-          "ref/netcore50/System.dll": {},
+          "ref/netcore50/System.Xml.dll": {
+            "related": ".Linq.dll;.Serialization.dll"
+          },
+          "ref/netcore50/System.dll": {
+            "related": ".ComponentModel.DataAnnotations.dll;.Core.dll;.Net.dll;.Numerics.dll;.Runtime.Serialization.dll;.ServiceModel.dll;.ServiceModel.Web.dll;.Windows.dll;.Xml.dll;.Xml.Linq.dll;.Xml.Serialization.dll"
+          },
           "ref/netcore50/mscorlib.dll": {}
         },
         "runtime": {
@@ -3744,12 +4118,18 @@
           "runtimes/aot/lib/netcore50/System.Numerics.dll": {},
           "runtimes/aot/lib/netcore50/System.Runtime.Serialization.dll": {},
           "runtimes/aot/lib/netcore50/System.ServiceModel.Web.dll": {},
-          "runtimes/aot/lib/netcore50/System.ServiceModel.dll": {},
+          "runtimes/aot/lib/netcore50/System.ServiceModel.dll": {
+            "related": ".Web.dll"
+          },
           "runtimes/aot/lib/netcore50/System.Windows.dll": {},
           "runtimes/aot/lib/netcore50/System.Xml.Linq.dll": {},
           "runtimes/aot/lib/netcore50/System.Xml.Serialization.dll": {},
-          "runtimes/aot/lib/netcore50/System.Xml.dll": {},
-          "runtimes/aot/lib/netcore50/System.dll": {},
+          "runtimes/aot/lib/netcore50/System.Xml.dll": {
+            "related": ".Linq.dll;.Serialization.dll"
+          },
+          "runtimes/aot/lib/netcore50/System.dll": {
+            "related": ".ComponentModel.DataAnnotations.dll;.Core.dll;.Net.dll;.Numerics.dll;.Runtime.Serialization.dll;.ServiceModel.dll;.ServiceModel.Web.dll;.Windows.dll;.Xml.dll;.Xml.Linq.dll;.Xml.Serialization.dll"
+          },
           "runtimes/aot/lib/netcore50/mscorlib.dll": {}
         }
       },
@@ -3852,7 +4232,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/Microsoft.VisualBasic.dll": {}
+          "ref/netcore50/Microsoft.VisualBasic.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/Microsoft.VisualBasic.dll": {}
@@ -3865,7 +4247,9 @@
           "System.Runtime.InteropServices": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/Microsoft.Win32.Primitives.dll": {}
+          "ref/dotnet/Microsoft.Win32.Primitives.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/Microsoft.Win32.Primitives.dll": {}
@@ -3880,7 +4264,9 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.AppContext.dll": {}
+          "ref/dotnet/System.AppContext.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.AppContext.dll": {}
@@ -3896,7 +4282,9 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Collections.dll": {}
+          "ref/dotnet/System.Collections.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Collections.dll": {}
@@ -3916,7 +4304,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Collections.Concurrent.dll": {}
+          "ref/dotnet/System.Collections.Concurrent.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Collections.Concurrent.dll": {}
@@ -3935,10 +4325,14 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "lib/dotnet/System.Collections.Immutable.dll": {}
+          "lib/dotnet/System.Collections.Immutable.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
-          "lib/dotnet/System.Collections.Immutable.dll": {}
+          "lib/dotnet/System.Collections.Immutable.dll": {
+            "related": ".xml"
+          }
         }
       },
       "System.Collections.NonGeneric/4.0.0": {
@@ -3952,7 +4346,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Collections.NonGeneric.dll": {}
+          "ref/dotnet/System.Collections.NonGeneric.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Collections.NonGeneric.dll": {}
@@ -3970,7 +4366,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Collections.Specialized.dll": {}
+          "ref/dotnet/System.Collections.Specialized.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Collections.Specialized.dll": {}
@@ -3982,7 +4380,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.ComponentModel.dll": {}
+          "ref/netcore50/System.ComponentModel.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.ComponentModel.dll": {}
@@ -4004,7 +4404,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.ComponentModel.Annotations.dll": {}
+          "ref/dotnet/System.ComponentModel.Annotations.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.ComponentModel.Annotations.dll": {}
@@ -4019,7 +4421,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.ComponentModel.EventBasedAsync.dll": {}
+          "ref/dotnet/System.ComponentModel.EventBasedAsync.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.ComponentModel.EventBasedAsync.dll": {}
@@ -4039,7 +4443,9 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Data.Common.dll": {}
+          "ref/dotnet/System.Data.Common.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Data.Common.dll": {}
@@ -4048,7 +4454,9 @@
       "System.Diagnostics.Contracts/4.0.0": {
         "type": "package",
         "compile": {
-          "ref/netcore50/System.Diagnostics.Contracts.dll": {}
+          "ref/netcore50/System.Diagnostics.Contracts.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Contracts.dll": {}
@@ -4060,7 +4468,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Diagnostics.Debug.dll": {}
+          "ref/dotnet/System.Diagnostics.Debug.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Debug.dll": {}
@@ -4072,7 +4482,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Diagnostics.StackTrace.dll": {}
+          "ref/dotnet/System.Diagnostics.StackTrace.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Diagnostics.StackTrace.dll": {}
@@ -4081,7 +4493,9 @@
       "System.Diagnostics.Tools/4.0.0": {
         "type": "package",
         "compile": {
-          "ref/netcore50/System.Diagnostics.Tools.dll": {}
+          "ref/netcore50/System.Diagnostics.Tools.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tools.dll": {}
@@ -4102,7 +4516,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Diagnostics.Tracing.dll": {}
+          "ref/dotnet/System.Diagnostics.Tracing.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tracing.dll": {}
@@ -4125,7 +4541,9 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Dynamic.Runtime.dll": {}
+          "ref/dotnet/System.Dynamic.Runtime.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Dynamic.Runtime.dll": {}
@@ -4137,7 +4555,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Globalization.dll": {}
+          "ref/dotnet/System.Globalization.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Globalization.dll": {}
@@ -4150,7 +4570,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Globalization.Calendars.dll": {}
+          "ref/dotnet/System.Globalization.Calendars.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Globalization.Calendars.dll": {}
@@ -4166,7 +4588,9 @@
           "System.Runtime.InteropServices": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Globalization.Extensions.dll": {}
+          "ref/dotnet/System.Globalization.Extensions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Globalization.Extensions.dll": {}
@@ -4183,7 +4607,9 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.IO.dll": {}
+          "ref/dotnet/System.IO.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.IO.dll": {}
@@ -4204,7 +4630,9 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "ref/netcore50/System.IO.Compression.dll": {}
+          "ref/netcore50/System.IO.Compression.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.IO.Compression.dll": {}
@@ -4229,7 +4657,9 @@
           "System.Text.Encoding": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.IO.Compression.ZipFile.dll": {}
+          "ref/dotnet/System.IO.Compression.ZipFile.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.IO.Compression.ZipFile.dll": {}
@@ -4255,7 +4685,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.IO.FileSystem.dll": {}
+          "ref/dotnet/System.IO.FileSystem.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.IO.FileSystem.dll": {}
@@ -4267,7 +4699,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.IO.FileSystem.Primitives.dll": {}
+          "ref/dotnet/System.IO.FileSystem.Primitives.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.IO.FileSystem.Primitives.dll": {}
@@ -4287,7 +4721,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.IO.IsolatedStorage.dll": {}
+          "ref/dotnet/System.IO.IsolatedStorage.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.IO.IsolatedStorage.dll": {}
@@ -4305,7 +4741,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.IO.UnmanagedMemoryStream.dll": {}
+          "ref/dotnet/System.IO.UnmanagedMemoryStream.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.IO.UnmanagedMemoryStream.dll": {}
@@ -4321,7 +4759,9 @@
           "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Linq.dll": {}
+          "ref/netcore50/System.Linq.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Linq.dll": {}
@@ -4345,7 +4785,9 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Linq.Expressions.dll": {}
+          "ref/dotnet/System.Linq.Expressions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Linq.Expressions.dll": {}
@@ -4366,7 +4808,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Linq.Parallel.dll": {}
+          "ref/netcore50/System.Linq.Parallel.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Linq.Parallel.dll": {}
@@ -4384,7 +4828,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.Linq.Queryable.dll": {}
+          "ref/netcore50/System.Linq.Queryable.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Linq.Queryable.dll": {}
@@ -4409,7 +4855,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Net.Http.dll": {}
+          "ref/netcore50/System.Net.Http.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Net.Http.dll": {}
@@ -4422,7 +4870,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.Net.Http.Rtc.dll": {}
+          "ref/netcore50/System.Net.Http.Rtc.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Net.Http.Rtc.dll": {}
@@ -4436,7 +4886,9 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "ref/netcore50/System.Net.NetworkInformation.dll": {}
+          "ref/netcore50/System.Net.NetworkInformation.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Net.NetworkInformation.dll": {}
@@ -4449,7 +4901,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Net.Primitives.dll": {}
+          "ref/dotnet/System.Net.Primitives.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Net.Primitives.dll": {}
@@ -4470,7 +4924,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Net.Requests.dll": {}
+          "ref/dotnet/System.Net.Requests.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Net.Requests.dll": {}
@@ -4483,7 +4939,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Net.Sockets.dll": {}
+          "ref/dotnet/System.Net.Sockets.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Net.Sockets.dll": {}
@@ -4498,7 +4956,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Net.WebHeaderCollection.dll": {}
+          "ref/dotnet/System.Net.WebHeaderCollection.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Net.WebHeaderCollection.dll": {}
@@ -4543,7 +5003,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.ObjectModel.dll": {}
+          "ref/dotnet/System.ObjectModel.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.ObjectModel.dll": {}
@@ -4672,7 +5134,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Reflection.dll": {}
+          "ref/dotnet/System.Reflection.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Reflection.dll": {}
@@ -4686,7 +5150,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.Reflection.Context.dll": {}
+          "ref/netcore50/System.Reflection.Context.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Reflection.Context.dll": {}
@@ -4705,7 +5171,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Reflection.DispatchProxy.dll": {}
+          "ref/dotnet/System.Reflection.DispatchProxy.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Reflection.DispatchProxy.dll": {}
@@ -4721,7 +5189,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Reflection.Emit.dll": {}
+          "ref/dotnet/System.Reflection.Emit.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Reflection.Emit.dll": {}
@@ -4735,7 +5205,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Reflection.Emit.ILGeneration.dll": {}
+          "ref/dotnet/System.Reflection.Emit.ILGeneration.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Reflection.Emit.ILGeneration.dll": {}
@@ -4753,7 +5225,9 @@
           "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Reflection.Extensions.dll": {}
+          "ref/netcore50/System.Reflection.Extensions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Reflection.Extensions.dll": {}
@@ -4778,10 +5252,14 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "lib/dotnet/System.Reflection.Metadata.dll": {}
+          "lib/dotnet/System.Reflection.Metadata.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
-          "lib/dotnet/System.Reflection.Metadata.dll": {}
+          "lib/dotnet/System.Reflection.Metadata.dll": {
+            "related": ".xml"
+          }
         }
       },
       "System.Reflection.Primitives/4.0.0": {
@@ -4791,7 +5269,9 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "ref/netcore50/System.Reflection.Primitives.dll": {}
+          "ref/netcore50/System.Reflection.Primitives.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Reflection.Primitives.dll": {}
@@ -4810,7 +5290,9 @@
           "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Reflection.TypeExtensions.dll": {}
+          "ref/dotnet/System.Reflection.TypeExtensions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Reflection.TypeExtensions.dll": {}
@@ -4824,7 +5306,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.Resources.ResourceManager.dll": {}
+          "ref/netcore50/System.Resources.ResourceManager.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Resources.ResourceManager.dll": {}
@@ -4836,7 +5320,9 @@
           "System.Private.Uri": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Runtime.dll": {}
+          "ref/dotnet/System.Runtime.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Runtime.dll": {}
@@ -4848,7 +5334,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Runtime.Extensions.dll": {}
+          "ref/dotnet/System.Runtime.Extensions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Runtime.Extensions.dll": {}
@@ -4860,7 +5348,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Runtime.Handles.dll": {}
+          "ref/dotnet/System.Runtime.Handles.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Runtime.Handles.dll": {}
@@ -4875,7 +5365,9 @@
           "System.Runtime.Handles": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Runtime.InteropServices.dll": {}
+          "ref/dotnet/System.Runtime.InteropServices.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Runtime.InteropServices.dll": {}
@@ -4884,7 +5376,9 @@
       "System.Runtime.InteropServices.WindowsRuntime/4.0.0": {
         "type": "package",
         "compile": {
-          "ref/netcore50/System.Runtime.InteropServices.WindowsRuntime.dll": {}
+          "ref/netcore50/System.Runtime.InteropServices.WindowsRuntime.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Runtime.InteropServices.WindowsRuntime.dll": {}
@@ -4899,7 +5393,9 @@
           "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Runtime.Numerics.dll": {}
+          "ref/netcore50/System.Runtime.Numerics.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.Numerics.dll": {}
@@ -4911,7 +5407,9 @@
           "System.Private.DataContractSerialization": "4.0.0"
         },
         "compile": {
-          "ref/netcore50/System.Runtime.Serialization.Json.dll": {}
+          "ref/netcore50/System.Runtime.Serialization.Json.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Runtime.Serialization.Json.dll": {}
@@ -4924,7 +5422,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Runtime.Serialization.Primitives.dll": {}
+          "ref/dotnet/System.Runtime.Serialization.Primitives.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Runtime.Serialization.Primitives.dll": {}
@@ -4937,7 +5437,9 @@
           "System.Runtime.Serialization.Primitives": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Runtime.Serialization.Xml.dll": {}
+          "ref/dotnet/System.Runtime.Serialization.Xml.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Runtime.Serialization.Xml.dll": {}
@@ -4958,7 +5460,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Runtime.WindowsRuntime.dll": {}
+          "ref/netcore50/System.Runtime.WindowsRuntime.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Runtime.WindowsRuntime.dll": {}
@@ -4974,7 +5478,9 @@
           "System.Runtime.WindowsRuntime": "4.0.0"
         },
         "compile": {
-          "ref/netcore50/System.Runtime.WindowsRuntime.UI.Xaml.dll": {}
+          "ref/netcore50/System.Runtime.WindowsRuntime.UI.Xaml.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.WindowsRuntime.UI.Xaml.dll": {}
@@ -4993,7 +5499,9 @@
           "System.Security.Principal": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Security.Claims.dll": {}
+          "ref/dotnet/System.Security.Claims.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Security.Claims.dll": {}
@@ -5005,7 +5513,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/netcore50/System.Security.Principal.dll": {}
+          "ref/netcore50/System.Security.Principal.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Security.Principal.dll": {}
@@ -5018,7 +5528,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.ServiceModel.Duplex.dll": {}
+          "ref/netcore50/System.ServiceModel.Duplex.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.ServiceModel.Duplex.dll": {}
@@ -5031,7 +5543,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.ServiceModel.Http.dll": {}
+          "ref/dotnet/System.ServiceModel.Http.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.ServiceModel.Http.dll": {}
@@ -5044,7 +5558,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.ServiceModel.NetTcp.dll": {}
+          "ref/netcore50/System.ServiceModel.NetTcp.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.ServiceModel.NetTcp.dll": {}
@@ -5057,7 +5573,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.ServiceModel.Primitives.dll": {}
+          "ref/netcore50/System.ServiceModel.Primitives.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.ServiceModel.Primitives.dll": {}
@@ -5070,7 +5588,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.ServiceModel.Security.dll": {}
+          "ref/netcore50/System.ServiceModel.Security.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.ServiceModel.Security.dll": {}
@@ -5082,7 +5602,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Text.Encoding.dll": {}
+          "ref/dotnet/System.Text.Encoding.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.dll": {}
@@ -5104,7 +5626,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Text.Encoding.CodePages.dll": {}
+          "ref/dotnet/System.Text.Encoding.CodePages.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Text.Encoding.CodePages.dll": {}
@@ -5117,7 +5641,9 @@
           "System.Text.Encoding": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Text.Encoding.Extensions.dll": {}
+          "ref/dotnet/System.Text.Encoding.Extensions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.Extensions.dll": {}
@@ -5134,7 +5660,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Text.RegularExpressions.dll": {}
+          "ref/dotnet/System.Text.RegularExpressions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Text.RegularExpressions.dll": {}
@@ -5147,7 +5675,9 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Threading.dll": {}
+          "ref/dotnet/System.Threading.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Threading.dll": {}
@@ -5164,7 +5694,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Threading.Overlapped.dll": {}
+          "ref/dotnet/System.Threading.Overlapped.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Threading.Overlapped.dll": {}
@@ -5176,7 +5708,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Threading.Tasks.dll": {}
+          "ref/dotnet/System.Threading.Tasks.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Threading.Tasks.dll": {}
@@ -5198,10 +5732,14 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "lib/dotnet/System.Threading.Tasks.Dataflow.dll": {}
+          "lib/dotnet/System.Threading.Tasks.Dataflow.dll": {
+            "related": ".XML"
+          }
         },
         "runtime": {
-          "lib/dotnet/System.Threading.Tasks.Dataflow.dll": {}
+          "lib/dotnet/System.Threading.Tasks.Dataflow.dll": {
+            "related": ".XML"
+          }
         }
       },
       "System.Threading.Tasks.Parallel/4.0.0": {
@@ -5217,7 +5755,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Threading.Tasks.Parallel.dll": {}
+          "ref/netcore50/System.Threading.Tasks.Parallel.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Threading.Tasks.Parallel.dll": {}
@@ -5226,7 +5766,9 @@
       "System.Threading.Timer/4.0.0": {
         "type": "package",
         "compile": {
-          "ref/netcore50/System.Threading.Timer.dll": {}
+          "ref/netcore50/System.Threading.Timer.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Threading.Timer.dll": {}
@@ -5251,7 +5793,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Xml.ReaderWriter.dll": {}
+          "ref/dotnet/System.Xml.ReaderWriter.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Xml.ReaderWriter.dll": {}
@@ -5273,7 +5817,9 @@
           "System.Xml.ReaderWriter": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Xml.XDocument.dll": {}
+          "ref/dotnet/System.Xml.XDocument.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Xml.XDocument.dll": {}
@@ -5294,7 +5840,9 @@
           "System.Xml.ReaderWriter": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Xml.XmlDocument.dll": {}
+          "ref/dotnet/System.Xml.XmlDocument.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Xml.XmlDocument.dll": {}
@@ -5323,7 +5871,9 @@
           "System.Xml.XmlDocument": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Xml.XmlSerializer.dll": {}
+          "ref/dotnet/System.Xml.XmlSerializer.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Xml.XmlSerializer.dll": {}
@@ -5352,7 +5902,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/Microsoft.CSharp.dll": {}
+          "ref/netcore50/Microsoft.CSharp.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/Microsoft.CSharp.dll": {}
@@ -5433,12 +5985,18 @@
           "ref/netcore50/System.Numerics.dll": {},
           "ref/netcore50/System.Runtime.Serialization.dll": {},
           "ref/netcore50/System.ServiceModel.Web.dll": {},
-          "ref/netcore50/System.ServiceModel.dll": {},
+          "ref/netcore50/System.ServiceModel.dll": {
+            "related": ".Web.dll"
+          },
           "ref/netcore50/System.Windows.dll": {},
           "ref/netcore50/System.Xml.Linq.dll": {},
           "ref/netcore50/System.Xml.Serialization.dll": {},
-          "ref/netcore50/System.Xml.dll": {},
-          "ref/netcore50/System.dll": {},
+          "ref/netcore50/System.Xml.dll": {
+            "related": ".Linq.dll;.Serialization.dll"
+          },
+          "ref/netcore50/System.dll": {
+            "related": ".ComponentModel.DataAnnotations.dll;.Core.dll;.Net.dll;.Numerics.dll;.Runtime.Serialization.dll;.ServiceModel.dll;.ServiceModel.Web.dll;.Windows.dll;.Xml.dll;.Xml.Linq.dll;.Xml.Serialization.dll"
+          },
           "ref/netcore50/mscorlib.dll": {}
         },
         "runtime": {
@@ -5448,12 +6006,18 @@
           "lib/netcore50/System.Numerics.dll": {},
           "lib/netcore50/System.Runtime.Serialization.dll": {},
           "lib/netcore50/System.ServiceModel.Web.dll": {},
-          "lib/netcore50/System.ServiceModel.dll": {},
+          "lib/netcore50/System.ServiceModel.dll": {
+            "related": ".Web.dll"
+          },
           "lib/netcore50/System.Windows.dll": {},
           "lib/netcore50/System.Xml.Linq.dll": {},
           "lib/netcore50/System.Xml.Serialization.dll": {},
-          "lib/netcore50/System.Xml.dll": {},
-          "lib/netcore50/System.dll": {}
+          "lib/netcore50/System.Xml.dll": {
+            "related": ".Linq.dll;.Serialization.dll"
+          },
+          "lib/netcore50/System.dll": {
+            "related": ".ComponentModel.DataAnnotations.dll;.Core.dll;.Net.dll;.Numerics.dll;.Runtime.Serialization.dll;.ServiceModel.dll;.ServiceModel.Web.dll;.Windows.dll;.Xml.dll;.Xml.Linq.dll;.Xml.Serialization.dll"
+          }
         }
       },
       "Microsoft.NETCore.Runtime/1.0.0": {
@@ -5577,7 +6141,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/Microsoft.VisualBasic.dll": {}
+          "ref/netcore50/Microsoft.VisualBasic.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/Microsoft.VisualBasic.dll": {}
@@ -5590,7 +6156,9 @@
           "System.Runtime.InteropServices": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/Microsoft.Win32.Primitives.dll": {}
+          "ref/dotnet/Microsoft.Win32.Primitives.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/Microsoft.Win32.Primitives.dll": {}
@@ -5605,7 +6173,9 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.AppContext.dll": {}
+          "ref/dotnet/System.AppContext.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.AppContext.dll": {}
@@ -5621,7 +6191,9 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Collections.dll": {}
+          "ref/dotnet/System.Collections.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Collections.dll": {}
@@ -5641,7 +6213,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Collections.Concurrent.dll": {}
+          "ref/dotnet/System.Collections.Concurrent.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Collections.Concurrent.dll": {}
@@ -5660,10 +6234,14 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "lib/dotnet/System.Collections.Immutable.dll": {}
+          "lib/dotnet/System.Collections.Immutable.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
-          "lib/dotnet/System.Collections.Immutable.dll": {}
+          "lib/dotnet/System.Collections.Immutable.dll": {
+            "related": ".xml"
+          }
         }
       },
       "System.Collections.NonGeneric/4.0.0": {
@@ -5677,7 +6255,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Collections.NonGeneric.dll": {}
+          "ref/dotnet/System.Collections.NonGeneric.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Collections.NonGeneric.dll": {}
@@ -5695,7 +6275,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Collections.Specialized.dll": {}
+          "ref/dotnet/System.Collections.Specialized.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Collections.Specialized.dll": {}
@@ -5707,7 +6289,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.ComponentModel.dll": {}
+          "ref/netcore50/System.ComponentModel.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.ComponentModel.dll": {}
@@ -5729,7 +6313,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.ComponentModel.Annotations.dll": {}
+          "ref/dotnet/System.ComponentModel.Annotations.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.ComponentModel.Annotations.dll": {}
@@ -5744,7 +6330,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.ComponentModel.EventBasedAsync.dll": {}
+          "ref/dotnet/System.ComponentModel.EventBasedAsync.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.ComponentModel.EventBasedAsync.dll": {}
@@ -5764,7 +6352,9 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Data.Common.dll": {}
+          "ref/dotnet/System.Data.Common.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Data.Common.dll": {}
@@ -5773,7 +6363,9 @@
       "System.Diagnostics.Contracts/4.0.0": {
         "type": "package",
         "compile": {
-          "ref/netcore50/System.Diagnostics.Contracts.dll": {}
+          "ref/netcore50/System.Diagnostics.Contracts.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Diagnostics.Contracts.dll": {}
@@ -5785,7 +6377,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Diagnostics.Debug.dll": {}
+          "ref/dotnet/System.Diagnostics.Debug.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Diagnostics.Debug.dll": {}
@@ -5797,7 +6391,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Diagnostics.StackTrace.dll": {}
+          "ref/dotnet/System.Diagnostics.StackTrace.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Diagnostics.StackTrace.dll": {}
@@ -5806,7 +6402,9 @@
       "System.Diagnostics.Tools/4.0.0": {
         "type": "package",
         "compile": {
-          "ref/netcore50/System.Diagnostics.Tools.dll": {}
+          "ref/netcore50/System.Diagnostics.Tools.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Diagnostics.Tools.dll": {}
@@ -5827,7 +6425,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Diagnostics.Tracing.dll": {}
+          "ref/dotnet/System.Diagnostics.Tracing.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Diagnostics.Tracing.dll": {}
@@ -5852,7 +6452,9 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Dynamic.Runtime.dll": {}
+          "ref/dotnet/System.Dynamic.Runtime.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Dynamic.Runtime.dll": {}
@@ -5864,7 +6466,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Globalization.dll": {}
+          "ref/dotnet/System.Globalization.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Globalization.dll": {}
@@ -5877,7 +6481,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Globalization.Calendars.dll": {}
+          "ref/dotnet/System.Globalization.Calendars.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Globalization.Calendars.dll": {}
@@ -5893,7 +6499,9 @@
           "System.Runtime.InteropServices": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Globalization.Extensions.dll": {}
+          "ref/dotnet/System.Globalization.Extensions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Globalization.Extensions.dll": {}
@@ -5910,7 +6518,9 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.IO.dll": {}
+          "ref/dotnet/System.IO.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.IO.dll": {}
@@ -5931,7 +6541,9 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "ref/netcore50/System.IO.Compression.dll": {}
+          "ref/netcore50/System.IO.Compression.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.IO.Compression.dll": {}
@@ -5956,7 +6568,9 @@
           "System.Text.Encoding": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.IO.Compression.ZipFile.dll": {}
+          "ref/dotnet/System.IO.Compression.ZipFile.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.IO.Compression.ZipFile.dll": {}
@@ -5982,7 +6596,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.IO.FileSystem.dll": {}
+          "ref/dotnet/System.IO.FileSystem.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.IO.FileSystem.dll": {}
@@ -5994,7 +6610,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.IO.FileSystem.Primitives.dll": {}
+          "ref/dotnet/System.IO.FileSystem.Primitives.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.IO.FileSystem.Primitives.dll": {}
@@ -6014,7 +6632,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.IO.IsolatedStorage.dll": {}
+          "ref/dotnet/System.IO.IsolatedStorage.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.IO.IsolatedStorage.dll": {}
@@ -6032,7 +6652,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.IO.UnmanagedMemoryStream.dll": {}
+          "ref/dotnet/System.IO.UnmanagedMemoryStream.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.IO.UnmanagedMemoryStream.dll": {}
@@ -6048,7 +6670,9 @@
           "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Linq.dll": {}
+          "ref/netcore50/System.Linq.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Linq.dll": {}
@@ -6074,7 +6698,9 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Linq.Expressions.dll": {}
+          "ref/dotnet/System.Linq.Expressions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Linq.Expressions.dll": {}
@@ -6095,7 +6721,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Linq.Parallel.dll": {}
+          "ref/netcore50/System.Linq.Parallel.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Linq.Parallel.dll": {}
@@ -6113,7 +6741,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.Linq.Queryable.dll": {}
+          "ref/netcore50/System.Linq.Queryable.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Linq.Queryable.dll": {}
@@ -6138,7 +6768,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Net.Http.dll": {}
+          "ref/netcore50/System.Net.Http.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Net.Http.dll": {}
@@ -6151,7 +6783,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.Net.Http.Rtc.dll": {}
+          "ref/netcore50/System.Net.Http.Rtc.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Net.Http.Rtc.dll": {}
@@ -6165,7 +6799,9 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "ref/netcore50/System.Net.NetworkInformation.dll": {}
+          "ref/netcore50/System.Net.NetworkInformation.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Net.NetworkInformation.dll": {}
@@ -6178,7 +6814,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Net.Primitives.dll": {}
+          "ref/dotnet/System.Net.Primitives.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Net.Primitives.dll": {}
@@ -6199,7 +6837,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Net.Requests.dll": {}
+          "ref/dotnet/System.Net.Requests.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Net.Requests.dll": {}
@@ -6212,7 +6852,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Net.Sockets.dll": {}
+          "ref/dotnet/System.Net.Sockets.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Net.Sockets.dll": {}
@@ -6227,7 +6869,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Net.WebHeaderCollection.dll": {}
+          "ref/dotnet/System.Net.WebHeaderCollection.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Net.WebHeaderCollection.dll": {}
@@ -6272,7 +6916,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.ObjectModel.dll": {}
+          "ref/dotnet/System.ObjectModel.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.ObjectModel.dll": {}
@@ -6403,7 +7049,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Reflection.dll": {}
+          "ref/dotnet/System.Reflection.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Reflection.dll": {}
@@ -6417,7 +7065,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.Reflection.Context.dll": {}
+          "ref/netcore50/System.Reflection.Context.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Reflection.Context.dll": {}
@@ -6438,7 +7088,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Reflection.DispatchProxy.dll": {}
+          "ref/dotnet/System.Reflection.DispatchProxy.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Reflection.DispatchProxy.dll": {}
@@ -6454,7 +7106,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Reflection.Emit.dll": {}
+          "ref/dotnet/System.Reflection.Emit.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Reflection.Emit.dll": {}
@@ -6468,7 +7122,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Reflection.Emit.ILGeneration.dll": {}
+          "ref/dotnet/System.Reflection.Emit.ILGeneration.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Reflection.Emit.ILGeneration.dll": {}
@@ -6483,7 +7139,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Reflection.Emit.Lightweight.dll": {}
+          "ref/dotnet/System.Reflection.Emit.Lightweight.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Reflection.Emit.Lightweight.dll": {}
@@ -6501,7 +7159,9 @@
           "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Reflection.Extensions.dll": {}
+          "ref/netcore50/System.Reflection.Extensions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Reflection.Extensions.dll": {}
@@ -6526,10 +7186,14 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "lib/dotnet/System.Reflection.Metadata.dll": {}
+          "lib/dotnet/System.Reflection.Metadata.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
-          "lib/dotnet/System.Reflection.Metadata.dll": {}
+          "lib/dotnet/System.Reflection.Metadata.dll": {
+            "related": ".xml"
+          }
         }
       },
       "System.Reflection.Primitives/4.0.0": {
@@ -6539,7 +7203,9 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "ref/netcore50/System.Reflection.Primitives.dll": {}
+          "ref/netcore50/System.Reflection.Primitives.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Reflection.Primitives.dll": {}
@@ -6558,7 +7224,9 @@
           "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Reflection.TypeExtensions.dll": {}
+          "ref/dotnet/System.Reflection.TypeExtensions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Reflection.TypeExtensions.dll": {}
@@ -6572,7 +7240,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.Resources.ResourceManager.dll": {}
+          "ref/netcore50/System.Resources.ResourceManager.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Resources.ResourceManager.dll": {}
@@ -6584,7 +7254,9 @@
           "System.Private.Uri": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Runtime.dll": {}
+          "ref/dotnet/System.Runtime.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.dll": {}
@@ -6596,7 +7268,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Runtime.Extensions.dll": {}
+          "ref/dotnet/System.Runtime.Extensions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.Extensions.dll": {}
@@ -6608,7 +7282,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Runtime.Handles.dll": {}
+          "ref/dotnet/System.Runtime.Handles.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.Handles.dll": {}
@@ -6623,7 +7299,9 @@
           "System.Runtime.Handles": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Runtime.InteropServices.dll": {}
+          "ref/dotnet/System.Runtime.InteropServices.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.InteropServices.dll": {}
@@ -6632,7 +7310,9 @@
       "System.Runtime.InteropServices.WindowsRuntime/4.0.0": {
         "type": "package",
         "compile": {
-          "ref/netcore50/System.Runtime.InteropServices.WindowsRuntime.dll": {}
+          "ref/netcore50/System.Runtime.InteropServices.WindowsRuntime.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.InteropServices.WindowsRuntime.dll": {}
@@ -6647,7 +7327,9 @@
           "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Runtime.Numerics.dll": {}
+          "ref/netcore50/System.Runtime.Numerics.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.Numerics.dll": {}
@@ -6659,7 +7341,9 @@
           "System.Private.DataContractSerialization": "4.0.0"
         },
         "compile": {
-          "ref/netcore50/System.Runtime.Serialization.Json.dll": {}
+          "ref/netcore50/System.Runtime.Serialization.Json.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.Serialization.Json.dll": {}
@@ -6672,7 +7356,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Runtime.Serialization.Primitives.dll": {}
+          "ref/dotnet/System.Runtime.Serialization.Primitives.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Runtime.Serialization.Primitives.dll": {}
@@ -6685,7 +7371,9 @@
           "System.Runtime.Serialization.Primitives": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Runtime.Serialization.Xml.dll": {}
+          "ref/dotnet/System.Runtime.Serialization.Xml.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.Serialization.Xml.dll": {}
@@ -6706,7 +7394,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Runtime.WindowsRuntime.dll": {}
+          "ref/netcore50/System.Runtime.WindowsRuntime.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.WindowsRuntime.dll": {}
@@ -6722,7 +7412,9 @@
           "System.Runtime.WindowsRuntime": "4.0.0"
         },
         "compile": {
-          "ref/netcore50/System.Runtime.WindowsRuntime.UI.Xaml.dll": {}
+          "ref/netcore50/System.Runtime.WindowsRuntime.UI.Xaml.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.WindowsRuntime.UI.Xaml.dll": {}
@@ -6741,7 +7433,9 @@
           "System.Security.Principal": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Security.Claims.dll": {}
+          "ref/dotnet/System.Security.Claims.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Security.Claims.dll": {}
@@ -6753,7 +7447,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/netcore50/System.Security.Principal.dll": {}
+          "ref/netcore50/System.Security.Principal.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Security.Principal.dll": {}
@@ -6766,7 +7462,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.ServiceModel.Duplex.dll": {}
+          "ref/netcore50/System.ServiceModel.Duplex.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.ServiceModel.Duplex.dll": {}
@@ -6779,7 +7477,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.ServiceModel.Http.dll": {}
+          "ref/dotnet/System.ServiceModel.Http.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.ServiceModel.Http.dll": {}
@@ -6792,7 +7492,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.ServiceModel.NetTcp.dll": {}
+          "ref/netcore50/System.ServiceModel.NetTcp.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.ServiceModel.NetTcp.dll": {}
@@ -6805,7 +7507,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.ServiceModel.Primitives.dll": {}
+          "ref/netcore50/System.ServiceModel.Primitives.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.ServiceModel.Primitives.dll": {}
@@ -6818,7 +7522,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.ServiceModel.Security.dll": {}
+          "ref/netcore50/System.ServiceModel.Security.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.ServiceModel.Security.dll": {}
@@ -6830,7 +7536,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Text.Encoding.dll": {}
+          "ref/dotnet/System.Text.Encoding.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Text.Encoding.dll": {}
@@ -6852,7 +7560,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Text.Encoding.CodePages.dll": {}
+          "ref/dotnet/System.Text.Encoding.CodePages.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Text.Encoding.CodePages.dll": {}
@@ -6865,7 +7575,9 @@
           "System.Text.Encoding": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Text.Encoding.Extensions.dll": {}
+          "ref/dotnet/System.Text.Encoding.Extensions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Text.Encoding.Extensions.dll": {}
@@ -6882,7 +7594,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Text.RegularExpressions.dll": {}
+          "ref/dotnet/System.Text.RegularExpressions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Text.RegularExpressions.dll": {}
@@ -6895,7 +7609,9 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Threading.dll": {}
+          "ref/dotnet/System.Threading.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Threading.dll": {}
@@ -6912,7 +7628,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Threading.Overlapped.dll": {}
+          "ref/dotnet/System.Threading.Overlapped.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Threading.Overlapped.dll": {}
@@ -6924,7 +7642,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Threading.Tasks.dll": {}
+          "ref/dotnet/System.Threading.Tasks.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Threading.Tasks.dll": {}
@@ -6946,10 +7666,14 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "lib/dotnet/System.Threading.Tasks.Dataflow.dll": {}
+          "lib/dotnet/System.Threading.Tasks.Dataflow.dll": {
+            "related": ".XML"
+          }
         },
         "runtime": {
-          "lib/dotnet/System.Threading.Tasks.Dataflow.dll": {}
+          "lib/dotnet/System.Threading.Tasks.Dataflow.dll": {
+            "related": ".XML"
+          }
         }
       },
       "System.Threading.Tasks.Parallel/4.0.0": {
@@ -6965,7 +7689,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Threading.Tasks.Parallel.dll": {}
+          "ref/netcore50/System.Threading.Tasks.Parallel.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Threading.Tasks.Parallel.dll": {}
@@ -6974,7 +7700,9 @@
       "System.Threading.Timer/4.0.0": {
         "type": "package",
         "compile": {
-          "ref/netcore50/System.Threading.Timer.dll": {}
+          "ref/netcore50/System.Threading.Timer.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Threading.Timer.dll": {}
@@ -6999,7 +7727,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Xml.ReaderWriter.dll": {}
+          "ref/dotnet/System.Xml.ReaderWriter.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Xml.ReaderWriter.dll": {}
@@ -7021,7 +7751,9 @@
           "System.Xml.ReaderWriter": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Xml.XDocument.dll": {}
+          "ref/dotnet/System.Xml.XDocument.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Xml.XDocument.dll": {}
@@ -7042,7 +7774,9 @@
           "System.Xml.ReaderWriter": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Xml.XmlDocument.dll": {}
+          "ref/dotnet/System.Xml.XmlDocument.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Xml.XmlDocument.dll": {}
@@ -7071,7 +7805,9 @@
           "System.Xml.XmlDocument": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Xml.XmlSerializer.dll": {}
+          "ref/dotnet/System.Xml.XmlSerializer.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Xml.XmlSerializer.dll": {}
@@ -7100,7 +7836,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/Microsoft.CSharp.dll": {}
+          "ref/netcore50/Microsoft.CSharp.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/Microsoft.CSharp.dll": {}
@@ -7181,12 +7919,18 @@
           "ref/netcore50/System.Numerics.dll": {},
           "ref/netcore50/System.Runtime.Serialization.dll": {},
           "ref/netcore50/System.ServiceModel.Web.dll": {},
-          "ref/netcore50/System.ServiceModel.dll": {},
+          "ref/netcore50/System.ServiceModel.dll": {
+            "related": ".Web.dll"
+          },
           "ref/netcore50/System.Windows.dll": {},
           "ref/netcore50/System.Xml.Linq.dll": {},
           "ref/netcore50/System.Xml.Serialization.dll": {},
-          "ref/netcore50/System.Xml.dll": {},
-          "ref/netcore50/System.dll": {},
+          "ref/netcore50/System.Xml.dll": {
+            "related": ".Linq.dll;.Serialization.dll"
+          },
+          "ref/netcore50/System.dll": {
+            "related": ".ComponentModel.DataAnnotations.dll;.Core.dll;.Net.dll;.Numerics.dll;.Runtime.Serialization.dll;.ServiceModel.dll;.ServiceModel.Web.dll;.Windows.dll;.Xml.dll;.Xml.Linq.dll;.Xml.Serialization.dll"
+          },
           "ref/netcore50/mscorlib.dll": {}
         },
         "runtime": {
@@ -7196,12 +7940,18 @@
           "runtimes/aot/lib/netcore50/System.Numerics.dll": {},
           "runtimes/aot/lib/netcore50/System.Runtime.Serialization.dll": {},
           "runtimes/aot/lib/netcore50/System.ServiceModel.Web.dll": {},
-          "runtimes/aot/lib/netcore50/System.ServiceModel.dll": {},
+          "runtimes/aot/lib/netcore50/System.ServiceModel.dll": {
+            "related": ".Web.dll"
+          },
           "runtimes/aot/lib/netcore50/System.Windows.dll": {},
           "runtimes/aot/lib/netcore50/System.Xml.Linq.dll": {},
           "runtimes/aot/lib/netcore50/System.Xml.Serialization.dll": {},
-          "runtimes/aot/lib/netcore50/System.Xml.dll": {},
-          "runtimes/aot/lib/netcore50/System.dll": {},
+          "runtimes/aot/lib/netcore50/System.Xml.dll": {
+            "related": ".Linq.dll;.Serialization.dll"
+          },
+          "runtimes/aot/lib/netcore50/System.dll": {
+            "related": ".ComponentModel.DataAnnotations.dll;.Core.dll;.Net.dll;.Numerics.dll;.Runtime.Serialization.dll;.ServiceModel.dll;.ServiceModel.Web.dll;.Windows.dll;.Xml.dll;.Xml.Linq.dll;.Xml.Serialization.dll"
+          },
           "runtimes/aot/lib/netcore50/mscorlib.dll": {}
         }
       },
@@ -7304,7 +8054,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/Microsoft.VisualBasic.dll": {}
+          "ref/netcore50/Microsoft.VisualBasic.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/Microsoft.VisualBasic.dll": {}
@@ -7317,7 +8069,9 @@
           "System.Runtime.InteropServices": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/Microsoft.Win32.Primitives.dll": {}
+          "ref/dotnet/Microsoft.Win32.Primitives.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/Microsoft.Win32.Primitives.dll": {}
@@ -7332,7 +8086,9 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.AppContext.dll": {}
+          "ref/dotnet/System.AppContext.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.AppContext.dll": {}
@@ -7348,7 +8104,9 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Collections.dll": {}
+          "ref/dotnet/System.Collections.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Collections.dll": {}
@@ -7368,7 +8126,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Collections.Concurrent.dll": {}
+          "ref/dotnet/System.Collections.Concurrent.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Collections.Concurrent.dll": {}
@@ -7387,10 +8147,14 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "lib/dotnet/System.Collections.Immutable.dll": {}
+          "lib/dotnet/System.Collections.Immutable.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
-          "lib/dotnet/System.Collections.Immutable.dll": {}
+          "lib/dotnet/System.Collections.Immutable.dll": {
+            "related": ".xml"
+          }
         }
       },
       "System.Collections.NonGeneric/4.0.0": {
@@ -7404,7 +8168,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Collections.NonGeneric.dll": {}
+          "ref/dotnet/System.Collections.NonGeneric.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Collections.NonGeneric.dll": {}
@@ -7422,7 +8188,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Collections.Specialized.dll": {}
+          "ref/dotnet/System.Collections.Specialized.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Collections.Specialized.dll": {}
@@ -7434,7 +8202,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.ComponentModel.dll": {}
+          "ref/netcore50/System.ComponentModel.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.ComponentModel.dll": {}
@@ -7456,7 +8226,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.ComponentModel.Annotations.dll": {}
+          "ref/dotnet/System.ComponentModel.Annotations.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.ComponentModel.Annotations.dll": {}
@@ -7471,7 +8243,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.ComponentModel.EventBasedAsync.dll": {}
+          "ref/dotnet/System.ComponentModel.EventBasedAsync.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.ComponentModel.EventBasedAsync.dll": {}
@@ -7491,7 +8265,9 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Data.Common.dll": {}
+          "ref/dotnet/System.Data.Common.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Data.Common.dll": {}
@@ -7500,7 +8276,9 @@
       "System.Diagnostics.Contracts/4.0.0": {
         "type": "package",
         "compile": {
-          "ref/netcore50/System.Diagnostics.Contracts.dll": {}
+          "ref/netcore50/System.Diagnostics.Contracts.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Contracts.dll": {}
@@ -7512,7 +8290,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Diagnostics.Debug.dll": {}
+          "ref/dotnet/System.Diagnostics.Debug.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Debug.dll": {}
@@ -7524,7 +8304,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Diagnostics.StackTrace.dll": {}
+          "ref/dotnet/System.Diagnostics.StackTrace.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Diagnostics.StackTrace.dll": {}
@@ -7533,7 +8315,9 @@
       "System.Diagnostics.Tools/4.0.0": {
         "type": "package",
         "compile": {
-          "ref/netcore50/System.Diagnostics.Tools.dll": {}
+          "ref/netcore50/System.Diagnostics.Tools.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tools.dll": {}
@@ -7554,7 +8338,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Diagnostics.Tracing.dll": {}
+          "ref/dotnet/System.Diagnostics.Tracing.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tracing.dll": {}
@@ -7577,7 +8363,9 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Dynamic.Runtime.dll": {}
+          "ref/dotnet/System.Dynamic.Runtime.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Dynamic.Runtime.dll": {}
@@ -7589,7 +8377,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Globalization.dll": {}
+          "ref/dotnet/System.Globalization.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Globalization.dll": {}
@@ -7602,7 +8392,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Globalization.Calendars.dll": {}
+          "ref/dotnet/System.Globalization.Calendars.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Globalization.Calendars.dll": {}
@@ -7618,7 +8410,9 @@
           "System.Runtime.InteropServices": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Globalization.Extensions.dll": {}
+          "ref/dotnet/System.Globalization.Extensions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Globalization.Extensions.dll": {}
@@ -7635,7 +8429,9 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.IO.dll": {}
+          "ref/dotnet/System.IO.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.IO.dll": {}
@@ -7656,7 +8452,9 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "ref/netcore50/System.IO.Compression.dll": {}
+          "ref/netcore50/System.IO.Compression.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.IO.Compression.dll": {}
@@ -7681,7 +8479,9 @@
           "System.Text.Encoding": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.IO.Compression.ZipFile.dll": {}
+          "ref/dotnet/System.IO.Compression.ZipFile.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.IO.Compression.ZipFile.dll": {}
@@ -7707,7 +8507,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.IO.FileSystem.dll": {}
+          "ref/dotnet/System.IO.FileSystem.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.IO.FileSystem.dll": {}
@@ -7719,7 +8521,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.IO.FileSystem.Primitives.dll": {}
+          "ref/dotnet/System.IO.FileSystem.Primitives.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.IO.FileSystem.Primitives.dll": {}
@@ -7739,7 +8543,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.IO.IsolatedStorage.dll": {}
+          "ref/dotnet/System.IO.IsolatedStorage.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.IO.IsolatedStorage.dll": {}
@@ -7757,7 +8563,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.IO.UnmanagedMemoryStream.dll": {}
+          "ref/dotnet/System.IO.UnmanagedMemoryStream.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.IO.UnmanagedMemoryStream.dll": {}
@@ -7773,7 +8581,9 @@
           "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Linq.dll": {}
+          "ref/netcore50/System.Linq.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Linq.dll": {}
@@ -7797,7 +8607,9 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Linq.Expressions.dll": {}
+          "ref/dotnet/System.Linq.Expressions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Linq.Expressions.dll": {}
@@ -7818,7 +8630,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Linq.Parallel.dll": {}
+          "ref/netcore50/System.Linq.Parallel.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Linq.Parallel.dll": {}
@@ -7836,7 +8650,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.Linq.Queryable.dll": {}
+          "ref/netcore50/System.Linq.Queryable.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Linq.Queryable.dll": {}
@@ -7861,7 +8677,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Net.Http.dll": {}
+          "ref/netcore50/System.Net.Http.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Net.Http.dll": {}
@@ -7874,7 +8692,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.Net.Http.Rtc.dll": {}
+          "ref/netcore50/System.Net.Http.Rtc.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Net.Http.Rtc.dll": {}
@@ -7888,7 +8708,9 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "ref/netcore50/System.Net.NetworkInformation.dll": {}
+          "ref/netcore50/System.Net.NetworkInformation.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Net.NetworkInformation.dll": {}
@@ -7901,7 +8723,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Net.Primitives.dll": {}
+          "ref/dotnet/System.Net.Primitives.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Net.Primitives.dll": {}
@@ -7922,7 +8746,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Net.Requests.dll": {}
+          "ref/dotnet/System.Net.Requests.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Net.Requests.dll": {}
@@ -7935,7 +8761,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Net.Sockets.dll": {}
+          "ref/dotnet/System.Net.Sockets.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Net.Sockets.dll": {}
@@ -7950,7 +8778,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Net.WebHeaderCollection.dll": {}
+          "ref/dotnet/System.Net.WebHeaderCollection.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Net.WebHeaderCollection.dll": {}
@@ -7995,7 +8825,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.ObjectModel.dll": {}
+          "ref/dotnet/System.ObjectModel.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.ObjectModel.dll": {}
@@ -8124,7 +8956,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Reflection.dll": {}
+          "ref/dotnet/System.Reflection.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Reflection.dll": {}
@@ -8138,7 +8972,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.Reflection.Context.dll": {}
+          "ref/netcore50/System.Reflection.Context.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Reflection.Context.dll": {}
@@ -8157,7 +8993,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Reflection.DispatchProxy.dll": {}
+          "ref/dotnet/System.Reflection.DispatchProxy.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Reflection.DispatchProxy.dll": {}
@@ -8173,7 +9011,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Reflection.Emit.dll": {}
+          "ref/dotnet/System.Reflection.Emit.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Reflection.Emit.dll": {}
@@ -8187,7 +9027,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Reflection.Emit.ILGeneration.dll": {}
+          "ref/dotnet/System.Reflection.Emit.ILGeneration.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Reflection.Emit.ILGeneration.dll": {}
@@ -8205,7 +9047,9 @@
           "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Reflection.Extensions.dll": {}
+          "ref/netcore50/System.Reflection.Extensions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Reflection.Extensions.dll": {}
@@ -8230,10 +9074,14 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "lib/dotnet/System.Reflection.Metadata.dll": {}
+          "lib/dotnet/System.Reflection.Metadata.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
-          "lib/dotnet/System.Reflection.Metadata.dll": {}
+          "lib/dotnet/System.Reflection.Metadata.dll": {
+            "related": ".xml"
+          }
         }
       },
       "System.Reflection.Primitives/4.0.0": {
@@ -8243,7 +9091,9 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "ref/netcore50/System.Reflection.Primitives.dll": {}
+          "ref/netcore50/System.Reflection.Primitives.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Reflection.Primitives.dll": {}
@@ -8262,7 +9112,9 @@
           "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Reflection.TypeExtensions.dll": {}
+          "ref/dotnet/System.Reflection.TypeExtensions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Reflection.TypeExtensions.dll": {}
@@ -8276,7 +9128,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.Resources.ResourceManager.dll": {}
+          "ref/netcore50/System.Resources.ResourceManager.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Resources.ResourceManager.dll": {}
@@ -8288,7 +9142,9 @@
           "System.Private.Uri": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Runtime.dll": {}
+          "ref/dotnet/System.Runtime.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Runtime.dll": {}
@@ -8300,7 +9156,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Runtime.Extensions.dll": {}
+          "ref/dotnet/System.Runtime.Extensions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Runtime.Extensions.dll": {}
@@ -8312,7 +9170,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Runtime.Handles.dll": {}
+          "ref/dotnet/System.Runtime.Handles.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Runtime.Handles.dll": {}
@@ -8327,7 +9187,9 @@
           "System.Runtime.Handles": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Runtime.InteropServices.dll": {}
+          "ref/dotnet/System.Runtime.InteropServices.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Runtime.InteropServices.dll": {}
@@ -8336,7 +9198,9 @@
       "System.Runtime.InteropServices.WindowsRuntime/4.0.0": {
         "type": "package",
         "compile": {
-          "ref/netcore50/System.Runtime.InteropServices.WindowsRuntime.dll": {}
+          "ref/netcore50/System.Runtime.InteropServices.WindowsRuntime.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Runtime.InteropServices.WindowsRuntime.dll": {}
@@ -8351,7 +9215,9 @@
           "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Runtime.Numerics.dll": {}
+          "ref/netcore50/System.Runtime.Numerics.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.Numerics.dll": {}
@@ -8363,7 +9229,9 @@
           "System.Private.DataContractSerialization": "4.0.0"
         },
         "compile": {
-          "ref/netcore50/System.Runtime.Serialization.Json.dll": {}
+          "ref/netcore50/System.Runtime.Serialization.Json.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Runtime.Serialization.Json.dll": {}
@@ -8376,7 +9244,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Runtime.Serialization.Primitives.dll": {}
+          "ref/dotnet/System.Runtime.Serialization.Primitives.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Runtime.Serialization.Primitives.dll": {}
@@ -8389,7 +9259,9 @@
           "System.Runtime.Serialization.Primitives": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Runtime.Serialization.Xml.dll": {}
+          "ref/dotnet/System.Runtime.Serialization.Xml.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Runtime.Serialization.Xml.dll": {}
@@ -8410,7 +9282,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Runtime.WindowsRuntime.dll": {}
+          "ref/netcore50/System.Runtime.WindowsRuntime.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Runtime.WindowsRuntime.dll": {}
@@ -8426,7 +9300,9 @@
           "System.Runtime.WindowsRuntime": "4.0.0"
         },
         "compile": {
-          "ref/netcore50/System.Runtime.WindowsRuntime.UI.Xaml.dll": {}
+          "ref/netcore50/System.Runtime.WindowsRuntime.UI.Xaml.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.WindowsRuntime.UI.Xaml.dll": {}
@@ -8445,7 +9321,9 @@
           "System.Security.Principal": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Security.Claims.dll": {}
+          "ref/dotnet/System.Security.Claims.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Security.Claims.dll": {}
@@ -8457,7 +9335,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/netcore50/System.Security.Principal.dll": {}
+          "ref/netcore50/System.Security.Principal.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Security.Principal.dll": {}
@@ -8470,7 +9350,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.ServiceModel.Duplex.dll": {}
+          "ref/netcore50/System.ServiceModel.Duplex.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.ServiceModel.Duplex.dll": {}
@@ -8483,7 +9365,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.ServiceModel.Http.dll": {}
+          "ref/dotnet/System.ServiceModel.Http.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.ServiceModel.Http.dll": {}
@@ -8496,7 +9380,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.ServiceModel.NetTcp.dll": {}
+          "ref/netcore50/System.ServiceModel.NetTcp.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.ServiceModel.NetTcp.dll": {}
@@ -8509,7 +9395,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.ServiceModel.Primitives.dll": {}
+          "ref/netcore50/System.ServiceModel.Primitives.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.ServiceModel.Primitives.dll": {}
@@ -8522,7 +9410,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.ServiceModel.Security.dll": {}
+          "ref/netcore50/System.ServiceModel.Security.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.ServiceModel.Security.dll": {}
@@ -8534,7 +9424,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Text.Encoding.dll": {}
+          "ref/dotnet/System.Text.Encoding.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.dll": {}
@@ -8556,7 +9448,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Text.Encoding.CodePages.dll": {}
+          "ref/dotnet/System.Text.Encoding.CodePages.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Text.Encoding.CodePages.dll": {}
@@ -8569,7 +9463,9 @@
           "System.Text.Encoding": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Text.Encoding.Extensions.dll": {}
+          "ref/dotnet/System.Text.Encoding.Extensions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.Extensions.dll": {}
@@ -8586,7 +9482,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Text.RegularExpressions.dll": {}
+          "ref/dotnet/System.Text.RegularExpressions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Text.RegularExpressions.dll": {}
@@ -8599,7 +9497,9 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Threading.dll": {}
+          "ref/dotnet/System.Threading.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Threading.dll": {}
@@ -8616,7 +9516,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Threading.Overlapped.dll": {}
+          "ref/dotnet/System.Threading.Overlapped.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Threading.Overlapped.dll": {}
@@ -8628,7 +9530,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Threading.Tasks.dll": {}
+          "ref/dotnet/System.Threading.Tasks.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Threading.Tasks.dll": {}
@@ -8650,10 +9554,14 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "lib/dotnet/System.Threading.Tasks.Dataflow.dll": {}
+          "lib/dotnet/System.Threading.Tasks.Dataflow.dll": {
+            "related": ".XML"
+          }
         },
         "runtime": {
-          "lib/dotnet/System.Threading.Tasks.Dataflow.dll": {}
+          "lib/dotnet/System.Threading.Tasks.Dataflow.dll": {
+            "related": ".XML"
+          }
         }
       },
       "System.Threading.Tasks.Parallel/4.0.0": {
@@ -8669,7 +9577,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Threading.Tasks.Parallel.dll": {}
+          "ref/netcore50/System.Threading.Tasks.Parallel.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Threading.Tasks.Parallel.dll": {}
@@ -8678,7 +9588,9 @@
       "System.Threading.Timer/4.0.0": {
         "type": "package",
         "compile": {
-          "ref/netcore50/System.Threading.Timer.dll": {}
+          "ref/netcore50/System.Threading.Timer.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Threading.Timer.dll": {}
@@ -8703,7 +9615,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Xml.ReaderWriter.dll": {}
+          "ref/dotnet/System.Xml.ReaderWriter.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Xml.ReaderWriter.dll": {}
@@ -8725,7 +9639,9 @@
           "System.Xml.ReaderWriter": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Xml.XDocument.dll": {}
+          "ref/dotnet/System.Xml.XDocument.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Xml.XDocument.dll": {}
@@ -8746,7 +9662,9 @@
           "System.Xml.ReaderWriter": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Xml.XmlDocument.dll": {}
+          "ref/dotnet/System.Xml.XmlDocument.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Xml.XmlDocument.dll": {}
@@ -8775,7 +9693,9 @@
           "System.Xml.XmlDocument": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Xml.XmlSerializer.dll": {}
+          "ref/dotnet/System.Xml.XmlSerializer.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Xml.XmlSerializer.dll": {}
@@ -8804,7 +9724,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/Microsoft.CSharp.dll": {}
+          "ref/netcore50/Microsoft.CSharp.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/Microsoft.CSharp.dll": {}
@@ -8885,12 +9807,18 @@
           "ref/netcore50/System.Numerics.dll": {},
           "ref/netcore50/System.Runtime.Serialization.dll": {},
           "ref/netcore50/System.ServiceModel.Web.dll": {},
-          "ref/netcore50/System.ServiceModel.dll": {},
+          "ref/netcore50/System.ServiceModel.dll": {
+            "related": ".Web.dll"
+          },
           "ref/netcore50/System.Windows.dll": {},
           "ref/netcore50/System.Xml.Linq.dll": {},
           "ref/netcore50/System.Xml.Serialization.dll": {},
-          "ref/netcore50/System.Xml.dll": {},
-          "ref/netcore50/System.dll": {},
+          "ref/netcore50/System.Xml.dll": {
+            "related": ".Linq.dll;.Serialization.dll"
+          },
+          "ref/netcore50/System.dll": {
+            "related": ".ComponentModel.DataAnnotations.dll;.Core.dll;.Net.dll;.Numerics.dll;.Runtime.Serialization.dll;.ServiceModel.dll;.ServiceModel.Web.dll;.Windows.dll;.Xml.dll;.Xml.Linq.dll;.Xml.Serialization.dll"
+          },
           "ref/netcore50/mscorlib.dll": {}
         },
         "runtime": {
@@ -8900,12 +9828,18 @@
           "lib/netcore50/System.Numerics.dll": {},
           "lib/netcore50/System.Runtime.Serialization.dll": {},
           "lib/netcore50/System.ServiceModel.Web.dll": {},
-          "lib/netcore50/System.ServiceModel.dll": {},
+          "lib/netcore50/System.ServiceModel.dll": {
+            "related": ".Web.dll"
+          },
           "lib/netcore50/System.Windows.dll": {},
           "lib/netcore50/System.Xml.Linq.dll": {},
           "lib/netcore50/System.Xml.Serialization.dll": {},
-          "lib/netcore50/System.Xml.dll": {},
-          "lib/netcore50/System.dll": {}
+          "lib/netcore50/System.Xml.dll": {
+            "related": ".Linq.dll;.Serialization.dll"
+          },
+          "lib/netcore50/System.dll": {
+            "related": ".ComponentModel.DataAnnotations.dll;.Core.dll;.Net.dll;.Numerics.dll;.Runtime.Serialization.dll;.ServiceModel.dll;.ServiceModel.Web.dll;.Windows.dll;.Xml.dll;.Xml.Linq.dll;.Xml.Serialization.dll"
+          }
         }
       },
       "Microsoft.NETCore.Runtime/1.0.0": {
@@ -9029,7 +9963,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/Microsoft.VisualBasic.dll": {}
+          "ref/netcore50/Microsoft.VisualBasic.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/Microsoft.VisualBasic.dll": {}
@@ -9042,7 +9978,9 @@
           "System.Runtime.InteropServices": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/Microsoft.Win32.Primitives.dll": {}
+          "ref/dotnet/Microsoft.Win32.Primitives.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/Microsoft.Win32.Primitives.dll": {}
@@ -9057,7 +9995,9 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.AppContext.dll": {}
+          "ref/dotnet/System.AppContext.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.AppContext.dll": {}
@@ -9073,7 +10013,9 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Collections.dll": {}
+          "ref/dotnet/System.Collections.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Collections.dll": {}
@@ -9093,7 +10035,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Collections.Concurrent.dll": {}
+          "ref/dotnet/System.Collections.Concurrent.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Collections.Concurrent.dll": {}
@@ -9112,10 +10056,14 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "lib/dotnet/System.Collections.Immutable.dll": {}
+          "lib/dotnet/System.Collections.Immutable.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
-          "lib/dotnet/System.Collections.Immutable.dll": {}
+          "lib/dotnet/System.Collections.Immutable.dll": {
+            "related": ".xml"
+          }
         }
       },
       "System.Collections.NonGeneric/4.0.0": {
@@ -9129,7 +10077,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Collections.NonGeneric.dll": {}
+          "ref/dotnet/System.Collections.NonGeneric.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Collections.NonGeneric.dll": {}
@@ -9147,7 +10097,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Collections.Specialized.dll": {}
+          "ref/dotnet/System.Collections.Specialized.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Collections.Specialized.dll": {}
@@ -9159,7 +10111,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.ComponentModel.dll": {}
+          "ref/netcore50/System.ComponentModel.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.ComponentModel.dll": {}
@@ -9181,7 +10135,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.ComponentModel.Annotations.dll": {}
+          "ref/dotnet/System.ComponentModel.Annotations.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.ComponentModel.Annotations.dll": {}
@@ -9196,7 +10152,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.ComponentModel.EventBasedAsync.dll": {}
+          "ref/dotnet/System.ComponentModel.EventBasedAsync.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.ComponentModel.EventBasedAsync.dll": {}
@@ -9216,7 +10174,9 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Data.Common.dll": {}
+          "ref/dotnet/System.Data.Common.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Data.Common.dll": {}
@@ -9225,7 +10185,9 @@
       "System.Diagnostics.Contracts/4.0.0": {
         "type": "package",
         "compile": {
-          "ref/netcore50/System.Diagnostics.Contracts.dll": {}
+          "ref/netcore50/System.Diagnostics.Contracts.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Diagnostics.Contracts.dll": {}
@@ -9237,7 +10199,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Diagnostics.Debug.dll": {}
+          "ref/dotnet/System.Diagnostics.Debug.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Diagnostics.Debug.dll": {}
@@ -9249,7 +10213,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Diagnostics.StackTrace.dll": {}
+          "ref/dotnet/System.Diagnostics.StackTrace.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Diagnostics.StackTrace.dll": {}
@@ -9258,7 +10224,9 @@
       "System.Diagnostics.Tools/4.0.0": {
         "type": "package",
         "compile": {
-          "ref/netcore50/System.Diagnostics.Tools.dll": {}
+          "ref/netcore50/System.Diagnostics.Tools.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Diagnostics.Tools.dll": {}
@@ -9279,7 +10247,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Diagnostics.Tracing.dll": {}
+          "ref/dotnet/System.Diagnostics.Tracing.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Diagnostics.Tracing.dll": {}
@@ -9304,7 +10274,9 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Dynamic.Runtime.dll": {}
+          "ref/dotnet/System.Dynamic.Runtime.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Dynamic.Runtime.dll": {}
@@ -9316,7 +10288,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Globalization.dll": {}
+          "ref/dotnet/System.Globalization.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Globalization.dll": {}
@@ -9329,7 +10303,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Globalization.Calendars.dll": {}
+          "ref/dotnet/System.Globalization.Calendars.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Globalization.Calendars.dll": {}
@@ -9345,7 +10321,9 @@
           "System.Runtime.InteropServices": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Globalization.Extensions.dll": {}
+          "ref/dotnet/System.Globalization.Extensions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Globalization.Extensions.dll": {}
@@ -9362,7 +10340,9 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.IO.dll": {}
+          "ref/dotnet/System.IO.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.IO.dll": {}
@@ -9383,7 +10363,9 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "ref/netcore50/System.IO.Compression.dll": {}
+          "ref/netcore50/System.IO.Compression.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.IO.Compression.dll": {}
@@ -9408,7 +10390,9 @@
           "System.Text.Encoding": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.IO.Compression.ZipFile.dll": {}
+          "ref/dotnet/System.IO.Compression.ZipFile.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.IO.Compression.ZipFile.dll": {}
@@ -9434,7 +10418,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.IO.FileSystem.dll": {}
+          "ref/dotnet/System.IO.FileSystem.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.IO.FileSystem.dll": {}
@@ -9446,7 +10432,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.IO.FileSystem.Primitives.dll": {}
+          "ref/dotnet/System.IO.FileSystem.Primitives.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.IO.FileSystem.Primitives.dll": {}
@@ -9466,7 +10454,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.IO.IsolatedStorage.dll": {}
+          "ref/dotnet/System.IO.IsolatedStorage.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.IO.IsolatedStorage.dll": {}
@@ -9484,7 +10474,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.IO.UnmanagedMemoryStream.dll": {}
+          "ref/dotnet/System.IO.UnmanagedMemoryStream.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.IO.UnmanagedMemoryStream.dll": {}
@@ -9500,7 +10492,9 @@
           "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Linq.dll": {}
+          "ref/netcore50/System.Linq.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Linq.dll": {}
@@ -9526,7 +10520,9 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Linq.Expressions.dll": {}
+          "ref/dotnet/System.Linq.Expressions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Linq.Expressions.dll": {}
@@ -9547,7 +10543,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Linq.Parallel.dll": {}
+          "ref/netcore50/System.Linq.Parallel.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Linq.Parallel.dll": {}
@@ -9565,7 +10563,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.Linq.Queryable.dll": {}
+          "ref/netcore50/System.Linq.Queryable.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Linq.Queryable.dll": {}
@@ -9590,7 +10590,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Net.Http.dll": {}
+          "ref/netcore50/System.Net.Http.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Net.Http.dll": {}
@@ -9603,7 +10605,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.Net.Http.Rtc.dll": {}
+          "ref/netcore50/System.Net.Http.Rtc.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Net.Http.Rtc.dll": {}
@@ -9617,7 +10621,9 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "ref/netcore50/System.Net.NetworkInformation.dll": {}
+          "ref/netcore50/System.Net.NetworkInformation.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Net.NetworkInformation.dll": {}
@@ -9630,7 +10636,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Net.Primitives.dll": {}
+          "ref/dotnet/System.Net.Primitives.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Net.Primitives.dll": {}
@@ -9651,7 +10659,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Net.Requests.dll": {}
+          "ref/dotnet/System.Net.Requests.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Net.Requests.dll": {}
@@ -9664,7 +10674,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Net.Sockets.dll": {}
+          "ref/dotnet/System.Net.Sockets.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Net.Sockets.dll": {}
@@ -9679,7 +10691,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Net.WebHeaderCollection.dll": {}
+          "ref/dotnet/System.Net.WebHeaderCollection.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Net.WebHeaderCollection.dll": {}
@@ -9724,7 +10738,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.ObjectModel.dll": {}
+          "ref/dotnet/System.ObjectModel.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.ObjectModel.dll": {}
@@ -9855,7 +10871,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Reflection.dll": {}
+          "ref/dotnet/System.Reflection.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Reflection.dll": {}
@@ -9869,7 +10887,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.Reflection.Context.dll": {}
+          "ref/netcore50/System.Reflection.Context.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Reflection.Context.dll": {}
@@ -9890,7 +10910,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Reflection.DispatchProxy.dll": {}
+          "ref/dotnet/System.Reflection.DispatchProxy.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Reflection.DispatchProxy.dll": {}
@@ -9906,7 +10928,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Reflection.Emit.dll": {}
+          "ref/dotnet/System.Reflection.Emit.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Reflection.Emit.dll": {}
@@ -9920,7 +10944,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Reflection.Emit.ILGeneration.dll": {}
+          "ref/dotnet/System.Reflection.Emit.ILGeneration.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Reflection.Emit.ILGeneration.dll": {}
@@ -9935,7 +10961,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Reflection.Emit.Lightweight.dll": {}
+          "ref/dotnet/System.Reflection.Emit.Lightweight.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Reflection.Emit.Lightweight.dll": {}
@@ -9953,7 +10981,9 @@
           "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Reflection.Extensions.dll": {}
+          "ref/netcore50/System.Reflection.Extensions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Reflection.Extensions.dll": {}
@@ -9978,10 +11008,14 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "lib/dotnet/System.Reflection.Metadata.dll": {}
+          "lib/dotnet/System.Reflection.Metadata.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
-          "lib/dotnet/System.Reflection.Metadata.dll": {}
+          "lib/dotnet/System.Reflection.Metadata.dll": {
+            "related": ".xml"
+          }
         }
       },
       "System.Reflection.Primitives/4.0.0": {
@@ -9991,7 +11025,9 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "ref/netcore50/System.Reflection.Primitives.dll": {}
+          "ref/netcore50/System.Reflection.Primitives.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Reflection.Primitives.dll": {}
@@ -10010,7 +11046,9 @@
           "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Reflection.TypeExtensions.dll": {}
+          "ref/dotnet/System.Reflection.TypeExtensions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Reflection.TypeExtensions.dll": {}
@@ -10024,7 +11062,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.Resources.ResourceManager.dll": {}
+          "ref/netcore50/System.Resources.ResourceManager.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Resources.ResourceManager.dll": {}
@@ -10036,7 +11076,9 @@
           "System.Private.Uri": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Runtime.dll": {}
+          "ref/dotnet/System.Runtime.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.dll": {}
@@ -10048,7 +11090,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Runtime.Extensions.dll": {}
+          "ref/dotnet/System.Runtime.Extensions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.Extensions.dll": {}
@@ -10060,7 +11104,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Runtime.Handles.dll": {}
+          "ref/dotnet/System.Runtime.Handles.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.Handles.dll": {}
@@ -10075,7 +11121,9 @@
           "System.Runtime.Handles": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Runtime.InteropServices.dll": {}
+          "ref/dotnet/System.Runtime.InteropServices.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.InteropServices.dll": {}
@@ -10084,7 +11132,9 @@
       "System.Runtime.InteropServices.WindowsRuntime/4.0.0": {
         "type": "package",
         "compile": {
-          "ref/netcore50/System.Runtime.InteropServices.WindowsRuntime.dll": {}
+          "ref/netcore50/System.Runtime.InteropServices.WindowsRuntime.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.InteropServices.WindowsRuntime.dll": {}
@@ -10099,7 +11149,9 @@
           "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Runtime.Numerics.dll": {}
+          "ref/netcore50/System.Runtime.Numerics.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.Numerics.dll": {}
@@ -10111,7 +11163,9 @@
           "System.Private.DataContractSerialization": "4.0.0"
         },
         "compile": {
-          "ref/netcore50/System.Runtime.Serialization.Json.dll": {}
+          "ref/netcore50/System.Runtime.Serialization.Json.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.Serialization.Json.dll": {}
@@ -10124,7 +11178,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Runtime.Serialization.Primitives.dll": {}
+          "ref/dotnet/System.Runtime.Serialization.Primitives.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Runtime.Serialization.Primitives.dll": {}
@@ -10137,7 +11193,9 @@
           "System.Runtime.Serialization.Primitives": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Runtime.Serialization.Xml.dll": {}
+          "ref/dotnet/System.Runtime.Serialization.Xml.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.Serialization.Xml.dll": {}
@@ -10158,7 +11216,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Runtime.WindowsRuntime.dll": {}
+          "ref/netcore50/System.Runtime.WindowsRuntime.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.WindowsRuntime.dll": {}
@@ -10174,7 +11234,9 @@
           "System.Runtime.WindowsRuntime": "4.0.0"
         },
         "compile": {
-          "ref/netcore50/System.Runtime.WindowsRuntime.UI.Xaml.dll": {}
+          "ref/netcore50/System.Runtime.WindowsRuntime.UI.Xaml.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.WindowsRuntime.UI.Xaml.dll": {}
@@ -10193,7 +11255,9 @@
           "System.Security.Principal": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Security.Claims.dll": {}
+          "ref/dotnet/System.Security.Claims.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Security.Claims.dll": {}
@@ -10205,7 +11269,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/netcore50/System.Security.Principal.dll": {}
+          "ref/netcore50/System.Security.Principal.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Security.Principal.dll": {}
@@ -10218,7 +11284,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.ServiceModel.Duplex.dll": {}
+          "ref/netcore50/System.ServiceModel.Duplex.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.ServiceModel.Duplex.dll": {}
@@ -10231,7 +11299,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.ServiceModel.Http.dll": {}
+          "ref/dotnet/System.ServiceModel.Http.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.ServiceModel.Http.dll": {}
@@ -10244,7 +11314,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.ServiceModel.NetTcp.dll": {}
+          "ref/netcore50/System.ServiceModel.NetTcp.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.ServiceModel.NetTcp.dll": {}
@@ -10257,7 +11329,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.ServiceModel.Primitives.dll": {}
+          "ref/netcore50/System.ServiceModel.Primitives.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.ServiceModel.Primitives.dll": {}
@@ -10270,7 +11344,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.ServiceModel.Security.dll": {}
+          "ref/netcore50/System.ServiceModel.Security.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.ServiceModel.Security.dll": {}
@@ -10282,7 +11358,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Text.Encoding.dll": {}
+          "ref/dotnet/System.Text.Encoding.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Text.Encoding.dll": {}
@@ -10304,7 +11382,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Text.Encoding.CodePages.dll": {}
+          "ref/dotnet/System.Text.Encoding.CodePages.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Text.Encoding.CodePages.dll": {}
@@ -10317,7 +11397,9 @@
           "System.Text.Encoding": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Text.Encoding.Extensions.dll": {}
+          "ref/dotnet/System.Text.Encoding.Extensions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Text.Encoding.Extensions.dll": {}
@@ -10334,7 +11416,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Text.RegularExpressions.dll": {}
+          "ref/dotnet/System.Text.RegularExpressions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Text.RegularExpressions.dll": {}
@@ -10347,7 +11431,9 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Threading.dll": {}
+          "ref/dotnet/System.Threading.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Threading.dll": {}
@@ -10364,7 +11450,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Threading.Overlapped.dll": {}
+          "ref/dotnet/System.Threading.Overlapped.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Threading.Overlapped.dll": {}
@@ -10376,7 +11464,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Threading.Tasks.dll": {}
+          "ref/dotnet/System.Threading.Tasks.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Threading.Tasks.dll": {}
@@ -10398,10 +11488,14 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "lib/dotnet/System.Threading.Tasks.Dataflow.dll": {}
+          "lib/dotnet/System.Threading.Tasks.Dataflow.dll": {
+            "related": ".XML"
+          }
         },
         "runtime": {
-          "lib/dotnet/System.Threading.Tasks.Dataflow.dll": {}
+          "lib/dotnet/System.Threading.Tasks.Dataflow.dll": {
+            "related": ".XML"
+          }
         }
       },
       "System.Threading.Tasks.Parallel/4.0.0": {
@@ -10417,7 +11511,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Threading.Tasks.Parallel.dll": {}
+          "ref/netcore50/System.Threading.Tasks.Parallel.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Threading.Tasks.Parallel.dll": {}
@@ -10426,7 +11522,9 @@
       "System.Threading.Timer/4.0.0": {
         "type": "package",
         "compile": {
-          "ref/netcore50/System.Threading.Timer.dll": {}
+          "ref/netcore50/System.Threading.Timer.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Threading.Timer.dll": {}
@@ -10451,7 +11549,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Xml.ReaderWriter.dll": {}
+          "ref/dotnet/System.Xml.ReaderWriter.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Xml.ReaderWriter.dll": {}
@@ -10473,7 +11573,9 @@
           "System.Xml.ReaderWriter": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Xml.XDocument.dll": {}
+          "ref/dotnet/System.Xml.XDocument.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Xml.XDocument.dll": {}
@@ -10494,7 +11596,9 @@
           "System.Xml.ReaderWriter": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Xml.XmlDocument.dll": {}
+          "ref/dotnet/System.Xml.XmlDocument.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Xml.XmlDocument.dll": {}
@@ -10523,7 +11627,9 @@
           "System.Xml.XmlDocument": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Xml.XmlSerializer.dll": {}
+          "ref/dotnet/System.Xml.XmlSerializer.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Xml.XmlSerializer.dll": {}
@@ -10552,7 +11658,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/Microsoft.CSharp.dll": {}
+          "ref/netcore50/Microsoft.CSharp.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/Microsoft.CSharp.dll": {}
@@ -10633,12 +11741,18 @@
           "ref/netcore50/System.Numerics.dll": {},
           "ref/netcore50/System.Runtime.Serialization.dll": {},
           "ref/netcore50/System.ServiceModel.Web.dll": {},
-          "ref/netcore50/System.ServiceModel.dll": {},
+          "ref/netcore50/System.ServiceModel.dll": {
+            "related": ".Web.dll"
+          },
           "ref/netcore50/System.Windows.dll": {},
           "ref/netcore50/System.Xml.Linq.dll": {},
           "ref/netcore50/System.Xml.Serialization.dll": {},
-          "ref/netcore50/System.Xml.dll": {},
-          "ref/netcore50/System.dll": {},
+          "ref/netcore50/System.Xml.dll": {
+            "related": ".Linq.dll;.Serialization.dll"
+          },
+          "ref/netcore50/System.dll": {
+            "related": ".ComponentModel.DataAnnotations.dll;.Core.dll;.Net.dll;.Numerics.dll;.Runtime.Serialization.dll;.ServiceModel.dll;.ServiceModel.Web.dll;.Windows.dll;.Xml.dll;.Xml.Linq.dll;.Xml.Serialization.dll"
+          },
           "ref/netcore50/mscorlib.dll": {}
         },
         "runtime": {
@@ -10648,12 +11762,18 @@
           "runtimes/aot/lib/netcore50/System.Numerics.dll": {},
           "runtimes/aot/lib/netcore50/System.Runtime.Serialization.dll": {},
           "runtimes/aot/lib/netcore50/System.ServiceModel.Web.dll": {},
-          "runtimes/aot/lib/netcore50/System.ServiceModel.dll": {},
+          "runtimes/aot/lib/netcore50/System.ServiceModel.dll": {
+            "related": ".Web.dll"
+          },
           "runtimes/aot/lib/netcore50/System.Windows.dll": {},
           "runtimes/aot/lib/netcore50/System.Xml.Linq.dll": {},
           "runtimes/aot/lib/netcore50/System.Xml.Serialization.dll": {},
-          "runtimes/aot/lib/netcore50/System.Xml.dll": {},
-          "runtimes/aot/lib/netcore50/System.dll": {},
+          "runtimes/aot/lib/netcore50/System.Xml.dll": {
+            "related": ".Linq.dll;.Serialization.dll"
+          },
+          "runtimes/aot/lib/netcore50/System.dll": {
+            "related": ".ComponentModel.DataAnnotations.dll;.Core.dll;.Net.dll;.Numerics.dll;.Runtime.Serialization.dll;.ServiceModel.dll;.ServiceModel.Web.dll;.Windows.dll;.Xml.dll;.Xml.Linq.dll;.Xml.Serialization.dll"
+          },
           "runtimes/aot/lib/netcore50/mscorlib.dll": {}
         }
       },
@@ -10756,7 +11876,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/Microsoft.VisualBasic.dll": {}
+          "ref/netcore50/Microsoft.VisualBasic.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/Microsoft.VisualBasic.dll": {}
@@ -10769,7 +11891,9 @@
           "System.Runtime.InteropServices": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/Microsoft.Win32.Primitives.dll": {}
+          "ref/dotnet/Microsoft.Win32.Primitives.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/Microsoft.Win32.Primitives.dll": {}
@@ -10784,7 +11908,9 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.AppContext.dll": {}
+          "ref/dotnet/System.AppContext.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.AppContext.dll": {}
@@ -10800,7 +11926,9 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Collections.dll": {}
+          "ref/dotnet/System.Collections.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Collections.dll": {}
@@ -10820,7 +11948,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Collections.Concurrent.dll": {}
+          "ref/dotnet/System.Collections.Concurrent.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Collections.Concurrent.dll": {}
@@ -10839,10 +11969,14 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "lib/dotnet/System.Collections.Immutable.dll": {}
+          "lib/dotnet/System.Collections.Immutable.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
-          "lib/dotnet/System.Collections.Immutable.dll": {}
+          "lib/dotnet/System.Collections.Immutable.dll": {
+            "related": ".xml"
+          }
         }
       },
       "System.Collections.NonGeneric/4.0.0": {
@@ -10856,7 +11990,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Collections.NonGeneric.dll": {}
+          "ref/dotnet/System.Collections.NonGeneric.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Collections.NonGeneric.dll": {}
@@ -10874,7 +12010,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Collections.Specialized.dll": {}
+          "ref/dotnet/System.Collections.Specialized.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Collections.Specialized.dll": {}
@@ -10886,7 +12024,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.ComponentModel.dll": {}
+          "ref/netcore50/System.ComponentModel.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.ComponentModel.dll": {}
@@ -10908,7 +12048,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.ComponentModel.Annotations.dll": {}
+          "ref/dotnet/System.ComponentModel.Annotations.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.ComponentModel.Annotations.dll": {}
@@ -10923,7 +12065,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.ComponentModel.EventBasedAsync.dll": {}
+          "ref/dotnet/System.ComponentModel.EventBasedAsync.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.ComponentModel.EventBasedAsync.dll": {}
@@ -10943,7 +12087,9 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Data.Common.dll": {}
+          "ref/dotnet/System.Data.Common.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Data.Common.dll": {}
@@ -10952,7 +12098,9 @@
       "System.Diagnostics.Contracts/4.0.0": {
         "type": "package",
         "compile": {
-          "ref/netcore50/System.Diagnostics.Contracts.dll": {}
+          "ref/netcore50/System.Diagnostics.Contracts.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Contracts.dll": {}
@@ -10964,7 +12112,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Diagnostics.Debug.dll": {}
+          "ref/dotnet/System.Diagnostics.Debug.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Debug.dll": {}
@@ -10976,7 +12126,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Diagnostics.StackTrace.dll": {}
+          "ref/dotnet/System.Diagnostics.StackTrace.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Diagnostics.StackTrace.dll": {}
@@ -10985,7 +12137,9 @@
       "System.Diagnostics.Tools/4.0.0": {
         "type": "package",
         "compile": {
-          "ref/netcore50/System.Diagnostics.Tools.dll": {}
+          "ref/netcore50/System.Diagnostics.Tools.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tools.dll": {}
@@ -11006,7 +12160,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Diagnostics.Tracing.dll": {}
+          "ref/dotnet/System.Diagnostics.Tracing.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tracing.dll": {}
@@ -11029,7 +12185,9 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Dynamic.Runtime.dll": {}
+          "ref/dotnet/System.Dynamic.Runtime.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Dynamic.Runtime.dll": {}
@@ -11041,7 +12199,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Globalization.dll": {}
+          "ref/dotnet/System.Globalization.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Globalization.dll": {}
@@ -11054,7 +12214,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Globalization.Calendars.dll": {}
+          "ref/dotnet/System.Globalization.Calendars.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Globalization.Calendars.dll": {}
@@ -11070,7 +12232,9 @@
           "System.Runtime.InteropServices": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Globalization.Extensions.dll": {}
+          "ref/dotnet/System.Globalization.Extensions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Globalization.Extensions.dll": {}
@@ -11087,7 +12251,9 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.IO.dll": {}
+          "ref/dotnet/System.IO.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.IO.dll": {}
@@ -11108,7 +12274,9 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "ref/netcore50/System.IO.Compression.dll": {}
+          "ref/netcore50/System.IO.Compression.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.IO.Compression.dll": {}
@@ -11133,7 +12301,9 @@
           "System.Text.Encoding": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.IO.Compression.ZipFile.dll": {}
+          "ref/dotnet/System.IO.Compression.ZipFile.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.IO.Compression.ZipFile.dll": {}
@@ -11159,7 +12329,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.IO.FileSystem.dll": {}
+          "ref/dotnet/System.IO.FileSystem.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.IO.FileSystem.dll": {}
@@ -11171,7 +12343,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.IO.FileSystem.Primitives.dll": {}
+          "ref/dotnet/System.IO.FileSystem.Primitives.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.IO.FileSystem.Primitives.dll": {}
@@ -11191,7 +12365,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.IO.IsolatedStorage.dll": {}
+          "ref/dotnet/System.IO.IsolatedStorage.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.IO.IsolatedStorage.dll": {}
@@ -11209,7 +12385,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.IO.UnmanagedMemoryStream.dll": {}
+          "ref/dotnet/System.IO.UnmanagedMemoryStream.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.IO.UnmanagedMemoryStream.dll": {}
@@ -11225,7 +12403,9 @@
           "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Linq.dll": {}
+          "ref/netcore50/System.Linq.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Linq.dll": {}
@@ -11249,7 +12429,9 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Linq.Expressions.dll": {}
+          "ref/dotnet/System.Linq.Expressions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Linq.Expressions.dll": {}
@@ -11270,7 +12452,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Linq.Parallel.dll": {}
+          "ref/netcore50/System.Linq.Parallel.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Linq.Parallel.dll": {}
@@ -11288,7 +12472,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.Linq.Queryable.dll": {}
+          "ref/netcore50/System.Linq.Queryable.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Linq.Queryable.dll": {}
@@ -11313,7 +12499,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Net.Http.dll": {}
+          "ref/netcore50/System.Net.Http.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Net.Http.dll": {}
@@ -11326,7 +12514,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.Net.Http.Rtc.dll": {}
+          "ref/netcore50/System.Net.Http.Rtc.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Net.Http.Rtc.dll": {}
@@ -11340,7 +12530,9 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "ref/netcore50/System.Net.NetworkInformation.dll": {}
+          "ref/netcore50/System.Net.NetworkInformation.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Net.NetworkInformation.dll": {}
@@ -11353,7 +12545,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Net.Primitives.dll": {}
+          "ref/dotnet/System.Net.Primitives.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Net.Primitives.dll": {}
@@ -11374,7 +12568,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Net.Requests.dll": {}
+          "ref/dotnet/System.Net.Requests.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Net.Requests.dll": {}
@@ -11387,7 +12583,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Net.Sockets.dll": {}
+          "ref/dotnet/System.Net.Sockets.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Net.Sockets.dll": {}
@@ -11402,7 +12600,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Net.WebHeaderCollection.dll": {}
+          "ref/dotnet/System.Net.WebHeaderCollection.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Net.WebHeaderCollection.dll": {}
@@ -11447,7 +12647,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.ObjectModel.dll": {}
+          "ref/dotnet/System.ObjectModel.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.ObjectModel.dll": {}
@@ -11576,7 +12778,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Reflection.dll": {}
+          "ref/dotnet/System.Reflection.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Reflection.dll": {}
@@ -11590,7 +12794,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.Reflection.Context.dll": {}
+          "ref/netcore50/System.Reflection.Context.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Reflection.Context.dll": {}
@@ -11609,7 +12815,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Reflection.DispatchProxy.dll": {}
+          "ref/dotnet/System.Reflection.DispatchProxy.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Reflection.DispatchProxy.dll": {}
@@ -11625,7 +12833,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Reflection.Emit.dll": {}
+          "ref/dotnet/System.Reflection.Emit.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Reflection.Emit.dll": {}
@@ -11639,7 +12849,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Reflection.Emit.ILGeneration.dll": {}
+          "ref/dotnet/System.Reflection.Emit.ILGeneration.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Reflection.Emit.ILGeneration.dll": {}
@@ -11657,7 +12869,9 @@
           "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Reflection.Extensions.dll": {}
+          "ref/netcore50/System.Reflection.Extensions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Reflection.Extensions.dll": {}
@@ -11682,10 +12896,14 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "lib/dotnet/System.Reflection.Metadata.dll": {}
+          "lib/dotnet/System.Reflection.Metadata.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
-          "lib/dotnet/System.Reflection.Metadata.dll": {}
+          "lib/dotnet/System.Reflection.Metadata.dll": {
+            "related": ".xml"
+          }
         }
       },
       "System.Reflection.Primitives/4.0.0": {
@@ -11695,7 +12913,9 @@
           "System.Threading": "4.0.0"
         },
         "compile": {
-          "ref/netcore50/System.Reflection.Primitives.dll": {}
+          "ref/netcore50/System.Reflection.Primitives.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Reflection.Primitives.dll": {}
@@ -11714,7 +12934,9 @@
           "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Reflection.TypeExtensions.dll": {}
+          "ref/dotnet/System.Reflection.TypeExtensions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Reflection.TypeExtensions.dll": {}
@@ -11728,7 +12950,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.Resources.ResourceManager.dll": {}
+          "ref/netcore50/System.Resources.ResourceManager.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Resources.ResourceManager.dll": {}
@@ -11740,7 +12964,9 @@
           "System.Private.Uri": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Runtime.dll": {}
+          "ref/dotnet/System.Runtime.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Runtime.dll": {}
@@ -11752,7 +12978,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Runtime.Extensions.dll": {}
+          "ref/dotnet/System.Runtime.Extensions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Runtime.Extensions.dll": {}
@@ -11764,7 +12992,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Runtime.Handles.dll": {}
+          "ref/dotnet/System.Runtime.Handles.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Runtime.Handles.dll": {}
@@ -11779,7 +13009,9 @@
           "System.Runtime.Handles": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Runtime.InteropServices.dll": {}
+          "ref/dotnet/System.Runtime.InteropServices.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Runtime.InteropServices.dll": {}
@@ -11788,7 +13020,9 @@
       "System.Runtime.InteropServices.WindowsRuntime/4.0.0": {
         "type": "package",
         "compile": {
-          "ref/netcore50/System.Runtime.InteropServices.WindowsRuntime.dll": {}
+          "ref/netcore50/System.Runtime.InteropServices.WindowsRuntime.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Runtime.InteropServices.WindowsRuntime.dll": {}
@@ -11803,7 +13037,9 @@
           "System.Runtime.Extensions": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Runtime.Numerics.dll": {}
+          "ref/netcore50/System.Runtime.Numerics.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.Numerics.dll": {}
@@ -11815,7 +13051,9 @@
           "System.Private.DataContractSerialization": "4.0.0"
         },
         "compile": {
-          "ref/netcore50/System.Runtime.Serialization.Json.dll": {}
+          "ref/netcore50/System.Runtime.Serialization.Json.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Runtime.Serialization.Json.dll": {}
@@ -11828,7 +13066,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.Runtime.Serialization.Primitives.dll": {}
+          "ref/dotnet/System.Runtime.Serialization.Primitives.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Runtime.Serialization.Primitives.dll": {}
@@ -11841,7 +13081,9 @@
           "System.Runtime.Serialization.Primitives": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Runtime.Serialization.Xml.dll": {}
+          "ref/dotnet/System.Runtime.Serialization.Xml.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Runtime.Serialization.Xml.dll": {}
@@ -11862,7 +13104,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Runtime.WindowsRuntime.dll": {}
+          "ref/netcore50/System.Runtime.WindowsRuntime.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Runtime.WindowsRuntime.dll": {}
@@ -11878,7 +13122,9 @@
           "System.Runtime.WindowsRuntime": "4.0.0"
         },
         "compile": {
-          "ref/netcore50/System.Runtime.WindowsRuntime.UI.Xaml.dll": {}
+          "ref/netcore50/System.Runtime.WindowsRuntime.UI.Xaml.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Runtime.WindowsRuntime.UI.Xaml.dll": {}
@@ -11897,7 +13143,9 @@
           "System.Security.Principal": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Security.Claims.dll": {}
+          "ref/dotnet/System.Security.Claims.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Security.Claims.dll": {}
@@ -11909,7 +13157,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/netcore50/System.Security.Principal.dll": {}
+          "ref/netcore50/System.Security.Principal.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Security.Principal.dll": {}
@@ -11922,7 +13172,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.ServiceModel.Duplex.dll": {}
+          "ref/netcore50/System.ServiceModel.Duplex.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.ServiceModel.Duplex.dll": {}
@@ -11935,7 +13187,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/System.ServiceModel.Http.dll": {}
+          "ref/dotnet/System.ServiceModel.Http.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.ServiceModel.Http.dll": {}
@@ -11948,7 +13202,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.ServiceModel.NetTcp.dll": {}
+          "ref/netcore50/System.ServiceModel.NetTcp.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.ServiceModel.NetTcp.dll": {}
@@ -11961,7 +13217,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.ServiceModel.Primitives.dll": {}
+          "ref/netcore50/System.ServiceModel.Primitives.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.ServiceModel.Primitives.dll": {}
@@ -11974,7 +13232,9 @@
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/netcore50/System.ServiceModel.Security.dll": {}
+          "ref/netcore50/System.ServiceModel.Security.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.ServiceModel.Security.dll": {}
@@ -11986,7 +13246,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Text.Encoding.dll": {}
+          "ref/dotnet/System.Text.Encoding.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.dll": {}
@@ -12008,7 +13270,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Text.Encoding.CodePages.dll": {}
+          "ref/dotnet/System.Text.Encoding.CodePages.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Text.Encoding.CodePages.dll": {}
@@ -12021,7 +13285,9 @@
           "System.Text.Encoding": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Text.Encoding.Extensions.dll": {}
+          "ref/dotnet/System.Text.Encoding.Extensions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.Extensions.dll": {}
@@ -12038,7 +13304,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Text.RegularExpressions.dll": {}
+          "ref/dotnet/System.Text.RegularExpressions.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Text.RegularExpressions.dll": {}
@@ -12051,7 +13319,9 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Threading.dll": {}
+          "ref/dotnet/System.Threading.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Threading.dll": {}
@@ -12068,7 +13338,9 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Threading.Overlapped.dll": {}
+          "ref/dotnet/System.Threading.Overlapped.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Threading.Overlapped.dll": {}
@@ -12080,7 +13352,9 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Threading.Tasks.dll": {}
+          "ref/dotnet/System.Threading.Tasks.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Threading.Tasks.dll": {}
@@ -12102,10 +13376,14 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "lib/dotnet/System.Threading.Tasks.Dataflow.dll": {}
+          "lib/dotnet/System.Threading.Tasks.Dataflow.dll": {
+            "related": ".XML"
+          }
         },
         "runtime": {
-          "lib/dotnet/System.Threading.Tasks.Dataflow.dll": {}
+          "lib/dotnet/System.Threading.Tasks.Dataflow.dll": {
+            "related": ".XML"
+          }
         }
       },
       "System.Threading.Tasks.Parallel/4.0.0": {
@@ -12121,7 +13399,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/netcore50/System.Threading.Tasks.Parallel.dll": {}
+          "ref/netcore50/System.Threading.Tasks.Parallel.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/netcore50/System.Threading.Tasks.Parallel.dll": {}
@@ -12130,7 +13410,9 @@
       "System.Threading.Timer/4.0.0": {
         "type": "package",
         "compile": {
-          "ref/netcore50/System.Threading.Timer.dll": {}
+          "ref/netcore50/System.Threading.Timer.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Threading.Timer.dll": {}
@@ -12155,7 +13437,9 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Xml.ReaderWriter.dll": {}
+          "ref/dotnet/System.Xml.ReaderWriter.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Xml.ReaderWriter.dll": {}
@@ -12177,7 +13461,9 @@
           "System.Xml.ReaderWriter": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Xml.XDocument.dll": {}
+          "ref/dotnet/System.Xml.XDocument.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Xml.XDocument.dll": {}
@@ -12198,7 +13484,9 @@
           "System.Xml.ReaderWriter": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Xml.XmlDocument.dll": {}
+          "ref/dotnet/System.Xml.XmlDocument.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "lib/dotnet/System.Xml.XmlDocument.dll": {}
@@ -12227,7 +13515,9 @@
           "System.Xml.XmlDocument": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Xml.XmlSerializer.dll": {}
+          "ref/dotnet/System.Xml.XmlSerializer.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Xml.XmlSerializer.dll": {}

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/PackagesWithRelatedFilesTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/PackagesWithRelatedFilesTests.cs
@@ -1,0 +1,267 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+using NuGet.Configuration;
+using NuGet.Frameworks;
+using NuGet.ProjectModel;
+using NuGet.Test.Utility;
+using Xunit;
+
+namespace NuGet.Commands.Test
+{
+    public class PackagesWithRelatedFilesTests
+    {
+        [Theory]
+        [InlineData(".exe", "X", new[] { ".config.json", ".pdb", ".xml" })]
+        [InlineData(".dll", "Test.X", new string[] { })]
+        [InlineData(".winmd", "NuGet.Test.X", new[] { ".pdb", ".some.random.extension", ".xml" })]
+        public async Task RelatedProperty_TopLevelPackageWithDifferentExtensions_RelatedPropertyAddedSuccessfully(string assemblyExtension, string assemblyName, string[] relatedExtensionList)
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                var framework = "net5.0";
+                // A -> packaegX
+                var projectA = SimpleTestProjectContext.CreateNETCoreWithSDK(
+                    "A",
+                    pathContext.SolutionRoot,
+                    framework);
+
+                var packageX = new SimpleTestPackageContext("packageX", "1.0.0");
+                packageX.Files.Clear();
+
+                packageX.AddFile($"lib/net5.0/{assemblyName}{assemblyExtension}");
+                foreach (string relatedExtension in relatedExtensionList)
+                {
+                    packageX.AddFile($"lib/net5.0/{assemblyName}{relatedExtension}");
+                }
+
+                await SimpleTestPackageUtility.CreatePackagesAsync(pathContext.PackageSource, packageX);
+                projectA.AddPackageToAllFrameworks(packageX);
+
+                var sources = new List<PackageSource>();
+                sources.Add(new PackageSource(pathContext.PackageSource));
+                projectA.Sources = sources;
+                projectA.FallbackFolders = new List<string>();
+                projectA.FallbackFolders.Add(pathContext.FallbackFolder);
+                projectA.GlobalPackagesFolder = pathContext.UserPackagesFolder;
+
+                var logger = new TestLogger();
+                var request = new TestRestoreRequest(projectA.PackageSpec, projectA.Sources, pathContext.UserPackagesFolder, logger)
+                {
+                    LockFilePath = projectA.AssetsFileOutputPath
+                };
+
+                // Act
+                var command = new RestoreCommand(request);
+                var result = await command.ExecuteAsync();
+                await result.CommitAsync(logger, CancellationToken.None);
+
+                // Asert
+                Assert.True(result.Success);
+                var assetsFile = projectA.AssetsFile;
+                Assert.NotNull(assetsFile);
+
+                var targets = assetsFile.GetTarget(NuGetFramework.Parse(framework), null);
+                var lib = targets.Libraries.Single();
+                var compileAssemblies = lib.CompileTimeAssemblies;
+                var runtimeAssemblies = lib.RuntimeAssemblies;
+
+                string expectedRelatedProperty = null;
+                if (relatedExtensionList.Any())
+                {
+                    expectedRelatedProperty = string.Join(";", relatedExtensionList);
+                }
+
+                // Compile, "related" property is applied.
+                AssertRelatedProperty(compileAssemblies, $"lib/net5.0/{assemblyName}{assemblyExtension}", expectedRelatedProperty);
+
+                // Runtime, "related" property is applied.
+                AssertRelatedProperty(runtimeAssemblies, $"lib/net5.0/{assemblyName}{assemblyExtension}", expectedRelatedProperty);
+            }
+        }
+
+        [Fact]
+        public async Task RelatedProperty_TopLevelPackageWithMultipleAssets_RelatedPropertyAppliedOnCompileRuntimeEmbedOnly()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                var framework = "net5.0";
+                // A -> packaegX
+                var projectA = SimpleTestProjectContext.CreateNETCoreWithSDK(
+                    "A",
+                    pathContext.SolutionRoot,
+                    framework);
+
+                var packageX = new SimpleTestPackageContext("packageX", "1.0.0");
+                packageX.Files.Clear();
+                // Compile
+                packageX.AddFile("ref/net5.0/X.dll");
+                packageX.AddFile("ref/net5.0/X.xml");
+                // Runtime
+                packageX.AddFile("lib/net5.0/X.dll");
+                packageX.AddFile("lib/net5.0/X.xml");
+                // Embed
+                packageX.AddFile("embed/net5.0/X.dll");
+                packageX.AddFile("embed/net5.0/X.xml");
+                // Resources
+                packageX.AddFile("lib/net5.0/en-US/X.resources.dll");
+                packageX.AddFile("lib/net5.0/en-US/X.resources.xml");
+
+                await SimpleTestPackageUtility.CreatePackagesAsync(pathContext.PackageSource, packageX);
+                projectA.AddPackageToAllFrameworks(packageX);
+
+                var sources = new List<PackageSource>();
+                sources.Add(new PackageSource(pathContext.PackageSource));
+                projectA.Sources = sources;
+                projectA.FallbackFolders = new List<string>();
+                projectA.FallbackFolders.Add(pathContext.FallbackFolder);
+                projectA.GlobalPackagesFolder = pathContext.UserPackagesFolder;
+
+                var logger = new TestLogger();
+                var request = new TestRestoreRequest(projectA.PackageSpec, projectA.Sources, pathContext.UserPackagesFolder, logger)
+                {
+                    LockFilePath = projectA.AssetsFileOutputPath
+                };
+
+                // Act
+                var command = new RestoreCommand(request);
+                var result = await command.ExecuteAsync();
+                await result.CommitAsync(logger, CancellationToken.None);
+
+                // Asert
+                Assert.True(result.Success);
+                var assetsFile = projectA.AssetsFile;
+                Assert.NotNull(assetsFile);
+
+                var targets = assetsFile.GetTarget(NuGetFramework.Parse(framework), null);
+                var lib = targets.Libraries.Single();
+
+                // Compile, "related" property is applied.
+                var compileAssemblies = lib.CompileTimeAssemblies;
+                AssertRelatedProperty(compileAssemblies, "ref/net5.0/X.dll", ".xml");
+
+                // Runtime, "related" property is applied.
+                var runtimeAssemblies = lib.RuntimeAssemblies;
+                AssertRelatedProperty(runtimeAssemblies, "lib/net5.0/X.dll", ".xml");
+
+                // Embed, "related" property is applied.
+                var embedAssemblies = lib.EmbedAssemblies;
+                AssertRelatedProperty(embedAssemblies, "embed/net5.0/X.dll", ".xml");
+
+                // Resources, "related" property is NOT applied.
+                var resourceAssemblies = lib.ResourceAssemblies;
+                AssertRelatedProperty(resourceAssemblies, "lib/net5.0/en-US/X.resources.dll", null);
+            }
+        }
+
+        [Fact]
+        public async Task RelatedProperty_TransitivePackageReferenceWithMultipleAssets_RelatedPropertyAppliedOnCompileRuntimeEmbedOnly()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                var framework = "net5.0";
+                // A -> packageX -> packageY
+                var projectA = SimpleTestProjectContext.CreateNETCoreWithSDK(
+                    "A",
+                    pathContext.SolutionRoot,
+                    framework);
+
+                var packageX = new SimpleTestPackageContext("packageX", "1.0.0");
+                packageX.Files.Clear();
+                packageX.AddFile($"lib/net5.0/X.dll");
+
+                var packageY = new SimpleTestPackageContext("packageY", "1.0.0");
+                packageY.Files.Clear();
+                // Compile
+                packageY.AddFile("ref/net5.0/Y.dll");
+                packageY.AddFile("ref/net5.0/Y.xml");
+                // Runtime
+                packageY.AddFile("lib/net5.0/Y.dll");
+                packageY.AddFile("lib/net5.0/Y.xml");
+                // Embed
+                packageY.AddFile("embed/net5.0/Y.dll");
+                packageY.AddFile("embed/net5.0/Y.xml");
+                // Resources
+                packageY.AddFile("lib/net5.0/en-US/Y.resources.dll");
+                packageY.AddFile("lib/net5.0/en-US/Y.resources.xml");
+
+                packageX.Dependencies.Add(packageY);
+
+                await SimpleTestPackageUtility.CreatePackagesAsync(pathContext.PackageSource, packageX, packageY);
+                projectA.AddPackageToAllFrameworks(packageX);
+
+                var sources = new List<PackageSource>();
+                sources.Add(new PackageSource(pathContext.PackageSource));
+                projectA.Sources = sources;
+                projectA.FallbackFolders = new List<string>();
+                projectA.FallbackFolders.Add(pathContext.FallbackFolder);
+                projectA.GlobalPackagesFolder = pathContext.UserPackagesFolder;
+
+                var logger = new TestLogger();
+                var request = new TestRestoreRequest(projectA.PackageSpec, projectA.Sources, pathContext.UserPackagesFolder, logger)
+                {
+                    LockFilePath = projectA.AssetsFileOutputPath
+                };
+
+                // Act
+                var command = new RestoreCommand(request);
+                var result = await command.ExecuteAsync();
+                await result.CommitAsync(logger, CancellationToken.None);
+
+                // Asert
+                Assert.True(result.Success);
+                var assetsFile = projectA.AssetsFile;
+                Assert.NotNull(assetsFile);
+
+                var targets = assetsFile.GetTarget(NuGetFramework.Parse(framework), null);
+
+                var libX = targets.Libraries.Single(i => i.Name.Equals("packageX"));
+                var runtimeAssembliesX = libX.RuntimeAssemblies;
+                AssertRelatedProperty(runtimeAssembliesX, $"lib/net5.0/X.dll", null);
+
+                var libY = targets.Libraries.Single(i => i.Name.Equals("packageY"));
+
+                // Compile, "related" property is applied.
+                var compileAssembliesY = libY.CompileTimeAssemblies;
+                AssertRelatedProperty(compileAssembliesY, $"ref/net5.0/Y.dll", ".xml");
+
+                // Runtime, "related" property is applied.
+                var runtimeAssembliesY = libY.RuntimeAssemblies;
+                AssertRelatedProperty(runtimeAssembliesY, $"lib/net5.0/Y.dll", ".xml");
+
+                // Embed, "related" property is applied.
+                var embedAssembliesY = libY.EmbedAssemblies;
+                AssertRelatedProperty(embedAssembliesY, $"embed/net5.0/Y.dll", ".xml");
+
+                // Resources, "related" property is NOT applied.
+                var resourceAssembliesY = libY.ResourceAssemblies;
+                AssertRelatedProperty(resourceAssembliesY, "lib/net5.0/en-US/Y.resources.dll", null);
+            }
+        }
+
+
+        private void AssertRelatedProperty(IList<LockFileItem> items, string path, string related)
+        {
+            var item = items.Single(i => i.Path.Equals(path));
+            if (related == null)
+            {
+                Assert.False(item.Properties.ContainsKey("related"));
+            }
+            else
+            {
+                Assert.Equal(related, item.Properties["related"]);
+            }
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/LockFileTargetLibraryTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/LockFileTargetLibraryTests.cs
@@ -987,5 +987,46 @@ namespace NuGet.ProjectModel.Test
 
             leftSide.GetHashCode().Should().Be(rightSide.GetHashCode());
         }
+
+        [Theory]
+        [InlineData("a", "a", true)]
+        [InlineData("a .pdb;.xml", "a .pdb;.xml", true)]
+        [InlineData("a .pdb;.xml", "a;", false)]
+        [InlineData("a .pdb", "b .pdb", false)]
+        [InlineData("a .pdb;.xml", "a .xml;.pdb", false)]
+        public void Equals_WithRuntimeAssembliesAndRelatedFiles(string left, string right, bool expected)
+        {
+            string[] leftParts = left.Trim().Split(' ');
+            var leftRuntimeAssembly = new LockFileItem(leftParts[0]);
+            if (leftParts.Length > 1)
+            {
+                leftRuntimeAssembly.Properties.Add("related", leftParts[1]);
+            }
+            var leftSide = new LockFileTargetLibrary()
+            {
+                RuntimeAssemblies = new List<LockFileItem>() { leftRuntimeAssembly }
+            };
+
+            string[] rightParts = right.Split(' ');
+            var rightRuntimeAssembly = new LockFileItem(rightParts[0]);
+            if (rightParts.Length > 1)
+            {
+                rightRuntimeAssembly.Properties.Add("related", rightParts[1]);
+            }
+            var rightSide = new LockFileTargetLibrary()
+            {
+                RuntimeAssemblies = new List<LockFileItem>() { rightRuntimeAssembly }
+            };
+
+            // Act & Assert
+            if (expected)
+            {
+                leftSide.Should().Be(rightSide);
+            }
+            else
+            {
+                leftSide.Should().NotBe(rightSide);
+            }
+        }
     }
 }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11352

Regression? Last working version:

## Description
This is a draft PR for implementing consuming pdb ([spec](https://github.com/NuGet/Home/blob/dev/proposed/2021/NuGetConsumePDBInPackageReference.md)), to get preliminary reviews.
The perftest results is:
<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<link id=Main-File rel=Main-File
href="file:///C:/Users/henli/AppData/Local/Temp/msohtmlclip1/01/clip.htm">
<link rel=File-List
href="file:///C:/Users/henli/AppData/Local/Temp/msohtmlclip1/01/clip_filelist.xml">
<style>
<!--table
	{mso-displayed-decimal-separator:"\.";
	mso-displayed-thousand-separator:"\,";}
@page
	{margin:.75in .7in .75in .7in;
	mso-header-margin:.3in;
	mso-footer-margin:.3in;}
tr
	{mso-height-source:auto;}
col
	{mso-width-source:auto;}
br
	{mso-data-placement:same-cell;}
td
	{padding-top:1px;
	padding-right:1px;
	padding-left:1px;
	mso-ignore:padding;
	color:black;
	font-size:11.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:Calibri, sans-serif;
	mso-font-charset:0;
	mso-number-format:General;
	text-align:general;
	vertical-align:bottom;
	border:none;
	mso-background-source:auto;
	mso-pattern:auto;
	mso-protection:locked visible;
	white-space:nowrap;
	mso-rotate:0;}
.xl65
	{font-weight:700;
	vertical-align:middle;}
.xl66
	{font-weight:700;
	vertical-align:middle;
	border:.5pt solid windowtext;}
.xl67
	{font-weight:700;
	text-align:center;
	vertical-align:middle;
	border:.5pt solid windowtext;
	white-space:normal;}
.xl68
	{border:.5pt solid windowtext;}
.xl69
	{mso-number-format:Percent;
	border:.5pt solid windowtext;}
-->
</style>
</head>

<body link="#0563C1" vlink="#954F72">



Client   Name | Client Version | Solution Name | Restore   scenarios | Average total   restore time for 10 runs (seconds)     Before the change | Average total   restore time for 10 runs (seconds)     After the change | Time   increases(%)
-- | -- | -- | -- | -- | -- | --
dotnet.exe | 7.0.100-preview.4.22252.9 | OrchardCore | arctic | 108.7990715 | 108.7093849 | -0.08%
dotnet.exe | 7.0.100-preview.4.22252.9 | OrchardCore | cold | 97.57810247 | 98.14389973 | 0.58%
dotnet.exe | 7.0.100-preview.4.22252.9 | OrchardCore | force | 24.09872892 | 25.12253743 | 4.08%
dotnet.exe | 7.0.100-preview.4.22252.9 | OrchardCore | noop | 15.28024177 | 15.67289567 | 2.51%
  |   |   |   |   |   |  
dotnet.exe | 7.0.100-preview.4.22252.9 | NuGet | arctic | 107.3057985 | 108.0651938 | 0.70%
dotnet.exe | 7.0.100-preview.4.22252.9 | NuGet | cold | 90.47450225 | 90.31247012 | -0.18%
dotnet.exe | 7.0.100-preview.4.22252.9 | NuGet | force | 17.4294302 | 18.31705519 | 4.85%
dotnet.exe | 7.0.100-preview.4.22252.9 | NuGet | noop | 11.36582764 | 11.48095707 | 1.00%



</body>

</html>



Unfinished parts/concerns:
1. Enable this only in .NET 7 (tried with environment variable. It's difficult to mock in unit test, might need to convert the current unit test into functional tests)
2. Some packages like NETStandard.Library, has 100+ .dll files. System.dll and System.Core.dll will be in the same folder so System.dll will have related property as `.ComponentModel.DataAnnotations.dll;.Core.dll;.Net.dll;.Numerics.dll;.Runtime.Serialization.dll;.ServiceModel.dll;.ServiceModel.Web.dll;.Windows.dll;.Xml.dll;.Xml.Linq.dll;.Xml.Serialization.dll`
3. If the restore time increase is a concern, it might be optimized: cache the related file extensions for each assembly. Then project targets multiple TFMs and has both runtime and compile could calculate related file extensions for only one time.

## PR Checklist

- [ ] PR has a meaningful title
- [ ] PR has a linked issue.
- [ ] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [ ] N/A
