### PR TITLE
dependency group uses project TFM when packing legacy csproj

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/ProjectFactory.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/ProjectFactory.cs
@@ -983,12 +983,10 @@ namespace NuGet.CommandLine
             }
             else
             {
-                // TO FIX: when we persist the target framework into packages.config file,
-                // we need to pull that info into building the PackageDependencySet object
                 builder.DependencyGroups.Clear();
 
-                // REVIEW: IS NuGetFramework.AnyFramework correct?
-                builder.DependencyGroups.Add(new PackageDependencyGroup(NuGetFramework.AnyFramework, new HashSet<Packaging.Core.PackageDependency>(dependencies.Values)));
+                var targetFramework = TargetFramework ?? NuGetFramework.AnyFramework;
+                builder.DependencyGroups.Add(new PackageDependencyGroup(targetFramework, new HashSet<PackageDependency>(dependencies.Values)));
             }
         }
 

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
@@ -3205,6 +3205,9 @@ namespace Proj1
                 var dependency = dependencySet.Packages.First();
                 Assert.Equal("testPackage1", dependency.Id);
                 Assert.Equal("[1.1.0, )", dependency.VersionRange.ToString());
+
+                // Ensure that the dependency group has the same TFM as the project
+                Assert.Equal(FrameworkConstants.CommonFrameworks.Net472, dependencySet.TargetFramework);
             }
         }
 
@@ -3289,6 +3292,9 @@ namespace Proj1
                 var dependency = dependencySet.Packages.First();
                 Assert.Equal("testPackage1", dependency.Id);
                 Assert.Equal("[1.1.0, )", dependency.VersionRange.ToString());
+
+                // Ensure that the dependency group has the same TFM as the project
+                Assert.Equal(FrameworkConstants.CommonFrameworks.Net472, dependencySet.TargetFramework);
             }
         }
 
@@ -3398,6 +3404,9 @@ namespace Proj1
                 var package = new PackageArchiveReader(File.OpenRead(Path.Combine(proj1Directory, "proj1.0.0.0.nupkg")));
                 Assert.Equal(1, package.NuspecReader.GetDependencyGroups().Count());
                 var dependencySet = package.NuspecReader.GetDependencyGroups().First();
+
+                // Ensure that the dependency group has the same TFM as the project
+                Assert.Equal(FrameworkConstants.CommonFrameworks.Net472, dependencySet.TargetFramework);
 
                 // Verify that testPackage2 is added as dependency in addition to testPackage1.
                 // testPackage3 and testPackage4 are not added because they are already referenced by testPackage1 with the correct version range.
@@ -3510,6 +3519,9 @@ namespace Proj1
                 var package = new PackageArchiveReader(File.OpenRead(Path.Combine(proj1Directory, "proj1.0.0.0.nupkg")));
                 Assert.Equal(1, package.NuspecReader.GetDependencyGroups().Count());
                 var dependencySet = package.NuspecReader.GetDependencyGroups().First();
+
+                // Ensure that the dependency group has the same TFM as the project
+                Assert.Equal(FrameworkConstants.CommonFrameworks.Net472, dependencySet.TargetFramework);
 
                 // Verify that testPackage1 is added as dependency in addition to testPackage3.
                 // testPackage2 is not added because it is already referenced by testPackage3 with the correct version range.


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/8713

Regression? No, but bug didn't exist before pack warning NU5128 was added.

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

When packing a (non-SDK style) project that has a packages.config file, NuGet will overwrite any dependencies defined in the nuspec, and add packages from packages.config as depdencies. The dependency group that it creates was hardcoded to `NuGetFramework.AnyFramework`, and this PR changes it to use the TFM of the project.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
