### PR TITLE
Extend staleness rules to draft PRs as well

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -200,15 +200,9 @@
           {
             "name": "isOpen",
             "parameters": {}
-          },
-          {
-            "name": "isDraftPr",
-            "parameters": {
-              "value": "false"
-            }
           }
         ],
-        "taskName": "[stale non-community PR] [5-1] Search for PRs with no activity over 7 days and warn. (except community PRs and draft PRs)",
+        "taskName": "[stale non-community PR] [5-1] Search for PRs with no activity over 7 days and warn. (except community PRs)",
         "actions": [
           {
             "name": "addLabel",
@@ -605,19 +599,13 @@
             "parameters": {}
           },
           {
-            "name": "isDraftPr",
-            "parameters": {
-              "value": "false"
-            }
-          },
-          {
             "name": "noLabel",
             "parameters": {
               "label": "Status:No recent activity"
             }
           }
         ],
-        "taskName": "[stale community PR] [5-1] Search for community PRs with no activity over 30 days and warn. (except draft PRs)",
+        "taskName": "[stale community PR] [5-1] Search for community PRs with no activity over 30 days and warn.",
         "actions": [
           {
             "name": "addLabel",

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -12,6 +12,8 @@ In general a PR should be approved by the Subject Matter Expert (SME) of that co
 
 To commit the PR to the repo use the GitHub `Squash and Merge` button. We can't stress this enough. Always use `Squash and Merge` unless an exception is explicitly stated in this document.
 
+This repo has bots that manage all stale PRs. Stale PRs will be autoclosed.
+
 - *Do* favor having more than 1 reviewer.
 - *Do not* merge too quickly. Wait for at least 24h after the last significant changes before merging unless the change is urgent.
 - *Do* address all feedback. Not necessarily by accepting it, but by reaching a resolution with the reviewer. All comments need to be marked as resolved before merging.
@@ -31,7 +33,6 @@ GitHub merges have 2 means to specify a commit message when squash merging. Insp
 #### Draft Pull Requests
 
 Draft pull requests are allowed, but should have a clear plan for transition to a review ready pull request.
-Draft pull requests will be closed within 30 days.
 
 ### Branching strategy
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1768

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

This change extends the staleness rules to the draft PRs in a similar way as the 
## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
