### PR TITLE
EqualityUtility allocation improvements

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
@@ -600,7 +600,7 @@ namespace NuGet.CommandLine
             var entryPointProjects = dgFileOutput
                 .Projects
                 .Where(project => dgFileOutput.Restore.Contains(project.RestoreMetadata.ProjectUniqueName, StringComparer.Ordinal))
-                .ToHashSet();
+                .ToList();
 
             // possible packages.config
             // Compare paths case-insenstive here since we do not know how msbuild modified them
@@ -616,10 +616,8 @@ namespace NuGet.CommandLine
 
             // Filter down to just the requested projects in the file
             // that support transitive references.
-            var v3RestoreProjects = dgFileOutput.Projects
-                .Where(project => (project.RestoreMetadata.ProjectStyle == ProjectStyle.PackageReference
-                    || project.RestoreMetadata.ProjectStyle == ProjectStyle.ProjectJson)
-                    && entryPointProjects.Contains(project));
+            var v3RestoreProjects = entryPointProjects
+                .Where(project => project.RestoreMetadata.ProjectStyle is ProjectStyle.PackageReference or ProjectStyle.ProjectJson);
 
             packageRestoreInputs.RestoreV3Context.Inputs.AddRange(v3RestoreProjects
                 .Select(project => project.RestoreMetadata.ProjectPath));

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
@@ -600,7 +600,7 @@ namespace NuGet.CommandLine
             var entryPointProjects = dgFileOutput
                 .Projects
                 .Where(project => dgFileOutput.Restore.Contains(project.RestoreMetadata.ProjectUniqueName, StringComparer.Ordinal))
-                .ToList();
+                .ToHashSet();
 
             // possible packages.config
             // Compare paths case-insenstive here since we do not know how msbuild modified them

