### PR TITLE
Use JsonTextWriter in LockFileFormat

### DIFF
--- a/src/NuGet.Core/NuGet.ProjectModel/JsonUtility.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/JsonUtility.cs
@@ -58,11 +58,23 @@ namespace NuGet.ProjectModel
                 WriteString(item.VersionRange?.ToNonSnapshotRange().ToLegacyShortString()));
         }
 
+        internal static void WritePackageDependencyWithLegacyString(JsonWriter writer, PackageDependency item)
+        {
+            writer.WritePropertyName(item.Id);
+            writer.WriteValue(item.VersionRange?.ToNonSnapshotRange().ToLegacyShortString());
+        }
+
         internal static JProperty WritePackageDependency(PackageDependency item)
         {
             return new JProperty(
                 item.Id,
                 WriteString(item.VersionRange?.ToString()));
+        }
+
+        internal static void WritePackageDependency(JsonWriter writer, PackageDependency item)
+        {
+            writer.WritePropertyName(item.Id);
+            writer.WriteValue(item.VersionRange?.ToString());
         }
 
         internal static TItem ReadProperty<TItem>(JObject jObject, string propertyName)
@@ -101,6 +113,18 @@ namespace NuGet.ProjectModel
                 array.Add(writeItem(item));
             }
             return array;
+        }
+
+        internal static void WriteObject<TItem>(JsonWriter writer, IEnumerable<TItem> items, Action<JsonWriter, TItem> writeItem)
+        {
+            writer.WriteStartObject();
+
+            foreach (var item in items)
+            {
+                writeItem(writer, item);
+            }
+
+            writer.WriteEndObject();
         }
 
         internal static int ReadInt(JToken cursor, string property, int defaultValue)

--- a/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileFormat.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileFormat.cs
@@ -11,6 +11,7 @@ using Newtonsoft.Json.Linq;
 using NuGet.Common;
 using NuGet.Frameworks;
 using NuGet.LibraryModel;
+using NuGet.Packaging.Core;
 using NuGet.RuntimeModel;
 using NuGet.Versioning;
 
@@ -144,11 +145,11 @@ namespace NuGet.ProjectModel
         public void Write(TextWriter textWriter, LockFile lockFile)
         {
             using (var jsonWriter = new JsonTextWriter(textWriter))
+            using (var jsonObjectWriter = new JsonObjectWriter(jsonWriter))
             {
                 jsonWriter.Formatting = Formatting.Indented;
 
-                var json = WriteLockFile(lockFile);
-                json.WriteTo(jsonWriter);
+                WriteLockFile(jsonWriter, jsonObjectWriter, lockFile);
             }
         }
 
@@ -180,35 +181,39 @@ namespace NuGet.ProjectModel
             return lockFile;
         }
 
-        private static JObject WriteLockFile(LockFile lockFile)
+        private static void WriteLockFile(JsonWriter writer, IObjectWriter jsonObjectWriter, LockFile lockFile)
         {
-            var json = new JObject
-            {
-                [VersionProperty] = new JValue(lockFile.Version),
-                [TargetsProperty] = JsonUtility.WriteObject(lockFile.Targets, WriteTarget),
-                [LibrariesProperty] = JsonUtility.WriteObject(lockFile.Libraries, WriteLibrary),
-                [ProjectFileDependencyGroupsProperty] = JsonUtility.WriteObject(lockFile.ProjectFileDependencyGroups, WriteProjectFileDependencyGroup)
-            };
+            writer.WriteStartObject();
+
+            writer.WritePropertyName(VersionProperty);
+            writer.WriteValue(lockFile.Version);
+
+            writer.WritePropertyName(TargetsProperty);
+            JsonUtility.WriteObject(writer, lockFile.Targets, WriteTarget);
+
+            writer.WritePropertyName(LibrariesProperty);
+            JsonUtility.WriteObject(writer, lockFile.Libraries, WriteLibrary);
+
+            writer.WritePropertyName(ProjectFileDependencyGroupsProperty);
+            JsonUtility.WriteObject(writer, lockFile.ProjectFileDependencyGroups, WriteProjectFileDependencyGroup);
+
             if (lockFile.PackageFolders?.Any() == true)
             {
-                json[PackageFoldersProperty] = JsonUtility.WriteObject(lockFile.PackageFolders, WriteFileItem);
+                writer.WritePropertyName(PackageFoldersProperty);
+                JsonUtility.WriteObject(writer, lockFile.PackageFolders, WriteFileItem);
             }
 
             if (lockFile.Version >= 2)
             {
                 if (lockFile.PackageSpec != null)
                 {
-                    using (var jsonWriter = new JTokenWriter())
-                    using (var writer = new JsonObjectWriter(jsonWriter))
-                    {
-                        writer.WriteObjectStart();
+                    writer.WritePropertyName(PackageSpecProperty);
 
-                        PackageSpecWriter.Write(lockFile.PackageSpec, writer);
+                    jsonObjectWriter.WriteObjectStart();
 
-                        writer.WriteObjectEnd();
+                    PackageSpecWriter.Write(lockFile.PackageSpec, jsonObjectWriter);
 
-                        json[PackageSpecProperty] = (JObject)jsonWriter.Token;
-                    }
+                    jsonObjectWriter.WriteObjectEnd();
                 }
             }
 
@@ -217,17 +222,18 @@ namespace NuGet.ProjectModel
                 if (lockFile.LogMessages.Count > 0)
                 {
                     var projectPath = lockFile.PackageSpec?.RestoreMetadata?.ProjectPath;
-                    json[LogsProperty] = WriteLogMessages(lockFile.LogMessages, projectPath);
+                    writer.WritePropertyName(LogsProperty);
+                    WriteLogMessages(writer, lockFile.LogMessages, projectPath);
                 }
             }
 
             if (lockFile.CentralTransitiveDependencyGroups.Any())
             {
-                JToken token = WriteCentralTransitiveDependencyGroup(lockFile.CentralTransitiveDependencyGroups);
-                json[CentralTransitiveDependencyGroupsProperty] = (JObject)token;
+                writer.WritePropertyName(CentralTransitiveDependencyGroupsProperty);
+                WriteCentralTransitiveDependencyGroup(jsonObjectWriter, lockFile.CentralTransitiveDependencyGroups);
             }
 
