### PR TITLE
Fix tests for machines without net40 or net45 targeting pack

### DIFF
--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetInstallCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetInstallCommandTest.cs
@@ -934,7 +934,7 @@ namespace NuGet.CommandLine.Test
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <OutputPath>out</OutputPath>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <ItemGroup>
     <None Include='packages.config' />
@@ -995,7 +995,7 @@ namespace NuGet.CommandLine.Test
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <OutputPath>out</OutputPath>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <ItemGroup>
     <None Include='packages.config' />

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
@@ -882,8 +882,8 @@ namespace Proj2
                     new string[]
                     {
                         "content/proj1_file2.txt",
-                        "lib/net40/proj1.dll",
-                        "lib/net40/proj2.dll"
+                        "lib/net472/proj1.dll",
+                        "lib/net472/proj2.dll"
                     },
                     files);
             }
@@ -1187,22 +1187,22 @@ namespace Proj2
                         new string[]
                         {
                             Path.Combine("content", "proj1_file2.txt"),
-                            Path.Combine("lib", "net40", "proj1.dll"),
-                            Path.Combine("lib", "net40", "proj1.pdb"),
-                            Path.Combine("lib", "net40", "proj2.dll"),
-                            Path.Combine("lib", "net40", "proj2.pdb"),
+                            Path.Combine("lib", "net472", "proj1.dll"),
+                            Path.Combine("lib", "net472", "proj1.pdb"),
+                            Path.Combine("lib", "net472", "proj2.dll"),
+                            Path.Combine("lib", "net472", "proj2.pdb"),
                             "proj2.nuspec",
                             Path.Combine("src", "proj1", "proj1_file1.cs"),
                             Path.Combine("src", "proj2", "proj2_file1.cs"),
                         }
                         : new string[]
                         {
-                            Path.Combine("lib", "net40", "proj1.pdb"),
-                            Path.Combine("lib", "net40", "proj2.pdb"),
+                            Path.Combine("lib", "net472", "proj1.pdb"),
+                            Path.Combine("lib", "net472", "proj2.pdb"),
                             "proj2.nuspec"
                         };
                     actual = actual.Select(t => NuGet.Common.PathUtility.GetPathWithForwardSlashes(t)).ToArray();
-                    Assert.Equal(actual, files);
+                    Assert.Equal(files, actual);
                 }
             }
         }
@@ -1262,17 +1262,17 @@ namespace Proj2
                     var actual = symbolPackageFormat == SymbolPackageFormat.SymbolsNupkg ? new string[]
                         {
                         "A.nuspec",
-                        "lib/net40/A.dll",
-                        "lib/net40/A.pdb",
+                        "lib/net472/A.dll",
+                        "lib/net472/A.pdb",
                         "src/B.cs"
                         }
                         : new string[]
                         {
                         "A.nuspec",
-                        "lib/net40/A.pdb"
+                        "lib/net472/A.pdb"
                         };
                     actual = actual.Select(t => NuGet.Common.PathUtility.GetPathWithForwardSlashes(t)).ToArray();
-                    Assert.Equal(actual, files);
+                    Assert.Equal(files, actual);
                 }
             }
         }
@@ -1332,14 +1332,14 @@ public class B
                     var actual = symbolPackageFormat == SymbolPackageFormat.SymbolsNupkg ? new string[]
                         {
                         "A.nuspec",
-                        "lib/net40/A.exe",
-                        "lib/net40/A.pdb",
+                        "lib/net472/A.exe",
+                        "lib/net472/A.pdb",
                         "src/B.cs"
                         }
                         : new string[]
                         {
                         "A.nuspec",
-                        "lib/net40/A.pdb"
+                        "lib/net472/A.pdb"
                         };
                     Assert.Equal(actual, files);
                 }
@@ -1401,8 +1401,8 @@ public class B
                 Assert.Equal(
                     new string[]
                     {
-                        "lib/net40/A.dll",
-                        "lib/net40/A.xml",
+                        "lib/net472/A.dll",
+                        "lib/net472/A.xml",
                     },
                     files);
             }
@@ -1499,9 +1499,9 @@ public class B
                 Assert.Equal(
                     new string[]
                     {
-                        "lib/net40/proj1.dll",
-                        "lib/net40/proj3.dll",
-                        "lib/net40/proj7.dll",
+                        "lib/net472/proj1.dll",
+                        "lib/net472/proj3.dll",
+                        "lib/net472/proj7.dll",
                     },
                     files);
 