--- a/test/NuGet.Core.Tests/NuGet.Shared.Tests/EqualityUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Shared.Tests/EqualityUtilityTests.cs
@@ -10,6 +10,8 @@ namespace NuGet.Shared.Tests
 {
     public class EqualityUtilityTests
     {
+        // OrderedEquals IList
+
         [Fact]
         public void OrderedEquals_CompareWithNullList_ReturnsFalse()
         {
@@ -77,7 +79,7 @@ namespace NuGet.Shared.Tests
         {
             // Arrange
             var list1 = new List<string> { "unit.test" };
-            var list2 = new List<string> { "unit.test" };
+            var list2 = new List<string> { "Unit.test" };
 
             // Act & Assert
             list1.OrderedEquals(list2, s => s, StringComparer.OrdinalIgnoreCase, StringComparer.OrdinalIgnoreCase).Should().BeTrue();
@@ -93,6 +95,213 @@ namespace NuGet.Shared.Tests
             // Act & Assert
             list1.OrderedEquals(list2, s => s, StringComparer.Ordinal, StringComparer.Ordinal).Should().BeFalse();
         }
+
+        [Fact]
+        public void OrderedEquals_CompareListsWithSameElementsInDifferentOrder_ReturnsTrue()
+        {
+            // Arrange
+            var list1 = new List<string> { "unit", "test" };
+            var list2 = new List<string> { "test", "unit" };
+
+            // Act & Assert
+            list1.OrderedEquals(list2, x => x, StringComparer.Ordinal, StringComparer.Ordinal).Should().BeTrue();
+        }
+
+        //  OrderedEquals ICollection
+
+        [Fact]
+        public void OrderedEquals_CompareWithNullCollection_ReturnsFalse()
+        {
+            // Arrange
+            ICollection<string> list = new List<string>();
+
+            // Act & Assert
+            list.OrderedEquals(null, s => s, StringComparer.Ordinal, StringComparer.Ordinal).Should().BeFalse();
+        }
+
+        [Fact]
+        public void OrderedEquals_CompareFromANullCollection_ReturnsFalse()
+        {
+            // Arrange
+            ICollection<string> list = null;
+
+            // Act & Assert
+            list.OrderedEquals(new List<string>(), s => s, StringComparer.Ordinal, StringComparer.Ordinal).Should().BeFalse();
+        }
+
+        [Fact]
+        public void OrderedEquals_CompareTwoNullCollections_ReturnsTrue()
+        {
+            // Arrange
+            ICollection<string> list = null;
+
+            // Act & Assert
+            list.OrderedEquals(null, s => s, StringComparer.Ordinal, StringComparer.Ordinal).Should().BeTrue();
+        }
+
+        [Fact]
+        public void OrderedEquals_CompareSameCollections_ReturnsTrue()
+        {
+            // Arrange
+            ICollection<string> list = new List<string>();
+
+            // Act & Assert
+            list.OrderedEquals(list, s => s, StringComparer.Ordinal, StringComparer.Ordinal).Should().BeTrue();
+        }
+
+        [Fact]
+        public void OrderedEquals_CompareEmptyCollections_ReturnsTrue()
+        {
+            // Arrange
+            ICollection<string> list1 = new List<string>();
+            ICollection<string> list2 = new List<string>();
+
+            // Act & Assert
+            list1.OrderedEquals(list2, s => s, StringComparer.OrdinalIgnoreCase, StringComparer.OrdinalIgnoreCase).Should().BeTrue();
+        }
+
+        [Fact]
+        public void OrderedEquals_CompareCollectionsWithDifferentLengths_ReturnsFalse()
+        {
+            // Arrange
+            ICollection<string> list1 = new List<string> { "unit.test" };
+            ICollection<string> list2 = new List<string> { "unit.test", "unit.test" };
+
+            // Act & Assert
+            list1.OrderedEquals(list2, s => s, StringComparer.OrdinalIgnoreCase, StringComparer.OrdinalIgnoreCase).Should().BeFalse();
+        }
+
+        [Fact]
+        public void OrderedEquals_CompareCollectionsWithDifferentCaseWithOrdinalIgnoreCase_ReturnsTrue()
+        {
+            // Arrange
+            ICollection<string> list1 = new List<string> { "unit.test" };
+            ICollection<string> list2 = new List<string> { "Unit.test" };
+
+            // Act & Assert
+            list1.OrderedEquals(list2, s => s, StringComparer.OrdinalIgnoreCase, StringComparer.OrdinalIgnoreCase).Should().BeTrue();
+        }
+
+        [Fact]
+        public void OrderedEquals_CompareCollectionsWithDifferentCaseWithOrdinal_ReturnsFalse()
+        {
+            // Arrange
+            ICollection<string> list1 = new List<string> { "unit.test" };
+            ICollection<string> list2 = new List<string> { "Unit.test" };
+
+            // Act & Assert
+            list1.OrderedEquals(list2, s => s, StringComparer.Ordinal, StringComparer.Ordinal).Should().BeFalse();
+        }
+
+        [Fact]
+        public void OrderedEquals_CompareCollectionsWithSameElementsInDifferentOrder_ReturnsTrue()
+        {
+            // Arrange
+            ICollection<string> list1 = new List<string> { "unit", "test" };
+            ICollection<string> list2 = new List<string> { "test", "unit" };
+
+            // Act & Assert
+            list1.OrderedEquals(list2, x => x, StringComparer.Ordinal, StringComparer.Ordinal).Should().BeTrue();
+        }
+
+        // OrderedEquals IEnumerable
+
+        [Fact]
+        public void OrderedEquals_CompareWithNullEnumerable_ReturnsFalse()
+        {
+            // Arrange
+            IEnumerable<string> list = new List<string>();
+
+            // Act & Assert
+            list.OrderedEquals(null, s => s, StringComparer.Ordinal, StringComparer.Ordinal).Should().BeFalse();
+        }
+
+        [Fact]
+        public void OrderedEquals_CompareFromANullEnumerable_ReturnsFalse()
+        {
+            // Arrange
+            IEnumerable<string> list = null;
+
+            // Act & Assert
+            list.OrderedEquals(new List<string>(), s => s, StringComparer.Ordinal, StringComparer.Ordinal).Should().BeFalse();
+        }
+
+        [Fact]
+        public void OrderedEquals_CompareTwoNullEnumerables_ReturnsTrue()
+        {
+            // Arrange
+            IEnumerable<string> list = null;
+
+            // Act & Assert
+            list.OrderedEquals(null, s => s, StringComparer.Ordinal, StringComparer.Ordinal).Should().BeTrue();
+        }
+
+        [Fact]
+        public void OrderedEquals_CompareSameEnumerables_ReturnsTrue()
+        {
+            // Arrange
+            IEnumerable<string> list = new List<string>();
+
+            // Act & Assert
+            list.OrderedEquals(list, s => s, StringComparer.Ordinal, StringComparer.Ordinal).Should().BeTrue();
+        }
+
+        [Fact]
+        public void OrderedEquals_CompareEmptyEnumerables_ReturnsTrue()
+        {
+            // Arrange
+            IEnumerable<string> list1 = new List<string>();
+            IEnumerable<string> list2 = new List<string>();
+
+            // Act & Assert
+            list1.OrderedEquals(list2, s => s, StringComparer.OrdinalIgnoreCase, StringComparer.OrdinalIgnoreCase).Should().BeTrue();
+        }
+
+        [Fact]
+        public void OrderedEquals_CompareEnumerablesWithDifferentLengths_ReturnsFalse()
+        {
+            // Arrange
+            IEnumerable<string> list1 = new List<string> { "unit.test" };
+            IEnumerable<string> list2 = new List<string> { "unit.test", "unit.test" };
+
+            // Act & Assert
+            list1.OrderedEquals(list2, s => s, StringComparer.OrdinalIgnoreCase, StringComparer.OrdinalIgnoreCase).Should().BeFalse();
+        }
+
+        [Fact]
+        public void OrderedEquals_CompareEnumerablesWithDifferentCaseWithOrdinalIgnoreCase_ReturnsTrue()
+        {
+            // Arrange
+            IEnumerable<string> list1 = new List<string> { "unit.test" };
+            IEnumerable<string> list2 = new List<string> { "Unit.test" };
+
+            // Act & Assert
+            list1.OrderedEquals(list2, s => s, StringComparer.OrdinalIgnoreCase, StringComparer.OrdinalIgnoreCase).Should().BeTrue();
+        }
+
+        [Fact]
+        public void OrderedEquals_CompareEnumerablesWithDifferentCaseWithOrdinal_ReturnsFalse()
+        {
+            // Arrange
+            IEnumerable<string> list1 = new List<string> { "unit.test" };
+            IEnumerable<string> list2 = new List<string> { "Unit.test" };
+
+            // Act & Assert
+            list1.OrderedEquals(list2, s => s, StringComparer.Ordinal, StringComparer.Ordinal).Should().BeFalse();
+        }
+
+        [Fact]
+        public void OrderedEquals_CompareEnumerablesWithSameElementsInDifferentOrder_ReturnsTrue()
+        {
+            // Arrange
+            IEnumerable<string> list1 = new List<string> { "unit", "test" };
+            IEnumerable<string> list2 = new List<string> { "test", "unit" };
+
+            // Act & Assert
+            list1.OrderedEquals(list2, x => x, StringComparer.Ordinal, StringComparer.Ordinal).Should().BeTrue();
+        }
+
+        // SequenceEqualWithNullCheck IList
 
         [Fact]
         public void SequenceEqualWithNullCheck_CompareWithNullList_ReturnsFalse()
@@ -125,13 +334,274 @@ namespace NuGet.Shared.Tests
         }
 
         [Fact]
+        public void SequenceEqualWithNullCheck_CompareSameLists_ReturnsTrue()
+        {
+            // Arrange
+            var list = new List<string>();
+
+            // Act & Assert
+            list.SequenceEqualWithNullCheck(list, StringComparer.Ordinal).Should().BeTrue();
+        }
+
+        [Fact]
+        public void SequenceEqualWithNullCheck_CompareEmptyLists_ReturnsTrue()
+        {
+            // Arrange
+            var list1 = new List<string>();
+            var list2 = new List<string>();
+
+            // Act & Assert
+            list1.SequenceEqualWithNullCheck(list2, StringComparer.Ordinal).Should().BeTrue();
+        }
+
+        [Fact]
+        public void SequenceEqualWithNullCheck_CompareListsWithDifferentLengths_ReturnsFalse()
+        {
+            // Arrange
+            var list1 = new List<string> { "unit.test" };
+            var list2 = new List<string> { "unit.test", "unit.test" };
+
+            // Act & Assert
+            list1.SequenceEqualWithNullCheck(list2, StringComparer.OrdinalIgnoreCase).Should().BeFalse();
+        }
+
+        [Fact]
+        public void SequenceEqualWithNullCheck_CompareListsWithDifferentCaseWithOrdinalIgnoreCase_ReturnsTrue()
+        {
+            // Arrange
+            var list1 = new List<string> { "unit.test" };
+            var list2 = new List<string> { "Unit.test" };
+
+            // Act & Assert
+            list1.SequenceEqualWithNullCheck(list2, StringComparer.OrdinalIgnoreCase).Should().BeTrue();
+        }
+
+        [Fact]
+        public void SequenceEqualWithNullCheck_CompareListsWithDifferentCaseWithOrdinal_ReturnsFalse()
+        {
+            // Arrange
+            var list1 = new List<string> { "unit.test" };
+            var list2 = new List<string> { "Unit.test" };
+
+            // Act & Assert
+            list1.SequenceEqualWithNullCheck(list2, StringComparer.Ordinal).Should().BeFalse();
+        }
+
+        [Fact]
+        public void SequenceEqualWithNullCheck_CompareListsWithSameElementsInDifferentOrder_ReturnsFalse()
+        {
+            // Arrange
+            var list1 = new List<string> { "unit", "test" };
+            var list2 = new List<string> { "test", "unit" };
+
+            // Act & Assert
+            list1.SequenceEqualWithNullCheck(list2, StringComparer.Ordinal).Should().BeFalse();
+        }
+
+        // SequenceEqualWithNullCheck ICollection
+
+        [Fact]
+        public void SequenceEqualWithNullCheck_CompareWithNullCollection_ReturnsFalse()
+        {
+            // Arrange
+            ICollection<string> list = new List<string>();
+
+            // Act & Assert
+            list.SequenceEqualWithNullCheck(null).Should().BeFalse();
+        }
+
+        [Fact]
+        public void SequenceEqualWithNullCheck_CompareFromANullCollection_ReturnsFalse()
+        {
+            // Arrange
+            ICollection<string> list = null;
+
+            // Act & Assert
+            list.SequenceEqualWithNullCheck(new List<string>()).Should().BeFalse();
+        }
+
+        [Fact]
+        public void SequenceEqualWithNullCheck_CompareTwoNullCollections_ReturnsTrue()
+        {
+            // Arrange
+            ICollection<string> list = null;
+
+            // Act & Assert
+            list.SequenceEqualWithNullCheck(null).Should().BeTrue();
+        }
+
+        [Fact]
+        public void SequenceEqualWithNullCheck_CompareSameCollections_ReturnsTrue()
+        {
+            // Arrange
+            ICollection<string> list = new List<string>();
+
+            // Act & Assert
+            list.SequenceEqualWithNullCheck(list, StringComparer.Ordinal).Should().BeTrue();
+        }
+
+        [Fact]
+        public void SequenceEqualWithNullCheck_CompareEmptyCollections_ReturnsTrue()
+        {
+            // Arrange
+            ICollection<string> list1 = new List<string>();
+            ICollection<string> list2 = new List<string>();
+
+            // Act & Assert
+            list1.SequenceEqualWithNullCheck(list2, StringComparer.Ordinal).Should().BeTrue();
+        }
+
+        [Fact]
+        public void SequenceEqualWithNullCheck_CompareCollectionsWithDifferentLengths_ReturnsFalse()
+        {
+            // Arrange
+            ICollection<string> list1 = new List<string> { "unit.test" };
+            ICollection<string> list2 = new List<string> { "unit.test", "unit.test" };
+
+            // Act & Assert
+            list1.SequenceEqualWithNullCheck(list2, StringComparer.OrdinalIgnoreCase).Should().BeFalse();
+        }
+
+        [Fact]
+        public void SequenceEqualWithNullCheck_CompareCollectionsWithDifferentCaseWithOrdinalIgnoreCase_ReturnsTrue()
+        {
+            // Arrange
+            ICollection<string> list1 = new List<string> { "unit.test" };
+            ICollection<string> list2 = new List<string> { "Unit.test" };
+
+            // Act & Assert
+            list1.SequenceEqualWithNullCheck(list2, StringComparer.OrdinalIgnoreCase).Should().BeTrue();
+        }
+
+        [Fact]
+        public void SequenceEqualWithNullCheck_CompareCollectionsWithDifferentCaseWithOrdinal_ReturnsFalse()
+        {
+            // Arrange
+            ICollection<string> list1 = new List<string> { "unit.test" };
+            ICollection<string> list2 = new List<string> { "Unit.test" };
+
+            // Act & Assert
+            list1.SequenceEqualWithNullCheck(list2, StringComparer.Ordinal).Should().BeFalse();
+        }
+
+        [Fact]
+        public void SequenceEqualWithNullCheck_CompareCollectionsWithSameElementsInDifferentOrder_ReturnsFalse()
+        {
+            // Arrange
+            ICollection<string> list1 = new List<string> { "unit", "test" };
+            ICollection<string> list2 = new List<string> { "test", "unit" };
+
+            // Act & Assert
+            list1.SequenceEqualWithNullCheck(list2, StringComparer.Ordinal).Should().BeFalse();
+        }
+
+        // SequenceEqualWithNullCheck IEnumerable
+
+        [Fact]
+        public void SequenceEqualWithNullCheck_CompareWithNullEnumerable_ReturnsFalse()
+        {
+            // Arrange
+            IEnumerable<string> list = new List<string>();
+
+            // Act & Assert
+            list.SequenceEqualWithNullCheck(null).Should().BeFalse();
+        }
+
+        [Fact]
+        public void SequenceEqualWithNullCheck_CompareFromANullEnumerable_ReturnsFalse()
+        {
+            // Arrange
+            IEnumerable<string> list = null;
+
+            // Act & Assert
+            list.SequenceEqualWithNullCheck(new List<string>()).Should().BeFalse();
+        }
+
+        [Fact]
+        public void SequenceEqualWithNullCheck_CompareTwoNullEnumerables_ReturnsTrue()
+        {
+            // Arrange
+            IEnumerable<string> list = null;
+
+            // Act & Assert
+            list.SequenceEqualWithNullCheck(null).Should().BeTrue();
+        }
+
+        [Fact]
+        public void SequenceEqualWithNullCheck_CompareSameEnumerables_ReturnsTrue()
+        {
+            // Arrange
+            IEnumerable<string> list = new List<string>();
+
+            // Act & Assert
+            list.SequenceEqualWithNullCheck(list, StringComparer.Ordinal).Should().BeTrue();
+        }
+
+        [Fact]
+        public void SequenceEqualWithNullCheck_CompareEmptyEnumerables_ReturnsTrue()
+        {
+            // Arrange
+            IEnumerable<string> list1 = new List<string>();
+            IEnumerable<string> list2 = new List<string>();
+
+            // Act & Assert
+            list1.SequenceEqualWithNullCheck(list2, StringComparer.Ordinal).Should().BeTrue();
+        }
+
+        [Fact]
+        public void SequenceEqualWithNullCheck_CompareEnumerablesWithDifferentLengths_ReturnsFalse()
+        {
+            // Arrange
+            IEnumerable<string> list1 = new List<string> { "unit.test" };
+            IEnumerable<string> list2 = new List<string> { "unit.test", "unit.test" };
+
+            // Act & Assert
+            list1.SequenceEqualWithNullCheck(list2, StringComparer.OrdinalIgnoreCase).Should().BeFalse();
+        }
+
+        [Fact]
+        public void SequenceEqualWithNullCheck_CompareEnumerablesWithDifferentCaseWithOrdinalIgnoreCase_ReturnsTrue()
+        {
+            // Arrange
+            IEnumerable<string> list1 = new List<string> { "unit.test" };
+            IEnumerable<string> list2 = new List<string> { "Unit.test" };
+
+            // Act & Assert
+            list1.SequenceEqualWithNullCheck(list2, StringComparer.OrdinalIgnoreCase).Should().BeTrue();
+        }
+
+        [Fact]
+        public void SequenceEqualWithNullCheck_CompareEnumerablesWithDifferentCaseWithOrdinal_ReturnsFalse()
+        {
+            // Arrange
+            IEnumerable<string> list1 = new List<string> { "unit.test" };
+            IEnumerable<string> list2 = new List<string> { "Unit.test" };
+
+            // Act & Assert
+            list1.SequenceEqualWithNullCheck(list2, StringComparer.Ordinal).Should().BeFalse();
+        }
+
+        [Fact]
+        public void SequenceEqualWithNullCheck_CompareEnumerablesWithSameElementsInDifferentOrder_ReturnsFalse()
+        {
+            // Arrange
+            IEnumerable<string> list1 = new List<string> { "unit", "test" };
+            IEnumerable<string> list2 = new List<string> { "test", "unit" };
+
+            // Act & Assert
+            list1.SequenceEqualWithNullCheck(list2, StringComparer.Ordinal).Should().BeFalse();
+        }
+
+        // SetEqualsWithNullCheck
+
+        [Fact]
         public void SetEqualsWithNullCheck_CompareWithNullSet_ReturnsFalse()
         {
             // Arrange
             var set = new HashSet<string>();
 
             // Act & Assert
-            set.SequenceEqualWithNullCheck(null).Should().BeFalse();
+            set.SetEqualsWithNullCheck(null).Should().BeFalse();
         }
 
         [Fact]
@@ -141,7 +611,7 @@ namespace NuGet.Shared.Tests
             HashSet<string> set = null;
 
             // Act & Assert
-            set.SequenceEqualWithNullCheck(new HashSet<string>()).Should().BeFalse();
+            set.SetEqualsWithNullCheck(new HashSet<string>()).Should().BeFalse();
         }
 
         [Fact]
@@ -151,7 +621,7 @@ namespace NuGet.Shared.Tests
             HashSet<string> set = null;
 
             // Act & Assert
-            set.SequenceEqualWithNullCheck(null).Should().BeTrue();
+            set.SetEqualsWithNullCheck(null).Should().BeTrue();
         }
 
         [Fact]
