### PR TITLE
Add a fast nuget supports check in Visual Studio

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
@@ -401,7 +401,10 @@ namespace NuGet.PackageManagement.VisualStudio
             if (await _featureFlagService.IsFeatureEnabledAsync(NuGetFeatureFlagConstants.NuGetSolutionCacheInitilization))
             {
                 var ivsSolution = await _asyncVSSolution.GetValueAsync();
-                return VsHierarchyUtility.AreAnyLoadedProjectsNuGetCompatible(ivsSolution);
+                if (IsSolutionOpenFromVSSolution(ivsSolution))
+                {
+                    return VsHierarchyUtility.AreAnyLoadedProjectsNuGetCompatible(ivsSolution);
+                }
             }
             else
             {

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
@@ -396,15 +396,23 @@ namespace NuGet.PackageManagement.VisualStudio
             // the UI stop responding for right click on solution.
             await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
-            // first check with DTE, and if we find any supported project, then return immediately.
-            var dte = await _dte.GetValueAsync();
-
             var isSupported = false;
 
-            foreach (Project project in await EnvDTESolutionUtility.GetAllEnvDTEProjectsAsync(dte))
+            if (await _featureFlagService.IsFeatureEnabledAsync(NuGetFeatureFlagConstants.NuGetSolutionCacheInitilization))
             {
-                isSupported = true;
-                break;
+                var ivsSolution = await _asyncVSSolution.GetValueAsync();
+                return VsHierarchyUtility.AreAnyLoadedProjectsNuGetCompatible(ivsSolution);
+            }
+            else
+            {
+                // first check with DTE, and if we find any supported project, then return immediately.
+                var dte = await _dte.GetValueAsync();
+
+                foreach (Project project in await EnvDTESolutionUtility.GetAllEnvDTEProjectsAsync(dte))
+                {
+                    isSupported = true;
+                    break;
+                }
             }
 
             return isSupported;

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/IDE/VsHierarchyUtility.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/IDE/VsHierarchyUtility.cs
@@ -195,6 +195,26 @@ namespace NuGet.VisualStudio
             return compatibleProjectHierarchies;
         }
 
+        public static bool AreAnyLoadedProjectsNuGetCompatible(IVsSolution vsSolution)
+        {
+            Assumes.NotNull(vsSolution);
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            var hr = vsSolution.GetProjectEnum((uint)__VSENUMPROJFLAGS.EPF_LOADEDINSOLUTION, Guid.Empty, out IEnumHierarchies ppenum);
+            ErrorHandler.ThrowOnFailure(hr);
+
+            IVsHierarchy[] hierarchies = new IVsHierarchy[1];
+            while ((ppenum.Next((uint)hierarchies.Length, hierarchies, out uint fetched) == VSConstants.S_OK) && (fetched == (uint)hierarchies.Length))
+            {
+                var hierarchy = hierarchies[0];
+                if (IsNuGetSupported(hierarchy))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
         private static async Task<ICollection<VsHierarchyItem>> GetExpandedProjectHierarchyItemsAsync(EnvDTE.Project project)
         {
             var projectHierarchyItem = await VsHierarchyItem.FromDteProjectAsync(project);


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11555

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

VSSolutionManager.DoesNuGetSupportsAnyProjectAsync is not very efficient. 
Adding an efficient solution where we use ivssolution instead of dte.solution. 

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