@@ -1615,9 +1615,9 @@ public class B
                 Assert.Equal(
                     new string[]
                     {
-                        "lib/net40/proj1.dll",
-                        "lib/net40/proj3.dll",
-                        "lib/net40/proj7.dll",
+                        "lib/net472/proj1.dll",
+                        "lib/net472/proj3.dll",
+                        "lib/net472/proj7.dll",
                     },
                     files);
 
@@ -2377,7 +2377,7 @@ namespace " + projectName + @"
                     new string[] {
                         @"..\proj2\proj2.csproj"
                     });
-                CreateTestProject(workingDirectory, "proj2", null, "v4.0", "1.2");
+                CreateTestProject(workingDirectory, "proj2", null, "4.7.2", "1.2");
                 Util.CreateFile(
                     Path.Combine(workingDirectory, "proj2"),
                     "proj2.nuspec",
@@ -2413,7 +2413,7 @@ namespace " + projectName + @"
                 Assert.Equal(
                     new string[]
                     {
-                        "lib/net40/proj1.dll"
+                        "lib/net472/proj1.dll"
                     },
                     files);
 
@@ -2716,7 +2716,7 @@ namespace " + projectName + @"
                 Assert.Equal(
                     new string[]
                     {
-                        "lib/net40/proj1.dll"
+                        "lib/net472/proj1.dll"
                     },
                     files);
             }
@@ -2765,9 +2765,9 @@ namespace " + projectName + @"
                 Assert.Equal(
                     new string[]
                     {
-                       "lib/net40/proj1.dll",
-                       "lib/net40/proj2.dll",
-                       "lib/net40/proj3.dll"
+                       "lib/net472/proj1.dll",
+                       "lib/net472/proj2.dll",
+                       "lib/net472/proj3.dll"
                     },
                     files);
             }
@@ -2808,8 +2808,8 @@ namespace " + projectName + @"
                 Assert.Equal(
                     new string[]
                     {
-                        "lib/net40/proj1.dll",
-                        "lib/net40/proj2.dll"
+                        "lib/net472/proj1.dll",
+                        "lib/net472/proj2.dll"
                     },
                     files);
             }
@@ -3056,8 +3056,8 @@ namespace Proj2
                     new string[]
                     {
                         "content/proj1_file2.txt",
-                        "lib/net40/proj1.dll",
-                        "lib/net40/proj2.dll"
+                        "lib/net472/proj1.dll",
+                        "lib/net472/proj2.dll"
                     },
                     files);
             }
@@ -4119,8 +4119,8 @@ namespace Proj2
                     new string[]
                     {
                         "content/proj1_file2.txt",
-                        "lib/net40/proj1.dll",
-                        "lib/net40/proj2.dll"
+                        "lib/net472/proj1.dll",
+                        "lib/net472/proj2.dll"
                     });
             }
         }
@@ -4245,13 +4245,13 @@ namespace Proj2
                 var files = package.GetNonPackageDefiningFiles();
                 Array.Sort(files);
                 Assert.Equal(
-                    files,
                     new string[]
                     {
                         "content/proj1_file2.txt",
-                        "lib/net40/proj1.dll",
-                        "lib/net40/proj2.dll"
-                    });
+                        "lib/net472/proj1.dll",
+                        "lib/net427/proj2.dll"
+                    },
+                    files);
             }
         }
 
@@ -4406,7 +4406,7 @@ namespace Proj2
             string baseDirectory,
             string projectName,
             string[] referencedProject,
-            string targetFrameworkVersion = "v4.0",
+            string targetFrameworkVersion = "v4.7.2",
             string version = "0.0.0.0")
         {
             var projectDirectory = Path.Combine(baseDirectory, projectName);
@@ -4718,7 +4718,7 @@ namespace Proj1
                     new string[]
                     {
                         "content/proj1_file2.txt",
-                        "lib/net40/proj1.dll"
+                        "lib/net472/proj1.dll"
                     },
                     files);
             }
