### PR TITLE
Reduce boxing when generating hash code

### DIFF
--- a/build/Shared/HashCodeCombiner.cs
+++ b/build/Shared/HashCodeCombiner.cs
@@ -58,6 +58,15 @@ namespace NuGet.Shared
             }
         }
 
+        // Optimization: for value types, we can avoid boxing "o" by skipping the null check
+        internal void AddStruct<T>(T o)
+            where T : struct
+        {
+            CheckInitialized();
+
+            AddHashCode(o.GetHashCode());
+        }
+
         internal void AddStringIgnoreCase(string s)
         {
             CheckInitialized();

--- a/build/Shared/HashCodeCombiner.cs
+++ b/build/Shared/HashCodeCombiner.cs
@@ -41,6 +41,7 @@ namespace NuGet.Shared
         }
 
         internal void AddObject<TValue>(TValue o, IEqualityComparer<TValue> comparer)
+            where TValue : class
         {
             CheckInitialized();
             if (o != null)
@@ -50,9 +51,22 @@ namespace NuGet.Shared
         }
 
         internal void AddObject<T>(T o)
+            where T : class
         {
             CheckInitialized();
             if (o != null)
+            {
+                AddHashCode(o.GetHashCode());
+            }
+        }
+
+        // Optimization: for value types, we can avoid boxing "o" by skipping the null check
+        internal void AddStruct<T>(T? o)
+            where T : struct
+        {
+            CheckInitialized();
+
+            if (o.HasValue)
             {
                 AddHashCode(o.GetHashCode());
             }

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/FormattedCell.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/FormattedCell.cs
@@ -28,7 +28,7 @@ namespace NuGet.CommandLine.XPlat.Utility
             var combiner = new HashCodeCombiner();
 
             combiner.AddObject(StringComparer.Ordinal.GetHashCode(Value));
-            combiner.AddObject(ForegroundColor);
+            combiner.AddStruct(ForegroundColor);
 
             return combiner.CombinedHash;
         }

--- a/src/NuGet.Core/NuGet.LibraryModel/FrameworkDependency.cs
+++ b/src/NuGet.Core/NuGet.LibraryModel/FrameworkDependency.cs
@@ -59,7 +59,7 @@ namespace NuGet.LibraryModel
         {
             var hashCode = new HashCodeCombiner();
             hashCode.AddObject(ComparisonUtility.FrameworkReferenceNameComparer.GetHashCode(Name));
-            hashCode.AddObject(PrivateAssets);
+            hashCode.AddStruct(PrivateAssets);
             return hashCode.CombinedHash;
         }
     }

--- a/src/NuGet.Core/NuGet.LibraryModel/LibraryDependency.cs
+++ b/src/NuGet.Core/NuGet.LibraryModel/LibraryDependency.cs
@@ -87,14 +87,14 @@ namespace NuGet.LibraryModel
             var hashCode = new HashCodeCombiner();
 
             hashCode.AddObject(LibraryRange);
-            hashCode.AddObject(IncludeType);
-            hashCode.AddObject(SuppressParent);
+            hashCode.AddStruct(IncludeType);
+            hashCode.AddStruct(SuppressParent);
             hashCode.AddObject(AutoReferenced);
             hashCode.AddSequence(NoWarn);
             hashCode.AddObject(GeneratePathProperty);
             hashCode.AddObject(VersionCentrallyManaged);
             hashCode.AddObject(Aliases);
-            hashCode.AddObject(ReferenceType);
+            hashCode.AddStruct(ReferenceType);
 
             return hashCode.CombinedHash;
         }

--- a/src/NuGet.Core/NuGet.LibraryModel/LibraryIdentity.cs
+++ b/src/NuGet.Core/NuGet.LibraryModel/LibraryIdentity.cs
@@ -58,7 +58,7 @@ namespace NuGet.LibraryModel
 
             combiner.AddStringIgnoreCase(Name);
             combiner.AddObject(Version);
-            combiner.AddObject(Type);
+            combiner.AddStruct(Type);
 
             return combiner.CombinedHash;
         }

--- a/src/NuGet.Core/NuGet.LibraryModel/LibraryRange.cs
+++ b/src/NuGet.Core/NuGet.LibraryModel/LibraryRange.cs
@@ -151,7 +151,7 @@ namespace NuGet.LibraryModel
 
             combiner.AddStringIgnoreCase(Name);
             combiner.AddObject(VersionRange);