-            return json;
+            writer.WriteEndObject();
         }
 
         private static LockFileLibrary ReadLibrary(string property, JToken json)
@@ -255,50 +261,57 @@ namespace NuGet.ProjectModel
             return library;
         }
 
-        private static JProperty WriteLibrary(LockFileLibrary library)
+        private static void WriteLibrary(JsonWriter writer, LockFileLibrary library)
         {
-            var json = new JObject();
+            writer.WritePropertyName(library.Name + "/" + library.Version.ToNormalizedString());
+
+            writer.WriteStartObject();
+
             if (library.IsServiceable)
             {
-                WriteBool(json, ServicableProperty, library.IsServiceable);
+                writer.WritePropertyName(ServicableProperty);
+                writer.WriteValue(library.IsServiceable);
             }
 
             if (library.Sha512 != null)
             {
-                json[Sha512Property] = JsonUtility.WriteString(library.Sha512);
+                writer.WritePropertyName(Sha512Property);
+                writer.WriteValue(library.Sha512);
             }
 
-            json[TypeProperty] = JsonUtility.WriteString(library.Type);
+            writer.WritePropertyName(TypeProperty);
+            writer.WriteValue(library.Type);
 
             if (library.Path != null)
             {
-                json[PathProperty] = JsonUtility.WriteString(library.Path);
+                writer.WritePropertyName(PathProperty);
+                writer.WriteValue(library.Path);
             }
 
             if (library.MSBuildProject != null)
             {
-                json[MSBuildProjectProperty] = JsonUtility.WriteString(library.MSBuildProject);
+                writer.WritePropertyName(MSBuildProjectProperty);
+                writer.WriteValue(library.MSBuildProject);
             }
 
             if (library.HasTools)
             {
-                WriteBool(json, HasToolsProperty, library.HasTools);
+                writer.WritePropertyName(HasToolsProperty);
+                writer.WriteValue(library.HasTools);
             }
 
-            WritePathArray(json, FilesProperty, library.Files, JsonUtility.WriteString);
+            WritePathArray(writer, FilesProperty, library.Files);
 
-            return new JProperty(
-                library.Name + "/" + library.Version.ToNormalizedString(),
-                json);
+            writer.WriteEndObject();
         }
 
-        private static JProperty WriteTarget(LockFileTarget target)
+        private static void WriteTarget(JsonWriter writer, LockFileTarget target)
         {
-            var json = JsonUtility.WriteObject(target.Libraries, WriteTargetLibrary);
-
             var key = target.Name;
 
-            return new JProperty(key, json);
+            writer.WritePropertyName(key);
+
+            JsonUtility.WriteObject(writer, target.Libraries, WriteTargetLibrary);
         }
 
         private static LockFileTarget ReadTarget(string property, JToken json)
@@ -317,21 +330,23 @@ namespace NuGet.ProjectModel
         }
 
         /// <summary>
-        /// Converts the <code>IAssetsLogMessage</code> object into a <code>JObject</code> that can be written into the assets file.
+        /// Writes the <see cref="IAssetsLogMessage"/> object to the <see cref="JsonWriter"/>.
         /// </summary>
         /// <param name="logMessage"><code>IAssetsLogMessage</code> representing the log message.</param>