@@ -5662,15 +5662,15 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
                         {
 
                          $"{packageName}.nuspec",
-                         $"lib/net40/{packageName}.dll",
-                         $"lib/net40/{packageName}.pdb",
+                         $"lib/net472/{packageName}.dll",
+                         $"lib/net472/{packageName}.pdb",
                          "LICENSE.txt",
                          "src/B.cs"
                         }
                         : new string[]
                         {
                          $"{packageName}.nuspec",
-                         $"lib/net40/{packageName}.pdb",
+                         $"lib/net472/{packageName}.pdb",
                          "LICENSE.txt"
                         };
                     actual = actual.Select(t => Common.PathUtility.GetPathWithForwardSlashes(t)).ToArray();
@@ -7407,7 +7407,7 @@ namespace proj1
                     Assert.Equal(
                         new string[]
                         {
-                          "lib/net40/proj1.dll"
+                          "lib/net472/proj1.dll"
                         },
                         files);
 

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
@@ -1831,9 +1831,9 @@ public class B
                 Assert.Equal(
                     new string[]
                     {
-                        Path.Combine("lib", "net40", "proj1.dll"),
-                        Path.Combine("lib", "net40", "proj3.dll"),
-                        Path.Combine("lib", "net40", "proj7.dll")
+                        Path.Combine("lib", "net472", "proj1.dll"),
+                        Path.Combine("lib", "net472", "proj3.dll"),
+                        Path.Combine("lib", "net472", "proj7.dll")
                     },
                     files);
 
@@ -2060,9 +2060,9 @@ public class B
                 Assert.Equal(
                     new string[]
                     {
-                        Path.Combine("lib", "net40", "proj1.dll"),
-                        Path.Combine("lib", "net40", "proj3.dll"),
-                        Path.Combine("lib", "net40", "proj7.dll")
+                        Path.Combine("lib", "net472", "proj1.dll"),
+                        Path.Combine("lib", "net472", "proj3.dll"),
+                        Path.Combine("lib", "net472", "proj7.dll")
                     },
                     files);
 
@@ -3865,8 +3865,8 @@ namespace Proj2
                     new string[]
                     {
                         Path.Combine("content", "proj1_file2.txt"),
-                        Path.Combine("lib", "net40", "proj1.dll"),
-                        Path.Combine("lib", "net40", "proj2.dll")
+                        Path.Combine("lib", "net472", "proj1.dll"),
+                        Path.Combine("lib", "net472", "proj2.dll")
                     },
                     files);
             }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
@@ -807,7 +807,7 @@ namespace NuGet.CommandLine.Test
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <OutputPath>out</OutputPath>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include='proj1_file1.cs' />
@@ -843,7 +843,7 @@ namespace Proj1
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <OutputPath>out</OutputPath>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include='..\proj1\proj1.csproj' />
@@ -1023,7 +1023,7 @@ namespace Proj1
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <OutputPath>out</OutputPath>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include='proj1_file1.cs'/>
@@ -1109,7 +1109,7 @@ namespace Proj1
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <OutputPath>out</OutputPath>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include='proj1_file1.cs' />
@@ -1145,7 +1145,7 @@ namespace Proj1
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <OutputPath>out</OutputPath>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include='..\proj1\proj1.csproj' />
@@ -1226,7 +1226,7 @@ namespace Proj2
   <PropertyGroup>
     <OutputType>library</OutputType>
     <OutputPath>out</OutputPath>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include='B.cs' />
@@ -1296,7 +1296,7 @@ namespace Proj2
   <PropertyGroup>
     <OutputType>exe</OutputType>
     <OutputPath>out</OutputPath>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include='B.cs' />
@@ -1363,7 +1363,7 @@ public class B
   <PropertyGroup>
     <OutputType>library</OutputType>
     <OutputPath>out</OutputPath>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <DocumentationFile>out\A.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
@@ -2302,7 +2302,7 @@ public class B
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <OutputPath>out</OutputPath>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include='file1.cs' />
@@ -2844,7 +2844,7 @@ namespace " + projectName + @"
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <Config Condition=" + "\" '$(Config)' == ''\"" + @">Debug</Config>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" + "\"'$(Config)'=='Debug'\"" + @">
     <OutputPath>debug_out</OutputPath>
@@ -2886,7 +2886,7 @@ namespace Proj1
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <Config Condition=" + "\" '$(Config)' == ''\"" + @">Debug</Config>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" + "\"'$(Config)'=='Debug'\"" + @">
     <OutputPath>debug_out</OutputPath>
@@ -2965,7 +2965,7 @@ namespace Proj2
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <Config Condition=" + "\" '$(Config)' == ''\"" + @">Debug</Config>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" + "\"'$(Config)'=='Debug'\"" + @">
     <OutputPath>debug_out</OutputPath>
