### PR TITLE
dotnet add package cli support for cpm projects

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommandRunner.cs
@@ -57,7 +57,7 @@ namespace NuGet.CommandLine.XPlat
                         typeConstraint: LibraryDependencyTarget.Package)
                 };
 
-                msBuild.AddPackageReference(packageReferenceArgs.ProjectPath, libraryDependency, packageReferenceArgs.PackageVersion);
+                msBuild.AddPackageReference(packageReferenceArgs.ProjectPath, libraryDependency, packageReferenceArgs.NoVersion);
                 return 0;
             }
 
@@ -219,7 +219,7 @@ namespace NuGet.CommandLine.XPlat
                 // generate a library dependency with all the metadata like Include, Exlude and SuppressParent
                 var libraryDependency = GenerateLibraryDependency(updatedPackageSpec, packageReferenceArgs, restorePreviewResult, userSpecifiedFrameworks, packageDependency);
 
-                msBuild.AddPackageReference(packageReferenceArgs.ProjectPath, libraryDependency, packageReferenceArgs.PackageVersion);
+                msBuild.AddPackageReference(packageReferenceArgs.ProjectPath, libraryDependency, packageReferenceArgs.NoVersion);
             }
             else
             {
@@ -240,7 +240,7 @@ namespace NuGet.CommandLine.XPlat
                 msBuild.AddPackageReferencePerTFM(packageReferenceArgs.ProjectPath,
                     libraryDependency,
                     compatibleOriginalFrameworks,
-                    packageReferenceArgs.PackageVersion);
+                    packageReferenceArgs.NoVersion);
             }
 
             // 6. Commit restore result

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommandRunner.cs
@@ -276,6 +276,9 @@ namespace NuGet.CommandLine.XPlat
             // update default packages path if user specified custom package directory
             var packagesPath = project.RestoreMetadata.PackagesPath;
 
+            // get if the project is onboarded to CPM
+            var isCentralPackageManagementEnabled = project.RestoreMetadata.CentralPackageVersionsEnabled;
+
             if (!string.IsNullOrEmpty(packageReferenceArgs.PackageDirectory))
             {
                 packagesPath = packageReferenceArgs.PackageDirectory;
@@ -314,6 +317,7 @@ namespace NuGet.CommandLine.XPlat
                     if (dependency != null)
                     {
                         dependency.LibraryRange.VersionRange = version;
+                        dependency.VersionCentrallyManaged = isCentralPackageManagementEnabled;
                         return dependency;
                     }
                 }
@@ -324,7 +328,8 @@ namespace NuGet.CommandLine.XPlat
                 LibraryRange = new LibraryRange(
                     name: packageReferenceArgs.PackageId,
                     versionRange: version,
-                    typeConstraint: LibraryDependencyTarget.Package)
+                    typeConstraint: LibraryDependencyTarget.Package),
+                VersionCentrallyManaged = isCentralPackageManagementEnabled
             };
         }
 

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommandRunner.cs
@@ -57,7 +57,7 @@ namespace NuGet.CommandLine.XPlat
                         typeConstraint: LibraryDependencyTarget.Package)
                 };
 
-                msBuild.AddPackageReference(packageReferenceArgs.ProjectPath, libraryDependency);
+                msBuild.AddPackageReference(packageReferenceArgs.ProjectPath, libraryDependency, packageReferenceArgs.PackageVersion);
                 return 0;
             }
 
@@ -219,7 +219,7 @@ namespace NuGet.CommandLine.XPlat
                 // generate a library dependency with all the metadata like Include, Exlude and SuppressParent
                 var libraryDependency = GenerateLibraryDependency(updatedPackageSpec, packageReferenceArgs, restorePreviewResult, userSpecifiedFrameworks, packageDependency);
 
