### PR TITLE
Add total fault count to instance close telemetry

### DIFF
--- a/src/NuGet.Clients/NuGet.Tools/NuGetPackage.cs
+++ b/src/NuGet.Clients/NuGet.Tools/NuGetPackage.cs
@@ -189,7 +189,7 @@ namespace NuGetVSExtension
 
             await NuGetBrokeredServiceFactory.ProfferServicesAsync(this);
 
-            VsShellUtilities.ShutdownToken.Register(RegisterEmitVSInstancePowerShellTelemetry);
+            VsShellUtilities.ShutdownToken.Register(InstanceCloseEvent.OnShutdown);
 
             var componentModel = await this.GetFreeThreadedServiceAsync<SComponentModel, IComponentModel>();
             Assumes.Present(componentModel);
@@ -1263,11 +1263,6 @@ namespace NuGetVSExtension
         }
 
         #endregion IVsPackageExtensionProvider implementation
-
-        private void RegisterEmitVSInstancePowerShellTelemetry()
-        {
-            NuGetPowerShellUsage.RaiseVSInstanceCloseEvent();
-        }
 
         #region IVsPersistSolutionOpts
 

--- a/src/NuGet.Clients/NuGet.Tools/NuGetPackage.cs
+++ b/src/NuGet.Clients/NuGet.Tools/NuGetPackage.cs
@@ -27,7 +27,6 @@ using NuGet.ProjectManagement;
 using NuGet.VisualStudio;
 using NuGet.VisualStudio.Common;
 using NuGet.VisualStudio.Common.Telemetry;
-using NuGet.VisualStudio.Common.Telemetry.PowerShell;
 using NuGet.VisualStudio.Internal.Contracts;
 using NuGet.VisualStudio.Telemetry;
 using NuGetConsole;
@@ -189,7 +188,7 @@ namespace NuGetVSExtension
 
             await NuGetBrokeredServiceFactory.ProfferServicesAsync(this);
 
-            VsShellUtilities.ShutdownToken.Register(InstanceCloseEvent.OnShutdown);
+            VsShellUtilities.ShutdownToken.Register(InstanceCloseTelemetryEmitter.OnShutdown);
 
             var componentModel = await this.GetFreeThreadedServiceAsync<SComponentModel, IComponentModel>();
             Assumes.Present(componentModel);

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/InstanceCloseTelemetryEmitter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/InstanceCloseTelemetryEmitter.cs
@@ -2,23 +2,28 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using NuGet.Common;
-using NuGet.VisualStudio.Telemetry;
 
-namespace NuGet.VisualStudio.Common.Telemetry.PowerShell
+namespace NuGet.VisualStudio.Telemetry
 {
-    public static class InstanceCloseEvent
+    public static class InstanceCloseTelemetryEmitter
     {
         private const string EventName = "InstanceClose";
 
         public static void OnShutdown()
         {
+            var telemetryEvent = CreateTelemetryEvent();
+            TelemetryActivity.EmitTelemetryEvent(telemetryEvent);
+        }
+
+        internal static TelemetryEvent CreateTelemetryEvent()
+        {
             var telemetryEvent = new TelemetryEvent(EventName);
 
             AddEventsOnShutdown?.Invoke(null, telemetryEvent);
 
-            telemetryEvent["faults.total"] = TelemetryUtility.TotalFaultEvents;
+            telemetryEvent["faults.sessioncount"] = TelemetryUtility.TotalFaultEvents;
 
-            TelemetryActivity.EmitTelemetryEvent(telemetryEvent);
+            return telemetryEvent;
         }
 
         public static event System.EventHandler<TelemetryEvent> AddEventsOnShutdown;

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/NuGetPowerShellUsageCollector.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/NuGetPowerShellUsageCollector.cs
@@ -56,7 +56,8 @@ namespace NuGet.VisualStudio.Common.Telemetry
             NuGetPowerShellUsage.PmcWindowsEvent += NuGetPowerShellUsage_PMCWindowsEventHandler;
             NuGetPowerShellUsage.SolutionOpenEvent += NuGetPowerShellUsage_SolutionOpenHandler;
             NuGetPowerShellUsage.SolutionCloseEvent += NuGetPowerShellUsage_SolutionCloseHandler;
-            NuGetPowerShellUsage.VSInstanceCloseEvent += NuGetPowerShellUsage_VSInstanseCloseHandler;
+
+            InstanceCloseEvent.AddEventsOnShutdown += NuGetPowerShellUsage_VSInstanseCloseHandler;
         }
 
         private void NuGetPowerShellUsage_PMCLoadEventHandler(bool isPMC)
@@ -228,7 +229,7 @@ namespace NuGet.VisualStudio.Common.Telemetry
             }
         }
 
