### PR TITLE
Fix a typo in LockFileFormat.cs

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/DiagnosticCommands.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/DiagnosticCommands.cs
@@ -64,7 +64,7 @@ namespace NuGet.CommandLine
             }
 
             _log.LogMinimal($"{lib.Name} {lib.Version}");
-            _log.LogMinimal($"Servicable: {lib.IsServiceable}");
+            _log.LogMinimal($"Serviceable: {lib.IsServiceable}");
             _log.LogMinimal($"SHA512 Hash: {lib.Sha512}");
             _log.LogMinimal($"Files:");
             foreach (var file in lib.Files)

--- a/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileFormat.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileFormat.cs
@@ -254,7 +254,7 @@ namespace NuGet.ProjectModel
             library.MSBuildProject = JsonUtility.ReadProperty<string>(jObject, MSBuildProjectProperty);
             library.Sha512 = JsonUtility.ReadProperty<string>(jObject, Sha512Property);
 
-            library.IsServiceable = ReadBool(json, ServicableProperty, defaultValue: false);
+            library.IsServiceable = ReadBool(json, ServiceableProperty, defaultValue: false);
             library.Files = ReadPathArray(json[FilesProperty] as JArray);
 
             library.HasTools = ReadBool(json, HasToolsProperty, defaultValue: false);
@@ -269,7 +269,7 @@ namespace NuGet.ProjectModel
 
             if (library.IsServiceable)
             {
-                writer.WritePropertyName(ServicableProperty);
+                writer.WritePropertyName(ServiceableProperty);
                 writer.WriteValue(library.IsServiceable);
             }
 

--- a/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileFormat.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileFormat.cs
@@ -28,7 +28,7 @@ namespace NuGet.ProjectModel
         private const string LibrariesProperty = "libraries";
         private const string TargetsProperty = "targets";
         private const string ProjectFileDependencyGroupsProperty = "projectFileDependencyGroups";
-        private const string ServicableProperty = "servicable";
+        private const string ServiceableProperty = "serviceable";
         private const string Sha512Property = "sha512";
         private const string FilesProperty = "files";
         private const string HasToolsProperty = "hasTools";


### PR DESCRIPTION
change `ServicableProperty = "servicable"` to `ServiceableProperty = "serviceable"`

<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12018

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
missing `e` in `ServicableProperty`
## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [ ] N/A