-                msBuild.AddPackageReference(packageReferenceArgs.ProjectPath, libraryDependency);
+                msBuild.AddPackageReference(packageReferenceArgs.ProjectPath, libraryDependency, packageReferenceArgs.PackageVersion);
             }
             else
             {
@@ -239,7 +239,8 @@ namespace NuGet.CommandLine.XPlat
 
                 msBuild.AddPackageReferencePerTFM(packageReferenceArgs.ProjectPath,
                     libraryDependency,
-                    compatibleOriginalFrameworks);
+                    compatibleOriginalFrameworks,
+                    packageReferenceArgs.PackageVersion);
             }
 
             // 6. Commit restore result

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
@@ -511,6 +511,15 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to PackageReference for package &apos;{0}&apos; added to &apos;{1}&apos; and PackageVersion added to central package management file &apos;{2}&apos;..
+        /// </summary>
+        internal static string Info_AddPkgCPM {
+            get {
+                return ResourceManager.GetString("Info_AddPkgCPM", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to PackageReference for package &apos;{0}&apos; version &apos;{1}&apos; updated in file &apos;{2}&apos;..
         /// </summary>
         internal static string Info_AddPkgUpdated {

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
@@ -755,7 +755,6 @@ Non-HTTPS access will be removed in a future version. Consider migrating to 'HTT
   </data>
   <data name="Info_AddPkgCPM" xml:space="preserve">
     <value>PackageReference for package '{0}' added to '{1}' and PackageVersion added to central package management file '{2}'.</value>
-    <comment>[2:19 PM] Kartheek Penagamuri
-0 - The package ID. 1 - Directory.Packages.props file path. 2 - Project file path.</comment>
+    <comment>0 - The package ID. 1 - Directory.Packages.props file path. 2 - Project file path.</comment>
   </data>
 </root>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
@@ -753,4 +753,9 @@ The search is a case-insensitive string comparison using the supplied value, whi
 Non-HTTPS access will be removed in a future version. Consider migrating to 'HTTPS' sources.</value>
     <comment>0 - The command name. Ex. Push/Delete. 1 - list of server uris</comment>
   </data>
+  <data name="Info_AddPkgCPM" xml:space="preserve">
+    <value>PackageReference for package '{0}' added to '{1}' and PackageVersion added to central package management file '{2}'.</value>
+    <comment>[2:19 PM] Kartheek Penagamuri
+0 - The package ID. 1 - Directory.Packages.props file path. 2 - Project file path.</comment>
+  </data>
 </root>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/MSBuildAPIUtility.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/MSBuildAPIUtility.cs
@@ -194,11 +194,14 @@ namespace NuGet.CommandLine.XPlat
             }
             else
             {
+                if (!existingPackageReferences.Any())
+                {
+                    //Add <PackageReference/> to the project file.
+                    AddPackageReferenceIntoItemGroupCPM(project, itemGroup, libraryDependency);
+                }
+
                 // Get package version if it already exists in the props file. Returns null if there is no matching package version.
                 ProjectItem packageVersionInProps = project.Items.LastOrDefault(i => i.ItemType == PACKAGE_VERSION_TYPE_TAG && i.EvaluatedInclude.Equals(libraryDependency.Name));
-
-                //Add <PackageReference/> to the project file.
-                AddPackageReferenceIntoItemGroupCPM(project, itemGroup, libraryDependency);
 
                 // If no <PackageVersion /> exists in the Directory.Packages.props file.
                 if (packageVersionInProps == null)
@@ -263,11 +266,7 @@ namespace NuGet.CommandLine.XPlat
             var item = itemGroup.AddItem(PACKAGE_VERSION_TYPE_TAG, libraryDependency.Name);
             var packageVersion = AddVersionMetadata(libraryDependency, item);
             AddExtraMetadataToProjectItemElement(libraryDependency, item);
-            Logger.LogInformation(string.Format(CultureInfo.CurrentCulture,
-            Strings.Info_AddPkgAdded,
-            libraryDependency.Name,
-            packageVersion,
-            itemGroup.ContainingProject.FullPath
+            Logger.LogInformation(string.Format(CultureInfo.CurrentCulture, Strings.Info_AddPkgAdded, libraryDependency.Name, packageVersion, itemGroup.ContainingProject.FullPath
             ));
         }
 

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/MSBuildAPIUtility.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/MSBuildAPIUtility.cs
@@ -125,8 +125,8 @@ namespace NuGet.CommandLine.XPlat
         /// </summary>
         /// <param name="projectPath">Path to the csproj file of the project.</param>
         /// <param name="libraryDependency">Package Dependency of the package to be added.</param>
-        /// <param name="packageVersion">The version that is passed in as a CLI argument. Null if no version is passed in the command.</param>
-        public void AddPackageReference(string projectPath, LibraryDependency libraryDependency, string packageVersion)
+        /// <param name="noVersion">If a version is passed in as a CLI argument.</param>
+        public void AddPackageReference(string projectPath, LibraryDependency libraryDependency, bool noVersion)
         {
             var project = GetProject(projectPath);
 
@@ -134,7 +134,7 @@ namespace NuGet.CommandLine.XPlat
             // If the project has a conditional reference, then an unconditional reference is not added.
 
             var existingPackageReferences = GetPackageReferencesForAllFrameworks(project, libraryDependency);
-            AddPackageReference(project, libraryDependency, existingPackageReferences, packageVersion);
+            AddPackageReference(project, libraryDependency, existingPackageReferences, noVersion);
             ProjectCollection.GlobalProjectCollection.UnloadProject(project);
         }
 
@@ -144,9 +144,9 @@ namespace NuGet.CommandLine.XPlat
         /// <param name="projectPath">Path to the csproj file of the project.</param>
         /// <param name="libraryDependency">Package Dependency of the package to be added.</param>
         /// <param name="frameworks">Target Frameworks for which the package reference should be added.</param>
-        /// <param name="packageVersion">The version that is passed in as a CLI argument. Null if no version is passed in the command.</param>
+        /// <param name="noVersion">If a version is passed in as a CLI argument.</param>
         public void AddPackageReferencePerTFM(string projectPath, LibraryDependency libraryDependency,
-            IEnumerable<string> frameworks, string packageVersion)
+            IEnumerable<string> frameworks, bool noVersion)
         {
             foreach (var framework in frameworks)
             {
@@ -154,7 +154,7 @@ namespace NuGet.CommandLine.XPlat
                 { { "TargetFramework", framework } };
                 var project = GetProject(projectPath, globalProperties);
                 var existingPackageReferences = GetPackageReferences(project, libraryDependency);
-                AddPackageReference(project, libraryDependency, existingPackageReferences, packageVersion, framework);
+                AddPackageReference(project, libraryDependency, existingPackageReferences, noVersion, framework);
                 ProjectCollection.GlobalProjectCollection.UnloadProject(project);
             }
         }
@@ -165,12 +165,12 @@ namespace NuGet.CommandLine.XPlat
         /// <param name="project">Project that needs to be modified.</param>
         /// <param name="libraryDependency">Package Dependency of the package to be added.</param>
         /// <param name="existingPackageReferences">Package references that already exist in the project.</param>
-        /// <param name="packageVersion">The version that is passed in as a CLI argument. Null if no version is passed in the command.</param>
+        /// <param name="noVersion">If a version is passed in as a CLI argument.</param>
         /// <param name="framework">Target Framework for which the package reference should be added.</param>
         private void AddPackageReference(Project project,
             LibraryDependency libraryDependency,
             IEnumerable<ProjectItem> existingPackageReferences,
-            string packageVersion,
+            bool noVersion,
             string framework = null)
         {
             // Getting all the item groups in a given project
@@ -212,8 +212,9 @@ namespace NuGet.CommandLine.XPlat
                 else
                 {
                     // Modify the Directory.Packages.props file with the version that is passed in.
-                    if (packageVersion != null)
+                    if (!noVersion)
                     {
+                        string packageVersion = libraryDependency.LibraryRange.VersionRange.OriginalString;
                         UpdatePackageVersion(project, packageVersionInProps, packageVersion);
                     }
                 }

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/MSBuildAPIUtility.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/MSBuildAPIUtility.cs
@@ -21,6 +21,7 @@ namespace NuGet.CommandLine.XPlat
     internal class MSBuildAPIUtility
     {
         private const string PACKAGE_REFERENCE_TYPE_TAG = "PackageReference";
+        private const string PACKAGE_VERSION_TYPE_TAG = "PackageVersion";
         private const string VERSION_TAG = "Version";
         private const string FRAMEWORK_TAG = "TargetFramework";
         private const string FRAMEWORKS_TAG = "TargetFrameworks";
@@ -32,6 +33,10 @@ namespace NuGet.CommandLine.XPlat
         private const string IncludeAssets = "IncludeAssets";
         private const string PrivateAssets = "PrivateAssets";
         private const string CollectPackageReferences = "CollectPackageReferences";
+        /// <summary>
+        /// The name of the MSBuild property that represents the path to the central package management file, usually Directory.Packages.props.
+        /// </summary>
+        private const string DirectoryPackagesPropsPathPropertyName = "DirectoryPackagesPropsPath";
 
         public ILogger Logger { get; }
 
@@ -152,27 +157,178 @@ namespace NuGet.CommandLine.XPlat
             }
         }
 
+        /// <summary>
+        /// Add package version/package reference to the solution/project based on if the project has been onboarded to CPM or not.
+        /// </summary>
+        /// <param name="project">Project that needs to be modified.</param>
+        /// <param name="libraryDependency">Package Dependency of the package to be added.</param>
+        /// <param name="existingPackageReferences">Package references that already exist in the project.</param>
+        /// <param name="framework">Target Framework for which the package reference should be added.</param>
         private void AddPackageReference(Project project,
             LibraryDependency libraryDependency,
             IEnumerable<ProjectItem> existingPackageReferences,
             string framework = null)
         {
+            // Getting all the item groups in a given project
             var itemGroups = GetItemGroups(project);
 
-            if (!existingPackageReferences.Any())
+            // Add packageReference to the project file only if it does not exist.
+            var itemGroup = GetItemGroup(itemGroups, PACKAGE_REFERENCE_TYPE_TAG) ?? CreateItemGroup(project, framework);
+
+            if (!libraryDependency.VersionCentrallyManaged)
             {
-                // Add packageReference only if it does not exist.
-                var itemGroup = GetItemGroup(itemGroups, PACKAGE_REFERENCE_TYPE_TAG) ?? CreateItemGroup(project, framework);
-                AddPackageReferenceIntoItemGroup(itemGroup, libraryDependency);
+                if (!existingPackageReferences.Any())
+                {
+                    //Modify the project file.
+                    AddPackageReferenceIntoItemGroup(itemGroup, libraryDependency);
+                }
+                else
+                {
+                    // If the package already has a reference then try to update the reference.
+                    UpdatePackageReferenceItems(existingPackageReferences, libraryDependency);
+                }
             }
             else
             {
-                // If the package already has a reference then try to update the reference.
-                UpdatePackageReferenceItems(existingPackageReferences, libraryDependency);
+                // Get package version if it already exists in the props file. Returns null if there is no matching package version.
+                ProjectItem packageVersion = project.Items.LastOrDefault(i => i.ItemType == PACKAGE_VERSION_TYPE_TAG && i.EvaluatedInclude.Equals(libraryDependency.Name));
+                var versionCLIArgument = libraryDependency.LibraryRange.VersionRange.OriginalString;
+
+                //Add <PackageReference/> to the project file.
+                AddPackageReferenceIntoItemGroupCPM(project, itemGroup, libraryDependency);
+
+                // If no <PackageVersion /> exists in the Directory.Packages.props file.
+                if (packageVersion == null)
+                {
+                    // Modifying the props file if project is onboarded to CPM.
+                    AddPackageVersionIntoItemGroupCPM(project, libraryDependency);
+                }
+                else
+                {
+                    // Modify the Directory.Packages.props file with the version that is passed in.
+                    if (versionCLIArgument != null)
+                    {
+                        UpdatePackageVersion(project, packageVersion, versionCLIArgument);
+                    }
+                }
             }
+
             project.Save();
         }
 
+        /// <summary>
+        /// Add package name and version using PackageVersion tag for projects onboarded to CPM.
+        /// </summary>
+        /// <param name="project">Project that needs to be modified.</param>
+        /// <param name="libraryDependency">Package Dependency of the package to be added.</param>
+        private void AddPackageVersionIntoItemGroupCPM(Project project, LibraryDependency libraryDependency)
+        {
+            // If onboarded to CPM get the directoryBuildPropsRootElement.
+            ProjectRootElement directoryBuildPropsRootElement = GetDirectoryBuildPropsRootElement(project);
+
+            // Get the ItemGroup to add a PackageVersion to or create a new one.
+            var propsItemGroup = GetItemGroup(directoryBuildPropsRootElement.ItemGroups, PACKAGE_VERSION_TYPE_TAG) ?? directoryBuildPropsRootElement.AddItemGroup();
+            AddPackageVersionIntoPropsItemGroup(project, propsItemGroup, libraryDependency);
+
+            // Save the updated props file.
+            directoryBuildPropsRootElement.Save();
+        }
+
+        /// <summary>
+        /// Get the Directory build props root element for projects onboarded to CPM.
+        /// </summary>
+        /// <param name="project">Project that needs to be modified.</param>
+        /// <returns>The directory build props root element.</returns>
+        private ProjectRootElement GetDirectoryBuildPropsRootElement(Project project)
+        {
+            // Get the Directory.Packages.props path.
+            string directoryPackagesPropsPath = project.GetPropertyValue(DirectoryPackagesPropsPathPropertyName);
+            ProjectRootElement directoryBuildPropsRootElement = project.Imports.FirstOrDefault(i => i.ImportedProject.FullPath.Equals(directoryPackagesPropsPath)).ImportedProject;
+            return directoryBuildPropsRootElement;
+        }
+
+        /// <summary>
+        /// Add package name and version into the props file.
+        /// </summary>
+        /// <param name="project">Project that is being modified.</param>
+        /// <param name="itemGroup">Item group that needs to be modified in the props file.</param>
+        /// <param name="libraryDependency">Package Dependency of the package to be added.</param>
+        private void AddPackageVersionIntoPropsItemGroup(Project project, ProjectItemGroupElement itemGroup,
+            LibraryDependency libraryDependency)
+        {
+            // Add both package reference information and version metadata using the PACKAGE_VERSION_TYPE_TAG.
+            var item = itemGroup.AddItem(PACKAGE_VERSION_TYPE_TAG, libraryDependency.Name);
+            var packageVersion = AddVersionMetadata(libraryDependency, item);
+
+            Logger.LogInformation(string.Format(CultureInfo.CurrentCulture,
+            Strings.Info_AddPkgAdded,
+            libraryDependency.Name,
+            packageVersion,
+            itemGroup.ContainingProject.FullPath
+            ));
+
+            AddExtraMetadataToProjectItemElement(libraryDependency, item);
+        }
+
+        /// <summary>
+        /// Add package name and version into item group.
+        /// </summary>
+        /// <param name="itemGroup">Item group to add to.</param>
+        /// <param name="libraryDependency">Package Dependency of the package to be added.</param>
+        private void AddPackageReferenceIntoItemGroup(ProjectItemGroupElement itemGroup,
+            LibraryDependency libraryDependency)
+        {
+            // Add both package reference information and version metadata using the PACKAGE_REFERENCE_TYPE_TAG.
+            var item = itemGroup.AddItem(PACKAGE_REFERENCE_TYPE_TAG, libraryDependency.Name);
+            var packageVersion = AddVersionMetadata(libraryDependency, item);
+
+            Logger.LogInformation(string.Format(CultureInfo.CurrentCulture, Strings.Info_AddPkgAdded, libraryDependency.Name, packageVersion, itemGroup.ContainingProject.FullPath));
+
+            AddExtraMetadataToProjectItemElement(libraryDependency, item);
+        }
+
+        /// <summary>
+        /// Add only the package name into the project file for projects onboarded to CPM.
+        /// </summary>
+        /// <param name="project">Project to be modified.</param>
+        /// <param name="itemGroup">Item group to add to.</param>
+        /// <param name="libraryDependency">Package Dependency of the package to be added.</param>
+        private void AddPackageReferenceIntoItemGroupCPM(Project project, ProjectItemGroupElement itemGroup,
+            LibraryDependency libraryDependency)
+        {
+            // Only add the package reference information using the PACKAGE_REFERENCE_TYPE_TAG.
+            ProjectItemElement item = itemGroup.AddItem(PACKAGE_REFERENCE_TYPE_TAG, libraryDependency.Name);
+
+            Logger.LogInformation(string.Format(CultureInfo.CurrentCulture, Strings.Info_AddPkgCPM, libraryDependency.Name, project.GetPropertyValue(DirectoryPackagesPropsPathPropertyName), itemGroup.ContainingProject.FullPath));
+
+            AddExtraMetadataToProjectItemElement(libraryDependency, item);
+        }
+
+        /// <summary>
+        /// Add other metadata based on certain flags.
+        /// </summary>
+        /// <param name="libraryDependency">Package Dependency of the package to be added.</param>
+        /// <param name="item">Item to add the metadata to.</param>
+        private void AddExtraMetadataToProjectItemElement(LibraryDependency libraryDependency, ProjectItemElement item)
+        {
+            if (libraryDependency.IncludeType != LibraryIncludeFlags.All)
+            {
+                var includeFlags = MSBuildStringUtility.Convert(LibraryIncludeFlagUtils.GetFlagString(libraryDependency.IncludeType));
+                item.AddMetadata(IncludeAssets, includeFlags, expressAsAttribute: false);
+            }
+
+            if (libraryDependency.SuppressParent != LibraryIncludeFlagUtils.DefaultSuppressParent)
+            {
+                var suppressParent = MSBuildStringUtility.Convert(LibraryIncludeFlagUtils.GetFlagString(libraryDependency.SuppressParent));
+                item.AddMetadata(PrivateAssets, suppressParent, expressAsAttribute: false);
+            }
+        }
+
+        /// <summary>
+        /// Get all the item groups in a given project.
+        /// </summary>
+        /// <param name="project">A specified project.</param>
+        /// <returns></returns>
         private static IEnumerable<ProjectItemGroupElement> GetItemGroups(Project project)
         {
             return project
@@ -198,6 +354,12 @@ namespace NuGet.CommandLine.XPlat
             return itemGroup;
         }
 
+        /// <summary>
+        /// Creating an item group in a project.
+        /// </summary>
+        /// <param name="project">Project where the item group should be created.</param>
+        /// <param name="framework">Target Framework for which the package reference should be added.</param>
+        /// <returns>An Item Group.</returns>
         private static ProjectItemGroupElement CreateItemGroup(Project project, string framework = null)
         {
             // Create a new item group and add a condition if given
@@ -209,8 +371,39 @@ namespace NuGet.CommandLine.XPlat
             return itemGroup;
         }
 
+        /// <summary>
+        /// Adding version metadata to a given project item element.
+        /// </summary>
+        /// <param name="libraryDependency">Package Dependency of the package to be added.</param>
+        /// <param name="item">The item that the version metadata should be added to.</param>
+        /// <returns>The package version that is added in the metadata.</returns>
+        private string AddVersionMetadata(LibraryDependency libraryDependency, ProjectItemElement item)
+        {
+            var packageVersion = libraryDependency.LibraryRange.VersionRange.OriginalString ??
+                    libraryDependency.LibraryRange.VersionRange.MinVersion.ToString();
+
+            ProjectMetadataElement versionAttribute = item.Metadata.FirstOrDefault(i => i.Name.Equals("Version"));
+
+            // If version attribute does not exist at all, add it.
+            if (versionAttribute == null)
+            {
+                item.AddMetadata(VERSION_TAG, packageVersion, expressAsAttribute: true);
+            }
+            // Else, just update the version in the already existing version attribute.
+            else
+            {
+                versionAttribute.Value = packageVersion;
+            }
+            return packageVersion;
+        }
+
+        /// <summary>
+        /// Update package references for a project that is not onboarded to CPM.
+        /// </summary>
+        /// <param name="packageReferencesItems">Existing package references.</param>
+        /// <param name="libraryDependency">Package Dependency of the package to be added.</param>
         private void UpdatePackageReferenceItems(IEnumerable<ProjectItem> packageReferencesItems,
-            LibraryDependency libraryDependency)
+           LibraryDependency libraryDependency)
         {
             // We validate that the operation does not update any imported items
             // If it does then we throw a user friendly exception without making any changes
@@ -223,17 +416,7 @@ namespace NuGet.CommandLine.XPlat
 
                 packageReferenceItem.SetMetadataValue(VERSION_TAG, packageVersion);
 
-                if (libraryDependency.IncludeType != LibraryIncludeFlags.All)
-                {
-                    var includeFlags = MSBuildStringUtility.Convert(LibraryIncludeFlagUtils.GetFlagString(libraryDependency.IncludeType));
-                    packageReferenceItem.SetMetadataValue(IncludeAssets, includeFlags);
-                }
-
-                if (libraryDependency.SuppressParent != LibraryIncludeFlagUtils.DefaultSuppressParent)
-                {
-                    var suppressParent = MSBuildStringUtility.Convert(LibraryIncludeFlagUtils.GetFlagString(libraryDependency.SuppressParent));
-                    packageReferenceItem.SetMetadataValue(PrivateAssets, suppressParent);
-                }
+                UpdateExtraMetadataInProjectItem(libraryDependency, packageReferenceItem);
 
                 Logger.LogInformation(string.Format(CultureInfo.CurrentCulture,
                     Strings.Info_AddPkgUpdated,
@@ -243,34 +426,31 @@ namespace NuGet.CommandLine.XPlat
             }
         }
 
-        private void AddPackageReferenceIntoItemGroup(ProjectItemGroupElement itemGroup,
-            LibraryDependency libraryDependency)
+        /// <summary>
+        /// Update the <PackageVersion /> element if a version is passed in as a CLI argument.
+        /// </summary>
+        /// <param name="project"></param>
+        /// <param name="packageVersion"><PackageVersion /> item with a matching package ID.</param>
+        /// <param name="versionCLIArgument">Version that is passed in as a CLI argument.</param>
+        private static void UpdatePackageVersion(Project project, ProjectItem packageVersion, string versionCLIArgument)
         {
-            var packageVersion = libraryDependency.LibraryRange.VersionRange.OriginalString ??
-                libraryDependency.LibraryRange.VersionRange.MinVersion.ToString();
+            // Determine where the <PackageVersion /> item is decalred
+            ProjectItemElement packageVersionItemElement = project.GetItemProvenance(packageVersion).LastOrDefault()?.ItemElement;
 
-            var item = itemGroup.AddItem(PACKAGE_REFERENCE_TYPE_TAG, libraryDependency.Name);
-            item.AddMetadata(VERSION_TAG, packageVersion, expressAsAttribute: true);
-
-            if (libraryDependency.IncludeType != LibraryIncludeFlags.All)
-            {
-                var includeFlags = MSBuildStringUtility.Convert(LibraryIncludeFlagUtils.GetFlagString(libraryDependency.IncludeType));
-                item.AddMetadata(IncludeAssets, includeFlags, expressAsAttribute: false);
-            }
-
-            if (libraryDependency.SuppressParent != LibraryIncludeFlagUtils.DefaultSuppressParent)
-            {
-                var suppressParent = MSBuildStringUtility.Convert(LibraryIncludeFlagUtils.GetFlagString(libraryDependency.SuppressParent));
-                item.AddMetadata(PrivateAssets, suppressParent, expressAsAttribute: false);
-            }
-
-            Logger.LogInformation(string.Format(CultureInfo.CurrentCulture,
-                Strings.Info_AddPkgAdded,
-                libraryDependency.Name,
-                packageVersion,
-                itemGroup.ContainingProject.FullPath));
+            // Get the Version attribute on the packageVersionItemElement.
+            ProjectMetadataElement versionAttribute = packageVersionItemElement.Metadata.FirstOrDefault(i => i.Name.Equals("Version"));
+            // Update the version
+            versionAttribute.Value = versionCLIArgument;
+            packageVersionItemElement.ContainingProject.Save();
         }
 
+        /// <summary>
+        /// Validate that no imported items in the project are updated with the package version.
+        /// </summary>
+        /// <param name="packageReferencesItems">Existing package reference items.</param>
+        /// <param name="libraryDependency">Package Dependency of the package to be added.</param>
+        /// <param name="operationType">Operation types such as if a package reference is being updated.</param>
+        /// <exception cref="InvalidOperationException"></exception>
         private static void ValidateNoImportedItemsAreUpdated(IEnumerable<ProjectItem> packageReferencesItems,
             LibraryDependency libraryDependency,
             string operationType)
@@ -297,6 +477,46 @@ namespace NuGet.CommandLine.XPlat
                     libraryDependency.Name,
                     Environment.NewLine,
                     errors));
+            }
+        }
+
+        /// <summary>
+        /// Update other metadata for items based on certain flags.
+        /// </summary>
+        /// <param name="libraryDependency">Package Dependency of the package to be added.</param>
+        /// <param name="packageReferenceItem">Item to be modified.</param>
+        private void UpdateExtraMetadataInProjectItem(LibraryDependency libraryDependency, ProjectItem packageReferenceItem)
+        {
+            if (libraryDependency.IncludeType != LibraryIncludeFlags.All)
+            {
+                var includeFlags = MSBuildStringUtility.Convert(LibraryIncludeFlagUtils.GetFlagString(libraryDependency.IncludeType));
+                packageReferenceItem.SetMetadataValue(IncludeAssets, includeFlags);
+            }
+
+            if (libraryDependency.SuppressParent != LibraryIncludeFlagUtils.DefaultSuppressParent)
+            {
+                var suppressParent = MSBuildStringUtility.Convert(LibraryIncludeFlagUtils.GetFlagString(libraryDependency.SuppressParent));
+                packageReferenceItem.SetMetadataValue(PrivateAssets, suppressParent);
+            }
+        }
+
+        /// <summary>
+        /// Update other metadata for items based on certain flags.
+        /// </summary>
+        /// <param name="libraryDependency">Package Dependency of the package to be added.</param>
+        /// <param name="packageReferenceItem">Item to be modified.</param>
+        private void UpdateExtraMetadata(LibraryDependency libraryDependency, ProjectItem packageReferenceItem)
+        {
+            if (libraryDependency.IncludeType != LibraryIncludeFlags.All)
+            {
+                var includeFlags = MSBuildStringUtility.Convert(LibraryIncludeFlagUtils.GetFlagString(libraryDependency.IncludeType));
+                packageReferenceItem.SetMetadataValue(IncludeAssets, includeFlags);
+            }
+
+            if (libraryDependency.SuppressParent != LibraryIncludeFlagUtils.DefaultSuppressParent)
+            {
+                var suppressParent = MSBuildStringUtility.Convert(LibraryIncludeFlagUtils.GetFlagString(libraryDependency.SuppressParent));
+                packageReferenceItem.SetMetadataValue(PrivateAssets, suppressParent);
             }
         }
 

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/MSBuildAPIUtility.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/MSBuildAPIUtility.cs
@@ -262,15 +262,13 @@ namespace NuGet.CommandLine.XPlat
             // Add both package reference information and version metadata using the PACKAGE_VERSION_TYPE_TAG.
             var item = itemGroup.AddItem(PACKAGE_VERSION_TYPE_TAG, libraryDependency.Name);
             var packageVersion = AddVersionMetadata(libraryDependency, item);
