### PR TITLE
Test:  enable .NET 5 SDK restore tests to run on .NET 5 SDK and later

### DIFF
--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
@@ -1288,7 +1288,7 @@ EndGlobal";
             }
         }
 
-#if NET5_0
+#if NET5_0_OR_GREATER
         [Fact]
         public async Task DotnetRestore_WithTargetFrameworksProperty_StaticGraphAndRegularRestore_AreEquivalent()
         {


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes:  https://github.com/NuGet/Home/issues/11954

Regression? Last working version:  N/A

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
Enables 2 .NET SDK restore tests to run on .NET 5 SDK **and later**.

CC @nkolev92

## PR Checklist

- [X] PR has a meaningful title
- [X] PR has a linked issue.
- [X] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [X] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [X] N/A