-            combiner.AddObject(TypeConstraint);
+            combiner.AddStruct(TypeConstraint);
 
             return combiner.CombinedHash;
         }

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/LicenseMetadata.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/LicenseMetadata.cs
@@ -82,7 +82,7 @@ namespace NuGet.Packaging
         {
             var combiner = new HashCodeCombiner();
 
-            combiner.AddObject(Type);
+            combiner.AddStruct(Type);
             combiner.AddObject(License);
             combiner.AddObject(LicenseExpression);
             combiner.AddSequence(WarningsAndErrors);

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Verification/CertificateHashAllowListEntry.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Verification/CertificateHashAllowListEntry.cs
@@ -70,10 +70,10 @@ namespace NuGet.Packaging.Signing
         {
             var combiner = new HashCodeCombiner();
 
-            combiner.AddObject(Placement);
-            combiner.AddObject(Target);
+            combiner.AddStruct(Placement);
+            combiner.AddStruct(Target);
             combiner.AddObject(Fingerprint);
-            combiner.AddObject(FingerprintAlgorithm);
+            combiner.AddStruct(FingerprintAlgorithm);
 
             return combiner.GetHashCode();
         }

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Verification/TrustedSignerAllowListEntry.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Verification/TrustedSignerAllowListEntry.cs
@@ -56,10 +56,10 @@ namespace NuGet.Packaging.Signing
         {
             var combiner = new HashCodeCombiner();
 
-            combiner.AddObject(Placement);
-            combiner.AddObject(Target);
+            combiner.AddStruct(Placement);
+            combiner.AddStruct(Target);
             combiner.AddObject(Fingerprint);
-            combiner.AddObject(FingerprintAlgorithm);
+            combiner.AddStruct(FingerprintAlgorithm);
 
             if (Owners != null)
             {

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/LockFileDependencyComparerWithoutContentHash.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/LockFileDependencyComparerWithoutContentHash.cs
@@ -34,7 +34,7 @@ namespace NuGet.ProjectModel.ProjectLockFile
             combiner.AddObject(LockFileDependencyIdVersionComparer.Default.GetHashCode(obj));
             combiner.AddObject(obj.RequestedVersion);
             combiner.AddSequence(obj.Dependencies);
-            combiner.AddObject(obj.Type);
+            combiner.AddStruct(obj.Type);
             return combiner.CombinedHash;
         }
     }

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadata.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadata.cs
@@ -129,39 +129,41 @@ namespace NuGet.ProjectModel
         {
             var hashCode = new HashCodeCombiner();
 
-            hashCode.AddObject(ProjectStyle);
+            hashCode.AddStruct(ProjectStyle);
+
+            StringComparer osStringComparer = PathUtility.GetStringComparerBasedOnOS();
             if (ProjectPath != null)
             {
-                hashCode.AddObject(PathUtility.GetStringComparerBasedOnOS().GetHashCode(ProjectPath));
+                hashCode.AddObject(osStringComparer.GetHashCode(ProjectPath));
             }
             if (ProjectJsonPath != null)
             {
-                hashCode.AddObject(PathUtility.GetStringComparerBasedOnOS().GetHashCode(ProjectJsonPath));
+                hashCode.AddObject(osStringComparer.GetHashCode(ProjectJsonPath));
             }
             if (OutputPath != null)
             {
-                hashCode.AddObject(PathUtility.GetStringComparerBasedOnOS().GetHashCode(OutputPath));
+                hashCode.AddObject(osStringComparer.GetHashCode(OutputPath));
             }
             if (ProjectName != null)
             {
-                hashCode.AddObject(PathUtility.GetStringComparerBasedOnOS().GetHashCode(ProjectName));
+                hashCode.AddObject(osStringComparer.GetHashCode(ProjectName));
             }
             if (ProjectUniqueName != null)
             {
-                hashCode.AddObject(PathUtility.GetStringComparerBasedOnOS().GetHashCode(ProjectUniqueName));
+                hashCode.AddObject(osStringComparer.GetHashCode(ProjectUniqueName));
             }
             hashCode.AddSequence(Sources.OrderBy(e => e.Source, StringComparer.OrdinalIgnoreCase));
             if (PackagesPath != null)
             {
-                hashCode.AddObject(PathUtility.GetStringComparerBasedOnOS().GetHashCode(PackagesPath));
+                hashCode.AddObject(osStringComparer.GetHashCode(PackagesPath));
             }
-            foreach (var reference in ConfigFilePaths.OrderBy(s => s, PathUtility.GetStringComparerBasedOnOS()))
+            foreach (var reference in ConfigFilePaths.OrderBy(s => s, osStringComparer))
             {
-                hashCode.AddObject(PathUtility.GetStringComparerBasedOnOS().GetHashCode(reference));
+                hashCode.AddObject(osStringComparer.GetHashCode(reference));
             }
-            foreach (var reference in FallbackFolders.OrderBy(s => s, PathUtility.GetStringComparerBasedOnOS()))
+            foreach (var reference in FallbackFolders.OrderBy(s => s, osStringComparer))
             {
-                hashCode.AddObject(PathUtility.GetStringComparerBasedOnOS().GetHashCode(reference));
+                hashCode.AddObject(osStringComparer.GetHashCode(reference));
             }
             hashCode.AddSequence(TargetFrameworks.OrderBy(dep => dep.TargetAlias, StringComparer.OrdinalIgnoreCase));
             foreach (var reference in OriginalTargetFrameworks.OrderBy(s => s, StringComparer.OrdinalIgnoreCase))
@@ -199,16 +201,17 @@ namespace NuGet.ProjectModel
                 return true;
             }
 
+            StringComparer osStringComparer = PathUtility.GetStringComparerBasedOnOS();
             return ProjectStyle == other.ProjectStyle &&
-                   PathUtility.GetStringComparerBasedOnOS().Equals(ProjectPath, other.ProjectPath) &&
-                   PathUtility.GetStringComparerBasedOnOS().Equals(ProjectJsonPath, other.ProjectJsonPath) &&
-                   PathUtility.GetStringComparerBasedOnOS().Equals(OutputPath, other.OutputPath) &&
-                   PathUtility.GetStringComparerBasedOnOS().Equals(ProjectName, other.ProjectName) &&
-                   PathUtility.GetStringComparerBasedOnOS().Equals(ProjectUniqueName, other.ProjectUniqueName) &&
+                   osStringComparer.Equals(ProjectPath, other.ProjectPath) &&
+                   osStringComparer.Equals(ProjectJsonPath, other.ProjectJsonPath) &&
+                   osStringComparer.Equals(OutputPath, other.OutputPath) &&
+                   osStringComparer.Equals(ProjectName, other.ProjectName) &&
+                   osStringComparer.Equals(ProjectUniqueName, other.ProjectUniqueName) &&
                    Sources.OrderedEquals(other.Sources.Distinct(), source => source.Source, StringComparer.OrdinalIgnoreCase) &&
-                   PathUtility.GetStringComparerBasedOnOS().Equals(PackagesPath, other.PackagesPath) &&
-                   ConfigFilePaths.OrderedEquals(other.ConfigFilePaths, filePath => filePath, PathUtility.GetStringComparerBasedOnOS(), PathUtility.GetStringComparerBasedOnOS()) &&
-                   FallbackFolders.OrderedEquals(other.FallbackFolders, fallbackFolder => fallbackFolder, PathUtility.GetStringComparerBasedOnOS(), PathUtility.GetStringComparerBasedOnOS()) &&
+                   osStringComparer.Equals(PackagesPath, other.PackagesPath) &&
+                   ConfigFilePaths.OrderedEquals(other.ConfigFilePaths, filePath => filePath, osStringComparer, osStringComparer) &&
+                   FallbackFolders.OrderedEquals(other.FallbackFolders, fallbackFolder => fallbackFolder, osStringComparer, osStringComparer) &&
                    EqualityUtility.OrderedEquals(TargetFrameworks, other.TargetFrameworks, dep => dep.TargetAlias, StringComparer.OrdinalIgnoreCase) &&
                    OriginalTargetFrameworks.OrderedEquals(other.OriginalTargetFrameworks, fw => fw, StringComparer.OrdinalIgnoreCase, StringComparer.OrdinalIgnoreCase) &&
                    CrossTargeting == other.CrossTargeting &&

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreReference.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreReference.cs
@@ -34,9 +34,9 @@ namespace NuGet.ProjectModel
 
             combiner.AddObject(ProjectPath);
             combiner.AddStringIgnoreCase(ProjectUniqueName);
-            combiner.AddObject(IncludeAssets);
-            combiner.AddObject(ExcludeAssets);
-            combiner.AddObject(PrivateAssets);
+            combiner.AddStruct(IncludeAssets);
+            combiner.AddStruct(ExcludeAssets);
+            combiner.AddStruct(PrivateAssets);
 
             return combiner.CombinedHash;
         }