@@ -3007,7 +3007,7 @@ namespace Proj1
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <Config Condition=" + "\" '$(Config)' == ''\"" + @">Debug</Config>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" + "\"'$(Config)'=='Debug'\"" + @">
     <OutputPath>debug_out</OutputPath>
@@ -3143,7 +3143,7 @@ namespace Proj2
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <OutputPath>out</OutputPath>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include='proj1_file1.cs' />
@@ -3232,7 +3232,7 @@ namespace Proj1
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <OutputPath>out</OutputPath>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include='proj1_file1.cs' />
@@ -3317,7 +3317,7 @@ namespace Proj1
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <OutputPath>out</OutputPath>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include='proj1_file1.cs' />
@@ -3438,7 +3438,7 @@ namespace Proj1
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <OutputPath>out</OutputPath>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include='proj1_file1.cs' />
@@ -3549,7 +3549,7 @@ namespace Proj1
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <Config Condition=" + "\" '$(Config)' == ''\"" + @">Debug</Config>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" + "\"'$(Config)'=='Debug'\"" + @">
     <OutputPath>debug_out</OutputPath>
@@ -3643,7 +3643,7 @@ namespace Proj1
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <Config Condition=" + "\" '$(Config)' == ''\"" + @">Debug</Config>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" + "\"'$(Config)'=='Debug'\"" + @">
     <OutputPath>debug_out</OutputPath>
@@ -3688,7 +3688,7 @@ namespace Proj1
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <Config Condition=" + "\" '$(Config)' == ''\"" + @">Debug</Config>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" + "\"'$(Config)'=='Debug'\"" + @">
     <OutputPath>debug_out</OutputPath>
@@ -3768,7 +3768,7 @@ namespace Proj2
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <Config Condition=" + "\" '$(Config)' == ''\"" + @">Debug</Config>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" + "\"'$(Config)'=='Debug'\"" + @">
     <OutputPath>debug_out</OutputPath>
@@ -3813,7 +3813,7 @@ namespace Proj1
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <Config Condition=" + "\" '$(Config)' == ''\"" + @">Debug</Config>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" + "\"'$(Config)'=='Debug'\"" + @">
     <OutputPath>debug_out</OutputPath>
@@ -3892,7 +3892,7 @@ namespace Proj2
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <Config Condition=" + "\" '$(Config)' == ''\"" + @">Debug</Config>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" + "\"'$(Config)'=='Debug'\"" + @">
     <OutputPath>debug_out</OutputPath>
@@ -3937,7 +3937,7 @@ namespace Proj1
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <Config Condition=" + "\" '$(Config)' == ''\"" + @">Debug</Config>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" + "\"'$(Config)'=='Debug'\"" + @">
     <OutputPath>debug_out</OutputPath>
@@ -4015,7 +4015,7 @@ namespace Proj2
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <Config Condition=" + "\" '$(Config)' == ''\"" + @">Debug</Config>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" + "\"'$(Config)'=='Debug'\"" + @">
     <OutputPath>debug_out</OutputPath>
@@ -4060,7 +4060,7 @@ namespace Proj1
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <Config Condition=" + "\" '$(Config)' == ''\"" + @">Debug</Config>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" + "\"'$(Config)'=='Debug'\"" + @">
     <OutputPath>debug_out</OutputPath>
@@ -4144,7 +4144,7 @@ namespace Proj2
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <Config Condition=" + "\" '$(Config)' == ''\"" + @">Debug</Config>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" + "\"'$(Config)'=='Debug'\"" + @">
     <OutputPath>debug_out</OutputPath>
@@ -4189,7 +4189,7 @@ namespace Proj1
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <Config Condition=" + "\" '$(Config)' == ''\"" + @">Debug</Config>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" + "\"'$(Config)'=='Debug'\"" + @">
     <OutputPath>debug_out</OutputPath>
@@ -4274,7 +4274,7 @@ namespace Proj2
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <Config Condition=" + "\" '$(Config)' == ''\"" + @">Debug</Config>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" + "\"'$(Config)'=='Debug'\"" + @">
     <OutputPath>debug_out</OutputPath>
