### PR TITLE
Reduce redundant SolutionDirectory calculation, special-case template wizard solution directory retrieval

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSDeleteOnRestartManager.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSDeleteOnRestartManager.cs
@@ -59,10 +59,11 @@ namespace NuGet.PackageManagement.VisualStudio
         {
             get
             {
-                if (SolutionManager.SolutionDirectory != null)
+                var solutionDirectory = SolutionManager.SolutionDirectory;
+                if (solutionDirectory != null)
                 {
                     _packagesFolderPath =
-                        PackagesFolderPathUtility.GetPackagesFolderPath(SolutionManager, Settings);
+                        PackagesFolderPathUtility.GetPackagesFolderPath(solutionDirectory, Settings);
                 }
 
                 return _packagesFolderPath;

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
@@ -351,14 +351,7 @@ namespace NuGet.PackageManagement.VisualStudio
             await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
             var vsSolution = await _asyncVSSolution.GetValueAsync();
-            if (!IsSolutionOpenFromVSSolution(vsSolution))
-            {
-                // During new solution creation, NuGet runs as part of the VSTemplateWizard,
-                // the VSSolution might not recognize the solution as open, while the DTE does.
-                var dte = await _dte.GetValueAsync();
-                return IsSolutionOpenFromDTE(dte);
-            }
-            return true;
+            return IsSolutionOpenFromVSSolution(vsSolution);
         }
 
         public async Task<bool> IsSolutionAvailableAsync()
@@ -433,62 +426,18 @@ namespace NuGet.PackageManagement.VisualStudio
         {
             await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
             var vsSolution = await _asyncVSSolution.GetValueAsync();
-
             if (IsSolutionOpenFromVSSolution(vsSolution))
             {
                 return (string)GetVSSolutionProperty(vsSolution, (int)__VSPROPID.VSPROPID_SolutionDirectory);
             }
-            else
-            {
-                // During new solution creation, NuGet runs as part of the VSTemplateWizard,
-                // the VSSolution might not recognize the solution as open, while the DTE does.
-                var dte = await _dte.GetValueAsync();
-                if (IsSolutionOpenFromDTE(dte))
-                {
-                    return GetSolutionDirectoryFromDte(dte);
-                }
-            }
-
             return null;
-        }
-
-        private static bool IsSolutionOpenFromDTE(DTE dte)
-        {
-            return dte != null &&
-                    dte.Solution != null &&
-                    dte.Solution.IsOpen;
-        }
-
-        private string GetSolutionDirectoryFromDte(DTE dte)
-        {
-            // Use .Properties.Item("Path") instead of .FullName because .FullName might not be
-            // available if the solution is just being created
-            string solutionFilePath;
-
-            var property = dte.Solution.Properties.Item("Path");
-            if (property == null)
-            {
-                return null;
-            }
-            try
-            {
-                // When using a temporary solution, (such as by saying File -> New File), querying this value throws.
-                // Since we wouldn't be able to do manage any packages at this point, we return null. Consumers of this property typically
-                // use a String.IsNullOrEmpty check either way, so it's alright.
-                solutionFilePath = (string)property.Value;
-            }
-            catch (COMException)
-            {
-                return null;
-            }
-
-            return Path.GetDirectoryName(solutionFilePath);
         }
 
         private static bool IsSolutionOpenFromVSSolution(IVsSolution vsSolution)
         {
             ThreadHelper.ThrowIfNotOnUIThread();
-            return (bool)GetVSSolutionProperty(vsSolution, (int)__VSPROPID.VSPROPID_IsSolutionOpen);
+            var isOpen = (bool)GetVSSolutionProperty(vsSolution, (int)__VSPROPID.VSPROPID_IsSolutionOpen);
+            return isOpen;
         }
 
         public async Task<string> GetSolutionFilePathAsync()

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/VSSettings.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/VSSettings.cs
@@ -57,16 +57,16 @@ namespace NuGet.PackageManagement.VisualStudio
 
         private bool ResetSolutionSettingsIfNeeded()
         {
-            string root;
+            string root, solutionDirectory;
             if (SolutionManager == null
                 || !SolutionManager.IsSolutionOpen
-                || string.IsNullOrEmpty(SolutionManager.SolutionDirectory))
+                || string.IsNullOrEmpty(solutionDirectory = SolutionManager.SolutionDirectory))
             {
                 root = null;
             }
             else
             {
-                root = Path.Combine(SolutionManager.SolutionDirectory, NuGetSolutionSettingsFolder);
+                root = Path.Combine(solutionDirectory, NuGetSolutionSettingsFolder);
             }
 
             // This is a performance optimization.

--- a/src/NuGet.Core/NuGet.PackageManagement/Utility/PackagesFolderPathUtility.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Utility/PackagesFolderPathUtility.cs
@@ -14,7 +14,7 @@ namespace NuGet.PackageManagement
     {
         private const string DefaultRepositoryPath = "packages";
 
-        public static string GetPackagesFolderPath(ISolutionManager solutionManager, Configuration.ISettings settings)
+        public static string GetPackagesFolderPath(ISolutionManager solutionManager, ISettings settings)
         {
             if (solutionManager == null)
             {
@@ -22,15 +22,16 @@ namespace NuGet.PackageManagement
             }
 
             // If the solution directory is unavailable then throw an exception
-            if (solutionManager.SolutionDirectory == null)
+            var solutionDirectory = solutionManager.SolutionDirectory;
+            if (solutionDirectory == null)
             {
                 throw new InvalidOperationException(Strings.SolutionDirectoryNotAvailable);
             }
 
-            return GetPackagesFolderPath(solutionManager.SolutionDirectory, settings);
+            return GetPackagesFolderPath(solutionDirectory, settings);
         }
 
-        public static string GetPackagesFolderPath(string solutionDirectory, Configuration.ISettings settings)
+        public static string GetPackagesFolderPath(string solutionDirectory, ISettings settings)
         {
             if (string.IsNullOrEmpty(solutionDirectory))
             {


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11936

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

- Remove double calculation of the SolutionDirectory (most of this calls were accidents because the author could not have guessed the performance characteristics of calling the method.
- Explicitly use the DTE to get the solution directory in the template wizard and not anywhere else. This is a more targeted fix for https://github.com/NuGet/NuGet.Client/commit/4c236cd40ee329c1b8b3d26fa16d5f37598ab605
- Remove DTE calls for solution open in the solution manager. 

Thanks to @richardstanton, we understand why DTE.Solution.IsOpen returns a different value from the IVsSolution open check.


> The wizard creates the solution with the "CSF_DELAYNOTIFY" flag. This tells the solution to report that is not opened until the wizard finishes running. Since the NuGet code is running while the wizard is still running the solution says it isn't open. However the DTE.Solution.IsOpen does report it as open. The call to get the solution directory would work, however it never happens in the NuGet code since it doesn't check if the solution isn't open.

  
## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception - E2E + vendor manual tests cover this scenario.
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
