### PR TITLE
Allow disabling the AssetTargetFallback dependency resolution via an environment variable

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/SourceRepositoryDependencyProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/SourceRepositoryDependencyProvider.cs
@@ -87,13 +87,13 @@ namespace NuGet.Commands
         /// is <c>null</c>.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> is <c>null</c>.</exception>
         public SourceRepositoryDependencyProvider(
-        SourceRepository sourceRepository,
-        ILogger logger,
-        SourceCacheContext cacheContext,
-        bool ignoreFailedSources,
-        bool ignoreWarning,
-        LocalPackageFileCache fileCache,
-        bool isFallbackFolderSource) :
+            SourceRepository sourceRepository,
+            ILogger logger,
+            SourceCacheContext cacheContext,
+            bool ignoreFailedSources,
+            bool ignoreWarning,
+            LocalPackageFileCache fileCache,
+            bool isFallbackFolderSource) :
             this(sourceRepository,
                 logger,
                 cacheContext,
@@ -106,14 +106,14 @@ namespace NuGet.Commands
         }
 
         internal SourceRepositoryDependencyProvider(
-        SourceRepository sourceRepository,
-        ILogger logger,
-        SourceCacheContext cacheContext,
-        bool ignoreFailedSources,
-        bool ignoreWarning,
-        LocalPackageFileCache fileCache,
-        bool isFallbackFolderSource,
-        IEnvironmentVariableReader environmentVariableReader)
+            SourceRepository sourceRepository,
+            ILogger logger,
+            SourceCacheContext cacheContext,
+            bool ignoreFailedSources,
+            bool ignoreWarning,
+            LocalPackageFileCache fileCache,
+            bool isFallbackFolderSource,
+            IEnvironmentVariableReader environmentVariableReader)
         {
             _sourceRepository = sourceRepository ?? throw new ArgumentNullException(nameof(sourceRepository));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/SourceRepositoryDependencyProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/SourceRepositoryDependencyProvider.cs
@@ -34,6 +34,7 @@ namespace NuGet.Commands
         private bool _ignoreFailedSources;
         private bool _ignoreWarning;
         private bool _isFallbackFolderSource;
+        private bool _useLegacyAssetTargetFallbackBehavior;
 
         private readonly ConcurrentDictionary<LibraryRangeCacheKey, AsyncLazy<LibraryDependencyInfo>> _dependencyInfoCache
             = new ConcurrentDictionary<LibraryRangeCacheKey, AsyncLazy<LibraryDependencyInfo>>();
@@ -92,7 +93,27 @@ namespace NuGet.Commands
         bool ignoreFailedSources,
         bool ignoreWarning,
         LocalPackageFileCache fileCache,
-        bool isFallbackFolderSource)
+        bool isFallbackFolderSource) :
+            this(sourceRepository,
+                logger,
+                cacheContext,
+                ignoreFailedSources,
+                ignoreWarning,
+                fileCache,
+                isFallbackFolderSource,
+                environmentVariableReader: EnvironmentVariableWrapper.Instance)
+        {
+        }
+
+        internal SourceRepositoryDependencyProvider(
+        SourceRepository sourceRepository,
+        ILogger logger,
+        SourceCacheContext cacheContext,
+        bool ignoreFailedSources,
+        bool ignoreWarning,
+        LocalPackageFileCache fileCache,
+        bool isFallbackFolderSource,
+        IEnvironmentVariableReader environmentVariableReader)
         {
             _sourceRepository = sourceRepository ?? throw new ArgumentNullException(nameof(sourceRepository));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
@@ -101,6 +122,7 @@ namespace NuGet.Commands
             _ignoreWarning = ignoreWarning;
             _packageFileCache = fileCache;
             _isFallbackFolderSource = isFallbackFolderSource;
+            _useLegacyAssetTargetFallbackBehavior = MSBuildStringUtility.IsTrue(environmentVariableReader.GetEnvironmentVariable(Environment.GetEnvironmentVariable("NUGET_USE_LEGACY_ASSET_TARGET_FALLBACK_DEPENDENCY_RESOLUTION")));
         }
 
         /// <summary>
@@ -293,6 +315,7 @@ namespace NuGet.Commands
 
             AsyncLazy<LibraryDependencyInfo> result = null;
 
+            // Therre's caching here which happens based on a bunch of stuff.
             var action = new AsyncLazy<LibraryDependencyInfo>(async () =>
                 await GetDependenciesCoreAsync(libraryIdentity, targetFramework, cacheContext, logger, cancellationToken));
 
@@ -470,7 +493,7 @@ namespace NuGet.Commands
             return null;
         }
 
