### PR TITLE
Test:  enable .NET SDK tests to provide custom trust implementation

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/Signing/Utility/IX509CertificateChain.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Utility/IX509CertificateChain.cs
@@ -7,6 +7,9 @@ using System.Security.Cryptography.X509Certificates;
 
 namespace NuGet.Packaging.Signing
 {
+    /// <summary>
+    /// Represents a certificate chain ordered from end certificate (index 0) to root certificate.
+    /// </summary>
     public interface IX509CertificateChain : IReadOnlyList<X509Certificate2>, IDisposable
     {
     }

--- a/test/TestUtilities/Test.Utility/Signing/IX509StoreCertificate.cs
+++ b/test/TestUtilities/Test.Utility/Signing/IX509StoreCertificate.cs
@@ -1,0 +1,17 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Security.Cryptography.X509Certificates;
+
+namespace Test.Utility.Signing
+{
+    /// <summary>
+    /// Represents an X.509 certificate in a specific X.509 store.  No trust is implied.
+    /// </summary>
+    public interface IX509StoreCertificate
+    {
+        StoreLocation StoreLocation { get; }
+        StoreName StoreName { get; }
+        X509Certificate2 Certificate { get; }
+    }
+}

--- a/test/TestUtilities/Test.Utility/Signing/TrustedTestCert.cs
+++ b/test/TestUtilities/Test.Utility/Signing/TrustedTestCert.cs
@@ -2,11 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.IO;
 using System.Security.Cryptography.X509Certificates;
-using System.Threading;
-using NuGet.Common;
-using NuGet.Test.Utility;
 
 namespace Test.Utility.Signing
 {
@@ -32,8 +28,6 @@ namespace Test.Utility.Signing
     /// </summary>
     public class TrustedTestCert<T> : IDisposable
     {
-        private X509Store _store;
-
         public X509Certificate2 TrustedCert { get; }
 
         public T Source { get; }
@@ -43,12 +37,6 @@ namespace Test.Utility.Signing
         public StoreLocation StoreLocation { get; }
 
         private bool _isDisposed;
-
-        private const string KeychainForMac = "/Library/Keychains/System.keychain";
-
-        //Macos-11.6 (Big Sur) has different security settings and permissions
-        //This command will bypass a popup asking for unlocking a keychain.
-        private const string BypassGUICommandForMac = "sudo security authorizationdb write com.apple.trust-settings.admin allow";
 
         public TrustedTestCert(T source,
             Func<T, X509Certificate2> getCert,
@@ -73,111 +61,9 @@ namespace Test.Utility.Signing
             StoreName = storeName;
             StoreLocation = storeLocation;
 
-            // According to https://github.com/dotnet/runtime/blob/master/docs/design/features/cross-platform-cryptography.md#x509store,
-            // on macOS, when StoreName = My, StoreLocation = CurrentUser, the X509Store is read/write. 
-            // For other cases, the X509Store is read-only, writing will throw CryptographicException.
-            if ((RuntimeEnvironmentHelper.IsMacOSX && storeName.Equals(StoreName.My) && storeLocation.Equals(StoreLocation.CurrentUser)) || !RuntimeEnvironmentHelper.IsMacOSX)
-            {
-                AddCertificateToStore();
-            }
-            else
-            {
-                AddCertificateToStoreForMacOSX();
-            }
+            X509StoreUtilities.AddCertificateToStore(StoreLocation, StoreName, TrustedCert);
 
             ExportCrl();
-        }
-
-        private void AddCertificateToStore()
-        {
-            _store = new X509Store(StoreName, StoreLocation);
-            _store.Open(OpenFlags.ReadWrite);
-            _store.Add(TrustedCert);
-
-            //Add wait for Linux, as https://github.com/dotnet/runtime/issues/32608
-            //Windows has a live-synchronized model, and on Linux, there is a filesystem/rescan delay problem.
-            //For performance reasons, dotnet/runtime only check to see if the store has been modified once a second.
-            if (RuntimeEnvironmentHelper.IsLinux)
-            {
-                Thread.Sleep(1500);
-
-                var MaxTries = 30;
-
-                for (var i = 0; i < MaxTries; i++)
-                {
-                    using (var chain = new X509Chain())
-                    {
-                        chain.ChainPolicy.RevocationMode = X509RevocationMode.Online;
-
-                        if (chain.Build(TrustedCert))
-                        {
-                            break;
-                        }
-                        else
-                        {
-                            Thread.Sleep(1000);
-                        }
-                    }
-                }
-            }
-        }
-
-        //According to https://github.com/dotnet/runtime/blob/master/docs/design/features/cross-platform-cryptography.md#x509store,
-        //on macOS the X509Store class is a projection of system trust decisions (read-only), user trust decisions (read-only), and user key storage (read-write).
-        //So we have to run command to add certificate to System.keychain to make it trusted.
-        private void AddCertificateToStoreForMacOSX()
-        {
-            var certFile = new FileInfo(Path.Combine("/tmp", $"{TrustedCert.Thumbprint}.cer"));
-
-            File.WriteAllBytes(certFile.FullName, TrustedCert.RawData);
-
-            RunMacCommand(BypassGUICommandForMac);
-
-            string addToKeyChainCmd = $"sudo security add-trusted-cert -d -r trustRoot " +
-                                      $"-k \"{KeychainForMac}\" " +
-                                      $"\"{certFile.FullName}\"";
-
-            RunMacCommand(addToKeyChainCmd);
-        }
-
-        //According to https://github.com/dotnet/runtime/blob/master/docs/design/features/cross-platform-cryptography.md#x509store,
-        //on macOS the X509Store class is a projection of system trust decisions (read-only), user trust decisions (read-only), and user key storage (read-write).
-        //So we have to run command to remove certificate from System.keychain to make it untrusted.
-        private void RemoveTrustedCert()
-        {
-            var certFile = new FileInfo(Path.Combine("/tmp", $"{TrustedCert.Thumbprint}.cer"));
-
-            string removeFromKeyChainCmd = $"sudo security delete-certificate -Z {TrustedCert.Thumbprint}  \"{KeychainForMac}\"";
-
-            try
-            {
-                RunMacCommand(BypassGUICommandForMac);
-                RunMacCommand(removeFromKeyChainCmd);
-            }
-            finally
-            {
-                certFile.Delete();
-            }
-        }
-
-        private static void RunMacCommand(string cmd)
-        {
-            string workingDirectory = "/bin";
-            string args = "-c \"" + cmd + "\"";
-
-            CommandRunnerResult result = CommandRunner.Run("/bin/bash",
-                workingDirectory,
-                args,
-                waitForExit: true,
-                timeOutInMilliseconds: 60000);
-
-            if (!result.Success)
-            {
-                throw new SystemToolException($"Run security command failed with following log information :\n" +
-                                              $"exit code   = {result.ExitCode} \n" +
-                                              $"exit output = {result.Output} \n" +
-                                              $"exit error  = {result.Errors} \n");
-            }
         }
 
         private void ExportCrl()
@@ -204,17 +90,7 @@ namespace Test.Utility.Signing
         {
             if (!_isDisposed)
             {
-                if ((RuntimeEnvironmentHelper.IsMacOSX && StoreName.Equals(StoreName.My) && StoreLocation.Equals(StoreLocation.CurrentUser)) || !RuntimeEnvironmentHelper.IsMacOSX)
-                {
-                    using (_store)
-                    {
-                        _store.Remove(TrustedCert);
-                    }
-                }
-                else
-                {
-                    RemoveTrustedCert();
-                }
+                X509StoreUtilities.RemoveCertificateFromStore(StoreLocation, StoreName, TrustedCert);
 
                 DisposeCrl();
 

--- a/test/TestUtilities/Test.Utility/Signing/X509StoreCertificate.cs
+++ b/test/TestUtilities/Test.Utility/Signing/X509StoreCertificate.cs
@@ -1,0 +1,45 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Security.Cryptography.X509Certificates;
+
+namespace Test.Utility.Signing
+{
+    public sealed class X509StoreCertificate : IX509StoreCertificate, IDisposable
+    {
+        private bool _isDisposed;
+
+        public StoreLocation StoreLocation { get; }
+        public StoreName StoreName { get; }
+        public X509Certificate2 Certificate { get; }
+
+        public X509StoreCertificate(StoreLocation storeLocation, StoreName storeName, X509Certificate2 certificate)
+        {
+            if (certificate is null)
+            {
+                throw new ArgumentNullException(nameof(certificate));
+            }
+
+            StoreLocation = storeLocation;
+            StoreName = storeName;
+            Certificate = certificate;
+
+            X509StoreUtilities.AddCertificateToStore(storeLocation, storeName, certificate);
+        }
+
+        public void Dispose()
+        {
+            if (!_isDisposed)
+            {
+                X509StoreUtilities.RemoveCertificateFromStore(StoreLocation, StoreName, Certificate);
+
+                Certificate.Dispose();
+
+                GC.SuppressFinalize(this);
+
+                _isDisposed = true;
+            }
+        }
+    }
+}

--- a/test/TestUtilities/Test.Utility/Signing/X509StoreUtilities.cs
+++ b/test/TestUtilities/Test.Utility/Signing/X509StoreUtilities.cs
@@ -1,0 +1,155 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading;
+using NuGet.Common;
+using NuGet.Test.Utility;
+
+namespace Test.Utility.Signing
+{
+    internal static class X509StoreUtilities
+    {
+        private const string KeychainForMac = "/Library/Keychains/System.keychain";
+
+        // Macos-11.6 (Big Sur) has different security settings and permissions
+        // This command will bypass a popup asking for unlocking a keychain.
+        private const string BypassGUICommandForMac = "sudo security authorizationdb write com.apple.trust-settings.admin allow";
+
+        internal static void AddCertificateToStore(StoreLocation storeLocation, StoreName storeName, X509Certificate2 certificate)
+        {
+            if (certificate is null)
+            {
+                throw new ArgumentNullException(nameof(certificate));
+            }
+
+            // According to https://github.com/dotnet/runtime/blob/master/docs/design/features/cross-platform-cryptography.md#x509store,
+            // on macOS, when StoreName = My, StoreLocation = CurrentUser, the X509Store is read/write. 
+            // For other cases, the X509Store is read-only, writing will throw CryptographicException.
+            if ((RuntimeEnvironmentHelper.IsMacOSX && storeName.Equals(StoreName.My) && storeLocation.Equals(StoreLocation.CurrentUser)) || !RuntimeEnvironmentHelper.IsMacOSX)
+            {
+                AddCertificateToStoreCommon(storeLocation, storeName, certificate);
+            }
+            else
+            {
+                AddCertificateToStoreForMacOSX(certificate);
+            }
+        }
+
+        private static void AddCertificateToStoreCommon(StoreLocation storeLocation, StoreName storeName, X509Certificate2 certificate)
+        {
+            using (X509Store store = new(storeName, storeLocation))
+            {
+                store.Open(OpenFlags.ReadWrite);
+                store.Add(certificate);
+
+                // Add wait for Linux, as https://github.com/dotnet/runtime/issues/32608
+                // Windows has a live-synchronized model, and on Linux, there is a filesystem/rescan delay problem.
+                // For performance reasons, dotnet/runtime only check to see if the store has been modified once a second.
+                if (RuntimeEnvironmentHelper.IsLinux)
+                {
+                    Thread.Sleep(1500);
+
+                    var MaxTries = 30;
+
+                    for (var i = 0; i < MaxTries; i++)
+                    {
+                        using (X509Chain chain = new())
+                        {
+                            chain.ChainPolicy.RevocationMode = X509RevocationMode.Online;
+
+                            if (chain.Build(certificate))
+                            {
+                                break;
+                            }
+                            else
+                            {
+                                Thread.Sleep(1000);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // According to https://github.com/dotnet/runtime/blob/master/docs/design/features/cross-platform-cryptography.md#x509store,
+        // on macOS the X509Store class is a projection of system trust decisions (read-only), user trust decisions (read-only), and user key storage (read-write).
+        // So we have to run command to add certificate to System.keychain to make it trusted.
+        private static void AddCertificateToStoreForMacOSX(X509Certificate2 certificate)
+        {
+            FileInfo certFile = new(Path.Combine("/tmp", $"{certificate.Thumbprint}.cer"));
+
+            File.WriteAllBytes(certFile.FullName, certificate.RawData);
+
+            RunMacCommand(BypassGUICommandForMac);
+
+            string addToKeyChainCmd = $"sudo security add-trusted-cert -d -r trustRoot " +
+                                      $"-k \"{KeychainForMac}\" " +
+                                      $"\"{certFile.FullName}\"";
+
+            RunMacCommand(addToKeyChainCmd);
+        }
+
+        internal static void RemoveCertificateFromStore(StoreLocation storeLocation, StoreName storeName, X509Certificate2 certificate)
+        {
+            if (certificate is null)
+            {
+                throw new ArgumentNullException(nameof(certificate));
+            }
+
+            if ((RuntimeEnvironmentHelper.IsMacOSX && storeName.Equals(StoreName.My) && storeLocation.Equals(StoreLocation.CurrentUser)) || !RuntimeEnvironmentHelper.IsMacOSX)
+            {
+                using (X509Store store = new(storeName, storeLocation))
+                {
+                    store.Open(OpenFlags.ReadWrite);
+                    store.Remove(certificate);
+                }
+            }
+            else
+            {
+                RemoveCertificateFromStoreForMacOSX(certificate);
+            }
+        }
+
+        // According to https://github.com/dotnet/runtime/blob/master/docs/design/features/cross-platform-cryptography.md#x509store,
+        // on macOS the X509Store class is a projection of system trust decisions (read-only), user trust decisions (read-only), and user key storage (read-write).
+        // So we have to run command to remove certificate from System.keychain to make it untrusted.
+        private static void RemoveCertificateFromStoreForMacOSX(X509Certificate2 certificate)
+        {
+            FileInfo certFile = new(Path.Combine("/tmp", $"{certificate.Thumbprint}.cer"));
+            string removeFromKeyChainCmd = $"sudo security delete-certificate -Z {certificate.Thumbprint}  \"{KeychainForMac}\"";
+
+            try
+            {
+                RunMacCommand(BypassGUICommandForMac);
+                RunMacCommand(removeFromKeyChainCmd);
+            }
+            finally
+            {
+                certFile.Delete();
+            }
+        }
+
+        private static void RunMacCommand(string cmd)
+        {
+            string workingDirectory = "/bin";
+            string args = "-c \"" + cmd + "\"";
+
+            CommandRunnerResult result = CommandRunner.Run("/bin/bash",
+                workingDirectory,
+                args,
+                waitForExit: true,
+                timeOutInMilliseconds: 60000);
+
+            if (!result.Success)
+            {
+                throw new SystemToolException($"Run security command failed with following log information :\n" +
+                                              $"exit code   = {result.ExitCode} \n" +
+                                              $"exit output = {result.Output} \n" +
+                                              $"exit error  = {result.Errors} \n");
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes:  https://github.com/NuGet/Home/issues/11920

Regression? Last working version:  N/A

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
This change enables .NET SDK tests to provide a non-default trust implementation for trusted certificates.

The new test type `IX509StoreCertificate` simply links a certificate to a storage location.  The implementation `X509StoreCertificate` provides the implementation of how a certificate is trusted (if it is) and the implementation of the storage location.  A future PR will change the implementation to read/write trust anchors in the test .NET SDK fallback certificate bundle.

## PR Checklist

- [X] PR has a meaningful title
- [X] PR has a linked issue.
- [X] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [X] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [X] N/A