-        /// <returns><code>JObject</code> containg the json representation of the log message.</returns>
-        private static JObject WriteLogMessage(IAssetsLogMessage logMessage, string projectPath)
+        private static void WriteLogMessage(JsonWriter writer, IAssetsLogMessage logMessage, string projectPath)
         {
-            var logJObject = new JObject()
-            {
-                [LogMessageProperties.CODE] = Enum.GetName(typeof(NuGetLogCode), logMessage.Code),
-                [LogMessageProperties.LEVEL] = Enum.GetName(typeof(LogLevel), logMessage.Level)
-            };
+            writer.WriteStartObject();
+
+            writer.WritePropertyName(LogMessageProperties.CODE);
+            writer.WriteValue(Enum.GetName(typeof(NuGetLogCode), logMessage.Code));
+
+            writer.WritePropertyName(LogMessageProperties.LEVEL);
+            writer.WriteValue(Enum.GetName(typeof(LogLevel), logMessage.Level));
 
             if (logMessage.Level == LogLevel.Warning)
             {
-                logJObject[LogMessageProperties.WARNING_LEVEL] = (int)logMessage.WarningLevel;
+                writer.WritePropertyName(LogMessageProperties.WARNING_LEVEL);
+                writer.WriteValue((int)logMessage.WarningLevel);
             }
 
             if (logMessage.FilePath != null &&
@@ -339,47 +354,55 @@ namespace NuGet.ProjectModel
             {
                 // Do not write the file path if it is the same as the project path.
                 // This prevents duplicate information in the lock file.
-                logJObject[LogMessageProperties.FILE_PATH] = logMessage.FilePath;
+                writer.WritePropertyName(LogMessageProperties.FILE_PATH);
+                writer.WriteValue(logMessage.FilePath);
             }
 
             if (logMessage.StartLineNumber > 0)
             {
-                logJObject[LogMessageProperties.START_LINE_NUMBER] = logMessage.StartLineNumber;
+                writer.WritePropertyName(LogMessageProperties.START_LINE_NUMBER);
+                writer.WriteValue(logMessage.StartLineNumber);
             }
 
             if (logMessage.StartColumnNumber > 0)
             {
-                logJObject[LogMessageProperties.START_COLUMN_NUMBER] = logMessage.StartColumnNumber;
+                writer.WritePropertyName(LogMessageProperties.START_COLUMN_NUMBER);
+                writer.WriteValue(logMessage.StartColumnNumber);
             }
 
             if (logMessage.EndLineNumber > 0)
             {
-                logJObject[LogMessageProperties.END_LINE_NUMBER] = logMessage.EndLineNumber;
+                writer.WritePropertyName(LogMessageProperties.END_LINE_NUMBER);
+                writer.WriteValue(logMessage.EndLineNumber);
             }
 
             if (logMessage.EndColumnNumber > 0)
             {
-                logJObject[LogMessageProperties.END_COLUMN_NUMBER] = logMessage.EndColumnNumber;
+                writer.WritePropertyName(LogMessageProperties.END_COLUMN_NUMBER);
+                writer.WriteValue(logMessage.EndColumnNumber);
             }
 
             if (logMessage.Message != null)
             {
-                logJObject[LogMessageProperties.MESSAGE] = logMessage.Message;
+                writer.WritePropertyName(LogMessageProperties.MESSAGE);
+                writer.WriteValue(logMessage.Message);
             }
 
             if (logMessage.LibraryId != null)
             {
-                logJObject[LogMessageProperties.LIBRARY_ID] = logMessage.LibraryId;
+                writer.WritePropertyName(LogMessageProperties.LIBRARY_ID);
+                writer.WriteValue(logMessage.LibraryId);
             }
 
             if (logMessage.TargetGraphs != null &&
                 logMessage.TargetGraphs.Any() &&
                 logMessage.TargetGraphs.All(l => !string.IsNullOrEmpty(l)))
             {
-                logJObject[LogMessageProperties.TARGET_GRAPHS] = new JArray(logMessage.TargetGraphs);
+                writer.WritePropertyName(LogMessageProperties.TARGET_GRAPHS);
+                WriteArray(writer, logMessage.TargetGraphs);
             }
 
-            return logJObject;
+            writer.WriteEndObject();
         }
 
         /// <summary>
@@ -463,12 +486,23 @@ namespace NuGet.ProjectModel
 
         internal static JArray WriteLogMessages(IEnumerable<IAssetsLogMessage> logMessages, string projectPath)
         {
-            var logMessageArray = new JArray();
+            using var writer = new JTokenWriter();
+
+            WriteLogMessages(writer, logMessages, projectPath);
+
+            return (JArray)writer.Token;
+        }
+
+        internal static void WriteLogMessages(JsonWriter writer, IEnumerable<IAssetsLogMessage> logMessages, string projectPath)
+        {
+            writer.WriteStartArray();
+
             foreach (var logMessage in logMessages)
             {
-                logMessageArray.Add(WriteLogMessage(logMessage, projectPath));
+                WriteLogMessage(writer, logMessage, projectPath);
             }
-            return logMessageArray;
+
+            writer.WriteEndArray();
         }
 
         private static LockFileTargetLibrary ReadTargetLibrary(string property, JToken json)
@@ -503,112 +537,129 @@ namespace NuGet.ProjectModel
             return library;
         }
 