-        private static IEnumerable<LibraryDependency> GetDependencies(
+        private IEnumerable<LibraryDependency> GetDependencies(
             FindPackageByIdDependencyInfo packageInfo,
             NuGetFramework targetFramework)
         {
@@ -488,13 +511,17 @@ namespace NuGet.Commands
                 dependencyGroup = NuGetFrameworkUtility.GetNearest(packageInfo.DependencyGroups, dualCompatibilityFramework.SecondaryFramework, item => item.TargetFramework);
             }
 
-            // FrameworkReducer.GetNearest does not consider ATF since it is used for more than just compat
-            if (dependencyGroup == null &&
-                targetFramework is AssetTargetFallbackFramework assetTargetFallbackFramework)
+            if (!_useLegacyAssetTargetFallbackBehavior)
             {
-                dependencyGroup = NuGetFrameworkUtility.GetNearest(packageInfo.DependencyGroups,
-                    assetTargetFallbackFramework.AsFallbackFramework(),
-                    item => item.TargetFramework);
+                // FrameworkReducer.GetNearest does not consider ATF since it is used for more than just compat
+
+                if (dependencyGroup == null &&
+                    targetFramework is AssetTargetFallbackFramework assetTargetFallbackFramework)
+                {
+                    dependencyGroup = NuGetFrameworkUtility.GetNearest(packageInfo.DependencyGroups,
+                        assetTargetFallbackFramework.AsFallbackFramework(),
+                        item => item.TargetFramework);
+                }
             }
 
             if (dependencyGroup != null)

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/SourceRepositoryDependencyProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/SourceRepositoryDependencyProvider.cs
@@ -315,7 +315,6 @@ namespace NuGet.Commands
 
             AsyncLazy<LibraryDependencyInfo> result = null;
 
-            // Therre's caching here which happens based on a bunch of stuff.
             var action = new AsyncLazy<LibraryDependencyInfo>(async () =>
                 await GetDependenciesCoreAsync(libraryIdentity, targetFramework, cacheContext, logger, cancellationToken));
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/SourceRepositoryDependencyProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/SourceRepositoryDependencyProvider.cs
@@ -122,7 +122,7 @@ namespace NuGet.Commands
             _ignoreWarning = ignoreWarning;
             _packageFileCache = fileCache;
             _isFallbackFolderSource = isFallbackFolderSource;
-            _useLegacyAssetTargetFallbackBehavior = MSBuildStringUtility.IsTrue(environmentVariableReader.GetEnvironmentVariable(Environment.GetEnvironmentVariable("NUGET_USE_LEGACY_ASSET_TARGET_FALLBACK_DEPENDENCY_RESOLUTION")));
+            _useLegacyAssetTargetFallbackBehavior = MSBuildStringUtility.IsTrue(environmentVariableReader.GetEnvironmentVariable("NUGET_USE_LEGACY_ASSET_TARGET_FALLBACK_DEPENDENCY_RESOLUTION"));
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpecReferenceDependencyProvider.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpecReferenceDependencyProvider.cs
@@ -199,12 +199,9 @@ namespace NuGet.ProjectModel
                 var targetFrameworkInfo = packageSpec.GetTargetFramework(targetFramework);
 
                 // FrameworkReducer.GetNearest does not consider ATF since it is used for more than just compat
-                if (!_useLegacyAssetTargetFallbackBehavior)
+                if (targetFrameworkInfo.FrameworkName == null && targetFramework is AssetTargetFallbackFramework atfFramework)
                 {
-                    if (targetFrameworkInfo.FrameworkName == null && targetFramework is AssetTargetFallbackFramework atfFramework)
-                    {
-                        targetFrameworkInfo = packageSpec.GetTargetFramework(atfFramework.AsFallbackFramework());
-                    }
+                    targetFrameworkInfo = packageSpec.GetTargetFramework(atfFramework.AsFallbackFramework());
                 }
 
                 if (targetFrameworkInfo.FrameworkName == null && targetFramework is DualCompatibilityFramework mcfFramework)
@@ -337,7 +334,7 @@ namespace NuGet.ProjectModel
             return dependencies;
         }
 
