### PR TITLE
Moves unshipped NuGet 5.11 APIs to PublicAPI.Shipped.txt files

### DIFF
--- a/src/NuGet.Core/NuGet.Common/PublicAPI/net45/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Common/PublicAPI/net45/PublicAPI.Shipped.txt
@@ -623,6 +623,7 @@ static NuGet.Common.UriUtility.CreateSourceUri(string source, System.UriKind kin
 static NuGet.Common.UriUtility.GetAbsolutePath(string rootDirectory, string path) -> string
 static NuGet.Common.UriUtility.GetAbsolutePathFromFile(string sourceFile, string path) -> string
 static NuGet.Common.UriUtility.GetLocalPath(string localOrUriPath) -> string
+static NuGet.Common.UriUtility.IsNuGetOrg(string source) -> bool
 static NuGet.Common.UriUtility.TryCreateSourceUri(string source, System.UriKind kind) -> System.Uri
 static NuGet.Common.UriUtility.UrlEncodeOdataParameter(string value) -> string
 static NuGet.Common.XmlUtility.Load(string filePath) -> System.Xml.Linq.XDocument

--- a/src/NuGet.Core/NuGet.Common/PublicAPI/net45/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Common/PublicAPI/net45/PublicAPI.Unshipped.txt
@@ -1,1 +1,0 @@
-static NuGet.Common.UriUtility.IsNuGetOrg(string source) -> bool

--- a/src/NuGet.Core/NuGet.Common/PublicAPI/net472/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Common/PublicAPI/net472/PublicAPI.Shipped.txt
@@ -624,6 +624,7 @@ static NuGet.Common.UriUtility.CreateSourceUri(string source, System.UriKind kin
 static NuGet.Common.UriUtility.GetAbsolutePath(string rootDirectory, string path) -> string
 static NuGet.Common.UriUtility.GetAbsolutePathFromFile(string sourceFile, string path) -> string
 static NuGet.Common.UriUtility.GetLocalPath(string localOrUriPath) -> string
+static NuGet.Common.UriUtility.IsNuGetOrg(string source) -> bool
 static NuGet.Common.UriUtility.TryCreateSourceUri(string source, System.UriKind kind) -> System.Uri
 static NuGet.Common.UriUtility.UrlEncodeOdataParameter(string value) -> string
 static NuGet.Common.XmlUtility.Load(string filePath) -> System.Xml.Linq.XDocument

--- a/src/NuGet.Core/NuGet.Common/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Common/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -1,1 +1,0 @@
-static NuGet.Common.UriUtility.IsNuGetOrg(string source) -> bool

--- a/src/NuGet.Core/NuGet.Common/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Common/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
@@ -624,6 +624,7 @@ static NuGet.Common.UriUtility.CreateSourceUri(string source, System.UriKind kin
 static NuGet.Common.UriUtility.GetAbsolutePath(string rootDirectory, string path) -> string
 static NuGet.Common.UriUtility.GetAbsolutePathFromFile(string sourceFile, string path) -> string
 static NuGet.Common.UriUtility.GetLocalPath(string localOrUriPath) -> string
+static NuGet.Common.UriUtility.IsNuGetOrg(string source) -> bool
 static NuGet.Common.UriUtility.TryCreateSourceUri(string source, System.UriKind kind) -> System.Uri
 static NuGet.Common.UriUtility.UrlEncodeOdataParameter(string value) -> string
 static NuGet.Common.XmlUtility.Load(string filePath) -> System.Xml.Linq.XDocument

--- a/src/NuGet.Core/NuGet.Common/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Common/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,1 +1,0 @@
-static NuGet.Common.UriUtility.IsNuGetOrg(string source) -> bool

--- a/src/NuGet.Core/NuGet.Frameworks/PublicAPI/net40/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Frameworks/PublicAPI/net40/PublicAPI.Shipped.txt
@@ -326,7 +326,9 @@ static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net46 -> Nu
 static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net461 -> NuGet.Frameworks.NuGetFramework
 static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net462 -> NuGet.Frameworks.NuGetFramework
 static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net463 -> NuGet.Frameworks.NuGetFramework
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net472 -> NuGet.Frameworks.NuGetFramework
 static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net50 -> NuGet.Frameworks.NuGetFramework
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net60 -> NuGet.Frameworks.NuGetFramework
 static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.NetCore45 -> NuGet.Frameworks.NuGetFramework
 static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.NetCore451 -> NuGet.Frameworks.NuGetFramework
 static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.NetCore50 -> NuGet.Frameworks.NuGetFramework
@@ -368,6 +370,7 @@ static readonly NuGet.Frameworks.FrameworkConstants.EmptyVersion -> System.Versi
 static readonly NuGet.Frameworks.FrameworkConstants.MaxVersion -> System.Version
 static readonly NuGet.Frameworks.FrameworkConstants.Version10 -> System.Version
 static readonly NuGet.Frameworks.FrameworkConstants.Version5 -> System.Version
+static readonly NuGet.Frameworks.FrameworkConstants.Version6 -> System.Version
 static readonly NuGet.Frameworks.NuGetFramework.AgnosticFramework -> NuGet.Frameworks.NuGetFramework
 static readonly NuGet.Frameworks.NuGetFramework.AnyFramework -> NuGet.Frameworks.NuGetFramework
 static readonly NuGet.Frameworks.NuGetFramework.Comparer -> System.Collections.Generic.IEqualityComparer<NuGet.Frameworks.NuGetFramework>

--- a/src/NuGet.Core/NuGet.Frameworks/PublicAPI/net40/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Frameworks/PublicAPI/net40/PublicAPI.Unshipped.txt
@@ -1,3 +1,0 @@
-static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net472 -> NuGet.Frameworks.NuGetFramework
-static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net60 -> NuGet.Frameworks.NuGetFramework
-static readonly NuGet.Frameworks.FrameworkConstants.Version6 -> System.Version

--- a/src/NuGet.Core/NuGet.Frameworks/PublicAPI/net472/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Frameworks/PublicAPI/net472/PublicAPI.Shipped.txt
@@ -326,7 +326,9 @@ static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net46 -> Nu
 static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net461 -> NuGet.Frameworks.NuGetFramework
 static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net462 -> NuGet.Frameworks.NuGetFramework
 static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net463 -> NuGet.Frameworks.NuGetFramework
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net472 -> NuGet.Frameworks.NuGetFramework
 static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net50 -> NuGet.Frameworks.NuGetFramework
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net60 -> NuGet.Frameworks.NuGetFramework
 static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.NetCore45 -> NuGet.Frameworks.NuGetFramework
 static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.NetCore451 -> NuGet.Frameworks.NuGetFramework
 static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.NetCore50 -> NuGet.Frameworks.NuGetFramework
@@ -368,6 +370,7 @@ static readonly NuGet.Frameworks.FrameworkConstants.EmptyVersion -> System.Versi
 static readonly NuGet.Frameworks.FrameworkConstants.MaxVersion -> System.Version
 static readonly NuGet.Frameworks.FrameworkConstants.Version10 -> System.Version
 static readonly NuGet.Frameworks.FrameworkConstants.Version5 -> System.Version
+static readonly NuGet.Frameworks.FrameworkConstants.Version6 -> System.Version
 static readonly NuGet.Frameworks.NuGetFramework.AgnosticFramework -> NuGet.Frameworks.NuGetFramework
 static readonly NuGet.Frameworks.NuGetFramework.AnyFramework -> NuGet.Frameworks.NuGetFramework
 static readonly NuGet.Frameworks.NuGetFramework.Comparer -> System.Collections.Generic.IEqualityComparer<NuGet.Frameworks.NuGetFramework>

--- a/src/NuGet.Core/NuGet.Frameworks/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Frameworks/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -1,3 +1,0 @@
-static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net472 -> NuGet.Frameworks.NuGetFramework
-static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net60 -> NuGet.Frameworks.NuGetFramework
-static readonly NuGet.Frameworks.FrameworkConstants.Version6 -> System.Version

--- a/src/NuGet.Core/NuGet.Frameworks/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Frameworks/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
@@ -326,7 +326,9 @@ static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net46 -> Nu
 static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net461 -> NuGet.Frameworks.NuGetFramework
 static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net462 -> NuGet.Frameworks.NuGetFramework
 static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net463 -> NuGet.Frameworks.NuGetFramework
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net472 -> NuGet.Frameworks.NuGetFramework
 static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net50 -> NuGet.Frameworks.NuGetFramework
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net60 -> NuGet.Frameworks.NuGetFramework
 static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.NetCore45 -> NuGet.Frameworks.NuGetFramework
 static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.NetCore451 -> NuGet.Frameworks.NuGetFramework
 static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.NetCore50 -> NuGet.Frameworks.NuGetFramework
@@ -368,6 +370,7 @@ static readonly NuGet.Frameworks.FrameworkConstants.EmptyVersion -> System.Versi
 static readonly NuGet.Frameworks.FrameworkConstants.MaxVersion -> System.Version
 static readonly NuGet.Frameworks.FrameworkConstants.Version10 -> System.Version
 static readonly NuGet.Frameworks.FrameworkConstants.Version5 -> System.Version
+static readonly NuGet.Frameworks.FrameworkConstants.Version6 -> System.Version
 static readonly NuGet.Frameworks.NuGetFramework.AgnosticFramework -> NuGet.Frameworks.NuGetFramework
 static readonly NuGet.Frameworks.NuGetFramework.AnyFramework -> NuGet.Frameworks.NuGetFramework
 static readonly NuGet.Frameworks.NuGetFramework.Comparer -> System.Collections.Generic.IEqualityComparer<NuGet.Frameworks.NuGetFramework>

--- a/src/NuGet.Core/NuGet.Frameworks/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Frameworks/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,3 +1,0 @@
-static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net472 -> NuGet.Frameworks.NuGetFramework
-static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net60 -> NuGet.Frameworks.NuGetFramework
-static readonly NuGet.Frameworks.FrameworkConstants.Version6 -> System.Version


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1683

Regression? Last working version:

## Description
Ran tools-local\ship-public-apis tool to mark unshipped APIs as shipped in NuGet 5.11 release branch.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
