### PR TITLE
Optimize global property retrieval in RestoreTaskEx

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks/RestoreTaskEx.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/RestoreTaskEx.cs
@@ -281,7 +281,7 @@ namespace NuGet.Build.Tasks
                 {
                     try
                     {
-                        globalProperties = getGlobalPropertiesMethod.Invoke(BuildEngine, null) as IReadOnlyDictionary<string, string>;
+                        globalProperties = getGlobalPropertiesMethod.Invoke(BuildEngine, parameters: null) as IReadOnlyDictionary<string, string>;
                     }
                     catch (Exception)
                     {

--- a/src/NuGet.Core/NuGet.Build.Tasks/RestoreTaskEx.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/RestoreTaskEx.cs
@@ -6,11 +6,12 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+#if !IS_CORECLR
 using System.Reflection;
+#endif
 using System.Threading;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
-using NuGet.Packaging;
 
 namespace NuGet.Build.Tasks
 {
@@ -213,6 +214,7 @@ namespace NuGet.Build.Tasks
                 [nameof(Recursive)] = Recursive,
                 [nameof(RestorePackagesConfig)] = RestorePackagesConfig,
             };
+
             // Semicolon delimited list of options
             yield return string.Join(";", options.Where(i => i.Value).Select(i => $"{i.Key}={i.Value}"));
 
@@ -230,9 +232,7 @@ namespace NuGet.Build.Tasks
                     : ProjectFullPath;
 
             // Semicolon delimited list of MSBuild global properties
-            var globalProperties = GetGlobalProperties().Select(i => $"{i.Key}={i.Value}").Concat(new string[] { $"OriginalMSBuildStartupDirectory={MSBuildStartupDirectory}" });
-
-            yield return string.Join(";", globalProperties);
+            yield return string.Join(";", GetGlobalProperties().Select(i => $"{i.Key}={i.Value}"));
         }
 
         /// <summary>
@@ -253,33 +253,35 @@ namespace NuGet.Build.Tasks
 #endif
         }
 
-        private Dictionary<string, string> GetGlobalProperties()
+        /// <summary>
+        /// Enumerates a list of global properties for the current MSBuild instance.
+        /// </summary>
+        /// <returns>An <see cref="IEnumerable{T}" /> of <see cref="KeyValuePair{TKey, TValue}" /> objects containing global properties.</returns>
+        internal IEnumerable<KeyValuePair<string, string>> GetGlobalProperties()
         {
+            IReadOnlyDictionary<string, string> globalProperties = null;
+
 #if IS_CORECLR
             // MSBuild 16.5 and above has a method to get the global properties, older versions do not
-            Dictionary<string, string> msBuildGlobalProperties = BuildEngine is IBuildEngine6 buildEngine6
-                ? buildEngine6.GetGlobalProperties().ToDictionary(i => i.Key, i => i.Value, StringComparer.OrdinalIgnoreCase)
-                : new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            if (BuildEngine is IBuildEngine6 buildEngine6)
+            {
+                globalProperties = buildEngine6.GetGlobalProperties();
+            }
 #else
-            var msBuildGlobalProperties = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-
             // MSBuild 16.5 added a new interface, IBuildEngine6, which has a GetGlobalProperties() method.  However, we compile against
             // Microsoft.Build.Framework version 4.0 when targeting .NET Framework, so reflection is required since type checking
             // can't be done at compile time
-            var buildEngine6Type = typeof(IBuildEngine).Assembly.GetType("Microsoft.Build.Framework.IBuildEngine6");
+            Type buildEngine6Type = typeof(IBuildEngine).Assembly.GetType("Microsoft.Build.Framework.IBuildEngine6");
 
             if (buildEngine6Type != null)
             {
-                var getGlobalPropertiesMethod = buildEngine6Type.GetMethod("GetGlobalProperties", BindingFlags.Instance | BindingFlags.Public);
+                MethodInfo getGlobalPropertiesMethod = buildEngine6Type.GetMethod("GetGlobalProperties", BindingFlags.Instance | BindingFlags.Public);
 
                 if (getGlobalPropertiesMethod != null)
                 {
                     try
                     {
-                        if (getGlobalPropertiesMethod.Invoke(BuildEngine, null) is IReadOnlyDictionary<string, string> globalProperties)
-                        {
-                            msBuildGlobalProperties.AddRange(globalProperties);
-                        }
+                        globalProperties = getGlobalPropertiesMethod.Invoke(BuildEngine, null) as IReadOnlyDictionary<string, string>;
                     }
                     catch (Exception)
                     {
@@ -288,14 +290,22 @@ namespace NuGet.Build.Tasks
                 }
             }
 #endif
-            msBuildGlobalProperties["ExcludeRestorePackageImports"] = "true";
+            if (globalProperties != null)
+            {
+                foreach (KeyValuePair<string, string> item in globalProperties)
+                {
+                    yield return item;
+                }
+            }
+
+            yield return new KeyValuePair<string, string>("ExcludeRestorePackageImports", bool.TrueString);
+
+            yield return new KeyValuePair<string, string>("OriginalMSBuildStartupDirectory", MSBuildStartupDirectory);
 
             if (IsSolutionPathDefined)
             {
-                msBuildGlobalProperties["SolutionPath"] = SolutionPath;
+                yield return new KeyValuePair<string, string>("SolutionPath", SolutionPath);
             }
-
-            return msBuildGlobalProperties;
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/RestoreTaskExTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/RestoreTaskExTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -70,6 +71,42 @@ namespace NuGet.Build.Tasks.Test
                     projectPath,
                         $"Property1=Value1;Property2=  Value2  ;ExcludeRestorePackageImports=true;OriginalMSBuildStartupDirectory={testDirectory}");
                 }
