### PR TITLE
Run NuGet.XPlat.Functest in parallel #4502

### DIFF
--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/NuGet.XPlat.FuncTest.csproj
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/NuGet.XPlat.FuncTest.csproj
@@ -1,4 +1,4 @@
-﻿<Project>
+<Project>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'NuGet.sln'))\build\common.test.props" />
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
@@ -6,6 +6,7 @@
     <TargetFrameworks>$(TargetFrameworksExeForSigning)</TargetFrameworks>
     <TestProjectType>functional</TestProjectType>
     <Description>Functional tests for nuget in dotnet CLI scenarios, using the NuGet.CommandLine.XPlat assembly.</Description>
+    <UseParallelXunit>true</UseParallelXunit>
   </PropertyGroup>
 
   <ItemGroup>
@@ -26,9 +27,6 @@
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="xunit.runner.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
     <None Include="$(NuGetCoreSrcDirectory)NuGet.Build.Tasks\NuGet.targets">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/xunit.runner.json
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/xunit.runner.json
@@ -1,4 +1,0 @@
-﻿{
-  "maxParallelThreads": 1,
-  "parallelizeTestCollections": false
-}


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1289

Regression? Last working version:

## Description
Added UseParallelXunit property to NuGet.XPlat.Functest project so that the tests can run in parallel using the settings defined in the shared [xunit.runner.json](https://github.com/NuGet/NuGet.Client/blob/dev/build/TestShared/xunit.runner.json) file. I deleted xunit.runner.json file that was created under project root directory which instructed xUnit to disable parallelism.

**Before change:**
[Duration: 1 m 51 s - NuGet.XPlat.FuncTest.dll (net472)](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=6256295&view=logs&j=106ab241-4188-5d29-8df9-3fba036cc1ed&t=16b2ebcd-f324-51bf-b1f0-feedee00c8c2&l=1456)

**After change, it's 3-4 times faster:**
[Duration: 34 s - NuGet.XPlat.FuncTest.dll (net472)](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=6256317&view=logs&j=106ab241-4188-5d29-8df9-3fba036cc1ed&t=16b2ebcd-f324-51bf-b1f0-feedee00c8c2&l=1267)

In order to make sure it's not introducing flakiness due to race condition I ran CI pipeline tests about 10 times on this branch, only once [ClientCertAddCommand_Success_StoreCertificate](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=6250580&view=ms.vss-test-web.build-test-results-tab&runId=42956004&resultId=110111&paneView=debug) test from NuGet.XPlat.Functest path failed, there where few other flaky test failures but not from this project. 

I believe `ClientCertAddCommand_Success_StoreCertificate` test was already flaky on `dev` branch even before this change. [1](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=6250610&view=ms.vss-test-web.build-test-results-tab&runId=42961120&resultId=101003), [2](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=6250610&view=ms.vss-test-web.build-test-results-tab&runId=42961120&resultId=101003) , [3](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=6166564&view=ms.vss-test-web.build-test-results-tab&runId=40994874&resultId=101063), [4](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=6190700&view=ms.vss-test-web.build-test-results-tab&runId=41462172&resultId=100741) etc..

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
