### PR TITLE
Retry reading .nupkg.metadata files

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/NupkgMetadata/NupkgMetadataFileFormat.cs
+++ b/src/NuGet.Core/NuGet.Packaging/NupkgMetadata/NupkgMetadataFileFormat.cs
@@ -26,10 +26,7 @@ namespace NuGet.Packaging
 
         public static NupkgMetadataFile Read(string filePath, ILogger log)
         {
-            using (var stream = File.OpenRead(filePath))
-            {
-                return Read(stream, log, filePath);
-            }
+            return FileUtility.SafeRead(filePath, (stream, nupkgMetadataFilePath) => Read(stream, log, nupkgMetadataFilePath));
         }
 
         public static NupkgMetadataFile Read(Stream stream, ILogger log, string path)


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/10882

Regression? No Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
Some restores seem to fail when reading the `.nupkg.metadata` file.  We haven't been able to determine what code path allows this since package extraction should be complete long before the `.nupkg.metadata` file is read.  This change looks to mitigate the problem by adding retries around reading the file.  Note that this issue is hit very rarely.

I'm not updating tests because I'm worried the test would be flaky since it needs very precise timing to induce the retry.  Existing tests at least show that nothing changed for the successful code path.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
