### PR TITLE
Rewrite solution initialization with vs hierarchy

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
@@ -675,19 +675,17 @@ namespace NuGet.PackageManagement.VisualStudio
                 {
                     try
                     {
-                        var dte = await _dte.GetValueAsync();
-
-                        foreach (var project in await EnvDTESolutionUtility.GetAllEnvDTEProjectsAsync(dte))
+                        foreach (var hierarchy in await EnvDTESolutionUtility.GetAllProjectsAsync(await _asyncVSSolution.GetValueAsync()))
                         {
                             try
                             {
-                                var vsProjectAdapter = await _vsProjectAdapterProvider.CreateAdapterForFullyLoadedProjectAsync(project);
+                                var vsProjectAdapter = await _vsProjectAdapterProvider.CreateAdapterForFullyLoadedProjectAsync(hierarchy);
                                 await AddVsProjectAdapterToCacheAsync(vsProjectAdapter);
                             }
                             catch (Exception e)
                             {
                                 // Ignore failed projects.
-                                _logger.LogWarning($"The project {project.Name} failed to initialize as a NuGet project.");
+                                _logger.LogWarning($"The project {VsHierarchyUtility.GetProjectPath(hierarchy)} failed to initialize as a NuGet project.");
                                 _logger.LogError(e.ToString());
                             }
 
@@ -695,10 +693,6 @@ namespace NuGet.PackageManagement.VisualStudio
                             _cacheInitialized = true;
                         }
 
-                        foreach (var project in await EnvDTESolutionUtility.GetAllProjectsAsync(await _asyncVSSolution.GetValueAsync()))
-                        {
-
-                        }
                         await SetDefaultProjectNameAsync();
                     }
                     catch

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
@@ -675,7 +675,7 @@ namespace NuGet.PackageManagement.VisualStudio
                 {
                     try
                     {
-                        foreach (var hierarchy in await EnvDTESolutionUtility.GetAllProjectsAsync(await _asyncVSSolution.GetValueAsync()))
+                        foreach (var hierarchy in EnvDTESolutionUtility.GetAllProjects(await _asyncVSSolution.GetValueAsync()))
                         {
                             try
                             {

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
@@ -697,6 +697,7 @@ namespace NuGet.PackageManagement.VisualStudio
                                 _cacheInitialized = true;
                             }
                         }
+                        else
                         {
                             var dte = await _dte.GetValueAsync();
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
@@ -695,6 +695,10 @@ namespace NuGet.PackageManagement.VisualStudio
                             _cacheInitialized = true;
                         }
 
+                        foreach (var project in await EnvDTESolutionUtility.GetAllProjectsAsync(await _asyncVSSolution.GetValueAsync()))
+                        {
+
+                        }
                         await SetDefaultProjectNameAsync();
                     }
                     catch

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
@@ -465,12 +465,7 @@ namespace NuGet.PackageManagement.VisualStudio
         private static object GetVSSolutionProperty(IVsSolution vsSolution, int propId)
         {
             ThreadHelper.ThrowIfNotOnUIThread();
-
-            object value;
-            var hr = vsSolution.GetProperty(propId, out value);
-
-            ErrorHandler.ThrowOnFailure(hr);
-
+            ErrorHandler.ThrowOnFailure(vsSolution.GetProperty(propId, out object value));
             return value;
         }
 
@@ -675,7 +670,7 @@ namespace NuGet.PackageManagement.VisualStudio
                 {
                     try
                     {
-                        foreach (var hierarchy in EnvDTESolutionUtility.GetAllProjects(await _asyncVSSolution.GetValueAsync()))
+                        foreach (var hierarchy in VsHierarchyUtility.GetAllLoadedProjects(await _asyncVSSolution.GetValueAsync()))
                         {
                             try
                             {

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectServices/VsProjectBuildProperties.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectServices/VsProjectBuildProperties.cs
@@ -37,15 +37,14 @@ namespace NuGet.PackageManagement.VisualStudio
         }
 
         public VsProjectBuildProperties(
-            IVsHierarchy vsHierarchy,
-            Func<IVsHierarchy, EnvDTE.Project> loadDteProject,
+            Lazy<Project> project,
             IVsBuildPropertyStorage propertyStorage,
             IVsProjectThreadingService threadingService)
         {
-            Assumes.Present(loadDteProject);
+            Assumes.Present(project);
             Assumes.Present(threadingService);
 
-            _dteProject = new Lazy<EnvDTE.Project>(() => loadDteProject(vsHierarchy));
+            _dteProject = project;
             _propertyStorage = propertyStorage;
             _threadingService = threadingService;
         }

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/IVsProjectAdapterProvider.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/IVsProjectAdapterProvider.cs
@@ -22,7 +22,7 @@ namespace NuGet.PackageManagement.VisualStudio
         /// <summary>
         /// Creates a project adapter for fully loaded project represented by IVsHierarchy object.
         /// </summary>
-        /// <param name="hierarchy">Input project object</param>
+        /// <param name="hierarchy">Input hierarchy object</param>
         /// <returns>New instance of project adapter encapsulating hierarchy project.</returns>
         Task<IVsProjectAdapter> CreateAdapterForFullyLoadedProjectAsync(IVsHierarchy hierarchy);
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/IVsProjectAdapterProvider.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/IVsProjectAdapterProvider.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
+using Microsoft.VisualStudio.Shell.Interop;
 using NuGet.VisualStudio;
 
 namespace NuGet.PackageManagement.VisualStudio
@@ -17,6 +18,13 @@ namespace NuGet.PackageManagement.VisualStudio
         /// <param name="dteProject">Input project object</param>
         /// <returns>New instance of project adapter encapsulating DTE project.</returns>
         Task<IVsProjectAdapter> CreateAdapterForFullyLoadedProjectAsync(EnvDTE.Project dteProject);
+
+        /// <summary>
+        /// Creates a project adapter for fully loaded project represented by IVsHierarchy object.
+        /// </summary>
+        /// <param name="hierarchy">Input project object</param>
+        /// <returns>New instance of project adapter encapsulating hierarchy project.</returns>
+        Task<IVsProjectAdapter> CreateAdapterForFullyLoadedProjectAsync(IVsHierarchy hierarchy);
 
         /// <summary>
         /// Creates a project adapter for fully loaded project represented by DTE object.

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/VsProjectAdapter.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/VsProjectAdapter.cs
@@ -142,9 +142,11 @@ namespace NuGet.PackageManagement.VisualStudio
 
         #region Getters
 
-        public Task<string[]> GetProjectTypeGuidsAsync()
+        public async Task<string[]> GetProjectTypeGuidsAsync()
         {
-            return Project.GetProjectTypeGuidsAsync();
+            await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+            return VsHierarchyUtility.GetProjectTypeGuids(VsHierarchy, Project.Kind);
         }
 
         public async Task<FrameworkName> GetDotNetFrameworkNameAsync()

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/VsProjectAdapter.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/VsProjectAdapter.cs
@@ -12,7 +12,6 @@ using Microsoft;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using NuGet.Commands;
-using NuGet.Common;
 using NuGet.Frameworks;
 using NuGet.ProjectManagement;
 using NuGet.RuntimeModel;

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/VsProjectAdapter.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/VsProjectAdapter.cs
@@ -28,7 +28,6 @@ namespace NuGet.PackageManagement.VisualStudio
         private readonly VsHierarchyItem _vsHierarchyItem;
         private readonly Lazy<EnvDTE.Project> _dteProject;
         private readonly IVsProjectThreadingService _threadingService;
-        private readonly string _projectTypeGuid;
 
         #endregion Private members
 
@@ -126,7 +125,6 @@ namespace NuGet.PackageManagement.VisualStudio
             VsHierarchyItem vsHierarchyItem,
             ProjectNames projectNames,
             string fullProjectPath,
-            string projectTypeGuid,
             Func<IVsHierarchy, EnvDTE.Project> loadDteProject,
             IProjectBuildProperties buildProperties,
             IVsProjectThreadingService threadingService)
@@ -136,8 +134,6 @@ namespace NuGet.PackageManagement.VisualStudio
             _vsHierarchyItem = vsHierarchyItem;
             _dteProject = new Lazy<EnvDTE.Project>(() => loadDteProject(_vsHierarchyItem.VsHierarchy));
             _threadingService = threadingService;
-            _projectTypeGuid = projectTypeGuid;
-
             FullProjectPath = fullProjectPath;
             ProjectNames = projectNames;
             BuildProperties = buildProperties;

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/VsProjectAdapterProvider.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/VsProjectAdapterProvider.cs
@@ -72,7 +72,6 @@ namespace NuGet.PackageManagement.VisualStudio
                 vsHierarchyItem,
                 projectNames,
                 fullProjectPath,
-                dteProject.Kind,
                 loadDteProject,
                 vsBuildProperties,
                 _threadingService);
@@ -97,15 +96,12 @@ namespace NuGet.PackageManagement.VisualStudio
                 hierarchy, loadDteProject, buildStorageProperty, _threadingService);
 
             var fullProjectPath = VsHierarchyUtility.GetProjectPath(hierarchy);
-
-            //hierarchy.GetProperty(0, (int)__VSHPROPID.VSHPROPID_TypeGuid, out object kind);
             var projectNames = await ProjectNames.FromIVsSolution2(fullProjectPath, vsSolution, CancellationToken.None);
 
             return new VsProjectAdapter(
                 vsHierarchyItem,
                 projectNames,
                 fullProjectPath,
-                string.Empty,
                 loadDteProject,
                 vsBuildProperties,
                 _threadingService);

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/VsProjectAdapterProvider.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/VsProjectAdapterProvider.cs
@@ -76,5 +76,11 @@ namespace NuGet.PackageManagement.VisualStudio
                 vsBuildProperties,
                 _threadingService);
         }