+            }
+        }
+
+        /// <summary>
+        /// Verifies that the <see cref="RestoreTaskEx.GetGlobalProperties" /> returns the global properties plus any extra ones set by NuGet.
+        /// </summary>
+        [Fact]
+        public void GetGlobalProperties_ExtraGlobalProperties_AreSetCorrectly()
+        {
+            const string MSBuildStartupDirectory = @"C:\something";
+
+            Dictionary<string, string> globalProperties = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["Property1"] = "Value1",
+                ["Property2"] = "Value2"
+            };
+
+            using (var task = new RestoreTaskEx()
+            {
+                BuildEngine = new TestBuildEngine(globalProperties),
+                MSBuildStartupDirectory = MSBuildStartupDirectory
+            })
+            {
+                var actual = task.GetGlobalProperties().ToDictionary(i => i.Key, i => i.Value, StringComparer.OrdinalIgnoreCase);
+
+                actual.TryGetValue("Property1", out string value1).Should().BeTrue();
+                value1.Should().Be("Value1");
+
+                actual.TryGetValue("Property2", out string value2).Should().BeTrue();
+                value2.Should().Be("Value2");
+
+                actual.TryGetValue("ExcludeRestorePackageImports", out string excludeRestorePackageImports).Should().BeTrue();
+                excludeRestorePackageImports.Should().Be(bool.TrueString);
+
+                actual.TryGetValue("OriginalMSBuildStartupDirectory", out string originalMSBuildStartupDirectory).Should().BeTrue();
+                originalMSBuildStartupDirectory.Should().Be(MSBuildStartupDirectory);
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/RestoreTaskExTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/RestoreTaskExTests.cs
@@ -69,7 +69,7 @@ namespace NuGet.Build.Tasks.Test
                     Path.Combine(msbuildBinPath, "MSBuild.exe"),
 #endif
                     projectPath,
-                        $"Property1=Value1;Property2=  Value2  ;ExcludeRestorePackageImports=true;OriginalMSBuildStartupDirectory={testDirectory}");
+                        $"Property1=Value1;Property2=  Value2  ;ExcludeRestorePackageImports=True;OriginalMSBuildStartupDirectory={testDirectory}");
                 }
             }
         }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1814

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
Have `GetGlobalProperties()` return an `IEnumerable<T>` to avoid copying dictionaries since the values are only used to generate a semi-colon delimited string.  Also moves all extra global properties to the same method so you can easily see what's being set.

I also added a unit test to verify that global properties are being retrieved and that the extra ones are being set.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
