### PR TITLE
Operate on a copy of the TransitiveOriginsCache to prevent concurrency issues

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/PackageReferenceProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/PackageReferenceProject.cs
@@ -63,6 +63,7 @@ namespace NuGet.PackageManagement.VisualStudio
             ProjectName = projectName;
             ProjectUniqueName = projectUniqueName;
             ProjectFullPath = projectFullPath;
+            _frameworkSorter = new NuGetFrameworkSorter();
         }
 
         public override async Task<string> GetAssetsFilePathAsync()

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/PackageReferenceProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/PackageReferenceProject.cs
@@ -51,6 +51,7 @@ namespace NuGet.PackageManagement.VisualStudio
         private protected DateTime _lastTimeAssetsModified;
         private protected WeakReference<PackageSpec> _lastPackageSpec;
         private protected IList<LockFileItem> _packageFolders;
+        private readonly NuGetFrameworkSorter _frameworkSorter;
 
         protected bool IsInstalledAndTransitiveComputationNeeded { get; set; } = true;
 
@@ -142,14 +143,12 @@ namespace NuGet.PackageManagement.VisualStudio
                 }
             }
 
-            var frameworkSorter = new NuGetFrameworkSorter(); // TODO: Should we promote to instance variable and not allocate on each call??
-
             // get installed packages
             List<PackageReference> calculatedInstalledPackages = packageSpec
                 .TargetFrameworks
                 .SelectMany(f => ResolvedInstalledPackagesList(f.Dependencies, f.FrameworkName, targetsList, installedPackages))
                 .GroupBy(p => p.PackageIdentity)
-                .Select(g => g.OrderBy(p => p.TargetFramework, frameworkSorter).First())
+                .Select(g => g.OrderBy(p => p.TargetFramework, _frameworkSorter).First())
                 .ToList();
 
             // get transitive packages
@@ -157,7 +156,7 @@ namespace NuGet.PackageManagement.VisualStudio
                 .TargetFrameworks
                 .SelectMany(f => ResolvedTransitivePackagesList(f.FrameworkName, targetsList, installedPackages, transitivePackages))
                 .GroupBy(p => p.PackageIdentity)
-                .Select(g => g.OrderBy(p => p.TargetFramework, frameworkSorter).First());
+                .Select(g => g.OrderBy(p => p.TargetFramework, _frameworkSorter).First());
 
             CounterfactualLoggers.TransitiveDependencies.EmitIfNeeded(); // Emit only one event per VS session
             IEnumerable<TransitivePackageReference> transitivePackagesWithOrigins;

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/PackageReferenceProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/PackageReferenceProject.cs
@@ -36,17 +36,17 @@ namespace NuGet.PackageManagement.VisualStudio
     {
         internal static readonly Comparer<PackageReference> PackageReferenceMergeComparer = Comparer<PackageReference>.Create((a, b) => a?.PackageIdentity?.CompareTo(b.PackageIdentity) ?? 1);
 
-        private protected readonly Dictionary<string, TransitiveEntry> TransitiveOriginsCache = new();
-
         private readonly protected string _projectName;
         private readonly protected string _projectUniqueName;
         private readonly protected string _projectFullPath;
 
         // Cache
+        private protected Dictionary<string, TransitiveEntry> TransitiveOriginsCache { get; set; }
         protected T InstalledPackages { get; set; }
         protected T TransitivePackages { get; set; }
 
-        private readonly object _lockObj = new object();
+        private readonly object _installedAndTransitivePackagesLock = new object();
+        private readonly object _transitiveOriginsLock = new object();
 
         private protected DateTime _lastTimeAssetsModified;
         private protected WeakReference<PackageSpec> _lastPackageSpec;
@@ -135,14 +135,14 @@ namespace NuGet.PackageManagement.VisualStudio
                 else
                 {
                     // Don't mutate cache for threadsafety, instead we works on copy then replace cache when done.
-                    lock (_lockObj)
+                    lock (_installedAndTransitivePackagesLock)
                     {
                         (installedPackages, transitivePackages) = GetInstalledAndTransitivePackagesCacheCopy();
                     }
                 }
             }
 
-            var frameworkSorter = new NuGetFrameworkSorter();
+            var frameworkSorter = new NuGetFrameworkSorter(); // TODO: Should we promote to instance variable and not allocate on each call??
 
             // get installed packages
             List<PackageReference> calculatedInstalledPackages = packageSpec