+
+        public Task<IVsProjectAdapter> CreateAdapterForFullyLoadedProjectAsync(IVsHierarchy hierarchy)
+        {
+            // TODO NK - Create a hierarchy equivalent of the DTE.
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/VsProjectAdapterProvider.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/VsProjectAdapterProvider.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.ComponentModel.Composition;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft;
 using Microsoft.VisualStudio.Shell;
@@ -17,7 +18,7 @@ namespace NuGet.PackageManagement.VisualStudio
     internal class VsProjectAdapterProvider : IVsProjectAdapterProvider
     {
         private readonly IVsProjectThreadingService _threadingService;
-        private readonly AsyncLazy<SVsSolution> _vsSolution;
+        private readonly AsyncLazy<IVsSolution2> _vsSolution;
 
         [ImportingConstructor]
         public VsProjectAdapterProvider(
@@ -26,13 +27,13 @@ namespace NuGet.PackageManagement.VisualStudio
             IVsProjectThreadingService threadingService)
             : this(
                   threadingService,
-                  new AsyncLazy<SVsSolution>(() => serviceProvider.GetServiceAsync<SVsSolution, SVsSolution>(throwOnFailure: false), threadingService.JoinableTaskFactory))
+                  new AsyncLazy<IVsSolution2>(() => serviceProvider.GetServiceAsync<SVsSolution, IVsSolution2>(throwOnFailure: false), threadingService.JoinableTaskFactory))
         {
         }
 
         internal VsProjectAdapterProvider(
             IVsProjectThreadingService threadingService,
-            AsyncLazy<SVsSolution> vsSolution)
+            AsyncLazy<IVsSolution2> vsSolution)
         {
             Assumes.Present(threadingService);
             Assumes.Present(vsSolution);
@@ -64,7 +65,7 @@ namespace NuGet.PackageManagement.VisualStudio
             var vsBuildProperties = new VsProjectBuildProperties(
                 dteProject, buildStorageProperty, _threadingService);
 
-            var projectNames = await ProjectNames.FromDTEProjectAsync(dteProject, vsSolution);
+            var projectNames = await ProjectNames.FromDTEProjectAsync(dteProject, (SVsSolution)vsSolution);
             var fullProjectPath = dteProject.GetFullProjectPath();
 
             return new VsProjectAdapter(
@@ -77,10 +78,37 @@ namespace NuGet.PackageManagement.VisualStudio
                 _threadingService);
         }
 