-
+            AddExtraMetadataToProjectItemElement(libraryDependency, item);
             Logger.LogInformation(string.Format(CultureInfo.CurrentCulture,
             Strings.Info_AddPkgAdded,
             libraryDependency.Name,
             packageVersion,
             itemGroup.ContainingProject.FullPath
             ));
-
-            AddExtraMetadataToProjectItemElement(libraryDependency, item);
         }
 
         /// <summary>
@@ -284,10 +282,8 @@ namespace NuGet.CommandLine.XPlat
             // Add both package reference information and version metadata using the PACKAGE_REFERENCE_TYPE_TAG.
             var item = itemGroup.AddItem(PACKAGE_REFERENCE_TYPE_TAG, libraryDependency.Name);
             var packageVersion = AddVersionMetadata(libraryDependency, item);
-
-            Logger.LogInformation(string.Format(CultureInfo.CurrentCulture, Strings.Info_AddPkgAdded, libraryDependency.Name, packageVersion, itemGroup.ContainingProject.FullPath));
-
             AddExtraMetadataToProjectItemElement(libraryDependency, item);
+            Logger.LogInformation(string.Format(CultureInfo.CurrentCulture, Strings.Info_AddPkgAdded, libraryDependency.Name, packageVersion, itemGroup.ContainingProject.FullPath));
         }
 
         /// <summary>
