### PR TITLE
Remove dotnet.integration.test Newtonsoft.Json workaround

### DIFF
--- a/test/TestUtilities/Test.Utility/TestDotnetCLiUtility.cs
+++ b/test/TestUtilities/Test.Utility/TestDotnetCLiUtility.cs
@@ -224,12 +224,6 @@ SDKs found: {string.Join(", ", Directory.EnumerateDirectories(SdkDirSource).Sele
                         overwrite: true);
                 }
             }
-
-            // temp: delete once the .NET SDK ships Newtonsoft.Json 13.0.1 or higher. Tracked by https://github.com/NuGet/Home/issues/11135
-            File.Copy(
-                sourceFileName: typeof(Newtonsoft.Json.JsonSerializer).Assembly.Location,
-                destFileName: Path.Combine(pathToSdkInCli, "Newtonsoft.Json.dll"),
-                overwrite: true);
         }
 
         private static string GetTfmToCopy(string projectArtifactsBinFolder)


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11135

Regression? No

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Remove workaround, since we're now using .NET SDK 6.0.4xx for testing.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
