### PR TITLE
Improve ci initialization script

### DIFF
--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -12,7 +12,7 @@ steps:
 - task: PowerShell@1
   inputs:
     scriptName: "$(Build.Repository.LocalPath)\\scripts\\cibuild\\ConfigureVstsBuild.ps1"
-    arguments: "-BuildRTM $(BuildRTM)"
+    arguments: "-BuildRTM $(BuildRTM) -RepositoryPath $(Build.Repository.LocalPath) -BranchName $(Build.SourceBranchName) -CommitHash $(Build.SourceVersion) -BuildNumber $(Build.BuildNumber)"
   displayName: "Configure VSTS CI Environment"
 
 - task: PublishBuildArtifacts@1

--- a/scripts/cibuild/ConfigureVstsBuild.ps1
+++ b/scripts/cibuild/ConfigureVstsBuild.ps1
@@ -1,34 +1,53 @@
 <#
 .SYNOPSIS
-Sets build variables during a VSTS build dynamically.
+Sets build variables during a CI build dynamically.
 
 .DESCRIPTION
-This script is used to dynamically set some build variables during VSTS build.
+This script is used to dynamically set some build variables during CI build.
 Specifically, this script determines the build number of the artifacts,
 also it sets the $(NupkgOutputDir) based on whether $(BuildRTM) is true or false.
 
 .PARAMETER BuildRTM
 True/false depending on whether nupkgs are being with or without the release labels.
 