@@ -4319,7 +4319,7 @@ namespace Proj1
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <Config Condition=" + "\" '$(Config)' == ''\"" + @">Debug</Config>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" + "\"'$(Config)'=='Debug'\"" + @">
     <OutputPath>debug_out</OutputPath>
@@ -4558,7 +4558,7 @@ stuff \n <<".Replace("\r\n", "\n");
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <OutputPath>out</OutputPath>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <Import Project='$(MSBuildToolsPath)\Microsoft.CSharp.targets' />
 </Project>");
@@ -4672,7 +4672,7 @@ stuff \n <<".Replace("\r\n", "\n");
     <Configuration Condition="" '$(Configuration)' == '' "">Debug</Configuration>
     <OutputType>Library</OutputType>
     <OutputPath>out\$(Configuration)\</OutputPath>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include=""proj1_file1.cs"" />
@@ -4744,7 +4744,7 @@ $@"<Project ToolsVersion='4.0' DefaultTargets='Build'
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <OutputPath>out</OutputPath>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <NoWarn>{value}</NoWarn>
   </PropertyGroup>
   <ItemGroup>
@@ -4812,7 +4812,7 @@ $@"<Project ToolsVersion='4.0' DefaultTargets='Build'
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <OutputPath>out</OutputPath>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <{property}>{value}</{property}>
   </PropertyGroup>
   <ItemGroup>
@@ -5571,7 +5571,7 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
    <PropertyGroup>
      <OutputType>library</OutputType>
      <OutputPath>out</OutputPath>
-     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
    </PropertyGroup>
    <ItemGroup>
      <Compile Include='B.cs' />
@@ -6056,7 +6056,7 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
   <PropertyGroup>
     <OutputType>library</OutputType>
     <OutputPath>out</OutputPath>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include='B.cs' />
@@ -6127,7 +6127,7 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
   <PropertyGroup>
     <OutputType>library</OutputType>
     <OutputPath>out</OutputPath>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <PackageIconUrl>https://test/icon.jpg</PackageIconUrl>
     <Authors>Alice</Authors>
   </PropertyGroup>
@@ -6725,7 +6725,7 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <OutputPath>out</OutputPath>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <Import Project='$(MSBuildToolsPath)\Microsoft.CSharp.targets' />
 </Project>");
@@ -6775,7 +6775,7 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <OutputPath>out</OutputPath>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <Import Project='$(MSBuildToolsPath)\Microsoft.CSharp.targets' />
 </Project>");
@@ -6829,7 +6829,7 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <OutputPath>out</OutputPath>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include='..\proj2\proj2.csproj' />
@@ -6843,7 +6843,7 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <OutputPath>out</OutputPath>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include='Program.cs' />
@@ -6959,7 +6959,7 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <OutputPath>out</OutputPath>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include='proj1_file1.cs' />
@@ -7019,7 +7019,7 @@ namespace Proj1
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include='System'/>
@@ -7134,7 +7134,7 @@ using System.Runtime.InteropServices;
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include='System'/>
@@ -7250,7 +7250,7 @@ using System.Runtime.InteropServices;
   <PropertyGroup>
     <OutputType>library</OutputType>
     <OutputPath>out</OutputPath>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <Import Project='$(MSBuildToolsPath)\Microsoft.CSharp.targets' />
 </Project>");
@@ -7354,7 +7354,7 @@ using System.Runtime.InteropServices;
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <OutputPath>out</OutputPath>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include='file1.cs' />

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
@@ -4249,7 +4249,7 @@ namespace Proj2
                     {
                         "content/proj1_file2.txt",
                         "lib/net472/proj1.dll",
-                        "lib/net427/proj2.dll"
+                        "lib/net472/proj2.dll"
                     },
                     files);
             }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
@@ -353,7 +353,7 @@ namespace NuGet.CommandLine.Test
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <OutputPath>out</OutputPath>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <ItemGroup>
     <None Include='packages.config' />
@@ -621,7 +621,7 @@ EndProject");
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <OutputPath>out</OutputPath>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <Import Project='..\packages\a.targets' />
 </Project>");
@@ -847,7 +847,7 @@ EndProject");
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <OutputPath>out</OutputPath>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <ItemGroup>
     <None Include='packages.config' />
@@ -864,7 +864,7 @@ EndProject");
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <OutputPath>out</OutputPath>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <ItemGroup>
     <None Include='packages.config' />
@@ -920,7 +920,7 @@ EndProject");
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <OutputPath>out</OutputPath>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <ItemGroup>
     <None Include='packages.config' />
