### PR TITLE
Fix issue with _CleanPackageFiles target failing on rebuild

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.targets
@@ -168,7 +168,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Target Name="_CleanPackageFiles"
           DependsOnTargets="_GetOutputItemsFromPack"
           AfterTargets="Clean"
-          Condition="'$(GeneratePackageOnBuild)' == 'true'">
+          Condition="'$(GeneratePackageOnBuild)' == 'true' AND '$(IsInnerBuild)' != 'true'">
     <ItemGroup>
       <_PackageFilesToDelete Include="@(_OutputPackItems)"/>
     </ItemGroup>


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11710

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
See linked issue. The _CleanPackageFiles target occasionally fails during project rebuilds with multiple target frameworks. This change ensures the clean step only runs once during the outer build. 

## PR Checklist

- [X] PR has a meaningful title
- [X] PR has a linked issue.
- [X] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [X] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [X] N/A