-        private static JProperty WriteTargetLibrary(LockFileTargetLibrary library)
+        private static void WriteTargetLibrary(JsonWriter writer, LockFileTargetLibrary library)
         {
-            var json = new JObject();
+            writer.WritePropertyName(library.Name + "/" + library.Version.ToNormalizedString());
+
+            writer.WriteStartObject();
 
             if (library.Type != null)
             {
-                json[TypeProperty] = library.Type;
+                writer.WritePropertyName(TypeProperty);
+                writer.WriteValue(library.Type);
             }
 
             if (library.Framework != null)
             {
-                json[FrameworkProperty] = library.Framework;
+                writer.WritePropertyName(FrameworkProperty);
+                writer.WriteValue(library.Framework);
             }
 
             if (library.Dependencies.Count > 0)
             {
                 var ordered = library.Dependencies.OrderBy(dependency => dependency.Id, StringComparer.Ordinal);
 
-                json[DependenciesProperty] = JsonUtility.WriteObject(ordered, JsonUtility.WritePackageDependencyWithLegacyString);
+                writer.WritePropertyName(DependenciesProperty);
+                JsonUtility.WriteObject(writer, ordered, JsonUtility.WritePackageDependencyWithLegacyString);
             }
 
             if (library.FrameworkAssemblies.Count > 0)
             {
                 var ordered = library.FrameworkAssemblies.OrderBy(assembly => assembly, StringComparer.Ordinal);
 
-                json[FrameworkAssembliesProperty] = WriteArray(ordered, JsonUtility.WriteString);
+                writer.WritePropertyName(FrameworkAssembliesProperty);
+                WriteArray(writer, ordered);
             }
 
             if (library.CompileTimeAssemblies.Count > 0)
             {
                 var ordered = library.CompileTimeAssemblies.OrderBy(assembly => assembly.Path, StringComparer.Ordinal);
 
-                json[CompileProperty] = JsonUtility.WriteObject(ordered, WriteFileItem);
+                writer.WritePropertyName(CompileProperty);
+                JsonUtility.WriteObject(writer, ordered, WriteFileItem);
             }
 
             if (library.RuntimeAssemblies.Count > 0)
             {
                 var ordered = library.RuntimeAssemblies.OrderBy(assembly => assembly.Path, StringComparer.Ordinal);
 
-                json[RuntimeProperty] = JsonUtility.WriteObject(ordered, WriteFileItem);
+                writer.WritePropertyName(RuntimeProperty);
+                JsonUtility.WriteObject(writer, ordered, WriteFileItem);
             }
 
             if (library.FrameworkReferences.Count > 0)
             {
                 var ordered = library.FrameworkReferences.OrderBy(reference => reference, StringComparer.Ordinal);
 
-                json[FrameworkReferencesProperty] = WriteArray(ordered, JsonUtility.WriteString);
+                writer.WritePropertyName(FrameworkReferencesProperty);
+                WriteArray(writer, ordered);
             }
 
             if (library.ResourceAssemblies.Count > 0)
             {
                 var ordered = library.ResourceAssemblies.OrderBy(assembly => assembly.Path, StringComparer.Ordinal);
 
-                json[ResourceProperty] = JsonUtility.WriteObject(ordered, WriteFileItem);
+                writer.WritePropertyName(ResourceProperty);
+                JsonUtility.WriteObject(writer, ordered, WriteFileItem);
             }
 
             if (library.NativeLibraries.Count > 0)
             {
                 var ordered = library.NativeLibraries.OrderBy(assembly => assembly.Path, StringComparer.Ordinal);
 
-                json[NativeProperty] = JsonUtility.WriteObject(ordered, WriteFileItem);
+                writer.WritePropertyName(NativeProperty);
+                JsonUtility.WriteObject(writer, ordered, WriteFileItem);
             }
 
             if (library.ContentFiles.Count > 0)
             {
                 var ordered = library.ContentFiles.OrderBy(assembly => assembly.Path, StringComparer.Ordinal);
 
-                json[ContentFilesProperty] = JsonUtility.WriteObject(ordered, WriteFileItem);
+                writer.WritePropertyName(ContentFilesProperty);
+                JsonUtility.WriteObject(writer, ordered, WriteFileItem);
             }
 
             if (library.Build.Count > 0)
             {
                 var ordered = library.Build.OrderBy(assembly => assembly.Path, StringComparer.Ordinal);
 
-                json[BuildProperty] = JsonUtility.WriteObject(ordered, WriteFileItem);
+                writer.WritePropertyName(BuildProperty);
+                JsonUtility.WriteObject(writer, ordered, WriteFileItem);
             }
 
             if (library.BuildMultiTargeting.Count > 0)
             {
                 var ordered = library.BuildMultiTargeting.OrderBy(assembly => assembly.Path, StringComparer.Ordinal);
 
-                json[BuildMultiTargetingProperty] = JsonUtility.WriteObject(ordered, WriteFileItem);
+                writer.WritePropertyName(BuildMultiTargetingProperty);
+                JsonUtility.WriteObject(writer, ordered, WriteFileItem);
             }
 
             if (library.RuntimeTargets.Count > 0)
             {
                 var ordered = library.RuntimeTargets.OrderBy(assembly => assembly.Path, StringComparer.Ordinal);
 
-                json[RuntimeTargetsProperty] = JsonUtility.WriteObject(ordered, WriteFileItem);
+                writer.WritePropertyName(RuntimeTargetsProperty);
+                JsonUtility.WriteObject(writer, ordered, WriteFileItem);
             }
 
             if (library.ToolsAssemblies.Count > 0)
             {
                 var ordered = library.ToolsAssemblies.OrderBy(assembly => assembly.Path, StringComparer.Ordinal);
 
-                json[ToolsProperty] = JsonUtility.WriteObject(ordered, WriteFileItem);
+                writer.WritePropertyName(ToolsProperty);
+                JsonUtility.WriteObject(writer, ordered, WriteFileItem);
             }
 
             if (library.EmbedAssemblies.Count > 0)
             {
-                var ordered = library.EmbedAssemblies.OrderBy(assemby => assemby.Path, StringComparer.Ordinal);
+                var ordered = library.EmbedAssemblies.OrderBy(assembly => assembly.Path, StringComparer.Ordinal);
 
-                json[EmbedProperty] = JsonUtility.WriteObject(ordered, WriteFileItem);
+                writer.WritePropertyName(EmbedProperty);
+                JsonUtility.WriteObject(writer, ordered, WriteFileItem);
             }
 
-            return new JProperty(library.Name + "/" + library.Version.ToNormalizedString(), json);
+            writer.WriteEndObject();
         }
 
         private static LockFileRuntimeTarget ReadRuntimeTarget(string property, JToken json)
