### PR TITLE
Deconstruct redundant async calls when retrieving properties

### DIFF
--- a/build/Shared/vs-threading.MembersRequiringMainThread.txt
+++ b/build/Shared/vs-threading.MembersRequiringMainThread.txt
@@ -10,3 +10,4 @@
 [NuGet.PackageManagement.VisualStudio.EnvDTEProjectUtility]::TryGetFile
 [NuGet.PackageManagement.VisualStudio.EnvDTEProjectUtility]::TryGetFolder
 [NuGet.PackageManagement.VisualStudio.EnvDTEProjectUtility]::TryGetNestedFile
+[NuGet.ProjectManagement.IProjectBuildProperties]::GetPropertyValue

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectServices/VsManagedLanguagesProjectSystemServices.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectServices/VsManagedLanguagesProjectSystemServices.cs
@@ -338,7 +338,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
         private async Task<bool> IsCentralPackageManagementVersionsEnabledAsync()
         {
-            return MSBuildStringUtility.IsTrue(await _vsProjectAdapter.GetPropertyValueAsync(ProjectBuildProperties.ManagePackageVersionsCentrally));
+            return MSBuildStringUtility.IsTrue(await _vsProjectAdapter.BuildProperties.GetPropertyValueAsync(ProjectBuildProperties.ManagePackageVersionsCentrally));
         }
 
         private class ProjectReference

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectSystems/VsMSBuildProjectSystem.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectSystems/VsMSBuildProjectSystem.cs
@@ -470,7 +470,13 @@ namespace NuGet.PackageManagement.VisualStudio
 
         public virtual dynamic GetPropertyValue(string propertyName)
         {
-            return VsProjectAdapter.BuildProperties.GetPropertyValue(propertyName);
+            return NuGetUIThreadHelper.JoinableTaskFactory.Run(async delegate
+            {
+                await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+                return VsProjectAdapter.BuildProperties.GetPropertyValue(propertyName);
+
+            });
         }
 
         public virtual bool IsSupportedFile(string path)

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/CpsPackageReferenceProjectProvider.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/CpsPackageReferenceProjectProvider.cs
@@ -76,7 +76,7 @@ namespace NuGet.PackageManagement.VisualStudio
             var buildProperties = vsProject.BuildProperties;
 
             // read MSBuild property RestoreProjectStyle