-        public Task<IVsProjectAdapter> CreateAdapterForFullyLoadedProjectAsync(IVsHierarchy hierarchy)
+        public async Task<IVsProjectAdapter> CreateAdapterForFullyLoadedProjectAsync(IVsHierarchy hierarchy)
         {
-            // TODO NK - Create a hierarchy equivalent of the DTE.
-            throw new NotImplementedException();
+            Assumes.Present(hierarchy);
+
+            // Get services while we might be on background thread
+            var vsSolution = await _vsSolution.GetValueAsync();
+
+            // switch to main thread and use services we know must be done on main thread.
+            await _threadingService.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+            var vsHierarchyItem = VsHierarchyItem.FromVsHierarchy(hierarchy);
+
+            Func<IVsHierarchy, EnvDTE.Project> loadDteProject = hierarchy => VsHierarchyUtility.GetProjectFromHierarchy(hierarchy);
+
+            var buildStorageProperty = vsHierarchyItem.VsHierarchy as IVsBuildPropertyStorage;
+            var vsBuildProperties = new VsProjectBuildProperties(
+                hierarchy, loadDteProject, buildStorageProperty, _threadingService);
+
+            var fullProjectPath = VsHierarchyUtility.GetProjectPath(hierarchy);
+
+            //hierarchy.GetProperty(0, (int)__VSHPROPID.VSHPROPID_TypeGuid, out object kind);
+            var projectNames = await ProjectNames.FromIVsSolution2(fullProjectPath, vsSolution, CancellationToken.None);
+
+            return new VsProjectAdapter(
+                vsHierarchyItem,
+                projectNames,
+                fullProjectPath,
+                string.Empty,
+                loadDteProject,
+                vsBuildProperties,
+                _threadingService);
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Utility/EnvDTEProjectUtility.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Utility/EnvDTEProjectUtility.cs
@@ -391,25 +391,14 @@ namespace NuGet.PackageManagement.VisualStudio
         public static async Task<bool> IsSupportedAsync(EnvDTE.Project envDTEProject)
         {
             Assumes.Present(envDTEProject);
-
-            if (await IsProjectCapabilityCompliantAsync(envDTEProject))
+            await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            var hierarchy = await envDTEProject.ToVsHierarchyAsync();
+            if (VsHierarchyUtility.IsProjectCapabilityCompliant(hierarchy))
             {
                 return true;
             }
 
-            await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-
-            return envDTEProject.Kind != null && ProjectType.IsSupported(envDTEProject.Kind) && !await HasUnsupportedProjectCapabilityAsync(envDTEProject);
-        }
-
-        private static async Task<bool> IsProjectCapabilityCompliantAsync(EnvDTE.Project envDTEProject)
-        {
-            Debug.Assert(envDTEProject != null);
-
-            await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-
-            var hierarchy = await envDTEProject.ToVsHierarchyAsync();
-            return VsHierarchyUtility.IsProjectCapabilityCompliant(hierarchy);
+            return envDTEProject.Kind != null && ProjectType.IsSupported(envDTEProject.Kind) && !VsHierarchyUtility.HasUnsupportedProjectCapability(hierarchy);
         }
 
         public async static Task<NuGetProject> GetNuGetProjectAsync(EnvDTE.Project project, ISolutionManager solutionManager)

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Utility/EnvDTESolutionUtility.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Utility/EnvDTESolutionUtility.cs
@@ -5,63 +5,12 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft;
-using Microsoft.VisualStudio;
-using Microsoft.VisualStudio.Shell;
-using Microsoft.VisualStudio.Shell.Interop;
 using NuGet.VisualStudio;
 
 namespace NuGet.PackageManagement.VisualStudio
 {
     public static class EnvDTESolutionUtility
     {
-        public static IEnumerable<IVsHierarchy> GetAllProjects(IVsSolution vsSolution)
-        {
-            Assumes.NotNull(vsSolution);
-            ThreadHelper.ThrowIfNotOnUIThread();
-
-            if (!IsSolutionOpen(vsSolution))
-            {
-                return Enumerable.Empty<IVsHierarchy>();
-            }
-
-            var compatibleProjectHierarchies = new List<IVsHierarchy>();
-
-            var hr = vsSolution.GetProjectEnum((uint)__VSENUMPROJFLAGS.EPF_LOADEDINSOLUTION, Guid.Empty, out IEnumHierarchies ppenum);
-            // EPF_LOADEDINSOLUTION instead maybe? EPF_ALLPROJECTS
-            ErrorHandler.ThrowOnFailure(hr);
-
-            IVsHierarchy[] hierarchies = new IVsHierarchy[1];
-            while ((ppenum.Next((uint)hierarchies.Length, hierarchies, out uint fetched) == VSConstants.S_OK) && (fetched == (uint)hierarchies.Length))
-            {
-                var hierarchy = hierarchies[0];
-                if (VsHierarchyUtility.IsNuGetSupported(hierarchy))
-                {
-                    compatibleProjectHierarchies.Add(hierarchy);
-                }
-            }
-
-            return compatibleProjectHierarchies;
-        }
-
-        private static bool IsSolutionOpen(IVsSolution vsSolution)
-        {
-            ThreadHelper.ThrowIfNotOnUIThread();
-            return (bool)GetVSSolutionProperty(vsSolution, (int)__VSPROPID.VSPROPID_IsSolutionOpen);
-        }
-
-        private static object GetVSSolutionProperty(IVsSolution vsSolution, int propId)
-        {
-            ThreadHelper.ThrowIfNotOnUIThread();
-
-            object value;
-            var hr = vsSolution.GetProperty(propId, out value);
-
-            ErrorHandler.ThrowOnFailure(hr);
-
-            return value;
-        }
-
         public static async Task<IEnumerable<EnvDTE.Project>> GetAllEnvDTEProjectsAsync(EnvDTE.DTE dte)
         {
             await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Utility/EnvDTESolutionUtility.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Utility/EnvDTESolutionUtility.cs
@@ -20,7 +20,7 @@ namespace NuGet.PackageManagement.VisualStudio
             Assumes.NotNull(vsSolution);
             await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
-            if (!IsSolutionOpenFromVSSolution(vsSolution))
+            if (!IsSolutionOpen(vsSolution))
             {
                 return Enumerable.Empty<IVsHierarchy>();
             }
@@ -44,6 +44,12 @@ namespace NuGet.PackageManagement.VisualStudio
             return compatibleProjectHierarchies;
         }
 
+        private static bool IsSolutionOpen(IVsSolution vsSolution)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+            return (bool)GetVSSolutionProperty(vsSolution, (int)__VSPROPID.VSPROPID_IsSolutionOpen);
+        }
+
         private static object GetVSSolutionProperty(IVsSolution vsSolution, int propId)
         {
             ThreadHelper.ThrowIfNotOnUIThread();
@@ -54,12 +60,6 @@ namespace NuGet.PackageManagement.VisualStudio
             ErrorHandler.ThrowOnFailure(hr);
 
             return value;
-        }
-
-        private static bool IsSolutionOpenFromVSSolution(IVsSolution vsSolution)
-        {
-            ThreadHelper.ThrowIfNotOnUIThread();
-            return (bool)GetVSSolutionProperty(vsSolution, (int)__VSPROPID.VSPROPID_IsSolutionOpen);
         }
 
         public static async Task<IEnumerable<EnvDTE.Project>> GetAllEnvDTEProjectsAsync(EnvDTE.DTE dte)

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Utility/EnvDTESolutionUtility.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Utility/EnvDTESolutionUtility.cs
@@ -80,7 +80,7 @@ namespace NuGet.PackageManagement.VisualStudio
                 {
                     envDTEProjects.Push(envDTEProject);
                 }
-            } // Can we check this using a hierarchy?
+            }
 
             var resultantEnvDTEProjects = new List<EnvDTE.Project>();
             while (envDTEProjects.Any())
