### PR TITLE
Locks translated nuget.exe strings

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.Designer.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.Designer.cs
@@ -19,7 +19,7 @@ namespace NuGet.CommandLine {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class NuGetCommand {
@@ -108,7 +108,7 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Path to certificate file added to a file client certificate source..
+        ///   Looks up a localized string similar to Path to certificate file..
         /// </summary>
         internal static string ClientCertificatesCommandFilePathDescription {
             get {
@@ -117,7 +117,7 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to FindBy added to a store client certificate source..
+        ///   Looks up a localized string similar to Search method to find certificate in certificate store (see docs)..
         /// </summary>
         internal static string ClientCertificatesCommandFindByDescription {
             get {
@@ -126,7 +126,7 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to FindValue added to a storage client certificate source..
+        ///   Looks up a localized string similar to Search the certificate store for the supplied value. Used with FindValue (see docs)..
         /// </summary>
         internal static string ClientCertificatesCommandFindValueDescription {
             get {
@@ -135,7 +135,7 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Bypass certificate validation..
+        ///   Looks up a localized string similar to Skip certificate validation..
         /// </summary>
         internal static string ClientCertificatesCommandForceDescription {
             get {
@@ -144,7 +144,7 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Determines to which package source client certificate will be applied to..
+        ///   Looks up a localized string similar to Package source name..
         /// </summary>
         internal static string ClientCertificatesCommandPackageSourceDescription {
             get {
@@ -153,7 +153,7 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Password for the certificate, if needed. This option can be used to specify the password for the certificate..
+        ///   Looks up a localized string similar to Password for the certificate, if needed..
         /// </summary>
         internal static string ClientCertificatesCommandPasswordDescription {
             get {
@@ -162,7 +162,7 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to StoreLocation added to a storage client certificate source..
+        ///   Looks up a localized string similar to Certificate store location (see docs)..
         /// </summary>
         internal static string ClientCertificatesCommandStoreLocationDescription {
             get {
@@ -171,7 +171,7 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to StoreName added to a storage client certificate source..
+        ///   Looks up a localized string similar to Certificate store name (see docs)..
         /// </summary>
         internal static string ClientCertificatesCommandStoreNameDescription {
             get {
@@ -180,7 +180,7 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Enables storing password for the certificate by disabling password encryption..
+        ///   Looks up a localized string similar to Enables storing portable certificate password by disabling password encryption..
         /// </summary>
         internal static string ClientCertificatesCommandStorePasswordInClearTextDescription {
             get {
@@ -206,7 +206,7 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &lt;List|Add|Update|Remove|&gt; [options].
+        ///   Looks up a localized string similar to &lt;List|Add|Update|Remove&gt; [options].
         /// </summary>
         internal static string ClientCertificatesCommandUsageSummary {
             get {
@@ -215,7 +215,7 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Provides the ability to manage list of client certificates located in %AppData%\NuGet\NuGet.config.
+        ///   Looks up a localized string similar to Provides the ability to manage list of client certificates located in NuGet.config files.
         /// </summary>
         internal static string ClientCertificatesDescription {
             get {
@@ -11052,6 +11052,73 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Searches a given source using the query string provided. If no sources are specified, all sources defined in %AppData%\NuGet\NuGet.config are used..
+        /// </summary>
+        internal static string SearchCommandDescription {
+            get {
+                return ResourceManager.GetString("SearchCommandDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Include prerelease packages..
+        /// </summary>
+        internal static string SearchCommandPreRelease {
+            get {
+                return ResourceManager.GetString("SearchCommandPreRelease", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The package source to search. You can pass multiple -Source options to search multiple package sources..
+        /// </summary>
+        internal static string SearchCommandSourceDescription {
+            get {
+                return ResourceManager.GetString("SearchCommandSourceDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The number of results to return. The default value is 20..
+        /// </summary>
+        internal static string SearchCommandTake {
+            get {
+                return ResourceManager.GetString("SearchCommandTake", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Specify search terms..
+        /// </summary>
+        internal static string SearchCommandUsageDescription {
+            get {
+                return ResourceManager.GetString("SearchCommandUsageDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to nuget search foo
+        ///
+        ///nuget search foo -Verbosity detailed
+        ///
+        ///nuget search foo -PreRelease -Take 5.
+        /// </summary>
+        internal static string SearchCommandUsageExamples {
+            get {
+                return ResourceManager.GetString("SearchCommandUsageExamples", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to [search terms] [options].
+        /// </summary>
+        internal static string SearchCommandUsageSummary {
+            get {
+                return ResourceManager.GetString("SearchCommandUsageSummary", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Saves an API key for a given server URL. When no URL is provided API key is saved for the NuGet gallery..
         /// </summary>
         internal static string SetApiKeyCommandDescription {
@@ -12819,7 +12886,7 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to UserName to be used when connecting to an authenticated source..
+        ///   Looks up a localized string similar to Username to be used when connecting to an authenticated source..
         /// </summary>
         internal static string SourcesCommandUserNameDescription {
             get {
@@ -13756,6 +13823,7 @@ namespace NuGet.CommandLine {
                 return ResourceManager.GetString("TrustedSignersCommandUsageSummary", resourceCulture);
             }
         }
+        
         /// <summary>
         ///   Looks up a localized string similar to Overrides the default dependency resolution behavior..
         /// </summary>
@@ -13764,6 +13832,7 @@ namespace NuGet.CommandLine {
                 return ResourceManager.GetString("UpdateCommandDependencyVersion", resourceCulture);
             }
         }
+        
         /// <summary>
         ///   Looks up a localized string similar to Update packages to latest available versions. This command also updates NuGet.exe itself..
         /// </summary>

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.resx
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.resx
@@ -123,7 +123,7 @@
   <data name="ConfigCommandExamples" xml:space="preserve">
     <value>nuget config -Set HTTP_PROXY=http://127.0.0.1 -Set HTTP_PROXY.USER=domain\user
 nuget config HTTP_PROXY</value>
-    <comment>Please don't localize this string</comment>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConfigCommandSetDesc" xml:space="preserve">
     <value>One on more key-value pairs to be set in config.</value>
@@ -134,7 +134,7 @@ nuget config HTTP_PROXY</value>
   </data>
   <data name="ConfigCommandSummary" xml:space="preserve">
     <value>&lt;-Set name=value | name&gt;</value>
-    <comment>Please don't localize this string</comment>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandDescription" xml:space="preserve">
     <value>Deletes a package from the server.</value>
@@ -152,7 +152,7 @@ nuget config HTTP_PROXY</value>
     <value>nuget delete MyPackage 1.0
     
 nuget delete MyPackage 1.0 -NoPrompt</value>
-    <comment>Please don't localize this string</comment>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandUsageSummary" xml:space="preserve">
     <value>&lt;package Id&gt; &lt;package version&gt; [API Key] [options]</value>
@@ -177,7 +177,7 @@ nuget help push
 nuget ?
 
 nuget push -?</value>
-    <comment>Please don't localize this string</comment>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandUsageSummary" xml:space="preserve">
     <value>[command]</value>
@@ -211,7 +211,7 @@ nuget push -?</value>
 nuget install packages.config
 
 nuget install ninject -o c:\foo</value>
-    <comment>Please don't localize this string</comment>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandUsageSummary" xml:space="preserve">
     <value>packageId|pathToPackagesConfig [options]</value>
@@ -242,7 +242,7 @@ nuget install ninject -o c:\foo</value>
     <value>nuget list
 
 nuget list -verbose -allversions</value>
-    <comment>Please don't localize this string</comment>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandUsageSummary" xml:space="preserve">
     <value>[search terms] [options]</value>
@@ -318,7 +318,7 @@ nuget pack foo.csproj
 nuget pack foo.csproj -Build -Symbols -Properties Configuration=Release
 
 nuget pack foo.nuspec -Version 2.1.0</value>
-    <comment>Please don't localize this string</comment>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandDescription" xml:space="preserve">
     <value>Pushes a package to the server and publishes it.</value>
@@ -346,7 +346,7 @@ nuget push foo.nupkg
 nuget push foo.nupkg.symbols
 
 nuget push foo.nupkg -Timeout 360</value>
-    <comment>Please don't localize this string</comment>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandUsageSummary" xml:space="preserve">
     <value>&lt;package path&gt; [API key] [options]</value>
@@ -373,7 +373,7 @@ nuget push foo.nupkg -Timeout 360</value>
 nuget search foo -Verbosity detailed
 
 nuget search foo -PreRelease -Take 5</value>
-    <comment>Please don't localize this string</comment>
+    <comment>{Locked}</comment>
   </data>
   <data name="SearchCommandUsageSummary" xml:space="preserve">
     <value>[search terms] [options]</value>
@@ -391,7 +391,7 @@ nuget search foo -PreRelease -Take 5</value>
     <value>nuget setapikey 4003d786-cc37-4004-bfdf-c4f3e8ef9b3a
 
 nuget setapikey 4003d786-cc37-4004-bfdf-c4f3e8ef9b3a -Source http://example.com/nugetfeed</value>
-    <comment>Please don't localize this string</comment>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandUsageSummary" xml:space="preserve">
     <value>&lt;API key&gt; [options]</value>
@@ -433,7 +433,7 @@ nuget setapikey 4003d786-cc37-4004-bfdf-c4f3e8ef9b3a -Source http://example.com/
 nuget spec MyPackage
 
 nuget spec -a MyAssembly.dll</value>
-    <comment>Please don't localize this string</comment>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandUsageSummary" xml:space="preserve">
     <value>[package id]</value>
@@ -468,7 +468,7 @@ nuget spec -a MyAssembly.dll</value>
 nuget update -Safe
 
 nuget update -Self</value>
-    <comment>Please don't localize this string</comment>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandVerboseDescription" xml:space="preserve">
     <value>Show verbose output while updating.</value>
@@ -533,627 +533,822 @@ nuget update -Self</value>
   </data>
   <data name="ConfigCommandDesc_csy" xml:space="preserve">
     <value>Získá nebo nastaví konfigurační hodnoty NuGet.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConfigCommandDesc_deu" xml:space="preserve">
     <value>Ruft NuGet-Konfigurationswerte ab oder legt sie fest.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConfigCommandDesc_esp" xml:space="preserve">
     <value>Obtiene o establece valores de configuración de NuGet.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConfigCommandDesc_fra" xml:space="preserve">
     <value>Obtient ou définit les valeurs de configuration NuGet.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConfigCommandDesc_ita" xml:space="preserve">
     <value>Ottenere o impostare  valori config NuGet.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConfigCommandDesc_jpn" xml:space="preserve">
     <value>NuGet 構成値を取得または設定します。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConfigCommandDesc_kor" xml:space="preserve">
     <value>NuGet config 값을 가져오거나 설정합니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConfigCommandDesc_plk" xml:space="preserve">
     <value>Pobiera lub ustawia wartości konfiguracji pakietu NuGet.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConfigCommandDesc_ptb" xml:space="preserve">
     <value>Obtém ou define os valores de configuração NuGet.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConfigCommandDesc_rus" xml:space="preserve">
     <value>Получает или задает значения конфигурации NuGet.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConfigCommandDesc_trk" xml:space="preserve">
     <value>NuGet yapılandırma değerlerini alır veya ayarlar.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConfigCommandDesc_chs" xml:space="preserve">
     <value>获取或设置 NuGet 配置值。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConfigCommandDesc_cht" xml:space="preserve">
     <value>取得或設定 NuGet 設定值。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConfigCommandExamples_csy" xml:space="preserve">
     <value>nuget config -Set HTTP_PROXY=http://127.0.0.1 -Set HTTP_PROXY.USER=domain\user
 nuget config HTTP_PROXY</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConfigCommandExamples_deu" xml:space="preserve">
     <value>nuget config -Set HTTP_PROXY=http://127.0.0.1 -Set HTTP_PROXY.USER=domain\user
 nuget config HTTP_PROXY</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConfigCommandExamples_esp" xml:space="preserve">
     <value>nuget config -Set HTTP_PROXY=http://127.0.0.1 -Set HTTP_PROXY.USER=domain\user
 nuget config HTTP_PROXY</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConfigCommandExamples_fra" xml:space="preserve">
     <value>nuget config -Set HTTP_PROXY=http://127.0.0.1 -Set HTTP_PROXY.USER=domain\user
 nuget config HTTP_PROXY</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConfigCommandExamples_ita" xml:space="preserve">
     <value>nuget config -Set HTTP_PROXY=http://127.0.0.1 -Set HTTP_PROXY.USER=domain\user
 nuget config HTTP_PROXY</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConfigCommandExamples_jpn" xml:space="preserve">
     <value>nuget config -Set HTTP_PROXY=http://127.0.0.1 -Set HTTP_PROXY.USER=domain\user
 nuget config HTTP_PROXY</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConfigCommandExamples_kor" xml:space="preserve">
     <value>nuget config -Set HTTP_PROXY=http://127.0.0.1 -Set HTTP_PROXY.USER=domain\user
 nuget config HTTP_PROXY</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConfigCommandExamples_plk" xml:space="preserve">
     <value>nuget config -Set HTTP_PROXY=http://127.0.0.1 -Set HTTP_PROXY.USER=domain\user
 nuget config HTTP_PROXY</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConfigCommandExamples_ptb" xml:space="preserve">
     <value>nuget config -Set HTTP_PROXY=http://127.0.0.1 -Set HTTP_PROXY.USER=domain\user
 nuget config HTTP_PROXY</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConfigCommandExamples_rus" xml:space="preserve">
     <value>nuget config -Set HTTP_PROXY=http://127.0.0.1 -Set HTTP_PROXY.USER=domain\user
 nuget config HTTP_PROXY</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConfigCommandExamples_trk" xml:space="preserve">
     <value>nuget config -Set HTTP_PROXY=http://127.0.0.1 -Set HTTP_PROXY.USER=domain\user
 nuget config HTTP_PROXY</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConfigCommandExamples_chs" xml:space="preserve">
     <value>nuget config -Set HTTP_PROXY=http://127.0.0.1 -Set HTTP_PROXY.USER=domain\user
 nuget config HTTP_PROXY</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConfigCommandExamples_cht" xml:space="preserve">
     <value>nuget config -Set HTTP_PROXY=http://127.0.0.1 -Set HTTP_PROXY.USER=domain\user
 nuget config HTTP_PROXY</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConfigCommandSetDesc_csy" xml:space="preserve">
     <value>Jedna nebo více dvojic klíč/hodnota, které mají být nastaveny v konfiguračním souboru</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConfigCommandSetDesc_deu" xml:space="preserve">
     <value>Mindestens ein Schlüssel-Wert-Paar, das in der Konfiguration festgelegt wird.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConfigCommandSetDesc_esp" xml:space="preserve">
     <value>Se deben establecer uno o más pares clave-valor en configuración.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConfigCommandSetDesc_fra" xml:space="preserve">
     <value>Une ou plusieurs paires clé-valeur doivent être configurées lors de la configuration.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConfigCommandSetDesc_ita" xml:space="preserve">
     <value>Impostare una o pi+u coppie di valore -key in config.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConfigCommandSetDesc_jpn" xml:space="preserve">
     <value>構成で設定される 1 つまたは複数のキー値ペア</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConfigCommandSetDesc_kor" xml:space="preserve">
     <value>config에서 설정되는 하나 이상의 키-값 쌍입니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConfigCommandSetDesc_plk" xml:space="preserve">
     <value>W konfiguracji należy ustawić co najmniej jedną parę klucz-wartość.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConfigCommandSetDesc_ptb" xml:space="preserve">
     <value>nuget config HTTP_PROXY "</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConfigCommandSetDesc_rus" xml:space="preserve">
     <value>Одна или несколько пар ключ-значение, задаваемых в конфигурации.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConfigCommandSetDesc_trk" xml:space="preserve">
     <value>Yapılandırmada ayarlanacak bir veya daha fazla anahtar-değer çifti var.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConfigCommandSetDesc_chs" xml:space="preserve">
     <value>要在配置中设置的一个或多个键值对。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConfigCommandSetDesc_cht" xml:space="preserve">
     <value>要在設定中設定的一或多個索引鍵/值組。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConfigCommandAsPathDesc_csy" xml:space="preserve">
     <value>Vrátí konfigurační hodnotu jako cestu. Při zadání argumentu -Set je tato možnost ignorována.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConfigCommandAsPathDesc_deu" xml:space="preserve">
     <value>Gibt den Konfigurationswert als Pfad zurück. Diese Option wird ignoriert, wenn "-Set" angegeben wird.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConfigCommandAsPathDesc_esp" xml:space="preserve">
     <value>Devuelve el valor de configuración como ruta de acceso. Esta opción se ignora cuando se especifica -Set.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConfigCommandAsPathDesc_fra" xml:space="preserve">
     <value>Retourne la valeur de configuration en tant que chemin d'accès. Cette option est ignorée lorsque -Set est spécifié.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConfigCommandAsPathDesc_ita" xml:space="preserve">
     <value>Ritorna al valore config come path. Questa opzione è ignorata quando -Set è specificato.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConfigCommandAsPathDesc_jpn" xml:space="preserve">
     <value>パスとして構成値を返します。-Set を指定すると、このオプションは無視されます。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConfigCommandAsPathDesc_kor" xml:space="preserve">
     <value>config 값을 경로로 반환합니다. -Set가 지정된 경우 이 옵션은 무시됩니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConfigCommandAsPathDesc_plk" xml:space="preserve">
     <value>Zwraca wartość konfiguracji jako ścieżkę. Ta opcja jest ignorowana, gdy jest określona opcja -Set.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConfigCommandAsPathDesc_ptb" xml:space="preserve">
     <value>Retorna o valor de configuração como um caminho. Esta opção é ignorada quando -Set é especificado.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConfigCommandAsPathDesc_rus" xml:space="preserve">
     <value>Возвращает значение конфигурации как путь. Этот параметр пропускается, если указан параметр -Set.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConfigCommandAsPathDesc_trk" xml:space="preserve">
     <value>Yapılandırma değerini yol olarak döndürür. -Set belirtildiğinde bu seçenek yok sayılır.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConfigCommandAsPathDesc_chs" xml:space="preserve">
     <value>返回配置值作为路径。指定 -Set 时，将忽略此选项。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConfigCommandAsPathDesc_cht" xml:space="preserve">
     <value>傳回設定值為路徑。此選項在指定 -Set 時會忽略。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConfigCommandSummary_csy" xml:space="preserve">
     <value>&lt;-Set name=value | name&gt;</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConfigCommandSummary_deu" xml:space="preserve">
     <value>&lt;-Set name=value | name&gt;</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConfigCommandSummary_esp" xml:space="preserve">
     <value>&lt;-Set name=value | name&gt;</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConfigCommandSummary_fra" xml:space="preserve">
     <value>&lt;-Set name=value | name&gt;</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConfigCommandSummary_ita" xml:space="preserve">
     <value>&lt;-Set name=value | name&gt;</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConfigCommandSummary_jpn" xml:space="preserve">
     <value>&lt;-Set name=value | name&gt;</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConfigCommandSummary_kor" xml:space="preserve">
     <value>&lt;-Set name=value | name&gt;</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConfigCommandSummary_plk" xml:space="preserve">
     <value>&lt;-Set name=value | name&gt;</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConfigCommandSummary_ptb" xml:space="preserve">
     <value>&lt;-Set name=value | name&gt;</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConfigCommandSummary_rus" xml:space="preserve">
     <value>&lt;-Set name=value | name&gt;</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConfigCommandSummary_trk" xml:space="preserve">
     <value>&lt;-Set name=value | name&gt;</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConfigCommandSummary_chs" xml:space="preserve">
     <value>&lt;-Set name=value | name&gt;</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConfigCommandSummary_cht" xml:space="preserve">
     <value>&lt;-Set name=value | name&gt;</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandDescription_csy" xml:space="preserve">
     <value>Odstraní balíček ze serveru.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandDescription_deu" xml:space="preserve">
     <value>Löscht ein Paket vom Server.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandDescription_esp" xml:space="preserve">
     <value>Elimina un paquete del servidor.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandDescription_fra" xml:space="preserve">
     <value>Supprime un package du serveur.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandDescription_ita" xml:space="preserve">
     <value>Cancellare un pacchetto dal server.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandDescription_jpn" xml:space="preserve">
     <value>サーバーからパッケージを削除します。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandDescription_kor" xml:space="preserve">
     <value>서버에서 패키지를 삭제합니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandDescription_plk" xml:space="preserve">
     <value>Usuwa pakiet z serwera.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandDescription_ptb" xml:space="preserve">
     <value>Exclui um pacote do servidor.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandDescription_rus" xml:space="preserve">
     <value>Удаляет пакет с сервера.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandDescription_trk" xml:space="preserve">
     <value>Paketi sürücüden siler.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandDescription_chs" xml:space="preserve">
     <value>从服务器中删除程序包。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandDescription_cht" xml:space="preserve">
     <value>從伺服器刪除封裝。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandNoPromptDescription_csy" xml:space="preserve">
     <value>Při odstraňování nezobrazovat výzvu</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandNoPromptDescription_deu" xml:space="preserve">
     <value>Keine Eingabeaufforderung beim Löschvorgang.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandNoPromptDescription_esp" xml:space="preserve">
     <value>No pedir confirmación al eliminarlo.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandNoPromptDescription_fra" xml:space="preserve">
     <value>N'affichez pas d'invites lors des suppressions.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandNoPromptDescription_ita" xml:space="preserve">
     <value>Non richiedere quando si cancella.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandNoPromptDescription_jpn" xml:space="preserve">
     <value>削除時にプロンプトを表示しません。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandNoPromptDescription_kor" xml:space="preserve">
     <value>삭제 시 메시지를 표시하지 않습니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandNoPromptDescription_plk" xml:space="preserve">
     <value>Bez monitów podczas usuwania.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandNoPromptDescription_ptb" xml:space="preserve">
     <value>Não avise ao excluir.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandNoPromptDescription_rus" xml:space="preserve">
     <value>Перед удалением запрос не отображается.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandNoPromptDescription_trk" xml:space="preserve">
     <value>Silerken sorma.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandNoPromptDescription_chs" xml:space="preserve">
     <value>删除时不提示。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandNoPromptDescription_cht" xml:space="preserve">
     <value>刪除時請勿提示。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandSourceDescription_csy" xml:space="preserve">
     <value>Určuje adresu URL serveru.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandSourceDescription_deu" xml:space="preserve">
     <value>Gibt die Server-URL an.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandSourceDescription_esp" xml:space="preserve">
     <value>Especifica la URL del servidor.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandSourceDescription_fra" xml:space="preserve">
     <value>Spécifie l'URL du serveur.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandSourceDescription_ita" xml:space="preserve">
     <value>Specifica il server URL.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandSourceDescription_jpn" xml:space="preserve">
     <value>サーバーの URL を指定します。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandSourceDescription_kor" xml:space="preserve">
     <value>서버 URL을 지정합니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandSourceDescription_plk" xml:space="preserve">
     <value>Określa adres URL serwera.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandSourceDescription_ptb" xml:space="preserve">
     <value>Especifica o URL do servidor.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandSourceDescription_rus" xml:space="preserve">
     <value>Указывает URL-адрес сервера.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandSourceDescription_trk" xml:space="preserve">
     <value>Sunucu URL'sini belirtir.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandSourceDescription_chs" xml:space="preserve">
     <value>指定服务器 URL。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandSourceDescription_cht" xml:space="preserve">
     <value>指定伺服器 URL。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandUsageDescription_csy" xml:space="preserve">
     <value>Zadejte ID a verzi balíčku, který má být odstraněn ze serveru.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandUsageDescription_deu" xml:space="preserve">
     <value>Geben Sie die ID und die Version des Pakets an, das vom Server gelöscht werden soll.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandUsageDescription_esp" xml:space="preserve">
     <value>Especificar el id. y la versión del paquete para eliminarlo del servidor.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandUsageDescription_fra" xml:space="preserve">
     <value>Spécifiez l'ID et la version du package à supprimer du serveur.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandUsageDescription_ita" xml:space="preserve">
     <value>Specificare Id e versione del pacchetto da cancellare dal server.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandUsageDescription_jpn" xml:space="preserve">
     <value>サーバーから削除するパッケージの ID とパッケージを指定します。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandUsageDescription_kor" xml:space="preserve">
     <value>서버에서 삭제할 패키지의 ID 및 버전을 지정합니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandUsageDescription_plk" xml:space="preserve">
     <value>Określ identyfikator i wersję pakietu, który chcesz usunąć z serwera.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandUsageDescription_ptb" xml:space="preserve">
     <value>Especifique a ID e a versão do pacote a excluir do servidor.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandUsageDescription_rus" xml:space="preserve">
     <value>Укажите идентификатор и версию пакета, чтобы удалить его с сервера.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandUsageDescription_trk" xml:space="preserve">
     <value>Sunucudan silinecek paketin kimliğini ve sürümünü belirtin.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandUsageDescription_chs" xml:space="preserve">
     <value>指定要从服务器中删除的程序包的 ID 和版本。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandUsageDescription_cht" xml:space="preserve">
     <value>指定要從伺服器刪除的封裝 ID 和版本。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandUsageExamples_csy" xml:space="preserve">
     <value>nuget delete MyPackage 1.0
     
 nuget delete MyPackage 1.0 -NoPrompt</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandUsageExamples_deu" xml:space="preserve">
     <value>nuget delete MyPackage 1.0
     
 nuget delete MyPackage 1.0 -NoPrompt</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandUsageExamples_esp" xml:space="preserve">
     <value>nuget delete MyPackage 1.0
     
 nuget delete MyPackage 1.0 -NoPrompt</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandUsageExamples_fra" xml:space="preserve">
     <value>nuget delete MyPackage 1.0
     
 nuget delete MyPackage 1.0 -NoPrompt</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandUsageExamples_ita" xml:space="preserve">
     <value>nuget delete MyPackage 1.0
     
 nuget delete MyPackage 1.0 -NoPrompt</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandUsageExamples_jpn" xml:space="preserve">
     <value>nuget delete MyPackage 1.0
     
 nuget delete MyPackage 1.0 -NoPrompt</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandUsageExamples_kor" xml:space="preserve">
     <value>nuget delete MyPackage 1.0
     
 nuget delete MyPackage 1.0 -NoPrompt</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandUsageExamples_plk" xml:space="preserve">
     <value>nuget delete MyPackage 1.0
     
 nuget delete MyPackage 1.0 -NoPrompt</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandUsageExamples_ptb" xml:space="preserve">
     <value>nuget delete MyPackage 1.0
     
 nuget delete MyPackage 1.0 -NoPrompt</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandUsageExamples_rus" xml:space="preserve">
     <value>nuget delete MyPackage 1.0
     
 nuget delete MyPackage 1.0 -NoPrompt</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandUsageExamples_trk" xml:space="preserve">
     <value>nuget delete MyPackage 1.0
     
 nuget delete MyPackage 1.0 -NoPrompt</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandUsageExamples_chs" xml:space="preserve">
     <value>nuget delete MyPackage 1.0
     
 nuget delete MyPackage 1.0 -NoPrompt</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandUsageExamples_cht" xml:space="preserve">
     <value>nuget delete MyPackage 1.0
     
 nuget delete MyPackage 1.0 -NoPrompt</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandUsageSummary_csy" xml:space="preserve">
     <value>&lt;ID balíčku&gt; &lt;verze balíčku&gt; [klíč API] [možnosti]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandUsageSummary_deu" xml:space="preserve">
     <value>&lt;Paket-ID&gt; &lt;Paketversion&gt; [API-Schlüssel] [Optionen]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandUsageSummary_esp" xml:space="preserve">
     <value>&lt;id. del paquete&gt; &lt;versión del paquete&gt; [clave API] [opciones]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandUsageSummary_fra" xml:space="preserve">
     <value>&lt;package Id&gt; &lt;package version&gt; [@@@Clé API] [@@@options]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandUsageSummary_ita" xml:space="preserve">
     <value>&lt;package Id&gt; &lt;package version&gt; [API Key] [options]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandUsageSummary_jpn" xml:space="preserve">
     <value>&lt;package Id&gt; &lt;package version&gt; [API Key] [options]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandUsageSummary_kor" xml:space="preserve">
     <value>&lt;패키지 ID&gt; &lt;패키지 버전&gt; [API 키] [옵션]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandUsageSummary_plk" xml:space="preserve">
     <value>&lt;identyfikator pakietu&gt; &lt;wersja pakietu&gt; [klucz interfejsu API] [opcje]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandUsageSummary_ptb" xml:space="preserve">
     <value>&lt;Id do pacote&gt; &lt;versão do pacote&gt; [Chave de API] [opções]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandUsageSummary_rus" xml:space="preserve">
     <value>&lt;идентификатор пакета&gt; &lt;версия пакета&gt; [ключ API] [параметры]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandUsageSummary_trk" xml:space="preserve">
     <value>&lt;paket kimliği&gt; &lt;paket sürümü&gt; [API Anahtarı] [seçenekler]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandUsageSummary_chs" xml:space="preserve">
     <value>&lt;程序包 ID&gt; &lt;程序包版本&gt; [API 密钥] [选项]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandUsageSummary_cht" xml:space="preserve">
     <value>&lt;package Id&gt; &lt;package version&gt; [API 索引鍵] [選項]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandAll_csy" xml:space="preserve">
     <value>Vytiskne podrobnou nápovědu ke všem dostupným příkazům.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandAll_deu" xml:space="preserve">
     <value>Ausführliche Hilfe für alle verfügbaren Befehle ausgeben.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandAll_esp" xml:space="preserve">
     <value>Imprimir ayuda detallada de todos los comandos disponibles.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandAll_fra" xml:space="preserve">
     <value>Imprimez l'aide détaillée correspondante à l'ensemble des commandes disponibles.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandAll_ita" xml:space="preserve">
     <value>Stampare aiutoper tutti i comandi disponibili.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandAll_jpn" xml:space="preserve">
     <value>使用できるすべてのコマンドについては、詳細なヘルプを印刷してください。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandAll_kor" xml:space="preserve">
     <value>사용 가능한 모든 명령에 대한 자세한 도움말을 인쇄합니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandAll_plk" xml:space="preserve">
     <value>Wydrukuj szczegółową pomoc dla wszystkich dostępnych poleceń.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandAll_ptb" xml:space="preserve">
     <value>Imprimir ajuda detalhada para todos os comandos disponíveis.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandAll_rus" xml:space="preserve">
     <value>Выводит на печать подробную справку по всем доступным командам.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandAll_trk" xml:space="preserve">
     <value>Mevcut tüm komutlar için ayrıntılı yardımı yazdır.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandAll_chs" xml:space="preserve">
     <value>打印所有可用命令的详细帮助。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandAll_cht" xml:space="preserve">
     <value>列印所有可用命令的詳細說明。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandDescription_csy" xml:space="preserve">
     <value>Zobrazí obecné informace nápovědy a informace nápovědy k ostatním příkazům.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandDescription_deu" xml:space="preserve">
     <value>Zeigt allgemeine Hilfeinformationen und Hilfeinformationen zu anderen Befehlen an.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandDescription_esp" xml:space="preserve">
     <value>Muestra información de ayuda general e información de ayuda de los otros comandos.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandDescription_fra" xml:space="preserve">
     <value>Affiche les informations d'aide générale et les informations d'aide relatives à d'autres commandes.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandDescription_ita" xml:space="preserve">
     <value>Mostra informazioni generali di aiuto su altri comandi.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandDescription_jpn" xml:space="preserve">
     <value>全般的なヘルプ情報と他のコマンドに関するヘルプ情報を表示します。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandDescription_kor" xml:space="preserve">
     <value>일반적인 도움말 정보 및 다른 명령에 대한 도움말 정보를 표시합니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandDescription_plk" xml:space="preserve">
     <value>Wyświetla ogólne informacje pomocy oraz informacje pomocy na temat innych poleceń.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandDescription_ptb" xml:space="preserve">
     <value>Exibe informações de ajuda em geral e informações de ajuda sobre outros comandos.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandDescription_rus" xml:space="preserve">
     <value>Отображает общую справочную информацию о других командах.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandDescription_trk" xml:space="preserve">
     <value>Genel yardım bilgilerini ve diğer komutlarla ilgili yardım bilgilerini görüntüler.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandDescription_chs" xml:space="preserve">
     <value>显示一般帮助信息，以及有关其他命令的帮助信息。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandDescription_cht" xml:space="preserve">
     <value>顯示一般說明資訊以及其他命令的相關說明資訊。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandMarkdown_csy" xml:space="preserve">
     <value>Vytiskne podrobně veškerou nápovědu ve formátu markdown.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandMarkdown_deu" xml:space="preserve">
     <value>Ausführliche Hilfe im Markdownformat ausgeben.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandMarkdown_esp" xml:space="preserve">
     <value>Imprimir toda la información detallada en formato reducido.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandMarkdown_fra" xml:space="preserve">
     <value>Imprimez l'ensemble de l'aide détaillée au format Markdown.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandMarkdown_ita" xml:space="preserve">
     <value>Stampare tutto l'aiuto in formato markdown</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandMarkdown_jpn" xml:space="preserve">
     <value>マークダウン形式ですべての詳細なヘルプを印刷します。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandMarkdown_kor" xml:space="preserve">
     <value>자세한 도움말을 마크다운 형식으로 모두 인쇄합니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandMarkdown_plk" xml:space="preserve">
     <value>Wydrukuj szczegółową pomoc w formacie języka znaczników markdown.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandMarkdown_ptb" xml:space="preserve">
     <value>Impressão detalhada de toda a ajuda em formato reduzido.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandMarkdown_rus" xml:space="preserve">
     <value>Выводит на печать всю справку в формате Markdown.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandMarkdown_trk" xml:space="preserve">
     <value>Ayrıntılı tüm yardımı döküm biçiminde yazdır.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandMarkdown_chs" xml:space="preserve">
     <value>以 Markdown 格式打印所有详细帮助。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandMarkdown_cht" xml:space="preserve">
     <value>以 Markdown 格式列印所有詳細說明。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandUsageDescription_csy" xml:space="preserve">
     <value>Předá název příkazu pro zobrazení informací nápovědy k tomuto příkazu.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandUsageDescription_deu" xml:space="preserve">
     <value>Übergeben Sie einen Befehlsnamen, um Hilfeinformationen zu diesem Befehl anzuzeigen.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandUsageDescription_esp" xml:space="preserve">
     <value>Pasar un nombre de comando para mostrar la información de ayuda de aquel comando.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandUsageDescription_fra" xml:space="preserve">
     <value>Saisissez le nom d'une commande pour afficher les informations d'aide correspondantes.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandUsageDescription_ita" xml:space="preserve">
     <value>Passare un nome comando per visualizzare le informazioni su quel comando</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandUsageDescription_jpn" xml:space="preserve">
     <value>パス名を渡して、そのコマンドに関するヘルプ情報を表示します。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandUsageDescription_kor" xml:space="preserve">
     <value>명령 이름을 전달하여 해당 명령에 대한 도움말 정보를 표시합니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandUsageDescription_plk" xml:space="preserve">
     <value>Przekaż nazwę polecenia, aby wyświetlić informacje pomocy dla tego polecenia.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandUsageDescription_ptb" xml:space="preserve">
     <value>Passe um nome de comando para exibir as informações de ajuda para esse comando.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandUsageDescription_rus" xml:space="preserve">
     <value>Передает имя команды для отображения справки по этой команде.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandUsageDescription_trk" xml:space="preserve">
     <value>Komut adını, bu komuta yönelik yardım bilgilerini görüntülemek için geçir.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandUsageDescription_chs" xml:space="preserve">
     <value>传递命令名称，以显示该命令的帮助信息。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandUsageDescription_cht" xml:space="preserve">
     <value>傳送命令名稱以顯示該命名的說明資訊。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandUsageExamples_csy" xml:space="preserve">
     <value>nuget help
@@ -1163,6 +1358,7 @@ nuget help push
 nuget ?
 
 nuget push -?</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandUsageExamples_deu" xml:space="preserve">
     <value>nuget help
@@ -1172,6 +1368,7 @@ nuget help push
 nuget ?
 
 nuget push -?</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandUsageExamples_esp" xml:space="preserve">
     <value>nuget help
@@ -1181,6 +1378,7 @@ nuget help push
 nuget ?
 
 nuget push -?</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandUsageExamples_fra" xml:space="preserve">
     <value>nuget help
@@ -1190,6 +1388,7 @@ nuget help push
 nuget ?
 
 nuget push -?</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandUsageExamples_ita" xml:space="preserve">
     <value>nuget help
@@ -1199,6 +1398,7 @@ nuget help push
 nuget ?
 
 nuget push -?</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandUsageExamples_jpn" xml:space="preserve">
     <value>nuget help
@@ -1208,6 +1408,7 @@ nuget help push
 nuget ?
 
 nuget push -?</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandUsageExamples_kor" xml:space="preserve">
     <value>nuget help
@@ -1217,6 +1418,7 @@ nuget help push
 nuget ?
 
 nuget push -?</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandUsageExamples_plk" xml:space="preserve">
     <value>nuget help
@@ -1226,6 +1428,7 @@ nuget help push
 nuget ?
 
 nuget push -?</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandUsageExamples_ptb" xml:space="preserve">
     <value>nuget help
@@ -1235,6 +1438,7 @@ nuget help push
 nuget ?
 
 nuget push -?</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandUsageExamples_rus" xml:space="preserve">
     <value>nuget help
@@ -1244,6 +1448,7 @@ nuget help push
 nuget ?
 
 nuget push -?</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandUsageExamples_trk" xml:space="preserve">
     <value>nuget help
@@ -1253,6 +1458,7 @@ nuget help push
 nuget ?
 
 nuget push -?</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandUsageExamples_chs" xml:space="preserve">
     <value>nuget help
@@ -1262,6 +1468,7 @@ nuget help push
 nuget ?
 
 nuget push -?</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandUsageExamples_cht" xml:space="preserve">
     <value>nuget help
@@ -1271,318 +1478,423 @@ nuget help push
 nuget ?
 
 nuget push -?</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandUsageSummary_csy" xml:space="preserve">
     <value>[příkaz]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandUsageSummary_deu" xml:space="preserve">
     <value>[Befehl]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandUsageSummary_esp" xml:space="preserve">
     <value>[comando]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandUsageSummary_fra" xml:space="preserve">
     <value>[@@@commande]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandUsageSummary_ita" xml:space="preserve">
     <value>[comando]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandUsageSummary_jpn" xml:space="preserve">
     <value>[command]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandUsageSummary_kor" xml:space="preserve">
     <value>[명령]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandUsageSummary_plk" xml:space="preserve">
     <value>[polecenie]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandUsageSummary_ptb" xml:space="preserve">
     <value>[comando]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandUsageSummary_rus" xml:space="preserve">
     <value>[команда]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandUsageSummary_trk" xml:space="preserve">
     <value>[komut]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandUsageSummary_chs" xml:space="preserve">
     <value>[命令]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandUsageSummary_cht" xml:space="preserve">
     <value>[命令]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandDescription_csy" xml:space="preserve">
     <value>Nainstaluje balíček s využitím zadaným zdrojů. Pokud nejsou zadány žádné zdroje, použijí se všechny zdroje definované v konfiguračním souboru NuGet. Pokud konfigurační soubor nespecifikuje žádné zdroje, použije se výchozí informační kanál NuGet.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandDescription_deu" xml:space="preserve">
     <value>Installiert ein Paket mithilfe der angegebenen Quellen. Wenn keine Quellen angegeben werden, werden alle Quellen verwendet, die in der NuGet-Konfigurationsdatei definiert sind. Wenn die Konfigurationsdatei keine Quellen angibt, wird der NuGet-Standardfeed verwendet.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandDescription_esp" xml:space="preserve">
     <value>Instala un paquete usando los orígenes especificados. Si no se especifica ningún origen, se usan todos los orígenes definidos en la configuración de NuGet. Si el archivo de configuración no especifica ningún origen, se usa la fuente predeterminada de NuGet.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandDescription_fra" xml:space="preserve">
     <value>Installe un package à partir des sources spécifiées. Si aucune source n'est spécifiée, toutes les sources définies dans le fichier de configuration NuGet seront utilisées. Si le fichier de configuration ne spécifie aucune source, il s'alimentera du flux NuGet.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandDescription_ita" xml:space="preserve">
     <value>Installa un pacchetto usando le fonti specificate. Se non sono specificate fonti, tutte le fonti definite nella configurazione NuGet saranno usata. Se il file di configurazione non specifica fonti, usare NuGet feed di default.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandDescription_jpn" xml:space="preserve">
     <value>指定されたソースを使用してパッケージをインストールします。ソースが指定されていない場合、NuGet 構成ファイルに定義されているすべてのソースが使用されます。構成ファイルにソースが指定されていない場合、既定の NuGet フィードが使用されます。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandDescription_kor" xml:space="preserve">
     <value>지정된 소스를 사용하여 패키지를 설치합니다. 소스가 지정되지 않은 경우 NuGet 구성 파일에 정의된 모든 소스가 사용됩니다. 구성 파일로도 소스가 지정되지 않으면 기본 NuGet 피드가 사용됩니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandDescription_plk" xml:space="preserve">
     <value>Instaluje pakiet przy użyciu określonych źródeł. Jeśli żadne źródło nie zostanie określone, są używane wszystkie źródła zdefiniowane w pliku konfiguracji pakietu NuGet. Jeśli w pliku konfiguracji nie zostaną określone żadne źródła, jest używane domyślne źródło NuGet.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandDescription_ptb" xml:space="preserve">
     <value>Instala um pacote usando as origens especificadas. Se não houver origens especificadas, são utilizadas todas as origens definidas no arquivo de configuração NuGet. Se o arquivo de configuração não especificar nenhuma origem, usa o feed NuGet padrão.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandDescription_rus" xml:space="preserve">
     <value>Устанавливает пакет с помощью указанных источников. Если они не указаны, используются все источники, определенные в файле конфигурации NuGet. Если в файле конфигурации не указаны источники, используется канал NuGet по умолчанию.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandDescription_trk" xml:space="preserve">
     <value>Belirtilen kaynakları kullanarak paketi yükler. Hiçbir kaynak belirtilmemişse, NuGet yapılandırma dosyasında belirtilen tüm kaynaklar kullanılır. Yapılandırma dosyasında hiçbir kaynak belirtilmemişse, varsayılan NuGet akışını kullanır.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandDescription_chs" xml:space="preserve">
     <value>使用指定的源安装程序包。如果未指定源，则将使用 NuGet 配置文件中定义的所有源。如果配置文件未指定源，则使用默认的 NuGet 源。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandDescription_cht" xml:space="preserve">
     <value>使用指定來源安裝封裝。如果沒有指定來源，在 NuGet 設定檔中定義的所有來源均已使用。如果設定檔並未指定來源，請使用預設 NuGet 摘要。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandExcludeVersionDescription_csy" xml:space="preserve">
     <value>Pokud je tato možnost nastavena, cílová složka bude obsahovat pouze název balíčku, ale ne číslo verze.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandExcludeVersionDescription_deu" xml:space="preserve">
     <value>Wenn diese Option festgelegt ist, enthält der Zielordner nur den Paketnamen, nicht die Versionsnummer.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandExcludeVersionDescription_esp" xml:space="preserve">
     <value>Si se configura, la carpeta de destino solo contendrá el nombre de paquete y no el número de versión</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandExcludeVersionDescription_fra" xml:space="preserve">
     <value>Si défini, le dossier de destination ne contiendra que le nom de package et pas le numéro de version.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandExcludeVersionDescription_ita" xml:space="preserve">
     <value>Se impostata, la cartella di destinazione conterrà il nome del pacchetto, non il numero di versione</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandExcludeVersionDescription_jpn" xml:space="preserve">
     <value>設定すると、対象フォルダーにはバージョン番号ではなくパッケージ名のみが含まれます。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandExcludeVersionDescription_kor" xml:space="preserve">
     <value>설정할 경우 대상 폴더에 패키지 이름만 포함되며 버전 이름은 포함되지 않습니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandExcludeVersionDescription_plk" xml:space="preserve">
     <value>Jeśli ta opcja zostanie ustawiona, folder docelowy będzie zawierał tylko nazwę pakietu, bez numeru wersji</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandExcludeVersionDescription_ptb" xml:space="preserve">
     <value>Se assim for definida, a pasta de destino conterá apenas o nome do pacote, e não o número da versão</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandExcludeVersionDescription_rus" xml:space="preserve">
     <value>Если этот параметр задан, папка назначения будет содержать только имя пакета, но не номер версии</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandExcludeVersionDescription_trk" xml:space="preserve">
     <value>Ayarlanmışsa, hedef klasörde sürüm numarası değil, yalnızca paket adı bulunur.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandExcludeVersionDescription_chs" xml:space="preserve">
     <value>如果已设置，则目标文件夹将只包含程序包名称，而不包含版本号</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandExcludeVersionDescription_cht" xml:space="preserve">
     <value>若設定，目的地資料夾僅會包含封裝名稱，而不會有版本號碼</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandNoCache_csy" xml:space="preserve">
     <value>Zakáže použití mezipaměti počítače jako prvního zdroje balíčků.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandNoCache_deu" xml:space="preserve">
     <value>Verwenden des Computercaches als erste Paketquelle deaktivieren.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandNoCache_esp" xml:space="preserve">
     <value>Deshabilitar el caché de la máquina como el origen del primer paquete.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandNoCache_fra" xml:space="preserve">
     <value>Désactivation grâce au cache de l'ordinateur, agissant comme première source du package.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandNoCache_ita" xml:space="preserve">
     <value>Disabilitare usando la cache della macchina come prima fonte pacchetto.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandNoCache_jpn" xml:space="preserve">
     <value>最初のパッケージ ソースとしてのコンピューター キャッシュの使用を無効にします。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandNoCache_kor" xml:space="preserve">
     <value>시스템 캐시를 첫 번째 패키지 소스로 사용하지 않도록 설정합니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandNoCache_plk" xml:space="preserve">
     <value>Wyłącz, używając pamięci podręcznej komputera jako pierwszego źródła pakietu.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandNoCache_ptb" xml:space="preserve">
     <value>Desative usando o cache da máquina como a primeira origem de pacotes.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandNoCache_rus" xml:space="preserve">
     <value>Отключает использование кэша компьютера в качестве первого источника пакетов.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandNoCache_trk" xml:space="preserve">
     <value>Birinci paket kaynağı olarak makine önbelleğinin kullanılmasını devre dışı bırak.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandNoCache_chs" xml:space="preserve">
     <value>禁止使用计算机缓存作为第一个程序包源。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandNoCache_cht" xml:space="preserve">
     <value>停用使用機器快取做為第一個封裝來源。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandOutputDirDescription_csy" xml:space="preserve">
     <value>Určuje adresář, do něhož budou nainstalovány balíčky. Není-li zadán, použije se aktuální adresář.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandOutputDirDescription_deu" xml:space="preserve">
     <value>Gibt das Verzeichnis an, in dem Pakete installiert werden. Wenn kein Verzeichnis angegeben wird, wird das aktuelle Verzeichnis verwendet.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandOutputDirDescription_esp" xml:space="preserve">
     <value>Especifica el directorio en el que se instalarán los paquetes. Si no se especifica ninguno, se usa el directorio actual.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandOutputDirDescription_fra" xml:space="preserve">
     <value>Spécifie le répertoire d'installation des packages. S'il n'est pas spécifié, le répertoire actuel sera utilisé.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandOutputDirDescription_ita" xml:space="preserve">
     <value>Specifica la directory in cui i pacchetti saranno installati. Altrimenti, usare la directory attuale.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandOutputDirDescription_jpn" xml:space="preserve">
     <value>パッケージをインストールするディレクトリを指定します。指定しない場合、現在のディレクトリが使用されます。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandOutputDirDescription_kor" xml:space="preserve">
     <value>패키지가 설치될 디렉터리를 지정합니다. 지정되지 않은 경우 현재 디렉터리를 사용합니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandOutputDirDescription_plk" xml:space="preserve">
     <value>Określa katalog, w którym zostaną zainstalowane pakiety. Jeśli żaden nie zostanie określony, będzie używany katalog bieżący.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandOutputDirDescription_ptb" xml:space="preserve">
     <value>Especifica o diretório em que os pacotes serão instalados. Se nenhum for especificado, usa o diretório atual.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandOutputDirDescription_rus" xml:space="preserve">
     <value>Задает каталог для установки пакетов. Если он не указан, используется текущий каталог.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandOutputDirDescription_trk" xml:space="preserve">
     <value>Paketlerin yükleneceği dizini belirtir. Hiçbiri belirtilmemişse, geçerli dizini kullanır.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandOutputDirDescription_chs" xml:space="preserve">
     <value>指定将在其中安装程序包的目录。如果未指定，则使用当前目录。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandOutputDirDescription_cht" xml:space="preserve">
     <value>指定要安全的封裝中的目錄。若未指定，則使用目前的目錄。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandPrerelease_csy" xml:space="preserve">
     <value>Umožňuje nainstalovat předběžné verze balíčků. Tento příznak není vyžadován při obnově balíčků pomocí instalace ze souboru packages.config.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandPrerelease_deu" xml:space="preserve">
     <value>Ermöglicht die Installation von Vorabversionspaketen. Diese Kennzeichnung ist nicht erforderlich, wenn Pakete durch Installieren aus "packages.config" wiederhergestellt werden.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandPrerelease_esp" xml:space="preserve">
     <value>Permite instalar paquetes de versión preliminar. Esta marca no es necesaria al restaurar paquetes mediante la instalación desde packages.config.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandPrerelease_fra" xml:space="preserve">
     <value>Permet l'installation de la version préliminaire des packages. Cet indicateur n'est pas requis lors de la restauration des packages depuis packages.config.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandPrerelease_ita" xml:space="preserve">
     <value>Permette ai pacchetti prelease di essere installati. Questo flag non è richiesto quando si ripristinano pacchetti installando da packages.config.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandPrerelease_jpn" xml:space="preserve">
     <value>プレリリース パッケージのインストールを許可します。packages.config からインストールしてパッケージを復元する場合、このフラグは必要ありません。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandPrerelease_kor" xml:space="preserve">
     <value>시험판 패키지를 설치하도록 허용합니다. packages.config에서 설치하여 패키지를 복원하는 경우 이 플래그는 필요하지 않습니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandPrerelease_plk" xml:space="preserve">
     <value>Zezwala na zainstalowanie pakietów w wersji wstępnej. Ta flaga nie jest wymagana podczas przywracania pakietów przez instalację z pliku packages.config.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandPrerelease_ptb" xml:space="preserve">
     <value>Permite que pacotes de pré-lançamento sejam instalados. Este sinal não é obrigatório ao restaurar pacotes pela instalação de packages.config.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandPrerelease_rus" xml:space="preserve">
     <value>Разрешает установку предварительных версий пакетов. Этот флаг не нужен при восстановлении пакетов путем установки из packages.config.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandPrerelease_trk" xml:space="preserve">
     <value>Önsürüm paketlerinin yüklenmesine izin verir. Paketler packages.config üzerinden geri yüklendiğinde bu bayrağa gerek duyulmaz.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandPrerelease_chs" xml:space="preserve">
     <value>允许安装预发布程序包。通过从 packages.config 安装来还原程序包时，不需要此标志。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandPrerelease_cht" xml:space="preserve">
     <value>允許安裝預先發行的封裝。若從 packages.config 安裝來還原封裝時則不需要此標幟。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandSourceDescription_csy" xml:space="preserve">
     <value>Seznam zdrojů balíčků pro použití při instalaci</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandSourceDescription_deu" xml:space="preserve">
     <value>Eine Liste der Paketquellen, die für die Installation verwendet werden sollen.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandSourceDescription_esp" xml:space="preserve">
     <value>Lista de orígenes de paquetes que se usa para la instalación.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandSourceDescription_fra" xml:space="preserve">
     <value>Liste de sources de packages à utiliser pour l'installation.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandSourceDescription_ita" xml:space="preserve">
     <value>Lista di fonti pacchetto da usare per l'installazione.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandSourceDescription_jpn" xml:space="preserve">
     <value>インストールに使用するパッケージ ソースの一覧。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandSourceDescription_kor" xml:space="preserve">
     <value>설치 시 사용되는 패키지 소스 목록입니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandSourceDescription_plk" xml:space="preserve">
     <value>Lista źródeł pakietów do użycia podczas instalacji.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandSourceDescription_ptb" xml:space="preserve">
     <value>Uma lista de origens de pacotes para usar para a instalação.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandSourceDescription_rus" xml:space="preserve">
     <value>Список источников пакетов, используемых для установки.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandSourceDescription_trk" xml:space="preserve">
     <value>Yükleme için kullanılacak paketlerin listesi.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandSourceDescription_chs" xml:space="preserve">
     <value>要用于安装的程序包源列表。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandSourceDescription_cht" xml:space="preserve">
     <value>要用來安裝的封裝來源清單。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandUsageDescription_csy" xml:space="preserve">
     <value>Určuje ID a volitelně také verzi balíčku, který se má nainstalovat. Je-li místo ID použita cesta k souboru packages.config, jsou nainstalovány všechny zde obsažené balíčky.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandUsageDescription_deu" xml:space="preserve">
     <value>Geben Sie die ID und optional die Version des zu installierenden Pakets an. Wenn ein Pfad zu einer Datei "packages.config" anstelle einer ID verwendet wird, werden alle darin enthaltenen Pakete installiert.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandUsageDescription_esp" xml:space="preserve">
     <value>Especificar el id. y opcionalmente la versión del paquete que se va a instalar. Si se usa una ruta de acceso a un archivo packages.config en lugar de un id., se instalan todos los paquetes que contiene.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandUsageDescription_fra" xml:space="preserve">
     <value>Spécifiez l'ID et, éventuellement, la version du package à installer. Si le chemin d'accès au fichier packages.config est utilisé au lieu de l'ID, tous les packages qu'il contient seront installés.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandUsageDescription_ita" xml:space="preserve">
     <value>Specificare l'ID e la versione del pacchetto da installare. Se si usa un percorso a packages.config invece di un id, saranno installati tutti i pacchetti che contiene.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandUsageDescription_jpn" xml:space="preserve">
     <value>インストールするパッケージの ID と、必要に応じてバージョンを指定します。ID ではなく packages.config ファイルのパスを使用する場合、そのパスに含まれるすべてのパッケージがインストールされます。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandUsageDescription_kor" xml:space="preserve">
     <value>설치할 패키지의 ID 및 버전(선택적)을 지정합니다. ID 대신 packages.config 파일 경로가 사용되는 경우 이 파일에 포함된 모든 패키지가 설치됩니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandUsageDescription_plk" xml:space="preserve">
     <value>Określ identyfikator i opcjonalnie wersję pakietu do zainstalowania. Jeśli zamiast identyfikatora zostanie użyta ścieżka do pliku packages.config, zostaną zainstalowane wszystkie pakiety zawarte w tym pliku.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandUsageDescription_ptb" xml:space="preserve">
     <value>Especifique a ID e, opcionalmente, a versão do pacote a ser instalado. Se for usado um caminho para um arquivo packages.config em vez de uma id, todos os pacotes que ele contém serão instalados.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandUsageDescription_rus" xml:space="preserve">
     <value>Укажите идентификатор и версию (необязательно) устанавливаемого пакета. Если вместо идентификатора используется путь к файлу packages.config, будут установлены все содержащиеся в нем пакеты.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandUsageDescription_trk" xml:space="preserve">
     <value>Yüklenecek paketin kimliğini ve isteğe bağlı olarak sürümünü belirtin. Kimlik yerine packages.config dosyasının yolu kullanılırsa, burada bulunan tüm paketler yüklenir.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandUsageDescription_chs" xml:space="preserve">
     <value>指定要安装的程序包的 ID 和版本(可选)。如果使用的是 packages.config 文件的路径(而不是 ID)，则将安装该路径包含的所有程序包。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandUsageDescription_cht" xml:space="preserve">
     <value>指定要安裝的封裝 ID 和版本 (選擇性)。如果使用 packages.config 檔案的路徑而非 ID，則會安裝其包含的所有封裝。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandUsageExamples_csy" xml:space="preserve">
     <value>nuget install elmah
@@ -1590,6 +1902,7 @@ nuget push -?</value>
 nuget install packages.config
 
 nuget install ninject -o c:\foo</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandUsageExamples_deu" xml:space="preserve">
     <value>nuget install elmah
@@ -1597,6 +1910,7 @@ nuget install ninject -o c:\foo</value>
 nuget install packages.config
 
 nuget install ninject -o c:\foo</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandUsageExamples_esp" xml:space="preserve">
     <value>nuget install elmah
@@ -1604,6 +1918,7 @@ nuget install ninject -o c:\foo</value>
 nuget install packages.config
 
 nuget install ninject -o c:\foo</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandUsageExamples_fra" xml:space="preserve">
     <value>nuget install elmah
@@ -1611,6 +1926,7 @@ nuget install ninject -o c:\foo</value>
 nuget install packages.config
 
 nuget install ninject -o c:\foo</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandUsageExamples_ita" xml:space="preserve">
     <value>nuget install elmah
@@ -1618,6 +1934,7 @@ nuget install ninject -o c:\foo</value>
 nuget install packages.config
 
 nuget install ninject -o c:\foo</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandUsageExamples_jpn" xml:space="preserve">
     <value>nuget install elmah
@@ -1625,6 +1942,7 @@ nuget install ninject -o c:\foo</value>
 nuget install packages.config
 
 nuget install ninject -o c:\foo</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandUsageExamples_kor" xml:space="preserve">
     <value>nuget install elmah
@@ -1632,6 +1950,7 @@ nuget install ninject -o c:\foo</value>
 nuget install packages.config
 
 nuget install ninject -o c:\foo</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandUsageExamples_plk" xml:space="preserve">
     <value>nuget install elmah
@@ -1639,6 +1958,7 @@ nuget install ninject -o c:\foo</value>
 nuget install packages.config
 
 nuget install ninject -o c:\foo</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandUsageExamples_ptb" xml:space="preserve">
     <value>nuget install elmah
@@ -1646,6 +1966,7 @@ nuget install ninject -o c:\foo</value>
 nuget install packages.config
 
 nuget install ninject -o c:\foo</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandUsageExamples_rus" xml:space="preserve">
     <value>nuget install elmah
@@ -1653,6 +1974,7 @@ nuget install ninject -o c:\foo</value>
 nuget install packages.config
 
 nuget install ninject -o c:\foo</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandUsageExamples_trk" xml:space="preserve">
     <value>nuget install elmah
@@ -1660,6 +1982,7 @@ nuget install ninject -o c:\foo</value>
 nuget install packages.config
 
 nuget install ninject -o c:\foo</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandUsageExamples_chs" xml:space="preserve">
     <value>nuget install elmah
@@ -1667,6 +1990,7 @@ nuget install ninject -o c:\foo</value>
 nuget install packages.config
 
 nuget install ninject -o c:\foo</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandUsageExamples_cht" xml:space="preserve">
     <value>nuget install elmah
@@ -1674,1085 +1998,1437 @@ nuget install ninject -o c:\foo</value>
 nuget install packages.config
 
 nuget install ninject -o c:\foo</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandUsageSummary_csy" xml:space="preserve">
     <value>packageId|pathToPackagesConfig [možnosti]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandUsageSummary_deu" xml:space="preserve">
     <value>PaketID|PfadzurPaketkonfiguration [Optionen]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandUsageSummary_esp" xml:space="preserve">
     <value>packageId|pathToPackagesConfig [opciones]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandUsageSummary_fra" xml:space="preserve">
     <value>packageId|pathToPackagesConfig [options]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandUsageSummary_ita" xml:space="preserve">
     <value>packageId|pathToPackagesConfig [options]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandUsageSummary_jpn" xml:space="preserve">
     <value>packageId|pathToPackagesConfig [options]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandUsageSummary_kor" xml:space="preserve">
     <value>packageId|pathToPackagesConfig [옵션]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandUsageSummary_plk" xml:space="preserve">
     <value>identyfikator_pakietu|ścieżka_do_PackagesConfig [opcje]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandUsageSummary_ptb" xml:space="preserve">
     <value>Idpacote|CaminhoParaConfigDePacotes [opções]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandUsageSummary_rus" xml:space="preserve">
     <value>packageId|pathToPackagesConfig [параметры]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandUsageSummary_trk" xml:space="preserve">
     <value>packageId|pathToPackagesConfig [options]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandUsageSummary_chs" xml:space="preserve">
     <value>packageId|pathToPackagesConfig [选项]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandUsageSummary_cht" xml:space="preserve">
     <value>packageId|pathToPackagesConfig [選項]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandVersionDescription_csy" xml:space="preserve">
     <value>Verze balíčku, který se má nainstalovat</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandVersionDescription_deu" xml:space="preserve">
     <value>Die Version des zu installierenden Pakets.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandVersionDescription_esp" xml:space="preserve">
     <value>Versión del paquete que se va a instalar.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandVersionDescription_fra" xml:space="preserve">
     <value>Version du package à installer.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandVersionDescription_ita" xml:space="preserve">
     <value>La versione del pacchetto da installare.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandVersionDescription_jpn" xml:space="preserve">
     <value>インストールするパッケージのバージョン。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandVersionDescription_kor" xml:space="preserve">
     <value>설치할 패키지의 버전입니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandVersionDescription_plk" xml:space="preserve">
     <value>Wersja pakietu do zainstalowania.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandVersionDescription_ptb" xml:space="preserve">
     <value>A versão do pacote a ser instalado.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandVersionDescription_rus" xml:space="preserve">
     <value>Версия устанавливаемого пакета.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandVersionDescription_trk" xml:space="preserve">
     <value>Yüklenecek paketin sürümü.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandVersionDescription_chs" xml:space="preserve">
     <value>要安装的程序包的版本。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandVersionDescription_cht" xml:space="preserve">
     <value>要安裝的封裝版本。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandAllVersionsDescription_csy" xml:space="preserve">
     <value>Zobrazí seznam všech verzí balíčku. Ve výchozím nastavení se zobrazí pouze nejnovější verze balíčku.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandAllVersionsDescription_deu" xml:space="preserve">
     <value>Listet alle Versionen eines Pakets auf. Standardmäßig wird nur die letzte Paketversion angezeigt.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandAllVersionsDescription_esp" xml:space="preserve">
     <value>Muestra todas las versiones de un paquete. De forma predeterminada, solo se muestra la versión del paquete más reciente.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandAllVersionsDescription_fra" xml:space="preserve">
     <value>Répertorie toutes les versions d'un package. Seule la dernière version du package est affichée par défaut.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandAllVersionsDescription_ita" xml:space="preserve">
     <value>Elencare tutte le versioni di un pacchetto. Per dafault, si visualizza solo l'ultima versione</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandAllVersionsDescription_jpn" xml:space="preserve">
     <value>パッケージのすべてのバージョンを表示します。既定では、最新のパッケージ バージョンのみが表示されます。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandAllVersionsDescription_kor" xml:space="preserve">
     <value>모든 패키지 버전을 나열합니다. 기본적으로 최신 패키지 버전만 표시됩니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandAllVersionsDescription_plk" xml:space="preserve">
     <value>Lista wszystkich wersji pakietu. Domyślnie wyświetlana jest tylko najnowsza wersja pakietu.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandAllVersionsDescription_ptb" xml:space="preserve">
     <value>Liste todas as versões de um pacote. Por padrão, apenas a versão mais recente do pacote é exibida.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandAllVersionsDescription_rus" xml:space="preserve">
     <value>Выводит список всех версий пакета. По умолчанию отображается только последняя версия пакета.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandAllVersionsDescription_trk" xml:space="preserve">
     <value>Bir paketin tüm sürümlerini listele. Varsayılan olarak yalnızca son paket sürümü görüntülenir.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandAllVersionsDescription_chs" xml:space="preserve">
     <value>列出程序包的所有版本。默认情况下，只显示最新程序包版本。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandAllVersionsDescription_cht" xml:space="preserve">
     <value>列出封裝的所有版本。依預設，僅會顯示最新的封裝版本。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandDescription_csy" xml:space="preserve">
     <value>Zobrazí seznam balíčků ze zadaného zdroje. Pokud není zadán žádný zdroj, použijí se všechny zdroje definované v souboru %AppData%\NuGet\NuGet.config. Pokud soubor NuGet.config nespecifikuje žádné zdroje, použije se výchozí informační kanál NuGet.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandDescription_deu" xml:space="preserve">
     <value>Zeigt eine Liste der Pakete aus einer angegebenen Quelle an. Wenn keine Quellen angegeben werden, werden alle in "%AppData%\NuGet\NuGet.config" definierten Quellen verwendet. Wenn "NuGet.config" keine Quellen angibt, wird der NuGet-Standardfeed verwendet.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandDescription_esp" xml:space="preserve">
     <value>Muestra una lista de paquetes de un origen especificado. Si no se especifican orígenes, se usan todos los orígenes definidos en %AppData%\NuGet\NuGet.config. Si NuGet.config no especifica ningún origen, usa la fuente NuGet predeterminada.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandDescription_fra" xml:space="preserve">
     <value>Affiche la liste des packages d'une source donnée. Si aucune source n'est spécifiée, toutes les sources définies dans %AppData%\NuGet\NuGet.config seront utilisées. Si NuGet.config ne spécifie aucune source, il s'alimentera du flux NuGet par défaut.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandDescription_ita" xml:space="preserve">
     <value>Visualizza un elenco pacchetti da una data fonte. Se non è specificata alcuna fonta, tutte le fonti definite in %AppData%\NuGet\NuGet.config saranno usate. Se NuGet.config non specifica fonti. Usare il feed NuGet di default.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandDescription_jpn" xml:space="preserve">
     <value>指定したソースのパッケージ一覧を表示します。ソースが指定されていない場合、%AppData%\NuGet\NuGet.config に定義されているすべてのソースが使用されます。NuGet.config にソースが指定されていない場合、既定の NuGet フィードが使用されます。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandDescription_kor" xml:space="preserve">
     <value>지정한 소스의 패키지 목록을 표시합니다. 소스가 지정되지 않은 경우 %AppData%\NuGet\NuGet.config에 정의된 모든 소스가 사용됩니다. NuGet.config로도 소스가 지정되지 않으면 기본 NuGet 피드가 사용됩니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandDescription_plk" xml:space="preserve">
     <value>Wyświetla listę pakietów z danego źródła. Jeśli nie zostaną określone żadne źródła, są używane wszystkie źródła zdefiniowane w pliku %AppData%\NuGet\NuGet.config. Jeśli w pliku NuGet.config nie określono żadnych źródeł, jest używane domyślne źródło NuGet.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandDescription_ptb" xml:space="preserve">
     <value>Exibe uma lista de pacotes de uma determinada origem. Se não houver origens especificadas, todas as origens definidas em %AppData%\NuGet\NuGet.config serão usadas. Se NuGet.config não especificar nenhuma origem, usa o feed NuGet padrão.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandDescription_rus" xml:space="preserve">
     <value>Отображает список пакетов из указанного источника. Если источники не указаны, используются все источники, определенные в %AppData%\NuGet\NuGet.config. Если источники не указаны в NuGet.config, используется канал NuGet по умолчанию.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandDescription_trk" xml:space="preserve">
     <value>Belirli bir kaynaktan paket listesini görüntüler. Hiçbir kaynak belirtilmemişse, %AppData%\NuGet\NuGet.config içinde belirtilen tüm kaynaklar kullanılır. NuGet.config hiçbir kaynak belirtmiyorsa, varsayılan NuGet akışını kullanır.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandDescription_chs" xml:space="preserve">
     <value>显示给定源中的程序包列表。如果未指定源，则使用 %AppData%\NuGet\NuGet.config 中定义的所有源。如果 NuGet.config 未指定源，则使用默认 NuGet 源。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandDescription_cht" xml:space="preserve">
     <value>顯示給定來源的封裝清單。如果未指定來源，已使用 %AppData%\NuGet\NuGet.config 中定義的所有來源。如果 NuGet.config 並未指定來源，使用預設的 NuGet 摘要。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandPrerelease_csy" xml:space="preserve">
     <value>Umožňuje zobrazit předběžné verze balíčků.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandPrerelease_deu" xml:space="preserve">
     <value>Ermöglicht die Anzeige von Vorabversionspaketen.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandPrerelease_esp" xml:space="preserve">
     <value>Permitir que se muestren los paquetes de versión preliminar.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandPrerelease_fra" xml:space="preserve">
     <value>Permet l'affichage de la version préliminaire des packages.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandPrerelease_ita" xml:space="preserve">
     <value>Permette di visualizzare i pacchetti prerelease.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandPrerelease_jpn" xml:space="preserve">
     <value>プレリリース パッケージの表示を許可します。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandPrerelease_kor" xml:space="preserve">
     <value>시험판 패키지를 표시하도록 허용합니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandPrerelease_plk" xml:space="preserve">
     <value>Zezwala na wyświetlanie pakietów w wersji wstępnej.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandPrerelease_ptb" xml:space="preserve">
     <value>Permita que os pacotes de pré-lançamento sejam mostrados.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandPrerelease_rus" xml:space="preserve">
     <value>Разрешает отображение предварительных версий пакетов.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandPrerelease_trk" xml:space="preserve">
     <value>Önsürüm paketlerinin gösterilmesine izin verir.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandPrerelease_chs" xml:space="preserve">
     <value>允许显示预发布程序包。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandPrerelease_cht" xml:space="preserve">
     <value>允許顯示預先發行的封裝。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandSourceDescription_csy" xml:space="preserve">
     <value>Seznam zdrojů balíčků k prohledání</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandSourceDescription_deu" xml:space="preserve">
     <value>Eine Liste der zu durchsuchenden Paketquellen.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandSourceDescription_esp" xml:space="preserve">
     <value>Lista de orígenes de paquetes para buscar.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandSourceDescription_fra" xml:space="preserve">
     <value>Liste de sources de packages à rechercher.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandSourceDescription_ita" xml:space="preserve">
     <value>Un elenco di fonti pacchetti da ricercare.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandSourceDescription_jpn" xml:space="preserve">
     <value>検索するパッケージ ソースの一覧。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandSourceDescription_kor" xml:space="preserve">
     <value>검색할 패키지 소스의 목록입니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandSourceDescription_plk" xml:space="preserve">
     <value>Lista źródeł pakietów do przeszukania.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandSourceDescription_ptb" xml:space="preserve">
     <value>Uma lista de origens de pacotes para pesquisar.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandSourceDescription_rus" xml:space="preserve">
     <value>Список источников пакетов для поиска.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandSourceDescription_trk" xml:space="preserve">
     <value>Aranacak paket kaynaklarının listesi.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandSourceDescription_chs" xml:space="preserve">
     <value>要搜索的程序包源的列表。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandSourceDescription_cht" xml:space="preserve">
     <value>要搜尋的封裝來源清單。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandUsageDescription_csy" xml:space="preserve">
     <value>Zadejte volitelné hledané termíny.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandUsageDescription_deu" xml:space="preserve">
     <value>Geben Sie optionale Suchbegriffe an.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandUsageDescription_esp" xml:space="preserve">
     <value>Especificar términos de búsqueda opcionales.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandUsageDescription_fra" xml:space="preserve">
     <value>Spécifiez les termes optionnels recherchés.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandUsageDescription_ita" xml:space="preserve">
     <value>Specifica i termini di ricerca opzionali.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandUsageDescription_jpn" xml:space="preserve">
     <value>検索用語を指定します (省略可能)。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandUsageDescription_kor" xml:space="preserve">
     <value>검색어를 지정합니다(선택적).</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandUsageDescription_plk" xml:space="preserve">
     <value>Określ opcjonalne terminy wyszukiwania.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandUsageDescription_ptb" xml:space="preserve">
     <value>Especificar os termos de pesquisa opcionais.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandUsageDescription_rus" xml:space="preserve">
     <value>Выбор дополнительныех условий поиска.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandUsageDescription_trk" xml:space="preserve">
     <value>İsteğe bağlı arama terimlerini belirtir.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandUsageDescription_chs" xml:space="preserve">
     <value>指定可选的搜索词。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandUsageDescription_cht" xml:space="preserve">
     <value>指定選擇性的搜尋字詞。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandUsageExamples_csy" xml:space="preserve">
     <value>nuget list
 
 nuget list -verbose -allversions</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandUsageExamples_deu" xml:space="preserve">
     <value>nuget list
 
 nuget list -verbose -allversions</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandUsageExamples_esp" xml:space="preserve">
     <value>nuget list
 
 nuget list -verbose -allversions</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandUsageExamples_fra" xml:space="preserve">
     <value>nuget list
 
 nuget list -verbose -allversions</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandUsageExamples_ita" xml:space="preserve">
     <value>nuget list
 
 nuget list -verbose -allversions</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandUsageExamples_jpn" xml:space="preserve">
     <value>nuget list
 
 nuget list -verbose -allversions</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandUsageExamples_kor" xml:space="preserve">
     <value>nuget list
 
 nuget list -verbose -allversions</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandUsageExamples_plk" xml:space="preserve">
     <value>nuget list
 
 nuget list -verbose -allversions</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandUsageExamples_ptb" xml:space="preserve">
     <value>nuget list
 
 nuget list -verbose -allversions</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandUsageExamples_rus" xml:space="preserve">
     <value>nuget list
 
 nuget list -verbose -allversions</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandUsageExamples_trk" xml:space="preserve">
     <value>nuget list
 
 nuget list -verbose -allversions</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandUsageExamples_chs" xml:space="preserve">
     <value>nuget list
 
 nuget list -verbose -allversions</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandUsageExamples_cht" xml:space="preserve">
     <value>nuget list
 
 nuget list -verbose -allversions</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandUsageSummary_csy" xml:space="preserve">
     <value>[hledané termíny] [možnosti]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandUsageSummary_deu" xml:space="preserve">
     <value>[Suchbegriffe] [Optionen]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandUsageSummary_esp" xml:space="preserve">
     <value>[buscar términos] [opciones]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandUsageSummary_fra" xml:space="preserve">
     <value>[@@@termes recherchés] [@@@options]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandUsageSummary_ita" xml:space="preserve">
     <value>[ricerca termini] [opzioni]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandUsageSummary_jpn" xml:space="preserve">
     <value>[search terms] [options]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandUsageSummary_kor" xml:space="preserve">
     <value>[검색어] [옵션]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandUsageSummary_plk" xml:space="preserve">
     <value>[terminy wyszukiwania] [opcje]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandUsageSummary_ptb" xml:space="preserve">
     <value>[termos de pesquisa] [opções]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandUsageSummary_rus" xml:space="preserve">
     <value>[условия поиска] [параметры]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandUsageSummary_trk" xml:space="preserve">
     <value>[arama terimleri] [seçenekler]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandUsageSummary_chs" xml:space="preserve">
     <value>[搜索词] [选项]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandUsageSummary_cht" xml:space="preserve">
     <value>搜尋字詞] [選項]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandVerboseListDescription_csy" xml:space="preserve">
     <value>Zobrazí podrobný seznam informací pro každý balíček.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandVerboseListDescription_deu" xml:space="preserve">
     <value>Zeigt eine detaillierte Liste mit Informationen zu jedem Paket an.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandVerboseListDescription_esp" xml:space="preserve">
     <value>Muestra una lista detallada de información para cada paquete.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandVerboseListDescription_fra" xml:space="preserve">
     <value>Affiche une liste détaillée d'informations pour chaque package.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandVerboseListDescription_ita" xml:space="preserve">
     <value>Visualizza un elenco dettagliato di informazioni per ogni pacchetto.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandVerboseListDescription_jpn" xml:space="preserve">
     <value>各パッケージの情報の詳細な一覧を表示します。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandVerboseListDescription_kor" xml:space="preserve">
     <value>각 패키지에 대한 자세한 정보 목록을 표시합니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandVerboseListDescription_plk" xml:space="preserve">
     <value>Wyświetla szczegółową listę informacji dla każdego pakietu.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandVerboseListDescription_ptb" xml:space="preserve">
     <value>Exibe uma lista detalhada de informações para cada pacote.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandVerboseListDescription_rus" xml:space="preserve">
     <value>Отображает подробный список сведений о каждом пакете.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandVerboseListDescription_trk" xml:space="preserve">
     <value>Her paket için ayrıntılı bilgi listesini görüntüler.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandVerboseListDescription_chs" xml:space="preserve">
     <value>显示每个程序包的详细信息列表。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandVerboseListDescription_cht" xml:space="preserve">
     <value>顯示為每個封裝的資訊詳細清單。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Option_NonInteractive_csy" xml:space="preserve">
     <value>Nezobrazovat výzvu pro uživatelský vstup nebo potvrzení</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Option_NonInteractive_deu" xml:space="preserve">
     <value>Keine Eingabeaufforderung für Benutzereingaben oder Bestätigungen.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Option_NonInteractive_esp" xml:space="preserve">
     <value>No solicitar la entrada del usuario o confirmaciones.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Option_NonInteractive_fra" xml:space="preserve">
     <value>N'affichez pas d'invites de saisies ou de confirmations faites à l'utilisateur.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Option_NonInteractive_ita" xml:space="preserve">
     <value>Non richiedere input o conferma dell'utente.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Option_NonInteractive_jpn" xml:space="preserve">
     <value>ユーザー入力または確認のプロンプトを表示しません。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Option_NonInteractive_kor" xml:space="preserve">
     <value>사용자 입력 또는 확인 시 메시지를 표시하지 않습니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Option_NonInteractive_plk" xml:space="preserve">
     <value>Bez monitów o dane wejściowe użytkownika i potwierdzenia.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Option_NonInteractive_ptb" xml:space="preserve">
     <value />
+    <comment>{Locked}</comment>
   </data>
   <data name="Option_NonInteractive_rus" xml:space="preserve">
     <value>Отключение запросов ввода или подтверждения пользователя.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Option_NonInteractive_trk" xml:space="preserve">
     <value>Kullanıcı girişi veya onayları istenmez.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Option_NonInteractive_chs" xml:space="preserve">
     <value>不提示用户进行输入或确认。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Option_NonInteractive_cht" xml:space="preserve">
     <value>不要提供使用者輸入或確認。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Option_Verbosity_csy" xml:space="preserve">
     <value>Zobrazí odpovídající úroveň informací ve výstupu: normal, quiet, detailed.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Option_Verbosity_deu" xml:space="preserve">
     <value>Diesen Detailgrad in der Ausgabe anzeigen: "normal", "quiet", "detailed".</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Option_Verbosity_esp" xml:space="preserve">
     <value>Mostrar esta cantidad de detalles en la salida: normal, quiet, detailed.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Option_Verbosity_fra" xml:space="preserve">
     <value>Niveau de détail du résultat affiché : normal, quiet, detailed.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Option_Verbosity_ita" xml:space="preserve">
     <value>Visualizza i dettagli nell'outputt: normal, quiet, detailed.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Option_Verbosity_jpn" xml:space="preserve">
     <value>出力に表示する詳細情報の量:normal、quiet、detailed。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Option_Verbosity_kor" xml:space="preserve">
     <value>출력에 사용되는 세부 정보의 양을 표시합니다(normal, quiet, detailed).</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Option_Verbosity_plk" xml:space="preserve">
     <value>Wyświetlaj taki poziom szczegółów w danych wyjściowych: normal, quiet, detailed.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Option_Verbosity_ptb" xml:space="preserve">
     <value>Exibir essa quantidade de detalhes na saída: normal, quiet, detailed.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Option_Verbosity_rus" xml:space="preserve">
     <value>Отображение следующего уровня подробности при выводе: normal, quiet, detailed.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Option_Verbosity_trk" xml:space="preserve">
     <value>Çıktıdaki ayrıntı miktarı buna göre belirlenir: normal, quiet, detailed.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Option_Verbosity_chs" xml:space="preserve">
     <value>在输出中显示以下数量的详细信息: normal、quiet、detailed。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Option_Verbosity_cht" xml:space="preserve">
     <value>在輸出中顯示詳細資料的數量: normal, quiet, detailed.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandBasePathDescription_csy" xml:space="preserve">
     <value>Základní cesta souborů definovaná v souboru nuspec</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandBasePathDescription_deu" xml:space="preserve">
     <value>Der Basispfad der in der nuspec-Datei definierten Dateien.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandBasePathDescription_esp" xml:space="preserve">
     <value>La ruta de acceso base de los archivos definida en el archivo nuspec.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandBasePathDescription_fra" xml:space="preserve">
     <value>Chemins d'accès de base aux fichiers définis dans le fichier .nuspec.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandBasePathDescription_ita" xml:space="preserve">
     <value>Il percorso base dei file definito nel file nuspec.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandBasePathDescription_jpn" xml:space="preserve">
     <value>nuspec ファイルに定義されているファイルの基本パス。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandBasePathDescription_kor" xml:space="preserve">
     <value>nuspec 파일에 정의된 파일의 기본 경로입니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandBasePathDescription_plk" xml:space="preserve">
     <value>Ścieżka podstawowa plików zdefiniowanych w pliku nuspec.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandBasePathDescription_ptb" xml:space="preserve">
     <value>O caminho base dos arquivos definidos no arquivo nuspec.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandBasePathDescription_rus" xml:space="preserve">
     <value>Базовый путь к файлам, определенным в NUSPEC-файле.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandBasePathDescription_trk" xml:space="preserve">
     <value>Nuspec dosyasında tanımlanan dosyaların taban yolu.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandBasePathDescription_chs" xml:space="preserve">
     <value>nuspec 文件中定义的文件的基本路径。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandBasePathDescription_cht" xml:space="preserve">
     <value>nuspec 檔案中定義檔案基本路徑。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandBuildDescription_csy" xml:space="preserve">
     <value>Určuje, zda projekt má být sestaven před sestavením balíčku.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandBuildDescription_deu" xml:space="preserve">
     <value>Ermittelt, ob das Projekt vor dem Erstellen des Pakets erstellt werden soll.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandBuildDescription_esp" xml:space="preserve">
     <value>Determina si se debería compilar el proyecto antes de la compilación del paquete.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandBuildDescription_fra" xml:space="preserve">
     <value>Détermine si le projet doit être créé avant la création du package.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandBuildDescription_ita" xml:space="preserve">
     <value>Determina se il progetto sarà creatp prima del pacchetto.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandBuildDescription_jpn" xml:space="preserve">
     <value>パッケージのビルド前に、プロジェクトのビルドが必要かどうかを決定します。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandBuildDescription_kor" xml:space="preserve">
     <value>패키지를 빌드하기 전에 프로젝트를 빌드해야 하는지 확인합니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandBuildDescription_plk" xml:space="preserve">
     <value>Określa, czy przed kompilacją pakietu trzeba skompilować projekt.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandBuildDescription_ptb" xml:space="preserve">
     <value>Determina se o projeto deve ser construído antes de construir o pacote.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandBuildDescription_rus" xml:space="preserve">
     <value>Определяет, следует ли выполнить сборку проекта перед сборкой пакета.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandBuildDescription_trk" xml:space="preserve">
     <value>Projenin paketten önce oluşturulması gerekip gerekmediğini belirler.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandBuildDescription_chs" xml:space="preserve">
     <value>确定是否应在生成程序包之前生成项目。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandBuildDescription_cht" xml:space="preserve">
     <value>判斷是否要在建置封裝之前建置專案。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandDescription_csy" xml:space="preserve">
     <value>Vytvoří balíček NuGet na základě zadaného souboru nuspec nebo souboru projektu.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandDescription_deu" xml:space="preserve">
     <value>Erstellt ein NuGet-Paket basierend auf der angegebenen nuspec- oder Projektdatei.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandDescription_esp" xml:space="preserve">
     <value>Crea un paquete NuGet basado en el archivo de proyecto o el nuspec especificado.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandDescription_fra" xml:space="preserve">
     <value>Crée un package NuGet en fonction du fichier .nuspec ou projet spécifié.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandDescription_ita" xml:space="preserve">
     <value>Crea un pacchetto NuGet in base al file progetto o nuspec specificato.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandDescription_jpn" xml:space="preserve">
     <value>指定された nuspec または project ファイルに基づいて、NuGet パッケージを作成します。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandDescription_kor" xml:space="preserve">
     <value>지정된 nuspec 또는 프로젝트 파일을 기반으로 NuGet 패키지를 만듭니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandDescription_plk" xml:space="preserve">
     <value>Tworzy pakiet NuGet na podstawie określonego pliku nuspec lub pliku projektu.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandDescription_ptb" xml:space="preserve">
     <value>Cria um pacote NuGet com base no nuspec especificado ou no arquivo de projeto.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandDescription_rus" xml:space="preserve">
     <value>Создает пакет NuGet при помощи указанного NUSPEC-файла или файла проекта.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandDescription_trk" xml:space="preserve">
     <value>Belirtilen nuspec veya proje dosyasını temel alarak NuGet paketi oluşturur.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandDescription_chs" xml:space="preserve">
     <value>基于指定的 nuspec 或项目文件创建 NuGet 程序包。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandDescription_cht" xml:space="preserve">
     <value>依指定的 nuspec 或專案檔建立 NuGet 封裝。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandExcludeDescription_csy" xml:space="preserve">
     <value>Určuje jeden nebo více vzorů zástupných znaků pro vyloučení při vytváření balíčku.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandExcludeDescription_deu" xml:space="preserve">
     <value>Gibt mindestens ein Platzhaltermuster ein, das beim Erstellen eines Pakets ausgeschlossen werden soll.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandExcludeDescription_esp" xml:space="preserve">
     <value>Especifica uno o más patrones de caracteres comodín que se deben excluir al crear un paquete.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandExcludeDescription_fra" xml:space="preserve">
     <value>Spécifie un ou plusieurs modèles à caractère générique à exclure lors de la création du package.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandExcludeDescription_ita" xml:space="preserve">
     <value>Specifica uno o più pattern wildcard da escludere nella creazione di un pacchetto.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandExcludeDescription_jpn" xml:space="preserve">
     <value>パッケージの作成時に除外するには、1 つまたは複数のワイルドカード パターンを指定します。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandExcludeDescription_kor" xml:space="preserve">
     <value>패키지를 만들 때 제외할 와일드카드 패턴을 하나 이상 지정합니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandExcludeDescription_plk" xml:space="preserve">
     <value>Określa jeden lub więcej wzorców symboli wieloznacznych, które mają zostać wykluczone podczas tworzenia pakietu.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandExcludeDescription_ptb" xml:space="preserve">
     <value>Especifica um ou mais padrões curinga a excluir ao criar um pacote.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandExcludeDescription_rus" xml:space="preserve">
     <value>Указывает один или несколько шаблонов подстановочных знаков, исключаемых при создании пакета.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandExcludeDescription_trk" xml:space="preserve">
     <value>Paket oluşturulurken hariç tutulacak bir veya daha fazla joker karakter desenini belirtir.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandExcludeDescription_chs" xml:space="preserve">
     <value>指定创建程序包时要排除的一个或多个通配符模式。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandExcludeDescription_cht" xml:space="preserve">
     <value>指定建立封裝時要排除的一或多個萬用字元模式。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandExcludeEmptyDirectories_csy" xml:space="preserve">
     <value>Zabrání zahrnutí prázdných adresářů při sestavování balíčku.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandExcludeEmptyDirectories_deu" xml:space="preserve">
     <value>Den Einschluss leerer Verzeichnisse beim Erstellen des Pakets verhindern.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandExcludeEmptyDirectories_esp" xml:space="preserve">
     <value>Impedir la inclusión de directorios vacíos al compilar el paquete.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandExcludeEmptyDirectories_fra" xml:space="preserve">
     <value>Empêche l'inclusion de répertoires vides lors de la création du package.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandExcludeEmptyDirectories_ita" xml:space="preserve">
     <value>Evita l'inclusione di directory vuote nella costruzione di un pacchetto.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandExcludeEmptyDirectories_jpn" xml:space="preserve">
     <value>パッケージのビルド時には、空のディレクトリを含めないでください。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandExcludeEmptyDirectories_kor" xml:space="preserve">
     <value>패키지 빌드 시 빈 디렉터리를 포함하지 않도록 합니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandExcludeEmptyDirectories_plk" xml:space="preserve">
     <value>Zapobiega dołączaniu pustych katalogów podczas kompilowania pakietu.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandExcludeEmptyDirectories_ptb" xml:space="preserve">
     <value>Evite a inclusão de diretórios vazios durante a construção do pacote.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandExcludeEmptyDirectories_rus" xml:space="preserve">
     <value>Предотвращает добавление пустых каталогов при выполнении сборки пакета.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandExcludeEmptyDirectories_trk" xml:space="preserve">
     <value>Paket oluşturulurken boş dizinlerin eklenmesini önle.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandExcludeEmptyDirectories_chs" xml:space="preserve">
     <value>防止在生成程序包时包含空目录。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandExcludeEmptyDirectories_cht" xml:space="preserve">
     <value>建置封裝時不包含空目錄。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandNoDefaultExcludes_csy" xml:space="preserve">
     <value>Zabrání výchozímu vyloučení souborů balíčku NuGet a souborů a složek, jejichž název začíná tečkou, např. .svn.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandNoDefaultExcludes_deu" xml:space="preserve">
     <value>Den Standardausschluss von NuGet-Paketdateien und Dateien und Ordnern verhindern, die mit einem Punkt beginnen, z. B. ".svn".</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandNoDefaultExcludes_esp" xml:space="preserve">
     <value>Impedir la exclusión predeterminada de los archivos del proyecto NuGet y los archivos y carpetas que empiecen con un punto, por ej. .svn.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandNoDefaultExcludes_fra" xml:space="preserve">
     <value>Empêchez l'exclusion par défaut des fichiers du package NuGet et des fichiers et dossiers dont le nom commence par un point (.svn par exemple).</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandNoDefaultExcludes_ita" xml:space="preserve">
     <value>Evita l'esclusione per default di NuGet e file e cartelle a partire da dot e.g. .svn.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandNoDefaultExcludes_jpn" xml:space="preserve">
     <value>NuGet パッケージ ファイルと、ドットで始まるファイルやフォルダー (.svn など) は、既定の除外に指定しないでください。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandNoDefaultExcludes_kor" xml:space="preserve">
     <value>점으로 시작하는 NuGet 패키지 파일 및 파일과 폴더가 기본적으로 제외되지 않도록 합니다(예: .svn).</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandNoDefaultExcludes_plk" xml:space="preserve">
     <value>Zapobiega domyślnemu wykluczeniu plików pakietów NuGet i plików oraz folderów, których nazwy zaczynają się kropką, np. .svn.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandNoDefaultExcludes_ptb" xml:space="preserve">
     <value>Evite a exclusão padrão de arquivos de pacotes NuGet e arquivos e pastas começando com um ponto, por exemplo .svn.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandNoDefaultExcludes_rus" xml:space="preserve">
     <value>Предотвращение используемого по умолчанию исключения файлов и папок пакета NuGet, начинающихся с точки, например ".svn".</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandNoDefaultExcludes_trk" xml:space="preserve">
     <value>NuGet paket dosyalarının ve nokta ile başlayan .svn gibi dosya ve klasörlerin varsayılan olarak hariç tutulmasını önle.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandNoDefaultExcludes_chs" xml:space="preserve">
     <value>防止默认排除 NuGet 程序包文件以及以点开头的文件和文件夹(例如 .svn)。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandNoDefaultExcludes_cht" xml:space="preserve">
     <value>防止預設執行以小數點開頭的 NuGet 封裝檔案和資料夾，例如 .svn。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandNoRunAnalysis_csy" xml:space="preserve">
     <value>Určuje, zda příkaz nemá po sestavení balíčku spustit jeho analýzu.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandNoRunAnalysis_deu" xml:space="preserve">
     <value>Geben Sie an, ob der Befehl keine Paketanalyse nach dem Erstellen des Pakets ausführen soll.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandNoRunAnalysis_esp" xml:space="preserve">
     <value>Especificar si el comando no debe ejecutar el análisis del paquete antes de compilar el paquete.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandNoRunAnalysis_fra" xml:space="preserve">
     <value>Spécifiez si la commande ne doit pas exécuter une analyse du package après la création de celui-ci.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandNoRunAnalysis_ita" xml:space="preserve">
     <value>Specificare se il comando non deve eseguire l'analisi del pacchetto dopo la creazione.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandNoRunAnalysis_jpn" xml:space="preserve">
     <value>パッケージのビルド後に、コマンドでパッケージの分析を実行しないかどうかを指定します。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandNoRunAnalysis_kor" xml:space="preserve">
     <value>패키지 빌드 후 명령이 패키지 분석을 실행해야 하는지 여부를 지정합니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandNoRunAnalysis_plk" xml:space="preserve">
     <value>Określ, czy polecenie nie powinno uruchamiać analizy pakietu po kompilacji pakietu.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandNoRunAnalysis_ptb" xml:space="preserve">
     <value>Especifique se o comando não deve executar a análise do pacote depois de construir o pacote.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandNoRunAnalysis_rus" xml:space="preserve">
     <value>Указывает, следует ли команде запустить анализ пакета после его сборки.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandNoRunAnalysis_trk" xml:space="preserve">
     <value>Komutun paket oluşturulduktan sonra paket analizini çalıştırması gerekip gerekmediğini belirtin.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandNoRunAnalysis_chs" xml:space="preserve">
     <value>指定命令在生成程序包后，是否不应运行程序包分析。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandNoRunAnalysis_cht" xml:space="preserve">
     <value>指定命令是否不應該在建置封裝之後執行封裝分析。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandOutputDirDescription_csy" xml:space="preserve">
     <value>Určuje adresář pro vytvořený soubor balíčku NuGet. Není-li zadán, použije se aktuální adresář.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandOutputDirDescription_deu" xml:space="preserve">
     <value>Gibt das Verzeichnis für die erstellte NuGet-Paketdatei an. Erfolgt keine Angabe, wird das aktuelle Verzeichnis verwendet.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandOutputDirDescription_esp" xml:space="preserve">
     <value>Especifica el directorio para el archivo del paquete NuGet creado. Si no se especifica, usa el directorio actual.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandOutputDirDescription_fra" xml:space="preserve">
     <value>Spécifie le répertoire du fichier du package NuGet créé. S'il n'est pas spécifié, le répertoire actuel sera utilisé.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandOutputDirDescription_ita" xml:space="preserve">
     <value>Specifica la directory per il file NuGet creato. Se non specificato, usare la directory attuale.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandOutputDirDescription_jpn" xml:space="preserve">
     <value>作成される NuGet パッケージ ファイルのディレクトリを指定します。指定しない場合、現在のディレクトリが使用されます。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandOutputDirDescription_kor" xml:space="preserve">
     <value>만든 NuGet 패키지 파일의 디렉터리를 지정합니다. 지정되지 않은 경우 현재 디렉터리를 사용합니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandOutputDirDescription_plk" xml:space="preserve">
     <value>Określa katalog dla utworzonego pliku pakietu NuGet. Jeśli nie zostanie on określony, jest używany katalog bieżący.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandOutputDirDescription_ptb" xml:space="preserve">
     <value>Especifica o diretório para o arquivo do pacote NuGet criado. Se não for especificado, usa o diretório atual.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandOutputDirDescription_rus" xml:space="preserve">
     <value>Указывает каталог для созданного файла пакета NuGet. Если не указан, используется текущий каталог.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandOutputDirDescription_trk" xml:space="preserve">
     <value>Oluşturulan NuGet paket dosyasının dizinini belirtir. Belirtilmemişse, geçerli dizin kullanılır.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandOutputDirDescription_chs" xml:space="preserve">
     <value>为创建的 NuGet 程序包文件指定目录。如果未指定，则使用当前目录。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandOutputDirDescription_cht" xml:space="preserve">
     <value>指定已建立的 NuGet package 檔案的目錄。若未指定，請使用目前的目錄。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandPropertiesDescription_csy" xml:space="preserve">
     <value>Poskytuje možnost zadat při vytváření balíčku seznam vlastností oddělených středníkem (;).</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandPropertiesDescription_deu" xml:space="preserve">
     <value>Stellt die Möglichkeit zur Verfügung, eine durch Semikolons (";") getrennte Liste der Eigenschaften beim Erstellen eines Pakets anzugeben.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandPropertiesDescription_esp" xml:space="preserve">
     <value>Proporciona la capacidad de especificar una lista de propiedades delimitada con un punto y coma ";" al crear un paquete.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandPropertiesDescription_fra" xml:space="preserve">
     <value>Permet de spécifier une liste des propriétés, délimitée par des points-virgules « ; », lors de la création du package.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandPropertiesDescription_ita" xml:space="preserve">
     <value>Fornisce l'abilità di specificare un ";" una lista delimitata di proprietà nella creazione di un pacchetto.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandPropertiesDescription_jpn" xml:space="preserve">
     <value>パッケージの作成時に、セミコロン (";") 区切りのプロパティ一覧を指定することができます。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandPropertiesDescription_kor" xml:space="preserve">
     <value>패키지를 만들 때 세미콜론(";")으로 구분된 속성 목록을 지정할 수 있는 기능을 제공합니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandPropertiesDescription_plk" xml:space="preserve">
     <value>Zapewnia możliwość określenia listy właściwości rozdzielonych średnikami „;” podczas tworzenia pakietu.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandPropertiesDescription_ptb" xml:space="preserve">
     <value>Fornece a capacidade para especificar uma  lista delimitada de propriedades com ponto e vírgula ";" ao criar um pacote.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandPropertiesDescription_rus" xml:space="preserve">
     <value>Дает возможность указать список свойств, разделенных точкой с запятой (;), при создании пакета.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandPropertiesDescription_trk" xml:space="preserve">
     <value>Paket oluşturulurken, özelliklerin noktalı virgülle ";" ayrılmış listesinin belirtilebilmesini sağlar.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandPropertiesDescription_chs" xml:space="preserve">
     <value>在创建程序包时，可以指定以分号 ";" 分隔的属性列表。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandPropertiesDescription_cht" xml:space="preserve">
     <value>建立封裝時，提供可指定屬性分號 ";" 分隔清單的功能。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandSymbolsDescription_csy" xml:space="preserve">
     <value>Určuje, zda by měl být vytvořen balíček obsahující zdroje a symboly. Při zadání pomocí souboru nuspec vytvoří běžný soubor balíčku NuGet a odpovídající balíček symbolů.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandSymbolsDescription_deu" xml:space="preserve">
     <value>Legt fest, ob ein Paket erstellt werden soll, das Quellen und Symbole enthält. Wenn die Angabe mit einer nuspec-Datei erfolgt, werden eine reguläre NuGet-Paketdatei und das zugehörige Symbolpaket erstellt.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandSymbolsDescription_esp" xml:space="preserve">
     <value>Determina si se debe crear un paquete que contiene orígenes y símbolos. Cuando se especifica con un nuspec, se crea un archivo de proyecto NuGet regular y el paquete de símbolos correspondiente.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandSymbolsDescription_fra" xml:space="preserve">
     <value>Détermine si un package contenant sources et symboles doit être créé. Lorsqu'il est spécifié avec un nuspec, il crée un fichier de package NuGet normal et le package de symboles correspondant.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandSymbolsDescription_ita" xml:space="preserve">
     <value>Determina se il pacchetto contiene fonti e simboli da creare. Quando specificato con nuspec, creare un file NuGet e il corrispondente pacchetto di simboli.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandSymbolsDescription_jpn" xml:space="preserve">
     <value>ソースとシンボルを含むパッケージを作成する必要があるかどうかを決定します。nuspec と共に使用すると、通常の NuGet パッケージ ファイルと対応するシンボル パッケージが作成されます。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandSymbolsDescription_kor" xml:space="preserve">
     <value>소스 및 기호가 포함된 패키지를 만들어야 하는지 여부를 결정합니다. nuspec으로 지정된 경우 일반 NuGet 패키지 파일 및 해당 기호 패키지를 만듭니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandSymbolsDescription_plk" xml:space="preserve">
     <value>Określa, czy powinien zostać utworzony pakiet zawierający źródła i symbole. W przypadku określenia za pomocą pliku nuspec jest tworzony normalny plik pakietu NuGet i odpowiadający mu pakiet symboli.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandSymbolsDescription_ptb" xml:space="preserve">
     <value>Determina se um pacote contendo origens e símbolos deve ser criado. Quando especificado com um nuspec, cria um arquivo de pacote NuGet comum e o pacote de símbolos correspondente.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandSymbolsDescription_rus" xml:space="preserve">
     <value>Определяет, следует ли создать пакет, содержащий источники и символы. Если задан посредством NUSPEC-файла, создает обычный файл пакета NuGet и соответствующий пакет символов.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandSymbolsDescription_trk" xml:space="preserve">
     <value>Kaynakları ve simgeleri içeren bir paket oluşturulması gerekip gerekmediğini belirler. Bir nuspec ile belirtildiğinde, normal NuGet paket dosyasını ve ilgili simge paketini oluşturur.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandSymbolsDescription_chs" xml:space="preserve">
     <value>确定是否应创建包含源和符号的程序包。当使用 nuspec 指定时，创建常规 NuGet 程序包文件和相应的符号程序包。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandSymbolsDescription_cht" xml:space="preserve">
     <value>判斷是否應該建立包含來源和符號的封裝。以 nuspec 指定時，建立一班 NuGet 封裝檔以及相對應的符號封裝。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandToolDescription_csy" xml:space="preserve">
     <value>Určuje, zda výstupní soubory projektu mají být uloženy ve složce nástrojů. </value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandToolDescription_deu" xml:space="preserve">
     <value>Legt fest, ob sich die Ausgabedateien des Projekts im Ordner "tool" befinden sollen. </value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandToolDescription_esp" xml:space="preserve">
     <value>Determina si los archivos de salida del proyecto deben estar en la carpeta de herramientas.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandToolDescription_fra" xml:space="preserve">
     <value>Détermine si les fichiers de sortie du projet doivent se trouver dans le dossier de l'outil. </value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandToolDescription_ita" xml:space="preserve">
     <value>Determina se il file d'uscita del progetto deve trovarsi nella cartella strumenti.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandToolDescription_jpn" xml:space="preserve">
     <value>プロジェクトの出力ファイルをツール フォルダーにする必要があるかどうかを決定します。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandToolDescription_kor" xml:space="preserve">
     <value>프로젝트의 출력 파일이 도구 폴더에 있어야 하는지 여부를 결정합니다. </value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandToolDescription_plk" xml:space="preserve">
     <value>Określa, czy pliki wyjściowe projektu powinny znajdować się z folderze narzędzi. </value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandToolDescription_ptb" xml:space="preserve">
     <value>Determina se os arquivos de saída do projeto devem estar na pasta da ferramenta.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandToolDescription_rus" xml:space="preserve">
     <value>Определяет, должны ли выходные файлы проекта находиться в папке средства. </value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandToolDescription_trk" xml:space="preserve">
     <value>Projenin çıktı dosyalarının araç klasöründe olması gerekip gerekmediğini belirler.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandToolDescription_chs" xml:space="preserve">
     <value>确定项目的输出文件是否应在工具文件夹中。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandToolDescription_cht" xml:space="preserve">
     <value>判斷專案的輸出檔是否應該放在工具資料夾中。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandUsageDescription_csy" xml:space="preserve">
     <value>Určuje umístění souboru nuspec nebo souboru projektu pro vytvoření balíčku.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandUsageDescription_deu" xml:space="preserve">
     <value>Geben Sie den Speicherort der nuspec- oder Projektdatei an, um ein Paket zu erstellen.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandUsageDescription_esp" xml:space="preserve">
     <value>Especificar la ubicación del archivo nuspec o de proyecto para crear un paquete.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandUsageDescription_fra" xml:space="preserve">
     <value>Spécifiez l'emplacement du fichier .nuspec ou projet pour créer un package.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandUsageDescription_ita" xml:space="preserve">
     <value>Specificare la posizione del file di progetto nuspec o file fi progetto per creare il pacchetto.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandUsageDescription_jpn" xml:space="preserve">
     <value>パッケージを作成する nuspec または project ファイルの場所を指定します。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandUsageDescription_kor" xml:space="preserve">
     <value>패키지를 만들 nuspec 또는 프로젝트 파일의 위치를 지정합니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandUsageDescription_plk" xml:space="preserve">
     <value>Określa lokalizację pliku nuspec lub pliku projektu na potrzeby utworzenia pakietu.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandUsageDescription_ptb" xml:space="preserve">
     <value>Especifique o local do arquivo nuspec ou de projeto para criar um pacote.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandUsageDescription_rus" xml:space="preserve">
     <value>Задание расположения NUSPEC-файла или файла проекта для создания пакета.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandUsageDescription_trk" xml:space="preserve">
     <value>Paket oluşturmak için nuspec veya proje dosyalarının konumunu belirtir.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandUsageDescription_chs" xml:space="preserve">
     <value>指定用于创建程序包的 nuspec 或项目文件的位置。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandUsageDescription_cht" xml:space="preserve">
     <value>指定 nuspec 位置或專案檔以建立封裝。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandUsageSummary_csy" xml:space="preserve">
     <value>&lt;nuspec | projekt&gt; [možnosti]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandUsageSummary_deu" xml:space="preserve">
     <value>&lt;nuspec | Projekt&gt; [Optionen]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandUsageSummary_esp" xml:space="preserve">
     <value>&lt;nuspec | proyecto&gt; [options]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandUsageSummary_fra" xml:space="preserve">
     <value>&lt;nuspec | project&gt; [options]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandUsageSummary_ita" xml:space="preserve">
     <value>&lt;nuspec | progettot&gt; [opzioni]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandUsageSummary_jpn" xml:space="preserve">
     <value>&lt;nuspec | project&gt; [options]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandUsageSummary_kor" xml:space="preserve">
     <value>&lt;nuspec | 프로젝트&gt; [옵션]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandUsageSummary_plk" xml:space="preserve">
     <value>&lt;nuspec | projekt&gt; [opcje]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandUsageSummary_ptb" xml:space="preserve">
     <value>&lt;nuspec | projeto&gt; [opções]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandUsageSummary_rus" xml:space="preserve">
     <value>&lt;nuspec-файл | проект&gt; [параметры]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandUsageSummary_trk" xml:space="preserve">
     <value>&lt;nuspec | proje&gt; [seçenekler]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandUsageSummary_chs" xml:space="preserve">
     <value>&lt;nuspec | project&gt; [选项]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandUsageSummary_cht" xml:space="preserve">
     <value>&lt;nuspec | 專案&gt; [選項]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandVerboseDescription_csy" xml:space="preserve">
     <value>Zobrazí podrobný výstup pro sestavování balíčků.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandVerboseDescription_deu" xml:space="preserve">
     <value>Zeigt die ausführliche Ausgabe für die Paketerstellung an.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandVerboseDescription_esp" xml:space="preserve">
     <value>Muestra los resultados detallados de la compilación del paquete.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandVerboseDescription_fra" xml:space="preserve">
     <value>Affiche la sortie détaillée de création du package.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandVerboseDescription_ita" xml:space="preserve">
     <value>Mostra l'uscita ridondante del pacchetto</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandVerboseDescription_jpn" xml:space="preserve">
     <value>パッケージ ビルドの詳細な出力を表示します。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandVerboseDescription_kor" xml:space="preserve">
     <value>패키지 빌드에 대한 자세한 출력을 표시합니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandVerboseDescription_plk" xml:space="preserve">
     <value>Pokazuje dane wyjściowe w trybie pełnym na potrzeby kompilacji pakietu.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandVerboseDescription_ptb" xml:space="preserve">
     <value>Mostra a saída detalhada para a construção do pacote.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandVerboseDescription_rus" xml:space="preserve">
     <value>Отображает подробные выходные данные при сборке пакета.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandVerboseDescription_trk" xml:space="preserve">
     <value>Paket oluşturma için ayrıntılı çıktıyı gösterir.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandVerboseDescription_chs" xml:space="preserve">
     <value>显示程序包生成的详细输出。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandVerboseDescription_cht" xml:space="preserve">
     <value>顯示封裝建置的詳細資料輸出。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandVersionDescription_csy" xml:space="preserve">
     <value>Přepíše číslo verze ze souboru nuspec.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandVersionDescription_deu" xml:space="preserve">
     <value>Setzt die Versionsnummer aus der nuspec-Datei außer Kraft.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandVersionDescription_esp" xml:space="preserve">
     <value>Reemplaza el número de versión del archivo nuspec.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandVersionDescription_fra" xml:space="preserve">
     <value>Remplace le numéro de version provenant du fichier .nuspec.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandVersionDescription_ita" xml:space="preserve">
     <value />
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandVersionDescription_jpn" xml:space="preserve">
     <value>nuspec ファイルのバージョン番号を上書きします。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandVersionDescription_kor" xml:space="preserve">
     <value>nuspec 파일의 버전 번호를 재정의합니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandVersionDescription_plk" xml:space="preserve">
     <value>Przesłania numer wersji z pliku nuspec.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandVersionDescription_ptb" xml:space="preserve">
     <value>Substitui o número da versão do arquivo nuspec.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandVersionDescription_rus" xml:space="preserve">
     <value>Переопределяет номер версии из NUSPEC-файла.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandVersionDescription_trk" xml:space="preserve">
     <value>Nuspec dosyasındaki sürüm numarasını geçersiz kılar.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandVersionDescription_chs" xml:space="preserve">
     <value>覆盖 nuspec 文件中的版本号。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandVersionDescription_cht" xml:space="preserve">
     <value>覆寫 nuspec 檔案的版本號碼。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackCommandUsageExamples_csy" xml:space="preserve">
     <value>nuget pack
@@ -2764,6 +3440,7 @@ nuget pack foo.csproj
 nuget pack foo.csproj -Build -Symbols -Properties Configuration=Release
 
 nuget pack foo.nuspec -Version 2.1.0</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackCommandUsageExamples_deu" xml:space="preserve">
     <value>nuget pack
@@ -2775,6 +3452,7 @@ nuget pack foo.csproj
 nuget pack foo.csproj -Build -Symbols -Properties Configuration=Release
 
 nuget pack foo.nuspec -Version 2.1.0</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackCommandUsageExamples_esp" xml:space="preserve">
     <value>nuget pack
@@ -2786,6 +3464,7 @@ nuget pack foo.csproj
 nuget pack foo.csproj -Build -Symbols -Properties Configuration=Release
 
 nuget pack foo.nuspec -Version 2.1.0</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackCommandUsageExamples_fra" xml:space="preserve">
     <value>nuget pack
@@ -2797,6 +3476,7 @@ nuget pack foo.csproj
 nuget pack foo.csproj -Build -Symbols -Properties Configuration=Release
 
 nuget pack foo.nuspec -Version 2.1.0</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackCommandUsageExamples_ita" xml:space="preserve">
     <value>nuget pack
@@ -2808,6 +3488,7 @@ nuget pack foo.csproj
 nuget pack foo.csproj -Build -Symbols -Properties Configuration=Release
 
 nuget pack foo.nuspec -Version 2.1.0</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackCommandUsageExamples_jpn" xml:space="preserve">
     <value>nuget pack
@@ -2819,6 +3500,7 @@ nuget pack foo.csproj
 nuget pack foo.csproj -Build -Symbols -Properties Configuration=Release
 
 nuget pack foo.nuspec -Version 2.1.0</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackCommandUsageExamples_kor" xml:space="preserve">
     <value>nuget pack
@@ -2830,6 +3512,7 @@ nuget pack foo.csproj
 nuget pack foo.csproj -Build -Symbols -Properties Configuration=Release
 
 nuget pack foo.nuspec -Version 2.1.0</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackCommandUsageExamples_plk" xml:space="preserve">
     <value>nuget pack
@@ -2841,6 +3524,7 @@ nuget pack foo.csproj
 nuget pack foo.csproj -Build -Symbols -Properties Configuration=Release
 
 nuget pack foo.nuspec -Version 2.1.0</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackCommandUsageExamples_ptb" xml:space="preserve">
     <value>nuget pack
@@ -2852,6 +3536,7 @@ nuget pack foo.csproj
 nuget pack foo.csproj -Build -Symbols -Properties Configuration=Release
 
 nuget pack foo.nuspec -Version 2.1.0</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackCommandUsageExamples_rus" xml:space="preserve">
     <value>nuget pack
@@ -2863,6 +3548,7 @@ nuget pack foo.csproj
 nuget pack foo.csproj -Build -Symbols -Properties Configuration=Release
 
 nuget pack foo.nuspec -Version 2.1.0</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackCommandUsageExamples_trk" xml:space="preserve">
     <value>nuget pack
@@ -2874,6 +3560,7 @@ nuget pack foo.csproj
 nuget pack foo.csproj -Build -Symbols -Properties Configuration=Release
 
 nuget pack foo.nuspec -Version 2.1.0</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackCommandUsageExamples_chs" xml:space="preserve">
     <value>nuget pack
@@ -2885,6 +3572,7 @@ nuget pack foo.csproj
 nuget pack foo.csproj -Build -Symbols -Properties Configuration=Release
 
 nuget pack foo.nuspec -Version 2.1.0</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackCommandUsageExamples_cht" xml:space="preserve">
     <value>nuget pack
@@ -2896,123 +3584,163 @@ nuget pack foo.csproj
 nuget pack foo.csproj -Build -Symbols -Properties Configuration=Release
 
 nuget pack foo.nuspec -Version 2.1.0</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandSourceDescription_csy" xml:space="preserve">
     <value>Určuje adresu URL serveru. Není-li zadána, použije se adresa nuget.org, pokud v konfiguračním souboru NuGet není nastavena konfigurační hodnota DefaultPushSource.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandSourceDescription_deu" xml:space="preserve">
     <value>Gibt die Server-URL an. Erfolgt keine Angabe, wird "nuget.org" verwendet. Dies ist nur dann nicht der Fall, wenn der Konfigurationswert "DefaultPushSource" in der NuGet-Konfigurationsdatei festgelegt ist.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandSourceDescription_esp" xml:space="preserve">
     <value>Especifica la URL del servidor. Si no se especifica, se usa nuget.org a menos que el valor de configuración de DefaultPushSource se establezca en el archivo de configuración de NuGet.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandSourceDescription_fra" xml:space="preserve">
     <value>Spécifie l'URL du serveur. nuget.org est utilisé en l'absence de spécification, sauf si la valeur de configuration DefaultPushSource est définie dans le fichier de configuration NuGet.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandSourceDescription_ita" xml:space="preserve">
     <value>Specifica il server URL. Se non specificato, nuget.org èe quello usato a mano che DefaultPushSource config value è impostato nel file NuGet config.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandSourceDescription_jpn" xml:space="preserve">
     <value>サーバーの URL を指定します。指定しない場合、NuGet 構成ファイルに DefaultPushSource 構成値が設定されていなければ、nuget.org が使用されます。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandSourceDescription_kor" xml:space="preserve">
     <value>서버 URL을 지정합니다. 지정되지 않은 경우 NuGet config 파일에 DefaultPushSource config 값이 설정되어 있지 않으면 nuget.org가 사용됩니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandSourceDescription_plk" xml:space="preserve">
     <value>Określa adres URL serwera. Jeśli nie zostanie on określony, będzie używana witryna nuget.org, chyba że w pliku konfiguracji NuGet zostanie określona wartość DefaultPushSource.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandSourceDescription_ptb" xml:space="preserve">
     <value>Especifica a URL do servidor. Se não for especificado, nuget.org é usado a menos que o valor de configuração DefaultPushSource seja definido no arquivo de configuração NuGet.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandSourceDescription_rus" xml:space="preserve">
     <value>Указывает URL-адрес сервера. Если не указан, используется адрес "nuget.org", если только в файле конфигурации NuGet не задано значение конфигурации DefaultPushSource.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandSourceDescription_trk" xml:space="preserve">
     <value>Sunucu URL'sini belirtir. Belirtilmemişse, NuGet yapılandırma dosyasında DefaultPushSource yapılandırma değerinin ayarlanmamış olması halinde, nuget.org kullanılır.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandSourceDescription_chs" xml:space="preserve">
     <value>指定服务器 URL。如果未指定，则除非在 NuGet 配置文件中设置了 DefaultPushSource 配置值，否则使用 nuget.org。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandSourceDescription_cht" xml:space="preserve">
     <value>指定伺服器 URL。若未指定，除非在 NuGet 設定檔中設定了 DefaultPushSource config 值，否則會使用 nuget.orgis。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandTimeoutDescription_csy" xml:space="preserve">
     <value>Určuje prodlevu pro předání na server (v sekundách). Výchozí nastavení je 300 sekund (5 minut).</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandTimeoutDescription_deu" xml:space="preserve">
     <value>Gibt das Timeout für den Pushvorgang auf einen Server in Sekunden an. Der Standardwert sind 300 Sekunden (5 Minuten).</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandTimeoutDescription_esp" xml:space="preserve">
     <value>Especifica el tiempo de expiración en segundos de la inserción a un servidor. Se predetermina a 300 segundos (5 minutos).</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandTimeoutDescription_fra" xml:space="preserve">
     <value>Spécifie en secondes le délai d'expiration d'émission vers un serveur. 300 secondes (5 minutes) par défaut.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandTimeoutDescription_ita" xml:space="preserve">
     <value>Specifica il timeout per il push al server in secondi. Default di 300 secondi (5 minuti).</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandTimeoutDescription_jpn" xml:space="preserve">
     <value>サーバーにプッシュする場合のタイムアウト (秒) を指定します。既定は 300 秒 (5 分) です。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandTimeoutDescription_kor" xml:space="preserve">
     <value>서버에 푸시하는 시간 제한(초)을 지정합니다. 300초(5분)로 기본 설정됩니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandTimeoutDescription_plk" xml:space="preserve">
     <value>Określa limit czasu dla wypychania na serwer (w sekundach). Wartość domyślna to 300 sekund (5 minut).</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandTimeoutDescription_ptb" xml:space="preserve">
     <value>Especifica o tempo limite para enviar para um servidor em segundos. O padrão é 300 segundos (5 minutos).</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandTimeoutDescription_rus" xml:space="preserve">
     <value>Задает время ожидания отправки на сервер в секундах. По умолчанию составляет 300 секунд (5 минут).</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandTimeoutDescription_trk" xml:space="preserve">
     <value>Saniye cinsinden sunucuya iletim için zaman aşımını belirtir. Varsayılan değer 300 saniyedir (5 dakika).</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandTimeoutDescription_chs" xml:space="preserve">
     <value>指定推送到服务器的超时值(以秒为单位)。默认值为 300 秒(5 分钟)。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandTimeoutDescription_cht" xml:space="preserve">
     <value>指定推入伺服器的逾時 (以秒為單位)。預設為 300秒 (5 分鐘)。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandUsageDescription_csy" xml:space="preserve">
     <value>Určuje cestu k balíčku a klíč API pro předání balíčku na server.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandUsageDescription_deu" xml:space="preserve">
     <value>Geben Sie den Pfad zum Paket und Ihren API-Schlüssel an, um das Paket mittels Push an den Server zu senden.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandUsageDescription_esp" xml:space="preserve">
     <value>Especificar la ruta de acceso al paquete y su clave API para insertar el paquete al servidor.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandUsageDescription_fra" xml:space="preserve">
     <value>Spécifiez le chemin d'accès au package et la clé API pour émettre le package vers le serveur.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandUsageDescription_ita" xml:space="preserve">
     <value>Specifica il percorso al pacchetto e l'API key per eseguire il push del pacchetto al server.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandUsageDescription_jpn" xml:space="preserve">
     <value>パッケージをサーバーにプッシュするパッケージのパスと API キーを指定します。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandUsageDescription_kor" xml:space="preserve">
     <value>서버에 패키지를 푸시할 패키지 및 API 키의 경로를 지정합니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandUsageDescription_plk" xml:space="preserve">
     <value>Określ ścieżkę do pakietu i klucz interfejsu API, aby wypchnąć pakiet na serwer.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandUsageDescription_ptb" xml:space="preserve">
     <value>Especifique o caminho para o pacote e sua chave de API para enviar o pacote para o servidor.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandUsageDescription_rus" xml:space="preserve">
     <value>Настройка пути к пакету и ключа API для отправки пакета на сервер.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandUsageDescription_trk" xml:space="preserve">
     <value>Paketin sunucuya iletilmesi için paket yolunu ve API anahtarınızı belirtin.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandUsageDescription_chs" xml:space="preserve">
     <value>指定程序包的路径以及用于将程序包推送到服务器的 API 密钥。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandUsageDescription_cht" xml:space="preserve">
     <value>指定封裝路徑和 API 索引鍵以將套件推入伺服器。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandUsageExamples_csy" xml:space="preserve">
     <value>nuget push foo.nupkg 4003d786-cc37-4004-bfdf-c4f3e8ef9b3a
@@ -3024,6 +3752,7 @@ nuget push foo.nupkg
 nuget push foo.nupkg.symbols
 
 nuget push foo.nupkg -Timeout 360</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandUsageExamples_deu" xml:space="preserve">
     <value>nuget push foo.nupkg 4003d786-cc37-4004-bfdf-c4f3e8ef9b3a
@@ -3035,6 +3764,7 @@ nuget push foo.nupkg
 nuget push foo.nupkg.symbols
 
 nuget push foo.nupkg -Timeout 360</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandUsageExamples_esp" xml:space="preserve">
     <value>nuget push foo.nupkg 4003d786-cc37-4004-bfdf-c4f3e8ef9b3a
@@ -3046,6 +3776,7 @@ nuget push foo.nupkg
 nuget push foo.nupkg.symbols
 
 nuget push foo.nupkg -Timeout 360</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandUsageExamples_fra" xml:space="preserve">
     <value>nuget push foo.nupkg 4003d786-cc37-4004-bfdf-c4f3e8ef9b3a
@@ -3057,6 +3788,7 @@ nuget push foo.nupkg
 nuget push foo.nupkg.symbols
 
 nuget push foo.nupkg -Timeout 360</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandUsageExamples_ita" xml:space="preserve">
     <value>nuget push foo.nupkg 4003d786-cc37-4004-bfdf-c4f3e8ef9b3a
@@ -3068,6 +3800,7 @@ nuget push foo.nupkg
 nuget push foo.nupkg.symbols
 
 nuget push foo.nupkg -Timeout 360</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandUsageExamples_jpn" xml:space="preserve">
     <value>nuget push foo.nupkg 4003d786-cc37-4004-bfdf-c4f3e8ef9b3a
@@ -3079,6 +3812,7 @@ nuget push foo.nupkg
 nuget push foo.nupkg.symbols
 
 nuget push foo.nupkg -Timeout 360</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandUsageExamples_kor" xml:space="preserve">
     <value>nuget push foo.nupkg 4003d786-cc37-4004-bfdf-c4f3e8ef9b3a
@@ -3090,6 +3824,7 @@ nuget push foo.nupkg
 nuget push foo.nupkg.symbols
 
 nuget push foo.nupkg -Timeout 360</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandUsageExamples_plk" xml:space="preserve">
     <value>nuget push foo.nupkg 4003d786-cc37-4004-bfdf-c4f3e8ef9b3a
@@ -3101,6 +3836,7 @@ nuget push foo.nupkg
 nuget push foo.nupkg.symbols
 
 nuget push foo.nupkg -Timeout 360</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandUsageExamples_ptb" xml:space="preserve">
     <value>nuget push foo.nupkg 4003d786-cc37-4004-bfdf-c4f3e8ef9b3a
@@ -3112,6 +3848,7 @@ nuget push foo.nupkg
 nuget push foo.nupkg.symbols
 
 nuget push foo.nupkg -Timeout 360</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandUsageExamples_rus" xml:space="preserve">
     <value>nuget push foo.nupkg 4003d786-cc37-4004-bfdf-c4f3e8ef9b3a
@@ -3123,6 +3860,7 @@ nuget push foo.nupkg
 nuget push foo.nupkg.symbols
 
 nuget push foo.nupkg -Timeout 360</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandUsageExamples_trk" xml:space="preserve">
     <value>nuget push foo.nupkg 4003d786-cc37-4004-bfdf-c4f3e8ef9b3a
@@ -3134,6 +3872,7 @@ nuget push foo.nupkg
 nuget push foo.nupkg.symbols
 
 nuget push foo.nupkg -Timeout 360</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandUsageExamples_chs" xml:space="preserve">
     <value>nuget push foo.nupkg 4003d786-cc37-4004-bfdf-c4f3e8ef9b3a
@@ -3145,6 +3884,7 @@ nuget push foo.nupkg
 nuget push foo.nupkg.symbols
 
 nuget push foo.nupkg -Timeout 360</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandUsageExamples_cht" xml:space="preserve">
     <value>nuget push foo.nupkg 4003d786-cc37-4004-bfdf-c4f3e8ef9b3a
@@ -3156,617 +3896,813 @@ nuget push foo.nupkg
 nuget push foo.nupkg.symbols
 
 nuget push foo.nupkg -Timeout 360</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandUsageSummary_csy" xml:space="preserve">
     <value>&lt;cesta k balíčku&gt; [klíč API] [možnosti]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandUsageSummary_deu" xml:space="preserve">
     <value>&lt;Paketpfad&gt; [API-Schlüssel] [Optionen]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandUsageSummary_esp" xml:space="preserve">
     <value>&lt;ruta de acceso&gt; [clave API] [opciones]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandUsageSummary_fra" xml:space="preserve">
     <value>&lt;package path&gt; [@@@clé API] [@@@options]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandUsageSummary_ita" xml:space="preserve">
     <value>&lt;percorso pacchetto&gt; [API key] [opzioni]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandUsageSummary_jpn" xml:space="preserve">
     <value>&lt;package path&gt; [API key] [options]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandUsageSummary_kor" xml:space="preserve">
     <value>&lt;패키지 경로&gt; [API 키] [옵션]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandUsageSummary_plk" xml:space="preserve">
     <value>&lt;ścieżka pakietu&gt; [klucz interfejsu API] [opcje]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandUsageSummary_ptb" xml:space="preserve">
     <value>&lt;caminho do pacote&gt; [Chave de API] [opções]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandUsageSummary_rus" xml:space="preserve">
     <value>&lt;путь пакета&gt; [ключ API] [параметры]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandUsageSummary_trk" xml:space="preserve">
     <value>&lt;paket yolu&gt; [API anahtarı] [seçenekler]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandUsageSummary_chs" xml:space="preserve">
     <value>&lt;程序包路径&gt; [API 密钥] [选项]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandUsageSummary_cht" xml:space="preserve">
     <value>&lt;封裝路徑&gt; [API 索引鍵] [選項]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandDescription_csy" xml:space="preserve">
     <value>Uloží klíč API pro danou adresu URL serveru. Není-li zadána žádná adresa URL, je uložen klíč API pro galerii NuGet.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandDescription_deu" xml:space="preserve">
     <value>Speichert einen API-Schlüssel für eine angegebene Server-URL. Wenn keine URL bereitgestellt wird, wird der API-Schlüssel für den NuGet-Katalog gespeichert.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandDescription_esp" xml:space="preserve">
     <value>Guarda una clave API para una URL de servidor especificada. Cuando no se proporciona ninguna URL, se guarda la clave API para la galería NuGet.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandDescription_fra" xml:space="preserve">
     <value>Enregistre la clé API d'un serveur URL donné. Lorsqu'aucune URL n'est fournie, la clé API est enregistrée pour la galerie NuGet.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandDescription_ita" xml:space="preserve">
     <value>Salva un API key per un determinato server URL. Quando non si fornisce un URL , API key si salva per la NuGet gallery.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandDescription_jpn" xml:space="preserve">
     <value>指定されたサーバーの URL の API キーを保存します。URL が指定されていない場合、NuGet ギャラリーの API キーが保存されます。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandDescription_kor" xml:space="preserve">
     <value>지정된 서버 URL에 대한 API 키를 저장합니다. URL이 제공되지 않은 경우 NuGet 갤러리에 대한 API 키가 저장됩니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandDescription_plk" xml:space="preserve">
     <value>Zapisuje klucz interfejsu API dla danego adresu URL serwera. Jeśli nie podano adresu URL, klucz interfejsu API jest zapisywany dla galerii NuGet.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandDescription_ptb" xml:space="preserve">
     <value>Salva uma chave de API para uma determinada URL do servidor. Quando nenhuma URL é fornecida, a chave de API é salva na galeria NuGet.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandDescription_rus" xml:space="preserve">
     <value>Сохраняет ключ API для указанного URL-адреса сервера. Если URL-адрес не указан, сохраняется ключ API для коллекции NuGet.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandDescription_trk" xml:space="preserve">
     <value>Belirli bir sunucu URL'si içim API anahtarını kaydeder. Hiçbir URL belirtilmemişse, API anahtarı NuGet galerisi için kaydedilir.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandDescription_chs" xml:space="preserve">
     <value>保存给定服务器 URL 所对应的 API 密钥。如果未提供 URL，则保存 NuGet 库的 API 密钥。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandDescription_cht" xml:space="preserve">
     <value>儲存給定伺服器 URL 的 API 索引鍵。若未提供 URL，會為 NuGet 陳列庫儲存 API 索引鍵。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandSourceDescription_csy" xml:space="preserve">
     <value>Adresa URL serveru, pro nějž je platný daný klíč API</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandSourceDescription_deu" xml:space="preserve">
     <value>Die Server-URL, für die der API-Schlüssel gültig ist.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandSourceDescription_esp" xml:space="preserve">
     <value>La URL de servidor donde la clave API es válida.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandSourceDescription_fra" xml:space="preserve">
     <value>Serveur URL de la clé API valide.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandSourceDescription_ita" xml:space="preserve">
     <value>Server URL in cui API key è valido.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandSourceDescription_jpn" xml:space="preserve">
     <value>API キーが有効なサーバーの URL。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandSourceDescription_kor" xml:space="preserve">
     <value>API 키를 올바른 서버 URL입니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandSourceDescription_plk" xml:space="preserve">
     <value>Adres URL serwera, gdzie klucz interfejsu API jest ważny.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandSourceDescription_ptb" xml:space="preserve">
     <value>URL do servidor onde a chave API é válida.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandSourceDescription_rus" xml:space="preserve">
     <value>URL-адрес сервера, для которого действителен ключ API.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandSourceDescription_trk" xml:space="preserve">
     <value>API anahtarının geçerli olduğu sunucu URL'si.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandSourceDescription_chs" xml:space="preserve">
     <value>API 密钥有效的服务器 URL。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandSourceDescription_cht" xml:space="preserve">
     <value>API 索引鍵有效的伺服器 URL。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandUsageDescription_csy" xml:space="preserve">
     <value>Určuje klíč API k uložení a volitelnou adresu URL pro server, který tento klíč API poskytl.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandUsageDescription_deu" xml:space="preserve">
     <value>Geben Sie den zu speichernden API-Schlüssel und eine optionale URL zum Server an, der den API-Schlüssel bereitgestellt hat.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandUsageDescription_esp" xml:space="preserve">
     <value>Especificar la clave API para guardar y una URL opcional al servidor que proporcionó la clave API.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandUsageDescription_fra" xml:space="preserve">
     <value>Spécifiez la clé API à enregistrer et, éventuellement, l'URL du serveur l'ayant fournie.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandUsageDescription_ita" xml:space="preserve">
     <value>Specifica l' API key da salvare e un URL opzionale al server che ha fornito la API key.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandUsageDescription_jpn" xml:space="preserve">
     <value>保存する API キーと、API キーを提供したサーバーの URL (省略可能) を指定します。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandUsageDescription_kor" xml:space="preserve">
     <value>저장할 API 키와 API 키를 제공한 서버에 대한 URL(선택적)을 지정합니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandUsageDescription_plk" xml:space="preserve">
     <value>Określ klucz interfejsu API do zapisania i opcjonalny adres URL serwera, który dostarcza ten klucz interfejsu API.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandUsageDescription_ptb" xml:space="preserve">
     <value>Especifique a chave de API para salvar e uma URL opcional para o servidor que forneceu a chave de API.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandUsageDescription_rus" xml:space="preserve">
     <value>Укажите ключ API для сохранения и необязательный URL-адрес сервера, предоставившего ключ API.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandUsageDescription_trk" xml:space="preserve">
     <value>Kaydedilecek API anahtarını ve API anahtarını sağlayan sunucunun isteğe bağlı URL'sini belirtin.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandUsageDescription_chs" xml:space="preserve">
     <value>指定要保存的 API 密钥以及提供该 API 密钥的服务器的可选 URL。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandUsageDescription_cht" xml:space="preserve">
     <value>指定要儲存的 API 索引鍵以及提供 API 索引鍵的伺服器選擇性 URL。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandUsageExamples_csy" xml:space="preserve">
     <value>nuget setapikey 4003d786-cc37-4004-bfdf-c4f3e8ef9b3a
 
 nuget setapikey 4003d786-cc37-4004-bfdf-c4f3e8ef9b3a -Source http://example.com/nugetfeed</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandUsageExamples_deu" xml:space="preserve">
     <value>nuget setapikey 4003d786-cc37-4004-bfdf-c4f3e8ef9b3a
 
 nuget setapikey 4003d786-cc37-4004-bfdf-c4f3e8ef9b3a -Source http://example.com/nugetfeed</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandUsageExamples_esp" xml:space="preserve">
     <value>nuget setapikey 4003d786-cc37-4004-bfdf-c4f3e8ef9b3a
 
 nuget setapikey 4003d786-cc37-4004-bfdf-c4f3e8ef9b3a -Source http://example.com/nugetfeed</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandUsageExamples_fra" xml:space="preserve">
     <value>nuget setapikey 4003d786-cc37-4004-bfdf-c4f3e8ef9b3a
 
 nuget setapikey 4003d786-cc37-4004-bfdf-c4f3e8ef9b3a -Source http://example.com/nugetfeed</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandUsageExamples_ita" xml:space="preserve">
     <value>nuget setapikey 4003d786-cc37-4004-bfdf-c4f3e8ef9b3a
 
 nuget setapikey 4003d786-cc37-4004-bfdf-c4f3e8ef9b3a -Source http://example.com/nugetfeed</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandUsageExamples_jpn" xml:space="preserve">
     <value>nuget setapikey 4003d786-cc37-4004-bfdf-c4f3e8ef9b3a
 
 nuget setapikey 4003d786-cc37-4004-bfdf-c4f3e8ef9b3a -Source http://example.com/nugetfeed</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandUsageExamples_kor" xml:space="preserve">
     <value>nuget setapikey 4003d786-cc37-4004-bfdf-c4f3e8ef9b3a
 
 nuget setapikey 4003d786-cc37-4004-bfdf-c4f3e8ef9b3a -Source http://example.com/nugetfeed</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandUsageExamples_plk" xml:space="preserve">
     <value>nuget setapikey 4003d786-cc37-4004-bfdf-c4f3e8ef9b3a
 
 nuget setapikey 4003d786-cc37-4004-bfdf-c4f3e8ef9b3a -Source http://example.com/nugetfeed</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandUsageExamples_ptb" xml:space="preserve">
     <value>nuget setapikey 4003d786-cc37-4004-bfdf-c4f3e8ef9b3a
 
 nuget setapikey 4003d786-cc37-4004-bfdf-c4f3e8ef9b3a -Source http://example.com/nugetfeed</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandUsageExamples_rus" xml:space="preserve">
     <value>nuget setapikey 4003d786-cc37-4004-bfdf-c4f3e8ef9b3a
 
 nuget setapikey 4003d786-cc37-4004-bfdf-c4f3e8ef9b3a -Source http://example.com/nugetfeed</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandUsageExamples_trk" xml:space="preserve">
     <value>nuget setapikey 4003d786-cc37-4004-bfdf-c4f3e8ef9b3a
 
 nuget setapikey 4003d786-cc37-4004-bfdf-c4f3e8ef9b3a -Source http://example.com/nugetfeed</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandUsageExamples_chs" xml:space="preserve">
     <value>nuget setapikey 4003d786-cc37-4004-bfdf-c4f3e8ef9b3a
 
 nuget setapikey 4003d786-cc37-4004-bfdf-c4f3e8ef9b3a -Source http://example.com/nugetfeed</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandUsageExamples_cht" xml:space="preserve">
     <value>nuget setapikey 4003d786-cc37-4004-bfdf-c4f3e8ef9b3a
 
 nuget setapikey 4003d786-cc37-4004-bfdf-c4f3e8ef9b3a -Source http://example.com/nugetfeed</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandUsageSummary_csy" xml:space="preserve">
     <value>&lt;klíč API&gt; [možnosti]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandUsageSummary_deu" xml:space="preserve">
     <value>&lt;API-Schlüssel&gt; [Optionen]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandUsageSummary_esp" xml:space="preserve">
     <value>&lt;clave API&gt; [opciones]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandUsageSummary_fra" xml:space="preserve">
     <value>&lt;API key&gt; [options]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandUsageSummary_ita" xml:space="preserve">
     <value>&lt;API key&gt; [opzioni]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandUsageSummary_jpn" xml:space="preserve">
     <value>&lt;API key&gt; [options]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandUsageSummary_kor" xml:space="preserve">
     <value>&lt;API 키&gt; [옵션]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandUsageSummary_plk" xml:space="preserve">
     <value>&lt;klucz interfejsu API&gt; [opcje]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandUsageSummary_ptb" xml:space="preserve">
     <value>&lt;Chave de API&gt; [opções]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandUsageSummary_rus" xml:space="preserve">
     <value>&lt;ключ API &gt; [параметры]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandUsageSummary_trk" xml:space="preserve">
     <value>&lt;API anahtarı&gt; [seçenekler]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandUsageSummary_chs" xml:space="preserve">
     <value>&lt;API 密钥&gt; [选项]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandUsageSummary_cht" xml:space="preserve">
     <value>&lt;API key&gt; [選項]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandDescription_csy" xml:space="preserve">
     <value>Poskytuje možnost pro správu seznamu zdrojů umístěných v souboru %AppData%\NuGet\NuGet.config.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandDescription_deu" xml:space="preserve">
     <value>Stellt die Möglichkeit zur Verfügung, eine Liste der Quellen zu verwalten, die sich in "%AppData%\NuGet\NuGet.config" befinden.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandDescription_esp" xml:space="preserve">
     <value>Proporciona la capacidad de gestionar la lista de orígenes ubicada en %AppData%\NuGet\NuGet.config</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandDescription_fra" xml:space="preserve">
     <value>Offre la possibilité de gérer la liste de sources située dans %AppData%\NuGet\NuGet.config.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandDescription_ita" xml:space="preserve">
     <value>Permette la gestione di un elenco di fonti localizzato in %AppData%\NuGet\NuGet.config</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandDescription_jpn" xml:space="preserve">
     <value>%AppData%\NuGet\NuGet.config に指定されたソースの一覧を管理できます</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandDescription_kor" xml:space="preserve">
     <value>%AppData%\NuGet\NuGet.config에 있는 소스 목록을 관리할 수 있는 기능을 제공합니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandDescription_plk" xml:space="preserve">
     <value>Zapewnia możliwość zarządzania listą źródeł znajdującą się w pliku %AppData%\NuGet\NuGet .config</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandDescription_ptb" xml:space="preserve">
     <value>Fornece a capacidade de gerenciar a lista de origens localizadas em %AppData%\NuGet\NuGet.config</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandDescription_rus" xml:space="preserve">
     <value>Дает возможность управлять списком источников, расположенным в %AppData%\NuGet\NuGet.config</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandDescription_trk" xml:space="preserve">
     <value>%AppData%\NuGet\NuGet.config içinde yer alan kaynakların listesinin yönetilebilmesini mümkün kılar.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandDescription_chs" xml:space="preserve">
     <value>可以管理位于 %AppData%\NuGet\NuGet.config 的源列表</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandDescription_cht" xml:space="preserve">
     <value>提供管理位於 %AppData%\NuGet\NuGet.config 的來源清單的功能。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandNameDescription_csy" xml:space="preserve">
     <value>Název zdroje</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandNameDescription_deu" xml:space="preserve">
     <value>Der Name der Quelle.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandNameDescription_esp" xml:space="preserve">
     <value>Nombre del origen.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandNameDescription_fra" xml:space="preserve">
     <value>Nom de la source.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandNameDescription_ita" xml:space="preserve">
     <value>Nome della fonte.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandNameDescription_jpn" xml:space="preserve">
     <value>ソースの名前。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandNameDescription_kor" xml:space="preserve">
     <value>소스 이름입니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandNameDescription_plk" xml:space="preserve">
     <value>Nazwa źródła.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandNameDescription_ptb" xml:space="preserve">
     <value>Nome da origem.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandNameDescription_rus" xml:space="preserve">
     <value>Имя источника.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandNameDescription_trk" xml:space="preserve">
     <value>Kaynağın adı.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandNameDescription_chs" xml:space="preserve">
     <value>源的名称。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandNameDescription_cht" xml:space="preserve">
     <value>來源名稱。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandPasswordDescription_csy" xml:space="preserve">
     <value>Heslo, které má být použito při připojení k ověřenému zdroji</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandPasswordDescription_deu" xml:space="preserve">
     <value>Das Kennwort, das beim Herstellen einer Verbindung mit einer authentifizierten Quelle verwendet werden soll.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandPasswordDescription_esp" xml:space="preserve">
     <value>Contraseña que se va a usar al conectar al origen autenticado.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandPasswordDescription_fra" xml:space="preserve">
     <value>Utilisez le mot de passe pour vous connecter à une source authentifiée.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandPasswordDescription_ita" xml:space="preserve">
     <value>Password da usare quando ci si collega a una fonte autenticata.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandPasswordDescription_jpn" xml:space="preserve">
     <value>認証済みソースに接続するときに使用されるパスワード。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandPasswordDescription_kor" xml:space="preserve">
     <value>인증된 소스에 연결할 때 사용되는 암호입니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandPasswordDescription_plk" xml:space="preserve">
     <value>Hasło, którego należy używać podczas łączenia się z uwierzytelnionym źródłem.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandPasswordDescription_ptb" xml:space="preserve">
     <value>Senha a ser usada ao conectar-se a uma origem autenticada.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandPasswordDescription_rus" xml:space="preserve">
     <value>Пароль, используемый при подключении к проверенному источнику.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandPasswordDescription_trk" xml:space="preserve">
     <value>Kimliği doğrulanmış bir kaynağa bağlanırken kullanılacak parola.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandPasswordDescription_chs" xml:space="preserve">
     <value>连接到已通过身份验证的源时要使用的密码。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandPasswordDescription_cht" xml:space="preserve">
     <value>連線至已驗證來源時使用的密碼。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandSourceDescription_csy" xml:space="preserve">
     <value>Cesta ke zdroji balíčků</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandSourceDescription_deu" xml:space="preserve">
     <value>Der Pfad zu der Paketquelle.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandSourceDescription_esp" xml:space="preserve">
     <value>Ruta de acceso al origen de los paquetes.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandSourceDescription_fra" xml:space="preserve">
     <value>Chemin d'accès à la source de packages.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandSourceDescription_ita" xml:space="preserve">
     <value>Percorso alle fonti pacchetto.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandSourceDescription_jpn" xml:space="preserve">
     <value>パッケージ ソースのパス。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandSourceDescription_kor" xml:space="preserve">
     <value>패키지 소스의 경로입니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandSourceDescription_plk" xml:space="preserve">
     <value>Ścieżka do źródła pakietów.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandSourceDescription_ptb" xml:space="preserve">
     <value>Caminho para as origens do pacote.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandSourceDescription_rus" xml:space="preserve">
     <value>Путь к источнику пакетов.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandSourceDescription_trk" xml:space="preserve">
     <value>Paket kaynağına giden yol.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandSourceDescription_chs" xml:space="preserve">
     <value>程序包源的路径。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandSourceDescription_cht" xml:space="preserve">
     <value>封裝來源的路徑。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandUsageSummary_csy" xml:space="preserve">
     <value>&lt;List|Add|Remove|Enable|Disable|Update&gt; -Name [název] -Source [zdroj]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandUsageSummary_deu" xml:space="preserve">
     <value>&lt;List|Add|Remove|Enable|Disable|Update&gt; -Name [Name] -Source [Quelle]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandUsageSummary_esp" xml:space="preserve">
     <value>&lt;List|Add|Remove|Enable|Disable|Update&gt; -Name [nombre] -Source [origen]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandUsageSummary_fra" xml:space="preserve">
     <value>&lt;List|Add|Remove|Enable|Disable|Update&gt; -Name [nom] -Source [source]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandUsageSummary_ita" xml:space="preserve">
     <value>&lt;List|Add|Remove|Enable|Disable|Update&gt; -Name [nome] -Source [fonte]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandUsageSummary_jpn" xml:space="preserve">
     <value>&lt;List|Add|Remove|Enable|Disable|Update&gt; -Name [name] -Source [source]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandUsageSummary_kor" xml:space="preserve">
     <value>&lt;List|Add|Remove|Enable|Disable|Update&gt; -Name [이름] -Source [소스]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandUsageSummary_plk" xml:space="preserve">
     <value>&lt;List|Add|Remove|Enable|Disable|Update&gt; -Name [nazwa] -Source [źródło]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandUsageSummary_ptb" xml:space="preserve">
     <value>&lt;List|Add|Remove|Enable|Disable|Update&gt; -Name [nome] -Source [origem]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandUsageSummary_rus" xml:space="preserve">
     <value>&lt;List|Add|Remove|Enable|Disable|Update&gt; -Name [имя] -Source [источник]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandUsageSummary_trk" xml:space="preserve">
     <value>&lt;List|Add|Remove|Enable|Disable|Update&gt; -Name [ad] -Source [kaynak]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandUsageSummary_chs" xml:space="preserve">
     <value>&lt;List|Add|Remove|Enable|Disable|Update&gt; -Name [名称] -Source [源]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandUsageSummary_cht" xml:space="preserve">
     <value>&lt;List|Add|Remove|Enable|Disable|Update&gt; -Name [名稱] -Source [來源]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandUserNameDescription_csy" xml:space="preserve">
     <value>Uživatelské jméno, které má být použito při připojení k ověřenému zdroji</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandUserNameDescription_deu" xml:space="preserve">
     <value>Der "UserName", der beim Herstellen einer Verbindung mit einer authentifizierten Quelle verwendet werden soll.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandUserNameDescription_esp" xml:space="preserve">
     <value>Nombre de usuario que se va a usar cuando se conecte a un origen autenticado.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandUserNameDescription_fra" xml:space="preserve">
     <value>Utilisez le @@@nom d'utilisateur pour vous connecter à une source authentifiée.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandUserNameDescription_ita" xml:space="preserve">
     <value>Nomeutente da usare quando ci si collega a una fonte autenticata.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandUserNameDescription_jpn" xml:space="preserve">
     <value>認証済みソースに接続するときに使用されるユーザー名。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandUserNameDescription_kor" xml:space="preserve">
     <value>인증된 소스에 연결할 때 사용되는 사용자 이름입니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandUserNameDescription_plk" xml:space="preserve">
     <value>Nazwa użytkownika, którą należy stosować podczas łączenia się z uwierzytelnionym źródłem.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandUserNameDescription_ptb" xml:space="preserve">
     <value>Nome de usuário a ser usado na conexão com uma origem autenticada.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandUserNameDescription_rus" xml:space="preserve">
     <value>Имя пользователя, используемое при подключении к проверенному источнику.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandUserNameDescription_trk" xml:space="preserve">
     <value>Kimliği doğrulanmış bir kaynağa bağlanırken kullanılacak KullanıcıAdı.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandUserNameDescription_chs" xml:space="preserve">
     <value>连接到已通过身份验证的源时要使用的用户名。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandUserNameDescription_cht" xml:space="preserve">
     <value>連線至已驗證來源時要使用的使用者名稱。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandAssemblyPathDescription_csy" xml:space="preserve">
     <value>Sestavení, které má být použito pro metadata</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandAssemblyPathDescription_deu" xml:space="preserve">
     <value>Die für Metadaten zu verwendende Assembly.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandAssemblyPathDescription_esp" xml:space="preserve">
     <value>Ensamblado que se va a usar para los metadatos.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandAssemblyPathDescription_fra" xml:space="preserve">
     <value>Assembly à utiliser pour les métadonnées.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandAssemblyPathDescription_ita" xml:space="preserve">
     <value>Assembly da usare come metadata.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandAssemblyPathDescription_jpn" xml:space="preserve">
     <value>メタデータに使用するアセンブリ。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandAssemblyPathDescription_kor" xml:space="preserve">
     <value>메타데이터에 사용할 어셈블리입니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandAssemblyPathDescription_plk" xml:space="preserve">
     <value>Zestaw do użycia na potrzeby metadanych.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandAssemblyPathDescription_ptb" xml:space="preserve">
     <value>Assembly a ser usado para metadados.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandAssemblyPathDescription_rus" xml:space="preserve">
     <value>Сборка, используемая для метаданных.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandAssemblyPathDescription_trk" xml:space="preserve">
     <value>Meta veriler için kullanılacak derleme.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandAssemblyPathDescription_chs" xml:space="preserve">
     <value>要用于元数据的程序集。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandAssemblyPathDescription_cht" xml:space="preserve">
     <value>中繼資料要使用的組件。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandDescription_csy" xml:space="preserve">
     <value>Vytvoří soubor nuspec pro nový balíček. Je-li tento příkaz spuštěn ve stejné složce jako soubor projektu (.csproj, .vbproj, .fsproj), vytvoří tokenizovaný soubor nuspec.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandDescription_deu" xml:space="preserve">
     <value>Generiert eine nuspec-Datei für ein neues Paket. Wenn dieser Befehl im gleichen Ordner wie eine Projektdatei (CSPROJ, VBPROJ, FSPROJ) ausgeführt wird, wird eine nuspec-Datei mit einem Token erstellt.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandDescription_esp" xml:space="preserve">
     <value>Genera un archivo nuspec para un nuevo paquete. Si este comando se ejecuta en la misma carpeta como archivo de proyecto (.csproj, .vbproj, .fsproj), creará un archivo nuspec acortado. </value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandDescription_fra" xml:space="preserve">
     <value>Génère un nuspec pour un nouveau package. Si cette commande s'exécute dans le même dossier que le fichier projet (.csproj, .vbproj, .fsproj), un fichier .nuspec tokenisé sera créé.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandDescription_ita" xml:space="preserve">
     <value>Genera un nuspec per un nuovo pacchetto. Se si esegue questo comando nella stessa cartella di un file di progetto (.csproj, .vbproj, .fsproj), creerà un file nuspec nominale.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandDescription_jpn" xml:space="preserve">
     <value>新しいパッケージの nuspec を生成します。このコマンドをプロジェクト ファイル (.csproj, .vbproj, .fsproj) と同じフォルダーで実行する場合、トークン化された nuspec ファイルが作成されます。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandDescription_kor" xml:space="preserve">
     <value>새 패키지의 nuspec을 생성합니다. 이 명령이 프로젝트 파일(.csproj, .vbproj, .fsproj)과 동일한 폴더에서 실행되면 토큰화된 nuspec 파일을 생성합니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandDescription_plk" xml:space="preserve">
     <value>Generuje plik nuspec dla nowego pakietu. Jeśli to polecenie zostanie uruchomione w tym samym folderze co plik projektu (csproj, vbproj, fsproj), spowoduje utworzenie pliku nuspec z tokenizacją.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandDescription_ptb" xml:space="preserve">
     <value>Gera um nuspec para um novo pacote. Se esse comando for executado na mesma pasta que um arquivo de projeto (.csproj, .vbproj, .fsproj), ele criará um arquivo nuspec com token.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandDescription_rus" xml:space="preserve">
     <value>Создает NUSPEC-файл для нового пакета. Если эта команда запущена в папке с файлом проекта (.csproj, .vbproj, .fsproj), она создаст размеченный NUSPEC-файл.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandDescription_trk" xml:space="preserve">
     <value>Yeni paket için bir nuspec oluşturur. Bu komut proje dosyasıyla (.csproj, .vbproj, .fsproj) aynı klasörde çalıştırılırsa, parçalanmış bir nuspec dosyası oluşturur.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandDescription_chs" xml:space="preserve">
     <value>为新程序包生成 nuspec。如果此命令在项目文件(.csproj、.vbproj、.fsproj)所在的文件夹中运行，则它将创建已标记化的 nuspec 文件。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandDescription_cht" xml:space="preserve">
     <value>為新封裝產生 nuspec。如果此命令在與專案檔 (.csproj, .vbproj, .fsproj) 相同資料夾中執行，則會建立 Token 化的 nuspec 檔案。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandForceDescription_csy" xml:space="preserve">
     <value>Přepíše soubor nuspec, existuje-li.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandForceDescription_deu" xml:space="preserve">
     <value>Überschreibt die nuspec-Datei, wenn vorhanden.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandForceDescription_esp" xml:space="preserve">
     <value>Reemplazar el archivo nuspec si existe.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandForceDescription_fra" xml:space="preserve">
     <value>Remplacez le fichier .nuspec s'il existe.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandForceDescription_ita" xml:space="preserve">
     <value>Sovrascrive il file nuspec se esistente.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandForceDescription_jpn" xml:space="preserve">
     <value>nuspec ファイルが存在する場合は上書きします。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandForceDescription_kor" xml:space="preserve">
     <value>nuspec 파일이 있는 경우 덮어씁니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandForceDescription_plk" xml:space="preserve">
     <value>Zastąp plik nuspec, jeśli istnieje.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandForceDescription_ptb" xml:space="preserve">
     <value>Substitua o arquivo nuspec se ele já existir.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandForceDescription_rus" xml:space="preserve">
     <value>Если NUSPEC-файл существует, он будет перезаписан.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandForceDescription_trk" xml:space="preserve">
     <value>Mevcutsa nuspec dosyasını geçersiz kıl.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandForceDescription_chs" xml:space="preserve">
     <value>覆盖 nuspec 文件(如果存在)。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandForceDescription_cht" xml:space="preserve">
     <value>若存在則覆寫 nuspec 檔案。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandUsageExamples_csy" xml:space="preserve">
     <value>nuget spec
@@ -3774,6 +4710,7 @@ nuget setapikey 4003d786-cc37-4004-bfdf-c4f3e8ef9b3a -Source http://example.com/
 nuget spec MyPackage
 
 nuget spec -a MyAssembly.dll</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandUsageExamples_deu" xml:space="preserve">
     <value>nuget spec
@@ -3781,6 +4718,7 @@ nuget spec -a MyAssembly.dll</value>
 nuget spec MyPackage
 
 nuget spec -a MyAssembly.dll</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandUsageExamples_esp" xml:space="preserve">
     <value>nuget spec
@@ -3788,6 +4726,7 @@ nuget spec -a MyAssembly.dll</value>
 nuget spec MyPackage
 
 nuget spec -a MyAssembly.dll</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandUsageExamples_fra" xml:space="preserve">
     <value>nuget spec
@@ -3795,6 +4734,7 @@ nuget spec -a MyAssembly.dll</value>
 nuget spec MyPackage
 
 nuget spec -a MyAssembly.dll</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandUsageExamples_ita" xml:space="preserve">
     <value>nuget spec
@@ -3802,6 +4742,7 @@ nuget spec -a MyAssembly.dll</value>
 nuget spec MyPackage
 
 nuget spec -a MyAssembly.dll</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandUsageExamples_jpn" xml:space="preserve">
     <value>nuget spec
@@ -3809,6 +4750,7 @@ nuget spec -a MyAssembly.dll</value>
 nuget spec MyPackage
 
 nuget spec -a MyAssembly.dll</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandUsageExamples_kor" xml:space="preserve">
     <value>nuget spec
@@ -3816,6 +4758,7 @@ nuget spec -a MyAssembly.dll</value>
 nuget spec MyPackage
 
 nuget spec -a MyAssembly.dll</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandUsageExamples_plk" xml:space="preserve">
     <value>nuget spec
@@ -3823,6 +4766,7 @@ nuget spec -a MyAssembly.dll</value>
 nuget spec MyPackage
 
 nuget spec -a MyAssembly.dll</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandUsageExamples_ptb" xml:space="preserve">
     <value>nuget spec
@@ -3830,6 +4774,7 @@ nuget spec -a MyAssembly.dll</value>
 nuget spec MyPackage
 
 nuget spec -a MyAssembly.dll</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandUsageExamples_rus" xml:space="preserve">
     <value>nuget spec
@@ -3837,6 +4782,7 @@ nuget spec -a MyAssembly.dll</value>
 nuget spec MyPackage
 
 nuget spec -a MyAssembly.dll</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandUsageExamples_trk" xml:space="preserve">
     <value>nuget spec
@@ -3844,6 +4790,7 @@ nuget spec -a MyAssembly.dll</value>
 nuget spec MyPackage
 
 nuget spec -a MyAssembly.dll</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandUsageExamples_chs" xml:space="preserve">
     <value>nuget spec
@@ -3851,6 +4798,7 @@ nuget spec -a MyAssembly.dll</value>
 nuget spec MyPackage
 
 nuget spec -a MyAssembly.dll</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandUsageExamples_cht" xml:space="preserve">
     <value>nuget spec
@@ -3858,318 +4806,423 @@ nuget spec -a MyAssembly.dll</value>
 nuget spec MyPackage
 
 nuget spec -a MyAssembly.dll</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandUsageSummary_csy" xml:space="preserve">
     <value>[ID balíčku]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandUsageSummary_deu" xml:space="preserve">
     <value>[Paket-ID]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandUsageSummary_esp" xml:space="preserve">
     <value>[id. de paquete]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandUsageSummary_fra" xml:space="preserve">
     <value>[ID package]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandUsageSummary_ita" xml:space="preserve">
     <value>[id pacchetto]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandUsageSummary_jpn" xml:space="preserve">
     <value>[package id]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandUsageSummary_kor" xml:space="preserve">
     <value>[패키지 ID]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandUsageSummary_plk" xml:space="preserve">
     <value>[identyfikator pakietu]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandUsageSummary_ptb" xml:space="preserve">
     <value>[id do pacote]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandUsageSummary_rus" xml:space="preserve">
     <value>[идентификатор пакета]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandUsageSummary_trk" xml:space="preserve">
     <value>[paket kimliği]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandUsageSummary_chs" xml:space="preserve">
     <value>[程序包 ID]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandUsageSummary_cht" xml:space="preserve">
     <value>[封裝 ID]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandDescription_csy" xml:space="preserve">
     <value>Aktualizuje balíčky na nejnovější dostupné verze. Tento příkaz rovněž aktualizuje vlastní soubor NuGet.exe.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandDescription_deu" xml:space="preserve">
     <value>Pakete auf die aktuellsten verfügbaren Versionen aktualisieren. Dieser Befehl aktualisiert auch die Datei "NuGet.exe" selbst.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandDescription_esp" xml:space="preserve">
     <value>Actualizar paquetes a las últimas versiones disponibles. Este comando también actualiza NuGet.exe.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandDescription_fra" xml:space="preserve">
     <value>Mettez à jour les packages vers les versions disponibles les plus récentes. Cette commande met également à jour NuGet.exe.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandDescription_ita" xml:space="preserve">
     <value>Aggiornare paccheti alle ultime versioni. Questo comando aggiorna anche NuGet.exe.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandDescription_jpn" xml:space="preserve">
     <value>パッケージを利用可能な最新バージョンに更新します。このコマンドで、NuGet.exe も更新されます。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandDescription_kor" xml:space="preserve">
     <value>패키지를 사용 가능한 최신 버전으로 업데이트합니다. 이 명령은 NuGet.exe 자체도 업데이트합니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandDescription_plk" xml:space="preserve">
     <value>Zaktualizuj pakiety do najnowszych dostępnych wersji. To polecenie aktualizuje również plik NuGet.exe.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandDescription_ptb" xml:space="preserve">
     <value>Atualize os pacotes para as versões mais recentes disponíveis. Este comando também atualiza NuGet.exe em si.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandDescription_rus" xml:space="preserve">
     <value>Обновление пакетов до последних доступных версий. Кроме того, эта команда обновляет и файл NuGet.exe.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandDescription_trk" xml:space="preserve">
     <value>Paketleri mevcut en son sürümlerine günceller. Bu komut ayrıca NuGet.exe öğesinin kendisini de günceller.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandDescription_chs" xml:space="preserve">
     <value>将程序包更新到最新的可用版本。此命令还更新 NuGet.exe 本身。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandDescription_cht" xml:space="preserve">
     <value>更新封裝為可用的最新版本。此命令也會更新 NuGet.exe 本身。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandIdDescription_csy" xml:space="preserve">
     <value>ID balíčků k aktualizaci</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandIdDescription_deu" xml:space="preserve">
     <value>Die zu aktualisierenden Paket-IDs.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandIdDescription_esp" xml:space="preserve">
     <value>Id. de paquetes que se van a actualizar.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandIdDescription_fra" xml:space="preserve">
     <value>ID des packages à mettre à jour.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandIdDescription_ita" xml:space="preserve">
     <value>Id del pacchetto da aggiornare.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandIdDescription_jpn" xml:space="preserve">
     <value>更新するパッケージ ID。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandIdDescription_kor" xml:space="preserve">
     <value>업데이트할 패키지 ID입니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandIdDescription_plk" xml:space="preserve">
     <value>Identyfikatory pakietów do zaktualizowania.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandIdDescription_ptb" xml:space="preserve">
     <value>Pacote de IDs a serem atualizadas.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandIdDescription_rus" xml:space="preserve">
     <value>Идентификаторы обновляемых пакетов.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandIdDescription_trk" xml:space="preserve">
     <value>Güncellenecek paket kimlikleri.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandIdDescription_chs" xml:space="preserve">
     <value>要更新的程序包 ID。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandIdDescription_cht" xml:space="preserve">
     <value>要更新的封裝 ID。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandPrerelease_csy" xml:space="preserve">
     <value>Umožňuje aktualizovat na předběžné verze. Tento příznak není vyžadován při aktualizaci předběžných balíčků, které jsou již nainstalovány.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandPrerelease_deu" xml:space="preserve">
     <value>Ermöglicht das Update auf Vorabversionen. Diese Kennzeichnung ist bei einem Update auf Vorabversionspakete nicht erforderlich, die bereits installiert sind.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandPrerelease_esp" xml:space="preserve">
     <value>Permite actualizar a versiones preliminares. Esta marca no es necesaria cuando se actualizan paquetes de versión preliminar que ya están instalados.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandPrerelease_fra" xml:space="preserve">
     <value>Permet la mise à jour vers des versions préliminaires. Cet indicateur n'est pas requis lors de la mise à jour de la version préliminaire des packages déjà installés.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandPrerelease_ita" xml:space="preserve">
     <value>Permette l'aggiornamento di versioni prerelease. Questo flag non è richiesto quando si aggiornano pacchetti prerelease già installati.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandPrerelease_jpn" xml:space="preserve">
     <value>プレリリース バージョンへの更新を許可します。既にインストールされているプレリリース パッケージを更新する場合、このフラグは必要ありません。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandPrerelease_kor" xml:space="preserve">
     <value>시험판 버전으로 업데이트하도록 허용합니다. 이미 설치된 시험판 패키지를 업데이트하는 경우 이 플래그는 필요하지 않습니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandPrerelease_plk" xml:space="preserve">
     <value>Zezwala na aktualizację do wersji wstępnych. Ta flaga nie jest wymagana w przypadku aktualizowania pakietów w wersji wstępnej, które zostały już zainstalowane.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandPrerelease_ptb" xml:space="preserve">
     <value>Permite atualizar para versões de pré-lançamento. Este sinal não é necessário ao atualizar pacotes de pré-lançamento que já estão instalados.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandPrerelease_rus" xml:space="preserve">
     <value>Позволяет обновлять предварительные версии. Этот флаг не нужен при обновлении предварительных версий пакетов, которые уже установлены.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandPrerelease_trk" xml:space="preserve">
     <value>Önsürümlere güncelleme yapılmasına izin verir. Zaten yüklü olan önsürüm paketleri güncellenirken bu bayrak gerekli değildir.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandPrerelease_chs" xml:space="preserve">
     <value>允许更新到预发布版本。当更新已安装的预发布程序包时，不需要此标志。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandPrerelease_cht" xml:space="preserve">
     <value>允許更新至預先更新的版本。更新已安裝的預先發行封裝時不需要此標幟。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandRepositoryPathDescription_csy" xml:space="preserve">
     <value>Cesta k místní složce balíčků (umístění, v němž jsou balíčky nainstalovány)</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandRepositoryPathDescription_deu" xml:space="preserve">
     <value>Der Pfad zum lokalen Paketordner (zu dem Speicherort, an dem Pakete installiert sind).</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandRepositoryPathDescription_esp" xml:space="preserve">
     <value>Ruta de acceso a la carpeta de paquetes local (ubicación de los paquetes instalados).</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandRepositoryPathDescription_fra" xml:space="preserve">
     <value>Chemin d'accès au dossier de packages locaux (emplacement des packages installés).</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandRepositoryPathDescription_ita" xml:space="preserve">
     <value>Percorso a cartelle locali pacchetti (dove sono installati i pacchetti).</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandRepositoryPathDescription_jpn" xml:space="preserve">
     <value>ローカル パッケージ フォルダーのパス (パッケージがインストールされている場所)。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandRepositoryPathDescription_kor" xml:space="preserve">
     <value>로컬 패키지 폴더의 경로(패키지가 설치된 위치)입니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandRepositoryPathDescription_plk" xml:space="preserve">
     <value>Ścieżka do lokalnego folderu pakietów (lokalizacja, w której są instalowane pakiety).</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandRepositoryPathDescription_ptb" xml:space="preserve">
     <value>Caminho para a pasta de pacotes local (local onde os pacotes estão instalados).</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandRepositoryPathDescription_rus" xml:space="preserve">
     <value>Путь к локальной папке пакетов (в которой установлены пакеты).</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandRepositoryPathDescription_trk" xml:space="preserve">
     <value>Yerel paket klasörünün yolu (paketlerin yüklü olduğu konum).</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandRepositoryPathDescription_chs" xml:space="preserve">
     <value>本地程序包文件夹的路径(安装程序包的位置)。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandRepositoryPathDescription_cht" xml:space="preserve">
     <value>本機封裝資料夾的路徑 (安裝封裝的位置)。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandSafeDescription_csy" xml:space="preserve">
     <value>Vyhledá aktualizace s nejvyšší dostupnou verzí v rámci stejné hlavní verze a podverze jako nainstalovaný balíček.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandSafeDescription_deu" xml:space="preserve">
     <value>Sucht nach Updates mit der höchsten Version, die in der gleichen Haupt- und Nebenversion wie das installierte Paket verfügbar sind.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandSafeDescription_esp" xml:space="preserve">
     <value>Busca actualizaciones con la última versión disponible en la versión principal y secundaria como el paquete instalado.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandSafeDescription_fra" xml:space="preserve">
     <value>Recherche les mises à jour vers la version maximale, disponibles pour les versions principale et secondaire identiques au package installé.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandSafeDescription_ita" xml:space="preserve">
     <value>Ricerca aggiornamenti delle versioni ultime disponibili nella stessa versione maggiore e minore dei pacchetti installati.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandSafeDescription_jpn" xml:space="preserve">
     <value>インストールされているパッケージと同じメジャー バージョンおよびマイナー バージョン内で最も新しいバージョンの更新プログラムを検索します。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandSafeDescription_kor" xml:space="preserve">
     <value>설치된 패키지와 동일한 주 버전 및 부 버전에서 사용 가능한 가장 높은 버전의 업데이트를 찾습니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandSafeDescription_plk" xml:space="preserve">
     <value>Szuka aktualizacji z najwyższą wersją dostępnych w obrębie tej samej wersji głównej i pomocniczej co zainstalowany pakiet.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandSafeDescription_ptb" xml:space="preserve">
     <value>Procura por atualizações com a maior versão disponível dentro da mesma versão principal e secundária do pacote instalado.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandSafeDescription_rus" xml:space="preserve">
     <value>Выполняет поиск обновлений с самой последней версией, которые доступны в пределах основного и дополнительного номера версии установленного пакета.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandSafeDescription_trk" xml:space="preserve">
     <value>Yüklü paket ile aynı ana ve alt sürüm aralığındaki mevcut en yüksek sürüme sahip güncellemeleri arar.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandSafeDescription_chs" xml:space="preserve">
     <value>查找具有已安装程序包的主要版本和次要版本内的最高可用版本的更新。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandSafeDescription_cht" xml:space="preserve">
     <value>以與已安裝封裝同樣的主要和次要版本中可取得的最高版本尋找更新。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandSelfDescription_csy" xml:space="preserve">
     <value>Aktualizuje spuštěný soubor NuGet.exe na nejnovější verzi dostupnou na serveru.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandSelfDescription_deu" xml:space="preserve">
     <value>Update der aktuell ausgeführten Datei "NuGet.exe" auf die aktuellste Version ausführen, die vom Server verfügbar ist.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandSelfDescription_esp" xml:space="preserve">
     <value>Actualizar NuGet.exe que se ejecuta a la última versión disponible del servidor.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandSelfDescription_fra" xml:space="preserve">
     <value>Mettez à jour le fichier NuGet.exe en service vers la version disponible la plus récente, depuis le serveur.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandSelfDescription_ita" xml:space="preserve">
     <value>Aggiorna l'esecuzione di NuGet.exe alla nuova versione disponibile dal server.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandSelfDescription_jpn" xml:space="preserve">
     <value>実行されている NuGet.exe を、サーバーから入手可能な最新バージョンに更新します。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandSelfDescription_kor" xml:space="preserve">
     <value>실행 중인 NuGet.exe를 서버에서 사용 가능한 최신 버전으로 업데이트합니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandSelfDescription_plk" xml:space="preserve">
     <value>Zaktualizuj uruchomiony plik NuGet.exe do najnowszej wersji dostępnej na serwerze.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandSelfDescription_ptb" xml:space="preserve">
     <value>Atualize o NuGet.exe em execução para a versão mais recente disponível do servidor.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandSelfDescription_rus" xml:space="preserve">
     <value>Обновление запущенного файла NuGet.exe до самой последней версии, доступной на сервере.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandSelfDescription_trk" xml:space="preserve">
     <value>Çalıştırılan NuGet.exe öğesini sunucudaki mevcut en yeni sürüme güncelle.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandSelfDescription_chs" xml:space="preserve">
     <value>将正在运行的 NuGet.exe 更新到可从服务器获得的最新版本。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandSelfDescription_cht" xml:space="preserve">
     <value>將執行中的 NuGet.exe 更新為伺服器中可取得的最新版本。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandSourceDescription_csy" xml:space="preserve">
     <value>Seznam zdrojů balíčků pro vyhledání aktualizací</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandSourceDescription_deu" xml:space="preserve">
     <value>Eine Liste der Paketquellen, die nach Updates durchsucht werden sollen.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandSourceDescription_esp" xml:space="preserve">
     <value>Lista de orígenes del paquete para buscar actualizaciones.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandSourceDescription_fra" xml:space="preserve">
     <value>Liste des mises à jour de sources de package à rechercher.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandSourceDescription_ita" xml:space="preserve">
     <value>Un elenco di fonti pacchetti per ricercare aggiornamenti.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandSourceDescription_jpn" xml:space="preserve">
     <value>更新プログラムを検索するパッケージ ソースの一覧。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandSourceDescription_kor" xml:space="preserve">
     <value>업데이트를 검색할 패키지 소스의 목록입니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandSourceDescription_plk" xml:space="preserve">
     <value>Lista źródeł pakietów na potrzeby wyszukiwania aktualizacji.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandSourceDescription_ptb" xml:space="preserve">
     <value>Uma lista de origens de pacotes para buscar atualizações.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandSourceDescription_rus" xml:space="preserve">
     <value>Список источников пакетов для поиска обновлений.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandSourceDescription_trk" xml:space="preserve">
     <value>Güncellemeler için aranacak paket kaynaklarının listesi.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandSourceDescription_chs" xml:space="preserve">
     <value>要搜索更新的程序包源的列表。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandSourceDescription_cht" xml:space="preserve">
     <value>要搜尋更新的封裝來源清單。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandUsageExamples_csy" xml:space="preserve">
     <value>nuget update
@@ -4177,6 +5230,7 @@ nuget spec -a MyAssembly.dll</value>
 nuget update -Safe
 
 nuget update -Self</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandUsageExamples_deu" xml:space="preserve">
     <value>nuget update
@@ -4184,6 +5238,7 @@ nuget update -Self</value>
 nuget update -Safe
 
 nuget update -Self</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandUsageExamples_esp" xml:space="preserve">
     <value>nuget update
@@ -4191,6 +5246,7 @@ nuget update -Self</value>
 nuget update -Safe
 
 nuget update -Self</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandUsageExamples_fra" xml:space="preserve">
     <value>nuget update
@@ -4198,6 +5254,7 @@ nuget update -Self</value>
 nuget update -Safe
 
 nuget update -Self</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandUsageExamples_ita" xml:space="preserve">
     <value>nuget update
@@ -4205,6 +5262,7 @@ nuget update -Self</value>
 nuget update -Safe
 
 nuget update -Self</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandUsageExamples_jpn" xml:space="preserve">
     <value>nuget update
@@ -4212,6 +5270,7 @@ nuget update -Self</value>
 nuget update -Safe
 
 nuget update -Self</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandUsageExamples_kor" xml:space="preserve">
     <value>nuget update
@@ -4219,6 +5278,7 @@ nuget update -Self</value>
 nuget update -Safe
 
 nuget update -Self</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandUsageExamples_plk" xml:space="preserve">
     <value>nuget update
@@ -4226,6 +5286,7 @@ nuget update -Self</value>
 nuget update -Safe
 
 nuget update -Self</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandUsageExamples_ptb" xml:space="preserve">
     <value>nuget update
@@ -4233,6 +5294,7 @@ nuget update -Self</value>
 nuget update -Safe
 
 nuget update -Self</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandUsageExamples_rus" xml:space="preserve">
     <value>nuget update
@@ -4240,6 +5302,7 @@ nuget update -Self</value>
 nuget update -Safe
 
 nuget update -Self</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandUsageExamples_trk" xml:space="preserve">
     <value>nuget update
@@ -4247,6 +5310,7 @@ nuget update -Self</value>
 nuget update -Safe
 
 nuget update -Self</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandUsageExamples_chs" xml:space="preserve">
     <value>nuget update
@@ -4254,6 +5318,7 @@ nuget update -Self</value>
 nuget update -Safe
 
 nuget update -Self</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandUsageExamples_cht" xml:space="preserve">
     <value>nuget update
@@ -4261,1020 +5326,1359 @@ nuget update -Self</value>
 nuget update -Safe
 
 nuget update -Self</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandVerboseDescription_csy" xml:space="preserve">
     <value>Zobrazí podrobný výstup při aktualizaci.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandVerboseDescription_deu" xml:space="preserve">
     <value>Ausführliche Ausgabe während des Updates anzeigen.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandVerboseDescription_esp" xml:space="preserve">
     <value>Mostrar resultados detallados mientras se actualiza.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandVerboseDescription_fra" xml:space="preserve">
     <value>Affichez la sortie détaillée pendant la mise à jour.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandVerboseDescription_ita" xml:space="preserve">
     <value>Mostra l'uscita ridondante durante l'aggiornamento.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandVerboseDescription_jpn" xml:space="preserve">
     <value>更新せずに詳細な出力を表示します。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandVerboseDescription_kor" xml:space="preserve">
     <value>업데이트하는 동안 자세한 출력을 표시합니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandVerboseDescription_plk" xml:space="preserve">
     <value>Pokaż dane wyjściowe w trybie pełnym podczas aktualizacji.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandVerboseDescription_ptb" xml:space="preserve">
     <value>Mostrar a saída detalhada durante a atualização.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandVerboseDescription_rus" xml:space="preserve">
     <value>Отображение подробных выходных данных при обновлении.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandVerboseDescription_trk" xml:space="preserve">
     <value>Güncellerken ayrıntılı çıktıyı göster.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandVerboseDescription_chs" xml:space="preserve">
     <value>显示更新时的详细输出。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandVerboseDescription_cht" xml:space="preserve">
     <value>更新時顯示詳細資訊輸出</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="CommandApiKey_csy" xml:space="preserve">
     <value>Klíč API pro server</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="CommandApiKey_deu" xml:space="preserve">
     <value>Der API-Schlüssel für den Server.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="CommandApiKey_esp" xml:space="preserve">
     <value>Clave API para el servidor.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="CommandApiKey_fra" xml:space="preserve">
     <value>La Clé API dédiée au serveur.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="CommandApiKey_ita" xml:space="preserve">
     <value>API key per il server.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="CommandApiKey_jpn" xml:space="preserve">
     <value>サーバーの API キー。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="CommandApiKey_kor" xml:space="preserve">
     <value>서버에 대한 API 키입니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="CommandApiKey_plk" xml:space="preserve">
     <value>Klucz interfejsu API dla serwera.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="CommandApiKey_ptb" xml:space="preserve">
     <value>A chave de API para o servidor.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="CommandApiKey_rus" xml:space="preserve">
     <value>Ключ API для сервера.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="CommandApiKey_trk" xml:space="preserve">
     <value>Sunucu için API anahtarı.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="CommandApiKey_chs" xml:space="preserve">
     <value>服务器的 API 密钥。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="CommandApiKey_cht" xml:space="preserve">
     <value>伺服器的 API 索引鍵。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DefaultConfigDescription_csy" xml:space="preserve">
     <value>Výchozí konfigurace NuGet se získá načtením souboru %AppData%\NuGet\NuGet.config a následným načtením všech souborů nuget.config nebo .nuget\nuget.config, počínaje kořenovým adresářem jednotky a konče aktuálním adresářem.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DefaultConfigDescription_deu" xml:space="preserve">
     <value>Die Standardkonfiguration von NuGet wird durch Laden von "%AppData%\NuGet\NuGet.config" und anschließendes Laden von "nuget.config" oder ".nuget\nuget.config" mit Start im Stamm des Laufwerks und Ende im aktuellen Verzeichnis abgerufen.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DefaultConfigDescription_esp" xml:space="preserve">
     <value>La configuración predeterminada de NuGet se obtiene cargando %AppData%\NuGet\NuGet.config y, a continuación, cualquier nuget.config o .nuget\nuget.config empezando desde la raíz de la unidad hasta el directorio actual.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DefaultConfigDescription_fra" xml:space="preserve">
     <value>La configuration NuGet par défaut est obtenue en chargeant %AppData%\NuGet\NuGet.config, puis en chargeant nuget.config ou .nuget\nuget.config commençant à la racine du lecteur et terminant dans le répertoire actuel.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DefaultConfigDescription_ita" xml:space="preserve">
     <value>La configurazione di default di NuGet si ottiene caricando %AppData%\NuGet\NuGet.config, poi caricando qualsiasi nuget.config o .nuget\nuget.config a partire dal root del drive e terminando nell'attuale directory.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DefaultConfigDescription_jpn" xml:space="preserve">
     <value>NuGet の既定の構成を取得するには、%AppData%\NuGet\NuGet.config を読み込み、ドライブのルートから現在のディレクトリの間にあるすべての nuget.config または .nuget\nuget.config を読み込みます。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DefaultConfigDescription_kor" xml:space="preserve">
     <value>%AppData%\NuGet\NuGet.config를 로드한 후 드라이브 루트에서 현재 디렉터리까지의 nuget.config 또는 .nuget\nuget.config를 로드하여 NuGet의 기본 구성을 가져옵니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DefaultConfigDescription_plk" xml:space="preserve">
     <value>Domyślna konfiguracja pakietu NuGet jest uzyskiwana przez załadowanie pliku %AppData%\NuGet\NuGet.config, a następnie załadowanie dowolnego pliku nuget.config lub .nuget\nuget.config, zaczynając od folderu głównego dysku i kończąc w katalogu bieżącym.\n</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DefaultConfigDescription_ptb" xml:space="preserve">
     <value>A configuração padrão do NuGet é obtida ao carregar %AppData%\NuGet\NuGet.config, e depois ao carrear qualquer nuget.config ou .nuget\nuget.config começando pela raiz da unidade e terminando no diretório atual.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DefaultConfigDescription_rus" xml:space="preserve">
     <value>Чтобы получить используемую по умолчанию конфигурацию NuGet, следует загрузить файл %AppData%\NuGet\NuGet.config, а затем загрузить все файлы nuget.config или .nuget\nuget.config, начиная с корня диска и заканчивая текущим каталогом.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DefaultConfigDescription_trk" xml:space="preserve">
     <value>Varsayılan NuGet yapılandırması %AppData%\NuGet\NuGet.config yüklenerek, ardından sürücü kökünden başlanıp geçerli dizinde sonlandırılarak tüm nuget.config ve .nuget\nuget.config öğeleri yüklenerek edinildi.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DefaultConfigDescription_chs" xml:space="preserve">
     <value>通过加载 %AppData%\NuGet\NuGet.config，然后加载从驱动器的根目录开始到当前目录为止的任何 nuget.config 或 .nuget\nuget.config 来获取 NuGet 的默认配置。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DefaultConfigDescription_cht" xml:space="preserve">
     <value>NuGet 的預設設定可載入 %AppData%\NuGet\NuGet.config 以取得，接著載入任何從磁碟根啟動且在目前目錄中結束的 nuget.config 或 .nuget\nuget.config。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandRequireConsent_csy" xml:space="preserve">
     <value>Před zahájením instalace balíčku ověří, zda je udělen souhlas s obnovením tohoto balíčku.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandRequireConsent_deu" xml:space="preserve">
     <value>Überprüft, ob die Zustimmung zur Paketwiederherstellung erteilt wurde, bevor ein Paket installiert wird.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandRequireConsent_esp" xml:space="preserve">
     <value>Comprueba si se concede consentimiento de restauración del paquete antes de instalar un paquete.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandRequireConsent_fra" xml:space="preserve">
     <value>Vérifie si l'accord de restauration du package est donné avant d'installer le package.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandRequireConsent_ita" xml:space="preserve">
     <value>Verificare che sia garantito il consenso al ripristino pacchetti prima di installarli.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandRequireConsent_jpn" xml:space="preserve">
     <value>パッケージをインストールする前に、パッケージの復元が同意されているかどうかを確認します。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandRequireConsent_kor" xml:space="preserve">
     <value>패키지를 설치하기 전에 패키지 복원에 동의했는지 확인하십시오.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandRequireConsent_plk" xml:space="preserve">
     <value>Sprawdza, czy przed zainstalowaniem pakietu udzielono zgody na przywrócenie pakietu.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandRequireConsent_ptb" xml:space="preserve">
     <value>Verifica se a autorização de restauração do pacote foi concedida antes de instalar um pacote.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandRequireConsent_rus" xml:space="preserve">
     <value>Проверяет, было ли дано согласие на восстановление пакета перед установкой пакета.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandRequireConsent_trk" xml:space="preserve">
     <value>Paket yüklenmeden önce, paket geri yükleme izninin verilip verilmediğini denetler.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandRequireConsent_chs" xml:space="preserve">
     <value>在安装程序包之前，检查是否已同意还原程序包。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandRequireConsent_cht" xml:space="preserve">
     <value>檢查是否在安裝封裝前已授予封裝還原同意。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandSolutionDirectory_csy" xml:space="preserve">
     <value>Kořenový adresář řešení pro obnovení balíčků</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandSolutionDirectory_deu" xml:space="preserve">
     <value>Paketstamm für die Paketwiederherstellung.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandSolutionDirectory_esp" xml:space="preserve">
     <value>Raíz de la solución para la restauración del paquete.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandSolutionDirectory_fra" xml:space="preserve">
     <value>Racine de la solution pour la restauration du package.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandSolutionDirectory_ita" xml:space="preserve">
     <value>Solution root per ripristino pacchetti.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandSolutionDirectory_jpn" xml:space="preserve">
     <value>パッケージ復元のソリューション ルート。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandSolutionDirectory_kor" xml:space="preserve">
     <value>패키지 복원에 사용되는 솔루션 루트입니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandSolutionDirectory_plk" xml:space="preserve">
     <value>Katalog główny rozwiązania na potrzeby przywracania pakietu.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandSolutionDirectory_ptb" xml:space="preserve">
     <value>Raiz de solução para restauração de pacotes.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandSolutionDirectory_rus" xml:space="preserve">
     <value>Корень решения для восстановления пакета.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandSolutionDirectory_trk" xml:space="preserve">
     <value>Paket geri yüklemesi için çözüm kökü.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandSolutionDirectory_chs" xml:space="preserve">
     <value>用于还原程序包的解决方案根目录。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandSolutionDirectory_cht" xml:space="preserve">
     <value>封裝還原的方案根。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Option_ConfigFile_csy" xml:space="preserve">
     <value>Konfigurační soubor NuGet. Není-li zadán, je jako konfigurační soubor použit soubor %AppData%\NuGet\NuGet.config.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Option_ConfigFile_deu" xml:space="preserve">
     <value>Die NuGet-Konfigurationsdatei. Erfolgt keine Angabe, wird "%AppData%\NuGet\NuGet.config" als Konfigurationsdatei verwendet.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Option_ConfigFile_esp" xml:space="preserve">
     <value>Archivo de configuración NuGet. Si no se especifica, el archivo %AppData%\NuGet\NuGet.config se usa como archivo de configuración.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Option_ConfigFile_fra" xml:space="preserve">
     <value>Fichier de configuration NuGet. Si aucun fichier n'est spécifié, %AppData%\NuGet\NuGet.config servira de fichier de configuration.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Option_ConfigFile_ita" xml:space="preserve">
     <value>File  configurazione NuGet. Se non specificato, si usa il file %AppData%\NuGet\NuGet.config come file configurazione.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Option_ConfigFile_jpn" xml:space="preserve">
     <value>NuGet 構成ファイル。指定しない場合、構成ファイルとして %AppData%\NuGet\NuGet.config ファイルが使用されます。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Option_ConfigFile_kor" xml:space="preserve">
     <value>NuGet 구성 파일입니다. 지정되지 않은 경우 %AppData%\NuGet\NuGet.config가 구성 파일로 사용됩니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Option_ConfigFile_plk" xml:space="preserve">
     <value>Plik konfiguracji NuGet. Jeśli nie zostanie określony, jako plik konfiguracji jest używany plik %AppData%\NuGet\NuGet.config.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Option_ConfigFile_ptb" xml:space="preserve">
     <value>O arquivo de configuração NuGet. Se não for especificado, o arquivo %AppData%\NuGet\NuGet.config será usado como arquivo de configuração.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Option_ConfigFile_rus" xml:space="preserve">
     <value>Файл конфигурации NuGet. Если не указан, в качестве файла конфигурации используется файл %AppData%\NuGet\NuGet.config.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Option_ConfigFile_trk" xml:space="preserve">
     <value>NuGet yapılandırma dosyası. Belirtilmemişse, %AppData%\NuGet\NuGet.config dosyası yapılandırma dosyası olarak kullanılır.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Option_ConfigFile_chs" xml:space="preserve">
     <value>NuGet 配置文件。如果未指定，则将文件 %AppData%\NuGet\NuGet.config 用作配置文件。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Option_ConfigFile_cht" xml:space="preserve">
     <value>NuGet 設定檔。如果未指定，檔案 %AppData%\NuGet\NuGet.config 會用做設定檔。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandDisableParallel_csy" xml:space="preserve">
     <value>Zakáže instalaci paralelních balíčků nuget.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandDisableParallel_deu" xml:space="preserve">
     <value>Parallele nuget-Paketinstallationen deaktivieren.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandDisableParallel_esp" xml:space="preserve">
     <value>Deshabilitar las instalaciones del paquete nuget en paralelo.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandDisableParallel_fra" xml:space="preserve">
     <value>Désactivez les installations du package nuget parallèle.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandDisableParallel_ita" xml:space="preserve">
     <value>Disabilita parallel nuget package installs.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandDisableParallel_jpn" xml:space="preserve">
     <value>nuget パッケージの並列インストールを無効にします。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandDisableParallel_kor" xml:space="preserve">
     <value>병렬 nuget 패키지 설치를 사용하지 않도록 설정합니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandDisableParallel_plk" xml:space="preserve">
     <value>Wyłącz równoległe instalacje pakietów nuget.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandDisableParallel_ptb" xml:space="preserve">
     <value>Desabilite instalações de pacotes NuGet paralelas.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandDisableParallel_rus" xml:space="preserve">
     <value>Отключает параллельную установку пакетов NuGet.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandDisableParallel_trk" xml:space="preserve">
     <value>Paralel nuget paketi yüklemelerini devre dışı bırak.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandDisableParallel_chs" xml:space="preserve">
     <value>禁止并行 nuget 程序包安装。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandDisableParallel_cht" xml:space="preserve">
     <value>停用平行 nuget 封裝安裝。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandMinClientVersion_csy" xml:space="preserve">
     <value>Nastaví atribut minClientVersion pro vytvořený balíček.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandMinClientVersion_deu" xml:space="preserve">
     <value>Legen Sie das Attribut "minClientVersion" für das erstellte Paket fest.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandMinClientVersion_esp" xml:space="preserve">
     <value>Establecer el atributo minClientVersion para el paquete creado.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandMinClientVersion_fra" xml:space="preserve">
     <value>Définissez l'attribut minClientVersion du package créé.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandMinClientVersion_ita" xml:space="preserve">
     <value>Imposta l'attributo minClientVersion per il pacchetto creato.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandMinClientVersion_jpn" xml:space="preserve">
     <value>作成されるパッケージの minClientVersion 属性を設定してください。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandMinClientVersion_kor" xml:space="preserve">
     <value>만든 패키지에 대해 minClientVersion 특성을 설정합니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandMinClientVersion_plk" xml:space="preserve">
     <value>Ustaw atrybut minClientVersion dla utworzonego pakietu.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandMinClientVersion_ptb" xml:space="preserve">
     <value>Defina o atributo minClientVersion para o pacote criado.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandMinClientVersion_rus" xml:space="preserve">
     <value>Настройка атрибута minClientVersion для созданного пакета.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandMinClientVersion_trk" xml:space="preserve">
     <value>Oluşturulan paket için minClientVersion özniteliğini ayarla.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandMinClientVersion_chs" xml:space="preserve">
     <value>设置创建的程序包的 minClientVersion 属性。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandMinClientVersion_cht" xml:space="preserve">
     <value>為已建立的封裝設定 minClientVersion 屬性。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandIncludeReferencedProjects_csy" xml:space="preserve">
     <value>Zahrne odkazované projekty jako závislosti nebo jako součást balíčku.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandIncludeReferencedProjects_deu" xml:space="preserve">
     <value>Projekte, auf die verwiesen wird, als Abhängigkeiten oder Teil des Pakets einschließen.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandIncludeReferencedProjects_esp" xml:space="preserve">
     <value>Incluir proyectos a los que se hace referencia como dependencias o parte del paquete.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandIncludeReferencedProjects_fra" xml:space="preserve">
     <value>Incluez des projets référencés, soit comme dépendances, soit comme éléments du package.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandIncludeReferencedProjects_ita" xml:space="preserve">
     <value>Include i progetti di riferimento come dipendenze o parte del pacchetto.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandIncludeReferencedProjects_jpn" xml:space="preserve">
     <value>依存関係またはパッケージの一部として、参照されているプロジェクトを含めてください。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandIncludeReferencedProjects_kor" xml:space="preserve">
     <value>참조된 프로젝트를 종속성 또는 패키지의 일부로 포함합니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandIncludeReferencedProjects_plk" xml:space="preserve">
     <value>Uwzględnij przywoływane projekty jako zależności lub jako części pakietu.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandIncludeReferencedProjects_ptb" xml:space="preserve">
     <value>Inclua projetos referenciados como dependências ou como parte do pacote.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandIncludeReferencedProjects_rus" xml:space="preserve">
     <value>Добавляет указанные по ссылкам проекты в качестве зависимостей или части проекта.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandIncludeReferencedProjects_trk" xml:space="preserve">
     <value>Başvurulan projeleri bağımlılık veya paketin bir parçası olarak dahil et.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandIncludeReferencedProjects_chs" xml:space="preserve">
     <value>包括作为依赖项或作为程序包的一部分的引用项目。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandIncludeReferencedProjects_cht" xml:space="preserve">
     <value>包含做為相依項或部份封裝的已參照專案。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandFileConflictAction_csy" xml:space="preserve">
     <value>Nastaví výchozí akci, pokud soubor z balíčku již existuje v cílovém projektu. Chcete-li vždy přepisovat soubory, nastavte možnost Overwrite. Chcete-li soubory přeskočit, nastavte možnost Ignore. Pokud možnost není zadána, zobrazí se výzva pro každý konfliktní soubor.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandFileConflictAction_deu" xml:space="preserve">
     <value>Legt die Standardaktion fest, wenn eine Datei aus einem Paket bereits im Zielprojekt vorhanden ist. Legen Sie den Wert auf "Overwrite" fest, um Dateien immer zu überschreiben. Legen Sie den Wert auf "Ignore" fest, um Dateien zu überspringen. Wenn keine Angabe erfolgt, wird eine Eingabeaufforderung für jede Datei angezeigt, die einen Konflikt verursacht.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandFileConflictAction_esp" xml:space="preserve">
     <value>Establecer una acción predeterminada cuando un archivo de un paquete ya exista en el proyecto de destino. Establecer a Overwrite para reemplazar siempre los archivos. Establecer a Ignore para omitir los archivos. Si no se especifica, pedirá confirmación para cada archivo conflictivo.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandFileConflictAction_fra" xml:space="preserve">
     <value>Définissez l'action par défaut lorsqu'un fichier du package existe déjà dans le projet cible. Affectez la valeur Overwrite pour remplacer systématiquement les fichiers. Affectez la valeur Ignore pour ignorer les fichiers. En l'absence de spécification, une invite s'affichera pour chaque fichier provoquant un conflit.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandFileConflictAction_ita" xml:space="preserve">
     <value>Impostare azione di default quando esiste già un file da un pacchetto. Impostare su Overwrite per sovrascrivere il file. Impostare su Ignore per saltare il file. Se non specificato, richiederà per ogni file in conflitto.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandFileConflictAction_jpn" xml:space="preserve">
     <value>パッケージのファイルがターゲット プロジェクトに既に存在する場合の既定のアクションを設定します。常にファイルを上書きするには、Overwrite に設定します。ファイルをスキップするには、Ignore に設定します。指定しない場合、競合するファイルごとにプロンプトが表示されます。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandFileConflictAction_kor" xml:space="preserve">
     <value>패키지의 파일이 대상 프로젝트에 이미 있는 경우의 기본 동작을 설정합니다. 파일을 항상 덮어쓰려면 Overwrite로 설정합니다. 파일을 건너뛰려면 Ignore로 설정합니다. 지정되지 않은 경우 충돌하는 각 파일에 대한 메시지를 표시합니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandFileConflictAction_plk" xml:space="preserve">
     <value>Ustaw domyślną akcję, jeśli plik z pakietu istnieje już w projekcie docelowym. Ustaw wartość Overwrite, aby zawsze zastępować pliki. Ustaw wartość Ignore, aby pomijać pliki. Jeśli akcja nie zostanie określona, dla każdego pliku powodującego konflikt będzie wyświetlany monit.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandFileConflictAction_ptb" xml:space="preserve">
     <value>Defina a ação padrão quando um arquivo de um pacote já existir no projeto de destino. Defina para Overwrite para sempre substituir arquivos. Defina para Ignore para ignorar arquivos. Se não for especificado, ele avisará sobre cada arquivo conflitante.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandFileConflictAction_rus" xml:space="preserve">
     <value>Задайте действие по умолчанию, которое выполняется, если файл из пакета уже существует в целевом проекте. Если указать значение "Overwrite", файлы всегда будут перезаписываться. Если указать значение "Ignore", файлы будут пропускаться. Если значение не указать, для каждого конфликтного файла будет отображен запрос действия.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandFileConflictAction_trk" xml:space="preserve">
     <value>Paketteki bir dosya hedef projede zaten mevcutsa uygulanacak varsayılan eylemi ayarlayın. Dosyaların her zaman geçersiz kılınması için Overwrite seçimin belirtin. Dosyaların atlanması için Ignore seçimin belirtin. Hiçbiri belirtilmemişse, çakışan her dosya için ne yapılacağını sorar.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandFileConflictAction_chs" xml:space="preserve">
     <value>设置当程序包中的文件已在目标项目中存在时的默认操作。设置为 "Overwrite" 可始终覆盖文件。设置为 "Ignore" 可跳过文件。如果未指定，则它将提示每个存在冲突的文件。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandFileConflictAction_cht" xml:space="preserve">
     <value>當封裝檔案已存在於目標專案時，設定預設動作。設定為 Overwrite 一律覆寫檔案。設定為 Ignore 以略過檔案。若未指定，則會提示每個衝突的檔案。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandStorePasswordInClearTextDescription_csy" xml:space="preserve">
     <value>Umožňuje uložení přihlašovacích údajů zdroje přenosného balíčku, a to zákazem šifrování hesel.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandStorePasswordInClearTextDescription_deu" xml:space="preserve">
     <value>Ermöglicht das Speichern der Anmeldeinformationen der portablen Paketquelle durch Deaktivieren von Kennwortverschlüsselung.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandStorePasswordInClearTextDescription_esp" xml:space="preserve">
     <value>Habilita el almacenamiento de las credenciales de origen del paquete portátil deshabilitando el cifrado de la contraseña.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandStorePasswordInClearTextDescription_fra" xml:space="preserve">
     <value>Active les informations d'identification de la source du package portable de stockage en désactivant le chiffrement de mot de passe.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandStorePasswordInClearTextDescription_ita" xml:space="preserve">
     <value>Permette di immagazzinare le credenziali della fonte disabilitando il criptaggio della password.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandStorePasswordInClearTextDescription_jpn" xml:space="preserve">
     <value>パスワードの暗号化を無効にして、ポータブル パッケージ ソースの資格情報の保存を有効にします。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandStorePasswordInClearTextDescription_kor" xml:space="preserve">
     <value>암호의 암호화를 사용하지 않도록 설정하여 휴대용 패키지 소스 자격 증명을 저장할 수 있도록 합니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandStorePasswordInClearTextDescription_plk" xml:space="preserve">
     <value>Umożliwia przechowywanie poświadczeń przenośnego źródła pakietów, wyłączając szyfrowanie haseł.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandStorePasswordInClearTextDescription_ptb" xml:space="preserve">
     <value>Ativa as credenciais de origem do pacote portátil de armazenamento desativando a criptografia de senha.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandStorePasswordInClearTextDescription_rus" xml:space="preserve">
     <value>Позволяет хранить переносимые учетные данные источника пакетов посредством отключения шифрования пароля.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandStorePasswordInClearTextDescription_trk" xml:space="preserve">
     <value>Parola şifrelemesini devre dışı bırakarak taşınabilir paket kaynağı kimlik bilgilerinin saklanmasını sağlar.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandStorePasswordInClearTextDescription_chs" xml:space="preserve">
     <value>通过禁用密码加密来允许存储可移植程序包源凭据。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandStorePasswordInClearTextDescription_cht" xml:space="preserve">
     <value>以停用密碼加密的方式來啟用儲存可攜式封裝來源認證。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandDescription_csy" xml:space="preserve">
     <value>Obnoví balíčky NuGet.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandDescription_deu" xml:space="preserve">
     <value>Stellt NuGet-Pakete wieder her.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandDescription_esp" xml:space="preserve">
     <value>Restaura los paquetes NuGet.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandDescription_fra" xml:space="preserve">
     <value>Restaure les packages NuGet.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandDescription_ita" xml:space="preserve">
     <value>Ripristina pacchetti NuGet.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandDescription_jpn" xml:space="preserve">
     <value>NuGet パッケージを復元します。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandDescription_kor" xml:space="preserve">
     <value>NuGet 패키지를 복원합니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandDescription_plk" xml:space="preserve">
     <value>Przywraca pakiety NuGet.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandDescription_ptb" xml:space="preserve">
     <value>Restaura os pacotes NuGet.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandDescription_rus" xml:space="preserve">
     <value>Восстанавливает пакеты NuGet.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandDescription_trk" xml:space="preserve">
     <value>NuGet paketlerini geri yükler.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandDescription_chs" xml:space="preserve">
     <value>还原 NuGet 程序包。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandDescription_cht" xml:space="preserve">
     <value>還原 NuGet 封裝。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandDisableParallelProcessing_csy" xml:space="preserve">
     <value>Zakáže obnovení paralelních balíčků nuget.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandDisableParallelProcessing_deu" xml:space="preserve">
     <value>Parallele nuget-Paketwiederherstllungen deaktivieren.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandDisableParallelProcessing_esp" xml:space="preserve">
     <value>Deshabilitar las restauraciones del paquete nuget en paralelo.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandDisableParallelProcessing_fra" xml:space="preserve">
     <value>Désactivez les restaurations du package nuget parallèle.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandDisableParallelProcessing_ita" xml:space="preserve">
     <value>Disailita  il ripristino parallel nuget package.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandDisableParallelProcessing_jpn" xml:space="preserve">
     <value>nuget パッケージの並列復元を無効にします。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandDisableParallelProcessing_kor" xml:space="preserve">
     <value>병렬 nuget 패키지 복원을 사용하지 않도록 설정합니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandDisableParallelProcessing_plk" xml:space="preserve">
     <value>Wyłącz równoległe przywracanie pakietów NuGet.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandDisableParallelProcessing_ptb" xml:space="preserve">
     <value>Desative as restaurações do pacote nuget paralelo.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandDisableParallelProcessing_rus" xml:space="preserve">
     <value>Отключает параллельное восстановление пакетов NuGet.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandDisableParallelProcessing_trk" xml:space="preserve">
     <value>Paralel nuget paketi geri yüklemelerini devre dışı bırak.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandDisableParallelProcessing_chs" xml:space="preserve">
     <value>禁止并行 nuget 程序包还原。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandDisableParallelProcessing_cht" xml:space="preserve">
     <value>停用平行 nuget 封裝還原。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandNoCache_csy" xml:space="preserve">
     <value>Zakáže použití mezipaměti počítače jako prvního zdroje balíčků.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandNoCache_deu" xml:space="preserve">
     <value>Verwendung des Computercaches als erste Paketquelle deaktivieren.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandNoCache_esp" xml:space="preserve">
     <value>Deshabilitar el uso del caché de máquina como origen del primer paquete.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandNoCache_fra" xml:space="preserve">
     <value>Désactivation grâce au cache de l'ordinateur, agissant comme première source du package.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandNoCache_ita" xml:space="preserve">
     <value>Disablita usando la cache della macchina come prima fonte del pacchetto.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandNoCache_jpn" xml:space="preserve">
     <value>最初のパッケージ ソースとしてのコンピューター キャッシュの使用を無効にします。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandNoCache_kor" xml:space="preserve">
     <value>시스템 캐시를 첫 번째 패키지 소스로 사용하지 않도록 설정합니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandNoCache_plk" xml:space="preserve">
     <value>Wyłącz, używając pamięci podręcznej komputera jako pierwszego źródła pakietu.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandNoCache_ptb" xml:space="preserve">
     <value>Desative usando o cache da máquina como a primeira origem de pacotes.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandNoCache_rus" xml:space="preserve">
     <value>Отключает использование кэша компьютера в качестве первого источника пакетов.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandNoCache_trk" xml:space="preserve">
     <value>Birinci paket kaynağı olarak makine önbelleğinin kullanılmasını devre dışı bırak.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandNoCache_chs" xml:space="preserve">
     <value>禁止使用计算机缓存作为第一个程序包源。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandNoCache_cht" xml:space="preserve">
     <value>停用使用機器快取做為第一個封裝來源。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandPackagesDirectory_csy" xml:space="preserve">
     <value>Určuje složku balíčků.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandPackagesDirectory_deu" xml:space="preserve">
     <value>Gibt den Paketordner an.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandPackagesDirectory_esp" xml:space="preserve">
     <value>Especifica la carpeta de los paquetes.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandPackagesDirectory_fra" xml:space="preserve">
     <value>Spécifie le dossier des packages.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandPackagesDirectory_ita" xml:space="preserve">
     <value>Specifica la cartella pacchetto.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandPackagesDirectory_jpn" xml:space="preserve">
     <value>パッケージ フォルダーを指定します。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandPackagesDirectory_kor" xml:space="preserve">
     <value>패키지 폴더를 지정합니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandPackagesDirectory_plk" xml:space="preserve">
     <value>Określa folder pakietów.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandPackagesDirectory_ptb" xml:space="preserve">
     <value>Especifica a pasta de pacotes.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandPackagesDirectory_rus" xml:space="preserve">
     <value>Указывает папку пакетов.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandPackagesDirectory_trk" xml:space="preserve">
     <value>Paket klasörünü belirtir.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandPackagesDirectory_chs" xml:space="preserve">
     <value>指定程序包文件夹。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandPackagesDirectory_cht" xml:space="preserve">
     <value>指定封裝資料夾。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandRequireConsent_csy" xml:space="preserve">
     <value>Před zahájením instalace balíčku ověří, zda je udělen souhlas s obnovením tohoto balíčku.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandRequireConsent_deu" xml:space="preserve">
     <value>Überprüft, ob die Zustimmung zur Paketwiederherstellung erteilt wurde, bevor ein Paket installiert wird.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandRequireConsent_esp" xml:space="preserve">
     <value>Comprueba si se concede consentimiento de restauración del paquete antes de instalar un paquete.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandRequireConsent_fra" xml:space="preserve">
     <value>Vérifie si l'accord de restauration du package est donné avant d'installer le package.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandRequireConsent_ita" xml:space="preserve">
     <value>Verificare che sia garantito il consenso al ripristino prima di installare il pacchetto.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandRequireConsent_jpn" xml:space="preserve">
     <value>パッケージをインストールする前に、パッケージの復元が同意されているかどうかを確認します。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandRequireConsent_kor" xml:space="preserve">
     <value>패키지를 설치하기 전에 패키지 복원에 동의했는지 확인하십시오.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandRequireConsent_plk" xml:space="preserve">
     <value>Sprawdza przed zainstalowaniem pakietu, czy udzielono zgody na przywrócenie pakietu.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandRequireConsent_ptb" xml:space="preserve">
     <value>Verifica se a autorização de restauração de pacote é concedida antes de instalar um pacote.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandRequireConsent_rus" xml:space="preserve">
     <value>Проверяет, было ли дано согласие на восстановление пакета перед установкой пакета.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandRequireConsent_trk" xml:space="preserve">
     <value>Paketin yüklenmesinden önce paket geri yükleme onayının verilip verilmediğini denetler.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandRequireConsent_chs" xml:space="preserve">
     <value>在安装程序包之前，检查是否已同意还原程序包。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandRequireConsent_cht" xml:space="preserve">
     <value>檢查是否在安裝封裝前已授予封裝還原同意。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandSolutionDirectory_csy" xml:space="preserve">
     <value>Určuje adresář řešení. Není platné při obnovování balíčků pro řešení.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandSolutionDirectory_deu" xml:space="preserve">
     <value>Gibt das Projektverzeichnis an. Beim Wiederherstellen von Paketen für ein Projekt nicht gültig.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandSolutionDirectory_esp" xml:space="preserve">
     <value>Especifica el directorio de la solución. No es válido cuando se restauran paquetes para una solución.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandSolutionDirectory_fra" xml:space="preserve">
     <value>Spécifie le répertoire de la solution. Non valide lors de la restauration de packages pour une solution.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandSolutionDirectory_ita" xml:space="preserve">
     <value>Specifica la soluzione della directory. Non valida quando si ripristinano pacchetti per una soluzione.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandSolutionDirectory_jpn" xml:space="preserve">
     <value>ソリューション ディレクトリを指定します。ソリューションのパッケージを復元する場合、無効です。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandSolutionDirectory_kor" xml:space="preserve">
     <value>솔루션 디렉터리를 지정합니다. 솔루션 패키지를 복원하는 경우 사용할 수 없습니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandSolutionDirectory_plk" xml:space="preserve">
     <value>Określa katalog rozwiązania. W przypadku przywracania pakietów dla rozwiązania nie jest on obowiązujący.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandSolutionDirectory_ptb" xml:space="preserve">
     <value>Especifica o diretório de solução. Não é válido ao restaurar pacotes para uma solução.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandSolutionDirectory_rus" xml:space="preserve">
     <value>Указывает каталог решения. При восстановлении пакетов для решения является недопустимым.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandSolutionDirectory_trk" xml:space="preserve">
     <value>Çözüm dizinini belirtir. Bir çözüm için paketler geri yüklenirken geçerli değildir.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandSolutionDirectory_chs" xml:space="preserve">
     <value>指定解决方案目录。当还原解决方案的程序包时无效。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandSolutionDirectory_cht" xml:space="preserve">
     <value>指定方案目錄。還原方案封裝時無效。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandSourceDescription_csy" xml:space="preserve">
     <value>Seznam zdrojů balíčků k použití</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandSourceDescription_deu" xml:space="preserve">
     <value>Eine Liste der zu verwendenden Paketquellen.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandSourceDescription_esp" xml:space="preserve">
     <value>Una lista de orígenes de paquetes para usar.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandSourceDescription_fra" xml:space="preserve">
     <value>Liste de sources de packages à utiliser.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandSourceDescription_ita" xml:space="preserve">
     <value>Lista di fonti pacchetti da usare.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandSourceDescription_jpn" xml:space="preserve">
     <value>使用するパッケージ ソースの一覧。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandSourceDescription_kor" xml:space="preserve">
     <value>사용할 패키지 소스의 목록입니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandSourceDescription_plk" xml:space="preserve">
     <value>Lista źródeł pakietów dostępnych do użycia.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandSourceDescription_ptb" xml:space="preserve">
     <value>Uma lista de origens de pacotes a serem usados.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandSourceDescription_rus" xml:space="preserve">
     <value>Список используемых источников пакетов.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandSourceDescription_trk" xml:space="preserve">
     <value>Kullanılacak paket kaynaklarının listesi.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandSourceDescription_chs" xml:space="preserve">
     <value>要使用的程序包源的列表。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandSourceDescription_cht" xml:space="preserve">
     <value>要使用的封裝來源清單。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandUsageDescription_csy" xml:space="preserve">
     <value>Je-li zadáno řešení, tento příkaz obnoví balíčky NuGet, které jsou nainstalovány v řešení a v projektech obsažených v tomto řešení. V opačném případě tento příkaz obnoví balíčky uvedené v zadaném souboru packages.config.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandUsageDescription_deu" xml:space="preserve">
     <value>Wenn ein Projekt angegeben wird, stellt dieser Befehl NuGet-Pakete wieder her, die im Projekt und den darin enthaltenen Projekten installiert sind. Andernfalls stellt der Befehl Pakete wieder her, die in der angegebenen Datei "packages.config" aufgelistet werden.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandUsageDescription_esp" xml:space="preserve">
     <value>Si se especifica una solución, este comando restaura los paquetes NuGet que están instalados en la solución y los proyectos que contiene la solución. De lo contrario, el comando restaura los paquetes mostrados en el archivo packages.config especificado.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandUsageDescription_fra" xml:space="preserve">
     <value>Si une solution est spécifiée, cette commande restaure les packages NuGet installés dans la solution et dans les projets contenus dans la solution. Sinon, la commande restaure les packages répertoriés dans le fichier packages.config spécifié.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandUsageDescription_ita" xml:space="preserve">
     <value>Se si specifica una soluzione, questo comando ripristina i pacchetti NuGet installati nella soluzione e nei progetti contenuti nella soluzione. Altrimenti, il comando ripristina i pacchetti elencati nel file packages.config.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandUsageDescription_jpn" xml:space="preserve">
     <value>ソリューションが指定された場合、ソリューションでインストールされた NuGet パッケージとソリューションに含まれるプロジェクトが復元されます。ソリューションが指定されない場合、指定された packages.config ファイルに含まれるパッケージが復元されます。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandUsageDescription_kor" xml:space="preserve">
     <value>솔루션이 지정된 경우 이 명령은 솔루션 및 솔루션에 포함된 프로젝트에 설치된 NuGet 패키지를 복원합니다. 솔루션이 지정되지 않은 경우 명령은 지정된 packages.config 파일에 나열된 패키지를 복원합니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandUsageDescription_plk" xml:space="preserve">
     <value>Jeśli zostało określone rozwiązanie, to polecenie przywraca pakiety NuGet zainstalowane w rozwiązaniu oraz w projektach zawartych w rozwiązaniu. W przeciwnym razie to polecenie przywraca pakiety wymienione w określonym pliku packages.config.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandUsageDescription_ptb" xml:space="preserve">
     <value>Se uma solução for especificada, este comando restaura os pacotes NuGet que estão instalados na solução e em projetos contidos na solução. Caso contrário, o comando restaura pacotes listados no arquivo especificado packages.config.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandUsageDescription_rus" xml:space="preserve">
     <value>Если указано решение, эта команда восстанавливает пакеты NuGet, установленные в решении и проектах, содержащихся в решении. В противном случае команда восстанавливает пакеты, указанные в файле packages.config.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandUsageDescription_trk" xml:space="preserve">
     <value>Bir çözüm belirtilmişse, bu komut çözüm içindeki ve çözüm içinde yer alan paketlerdeki yüklü NuGet paketlerini geri yükler. Aksi takdirde, komut belirtilen packages.config dosyasında listelenen paketleri geri yükler.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandUsageDescription_chs" xml:space="preserve">
     <value>如果指定了解决方案，则此命令将还原解决方案中安装的 NuGet 程序包，以及解决方案包含的项目中的 NuGet 程序包。否则，此命令将还原指定的 packages.config 文件中列出的程序包。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandUsageDescription_cht" xml:space="preserve">
     <value>如果已指定方案，此命令會還原方案中安裝在方案和專案中的 NuGet 封裝。否則命令會還原列在指定 packages.config 檔案中的封裝。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandUsageSummary_csy" xml:space="preserve">
     <value>[&lt;řešení&gt; | &lt;soubor packages.config&gt;] [možnosti]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandUsageSummary_deu" xml:space="preserve">
     <value>[&lt;Projekt&gt; | &lt;packages.config-Datei&gt;] [Optionen]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandUsageSummary_esp" xml:space="preserve">
     <value>[&lt;solución&gt; | &lt;packages.config file&gt;] [opciones]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandUsageSummary_fra" xml:space="preserve">
     <value>[&lt;solution&gt; | &lt;packages.config file&gt;] [options]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandUsageSummary_ita" xml:space="preserve">
     <value>[&lt;soluzione&gt; | &lt;packages.config file&gt;] [opzioni]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandUsageSummary_jpn" xml:space="preserve">
     <value>[&lt;solution&gt; | &lt;packages.config file&gt;] [options]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandUsageSummary_kor" xml:space="preserve">
     <value>[&lt;솔루션&gt; | &lt;packages.config 파일&gt;] [옵션]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandUsageSummary_plk" xml:space="preserve">
     <value>[&lt;rozwiązanie&gt; | &lt;plik packages.config&gt;] [opcje]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandUsageSummary_ptb" xml:space="preserve">
     <value>[&lt;solução&gt; | &lt;arquivo packages.config&gt;] [opções]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandUsageSummary_rus" xml:space="preserve">
     <value>[&lt;решение&gt; | &lt;файл packages.config&gt;] [параметры]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandUsageSummary_trk" xml:space="preserve">
     <value>[&lt;çözüm&gt; | &lt;packages.config file&gt;] [seçenekler]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandUsageSummary_chs" xml:space="preserve">
     <value>[&lt;解决方案&gt; | &lt;packages.config 文件&gt;] [选项]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandUsageSummary_cht" xml:space="preserve">
     <value>[&lt;方案&gt; | &lt;packages.config 檔案&gt;] [選項]</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="CommandNoCache_csy" xml:space="preserve">
     <value>Zakáže použití mezipaměti počítače jako prvního zdroje balíčků.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="CommandNoCache_deu" xml:space="preserve">
     <value>Deaktivieren der Verwendung des Computercaches als erste Paketquelle.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="CommandNoCache_esp" xml:space="preserve">
     <value>Deshabilitar el uso de la caché del equipo como primer origen del paquete.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="CommandNoCache_fra" xml:space="preserve">
     <value>Désactivez l'utilisation du cache de l'ordinateur comme première source de package.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="CommandNoCache_ita" xml:space="preserve">
     <value>Disabilitare utilizzando la cache del computer come prima origine pacchetto.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="CommandNoCache_jpn" xml:space="preserve">
     <value>最初のパッケージ ソースとしてマシン キャッシュを使用して無効にします。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="CommandNoCache_kor" xml:space="preserve">
     <value>시스템 캐시를 첫 번째 패키지 소스로 사용하지 않도록 설정합니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="CommandNoCache_plk" xml:space="preserve">
     <value>Wyłącz, używając pamięci podręcznej komputera jako pierwszego źródła pakietu.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="CommandNoCache_ptb" xml:space="preserve">
     <value>Desativar usando o cache da máquina como a primeira origem de pacotes.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="CommandNoCache_rus" xml:space="preserve">
     <value>Отключает использование кэша компьютера в качестве первого источника пакетов.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="CommandNoCache_trk" xml:space="preserve">
     <value>Makine önbelleğini ilk paket kaynağı olarak kullanarak devre dışı bırakın.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="CommandNoCache_chs" xml:space="preserve">
     <value>禁止使用计算机缓存作为第一个程序包源。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="CommandNoCache_cht" xml:space="preserve">
     <value>停用使用機器快取做為第一個套件</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="CommandSourceDescription_csy" xml:space="preserve">
     <value>Seznam zdrojů balíčků použitých tímto příkazem</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="CommandSourceDescription_deu" xml:space="preserve">
     <value>Eine Liste der Paketquellen, die für diesen Befehl verwendet werden sollen.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="CommandSourceDescription_esp" xml:space="preserve">
     <value>Lista de orígenes de paquetes para usar para este comando.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="CommandSourceDescription_fra" xml:space="preserve">
     <value>Liste de sources de packages à utiliser pour cette commande.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="CommandSourceDescription_ita" xml:space="preserve">
     <value>Elenco di origini pacchetti da utilizzare per questo comando.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="CommandSourceDescription_jpn" xml:space="preserve">
     <value>このコマンドで使用するパッケージ ソースの一覧。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="CommandSourceDescription_kor" xml:space="preserve">
     <value>이 명령에 사용할 패키지 소스 목록입니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="CommandSourceDescription_plk" xml:space="preserve">
     <value>Lista źródeł pakietów do użycia na potrzeby tego polecenia.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="CommandSourceDescription_ptb" xml:space="preserve">
     <value>Uma lista de origens de pacotes para usar para esse comando.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="CommandSourceDescription_rus" xml:space="preserve">
     <value>Список источников пакетов, используемых для этой команды.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="CommandSourceDescription_trk" xml:space="preserve">
     <value>Bu komut için kullanılacak paket kaynaklarının listesi.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="CommandSourceDescription_chs" xml:space="preserve">
     <value>要用于此命令的程序包源列表。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="CommandSourceDescription_cht" xml:space="preserve">
     <value>此命令使用的套件來源清單。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandDescription_csy" xml:space="preserve">
     <value>Předá balíček na server a publikuje jej.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandDescription_deu" xml:space="preserve">
     <value>Übertragen eines Paket mithilfe von Push auf den Server und Veröffentlichen des Pakets.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandDescription_esp" xml:space="preserve">
     <value>Inserta un paquete en el servidor y lo publica.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandDescription_fra" xml:space="preserve">
     <value>Applique au package un Push vers le serveur et le publie.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandDescription_ita" xml:space="preserve">
     <value>Effettua il push di un pacchetto verso il server e lo pubblica.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandDescription_jpn" xml:space="preserve">
     <value>サーバーにパッケージをプッシュして、公開します。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandDescription_kor" xml:space="preserve">
     <value>서버에 패키지를 푸시하고 게시합니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandDescription_plk" xml:space="preserve">
     <value>Wypycha pakiet na serwer i go publikuje.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandDescription_ptb" xml:space="preserve">
     <value>Envia um pacote para o servidor e publica-o.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandDescription_rus" xml:space="preserve">
     <value>Отправляет пакет на сервер и публикует его.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandDescription_trk" xml:space="preserve">
     <value>Paketi sunucuya gönderir ve yayımlar.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandDescription_chs" xml:space="preserve">
     <value>将程序包推送到服务器并进行发布。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandDescription_cht" xml:space="preserve">
     <value>將套件推向伺服器並發佈。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandFormatDescription_csy" xml:space="preserve">
     <value>Použije se na akce se seznamem. Přijímá dvě hodnoty: Podrobné (výchozí hodnota) a Krátké.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandFormatDescription_deu" xml:space="preserve">
     <value>Gilt für die Listenaktion. Nimmt zwei Werte an: "Detailed" (Standardwert) und "Short".</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandFormatDescription_esp" xml:space="preserve">
     <value>Se aplica a la acción de la lista. Acepta dos valores: Detallado (predeterminado) y Breve.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandFormatDescription_fra" xml:space="preserve">
     <value>S'applique à l'action de la liste. Accepte deux valeurs : Détaillé (valeur par défaut) et Bref.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandFormatDescription_ita" xml:space="preserve">
     <value>Si applica all'azione list. Accetta due valori: Detailed (impostazione predefinita) e Short.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandFormatDescription_jpn" xml:space="preserve">
     <value>リストの操作に適用します。Detailed (既定) および Short の 2 つの値を受け入れます。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandFormatDescription_kor" xml:space="preserve">
     <value>목록 동작에 적용합니다. [자세히](기본값) 및 [짧게]의 두 가지 값을 사용할 수 있습니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandFormatDescription_plk" xml:space="preserve">
     <value>Jest stosowany do akcji z listy. Akceptuje dwie wartości: Szczegółowe (wartość domyślna) i Krótkie.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandFormatDescription_ptb" xml:space="preserve">
     <value>Aplica à ação da lista. Aceita dois valores: Detalhada (a padrão) e Curta.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandFormatDescription_rus" xml:space="preserve">
     <value>Применяется к действию со списком. Принимает два значения: "Detailed" (по умолчанию) и "Short".</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandFormatDescription_trk" xml:space="preserve">
     <value>Liste eylemi için geçerlidir. Ayrıntılı (varsayılan) ve Kısa olmak üzere iki değer kabul eder.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandFormatDescription_chs" xml:space="preserve">
     <value>适用于列表操作。接受两个值:“详细”(默认值)和“简短”。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SourcesCommandFormatDescription_cht" xml:space="preserve">
     <value>套用至清單動作。接受兩種值: 詳細 (預設) 及簡短。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="CommandDisableParallelProcessing_csy" xml:space="preserve">
     <value>Zakáže pro tento příkaz paralelní zpracování balíčků.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="CommandDisableParallelProcessing_deu" xml:space="preserve">
     <value>Deaktivieren paralleler Verarbeitung von Pakten für diesen Befehl.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="CommandDisableParallelProcessing_esp" xml:space="preserve">
     <value>Deshabilitar el procesamiento paralelo de paquetes para este comando.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="CommandDisableParallelProcessing_fra" xml:space="preserve">
     <value>Désactive le traitement parallèle des packages pour cette commande.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="CommandDisableParallelProcessing_ita" xml:space="preserve">
     <value>Disabilitare l'elaborazione parallela dei pacchetti per questo comando.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="CommandDisableParallelProcessing_jpn" xml:space="preserve">
     <value>このコマンドのために、パッケージの並列処理を無効にします。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="CommandDisableParallelProcessing_kor" xml:space="preserve">
     <value>이 명령에 대한 패키지 병렬 처리를 사용하지 않도록 설정합니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="CommandDisableParallelProcessing_plk" xml:space="preserve">
     <value>Wyłącz równoległe przetwarzanie pakietów dla tego polecenia.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="CommandDisableParallelProcessing_ptb" xml:space="preserve">
     <value>Desativar processamento paralelo de pacotes para esse comando.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="CommandDisableParallelProcessing_rus" xml:space="preserve">
     <value>Отключает параллельную обработку пакетов для этой команды.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="CommandDisableParallelProcessing_trk" xml:space="preserve">
     <value>Bu komut için paketlerin paralel işlenmesini devre dışı bırak.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="CommandDisableParallelProcessing_chs" xml:space="preserve">
     <value>禁止为此命令并行处理程序包。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="CommandDisableParallelProcessing_cht" xml:space="preserve">
     <value>停用此項目的套件平行處理</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="CommandPackageSaveMode_csy" xml:space="preserve">
     <value>Určuje typy souborů, které se mají po instalaci balíčku uložit: nuspec, nupkg, nuspec;nupkg.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="CommandPackageSaveMode_deu" xml:space="preserve">
     <value>Angeben von Dateitypen, die nach der Paketinstallation gespeichert werden sollen: nuspec, nupkg, nuspec;nupkg.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="CommandPackageSaveMode_esp" xml:space="preserve">
     <value>Especifica los tipos de archivo que se guardarán después de la instalación del paquete: nuspec, nupkg, nuspec;nupkg.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="CommandPackageSaveMode_fra" xml:space="preserve">
     <value>Spécifie les types de fichiers à enregistrer après l'installation du package : nuspec, nupkg, nuspec, nupkg.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="CommandPackageSaveMode_ita" xml:space="preserve">
     <value>Specifica i tipi di file per il salvataggio dopo l'installazione del pacchetto: nuspec, nupkg, nuspec;nupkg.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="CommandPackageSaveMode_jpn" xml:space="preserve">
     <value>パッケージのインストール後に保存するファイルの種類を指定します: nuspec、nupkg、nuspec;nupkg。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="CommandPackageSaveMode_kor" xml:space="preserve">
     <value>패키지 설치 후에 저장할 파일 형식을 지정합니다. nuspec, nupkg, nuspec;nupkg.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="CommandPackageSaveMode_plk" xml:space="preserve">
     <value>Określa typy plików do zapisania po zainstalowaniu pakietów: nuspec, nupkg, nuspec, nupkg.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="CommandPackageSaveMode_ptb" xml:space="preserve">
     <value>Especifica tipos de arquivos para salvar após instalação de pacote: nuspec, nupkg, nuspec;nupkg.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="CommandPackageSaveMode_rus" xml:space="preserve">
     <value>Задает типы файлов, сохраняемых после установки пакета: nuspec, nupkg, nuspec, nupkg.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="CommandPackageSaveMode_trk" xml:space="preserve">
     <value>Paket kurulumundan sonra kaydedilecek dosya türlerini belirtir: nuspec, nupkg, nuspec;nupkg</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="CommandPackageSaveMode_chs" xml:space="preserve">
     <value>指定要在安装程序包后保存的文件类型: nuspec、nupkg、nuspec;nupkg。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="CommandPackageSaveMode_cht" xml:space="preserve">
     <value>指定套件安裝之後要儲存的檔案類型: nuspec, nupkg, nuspec;nupkg。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandDisableBufferingDescription" xml:space="preserve">
     <value>Disable buffering when pushing to an HTTP(S) server to decrease memory usage. Note that when this option is enabled, integrated windows authentication might not work.</value>
@@ -5333,11 +6737,11 @@ nuget locals http-cache -clear
 nuget locals temp -list
 
 nuget locals global-packages -list</value>
-    <comment>Please don't localize this string</comment>
+    <comment>{Locked}</comment>
   </data>
   <data name="LocalsCommandSummary" xml:space="preserve">
     <value>&lt;all | http-cache | global-packages | temp | plugins-cache&gt; [-clear | -list]</value>
-    <comment>Please don't localize this string</comment>
+    <comment>{Locked}</comment>
   </data>
   <data name="LocalsCommandClearDescription" xml:space="preserve">
     <value>Clear the selected local resources or cache location(s).</value>
@@ -5399,11 +6803,11 @@ nuget verify -Signatures C:\packages\MyPackage.nupkg -CertificateFingerprint CE4
 nuget verify -Signatures MyPackage.nupkg -Verbosity quiet
 
 nuget verify -Signatures .\*.nupkg</value>
-    <comment>Please don't localize this string</comment>
+    <comment>{Locked}</comment>
   </data>
   <data name="VerifyCommandUsageSummary" xml:space="preserve">
     <value>&lt;verification_type&gt; &lt;package_path&gt;  [options]</value>
-    <comment>Please don't localize this string</comment>
+    <comment>{Locked}</comment>
   </data>
   <data name="VerifyCommandSignaturesDescription" xml:space="preserve">
     <value>Specifies that package signature verification should be performed.</value>
@@ -5431,7 +6835,7 @@ The certificate store can be specified by -CertificateStoreName and -Certificate
     <value>nuget sign MyPackage.nupkg -CertificatePath C:\certificate.pfx
 nuget sign MyPackage.nupkg -CertificatePath \\path\to\certificate.pfx
 nuget sign MyPackage.nupkg -CertificateFingerprint certificate_fingerprint -OutputDirectory .\signed\</value>
-    <comment>Please don't localize this string</comment>
+    <comment>{Locked}</comment>
   </data>
   <data name="SignCommandOverwriteDescription" xml:space="preserve">
     <value>Switch to indicate if the current signature should be overwritten. By default the command will fail if the package already has a signature.</value>
@@ -5456,11 +6860,11 @@ nuget sign MyPackage.nupkg -CertificateFingerprint certificate_fingerprint -Outp
 
 nuget sign .\..\MyPackage.nupkg -Timestamper https://foo.bar -OutputDirectory .\..\Signed
 </value>
-    <comment>Please don't localize this string</comment>
+    <comment>{Locked}</comment>
   </data>
   <data name="SignCommandUsageSummary" xml:space="preserve">
     <value>&lt;package_path&gt; -Timestamper &lt;timestamp_server_url&gt; [-CertificatePath &lt;certificate_path&gt; | [ -CertificateStoreName &lt;certificate_store_name&gt; -CertificateStoreLocation &lt;certificate_store_location&gt; [-CertificateSubjectName &lt;certificate_subject_name&gt; | -CertificateFingerprint &lt;certificate_fingerprint&gt;]]] [options]</value>
-    <comment>Please don't localize this string</comment>
+    <comment>{Locked}</comment>
   </data>
   <data name="SignCommandCertificateStoreLocationDescription" xml:space="preserve">
     <value>Name of the X.509 certificate store use to search for the certificate. Defaults to "CurrentUser", the X.509 certificate store used by the current user.
@@ -5611,8 +7015,8 @@ nuget trusted-signers Remove -Name TrustedRepo</value>
     <value>Provides the ability to manage list of client certificates located in NuGet.config files</value>
   </data>
   <data name="ClientCertificatesCommandUsageSummary" xml:space="preserve">
-<value>&lt;List|Add|Update|Remove&gt; [options]</value>
-</data>
+    <value>&lt;List|Add|Update|Remove&gt; [options]</value>
+  </data>
   <data name="ClientCertificatesCommandUsageExamples" xml:space="preserve">
     <value>nuget client-certs Add -PackageSource Foo -Path .\MyCertificate.pfx
 

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
@@ -463,4422 +463,5891 @@ To prevent NuGet from downloading packages during build, open the Visual Studio 
   </data>
   <data name="DeleteCommandDeletedPackage_csy" xml:space="preserve">
     <value>{0} {1} bylo úspěšně odstraněno.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandDeletedPackage_deu" xml:space="preserve">
     <value>{0} {1} wurde erfolgreich gelöscht.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandDeletedPackage_esp" xml:space="preserve">
     <value>{0} {1} se ha eliminado correctamente.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandDeletedPackage_fra" xml:space="preserve">
     <value>{0} {1} a été correctement supprimé.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandDeletedPackage_ita" xml:space="preserve">
     <value>{0} {1} è stato correttamente cancellato.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandDeletedPackage_jpn" xml:space="preserve">
     <value>{0} {1} は正常に削除されました。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandDeletedPackage_kor" xml:space="preserve">
     <value>{0} {1}이(가) 삭제되었습니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandDeletedPackage_plk" xml:space="preserve">
     <value>Pomyślnie usunięto element {0} {1}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandDeletedPackage_ptb" xml:space="preserve">
     <value>{0} {1} foi excluído com sucesso.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandDeletedPackage_rus" xml:space="preserve">
     <value>Удаление {0} {1} выполнено.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandDeletedPackage_trk" xml:space="preserve">
     <value>{0} {1} başarıyla silindi.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandDeletedPackage_chs" xml:space="preserve">
     <value>已成功删除 {0} {1}。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandDeletedPackage_cht" xml:space="preserve">
     <value>{0} {1} 已成功刪除。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InvalidOptionValueError_csy" xml:space="preserve">
     <value>Neplatná hodnota možnosti: '{0} {1}'</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InvalidOptionValueError_deu" xml:space="preserve">
     <value>Ungültiger Optionswert: "{0} {1}"</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InvalidOptionValueError_esp" xml:space="preserve">
     <value>Valor de opción no válido: '{0} {1}'</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InvalidOptionValueError_fra" xml:space="preserve">
     <value>Valeur de l'option non valide : '{0} {1}'</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InvalidOptionValueError_ita" xml:space="preserve">
     <value>Valore opzione non valido: '{0} {1}'</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InvalidOptionValueError_jpn" xml:space="preserve">
     <value>無効なオプションの値: '{0} {1}'</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InvalidOptionValueError_kor" xml:space="preserve">
     <value>잘못된 옵션 값: '{0} {1}'</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InvalidOptionValueError_plk" xml:space="preserve">
     <value>Nieprawidłowa wartość opcji: „{0} {1}”</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InvalidOptionValueError_ptb" xml:space="preserve">
     <value>Valor de opção inválida: '{0} {1}'</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InvalidOptionValueError_rus" xml:space="preserve">
     <value>Недопустимое значение параметра: '{0} {1}'</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InvalidOptionValueError_trk" xml:space="preserve">
     <value>Geçersiz seçenek değeri: '{0} {1}'</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InvalidOptionValueError_chs" xml:space="preserve">
     <value>无效的选项值:“{0} {1}”</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InvalidOptionValueError_cht" xml:space="preserve">
     <value>無效的選項值: '{0} {1}'</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandNoPackages_csy" xml:space="preserve">
     <value>Nebyly nalezeny žádné balíčky.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandNoPackages_deu" xml:space="preserve">
     <value>Es wurden keine Pakete gefunden.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandNoPackages_esp" xml:space="preserve">
     <value>No se han encontrado paquetes.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandNoPackages_fra" xml:space="preserve">
     <value>Aucun package trouvé.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandNoPackages_ita" xml:space="preserve">
     <value>Nessun pacchetto trovato</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandNoPackages_jpn" xml:space="preserve">
     <value>パッケージが見つかりませんでした。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandNoPackages_kor" xml:space="preserve">
     <value>패키지를 찾을 수 없습니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandNoPackages_plk" xml:space="preserve">
     <value>Nie znaleziono żadnych pakietów.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandNoPackages_ptb" xml:space="preserve">
     <value>Nenhum pacote encontrado.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandNoPackages_rus" xml:space="preserve">
     <value>Пакеты не найдены.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandNoPackages_trk" xml:space="preserve">
     <value>Hiçbir paket bulunamadı.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandNoPackages_chs" xml:space="preserve">
     <value>找不到程序包。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommandNoPackages_cht" xml:space="preserve">
     <value>找不到封裝。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="MissingOptionValueError_csy" xml:space="preserve">
     <value>Chybějící hodnota možnosti: '{0}'</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="MissingOptionValueError_deu" xml:space="preserve">
     <value>Fehlender Optionswert für: "{0}"</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="MissingOptionValueError_esp" xml:space="preserve">
     <value>Falta el valor de opción para '{0}'</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="MissingOptionValueError_fra" xml:space="preserve">
     <value>Valeur de l'option manquante pour : '{0}'</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="MissingOptionValueError_ita" xml:space="preserve">
     <value>Valore opzione mancante per: '{0}'</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="MissingOptionValueError_jpn" xml:space="preserve">
     <value>次のオプションの値が見つかりません: '{0}'</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="MissingOptionValueError_kor" xml:space="preserve">
     <value>'{0}'에 대한 옵션 값이 없습니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="MissingOptionValueError_plk" xml:space="preserve">
     <value>Brak wartości opcji dla: „{0}”</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="MissingOptionValueError_ptb" xml:space="preserve">
     <value>Valor da opção ausente para: '{0}'</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="MissingOptionValueError_rus" xml:space="preserve">
     <value>Отсутствует значение параметра для: "{0}"</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="MissingOptionValueError_trk" xml:space="preserve">
     <value>Bu öğe için seçenek değeri eksik: '{0}'</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="MissingOptionValueError_chs" xml:space="preserve">
     <value>缺少以下项的选项值:“{0}”</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="MissingOptionValueError_cht" xml:space="preserve">
     <value>缺少下列項目的選項值: '{0}'</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="OptionInvalidWithoutSetter_csy" xml:space="preserve">
     <value>[možnost] pro {0} je bez metody Setter neplatná.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="OptionInvalidWithoutSetter_deu" xml:space="preserve">
     <value>[Option] für "{0}" ist ohne einen Setter ungültig.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="OptionInvalidWithoutSetter_esp" xml:space="preserve">
     <value>[option] en '{0}' no es válida si no se ha establecido de ningún modo.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="OptionInvalidWithoutSetter_fra" xml:space="preserve">
     <value>[option] sur '{0}' n'est pas valide sans un setter.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="OptionInvalidWithoutSetter_ita" xml:space="preserve">
     <value>[option] su '{0}' non valido senza setter.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="OptionInvalidWithoutSetter_jpn" xml:space="preserve">
     <value>セッターがない '{0}' の [option] は無効です。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="OptionInvalidWithoutSetter_kor" xml:space="preserve">
     <value>setter가 없으므로 '{0}'의 [옵션]이 잘못되었습니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="OptionInvalidWithoutSetter_plk" xml:space="preserve">
     <value>Opcja [opcja] dla „{0}” jest nieprawidłowa bez metody ustawiającej.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="OptionInvalidWithoutSetter_ptb" xml:space="preserve">
     <value>[option] em '{0}' não é válido sem um setter.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="OptionInvalidWithoutSetter_rus" xml:space="preserve">
     <value>[параметр] в "{0}" является недопустимым без метода задания значения.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="OptionInvalidWithoutSetter_trk" xml:space="preserve">
     <value>{0}' üzerindeki [option] ayarlayıcı olmadan geçersizdir.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="OptionInvalidWithoutSetter_chs" xml:space="preserve">
     <value>“{0}”上的 [option] 没有 setter，是无效的。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="OptionInvalidWithoutSetter_cht" xml:space="preserve">
     <value>{0}' 上的 [選項] 因為沒有 Setter 因此無效。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandSpecifyInputFileError_csy" xml:space="preserve">
     <value>Zadejte soubor nuspec nebo soubor projektu, který má být použit.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandSpecifyInputFileError_deu" xml:space="preserve">
     <value>Bitte geben Sie eine zu verwendende nuspec- oder Projektdatei an.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandSpecifyInputFileError_esp" xml:space="preserve">
     <value>Especifique el archivo de proyecto o nuspec que se va a usar.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandSpecifyInputFileError_fra" xml:space="preserve">
     <value>Veuillez spécifier le fichier .nuspec ou projet à utiliser.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandSpecifyInputFileError_ita" xml:space="preserve">
     <value>Specificare il file progetto o nuspec da usare.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandSpecifyInputFileError_jpn" xml:space="preserve">
     <value>使用する nuspec または project ファイルを指定してください。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandSpecifyInputFileError_kor" xml:space="preserve">
     <value>사용할 nuspec 또는 프로젝트 파일을 지정하십시오.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandSpecifyInputFileError_plk" xml:space="preserve">
     <value>Określ plik nuspec lub plik projektu, który ma zostać użyty.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandSpecifyInputFileError_ptb" xml:space="preserve">
     <value>Especifique um arquivo nuspec ou de projeto para usar.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandSpecifyInputFileError_rus" xml:space="preserve">
     <value>Укажите NUSPEC-файл или файл проекта для использования.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandSpecifyInputFileError_trk" xml:space="preserve">
     <value>Lütfen kullanılan nuspec veya proje dosyasını belirtin.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandSpecifyInputFileError_chs" xml:space="preserve">
     <value>请指定要使用的 nuspec 文件或项目文件。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandSpecifyInputFileError_cht" xml:space="preserve">
     <value>請指定 nuspec 或要使用的專案檔。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandSuccess_csy" xml:space="preserve">
     <value>Balíček {0} byl úspěšně vytvořen.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandSuccess_deu" xml:space="preserve">
     <value>Das Paket "{0}" wurde erfolgreich erstellt.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandSuccess_esp" xml:space="preserve">
     <value>Paquete '{0}' creado correctamente.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandSuccess_fra" xml:space="preserve">
     <value>Package '{0}' correctement créé.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandSuccess_ita" xml:space="preserve">
     <value>Creato pacchetto '{0}' correttamente.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandSuccess_jpn" xml:space="preserve">
     <value>パッケージ '{0}' が正常に作成されました。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandSuccess_kor" xml:space="preserve">
     <value>'{0}' 패키지를 만들었습니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandSuccess_plk" xml:space="preserve">
     <value>Pomyślnie utworzono pakiet „{0}”.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandSuccess_ptb" xml:space="preserve">
     <value>Pacote '{0}' criado com êxito.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandSuccess_rus" xml:space="preserve">
     <value>Пакет "{0}" успешно создан.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandSuccess_trk" xml:space="preserve">
     <value>{0}' paketi başarıyla oluşturuldu.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandSuccess_chs" xml:space="preserve">
     <value>已成功创建程序包“{0}”。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandSuccess_cht" xml:space="preserve">
     <value>已成功建立封裝 '{0}'。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandPushingPackage_csy" xml:space="preserve">
     <value>Probíhá předávání {0} do {1}...</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandPushingPackage_deu" xml:space="preserve">
     <value>{0} wird mittels Push an {1} übertragen...</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandPushingPackage_esp" xml:space="preserve">
     <value>Insertando {0} a {1}…</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandPushingPackage_fra" xml:space="preserve">
     <value>Transmission de {0} à {1}…</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandPushingPackage_ita" xml:space="preserve">
     <value>Comprimendo {0} di {1}...</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandPushingPackage_jpn" xml:space="preserve">
     <value>{0} を {1} にプッシュしています...</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandPushingPackage_kor" xml:space="preserve">
     <value>{0}을(를) {1}에 푸시하는 중...</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandPushingPackage_plk" xml:space="preserve">
     <value>Trwa wypychanie {0} do {1}...</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandPushingPackage_ptb" xml:space="preserve">
     <value>Empurrando {0} para {1} ...</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandPushingPackage_rus" xml:space="preserve">
     <value>Отправка {0} в {1}...</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandPushingPackage_trk" xml:space="preserve">
     <value>{0} öğesi {1} öğesine iletiliyor...</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandPushingPackage_chs" xml:space="preserve">
     <value>正在将 {0} 推送到 {1}...</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandPushingPackage_cht" xml:space="preserve">
     <value>正在將 {0} 推入 {1}...</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandNoSourceError_csy" xml:space="preserve">
     <value>Není nastaven výchozí zdroj. Zadejte zdroj.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandNoSourceError_deu" xml:space="preserve">
     <value>Es ist keine Standardquelle vorhanden. Bitte geben Sie eine Quelle an.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandNoSourceError_esp" xml:space="preserve">
     <value>No hay ningún origen predeterminado, especifique un origen.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandNoSourceError_fra" xml:space="preserve">
     <value>Absence de source par défaut, veuillez en spécifier une.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandNoSourceError_ita" xml:space="preserve">
     <value>Nessuna fonte di default, specificare una fonte.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandNoSourceError_jpn" xml:space="preserve">
     <value>既定のソースがありません。ソースを指定してください。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandNoSourceError_kor" xml:space="preserve">
     <value>기본 소스가 없습니다. 소스를 지정하십시오.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandNoSourceError_plk" xml:space="preserve">
     <value>Brak domyślnego źródła. Określ źródło.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandNoSourceError_ptb" xml:space="preserve">
     <value>Não há origem padrão. Especifique uma origem.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandNoSourceError_rus" xml:space="preserve">
     <value>Источник по умолчанию отсутствует, укажите источник.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandNoSourceError_trk" xml:space="preserve">
     <value>Varsayılan herhangi bir kaynak yok, lütfen bir kaynak belirtin.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandNoSourceError_chs" xml:space="preserve">
     <value>没有默认源，请指定源。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandNoSourceError_cht" xml:space="preserve">
     <value>沒有預設的來源，請指定來源。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ResourcePropertyIncorrectType_csy" xml:space="preserve">
     <value>Vlastnost {0} typu prostředku {1} není typu ResourceManager.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ResourcePropertyIncorrectType_deu" xml:space="preserve">
     <value>Die Eigenschaft "{0}" für den Ressourcentyp "{1}" ist kein Typ von "ResourceManager".</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ResourcePropertyIncorrectType_esp" xml:space="preserve">
     <value>La propiedad '{0}' del tipo de recurso '{1}' no es un tipo de ResourceManager.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ResourcePropertyIncorrectType_fra" xml:space="preserve">
     <value>La propriété '{0}' du type de ressource '{1}' n'est pas du type ResourceManager.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ResourcePropertyIncorrectType_ita" xml:space="preserve">
     <value>La proprietà '{0}' sulla risorsa tipo '{1}' non è un tipo in ResourceManager.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ResourcePropertyIncorrectType_jpn" xml:space="preserve">
     <value>リソースの種類 '{1}' のプロパティ '{0}' が ResourceManager 型ではありません。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ResourcePropertyIncorrectType_kor" xml:space="preserve">
     <value>리소스 형식 '{1}'의 '{0}' 속성이 ResourceManager 형식이 아닙니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ResourcePropertyIncorrectType_plk" xml:space="preserve">
     <value>Właściwość „{0}” w typie zasobu „{1}” nie jest typu ResourceManager.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ResourcePropertyIncorrectType_ptb" xml:space="preserve">
     <value>A propriedade '{0}' no tipo de recurso '{1}' não é um tipo de ResourceManager.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ResourcePropertyIncorrectType_rus" xml:space="preserve">
     <value>Типом свойства "{0}" типа ресурса "{1}" не является ResourceManager.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ResourcePropertyIncorrectType_trk" xml:space="preserve">
     <value>{1}' kaynak türündeki '{0}' özelliği bir ResourceManager türü değildir.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ResourcePropertyIncorrectType_chs" xml:space="preserve">
     <value>资源类型“{1}”的属性“{0}”不是 ResourceManager 类型。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ResourcePropertyIncorrectType_cht" xml:space="preserve">
     <value>資源類型 '{1}' 上的屬性 '{0}' 不是 ResourceManager 類型。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ResourceTypeDoesNotHaveProperty_csy" xml:space="preserve">
     <value>Typ prostředku {0} neobsahuje přístupnou statickou vlastnost s názvem {1}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ResourceTypeDoesNotHaveProperty_deu" xml:space="preserve">
     <value>Der Ressourcentyp "{0}" besitzt keine statische Eigenschaft namens "{1}", auf die zugegriffen werden kann.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ResourceTypeDoesNotHaveProperty_esp" xml:space="preserve">
     <value>El tipo de recurso '{0}' no tiene una propiedad estática accesible denominada '{1}'.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ResourceTypeDoesNotHaveProperty_fra" xml:space="preserve">
     <value>Le type de ressource '{0}' ne dispose pas d'une propriété statique accessible nommée '{1}'.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ResourceTypeDoesNotHaveProperty_ita" xml:space="preserve">
     <value>Il tipo di risorsa '{0}'non ha una proprietà statica accessibile di nome'{1}'.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ResourceTypeDoesNotHaveProperty_jpn" xml:space="preserve">
     <value>リソースの種類 '{0}' に、'{1}' というアクセスできる静的プロパティがありません。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ResourceTypeDoesNotHaveProperty_kor" xml:space="preserve">
     <value>리소스 형식 '{0}'에 액세스 가능한 '{1}' 이름의 정적 속성이 없습니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ResourceTypeDoesNotHaveProperty_plk" xml:space="preserve">
     <value>Typ zasobu „{0}” nie ma dostępnej właściwości statycznej o nazwie „{1}”.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ResourceTypeDoesNotHaveProperty_ptb" xml:space="preserve">
     <value>O tipo de recurso '{0}' não tem uma propriedade estática acessível chamada '{1}'.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ResourceTypeDoesNotHaveProperty_rus" xml:space="preserve">
     <value>У типа ресурса "{0}" отсутствует доступное статическое свойство с именем "{1}".</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ResourceTypeDoesNotHaveProperty_trk" xml:space="preserve">
     <value>{0}' kaynak türünün erişilebilir '{1}' adlı erişilebilir statik bir özelliği yok.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ResourceTypeDoesNotHaveProperty_chs" xml:space="preserve">
     <value>资源类型“{0}”没有名为“{1}”的可访问静态属性。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ResourceTypeDoesNotHaveProperty_cht" xml:space="preserve">
     <value>資源類型 '{0}' 沒有可存取的靜態屬性名為 '{1}'。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToConvertTypeError_csy" xml:space="preserve">
     <value>Nelze provést změnu z typu {0} na typ {1}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToConvertTypeError_deu" xml:space="preserve">
     <value>Der Typ kann nicht aus "{0}" in "{1}" geändert werden.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToConvertTypeError_esp" xml:space="preserve">
     <value>No se puede cambiar del tipo '{0}' a '{1}'.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToConvertTypeError_fra" xml:space="preserve">
     <value>Impossible de basculer du type '{0}' au type '{1}'.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToConvertTypeError_ita" xml:space="preserve">
     <value>Impossibile modificare da '{0}' a '{1}'.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToConvertTypeError_jpn" xml:space="preserve">
     <value>型 '{0}' から '{1}' に変更できません。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToConvertTypeError_kor" xml:space="preserve">
     <value>'{0}'에서 '{1}'(으)로 형식을 변경할 수 없습니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToConvertTypeError_plk" xml:space="preserve">
     <value>Nie można zmienić typu „{0}” na „{1}”.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToConvertTypeError_ptb" xml:space="preserve">
     <value>Não é possível mudar do tipo '{0}' para '{1}'.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToConvertTypeError_rus" xml:space="preserve">
     <value>Не удалось изменить тип "{0}" на "{1}".</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToConvertTypeError_trk" xml:space="preserve">
     <value>{0}' türünden '{1}' türüne değiştirilemiyor.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToConvertTypeError_chs" xml:space="preserve">
     <value>无法从类型“{0}”更改为“{1}”。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToConvertTypeError_cht" xml:space="preserve">
     <value>無法變更類型 '{0}' 為 '{1}'。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnknowCommandError_csy" xml:space="preserve">
     <value>Neznámý příkaz: '{0}'</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnknowCommandError_deu" xml:space="preserve">
     <value>Unbekannter Befehl: "{0}"</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnknowCommandError_esp" xml:space="preserve">
     <value>Comando desconocido: '{0}'</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnknowCommandError_fra" xml:space="preserve">
     <value>Commande inconnue : '{0}'</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnknowCommandError_ita" xml:space="preserve">
     <value>Comando sconosciuto: '{0}'</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnknowCommandError_jpn" xml:space="preserve">
     <value>不明なコマンド: '{0}'</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnknowCommandError_kor" xml:space="preserve">
     <value>알 수 없는 명령: '{0}'</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnknowCommandError_plk" xml:space="preserve">
     <value>Nieznane polecenie: „{0}”</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnknowCommandError_ptb" xml:space="preserve">
     <value>Comando desconhecido: '{0}'</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnknowCommandError_rus" xml:space="preserve">
     <value>Неизвестная команда: "{0}"</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnknowCommandError_trk" xml:space="preserve">
     <value>Bilinmeyen komut: '{0}'</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnknowCommandError_chs" xml:space="preserve">
     <value>未知命令:“{0}”</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnknowCommandError_cht" xml:space="preserve">
     <value>不明的命令: '{0}'</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnknownOptionError_csy" xml:space="preserve">
     <value>Neznámá možnost: '{0}'</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnknownOptionError_deu" xml:space="preserve">
     <value>Unbekannte Option: "{0}"</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnknownOptionError_esp" xml:space="preserve">
     <value>Opción desconocida: '{0}'</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnknownOptionError_fra" xml:space="preserve">
     <value>Option inconnue : '{0}'</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnknownOptionError_ita" xml:space="preserve">
     <value>Opzione sconosciuta: '{0}'</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnknownOptionError_jpn" xml:space="preserve">
     <value>不明なオプション: '{0}'</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnknownOptionError_kor" xml:space="preserve">
     <value>알 수 없는 옵션: '{0}'</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnknownOptionError_plk" xml:space="preserve">
     <value>Nieznana opcja: „{0}”</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnknownOptionError_ptb" xml:space="preserve">
     <value>Opção desconhecida: '{0}'</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnknownOptionError_rus" xml:space="preserve">
     <value>Неизвестный оператор: "{0}"</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnknownOptionError_trk" xml:space="preserve">
     <value>Bilinmeyen seçenek: '{0}'</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnknownOptionError_chs" xml:space="preserve">
     <value>未知选项:“{0}”</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnknownOptionError_cht" xml:space="preserve">
     <value>不明的選項: '{0}'</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandCheckingForUpdates_csy" xml:space="preserve">
     <value>Probíhá kontrola aktualizací z {0}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandCheckingForUpdates_deu" xml:space="preserve">
     <value>Es wird auf Updates von {0} überprüft.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandCheckingForUpdates_esp" xml:space="preserve">
     <value>Comprobando actualizaciones desde {0}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandCheckingForUpdates_fra" xml:space="preserve">
     <value>Recherche de mises à jour depuis {0}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandCheckingForUpdates_ita" xml:space="preserve">
     <value>Controllando aggiornamenti da {0}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandCheckingForUpdates_jpn" xml:space="preserve">
     <value>{0} の更新を確認しています。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandCheckingForUpdates_kor" xml:space="preserve">
     <value>{0}에서 업데이트를 확인하고 있습니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandCheckingForUpdates_plk" xml:space="preserve">
     <value>Sprawdzanie dostępności aktualizacji z {0}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandCheckingForUpdates_ptb" xml:space="preserve">
     <value>Verifique se há atualizações de {0}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandCheckingForUpdates_rus" xml:space="preserve">
     <value>Проверка обновлений из "{0}".</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandCheckingForUpdates_trk" xml:space="preserve">
     <value>Güncellemeler {0} konumundan denetleniyor.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandCheckingForUpdates_chs" xml:space="preserve">
     <value>正在检查来自 {0} 的更新。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandCheckingForUpdates_cht" xml:space="preserve">
     <value>正在檢查來自 {0} 的更新。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandCurrentlyRunningNuGetExe_csy" xml:space="preserve">
     <value>Aktuálně je spuštěn soubor NuGet.exe {0}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandCurrentlyRunningNuGetExe_deu" xml:space="preserve">
     <value>"NuGet.exe" {0} wird zurzeit ausgeführt.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandCurrentlyRunningNuGetExe_esp" xml:space="preserve">
     <value>Se está ejecutando NuGet.exe {0}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandCurrentlyRunningNuGetExe_fra" xml:space="preserve">
     <value>NuGet.exe {0} en cours d'exécution.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandCurrentlyRunningNuGetExe_ita" xml:space="preserve">
     <value> NuGet.exe {0} avviato.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandCurrentlyRunningNuGetExe_jpn" xml:space="preserve">
     <value>NuGet.exe {0} は実行中です。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandCurrentlyRunningNuGetExe_kor" xml:space="preserve">
     <value>현재 NuGet.exe {0}을(를) 실행하고 있습니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandCurrentlyRunningNuGetExe_plk" xml:space="preserve">
     <value>Plik NuGet.exe {0} jest obecnie uruchomiony.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandCurrentlyRunningNuGetExe_ptb" xml:space="preserve">
     <value>Atualmente executando NuGet.exe {0}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandCurrentlyRunningNuGetExe_rus" xml:space="preserve">
     <value>Сейчас запущен NuGet.exe {0}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandCurrentlyRunningNuGetExe_trk" xml:space="preserve">
     <value>NuGet.exe {0} şu anda çalıştırılıyor.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandCurrentlyRunningNuGetExe_chs" xml:space="preserve">
     <value>当前正在运行 NuGet.exe {0}。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandCurrentlyRunningNuGetExe_cht" xml:space="preserve">
     <value>目前正在執行 NuGet.exe {0}。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandNuGetUpToDate_csy" xml:space="preserve">
     <value>NuGet.exe je aktuální.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandNuGetUpToDate_deu" xml:space="preserve">
     <value>"NuGet.exe" ist aktuell.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandNuGetUpToDate_esp" xml:space="preserve">
     <value>NuGet.exe está actualizado.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandNuGetUpToDate_fra" xml:space="preserve">
     <value>NuGet.exe est à jour.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandNuGetUpToDate_ita" xml:space="preserve">
     <value>NuGet.exe è aggiornato.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandNuGetUpToDate_jpn" xml:space="preserve">
     <value>NuGet.exe は最新です。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandNuGetUpToDate_kor" xml:space="preserve">
     <value>NuGet.exe가 최신 버전입니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandNuGetUpToDate_plk" xml:space="preserve">
     <value>Plik NuGet.exe jest aktualny.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandNuGetUpToDate_ptb" xml:space="preserve">
     <value>O NuGet.exe está atualizado.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandNuGetUpToDate_rus" xml:space="preserve">
     <value>Обновление NuGet.exe не требуется.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandNuGetUpToDate_trk" xml:space="preserve">
     <value>NuGet.exe güncel.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandNuGetUpToDate_chs" xml:space="preserve">
     <value>NuGet.exe 是最新的。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandNuGetUpToDate_cht" xml:space="preserve">
     <value>NuGet.exe 是最新的。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandUnableToFindPackage_csy" xml:space="preserve">
     <value>Balíček {0} nebyl nalezen.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandUnableToFindPackage_deu" xml:space="preserve">
     <value>Das Paket "{0}" wurde nicht gefunden.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandUnableToFindPackage_esp" xml:space="preserve">
     <value>No se puede encontrar el paquete '{0}'.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandUnableToFindPackage_fra" xml:space="preserve">
     <value>Impossible de trouver le package '{0}'.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandUnableToFindPackage_ita" xml:space="preserve">
     <value>Impossibile trovare pacchetto '{0}'.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandUnableToFindPackage_jpn" xml:space="preserve">
     <value>'{0}' パッケージが見つかりません。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandUnableToFindPackage_kor" xml:space="preserve">
     <value>'{0}' 패키지를 찾을 수 없습니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandUnableToFindPackage_plk" xml:space="preserve">
     <value>Nie można odnaleźć pakietu „{0}”.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandUnableToFindPackage_ptb" xml:space="preserve">
     <value>Não foi possível encontrar o pacote '{0}'.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandUnableToFindPackage_rus" xml:space="preserve">
     <value>Не удалось найти пакет "{0}".</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandUnableToFindPackage_trk" xml:space="preserve">
     <value>{0}' paketi bulunamıyor.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandUnableToFindPackage_chs" xml:space="preserve">
     <value>找不到“{0}”程序包。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandUnableToFindPackage_cht" xml:space="preserve">
     <value>找不到 '{0}' 封裝。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandUnableToLocateNuGetExe_csy" xml:space="preserve">
     <value>Neplatný balíček NuGet.CommandLine. V tomto balíčku nebyl nalezen soubor NuGet.exe.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandUnableToLocateNuGetExe_deu" xml:space="preserve">
     <value>Ungültiges NuGet.CommandLine-Paket. "NuGet.exe" wurde im Paket nicht gefunden.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandUnableToLocateNuGetExe_esp" xml:space="preserve">
     <value>Paquete NuGet.CommandLine no válido. No se puede ubicar NuGet.exe en el paquete.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandUnableToLocateNuGetExe_fra" xml:space="preserve">
     <value>Package NuGet.CommandLine non valide. Impossible de trouver NuGet.exe dans le package.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandUnableToLocateNuGetExe_ita" xml:space="preserve">
     <value>Pacchetto NuGet.CommandLine invalido. Impossibile localizzare NuGet.exe all'interno del pacchetto.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandUnableToLocateNuGetExe_jpn" xml:space="preserve">
     <value>NuGet.CommandLine パッケージが無効です。パッケージ内に NuGet.exe が見つかりません。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandUnableToLocateNuGetExe_kor" xml:space="preserve">
     <value>잘못된 NuGet.CommandLine 패키지입니다. 패키지에서 NuGet.exe를 찾을 수 없습니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandUnableToLocateNuGetExe_plk" xml:space="preserve">
     <value>Nieprawidłowy pakiet NuGet.CommandLine. Nie można odnaleźć pliku NuGet.exe wewnątrz pakietu.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandUnableToLocateNuGetExe_ptb" xml:space="preserve">
     <value>Pacote NuGet.CommandLine inválido. Não foi possível localizar NuGet.exe dentro do pacote.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandUnableToLocateNuGetExe_rus" xml:space="preserve">
     <value>Недопустимый пакет NuGet.CommandLine. В пакете не удалось найти NuGet.exe.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandUnableToLocateNuGetExe_trk" xml:space="preserve">
     <value>Geçersiz NuGet.CommandLine paketi. Paket içindeki NuGet.exe bulunamıyor.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandUnableToLocateNuGetExe_chs" xml:space="preserve">
     <value>NuGet.CommandLine 程序包无效。在该程序包中找不到 NuGet.exe。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandUnableToLocateNuGetExe_cht" xml:space="preserve">
     <value>無效的 NuGet.CommandLine 封裝。在封裝中找不到 NuGet.exe。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandUpdateSuccessful_csy" xml:space="preserve">
     <value>Aktualizace proběhla úspěšně.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandUpdateSuccessful_deu" xml:space="preserve">
     <value>Das Update war erfolgreich.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandUpdateSuccessful_esp" xml:space="preserve">
     <value>Actualización correcta.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandUpdateSuccessful_fra" xml:space="preserve">
     <value>Mise à jour réussie.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandUpdateSuccessful_ita" xml:space="preserve">
     <value>Aggiornamento riuscito</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandUpdateSuccessful_jpn" xml:space="preserve">
     <value>正常に更新されました。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandUpdateSuccessful_kor" xml:space="preserve">
     <value>업데이트했습니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandUpdateSuccessful_plk" xml:space="preserve">
     <value>Aktualizacja powiodła się.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandUpdateSuccessful_ptb" xml:space="preserve">
     <value>Atualização bem-sucedida.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandUpdateSuccessful_rus" xml:space="preserve">
     <value>Обновление выполнено.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandUpdateSuccessful_trk" xml:space="preserve">
     <value>Güncelleme başarılı.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandUpdateSuccessful_chs" xml:space="preserve">
     <value>更新成功。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandUpdateSuccessful_cht" xml:space="preserve">
     <value>成功更新。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandUpdatingNuGet_csy" xml:space="preserve">
     <value>Probíhá aktualizace souboru NuGet.exe na {0}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandUpdatingNuGet_deu" xml:space="preserve">
     <value>"NuGet.exe" wird auf {0} aktualisiert.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandUpdatingNuGet_esp" xml:space="preserve">
     <value>Actualizando NuGet.exe a {0}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandUpdatingNuGet_fra" xml:space="preserve">
     <value>Mise à jour de NuGet.exe vers {0}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandUpdatingNuGet_ita" xml:space="preserve">
     <value>Aggiornando NuGet.exe a {0}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandUpdatingNuGet_jpn" xml:space="preserve">
     <value>NuGet.exe を {0} に更新しています。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandUpdatingNuGet_kor" xml:space="preserve">
     <value>NuGet.exe를 {0}(으)로 업데이트하고 있습니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandUpdatingNuGet_plk" xml:space="preserve">
     <value>Aktualizowanie pliku NuGet.exe do {0}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandUpdatingNuGet_ptb" xml:space="preserve">
     <value>Atualizando NuGet.exe para {0}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandUpdatingNuGet_rus" xml:space="preserve">
     <value>Обновление NuGet.exe в {0}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandUpdatingNuGet_trk" xml:space="preserve">
     <value>NuGet.exe {0} olarak güncelleniyor.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandUpdatingNuGet_chs" xml:space="preserve">
     <value>正在将 NuGet.exe 更新到 {0}。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdateCommandUpdatingNuGet_cht" xml:space="preserve">
     <value>正在更新 NuGet.exe 為 {0}。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InvalidArguments_csy" xml:space="preserve">
     <value>{0}: neplatné argumenty</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InvalidArguments_deu" xml:space="preserve">
     <value>{0}: ungültige Argumente.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InvalidArguments_esp" xml:space="preserve">
     <value>{0}: argumentos no válidos.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InvalidArguments_fra" xml:space="preserve">
     <value>{0} : arguments non valides.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InvalidArguments_ita" xml:space="preserve">
     <value>{0}: argomenti non validi.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InvalidArguments_jpn" xml:space="preserve">
     <value>{0}: 引数が無効です。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InvalidArguments_kor" xml:space="preserve">
     <value>{0}: 잘못된 인수입니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InvalidArguments_plk" xml:space="preserve">
     <value>{0}: nieprawidłowe argumenty.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InvalidArguments_ptb" xml:space="preserve">
     <value>{0}: argumentos inválidos.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InvalidArguments_rus" xml:space="preserve">
     <value>{0}: недопустимые аргументы.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InvalidArguments_trk" xml:space="preserve">
     <value>{0}: geçersiz bağımsız değişken.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InvalidArguments_chs" xml:space="preserve">
     <value>{0}: 参数无效。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InvalidArguments_cht" xml:space="preserve">
     <value>{0}: 無效的引數。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandAddedFile_csy" xml:space="preserve">
     <value>Byl přidán soubor {0}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandAddedFile_deu" xml:space="preserve">
     <value>Die Datei "{0}" wurde hinzugefügt.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandAddedFile_esp" xml:space="preserve">
     <value>Se ha agregado el archivo '{0}'.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandAddedFile_fra" xml:space="preserve">
     <value>Fichier ajouté '{0}'.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandAddedFile_ita" xml:space="preserve">
     <value>Aggiungere file '{0}'.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandAddedFile_jpn" xml:space="preserve">
     <value>ファイル '{0}' が追加されました。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandAddedFile_kor" xml:space="preserve">
     <value>'{0}' 파일을 추가했습니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandAddedFile_plk" xml:space="preserve">
     <value>Dodano plik „{0}”.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandAddedFile_ptb" xml:space="preserve">
     <value>Arquivo adicionado '{0}'.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandAddedFile_rus" xml:space="preserve">
     <value>Добавлен файл "{0}".</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandAddedFile_trk" xml:space="preserve">
     <value>{0}' dosyası eklendi.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandAddedFile_chs" xml:space="preserve">
     <value>已添加文件“{0}”。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandAddedFile_cht" xml:space="preserve">
     <value>已新增檔案 '{0}'。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandAttemptingToBuildPackage_csy" xml:space="preserve">
     <value>Probíhá pokus o sestavení balíčku z {0}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandAttemptingToBuildPackage_deu" xml:space="preserve">
     <value>Es wird versucht, das Paket aus "{0}" zu erstellen.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandAttemptingToBuildPackage_esp" xml:space="preserve">
     <value>Intentando compilar el paquete desde '{0}'. </value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandAttemptingToBuildPackage_fra" xml:space="preserve">
     <value>Tentative de création du package depuis '{0}'.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandAttemptingToBuildPackage_ita" xml:space="preserve">
     <value>Componendo pacchetto da'{0}'.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandAttemptingToBuildPackage_jpn" xml:space="preserve">
     <value>'{0}' からパッケージをビルドしています。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandAttemptingToBuildPackage_kor" xml:space="preserve">
     <value>'{0}'에서 패키지를 빌드하고 있습니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandAttemptingToBuildPackage_plk" xml:space="preserve">
     <value>Próba skompilowania pakietu z „{0}”.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandAttemptingToBuildPackage_ptb" xml:space="preserve">
     <value>Tentando construir o pacote de '{0}'.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandAttemptingToBuildPackage_rus" xml:space="preserve">
     <value>Попытка выполнить сборку пакета из "{0}".</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandAttemptingToBuildPackage_trk" xml:space="preserve">
     <value>Paket '{0}' konumundan oluşturulmaya çalışılıyor. </value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandAttemptingToBuildPackage_chs" xml:space="preserve">
     <value>正在尝试从“{0}”生成程序包。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandAttemptingToBuildPackage_cht" xml:space="preserve">
     <value>正在嘗試從 '{0}' 建置封裝。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DefaultCommandDescription_csy" xml:space="preserve">
     <value>Pro tento příkaz nebyl zadán žádný popis.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DefaultCommandDescription_deu" xml:space="preserve">
     <value>Für diesen Befehl wurde keine Beschreibung bereitgestellt.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DefaultCommandDescription_esp" xml:space="preserve">
     <value>No se ha proporcionado ninguna descripción para este comando.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DefaultCommandDescription_fra" xml:space="preserve">
     <value>Aucune description n'a été fournie pour cette commande.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DefaultCommandDescription_ita" xml:space="preserve">
     <value>Non è stata fornita alcuna descrizione per questo comando.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DefaultCommandDescription_jpn" xml:space="preserve">
     <value>このコマンドに説明は指定されていません。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DefaultCommandDescription_kor" xml:space="preserve">
     <value>이 명령에 대한 설명이 제공되지 않았습니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DefaultCommandDescription_plk" xml:space="preserve">
     <value>Nie podano opisu dla tego polecenia.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DefaultCommandDescription_ptb" xml:space="preserve">
     <value>Nenhuma descrição foi fornecida para este comando.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DefaultCommandDescription_rus" xml:space="preserve">
     <value>Описание для этой команды отсутствует.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DefaultCommandDescription_trk" xml:space="preserve">
     <value>Bu komut için açıklama belirtilmedi.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DefaultCommandDescription_chs" xml:space="preserve">
     <value>未提供此命令的说明。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DefaultCommandDescription_cht" xml:space="preserve">
     <value>並未提供此命令的描述。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConsoleConfirmMessage_csy" xml:space="preserve">
     <value>{0} (A/N): </value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConsoleConfirmMessage_deu" xml:space="preserve">
     <value>{0} (j/N) </value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConsoleConfirmMessage_esp" xml:space="preserve">
     <value>{0} (Sí/No) </value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConsoleConfirmMessage_fra" xml:space="preserve">
     <value>{0} (o/N) </value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConsoleConfirmMessage_ita" xml:space="preserve">
     <value>{0} (y/N) </value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConsoleConfirmMessage_jpn" xml:space="preserve">
     <value>{0} (y/N) </value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConsoleConfirmMessage_kor" xml:space="preserve">
     <value>{0}(y/N) </value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConsoleConfirmMessage_plk" xml:space="preserve">
     <value>{0} (t/N) </value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConsoleConfirmMessage_ptb" xml:space="preserve">
     <value>{0} (y / N)</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConsoleConfirmMessage_rus" xml:space="preserve">
     <value>{0} (д/н) </value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConsoleConfirmMessage_trk" xml:space="preserve">
     <value>{0} (e/H) </value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConsoleConfirmMessage_chs" xml:space="preserve">
     <value>{0} (y/N) </value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConsoleConfirmMessage_cht" xml:space="preserve">
     <value>{0} (是/否) </value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConsoleConfirmMessageAccept_csy" xml:space="preserve">
     <value>A</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConsoleConfirmMessageAccept_deu" xml:space="preserve">
     <value>j</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConsoleConfirmMessageAccept_esp" xml:space="preserve">
     <value>sí</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConsoleConfirmMessageAccept_fra" xml:space="preserve">
     <value>o</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConsoleConfirmMessageAccept_ita" xml:space="preserve">
     <value>y</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConsoleConfirmMessageAccept_jpn" xml:space="preserve">
     <value>y</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConsoleConfirmMessageAccept_kor" xml:space="preserve">
     <value>y</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConsoleConfirmMessageAccept_plk" xml:space="preserve">
     <value>t</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConsoleConfirmMessageAccept_ptb" xml:space="preserve">
     <value>y</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConsoleConfirmMessageAccept_rus" xml:space="preserve">
     <value>д</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConsoleConfirmMessageAccept_trk" xml:space="preserve">
     <value>e</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConsoleConfirmMessageAccept_chs" xml:space="preserve">
     <value>y</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConsoleConfirmMessageAccept_cht" xml:space="preserve">
     <value>是</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandCanceled_csy" xml:space="preserve">
     <value>Odstranit zrušené</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandCanceled_deu" xml:space="preserve">
     <value>Der Löschvorgang wurde abgebrochen.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandCanceled_esp" xml:space="preserve">
     <value>Eliminación cancelada</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandCanceled_fra" xml:space="preserve">
     <value>Suppression annulée</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandCanceled_ita" xml:space="preserve">
     <value>cancellazione teminata</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandCanceled_jpn" xml:space="preserve">
     <value>削除は取り消されました</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandCanceled_kor" xml:space="preserve">
     <value>삭제가 취소됨</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandCanceled_plk" xml:space="preserve">
     <value>Usuwanie anulowane</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandCanceled_ptb" xml:space="preserve">
     <value>Excluir cancelado</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandCanceled_rus" xml:space="preserve">
     <value>Удаление отменено</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandCanceled_trk" xml:space="preserve">
     <value>Silme iptal edildi</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandCanceled_chs" xml:space="preserve">
     <value>已取消删除</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandCanceled_cht" xml:space="preserve">
     <value>已取消刪除</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandConfirm_csy" xml:space="preserve">
     <value>{0} {1} bude odstraněno z {2}. Chcete pokračovat?</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandConfirm_deu" xml:space="preserve">
     <value>{0} {1} wird aus "{2}" gelöscht. Möchten Sie den Vorgang fortsetzen?</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandConfirm_esp" xml:space="preserve">
     <value>{0} {1} se eliminará de {2}. ¿Desea continuar?</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandConfirm_fra" xml:space="preserve">
     <value>{0} {1} sera supprimé de {2}. Souhaitez-vous continuer ?</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandConfirm_ita" xml:space="preserve">
     <value>{0} {1} sarà cancellato da {2}. Vuoi continuare?</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandConfirm_jpn" xml:space="preserve">
     <value>{0} {1} は {2} から削除されます。続行しますか?</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandConfirm_kor" xml:space="preserve">
     <value>{0} {1}이(가) {2}에서 삭제됩니다. 계속하시겠습니까?</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandConfirm_plk" xml:space="preserve">
     <value>Element {0} {1} zostanie usunięty z {2}. Czy chcesz kontynuować?</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandConfirm_ptb" xml:space="preserve">
     <value>{0} {1} será excluído do {2}. Deseja continuar?</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandConfirm_rus" xml:space="preserve">
     <value>Будет выполнено удаление {0} {1} из {2}. Продолжить?</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandConfirm_trk" xml:space="preserve">
     <value>{0} {1} öğeleri {2} konumundan silinecek. Devam etmek istiyor musunuz?</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandConfirm_chs" xml:space="preserve">
     <value>将从 {2} 中删除 {0} {1}。是否要继续?</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandConfirm_cht" xml:space="preserve">
     <value>{0} {1} 會從 {2} 刪除。您要繼續嗎?</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="AmbiguousCommand_csy" xml:space="preserve">
     <value>Nejednoznačný příkaz {0}. Možné hodnoty: {1}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="AmbiguousCommand_deu" xml:space="preserve">
     <value>Mehrdeutiger Befehl "{0}". Mögliche Werte: {1}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="AmbiguousCommand_esp" xml:space="preserve">
     <value>Comando ambiguo '{0}'. Valores posibles: {1}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="AmbiguousCommand_fra" xml:space="preserve">
     <value>Commande ambiguë '{0}'. Valeurs possibles : {1}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="AmbiguousCommand_ita" xml:space="preserve">
     <value>Comando ambiguo '{0}'. Possibili valori: {1}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="AmbiguousCommand_jpn" xml:space="preserve">
     <value>あいまいなコマンド '{0}'。指定可能な値: {1}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="AmbiguousCommand_kor" xml:space="preserve">
     <value>모호한 '{0}' 명령입니다. 사용 가능한 값: {1}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="AmbiguousCommand_plk" xml:space="preserve">
     <value>Niejednoznaczne polecenie „{0}”. Możliwe wartości: {1}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="AmbiguousCommand_ptb" xml:space="preserve">
     <value>Comando ambíguo '{0}'. Valores possíveis: {1}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="AmbiguousCommand_rus" xml:space="preserve">
     <value>Неоднозначная команда "{0}". Возможные значения: {1}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="AmbiguousCommand_trk" xml:space="preserve">
     <value>Belirsiz komut '{0}'. Olası değerler: {1}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="AmbiguousCommand_chs" xml:space="preserve">
     <value>命令“{0}”不明确。可能的值: {1}。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="AmbiguousCommand_cht" xml:space="preserve">
     <value>模糊的命令 '{0}'。可能值為: {1}。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="AmbiguousOption_csy" xml:space="preserve">
     <value>Nejednoznačná možnost {0}. Možné hodnoty: {1}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="AmbiguousOption_deu" xml:space="preserve">
     <value>Mehrdeutige Option "{0}". Mögliche Werte: {1}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="AmbiguousOption_esp" xml:space="preserve">
     <value>Opción ambigua '{0}'. Valores posibles: {1}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="AmbiguousOption_fra" xml:space="preserve">
     <value>Option ambiguë '{0}'. Valeurs possibles : {1}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="AmbiguousOption_ita" xml:space="preserve">
     <value>Opzione ambigua '{0}'. Possibili valori: {1}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="AmbiguousOption_jpn" xml:space="preserve">
     <value>あいまいなオプション '{0}'。指定可能な値: {1}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="AmbiguousOption_kor" xml:space="preserve">
     <value>모호한 '{0}' 옵션입니다. 사용 가능한 값: {1}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="AmbiguousOption_plk" xml:space="preserve">
     <value>Niejednoznaczna opcja „{0}”. Możliwe wartości: {1}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="AmbiguousOption_ptb" xml:space="preserve">
     <value>Opção ambígua '{0}'. Valores possíveis: {1}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="AmbiguousOption_rus" xml:space="preserve">
     <value>Неоднозначный параметр "{0}". Возможные значения: {1}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="AmbiguousOption_trk" xml:space="preserve">
     <value>Belirsiz seçenek '{0}'. Olası değerler: {1}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="AmbiguousOption_chs" xml:space="preserve">
     <value>选项“{0}”不明确。可能的值: {1}。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="AmbiguousOption_cht" xml:space="preserve">
     <value>模糊的選項 '{0}'。可能值為: {1}。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandNothingToInstall_csy" xml:space="preserve">
     <value>Všechny balíčky, které uvádí {0}, jsou již nainstalované.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandNothingToInstall_deu" xml:space="preserve">
     <value>Alle in "{0}" aufgeführten Pakete sind bereits installiert.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandNothingToInstall_esp" xml:space="preserve">
     <value>Ya se han instalado todos los paquetes mostrados en '{0}'.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandNothingToInstall_fra" xml:space="preserve">
     <value>Tous les packages répertoriés dans {0} sont déjà installés.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandNothingToInstall_ita" xml:space="preserve">
     <value>Tutti i pacchetti elencati in {0}sono già installati.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandNothingToInstall_jpn" xml:space="preserve">
     <value>{0} に含まれるすべてのパッケージは、既にインストールされています。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandNothingToInstall_kor" xml:space="preserve">
     <value>{0}에 나열된 모든 패키지가 이미 설치되었습니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandNothingToInstall_plk" xml:space="preserve">
     <value>Wszystkie pakiety wymienione w {0} zostały już zainstalowane.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandNothingToInstall_ptb" xml:space="preserve">
     <value>Todos os pacotes listados em {0} já estão instalados.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandNothingToInstall_rus" xml:space="preserve">
     <value>Все пакеты, перечисленные в {0}, уже установлены.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandNothingToInstall_trk" xml:space="preserve">
     <value>{0} içinde sıralanan tüm paketler zaten yüklü.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandNothingToInstall_chs" xml:space="preserve">
     <value>{0} 中列出的所有程序包均已安装。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandNothingToInstall_cht" xml:space="preserve">
     <value>{0} 中列出的所有封裝均已安裝。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="NoApiKeyFound_csy" xml:space="preserve">
     <value>Nebyl zadán žádný klíč API a nebyl nalezen žádný klíč API Key pro {0}. Chcete-li uložit klíč API pro určitý zdroj, použijte příkaz setApiKey.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="NoApiKeyFound_deu" xml:space="preserve">
     <value>Es wurde kein API-Schlüssel bereitgestellt bzw. für "{0}" gefunden. Verwenden Sie zum Speichern eines API-Schlüssels für eine Quelle den Befehl "setApiKey".</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="NoApiKeyFound_esp" xml:space="preserve">
     <value>No se ha proporcionado ninguna clave API ni tampoco se ha podido encontrar una para {0}. Para guardar una clave API para un origen use el comando 'setApiKey'.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="NoApiKeyFound_fra" xml:space="preserve">
     <value>Aucune clé API n'a été fournie et aucune clé API n'a été trouvée pour {0}. Utilisez la commande 'setApiKey' pour enregistrer une clé API pour une source.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="NoApiKeyFound_ita" xml:space="preserve">
     <value>Non è stato fornito alcun API Key  e non è stato possibile trovare API Key per {0}. Per salvare un API Key per una fonte usare il comando 'setApiKey'.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="NoApiKeyFound_jpn" xml:space="preserve">
     <value>API キーが指定されておらず、{0} の API キーが見つかりませんでした。ソースの API キーを保存するには、'setApiKey' コマンドを使用してください。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="NoApiKeyFound_kor" xml:space="preserve">
     <value>API 키가 제공되지 않았으므로 {0}에서 API 키를 찾을 수 없습니다. 소스에 대한 API 키를 저장하려면 'setApiKey' 명령을 사용하십시오.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="NoApiKeyFound_plk" xml:space="preserve">
     <value>Nie podano klucza interfejsu API i nie można znaleźć klucza interfejsu API dla {0}. Aby zapisać klucz interfejsu API dla źródła, użyj polecenia „setApiKey”.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="NoApiKeyFound_ptb" xml:space="preserve">
     <value>Nenhuma chave de API foi fornecida e nenhuma chave de API foi encontrada para {0}. Para salvar uma chave de API para uma origem, use o comando "setApiKey.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="NoApiKeyFound_rus" xml:space="preserve">
     <value>Ключ API не указан, также не удалось найти ключ API для {0}. Чтобы сохранить ключ API для источника, используйте команду "setApiKey".</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="NoApiKeyFound_trk" xml:space="preserve">
     <value>API Anahtarı belirtilmemiş ve {0} için hiçbir API Anahtarı bulunamadı. Bir kaynak için API Anahtarını kaydetmek için 'setApiKey' komutunu kullanın.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="NoApiKeyFound_chs" xml:space="preserve">
     <value>未提供 API 密钥并且找不到 {0} 的 API 密钥。若要保存源的 API 密钥，请使用 "setApiKey" 命令。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="NoApiKeyFound_cht" xml:space="preserve">
     <value>未提供 API 索引鍵，也找不到 {0} 的 API 索引鍵。如要儲存來源的 API 索引鍵，請使用 'setApiKey' 命令。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandApiKeySaved_csy" xml:space="preserve">
     <value>Klíč API {0} byl uložen pro {1}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandApiKeySaved_deu" xml:space="preserve">
     <value>Der API-Schlüssel "{0}" wurde für "{1}" gespeichert.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandApiKeySaved_esp" xml:space="preserve">
     <value>La clave API '{0}' se ha guardado para {1}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandApiKeySaved_fra" xml:space="preserve">
     <value>La clé API '{0}' a été enregistrée pour {1}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandApiKeySaved_ita" xml:space="preserve">
     <value>API Key '{0}' salvato per {1}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandApiKeySaved_jpn" xml:space="preserve">
     <value>{1} の API キー '{0}' が保存されました。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandApiKeySaved_kor" xml:space="preserve">
     <value>API 키 '{0}'이(가) {1}에 저장되었습니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandApiKeySaved_plk" xml:space="preserve">
     <value>Klucz interfejsu API „{0}” został zapisany dla {1}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandApiKeySaved_ptb" xml:space="preserve">
     <value>A chave de API '{0}' foi salva para {1}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandApiKeySaved_rus" xml:space="preserve">
     <value>Был сохранен ключ API "{0}" для {1}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandApiKeySaved_trk" xml:space="preserve">
     <value>{1} için '{0}' API Anahtarı kaydedildi.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandApiKeySaved_chs" xml:space="preserve">
     <value>已保存 {1} 的 API 密钥“{0}”。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandApiKeySaved_cht" xml:space="preserve">
     <value>已為 {1} 儲存 API 索引鍵 '{0}'。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="BuildingProjectTargetingFramework_csy" xml:space="preserve">
     <value>Vytváří se projekt {0} pro cílovou architekturu {1}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="BuildingProjectTargetingFramework_deu" xml:space="preserve">
     <value>Projekt "{0}" wird für das Zielframework "{1}" erstellt.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="BuildingProjectTargetingFramework_esp" xml:space="preserve">
     <value>Compilando proyecto '{0}' para el marco de trabajo de destino '{1}'.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="BuildingProjectTargetingFramework_fra" xml:space="preserve">
     <value>Création du projet '{0}' pour le Framework cible '{1}'.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="BuildingProjectTargetingFramework_ita" xml:space="preserve">
     <value>Creazione progetto '{0}' per quadro target '{1}'.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="BuildingProjectTargetingFramework_jpn" xml:space="preserve">
     <value>ターゲット フレームワーク '{1}' のプロジェクト '{0}' をビルドしています</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="BuildingProjectTargetingFramework_kor" xml:space="preserve">
     <value>대상 프레임워크 '{1}'에 대한 '{0}' 프로젝트를 빌드하고 있습니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="BuildingProjectTargetingFramework_plk" xml:space="preserve">
     <value>Kompilowanie projektu „{0}” dla struktury docelowej „{1}”.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="BuildingProjectTargetingFramework_ptb" xml:space="preserve">
     <value>Criar projeto '{0}' para a estrutura de destino '{1}'.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="BuildingProjectTargetingFramework_rus" xml:space="preserve">
     <value>Выполнение сборки проекта "{0}" для целевой платформы "{1}".</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="BuildingProjectTargetingFramework_trk" xml:space="preserve">
     <value>{1}' hedef framework'ü için '{0}' projesi oluşturuluyor.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="BuildingProjectTargetingFramework_chs" xml:space="preserve">
     <value>正在为目标框架“{1}”生成项目“{0}”。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="BuildingProjectTargetingFramework_cht" xml:space="preserve">
     <value>正在為目標架構 '{1}' 建置專案 '{0}'。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="FailedToBuildProject_csy" xml:space="preserve">
     <value>Sestavení {0} se nezdařilo.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="FailedToBuildProject_deu" xml:space="preserve">
     <value>Fehler beim Erstellen von "{0}".</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="FailedToBuildProject_esp" xml:space="preserve">
     <value>Error al compilar '{0}'.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="FailedToBuildProject_fra" xml:space="preserve">
     <value>Échec de la création de '{0}'.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="FailedToBuildProject_ita" xml:space="preserve">
     <value>Impossibile sviluppare '{0}'.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="FailedToBuildProject_jpn" xml:space="preserve">
     <value>'{0}' をビルドできませんでした。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="FailedToBuildProject_kor" xml:space="preserve">
     <value>'{0}'을(를) 빌드하지 못했습니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="FailedToBuildProject_plk" xml:space="preserve">
     <value>Nie można skompilować „{0}”.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="FailedToBuildProject_ptb" xml:space="preserve">
     <value>Falha ao construir '{0}'.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="FailedToBuildProject_rus" xml:space="preserve">
     <value>Ошибка при сборке "{0}".</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="FailedToBuildProject_trk" xml:space="preserve">
     <value>{0}' oluşturulamadı.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="FailedToBuildProject_chs" xml:space="preserve">
     <value>无法生成“{0}”。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="FailedToBuildProject_cht" xml:space="preserve">
     <value>無法建置 '{0}'。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackagingFilesFromOutputPath_csy" xml:space="preserve">
     <value>Probíhá balení souborů z {0}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackagingFilesFromOutputPath_deu" xml:space="preserve">
     <value>Paketerstellung der Dateien aus "{0}".</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackagingFilesFromOutputPath_esp" xml:space="preserve">
     <value>Empaquetando archivos de proyecto de '{0}'.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackagingFilesFromOutputPath_fra" xml:space="preserve">
     <value>Compression des fichiers depuis '{0}'.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackagingFilesFromOutputPath_ita" xml:space="preserve">
     <value>Impacchettando file da '{0}'.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackagingFilesFromOutputPath_jpn" xml:space="preserve">
     <value>'{0}' のファイルをパックしています。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackagingFilesFromOutputPath_kor" xml:space="preserve">
     <value>'{0}'에서 파일을 압축하고 있습니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackagingFilesFromOutputPath_plk" xml:space="preserve">
     <value>Pakowanie plików z „{0}”.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackagingFilesFromOutputPath_ptb" xml:space="preserve">
     <value>Embalar arquivos de '{0}'.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackagingFilesFromOutputPath_rus" xml:space="preserve">
     <value>Упаковка файлов из {0}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackagingFilesFromOutputPath_trk" xml:space="preserve">
     <value>{0}' dosyaları paketleniyor.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackagingFilesFromOutputPath_chs" xml:space="preserve">
     <value>正在打包“{0}”中的文件。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackagingFilesFromOutputPath_cht" xml:space="preserve">
     <value>正在封裝 '{0}' 中的檔案。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToExtractAssemblyMetadata_csy" xml:space="preserve">
     <value>Nelze extrahovat metadata z {0}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToExtractAssemblyMetadata_deu" xml:space="preserve">
     <value>Aus "{0}" können keine Metadaten extrahiert werden.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToExtractAssemblyMetadata_esp" xml:space="preserve">
     <value>No se pueden extraer metadatos desde '{0}'.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToExtractAssemblyMetadata_fra" xml:space="preserve">
     <value>Impossible d'extraire les métadonnées de '{0}'.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToExtractAssemblyMetadata_ita" xml:space="preserve">
     <value>Impossibile estrarre metadati da '{0}'.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToExtractAssemblyMetadata_jpn" xml:space="preserve">
     <value>'{0}' からメタデータを抽出できません。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToExtractAssemblyMetadata_kor" xml:space="preserve">
     <value>'{0}'에서 메타데이터를 추출할 수 없습니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToExtractAssemblyMetadata_plk" xml:space="preserve">
     <value>Nie można wyodrębnić metadanych z „{0}”.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToExtractAssemblyMetadata_ptb" xml:space="preserve">
     <value>Não foi possível extrair os metadados de '{0}'.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToExtractAssemblyMetadata_rus" xml:space="preserve">
     <value>Не удалось извлечь метаданные из "{0}".</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToExtractAssemblyMetadata_trk" xml:space="preserve">
     <value>Meta veriler '{0}' konumundan ayıklanamıyor.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToExtractAssemblyMetadata_chs" xml:space="preserve">
     <value>无法从“{0}”中提取元数据。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToExtractAssemblyMetadata_cht" xml:space="preserve">
     <value>無法從 '{0}' 擷取中繼資料。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UsingPackagesConfigForDependencies_csy" xml:space="preserve">
     <value>Byl nalezen soubor packages.config. Používají se balíčky uvedené jako závislosti.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UsingPackagesConfigForDependencies_deu" xml:space="preserve">
     <value>"packages.config" wurde gefunden. Die aufgelisteten Pakete werden als Abhängigkeiten verwendet.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UsingPackagesConfigForDependencies_esp" xml:space="preserve">
     <value>Se ha encontrado packages.config. Usando paquetes mostrados como dependencias</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UsingPackagesConfigForDependencies_fra" xml:space="preserve">
     <value>Packages.config trouvé. Utilisation de packages répertoriés comme dépendances</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UsingPackagesConfigForDependencies_ita" xml:space="preserve">
     <value>Trovato packages.config. Usando pacchetti elencati come dipendenze.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UsingPackagesConfigForDependencies_jpn" xml:space="preserve">
     <value>packages.config が見つかりました。依存関係として登録されているパッケージを使用します</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UsingPackagesConfigForDependencies_kor" xml:space="preserve">
     <value>packages.config를 찾았습니다. 나열된 패키지를 종속성으로 사용하고 있습니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UsingPackagesConfigForDependencies_plk" xml:space="preserve">
     <value>Znaleziono plik packages.config. Wymienione pakiety zostaną użyte jako zależności</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UsingPackagesConfigForDependencies_ptb" xml:space="preserve">
     <value>Encontrado packages.config. Usando pacotes listados como dependências</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UsingPackagesConfigForDependencies_rus" xml:space="preserve">
     <value>Найден файл packages.config. Перечисленные пакеты будут использованы как зависимости</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UsingPackagesConfigForDependencies_trk" xml:space="preserve">
     <value>Packages.config bulundu. Paketler bağımlılıklarda listelenen şekilde kullanılıyor</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UsingPackagesConfigForDependencies_chs" xml:space="preserve">
     <value>找到 packages.config。正在使用列出的程序包作为依赖关系</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UsingPackagesConfigForDependencies_cht" xml:space="preserve">
     <value>找到 packages.config。使用列出的封裝做為相依性。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_FileDoesNotExist_csy" xml:space="preserve">
     <value>Soubor {0} byl zahrnut v projektu, ale neexistuje. Dojde k přeskočení...</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_FileDoesNotExist_deu" xml:space="preserve">
     <value>"{0}" war im Projekt enthalten, ist jedoch nicht vorhanden. Das Element wird übersprungen...</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_FileDoesNotExist_esp" xml:space="preserve">
     <value>{0}' se ha incluido en el proyecto pero no existe. Omitiendo…</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_FileDoesNotExist_fra" xml:space="preserve">
     <value>'{0}' a été inclus au projet, mais n'existe pas. Ignorer…</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_FileDoesNotExist_ita" xml:space="preserve">
     <value>{0}' è incluso nel progetto ma non esiste. Saltare…</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_FileDoesNotExist_jpn" xml:space="preserve">
     <value>'{0}' がプロジェクトに含まれていますが、存在しません。スキップしています... Skipping...</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_FileDoesNotExist_kor" xml:space="preserve">
     <value>'{0}'이(가) 프로젝트에 포함되어 있지만 존재하지 않습니다. 건너뛰는 중...</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_FileDoesNotExist_plk" xml:space="preserve">
     <value>Plik „{0}” został uwzględniony w projekcie, ale nie istnieje. Trwa pomijanie...</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_FileDoesNotExist_ptb" xml:space="preserve">
     <value>{0}' foi incluído no projeto, mas não existe. Ignorando...</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_FileDoesNotExist_rus" xml:space="preserve">
     <value>"{0}" был добавлен в проект, но не существует. Пропуск...</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_FileDoesNotExist_trk" xml:space="preserve">
     <value>{0}' projeye dahil edildi ancak mevcut değil. Atlanıyor...</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_FileDoesNotExist_chs" xml:space="preserve">
     <value>“{0}”已包含在项目中，但不存在。正在跳过...</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_FileDoesNotExist_cht" xml:space="preserve">
     <value>{0}' 包含在專案中但並不存在。正在略過...</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_UnspecifiedField_csy" xml:space="preserve">
     <value>Hodnota {0} nebyla zadána. Použije se {1}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_UnspecifiedField_deu" xml:space="preserve">
     <value>"{0}" wurde nicht angegeben. "{1}" wird verwendet.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_UnspecifiedField_esp" xml:space="preserve">
     <value>{0} no se ha especificado. Se está usando '{1}'.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_UnspecifiedField_fra" xml:space="preserve">
     <value>{0} n'a pas été spécifié. Utilisation de '{1}'.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_UnspecifiedField_ita" xml:space="preserve">
     <value>{0} non specificato. Usare '{1}'.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_UnspecifiedField_jpn" xml:space="preserve">
     <value>{0} が指定されませんでした。'{1}' を使用しています。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_UnspecifiedField_kor" xml:space="preserve">
     <value>{0}이(가) 지정되지 않았습니다. '{1}'을(를) 사용하고 있습니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_UnspecifiedField_plk" xml:space="preserve">
     <value>Nie określono {0}. Zostanie użyta wartość „{1}”.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_UnspecifiedField_ptb" xml:space="preserve">
     <value>{0} não foi especificado. Usando '{1}'.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_UnspecifiedField_rus" xml:space="preserve">
     <value>{0} не указан. Будет использован "{1}".</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_UnspecifiedField_trk" xml:space="preserve">
     <value>{0} belirtilmemiş. '{1}' kullanılıyor.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_UnspecifiedField_chs" xml:space="preserve">
     <value>未指定 {0}。正在使用“{1}”。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_UnspecifiedField_cht" xml:space="preserve">
     <value>並未指定 {0}。使用 '{1}'。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DefaultSymbolServer_csy" xml:space="preserve">
     <value>server symbolů</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DefaultSymbolServer_deu" xml:space="preserve">
     <value>Symbolserver</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DefaultSymbolServer_esp" xml:space="preserve">
     <value>servidor de símbolos</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DefaultSymbolServer_fra" xml:space="preserve">
     <value>serveur de symboles</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DefaultSymbolServer_ita" xml:space="preserve">
     <value>il symbol server</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DefaultSymbolServer_jpn" xml:space="preserve">
     <value>シンボル サーバー</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DefaultSymbolServer_kor" xml:space="preserve">
     <value>기호 서버</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DefaultSymbolServer_plk" xml:space="preserve">
     <value>serwer symboli</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DefaultSymbolServer_ptb" xml:space="preserve">
     <value>o servidor de símbolos</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DefaultSymbolServer_rus" xml:space="preserve">
     <value>сервер символов</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DefaultSymbolServer_trk" xml:space="preserve">
     <value>simge sunucusu</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DefaultSymbolServer_chs" xml:space="preserve">
     <value>符号服务器</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DefaultSymbolServer_cht" xml:space="preserve">
     <value>符號伺服器</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="LiveFeed_csy" xml:space="preserve">
     <value>galerie NuGet</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="LiveFeed_deu" xml:space="preserve">
     <value>NuGet-Katalog</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="LiveFeed_esp" xml:space="preserve">
     <value>la galería NuGet</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="LiveFeed_fra" xml:space="preserve">
     <value>galerie NuGet</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="LiveFeed_ita" xml:space="preserve">
     <value>La galleria NuGet</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="LiveFeed_jpn" xml:space="preserve">
     <value>NuGet ギャラリー</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="LiveFeed_kor" xml:space="preserve">
     <value>NuGet 갤러리</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="LiveFeed_plk" xml:space="preserve">
     <value>galeria NuGet</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="LiveFeed_ptb" xml:space="preserve">
     <value>a galeria de NuGet</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="LiveFeed_rus" xml:space="preserve">
     <value>коллекция NuGet</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="LiveFeed_trk" xml:space="preserve">
     <value>NuGet galerisi</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="LiveFeed_chs" xml:space="preserve">
     <value>NuGet 库</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="LiveFeed_cht" xml:space="preserve">
     <value>NuGet 陳列庫</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandAttemptingToBuildSymbolsPackage_csy" xml:space="preserve">
     <value>Probíhá pokus o sestavení balíčku symbolů pro {0}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandAttemptingToBuildSymbolsPackage_deu" xml:space="preserve">
     <value>Es wird versucht, das Symbolpaket für "{0}" zu erstellen.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandAttemptingToBuildSymbolsPackage_esp" xml:space="preserve">
     <value>Intentando compilar el paquete de símbolos para '{0}'. </value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandAttemptingToBuildSymbolsPackage_fra" xml:space="preserve">
     <value>Tentative de création du package de symboles pour '{0}'.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandAttemptingToBuildSymbolsPackage_ita" xml:space="preserve">
     <value>Componendo pacchetti simboli '{0}'.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandAttemptingToBuildSymbolsPackage_jpn" xml:space="preserve">
     <value>'{0}' のシンボル パッケージをビルドしています。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandAttemptingToBuildSymbolsPackage_kor" xml:space="preserve">
     <value>'{0}'에 대한 기호 패키지를 빌드하고 있습니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandAttemptingToBuildSymbolsPackage_plk" xml:space="preserve">
     <value>Próba skompilowania pakietu symboli dla „{0}”.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandAttemptingToBuildSymbolsPackage_ptb" xml:space="preserve">
     <value>Tentando construir o pacote de símbolos para '{0}'.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandAttemptingToBuildSymbolsPackage_rus" xml:space="preserve">
     <value>Попытка выполнить сборку пакета символов для "{0}".</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandAttemptingToBuildSymbolsPackage_trk" xml:space="preserve">
     <value>{0}' için simge paketi oluşturulmaya çalışılıyor.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandAttemptingToBuildSymbolsPackage_chs" xml:space="preserve">
     <value>正在尝试为“{0}”生成符号程序包。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandAttemptingToBuildSymbolsPackage_cht" xml:space="preserve">
     <value>正在嘗試為 '{0}' 建置符號封裝。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_SymbolServerNotConfigured_csy" xml:space="preserve">
     <value>Byl nalezen balíček symbolů {0}, ale pro server symbolů nebyl zadán žádný klíč API. Chcete-li uložit klíč API, spusťte příkaz NuGet.exe setApiKey [klíč API z webu http://www.NuGet.org].</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_SymbolServerNotConfigured_deu" xml:space="preserve">
     <value>Das Symbolpaket "{0}" wurde gefunden, es wurde jedoch kein API-Schlüssel für den Symbolserver angegeben. Führen Sie zum Speichern eines API-Schlüssels "NuGet.exe setApiKey [Ihr API-Schlüssel von http://www.NuGet.org]" aus.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_SymbolServerNotConfigured_esp" xml:space="preserve">
     <value>Se ha encontrado el paquete de símbolos '{0}', pero no se ha especificado ninguna clave API para el servidor de símbolos. Para guardar una clave API, ejecute 'NuGet.exe setApiKey [su clave API de http://www.NuGet.org]'.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_SymbolServerNotConfigured_fra" xml:space="preserve">
     <value>Package de symboles '{0}' trouvé, mais aucune clé API n'a été spécifiée pour le serveur de symboles. Pour enregistrer une clé API, exécutez 'NuGet.exe setApiKey [votre clé API provenant de http://www.NuGet.org]'.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_SymbolServerNotConfigured_ita" xml:space="preserve">
     <value>Trovato pacchetto simboli '{0}', ma non è stata specificata alcuna API key per il symbol server. Per salvare una API Key, eseguire 'NuGet.exe setApiKey [ API key da http://www.NuGet.org]'.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_SymbolServerNotConfigured_jpn" xml:space="preserve">
     <value>シンボル パッケージ '{0}' が見つかりましたが、シンボル サーバーの API キーが指定されていません。API キーを保存するには、'NuGet.exe setApiKey [your API key from http://www.NuGet.org]' を実行してください。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_SymbolServerNotConfigured_kor" xml:space="preserve">
     <value>기호 패키지 '{0}'을(를) 찾았지만 기호 서버에 대한 API 키가 지정되지 않았습니다. API 키를 저장하려면 'NuGet.exe setApiKey [http://www.NuGet.org의 API 키]'를 실행하십시오.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_SymbolServerNotConfigured_plk" xml:space="preserve">
     <value>Odnaleziono pakiet symboli „{0}”, ale dla serwera symboli nie został określony klucz interfejsu API. Aby zapisać klucz interfejsu API, uruchom polecenie „NuGet.exe setApiKey [Twój klucz interfejsu API ze strony http://www.NuGet.org]”.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_SymbolServerNotConfigured_ptb" xml:space="preserve">
     <value>O pacote símbolos '{0}' foi localizado, mas nenhuma chave de API foi especificada para o servidor de símbolos. Para salvar uma chave de API,  execute "NuGet.exe setApiKey [sua chave de API de http://www.NuGet.org]".</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_SymbolServerNotConfigured_rus" xml:space="preserve">
     <value>Обнаружен пакет символов "{0}", но для сервера символов не был указан ключ API. Чтобы сохранить ключ API, выполните команду "NuGet.exe setApiKey [ваш ключ API с сайта http://www.NuGet.org]".</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_SymbolServerNotConfigured_trk" xml:space="preserve">
     <value>{0}' simge paketi bulundu ancak simge sunucusu için hiçbir API anahtarı belirtilmemiş. Bir API Anahtarını kaydetmek için 'NuGet.exe setApiKey [http://www.NuGet.org sayfasından aldığınız API anahtarı]' öğesini çalıştırın.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_SymbolServerNotConfigured_chs" xml:space="preserve">
     <value>找到符号程序包“{0}”，但未为符号服务器指定 API 密钥。若要保存 API 密钥，请运行“NuGet.exe setApiKey [来自 http://www.NuGet.org 的 API 密钥]”。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_SymbolServerNotConfigured_cht" xml:space="preserve">
     <value>找到符號封裝 '{0}'，但並未為符號伺服器指定 API 索引鍵。若要儲存 API 索引鍵，請執行 'NuGet.exe setApiKey [http://www.NuGet.org 中的 API 索引鍵]'。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UsingNuspecForMetadata_csy" xml:space="preserve">
     <value>{0} se používá pro metadata.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UsingNuspecForMetadata_deu" xml:space="preserve">
     <value>"{0}" wird für Metadaten verwendet.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UsingNuspecForMetadata_esp" xml:space="preserve">
     <value>Usando '{0}' para metadatos.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UsingNuspecForMetadata_fra" xml:space="preserve">
     <value>Utilisation de '{0}' pour les métadonnées.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UsingNuspecForMetadata_ita" xml:space="preserve">
     <value>Usando '{0}' per metadati.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UsingNuspecForMetadata_jpn" xml:space="preserve">
     <value>メタデータに '{0}' を使用しています。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UsingNuspecForMetadata_kor" xml:space="preserve">
     <value>메타데이터에 대한 '{0}'을(를) 사용하고 있습니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UsingNuspecForMetadata_plk" xml:space="preserve">
     <value>Używanie „{0}” na potrzeby metadanych.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UsingNuspecForMetadata_ptb" xml:space="preserve">
     <value>Usando '{0}' para metadados.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UsingNuspecForMetadata_rus" xml:space="preserve">
     <value>Использование "{0}" для метаданных.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UsingNuspecForMetadata_trk" xml:space="preserve">
     <value>Meta veriler için '{0}' kullanılıyor.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UsingNuspecForMetadata_chs" xml:space="preserve">
     <value>正在对元数据使用“{0}”。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UsingNuspecForMetadata_cht" xml:space="preserve">
     <value>正在使用中繼資料的 '{0}'。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InvalidSource_csy" xml:space="preserve">
     <value>Zadaný zdroj {0} je neplatný. Zadejte platný zdroj.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InvalidSource_deu" xml:space="preserve">
     <value>Die angegebene Quelle "{0}" ist ungültig. Bitte stellen Sie eine gültige Quelle zur Verfügung.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InvalidSource_esp" xml:space="preserve">
     <value>El origen especificado '{0}' no es válido. Proporcione un origen válido.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InvalidSource_fra" xml:space="preserve">
     <value>La source spécifiée '{0}' n'est pas valide. Veuillez fournir une source valide.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InvalidSource_ita" xml:space="preserve">
     <value>La fonte specificata '{0}' non è valida. Fornire una fonte valida.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InvalidSource_jpn" xml:space="preserve">
     <value>指定されたソース '{0}' は無効です。有効なソースを指定してください。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InvalidSource_kor" xml:space="preserve">
     <value>지정된 소스 '{0}'이(가) 잘못되었습니다. 올바른 소스를 제공하십시오.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InvalidSource_plk" xml:space="preserve">
     <value>Określone źródło „{0}” jest nieprawidłowe. Podaj prawidłowe źródło.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InvalidSource_ptb" xml:space="preserve">
     <value>A origem especificada '{0}' é inválida. Forneça uma origem válida.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InvalidSource_rus" xml:space="preserve">
     <value>Указанный источник "{0}" недопустим. Укажите допустимый источник.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InvalidSource_trk" xml:space="preserve">
     <value>Belirtilen '{0}' kaynağı geçersiz. Lütfen geçerli bir kaynak belirtin.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InvalidSource_chs" xml:space="preserve">
     <value>指定的源“{0}”无效。请提供有效源。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InvalidSource_cht" xml:space="preserve">
     <value>指定的來源 '{0}' 無效。請提供有效的來源。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandDefaultApiKeysSaved_csy" xml:space="preserve">
     <value>Klíč API {0} byl uložen pro {1} a {2}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandDefaultApiKeysSaved_deu" xml:space="preserve">
     <value>Der API-Schlüssel "{0}" wurde für "{1}" und "{2}" gespeichert.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandDefaultApiKeysSaved_esp" xml:space="preserve">
     <value>La clave API '{0}' se ha guardado para {1} y {2}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandDefaultApiKeysSaved_fra" xml:space="preserve">
     <value>La clé API '{0}' a été enregistrée pour {1} et {2}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandDefaultApiKeysSaved_ita" xml:space="preserve">
     <value>API Key '{0}'salvato per {1} e {2}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandDefaultApiKeysSaved_jpn" xml:space="preserve">
     <value>{1} と {2} の API キー '{0}' が保存されました。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandDefaultApiKeysSaved_kor" xml:space="preserve">
     <value>API 키 '{0}'이(가) {1} 및 {2}에 저장되었습니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandDefaultApiKeysSaved_plk" xml:space="preserve">
     <value>Klucz interfejsu API „{0}” został zapisany dla {1} i {2}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandDefaultApiKeysSaved_ptb" xml:space="preserve">
     <value>A chave de API '{0}' foi salva para {1} e {2}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandDefaultApiKeysSaved_rus" xml:space="preserve">
     <value>Был сохранен ключ API "{0}" для {1} и {2}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandDefaultApiKeysSaved_trk" xml:space="preserve">
     <value>{1} ve {2} için '{0}' API Anahtarı kaydedildi.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandDefaultApiKeysSaved_chs" xml:space="preserve">
     <value>已保存 {1} 和 {2} 的 API 密钥“{0}”。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SetApiKeyCommandDefaultApiKeysSaved_cht" xml:space="preserve">
     <value>已為 {1} 和 {2} 儲存 API 索引鍵 '{0}'。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToFindBuildOutput_csy" xml:space="preserve">
     <value>Nelze najít {0}. Ověřte, zda tento projekt byl sestaven.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToFindBuildOutput_deu" xml:space="preserve">
     <value>"{0}" wurde nicht gefunden. Stellen Sie sicher, dass das Projekt erstellt wurde.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToFindBuildOutput_esp" xml:space="preserve">
     <value>No se puede encontrar '{0}'. Asegúrese de que el proyecto se ha compilado.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToFindBuildOutput_fra" xml:space="preserve">
     <value>Impossible de trouver '{0}'. Assurez-vous que le projet a été créé.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToFindBuildOutput_ita" xml:space="preserve">
     <value>Impossibile trovare '{0}'. Assicurarsi che il progetto è stato creato.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToFindBuildOutput_jpn" xml:space="preserve">
     <value>'{0}' が見つかりません。プロジェクトが構築されたことを確認してください。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToFindBuildOutput_kor" xml:space="preserve">
     <value>'{0}'을(를) 찾을 수 없습니다. 프로젝트가 빌드되었는지 확인하십시오.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToFindBuildOutput_plk" xml:space="preserve">
     <value>Nie można znaleźć „{0}”. Upewnij się, że projekt został skompilowany.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToFindBuildOutput_ptb" xml:space="preserve">
     <value>Não é possível encontrar o '{0}'. Verifique se o projeto foi construído.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToFindBuildOutput_rus" xml:space="preserve">
     <value>Не удалось найти "{0}". Убедитесь, что была выполнена сборка проекта.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToFindBuildOutput_trk" xml:space="preserve">
     <value>{0}' bulunamıyor. Projenin oluşturulduğundan emin olun.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToFindBuildOutput_chs" xml:space="preserve">
     <value>找不到“{0}”。请确保已生成项目。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToFindBuildOutput_cht" xml:space="preserve">
     <value>找不到 '{0}'。確定已建置專案。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageDoesNotExist_csy" xml:space="preserve">
     <value>Nelze vyhledat {0} {1}. Před spuštěním aktualizace ověřte, zda jsou k dispozici všechny balíčky ve složce balíčků.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageDoesNotExist_deu" xml:space="preserve">
     <value>"{0} {1}" wurde nicht gefunden. Stellen Sie sicher, dass alle Pakete im Paketordner vorhanden sind, bevor Sie das Update ausführen.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageDoesNotExist_esp" xml:space="preserve">
     <value>No se puede ubicar '{0} {1}'. Asegúrese de que existen todos los paquetes en la carpeta de paquetes antes de ejecutar la actualización.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageDoesNotExist_fra" xml:space="preserve">
     <value>Impossible de trouver '{0} {1}'. Assurez-vous que tous les packages existent dans le dossier des packages avant d'exécuter la mise à jour.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageDoesNotExist_ita" xml:space="preserve">
     <value>Impossibile localizzare '{0} {1}'. Assicurarsi che esistono tutte le cartelle pacchetti prima di eseguire l'aggiornamento</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageDoesNotExist_jpn" xml:space="preserve">
     <value>'{0} {1}' が見つかりません。更新を実行する前に、パッケージ フォルダーにすべてのパッケージが存在することを確認してください。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageDoesNotExist_kor" xml:space="preserve">
     <value>'{0} {1}'을(를) 찾을 수 없습니다. 패키지 폴더에 모든 패키지가 있는지 확인한 후 업데이트를 실행하십시오.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageDoesNotExist_plk" xml:space="preserve">
     <value>Nie można znaleźć pakietu „{0} {1}”. Przed uruchomieniem aktualizacji upewnij się, że wszystkie pakiety znajdują się w folderze pakietów.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageDoesNotExist_ptb" xml:space="preserve">
     <value>Não foi possível localizar '{0} {1}'. Certifique-se que todos os pacotes estejam na pasta de pacotes antes de executar a atualização.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageDoesNotExist_rus" xml:space="preserve">
     <value>Не удалось найти "{0} {1}". Прежде чем запускать обновление, убедитесь, что в папке пакетов содержатся все пакеты.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageDoesNotExist_trk" xml:space="preserve">
     <value>{0} {1}' bulunamıyor. Güncellemeyi çalıştırmadan önce tüm paketlerin paket klasöründe mevcut olduğundan emin olun.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageDoesNotExist_chs" xml:space="preserve">
     <value>找不到“{0} {1}”。在运行更新之前，请确保所有程序包均存在于程序包文件夹中。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageDoesNotExist_cht" xml:space="preserve">
     <value>找不到 '{0} {1}'。請確定封裝資料夾中存在所有封裝，才能執行更新。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToFindPackages_csy" xml:space="preserve">
     <value>Nelze najít {0}. Ověřte, zda jsou zadány v souboru packages.config.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToFindPackages_deu" xml:space="preserve">
     <value>"{0}" wurde nicht gefunden. Stellen Sie sicher, dass das Element in "packages.config" spezifisch ist.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToFindPackages_esp" xml:space="preserve">
     <value>No se puede encontrar '{0}'. Asegúrese de que se han especificado en packages.config.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToFindPackages_fra" xml:space="preserve">
     <value>Impossible de trouver '{0}'. Assurez-vous qu'ils sont spécifiés dans packages.config.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToFindPackages_ita" xml:space="preserve">
     <value>Impossibile trovare '{0}'.Assicurarsi che siano specificati in packages.config.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToFindPackages_jpn" xml:space="preserve">
     <value>'{0}' が見つかりません。packages.config に指定されていることを確認してください。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToFindPackages_kor" xml:space="preserve">
     <value>'{0}'을(를) 찾을 수 없습니다. packages.config에 지정되어 있는지 확인하십시오.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToFindPackages_plk" xml:space="preserve">
     <value>Nie można odnaleźć pakietów „{0}”. Upewnij się, że zostały one określone w pliku packages.config.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToFindPackages_ptb" xml:space="preserve">
     <value>Não foi possível encontrar o '{0}'. Verifique se eles estão especificados em packages.config.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToFindPackages_rus" xml:space="preserve">
     <value>Не удалось найти "{0}". Убедитесь, что они указаны в файле packages.config.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToFindPackages_trk" xml:space="preserve">
     <value>{0}' bulunamıyor. Packages.config içinde belirtildiğinden emin olun.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToFindPackages_chs" xml:space="preserve">
     <value>找不到“{0}”。请确保已在 packages.config 中指定它们。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToFindPackages_cht" xml:space="preserve">
     <value>找不到 '{0}'。確定已在 packages.config 中指定。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToLocatePackagesFolder_csy" xml:space="preserve">
     <value>Složka balíčků nebyla nalezena. Zkuste ji zadat pomocí přepínače repositoryPath.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToLocatePackagesFolder_deu" xml:space="preserve">
     <value>Der Paketordner wurde nicht gefunden. Versuchen Sie, ihn mithilfe des Schalters "repositoryPath " anzugeben.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToLocatePackagesFolder_esp" xml:space="preserve">
     <value>No se puede ubicar la carpeta de los paquetes. Pruebe de especificarla usando el conmutador repositoryPath.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToLocatePackagesFolder_fra" xml:space="preserve">
     <value>Impossible de trouver le dossier de packages. Essayez de le spécifier à l'aide du commutateur repositoryPath.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToLocatePackagesFolder_ita" xml:space="preserve">
     <value>Impossibile localizzare la cartella pacchetto. Provare a specificarla usando repositoryPath switch.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToLocatePackagesFolder_jpn" xml:space="preserve">
     <value>packages フォルダーが見つかりません。repositoryPath スイッチを使用して指定してください。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToLocatePackagesFolder_kor" xml:space="preserve">
     <value>패키지 폴더를 찾을 수 없습니다. repositoryPath 스위치를 사용하여 지정해 보십시오.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToLocatePackagesFolder_plk" xml:space="preserve">
     <value>Nie można zlokalizować folderu pakietów. Spróbuj go określić przy użyciu przełącznika repositoryPath.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToLocatePackagesFolder_ptb" xml:space="preserve">
     <value>Não foi possível localizar a pasta de pacotes. Tente especificá-la usando a opção repositoryPath.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToLocatePackagesFolder_rus" xml:space="preserve">
     <value>Не удалось найти папку пакетов. Попробуйте указать ее с помощью параметра repositoryPath.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToLocatePackagesFolder_trk" xml:space="preserve">
     <value>Paket klasörü bulunamıyor. RepositoryPath anahtarını kullanarak belirlemeyi deneyin.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToLocatePackagesFolder_chs" xml:space="preserve">
     <value>找不到程序包文件夹。请尝试使用 repositoryPath 开关指定它。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToLocatePackagesFolder_cht" xml:space="preserve">
     <value>找不到封裝資料夾。嘗試使用 repositoryPath 切換指定。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToLocateProjectFile_csy" xml:space="preserve">
     <value>Soubor projektu pro {0} nebyl nalezen.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToLocateProjectFile_deu" xml:space="preserve">
     <value>Die Projektdatei für "{0}" wurde nicht gefunden.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToLocateProjectFile_esp" xml:space="preserve">
     <value>No se puede ubicar el archivo de proyecto para '{0}'.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToLocateProjectFile_fra" xml:space="preserve">
     <value>Impossible de trouver le fichier projet pour '{0}'.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToLocateProjectFile_ita" xml:space="preserve">
     <value>Impossibile localizzare file progetto per '{0}'.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToLocateProjectFile_jpn" xml:space="preserve">
     <value>'{0}' のプロジェクト ファイルが見つかりません。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToLocateProjectFile_kor" xml:space="preserve">
     <value>'{0}'에 대한 프로젝트 파일을 찾을 수 없습니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToLocateProjectFile_plk" xml:space="preserve">
     <value>Nie można zlokalizować pliku projektu dla „{0}”.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToLocateProjectFile_ptb" xml:space="preserve">
     <value>Não foi possível localizar arquivo de projeto para '{0}'.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToLocateProjectFile_rus" xml:space="preserve">
     <value>Не удалось найти файл проекта для "{0}".</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToLocateProjectFile_trk" xml:space="preserve">
     <value>{0}' için proje dosyası bulunamıyor.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToLocateProjectFile_chs" xml:space="preserve">
     <value>找不到“{0}”的项目文件。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToLocateProjectFile_cht" xml:space="preserve">
     <value>找不到 '{0}' 的專案檔。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="FoundProjects_csy" xml:space="preserve">
     <value>Počet nalezených projektů se souborem packages.config: {0}. ({1})</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="FoundProjects_deu" xml:space="preserve">
     <value>Es wurden {0} Projekte mit einer Datei "packages.config" gefunden. ({1})</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="FoundProjects_esp" xml:space="preserve">
     <value>Se han encontrado {0} proyectos con un archivo packages.config. ({1})</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="FoundProjects_fra" xml:space="preserve">
     <value>{0} projets contenant un fichier packages.config ont été trouvés. ({1})</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="FoundProjects_ita" xml:space="preserve">
     <value>Trovati {0} progetti con packages.config file. ({1})</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="FoundProjects_jpn" xml:space="preserve">
     <value>packages.config ファイルが指定されたプロジェクトが {0} 個見つかりました。({1})</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="FoundProjects_kor" xml:space="preserve">
     <value>packages.config 파일이 있는 프로젝트를 {0}개 찾았습니다. ({1})</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="FoundProjects_plk" xml:space="preserve">
     <value>Liczba znalezionych projektów z plikiem  packages.config: {0}. ({1})</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="FoundProjects_ptb" xml:space="preserve">
     <value>Encontrados projetos {0} com um arquivo packages.config. ({1})</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="FoundProjects_rus" xml:space="preserve">
     <value>Обнаружено проектов с файлом packages.config: {0}. ({1})</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="FoundProjects_trk" xml:space="preserve">
     <value>packages.config dosyası içeren {0} proje bulundu. ({1})</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="FoundProjects_chs" xml:space="preserve">
     <value>找到 {0} 个包含 packages.config 文件的项目。({1})</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="FoundProjects_cht" xml:space="preserve">
     <value>找到具有 packages.confi 檔案的 {0} 個專案。({1})</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="LookingForInstalledPackages_csy" xml:space="preserve">
     <value>Probíhá vyhledávání nainstalovaných balíčků v {0}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="LookingForInstalledPackages_deu" xml:space="preserve">
     <value>In "{0}" wird nach installierten Paketen gesucht.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="LookingForInstalledPackages_esp" xml:space="preserve">
     <value>Buscando paquetes instalados en '{0}'.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="LookingForInstalledPackages_fra" xml:space="preserve">
     <value>Recherche en cours des packages installés sur '{0}'.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="LookingForInstalledPackages_ita" xml:space="preserve">
     <value>Ricerca pacchetti installati in '{0}'.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="LookingForInstalledPackages_jpn" xml:space="preserve">
     <value>'{0}' にインストールされているパッケージを探しています。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="LookingForInstalledPackages_kor" xml:space="preserve">
     <value>'{0}'에서 설치된 패키지를 찾고 있습니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="LookingForInstalledPackages_plk" xml:space="preserve">
     <value>Wyszukiwanie zainstalowanych pakietów w „{0}”.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="LookingForInstalledPackages_ptb" xml:space="preserve">
     <value>Buscar pacotes instalados em '{0}'.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="LookingForInstalledPackages_rus" xml:space="preserve">
     <value>Поиск установленных пакетов в "{0}".</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="LookingForInstalledPackages_trk" xml:space="preserve">
     <value>{0}' içindeki yüklü paketler aranıyor.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="LookingForInstalledPackages_chs" xml:space="preserve">
     <value>正在“{0}”中查找已安装的程序包。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="LookingForInstalledPackages_cht" xml:space="preserve">
     <value>在 '{0}' 中尋找已安裝的封裝。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ScanningForProjects_csy" xml:space="preserve">
     <value>Probíhá hledání projektů...</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ScanningForProjects_deu" xml:space="preserve">
     <value>Suchen nach Projekten...</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ScanningForProjects_esp" xml:space="preserve">
     <value>Examinando proyectos…</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ScanningForProjects_fra" xml:space="preserve">
     <value>Recherche de projets en cours…</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ScanningForProjects_ita" xml:space="preserve">
     <value>Ricercando progetti...</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ScanningForProjects_jpn" xml:space="preserve">
     <value>プロジェクトをスキャンしています...</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ScanningForProjects_kor" xml:space="preserve">
     <value>프로젝트를 스캔하는 중...</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ScanningForProjects_plk" xml:space="preserve">
     <value>Trwa skanowanie w poszukiwaniu projektów...</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ScanningForProjects_ptb" xml:space="preserve">
     <value>Verificando projetos ...</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ScanningForProjects_rus" xml:space="preserve">
     <value>Сканирование проектов…</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ScanningForProjects_trk" xml:space="preserve">
     <value>Projeler taranıyor…</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ScanningForProjects_chs" xml:space="preserve">
     <value>正在扫描项目...</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ScanningForProjects_cht" xml:space="preserve">
     <value>正在掃瞄專案...</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdatingProject_csy" xml:space="preserve">
     <value>Probíhá aktualizace {0}...</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdatingProject_deu" xml:space="preserve">
     <value>"{0}" wird aktualisiert...</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdatingProject_esp" xml:space="preserve">
     <value>Actualizando '{0}'…</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdatingProject_fra" xml:space="preserve">
     <value>Mise à jour de '{0}'…</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdatingProject_ita" xml:space="preserve">
     <value>Aggiornando '{0}'...</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdatingProject_jpn" xml:space="preserve">
     <value>'{0}' を更新しています...</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdatingProject_kor" xml:space="preserve">
     <value>'{0}'을(를) 업데이트하는 중...</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdatingProject_plk" xml:space="preserve">
     <value>Trwa aktualizacja „{0}”...</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdatingProject_ptb" xml:space="preserve">
     <value>Atualizando '{0}' ...</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdatingProject_rus" xml:space="preserve">
     <value>Обновление "{0}"...</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdatingProject_trk" xml:space="preserve">
     <value>{0}' güncelleniyor...</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdatingProject_chs" xml:space="preserve">
     <value>正在更新“{0}”...</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UpdatingProject_cht" xml:space="preserve">
     <value>正在更新 '{0}'...</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="FoundProject_csy" xml:space="preserve">
     <value>Počet nalezených projektů se souborem packages.config: 1. ({0})</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="FoundProject_deu" xml:space="preserve">
     <value>Es wurde ein Projekt mit einer Datei "packages.config" gefunden. ({0})</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="FoundProject_esp" xml:space="preserve">
     <value>Se ha encontrado 1 proyecto con un archivo packages.config. ({0})</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="FoundProject_fra" xml:space="preserve">
     <value>Un projet contenant packages.config a été trouvé. ({0})</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="FoundProject_ita" xml:space="preserve">
     <value>Trovato 1 progetto con packages.config file. ({0})</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="FoundProject_jpn" xml:space="preserve">
     <value>packages.config ファイルが指定されたプロジェクトが 1 個見つかりました。({0})</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="FoundProject_kor" xml:space="preserve">
     <value>packages.config 파일이 있는 프로젝트를 1개 찾았습니다. ({0})</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="FoundProject_plk" xml:space="preserve">
     <value>Znaleziono 1 projekt z plikiem packages.config. ({0})</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="FoundProject_ptb" xml:space="preserve">
     <value>Encontrado um projeto com um arquivo packages.config. ({0})</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="FoundProject_rus" xml:space="preserve">
     <value>Обнаружен 1 проект с файлом packages.config. ({0})</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="FoundProject_trk" xml:space="preserve">
     <value>packages.config dosyası içeren 1 proje bulundu. ({0})</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="FoundProject_chs" xml:space="preserve">
     <value>找到一个包含 packages.config 文件的项目。({0})</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="FoundProject_cht" xml:space="preserve">
     <value>找到具有 packages.config 檔案的專案。({0})</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="NoProjectsFound_csy" xml:space="preserve">
     <value>Nebyly nalezeny žádné projekty se souborem packages.config.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="NoProjectsFound_deu" xml:space="preserve">
     <value>Es wurden keine Projekte mit "packages.config" gefunden.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="NoProjectsFound_esp" xml:space="preserve">
     <value>No se han encontrado proyectos con packages.config.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="NoProjectsFound_fra" xml:space="preserve">
     <value>Aucun projet contenant le fichier packages.config n'a été trouvé.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="NoProjectsFound_ita" xml:space="preserve">
     <value>Nessun progetto trovato per packages.config.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="NoProjectsFound_jpn" xml:space="preserve">
     <value>packages.config が指定されたプロジェクトが見つかりませんでした。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="NoProjectsFound_kor" xml:space="preserve">
     <value>packages.config가 있는 프로젝트를 찾을 수 없습니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="NoProjectsFound_plk" xml:space="preserve">
     <value>Nie odnaleziono żadnych projektów z plikiem packages.config.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="NoProjectsFound_ptb" xml:space="preserve">
     <value>Nenhum projeto encontrado com packages.config.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="NoProjectsFound_rus" xml:space="preserve">
     <value>Проекты с файлом packages.config не найдены.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="NoProjectsFound_trk" xml:space="preserve">
     <value>Packages.config içeren hiçbir paket bulunamadı.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="NoProjectsFound_chs" xml:space="preserve">
     <value>找不到包含 packages.config 的项目。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="NoProjectsFound_cht" xml:space="preserve">
     <value>找不到具有 packages.config 的專案。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToFindSolution_csy" xml:space="preserve">
     <value>Nelze najít řešení {0}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToFindSolution_deu" xml:space="preserve">
     <value>Das Projekt "{0}" wurde nicht gefunden.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToFindSolution_esp" xml:space="preserve">
     <value>No se puede encontrar la solución '{0}'.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToFindSolution_fra" xml:space="preserve">
     <value>Impossible de trouver la solution '{0}'.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToFindSolution_ita" xml:space="preserve">
     <value>Impossibile trovare soluzione '{0}'.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToFindSolution_jpn" xml:space="preserve">
     <value>ソリューション '{0}' が見つかりません。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToFindSolution_kor" xml:space="preserve">
     <value>'{0}' 솔루션을 찾을 수 없습니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToFindSolution_plk" xml:space="preserve">
     <value>Nie można znaleźć rozwiązania „{0}”.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToFindSolution_ptb" xml:space="preserve">
     <value>Não foi possível encontrar uma solução '{0}'.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToFindSolution_rus" xml:space="preserve">
     <value>Не удалось найти решение "{0}".</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToFindSolution_trk" xml:space="preserve">
     <value>{0}' çözümü bulunamıyor.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToFindSolution_chs" xml:space="preserve">
     <value>找不到解决方案“{0}”。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToFindSolution_cht" xml:space="preserve">
     <value>找不到方案 '{0}'。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="CommandLine_Warning_csy" xml:space="preserve">
     <value>UPOZORNĚNÍ: {0}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="CommandLine_Warning_deu" xml:space="preserve">
     <value>WARNUNG: {0}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="CommandLine_Warning_esp" xml:space="preserve">
     <value>ADVERTENCIA: '{0}'</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="CommandLine_Warning_fra" xml:space="preserve">
     <value>AVERTISSEMENT : {0}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="CommandLine_Warning_ita" xml:space="preserve">
     <value>AVVISO: {0}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="CommandLine_Warning_jpn" xml:space="preserve">
     <value>警告: {0}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="CommandLine_Warning_kor" xml:space="preserve">
     <value>경고: {0}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="CommandLine_Warning_plk" xml:space="preserve">
     <value>OSTRZEŻENIE: {0}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="CommandLine_Warning_ptb" xml:space="preserve">
     <value>AVISO: {0}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="CommandLine_Warning_rus" xml:space="preserve">
     <value>ПРЕДУПРЕЖДЕНИЕ. {0}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="CommandLine_Warning_trk" xml:space="preserve">
     <value>UYARI: {0}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="CommandLine_Warning_chs" xml:space="preserve">
     <value>警告: {0}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="CommandLine_Warning_cht" xml:space="preserve">
     <value>警告: {0}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Credentials_Password_csy" xml:space="preserve">
     <value>Heslo: </value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Credentials_Password_deu" xml:space="preserve">
     <value>Kennwort: </value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Credentials_Password_esp" xml:space="preserve">
     <value>Contraseña:</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Credentials_Password_fra" xml:space="preserve">
     <value>Mot de passe : </value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Credentials_Password_ita" xml:space="preserve">
     <value>Password:</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Credentials_Password_jpn" xml:space="preserve">
     <value>パスワード: </value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Credentials_Password_kor" xml:space="preserve">
     <value>암호: </value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Credentials_Password_plk" xml:space="preserve">
     <value>Hasło:</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Credentials_Password_ptb" xml:space="preserve">
     <value>Senha:</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Credentials_Password_rus" xml:space="preserve">
     <value>Пароль: </value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Credentials_Password_trk" xml:space="preserve">
     <value>Parola: </value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Credentials_Password_chs" xml:space="preserve">
     <value>密码: </value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Credentials_Password_cht" xml:space="preserve">
     <value>密碼: </value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Credentials_UserName_csy" xml:space="preserve">
     <value>Uživatelské jméno: </value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Credentials_UserName_deu" xml:space="preserve">
     <value>UserName: </value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Credentials_UserName_esp" xml:space="preserve">
     <value>Nombre de usuario:</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Credentials_UserName_fra" xml:space="preserve">
     <value>Nom d'utilisateur : </value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Credentials_UserName_ita" xml:space="preserve">
     <value>Nome utente:</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Credentials_UserName_jpn" xml:space="preserve">
     <value>UserName: </value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Credentials_UserName_kor" xml:space="preserve">
     <value>사용자 이름: </value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Credentials_UserName_plk" xml:space="preserve">
     <value>Nazwa użytkownika: </value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Credentials_UserName_ptb" xml:space="preserve">
     <value>Nome de usuário:</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Credentials_UserName_rus" xml:space="preserve">
     <value>Имя пользователя: </value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Credentials_UserName_trk" xml:space="preserve">
     <value>KullanıcıAdı: </value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Credentials_UserName_chs" xml:space="preserve">
     <value>用户名: </value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Credentials_UserName_cht" xml:space="preserve">
     <value>使用者名稱: </value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Credentials_RequestCredentials_csy" xml:space="preserve">
     <value>Zadejte přihlašovací údaje pro: {0}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Credentials_RequestCredentials_deu" xml:space="preserve">
     <value>Bitte stellen Sie Anmeldeinformationen zur Verfügung für: {0}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Credentials_RequestCredentials_esp" xml:space="preserve">
     <value>Proporcione las credenciales para: {0}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Credentials_RequestCredentials_fra" xml:space="preserve">
     <value>Veuillez fournir les informations d'identification relative à : {0}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Credentials_RequestCredentials_ita" xml:space="preserve">
     <value>Fornire credenziali per: {0}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Credentials_RequestCredentials_jpn" xml:space="preserve">
     <value>次の資格情報を指定してください: {0}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Credentials_RequestCredentials_kor" xml:space="preserve">
     <value>{0}에 대한 자격 증명을 제공하십시오.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Credentials_RequestCredentials_plk" xml:space="preserve">
     <value>Podaj poświadczenia dla: {0}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Credentials_RequestCredentials_ptb" xml:space="preserve">
     <value>Forneça as credenciais para: {0}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Credentials_RequestCredentials_rus" xml:space="preserve">
     <value>Укажите учетные данные для: {0}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Credentials_RequestCredentials_trk" xml:space="preserve">
     <value>Lütfen buna ait kimlik bilgilerini belirtin: {0}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Credentials_RequestCredentials_chs" xml:space="preserve">
     <value>请提供以下人员的凭据: {0}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Credentials_RequestCredentials_cht" xml:space="preserve">
     <value>請提供以下項目的認證: {0}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandPackageAlreadyExists_csy" xml:space="preserve">
     <value>Balíček {0} je již nainstalován.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandPackageAlreadyExists_deu" xml:space="preserve">
     <value>Das Paket "{0}" ist bereits installiert.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandPackageAlreadyExists_esp" xml:space="preserve">
     <value>Ya se ha instalado el paquete "{0}".</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandPackageAlreadyExists_fra" xml:space="preserve">
     <value>Le package « {0} » est déjà installé.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandPackageAlreadyExists_ita" xml:space="preserve">
     <value>Pacchetto "{0}" è già installato</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandPackageAlreadyExists_jpn" xml:space="preserve">
     <value>パッケージ "{0}" は既にインストールされています。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandPackageAlreadyExists_kor" xml:space="preserve">
     <value>{0} 패키지는 이미 설치되었습니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandPackageAlreadyExists_plk" xml:space="preserve">
     <value>Pakiet „{0}” został już zainstalowany.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandPackageAlreadyExists_ptb" xml:space="preserve">
     <value>O pacote "{0}" já está instalado.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandPackageAlreadyExists_rus" xml:space="preserve">
     <value>Пакет "{0}" уже установлен.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandPackageAlreadyExists_trk" xml:space="preserve">
     <value>"{0}" paketi zaten yüklü.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandPackageAlreadyExists_chs" xml:space="preserve">
     <value>已安装程序包“{0}”。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandPackageAlreadyExists_cht" xml:space="preserve">
     <value>已安裝封裝 "{0}"。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandNoFilesForLibPackage_csy" xml:space="preserve">
     <value>Sestavení balíčku se nezdařilo. Ověřte, zda {0} zahrnuje soubory sestavení. Nápovědu týkající se sestavení balíčku symbolů naleznete na webu {1}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandNoFilesForLibPackage_deu" xml:space="preserve">
     <value>Fehler beim Erstellen des Pakets. Stellen Sie sicher, dass "{0}" Assemblydateien enthält. Hilfe zum Erstellen eines Symbolpakets finden Sie unter {1}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandNoFilesForLibPackage_esp" xml:space="preserve">
     <value>Error al compilar el paquete. Asegúrese de que '{0}' incluye los archivos de ensamblado. Para obtener ayuda sobre la compilación de paquetes de símbolos, visite {1}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandNoFilesForLibPackage_fra" xml:space="preserve">
     <value>Échec de la création du package. Assurez-vous que '{0}' inclut les fichiers d'assembly. Pour obtenir l'aide relative à la création d'un package de symboles, visitez {1}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandNoFilesForLibPackage_ita" xml:space="preserve">
     <value>Impossibile impostare package. Assicurarsi che '{0}' include i file di assemblaggio. Per aiuto sull'impostazione dei simboli, visitare {1}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandNoFilesForLibPackage_jpn" xml:space="preserve">
     <value>パッケージをビルドできませんでした。'{0}' にアセンブリ ファイルが含まれることを確認してください。シンボル パッケージのビルド方法については、{1} を参照してください。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandNoFilesForLibPackage_kor" xml:space="preserve">
     <value>패키지를 빌드하지 못했습니다. '{0}'에 어셈블리 파일이 있는지 확인하십시오. 기호 패키지를 빌드하는 방법에 대한 도움말은 {1}을(를) 참조하십시오.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandNoFilesForLibPackage_plk" xml:space="preserve">
     <value>Nie można skompilować pakietu. Upewnij się, że „{0}” zawiera pliki zestawów. Aby uzyskać pomoc na temat kompilowania pakietów symboli, odwiedź {1}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandNoFilesForLibPackage_ptb" xml:space="preserve">
     <value>Falha ao construir pacote. Verifique se  '{0}' inclui arquivos de assembly. Para ajudar a construir pacotes de símbolos, visite {1}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandNoFilesForLibPackage_rus" xml:space="preserve">
     <value>Не удалось выполнить сборку пакета. Убедитесь, что "{0}" содержит файлы сборки. Справку о выполнении сборки пакета символов см. по адресу: {1}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandNoFilesForLibPackage_trk" xml:space="preserve">
     <value>Paket oluşturulamadı. '{0}' öğesinin derleme dosyalarını içerdiğinden emin olun. Simge paketi oluşturma konusunda yardım almak için, {1} sayfasını ziyaret edin.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandNoFilesForLibPackage_chs" xml:space="preserve">
     <value>无法生成程序包。请确保“{0}”包括程序集文件。有关生成符号程序包的帮助，请访问 {1}。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandNoFilesForLibPackage_cht" xml:space="preserve">
     <value>無法建置封裝。確定 '{0}' 包含組件檔案。如需建置符號封裝的說明，請造訪 {1}。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandNoFilesForSymbolsPackage_csy" xml:space="preserve">
     <value>Sestavení balíčku se nezdařilo. Ověřte, zda {0} zahrnuje zdroj a soubory symbolů. Nápovědu týkající se sestavení balíčku symbolů naleznete na webu {1}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandNoFilesForSymbolsPackage_deu" xml:space="preserve">
     <value>Fehler beim Erstellen des Pakets. Stellen Sie sicher, dass "{0}" Quell- und Symboldateien enthält. Hilfe zum Erstellen eines Symbolpakets finden Sie unter {1}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandNoFilesForSymbolsPackage_esp" xml:space="preserve">
     <value>Error al compilar el paquete. Asegúrese de que '{0}' incluye los archivos de símbolos y de origen. Para obtener ayuda sobre la compilación de paquetes de símbolos, visite {1}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandNoFilesForSymbolsPackage_fra" xml:space="preserve">
     <value>Échec de la création du package. Assurez-vous que '{0}' inclut les fichiers source et de symboles. Pour obtenir l'aide relative à la création d'un package de symboles, visitez {1}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandNoFilesForSymbolsPackage_ita" xml:space="preserve">
     <value>Impossibile impostare package. Assicurarsi che '{0}' include i file di assemblaggio. Per aiuto sull'impostazione dei simboli, visitare {1}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandNoFilesForSymbolsPackage_jpn" xml:space="preserve">
     <value>パッケージをビルドできませんでした。'{0}' にソースとシンボル ファイルが含まれることを確認してください。シンボル パッケージのビルド方法については、{1} を参照してください。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandNoFilesForSymbolsPackage_kor" xml:space="preserve">
     <value>패키지를 빌드하지 못했습니다. '{0}'에 소스 및 기호 파일이 있는지 확인하십시오. 기호 패키지를 빌드하는 방법에 대한 도움말은 {1}을(를) 참조하십시오.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandNoFilesForSymbolsPackage_plk" xml:space="preserve">
     <value>Nie można skompilować pakietu. Upewnij się, że „{0}” zawiera pliki źródłowe i pliki symboli. Aby uzyskać pomoc na temat kompilowania pakietów symboli, odwiedź {1}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandNoFilesForSymbolsPackage_ptb" xml:space="preserve">
     <value>Falha ao construir pacote. Verifique se '{0}' inclui arquivos de origem e símbolo. Para ajudar a construir pacotes símbolos, visite {1}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandNoFilesForSymbolsPackage_rus" xml:space="preserve">
     <value>Не удалось выполнить сборку пакета. Убедитесь, что "{0}" содержит файлы источников и файлы символов. Справку о выполнении сборки пакета символов см. по адресу: {1}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandNoFilesForSymbolsPackage_trk" xml:space="preserve">
     <value>Paket oluşturulamadı. '{0}' öğesinin kaynak ve simge dosyalarını içerdiğinden emin olun. Simge paketi oluşturma konusunda yardım almak için, {1} sayfasını ziyaret edin.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandNoFilesForSymbolsPackage_chs" xml:space="preserve">
     <value>无法生成程序包。请确保“{0}”包括源文件和符号文件。有关生成符号程序包的帮助，请访问 {1}。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandNoFilesForSymbolsPackage_cht" xml:space="preserve">
     <value>無法建置封裝。確定 '{0}' 包含來源和符號檔案。如需建置符號封裝的說明，請造訪 {1}。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandInvalidPackageReference_csy" xml:space="preserve">
     <value>{0} obsahuje neplatné odkazy na balíčky. </value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandInvalidPackageReference_deu" xml:space="preserve">
     <value>"{0}" enthält ungültige Paketverweise. </value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandInvalidPackageReference_esp" xml:space="preserve">
     <value>{0}' contiene referencias de paquete no válidas.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandInvalidPackageReference_fra" xml:space="preserve">
     <value>'{0}' contient des références de package non valides. </value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandInvalidPackageReference_ita" xml:space="preserve">
     <value>'{0}' contains invalid package references. </value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandInvalidPackageReference_jpn" xml:space="preserve">
     <value>'{0}' には無効なパッケージ参照が含まれています。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandInvalidPackageReference_kor" xml:space="preserve">
     <value>'{0}'에 잘못된 패키지 참조가 포함되어 있습니다. </value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandInvalidPackageReference_plk" xml:space="preserve">
     <value>„{0}” zawiera nieprawidłowe odwołania do pakietów. </value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandInvalidPackageReference_ptb" xml:space="preserve">
     <value>'{0}' contém referências de pacotes inválidos.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandInvalidPackageReference_rus" xml:space="preserve">
     <value>"{0}" содержит недопустимые ссылки на пакеты. </value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandInvalidPackageReference_trk" xml:space="preserve">
     <value>{0}' geçersiz paket başvuruları içeriyor. </value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandInvalidPackageReference_chs" xml:space="preserve">
     <value>“{0}”包含的程序包引用无效。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandInvalidPackageReference_cht" xml:space="preserve">
     <value>{0}' 包含無效的封裝參照。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandPackageReferenceInvalidVersion_csy" xml:space="preserve">
     <value>Řetězec verze zadaný pro odkaz na balíček {0} je neplatný.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandPackageReferenceInvalidVersion_deu" xml:space="preserve">
     <value>Die für den Paketverweis "{0}" angegebene Versionszeichenfolge ist ungültig.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandPackageReferenceInvalidVersion_esp" xml:space="preserve">
     <value>La cadena de versión especificada para la referencia de paquete '{0}' no es válida.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandPackageReferenceInvalidVersion_fra" xml:space="preserve">
     <value>La chaîne de version spécifiée pour la référence de package '{0}' n'est pas valide.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandPackageReferenceInvalidVersion_ita" xml:space="preserve">
     <value>Stringa versione specificata per il pacchetto di riferimento '{0}' non è valida.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandPackageReferenceInvalidVersion_jpn" xml:space="preserve">
     <value>パッケージ参照 '{0}' に指定されたバージョン文字列は無効です。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandPackageReferenceInvalidVersion_kor" xml:space="preserve">
     <value>패키지 참조 '{0}'에 대해 지정된 버전 문자열이 잘못되었습니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandPackageReferenceInvalidVersion_plk" xml:space="preserve">
     <value>Ciąg wersji określony dla odwołania do pakietu „{0}” jest nieprawidłowy.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandPackageReferenceInvalidVersion_ptb" xml:space="preserve">
     <value>A cadeia de caracteres de versão especificada para a referência do pacote '{0}' é inválida.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandPackageReferenceInvalidVersion_rus" xml:space="preserve">
     <value>Строка версии, указанная для ссылки на пакет "{0}", является недопустимой.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandPackageReferenceInvalidVersion_trk" xml:space="preserve">
     <value>{0}' paket referansı için belirtilen sürüm dizesi geçersiz.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandPackageReferenceInvalidVersion_chs" xml:space="preserve">
     <value>为程序包引用“{0}”指定的版本字符串无效。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandPackageReferenceInvalidVersion_cht" xml:space="preserve">
     <value>封裝參照 '{0}' 指定的版本字串無效。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandPackageIssueSummary_csy" xml:space="preserve">
     <value>Počet problémů zjištěných v balíčku {1}: {0}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandPackageIssueSummary_deu" xml:space="preserve">
     <value>Für das Paket "{1}" gefundene Probleme: {0}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandPackageIssueSummary_esp" xml:space="preserve">
     <value>Se han encontrado {0} problemas en el paquete '{1}'.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandPackageIssueSummary_fra" xml:space="preserve">
     <value>{0} problème(s) trouvé(s) concernant le package '{1}'.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandPackageIssueSummary_ita" xml:space="preserve">
     <value>{0} problema (i) trovati con pacchetto'{1}'.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandPackageIssueSummary_jpn" xml:space="preserve">
     <value>パッケージ '{1}' に {0} 個の問題が見つかりました。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandPackageIssueSummary_kor" xml:space="preserve">
     <value>'{1}' 패키지에 문제가 {0}개 있습니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandPackageIssueSummary_plk" xml:space="preserve">
     <value>Liczba znalezionych problemów z pakietem „{1}”: {0}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandPackageIssueSummary_ptb" xml:space="preserve">
     <value>{0} problemas encontrados com o pacote '{1}'.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandPackageIssueSummary_rus" xml:space="preserve">
     <value>Обнаружено неполадок пакета "{1}": {0}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandPackageIssueSummary_trk" xml:space="preserve">
     <value>{1}' sorunuyla ilgili {0} sorun bulundu.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandPackageIssueSummary_chs" xml:space="preserve">
     <value>发现程序包“{1}”存在 {0} 个问题。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandPackageIssueSummary_cht" xml:space="preserve">
     <value>找到{0} 個具有封裝 '{1}' 的問題。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandIssueDescription_csy" xml:space="preserve">
     <value>Popis: {0}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandIssueDescription_deu" xml:space="preserve">
     <value>Beschreibung: {0}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandIssueDescription_esp" xml:space="preserve">
     <value>Descripción: {0}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandIssueDescription_fra" xml:space="preserve">
     <value>Description : {0}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandIssueDescription_ita" xml:space="preserve">
     <value>Descrizione: {0}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandIssueDescription_jpn" xml:space="preserve">
     <value>説明: {0}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandIssueDescription_kor" xml:space="preserve">
     <value>설명: {0}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandIssueDescription_plk" xml:space="preserve">
     <value>Opis: {0}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandIssueDescription_ptb" xml:space="preserve">
     <value>Descrição: {0}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandIssueDescription_rus" xml:space="preserve">
     <value>Описание: {0}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandIssueDescription_trk" xml:space="preserve">
     <value>Açıklama: {0}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandIssueDescription_chs" xml:space="preserve">
     <value>说明: {0}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandIssueDescription_cht" xml:space="preserve">
     <value>描述: {0}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandIssueSolution_csy" xml:space="preserve">
     <value>Řešení: {0}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandIssueSolution_deu" xml:space="preserve">
     <value>Projekt: {0}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandIssueSolution_esp" xml:space="preserve">
     <value>Solución: {0}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandIssueSolution_fra" xml:space="preserve">
     <value>Solution : {0}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandIssueSolution_ita" xml:space="preserve">
     <value>Soluzione: {0}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandIssueSolution_jpn" xml:space="preserve">
     <value>ソリューション: {0}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandIssueSolution_kor" xml:space="preserve">
     <value>솔루션: {0}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandIssueSolution_plk" xml:space="preserve">
     <value>Rozwiązanie: {0}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandIssueSolution_ptb" xml:space="preserve">
     <value>Solução: {0}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandIssueSolution_rus" xml:space="preserve">
     <value>Решение: {0}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandIssueSolution_trk" xml:space="preserve">
     <value>Çözüm: {0}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandIssueSolution_chs" xml:space="preserve">
     <value>解决方案: {0}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandIssueSolution_cht" xml:space="preserve">
     <value>方案: {0}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandIssueTitle_csy" xml:space="preserve">
     <value>Problém: {0}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandIssueTitle_deu" xml:space="preserve">
     <value>Problem: {0}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandIssueTitle_esp" xml:space="preserve">
     <value>Problema: {0}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandIssueTitle_fra" xml:space="preserve">
     <value>Problème : {0}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandIssueTitle_ita" xml:space="preserve">
     <value>Versione: {0}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandIssueTitle_jpn" xml:space="preserve">
     <value>問題: {0}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandIssueTitle_kor" xml:space="preserve">
     <value>문제: {0}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandIssueTitle_plk" xml:space="preserve">
     <value>Problem: {0}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandIssueTitle_ptb" xml:space="preserve">
     <value>Edição: {0}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandIssueTitle_rus" xml:space="preserve">
     <value>Проблема: {0}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandIssueTitle_trk" xml:space="preserve">
     <value>Sorun: {0}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandIssueTitle_chs" xml:space="preserve">
     <value>问题: {0}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandIssueTitle_cht" xml:space="preserve">
     <value>問題: {0}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_DefaultSpecValue_csy" xml:space="preserve">
     <value>Hodnota {0} pro {1} je ukázková hodnota a měla by být odebrána.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_DefaultSpecValue_deu" xml:space="preserve">
     <value>Der Wert "{0}" für {1} ist ein Beispielwert und sollte entfernt werden.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_DefaultSpecValue_esp" xml:space="preserve">
     <value>El valor "{0}" para {1} es un valor de ejemplo y se debería quitar.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_DefaultSpecValue_fra" xml:space="preserve">
     <value>La valeur « {0} » pour {1} est un exemple et doit être supprimée.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_DefaultSpecValue_ita" xml:space="preserve">
     <value>Il valore "{0}" per {1} è un valore campione e debe essere rimosso.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_DefaultSpecValue_jpn" xml:space="preserve">
     <value>{1} の値 "{0}" はサンプル値なので、削除する必要があります。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_DefaultSpecValue_kor" xml:space="preserve">
     <value>{1}에 대한 "{0}" 값은 샘플 값이므로 제거해야 합니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_DefaultSpecValue_plk" xml:space="preserve">
     <value>Wartość „{0}” dla {1} jest wartością przykładową i należy ją usunąć.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_DefaultSpecValue_ptb" xml:space="preserve">
     <value>O valor "{0}" para {1} é um valor de amostra e deve ser removido.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_DefaultSpecValue_rus" xml:space="preserve">
     <value>Значение "{0}" для {1} является образцом значения, и его не следует удалять.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_DefaultSpecValue_trk" xml:space="preserve">
     <value>{1} için "{0}" örnek bir değerdir ve kaldırılması gerekir.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_DefaultSpecValue_chs" xml:space="preserve">
     <value>{1} 的值“{0}”是示例值，应将其删除。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_DefaultSpecValue_cht" xml:space="preserve">
     <value>{1} 的值 "{0}" 為範例值且應該移除。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_DefaultSpecValueSolution_csy" xml:space="preserve">
     <value>Nahraďte ji odpovídající hodnotou nebo ji odeberte a pak znovu sestavte balíček.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_DefaultSpecValueSolution_deu" xml:space="preserve">
     <value>Ersetzen Sie ihn durch einen geeigneten Wert, oder entfernen Sie ihn, und erstellen Sie das Paket dann erneut.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_DefaultSpecValueSolution_esp" xml:space="preserve">
     <value>Reemplazar con un valor apropiado o quitar y compilar el paquete.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_DefaultSpecValueSolution_fra" xml:space="preserve">
     <value>Remplacez-la par une valeur adéquate, ou supprimez-la et recréez le package.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_DefaultSpecValueSolution_ita" xml:space="preserve">
     <value>Sostituire con un valore appropriato o rimuoverlo e ricreare il pacchetto.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_DefaultSpecValueSolution_jpn" xml:space="preserve">
     <value>適切な値で置き換えるか、削除して、パッケージを再度ビルドする必要があります。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_DefaultSpecValueSolution_kor" xml:space="preserve">
     <value>적합한 값으로 바꾸거나 제거하고 패키지를 다시 빌드하십시오.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_DefaultSpecValueSolution_plk" xml:space="preserve">
     <value>Zastąp odpowiednią wartością lub usuń i ponownie skompiluj pakiet.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_DefaultSpecValueSolution_ptb" xml:space="preserve">
     <value>Substitua por um valor apropriado ou remova-o e reconstrua o seu pacote.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_DefaultSpecValueSolution_rus" xml:space="preserve">
     <value>Замените его соответствующим значением или удалите и повторно выполните сборку пакета.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_DefaultSpecValueSolution_trk" xml:space="preserve">
     <value>Uygun bir değerle değiştirin veya kaldırın ve paketinizi yeniden oluşturun.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_DefaultSpecValueSolution_chs" xml:space="preserve">
     <value>请替换为适当的值或删除它，然后重新生成程序包。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_DefaultSpecValueSolution_cht" xml:space="preserve">
     <value>以適當的值取代或移除並重新建置封裝。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_DefaultSpecValueTitle_csy" xml:space="preserve">
     <value>Odeberte ukázkové hodnoty nuspec.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_DefaultSpecValueTitle_deu" xml:space="preserve">
     <value>nuspec-Beispielwerte entfernen.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_DefaultSpecValueTitle_esp" xml:space="preserve">
     <value>Quitar los valores nuspec de ejemplo.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_DefaultSpecValueTitle_fra" xml:space="preserve">
     <value>Supprimez les valeurs nuspec d'exemple.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_DefaultSpecValueTitle_ita" xml:space="preserve">
     <value>Rimuovere valori campione nuspec.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_DefaultSpecValueTitle_jpn" xml:space="preserve">
     <value>サンプル nuspec 値を削除してください。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_DefaultSpecValueTitle_kor" xml:space="preserve">
     <value>샘플 nuspec 값을 제거합니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_DefaultSpecValueTitle_plk" xml:space="preserve">
     <value>Usuń przykładowe wartości nuspec.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_DefaultSpecValueTitle_ptb" xml:space="preserve">
     <value>Remova os valores nuspec de amostra.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_DefaultSpecValueTitle_rus" xml:space="preserve">
     <value>Удалите образцы значений nuspec.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_DefaultSpecValueTitle_trk" xml:space="preserve">
     <value>Örnek nuspec değerlerini kaldırın.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_DefaultSpecValueTitle_chs" xml:space="preserve">
     <value>删除示例 nuspec 值。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_DefaultSpecValueTitle_cht" xml:space="preserve">
     <value>移除範例 nuspec 值。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Credentials_ProxyCredentials_csy" xml:space="preserve">
     <value>Zadejte proxy přihlašovací údaje:</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Credentials_ProxyCredentials_deu" xml:space="preserve">
     <value>Bitte stellen Sie Proxyanmeldeinformationen zur Verfügung:</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Credentials_ProxyCredentials_esp" xml:space="preserve">
     <value>Proporcione las credenciales de proxy:</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Credentials_ProxyCredentials_fra" xml:space="preserve">
     <value>Veuillez fournir les informations d'identification du proxy :</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Credentials_ProxyCredentials_ita" xml:space="preserve">
     <value>Fornire credenziali proxy:</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Credentials_ProxyCredentials_jpn" xml:space="preserve">
     <value>プロキシの資格情報を指定してください:</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Credentials_ProxyCredentials_kor" xml:space="preserve">
     <value>프록시 자격 증명을 제공하십시오.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Credentials_ProxyCredentials_plk" xml:space="preserve">
     <value>Podaj poświadczenia serwera proxy:</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Credentials_ProxyCredentials_ptb" xml:space="preserve">
     <value>Forneça as credenciais de proxy:</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Credentials_ProxyCredentials_rus" xml:space="preserve">
     <value>Укажите учетные данные прокси-сервера:</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Credentials_ProxyCredentials_trk" xml:space="preserve">
     <value>Lütfen proxy kimlik bilgilerini belirtin:</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Credentials_ProxyCredentials_chs" xml:space="preserve">
     <value>请提供代理凭据:</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Credentials_ProxyCredentials_cht" xml:space="preserve">
     <value>請提供 Proxy 認證:</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_SemanticVersion_csy" xml:space="preserve">
     <value>Verze {0} nedodržuje pokyny pro správu sémantických verzí.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_SemanticVersion_deu" xml:space="preserve">
     <value>Die Version "{0}" genügt nicht den Richtlinien für semantische Versionsverwaltung.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_SemanticVersion_esp" xml:space="preserve">
     <value>La versión "{0}"no sigue las instrucciones de control de versiones semánticas.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_SemanticVersion_fra" xml:space="preserve">
     <value>La version « {0} » ne suit pas les instructions de contrôle de version sémantique.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_SemanticVersion_ita" xml:space="preserve">
     <value>La versione "{0}" non segue le linee guida di edizione semantica.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_SemanticVersion_jpn" xml:space="preserve">
     <value>バージョン "{0}" は、セマンティック バージョンのガイドラインに従っていません。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_SemanticVersion_kor" xml:space="preserve">
     <value>{0} 버전이 의미 체계의 버전 지정 지침을 따르지 않았습니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_SemanticVersion_plk" xml:space="preserve">
     <value>Wersja „{0}” nie jest zgodna ze wskazówkami dotyczącymi semantycznego przechowywania wersji.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_SemanticVersion_ptb" xml:space="preserve">
     <value>A versão "{0}" não segue as orientações de versionamento semântico.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_SemanticVersion_rus" xml:space="preserve">
     <value>Версия "{0}" не соответствует правилам управления семантическими версиями.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_SemanticVersion_trk" xml:space="preserve">
     <value>"{0}" sürümü anlamsal sürüm oluşturma kurallarına uymuyor.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_SemanticVersion_chs" xml:space="preserve">
     <value>版本“{0}”未遵循语义版本控制准则。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_SemanticVersion_cht" xml:space="preserve">
     <value>版本 "{0}" 不允許語意版本設定方針。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_SemanticVersionSolution_csy" xml:space="preserve">
     <value>Proveďte aktualizaci souboru nuspec nebo použijte atribut sestavení AssemblyInformationalVersion a zadejte sémantickou verzi podle popisu na webu http://semver.org. </value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_SemanticVersionSolution_deu" xml:space="preserve">
     <value>Aktualisieren Sie die nuspec-Datei, oder verwenden Sie das Assemblyattribut "AssemblyInformationalVersion", um eine semantische Version wie unter "http://semver.org" beschrieben anzugeben. </value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_SemanticVersionSolution_esp" xml:space="preserve">
     <value>Actualice su archivo nuspec o use el atributo de ensamblado AssemblyInformationalVersion para especificar una versión semántica como se describe en http://semver.org.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_SemanticVersionSolution_fra" xml:space="preserve">
     <value>Mettez à jour le fichier .nuspec, ou utilisez l'attribut d'assembly AssemblyInformationalVersion, pour spécifier la version sémantique comme décrit sur http://semver.org. </value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_SemanticVersionSolution_ita" xml:space="preserve">
     <value>Aggiornare il file nuspec o usare l'attributo AssemblyInformationalVersion  per specificare la versione semantica come descritto in http://semver.org. </value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_SemanticVersionSolution_jpn" xml:space="preserve">
     <value>nuspec ファイルを更新するか、AssemblyInformationalVersion アセンブリ属性を使用して、http://semver.org の説明に従ってセマンティック バージョンを指定してください。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_SemanticVersionSolution_kor" xml:space="preserve">
     <value>nuspec 파일을 업데이트하거나 AssemblyInformationalVersion 어셈블리 특성을 사용하여 http://semver.org에서 설명하는 것과 같이 의미 체계의 버전을 지정하십시오. </value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_SemanticVersionSolution_plk" xml:space="preserve">
     <value>Zaktualizuj plik nuspec lub użyj atrybutu zestawu AssemblyInformationalVersion, aby określić wersję semantyczną zgodnie z opisem na stronie http://semver.org. </value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_SemanticVersionSolution_ptb" xml:space="preserve">
     <value>Atualize seu arquivo nuspec ou usar o atributo de assembly AssemblyInformationalVersion para especificar uma versão semântica, como descrito em http://semver.org.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_SemanticVersionSolution_rus" xml:space="preserve">
     <value>Обновите ваш NUSPEC-файл или с помощью атрибута AssemblyInformationalVersion укажите семантическую версию, как описано по адресу: http://semver.org. </value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_SemanticVersionSolution_trk" xml:space="preserve">
     <value>Nuspec dosyanızı güncelleyin veya http://semver.org sayfasında açıklanan şekilde bir anlamsal sürüm belirlemek için AssemblyInformationalVersion derleme özniteliğini kullanın . </value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_SemanticVersionSolution_chs" xml:space="preserve">
     <value>更新 nuspec 文件，或使用 AssemblyInformationalVersion 程序集属性指定 http://semver.org 上所述的语义版本。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_SemanticVersionSolution_cht" xml:space="preserve">
     <value>更新您的 nuspec 檔案或使用 AssemblyInformationalVersion 組件屬性以指定語意版本設定，如t http://semver.org 中所述。 </value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_SemanticVersionTitle_csy" xml:space="preserve">
     <value>Použít správu sémantických verzí</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_SemanticVersionTitle_deu" xml:space="preserve">
     <value>Semantische Versionsverwaltung verwenden</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_SemanticVersionTitle_esp" xml:space="preserve">
     <value>Use el control de versiones semántico</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_SemanticVersionTitle_fra" xml:space="preserve">
     <value>Utilisation du contrôle de version sémantique</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_SemanticVersionTitle_ita" xml:space="preserve">
     <value>Usare edizione semantica</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_SemanticVersionTitle_jpn" xml:space="preserve">
     <value>セマンティック バージョンの使用</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_SemanticVersionTitle_kor" xml:space="preserve">
     <value>의미 체계의 버전 지정 사용</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_SemanticVersionTitle_plk" xml:space="preserve">
     <value>Zastosuj semantyczne przechowywanie wersji</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_SemanticVersionTitle_ptb" xml:space="preserve">
     <value>Usar versões semânticas</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_SemanticVersionTitle_rus" xml:space="preserve">
     <value>Использования управления семантическими версиями</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_SemanticVersionTitle_trk" xml:space="preserve">
     <value>Anlamsal sürüm oluşturmayı kullanın.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_SemanticVersionTitle_chs" xml:space="preserve">
     <value>使用语义版本控制</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_SemanticVersionTitle_cht" xml:space="preserve">
     <value>使用語意版本設定。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="OfficialPackageSourceName_csy" xml:space="preserve">
     <value>Oficiální zdroj balíčků NuGet</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="OfficialPackageSourceName_deu" xml:space="preserve">
     <value>Offizielle NuGet-Paketquelle</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="OfficialPackageSourceName_esp" xml:space="preserve">
     <value>origen del paquete oficial de NuGet</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="OfficialPackageSourceName_fra" xml:space="preserve">
     <value>Source du package officiel NuGet</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="OfficialPackageSourceName_ita" xml:space="preserve">
     <value>Fonte pacchetto ufficiale NuGet </value>
+    <comment>{Locked}</comment>
   </data>
   <data name="OfficialPackageSourceName_jpn" xml:space="preserve">
     <value>NuGet の正式なパッケージ ソース</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="OfficialPackageSourceName_kor" xml:space="preserve">
     <value>NuGet 공식 패키지 소스</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="OfficialPackageSourceName_plk" xml:space="preserve">
     <value>Oficjalne źródło pakietów NuGet</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="OfficialPackageSourceName_ptb" xml:space="preserve">
     <value>Origem de pacote oficial NuGet</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="OfficialPackageSourceName_rus" xml:space="preserve">
     <value>Официальный источник пакетов NuGet</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="OfficialPackageSourceName_trk" xml:space="preserve">
     <value>NuGet resmi paket kaynağı</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="OfficialPackageSourceName_chs" xml:space="preserve">
     <value>NuGet 官方程序包源</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="OfficialPackageSourceName_cht" xml:space="preserve">
     <value>NuGet 官方封裝來源</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandFileFromDependencyIsChanged_csy" xml:space="preserve">
     <value>Soubor ze závislosti se změnil. Probíhá přidávání souboru {0}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandFileFromDependencyIsChanged_deu" xml:space="preserve">
     <value>Die Datei aus der Abhängigkeit wurde geändert. Die Datei "{0}" wird hinzugefügt.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandFileFromDependencyIsChanged_esp" xml:space="preserve">
     <value>Se ha cambiado el archivo de la dependencia. Agregando archivo '{0}'.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandFileFromDependencyIsChanged_fra" xml:space="preserve">
     <value>Le @@@fichier de dépendance est modifié. Ajout du fichier '{0}'.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandFileFromDependencyIsChanged_ita" xml:space="preserve">
     <value>File da dipendenza modificato. Aggiungere file '{0}'.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandFileFromDependencyIsChanged_jpn" xml:space="preserve">
     <value>依存関係のファイルが変更されます。ファイル '{0}' を追加しています。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandFileFromDependencyIsChanged_kor" xml:space="preserve">
     <value>종속성에서 파일이 변경되었습니다. '{0}' 파일을 추가하고 있습니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandFileFromDependencyIsChanged_plk" xml:space="preserve">
     <value>Plik z zależności został zmieniony. Dodawanie pliku „{0}”.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandFileFromDependencyIsChanged_ptb" xml:space="preserve">
     <value>O arquivo de dependência foi alterado. Adicionando o arquivo '{0}'.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandFileFromDependencyIsChanged_rus" xml:space="preserve">
     <value>Файл из зависимости был изменен. Добавление файла "{0}".</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandFileFromDependencyIsChanged_trk" xml:space="preserve">
     <value>Bağımlılık dosyası değiştirildi. '{0}' dosyası ekleniyor.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandFileFromDependencyIsChanged_chs" xml:space="preserve">
     <value>依赖关系中的文件已更改。正在添加文件“{0}”。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandFileFromDependencyIsChanged_cht" xml:space="preserve">
     <value>相依性中的檔案已變更。正在新增檔案 '{0}'。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandPackagePushed_csy" xml:space="preserve">
     <value>Balíček byl předán.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandPackagePushed_deu" xml:space="preserve">
     <value>Ihr Paket wurde mittels Push übertragen.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandPackagePushed_esp" xml:space="preserve">
     <value>Se ha insertado su proyecto.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandPackagePushed_fra" xml:space="preserve">
     <value>Votre package a été transmis.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandPackagePushed_ita" xml:space="preserve">
     <value>Il pacchetto è stato compresso.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandPackagePushed_jpn" xml:space="preserve">
     <value>パッケージがプッシュされました。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandPackagePushed_kor" xml:space="preserve">
     <value>패키지가 푸시되었습니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandPackagePushed_plk" xml:space="preserve">
     <value>Pakiet został wypchnięty.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandPackagePushed_ptb" xml:space="preserve">
     <value>O pacote foi empurrado.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandPackagePushed_rus" xml:space="preserve">
     <value>Ваш пакет был отправлен.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandPackagePushed_trk" xml:space="preserve">
     <value>Paketiniz iletildi.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandPackagePushed_chs" xml:space="preserve">
     <value>已推送你的程序包。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PushCommandPackagePushed_cht" xml:space="preserve">
     <value>已推入您的封裝。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandFileFromDependencyIsNotChanged_csy" xml:space="preserve">
     <value>Soubor ze závislosti se nezměnil. Soubor {0} není přidán.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandFileFromDependencyIsNotChanged_deu" xml:space="preserve">
     <value>Die Datei aus der Abhängigkeit wurde nicht geändert. Die Datei "{0}" wird nicht hinzugefügt.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandFileFromDependencyIsNotChanged_esp" xml:space="preserve">
     <value>No se ha cambiado el archivo de la dependencia. El archivo '{0}' no se ha agregado.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandFileFromDependencyIsNotChanged_fra" xml:space="preserve">
     <value>Le @@@fichier de dépendance n'a pas été modifié. Le fichier '{0}' n'a pas été ajouté.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandFileFromDependencyIsNotChanged_ita" xml:space="preserve">
     <value>File da dipendenza non modificato. File '{0}' non aggiunto.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandFileFromDependencyIsNotChanged_jpn" xml:space="preserve">
     <value>依存関係のファイルは変更されません。ファイル '{0}' は追加されません。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandFileFromDependencyIsNotChanged_kor" xml:space="preserve">
     <value>종속성에서 파일이 변경되지 않았습니다. '{0}' 파일이 추가되지 않습니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandFileFromDependencyIsNotChanged_plk" xml:space="preserve">
     <value>Plik z zależności nie został zmieniony. Nie dodano pliku „{0}”.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandFileFromDependencyIsNotChanged_ptb" xml:space="preserve">
     <value>O arquivo da dependência não foi alterado. O arquivo '{0}' não foi adicionado.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandFileFromDependencyIsNotChanged_rus" xml:space="preserve">
     <value>Файл из зависимости не был изменен. Файл "{0}" не добавлен.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandFileFromDependencyIsNotChanged_trk" xml:space="preserve">
     <value>Bağımlılık dosyası değiştirilmedi. '{0}' dosyası eklenmedi.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandFileFromDependencyIsNotChanged_chs" xml:space="preserve">
     <value>依赖关系中的文件未更改。未添加文件“{0}”。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandFileFromDependencyIsNotChanged_cht" xml:space="preserve">
     <value>相依性中的檔案並未變更。並未新增檔案 '{0}'。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToFindFile_csy" xml:space="preserve">
     <value>Soubor neexistuje ({0}).</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToFindFile_deu" xml:space="preserve">
     <value>Die Datei ist nicht vorhanden ("{0}").</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToFindFile_esp" xml:space="preserve">
     <value>No existe el archivo ({0}).</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToFindFile_fra" xml:space="preserve">
     <value>Le fichier n'existe pas ({0}).</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToFindFile_ita" xml:space="preserve">
     <value>Il file non esiste ({0}).</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToFindFile_jpn" xml:space="preserve">
     <value>ファイルは存在しません ({0})。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToFindFile_kor" xml:space="preserve">
     <value>파일이 없습니다({0}).</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToFindFile_plk" xml:space="preserve">
     <value>Plik nie istnieje ({0}).</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToFindFile_ptb" xml:space="preserve">
     <value>O arquivo não existe ({0}).</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToFindFile_rus" xml:space="preserve">
     <value>Файл не существует ({0}).</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToFindFile_trk" xml:space="preserve">
     <value>Dosya mevcut değil ({0}).</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToFindFile_chs" xml:space="preserve">
     <value>文件不存在({0})。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToFindFile_cht" xml:space="preserve">
     <value>檔案不存在 ({0})。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandPackageRestoreConsentNotFound_csy" xml:space="preserve">
     <value>Obnovení balíčku je zakázáno. Chcete-li je povolit, otevřete dialogové okno Možnosti sady Visual Studio, klikněte na uzel Správce balíčků a zaškrtněte položku {0}. Obnovení balíčku můžete rovněž povolit nastavením proměnné prostředí EnableNuGetPackageRestore na hodnotu true.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandPackageRestoreConsentNotFound_deu" xml:space="preserve">
     <value>Die Paketwiederherstellung ist deaktiviert. Öffnen Sie zum Aktivieren das Dialogfeld "Optionen" von Visual Studio, klicken Sie auf den Knoten "Paket-Manager", und aktivieren Sie dann "{0}". Sie können die Paketwiederherstellung auch aktivieren, indem Sie die Umgebungsvariable "EnableNuGetPackageRestore" auf "true" festlegen.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandPackageRestoreConsentNotFound_esp" xml:space="preserve">
     <value>Se ha deshabilitado la restauración del paquete. Para habilitarla, abra el cuadro de diálogo Opciones de Visual Studio, haga clic en el nodo del Administrador de paquetes y compruebe '{0}'. Para habilitar la restauración de paquetes, también puede configurar la variable de entorno 'EnableNuGetPackageRestore' a 'true'.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandPackageRestoreConsentNotFound_fra" xml:space="preserve">
     <value>La restauration de package est désactivée. Pour l'activer, ouvrez la boîte de dialogue Options Visual Studio, cliquez sur le nœud Gestionnaire de package et cochez '{0}'. Vous pouvez également activer la restauration de package en définissant la variable d'environnement 'EnableNuGetPackageRestore' avec la valeur 'true'.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandPackageRestoreConsentNotFound_ita" xml:space="preserve">
     <value>Ripristino pacchetto disabilitato. Per abilitarlo, aprire la finestra di dialogo Visual Studio Options, fare clic su Package Manager node e verificare '{0}'. È possibile anche abilitare il pacchetto impostando la variabile ambiente 'EnableNuGetPackageRestore' su 'vero'.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandPackageRestoreConsentNotFound_jpn" xml:space="preserve">
     <value>パッケージの復元は無効です。有効にするには、Visual Studio の [オプション] ダイアログを開き、パッケージ マネージャー ノードをクリックし、'{0}' を確認します。環境変数 'EnableNuGetPackageRestore' を 'true' に設定して、パッケージの復元を有効にすることもできます。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandPackageRestoreConsentNotFound_kor" xml:space="preserve">
     <value>패키지 복원을 사용할 수 없습니다. 패키지 복원을 사용하도록 설정하려면 [Visual Studio 옵션] 대화 상자를 열고 [패키지 관리자] 노드를 클릭한 후 '{0}'을(를) 선택합니다. 또한 환경 변수 'EnableNuGetPackageRestore'를 'true'로 설정하여 패키지 복원을 사용하도록 설정할 수 있습니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandPackageRestoreConsentNotFound_plk" xml:space="preserve">
     <value>Przywracanie pakietu jest wyłączone. Aby je włączyć, otwórz okno dialogowe opcji programu Visual Studio, kliknij węzeł Menedżera pakietów i zaznacz pozycję „{0}”. Przywracanie pakietów możesz także włączyć, ustawiając wartość „true” dla zmiennej środowiskowej „EnableNuGetPackageRestore”.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandPackageRestoreConsentNotFound_ptb" xml:space="preserve">
     <value>A restauração do pacote está desativada. Para ativá-la, abra a caixa de diálogo Opções do Visual Studio, clique no nó do Gerenciador de Pacotes e marque '{0}'. Você também pode ativar a restauração do pacote definindo a variável de ambiente 'EnableNuGetPackageRestore' como "true".</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandPackageRestoreConsentNotFound_rus" xml:space="preserve">
     <value>Восстановление пакетов отключено. Чтобы включить его, в Visual Studio откройте диалоговое окно "Параметры", выберите узел "Диспетчер пакетов" и проверьте "{0}". Кроме того, чтобы включить восстановление пакетов, можно для переменной среды "EnableNuGetPackageRestore" задать значение "true".</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandPackageRestoreConsentNotFound_trk" xml:space="preserve">
     <value>Paket geri yükleme devre dışı. Etkinleştirmek için Visual Studio Seçenekler iletişim kutusunu açın, Paket Yöneticisi düğümünü tıklayın ve '{0}' öğesini kontrol edin. Paket geri yüklemesini ayrıca 'EnableNuGetPackageRestore' ortam değişkenini 'doğru' olarak ayarlayarak da etkinleştirebilirsiniz.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandPackageRestoreConsentNotFound_chs" xml:space="preserve">
     <value>已禁用程序包还原。若要启用它，请打开“Visual Studio 选项”对话框，单击“程序包管理器”节点并检查“{0}”。你还可以通过将环境变量 "EnableNuGetPackageRestore" 设置为 "true" 来启用程序包还原。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InstallCommandPackageRestoreConsentNotFound_cht" xml:space="preserve">
     <value>已停用封裝還原。若要啟用，開啟 Visual Studio 選項對話，按一下 [封裝管理員] 節點並勾選 '{0}'。您也可以設定環境變數 'EnableNuGetPackageRestore' 為 'true' 以啟用封裝還原。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConfigCommandKeyNotFound_csy" xml:space="preserve">
     <value>Klíč {0} nebyl nalezen.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConfigCommandKeyNotFound_deu" xml:space="preserve">
     <value>Der Schlüssel "{0}" wurde nicht gefunden.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConfigCommandKeyNotFound_esp" xml:space="preserve">
     <value>No se encuentra la clave '{0}'.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConfigCommandKeyNotFound_fra" xml:space="preserve">
     <value>Clé '{0}' introuvable.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConfigCommandKeyNotFound_ita" xml:space="preserve">
     <value>Chiave '{0}' non trovata.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConfigCommandKeyNotFound_jpn" xml:space="preserve">
     <value>キー '{0}' が見つかりません。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConfigCommandKeyNotFound_kor" xml:space="preserve">
     <value>'{0}' 키를 찾을 수 없습니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConfigCommandKeyNotFound_plk" xml:space="preserve">
     <value>Nie odnaleziono klucza „{0}”.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConfigCommandKeyNotFound_ptb" xml:space="preserve">
     <value>Chave '{0}' não encontrada.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConfigCommandKeyNotFound_rus" xml:space="preserve">
     <value>Ключ "{0}" не найден.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConfigCommandKeyNotFound_trk" xml:space="preserve">
     <value>{0}' anahtarı bulunamadı.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConfigCommandKeyNotFound_chs" xml:space="preserve">
     <value>找不到键“{0}”。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ConfigCommandKeyNotFound_cht" xml:space="preserve">
     <value>找不到索引鍵 '{0}'。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Error_CannotPromptForInput_csy" xml:space="preserve">
     <value>V neinteraktivním režimu nelze zobrazit výzvu pro zadání vstupu.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Error_CannotPromptForInput_deu" xml:space="preserve">
     <value>Im nicht interaktiven Modus kann keine Eingabeaufforderung erfolgen.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Error_CannotPromptForInput_esp" xml:space="preserve">
     <value>No se puede pedir confirmación de la entrada en un modo no interactivo.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Error_CannotPromptForInput_fra" xml:space="preserve">
     <value>Le mode non interactif ne permet pas l'invite de saisie de données.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Error_CannotPromptForInput_ita" xml:space="preserve">
     <value>Impossibile richiedere input in modalità non interattiva</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Error_CannotPromptForInput_jpn" xml:space="preserve">
     <value>非対話モードの場合、入力のプロンプトを表示できません。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Error_CannotPromptForInput_kor" xml:space="preserve">
     <value>비대화형 모드에서는 입력을 요청할 수 없습니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Error_CannotPromptForInput_plk" xml:space="preserve">
     <value>Nie można monitować o dane wejściowe w trybie nieinterakcyjnym.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Error_CannotPromptForInput_ptb" xml:space="preserve">
     <value>Não foi possível solicitar a entrada no modo não interativo.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Error_CannotPromptForInput_rus" xml:space="preserve">
     <value>Запрос ввода в неинтерактивном режиме невозможен.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Error_CannotPromptForInput_trk" xml:space="preserve">
     <value>Etkileşimli olmayan modda girdi istenemiyor.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Error_CannotPromptForInput_chs" xml:space="preserve">
     <value>无法在非交互式模式下提示输入。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Error_CannotPromptForInput_cht" xml:space="preserve">
     <value>無法在非互動模式下提供提示。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandDeletingPackage_csy" xml:space="preserve">
     <value>Probíhá odstraňování {0} {1} z {2}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandDeletingPackage_deu" xml:space="preserve">
     <value>{0} {1} wird aus "{2}" gelöscht.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandDeletingPackage_esp" xml:space="preserve">
     <value>Eliminando {0} {1} de {2}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandDeletingPackage_fra" xml:space="preserve">
     <value>Suppression de {0} {1} de {2}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandDeletingPackage_ita" xml:space="preserve">
     <value>Cancellando {0} {1} da {2}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandDeletingPackage_jpn" xml:space="preserve">
     <value>{2} から {0} {1} を削除しています。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandDeletingPackage_kor" xml:space="preserve">
     <value>{0} {1}을(를) {2}에서 삭제하고 있습니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandDeletingPackage_plk" xml:space="preserve">
     <value>Usuwanie elementu {0} {1} z {2}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandDeletingPackage_ptb" xml:space="preserve">
     <value>Excluindo {0} {1} do {2}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandDeletingPackage_rus" xml:space="preserve">
     <value>Удаление {0} {1} из {2}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandDeletingPackage_trk" xml:space="preserve">
     <value>{0} {1} öğeleri {2} konumundan siliniyor.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandDeletingPackage_chs" xml:space="preserve">
     <value>正在从 {2} 中删除 {0} {1}。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="DeleteCommandDeletingPackage_cht" xml:space="preserve">
     <value>正在從 {2} 刪除 {0} {1}。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Option_VerboseDeprecated_csy" xml:space="preserve">
     <value>Možnost Podrobný se již nepoužívá. Použijte místo toho možnost Podrobnosti.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Option_VerboseDeprecated_deu" xml:space="preserve">
     <value>Die Option "Verbose" ist veraltet. Verwenden Sie stattdessen "Verbosity".</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Option_VerboseDeprecated_esp" xml:space="preserve">
     <value>La opción 'Verbose' ha dejado de usarse. Use 'Verbosity' en su lugar.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Option_VerboseDeprecated_fra" xml:space="preserve">
     <value>L'option 'Verbose' a été dépréciée. Préférez plutôt 'Verbosity'.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Option_VerboseDeprecated_ita" xml:space="preserve">
     <value>Opzione 'Verbose' non approvata. Usare 'Verbosity' invece.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Option_VerboseDeprecated_jpn" xml:space="preserve">
     <value>オプション 'Verbose' は使用しないでください。代わりに 'Verbosity' を使用してください。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Option_VerboseDeprecated_kor" xml:space="preserve">
     <value>'Verbose' 옵션은 사용되지 않습니다. 대신 'Verbosity'를 사용하십시오.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Option_VerboseDeprecated_plk" xml:space="preserve">
     <value>Opcja „Verbose” jest przestarzała. Zamiast niej użyj opcji „Verbosity”.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Option_VerboseDeprecated_ptb" xml:space="preserve">
     <value>A opção "Detalhe" foi substituída. Use "Detalhamento" como alternativa.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Option_VerboseDeprecated_rus" xml:space="preserve">
     <value>Параметр "Verbose" удален из этой версии. Вместо него используйте "Verbosity".</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Option_VerboseDeprecated_trk" xml:space="preserve">
     <value>Ayrıntılı' seçeneği kullanım dışı bırakılmış. Bunun yerine 'Ayrıntı Düzeyi' seçimini kullanın.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Option_VerboseDeprecated_chs" xml:space="preserve">
     <value>选项 "Verbose" 已弃用。请改用 "Verbosity"。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Option_VerboseDeprecated_cht" xml:space="preserve">
     <value>Verbose' 選項已過時。請使用 'Verbosity'。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandCreatedNuSpec_csy" xml:space="preserve">
     <value>{0} úspěšně vytvořeno.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandCreatedNuSpec_deu" xml:space="preserve">
     <value>"{0}" wurde erfolgreich erstellt.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandCreatedNuSpec_esp" xml:space="preserve">
     <value>{0}' creado correctamente.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandCreatedNuSpec_fra" xml:space="preserve">
     <value>'{0}' créé correctement.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandCreatedNuSpec_ita" xml:space="preserve">
     <value>Creato '{0}' correttamente.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandCreatedNuSpec_jpn" xml:space="preserve">
     <value>'{0}' は正常に作成されました。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandCreatedNuSpec_kor" xml:space="preserve">
     <value>'{0}'을(를) 만들었습니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandCreatedNuSpec_plk" xml:space="preserve">
     <value>Pomyślnie utworzono „{0}”.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandCreatedNuSpec_ptb" xml:space="preserve">
     <value>Criado '{0}' com sucesso.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandCreatedNuSpec_rus" xml:space="preserve">
     <value>"{0}" успешно создан.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandCreatedNuSpec_trk" xml:space="preserve">
     <value>{0}' başarıyla oluşturuldu.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandCreatedNuSpec_chs" xml:space="preserve">
     <value>已成功创建“{0}”。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandCreatedNuSpec_cht" xml:space="preserve">
     <value>已成功建立 '{0}'。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandFileExists_csy" xml:space="preserve">
     <value>{0} již existuje, k přepsání použijte -Force.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandFileExists_deu" xml:space="preserve">
     <value>"{0}" ist bereits vorhanden. Verwenden Sie "-Force" zum Überschreiben.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandFileExists_esp" xml:space="preserve">
     <value>{0}' ya existe, use -Force para sobrescribirlo.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandFileExists_fra" xml:space="preserve">
     <value>'{0}' existe déjà. Utilisez -Force pour le remplacer.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandFileExists_ita" xml:space="preserve">
     <value>{0}' già esistente, usere  -Force per sostituire.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandFileExists_jpn" xml:space="preserve">
     <value>'{0}' は既に存在します。上書きするには、-Force を使用してください。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandFileExists_kor" xml:space="preserve">
     <value>'{0}'이(가) 이미 있습니다. 덮어쓰려면 -Force를 사용하십시오.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandFileExists_plk" xml:space="preserve">
     <value>Plik „{0}” już istnieje, użyj argumentu -Force, aby go zastąpić.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandFileExists_ptb" xml:space="preserve">
     <value>{0}' já existe, use -Force para substituí-lo.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandFileExists_rus" xml:space="preserve">
     <value>"{0}" уже существует. Для перезаписи используйте параметр -Force.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandFileExists_trk" xml:space="preserve">
     <value>{0}' zaten mevcut, geçersiz kılmak için -Force seçimini kullanın.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandFileExists_chs" xml:space="preserve">
     <value>“{0}”已存在，请使用 -Force 覆盖它。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SpecCommandFileExists_cht" xml:space="preserve">
     <value>{0}' 己存在，使用 -Force 加以覆寫。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_NoPromptDeprecated_csy" xml:space="preserve">
     <value>Možnost NoPrompt se již nepoužívá. Použijte místo toho možnost NonInteractive.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_NoPromptDeprecated_deu" xml:space="preserve">
     <value>Die Option "NoPrompt" ist veraltet. Verwenden Sie stattdessen "NonInteractive".</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_NoPromptDeprecated_esp" xml:space="preserve">
     <value>La opción 'NoPrompt' se ha desusado. Use 'NonInteractive' en su lugar.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_NoPromptDeprecated_fra" xml:space="preserve">
     <value>L'option 'NoPrompt' a été dépréciée. Préférez plutôt 'NonInteractive'.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_NoPromptDeprecated_ita" xml:space="preserve">
     <value>Opzione 'NoPrompt' disapprovata. Usare 'NonInteractive'.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_NoPromptDeprecated_jpn" xml:space="preserve">
     <value>オプション 'NoPrompt' は使用しないでください。代わりに 'NonInteractive' を使用してください。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_NoPromptDeprecated_kor" xml:space="preserve">
     <value>'NoPrompt' 옵션은 사용되지 않습니다. 대신 'NonInteractive'를 사용하십시오.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_NoPromptDeprecated_plk" xml:space="preserve">
     <value>Opcja „NoPrompt” jest przestarzała. Zamiast niej użyj opcji „NonInteractive”.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_NoPromptDeprecated_ptb" xml:space="preserve">
     <value>A opção 'NoPrompt' tornou-se obsoleta. Use "Não interativo" como alternativa.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_NoPromptDeprecated_rus" xml:space="preserve">
     <value>Параметр "NoPrompt" удален из этой версии. Вместо него используйте "NonInteractive".</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_NoPromptDeprecated_trk" xml:space="preserve">
     <value>NoPrompt' seçeneği kullanımdan kaldırılmış. Bunun yerine 'NonInteractive' seçeneğini kullanın.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_NoPromptDeprecated_chs" xml:space="preserve">
     <value>选项 "NoPrompt" 已弃用。请改用 "NonInteractive"。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_NoPromptDeprecated_cht" xml:space="preserve">
     <value>選項 'NoPrompt' 已過時。使用 'NonInteractive'。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Error_SettingsIsNull_csy" xml:space="preserve">
     <value>Vlastnost Settings má hodnotu null.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Error_SettingsIsNull_deu" xml:space="preserve">
     <value>Die Eigenschafteneinstellungen sind null.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Error_SettingsIsNull_esp" xml:space="preserve">
     <value>La configuración de propiedad es nula.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Error_SettingsIsNull_fra" xml:space="preserve">
     <value>Les paramètres de propriété sont nuls.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Error_SettingsIsNull_ita" xml:space="preserve">
     <value>Property Setting è nullo.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Error_SettingsIsNull_jpn" xml:space="preserve">
     <value>プロパティ設定が null です。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Error_SettingsIsNull_kor" xml:space="preserve">
     <value>Settings 속성이 null입니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Error_SettingsIsNull_plk" xml:space="preserve">
     <value>Właściwość Settings ma wartość null.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Error_SettingsIsNull_ptb" xml:space="preserve">
     <value>O item Property Settings é nulo.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Error_SettingsIsNull_rus" xml:space="preserve">
     <value>Settings свойства имеет значение NULL.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Error_SettingsIsNull_trk" xml:space="preserve">
     <value>Özellik Ayarları null.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Error_SettingsIsNull_chs" xml:space="preserve">
     <value>属性设置为 null。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Error_SettingsIsNull_cht" xml:space="preserve">
     <value>屬性設定為 Null。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Error_SourceProviderIsNull_csy" xml:space="preserve">
     <value>Vlastnost SourceProvider má hodnotu null.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Error_SourceProviderIsNull_deu" xml:space="preserve">
     <value>Die Eigenschaft "SourceProvider" ist null.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Error_SourceProviderIsNull_esp" xml:space="preserve">
     <value>La propiedad SourceProvider es nula.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Error_SourceProviderIsNull_fra" xml:space="preserve">
     <value>Le @@@fournisseur de source de propriété est nul.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Error_SourceProviderIsNull_ita" xml:space="preserve">
     <value>Property sSourceProvider è nullo.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Error_SourceProviderIsNull_jpn" xml:space="preserve">
     <value>プロパティ SourceProvider は null です。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Error_SourceProviderIsNull_kor" xml:space="preserve">
     <value>SourceProvider 속성이 null입니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Error_SourceProviderIsNull_plk" xml:space="preserve">
     <value>Właściwość SourceProvider ma wartość null.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Error_SourceProviderIsNull_ptb" xml:space="preserve">
     <value>O item SourceProvider de propriedade é nulo.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Error_SourceProviderIsNull_rus" xml:space="preserve">
     <value>SourceProvider свойства имеет значение NULL.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Error_SourceProviderIsNull_trk" xml:space="preserve">
     <value>Özellik SourceProvider null.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Error_SourceProviderIsNull_chs" xml:space="preserve">
     <value>SourceProvider 属性为 null。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Error_SourceProviderIsNull_cht" xml:space="preserve">
     <value>屬性 SourceProvider 為 Null。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandInvalidMinClientVersion_csy" xml:space="preserve">
     <value>Hodnotou argumentu MinClientVersion není platná verze.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandInvalidMinClientVersion_deu" xml:space="preserve">
     <value>Der Wert des Arguments "MinClientVersion" weist keine gültige Version auf.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandInvalidMinClientVersion_esp" xml:space="preserve">
     <value>El valor del argumento de MinClientVersion no es una versión válida.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandInvalidMinClientVersion_fra" xml:space="preserve">
     <value>La version de la valeur de l'argument MinClientVersion n'est pas valide.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandInvalidMinClientVersion_ita" xml:space="preserve">
     <value>Il valore dell'argomento MinClientVersion non ha una versione valida.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandInvalidMinClientVersion_jpn" xml:space="preserve">
     <value>MinClientVersion 引数の値は有効なバージョンではありません。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandInvalidMinClientVersion_kor" xml:space="preserve">
     <value>MinClientVersion 인수 값은 올바른 버전이 아닙니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandInvalidMinClientVersion_plk" xml:space="preserve">
     <value>Wartość argumentu MinClientVersion nie jest prawidłową wersją.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandInvalidMinClientVersion_ptb" xml:space="preserve">
     <value>O valor do argumento MinClientVersion não é uma versão válida.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandInvalidMinClientVersion_rus" xml:space="preserve">
     <value>Недопустимая версия значения аргумента MinClientVersion.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandInvalidMinClientVersion_trk" xml:space="preserve">
     <value>MinClientVersion bağımsız değişken değeri geçerli bir sürüm değildir.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandInvalidMinClientVersion_chs" xml:space="preserve">
     <value>MinClientVersion 参数的值不是有效版本。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="PackageCommandInvalidMinClientVersion_cht" xml:space="preserve">
     <value>MinClientVersion 引數的值不是有效版本。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="AddFileToPackage_csy" xml:space="preserve">
     <value>Přidat soubor {0} do balíčku jako {1}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="AddFileToPackage_deu" xml:space="preserve">
     <value>Datei "{0}" dem Paket als "{1}" hinzufügen</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="AddFileToPackage_esp" xml:space="preserve">
     <value>Agregar archivo '{0}' al paquete como '{1}'</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="AddFileToPackage_fra" xml:space="preserve">
     <value>Ajouter le fichier '{0}' au package comme '{1}'</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="AddFileToPackage_ita" xml:space="preserve">
     <value>Aggiungere file '{0}' a pacchetto come '{1}'</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="AddFileToPackage_jpn" xml:space="preserve">
     <value>ファイル '{0}' を '{1}' としてパッケージに追加します</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="AddFileToPackage_kor" xml:space="preserve">
     <value>패키지에 '{1}'(으)로 '{0}' 파일 추가</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="AddFileToPackage_plk" xml:space="preserve">
     <value>Dodaj plik „{0}” do pakietu jako „{1}”</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="AddFileToPackage_ptb" xml:space="preserve">
     <value>Adicionar arquivo '{0}' ao pacote como '{1}'</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="AddFileToPackage_rus" xml:space="preserve">
     <value>Добавление файла "{0}" в пакет как "{1}"</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="AddFileToPackage_trk" xml:space="preserve">
     <value>{0}' dosyasını pakete '{1}' olarak ekle</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="AddFileToPackage_chs" xml:space="preserve">
     <value>将文件“{0}”作为“{1}”添加到程序包</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="AddFileToPackage_cht" xml:space="preserve">
     <value>新增檔案 '{0}' 到封裝以做為 '{1}'</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="FileNotAddedToPackage_csy" xml:space="preserve">
     <value>Soubor {0} není přidán, protože balíček již obsahuje soubor {1}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="FileNotAddedToPackage_deu" xml:space="preserve">
     <value>Die Datei "{0}" wird nicht hinzugefügt, weil das Paket die Datei "{1}" bereits enthält.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="FileNotAddedToPackage_esp" xml:space="preserve">
     <value>No se ha agregado el archivo '{0}' porque el paquete aún contiene el archivo '{1}'</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="FileNotAddedToPackage_fra" xml:space="preserve">
     <value>Le fichier '{0}' n'a pas été ajouté car le package contient déjà le fichier '{1}'.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="FileNotAddedToPackage_ita" xml:space="preserve">
     <value>Impossibile aggiungere file '{0}' perché il pacchetto contiene già file '{1}'</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="FileNotAddedToPackage_jpn" xml:space="preserve">
     <value>パッケージには既にファイル '{1}' が含まれているため、ファイル '{0}' は追加されません</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="FileNotAddedToPackage_kor" xml:space="preserve">
     <value>패키지에 '{1}' 파일이 이미 있으므로 '{0}' 파일이 추가되지 않았습니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="FileNotAddedToPackage_plk" xml:space="preserve">
     <value>Plik „{0}” nie został dodany, ponieważ pakiet zawiera już plik „{1}”</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="FileNotAddedToPackage_ptb" xml:space="preserve">
     <value>O arquivo '{0}' não é adicionado porque o pacote já contém o arquivo '{1}'</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="FileNotAddedToPackage_rus" xml:space="preserve">
     <value>Файл "{0}" не добавлен, так как в пакете уже есть файл "{1}"</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="FileNotAddedToPackage_trk" xml:space="preserve">
     <value>Paket zaten '{1}'dosyası içerdiğinden '{0}' eklenmedi</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="FileNotAddedToPackage_chs" xml:space="preserve">
     <value>未添加文件“{0}”，因为程序包已包含文件“{1}”</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="FileNotAddedToPackage_cht" xml:space="preserve">
     <value>並未新增檔案 '{0}'，因為封裝已經包含檔案 '{1}'</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Error_ProcessingNuspecFile_csy" xml:space="preserve">
     <value>Při zpracování souboru {0} došlo k chybě: {1}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Error_ProcessingNuspecFile_deu" xml:space="preserve">
     <value>Fehler beim Verarbeiten der Datei "{0}": {1}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Error_ProcessingNuspecFile_esp" xml:space="preserve">
     <value>Error al procesar el archivo '{0}': {1}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Error_ProcessingNuspecFile_fra" xml:space="preserve">
     <value>Une erreur est survenue lors du traitement du fichier '{0}' : {1}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Error_ProcessingNuspecFile_ita" xml:space="preserve">
     <value>Si è verificato un errore nell'elaborazione del file '{0}': {1}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Error_ProcessingNuspecFile_jpn" xml:space="preserve">
     <value>ファイル '{0}' の処理中にエラーが発生しました: {1}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Error_ProcessingNuspecFile_kor" xml:space="preserve">
     <value>'{0}' 파일을 처리하는 동안 오류가 발생했습니다. {1}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Error_ProcessingNuspecFile_plk" xml:space="preserve">
     <value>Wystąpił błąd podczas przetwarzania pliku „{0}”: {1}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Error_ProcessingNuspecFile_ptb" xml:space="preserve">
     <value>Falha ao processar o arquivo '{0}: {1}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Error_ProcessingNuspecFile_rus" xml:space="preserve">
     <value>При обработке файла"{0}" произошла ошибка: {1}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Error_ProcessingNuspecFile_trk" xml:space="preserve">
     <value>{0}' dosyası işlenirken hata oluştu: {1}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Error_ProcessingNuspecFile_chs" xml:space="preserve">
     <value>处理文件“{0}”时出错: {1}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Error_ProcessingNuspecFile_cht" xml:space="preserve">
     <value>處理檔案 '{0}' 時發生錯誤: {1}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_DuplicatePropertyKey_csy" xml:space="preserve">
     <value>Klíč {0} již existuje v kolekci Properties. Přepisuje se hodnota.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_DuplicatePropertyKey_deu" xml:space="preserve">
     <value>Der Schlüssel "{0}" ist in der Eigenschaftenauflistung bereits vorhanden. Der Wert wird außer Kraft gesetzt.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_DuplicatePropertyKey_esp" xml:space="preserve">
     <value>La clave '{0}' ya existe en la colección Propiedades. Reemplazando valor.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_DuplicatePropertyKey_fra" xml:space="preserve">
     <value>La clé '{0}' existe déjà dans le Regroupement de propriétés. Remplacement de la valeur.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_DuplicatePropertyKey_ita" xml:space="preserve">
     <value>{0}' key è già presente in Properties collection. Valore prevalente.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_DuplicatePropertyKey_jpn" xml:space="preserve">
     <value>'{0}' キーは Properties コレクションに既に存在します。値を上書きします。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_DuplicatePropertyKey_kor" xml:space="preserve">
     <value>'{0}' 키가 Properties 컬렉션에 이미 있습니다. 값을 재정의하고 있습니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_DuplicatePropertyKey_plk" xml:space="preserve">
     <value>Klucz „{0}” już istnieje w kolekcji Właściwości. Wartość zostanie przesłonięta.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_DuplicatePropertyKey_ptb" xml:space="preserve">
     <value>A chave '{0}' já existe na coleção Propriedades. Substituindo valor.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_DuplicatePropertyKey_rus" xml:space="preserve">
     <value>Ключ "{0}" уже существует в коллекции свойств. Значение будет переопределено.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_DuplicatePropertyKey_trk" xml:space="preserve">
     <value>{0}' anahtarı zaten Özellikler koleksiyonunda mevcut. Değer geçersiz kılınıyor.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_DuplicatePropertyKey_chs" xml:space="preserve">
     <value>{0} 键已存在于属性集合中。正在重写值。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_DuplicatePropertyKey_cht" xml:space="preserve">
     <value>{0}' 索引鍵已存在於屬性集合中。覆寫該值。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommand_LicenseUrl_csy" xml:space="preserve">
     <value>Adresa URL licence: {0}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommand_LicenseUrl_deu" xml:space="preserve">
     <value>Lizenz-URL: {0}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommand_LicenseUrl_esp" xml:space="preserve">
     <value>URL de la licencia: {0}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommand_LicenseUrl_fra" xml:space="preserve">
     <value>URL de la licence : {0}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommand_LicenseUrl_ita" xml:space="preserve">
     <value>Licenze url: {0}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommand_LicenseUrl_jpn" xml:space="preserve">
     <value>ライセンス URL: {0}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommand_LicenseUrl_kor" xml:space="preserve">
     <value>라이선스 URL: {0}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommand_LicenseUrl_plk" xml:space="preserve">
     <value>Adres URL licencji: {0}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommand_LicenseUrl_ptb" xml:space="preserve">
     <value>Url de licença: {0}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommand_LicenseUrl_rus" xml:space="preserve">
     <value>URL-адрес лицензии: {0}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommand_LicenseUrl_trk" xml:space="preserve">
     <value>Lisans url'si: {0}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommand_LicenseUrl_chs" xml:space="preserve">
     <value>许可证 URL: {0}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="ListCommand_LicenseUrl_cht" xml:space="preserve">
     <value>授權 URL: {0}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="FileConflictChoiceText_csy" xml:space="preserve">
     <value>[Y] Ano [A] Ano pro všechny  [N] Ne  [L] Ne pro všechny?</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="FileConflictChoiceText_deu" xml:space="preserve">
     <value>[Y] Ja  [A] Ja, alle  [N] Nein  [L] Nein für alle?</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="FileConflictChoiceText_esp" xml:space="preserve">
     <value>[Y] Sí  [A] Sí a todo  [N] No  [L] ¿No a todo?</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="FileConflictChoiceText_fra" xml:space="preserve">
     <value>[Y] Oui  [A] Oui pour tout  [N] Non  [L] Non pour tout ?</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="FileConflictChoiceText_ita" xml:space="preserve">
     <value>[Y] Sì  [A] Sì a tutto  [N] No  [L] No a tutti ?</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="FileConflictChoiceText_jpn" xml:space="preserve">
     <value>[Y] はい  [A] すべてはい  [N] いいえ  [L] すべていいえ</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="FileConflictChoiceText_kor" xml:space="preserve">
     <value>[Y] 예  [A] 모두 예  [N] 아니요  [L] 모두 아니요 ?</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="FileConflictChoiceText_plk" xml:space="preserve">
     <value>[Y] Tak  [A] Tak dla wszystkich  [N] Nie  [L] Nie dla wszystkich ?</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="FileConflictChoiceText_ptb" xml:space="preserve">
     <value>[Y] Sim  [A] Sim para todos  [N] Não  [L] Não para todos?</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="FileConflictChoiceText_rus" xml:space="preserve">
     <value>[Y] Да  [A] Да для всех  [N] Нет  [L] Нет для всех ?</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="FileConflictChoiceText_trk" xml:space="preserve">
     <value>[Y] Evet  [A] Tümüne Evet  [N] Hayır  [L] Tümüne Hayır ?</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="FileConflictChoiceText_chs" xml:space="preserve">
     <value>[Y] 是  [A] 全部是  [N] 否  [L] 全部否 ?</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="FileConflictChoiceText_cht" xml:space="preserve">
     <value>[Y] 是  [A] 全部皆是  [N] 否  [L] 全部皆否 ?</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Error_MultipleSolutions_csy" xml:space="preserve">
     <value>Tato složka obsahuje více než jeden soubor řešení.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Error_MultipleSolutions_deu" xml:space="preserve">
     <value>Dieser Ordner enthält mehrere Projektdateien.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Error_MultipleSolutions_esp" xml:space="preserve">
     <value>Esta carpeta contiene más de un archivo de la solución.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Error_MultipleSolutions_fra" xml:space="preserve">
     <value>Ce dossier contient plus d'un fichier solution.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Error_MultipleSolutions_ita" xml:space="preserve">
     <value>La cartella contiene più di un solution file.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Error_MultipleSolutions_jpn" xml:space="preserve">
     <value>このフォルダーには、複数のソリューション ファイルが含まれています。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Error_MultipleSolutions_kor" xml:space="preserve">
     <value>이 폴더에 솔루션 파일이 두 개 이상 포함되어 있습니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Error_MultipleSolutions_plk" xml:space="preserve">
     <value>Ten folder zawiera więcej niż jeden plik rozwiązania.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Error_MultipleSolutions_ptb" xml:space="preserve">
     <value>Esta pasta contém mais de um arquivo de solução.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Error_MultipleSolutions_rus" xml:space="preserve">
     <value>Эта папка содержит более одного файла решения.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Error_MultipleSolutions_trk" xml:space="preserve">
     <value>Bu klasör birden çok çözüm dosyası içeriyor.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Error_MultipleSolutions_chs" xml:space="preserve">
     <value>此文件夹包含多个解决方案文件。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Error_MultipleSolutions_cht" xml:space="preserve">
     <value>此資料夾包含一個以上的方案檔案。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandOptionSolutionDirectoryIsInvalid_csy" xml:space="preserve">
     <value>Možnost -SolutionDirectory není platná při obnovování balíčků pro řešení.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandOptionSolutionDirectoryIsInvalid_deu" xml:space="preserve">
     <value>Die Option "-SolutionDirectory" ist beim Wiederherstellen von Paketen für ein Projekt nicht gültig.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandOptionSolutionDirectoryIsInvalid_esp" xml:space="preserve">
     <value>La opción SolutionDirectory no es válida cuando restaura paquetes para una solución.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandOptionSolutionDirectoryIsInvalid_fra" xml:space="preserve">
     <value>L'option -SolutionDirectory n'est pas valide lors de la restauration de packages pour une solution.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandOptionSolutionDirectoryIsInvalid_ita" xml:space="preserve">
     <value>Option -SolutionDirectory non è valida quando si ripristina pacchetti per una soluzione.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandOptionSolutionDirectoryIsInvalid_jpn" xml:space="preserve">
     <value>ソリューションのパッケージを復元する場合、オプション -SolutionDirectory は無効です。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandOptionSolutionDirectoryIsInvalid_kor" xml:space="preserve">
     <value>솔루션 패키지를 복원하는 경우 -SolutionDirectory 옵션은 사용할 수 없습니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandOptionSolutionDirectoryIsInvalid_plk" xml:space="preserve">
     <value>Opcja -SolutionDirectory jest nieprawidłowa podczas przywracania pakietów dla rozwiązania.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandOptionSolutionDirectoryIsInvalid_ptb" xml:space="preserve">
     <value>Option-SolutionDirectory não é válido ao restaurar pacotes para uma solução.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandOptionSolutionDirectoryIsInvalid_rus" xml:space="preserve">
     <value>При восстановлении пакетов для решения параметр -SolutionDirectory является недопустимым.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandOptionSolutionDirectoryIsInvalid_trk" xml:space="preserve">
     <value>Bir çözüme ait paketler geri yüklenirken -SolutionDirectory seçeneği geçerli değildir.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandOptionSolutionDirectoryIsInvalid_chs" xml:space="preserve">
     <value>为解决方案还原程序包时，选项 -SolutionDirectory 无效。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandOptionSolutionDirectoryIsInvalid_cht" xml:space="preserve">
     <value>為方案還原封裝時 Option -SolutionDirectory 為無效。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandRestoringPackagesForSolution_csy" xml:space="preserve">
     <value>Probíhá obnovení balíčků NuGet pro řešení {0}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandRestoringPackagesForSolution_deu" xml:space="preserve">
     <value>NuGet-Pakete für das Projekt "{0}" werden wiederhergestellt.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandRestoringPackagesForSolution_esp" xml:space="preserve">
     <value>Restaurando paquetes NuGet para la solución {0}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandRestoringPackagesForSolution_fra" xml:space="preserve">
     <value>Restauration des packages NuGet pour la solution {0}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandRestoringPackagesForSolution_ita" xml:space="preserve">
     <value>Ripristinando pacchetti NuGet per soluzione{0}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandRestoringPackagesForSolution_jpn" xml:space="preserve">
     <value>NuGet パッケージをソリューション {0} 用に復元しています。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandRestoringPackagesForSolution_kor" xml:space="preserve">
     <value>{0} 솔루션의 NuGet 패키지를 복원하고 있습니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandRestoringPackagesForSolution_plk" xml:space="preserve">
     <value>Przywracanie pakietów NuGet dla rozwiązania {0}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandRestoringPackagesForSolution_ptb" xml:space="preserve">
     <value>Restaurar pacotes NuGet para a solução {0}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandRestoringPackagesForSolution_rus" xml:space="preserve">
     <value>Восстановление пакетов NuGet для решения {0}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandRestoringPackagesForSolution_trk" xml:space="preserve">
     <value>{0} çözümü için NuGet paketleri geri yükleniyor.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandRestoringPackagesForSolution_chs" xml:space="preserve">
     <value>正在为解决方案 {0} 还原 NuGet 程序包。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandRestoringPackagesForSolution_cht" xml:space="preserve">
     <value>正在為方案 {0} 還原 NuGet 封裝。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandRestoringPackagesFromPackagesConfigFile_csy" xml:space="preserve">
     <value>Probíhá obnovení balíčků NuGet uvedených v souboru packages.config.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandRestoringPackagesFromPackagesConfigFile_deu" xml:space="preserve">
     <value>Die in der Datei "packages.config" aufgelisteten NuGet-Pakete werden wiederhergestellt.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandRestoringPackagesFromPackagesConfigFile_esp" xml:space="preserve">
     <value>Restaurando paquetes NuGet mostrados en el archivo packages.config.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandRestoringPackagesFromPackagesConfigFile_fra" xml:space="preserve">
     <value>Restauration des packages NuGet répertoriés dans le fichier packages.config.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandRestoringPackagesFromPackagesConfigFile_ita" xml:space="preserve">
     <value>Ripristinando pacchetti NuGet elencati in packages.config file.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandRestoringPackagesFromPackagesConfigFile_jpn" xml:space="preserve">
     <value>packages.config ファイルに含まれる NuGet パッケージを復元しています。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandRestoringPackagesFromPackagesConfigFile_kor" xml:space="preserve">
     <value>packages.config 파일에 나열된 NuGet 패키지를 복원하고 있습니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandRestoringPackagesFromPackagesConfigFile_plk" xml:space="preserve">
     <value>Przywracanie pakietów NuGet wymienionych w pliku packages.config.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandRestoringPackagesFromPackagesConfigFile_ptb" xml:space="preserve">
     <value>Restaurar pacotes NuGet listados no arquivo de packages.config.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandRestoringPackagesFromPackagesConfigFile_rus" xml:space="preserve">
     <value>Восстановление пакетов NuGet, перечисленных в файле packages.config.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandRestoringPackagesFromPackagesConfigFile_trk" xml:space="preserve">
     <value>Packages.config dosyasında listelenen NuGet paketleri geri yükleniyor.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandRestoringPackagesFromPackagesConfigFile_chs" xml:space="preserve">
     <value>正在还原 packages.config 文件中列出的 NuGet 程序包。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandRestoringPackagesFromPackagesConfigFile_cht" xml:space="preserve">
     <value>正在還原列在 packages.config 檔案中的 NuGet 封裝。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Error_CannotLoadTypeProjectInSolution_csy" xml:space="preserve">
     <value>Nelze načíst typ Microsoft.Build.Construction.ProjectInSolution z knihovny Microsoft.Build.dll.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Error_CannotLoadTypeProjectInSolution_deu" xml:space="preserve">
     <value>Der Typ "Microsoft.Build.Construction.ProjectInSolution" kann nicht aus "Microsoft.Build.dll" geladen werden.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Error_CannotLoadTypeProjectInSolution_esp" xml:space="preserve">
     <value>No se puede cargar el tipo Microsoft.Build.Construction.ProjectInSolution desde Microsoft.Build.dll</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Error_CannotLoadTypeProjectInSolution_fra" xml:space="preserve">
     <value>Chargement impossible du type Microsoft.Build.Construction.ProjectInSolution depuis Microsoft.Build.dll</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Error_CannotLoadTypeProjectInSolution_ita" xml:space="preserve">
     <value>Impossibile caricare Microsoft.Build.Construction.SolutionParser da Microsoft.Build.dll</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Error_CannotLoadTypeProjectInSolution_jpn" xml:space="preserve">
     <value>Microsoft.Build.dll から Microsoft.Build.Construction.ProjectInSolution 型を読み込めません</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Error_CannotLoadTypeProjectInSolution_kor" xml:space="preserve">
     <value>Microsoft.Build.dll에서 Microsoft.Build.Construction.ProjectInSolution 형식을 로드할 수 없습니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Error_CannotLoadTypeProjectInSolution_plk" xml:space="preserve">
     <value>Nie można załadować typu rozwiązania Microsoft.Build.Construction.ProjectInSolution z biblioteki Microsoft.Build.dll</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Error_CannotLoadTypeProjectInSolution_ptb" xml:space="preserve">
     <value>Não foi possível carregar o tipo Microsoft.Build.Construction.ProjectInSolution do Microsoft.Build.dll</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Error_CannotLoadTypeProjectInSolution_rus" xml:space="preserve">
     <value>Не удается загрузить тип Microsoft.Build.Construction.ProjectInSolution из Microsoft.Build.dll</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Error_CannotLoadTypeProjectInSolution_trk" xml:space="preserve">
     <value>Microsoft.Build.Construction.ProjectInSolution türü Microsoft.Build.dll üzerinden yüklenemiyor</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Error_CannotLoadTypeProjectInSolution_chs" xml:space="preserve">
     <value>无法从 Microsoft.Build.dll 中加载类型 Microsoft.Build.Construction.ProjectInSolution</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Error_CannotLoadTypeProjectInSolution_cht" xml:space="preserve">
     <value>無法從 Microsoft.Build.dll 載入類型  Microsoft.Build.Construction.ProjectInSolution</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Error_CannotLoadTypeSolutionParser_csy" xml:space="preserve">
     <value>Nelze načíst typ Microsoft.Build.Construction.SolutionParser z knihovny Microsoft.Build.dll.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Error_CannotLoadTypeSolutionParser_deu" xml:space="preserve">
     <value>Der Typ "Microsoft.Build.Construction.SolutionParser" kann nicht aus "Microsoft.Build.dll" geladen werden.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Error_CannotLoadTypeSolutionParser_esp" xml:space="preserve">
     <value>No se puede cargar el tipo Microsoft.Build.Construction.SolutionParser desde Microsoft.Build.dll</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Error_CannotLoadTypeSolutionParser_fra" xml:space="preserve">
     <value>Chargement impossible du type Microsoft.Build.Construction.SolutionParser depuis Microsoft.Build.dll</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Error_CannotLoadTypeSolutionParser_ita" xml:space="preserve">
     <value>Impossibile caricare Microsoft.Build.Construction.SolutionParser da Microsoft.Build.dll</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Error_CannotLoadTypeSolutionParser_jpn" xml:space="preserve">
     <value>Microsoft.Build.dll から Microsoft.Build.Construction.SolutionParser 型を読み込めません</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Error_CannotLoadTypeSolutionParser_kor" xml:space="preserve">
     <value>Microsoft.Build.dll에서 Microsoft.Build.Construction.SolutionParser 형식을 로드할 수 없습니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Error_CannotLoadTypeSolutionParser_plk" xml:space="preserve">
     <value>Nie można załadować typu parsera Microsoft.Build.Construction.SolutionParser z biblioteki Microsoft.Build.dll</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Error_CannotLoadTypeSolutionParser_ptb" xml:space="preserve">
     <value>Não foi possível carregar o tipo Microsoft.Build.Construction.SolutionParser do Microsoft.Build.dll</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Error_CannotLoadTypeSolutionParser_rus" xml:space="preserve">
     <value>Не удается загрузить тип Microsoft.Build.Construction.SolutionParser из Microsoft.Build.dll</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Error_CannotLoadTypeSolutionParser_trk" xml:space="preserve">
     <value>Microsoft.Build.Construction.SolutionParser türü Microsoft.Build.dll konumundan yüklenemiyor</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Error_CannotLoadTypeSolutionParser_chs" xml:space="preserve">
     <value>无法从 Microsoft.Build.dll 中加载类型 Microsoft.Build.Construction.SolutionParser</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Error_CannotLoadTypeSolutionParser_cht" xml:space="preserve">
     <value>無法從  Microsoft.Build.dll 載入類型 Microsoft.Build.Construction.SolutionParser</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandRestoringPackagesListedInFile_csy" xml:space="preserve">
     <value>Probíhá obnovení balíčků NuGet uvedených v souboru {0}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandRestoringPackagesListedInFile_deu" xml:space="preserve">
     <value>Die in der Datei "{0}" aufgelisteten NuGet-Pakete werden wiederhergestellt.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandRestoringPackagesListedInFile_esp" xml:space="preserve">
     <value>Restaurando paquetes NuGet mostrados en el archivo {0}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandRestoringPackagesListedInFile_fra" xml:space="preserve">
     <value>Restauration des packages NuGet répertoriés dans le fichier {0}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandRestoringPackagesListedInFile_ita" xml:space="preserve">
     <value>Ripristinando pacchetti NuGet elencati in file {0}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandRestoringPackagesListedInFile_jpn" xml:space="preserve">
     <value>ファイル {0} に含まれる NuGet パッケージを復元しています。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandRestoringPackagesListedInFile_kor" xml:space="preserve">
     <value>{0} 파일에 나열된 NuGet 패키지를 복원하고 있습니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandRestoringPackagesListedInFile_plk" xml:space="preserve">
     <value>Przywracanie pakietów NuGet wymienionych w pliku {0}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandRestoringPackagesListedInFile_ptb" xml:space="preserve">
     <value>Restaurar pacotes NuGet listados no arquivo {0}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandRestoringPackagesListedInFile_rus" xml:space="preserve">
     <value>Восстановление пакетов NuGet, перечисленных в файле {0}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandRestoringPackagesListedInFile_trk" xml:space="preserve">
     <value>{0} içinde listelenen NuGet paketleri geri yükleniyor.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandRestoringPackagesListedInFile_chs" xml:space="preserve">
     <value>正在还原文件 {0} 中列出的 NuGet 程序包。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandRestoringPackagesListedInFile_cht" xml:space="preserve">
     <value>正在還原列在檔案 {0} 中的 NuGet 封裝。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandCannotDeterminePackagesFolder_csy" xml:space="preserve">
     <value>Nelze určit složku balíčků pro obnovení balíčků NuGet. Zadejte parametr -PackagesDirectory nebo -SolutionDirectory.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandCannotDeterminePackagesFolder_deu" xml:space="preserve">
     <value>Der Paketordner zum Wiederherstellen von NuGet-Paketen konnte nicht ermittelt werden. Bitte geben Sie "-PackagesDirectory" oder "-SolutionDirectory" an.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandCannotDeterminePackagesFolder_esp" xml:space="preserve">
     <value>No se puede determinar la carpeta de paquetes para restaurar los paquetes NuGet. Especifique PackagesDirectory o SolutionDirectory.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandCannotDeterminePackagesFolder_fra" xml:space="preserve">
     <value>Impossible de déterminer le dossier de packages pour restaurer les packages NuGet. Veuillez spécifier soit -PackagesDirectory, soit -SolutionDirectory.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandCannotDeterminePackagesFolder_ita" xml:space="preserve">
     <value>Impossibile determinare le cartelle dei pacchetti per ripristinare i pacchetti NuGet. Specificare o PackagesDirectory o SolutionDirectory.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandCannotDeterminePackagesFolder_jpn" xml:space="preserve">
     <value>NuGet パッケージを復元するパッケージ フォルダーを特定できません。-PackagesDirectory または -SolutionDirectory を指定してください。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandCannotDeterminePackagesFolder_kor" xml:space="preserve">
     <value>NuGet 패키지를 복원하는 데 필요한 패키지 폴더를 확인할 수 없습니다. -PackagesDirectory 또는 -SolutionDirectory를 지정하십시오.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandCannotDeterminePackagesFolder_plk" xml:space="preserve">
     <value>Nie można ustalić folderu pakietów w celu przywrócenia pakietów NuGet. Określ opcję -PackagesDirectory lub opcję -SolutionDirectory.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandCannotDeterminePackagesFolder_ptb" xml:space="preserve">
     <value>Não é possível determinar os pacotes de pasta para restaurar pacotes NuGet. Especifique SolutionDirectory ou PackagesDirectory.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandCannotDeterminePackagesFolder_rus" xml:space="preserve">
     <value>Не удается определить папку пакетов для восстановления пакетов NuGet. Укажите -PackagesDirectory или -SolutionDirectory.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandCannotDeterminePackagesFolder_trk" xml:space="preserve">
     <value>NuGet paketlerinin geri yükleneceği paket klasörü belirlenemiyor. Lütfen -PackagesDirectory veya -SolutionDirectory seçimini belirtin.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandCannotDeterminePackagesFolder_chs" xml:space="preserve">
     <value>无法确定用于还原 NuGet 程序包的程序包文件夹。请指定 -PackagesDirectory 或 -SolutionDirectory。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandCannotDeterminePackagesFolder_cht" xml:space="preserve">
     <value>無法判斷要還原 NuGet 封裝的封裝資料夾。請指定 -PackagesDirectory 或 -SolutionDirectory。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandFileNotFound_csy" xml:space="preserve">
     <value>Vstupní soubor neexistuje: {0}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandFileNotFound_deu" xml:space="preserve">
     <value>Die Eingabedatei ist nicht vorhanden: {0}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandFileNotFound_esp" xml:space="preserve">
     <value>El archivo de entrada no existe: {0}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandFileNotFound_fra" xml:space="preserve">
     <value>Le fichier d'entrée n'existe pas : {0}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandFileNotFound_ita" xml:space="preserve">
     <value>Input file inesistente: {0}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandFileNotFound_jpn" xml:space="preserve">
     <value>入力ファイルが存在しません: {0}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandFileNotFound_kor" xml:space="preserve">
     <value>입력 파일이 없습니다. {0}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandFileNotFound_plk" xml:space="preserve">
     <value>Plik wejściowy nie istnieje: {0}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandFileNotFound_ptb" xml:space="preserve">
     <value>O arquivo de entrada não existe: {0}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandFileNotFound_rus" xml:space="preserve">
     <value>Входной файл не существует: {0}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandFileNotFound_trk" xml:space="preserve">
     <value>Girdi dosyası mevcut değil: {0}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandFileNotFound_chs" xml:space="preserve">
     <value>输入文件不存在: {0}。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandFileNotFound_cht" xml:space="preserve">
     <value>輸入檔不存在: {0}。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandProjectNotFound_csy" xml:space="preserve">
     <value>Soubor projektu {0} nebyl nalezen.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandProjectNotFound_deu" xml:space="preserve">
     <value>Die Projektdatei "{0}" wurde nicht gefunden.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandProjectNotFound_esp" xml:space="preserve">
     <value>No se puede encontrar el archivo de proyecto {0}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandProjectNotFound_fra" xml:space="preserve">
     <value>Le fichier projet {0} est introuvable.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandProjectNotFound_ita" xml:space="preserve">
     <value>Impossibile trovare file progetto {0}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandProjectNotFound_jpn" xml:space="preserve">
     <value>プロジェクト ファイル {0} が見つかりません。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandProjectNotFound_kor" xml:space="preserve">
     <value>프로젝트 파일 {0}을(를) 찾을 수 없습니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandProjectNotFound_plk" xml:space="preserve">
     <value>Nie można znaleźć pliku projektu {0}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandProjectNotFound_ptb" xml:space="preserve">
     <value>Não foi possível localizar o arquivo de projeto {0}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandProjectNotFound_rus" xml:space="preserve">
     <value>Не удалось найти файл проекта {0}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandProjectNotFound_trk" xml:space="preserve">
     <value>{0} proje dosyası bulunamadı.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandProjectNotFound_chs" xml:space="preserve">
     <value>找不到项目文件 {0}。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandProjectNotFound_cht" xml:space="preserve">
     <value>找不到專案檔 {0}。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandPackageRestoreOptOutMessage_csy" xml:space="preserve">
     <value>Probíhá obnovení balíčků NuGet...
 Chcete-li systému NuGet zabránit ve stahování balíčků během sestavování, otevřete dialogové okno Možnosti sady Visual Studio, klikněte na uzel Správce balíčků a zrušte zaškrtnutí položky {0}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandPackageRestoreOptOutMessage_deu" xml:space="preserve">
     <value>NuGet-Pakete werden wiederhergestellt...
 Damit verhindert wird, dass NuGet Pakete während des Buildvorgangs herunterlädt, öffnen Sie das Dialogfeld "Optionen" von Visual Studio, klicken Sie auf den Knoten "Paket-Manager", und deaktivieren Sie dann "{0}".</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandPackageRestoreOptOutMessage_esp" xml:space="preserve">
     <value>Restaurando paquetes NuGet…  
 Para impedir que NuGet descargue paquetes durante la compilación, abra el cuadro de diálogo Opciones de Visual Studio, haga clic en el nodo del Administrador de paquetes y desactive '{0}'. </value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandPackageRestoreOptOutMessage_fra" xml:space="preserve">
     <value>Restauration des packages NuGet…
 Pour empêcher NuGet de télécharger des packages lors de la création, ouvrez la boîte de dialogue Options Visual Studio, cliquez sur le nœud Gestionnaire de package et décochez '{0}'.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandPackageRestoreOptOutMessage_ita" xml:space="preserve">
     <value>Ripristinando pacchetti NuGet…                               Per evitare che NuGet scarichi pacchetti durante il build, aprire la finestra di dialogo Visual Studio Options dialog, fare clic su Package Manager e deselezionare '{0}'.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandPackageRestoreOptOutMessage_jpn" xml:space="preserve">
     <value>NuGet パッケージを復元しています...
 ビルド中に NuGet がパッケージをダウンロードしないようにするには、Visual Studio の [オプション] ダイアログを開き、パッケージ マネージャー ノードをクリックし、'{0}' をオフにします。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandPackageRestoreOptOutMessage_kor" xml:space="preserve">
     <value>NuGet 패키지를 복원하는 중...
 빌드 시 NuGet이 패키지를 다운로드하지 않도록 하려면 [Visual Studio 옵션] 대화 상자를 열고 [패키지 관리자] 노드를 클릭한 후 '{0}'을(를) 선택 취소합니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandPackageRestoreOptOutMessage_plk" xml:space="preserve">
     <value>Trwa przywracanie pakietów NuGet...
 Aby uniemożliwić pobieranie pakietów NuGet podczas kompilowania, otwórz okno dialogowe opcji programu Visual Studio, kliknij węzeł Menedżera pakietów i usuń zaznaczenie pozycji „{0}”.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandPackageRestoreOptOutMessage_ptb" xml:space="preserve">
     <value>Restaurando pacotes NuGet ...
 Para evitar que o NuGet baixe pacotes durante a construção, abra a caixa de diálogo Opções do Visual Studio, clique no nó Gerenciador de Pacotes e desmarque a opção '{0}'.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandPackageRestoreOptOutMessage_rus" xml:space="preserve">
     <value>Восстановление пакетов NuGet…
 Чтобы предотвратить загрузку пакетов NuGet во время выполнения сборки, в Visual Studio откройте диалоговое окно "Параметры", выберите узел "Диспетчер пакетов" и снимите флажок "{0}".</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandPackageRestoreOptOutMessage_trk" xml:space="preserve">
     <value>NuGet paketleri geri yükleniyor...
 Oluşturma sırasında NuGet'in paketleri indirmesini önlemek için, Visual Studio Seçenekleri iletişim kutusunu açın, Paket Yöneticisi düğümünü tıklayıp '{0}' seçimini işaretleyin.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandPackageRestoreOptOutMessage_chs" xml:space="preserve">
     <value>正在还原 NuGet 程序包...
 若要防止 NuGet 在生成期间下载程序包，请打开“Visual Studio 选项”对话框，单击“程序包管理器”节点并取消选中“{0}”。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="RestoreCommandPackageRestoreOptOutMessage_cht" xml:space="preserve">
     <value>正在還原 NuGet packages...
 若要防止 NuGet 在建置時下載封裝，按一下 [封裝管理員] 節點並取消勾選 '{0}'。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="MultipleProjectFilesFound" xml:space="preserve">
     <value>Found multiple project files for '{0}'.</value>
@@ -4904,315 +6373,419 @@ Oluşturma sırasında NuGet'in paketleri indirmesini önlemek için, Visual Stu
   </data>
   <data name="InvalidFile_csy" xml:space="preserve">
     <value>Nebyl určen žádný soubor packages.config, soubor projektu nebo balíčku. Použijte přepínač -self a aktualizujte soubor NuGet.exe.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InvalidFile_deu" xml:space="preserve">
     <value>Es wurde keine packages.config-, Projekt- oder Lösungsdatei angegeben. Verwenden Sie den Schalter "-self", um "NuGet.exe" zu aktualisieren.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InvalidFile_esp" xml:space="preserve">
     <value>No se ha especificado ningún archivo de solución, proyecto o packages.config. Use el modificador -self para actualizar NuGet.exe.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InvalidFile_fra" xml:space="preserve">
     <value>Aucun packages.config, projet ou fichier de solution spécifié. Utilisez le commutateur -self pour mettre à jour NuGet.exe.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InvalidFile_ita" xml:space="preserve">
     <value>Nessun file packages.config, di progetto o di soluzione specificato. Utilizzare l'opzione -self per aggiornare NuGet.exe.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InvalidFile_jpn" xml:space="preserve">
     <value>packages.config、プロジェクトまたはソリューション ファイルが指定されていません。-self スイッチ使用して、NuGet.exe を更新してください。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InvalidFile_kor" xml:space="preserve">
     <value>packages.config, 프로젝트 또는 솔루션 파일이 지정되지 않았습니다. -self 스위치를 사용하여 NuGet.exe를 업데이트하십시오.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InvalidFile_plk" xml:space="preserve">
     <value>Nie określono pliku packages.config, pliku projektu ani pliku rozwiązania. Użyj przełącznika -self, aby zaktualizować pakiet NuGet.exe.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InvalidFile_ptb" xml:space="preserve">
     <value>Nenhum arquivo de solução, projeto ou packages.config especificado. Use a chave -self para atualizar o NuGet.exe.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InvalidFile_rus" xml:space="preserve">
     <value>Не указан файл packages.config, файл проекта или решения. Используйте переключатель -self, чтобы обновить NuGet.exe.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InvalidFile_trk" xml:space="preserve">
     <value>packages.config, proje veya çözüm dosyası belirtilmemiş. NuGet.exe'yi güncelleştirmek için -self anahtarını kullanın.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InvalidFile_chs" xml:space="preserve">
     <value>未指定 packages.config、项目或解决方案文件。请使用 -self 开关更新 NuGet.exe。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InvalidFile_cht" xml:space="preserve">
     <value>未指定 packages.config、專案或方案。使用 -self 切換以更新 NuGet.exe。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="MultipleProjectFilesFound_csy" xml:space="preserve">
     <value>Bylo nalezeno více souborů projektu pro {0}.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="MultipleProjectFilesFound_deu" xml:space="preserve">
     <value>Es wurden mehrere Projektdateien für "{0}" gefunden.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="MultipleProjectFilesFound_esp" xml:space="preserve">
     <value>Se encontraron varios archivos de proyecto para '{0}'.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="MultipleProjectFilesFound_fra" xml:space="preserve">
     <value>Plusieurs fichiers de projet trouvés pour '{0}'.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="MultipleProjectFilesFound_ita" xml:space="preserve">
     <value>Trovati più file di progetto per '{0}'.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="MultipleProjectFilesFound_jpn" xml:space="preserve">
     <value>{0}' に複数のプロジェクト ファイルが見つかりました。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="MultipleProjectFilesFound_kor" xml:space="preserve">
     <value>'{0}'에 대한 프로젝트 파일이 여러 개 있습니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="MultipleProjectFilesFound_plk" xml:space="preserve">
     <value>Znaleziono wiele plików projektów dla elementu „{0}”.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="MultipleProjectFilesFound_ptb" xml:space="preserve">
     <value>Encontrados diversos arquivos de projeto para '{0}'.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="MultipleProjectFilesFound_rus" xml:space="preserve">
     <value>Обнаружено несколько файлов проектов для "{0}".</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="MultipleProjectFilesFound_trk" xml:space="preserve">
     <value>{0} için birden çok proje dosyası bulundu.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="MultipleProjectFilesFound_chs" xml:space="preserve">
     <value>发现了“{0}”的多个项目文件。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="MultipleProjectFilesFound_cht" xml:space="preserve">
     <value>找到 '{0}' 的多個專案檔案。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToFindProject_csy" xml:space="preserve">
     <value>Projekt {0} nebyl nalezen.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToFindProject_deu" xml:space="preserve">
     <value>Das Projekt "{0}" wurde nicht gefunden.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToFindProject_esp" xml:space="preserve">
     <value>No se encuentra el proyecto '{0}'.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToFindProject_fra" xml:space="preserve">
     <value>Impossible de trouver le projet '{0}'.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToFindProject_ita" xml:space="preserve">
     <value>Impossibile trovare il progetto '{0}'.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToFindProject_jpn" xml:space="preserve">
     <value>プロジェクト '{0}' が見つかりません。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToFindProject_kor" xml:space="preserve">
     <value>'{0}' 프로젝트를 찾을 수 없습니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToFindProject_plk" xml:space="preserve">
     <value>Nie można odnaleźć projektu „{0}”.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToFindProject_ptb" xml:space="preserve">
     <value>Não é possível encontrar o projeto '{0}'.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToFindProject_rus" xml:space="preserve">
     <value>Не удалось найти проект "{0}".</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToFindProject_trk" xml:space="preserve">
     <value>{0}' projesi bulunamadı.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToFindProject_chs" xml:space="preserve">
     <value>找不到项目“{0}”。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="UnableToFindProject_cht" xml:space="preserve">
     <value>找不到專案 '{0}'。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_InvalidPackageSaveMode_csy" xml:space="preserve">
     <value>Hodnota PackageSaveMode {0} je neplatná.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_InvalidPackageSaveMode_deu" xml:space="preserve">
     <value>Ungültiger PackageSaveMode-Wert "{0}".</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_InvalidPackageSaveMode_esp" xml:space="preserve">
     <value>El valor de PackageSaveMode '{0}' no es válido.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_InvalidPackageSaveMode_fra" xml:space="preserve">
     <value>valeur PackageSaveMode non valide : '{0}'.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_InvalidPackageSaveMode_ita" xml:space="preserve">
     <value>Valore '{0}' di PackageSaveMode non valido.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_InvalidPackageSaveMode_jpn" xml:space="preserve">
     <value>無効な PackageSaveMode 値  '{0}' です。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_InvalidPackageSaveMode_kor" xml:space="preserve">
     <value>잘못된 PackageSaveMode 값 '{0}'입니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_InvalidPackageSaveMode_plk" xml:space="preserve">
     <value>Nieprawidłowa wartość opcji PackageSaveMode („{0}”).</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_InvalidPackageSaveMode_ptb" xml:space="preserve">
     <value>Valor PackageSaveMode inválido '{0}'.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_InvalidPackageSaveMode_rus" xml:space="preserve">
     <value>Недопустимое значение PackageSaveMode: "{0}".</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_InvalidPackageSaveMode_trk" xml:space="preserve">
     <value>PackageSaveMode değeri '{0}' geçersiz.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_InvalidPackageSaveMode_chs" xml:space="preserve">
     <value>PackageSaveMode 值“{0}”无效。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_InvalidPackageSaveMode_cht" xml:space="preserve">
     <value>無效的 PackageSaveMode 值 '{0}'。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_UnspecifiedDependencyVersion_csy" xml:space="preserve">
     <value>Verze závislosti {0} není určena.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_UnspecifiedDependencyVersion_deu" xml:space="preserve">
     <value>Die Version der Abhängigkeit "{0}" wurde nicht angegeben.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_UnspecifiedDependencyVersion_esp" xml:space="preserve">
     <value>No se ha especificado la versión de la dependencia '{0}'.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_UnspecifiedDependencyVersion_fra" xml:space="preserve">
     <value>La version de dépendance '{0}' n'est pas spécifiée.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_UnspecifiedDependencyVersion_ita" xml:space="preserve">
     <value>Versione della dipendenza '{0}' non specificata.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_UnspecifiedDependencyVersion_jpn" xml:space="preserve">
     <value>依存関係のバージョン '{0}' が指定されていません。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_UnspecifiedDependencyVersion_kor" xml:space="preserve">
     <value>'{0}' 종속성 버전이 지정되지 않았습니다.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_UnspecifiedDependencyVersion_plk" xml:space="preserve">
     <value>Nie określono wersji zależności „{0}”.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_UnspecifiedDependencyVersion_ptb" xml:space="preserve">
     <value>A versão de dependência '{0}' não é especificada.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_UnspecifiedDependencyVersion_rus" xml:space="preserve">
     <value>Не указана версия зависимости "{0}".</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_UnspecifiedDependencyVersion_trk" xml:space="preserve">
     <value>{0}' bağımlılığının sürümü belirtilmemiş.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_UnspecifiedDependencyVersion_chs" xml:space="preserve">
     <value>未指定依赖项“{0}”的版本。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_UnspecifiedDependencyVersion_cht" xml:space="preserve">
     <value>未指定相依項 '{0}' 版本。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_UnspecifiedDependencyVersionSolution_csy" xml:space="preserve">
     <value>Určete verzi závislosti a sestavte balíček znovu.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_UnspecifiedDependencyVersionSolution_deu" xml:space="preserve">
     <value>Angeben der Version der Abhängigkeit und erneutes Erstellen des Pakets.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_UnspecifiedDependencyVersionSolution_esp" xml:space="preserve">
     <value>Especifique la versión de la dependencia y recompile el paquete.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_UnspecifiedDependencyVersionSolution_fra" xml:space="preserve">
     <value>Spécifiez la version de dépendance et regénérez votre package.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_UnspecifiedDependencyVersionSolution_ita" xml:space="preserve">
     <value>Specificare la versione della dipendenza e ricompilare il pacchetto.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_UnspecifiedDependencyVersionSolution_jpn" xml:space="preserve">
     <value>依存関係のバージョンを指定して、パッケージを再構築してください。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_UnspecifiedDependencyVersionSolution_kor" xml:space="preserve">
     <value>종속성 버전을 지정하고 패키지를 다시 빌드하십시오.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_UnspecifiedDependencyVersionSolution_plk" xml:space="preserve">
     <value>Określ wersję zależności i ponownie skompiluj pakiet.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_UnspecifiedDependencyVersionSolution_ptb" xml:space="preserve">
     <value>Especifique a versão de dependência e reconstrua seu pacote.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_UnspecifiedDependencyVersionSolution_rus" xml:space="preserve">
     <value>Укажите версию зависимости и повторите построение проекта.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_UnspecifiedDependencyVersionSolution_trk" xml:space="preserve">
     <value>Bağımlılığın sürümünü belirtin ve paketinizi tekrar oluşturun.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_UnspecifiedDependencyVersionSolution_chs" xml:space="preserve">
     <value>指定依赖项的版本并重新生成你的程序包。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_UnspecifiedDependencyVersionSolution_cht" xml:space="preserve">
     <value>指定相依相版本並重新建置您的套件。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_UnspecifiedDependencyVersionTitle_csy" xml:space="preserve">
     <value>Určete verzi závislostí.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_UnspecifiedDependencyVersionTitle_deu" xml:space="preserve">
     <value>Angeben der Version der Abhängigkeiten.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_UnspecifiedDependencyVersionTitle_esp" xml:space="preserve">
     <value>Especifique la versión de las dependencias.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_UnspecifiedDependencyVersionTitle_fra" xml:space="preserve">
     <value>Spécifiez la version des dépendances.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_UnspecifiedDependencyVersionTitle_ita" xml:space="preserve">
     <value>Specificare la versione delle dipendenze.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_UnspecifiedDependencyVersionTitle_jpn" xml:space="preserve">
     <value>依存関係のバージョンを指定してください。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_UnspecifiedDependencyVersionTitle_kor" xml:space="preserve">
     <value>종속성 버전을 지정하십시오.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_UnspecifiedDependencyVersionTitle_plk" xml:space="preserve">
     <value>Określ wersję zależności.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_UnspecifiedDependencyVersionTitle_ptb" xml:space="preserve">
     <value>Especifique uma versão de dependências.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_UnspecifiedDependencyVersionTitle_rus" xml:space="preserve">
     <value>Укажите версию зависимостей.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_UnspecifiedDependencyVersionTitle_trk" xml:space="preserve">
     <value>Bağımlılıkların sürümlerini belirtin.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_UnspecifiedDependencyVersionTitle_chs" xml:space="preserve">
     <value>指定依赖项的版本。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="Warning_UnspecifiedDependencyVersionTitle_cht" xml:space="preserve">
     <value>指定相依項版本。</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandForMoreInfo_csy" xml:space="preserve">
     <value>Další informace naleznete na adrese {0}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandForMoreInfo_deu" xml:space="preserve">
     <value>Besuchen Sie "{0}", um weitere Informationen zu erhalten.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandForMoreInfo_esp" xml:space="preserve">
     <value>Para obtener más información, visite {0}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandForMoreInfo_fra" xml:space="preserve">
     <value>Pour plus d'informations, consultez {0}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandForMoreInfo_ita" xml:space="preserve">
     <value>Per ulteriori informazioni, visitare {0}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandForMoreInfo_jpn" xml:space="preserve">
     <value>詳細については、{0} を参照してください</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandForMoreInfo_kor" xml:space="preserve">
     <value>자세한 내용은 {0}을(를) 참조하십시오.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandForMoreInfo_plk" xml:space="preserve">
     <value>Aby uzyskać więcej informacji, odwiedź stronę {0}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandForMoreInfo_ptb" xml:space="preserve">
     <value>Para obter mais informações, visite {0}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandForMoreInfo_rus" xml:space="preserve">
     <value>Дополнительные сведения см. на веб-сайте {0}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandForMoreInfo_trk" xml:space="preserve">
     <value>Daha fazla bilgi için {0} adresini ziyaret edin.</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandForMoreInfo_chs" xml:space="preserve">
     <value>有关详细信息，请访问 {0}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="HelpCommandForMoreInfo_cht" xml:space="preserve">
     <value>如需詳細資訊，請造訪 {0}</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="SettingsCredentials_UsingSavedCredentials" xml:space="preserve">
     <value>Using credentials from config. UserName: {0}</value>


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1804

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Per loc team ask, we are going to lock already-translated strings to avoid wasted work for translation team.

This PR adds a comment saying '{Locked}] to non-english string resources signaling that this string should not be localized.

Strings were locked using a custom program to identify strings ending with three letter language suffix: https://github.com/NuGet/Entropy/pull/90


## PR Checklist

- [x] PR has a meaningful title
- [ ] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception: Current Green CI should cover this scenario
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A: No product or string changes
