### PR TITLE
fix installed and selected version in solution level

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageDetailControlModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageDetailControlModel.cs
@@ -236,7 +236,9 @@ namespace NuGet.PackageManagement.UI
             // Add disabled versions
             AddBlockedVersions(blockedVersions);
 
-            SelectVersion(latestPrerelease.version ?? latestStableVersion.version);
+            var latestVersion = latestPrerelease.version > latestStableVersion.version ? latestPrerelease.version : latestStableVersion.version;
+
+            SelectVersion(latestVersion);
 
             return Task.CompletedTask;
         }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageSolutionDetailControlModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageSolutionDetailControlModel.cs
@@ -254,7 +254,7 @@ namespace NuGet.PackageManagement.UI
             // Add disabled versions
             AddBlockedVersions(blockedVersions);
 
-            SelectVersion();
+            SelectVersion(latestPrerelease.version ?? latestStableVersion.version);
 
             OnPropertyChanged(nameof(Versions));
         }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageSolutionDetailControlModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageSolutionDetailControlModel.cs
@@ -254,7 +254,9 @@ namespace NuGet.PackageManagement.UI
             // Add disabled versions
             AddBlockedVersions(blockedVersions);
 
-            SelectVersion(latestPrerelease.version ?? latestStableVersion.version);
+            var latestVersion = latestPrerelease.version > latestStableVersion.version ? latestPrerelease.version : latestStableVersion.version;
+
+            SelectVersion(latestVersion);
 
             OnPropertyChanged(nameof(Versions));
         }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/DetailControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/DetailControl.xaml.cs
@@ -142,8 +142,7 @@ namespace NuGet.PackageManagement.UI
                     model.Id,
                     model.SelectedVersion.Version,
                     Control.Model.IsSolution,