@@ -90,6 +90,11 @@ namespace NuGet.PackageManagement.VisualStudio
                 if (await EnvDTEProjectUtility.IsSupportedAsync(envDTEProject))
                 {
                     resultantEnvDTEProjects.Add(envDTEProject);
+                }
+                else if (EnvDTEProjectUtility.IsExplicitlyUnsupported(envDTEProject))
+                {
+                    // do not drill down further if this project is explicitly unsupported, e.g. LightSwitch projects
+                    continue;
                 }
 
                 EnvDTE.ProjectItems envDTEProjectItems = null;

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Utility/EnvDTESolutionUtility.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Utility/EnvDTESolutionUtility.cs
@@ -15,10 +15,10 @@ namespace NuGet.PackageManagement.VisualStudio
 {
     public static class EnvDTESolutionUtility
     {
-        public static async Task<IEnumerable<IVsHierarchy>> GetAllProjectsAsync(IVsSolution vsSolution)
+        public static IEnumerable<IVsHierarchy> GetAllProjects(IVsSolution vsSolution)
         {
             Assumes.NotNull(vsSolution);
-            await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            ThreadHelper.ThrowIfNotOnUIThread();
 
             if (!IsSolutionOpen(vsSolution))
             {
@@ -27,8 +27,8 @@ namespace NuGet.PackageManagement.VisualStudio
 
             var compatibleProjectHierarchies = new List<IVsHierarchy>();
 
-            var hr = vsSolution.GetProjectEnum((uint)__VSENUMPROJFLAGS.EPF_ALLPROJECTS, Guid.Empty, out IEnumHierarchies ppenum);
-            // EPF_LOADEDINSOLUTION instead maybe?
+            var hr = vsSolution.GetProjectEnum((uint)__VSENUMPROJFLAGS.EPF_LOADEDINSOLUTION, Guid.Empty, out IEnumHierarchies ppenum);
+            // EPF_LOADEDINSOLUTION instead maybe? EPF_ALLPROJECTS
             ErrorHandler.ThrowOnFailure(hr);
 
             IVsHierarchy[] hierarchies = new IVsHierarchy[1];

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/IDE/VsHierarchyUtility.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/IDE/VsHierarchyUtility.cs
@@ -31,21 +31,13 @@ namespace NuGet.VisualStudio
         public static bool IsSupportedByGuid(IVsHierarchy hierarchy)
         {
             ThreadHelper.ThrowIfNotOnUIThread();
-
-            var guids = GetProjectTypeGuids(hierarchy);
-
-            if (guids != null)
+            ErrorHandler.ThrowOnFailure(hierarchy.GetGuidProperty(VSConstants.VSITEMID_ROOT, (int)__VSHPROPID.VSHPROPID_TypeGuid, out Guid pguid));
+            var guid = pguid.ToString("B");
+            if (ProjectType.IsUnsupported(guid) || !ProjectType.IsSupported(guid))
             {
-                foreach (var guid in guids) // A project is supported only if all guids are supported.
-                {
-                    if (ProjectType.IsUnsupported(guid) || !ProjectType.IsSupported(guid))
-                    {
-                        return false;
-                    }
-                }
-                return true;
+                return false;
             }
-            return false;
+            return true;
         }
 
         public static bool IsNuGetSupported(IVsHierarchy hierarchy)

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/IDE/VsHierarchyUtility.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/IDE/VsHierarchyUtility.cs
@@ -24,7 +24,7 @@ namespace NuGet.VisualStudio
         {
             ThreadHelper.ThrowIfNotOnUIThread();
 
-            project.GetCanonicalName(VSConstants.VSITEMID_ROOT, out string projectPath);
+            project.GetCanonicalName((uint)VSConstants.VSITEMID.Root, out string projectPath); // Here we are getting a directory instead of a path. Why? How can we get the project?
             return projectPath;
         }
 

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/IDE/VsHierarchyUtility.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/IDE/VsHierarchyUtility.cs
@@ -23,7 +23,8 @@ namespace NuGet.VisualStudio
         public static string GetProjectPath(IVsHierarchy project)
         {
             ThreadHelper.ThrowIfNotOnUIThread();
-            project.GetCanonicalName((uint)VSConstants.VSITEMID.Root, out string projectPath); // Here we are getting a directory instead of a path. Why? How can we get the project?
+            var format = project as IPersistFileFormat;
+            format.GetCurFile(out string projectPath, out uint _);
             return projectPath;
         }
 

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/IDE/VsHierarchyUtility.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/IDE/VsHierarchyUtility.cs
@@ -23,7 +23,7 @@ namespace NuGet.VisualStudio
         public static string GetProjectPath(IVsHierarchy project)
         {
             ThreadHelper.ThrowIfNotOnUIThread();
-            var format = project as IPersistFileFormat;
+            var format = (IPersistFileFormat)project;
             format.GetCurFile(out string projectPath, out uint _);
             return projectPath;
         }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/IDE/VsHierarchyUtility.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/IDE/VsHierarchyUtility.cs
@@ -34,7 +34,7 @@ namespace NuGet.VisualStudio
 
             var guids = GetProjectTypeGuids(hierarchy);
 
-            foreach (var guid in guids)
+            foreach (var guid in guids) // How do we handle this? Can we have multiple guids here?
             {
                 if (ProjectType.IsUnsupported(guid))
                 {
@@ -55,19 +55,7 @@ namespace NuGet.VisualStudio
             {
                 return true;
             }
-            return IsSupportedByGuid(hierarchy) && HasUnsupportedProjectCapability(hierarchy);
-        }
-
-        public static bool IsSupported(IVsHierarchy hierarchy, string projectTypeGuid)
-        {
-            ThreadHelper.ThrowIfNotOnUIThread();
-
-            if (IsProjectCapabilityCompliant(hierarchy))
-            {
-                return true;
-            }
-
-            return !string.IsNullOrEmpty(projectTypeGuid) && ProjectType.IsSupported(projectTypeGuid) && !HasUnsupportedProjectCapability(hierarchy);
+            return IsSupportedByGuid(hierarchy) && !HasUnsupportedProjectCapability(hierarchy);
         }
 
         /// <summary>Check if this project appears to support NuGet.</summary>

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/IDE/VsHierarchyUtility.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/IDE/VsHierarchyUtility.cs
@@ -11,7 +11,6 @@ using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.ProjectSystem;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
-using NuGet.VisualStudio.Common;
 using Task = System.Threading.Tasks.Task;
 using TaskExpandedNodes = System.Threading.Tasks.Task<System.Collections.Generic.IDictionary<string, System.Collections.Generic.ISet<NuGet.VisualStudio.VsHierarchyItem>>>;
 
@@ -35,16 +34,16 @@ namespace NuGet.VisualStudio
 
             var guids = GetProjectTypeGuids(hierarchy);
 
-            foreach (var guid in guids) // TODO NK - How are we supposed to handle the multiple guid scenario?
+            if (guids != null)
             {
-                if (ProjectType.IsUnsupported(guid))
+                foreach (var guid in guids) // A project is supported only if all guids are supported.
                 {
-                    return false;
+                    if (ProjectType.IsUnsupported(guid) || !ProjectType.IsSupported(guid))
+                    {
+                        return false;
+                    }
                 }
-                if (ProjectType.IsSupported(guid))
-                {
-                    return true;
-                }
+                return true;
             }
             return false;
         }
@@ -155,7 +154,7 @@ namespace NuGet.VisualStudio
 
         public static async Task CollapseAllNodesAsync(IDictionary<string, ISet<VsHierarchyItem>> ignoreNodes)
         {
-            Verify.ArgumentIsNotNull(ignoreNodes, nameof(ignoreNodes));
+            Common.Verify.ArgumentIsNotNull(ignoreNodes, nameof(ignoreNodes));
 
             await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/IDE/VsHierarchyUtility.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/IDE/VsHierarchyUtility.cs
@@ -23,7 +23,6 @@ namespace NuGet.VisualStudio
         public static string GetProjectPath(IVsHierarchy project)
         {
             ThreadHelper.ThrowIfNotOnUIThread();
-
             project.GetCanonicalName((uint)VSConstants.VSITEMID.Root, out string projectPath); // Here we are getting a directory instead of a path. Why? How can we get the project?
             return projectPath;
         }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/IDE/VsHierarchyUtility.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/IDE/VsHierarchyUtility.cs
@@ -173,15 +173,16 @@ namespace NuGet.VisualStudio
             }
         }
 
+        /// <summary>
+        /// Gets all the hierarchies of all the NuGet compatible projects
+        /// </summary>
+        /// <param name="vsSolution">The VS Solution instance. Must not be <see cref="null"/>. </param>
+        /// <returns>Hierarchies of the NuGet compatible projects</returns>
+        /// <remarks>This method assumes the solution is open.</remarks>
         public static List<IVsHierarchy> GetAllLoadedProjects(IVsSolution vsSolution)
         {
             Assumes.NotNull(vsSolution);
             ThreadHelper.ThrowIfNotOnUIThread();
-
-            if (!IsSolutionOpen(vsSolution))
-            {
-                return new List<IVsHierarchy>();
-            }
 
             var compatibleProjectHierarchies = new List<IVsHierarchy>();
 
@@ -199,19 +200,6 @@ namespace NuGet.VisualStudio
             }
 
             return compatibleProjectHierarchies;
-        }
-
-        private static bool IsSolutionOpen(IVsSolution vsSolution)
-        {
-            ThreadHelper.ThrowIfNotOnUIThread();
-            return (bool)GetVSSolutionProperty(vsSolution, (int)__VSPROPID.VSPROPID_IsSolutionOpen);
-        }
-
-        private static object GetVSSolutionProperty(IVsSolution vsSolution, int propId)
-        {
-            ThreadHelper.ThrowIfNotOnUIThread();
-            ErrorHandler.ThrowOnFailure(vsSolution.GetProperty(propId, out object value));
-            return value;
         }
 
         private static async Task<ICollection<VsHierarchyItem>> GetExpandedProjectHierarchyItemsAsync(EnvDTE.Project project)

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/IDE/VsHierarchyUtility.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/IDE/VsHierarchyUtility.cs
@@ -28,6 +28,36 @@ namespace NuGet.VisualStudio
             return projectPath;
         }
 
+        public static bool IsSupportedByGuid(IVsHierarchy hierarchy)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            var guids = GetProjectTypeGuids(hierarchy);
+
+            foreach (var guid in guids)
+            {
+                if (ProjectType.IsUnsupported(guid))
+                {
+                    return false;
+                }
+                if (ProjectType.IsSupported(guid))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        public static bool IsNuGetSupported(IVsHierarchy hierarchy)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+            if (IsProjectCapabilityCompliant(hierarchy))
+            {
+                return true;
+            }
+            return IsSupportedByGuid(hierarchy) && HasUnsupportedProjectCapability(hierarchy);
+        }
+
         public static bool IsSupported(IVsHierarchy hierarchy, string projectTypeGuid)
         {
             ThreadHelper.ThrowIfNotOnUIThread();

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/ProjectSystems/ProjectNames.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/ProjectSystems/ProjectNames.cs
@@ -185,7 +185,7 @@ namespace NuGet.VisualStudio
 
             cancellationToken.ThrowIfCancellationRequested();
 
-            ErrorHandler.ThrowOnFailure(vsSolution2.GetProjectOfUniqueName(fullPath, out IVsHierarchy project));
+            ErrorHandler.ThrowOnFailure(vsSolution2.GetProjectOfUniqueName(fullPath, out IVsHierarchy project)); // TODO NK - We have the hierarchy here.
             ErrorHandler.ThrowOnFailure(vsSolution2.GetGuidOfProject(project, out Guid guid));
             ErrorHandler.ThrowOnFailure(vsSolution2.GetUniqueNameOfProject(project, out string uniqueName));
             ErrorHandler.ThrowOnFailure(project.GetProperty((uint)VSConstants.VSITEMID.Root, (int)__VSHPROPID.VSHPROPID_Name, out object projectNameObject));

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/ProjectSystems/ProjectNames.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/ProjectSystems/ProjectNames.cs
@@ -179,13 +179,11 @@ namespace NuGet.VisualStudio
         /// <param name="vsSolution2">Instance of <see cref="IVsSolution2"/></param>
         /// <param name="cancellationToken">The cancellation token to cancel operation</param>
         /// <returns></returns>
-        public static async Task<ProjectNames> FromIVsSolution2(string fullPath, IVsSolution2 vsSolution2, CancellationToken cancellationToken)
+        public static async Task<ProjectNames> FromIVsSolution2(string fullPath, IVsSolution2 vsSolution2, IVsHierarchy project, CancellationToken cancellationToken)
         {
             await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
 
             cancellationToken.ThrowIfCancellationRequested();
-
-            ErrorHandler.ThrowOnFailure(vsSolution2.GetProjectOfUniqueName(fullPath, out IVsHierarchy project)); // TODO NK - We have the hierarchy here.
             ErrorHandler.ThrowOnFailure(vsSolution2.GetGuidOfProject(project, out Guid guid));
             ErrorHandler.ThrowOnFailure(vsSolution2.GetUniqueNameOfProject(project, out string uniqueName));
             ErrorHandler.ThrowOnFailure(project.GetProperty((uint)VSConstants.VSITEMID.Root, (int)__VSHPROPID.VSHPROPID_Name, out object projectNameObject));
@@ -200,6 +198,13 @@ namespace NuGet.VisualStudio
                 projectId: guid.ToString());
 
             return projectNames;
+        }
+
+        public static async Task<ProjectNames> FromIVsSolution2(string fullPath, IVsSolution2 vsSolution2, CancellationToken cancellationToken)
+        {
+            await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+            ErrorHandler.ThrowOnFailure(vsSolution2.GetProjectOfUniqueName(fullPath, out IVsHierarchy project));
+            return await FromIVsSolution2(fullPath, vsSolution2, project, cancellationToken);
         }
 
         private static string GetCustomUniqueName(IVsHierarchy project)

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Services/NuGetFeatureFlagConstants.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Services/NuGetFeatureFlagConstants.cs
@@ -31,5 +31,6 @@ namespace NuGet.VisualStudio
         internal bool DefaultState { get; }
 
         public static readonly NuGetFeatureFlagConstants BulkRestoreCoordination = new("NuGet.BulkRestoreCoordination", "NUGET_BULK_RESTORE_COORDINATION", defaultState: true);
+        public static readonly NuGetFeatureFlagConstants NuGetSolutionCacheInitilization = new("NuGet.SolutionCacheInitialization", "NUGET_SOLUTION_CACHE_INITIALIZATION", defaultState: true);
     }
 }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1701

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

