### PR TITLE
Remove IsNuGetOrg method from Telemetry utility

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -913,7 +913,7 @@ namespace NuGet.PackageManagement.UI
             if (loadContext.IsSolution == false
                 && _topPanel.Filter == ItemFilter.All
                 && searchText == string.Empty
-                && SelectedSource.PackageSources.Any(item => TelemetryUtility.IsNuGetOrg(item.Source)))
+                && SelectedSource.PackageSources.Any(item => UriUtility.IsNuGetOrg(item.Source)))
             {
                 _recommendPackages = true;
             }

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/SourceTelemetry.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/SourceTelemetry.cs
@@ -87,7 +87,7 @@ namespace NuGet.PackageManagement.Telemetry
                                     httpsV3++;
                                 }
 
-                                if (TelemetryUtility.IsNuGetOrg(source.Source))
+                                if (UriUtility.IsNuGetOrg(source.Source))
                                 {
                                     nugetOrg |= HttpStyle.YesV3;
                                 }
@@ -102,7 +102,7 @@ namespace NuGet.PackageManagement.Telemetry
                                     httpsV2++;
                                 }
 
-                                if (TelemetryUtility.IsNuGetOrg(source.Source))
+                                if (UriUtility.IsNuGetOrg(source.Source))
                                 {
                                     if (source.Source.IndexOf(
                                         "api/v2/curated-feeds/microsoftdotnet",

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreJob.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreJob.cs
@@ -328,7 +328,7 @@ namespace NuGet.SolutionRestoreManager
                     if (packageSource.IsHttp)
                     {
                         NumHTTPFeeds++;
-                        hasNuGetOrg |= TelemetryUtility.IsNuGetOrg(packageSource.Source);
+                        hasNuGetOrg |= UriUtility.IsNuGetOrg(packageSource.Source);
                     }
                     else
                     {

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/PackageSourceTelemetry.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/PackageSourceTelemetry.cs
@@ -326,7 +326,7 @@ namespace NuGet.VisualStudio.Telemetry
         {
             if (source.IsHttp)
             {
-                if (TelemetryUtility.IsNuGetOrg(source.Source))
+                if (UriUtility.IsNuGetOrg(source.Source))
                 {
                     return "nuget.org";
                 }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/TelemetryUtility.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/TelemetryUtility.cs
@@ -77,39 +77,6 @@ namespace NuGet.VisualStudio.Telemetry
         }
 
         /// <summary>
-        /// True if the source is HTTP and has a *.nuget.org or nuget.org host.
-        /// </summary>
-        public static bool IsNuGetOrg(string source)
-        {
-            if (string.IsNullOrWhiteSpace(source))
-            {
-                throw new ArgumentNullException(nameof(source));
-            }
-
-            bool isHttp = source.StartsWith("http://", StringComparison.OrdinalIgnoreCase) ||
-                          source.StartsWith("https://", StringComparison.OrdinalIgnoreCase);
-
-            if (!isHttp)
-            {
-                return false;
-            }
-
-            var uri = UriUtility.TryCreateSourceUri(source, UriKind.Absolute);
-            if (uri == null)
-            {
-                return false;
-            }
-
-            if (StringComparer.OrdinalIgnoreCase.Equals(uri.Host, "nuget.org")
-                || uri.Host.EndsWith(".nuget.org", StringComparison.OrdinalIgnoreCase))
-            {
-                return true;
-            }
-
-            return false;
-        }
-
-        /// <summary>
         /// True if the source is an Azure Artifacts (DevOps) feed
         /// </summary>
         public static bool IsAzureArtifacts(PackageSource source)

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Common.Test/Telemetry/TelemetryUtilityTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Common.Test/Telemetry/TelemetryUtilityTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Linq;
 using FluentAssertions;
+using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.VisualStudio.Telemetry;
 using Xunit;
@@ -85,7 +86,7 @@ namespace NuGet.VisualStudio.Common.Test.Telemetry
             var source = new PackageSource(sourceUrl);
 
             // Act
-            var actual = TelemetryUtility.IsNuGetOrg(source.Source);
+            var actual = UriUtility.IsNuGetOrg(source.Source);
 
             // Assert
             Assert.Equal(expected, actual);


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1558

Regression? Last working version:

## Description
Currently we have 2 copies of same method IsNuGetOrg. We need to remove one in Telemetry utility.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