-        private void NuGetPowerShellUsage_VSInstanseCloseHandler()
+        private void NuGetPowerShellUsage_VSInstanseCloseHandler(object sender, TelemetryEvent telemetryEvent)
         {
             lock (_lock)
             {
@@ -239,8 +240,8 @@ namespace NuGet.VisualStudio.Common.Telemetry
                     TelemetryActivity.EmitTelemetryEvent(_vsSolutionData.ToTelemetryEvent());
                 }
 
-                // Emit VS Instance telemetry
-                TelemetryActivity.EmitTelemetryEvent(_vsInstanceData.ToTelemetryEvent());
+                // Add VS Instance telemetry
+                _vsInstanceData.AddProperties(telemetryEvent);
             }
         }
 
@@ -265,7 +266,8 @@ namespace NuGet.VisualStudio.Common.Telemetry
             NuGetPowerShellUsage.PmcWindowsEvent -= NuGetPowerShellUsage_PMCWindowsEventHandler;
             NuGetPowerShellUsage.SolutionOpenEvent -= NuGetPowerShellUsage_SolutionOpenHandler;
             NuGetPowerShellUsage.SolutionCloseEvent -= NuGetPowerShellUsage_SolutionCloseHandler;
-            NuGetPowerShellUsage.VSInstanceCloseEvent -= NuGetPowerShellUsage_VSInstanseCloseHandler;
+
+            InstanceCloseEvent.AddEventsOnShutdown -= NuGetPowerShellUsage_VSInstanseCloseHandler;
         }
 
         internal class SolutionData
@@ -341,18 +343,15 @@ namespace NuGet.VisualStudio.Common.Telemetry
                 SolutionCount = 0;
             }
 
-            internal TelemetryEvent ToTelemetryEvent()
+            internal void AddProperties(TelemetryEvent telemetryEvent)
             {
-                var telemetry = new InstanceCloseEvent(
-                    pmcExecuteCommandCount: PmcExecuteCommandCount,
-                    pmcWindowLoadCount: PmcWindowLoadCount,
-                    pmuiExecuteCommandCount: PmuiExecuteCommandCount,
-                    pmcPowerShellLoadedSolutionCount: PmcLoadedSolutionCount,
-                    pmuiPowerShellLoadedSolutionCount: PmuiLoadedSolutionCount,
-                    reOpenAtStart: ReOpenAtStart,
-                    solutionCount: SolutionCount
-                    );
-                return telemetry;
+                telemetryEvent[PowerShellHost + NuGetPowerShellUsageCollector.PmcExecuteCommandCount] = PmcExecuteCommandCount;
+                telemetryEvent[PowerShellHost + NuGetPowerShellUsageCollector.PmcWindowLoadCount] = PmcWindowLoadCount;
+                telemetryEvent[PowerShellHost + NuGetPowerShellUsageCollector.PmuiExecuteCommandCount] = PmuiExecuteCommandCount;
+                telemetryEvent[PowerShellHost + PmcPowerShellLoadedSolutionCount] = PmcLoadedSolutionCount;
+                telemetryEvent[PowerShellHost + PmuiPowerShellLoadedSolutionCount] = PmuiLoadedSolutionCount;
+                telemetryEvent[PowerShellHost + NuGetPowerShellUsageCollector.ReOpenAtStart] = ReOpenAtStart;
+                telemetryEvent[PowerShellHost + NuGetPowerShellUsageCollector.SolutionCount] = SolutionCount;
             }
         }
     }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/NuGetPowerShellUsageCollector.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/NuGetPowerShellUsageCollector.cs
