### PR TITLE
Add solution filter for VS projects

### DIFF
--- a/NuGet-VS.slnf
+++ b/NuGet-VS.slnf
@@ -1,0 +1,21 @@
+{
+  "solution": {
+    "path": "NuGet.sln",
+    "projects": [
+      "src\\NuGet.Clients\\NuGet.PackageManagement.PowerShellCmdlets\\NuGet.PackageManagement.PowerShellCmdlets.csproj",
+      "src\\NuGet.Clients\\NuGet.PackageManagement.UI\\NuGet.PackageManagement.UI.csproj",
+      "src\\NuGet.Clients\\NuGet.PackageManagement.VisualStudio\\NuGet.PackageManagement.VisualStudio.csproj",
+      "src\\NuGet.Clients\\NuGet.Tools\\NuGet.Tools.csproj",
+      "src\\NuGet.Clients\\NuGet.VisualStudio.Client\\NuGet.VisualStudio.Client.csproj",
+      "src\\NuGet.Clients\\NuGet.VisualStudio.Common\\NuGet.VisualStudio.Common.csproj",
+      "src\\NuGet.Clients\\NuGet.VisualStudio.Contracts\\NuGet.VisualStudio.Contracts.csproj",
+      "src\\NuGet.Clients\\NuGet.VisualStudio.Implementation\\NuGet.VisualStudio.Implementation.csproj",
+      "src\\NuGet.Clients\\NuGet.VisualStudio.Internal.Contracts\\NuGet.VisualStudio.Internal.Contracts.csproj",
+      "src\\NuGet.Clients\\NuGet.VisualStudio.Interop\\NuGet.VisualStudio.Interop.csproj",
+      "src\\NuGet.Clients\\NuGet.VisualStudio.OnlineEnvironment.Client\\NuGet.VisualStudio.OnlineEnvironment.Client.csproj",
+      "src\\NuGet.Clients\\NuGet.VisualStudio\\NuGet.VisualStudio.csproj",
+      "src\\NuGet.Core\\NuGet.Common\\NuGet.Common.csproj",
+
+    ]
+  }
+}

--- a/NuGet-VS.slnf
+++ b/NuGet-VS.slnf
@@ -2,10 +2,14 @@
   "solution": {
     "path": "NuGet.sln",
     "projects": [
+      "src\\NuGet.Clients\\NuGet.Console\\NuGet.Console.csproj",
+      "src\\NuGet.Clients\\NuGet.Indexing\\NuGet.Indexing.csproj",
       "src\\NuGet.Clients\\NuGet.PackageManagement.PowerShellCmdlets\\NuGet.PackageManagement.PowerShellCmdlets.csproj",
       "src\\NuGet.Clients\\NuGet.PackageManagement.UI\\NuGet.PackageManagement.UI.csproj",
       "src\\NuGet.Clients\\NuGet.PackageManagement.VisualStudio\\NuGet.PackageManagement.VisualStudio.csproj",
+      "src\\NuGet.Clients\\NuGet.SolutionRestoreManager\\NuGet.SolutionRestoreManager.csproj",
       "src\\NuGet.Clients\\NuGet.Tools\\NuGet.Tools.csproj",
+      "src\\NuGet.Clients\\NuGet.VisualStudio\\NuGet.VisualStudio.csproj",
       "src\\NuGet.Clients\\NuGet.VisualStudio.Client\\NuGet.VisualStudio.Client.csproj",
       "src\\NuGet.Clients\\NuGet.VisualStudio.Common\\NuGet.VisualStudio.Common.csproj",
       "src\\NuGet.Clients\\NuGet.VisualStudio.Contracts\\NuGet.VisualStudio.Contracts.csproj",
@@ -13,9 +17,7 @@
       "src\\NuGet.Clients\\NuGet.VisualStudio.Internal.Contracts\\NuGet.VisualStudio.Internal.Contracts.csproj",
       "src\\NuGet.Clients\\NuGet.VisualStudio.Interop\\NuGet.VisualStudio.Interop.csproj",
       "src\\NuGet.Clients\\NuGet.VisualStudio.OnlineEnvironment.Client\\NuGet.VisualStudio.OnlineEnvironment.Client.csproj",
-      "src\\NuGet.Clients\\NuGet.VisualStudio\\NuGet.VisualStudio.csproj",
-      "src\\NuGet.Core\\NuGet.Common\\NuGet.Common.csproj",
-
+      "src\\NuGet.Clients\\NuGetConsole.Host.PowerShell\\NuGetConsole.Host.PowerShell.csproj",
     ]
   }
 }

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -58,7 +58,7 @@ The recommended pattern for release branches is slightly different. We should pr
 ### Solution and project folder structure and naming
 
 The NuGet.Client repo currently has only one solution file named `NuGet.sln`. We do not want/need to have more than one solution file.
-If deemed necessary by the team, we can consider solution filters at a future point.
+We have some Solution Filters (.slnf files), currently for projects specific to working with NuGet's Command line, VS, or UnitTests directly, and can consider more based on team and community feedback.
 
 - Every project in the NuGet.Client repo should be [PackageReference-based](https://docs.microsoft.com/en-us/nuget/consume-packages/package-references-in-project-files) based and if possible (read this as not .NET Framework WPF), an [SDK-based](https://docs.microsoft.com/en-us/visualstudio/msbuild/how-to-use-project-sdk) one.
 - The production source code is under the `src` folder.


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11885

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
When working with VS projects like PMUI, we don't need all NuGet projects loaded on our machine in order to be able to build. This solution filter is my arbitrary guess at a minimum # projects to load for working on NuGet in VS. 

### devenv.exe Comparison on my Machine:
| Sln | Memory used | Time to projects loaded | Time to low-priority Background tasks complete |
|--------------|-----------|------------|------------|
| NuGet.sln | ~1.85GB | ~5 minutes  |  > 19 minutes
| NuGet-VS.slnf | 713MB  | ~1.5 minutes | ~5 minutes

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception - I verified I can launch Experimental VS same as always.
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [x] Documentation PR or issue filled - updated Workflow doc
  - **OR**
  - [ ] N/A