@@ -162,7 +632,7 @@ namespace NuGet.Shared.Tests
             var set2 = new HashSet<string>() { "unit.test" };
 
             // Act & Assert
-            set1.SequenceEqualWithNullCheck(set2).Should().BeFalse();
+            set1.SetEqualsWithNullCheck(set2).Should().BeFalse();
         }
 
         [Fact]
@@ -172,7 +642,7 @@ namespace NuGet.Shared.Tests
             var set = new HashSet<string>();
 
             // Act & Assert
-            set.SequenceEqualWithNullCheck(set).Should().BeTrue();
+            set.SetEqualsWithNullCheck(set).Should().BeTrue();
         }
 
         [Fact]
@@ -183,7 +653,7 @@ namespace NuGet.Shared.Tests
             var set2 = new HashSet<string>();
 
             // Act & Assert
-            set1.SequenceEqualWithNullCheck(set2).Should().BeTrue();
+            set1.SetEqualsWithNullCheck(set2).Should().BeTrue();
         }
 
         [Fact]
@@ -194,8 +664,10 @@ namespace NuGet.Shared.Tests
             var set2 = new HashSet<string>() { "unit.test" };
 
             // Act & Assert
-            set1.SequenceEqualWithNullCheck(set2).Should().BeTrue();
+            set1.SetEqualsWithNullCheck(set2).Should().BeTrue();
         }
+
+        // DictionaryEquals
 
         [Fact]
         public void DictionaryEquals_CompareWithNullDict_ReturnsFalse()


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11867

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
The allocations performed by `EqualityUtility.OrderedEquals` and `EqualityUtility.SequenceEqualWithNullCheck` can be reduced by adding overloads that take lists and collections, potentially bypassing the calls to `OrderBy` and `SequenceEqual`.

In testing OrchardCore and [SanitisedNet471](https://github.com/NuGet/Home/issues/10030#issue-701185886), I saw a reduction of ~10% across both objects and total size. Please see the linked issue for numbers.

Other improvements in this area:

- `SetEqualsWithNullCheck` and `DictionaryEquals` can return early if both collections are empty.
- In `RestoreCommand.AddInputsFromDependencyGraphSpec`, `entryPointProjects` should be a `HashSet`, not a `List`.
## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