NuGet currently uses the DTE to get all the projects in the solution. Currently that involves a lot of conversions into IVsHierarchy. Sometimes more than once per check. This PR cleans up some of those unnecessary conversions in the GetAllEnvDTEProjectsAsync method and attempts to use IVsHierarchy as often as possible. 

- Switch from using `DTE.Solution` to `IVsSolution` to enumerate the projects. 
- In VSProjectBuildProperties, the initialization is usually done with a Project as a fallback for reading properties. To avoid actively using the DTE project, we have a different constructor that lazily uses the DTE project instead. 
- VSProjectAdapter had a guid field that wasn't being used. I removed that.
- I did deconstruct some extra async calls as they were unnecessary (only called from the UI thread anyways).
- When checking IsSupportedAsync for the DTE.Project, I reduced the number of DTE.Project to IVsHierarchy conversions to 1 exactly.
- The biggest complexity/risk is with the compatible check, rewriting it from DTE to IVsHierarchy 
  - IsSupportedAsync
     - VsHierarchyUtility.IsProjectCapabilityCompliant - runs on IVsHierarchy
     - envDTEProject.Kind != null && ProjectType.IsSupported(envDTEProject.Kind) - Runs on Project.
       - Replaced DTE.Project.Kind with VsHierarchyUtility.GetProjectTypeGuids 
     - VsHierarchyUtility.HasUnsupportedProjectCapability - runs on IVsHierarchy
     - I also added a utility method in ProjectNames so we don't have to lookup the hierarchy again.
