### PR TITLE
Add a dedicated project references reader for native projects

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/NuGet.PackageManagement.VisualStudio.csproj
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/NuGet.PackageManagement.VisualStudio.csproj
@@ -44,6 +44,7 @@
     <Compile Include="PackageFeeds\InstalledAndTransitivePackageFeed.cs" />
     <Compile Include="PackageFeeds\PackageSourceMoniker.cs" />
     <Compile Include="PackageFeeds\RecommenderPackageFeed.cs" />
+    <Compile Include="ProjectServices\NativeProjectSystemReferencesReader.cs" />
     <Compile Include="ProjectServices\CpsProjectSystemReferenceReader.cs" />
     <Compile Include="Projects\IPackageReferenceProject.cs" />
     <Compile Include="Telemetry\CounterfactualLoggers.cs" />

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectServices/NativeProjectSystemReferencesReader.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectServices/NativeProjectSystemReferencesReader.cs
@@ -57,7 +57,8 @@ namespace NuGet.PackageManagement.VisualStudio
                 var vcReference = reference as VCReference;
                 if (vcReference.UseInBuild)
                 {
-                    var childProjectPath = vcReference.FullPath;
+                    var childProjectPath = vcReference.FullPath; // TODO: This returns the assembly path, but we really want the vcxproj path instead.
+
                     var projectRestoreReference = new ProjectRestoreReference()
                     {
                         ProjectPath = childProjectPath,

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectServices/NativeProjectSystemReferencesReader.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectServices/NativeProjectSystemReferencesReader.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using EnvDTE;
 using Microsoft;
 using Microsoft.VisualStudio.Threading;
 using Microsoft.VisualStudio.VCProjectEngine;
@@ -54,10 +55,10 @@ namespace NuGet.PackageManagement.VisualStudio
 
             foreach (var reference in projectReferences)
             {
-                var vcReference = reference as VCReference;
+                var vcReference = reference as VCProjectReference;
                 if (vcReference.UseInBuild)
                 {
-                    var childProjectPath = vcReference.FullPath; // TODO: This returns the assembly path, but we really want the vcxproj path instead.
+                    var childProjectPath = (vcReference.ReferencedProject as Project).FileName; // TODO: This returns the assembly path, but we really want the vcxproj path instead.
 
                     var projectRestoreReference = new ProjectRestoreReference()
                     {

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectServices/NativeProjectSystemReferencesReader.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectServices/NativeProjectSystemReferencesReader.cs
@@ -1,0 +1,79 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft;
+using Microsoft.VisualStudio.Threading;
+using Microsoft.VisualStudio.VCProjectEngine;
+using NuGet.Frameworks;
+using NuGet.LibraryModel;
+using NuGet.ProjectManagement;
+using NuGet.ProjectModel;
+using NuGet.VisualStudio;
+
+namespace NuGet.PackageManagement.VisualStudio
+{
+    /// <summary>
+    /// Reference reader implementation for the core project system in the integrated development environment (IDE).
+    /// </summary>
+    internal class NativeProjectSystemReferencesReader
+        : IProjectSystemReferencesReader
+    {
+        private readonly IVsProjectAdapter _vsProjectAdapter;
+        private readonly IVsProjectThreadingService _threadingService;
+        private readonly AsyncLazy<VCProject> _vcProject;
+
+        public NativeProjectSystemReferencesReader(
+            IVsProjectAdapter vsProjectAdapter,
+            IVsProjectThreadingService threadingService)
+        {
+            Assumes.Present(vsProjectAdapter);
+            Assumes.Present(threadingService);
+
+            _vsProjectAdapter = vsProjectAdapter;
+            _threadingService = threadingService;
+            _vcProject = new AsyncLazy<VCProject>(async () =>
+            {
+                await threadingService.JoinableTaskFactory.SwitchToMainThreadAsync();
+                return _vsProjectAdapter.Project.Object as VCProject;
+            }, threadingService.JoinableTaskFactory);
+        }
+
+        public async Task<IEnumerable<ProjectRestoreReference>> GetProjectReferencesAsync(
+            Common.ILogger logger, CancellationToken _)
+        {
+            var results = new List<ProjectRestoreReference>();
+
+            await _threadingService.JoinableTaskFactory.SwitchToMainThreadAsync();
+            var vcProject = await _vcProject.GetValueAsync();
+            var references = vcProject.VCReferences as VCReferences;
+            var projectReferences = references.GetReferencesOfType((uint)vcRefType.VCRT_PROJECT);
+
+            foreach (var reference in projectReferences)
+            {
+                var vcReference = reference as VCReference;
+                if (vcReference.UseInBuild)
+                {
+                    var childProjectPath = vcReference.FullPath;
+                    var projectRestoreReference = new ProjectRestoreReference()
+                    {
+                        ProjectPath = childProjectPath,
+                        ProjectUniqueName = childProjectPath
+                    };
+
+                    results.Add(projectRestoreReference);
+                }
+            }
+            return results;
+        }
+
+        public Task<IEnumerable<LibraryDependency>> GetPackageReferencesAsync(
+            NuGetFramework targetFramework, CancellationToken _)
+        {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/VsMSBuildProjectSystemServices.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/VsMSBuildProjectSystemServices.cs
@@ -64,9 +64,18 @@ namespace NuGet.PackageManagement.VisualStudio
             _vsProjectSystem = vsProjectSystem;
             _threadingService = threadingService;
 
-            ReferencesReader = vsProjectSystem is CpsProjectSystem ?
-                new CpsProjectSystemReferenceReader(vsProjectAdapter, _threadingService) :
-                new VsCoreProjectSystemReferenceReader(vsProjectAdapter, _threadingService);
+            if (vsProjectSystem is NativeProjectSystem)
+            {
+                ReferencesReader = new NativeProjectSystemReferencesReader(vsProjectAdapter, _threadingService);
+            }
+            else if (vsProjectSystem is CpsProjectSystem)
+            {
+                ReferencesReader = new CpsProjectSystemReferenceReader(vsProjectAdapter, _threadingService);
+            }
+            else
+            {
+                ReferencesReader = new VsCoreProjectSystemReferenceReader(vsProjectAdapter, _threadingService);
+            }
             ScriptService = new VsProjectScriptHostService(vsProjectAdapter, scriptExecutor);
         }
     }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11877

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

See more details: https://devdiv.visualstudio.com/DevDiv/_queries/edit/1521654/?triage=true.
The gist is that C++ implements CPS in an unconventional way, which forces a full load of a vc project.
Instead of the CPS references reader, we'll now use a dedicated references reader for native projects instead using APIs recommended by the C++ team.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception - Not an easily testable scenario.
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
