### PR TITLE
Fix bug when minimizing VS, combobox goes empty

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/ProjectView.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/ProjectView.xaml.cs
@@ -153,7 +153,6 @@ namespace NuGet.PackageManagement.UI
             if (PackageDetailControlModel.IsProjectPackageReference)
             {
                 string comboboxText = _versions.Text;
-                bool userTypedAVersionRange = comboboxText.StartsWith("(", StringComparison.OrdinalIgnoreCase) || comboboxText.StartsWith("[", StringComparison.OrdinalIgnoreCase);
                 IEnumerable<NuGetVersion> versions = DetailModel.Versions.Where(v => v != null).Select(v => v.Version);
 
                 switch (e.Key)
@@ -208,7 +207,7 @@ namespace NuGet.PackageManagement.UI
                             var selectionStart = TextBox.SelectionStart;
 
                             PackageDetailControlModel.UserInput = comboboxText; // Update the variable so the filter refreshes
-                            SetComboboxCurrentVersion(comboboxText, userTypedAVersionRange, versions);
+                            SetComboboxCurrentVersion(comboboxText, versions);
 
                             _versions.Text = comboboxText;
                             TextBox.SelectionStart = selectionStart;
@@ -226,7 +225,7 @@ namespace NuGet.PackageManagement.UI
             }
         }
 
-        private void SetComboboxCurrentVersion(string comboboxText, bool userTypedAVersionRange, IEnumerable<NuGetVersion> versions)
+        private void SetComboboxCurrentVersion(string comboboxText, IEnumerable<NuGetVersion> versions)
         {
             NuGetVersion matchVersion = null;
             VersionRange userRange = null;
@@ -236,6 +235,11 @@ namespace NuGet.PackageManagement.UI
             if (userTypedAValidVersionRange)
             {
                 matchVersion = userRange.FindBestMatch(versions);
+            }
+
+            if (matchVersion == null && userRange == null)
+            {
+                return;
             }
 
             // If the selected version is not the correct one, deselect a version so Install/Update button is disabled.
@@ -250,6 +254,7 @@ namespace NuGet.PackageManagement.UI
                 DisplayVersion currentItem = _versions.Items[i] as DisplayVersion;
                 if (currentItem != null && (comboboxText == _versions.Items[i].ToString() || _versions.Items[i].ToString() == matchVersion?.ToString()))
                 {
+                    _versions.SelectedIndex = i; // This is the "select" effect in the dropdown
                     PackageDetailControlModel.SelectedVersion = new DisplayVersion(userRange, matchVersion, additionalInfo: null);
                 }
             }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1640

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
When minimizing VS the combobox goes empty, this bug was caused because that first action is a `Key.System` and it will enter the default case in the switch, the problem is that the version has text and the code is unable to get the version from it causing a null reference later when comparing versions. Returning early helps us set the `PreviousSelectedVersion` that helps as cache and avoid recalculating

![floating_versions_1640](https://user-images.githubusercontent.com/43253759/171261529-a7f28ce5-cc88-4f17-9f7d-8e672fa6f426.gif)


## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception I will add tests for `SelectedVersion` and Floating Versions feature in general in another PR
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [ ] N/A