-            var restoreProjectStyle = await buildProperties.GetPropertyValueAsync(ProjectBuildProperties.RestoreProjectStyle);
+            var restoreProjectStyle = buildProperties.GetPropertyValue(ProjectBuildProperties.RestoreProjectStyle);
 
             // check for RestoreProjectStyle property is set and if not set to PackageReference then return false
             if (!(string.IsNullOrEmpty(restoreProjectStyle) ||

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyPackageReferenceProjectProvider.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyPackageReferenceProjectProvider.cs
@@ -94,7 +94,7 @@ namespace NuGet.PackageManagement.VisualStudio
             }
 
             // Check for RestoreProjectStyle property
-            var restoreProjectStyle = await vsProjectAdapter.BuildProperties.GetPropertyValueAsync(
+            var restoreProjectStyle = vsProjectAdapter.BuildProperties.GetPropertyValue(
                 ProjectBuildProperties.RestoreProjectStyle);
 
             // For legacy csproj, either the RestoreProjectStyle must be set to PackageReference or

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/VsProjectAdapter.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/VsProjectAdapter.cs
@@ -36,7 +36,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
         public async Task<string> GetMSBuildProjectExtensionsPathAsync()
         {
-            var msbuildProjectExtensionsPath = BuildProperties.GetPropertyValue(ProjectBuildProperties.MSBuildProjectExtensionsPath);
+            var msbuildProjectExtensionsPath = await BuildProperties.GetPropertyValueAsync(ProjectBuildProperties.MSBuildProjectExtensionsPath);
 
             if (string.IsNullOrEmpty(msbuildProjectExtensionsPath))
             {
@@ -50,6 +50,7 @@ namespace NuGet.PackageManagement.VisualStudio
         {
             get
             {
+                ThreadHelper.ThrowIfNotOnUIThread();
                 var restorePackagesPath = BuildProperties.GetPropertyValue(ProjectBuildProperties.RestorePackagesPath);
 
                 if (string.IsNullOrWhiteSpace(restorePackagesPath))
@@ -65,6 +66,7 @@ namespace NuGet.PackageManagement.VisualStudio
         {
             get
             {
+                ThreadHelper.ThrowIfNotOnUIThread();
                 var restoreSources = BuildProperties.GetPropertyValue(ProjectBuildProperties.RestoreSources);
 
                 if (string.IsNullOrWhiteSpace(restoreSources))
@@ -80,6 +82,7 @@ namespace NuGet.PackageManagement.VisualStudio
         {
             get
             {
+                ThreadHelper.ThrowIfNotOnUIThread();
                 var restoreFallbackFolders = BuildProperties.GetPropertyValue(ProjectBuildProperties.RestoreFallbackFolders);
 
                 if (string.IsNullOrWhiteSpace(restoreFallbackFolders))
@@ -121,6 +124,7 @@ namespace NuGet.PackageManagement.VisualStudio
         {
             get
             {
+                ThreadHelper.ThrowIfNotOnUIThread();
                 return BuildProperties.GetPropertyValue(ProjectBuildProperties.PackageTargetFallback);
             }
         }
@@ -129,6 +133,7 @@ namespace NuGet.PackageManagement.VisualStudio
         {
             get
             {
+                ThreadHelper.ThrowIfNotOnUIThread();
                 return BuildProperties.GetPropertyValue(ProjectBuildProperties.AssetTargetFallback);
             }
         }
@@ -257,9 +262,9 @@ namespace NuGet.PackageManagement.VisualStudio
         {
             await _threadingService.JoinableTaskFactory.SwitchToMainThreadAsync();
 
-            var unparsedRuntimeIdentifer = await BuildProperties.GetPropertyValueAsync(
+            var unparsedRuntimeIdentifer = BuildProperties.GetPropertyValue(
                 ProjectBuildProperties.RuntimeIdentifier);
-            var unparsedRuntimeIdentifers = await BuildProperties.GetPropertyValueAsync(
+            var unparsedRuntimeIdentifers = BuildProperties.GetPropertyValue(
                 ProjectBuildProperties.RuntimeIdentifiers);
 
             var runtimes = Enumerable.Empty<string>();
@@ -287,7 +292,7 @@ namespace NuGet.PackageManagement.VisualStudio
         {
             await _threadingService.JoinableTaskFactory.SwitchToMainThreadAsync();
 
-            var unparsedRuntimeSupports = await BuildProperties.GetPropertyValueAsync(
+            var unparsedRuntimeSupports = BuildProperties.GetPropertyValue(
                 ProjectBuildProperties.RuntimeSupports);
 
             if (unparsedRuntimeSupports == null)
@@ -331,16 +336,14 @@ namespace NuGet.PackageManagement.VisualStudio
             return MSBuildStringUtility.IsTrue(value);
         }
 
-        public async Task<string> GetPropertyValueAsync(string propertyName)
+        public Task<string> GetPropertyValueAsync(string propertyName)
         {
             if (propertyName == null)
             {
                 throw new ArgumentNullException(nameof(propertyName));
             }
 
-            await _threadingService.JoinableTaskFactory.SwitchToMainThreadAsync();
-
-            return await BuildProperties.GetPropertyValueAsync(propertyName);
+            return BuildProperties.GetPropertyValueAsync(propertyName);
         }
 
         public async Task<IEnumerable<(string ItemId, string[] ItemMetadata)>> GetBuildItemInformationAsync(string itemName, params string[] metadataNames)
@@ -373,13 +376,13 @@ namespace NuGet.PackageManagement.VisualStudio
             await _threadingService.JoinableTaskFactory.SwitchToMainThreadAsync();
 
             var projectPath = FullName;
-            var platformIdentifier = await BuildProperties.GetPropertyValueAsync(
+            var platformIdentifier = BuildProperties.GetPropertyValue(
                 ProjectBuildProperties.TargetPlatformIdentifier);
-            var platformVersion = await BuildProperties.GetPropertyValueAsync(
+            var platformVersion = BuildProperties.GetPropertyValue(
                 ProjectBuildProperties.TargetPlatformVersion);
-            var platformMinVersion = await BuildProperties.GetPropertyValueAsync(
+            var platformMinVersion = BuildProperties.GetPropertyValue(
                 ProjectBuildProperties.TargetPlatformMinVersion);
-            var targetFrameworkMoniker = await BuildProperties.GetPropertyValueAsync(
+            var targetFrameworkMoniker = BuildProperties.GetPropertyValue(
                 ProjectBuildProperties.TargetFrameworkMoniker);
 
             // Projects supporting TargetFramework and TargetFrameworks are detected before

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/VsProjectAdapter.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/VsProjectAdapter.cs
@@ -46,54 +46,6 @@ namespace NuGet.PackageManagement.VisualStudio
             return Path.Combine(await GetProjectDirectoryAsync(), msbuildProjectExtensionsPath);
         }
 
-        public string RestorePackagesPath
-        {
-            get
-            {
-                ThreadHelper.ThrowIfNotOnUIThread();
-                var restorePackagesPath = BuildProperties.GetPropertyValue(ProjectBuildProperties.RestorePackagesPath);
-
-                if (string.IsNullOrWhiteSpace(restorePackagesPath))
-                {
-                    return null;
-                }
-
-                return restorePackagesPath;
-            }
-        }
-
-        public string RestoreSources
-        {
-            get
-            {
-                ThreadHelper.ThrowIfNotOnUIThread();
-                var restoreSources = BuildProperties.GetPropertyValue(ProjectBuildProperties.RestoreSources);
-
-                if (string.IsNullOrWhiteSpace(restoreSources))
-                {
-                    return null;
-                }
-
-                return restoreSources;
-            }
-        }
-
-        public string RestoreFallbackFolders
-        {
-            get
-            {
-                ThreadHelper.ThrowIfNotOnUIThread();
-                var restoreFallbackFolders = BuildProperties.GetPropertyValue(ProjectBuildProperties.RestoreFallbackFolders);
-
-                if (string.IsNullOrWhiteSpace(restoreFallbackFolders))
-                {
-                    return null;
-                }
-
-                return restoreFallbackFolders;
-            }
-        }
-
         public IProjectBuildProperties BuildProperties { get; private set; }
 
         public string CustomUniqueName => ProjectNames.CustomUniqueName;
@@ -118,24 +70,6 @@ namespace NuGet.PackageManagement.VisualStudio
         public async Task<bool> IsSupportedAsync()
         {
             return await EnvDTEProjectUtility.IsSupportedAsync(Project);
-        }
-
-        public string PackageTargetFallback
-        {
-            get
-            {
-                ThreadHelper.ThrowIfNotOnUIThread();
-                return BuildProperties.GetPropertyValue(ProjectBuildProperties.PackageTargetFallback);
-            }
-        }
-
-        public string AssetTargetFallback
-        {
-            get
-            {
-                ThreadHelper.ThrowIfNotOnUIThread();
-                return BuildProperties.GetPropertyValue(ProjectBuildProperties.AssetTargetFallback);
-            }
         }
 
         public EnvDTE.Project Project => _dteProject.Value;
@@ -183,16 +117,6 @@ namespace NuGet.PackageManagement.VisualStudio
         }
 
         public IVsHierarchy VsHierarchy => _vsHierarchyItem.VsHierarchy;
-
-        public string RestoreAdditionalProjectSources => BuildProperties.GetPropertyValue(ProjectBuildProperties.RestoreAdditionalProjectSources);
-
-        public string RestoreAdditionalProjectFallbackFolders => BuildProperties.GetPropertyValue(ProjectBuildProperties.RestoreAdditionalProjectFallbackFolders);
-
-        public string NoWarn => BuildProperties.GetPropertyValue(ProjectBuildProperties.NoWarn);
-
-        public string WarningsAsErrors => BuildProperties.GetPropertyValue(ProjectBuildProperties.WarningsAsErrors);
-
-        public string TreatWarningsAsErrors => BuildProperties.GetPropertyValue(ProjectBuildProperties.TreatWarningsAsErrors);
 
         #endregion Properties
 
@@ -317,23 +241,6 @@ namespace NuGet.PackageManagement.VisualStudio
             }
 
             return NuGetFramework.UnsupportedFramework;
-        }
-
-        public Task<string> GetRestorePackagesWithLockFileAsync()
-        {
-            return GetPropertyValueAsync(ProjectBuildProperties.RestorePackagesWithLockFile);
-        }
-
-        public Task<string> GetNuGetLockFilePathAsync()
-        {
-            return GetPropertyValueAsync(ProjectBuildProperties.NuGetLockFilePath);
-        }
-
-        public async Task<bool> IsRestoreLockedAsync()
-        {
-            var value = await GetPropertyValueAsync(ProjectBuildProperties.RestoreLockedMode);
-
-            return MSBuildStringUtility.IsTrue(value);
         }
 
         public Task<string> GetPropertyValueAsync(string propertyName)

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/VsProjectJsonNuGetProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/VsProjectJsonNuGetProject.cs
@@ -69,17 +69,17 @@ namespace NuGet.PackageManagement.VisualStudio
                 var jsonTargetFramework = targetFramework as NuGetFramework;
                 if (IsUAPFramework(jsonTargetFramework))
                 {
-                    var platformMinVersionString = await _vsProjectAdapter
+                    var platformMinVersionString = _vsProjectAdapter
                         .BuildProperties
-                        .GetPropertyValueAsync(ProjectBuildProperties.TargetPlatformMinVersion);
+                        .GetPropertyValue(ProjectBuildProperties.TargetPlatformMinVersion);
 
                     var platformMinVersion = !string.IsNullOrEmpty(platformMinVersionString)
                         ? new Version(platformMinVersionString)
                         : null;
 
-                    var targetFrameworkMonikerString = await _vsProjectAdapter
+                    var targetFrameworkMonikerString = _vsProjectAdapter
                         .BuildProperties
-                        .GetPropertyValueAsync(ProjectBuildProperties.TargetFrameworkMoniker);
+                        .GetPropertyValue(ProjectBuildProperties.TargetFrameworkMoniker);
 
                     var targetFrameworkMoniker = !string.IsNullOrWhiteSpace(targetFrameworkMonikerString)
                         ? NuGetFramework.Parse(targetFrameworkMonikerString)

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/IVsProjectAdapter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/IVsProjectAdapter.cs
@@ -17,11 +17,6 @@ namespace NuGet.VisualStudio
     public interface IVsProjectAdapter
     {
         /// <summary>
-        /// AssetTargetFallback project property
-        /// </summary>
-        string AssetTargetFallback { get; }
-
-        /// <summary>
         /// MSBuildProjectExtensionsPath project property (e.g. c:\projFoo\obj)
         /// </summary>
         Task<string> GetMSBuildProjectExtensionsPathAsync();
@@ -35,16 +30,6 @@ namespace NuGet.VisualStudio
         string FullProjectPath { get; }
 
         Task<bool> IsSupportedAsync();
-
-        /// <summary>
-        /// Comma or Semicolon separated list of NU* diagnostic codes e.g. NU1000,NU1001
-        /// </summary>
-        string NoWarn { get; }
-
-        /// <summary>
-        /// PackageTargetFallback project property
-        /// </summary>
-        string PackageTargetFallback { get; }
 
         /// <summary>
         /// In unavoidable circumstances where we need to DTE object, it's exposed here
@@ -62,36 +47,6 @@ namespace NuGet.VisualStudio
 
         ProjectNames ProjectNames { get; }
 
-        /// <summary>
-        /// Additional fallback folders DTE property
-        /// </summary>
-        string RestoreAdditionalProjectFallbackFolders { get; }
-
-        /// <summary>
-        /// Additional Sources DTE property
-        /// </summary>
-        string RestoreAdditionalProjectSources { get; }
-
-        /// <summary>
-        /// RestoreFallbackFolders DTE property
-        /// </summary>
-        string RestoreFallbackFolders { get; }
-
-        /// <summary>
-        /// Restore Packages Path DTE property
-        /// </summary>
-        string RestorePackagesPath { get; }
-
-        /// <summary>
-        /// Restore Sources DTE property
-        /// </summary>
-        string RestoreSources { get; }
-
-        /// <summary>
-        /// TreatWarningsAsErrors true/false
-        /// </summary>
-        string TreatWarningsAsErrors { get; }
-
         string UniqueName { get; }
 
         /// <summary>
@@ -100,11 +55,6 @@ namespace NuGet.VisualStudio
         string Version { get; }
 
         IVsHierarchy VsHierarchy { get; }
-
-        /// <summary>
-        /// Comma or Semicolon separated list of NU* diagnostic codes e.g. NU1000,NU1001
-        /// </summary>
-        string WarningsAsErrors { get; }
 
         Task<string[]> GetProjectTypeGuidsAsync();
 
@@ -126,29 +76,6 @@ namespace NuGet.VisualStudio
         /// Project's target framework
         /// </summary>
         Task<NuGetFramework> GetTargetFrameworkAsync();
-
-        /// <summary>
-        /// RestorePackagesWithLockFile project property.
-        /// </summary>
-        /// <returns></returns>
-        Task<string> GetRestorePackagesWithLockFileAsync();
-
-        /// <summary>
-        /// NuGetLockFilePath project property.
-        /// </summary>
-        /// <returns></returns>
-        Task<string> GetNuGetLockFilePathAsync();
-
-        /// <summary>
-        /// RestoreLockedMode project property.
-        /// </summary>
-        /// <returns></returns>
-        Task<bool> IsRestoreLockedAsync();
-
-        /// <summary>
-        /// Reads a project property and return its value.
-        /// </summary>
-        Task<string> GetPropertyValueAsync(string propertyName);
 
         /// <summary>
         /// Reads a project build items and the requested metadata.

--- a/src/NuGet.Core/NuGet.PackageManagement/Projects/IProjectBuildProperties.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Projects/IProjectBuildProperties.cs
@@ -13,9 +13,11 @@ namespace NuGet.ProjectManagement
     {
         /// <summary>
         /// Returns a property value.
+        /// Must be called on the UI thread.
         /// </summary>
         /// <param name="propertyName">A property name</param>
         /// <returns>Property value or <code>null</code> if not found.</returns>
+        /// <remarks>Often times when retrieving properties we are already on the UI thread. In those cases, prefer calling this method over the async one to avoid the extra state machine allocations.</remarks>
         string GetPropertyValue(string propertyName);
 
         /// <summary>
@@ -23,6 +25,7 @@ namespace NuGet.ProjectManagement
         /// </summary>
         /// <param name="propertyName">A property name</param>
         /// <returns>Property value or <code>null</code> if not found.</returns>
+        /// <remarks>Often times when retrieving properties we are already on the UI thread. In those cases, prefer calling the synchronous version instead to avoid the extra state machine allocations.</remarks>
         Task<string> GetPropertyValueAsync(string propertyName);
     }
 }

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectFactories.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectFactories.cs
@@ -9,6 +9,7 @@ using Moq;
 using NuGet.Commands.Test;
 using NuGet.Frameworks;
 using NuGet.LibraryModel;
+using NuGet.ProjectManagement;
 using NuGet.ProjectModel;
 using NuGet.RuntimeModel;
 using NuGet.Test.Utility;
@@ -73,7 +74,14 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
         internal static IVsProjectAdapter CreateProjectAdapter(string fullPath)
         {
-            var projectAdapter = CreateProjectAdapter();
+            var projectBuildProperties = new Mock<IProjectBuildProperties>();
+            return CreateProjectAdapter(fullPath, projectBuildProperties);
+        }
+
+        internal static IVsProjectAdapter CreateProjectAdapter(string fullPath, Mock<IProjectBuildProperties> projectBuildProperties)
+        {
+            var projectAdapter = CreateProjectAdapter(projectBuildProperties);
+
             projectAdapter
                 .Setup(x => x.FullProjectPath)
                 .Returns(Path.Combine(fullPath, "foo.csproj"));
@@ -90,7 +98,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             return projectAdapter.Object;
         }
 
-        internal static Mock<IVsProjectAdapter> CreateProjectAdapter()
+        internal static Mock<IVsProjectAdapter> CreateProjectAdapter(Mock<IProjectBuildProperties> projectBuildProperties)
         {
             var projectAdapter = new Mock<IVsProjectAdapter>();
 
@@ -109,6 +117,10 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             projectAdapter
                 .Setup(x => x.Version)
                 .Returns("1.0.0");
+
+            projectAdapter
+                .Setup(x => x.BuildProperties)
+                .Returns(projectBuildProperties.Object);
 
             return projectAdapter;
         }

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/LegacyPackageReferenceProjectTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/LegacyPackageReferenceProjectTests.cs
@@ -932,7 +932,6 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         public async Task GetPackageSpecAsync_TransitiveDependencyPinning_CanBeEnabled(string transitiveDependencyPinning, bool expected)
         {
             // Arrange
-
             var projectNames = new ProjectNames(
                         fullName: "projectName",
                         uniqueName: "projectName",

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/LegacyPackageReferenceProjectTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/LegacyPackageReferenceProjectTests.cs
@@ -304,17 +304,19 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             // Arrange
             using (var testDirectory = TestDirectory.Create())
             {
-                var projectAdapter = CreateProjectAdapter(testDirectory);
-                Mock.Get(projectAdapter)
-                    .SetupGet(x => x.RestorePackagesPath)
+                var projectBuildProperties = new Mock<IProjectBuildProperties>();
+                var projectAdapter = CreateProjectAdapter(testDirectory, projectBuildProperties);
+
+                projectBuildProperties
+                    .Setup(x => x.GetPropertyValue(It.Is<string>( x => x.Equals(ProjectBuildProperties.RestorePackagesPath))))
                     .Returns(restorePackagesPath);
 
-                Mock.Get(projectAdapter)
-                    .SetupGet(x => x.RestoreSources)
+                projectBuildProperties
+                    .Setup(x => x.GetPropertyValue(It.Is<string>(x => x.Equals(ProjectBuildProperties.RestoreSources))))
                     .Returns(sources);
 
-                Mock.Get(projectAdapter)
-                    .SetupGet(x => x.RestoreFallbackFolders)
+                projectBuildProperties
+                    .Setup(x => x.GetPropertyValue(It.Is<string>(x => x.Equals(ProjectBuildProperties.RestoreFallbackFolders))))
                     .Returns(fallbackFolders);
 
                 var projectServices = new TestProjectSystemServices();
@@ -350,12 +352,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 Assert.True(Enumerable.SequenceEqual(expectedFolders.OrderBy(t => t), specFallback.OrderBy(t => t)));
 
                 // Verify
-                Mock.Get(projectAdapter)
-                    .Verify(x => x.RestorePackagesPath, Times.Once);
-                Mock.Get(projectAdapter)
-                    .Verify(x => x.RestoreSources, Times.Once);
-                Mock.Get(projectAdapter)
-                    .Verify(x => x.RestoreFallbackFolders, Times.Once);
+                projectBuildProperties.VerifyAll();
             }
         }
 
@@ -371,17 +368,19 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             // Arrange
             using (var testDirectory = TestDirectory.Create())
             {
-                var projectAdapter = CreateProjectAdapter(testDirectory);
-                Mock.Get(projectAdapter)
-                    .SetupGet(x => x.RestorePackagesPath)
+                var projectBuildProperties = new Mock<IProjectBuildProperties>();
+                var projectAdapter = CreateProjectAdapter(testDirectory, projectBuildProperties);
+
+                projectBuildProperties
+                    .Setup(x => x.GetPropertyValue(It.Is<string>(x => x.Equals(ProjectBuildProperties.RestorePackagesPath))))
                     .Returns(restorePackagesPath);
 
-                Mock.Get(projectAdapter)
-                    .SetupGet(x => x.RestoreSources)
+                projectBuildProperties
+                    .Setup(x => x.GetPropertyValue(It.Is<string>(x => x.Equals(ProjectBuildProperties.RestoreSources))))
                     .Returns(sources);
 
-                Mock.Get(projectAdapter)
-                    .SetupGet(x => x.RestoreFallbackFolders)
+                projectBuildProperties
+                    .Setup(x => x.GetPropertyValue(It.Is<string>(x => x.Equals(ProjectBuildProperties.RestoreFallbackFolders))))
                     .Returns(fallbackFolders);
 
                 var projectServices = new TestProjectSystemServices();
@@ -417,12 +416,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 Assert.True(Enumerable.SequenceEqual(expectedFolders.OrderBy(t => t), specFallback.OrderBy(t => t)));
 
                 // Verify
-                Mock.Get(projectAdapter)
-                    .Verify(x => x.RestorePackagesPath, Times.Once);
-                Mock.Get(projectAdapter)
-                    .Verify(x => x.RestoreSources, Times.Once);
-                Mock.Get(projectAdapter)
-                    .Verify(x => x.RestoreFallbackFolders, Times.Once);
+                projectBuildProperties.VerifyAll();
             }
         }
 
@@ -434,9 +428,11 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             // Arrange
             using (var testDirectory = TestDirectory.Create())
             {
-                var projectAdapter = CreateProjectAdapter(testDirectory);
-                Mock.Get(projectAdapter)
-                    .SetupGet(x => x.PackageTargetFallback)
+                var projectBuildProperties = new Mock<IProjectBuildProperties>();
+                var projectAdapter = CreateProjectAdapter(testDirectory, projectBuildProperties);
+
+                projectBuildProperties
+                    .Setup(x => x.GetPropertyValue(It.Is<string>(x => x.Equals(ProjectBuildProperties.PackageTargetFallback))))
                     .Returns("portable-net45+win8;dnxcore50");
 
                 var testProject = new LegacyPackageReferenceProject(
@@ -475,8 +471,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                     ((FallbackFramework)actualTfi.FrameworkName).Fallback);
 
                 // Verify
-                Mock.Get(projectAdapter)
-                    .Verify(x => x.PackageTargetFallback, Times.AtLeastOnce);
+                projectBuildProperties.VerifyAll();
             }
         }
 
@@ -779,18 +774,20 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             // Arrange
             using (var testDirectory = TestDirectory.Create())
             {
-                var projectAdapter = CreateProjectAdapter(testDirectory);
-                Mock.Get(projectAdapter)
-                    .Setup(x => x.GetRestorePackagesWithLockFileAsync())
-                    .ReturnsAsync(restorePackagesWithLockFile);
+                var projectBuildProperties = new Mock<IProjectBuildProperties>();
+                var projectAdapter = CreateProjectAdapter(testDirectory, projectBuildProperties);
 
-                Mock.Get(projectAdapter)
-                    .Setup(x => x.GetNuGetLockFilePathAsync())
-                    .ReturnsAsync(lockFilePath);
+                projectBuildProperties
+                    .Setup(x => x.GetPropertyValue(It.Is<string>(x => x.Equals(ProjectBuildProperties.RestorePackagesWithLockFile))))
+                    .Returns(restorePackagesWithLockFile);
 
-                Mock.Get(projectAdapter)
-                    .Setup(x => x.IsRestoreLockedAsync())
-                    .ReturnsAsync(restoreLockedMode);
+                projectBuildProperties
+                    .Setup(x => x.GetPropertyValue(It.Is<string>(x => x.Equals(ProjectBuildProperties.NuGetLockFilePath))))
+                    .Returns(lockFilePath);
+
+                projectBuildProperties
+                    .Setup(x => x.GetPropertyValue(It.Is<string>(x => x.Equals(ProjectBuildProperties.RestoreLockedMode))))
+                    .Returns(restoreLockedMode.ToString());
 
                 var projectServices = new TestProjectSystemServices();
 

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/TestVSProjectAdapter.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/TestVSProjectAdapter.cs
@@ -8,7 +8,6 @@ using System.Linq;
 using System.Runtime.Versioning;
 using System.Threading.Tasks;
 using EnvDTE;
-using Microsoft.TeamFoundation.VersionControl.Client;
 using Microsoft.VisualStudio.Shell.Interop;
 using Moq;
 using NuGet.Frameworks;
@@ -63,14 +62,18 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             Mock.Get(BuildProperties)
                 .Setup(x => x.GetPropertyValue(It.Is<string>(x => x.Equals(ProjectBuildProperties.CentralPackageTransitivePinningEnabled))))
                 .Returns(_CentralPackageTransitivePinningEnabled ?? string.Empty);
-        }
 
-        public string AssetTargetFallback
-        {
-            get
-            {
-                return null;
-            }
+            Mock.Get(BuildProperties)
+                .Setup(x => x.GetPropertyValue(It.Is<string>(x => x.Equals(ProjectBuildProperties.NuGetLockFilePath))))
+                .Returns(_nuGetLockFilePath);
+
+            Mock.Get(BuildProperties)
+                .Setup(x => x.GetPropertyValue(It.Is<string>(x => x.Equals(ProjectBuildProperties.RestorePackagesWithLockFile))))
+                .Returns(_restorePackagesWithLockFile);
+
+            Mock.Get(BuildProperties)
+                .Setup(x => x.GetPropertyValue(It.Is<string>(x => x.Equals(ProjectBuildProperties.RestoreLockedMode))))
+                .Returns(_restoreLockedMode.ToString());
         }
 
         public async Task<string> GetMSBuildProjectExtensionsPathAsync()
@@ -90,22 +93,6 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
         public Task<bool> IsSupportedAsync() => Task.FromResult(true);
 
-        public string NoWarn
-        {
-            get
-            {
-                return null;
-            }
-        }
-
-        public string PackageTargetFallback
-        {
-            get
-            {
-                return null;
-            }
-        }
-
         public Project Project { get; } = Mock.Of<Project>();
 
         public string ProjectId
@@ -122,54 +109,6 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
         public ProjectNames ProjectNames { get; private set; }
 
-        public string RestoreAdditionalProjectFallbackFolders
-        {
-            get
-            {
-                return null;
-            }
-        }
-
-        public string RestoreAdditionalProjectSources
-        {
-            get
-            {
-                return null;
-            }
-        }
-
-        public string RestoreFallbackFolders
-        {
-            get
-            {
-                return null;
-            }
-        }
-
-        public string RestorePackagesPath
-        {
-            get
-            {
-                return null;
-            }
-        }
-
-        public string RestoreSources
-        {
-            get
-            {
-                return null;
-            }
-        }
-
-        public string TreatWarningsAsErrors
-        {
-            get
-            {
-                return null;
-            }
-        }
-
         public string UniqueName => ProjectNames.UniqueName;
 
         public string Version
@@ -182,20 +121,10 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
         public IVsHierarchy VsHierarchy { get; } = Mock.Of<IVsHierarchy>();
 
-        public string WarningsAsErrors
-        {
-            get
-            {
-                return null;
-            }
-        }
-
         public Task<FrameworkName> GetDotNetFrameworkNameAsync()
         {
             return Task.FromResult(new FrameworkName(_targetFrameworkString));
         }
-
-        public Task<string> GetNuGetLockFilePathAsync() => Task.FromResult<string>(_nuGetLockFilePath);
 
         public Task<string[]> GetProjectTypeGuidsAsync()
         {
@@ -205,11 +134,6 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         public Task<IEnumerable<string>> GetReferencedProjectsAsync()
         {
             return Task.FromResult(Enumerable.Empty<string>());
-        }
-
-        public Task<string> GetRestorePackagesWithLockFileAsync()
-        {
-            return Task.FromResult<string>(_restorePackagesWithLockFile);
         }
 
         public Task<IEnumerable<RuntimeDescription>> GetRuntimeIdentifiersAsync()
@@ -225,11 +149,6 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         public Task<NuGetFramework> GetTargetFrameworkAsync()
         {
             return Task.FromResult(NuGetFramework.Parse(_targetFrameworkString));
-        }
-
-        public Task<bool> IsRestoreLockedAsync()
-        {
-            return Task.FromResult(_restoreLockedMode);
         }
 
         public Task<IEnumerable<(string PackageId, string Version)>> GetPackageVersionInformationAsync()

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/TestVSProjectAdapter.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/TestVSProjectAdapter.cs
@@ -53,15 +53,15 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             _CentralPackageTransitivePinningEnabled = CentralPackageTransitivePinningEnabled;
 
             Mock.Get(BuildProperties)
-                .SetupGet(x => x.GetPropertyValue(It.Is<string>(x => x.Equals(ProjectBuildProperties.ManagePackageVersionsCentrally))))
+                .Setup(x => x.GetPropertyValue(It.Is<string>(x => x.Equals(ProjectBuildProperties.ManagePackageVersionsCentrally))))
                 .Returns(_isCPVMEnabled.ToString());
 
             Mock.Get(BuildProperties)
-                .SetupGet(x => x.GetPropertyValue(It.Is<string>(x => x.Equals(ProjectBuildProperties.CentralPackageVersionOverrideEnabled))))
+                .Setup(x => x.GetPropertyValue(It.Is<string>(x => x.Equals(ProjectBuildProperties.CentralPackageVersionOverrideEnabled))))
                 .Returns(_isCentralPackageVersionOverrideEnabled ?? string.Empty);
 
             Mock.Get(BuildProperties)
-                .SetupGet(x => x.GetPropertyValue(It.Is<string>(x => x.Equals(ProjectBuildProperties.CentralPackageTransitivePinningEnabled))))
+                .Setup(x => x.GetPropertyValue(It.Is<string>(x => x.Equals(ProjectBuildProperties.CentralPackageTransitivePinningEnabled))))
                 .Returns(_CentralPackageTransitivePinningEnabled ?? string.Empty);
         }
 

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/TestVSProjectAdapter.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/TestVSProjectAdapter.cs
@@ -51,6 +51,18 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             _projectPackageVersions = projectPackageVersions;
             _isCentralPackageVersionOverrideEnabled = isCentralPackageVersionOverrideEnabled;
             _CentralPackageTransitivePinningEnabled = CentralPackageTransitivePinningEnabled;
+
+            Mock.Get(BuildProperties)
+                .SetupGet(x => x.GetPropertyValue(It.Is<string>(x => x.Equals(ProjectBuildProperties.ManagePackageVersionsCentrally))))
+                .Returns(_isCPVMEnabled.ToString());
+
+            Mock.Get(BuildProperties)
+                .SetupGet(x => x.GetPropertyValue(It.Is<string>(x => x.Equals(ProjectBuildProperties.CentralPackageVersionOverrideEnabled))))
+                .Returns(_isCentralPackageVersionOverrideEnabled ?? string.Empty);
+
+            Mock.Get(BuildProperties)
+                .SetupGet(x => x.GetPropertyValue(It.Is<string>(x => x.Equals(ProjectBuildProperties.CentralPackageTransitivePinningEnabled))))
+                .Returns(_CentralPackageTransitivePinningEnabled ?? string.Empty);
         }
 
         public string AssetTargetFallback
@@ -233,24 +245,6 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             }
 
             return Enumerable.Empty<(string ItemId, string[] ItemMetadata)>();
-        }
-
-        public Task<string> GetPropertyValueAsync(string propertyName)
-        {
-            switch (propertyName)
-            {
-                case ProjectBuildProperties.ManagePackageVersionsCentrally:
-                    return Task.FromResult(_isCPVMEnabled.ToString());
-
-                case ProjectBuildProperties.CentralPackageVersionOverrideEnabled:
-                    return Task.FromResult(_isCentralPackageVersionOverrideEnabled ?? string.Empty);
-
-                case ProjectBuildProperties.CentralPackageTransitivePinningEnabled:
-                    return Task.FromResult(_CentralPackageTransitivePinningEnabled ?? string.Empty);
-
-                default:
-                    return Task.FromResult(string.Empty);
-            }
         }
 
         public Task<bool> IsCapabilityMatchAsync(string capabilityExpression)


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11199

This change is 1 part of the bugs in https://github.com/NuGet/Client.Engineering/issues/1374.

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

With the current implementation we end up nesting async/JTF.Run unnecessarily. 
This is slower and causes lots of allocations. 

Small changes like this can go a long way.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception - Not really testable individually. As I was progressing, I did get some test failures, so we already have plenty of tests for these scenarios.
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