@@ -301,10 +297,8 @@ namespace NuGet.CommandLine.XPlat
         {
             // Only add the package reference information using the PACKAGE_REFERENCE_TYPE_TAG.
             ProjectItemElement item = itemGroup.AddItem(PACKAGE_REFERENCE_TYPE_TAG, libraryDependency.Name);
-
-            Logger.LogInformation(string.Format(CultureInfo.CurrentCulture, Strings.Info_AddPkgCPM, libraryDependency.Name, project.GetPropertyValue(DirectoryPackagesPropsPathPropertyName), itemGroup.ContainingProject.FullPath));
-
             AddExtraMetadataToProjectItemElement(libraryDependency, item);
+            Logger.LogInformation(string.Format(CultureInfo.CurrentCulture, Strings.Info_AddPkgCPM, libraryDependency.Name, project.GetPropertyValue(DirectoryPackagesPropsPathPropertyName), itemGroup.ContainingProject.FullPath));
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/MSBuildAPIUtility.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/MSBuildAPIUtility.cs
@@ -234,7 +234,7 @@ namespace NuGet.CommandLine.XPlat
 
             // Get the ItemGroup to add a PackageVersion to or create a new one.
             var propsItemGroup = GetItemGroup(directoryBuildPropsRootElement.ItemGroups, PACKAGE_VERSION_TYPE_TAG) ?? directoryBuildPropsRootElement.AddItemGroup();
-            AddPackageVersionIntoPropsItemGroup(project, propsItemGroup, libraryDependency);
+            AddPackageVersionIntoPropsItemGroup(propsItemGroup, libraryDependency);
 
             // Save the updated props file.
             directoryBuildPropsRootElement.Save();
@@ -245,7 +245,7 @@ namespace NuGet.CommandLine.XPlat
         /// </summary>
         /// <param name="project">Project that needs to be modified.</param>
         /// <returns>The directory build props root element.</returns>
-        private ProjectRootElement GetDirectoryBuildPropsRootElement(Project project)
+        internal ProjectRootElement GetDirectoryBuildPropsRootElement(Project project)
         {
             // Get the Directory.Packages.props path.
             string directoryPackagesPropsPath = project.GetPropertyValue(DirectoryPackagesPropsPathPropertyName);
@@ -256,10 +256,9 @@ namespace NuGet.CommandLine.XPlat
         /// <summary>
         /// Add package name and version into the props file.
         /// </summary>
-        /// <param name="project">Project that is being modified.</param>
         /// <param name="itemGroup">Item group that needs to be modified in the props file.</param>
         /// <param name="libraryDependency">Package Dependency of the package to be added.</param>
-        private void AddPackageVersionIntoPropsItemGroup(Project project, ProjectItemGroupElement itemGroup,
+        private void AddPackageVersionIntoPropsItemGroup(ProjectItemGroupElement itemGroup,
             LibraryDependency libraryDependency)
         {
             // Add both package reference information and version metadata using the PACKAGE_VERSION_TYPE_TAG.

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/MSBuildAPIUtility.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/MSBuildAPIUtility.cs
@@ -258,7 +258,7 @@ namespace NuGet.CommandLine.XPlat
         /// </summary>
         /// <param name="itemGroup">Item group that needs to be modified in the props file.</param>
         /// <param name="libraryDependency">Package Dependency of the package to be added.</param>
-        private void AddPackageVersionIntoPropsItemGroup(ProjectItemGroupElement itemGroup,
+        internal void AddPackageVersionIntoPropsItemGroup(ProjectItemGroupElement itemGroup,
             LibraryDependency libraryDependency)
         {
             // Add both package reference information and version metadata using the PACKAGE_VERSION_TYPE_TAG.
@@ -290,7 +290,7 @@ namespace NuGet.CommandLine.XPlat
         /// <param name="project">Project to be modified.</param>
         /// <param name="itemGroup">Item group to add to.</param>
         /// <param name="libraryDependency">Package Dependency of the package to be added.</param>
-        private void AddPackageReferenceIntoItemGroupCPM(Project project, ProjectItemGroupElement itemGroup,
+        internal void AddPackageReferenceIntoItemGroupCPM(Project project, ProjectItemGroupElement itemGroup,
             LibraryDependency libraryDependency)
         {
             // Only add the package reference information using the PACKAGE_REFERENCE_TYPE_TAG.
@@ -324,7 +324,7 @@ namespace NuGet.CommandLine.XPlat
         /// </summary>
         /// <param name="project">A specified project.</param>
         /// <returns></returns>
-        private static IEnumerable<ProjectItemGroupElement> GetItemGroups(Project project)
+        internal IEnumerable<ProjectItemGroupElement> GetItemGroups(Project project)
         {
             return project
                 .Items
@@ -339,7 +339,7 @@ namespace NuGet.CommandLine.XPlat
         /// <param name="itemGroups">List of all item groups in the project</param>
         /// <param name="itemType">An item type tag that must be in the item group. It if PackageReference in this case.</param>
         /// <returns>An ItemGroup, which could be null.</returns>
-        private static ProjectItemGroupElement GetItemGroup(IEnumerable<ProjectItemGroupElement> itemGroups,
+        internal ProjectItemGroupElement GetItemGroup(IEnumerable<ProjectItemGroupElement> itemGroups,
             string itemType)
         {
             var itemGroup = itemGroups?
@@ -355,7 +355,7 @@ namespace NuGet.CommandLine.XPlat
         /// <param name="project">Project where the item group should be created.</param>
         /// <param name="framework">Target Framework for which the package reference should be added.</param>
         /// <returns>An Item Group.</returns>
-        private static ProjectItemGroupElement CreateItemGroup(Project project, string framework = null)
+        internal ProjectItemGroupElement CreateItemGroup(Project project, string framework = null)
         {
             // Create a new item group and add a condition if given
             var itemGroup = project.Xml.AddItemGroup();
@@ -427,7 +427,7 @@ namespace NuGet.CommandLine.XPlat
         /// <param name="project"></param>
         /// <param name="packageVersion"><PackageVersion /> item with a matching package ID.</param>
         /// <param name="versionCLIArgument">Version that is passed in as a CLI argument.</param>
-        private static void UpdatePackageVersion(Project project, ProjectItem packageVersion, string versionCLIArgument)
+        internal void UpdatePackageVersion(Project project, ProjectItem packageVersion, string versionCLIArgument)
         {
             // Determine where the <PackageVersion /> item is decalred
             ProjectItemElement packageVersionItemElement = project.GetItemProvenance(packageVersion).LastOrDefault()?.ItemElement;

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetAddPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetAddPackageTests.cs
@@ -615,14 +615,13 @@ namespace Dotnet.Integration.Test
         }
 
         [Fact]
-        public async Task AddPkgWithNoVersion_WhenProjectOnboardedToCPMAndNoPackagesExistInProps()
+        public async Task AddPkg_WithCPM_WhenPackageVersionDoesNotExistAndVersionCLIArgNotPassed_Success()
         {
             using var pathContext = new SimpleTestPathContext();
 
             // Set up solution, and project
             var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
-            var projectName = "projectA";
-            var projectA = XPlatTestUtils.CreateProject(projectName, pathContext, "net5.0");
+            var projectA = XPlatTestUtils.CreateProject("projectA", pathContext, "net5.0");
 
             const string version1 = "1.0.0";
             const string version2 = "2.0.0";
@@ -635,10 +634,7 @@ namespace Dotnet.Integration.Test
             await SimpleTestPackageUtility.CreateFolderFeedV3Async(
                     pathContext.PackageSource,
                     PackageSaveMode.Defaultv3,
-                    packageX100);
-            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
-                    pathContext.PackageSource,
-                    PackageSaveMode.Defaultv3,
+                    packageX100,
                     packageX200);
 
             var propsFile = @$"<Project>
@@ -668,14 +664,13 @@ namespace Dotnet.Integration.Test
         }
 
         [Fact]
-        public async Task AddPkgWithVersion_WhenProjectOnboardedToCPMAndNoPackagesExistInProps()
+        public async Task AddPkg_WithCPM_WhenPackageVersionDoesNotExistAndVersionCLIArgPassed_Success() 
         {
             using var pathContext = new SimpleTestPathContext();
 
             // Set up solution, and project
             var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
-            var projectName = "projectA";
-            var projectA = XPlatTestUtils.CreateProject(projectName, pathContext, "net5.0");
+            var projectA = XPlatTestUtils.CreateProject("projectA", pathContext, "net5.0");
 
             const string version1 = "1.0.0";
             const string version2 = "2.0.0";
@@ -688,10 +683,7 @@ namespace Dotnet.Integration.Test
             await SimpleTestPackageUtility.CreateFolderFeedV3Async(
                     pathContext.PackageSource,
                     PackageSaveMode.Defaultv3,
-                    packageX100);
-            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
-                    pathContext.PackageSource,
-                    PackageSaveMode.Defaultv3,
+                    packageX100,
                     packageX200);
 
             var propsFile = @$"<Project>
@@ -721,14 +713,13 @@ namespace Dotnet.Integration.Test
         }
 
         [Fact]
-        public async Task AddPkgWithNoVersion_WhenProjectOnboardedToCPMAndPackageVersionExistsInProps()
+        public async Task AddPkg_WithCPM_WhenPackageVersionExistsAndVersionCLIArgNotPassed_Success() 
         {
             using var pathContext = new SimpleTestPathContext();
 
             // Set up solution and project
             var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
-            var projectNameA = "projectA";
-            var projectA = XPlatTestUtils.CreateProject(projectNameA, pathContext, "net5.0");
+            var projectA = XPlatTestUtils.CreateProject("projectA", pathContext, "net5.0");
 
             const string version = "2.0.0";
             const string packageX = "X";
@@ -772,14 +763,13 @@ namespace Dotnet.Integration.Test
         }
 
         [Fact]
-        public async Task AddPkgWithVersion_WhenProjectOnboardedToCPMAndPackageVersionExistsInProps()
+        public async Task AddPkg_WithCPM_WhenPackageVersionExistsAndVersionCLIArgPassed_Success()
         {
             using var pathContext = new SimpleTestPathContext();
 
             // Set up solution
             var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
-            var projectNameA = "projectA";
-            var projectA = XPlatTestUtils.CreateProject(projectNameA, pathContext, "net5.0");
+            var projectA = XPlatTestUtils.CreateProject("projectA", pathContext, "net5.0");
 
             const string version = "2.0.0";
             const string packageX = "X";
@@ -828,8 +818,7 @@ namespace Dotnet.Integration.Test
 
             // Set up solution
             var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
-            var projectNameA = "projectA";
-            var projectA = XPlatTestUtils.CreateProject(projectNameA, pathContext, "net5.0");
+            var projectA = XPlatTestUtils.CreateProject("projectA", pathContext, "net5.0");
 
             const string version = "1.0.0";
             const string packageX = "X";

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetAddPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetAddPackageTests.cs
@@ -659,7 +659,7 @@ namespace Dotnet.Integration.Test
             Assert.Contains(@$"<ItemGroup>
     <PackageVersion Include=""X"" Version=""2.0.0"" />
   </ItemGroup", File.ReadAllText(Path.Combine(pathContext.SolutionRoot, "Directory.Packages.props")));
-            Assert.DoesNotContain(@$"<ItemGroup> <PackageVersion Include=""X"" Version=""2.0.0"" /> </ItemGroup",
+            Assert.DoesNotContain(@$"<ItemGroup> <PackageReference Include=""X"" Version=""2.0.0"" /> </ItemGroup",
                 File.ReadAllText(Path.Combine(projectADirectory, "projectA.csproj")));
         }
 
@@ -713,7 +713,7 @@ namespace Dotnet.Integration.Test
         }
 
         [Fact]
-        public async Task AddPkg_WithCPM_WhenPackageVersionExistsAndVersionCLIArgNotPassed_Success() 
+        public async Task AddPkg_WithCPM_WhenPackageVersionExistsAndVersionCLIArgNotPassed_NoOp() 
         {
             using var pathContext = new SimpleTestPathContext();
 

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetAddPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetAddPackageTests.cs
@@ -812,7 +812,7 @@ namespace Dotnet.Integration.Test
         }
 
         [Fact]
-        public async Task AddPackageVersionToCorrectItemGroupInPropsFile()
+        public async Task AddPackageVersionToCorrectItemGroupInPropsFile_Success()
         {
             using var pathContext = new SimpleTestPathContext();
 

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetAddPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetAddPackageTests.cs
@@ -812,7 +812,7 @@ namespace Dotnet.Integration.Test
         }
 
         [Fact]
-        public async Task AddPackageVersionToCorrectItemGroupInPropsFile_Success()
+        public async Task AddPkg_WithCPM_WhenMultipleItemGroupsExist_Success()
         {
             using var pathContext = new SimpleTestPathContext();
 

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetAddPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetAddPackageTests.cs
@@ -757,9 +757,11 @@ namespace Dotnet.Integration.Test
             // Checking that the PackageVersion is not updated.
             Assert.Contains(@$"<PackageVersion Include=""X"" Version=""1.0.0"" />", File.ReadAllText(Path.Combine(pathContext.SolutionRoot, "Directory.Packages.props")));
 
+            var projectFileFromDisk = File.ReadAllText(Path.Combine(projectADirectory, "projectA.csproj"));
+
             // Checking that version metadata is not added to the project files.
-            Assert.Contains(@$"Include=""X""", File.ReadAllText(Path.Combine(projectADirectory, "projectA.csproj")));
-            Assert.DoesNotContain(@$"Include=""X"" Version=""1.0.0""", File.ReadAllText(Path.Combine(projectADirectory, "projectA.csproj")));
+            Assert.Contains(@$"Include=""X""", projectFileFromDisk);
+            Assert.DoesNotContain(@$"Include=""X"" Version=""1.0.0""", projectFileFromDisk);
         }
 
         [Fact]
@@ -805,10 +807,12 @@ namespace Dotnet.Integration.Test
             Assert.True(result.Success, result.Output);
             Assert.Contains(@$"<PackageVersion Include=""X"" Version=""2.0.0"" />", File.ReadAllText(Path.Combine(pathContext.SolutionRoot, "Directory.Packages.props")));
 
+            var projectFileFromDisk = File.ReadAllText(Path.Combine(projectADirectory, "projectA.csproj"));
+
             // Checking that version metadata is not added to the project files.
             Assert.Contains(@$"Include=""X""", File.ReadAllText(Path.Combine(projectADirectory, "projectA.csproj")));
-            Assert.DoesNotContain(@$"Include=""X"" Version=""1.0.0""", File.ReadAllText(Path.Combine(projectADirectory, "projectA.csproj")));
-            Assert.DoesNotContain(@$"Include=""X"" Version=""2.0.0""", File.ReadAllText(Path.Combine(projectADirectory, "projectA.csproj")));
+            Assert.DoesNotContain(@$"Include=""X"" Version=""1.0.0""", projectFileFromDisk);
+            Assert.DoesNotContain(@$"Include=""X"" Version=""2.0.0""", projectFileFromDisk);
         }
 
         [Fact]
@@ -855,15 +859,17 @@ namespace Dotnet.Integration.Test
             // Assert
             Assert.True(result.Success, result.Output);
 
+            var propsFileFromDisk = File.ReadAllText(Path.Combine(pathContext.SolutionRoot, "Directory.Packages.props"));
+
             Assert.Contains(@$"<ItemGroup>
     <PackageVersion Include=""X"" Version=""1.0.0"" />
     <PackageVersion Include=""Y"" Version=""1.0.0"" />
-  </ItemGroup>", File.ReadAllText(Path.Combine(pathContext.SolutionRoot, "Directory.Packages.props")));
+  </ItemGroup>", propsFileFromDisk);
 
             Assert.DoesNotContain($@"< ItemGroup >
     < Content Include = ""SomeFile"" />
     <PackageVersion Include=""X"" Version=""1.0.0"" />
-  </ ItemGroup >", File.ReadAllText(Path.Combine(pathContext.SolutionRoot, "Directory.Packages.props")));
+  </ ItemGroup >", propsFileFromDisk);
         }
     }
 }

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetAddPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetAddPackageTests.cs
@@ -709,7 +709,7 @@ namespace Dotnet.Integration.Test
             var projectADirectory = Path.Combine(pathContext.SolutionRoot, projectA.ProjectName);
 
             //Act
-            var result = _fixture.RunDotnet(projectADirectory, $"add {projectA.ProjectPath} package {packageX}", ignoreExitCode: true);
+            var result = _fixture.RunDotnet(projectADirectory, $"add {projectA.ProjectPath} package {packageX} -v {version1}", ignoreExitCode: true);
 
             // Assert
             Assert.True(result.Success, result.Output);
@@ -730,8 +730,7 @@ namespace Dotnet.Integration.Test
             var projectNameA = "projectA";
             var projectA = XPlatTestUtils.CreateProject(projectNameA, pathContext, "net5.0");
 
-            const string version1 = "1.0.0";
-            const string version2 = "2.0.0";
+            const string version = "2.0.0";
             const string packageX = "X";
 
             var packageFrameworks = "net5.0";

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/MSBuildAPIUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/MSBuildAPIUtilityTests.cs
@@ -21,10 +21,11 @@ namespace NuGet.CommandLine.Xplat.Tests
         {
             MSBuildLocator.RegisterDefaults();
         }
-
-        [Fact]
+        
+        [PlatformFact(Platform.Windows)]
         public void GetDirectoryBuildPropsRootElementWhenItExists_Success()
         {
+            // Arrange
             var testDirectory = TestDirectory.Create();
 
             var projectCollection = new ProjectCollection(
@@ -59,18 +60,19 @@ namespace NuGet.CommandLine.Xplat.Tests
 	</PropertyGroup>
 </Project>";
             File.WriteAllText(Path.Combine(testDirectory, "projectA.csproj"), projectContent);
-
             var project = Project.FromFile(Path.Combine(testDirectory, "projectA.csproj"), projectOptions);
 
+            // Act
             var result = new MSBuildAPIUtility(logger: new TestLogger()).GetDirectoryBuildPropsRootElement(project);
 
+            // Assert
             Assert.Equal(Path.Combine(testDirectory, "Directory.Packages.props"), result.FullPath);
         }
 
-        [Fact]
+        [PlatformFact(Platform.Windows)]
         public void AddPackageReferenceIntoProjectFileWhenItemGroupDoesNotExist_Success()
         {
-            // Set up
+            // Arrange
             var testDirectory = TestDirectory.Create();
             var projectCollection = new ProjectCollection(
                             globalProperties: null,
@@ -89,7 +91,7 @@ namespace NuGet.CommandLine.Xplat.Tests
                 ProjectCollection = projectCollection
             };
 
-            // Set up project file
+            // Arrange project file
             string projectContent =
 @$"<Project Sdk=""Microsoft.NET.Sdk"">
 <PropertyGroup>                   
@@ -116,14 +118,15 @@ namespace NuGet.CommandLine.Xplat.Tests
             project.Save();
 
             // Assert
-            Assert.Contains(@$"<PackageReference Include=""X"" />", File.ReadAllText(Path.Combine(testDirectory, "projectA.csproj")));
-            Assert.DoesNotContain(@$"<Version = ""1.0.0"" />", File.ReadAllText(Path.Combine(testDirectory, "projectA.csproj")));
+            string updatedProjectFile = File.ReadAllText(Path.Combine(testDirectory, "projectA.csproj"));
+            Assert.Contains(@$"<PackageReference Include=""X"" />", updatedProjectFile);
+            Assert.DoesNotContain(@$"<Version = ""1.0.0"" />", updatedProjectFile);
         }
 
-        [Fact]
+        [PlatformFact(Platform.Windows)]
         public void AddPackageReferenceIntoProjectFileWhenItemGroupDoesExist_Success()
         {
-            // Set up
+            // Arrange
             var testDirectory = TestDirectory.Create();
             var projectCollection = new ProjectCollection(
                             globalProperties: null,
@@ -142,7 +145,7 @@ namespace NuGet.CommandLine.Xplat.Tests
                 ProjectCollection = projectCollection
             };
 
-            // Set up project file
+            // Arrange project file
             string projectContent =
 @$"<Project Sdk=""Microsoft.NET.Sdk"">
 <PropertyGroup>                   
@@ -174,14 +177,15 @@ namespace NuGet.CommandLine.Xplat.Tests
             project.Save();
 
             // Assert
-            Assert.Contains(@$"<PackageReference Include=""X"" />", File.ReadAllText(Path.Combine(testDirectory, "projectA.csproj")));
-            Assert.DoesNotContain(@$"<Version = ""1.0.0"" />", File.ReadAllText(Path.Combine(testDirectory, "projectA.csproj")));
+            string updatedProjectFile = File.ReadAllText(Path.Combine(testDirectory, "projectA.csproj"));
+            Assert.Contains(@$"<PackageReference Include=""X"" />", updatedProjectFile);
+            Assert.DoesNotContain(@$"<Version = ""1.0.0"" />", updatedProjectFile);
         }
 
-        [Fact]
+        [PlatformFact(Platform.Windows)]
         public void AddPackageVersionIntoPropsFileWhenItemGroupDoesNotExist_Success()
         {
-            // Set up
+            // Arrange
             var testDirectory = TestDirectory.Create();
             var projectCollection = new ProjectCollection(
                             globalProperties: null,
@@ -200,7 +204,7 @@ namespace NuGet.CommandLine.Xplat.Tests
                 ProjectCollection = projectCollection
             };
 
-            // Set up Directory.Packages.props file
+            // Arrange Directory.Packages.props file
             var propsFile =
 @$"<Project>
     <PropertyGroup>
@@ -209,7 +213,7 @@ namespace NuGet.CommandLine.Xplat.Tests
 </Project>";
             File.WriteAllText(Path.Combine(testDirectory, "Directory.Packages.props"), propsFile);
 
-            // Set up project file
+            // Arrange project file
             string projectContent =
 @$"<Project Sdk=""Microsoft.NET.Sdk"">    
 	<PropertyGroup>                   
@@ -243,10 +247,10 @@ namespace NuGet.CommandLine.Xplat.Tests
   </ItemGroup>", File.ReadAllText(Path.Combine(testDirectory, "Directory.Packages.props")));
         }
 
-        [Fact]
+        [PlatformFact(Platform.Windows)]
         public void AddPackageVersionIntoPropsFileWhenItemGroupExists_Success()
         {
-            // Set up
+            // Arrange
             var testDirectory = TestDirectory.Create();
             var projectCollection = new ProjectCollection(
                             globalProperties: null,
@@ -265,7 +269,7 @@ namespace NuGet.CommandLine.Xplat.Tests
                 ProjectCollection = projectCollection
             };
 
-            // Set up Directory.Packages.props file
+            // Arrange Directory.Packages.props file
             var propsFile =
 @$"<Project>
     <PropertyGroup>
@@ -277,7 +281,7 @@ namespace NuGet.CommandLine.Xplat.Tests
 </Project>";
             File.WriteAllText(Path.Combine(testDirectory, "Directory.Packages.props"), propsFile);
 
-            // Set up project file
+            // Arrange project file
             string projectContent =
 @$"<Project Sdk=""Microsoft.NET.Sdk"">    
 	<PropertyGroup>                   
@@ -312,10 +316,10 @@ namespace NuGet.CommandLine.Xplat.Tests
             Assert.Contains(@$"<PackageVersion Include=""Y"" Version=""1.0.0"" />", File.ReadAllText(Path.Combine(testDirectory, "Directory.Packages.props")));
         }
 
-        [Fact]
+        [PlatformFact(Platform.Windows)]
         public void UpdatePackageVersionInPropsFileWhenItExists_Success()
         {
-            // Set up
+            // Arrange
             var testDirectory = TestDirectory.Create();
             var projectCollection = new ProjectCollection(
                             globalProperties: null,
@@ -334,7 +338,7 @@ namespace NuGet.CommandLine.Xplat.Tests
                 ProjectCollection = projectCollection
             };
 
-            // Set up Directory.Packages.props file
+            // Arrange Directory.Packages.props file
             var propsFile =
 @$"<Project>
     <PropertyGroup>
@@ -346,7 +350,7 @@ namespace NuGet.CommandLine.Xplat.Tests
 </Project>";
             File.WriteAllText(Path.Combine(testDirectory, "Directory.Packages.props"), propsFile);
 
-            // Set up project file
+            // Arrange project file
             string projectContent =
 @$"<Project Sdk=""Microsoft.NET.Sdk"">    
 	<PropertyGroup>                   
@@ -376,9 +380,9 @@ namespace NuGet.CommandLine.Xplat.Tests
 
             // Assert
             Assert.Equal(projectContent, File.ReadAllText(Path.Combine(testDirectory, "projectA.csproj")));
-            Assert.Contains(@$"<PackageVersion Include=""X"" Version=""2.0.0"" />", File.ReadAllText(Path.Combine(testDirectory, "Directory.Packages.props")));
-            Assert.DoesNotContain(@$"<PackageVersion Include=""X"" Version=""1.0.0"" />", File.ReadAllText(Path.Combine(testDirectory, "Directory.Packages.props")));
+            string updatedPropsFile = File.ReadAllText(Path.Combine(testDirectory, "Directory.Packages.props"));
+            Assert.Contains(@$"<PackageVersion Include=""X"" Version=""2.0.0"" />", updatedPropsFile);
+            Assert.DoesNotContain(@$"<PackageVersion Include=""X"" Version=""1.0.0"" />", updatedPropsFile);
         }
-
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/MSBuildAPIUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/MSBuildAPIUtilityTests.cs
@@ -1,0 +1,70 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO;
+using Microsoft.Build.Definition;
+using Microsoft.Build.Evaluation;
+using Microsoft.Build.Locator;
+using NuGet.CommandLine.XPlat;
+using NuGet.Test.Utility;
+using Xunit;
+using Project = Microsoft.Build.Evaluation.Project;
+
+namespace NuGet.CommandLine.Xplat.Tests
+{
+    public class MSBuildAPIUtilityTests
+    {
+        static MSBuildAPIUtilityTests()
+        {
+            MSBuildLocator.RegisterDefaults();
+        }
+
+        [Fact]
+        public void MSBuilldTest()
+        {
+            var testDirectory = TestDirectory.Create();
+
+            var projectCollection = new ProjectCollection(
+                            globalProperties: null,
+                            remoteLoggers: null,
+                            loggers: null,
+                            toolsetDefinitionLocations: ToolsetDefinitionLocations.Default,
+                            // Having more than 1 node spins up multiple msbuild.exe instances to run builds in parallel
+                            // However, these targets complete so quickly that the added overhead makes it take longer
+                            maxNodeCount: 1,
+                            onlyLogCriticalEvents: false,
+                            loadProjectsReadOnly: false);
+
+            var projectOptions = new ProjectOptions
+            {
+                LoadSettings = ProjectLoadSettings.DoNotEvaluateElementsWithFalseCondition,
+                ProjectCollection = projectCollection
+            };
+
+            var propsFile =
+@$"<Project>
+    <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    </PropertyGroup>
+</Project>";
+            File.WriteAllText(Path.Combine(testDirectory, "Directory.Packages.props"), propsFile);
+
+            string projectContent =
+@$"<Project Sdk=""Microsoft.NET.Sdk"">    
+	<PropertyGroup>                    
+	<OutputType>Exe</OutputType>
+	<TargetFramework>net6.0</TargetFramework>
+	<ImplicitUsings>enable</ImplicitUsings>
+	<Nullable>enable</Nullable>	
+	</PropertyGroup>
+</Project>";
+            File.WriteAllText(Path.Combine(testDirectory, "projectA.csproj"), projectContent);
+
+            var project = Project.FromFile(Path.Combine(testDirectory, "projectA.csproj"), projectOptions);
+
+            var yes = new MSBuildAPIUtility(logger: new TestLogger()).GetDirectoryBuildPropsRootElement(project);
+
+            Assert.Equal(Path.Combine(testDirectory, "Directory.Packages.props"), yes.FullPath);
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/MSBuildAPIUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/MSBuildAPIUtilityTests.cs
@@ -3,6 +3,7 @@
 
 using System.IO;
 using System.Linq;
+using Microsoft.Build.Construction;
 using Microsoft.Build.Definition;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Locator;
@@ -116,8 +117,8 @@ namespace NuGet.CommandLine.Xplat.Tests
             project.Save();
 
             // Assert
-            Assert.Contains(@$"<PackageReference Include=""X"" />", File.ReadAllText(Path.Combine(testDirectory, "projectA.csproj")));
-            Assert.DoesNotContain(@$"<Version = ""1.0.0"" />", File.ReadAllText(Path.Combine(testDirectory, "projectA.csproj")));
+            ProjectItem packageReference = project.Xml.Items.LastOrDefault(i => i.ItemType == "PackageReference" && i.EvaluatedInclude.Equals("X"));
+            Assert.True(packageReference != null, packageReference.ItemType);
         }
 
         [Fact]

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/MSBuildAPIUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/MSBuildAPIUtilityTests.cs
@@ -3,7 +3,6 @@
 
 using System.IO;
 using System.Linq;
-using Microsoft.Build.Construction;
 using Microsoft.Build.Definition;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Locator;
@@ -117,8 +116,8 @@ namespace NuGet.CommandLine.Xplat.Tests
             project.Save();
 
             // Assert
-            ProjectItem packageReference = project.Xml.Items.LastOrDefault(i => i.ItemType == "PackageReference" && i.EvaluatedInclude.Equals("X"));
-            Assert.True(packageReference != null, packageReference.ItemType);
+            Assert.Contains(@$"<PackageReference Include=""X"" />", File.ReadAllText(Path.Combine(testDirectory, "projectA.csproj")));
+            Assert.DoesNotContain(@$"<Version = ""1.0.0"" />", File.ReadAllText(Path.Combine(testDirectory, "projectA.csproj")));
         }
 
         [Fact]

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/NuGet.CommandLine.Xplat.Tests.csproj
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/NuGet.CommandLine.Xplat.Tests.csproj
@@ -17,6 +17,12 @@
     <Reference Include="System.IO.Compression" />
   </ItemGroup>
 
+  <ItemGroup>
+      <PackageReference Include="Microsoft.Build" ExcludeAssets="runtime" />
+      <PackageReference Include="Microsoft.Build.Framework" ExcludeAssets="runtime" />
+      <PackageReference Include="Microsoft.Build.Locator" />
+  </ItemGroup>
+  
   <Import Project="$(BuildCommonDirectory)common.targets" />
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 </Project>


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug
Fixes: https://github.com/NuGet/Home/issues/11890
Regression? No.

## Description
This feature is based on the design spec: https://github.com/NuGet/Home/pull/11915. The goal was to allow the dotnet add package command to be executed for projects that were onboarded to CPM. Previously, the command threw a NU1008 error whenever packages were attempted to be added to projects onboarded to CPM. However, with this change users will now be able to add or update package references in projects onboarded to CPM. Directory.Packages.props files and project files are now modified accordingly whenever a package is added/updated.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - Functional test that checks if a package version is added to the props file correctly when there are no existing package versions in the props file already. It also checks that the package reference is added to the project file and that it does not have the package version metadata included in it.
  - Functional test that checks if a package version is added to the props file correctly when there already other existing package versions in the props file. It also checks that the package reference is added to the project file and that it does not have the package version metadata included in it.
  - Functional test that checks if a package version is updated with the correct package version attribute in the Directory.Packages.props file.

- **Documentation**
  - [x] Documentation PR or issue filled: https://github.com/NuGet/Home/issues/13480
