### PR TITLE
Exclude runtime assets from Microsoft.Build package to fix flakey tests

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/NuGet.VisualStudio.Common.csproj
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/NuGet.VisualStudio.Common.csproj
@@ -18,7 +18,7 @@
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build" />
+    <PackageReference Include="Microsoft.Build" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.Internal.VisualStudio.Shell.Framework" />
     <PackageReference Include="Microsoft.TeamFoundationServer.ExtendedClient" />
     <PackageReference Include="Microsoft.VisualStudio.ProjectSystem" />


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1813

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
MSBuild does not support runtime scenarios where the `Microsoft.Build` DLL is placed in an output directory.
See https://docs.microsoft.com/en-us/visualstudio/msbuild/updating-an-existing-application?view=vs-2022#use-nuget-packages-preferred

The symptom of this is that depending on where MSBuild resolves its runtime assets on a given machine, it may utilize the DLL in our Test project's output directory. When this happens, certain tests fail because our MSBuild utilities attempt to load project files by `Activator.CreateInstance`.  When Version 4.x of MSBuild is loaded (likely in the GAC), it expects a `ToolsVersion`, but does not support the `Current` value which is used by latest MSBuild versions. https://github.com/NuGet/NuGet.Client/blob/c398135174adf62f43b8208c97393bebf892ecad/src/NuGet.Clients/NuGet.CommandLine/Common/MSBuildProjectSystem.cs#L448

### An example of an error that goes away with this change is:
> **Error: Microsoft.Build.Exceptions.InvalidProjectFileException : The tools version "Current" is unrecognized. Available tools versions are "2.0", "3.5", "4.0". D:\a_work\1\s.test\work\f6aff01c\749cdace\solution\proj1\proj1.nfproj**

```
Stack:    at Microsoft.Build.Shared.ProjectErrorUtilities.ThrowInvalidProject(String errorSubCategoryResourceName, IElementLocation elementLocation, String resourceName, Object[] args)
   at Microsoft.Build.Evaluation.Project.Data.InitializeForEvaluation(IToolsetProvider toolsetProvider, EvaluationContext evaluationContext)
   at Microsoft.Build.Evaluation.Evaluator`4..ctor(IEvaluatorData`4 data, Project project, ProjectRootElement projectRootElement, ProjectLoadSettings loadSettings, Int32 maxNodeCount, PropertyDictionary`1 environmentProperties, IItemFactory`2 itemFactory, IToolsetProvider toolsetProvider, ProjectRootElementCacheBase projectRootElementCache, ISdkResolverService sdkResolverService, Int32 submissionId, EvaluationContext evaluationContext, Boolean profileEvaluation, Boolean interactive, ILoggingService loggingService, BuildEventContext buildEventContext)
   at Microsoft.Build.Evaluation.Evaluator`4.Evaluate(IEvaluatorData`4 data, Project project, ProjectRootElement root, ProjectLoadSettings loadSettings, Int32 maxNodeCount, PropertyDictionary`1 environmentProperties, ILoggingService loggingService, IItemFactory`2 itemFactory, IToolsetProvider toolsetProvider, ProjectRootElementCacheBase projectRootElementCache, BuildEventContext buildEventContext, ISdkResolverService sdkResolverService, Int32 submissionId, EvaluationContext evaluationContext, Boolean interactive)
   at Microsoft.Build.Evaluation.Project.ProjectImpl.Reevaluate(ILoggingService loggingServiceForEvaluation, ProjectLoadSettings loadSettings, EvaluationContext evaluationContext)
   at Microsoft.Build.Evaluation.Project.ProjectImpl.ReevaluateIfNecessary(ILoggingService loggingServiceForEvaluation, ProjectLoadSettings loadSettings, EvaluationContext evaluationContext)
   at Microsoft.Build.Evaluation.Project.ProjectImpl.ReevaluateIfNecessary(EvaluationContext evaluationContext)
   at Microsoft.Build.Evaluation.Project.ProjectImpl.Initialize(IDictionary`2 globalProperties, String toolsVersion, String subToolsetVersion, ProjectLoadSettings loadSettings, EvaluationContext evaluationContext)
   at Microsoft.Build.Evaluation.Project..ctor(String projectFile, IDictionary`2 globalProperties, String toolsVersion, String subToolsetVersion, ProjectCollection projectCollection, ProjectLoadSettings loadSettings, EvaluationContext evaluationContext, IDirectoryCacheFactory directoryCacheFactory)
   at Microsoft.Build.Evaluation.Project..ctor(String projectFile)
```


## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
