### PR TITLE
Signing:  enable signed package verification by default on Linux in .NET 7 SDK

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs
@@ -524,7 +524,7 @@ namespace NuGet.Packaging
                 // Please note: Linux/MAC case sensitive for env var name.
                 string signVerifyEnvVariable = _environmentVariableReader.GetEnvironmentVariable("DOTNET_NUGET_SIGNATURE_VERIFICATION");
 
-                bool canVerify = false;
+                bool canVerify = RuntimeEnvironmentHelper.IsLinux;
 
                 if (!string.IsNullOrEmpty(signVerifyEnvVariable))
                 {

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageArchiveReaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageArchiveReaderTests.cs
@@ -2102,7 +2102,7 @@ namespace NuGet.Packaging.Test
 
         private static bool CanVerifySignedPackages()
         {
-            return RuntimeEnvironmentHelper.IsWindows &&
+            return (RuntimeEnvironmentHelper.IsWindows || RuntimeEnvironmentHelper.IsLinux) &&
 #if IS_SIGNING_SUPPORTED
                 true;
 #else


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes:  https://github.com/NuGet/Home/issues/11973

Regression? Last working version:  No

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
This change enables signed package verification by default during restore operations on Linux in .NET 7 SDK.

## PR Checklist

- [X] PR has a meaningful title
- [X] PR has a linked issue.
- [X] Described changes

- **Tests**
  - [X] Automated tests updated
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [X] Documentation PR or issue filled:  https://github.com/NuGet/docs.microsoft.com-nuget/issues/2809
  - **OR**
  - [ ] N/A

CC @richlander