@@ -937,7 +937,7 @@ EndProject");
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <OutputPath>out</OutputPath>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <ItemGroup>
     <None Include='packages.config' />
@@ -1004,7 +1004,7 @@ EndProject");
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <OutputPath>out</OutputPath>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <ItemGroup>
     <None Include='packages.config' />
@@ -1533,7 +1533,7 @@ EndProject";
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <OutputPath>out</OutputPath>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <ItemGroup>
     <None Include='packages.config' />
@@ -1606,7 +1606,7 @@ EndProject";
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <OutputPath>out</OutputPath>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <ItemGroup>
     <None Include='packages.config' />
@@ -1679,7 +1679,7 @@ EndProject";
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <OutputPath>out</OutputPath>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <ItemGroup>
     <None Include='packages.config' />
@@ -1762,7 +1762,7 @@ EndProject";
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <OutputPath>out</OutputPath>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <ItemGroup>
     <None Include='packages.config' />
@@ -1856,7 +1856,7 @@ EndProject";
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <OutputPath>out</OutputPath>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <ItemGroup>
     <None Include='packages.config' />
@@ -1955,7 +1955,7 @@ EndProject";
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <OutputPath>out</OutputPath>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <ItemGroup>
     <None Include='project.json' />
@@ -1979,7 +1979,7 @@ EndProject";
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <OutputPath>out</OutputPath>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include=""..\A\A.Util\A.Util.csproj"">
@@ -2251,7 +2251,7 @@ EndProject";
     <OutputType>Library</OutputType>
     <RootNamespace>ClassLibrary1</RootNamespace>
     <AssemblyName>ClassLibrary1</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition="" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "">
     <OutputPath>bin\Debug\</OutputPath>
@@ -2404,7 +2404,7 @@ EndProject";
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <OutputPath>out</OutputPath>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <ItemGroup>
     <None Include='packages.config' />
@@ -2568,7 +2568,7 @@ EndProject";
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <OutputPath>out</OutputPath>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <ItemGroup>
     <None Include='packages.config' />
@@ -2656,7 +2656,7 @@ EndProject";
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <OutputPath>out</OutputPath>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <ItemGroup>
     <None Include='packages.config' />
@@ -2742,7 +2742,7 @@ EndProject";
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <OutputPath>out</OutputPath>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <ItemGroup>
     <None Include='packages.config' />
@@ -2817,7 +2817,7 @@ EndProject";
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <OutputPath>out</OutputPath>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <ItemGroup>
     <None Include='packages.config' />
@@ -2900,7 +2900,7 @@ EndProject";
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <OutputPath>out</OutputPath>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <ItemGroup>
     <None Include='packages.config' />
@@ -2978,7 +2978,7 @@ EndProject";
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <OutputPath>out</OutputPath>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <ItemGroup>
     <None Include='packages.config' />
@@ -3045,7 +3045,7 @@ EndProject";
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <OutputPath>out</OutputPath>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <ItemGroup>
     <None Include='packages.config' />
@@ -3130,7 +3130,7 @@ EndProject";
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <OutputPath>out</OutputPath>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <ItemGroup>
     <None Include='packages.config' />
@@ -3219,7 +3219,7 @@ EndProject";
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <OutputPath>out</OutputPath>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <ItemGroup>
     <None Include='packages.config' />

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetUpdateCommandTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetUpdateCommandTests.cs
@@ -1305,7 +1305,7 @@ namespace NuGet.CommandLine.Test
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <OutputPath>out</OutputPath>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <ItemGroup>
     <None Include='{0}' />

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/ProjectFactoryTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/ProjectFactoryTest.cs
@@ -477,6 +477,8 @@ namespace NuGet.CommandLine
                     "pack Assembly.csproj -build",
                     waitForExit: true);
 
+                Util.VerifyResultSuccess(r);
+
                 // Assert
                 using (var package = new PackageArchiveReader(Path.Combine(workingDirectory, "Assembly.1.0.0.nupkg")))
                 {
@@ -485,12 +487,12 @@ namespace NuGet.CommandLine
                     Assert.Equal(0, r.ExitCode);
                     Array.Sort(files);
                     Assert.Equal(
-                        files,
                         new[]
                         {
-                            @"lib/net45/Assembly.dll",
-                            @"lib/net45/Assembly.xml"
-                        });
+                            @"lib/net472/Assembly.dll",
+                            @"lib/net472/Assembly.xml"
+                        },
+                        files);
                 }
             }
         }