- I have also made this feature flag toggleable. I want to be able to revert things without a code change in case I have an oversight. I have not added this feature flag in the vs repo yet. I'll do that once I confirm these changes have been approved.
 
Final notes:
* Not everything is being addressed here. There's a bunch of async that's unnecessary that can be cleaned up, but I'm trying to keep the changesets manageable. There will be more changes in this area.
* This doesn't mean `Project` won't be used during any project initialization. There are still a few places where we stll use Project. Similarly, future work can remove that.

@davkean , I'd appreciate your review. A few specific points I'd love your thoughts on.
- Is the IVsSolution project enum walk correct for all projects in VS? Any risk of double counting/special project types that I should be checking for in addition to what we have there? 
- DTE.Kind vs [GetProjectTypeGuids] (https://github.com/NuGet/NuGet.Client/blob/941658a56df18fb4307e2a4ebce575c4cb8ced35/src/NuGet.Clients/NuGet.VisualStudio.Common/IDE/VsHierarchyUtility.cs#L83-L103) Are these methods equivalent? Do you know if the GetProjectTypeGuids can return multiple different guids?
Right now, I assume that if one of the guids is not compatible, the full project is, but I haven't yet found a project that returns multiple guids there. 



## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception - This is a area that's in general pretty difficult to test. End to end did catch many of bugs during the implementation phase. 
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
