### PR TITLE
Flow PrivateAssets to transitively pinned centrally managed dependencies

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/LockFileBuilder.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/LockFileBuilder.cs
@@ -469,7 +469,7 @@ namespace NuGet.Commands
 
         private void AddCentralTransitiveDependencyGroupsForPackageReference(PackageSpec project, LockFile lockFile, IEnumerable<RestoreTargetGraph> targetGraphs)
         {
-            if (project.RestoreMetadata?.CentralPackageVersionsEnabled == false)
+            if (project.RestoreMetadata == null || !project.RestoreMetadata.CentralPackageVersionsEnabled)
             {
                 return;
             }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/LockFileBuilder.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/LockFileBuilder.cs
@@ -489,7 +489,7 @@ namespace NuGet.Commands
                 IEnumerable<LibraryDependency> centralEnforcedTransitiveDependencies = targetGraph
                     .Graphs
                     .SelectMany(i => i.InnerNodes)
-                    .Where(node => node.Item.IsCentralTransitive && targetFrameworkInformation.CentralPackageVersions.ContainsKey(node.Item.Key.Name))
+                    .Where(node => node?.Item != null && node.Disposition == Disposition.Accepted && node.Item.IsCentralTransitive && targetFrameworkInformation.CentralPackageVersions?.ContainsKey(node.Item.Key.Name) == true)
                     .Select((node) =>
                     {
                         CentralPackageVersion matchingCentralVersion = targetFrameworkInformation.CentralPackageVersions[node.Item.Key.Name];

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/LockFileBuilder.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/LockFileBuilder.cs
@@ -513,6 +513,7 @@ namespace NuGet.Commands
                                 suppressParent |= parentDependency.SuppressParent;
                             }
 
+                            // If all assets are suppressed then the dependency should not be added
                             if (suppressParent == LibraryIncludeFlags.All)
                             {
                                 return null;
@@ -551,7 +552,7 @@ namespace NuGet.Commands
         /// <typeparam name="T">The type of the node.</typeparam>
         /// <param name="graphNode">The <see cref="GraphNode{TItem}" /> to flatten the parent nodes of.</param>
         /// <returns>A top down flattened list of parent nodes of the specied node.</returns>
-        private IEnumerable<GraphNode<T>> FlattenParentNodes<T>(GraphNode<T> graphNode)
+        private static IEnumerable<GraphNode<T>> FlattenParentNodes<T>(GraphNode<T> graphNode)
         {
             foreach (GraphNode<T> item in graphNode.ParentNodes)
             {

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/GraphModel/GraphNode.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/GraphModel/GraphNode.cs
@@ -27,7 +27,7 @@ namespace NuGet.DependencyResolver
         /// <summary>
         /// Used in case that a node is removed from its outernode and needs to keep reference of its parents.
         /// </summary>
-        internal IList<GraphNode<TItem>> ParentNodes { get; }
+        public IList<GraphNode<TItem>> ParentNodes { get; }
 
         internal bool AreAllParentsRejected()
         {

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+NuGet.DependencyResolver.GraphNode<TItem>.ParentNodes.get -> System.Collections.Generic.IList<NuGet.DependencyResolver.GraphNode<TItem>>


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes:  https://github.com/NuGet/Home/issues/10311

Regression? No Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
When a centrally managed dependency version is pinned, the top-level package that pulled it in should have its `PrivateAssets` flow down.  This change looks for the top-level dependency that brought in a pinned dependency and then applies its `PrivateAssets`.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
