### PR TITLE
Handle duplicate packageSource keys in package source mapping

### DIFF
--- a/src/NuGet.Core/NuGet.Configuration/PackageSourceMapping/PackageSourceMapping.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSourceMapping/PackageSourceMapping.cs
@@ -64,15 +64,7 @@ namespace NuGet.Configuration
 
             foreach (PackageSourceMappingSourceItem packageSourceNamespaceItem in packageSourceMappingProvider.GetPackageSourceMappingItems())
             {
-                if (patterns.ContainsKey(packageSourceNamespaceItem.Key))
-                {
-                    patterns[packageSourceNamespaceItem.Key] = patterns[packageSourceNamespaceItem.Key].Concat(
-                        new List<string>(packageSourceNamespaceItem.Patterns.Select(e => e.Pattern))).ToList();
-                }
-                else
-                {
-                    patterns.Add(packageSourceNamespaceItem.Key, new List<string>(packageSourceNamespaceItem.Patterns.Select(e => e.Pattern)));
-                }
+                patterns.Add(packageSourceNamespaceItem.Key, new List<string>(packageSourceNamespaceItem.Patterns.Select(e => e.Pattern)));
             }
 
             return new PackageSourceMapping(patterns);

--- a/src/NuGet.Core/NuGet.Configuration/PackageSourceMapping/PackageSourceMapping.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSourceMapping/PackageSourceMapping.cs
@@ -64,7 +64,15 @@ namespace NuGet.Configuration
 
             foreach (PackageSourceMappingSourceItem packageSourceNamespaceItem in packageSourceMappingProvider.GetPackageSourceMappingItems())
             {
-                patterns.Add(packageSourceNamespaceItem.Key, new List<string>(packageSourceNamespaceItem.Patterns.Select(e => e.Pattern)));
+                if (patterns.ContainsKey(packageSourceNamespaceItem.Key))
+                {
+                    patterns[packageSourceNamespaceItem.Key] = patterns[packageSourceNamespaceItem.Key].Concat(
+                        new List<string>(packageSourceNamespaceItem.Patterns.Select(e => e.Pattern))).ToList();
+                }
+                else
+                {
+                    patterns.Add(packageSourceNamespaceItem.Key, new List<string>(packageSourceNamespaceItem.Patterns.Select(e => e.Pattern)));
+                }
             }
 
             return new PackageSourceMapping(patterns);

