### PR TITLE
Add rules for stale community PRs

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -615,15 +615,9 @@
             "parameters": {
               "label": "Status:No recent activity"
             }
-          },
-          {
-            "name": "hasLabel",
-            "parameters": {
-              "label": "internal-debugging"
-            }
           }
         ],
-        "taskName": "[Fernando internal-debugging] [stale community NuGet/NuGet.Client PR] [5-1] Search for community PRs with no activity over 30 days and warn. (except draft PRs)",
+        "taskName": "[stale community PR] [5-1] Search for community PRs with no activity over 30 days and warn. (except draft PRs)",
         "actions": [
           {
             "name": "addLabel",
@@ -671,12 +665,6 @@
               "parameters": {
                 "label": "Community"
               }
-            },
-            {
-              "name": "hasLabel",
-              "parameters": {
-                "label": "internal-debugging"
-              }
             }
           ]
         },
@@ -686,7 +674,7 @@
           "issues",
           "project_card"
         ],
-        "taskName": "[Fernando internal-debugging] [stale community NuGet/NuGet.Client PR] [5-2] Remove \"Status:No recent activity\" if there is any activity.",
+        "taskName": "[stale community PR] [5-2] Remove \"Status:No recent activity\" if there is any activity.",
         "actions": [
           {
             "name": "removeLabel",
@@ -717,12 +705,6 @@
               "parameters": {
                 "label": "Community"
               }
-            },
-            {
-              "name": "hasLabel",
-              "parameters": {
-                "label": "internal-debugging"
-              }
             }
           ]
         },
@@ -730,7 +712,7 @@
         "eventNames": [
           "issue_comment"
         ],
-        "taskName": "[Fernando internal-debugging] [stale community NuGet/NuGet.Client PR] [5-3] Remove \"Status:No recent activity\" if there is any comment.",
+        "taskName": "[stale community PR] [5-3] Remove \"Status:No recent activity\" if there is any comment.",
         "actions": [
           {
             "name": "removeLabel",
@@ -761,12 +743,6 @@
               "parameters": {
                 "label": "Community"
               }
-            },
-            {
-              "name": "hasLabel",
-              "parameters": {
-                "label": "internal-debugging"
-              }
             }
           ]
         },
@@ -774,7 +750,7 @@
         "eventNames": [
           "pull_request_review"
         ],
-        "taskName": "[Fernando internal-debugging] [stale community NuGet/NuGet.Client PR] [5-4] Remove \"Status:No recent activity\" if there are any reviews.",
+        "taskName": "[stale community PR] [5-4] Remove \"Status:No recent activity\" if there are any reviews.",
         "actions": [
           {
             "name": "removeLabel",
@@ -917,15 +893,9 @@
             "parameters": {
               "days": 60
             }
-          },
-          {
-            "name": "hasLabel",
-            "parameters": {
-              "label": "internal-debugging"
-            }
           }
         ],
-        "taskName": "[Fernando internal-debugging] [stale community NuGet/NuGet.Client PR] [5-5] Close PRs with no activity over 60 days after warn.",
+        "taskName": "[stale community PR] [5-5] Close PRs with no activity over 60 days after warn.",
         "actions": [
           {
             "name": "closeIssue",

--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -476,6 +476,463 @@
           }
         ]
       }
