### PR TITLE
Remove extra layers of abstractions from IVsProjectAdapter, move RuntimeGraph specific methods from VSProject to LegacyPackageReferenceProject

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyPackageReferenceProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyPackageReferenceProject.cs
@@ -376,8 +376,11 @@ namespace NuGet.PackageManagement.VisualStudio
             AssetTargetFallbackUtility.ApplyFramework(projectTfi, packageTargetFallback, assetTargetFallback);
 
             // Build up runtime information.
-            var runtimes = GetRuntimeIdentifiers(_vsProjectAdapter.BuildProperties);
-            var supports = GetRuntimeSupports(_vsProjectAdapter.BuildProperties);
+
+            var runtimes = GetRuntimeIdentifiers(
+                GetPropertySafe(_vsProjectAdapter.BuildProperties, ProjectBuildProperties.RuntimeIdentifier),
+                GetPropertySafe(_vsProjectAdapter.BuildProperties, ProjectBuildProperties.RuntimeIdentifiers));
+            var supports = GetRuntimeSupports(GetPropertySafe(_vsProjectAdapter.BuildProperties, ProjectBuildProperties.RuntimeSupports));
             var runtimeGraph = new RuntimeGraph(runtimes, supports);
 
             // In legacy CSProj, we only have one target framework per project
@@ -446,14 +449,8 @@ namespace NuGet.PackageManagement.VisualStudio
             };
         }
 
-        private static IEnumerable<RuntimeDescription> GetRuntimeIdentifiers(IProjectBuildProperties projectBuildProperties)
+        private static IEnumerable<RuntimeDescription> GetRuntimeIdentifiers(string unparsedRuntimeIdentifer, string unparsedRuntimeIdentifers)
         {
-            ThreadHelper.ThrowIfNotOnUIThread();
-            var unparsedRuntimeIdentifer = projectBuildProperties.GetPropertyValue(
-                ProjectBuildProperties.RuntimeIdentifier);
-            var unparsedRuntimeIdentifers = projectBuildProperties.GetPropertyValue(
-                ProjectBuildProperties.RuntimeIdentifiers);
-
             var runtimes = Enumerable.Empty<string>();
 
             if (unparsedRuntimeIdentifer != null)
@@ -475,12 +472,8 @@ namespace NuGet.PackageManagement.VisualStudio
                 .Select(runtime => new RuntimeDescription(runtime));
         }
 
-        private static IEnumerable<CompatibilityProfile> GetRuntimeSupports(IProjectBuildProperties projectBuildProperties)
+        private static IEnumerable<CompatibilityProfile> GetRuntimeSupports(string unparsedRuntimeSupports)
         {
-            ThreadHelper.ThrowIfNotOnUIThread();
-            var unparsedRuntimeSupports = projectBuildProperties.GetPropertyValue(
-                ProjectBuildProperties.RuntimeSupports);
-
             if (unparsedRuntimeSupports == null)
             {
                 return Enumerable.Empty<CompatibilityProfile>();

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyPackageReferenceProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyPackageReferenceProject.cs
@@ -449,7 +449,7 @@ namespace NuGet.PackageManagement.VisualStudio
             };
         }
 
-        private static IEnumerable<RuntimeDescription> GetRuntimeIdentifiers(string unparsedRuntimeIdentifer, string unparsedRuntimeIdentifers)
+        internal static IEnumerable<RuntimeDescription> GetRuntimeIdentifiers(string unparsedRuntimeIdentifer, string unparsedRuntimeIdentifers)
         {
             var runtimes = Enumerable.Empty<string>();
 
@@ -472,7 +472,7 @@ namespace NuGet.PackageManagement.VisualStudio
                 .Select(runtime => new RuntimeDescription(runtime));
         }
 