@@ -532,8 +534,8 @@ namespace NuGet.CommandLine
                         files,
                         new[]
                         {
-                            @"lib/net45/A.dll",
-                            @"lib/net45/Link.dll"
+                            @"lib/net472/A.dll",
+                            @"lib/net472/Link.dll"
                         });
                 }
             }
@@ -586,9 +588,9 @@ namespace NuGet.CommandLine
                         files,
                         new[]
                         {
-                            @"lib/net45/A.dll",
-                            @"lib/net45/C.dll",
-                            @"lib/net45/Link.dll"
+                            @"lib/net472/A.dll",
+                            @"lib/net472/C.dll",
+                            @"lib/net472/Link.dll"
                         });
                 }
             }
@@ -608,8 +610,8 @@ namespace NuGet.CommandLine
         <description>Description for Assembly.</description>
     </metadata>
     <files>
-        <file src=""bin\Debug\Assembly.dll"" target=""lib\net45\Assembly.dll"" />
-        <file src=""bin\Debug\Assembly.xml"" target=""lib\net45\Assembly.xml"" />
+        <file src=""bin\Debug\Assembly.dll"" target=""lib\net472\Assembly.dll"" />
+        <file src=""bin\Debug\Assembly.xml"" target=""lib\net472\Assembly.xml"" />
     </files>
 </package>";
         }
@@ -627,7 +629,7 @@ namespace NuGet.CommandLine
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Assembly</RootNamespace>
     <AssemblyName>Assembly</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition="" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "">
@@ -639,7 +641,7 @@ namespace NuGet.CommandLine
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition="" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "">
     <DebugType>pdbonly</DebugType>

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
@@ -7000,7 +7000,7 @@ namespace NuGet.CommandLine.Test
             {
                 // Set up solution, project, and packages
                 var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
-                var projectFrameworks = "net45;net46";
+                var projectFrameworks = "net472;net48";
 
                 var projectA = SimpleTestProjectContext.CreateNETCoreWithSDK(
                             projectName: "a",

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
@@ -7024,9 +7024,9 @@ namespace NuGet.CommandLine.Test
                     packageX1,
                     packageX2);
 
-                projectA.AddPackageDownloadToFramework("net45", packageX1);
+                projectA.AddPackageDownloadToFramework("net472", packageX1);
 
-                projectA.AddPackageDownloadToFramework("net46", packageX2);
+                projectA.AddPackageDownloadToFramework("net48", packageX2);
 
                 solution.Projects.Add(projectA);
                 solution.Create(pathContext.SolutionRoot);

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Util.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Util.cs
@@ -584,7 +584,7 @@ namespace NuGet.CommandLine.Test
 
         public static string CreateProjFileContent(
             string projectName = "proj1",
-            string targetFrameworkVersion = "v4.5",
+            string targetFrameworkVersion = "v4.7.2",
             string[] references = null,
             string[] contentFiles = null)
         {
@@ -594,7 +594,7 @@ namespace NuGet.CommandLine.Test
 
         public static XElement CreateProjFileXmlContent(
             string projectName = "proj1",
-            string targetFrameworkVersion = "v4.5",
+            string targetFrameworkVersion = "v4.7.2",
             string[] references = null,
             string[] contentFiles = null)
         {
@@ -831,7 +831,7 @@ EndProject";
                     <AppDesignerFolder>Properties</AppDesignerFolder>
                     <RootNamespace>$NAME$</RootNamespace>
                     <AssemblyName>$NAME$</AssemblyName>
-                    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+                    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
                     <FileAlignment>512</FileAlignment>
                     <DebugSymbols>true</DebugSymbols>
                     <DebugType>full</DebugType>
@@ -890,7 +890,7 @@ EndProject");
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <OutputPath>out</OutputPath>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <ItemGroup>
     <None Include='{include1}' />
@@ -919,7 +919,7 @@ EndProject");
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <OutputPath>out</OutputPath>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <ItemGroup>
     <None Include='{include2}' />


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11830

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

A bunch of tests wouldn't run locally on machines that only have VS2022 installed (and therefore no net40 or net4.5 targeting pack).  Tests updated to use net472 instead.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception: Modified existing tests
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