@@ -644,11 +695,10 @@ namespace NuGet.ProjectModel
 #pragma warning restore CS0618
         }
 
-        private static JProperty WriteProjectFileDependencyGroup(ProjectFileDependencyGroup frameworkInfo)
+        private static void WriteProjectFileDependencyGroup(JsonWriter writer, ProjectFileDependencyGroup frameworkInfo)
         {
-            return new JProperty(
-                frameworkInfo.FrameworkName,
-                WriteArray(frameworkInfo.Dependencies, JsonUtility.WriteString));
+            writer.WritePropertyName(frameworkInfo.FrameworkName);
+            WriteArray(writer, frameworkInfo.Dependencies);
         }
 
         private static LockFileItem ReadFileItem(string property, JToken json)
@@ -666,25 +716,31 @@ namespace NuGet.ProjectModel
             return item;
         }
 
-        private static JProperty WriteFileItem(LockFileItem item)
+        private static void WriteFileItem(JsonWriter writer, LockFileItem item)
         {
-            return new JProperty(
-                item.Path,
-                new JObject(item.Properties.OrderBy(prop => prop.Key, StringComparer.Ordinal).Select(x =>
+            writer.WritePropertyName(item.Path);
+
+            writer.WriteStartObject();
+
+            foreach (var property in item.Properties.OrderBy(x => x.Key, StringComparer.Ordinal))
+            {
+                writer.WritePropertyName(property.Key);
+
+                if (bool.TrueString.Equals(property.Value, StringComparison.OrdinalIgnoreCase))
                 {
-                    if (bool.TrueString.Equals(x.Value, StringComparison.OrdinalIgnoreCase))
-                    {
-                        return new JProperty(x.Key, true);
-                    }
-                    else if (bool.FalseString.Equals(x.Value, StringComparison.OrdinalIgnoreCase))
-                    {
-                        return new JProperty(x.Key, false);
-                    }
-                    else
-                    {
-                        return new JProperty(x.Key, x.Value);
-                    }
-                })));
+                    writer.WriteValue(true);
+                }
+                else if (bool.FalseString.Equals(property.Value, StringComparison.OrdinalIgnoreCase))
+                {
+                    writer.WriteValue(false);
+                }
+                else
+                {
+                    writer.WriteValue(property.Value);
+                }
+            }
+
+            writer.WriteEndObject();
         }
 
         private static IList<TItem> ReadArray<TItem>(JArray json, Func<JToken, TItem> readItem)
