### PR TITLE
Moves unshipped NuGet 6.2 APIs to PublicAPI.Shipped.txt files

### DIFF
--- a/src/NuGet.Core/NuGet.Common/PublicAPI/net45/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Common/PublicAPI/net45/PublicAPI.Shipped.txt
@@ -630,6 +630,7 @@ static NuGet.Common.UriUtility.CreateSourceUri(string source, System.UriKind kin
 static NuGet.Common.UriUtility.GetAbsolutePath(string rootDirectory, string path) -> string
 static NuGet.Common.UriUtility.GetAbsolutePathFromFile(string sourceFile, string path) -> string
 static NuGet.Common.UriUtility.GetLocalPath(string localOrUriPath) -> string
+static NuGet.Common.UriUtility.IsNuGetOrg(string source) -> bool
 static NuGet.Common.UriUtility.TryCreateSourceUri(string source, System.UriKind kind) -> System.Uri
 static NuGet.Common.UriUtility.UrlEncodeOdataParameter(string value) -> string
 static NuGet.Common.XmlUtility.Load(string filePath) -> System.Xml.Linq.XDocument

--- a/src/NuGet.Core/NuGet.Common/PublicAPI/net45/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Common/PublicAPI/net45/PublicAPI.Unshipped.txt
@@ -1,1 +1,0 @@
-static NuGet.Common.UriUtility.IsNuGetOrg(string source) -> bool

--- a/src/NuGet.Core/NuGet.Common/PublicAPI/net472/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Common/PublicAPI/net472/PublicAPI.Shipped.txt
@@ -631,6 +631,7 @@ static NuGet.Common.UriUtility.CreateSourceUri(string source, System.UriKind kin
 static NuGet.Common.UriUtility.GetAbsolutePath(string rootDirectory, string path) -> string
 static NuGet.Common.UriUtility.GetAbsolutePathFromFile(string sourceFile, string path) -> string
 static NuGet.Common.UriUtility.GetLocalPath(string localOrUriPath) -> string
+static NuGet.Common.UriUtility.IsNuGetOrg(string source) -> bool
 static NuGet.Common.UriUtility.TryCreateSourceUri(string source, System.UriKind kind) -> System.Uri
 static NuGet.Common.UriUtility.UrlEncodeOdataParameter(string value) -> string
 static NuGet.Common.XmlUtility.Load(string filePath) -> System.Xml.Linq.XDocument

--- a/src/NuGet.Core/NuGet.Common/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Common/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -1,1 +1,0 @@
-static NuGet.Common.UriUtility.IsNuGetOrg(string source) -> bool

--- a/src/NuGet.Core/NuGet.Common/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Common/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
@@ -631,6 +631,7 @@ static NuGet.Common.UriUtility.CreateSourceUri(string source, System.UriKind kin
 static NuGet.Common.UriUtility.GetAbsolutePath(string rootDirectory, string path) -> string
 static NuGet.Common.UriUtility.GetAbsolutePathFromFile(string sourceFile, string path) -> string
 static NuGet.Common.UriUtility.GetLocalPath(string localOrUriPath) -> string
+static NuGet.Common.UriUtility.IsNuGetOrg(string source) -> bool
 static NuGet.Common.UriUtility.TryCreateSourceUri(string source, System.UriKind kind) -> System.Uri
 static NuGet.Common.UriUtility.UrlEncodeOdataParameter(string value) -> string
 static NuGet.Common.XmlUtility.Load(string filePath) -> System.Xml.Linq.XDocument

--- a/src/NuGet.Core/NuGet.Common/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Common/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,1 +1,0 @@
-static NuGet.Common.UriUtility.IsNuGetOrg(string source) -> bool


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1685

Regression? Last working version:

## Description
Ran tools-local\ship-public-apis tool to mark unshipped APIs as shipped in NuGet 6.2 release branch.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