@@ -163,14 +163,40 @@ namespace NuGet.PackageManagement.VisualStudio
             IEnumerable<TransitivePackageReference> transitivePackagesWithOrigins;
             if (await ExperimentUtility.IsTransitiveOriginExpEnabled.GetValueAsync(token))
             {
-                // Get Transitive Origins
+                // Compute Transitive Origins
+                Dictionary<string, TransitiveEntry> transitiveOrigins;
+                if (IsInstalledAndTransitiveComputationNeeded || TransitiveOriginsCache == null)
+                {
+                    if (calculatedTransitivePackages.Any())
+                    {
+                        transitiveOrigins = ComputeTransitivePackageOrigins(calculatedInstalledPackages, targetsList, token);
+                    }
+                    else
+                    {
+                        transitiveOrigins = new Dictionary<string, TransitiveEntry>();
+                    }
+                }
+                else
+                {
+                    lock (_transitiveOriginsLock)
+                    {
+                        // Make a copy of the cache to prevent concurrency issues.
+                        transitiveOrigins = new Dictionary<string, TransitiveEntry>(TransitiveOriginsCache);
+                    }
+                }
+
+                // 4. Return cached result for specific transitive dependency
                 transitivePackagesWithOrigins = calculatedTransitivePackages
                     .Select(packageRef =>
                     {
-                        (PackageReference pr, TransitiveEntry transitiveEntry) tupl = (packageRef, GetTransitivePackageOrigin(packageRef, calculatedInstalledPackages, targetsList, token));
-                        return tupl;
-                    })
-                    .Select(tuple => MergeTransitiveOrigin(tuple.pr, tuple.transitiveEntry));
+                        transitiveOrigins.TryGetValue(packageRef.PackageIdentity.Id, out TransitiveEntry cacheEntry);
+                        return MergeTransitiveOrigin(packageRef, cacheEntry);
+                    });
+
+                lock (_transitiveOriginsLock)
+                {
+                    TransitiveOriginsCache = transitiveOrigins;
+                }
             }
             else
             {
@@ -183,7 +209,7 @@ namespace NuGet.PackageManagement.VisualStudio
             IsInstalledAndTransitiveComputationNeeded = false;
 
             // Refresh cache
-            lock (_lockObj)
+            lock (_installedAndTransitivePackagesLock)
             {
                 InstalledPackages = installedPackages;
                 TransitivePackages = transitivePackages;
@@ -251,36 +277,29 @@ namespace NuGet.PackageManagement.VisualStudio
         /// packages that depends on given transitive package, or <c>null</c> if none found</returns>
         /// <remarks>Computes all transitive origins for each Framework/Runtime-ID combiation. Runtime-ID can be <c>null</c>.
         /// Transitive origins are calculated using a Depth First Search algorithm on all direct dependencies exhaustively</remarks>
-        internal TransitiveEntry GetTransitivePackageOrigin(PackageReference transitivePackage, List<PackageReference> installedPackages, IReadOnlyList<LockFileTarget> targetsList, CancellationToken ct)
+        internal Dictionary<string, TransitiveEntry> ComputeTransitivePackageOrigins(List<PackageReference> installedPackages, IReadOnlyList<LockFileTarget> targetsList, CancellationToken ct)
         {
             ct.ThrowIfCancellationRequested();
-            if (IsInstalledAndTransitiveComputationNeeded)
+            // Assets file has changed. Recompute Transitive Origins
+            Dictionary<string, TransitiveEntry> transitiveOriginsCache = new();
+
+            // Otherwise, find all Transitive origin and update cache
+            var memoryVisited = new HashSet<PackageIdentity>();
+
+            // 3. For each target framework graph (Framework, RID)-pair:
+            foreach (LockFileTarget targetFxGraph in targetsList)
             {
-                // Assets file has changed. Recompute Transitive Origins
-                TransitiveOriginsCache.Clear();
+                var key = new FrameworkRuntimePair(targetFxGraph.TargetFramework, targetFxGraph.RuntimeIdentifier);
 
-                // Otherwise, find all Transitive origin and update cache
-                var memoryVisited = new HashSet<PackageIdentity>();
-
-                // 3. For each target framework graph (Framework, RID)-pair:
-                foreach (LockFileTarget targetFxGraph in targetsList)
+                foreach (var directPkg in installedPackages) // 3.1 For each direct dependency
                 {
-                    var key = new FrameworkRuntimePair(targetFxGraph.TargetFramework, targetFxGraph.RuntimeIdentifier);
-
-                    foreach (var directPkg in installedPackages) // 3.1 For each direct dependency
-                    {
-                        memoryVisited.Clear();
-                        // 3.1.1 Do DFS to mark directPkg as a transitive origin over all transitive dependencies found
-                        MarkTransitiveOrigin(directPkg, directPkg, targetFxGraph, memoryVisited, key, ct);
-                    }
+                    memoryVisited.Clear();
+                    // 3.1.1 Do DFS to mark directPkg as a transitive origin over all transitive dependencies found
+                    MarkTransitiveOrigin(transitiveOriginsCache, directPkg, directPkg, targetFxGraph, memoryVisited, key, ct);
                 }
             }
-            // Otherwise, assets file has not changed. Look at Transitive Origins Cache
-            TransitiveEntry cacheEntry;
-            TransitiveOriginsCache.TryGetValue(transitivePackage.PackageIdentity.Id, out cacheEntry);
 
-            // 4. Return cached result for specific transitive dependency
-            return cacheEntry;
+            return transitiveOriginsCache;
         }
 
         /// <summary>
@@ -343,7 +362,7 @@ namespace NuGet.PackageManagement.VisualStudio
         /// <param name="graph">Package dependency graph, from assets file</param>
         /// <param name="visited">Dictionary to remember visited nodes</param>
         /// <param name="fxRidEntry">Framework/Runtime-ID associated with current <paramref name="graph"/></param>
-        private void MarkTransitiveOrigin(PackageReference top, PackageReference current, LockFileTarget graph, HashSet<PackageIdentity> visited, FrameworkRuntimePair fxRidEntry, CancellationToken token)
+        private void MarkTransitiveOrigin(Dictionary<string, TransitiveEntry> transitiveOriginsCache, PackageReference top, PackageReference current, LockFileTarget graph, HashSet<PackageIdentity> visited, FrameworkRuntimePair fxRidEntry, CancellationToken token)
         {
             token.ThrowIfCancellationRequested();
 
@@ -368,7 +387,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
                 // Lookup Transitive Origins Cache
                 TransitiveEntry cachedEntry;
-                if (!TransitiveOriginsCache.TryGetValue(current.PackageIdentity.Id, out cachedEntry))
+                if (!transitiveOriginsCache.TryGetValue(current.PackageIdentity.Id, out cachedEntry))
                 {
                     cachedEntry = new Dictionary<FrameworkRuntimePair, IList<PackageReference>>
                     {
@@ -387,7 +406,7 @@ namespace NuGet.PackageManagement.VisualStudio
                 }
 
                 // Upsert Transitive Origins Cache
-                TransitiveOriginsCache[current.PackageIdentity.Id] = cachedEntry;
+                transitiveOriginsCache[current.PackageIdentity.Id] = cachedEntry;
 
                 foreach (PackageDependency dep in node.Dependencies.ToList()) // Casting to list to prevent backing allocations
                 {
@@ -402,7 +421,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
                     if (!visited.Contains(pkgChild.PackageIdentity))
                     {
-                        MarkTransitiveOrigin(top, pkgChild, graph, visited, fxRidEntry, token);
+                        MarkTransitiveOrigin(transitiveOriginsCache, top, pkgChild, graph, visited, fxRidEntry, token);
                     }
                 }
             }

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/PackageReferenceProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/PackageReferenceProject.cs
@@ -271,7 +271,7 @@ namespace NuGet.PackageManagement.VisualStudio
         /// packages that depends on given transitive package</returns>
         /// <remarks>Computes all transitive origins for each Framework/Runtime-ID combiation. Runtime-ID can be <c>null</c>.
         /// Transitive origins are calculated using a Depth First Search algorithm on all direct dependencies exhaustively</remarks>
-        static internal Dictionary<string, TransitiveEntry> ComputeTransitivePackageOrigins(List<PackageReference> installedPackages, IReadOnlyList<LockFileTarget> targetsList, CancellationToken ct)
+        internal static Dictionary<string, TransitiveEntry> ComputeTransitivePackageOrigins(List<PackageReference> installedPackages, IReadOnlyList<LockFileTarget> targetsList, CancellationToken ct)
         {
             ct.ThrowIfCancellationRequested();
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1646

Regression? Last working version: N/A

## Description
Operate on a copy of the TransitiveOriginsCache when computing transitive origins to prevent concurrency issues when multiple threads modify the cache. Use a lock to ensure two threads cannot read or write from/to the cache at the same time. This fixes an issue with two threads trying to update the cache's list at the same time.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
Tested by running unit tests and manually testing the feature by installing a package with transitive dependencies and loading the packages in the Installed tab, verifying the transitive origins were computed correctly.
  - [x] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