@@ -4,6 +4,7 @@
 using System;
 using NuGet.Common;
 using NuGet.VisualStudio.Common.Telemetry.PowerShell;
+using NuGet.VisualStudio.Telemetry;
 
 namespace NuGet.VisualStudio.Common.Telemetry
 {
@@ -57,7 +58,7 @@ namespace NuGet.VisualStudio.Common.Telemetry
             NuGetPowerShellUsage.SolutionOpenEvent += NuGetPowerShellUsage_SolutionOpenHandler;
             NuGetPowerShellUsage.SolutionCloseEvent += NuGetPowerShellUsage_SolutionCloseHandler;
 
-            InstanceCloseEvent.AddEventsOnShutdown += NuGetPowerShellUsage_VSInstanseCloseHandler;
+            InstanceCloseTelemetryEmitter.AddEventsOnShutdown += NuGetPowerShellUsage_VSInstanseCloseHandler;
         }
 
         private void NuGetPowerShellUsage_PMCLoadEventHandler(bool isPMC)
@@ -267,7 +268,7 @@ namespace NuGet.VisualStudio.Common.Telemetry
             NuGetPowerShellUsage.SolutionOpenEvent -= NuGetPowerShellUsage_SolutionOpenHandler;
             NuGetPowerShellUsage.SolutionCloseEvent -= NuGetPowerShellUsage_SolutionCloseHandler;
 
-            InstanceCloseEvent.AddEventsOnShutdown -= NuGetPowerShellUsage_VSInstanseCloseHandler;
+            InstanceCloseTelemetryEmitter.AddEventsOnShutdown -= NuGetPowerShellUsage_VSInstanseCloseHandler;
         }
 
         internal class SolutionData

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/Powershell/InstanceCloseEvent.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/Powershell/InstanceCloseEvent.cs
@@ -2,28 +2,25 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using NuGet.Common;
+using NuGet.VisualStudio.Telemetry;
 
 namespace NuGet.VisualStudio.Common.Telemetry.PowerShell
 {
-    public class InstanceCloseEvent : TelemetryEvent
+    public static class InstanceCloseEvent
     {
-        public InstanceCloseEvent(
-            int pmcExecuteCommandCount,
-            int pmcWindowLoadCount,
-            int pmuiExecuteCommandCount,
-            int pmcPowerShellLoadedSolutionCount,
-            int pmuiPowerShellLoadedSolutionCount,
-            bool reOpenAtStart,
-            int solutionCount
-            ) : base(NuGetPowerShellUsageCollector.InstanceClose)
+        private const string EventName = "InstanceClose";
+
+        public static void OnShutdown()
         {
-            base[NuGetPowerShellUsageCollector.PowerShellHost + NuGetPowerShellUsageCollector.PmcExecuteCommandCount] = pmcExecuteCommandCount;
-            base[NuGetPowerShellUsageCollector.PowerShellHost + NuGetPowerShellUsageCollector.PmcWindowLoadCount] = pmcWindowLoadCount;
-            base[NuGetPowerShellUsageCollector.PowerShellHost + NuGetPowerShellUsageCollector.PmuiExecuteCommandCount] = pmuiExecuteCommandCount;
-            base[NuGetPowerShellUsageCollector.PowerShellHost + NuGetPowerShellUsageCollector.PmcPowerShellLoadedSolutionCount] = pmcPowerShellLoadedSolutionCount;
-            base[NuGetPowerShellUsageCollector.PowerShellHost + NuGetPowerShellUsageCollector.PmuiPowerShellLoadedSolutionCount] = pmuiPowerShellLoadedSolutionCount;
-            base[NuGetPowerShellUsageCollector.PowerShellHost + NuGetPowerShellUsageCollector.ReOpenAtStart] = reOpenAtStart;
-            base[NuGetPowerShellUsageCollector.PowerShellHost + NuGetPowerShellUsageCollector.SolutionCount] = solutionCount;
+            var telemetryEvent = new TelemetryEvent(EventName);
+
+            AddEventsOnShutdown?.Invoke(null, telemetryEvent);
+
+            telemetryEvent["faults.total"] = TelemetryUtility.TotalFaultEvents;
+
+            TelemetryActivity.EmitTelemetryEvent(telemetryEvent);
         }
+
+        public static event System.EventHandler<TelemetryEvent> AddEventsOnShutdown;
     }
 }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/Powershell/NuGetPowerShellUsage.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/Powershell/NuGetPowerShellUsage.cs
