### PR TITLE
Tweak ApplySourceBuildPatchFiles target to support virtual mono repo (VMR)

### DIFF
--- a/eng/source-build/source-build.proj
+++ b/eng/source-build/source-build.proj
@@ -57,7 +57,7 @@
     </ItemGroup>
 
     <Exec
-      Command="git --work-tree=$(ProjectRoot) apply --ignore-whitespace --whitespace=nowarn &quot;%(SourceBuildPatchFile.FullPath)&quot;"
+      Command="git --work-tree=$(ProjectRoot) apply --ignore-whitespace --whitespace=nowarn --unsafe-paths &quot;%(SourceBuildPatchFile.FullPath)&quot;"
       WorkingDirectory="$(ProjectRoot)"
       Condition="'@(SourceBuildPatchFile)' != ''" />
   </Target>


### PR DESCRIPTION
This change is necessary in order to support building the .NET source-build tarball inside a [virtual mono repo (VMR)](https://github.com/dotnet/source-build/issues/2924).

cc @crummel 