@@ -729,44 +785,27 @@ namespace NuGet.ProjectModel
             return ReadArray(json, f => GetPathWithForwardSlashes(ReadString(f)));
         }
 
-        private static void WriteArray<TItem>(JToken json, string property, IEnumerable<TItem> items, Func<TItem, JToken> writeItem)
+        private static void WritePathArray(JsonWriter writer, string property, IEnumerable<string> items)
         {
             if (items.Any())
             {
-                json[property] = WriteArray(items, writeItem);
+                var orderedItems = items
+                    .Select(f => GetPathWithForwardSlashes(f))
+                    .OrderBy(f => f, StringComparer.Ordinal);
+
+                writer.WritePropertyName(property);
+                WriteArray(writer, orderedItems);
             }
         }
 
-        private static void WritePathArray(JToken json, string property, IEnumerable<string> items, Func<string, JToken> writeItem)
+        internal static void WriteArray(JsonWriter writer, IEnumerable<string> values)
         {
-            var orderedItems = items
-                .Select(f => GetPathWithForwardSlashes(f))
-                .OrderBy(f => f, StringComparer.Ordinal);
-
-            WriteArray(json, property, orderedItems, writeItem);
-        }
-
-        private static JArray WriteArray<TItem>(IEnumerable<TItem> items, Func<TItem, JToken> writeItem)
-        {
-            var array = new JArray();
-            foreach (var item in items)
+            writer.WriteStartArray();
+            foreach (var value in values)
             {
-                array.Add(writeItem(item));
+                writer.WriteValue(value);
             }
-            return array;
-        }
-
-        private static JArray WritePathArray(IEnumerable<string> items, Func<string, JToken> writeItem)
-        {
-            return WriteArray(items.Select(f => GetPathWithForwardSlashes(f)), writeItem);
-        }
-
-        private static void WriteObject<TItem>(JToken json, string property, IEnumerable<TItem> items, Func<TItem, JProperty> writeItem)
-        {
-            if (items.Any())
-            {
-                json[property] = JsonUtility.WriteObject(items, writeItem);
-            }
+            writer.WriteEndArray();
         }
 
         private static bool ReadBool(JToken cursor, string property, bool defaultValue)
@@ -794,11 +833,6 @@ namespace NuGet.ProjectModel
             return SemanticVersion.Parse(valueToken.Value<string>());
         }
 
-        private static void WriteBool(JToken token, string property, bool value)
-        {
-            token[property] = new JValue(value);
-        }
-
         private static string GetPathWithForwardSlashes(string path)
         {
             return path.Replace('\\', '/');
@@ -809,21 +843,16 @@ namespace NuGet.ProjectModel
             return path.Replace('/', '\\');
         }
 
-        private static JToken WriteCentralTransitiveDependencyGroup(IList<CentralTransitiveDependencyGroup> centralTransitiveDependencyGroups)
+        private static void WriteCentralTransitiveDependencyGroup(IObjectWriter writer, IList<CentralTransitiveDependencyGroup> centralTransitiveDependencyGroups)
         {
-            using (var jsonWriter = new JTokenWriter())
-            using (var writer = new JsonObjectWriter(jsonWriter))
+            writer.WriteObjectStart();
+
+            foreach (var centralTransitiveDepGroup in centralTransitiveDependencyGroups.OrderBy(ptdg => ptdg.FrameworkName))
             {
-                writer.WriteObjectStart();
-
-                foreach (var centralTransitiveDepGroup in centralTransitiveDependencyGroups.OrderBy(ptdg => ptdg.FrameworkName))
-                {
-                    PackageSpecWriter.SetCentralTransitveDependencyGroup(writer, centralTransitiveDepGroup.FrameworkName, centralTransitiveDepGroup.TransitiveDependencies);
-                }
-
-                writer.WriteObjectEnd();
-                return jsonWriter.Token;
+                PackageSpecWriter.SetCentralTransitveDependencyGroup(writer, centralTransitiveDepGroup.FrameworkName, centralTransitiveDepGroup.TransitiveDependencies);
             }
+
+            writer.WriteObjectEnd();
         }
 
         private static List<CentralTransitiveDependencyGroup> ReadProjectFileTransitiveDependencyGroup(JObject json, string path)

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/LockFileFormatTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/LockFileFormatTests.cs
@@ -251,9 +251,14 @@ namespace NuGet.ProjectModel.Test
         public void Test_WritePackageDependencyWithLegacyString(string version, string expectedVersion)
         {
             var package = new PackageDependency("a", VersionRange.Parse(version));
-            var dependency = JsonUtility.WritePackageDependencyWithLegacyString(package);
 
-            Assert.Equal(dependency.Value, expectedVersion);
+            using var writer = new JTokenWriter();
+
+            JsonUtility.WritePackageDependencyWithLegacyString(writer, package);
+
+            JToken actual = ((JProperty)writer.Token).Value;
+
+            Assert.Equal(expectedVersion, actual);
         }
 
         [Theory]
