### PR TITLE
For transitive packages, don't get latest versions for packages list

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
@@ -2151,7 +2151,7 @@ namespace NuGet.PackageManagement.UI {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Transitively referenced version.
+        ///   Looks up a localized string similar to Transitively referenced version: {0}.
         /// </summary>
         public static string ToolTip_TransitiveDependency {
             get {

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
@@ -934,7 +934,8 @@ Please see https://aka.ms/troubleshoot_nuget_cache for more help.</value>
     <comment>{0} = number of packages</comment>
   </data>
   <data name="ToolTip_TransitiveDependency" xml:space="preserve">
-    <value>Transitively referenced version</value>
+    <value>Transitively referenced version: {0}</value>
+    <comment>{0} is a version number</comment>
   </data>
   <data name="PackageVersionWithTransitiveOrigins" xml:space="preserve">
     <value>{0} by {1}</value>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/PackageItemViewModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/PackageItemViewModel.cs
@@ -756,7 +756,7 @@ namespace NuGet.PackageManagement.UI
 
         public void UpdateTransitivePackageStatus(NuGetVersion installedVersion)
         {
-            InstalledVersion = installedVersion;
+            InstalledVersion = installedVersion ?? throw new ArgumentNullException(nameof(installedVersion)); ;
 
             // Transitive packages cannot be updated and can only be installed as top-level packages with their currently installed version.
             LatestVersion = installedVersion;

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/PackageItemViewModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/PackageItemViewModel.cs
@@ -145,9 +145,10 @@ namespace NuGet.PackageManagement.UI
                     if (_latestVersion != null)
                     {
                         var displayVersion = new DisplayVersion(_latestVersion, string.Empty);
+                        string toolTipText = PackageLevel == PackageLevel.Transitive ? Resources.ToolTip_TransitiveDependency : Resources.ToolTip_LatestVersion;
                         LatestVersionToolTip = string.Format(
-                            CultureInfo.CurrentCulture,
-                            Resources.ToolTip_LatestVersion,
+                            CultureInfo.CurrentUICulture,
+                            toolTipText,
                             displayVersion);
                     }
                     else
@@ -757,9 +758,8 @@ namespace NuGet.PackageManagement.UI
         {
             InstalledVersion = installedVersion;
 
-            NuGetUIThreadHelper.JoinableTaskFactory
-                .RunAsync(ReloadPackageVersionsAsync)
-                .PostOnFailure(nameof(PackageItemViewModel), nameof(ReloadPackageVersionsAsync));
+            // Transitive packages cannot be updated and can only be installed as top-level packages with their currently installed version.
+            LatestVersion = installedVersion;
 
             OnPropertyChanged(nameof(Status));
         }

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/PackageItemViewModelTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/PackageItemViewModelTests.cs
@@ -323,6 +323,13 @@ namespace NuGet.PackageManagement.UI.Test
             };
         }
 
+        [Fact]
+        public void UpdateTransitivePackageStatus_WhenGivenInstalledVersion_SetsLatestVersionEqualToInstalledVersion()
+        {
+            _testInstance.UpdateTransitivePackageStatus(new NuGetVersion("1.0.0"));
+            Assert.Equal(_testInstance.LatestVersion, _testInstance.InstalledVersion);
+        }
+
         /// <summary>
         /// Tests the final bitmap returned by the view model, by waiting for the BitmapStatus to be "complete".
         /// </summary>


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1635

Regression? Last working version: N/A

## Description
No longer query for the versions list for transitive packages in the packages list. This call would go to the network and fetch all the package metadata for each package. Additionally, when there was a later version available than what is installed transitively, the update icon would appear for the transitive package and the latest version would be the one to be installed when the "Install" button is clicked in the package item in the list. We instead want the installed version to be installed as a top-level package when the installed button is clicked, we want no update icon to appear for transitive packages, and we don't want to make the network call for the metadata. This change also updates the tooltip to say "Transitively referenced version: {0}" instead of "Latest version: {0}".

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A

Additional testing:
Ran Fiddler before and after the change with a project that has 9 top-level packages and 32 transitive packages. Verified that there were 41 network calls for package version metadata in the before case and only 9 in the after case.
Manually tested the install functionality for transitive packages, verifying the installed version is the one that gets installed as a top-level package. Updated the top-level package, then uninstalled. Verified the transitive package was still the transitively referenced version. Also validated the tooltip is correct:
![image](https://user-images.githubusercontent.com/10777837/170610572-31b6f183-9e91-405c-b31c-15e303b79de4.png)
And validated the update icons don't appear anymore for transitive packages:
![image](https://user-images.githubusercontent.com/10777837/170610635-2142b957-1561-4149-a366-2bc0072e2a8b.png)