+    },
+    {
+      "taskType": "scheduled",
+      "capabilityId": "ScheduledSearch",
+      "subCapability": "ScheduledSearch",
+      "version": "1.1",
+      "config": {
+        "frequency": [
+          {
+            "weekDay": 0,
+            "hours": [
+              0,
+              3,
+              6,
+              9,
+              12,
+              15,
+              18,
+              21
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 1,
+            "hours": [
+              0,
+              3,
+              6,
+              9,
+              12,
+              15,
+              18,
+              21
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 2,
+            "hours": [
+              0,
+              3,
+              6,
+              9,
+              12,
+              15,
+              18,
+              21
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 3,
+            "hours": [
+              0,
+              3,
+              6,
+              9,
+              12,
+              15,
+              18,
+              21
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 4,
+            "hours": [
+              0,
+              3,
+              6,
+              9,
+              12,
+              15,
+              18,
+              21
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 5,
+            "hours": [
+              0,
+              3,
+              6,
+              9,
+              12,
+              15,
+              18,
+              21
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 6,
+            "hours": [
+              0,
+              3,
+              6,
+              9,
+              12,
+              15,
+              18,
+              21
+            ],
+            "timezoneOffset": -7
+          }
+        ],
+        "searchTerms": [
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": "Community"
+            }
+          },
+          {
+            "name": "noActivitySince",
+            "parameters": {
+              "days": 30
+            }
+          },
+          {
+            "name": "isPr",
+            "parameters": {}
+          },
+          {
+            "name": "isOpen",
+            "parameters": {}
+          },
+          {
+            "name": "isDraftPr",
+            "parameters": {
+              "value": "false"
+            }
+          },
+          {
+            "name": "noLabel",
+            "parameters": {
+              "label": "Status:No recent activity"
+            }
+          },
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": "internal-debugging"
+            }
+          }
+        ],
+        "taskName": "[Fernando internal-debugging] [stale community NuGet/NuGet.Client PR] [5-1] Search for community PRs with no activity over 30 days and warn. (except draft PRs)",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Status:No recent activity"
+            }
+          },
+          {
+            "name": "addReply",
+            "parameters": {
+              "comment": "This PR has been automatically marked as stale because it has no activity for **30 days**. It will be closed if no further activity occurs **within another 60 days** of this comment. If it is closed, you may reopen it anytime when you're ready again, as long as you don't delete the branch."
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "PullRequestResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "operator": "not",
+              "operands": [
+                {
+                  "name": "isAction",
+                  "parameters": {
+                    "action": "closed"
+                  }
+                }
+              ]
+            },
+            {
+              "name": "hasLabel",
+              "parameters": {
+                "label": "Status:No recent activity"
+              }
+            },
+            {
+              "name": "hasLabel",
+              "parameters": {
+                "label": "Community"
+              }
+            },
+            {
+              "name": "hasLabel",
+              "parameters": {
+                "label": "internal-debugging"
+              }
+            }
+          ]
+        },
+        "eventType": "pull_request",
+        "eventNames": [
+          "pull_request",
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[Fernando internal-debugging] [stale community NuGet/NuGet.Client PR] [5-2] Remove \"Status:No recent activity\" if there is any activity.",
+        "actions": [
+          {
+            "name": "removeLabel",
+            "parameters": {
+              "label": "Status:No recent activity"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "PullRequestCommentResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "hasLabel",
+              "parameters": {
+                "label": "Status:No recent activity"
+              }
+            },
+            {
+              "name": "hasLabel",
+              "parameters": {
+                "label": "Community"
+              }
+            },
+            {
+              "name": "hasLabel",
+              "parameters": {
+                "label": "internal-debugging"
+              }
+            }
+          ]
+        },
+        "eventType": "pull_request",
+        "eventNames": [
+          "issue_comment"
+        ],
+        "taskName": "[Fernando internal-debugging] [stale community NuGet/NuGet.Client PR] [5-3] Remove \"Status:No recent activity\" if there is any comment.",
+        "actions": [
+          {
+            "name": "removeLabel",
+            "parameters": {
+              "label": "Status:No recent activity"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "PullRequestReviewResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "hasLabel",
+              "parameters": {
+                "label": "Status:No recent activity"
+              }
+            },
+            {
+              "name": "hasLabel",
+              "parameters": {
+                "label": "Community"
+              }
+            },
+            {
+              "name": "hasLabel",
+              "parameters": {
+                "label": "internal-debugging"
+              }
+            }
+          ]
+        },
+        "eventType": "pull_request",
+        "eventNames": [
+          "pull_request_review"
+        ],
+        "taskName": "[Fernando internal-debugging] [stale community NuGet/NuGet.Client PR] [5-4] Remove \"Status:No recent activity\" if there are any reviews.",
+        "actions": [
+          {
+            "name": "removeLabel",
+            "parameters": {
+              "label": "Status:No recent activity"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "scheduled",
+      "capabilityId": "ScheduledSearch",
+      "subCapability": "ScheduledSearch",
+      "version": "1.1",
+      "config": {
+        "frequency": [
+          {
+            "weekDay": 0,
+            "hours": [
+              2,
+              5,
+              8,
+              11,
+              14,
+              17,
+              20,
+              23
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 1,
+            "hours": [
+              2,
+              5,
+              8,
+              11,
+              14,
+              17,
+              20,
+              23
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 2,
+            "hours": [
+              2,
+              5,
+              8,
+              11,
+              14,
+              17,
+              20,
+              23
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 3,
+            "hours": [
+              2,
+              5,
+              8,
+              11,
+              14,
+              17,
+              20,
+              23
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 4,
+            "hours": [
+              2,
+              5,
+              8,
+              11,
+              14,
+              17,
+              20,
+              23
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 5,
+            "hours": [
+              2,
+              5,
+              8,
+              11,
+              14,
+              17,
+              20,
+              23
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 6,
+            "hours": [
+              2,
+              5,
+              8,
+              11,
+              14,
+              17,
+              20,
+              23
+            ],
+            "timezoneOffset": -7
+          }
+        ],
+        "searchTerms": [
+          {
+            "name": "isPr",
+            "parameters": {}
+          },
+          {
+            "name": "isOpen",
+            "parameters": {}
+          },
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": "Status:No recent activity"
+            }
+          },
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": "Community"
+            }
+          },
+          {
+            "name": "noActivitySince",
+            "parameters": {
+              "days": 60
+            }
+          },
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": "internal-debugging"
+            }
+          }
+        ],
+        "taskName": "[Fernando internal-debugging] [stale community NuGet/NuGet.Client PR] [5-5] Close PRs with no activity over 60 days after warn.",
+        "actions": [
+          {
+            "name": "closeIssue",
+            "parameters": {}
+          }
+        ]
+      }
     }
   ],
   "userGroups": []


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1039

Regression? Last working version: N/A

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

- Adds rules to manage stale community PRs
- All of these rules will not be triggered unless the PR:
  - Has 'Community' label and,
  - Has 'internal-debugging' label.
- First warning is at 30 days, then, PR is closed if there's no activity within 60 days after first warning

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - ~[ ] Automated tests added~
  - [x] Test exception: Validated rules with PR in bot-testing repo. See https://github.com/NuGet/bot-testing/pull/14
  - **OR**
  - ~[ ] N/A~

- **Documentation**
  - ~[ ] Documentation PR or issue filled~
  - [x] N/A: No product changes