--- a/src/NuGet.Core/NuGet.Versioning/FloatRange.cs
+++ b/src/NuGet.Core/NuGet.Versioning/FloatRange.cs
@@ -404,7 +404,7 @@ namespace NuGet.Versioning
         {
             var combiner = new HashCodeCombiner();
 
-            combiner.AddObject(FloatBehavior);
+            combiner.AddStruct(FloatBehavior);
             combiner.AddObject(MinVersion);
 
             return combiner.CombinedHash;

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/V2V3ParityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/V2V3ParityTests.cs
@@ -107,7 +107,7 @@ namespace NuGet.Test
             {
                 var combiner = new NuGet.Shared.HashCodeCombiner();
                 combiner.AddObject(obj.PackageIdentity.GetHashCode());
-                combiner.AddObject(obj.NuGetProjectActionType);
+                combiner.AddStruct(obj.NuGetProjectActionType);
                 return combiner.CombinedHash;
             }
         }


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/11866

Regression? Last working version:

## Description
The HashCodeCombiner takes an object parameter in its AddObject method and when passed a value type such as a struct or enum value, it boxes it to do a null check and then compute the hashcode. This allocates boxed objects that are short-lived and not necessary.

After the fix for https://github.com/NuGet/Home/issues/11669, this becomes one of the top sources of allocation for NuGet restore for some scenarios.  See the bug above for "before" picture on allocations.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  - [ ] Test exception
  - **OR**
  - [x] N/A

- **Documentation**
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