@@ -11,9 +11,6 @@ namespace NuGet.VisualStudio.Common.Telemetry.PowerShell
         public delegate void SolutionCloseHandler();
         public static event SolutionCloseHandler SolutionCloseEvent;
 
-        public delegate void VSInstanceCloseHandler();
-        public static event VSInstanceCloseHandler VSInstanceCloseEvent;
-
         public delegate void PowerShellLoadEventHandler(bool isPMC);
         public static event PowerShellLoadEventHandler PowerShellLoadEvent;
 
@@ -62,11 +59,6 @@ namespace NuGet.VisualStudio.Common.Telemetry.PowerShell
         public static void RaiseSolutionCloseEvent()
         {
             SolutionCloseEvent?.Invoke();
-        }
-
-        public static void RaiseVSInstanceCloseEvent()
-        {
-            VSInstanceCloseEvent?.Invoke();
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/TelemetryUtility.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/TelemetryUtility.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
@@ -22,6 +23,9 @@ namespace NuGet.VisualStudio.Telemetry
 {
     public static class TelemetryUtility
     {
+        private static int FaultEventCount = 0;
+        public static int TotalFaultEvents => FaultEventCount;
+
         public static async Task PostFaultAsync(Exception e, string callerClassName, [CallerMemberName] string callerMemberName = null, IDictionary<string, object> extraProperties = null)
         {
             if (e == null)
@@ -45,6 +49,7 @@ namespace NuGet.VisualStudio.Telemetry
             }
 
             TelemetryService.DefaultSession.PostEvent(fault);
+            Interlocked.Increment(ref FaultEventCount);
 
             if (await IsShellAvailable.GetValueAsync())
             {

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/TelemetryUtility.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/TelemetryUtility.cs
@@ -23,8 +23,8 @@ namespace NuGet.VisualStudio.Telemetry
 {
     public static class TelemetryUtility
     {
-        private static int FaultEventCount = 0;
-        public static int TotalFaultEvents => FaultEventCount;
+        private static long FaultEventCount = 0;
+        public static long TotalFaultEvents => FaultEventCount;
 
         public static async Task PostFaultAsync(Exception e, string callerClassName, [CallerMemberName] string callerMemberName = null, IDictionary<string, object> extraProperties = null)
         {
@@ -35,6 +35,8 @@ namespace NuGet.VisualStudio.Telemetry
 
             var caller = $"{callerClassName}.{callerMemberName}";
             var description = $"{e.GetType().Name} - {e.Message}";
+
+            Interlocked.Increment(ref FaultEventCount);
 
             await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
@@ -49,7 +51,6 @@ namespace NuGet.VisualStudio.Telemetry
             }
 
             TelemetryService.DefaultSession.PostEvent(fault);
-            Interlocked.Increment(ref FaultEventCount);
 
             if (await IsShellAvailable.GetValueAsync())
             {

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Common.Test/Telemetry/InstanceCloseTelemetryEmitterTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Common.Test/Telemetry/InstanceCloseTelemetryEmitterTests.cs
@@ -1,0 +1,20 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using NuGet.VisualStudio.Telemetry;
+using Xunit;
+
+namespace NuGet.VisualStudio.Common.Test.Telemetry
+{
+    public class InstanceCloseTelemetryEmitterTests
+    {
+        [Fact]
+        public void CreateTelemetryEvent_HasExpectedNameAndFaultsCount()
+        {
+            var telemetryEvent = InstanceCloseTelemetryEmitter.CreateTelemetryEvent();
+            Assert.Equal("InstanceClose", telemetryEvent.Name);
+            Assert.NotNull(telemetryEvent["faults.sessioncount"]);
+            Assert.Equal(typeof(long), telemetryEvent["faults.sessioncount"].GetType());
+        }
+    }
+}


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1677

Regression? No

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

* Refactored the InstanceClose telemetry event so it's reusable by classes other than the powershell host.
* Added a count for faults, which gets added to the InstanceClose telemetry.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