-                    UIUtility.ToContractsItemFilter(Control._topPanel.Filter),
-                    model.SelectedVersion.Range);
+                    UIUtility.ToContractsItemFilter(Control._topPanel.Filter));
 
                 ExecuteUserAction(userAction, NuGetActionType.Install);
             }

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/V3DetailControlModelTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/V3DetailControlModelTests.cs
@@ -229,7 +229,7 @@ namespace NuGet.PackageManagement.UI.Test.Models
         public async Task SetCurrentPackageAsync_CorrectSelectedVersion(ItemFilter tab, string expectedSelectedVersion)
         {
             // Arrange
-            NuGetVersion installedVersion = NuGetVersion.Parse("*");
+            NuGetVersion installedVersion = NuGetVersion.Parse("1.0.0");
 
             var testVersions = new List<VersionInfoContextInfo>() {
                 new VersionInfoContextInfo(new NuGetVersion("2.10.1-dev-01248")),

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/V3DetailControlModelTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/V3DetailControlModelTests.cs
@@ -222,6 +222,45 @@ namespace NuGet.PackageManagement.UI.Test.Models
             Assert.Equal(expectedVersions, actualVersions);
         }
 
+        [Theory]
+        [InlineData(ItemFilter.All, "3.0.0")]
+        [InlineData(ItemFilter.Installed, "1.0.0")]
+        [InlineData(ItemFilter.UpdatesAvailable, "3.0.0")]
+        public async Task SetCurrentPackageAsync_CorrectSelectedVersion(ItemFilter tab, string expectedSelectedVersion)
+        {
+            // Arrange
+            NuGetVersion installedVersion = NuGetVersion.Parse("*");
+
+            var testVersions = new List<VersionInfoContextInfo>() {
+                new VersionInfoContextInfo(new NuGetVersion("2.10.1-dev-01248")),
+                new VersionInfoContextInfo(new NuGetVersion("2.10.0")),
+                new VersionInfoContextInfo(new NuGetVersion("3.0.0")),
+                new VersionInfoContextInfo(new NuGetVersion("1.0.0")),
+            };
+
+            var searchService = new Mock<IReconnectingNuGetSearchService>();
+            searchService.Setup(ss => ss.GetPackageVersionsAsync(It.IsAny<PackageIdentity>(), It.IsAny<IReadOnlyCollection<PackageSourceContextInfo>>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<IEnumerable<IProjectContextInfo>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(testVersions);
+
+            var vm = new PackageItemViewModel(searchService.Object)
+            {
+                Id = "package",
+                InstalledVersion = installedVersion,
+                Version = installedVersion,
+            };
+
+            // Act
+
+            await _testInstance.SetCurrentPackageAsync(
+                vm,
+                tab,
+                () => vm);
+
+            NuGetVersion selectedVersion = NuGetVersion.Parse(expectedSelectedVersion);
+
+            Assert.Equal(_testInstance.SelectedVersion.Version, selectedVersion);
+        }
+
         [Fact]
         public async Task SetCurrentPackageAsync_ClearVersions_Always()
         {
@@ -523,7 +562,6 @@ namespace NuGet.PackageManagement.UI.Test.Models
             Assert.Equal(model.SelectedVersion.Version.ToString(), "2.10.1-dev-01248");
             Assert.Equal(model.Versions.FirstOrDefault(), displayVersion);
         }
-
 
         [Theory]
         [InlineData(NuGetProjectKind.PackagesConfig, ProjectModel.ProjectStyle.PackagesConfig, null, "2.10.0")]
@@ -908,6 +946,44 @@ namespace NuGet.PackageManagement.UI.Test.Models
             };
 
             Assert.Equal(expectedVersions, actualVersions);
+        }
+
+        [Theory]
+        [InlineData(ItemFilter.All, "3.0.0")]
+        [InlineData(ItemFilter.Installed, "1.0.0")]
+        [InlineData(ItemFilter.UpdatesAvailable, "3.0.0")]
+        public async Task SetCurrentPackageAsync_CorrectSelectedVersion(ItemFilter tab, string expectedSelectedVersion)
+        {
+            // Arrange
+            NuGetVersion installedVersion = NuGetVersion.Parse("1.0.0");
+
+            var testVersions = new List<VersionInfoContextInfo>() {
+                new VersionInfoContextInfo(new NuGetVersion("2.10.1-dev-01248")),
+                new VersionInfoContextInfo(new NuGetVersion("2.10.0")),
+                new VersionInfoContextInfo(new NuGetVersion("3.0.0")),
+                new VersionInfoContextInfo(new NuGetVersion("1.0.0")),
+            };
+
+            var searchService = new Mock<IReconnectingNuGetSearchService>();
+            searchService.Setup(ss => ss.GetPackageVersionsAsync(It.IsAny<PackageIdentity>(), It.IsAny<IReadOnlyCollection<PackageSourceContextInfo>>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<IEnumerable<IProjectContextInfo>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(testVersions);
+
+            var vm = new PackageItemViewModel(searchService.Object)
+            {
+                Id = "package",
+                InstalledVersion = installedVersion,
+                Version = installedVersion,
+            };
+
+            // Act
+            await _testInstance.SetCurrentPackageAsync(
+                vm,
+                tab,
+                () => vm);
+
+            NuGetVersion selectedVersion = NuGetVersion.Parse(expectedSelectedVersion);
+
+            Assert.Equal(_testInstance.SelectedVersion.Version, selectedVersion);
         }
 
         [Fact]


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11805

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Solution Level PM UI was using the Project Level install action, resulting in installing closed version range

e.g: Installing version 13.0.1 resulted in writing [13.0.1] in the .csproj file showing no updates
![image](https://user-images.githubusercontent.com/43253759/171100286-4b786e1d-8f8c-4017-9596-1469e3fac080.png)

In this PR I also fix a bug where the Solution PM UI wasn't showing the latest version since I was passing null

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added Some tests were added, but I will add more related to this scenario in another PR, tracking here https://github.com/NuGet/Client.Engineering/issues/1657
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