@@ -265,9 +270,14 @@ namespace NuGet.ProjectModel.Test
         public void Test_WritePackageDependency(string version, string expectedVersion)
         {
             var package = new PackageDependency("a", VersionRange.Parse(version));
-            var dependency = JsonUtility.WritePackageDependency(package);
 
-            Assert.Equal(dependency.Value, expectedVersion);
+            using var writer = new JTokenWriter();
+
+            JsonUtility.WritePackageDependency(writer, package);
+
+            JToken actual = ((JProperty)writer.Token).Value;
+
+            Assert.Equal(expectedVersion, actual);
         }
 
         [Fact]

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/LockFileFormatTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/LockFileFormatTests.cs
@@ -390,6 +390,269 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Fact]
+        public void Render_LockFileWithPackageFolder_WritesPackageFolder()
+        {
+            // Arrange
+            var lockFileContent = @"{
+  ""version"": 2,
+  ""targets"": {},
+  ""libraries"": {},
+  ""projectFileDependencyGroups"": {},
+  ""packageFolders"": {
+    ""a"": {}
+  }
+}";
+
+            var lockFile = new LockFile
+            {
+                Version = 2,
+                PackageFolders = new List<LockFileItem>
+                {
+                    new("a")
+                }
+            };
+
+            var lockFileFormat = new LockFileFormat();
+
+            // Act
+            string actual = lockFileFormat.Render(lockFile);
+
+            // Assert
+            JObject expected = JObject.Parse(lockFileContent);
+            JObject output = JObject.Parse(actual);
+
+            Assert.Equal(expected.ToString(), output.ToString());
+        }
+
+        [Fact]
+        public void Render_LockFileWithLibrary_WritesLibrary()
+        {
+            // Arrange
+            var lockFileContent = @"{
+  ""version"": 2,
+  ""targets"": {},
+  ""libraries"": {
+    ""System.Runtime/4.0.20-beta-22927"": {
+      ""servicable"": true,
+      ""sha512"": ""sup3rs3cur3"",
+      ""type"": ""package"",
+      ""path"": ""foo"",
+      ""msbuildProject"": ""bar"",
+      ""hasTools"": true
+    }
+  },
+  ""projectFileDependencyGroups"": {}
+}";
+
+            var lockFile = new LockFile
+            {
+                Version = 2,
+                Libraries = new List<LockFileLibrary>
+                {
+                    new()
+                    {
+                        Name = "System.Runtime",
+                        Version = NuGetVersion.Parse("4.0.20-beta-22927"),
+                        Type = LibraryType.Package,
+                        Sha512 = "sup3rs3cur3",
+                        IsServiceable = true,
+                        Path = "foo",
+                        MSBuildProject = "bar",
+                        HasTools = true
+                    }
+                }
+            };
+
+            var lockFileFormat = new LockFileFormat();
+
+            // Act
+            string actual = lockFileFormat.Render(lockFile);
+
+            // Assert
+            JObject expected = JObject.Parse(lockFileContent);
+            JObject output = JObject.Parse(actual);
+
+            Assert.Equal(expected.ToString(), output.ToString());
+        }
+
+        [Fact]
+        public void Render_LockFileWithTarget_WritesTarget()
+        {
+            // Arrange
+            var lockFileContent = @"{
+  ""version"": 3,
+  ""targets"": {
+    ""net6.0"": {
+      ""Microsoft.AspNetCore.JsonPatch/6.0.4"": {
+        ""type"": ""package"",
+        ""dependencies"": {
+          ""Microsoft.CSharp"": ""4.7.0"",
+          ""Newtonsoft.Json"": ""13.0.1""
+        },
+        ""frameworkAssemblies"": [
+          ""System.Configuration""
+        ],
+        ""compile"": {
+          ""lib/net6.0/Microsoft.AspNetCore.JsonPatch.dll"": {}
+        },
+        ""runtime"": {
+          ""lib/net6.0/Microsoft.AspNetCore.JsonPatch.dll"": {}
+        },
+        ""resource"": {
+          ""lib/net45/cs/FSharp.Core.resources.dll"": {
+            ""locale"": ""cs""
+          }
+        },
+        ""contentFiles"": {
+          ""baz"": {
+            ""copyToOutput"": false
+          },
+          ""foo"": {
+            ""copyToOutput"": true,
+            ""outputPath"": ""bar""
+          }
+        }
+      },
+      ""Project10/1.0.0"": {
+        ""type"": ""project"",
+        ""framework"": "".NETCoreApp,Version=v6.0""
+      },
+      ""Microsoft.Extensions.ApiDescription.Server/3.0.0"": {
+        ""type"": ""package"",
+         ""build"": {
+          ""build/Microsoft.Extensions.ApiDescription.Server.props"": {},
+          ""build/Microsoft.Extensions.ApiDescription.Server.targets"": {}
+        },
+        ""buildMultiTargeting"": {
+          ""buildMultiTargeting/Microsoft.Extensions.ApiDescription.Server.props"": {},
+          ""buildMultiTargeting/Microsoft.Extensions.ApiDescription.Server.targets"": {}
+        }        
+      },
+       ""runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0"": {
+        ""type"": ""package"",
+        ""runtimeTargets"": {
+          ""runtimes/debian.8-x64/native/System.Security.Cryptography.Native.OpenSsl.so"": {
+            ""assetType"": ""native"",
+            ""rid"": ""debian.8-x64""
+          }
+        }
+      }
+    }
+  },
+  ""libraries"": {},
+  ""projectFileDependencyGroups"": {}
+}";
+
+            var lockFile = new LockFile
+            {
+                Version = 3,
+                Targets = new List<LockFileTarget>
+                {
+                    new()
+                    {
+                        TargetFramework = FrameworkConstants.CommonFrameworks.Net60,
+                        Libraries = new List<LockFileTargetLibrary>
+                        {
+                            new()
+                            {
+                                Name = "Microsoft.AspNetCore.JsonPatch",
+                                Version = NuGetVersion.Parse("6.0.4"),
+                                Type = LibraryType.Package,
+                                Dependencies = new List<PackageDependency>
+                                {
+                                    new("Microsoft.CSharp", new VersionRange(NuGetVersion.Parse("4.7.0"))),
+                                    new("Newtonsoft.Json", new VersionRange(NuGetVersion.Parse("13.0.1"))),
+                                },
+                                CompileTimeAssemblies = new List<LockFileItem>()
+                                {
+                                    new("lib/net6.0/Microsoft.AspNetCore.JsonPatch.dll")
+                                },
+                                FrameworkAssemblies = new List<string>
+                                {
+                                    "System.Configuration"
+                                },
+                                RuntimeAssemblies = new List<LockFileItem>
+                                {
+                                    new("lib/net6.0/Microsoft.AspNetCore.JsonPatch.dll")
+                                },
+                                ResourceAssemblies = new List<LockFileItem>
+                                {
+                                    new("lib/net45/cs/FSharp.Core.resources.dll")
+                                    {
+                                        Properties =
+                                        {
+                                            ["locale"] = "cs"
+                                        }
+                                    }
+                                },
+                                ContentFiles = new List<LockFileContentFile>
+                                {
+                                    new("foo")
+                                    {
+                                        OutputPath = "bar",
+                                        CopyToOutput = true
+                                    },
+                                    new("baz")
+                                    {
+                                        CopyToOutput = false
+                                    }
+                                }
+                            },
+                            new()
+                            {
+                                Name = "Project10",
+                                Version = NuGetVersion.Parse("1.0.0"),
+                                Type = "project",
+                                Framework = ".NETCoreApp,Version=v6.0",
+                            },
+                            new()
+                            {
+                                Name = "Microsoft.Extensions.ApiDescription.Server",
+                                Version = NuGetVersion.Parse("3.0.0"),
+                                Type = "package",
+                                Build = new List<LockFileItem>
+                                {
+                                    new("build/Microsoft.Extensions.ApiDescription.Server.props"),
+                                    new("build/Microsoft.Extensions.ApiDescription.Server.targets"),
+                                },
+                                BuildMultiTargeting = new List<LockFileItem>()
+                                {
+                                    new("buildMultiTargeting/Microsoft.Extensions.ApiDescription.Server.props"),
+                                    new("buildMultiTargeting/Microsoft.Extensions.ApiDescription.Server.targets")
+                                }
+                            },
+                            new()
+                            {
+                                Name = "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                                Version = NuGetVersion.Parse("4.3.0"),
+                                Type = "package",
+                                RuntimeTargets = new List<LockFileRuntimeTarget>
+                                {
+                                    new("runtimes/debian.8-x64/native/System.Security.Cryptography.Native.OpenSsl.so")
+                                    {
+                                        AssetType = "native",
+                                        Runtime = "debian.8-x64"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+                
+            var lockFileFormat = new LockFileFormat();
+
+            // Act
+            string actual = lockFileFormat.Render(lockFile);
+
+            // Assert
+            JObject expected = JObject.Parse(lockFileContent);
+            JObject output = JObject.Parse(actual);
+
+            Assert.Equal(expected.ToString(), output.ToString());
+        }
+
+        [Fact]
         public void LockFileFormat_ReadsPackageSpec()
         {
             // Arrange


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11870

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

This pull request changes `LockFileFormat` to use `JsonTextWriter` directly, resulting in fewer object allocations.

I have tried to keep the change as small as possible. The one exception is `WritePathArray`, which now calls `Any()` before sorting, in order to reduce allocations.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
