### PR TITLE
Fix VsCredentialProviderAdapterTests and skip failing FSharp E2E tests

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
@@ -331,6 +331,8 @@ namespace NuGet.PackageManagement.VisualStudio
             return false;
         }
 
+        public CancellationToken VsShutdownToken => VsShellUtilities.ShutdownToken;
+
         /// <summary>
         /// IsSolutionOpen is true, if the dte solution is open
         /// and is saved as required

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/VsCredentialProviderImporter.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/VsCredentialProviderImporter.cs
@@ -57,6 +57,9 @@ namespace NuGet.PackageManagement.VisualStudio
         [ImportMany(typeof(IVsCredentialProvider))]
         public IEnumerable<Lazy<IVsCredentialProvider>> ImportedProviders { get; set; }
 
+        [Import]
+        public IVsSolutionManager SolutionManager { get; set; }
+
         /// <summary>
         /// Plugin providers are entered loaded the same way as other nuget extensions,
         /// matching any extension named CredentialProvider.*.exe.
@@ -88,7 +91,7 @@ namespace NuGet.PackageManagement.VisualStudio
                     try
                     {
                         var credentialProvider = credentialProviderFactory.Value;
-                        importedProviders.Add(new VsCredentialProviderAdapter(credentialProvider));
+                        importedProviders.Add(new VsCredentialProviderAdapter(credentialProvider, SolutionManager));
                     }
                     catch (Exception exception)
                     {

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/IDE/IVsSolutionManager.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/IDE/IVsSolutionManager.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using NuGet.ProjectManagement;
 using NuGet.VisualStudio;
@@ -101,5 +102,8 @@ namespace NuGet.PackageManagement.VisualStudio
         /// Gets the current open solution directory. <see cref="null"/> if the there's no open solution.
         /// </summary>
         Task<string> GetSolutionDirectoryAsync();
+
+        /// <summary>Mockable indirection for <see cref="Microsoft.VisualStudio.Shell.VsShellUtilities.ShutdownToken"/></summary>
+        CancellationToken VsShutdownToken { get; }
     }
 }

--- a/test/EndToEnd/tests/InstallPackageTest.ps1
+++ b/test/EndToEnd/tests/InstallPackageTest.ps1
@@ -458,7 +458,8 @@ function Test-AddBindingRedirectToWebsiteWithNonExistingOutputPath {
 }
 
 function Test-InstallCanPipeToFSharpProjects {
-    param($context)    
+    [SkipTest('https://github.com/NuGet/Home/issues/11982')]
+    param($context)
     # Arrange
     $p = New-FSharpLibrary
     Build-Solution # wait for project nomination

--- a/test/EndToEnd/tests/UninstallPackageTest.ps1
+++ b/test/EndToEnd/tests/UninstallPackageTest.ps1
@@ -120,7 +120,7 @@ function Test-UninstallPackageWithNestedContentFiles {
 }
 
 function Test-SimpleFSharpUninstall {
-    [Skip('https://github.com/NuGet/Home/issues/11982')]
+    [SkipTest('https://github.com/NuGet/Home/issues/11982')]
     param($context)
 
     # Arrange

--- a/test/EndToEnd/tests/UninstallPackageTest.ps1
+++ b/test/EndToEnd/tests/UninstallPackageTest.ps1
@@ -120,6 +120,7 @@ function Test-UninstallPackageWithNestedContentFiles {
 }
 
 function Test-SimpleFSharpUninstall {
+    [Skip('https://github.com/NuGet/Home/issues/11982')]
     param($context)
 
     # Arrange

--- a/test/EndToEnd/tests/UpdatePackageTest.ps1
+++ b/test/EndToEnd/tests/UpdatePackageTest.ps1
@@ -632,7 +632,7 @@ function Test-UpdateAllPackagesInSolution {
 }
 
 function Test-UpdatePackageOnAnFSharpProjectWithMultiplePackages {
-    [Skip('https://github.com/NuGet/Home/issues/11982')]
+    [SkipTest('https://github.com/NuGet/Home/issues/11982')]
     param($context)
 
     # Arrange

--- a/test/EndToEnd/tests/UpdatePackageTest.ps1
+++ b/test/EndToEnd/tests/UpdatePackageTest.ps1
@@ -632,9 +632,8 @@ function Test-UpdateAllPackagesInSolution {
 }
 
 function Test-UpdatePackageOnAnFSharpProjectWithMultiplePackages {
-    param(
-        $context
-    )
+    [Skip('https://github.com/NuGet/Home/issues/11982')]
+    param($context)
 
     # Arrange
     $p = New-FSharpLibrary

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/NuGetProjectManagerServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/NuGetProjectManagerServiceTests.cs
@@ -1755,6 +1755,8 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
             public string SolutionDirectory => _directory.Path;
 
+            public CancellationToken VsShutdownToken => CancellationToken.None;
+
             public bool IsSolutionOpen => throw new NotImplementedException();
 
             public INuGetProjectContext NuGetProjectContext { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/VsCredentialProviderAdapterTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/VsCredentialProviderAdapterTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.VisualStudio.Sdk.TestFramework;
 using NuGet.Configuration;
 using NuGet.Credentials;
 using NuGet.VisualStudio;
@@ -12,8 +13,14 @@ using Xunit;
 
 namespace NuGet.PackageManagement.VisualStudio.Test
 {
+    [Collection(MockedVS.Collection)]
     public class VsCredentialProviderAdapterTests
     {
+        public VsCredentialProviderAdapterTests(GlobalServiceProvider gsp)
+        {
+            gsp.Reset();
+        }
+
         private class TestVsCredentialProvider : IVsCredentialProvider
         {
             private readonly ICredentials _testResponse;


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11970

Regression? no

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

The previous PR https://github.com/NuGet/NuGet.Client/pull/4724 added a dependency on `VsUtilities.ShutdownToken`, which a static in the VS SDK. If `MockedVS` is not used in the tests, then the implementation of this VS SDK property throws a null reference exception. Therefore, the PR that added the dependency must have been lucky in that a different test in the assembly had already initialized/reset the mocked VS services. Whereas other times, the exception is thrown, causing the test to fail.  This is an example of why statics are bad for testing.

One option is to add this test to the MockedVS collection, and then reset the global service provider in the constructor. This is quick and easy to implement, but it means this test cannot run in parallel with any other MockedVS test.

This PR instead added a `CancellationToken` property to an interface and made the production code composable, so that it can be mocked in tests, while using the VS SDK static in production code.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