+.PARAMETER RepositoryPath
+The path to the root of the NuGet.Client repo
+
+.PARAMETER BranchName
+The name of the branch being built
+
+.PARAMETER CommitHash
+The commit hash being built
+
+.PARAMETER BuildNumber
+The build number of the current build
 #>
 
 param
 (
     [Parameter(Mandatory=$True)]
-    [string]$BuildRTM
+    [string]$BuildRTM,
+    [Parameter(Mandatory=$true)]
+    [string]$RepositoryPath,
+    [Parameter(Mandatory=$true)]
+    [string]$BranchName,
+    [Parameter(Mandatory=$true)]
+    [string]$CommitHash,
+    [Parameter(Mandatory=$true)]
+    [int]$BuildNumber
 )
 
 Function Get-Version {
     param(
-        [string]$ProductVersion,
+        [string]$productVersion,
         [string]$build
     )
-        Write-Host "Evaluating the new VSIX Version : ProductVersion $ProductVersion, build $build"
+        Write-Host "Evaluating the new VSIX Version : ProductVersion $productVersion, build $build"
         # The major version is NuGetMajorVersion + 11, to match VS's number.
         # The new minor version is: 4.0.0 => 40000, 4.11.5 => 41105.
         # This assumes we only get to NuGet major/minor/patch 99 at worst, otherwise the logic breaks.
         # The final version for NuGet 4.0.0, build number 3128 would be 15.0.40000.3128
-        $versionParts = $ProductVersion -split '\.'
+        $versionParts = $productVersion -split '\.'
         $major = $($versionParts[0] / 1) + 11
         $finalVersion = "$major.0.$((-join ($versionParts | %{ '{0:D2}' -f ($_ -as [int]) } )).TrimStart("0")).$build"
 
@@ -38,11 +57,12 @@ Function Get-Version {
 
 Function Update-VsixVersion {
     param(
-        [string]$ReleaseProductVersion,
+        [string]$releaseProductVersion,
         [string]$manifestName,
-        [int]$buildNumber
+        [int]$buildNumber,
+        [string]$repositoryPath
     )
-    $vsixManifest = Join-Path $env:BUILD_REPOSITORY_LOCALPATH\src\NuGet.Clients\NuGet.VisualStudio.Client $manifestName
+    $vsixManifest = Join-Path "$repositoryPath\src\NuGet.Clients\NuGet.VisualStudio.Client" $manifestName
 
     Write-Host "Updating the VSIX version in manifest $vsixManifest"
 
@@ -52,7 +72,7 @@ Function Update-VsixVersion {
     # Reading the current version from the manifest
     $oldVersion = $root.Metadata.Identity.Version
     # Evaluate the new version
-    $newVersion = Get-Version $ReleaseProductVersion $buildNumber
+    $newVersion = Get-Version $releaseProductVersion $buildNumber
     Write-Host "Updating the VSIX version [$oldVersion] => [$newVersion]"
     Write-Host "##vso[task.setvariable variable=VsixBuildNumber;]$newVersion"
     # setting the revision to the new version
@@ -86,7 +106,7 @@ Function Get-LocBranchExists {
     )
 
     Write-Host "Looking for branch '$branchName' in NuGet.Build.Localization"
-    $lsRemoteOpts = 'ls-remote', 'origin', $branchName
+    $lsRemoteOpts = 'ls-remote', 'origin', "refs/heads/$branchName"
     $branchExists = & git -C $NuGetLocalization $lsRemoteOpts
     return $branchExists
 }
@@ -102,17 +122,15 @@ Set-RtmLabel -isRTMBuild $isRTMBuild
 $regKeyFileSystem = "HKLM:SYSTEM\CurrentControlSet\Control\FileSystem"
 $enableLongPathSupport = "LongPathsEnabled"
 
-$NuGetClientRoot = $env:BUILD_REPOSITORY_LOCALPATH
-$Submodules = Join-Path $NuGetClientRoot submodules -Resolve
+$Submodules = Join-Path $RepositoryPath submodules -Resolve
 
 # NuGet.Build.Localization repository set-up
 $NuGetLocalization = Join-Path $Submodules NuGet.Build.Localization -Resolve
 
 # Check if there is a localization branch associated with this branch repo
-$currentNuGetBranch = $env:BUILD_SOURCEBRANCHNAME
-if (Get-LocBranchExists $currentNuGetBranch)
+if (Get-LocBranchExists $BranchName)
 {
-    $NuGetLocalizationRepoBranch = $currentNuGetBranch
+    $NuGetLocalizationRepoBranch = $BranchName
 }
 else
 {
@@ -133,7 +151,7 @@ else
 Write-Host "NuGet.Build.Localization Branch: $NuGetLocalizationRepoBranch"
 
 # update submodule NuGet.Build.Localization
-$updateOpts = 'pull', 'origin', $NuGetLocalizationRepoBranch
+$updateOpts = 'switch', "origin/$NuGetLocalizationRepoBranch", "-q"
 Write-Host "git update NuGet.Build.Localization at $NuGetLocalization"
 & git -C $NuGetLocalization $updateOpts 2>&1 | Write-Host
 # Get the commit of the localization repository that will be used for this build.
@@ -153,14 +171,14 @@ if ($BuildRTM -eq $true)
 else
 {
     Write-Host "##vso[task.setvariable variable=VsixPublishDir;]VS15"
-    $newBuildCounter = $env:BUILD_BUILDNUMBER
-    $VsTargetBranch = & dotnet msbuild $env:BUILD_REPOSITORY_LOCALPATH\build\config.props /v:m /nologo /t:GetVsTargetBranch
-    $NuGetSdkVsVersion = & dotnet msbuild $env:BUILD_REPOSITORY_LOCALPATH\build\config.props /v:m /nologo /t:GetNuGetSdkVsSemanticVersion
-    Write-Host $VsTargetBranch
+    $newBuildCounter = $BuildNumber
+    $VsTargetBranch = & dotnet msbuild $RepositoryPath\build\config.props /v:m /nologo /t:GetVsTargetBranch
+    $NuGetSdkVsVersion = & dotnet msbuild $RepositoryPath\build\config.props /v:m /nologo /t:GetNuGetSdkVsSemanticVersion
+    Write-Host "VS target branch: $VsTargetBranch"
     $jsonRepresentation = @{
         BuildNumber = $newBuildCounter
-        CommitHash = $env:BUILD_SOURCEVERSION
-        BuildBranch = $env:BUILD_SOURCEBRANCHNAME
+        CommitHash = $CommitHash
+        BuildBranch = $BranchName
         LocalizationRepositoryBranch = $NuGetLocalizationRepoBranch
         LocalizationRepositoryCommitHash = $LocalizationRepoCommitHash
         VsTargetBranch = $VsTargetBranch.Trim()
@@ -168,16 +186,16 @@ else
     }
 
     # First create the file locally so that we can laster publish it as a build artifact from a local source file instead of a remote source file.
-    $localBuildInfoJsonFilePath = [System.IO.Path]::Combine("$Env:BUILD_REPOSITORY_LOCALPATH\artifacts", 'buildinfo.json')
+    $localBuildInfoJsonFilePath = [System.IO.Path]::Combine("$RepositoryPath\artifacts", 'buildinfo.json')
 
-    New-Item $localBuildInfoJsonFilePath -Force
+    New-Item $localBuildInfoJsonFilePath -Force | Out-Null
     $jsonRepresentation | ConvertTo-Json | Set-Content $localBuildInfoJsonFilePath
 
-    $productVersion = & dotnet msbuild $env:BUILD_REPOSITORY_LOCALPATH\build\config.props /v:m /nologo /t:GetSemanticVersion
+    $productVersion = & dotnet msbuild $RepositoryPath\build\config.props /v:m /nologo /t:GetSemanticVersion
     if (-not $?)
     {
         Write-Error "Failed to get product version."
         exit 1
     }
-    Update-VsixVersion -manifestName source.extension.vsixmanifest -ReleaseProductVersion $productVersion -buildNumber $env:BUILDNUMBER
+    Update-VsixVersion -manifestName source.extension.vsixmanifest -ReleaseProductVersion $productVersion -buildNumber $BuildNumber -RepositoryPath $RepositoryPath
 }

--- a/scripts/cibuild/ConfigureVstsBuild.ps1
+++ b/scripts/cibuild/ConfigureVstsBuild.ps1
@@ -20,7 +20,7 @@ The name of the branch being built
 The commit hash being built
 
 .PARAMETER BuildNumber
-The build number of the current build (example: "6.2.1.1234")
+The build number of the current build
 #>
 
 param
@@ -34,7 +34,7 @@ param
     [Parameter(Mandatory=$true)]
     [string]$CommitHash,
     [Parameter(Mandatory=$true)]
-    [string]$BuildNumber
+    [int]$BuildNumber
 )
 
 Function Get-Version {
@@ -59,7 +59,7 @@ Function Update-VsixVersion {
     param(
         [string]$releaseProductVersion,
         [string]$manifestName,
-        [int]$revisionNumber,
+        [int]$buildNumber,
         [string]$repositoryPath
     )
     $vsixManifest = Join-Path "$repositoryPath\src\NuGet.Clients\NuGet.VisualStudio.Client" $manifestName
@@ -72,7 +72,7 @@ Function Update-VsixVersion {
     # Reading the current version from the manifest
     $oldVersion = $root.Metadata.Identity.Version
     # Evaluate the new version
-    $newVersion = Get-Version $releaseProductVersion $revisionNumber
+    $newVersion = Get-Version $releaseProductVersion $buildNumber
     Write-Host "Updating the VSIX version [$oldVersion] => [$newVersion]"
     Write-Host "##vso[task.setvariable variable=VsixBuildNumber;]$newVersion"
     # setting the revision to the new version
@@ -99,16 +99,16 @@ Function Set-RtmLabel {
     Write-Host "##vso[task.setvariable variable=RtmLabel;]$label"
 }
 
-Function Initialize-LocalizationSubmodule {
+Function Get-LocBranchExists {
     param(
         [Parameter(Mandatory = $true)]
         [string]$branchName
     )
 
-    Write-Host "Switching to branch '$branchName' in NuGet.Build.Localization"
-    $opts = 'checkout', "origin/$branchName", '-q'
-    & git -C $NuGetLocalization $opts
-    return $LASTEXITCODE -eq 0
+    Write-Host "Looking for branch '$branchName' in NuGet.Build.Localization"
+    $lsRemoteOpts = 'ls-remote', 'origin', "refs/heads/$branchName"
+    $branchExists = & git -C $NuGetLocalization $lsRemoteOpts
+    return $branchExists
 }
 
 $isRTMBuild = [boolean]::Parse($BuildRTM)
@@ -127,18 +127,33 @@ $Submodules = Join-Path $RepositoryPath submodules -Resolve
 # NuGet.Build.Localization repository set-up
 $NuGetLocalization = Join-Path $Submodules NuGet.Build.Localization -Resolve
 
+# Check if there is a localization branch associated with this branch repo
+if (Get-LocBranchExists $BranchName)
+{
+    $NuGetLocalizationRepoBranch = $BranchName
+}
+else
+{
+    if ($currentNuGetBranch -like "*-MSRC") {
+        $currentNuGetBranch = $currentNuGetBranch -replace "-MSRC$", ""
+        if (Get-LocBranchExists $currentNuGetBranch) {
+            $NuGetLocalizationRepoBranch = $currentNuGetBranch
+        }
+        else
+        {
+            $NuGetLocalizationRepoBranch = "dev"
+        }
+    }
+    else {
+        $NuGetLocalizationRepoBranch = 'dev'
+    }
+}
+Write-Host "NuGet.Build.Localization Branch: $NuGetLocalizationRepoBranch"
+
 # update submodule NuGet.Build.Localization
-$successful = Initialize-LocalizationSubmodule $BranchName
-
-if (-not $successful -and $BranchName -like "*-MSRC") {
-    $currentBranchName = $branchName -replace "-MSRC$", ""
-    $successful = Initialize-LocalizationSubmodule $currentBranchName
-}
-
-if (-not $successful) {
-    Initialize-LocalizationSubmodule "dev" | Out-Null
-}
-
+$updateOpts = 'switch', "origin/$NuGetLocalizationRepoBranch", "-q"
+Write-Host "git update NuGet.Build.Localization at $NuGetLocalization"
+& git -C $NuGetLocalization $updateOpts 2>&1 | Write-Host
 # Get the commit of the localization repository that will be used for this build.
 $LocalizationRepoCommitHash = & git -C $NuGetLocalization log --pretty=format:'%H' -n 1
 
@@ -182,7 +197,5 @@ else
         Write-Error "Failed to get product version."
         exit 1
     }
-
-    $parsedVersion = [System.Version]::Parse($BuildNumber)
-    Update-VsixVersion -manifestName source.extension.vsixmanifest -ReleaseProductVersion $productVersion -revisionNumber $($parsedVersion.Revision) -RepositoryPath $RepositoryPath
+    Update-VsixVersion -manifestName source.extension.vsixmanifest -ReleaseProductVersion $productVersion -buildNumber $BuildNumber -RepositoryPath $RepositoryPath
 }

--- a/scripts/cibuild/ConfigureVstsBuild.ps1
+++ b/scripts/cibuild/ConfigureVstsBuild.ps1
@@ -105,7 +105,7 @@ Function Get-LocBranchExists {
     )
 
     Write-Host "Looking for branch '$branchName' in NuGet.Build.Localization"
-    $lsRemoteOpts = 'ls-remote', 'origin', "refs/heads/$branchName", '--exit-code'
+    $lsRemoteOpts = 'ls-remote', '--exit-code', 'origin', "refs/heads/$branchName"
     $branchExists = & git -C $NuGetLocalization $lsRemoteOpts
     return $LASTEXITCODE -eq 0
 }
@@ -133,8 +133,8 @@ if (Get-LocBranchExists $BranchName)
 }
 else
 {
-    if ($currentNuGetBranch -like "*-MSRC") {
-        $currentNuGetBranch = $currentNuGetBranch -replace "-MSRC$", ""
+    if ($BranchName -like "*-MSRC") {
+        $currentNuGetBranch = $BranchName -replace "-MSRC$", ""
         if (Get-LocBranchExists $currentNuGetBranch) {
             $NuGetLocalizationRepoBranch = $currentNuGetBranch
         }
@@ -150,7 +150,7 @@ else
 Write-Host "NuGet.Build.Localization Branch: $NuGetLocalizationRepoBranch"
 
 # update submodule NuGet.Build.Localization
-$updateOpts = 'switch', "origin/$NuGetLocalizationRepoBranch", "-q"
+$updateOpts = 'switch', '-d', "origin/$NuGetLocalizationRepoBranch", "-q"
 Write-Host "git update NuGet.Build.Localization at $NuGetLocalization"
 & git -C $NuGetLocalization $updateOpts 2>&1 | Write-Host
 # Get the commit of the localization repository that will be used for this build.


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1694

Regression? no

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

* Remove all environment variable usage from `ConfigureVstsBuild.ps1`, making them command line arguments, making it much, much easier to test locally.
  * Slightly refactored how the VSIX version is calculated, but it's the same end result
* I think the previous change to remove branch name suffix when searching for loc repo branches had a bug. In any case, fixed it to look for exact matches, and use the process exit code to signal whether or not a match was found.
* Use `git switch`, rather than `git pull` to change loc repo branches, as `pull` was causing errors when the repo was already on a certain branch and then the script wants to change to a different branch which has merge conflicts. This isn't a problem on CI, but it made testing locally easier.
  * Also switch in quiet mode, as I don't think getting a log with multiple screen fulls of checkout progress logs helps us in any way.
## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
