### PR TITLE
Ignore guid retrieval failures when checking NuGet compatibility in VS. Assume incompatible with NuGet

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/IDE/VsHierarchyUtility.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/IDE/VsHierarchyUtility.cs
@@ -33,13 +33,17 @@ namespace NuGet.VisualStudio
         public static bool IsSupportedByGuid(IVsHierarchy hierarchy)
         {
             ThreadHelper.ThrowIfNotOnUIThread();
-            ErrorHandler.ThrowOnFailure(hierarchy.GetGuidProperty(VSConstants.VSITEMID_ROOT, (int)__VSHPROPID.VSHPROPID_TypeGuid, out Guid pguid));
-            var guid = pguid.ToString("B", CultureInfo.CurrentCulture);
-            if (ProjectType.IsUnsupported(guid) || !ProjectType.IsSupported(guid))
+
+            if (ErrorHandler.Succeeded(hierarchy.GetGuidProperty(VSConstants.VSITEMID_ROOT, (int)__VSHPROPID.VSHPROPID_TypeGuid, out Guid pguid)))
             {
-                return false;
+                var guid = pguid.ToString("B");
+                if (ProjectType.IsUnsupported(guid) || !ProjectType.IsSupported(guid))
+                {
+                    return false;
+                }
+                return true;
             }
-            return true;
+            return false;
         }
 
         public static bool IsNuGetSupported(IVsHierarchy hierarchy)
@@ -92,8 +96,11 @@ namespace NuGet.VisualStudio
                 return projectTypeGuids.Split(';');
             }
 
-            ErrorHandler.ThrowOnFailure(hierarchy.GetGuidProperty(VSConstants.VSITEMID_ROOT, (int)__VSHPROPID.VSHPROPID_TypeGuid, out Guid pguid));
-            return new string[] { pguid.ToString("B", CultureInfo.CurrentCulture) };
+            if (ErrorHandler.Succeeded(hierarchy.GetGuidProperty(VSConstants.VSITEMID_ROOT, (int)__VSHPROPID.VSHPROPID_TypeGuid, out Guid pguid)))
+            {
+                return new string[] { pguid.ToString("B") };
+            }
+            return Array.Empty<string>();
         }
 
         /// <summary>


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12009

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

In https://github.com/NuGet/NuGet.Client/commit/a12891e5901e55985f023731eb87f705f2df73eb and https://github.com/NuGet/NuGet.Client/commit/e0db7dcd14807fd1f8874df18e9a7c7d9cd871f6, I rewrote the initialization to be done via IVsHierarchy instead of DTE.Project.

We used to discover the project guid via `Project.Kind`.
The equivalent for that in IVsHierarchy is `hierarchy.GetGuidProperty(VSConstants.VSITEMID_ROOT, (int)__VSHPROPID.VSHPROPID_TypeGuid, out Guid pguid);`

Unfortunately some project types, don't return that property, https://developercommunity.visualstudio.com/t/VS2022-1730-Preview-5---NUGET-Dialog-/10107880?viewtype=all, making NuGet unable to determine whether the project is compatible with NuGet. The project type in particular is vdproj, which isn't NuGet compatible anyways.

Currently we throw (expectation was that the property is always available). This changes assumes that projects that don't return that property are simply incompatible with NuGet. 
The project in question we found to be causing an issue is vdproj, so we're ok with the assume incompatible approach, but that doesn't mean it'd be good in every other case. 

~An alternative would be to convert the hierarchy to project check the Kind again. That is likely to be a more backwards compatible approach, but more of a maintenance annoyance.~

After consulting with some VS folks, this change is better  as we can't special case all special behaviors in project-systems.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception - This project system is only installed via an extension and does not come bundled with VS.
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
