### PR TITLE
Run NuGet.CommandLine.FuncTest in parallel

### DIFF
--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/NuGet.CommandLine.FuncTest.csproj
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/NuGet.CommandLine.FuncTest.csproj
@@ -27,12 +27,6 @@
     <Reference Include="System.Net.Http" />
   </ItemGroup>
 
-  <ItemGroup>
-    <None Include="xunit.runner.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
-
   <Target Name="CopyFinalNuGetExeToOutputPath" AfterTargets="Build" Condition="'$(SkipILMergeOfNuGetExe)' != 'true'">
       <Copy SourceFiles="$(ArtifactsDirectory)$(VsixOutputDirName)\NuGet.exe" DestinationFolder="$(OutputPath)NuGet\" />
   </Target>

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/xunit.runner.json
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/xunit.runner.json
@@ -1,4 +1,0 @@
-{
-  "maxParallelThreads": 1,
-  "parallelizeTestCollections": false
-}

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPushCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPushCommandTest.cs
@@ -816,7 +816,7 @@ namespace NuGet.CommandLine.Test
                         packageDirectory,
                         args,
                         waitForExit: true,
-                        timeOutInMilliseconds: 10000,
+                        timeOutInMilliseconds: 15000,
                         inputAction: (w) =>
                         {
                             // This user/password pair is first sent to
@@ -1120,7 +1120,7 @@ namespace NuGet.CommandLine.Test
                         packageDirectory,
                         args,
                         waitForExit: true,
-                        timeOutInMilliseconds: 10000,
+                        timeOutInMilliseconds: 15000,
                         inputAction: (w) =>
                         {
                         },

--- a/test/TestUtilities/Test.Utility/TestServer/PortReserverOfMockServer.cs
+++ b/test/TestUtilities/Test.Utility/TestServer/PortReserverOfMockServer.cs
@@ -133,7 +133,7 @@ namespace NuGet.Test.Server
 
         private static Mutex GetGlobalMutex()
         {
-            Mutex mutex = new Mutex(initiallyOwned: true, name: "NuGet-RandomPortAcquisition", out bool mutexWasCreated);
+            Mutex mutex = new Mutex(initiallyOwned: true, name: "Global\\NuGet-RandomPortAcquisition" + Guid.NewGuid(), out bool mutexWasCreated);
             if (!mutexWasCreated && !mutex.WaitOne(30000))
             {
                 throw new InvalidOperationException();

--- a/test/TestUtilities/Test.Utility/TestServer/PortReserverOfMockServer.cs
+++ b/test/TestUtilities/Test.Utility/TestServer/PortReserverOfMockServer.cs
@@ -133,7 +133,7 @@ namespace NuGet.Test.Server
 
         private static Mutex GetGlobalMutex()
         {
-            Mutex mutex = new Mutex(initiallyOwned: true, name: "Global\\NuGet-RandomPortAcquisition" + Guid.NewGuid(), out bool mutexWasCreated);
+            Mutex mutex = new Mutex(initiallyOwned: true, name: "NuGet-RandomPortAcquisition", out bool mutexWasCreated);
             if (!mutexWasCreated && !mutex.WaitOne(30000))
             {
                 throw new InvalidOperationException();


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1291

Regression? Last working version:

## Description
Added UseParallelXunit property to NuGet.CommandLine.Functest project so that the tests can run in parallel using the settings defined in the shared [xunit.runner.json](https://github.com/NuGet/NuGet.Client/blob/dev/build/TestShared/xunit.runner.json) file. I deleted xunit.runner.json file that was created under project root directory which instructed xUnit to disable parallelism.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [ ] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