-        private static IEnumerable<CompatibilityProfile> GetRuntimeSupports(string unparsedRuntimeSupports)
+        internal static IEnumerable<CompatibilityProfile> GetRuntimeSupports(string unparsedRuntimeSupports)
         {
             if (unparsedRuntimeSupports == null)
             {

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/VsProjectAdapter.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/VsProjectAdapter.cs
@@ -188,55 +188,6 @@ namespace NuGet.PackageManagement.VisualStudio
             return Enumerable.Empty<string>();
         }
 
-        public async Task<IEnumerable<RuntimeDescription>> GetRuntimeIdentifiersAsync()
-        {
-            await _threadingService.JoinableTaskFactory.SwitchToMainThreadAsync();
-
-            var unparsedRuntimeIdentifer = BuildProperties.GetPropertyValue(
-                ProjectBuildProperties.RuntimeIdentifier);
-            var unparsedRuntimeIdentifers = BuildProperties.GetPropertyValue(
-                ProjectBuildProperties.RuntimeIdentifiers);
-
-            var runtimes = Enumerable.Empty<string>();
-
-            if (unparsedRuntimeIdentifer != null)
-            {
-                runtimes = runtimes.Concat(new[] { unparsedRuntimeIdentifer });
-            }
-
-            if (unparsedRuntimeIdentifers != null)
-            {
-                runtimes = runtimes.Concat(unparsedRuntimeIdentifers.Split(';'));
-            }
-
-            runtimes = runtimes
-                .Select(x => x.Trim())
-                .Distinct(StringComparer.Ordinal)
-                .Where(x => !string.IsNullOrEmpty(x));
-
-            return runtimes
-                .Select(runtime => new RuntimeDescription(runtime));
-        }
-
-        public async Task<IEnumerable<CompatibilityProfile>> GetRuntimeSupportsAsync()
-        {
-            await _threadingService.JoinableTaskFactory.SwitchToMainThreadAsync();
-
-            var unparsedRuntimeSupports = BuildProperties.GetPropertyValue(
-                ProjectBuildProperties.RuntimeSupports);
-
-            if (unparsedRuntimeSupports == null)
-            {
-                return Enumerable.Empty<CompatibilityProfile>();
-            }
-
-            return unparsedRuntimeSupports
-                .Split(';')
-                .Select(x => x.Trim())
-                .Where(x => !string.IsNullOrEmpty(x))
-                .Select(support => new CompatibilityProfile(support));
-        }
-
         public async Task<NuGetFramework> GetTargetFrameworkAsync()
         {
             var frameworkString = await GetTargetFrameworkStringAsync();
@@ -247,16 +198,6 @@ namespace NuGet.PackageManagement.VisualStudio
             }
 
             return NuGetFramework.UnsupportedFramework;
-        }
-
-        public Task<string> GetPropertyValueAsync(string propertyName)
-        {
-            if (propertyName == null)
-            {
-                throw new ArgumentNullException(nameof(propertyName));
-            }
-
-            return BuildProperties.GetPropertyValueAsync(propertyName);
         }
 
         public async Task<IEnumerable<(string ItemId, string[] ItemMetadata)>> GetBuildItemInformationAsync(string itemName, params string[] metadataNames)

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/VSNominationUtilities.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/VSNominationUtilities.cs
@@ -78,6 +78,8 @@ namespace NuGet.SolutionRestoreManager
                 .Select(rid => new RuntimeDescription(rid))
                 .ToList();
 
+            // Maybe unify these? 
+
             var supports = targetFrameworks
                 .Cast<IVsTargetFrameworkInfo>()
                 .Select(tfi => GetPropertyValueOrNull(tfi.Properties, ProjectBuildProperties.RuntimeSupports))

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/VSNominationUtilities.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/VSNominationUtilities.cs
@@ -78,8 +78,6 @@ namespace NuGet.SolutionRestoreManager
                 .Select(rid => new RuntimeDescription(rid))
                 .ToList();
 
-            // Maybe unify these? 
-
             var supports = targetFrameworks
                 .Cast<IVsTargetFrameworkInfo>()
                 .Select(tfi => GetPropertyValueOrNull(tfi.Properties, ProjectBuildProperties.RuntimeSupports))

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/IVsProjectAdapter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/IVsProjectAdapter.cs
@@ -63,16 +63,6 @@ namespace NuGet.VisualStudio
         Task<IEnumerable<string>> GetReferencedProjectsAsync();
 
         /// <summary>
-        /// Project's runtime identifiers. Should never be null but can be an empty sequence.
-        /// </summary>
-        Task<IEnumerable<RuntimeDescription>> GetRuntimeIdentifiersAsync();
-
-        /// <summary>
-        /// Project's supports (a.k.a guardrails). Should never be null but can be an empty sequence.
-        /// </summary>
-        Task<IEnumerable<CompatibilityProfile>> GetRuntimeSupportsAsync();
-
-        /// <summary>
         /// Project's target framework
         /// </summary>
         Task<NuGetFramework> GetTargetFrameworkAsync();

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectFactories.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectFactories.cs
@@ -107,14 +107,6 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 .Returns("TestProject");
 
             projectAdapter
-                .Setup(x => x.GetRuntimeIdentifiersAsync())
-                .ReturnsAsync(Enumerable.Empty<RuntimeDescription>);
-
-            projectAdapter
-                .Setup(x => x.GetRuntimeSupportsAsync())
-                .ReturnsAsync(Enumerable.Empty<CompatibilityProfile>);
-
-            projectAdapter
                 .Setup(x => x.Version)
                 .Returns("1.0.0");
 

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/LegacyPackageReferenceProjectTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/LegacyPackageReferenceProjectTests.cs
@@ -242,10 +242,6 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 Mock.Get(projectAdapter)
                     .VerifyGet(x => x.ProjectName, Times.AtLeastOnce);
                 Mock.Get(projectAdapter)
-                    .Verify(x => x.GetRuntimeIdentifiersAsync(), Times.AtLeastOnce);
-                Mock.Get(projectAdapter)
-                    .Verify(x => x.GetRuntimeSupportsAsync(), Times.AtLeastOnce);
-                Mock.Get(projectAdapter)
                     .VerifyGet(x => x.FullProjectPath, Times.AtLeastOnce);
                 Mock.Get(projectAdapter)
                     .Verify(x => x.GetTargetFrameworkAsync(), Times.AtLeastOnce);


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11980

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Over the years, NuGet has added many many layers of abstraction in our codebase. Sometimes it was overdone. Sometimes implementations changed. 

This moves away an abstraction for reading runtime identifiers and runtime supports into the legacy package reference project because it's only relevant there and not in the generic IVsProjectAdapter. 

Note that this is still testable because we have IProjectBuildProperties as an abstraction for reading properties.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