--- a/src/NuGet.Core/NuGet.Configuration/Resources.Designer.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Resources.Designer.cs
@@ -151,7 +151,7 @@ namespace NuGet.Configuration {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to PackageSourceMapping is enabled, there are multiple package sources associated with the same key(s): {0}.
+        ///   Looks up a localized string similar to PackageSourceMapping is enabled and there are multiple package sources associated with the same key(s): {0}. Path: {1}.
         /// </summary>
         internal static string Error_DuplicatePackageSource {
             get {

--- a/src/NuGet.Core/NuGet.Configuration/Resources.Designer.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Resources.Designer.cs
@@ -151,6 +151,15 @@ namespace NuGet.Configuration {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Package source &apos;{0}&apos; has already been defined previously..
+        /// </summary>
+        internal static string Error_DuplicatePackageSource {
+            get {
+                return ResourceManager.GetString("Error_DuplicatePackageSource", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Encryption is not supported on non-Windows platforms..
         /// </summary>
         internal static string Error_EncryptionUnsupported {

--- a/src/NuGet.Core/NuGet.Configuration/Resources.Designer.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Resources.Designer.cs
@@ -151,7 +151,7 @@ namespace NuGet.Configuration {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Package source &apos;{0}&apos; has already been defined previously..
+        ///   Looks up a localized string similar to PackageSourceMapping is enabled, there are multiple package sources associated with the same key(s): {0}.
         /// </summary>
         internal static string Error_DuplicatePackageSource {
             get {

--- a/src/NuGet.Core/NuGet.Configuration/Resources.resx
+++ b/src/NuGet.Core/NuGet.Configuration/Resources.resx
@@ -299,4 +299,8 @@
   <data name="Argument_Cannot_Be_Null_Empty_Or_WhiteSpaceOnly" xml:space="preserve">
     <value>Argument cannot be null, empty, or whitespace only.</value>
   </data>
+  <data name="Error_DuplicatePackageSource" xml:space="preserve">
+    <value>Package source '{0}' has already been defined previously.</value>
+    <comment>0 - package source</comment>
+  </data>
 </root>

--- a/src/NuGet.Core/NuGet.Configuration/Resources.resx
+++ b/src/NuGet.Core/NuGet.Configuration/Resources.resx
@@ -300,7 +300,7 @@
     <value>Argument cannot be null, empty, or whitespace only.</value>
   </data>
   <data name="Error_DuplicatePackageSource" xml:space="preserve">
-    <value>Package source '{0}' has already been defined previously.</value>
-    <comment>0 - package source</comment>
+    <value>PackageSourceMapping is enabled, there are multiple package sources associated with the same key(s): {0}</value>
+    <comment>0 - package sources separated with comma</comment>
   </data>
 </root>

--- a/src/NuGet.Core/NuGet.Configuration/Resources.resx
+++ b/src/NuGet.Core/NuGet.Configuration/Resources.resx
@@ -300,7 +300,7 @@
     <value>Argument cannot be null, empty, or whitespace only.</value>
   </data>
   <data name="Error_DuplicatePackageSource" xml:space="preserve">
-    <value>PackageSourceMapping is enabled, there are multiple package sources associated with the same key(s): {0}</value>
-    <comment>0 - package sources separated with comma</comment>
+    <value>PackageSourceMapping is enabled and there are multiple package sources associated with the same key(s): {0}. Path: {1}</value>
+    <comment>0 - package sources separated with comma 1 - path</comment>
   </data>
 </root>

--- a/src/NuGet.Core/NuGet.Configuration/Settings/SettingFactory.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/SettingFactory.cs
@@ -157,17 +157,24 @@ namespace NuGet.Configuration
 
             HashSet<T> distinctDescendants = new HashSet<T>(comparer);
 
-            List<T> duplicatedDescendants = new List<T>();
+            List<T> duplicatedDescendants = null;
 
             foreach (var item in descendants)
             {
                 if (!distinctDescendants.Add(item))
                 {
+                    if (duplicatedDescendants == null)
+                    {
+                        duplicatedDescendants = new List<T>();
+                    }
+
                     duplicatedDescendants.Add(item);
                 }
             }
 
-            if (xElement.Name.LocalName.Equals(ConfigurationConstants.PackageSourceMapping, StringComparison.OrdinalIgnoreCase) && duplicatedDescendants.Any())
+            if (xElement.Name.LocalName.Equals(ConfigurationConstants.PackageSourceMapping, StringComparison.OrdinalIgnoreCase)
+                && duplicatedDescendants != null
+                && duplicatedDescendants.Any())
             {
                 var duplicatedKey = string.Join(", ", duplicatedDescendants.Select(d => d.Attributes["key"]));
                 var source = duplicatedDescendants.Select(d => d.Origin.ConfigFilePath).First();

--- a/src/NuGet.Core/NuGet.Configuration/Settings/SettingFactory.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/SettingFactory.cs
@@ -172,9 +172,7 @@ namespace NuGet.Configuration
                 }
             }
 
-            if (xElement.Name.LocalName.Equals(ConfigurationConstants.PackageSourceMapping, StringComparison.OrdinalIgnoreCase)
-                && duplicatedDescendants != null
-                && duplicatedDescendants.Any())
+            if (xElement.Name.LocalName.Equals(ConfigurationConstants.PackageSourceMapping, StringComparison.OrdinalIgnoreCase) && duplicatedDescendants != null)
             {
                 var duplicatedKey = string.Join(", ", duplicatedDescendants.Select(d => d.Attributes["key"]));
                 var source = duplicatedDescendants.Select(d => d.Origin.ConfigFilePath).First();

--- a/src/NuGet.Core/NuGet.Configuration/Settings/SettingFactory.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/SettingFactory.cs
@@ -97,11 +97,59 @@ namespace NuGet.Configuration
             return null;
         }
 
+        private class SettingElementComparer : IComparer<SettingElement>, IEqualityComparer<SettingElement>
+        {
+            public int Compare(SettingElement x, SettingElement y)
+            {
+                if (ReferenceEquals(x, y))
+                {
+                    return 0;
+                }
+
+                if (ReferenceEquals(x, null))
+                {
+                    return -1;
+                }
+
+                if (ReferenceEquals(y, null))
+                {
+                    return 1;
+                }
+
+                return StringComparer.OrdinalIgnoreCase.Compare(x.Attributes["key"], y.Attributes["key"]);
+            }
+
+            public bool Equals(SettingElement x, SettingElement y)
+            {
+                if (ReferenceEquals(x, y))
+                {
+                    return true;
+                }
+
+                if (ReferenceEquals(x, null) || ReferenceEquals(y, null))
+                {
+                    return false;
+                }
+                return StringComparer.OrdinalIgnoreCase.Equals(x.Attributes["key"], y.Attributes["key"]);
+            }
+
+            public int GetHashCode(SettingElement obj)
+            {
+                if (ReferenceEquals(obj, null))
+                {
+                    return 0;
+                }
+                return StringComparer.OrdinalIgnoreCase.GetHashCode(obj.ElementName + (obj.Attributes.ContainsKey("key") ? obj.Attributes["key"] : string.Empty));
+            }
+        }
+
         internal static IEnumerable<T> ParseChildren<T>(XElement xElement, SettingsFile origin, bool canBeCleared) where T : SettingElement
         {
             var children = new List<T>();
             IEnumerable<T> descendants = xElement.Elements().Select(d => Parse(d, origin)).OfType<T>();
-            HashSet<T> distinctDescendants = new HashSet<T>();
+            SettingElementComparer comparer = new SettingElementComparer();
+
+            HashSet<T> distinctDescendants = new HashSet<T>(comparer);
 
             List<T> duplicatedDescendants = new List<T>();
 

--- a/src/NuGet.Core/NuGet.Configuration/Settings/SettingFactory.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/SettingFactory.cs
@@ -99,8 +99,15 @@ namespace NuGet.Configuration
         internal static IEnumerable<T> ParseChildren<T>(XElement xElement, SettingsFile origin, bool canBeCleared) where T : SettingElement
         {
             var children = new List<T>();
-
-            var descendants = xElement.Elements().Select(d => Parse(d, origin)).OfType<T>().Distinct();
+            IEnumerable<T> descendants;
+            if (xElement.Name.LocalName.Equals("packageSourceMapping", StringComparison.OrdinalIgnoreCase))
+            {
+                descendants = xElement.Elements().Select(d => Parse(d, origin)).OfType<T>();
+            }
+            else
+            {
+                descendants = xElement.Elements().Select(d => Parse(d, origin)).OfType<T>().Distinct();
+            }
 
             foreach (var descendant in descendants)
             {

--- a/src/NuGet.Core/NuGet.Configuration/Settings/SettingFactory.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/SettingFactory.cs
@@ -104,9 +104,11 @@ namespace NuGet.Configuration
             if (xElement.Name.LocalName.Equals("packageSourceMapping", StringComparison.OrdinalIgnoreCase))
             {
                 descendants = xElement.Elements().Select(d => Parse(d, origin)).OfType<T>();
-                if (descendants.Count() != descendants.Distinct().Count())
+                var duplicates = descendants.ToLookup(d => d.Attributes["key"], d => d, StringComparer.OrdinalIgnoreCase).Where(g => g.Count() > 1).ToList();
+                if (duplicates.Any())
                 {
-                    throw new NuGetConfigurationException(string.Format(CultureInfo.CurrentCulture, Resources.Error_DuplicatePackageSource, descendants.First().Attributes.TryGetValue("Key", out string key)));
+                    var duplicatedPackageSources = string.Join(", ", duplicates.Select(d => d.Key));
+                    throw new NuGetConfigurationException(string.Format(CultureInfo.CurrentCulture, Resources.Error_DuplicatePackageSource, duplicatedPackageSources));
                 }
             }
             else

--- a/src/NuGet.Core/NuGet.Configuration/Settings/SettingFactory.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/SettingFactory.cs
@@ -101,7 +101,7 @@ namespace NuGet.Configuration
         {
             var children = new List<T>();
             IEnumerable<T> descendants;
-            if (xElement.Name.LocalName.Equals("packageSourceMapping", StringComparison.OrdinalIgnoreCase))
+            if (xElement.Name.LocalName.Equals(ConfigurationConstants.PackageSourceMapping, StringComparison.OrdinalIgnoreCase))
             {
                 descendants = xElement.Elements().Select(d => Parse(d, origin)).OfType<T>();
                 var duplicates = descendants.ToLookup(d => d.Attributes["key"], d => d, StringComparer.OrdinalIgnoreCase).Where(g => g.Count() > 1).ToList();

--- a/src/NuGet.Core/NuGet.Configuration/Settings/SettingFactory.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/SettingFactory.cs
@@ -104,11 +104,14 @@ namespace NuGet.Configuration
             if (xElement.Name.LocalName.Equals(ConfigurationConstants.PackageSourceMapping, StringComparison.OrdinalIgnoreCase))
             {
                 descendants = xElement.Elements().Select(d => Parse(d, origin)).OfType<T>();
-                var duplicates = descendants.ToLookup(d => d.Attributes["key"], d => d, StringComparer.OrdinalIgnoreCase).Where(g => g.Count() > 1).ToList();
-                if (duplicates.Any())
+                var duplicatedPackageSource = descendants.Where(node => node.ElementName.Equals(ConfigurationConstants.PackageSourceAttribute, StringComparison.OrdinalIgnoreCase))
+                                            .ToLookup(d => d.Attributes["key"], d => d, StringComparer.OrdinalIgnoreCase)
+                                            .Where(g => g.Count() > 1)
+                                            .ToList();
+                if (duplicatedPackageSource.Any())
                 {
-                    var duplicatedPackageSources = string.Join(", ", duplicates.Select(d => d.Key));
-                    throw new NuGetConfigurationException(string.Format(CultureInfo.CurrentCulture, Resources.Error_DuplicatePackageSource, duplicatedPackageSources));
+                    var duplicatedKey = string.Join(", ", duplicatedPackageSource.Select(d => d.Key));
+                    throw new NuGetConfigurationException(string.Format(CultureInfo.CurrentCulture, Resources.Error_DuplicatePackageSource, duplicatedKey));
                 }
             }
             else

--- a/src/NuGet.Core/NuGet.Configuration/Settings/SettingFactory.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/SettingFactory.cs
@@ -104,9 +104,9 @@ namespace NuGet.Configuration
             if (xElement.Name.LocalName.Equals("packageSourceMapping", StringComparison.OrdinalIgnoreCase))
             {
                 descendants = xElement.Elements().Select(d => Parse(d, origin)).OfType<T>();
-                if (descendants.Count() > 1)
+                if (descendants.Count() != descendants.Distinct().Count())
                 {
-                    throw new NuGetConfigurationException(string.Format(CultureInfo.CurrentCulture, Resources.Error_DuplicatePackageSource, descendants.First().Attributes["Key"]));
+                    throw new NuGetConfigurationException(string.Format(CultureInfo.CurrentCulture, Resources.Error_DuplicatePackageSource, descendants.First().Attributes.TryGetValue("Key", out string key)));
                 }
             }
             else

--- a/src/NuGet.Core/NuGet.Configuration/Settings/SettingFactory.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/SettingFactory.cs
@@ -106,12 +106,12 @@ namespace NuGet.Configuration
                     return 0;
                 }
 
-                if (ReferenceEquals(x, null))
+                if (ReferenceEquals(x, null) || !x.Attributes.ContainsKey("key"))
                 {
                     return -1;
                 }
 
-                if (ReferenceEquals(y, null))
+                if (ReferenceEquals(y, null) || !y.Attributes.ContainsKey("key"))
                 {
                     return 1;
                 }
@@ -127,6 +127,11 @@ namespace NuGet.Configuration
                 }
 
                 if (ReferenceEquals(x, null) || ReferenceEquals(y, null))
+                {
+                    return false;
+                }
+
+                if (!x.Attributes.ContainsKey("key") || !y.Attributes.ContainsKey("key"))
                 {
                     return false;
                 }

--- a/src/NuGet.Core/NuGet.Configuration/Settings/SettingFactory.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/SettingFactory.cs
@@ -162,6 +162,9 @@ namespace NuGet.Configuration
             {
                 if (!distinctDescendants.Add(item))
                 {
+                    // Updating element to the last one seen to match behavior like distinct
+                    distinctDescendants.Remove(item);
+                    distinctDescendants.Add(item);
                     duplicatedDescendants.Add(item);
                 }
             }

--- a/src/NuGet.Core/NuGet.Configuration/Settings/SettingFactory.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/SettingFactory.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Xml.Linq;
 
@@ -103,6 +104,10 @@ namespace NuGet.Configuration
             if (xElement.Name.LocalName.Equals("packageSourceMapping", StringComparison.OrdinalIgnoreCase))
             {
                 descendants = xElement.Elements().Select(d => Parse(d, origin)).OfType<T>();
+                if (descendants.Count() > 1)
+                {
+                    throw new NuGetConfigurationException(string.Format(CultureInfo.CurrentCulture, Resources.Error_DuplicatePackageSource, descendants.First().Attributes["Key"]));
+                }
             }
             else
             {

--- a/src/NuGet.Core/NuGet.Configuration/Settings/SettingFactory.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/SettingFactory.cs
@@ -147,7 +147,7 @@ namespace NuGet.Configuration
         {
             var children = new List<T>();
             IEnumerable<T> descendants = xElement.Elements().Select(d => Parse(d, origin)).OfType<T>();
-            SettingElementComparer comparer = new SettingElementComparer();
+            SettingElementKeyComparer comparer = new SettingElementKeyComparer();
 
             HashSet<T> distinctDescendants = new HashSet<T>(comparer);
 

--- a/src/NuGet.Core/NuGet.Configuration/Settings/SettingFactory.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/SettingFactory.cs
@@ -97,7 +97,7 @@ namespace NuGet.Configuration
             return null;
         }
 
-        private class SettingElementComparer : IComparer<SettingElement>, IEqualityComparer<SettingElement>
+        private class SettingElementKeyComparer : IComparer<SettingElement>, IEqualityComparer<SettingElement>
         {
             public int Compare(SettingElement x, SettingElement y)
             {

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceMappingProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceMappingProviderTests.cs
@@ -55,6 +55,7 @@ namespace NuGet.Configuration.Test
             SettingsTestUtils.CreateConfigurationFile(configPath1, @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
     <packageSourceMapping>
+        <clear/>
         <packageSource key=""dotnet"">
             <package pattern=""stuff"" />
         </packageSource>

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceMappingProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceMappingProviderTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using FluentAssertions;
@@ -51,8 +52,8 @@ namespace NuGet.Configuration.Test
         {
             // Arrange
             using var mockBaseDirectory = TestDirectory.Create();
-            var configPath1 = Path.Combine(mockBaseDirectory, "NuGet.Config");
-            SettingsTestUtils.CreateConfigurationFile(configPath1, @"<?xml version=""1.0"" encoding=""utf-8""?>
+            var configPath = Path.Combine(mockBaseDirectory, "NuGet.Config");
+            SettingsTestUtils.CreateConfigurationFile(configPath, @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
     <packageSourceMapping>
         <clear/>
@@ -76,8 +77,8 @@ namespace NuGet.Configuration.Test
 
             // Act & Assert
             var exception = Assert.Throws<NuGetConfigurationException>(
-                () => Settings.LoadSettingsGivenConfigPaths(new string[] { configPath1 }));
-            Assert.Equal("PackageSourceMapping is enabled, there are multiple package sources associated with the same key(s): dotnet, nuget.org", exception.Message);
+                () => Settings.LoadSettingsGivenConfigPaths(new string[] { configPath}));
+            Assert.Equal(string.Format(CultureInfo.CurrentCulture, "PackageSourceMapping is enabled and there are multiple package sources associated with the same key(s): dotnet, nuget.org. Path: {0}", configPath), exception.Message);
         }
 
         [Fact]

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceMappingProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceMappingProviderTests.cs
@@ -55,11 +55,20 @@ namespace NuGet.Configuration.Test
             SettingsTestUtils.CreateConfigurationFile(configPath1, @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
     <packageSourceMapping>
-        <packageSource key=""nuget.org"">
+        <packageSource key=""dotnet"">
             <package pattern=""stuff"" />
         </packageSource>
+        <packageSource key=""dotnet"">
+            <package pattern=""stuff1"" />
+        </packageSource>
         <packageSource key=""nuget.org"">
-            <package pattern=""stuff2"" />
+            <package pattern=""stuf2"" />
+        </packageSource>
+        <packageSource key=""nuget.org"">
+            <package pattern=""stuff3"" />
+        </packageSource>
+        <packageSource key=""source"">
+            <package pattern=""stuff4"" />
         </packageSource>
     </packageSourceMapping>
 </configuration>");
@@ -67,7 +76,7 @@ namespace NuGet.Configuration.Test
             // Act & Assert
             var exception = Assert.Throws<NuGetConfigurationException>(
                 () => Settings.LoadSettingsGivenConfigPaths(new string[] { configPath1 }));
-            Assert.Equal("Package source 'nuget.org' has already been defined previously.", exception.Message);
+            Assert.Equal("PackageSourceMapping is enabled, there are multiple package sources associated with the same key(s): dotnet, nuget.org", exception.Message);
         }
 
         [Fact]

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceMappingProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceMappingProviderTests.cs
@@ -47,7 +47,7 @@ namespace NuGet.Configuration.Test
         }
 
         [Fact]
-        public void GetPackageSourceMappingItems_WithOneConfig_WithDuplicateKeys_ReturnsCorrectPatterns()
+        public void GetPackageSourceMappingItems_WithOneConfig_WithDuplicateKeys_Throws()
         {
             // Arrange
             using var mockBaseDirectory = TestDirectory.Create();
@@ -64,22 +64,10 @@ namespace NuGet.Configuration.Test
     </packageSourceMapping>
 </configuration>");
 
-            var settings = Settings.LoadSettingsGivenConfigPaths(new string[] { configPath1 });
-
             // Act & Assert
-            var sourceMappingProvider = new PackageSourceMappingProvider(settings);
-            IReadOnlyList<PackageSourceMappingSourceItem> packageSourceMappingItems = sourceMappingProvider.GetPackageSourceMappingItems();
-            packageSourceMappingItems.Should().HaveCount(2);
-
-            var nugetOrgSourceItem = packageSourceMappingItems.First();
-            nugetOrgSourceItem.Key.Should().Be("nuget.org");
-            nugetOrgSourceItem.Patterns.Should().HaveCount(1);
-            nugetOrgSourceItem.Patterns.First().Pattern.Should().Be("stuff");
-
-            nugetOrgSourceItem = packageSourceMappingItems.Last();
-            nugetOrgSourceItem.Key.Should().Be("nuget.org");
-            nugetOrgSourceItem.Patterns.Should().HaveCount(1);
-            nugetOrgSourceItem.Patterns.First().Pattern.Should().Be("stuff2");
+            var exception = Assert.Throws<NuGetConfigurationException>(
+                () => Settings.LoadSettingsGivenConfigPaths(new string[] { configPath1 }));
+            Assert.Equal("Package source 'nuget.org' has already been defined previously.", exception.Message);
         }
 
         [Fact]


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11573

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
Added an Exception when a duplicate key is defined for packageSource when using PackageSourceMapping, this check is only for the same .config file, we won't be detecting duplicates across different configs


## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [ ] N/A