-        internal static List<LibraryDependency> GetSpecDependencies(
+        internal List<LibraryDependency> GetSpecDependencies(
             PackageSpec packageSpec,
             NuGetFramework targetFramework)
         {
@@ -349,12 +346,14 @@ namespace NuGet.ProjectModel
                 dependencies.AddRange(packageSpec.Dependencies);
 
                 // Add framework specific dependencies
-                // Disable?
                 var targetFrameworkInfo = packageSpec.GetTargetFramework(targetFramework);
 
-                if (targetFrameworkInfo.FrameworkName == null && targetFramework is AssetTargetFallbackFramework atfFramework)
+                if (!_useLegacyAssetTargetFallbackBehavior)
                 {
-                    targetFrameworkInfo = packageSpec.GetTargetFramework(atfFramework.AsFallbackFramework());
+                    if (targetFrameworkInfo.FrameworkName == null && targetFramework is AssetTargetFallbackFramework atfFramework)
+                    {
+                        targetFrameworkInfo = packageSpec.GetTargetFramework(atfFramework.AsFallbackFramework());
+                    }
                 }
 
                 dependencies.AddRange(targetFrameworkInfo.Dependencies);

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/SourceRepositoryDependencyProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/SourceRepositoryDependencyProviderTests.cs
@@ -808,11 +808,6 @@ namespace NuGet.Commands.Test
             source.SetupGet(s => s.PackageSource)
                 .Returns(new PackageSource("http://test/index.json"));
 
-            var libraryRange = new LibraryRange(
-                "x",
-                new VersionRange(new NuGetVersion(1, 0, 0, "beta")),
-                LibraryDependencyTarget.Package);
-
             var provider = new SourceRepositoryDependencyProvider(
                 source.Object,
                 testLogger,
@@ -874,11 +869,6 @@ namespace NuGet.Commands.Test
                 .ReturnsAsync(findResource.Object);
             source.SetupGet(s => s.PackageSource)
                 .Returns(new PackageSource("http://test/index.json"));
-
-            var libraryRange = new LibraryRange(
-                "x",
-                new VersionRange(new NuGetVersion(1, 0, 0, "beta")),
-                LibraryDependencyTarget.Package);
 
             var provider = new SourceRepositoryDependencyProvider(
                 source.Object,

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/SourceRepositoryDependencyProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/SourceRepositoryDependencyProviderTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -17,6 +18,7 @@ using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
 using NuGet.Test.Utility;
 using NuGet.Versioning;
+using Test.Utility;
 using Xunit;
 
 namespace NuGet.Commands.Test
@@ -770,6 +772,141 @@ namespace NuGet.Commands.Test
             results.Should().Be(null);
             secondTestLogger.WarningMessages.Should().HaveCount(1);
             secondTestLogger.ShowWarnings().Should().Contain("NU1801");
+        }
+
+        [Fact]
+        public async Task GetDependenciesAsync_WhenPackageHasVariousDependencyGroups_CorrectFrameworkIsSelected()
+        {
+            // Arrange
+            var testLogger = new TestLogger();
+            var cacheContext = new SourceCacheContext();
+            var findResource = new Mock<FindPackageByIdResource>();
+            var net46 = FrameworkConstants.CommonFrameworks.Net46;
+            var netstandard20 = FrameworkConstants.CommonFrameworks.NetStandard20;
+
+            var packageDependencyGroups = new List<PackageDependencyGroup>();
+            var net46group = new PackageDependencyGroup(net46, new PackageDependency[] { new PackageDependency("full.framework", VersionRange.Parse("1.0.0")) });
+            var netstandardGroup = new PackageDependencyGroup(netstandard20, new PackageDependency[] { new PackageDependency("netstandard", VersionRange.Parse("1.0.0")) });
+
+            packageDependencyGroups.Add(net46group);
+            packageDependencyGroups.Add(netstandardGroup);
+
+            findResource.Setup(s => s.GetDependencyInfoAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<NuGetVersion>(),
+                    It.IsAny<SourceCacheContext>(),
+                    It.IsAny<ILogger>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new FindPackageByIdDependencyInfo(
+                    new PackageIdentity("x", NuGetVersion.Parse("1.0.0-beta")),
+                    packageDependencyGroups,
+                    Enumerable.Empty<FrameworkSpecificGroup>()));
+
+            var source = new Mock<SourceRepository>();
+            source.Setup(s => s.GetResourceAsync<FindPackageByIdResource>())
+                .ReturnsAsync(findResource.Object);
+            source.SetupGet(s => s.PackageSource)
+                .Returns(new PackageSource("http://test/index.json"));
+
+            var libraryRange = new LibraryRange(
+                "x",
+                new VersionRange(new NuGetVersion(1, 0, 0, "beta")),
+                LibraryDependencyTarget.Package);
+
+            var provider = new SourceRepositoryDependencyProvider(
+                source.Object,
+                testLogger,
+                cacheContext,
+                ignoreFailedSources: true,
+                ignoreWarning: true,
+                fileCache: null,
+                isFallbackFolderSource: false,
+                new TestEnvironmentVariableReader(new Dictionary<string, string>()));
+
+            // Act
+            var library = await provider.GetDependenciesAsync(
+                new LibraryIdentity("x", NuGetVersion.Parse("1.0.0-beta"), LibraryType.Package),
+                FrameworkConstants.CommonFrameworks.Net472,
+                cacheContext,
+                testLogger,
+                CancellationToken.None);
+            // Assert
+            library.Dependencies.Should().HaveCount(1);
+            var dependencies = library.Dependencies.Single();
+            dependencies.Name.Should().Be("full.framework");
+        }
+
+        [Theory]
+        [InlineData("true", false)]
+        [InlineData("blbla", true)]
+        public async Task GetDependenciesAsync_WhenPackageIsSelectedWithAssetTargetFallback_AndLegacyDependencyResolutionVariableIsSpecified_CorrectDependenciesAreSelected(string envValue, bool areDependenciesSelected)
+        {
+            // Arrange
+            var testLogger = new TestLogger();
+            var cacheContext = new SourceCacheContext();
+            var findResource = new Mock<FindPackageByIdResource>();
+            var wrapper = new TestEnvironmentVariableReader(new Dictionary<string, string>
+            {
+                { "NUGET_USE_LEGACY_ASSET_TARGET_FALLBACK_DEPENDENCY_RESOLUTION", envValue }
+            });
+            var net472 = FrameworkConstants.CommonFrameworks.Net472;
+            var net60 = FrameworkConstants.CommonFrameworks.Net60;
+            var inputFramework = new AssetTargetFallbackFramework(net60, new List<NuGetFramework> { net472 });
+
+            var packageDependencyGroups = new List<PackageDependencyGroup>();
+            var net472Group = new PackageDependencyGroup(net472, new PackageDependency[] { new PackageDependency("full.framework", VersionRange.Parse("1.0.0")) });
+
+            packageDependencyGroups.Add(net472Group);
+
+            findResource.Setup(s => s.GetDependencyInfoAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<NuGetVersion>(),
+                    It.IsAny<SourceCacheContext>(),
+                    It.IsAny<ILogger>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new FindPackageByIdDependencyInfo(
+                    new PackageIdentity("x", NuGetVersion.Parse("1.0.0-beta")),
+                    packageDependencyGroups,
+                    Enumerable.Empty<FrameworkSpecificGroup>()));
+
+            var source = new Mock<SourceRepository>();
+            source.Setup(s => s.GetResourceAsync<FindPackageByIdResource>())
+                .ReturnsAsync(findResource.Object);
+            source.SetupGet(s => s.PackageSource)
+                .Returns(new PackageSource("http://test/index.json"));
+
+            var libraryRange = new LibraryRange(
+                "x",
+                new VersionRange(new NuGetVersion(1, 0, 0, "beta")),
+                LibraryDependencyTarget.Package);
+
+            var provider = new SourceRepositoryDependencyProvider(
+                source.Object,
+                testLogger,
+                cacheContext,
+                ignoreFailedSources: true,
+                ignoreWarning: true,
+                fileCache: null,
+                isFallbackFolderSource: false,
+                wrapper);
+
+            // Act
+            var library = await provider.GetDependenciesAsync(
+                new LibraryIdentity("x", NuGetVersion.Parse("1.0.0-beta"), LibraryType.Package),
+                inputFramework,
+                cacheContext,
+                testLogger,
+                CancellationToken.None);
+            // Assert
+            if (areDependenciesSelected)
+            {
+                library.Dependencies.Should().HaveCount(1);
+                var dependencies = library.Dependencies.Single();
+                dependencies.Name.Should().Be("full.framework");
+            } else
+            {
+                library.Dependencies.Should().HaveCount(0);
+            }
         }
 
         private sealed class SourceRepositoryDependencyProviderTest : IDisposable

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecReferenceDependencyProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecReferenceDependencyProviderTests.cs
@@ -3,10 +3,13 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using FluentAssertions;
+using NuGet.Commands.Test;
+using NuGet.Common;
 using NuGet.Frameworks;
 using NuGet.LibraryModel;
-using NuGet.Test.Utility;
 using NuGet.Versioning;
+using Test.Utility;
 using Xunit;
 
 namespace NuGet.ProjectModel.Test
@@ -40,8 +43,9 @@ namespace NuGet.ProjectModel.Test
             var dependencyGraphSpec = CreateDependencyGraphSpecWithCentralDependencies(cpvmEnabled, CentralPackageTransitivePinningEnabled, tfi);
             var packSpec = dependencyGraphSpec.Projects[0];
 
+            var dependencyProvider = new PackageSpecReferenceDependencyProvider(new List<ExternalProjectReference>(), NullLogger.Instance);
             // Act
-            var dependencies = PackageSpecReferenceDependencyProvider.GetSpecDependencies(packSpec, tfi.FrameworkName);
+            var dependencies = dependencyProvider.GetSpecDependencies(packSpec, tfi.FrameworkName);
 
             // Assert
             if (cpvmEnabled && CentralPackageTransitivePinningEnabled)
@@ -70,6 +74,44 @@ namespace NuGet.ProjectModel.Test
                 Assert.Equal(fooDep.LibraryRange.VersionRange != null, cpvmEnabled);
                 Assert.Equal(LibraryDependencyReferenceType.Direct, fooDep.ReferenceType);
             }
+        }
+
+        [Fact]
+        public void GetSpecDependencies_WithAssetTargetFallback_ReturnsCorrectDependencies()
+        {
+            // Arrange
+            var net60Framework = FrameworkConstants.CommonFrameworks.Net60;
+            var net472Framework = FrameworkConstants.CommonFrameworks.Net472;
+            var packageSpec = ProjectTestHelpers.GetPackageSpec(rootPath: "C:\\", projectName: "A", framework: net472Framework.GetShortFolderName(), dependencyName: "x");
+
+            var dependencyProvider = new PackageSpecReferenceDependencyProvider(new List<ExternalProjectReference>(), NullLogger.Instance);
+            var assetTargetFallback = new AssetTargetFallbackFramework(net60Framework, new List<NuGetFramework> { net472Framework });
+            // Act
+
+            var dependencies = dependencyProvider.GetSpecDependencies(packageSpec, assetTargetFallback);
+
+            // Assert
+            dependencies.Should().HaveCount(1);
+            dependencies[0].Name.Should().Be("x");
+        }
+
+        [Fact]
+        public void GetSpecDependencies_WithAssetTargetFallback_AndDependencyResolutionDisabled_ReturnsCorrectDependencies()
+        {
+            // Arrange
+            var net60Framework = FrameworkConstants.CommonFrameworks.Net60;
+            var net472Framework = FrameworkConstants.CommonFrameworks.Net472;
+            var packageSpec = ProjectTestHelpers.GetPackageSpec(rootPath: "C:\\", projectName: "A", framework: net472Framework.GetShortFolderName(), dependencyName: "x");
+
+            var envVarWrapper = new TestEnvironmentVariableReader(new Dictionary<string, string> { { "NUGET_USE_LEGACY_ASSET_TARGET_FALLBACK_DEPENDENCY_RESOLUTION", "true" } });
+            var dependencyProvider = new PackageSpecReferenceDependencyProvider(new List<ExternalProjectReference>(), NullLogger.Instance, envVarWrapper);
+            var assetTargetFallback = new AssetTargetFallbackFramework(net60Framework, new List<NuGetFramework> { net472Framework });
+            // Act
+
+            var dependencies = dependencyProvider.GetSpecDependencies(packageSpec, assetTargetFallback);
+
+            // Assert
+            dependencies.Should().HaveCount(0);
         }
 
         private static TargetFrameworkInformation CreateTargetFrameworkInformation(List<LibraryDependency> dependencies, List<CentralPackageVersion> centralVersionsDependencies, bool cpvmEnabled)


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11564

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
Some users have been affected by the recent bug fix to start resolving the dependencies via AssetTargetFallback. In particular, https://github.com/NuGet/NuGet.Client/pull/4372/files is the change. 

https://github.com/NuGet/Home/issues/11564 has testimonials about it, and as a response we will:
* Disable the behavior in 17.3/6.3/6.0.400. 
* Remove the fallback in 17.4/6.4/7.0.100. 

This should ease the transition for the more severely affected customers. 

Normally the most convenient way of disabling this would be a property in the project, but that change creates a bunch of public API changes that we'd need to keep. 
Current NuGet does a lot of heavy caching when running restore, to ensure that we don't do multiple assets selections for a package id/version/framework. In order to ensure correctness, we'd have to account for this extra variable as well, whether ATF dependency resolution is enabled or not. 
I'd argue this is risky and especially given that we'd want to revert this in 17.4, I think the cost would be too high to do it on a project level.  
For reference this is how the other change would look like: https://github.com/NuGet/NuGet.Client/compare/dev-nkolev92-ATFDependenciesBehaviorFallback?expand=1.

The env var name is NUGET_USE_LEGACY_ASSET_TARGET_FALLBACK_DEPENDENCY_RESOLUTION and only the `true` case ignored value will be considered.


 
## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled - TBD. Waiting on approval from @aortiz-msft on this.
  - **OR**
  - [ ] N/A
