### PR TITLE
Set CPM metadata during preview restore when installing a package in Visual Studio

### DIFF
--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpecOperations.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpecOperations.cs
@@ -26,7 +26,7 @@ namespace NuGet.ProjectModel
 
             if (!existing.Any())
             {
-                AddDependency(spec, spec.Dependencies, dependency.Id, range);
+                AddDependency(spec.Dependencies, dependency.Id, range, spec.RestoreMetadata?.CentralPackageVersionsEnabled ?? false);
             }
         }
 
@@ -164,21 +164,21 @@ namespace NuGet.ProjectModel
             }
             else
             {
-                AddDependency(spec, list, packageId, range);
+                AddDependency(list, packageId, range, spec.RestoreMetadata?.CentralPackageVersionsEnabled ?? false);
             }
 
         }
 
         private static void AddDependency(
-            PackageSpec spec,
             IList<LibraryDependency> list,
             string packageId,
-            VersionRange range)
+            VersionRange range,
+            bool centralPackageVersionsEnabled)
         {
             var dependency = new LibraryDependency
             {
                 LibraryRange = new LibraryRange(packageId, range, LibraryDependencyTarget.Package),
-                VersionCentrallyManaged = spec.RestoreMetadata?.CentralPackageVersionsEnabled ?? false
+                VersionCentrallyManaged = centralPackageVersionsEnabled
             };
 
             list.Add(dependency);

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecOperationsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecOperationsTests.cs
@@ -254,7 +254,42 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Fact]
-        public void AddOrUpdateDependency_WithCentralPackageManagementEnabled_AddsNewDependency()
+        public void AddOrUpdateDependency_WithCentralPackageManagementEnabled_AddsDependency()
+        {
+            // Arrange
+            var packageIdentity = new PackageIdentity("NuGet.Versioning", new NuGetVersion("1.0.0"));
+
+            var targetFrameworkInformation = new TargetFrameworkInformation
+            {
+                FrameworkName = FrameworkConstants.CommonFrameworks.Net45
+            };
+
+            var spec = new PackageSpec(new[] { targetFrameworkInformation })
+            {
+                RestoreMetadata = new ProjectRestoreMetadata
+                {
+                    CentralPackageVersionsEnabled = true
+                }
+            };
+
+            // Act
+            PackageSpecOperations.AddOrUpdateDependency(
+                spec,
+                packageIdentity,
+                new[] { targetFrameworkInformation.FrameworkName });
+
+            // Assert
+            Assert.Equal(1, spec.TargetFrameworks[0].Dependencies.Count);
+            Assert.Equal(packageIdentity.Id, spec.TargetFrameworks[0].Dependencies[0].LibraryRange.Name);
+            Assert.Equal(packageIdentity.Version, spec.TargetFrameworks[0].Dependencies[0].LibraryRange.VersionRange.MinVersion);
+            Assert.True(spec.TargetFrameworks[0].Dependencies[0].VersionCentrallyManaged);
+
+            Assert.True(spec.TargetFrameworks[0].CentralPackageVersions.ContainsKey(packageIdentity.Id));
+            Assert.Equal(packageIdentity.Version, spec.TargetFrameworks[0].CentralPackageVersions[packageIdentity.Id].VersionRange.MinVersion);
+        }
+
+        [Fact]
+        public void AddOrUpdateDependency_WithCentralPackageManagementEnabled_UpdatesDependency()
         {
             // Arrange
             var packageId = "NuGet.Versioning";

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecOperationsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecOperationsTests.cs
@@ -254,6 +254,67 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Fact]
+        public void AddOrUpdateDependency_WithCentralPackageManagementEnabled_AddsNewDependency()
+        {
+            // Arrange
+            var packageId = "NuGet.Versioning";
+            var oldVersion = new NuGetVersion("1.0.0");
+            var newVersion = new NuGetVersion("2.0.0");
+
+            var frameworkA = new TargetFrameworkInformation
+            {
+                FrameworkName = FrameworkConstants.CommonFrameworks.Net45
+            };
+
+            var ld = new LibraryDependency
+            {
+                LibraryRange = new LibraryRange(packageId, new VersionRange(oldVersion), LibraryDependencyTarget.Package),
+                VersionCentrallyManaged = true
+            };
+
+            var frameworkB = new TargetFrameworkInformation
+            {
+                FrameworkName = FrameworkConstants.CommonFrameworks.NetStandard16,
+                Dependencies = new List<LibraryDependency>() { ld },
+            };
+
+            frameworkB.CentralPackageVersions[ld.Name] = new CentralPackageVersion(ld.Name, ld.LibraryRange.VersionRange);
+
+            var spec = new PackageSpec(new[] { frameworkA, frameworkB })
+            {
+                RestoreMetadata = new ProjectRestoreMetadata
+                {
+                    CentralPackageVersionsEnabled = true
+                }
+            };
+            var identity = new PackageIdentity(packageId, newVersion);
+
+            //Preconditions
+            Assert.Equal(
+                oldVersion,
+                spec.TargetFrameworks[1].Dependencies[0].LibraryRange.VersionRange.MinVersion);
+
+            // Act
+            PackageSpecOperations.AddOrUpdateDependency(
+                spec,
+                identity,
+                new[] { frameworkB.FrameworkName });
+
+            // Assert
+            Assert.Empty(spec.Dependencies);
+
+            Assert.Empty(spec.TargetFrameworks[0].Dependencies);
+
+            Assert.Equal(1, spec.TargetFrameworks[1].Dependencies.Count);
+            Assert.Equal(identity.Id, spec.TargetFrameworks[1].Dependencies[0].LibraryRange.Name);
+            Assert.Equal(identity.Version, spec.TargetFrameworks[1].Dependencies[0].LibraryRange.VersionRange.MinVersion);
+            Assert.True(spec.TargetFrameworks[1].Dependencies[0].VersionCentrallyManaged);
+
+            Assert.True(spec.TargetFrameworks[1].CentralPackageVersions.ContainsKey(identity.Id));
+            Assert.Equal(identity.Version, spec.TargetFrameworks[1].CentralPackageVersions[identity.Id].VersionRange.MinVersion);
+        }
+
+        [Fact]
         public void RemoveDependency_RemovesFromAllFrameworkLists()
         {
             // Arrange


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11828

Regression? Last working version:

## Description
This code is used to modify the in-memory representation of the package spec and is modified to do a preview restore before committing changes via project system.  The code needs to set the `VersionCentrallyManaged` property if central package management is enabled otherwise the restore fails since it thinks the user set the version in a project.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
