### PR TITLE
Refactor Combobox Versions SelectionChanged to update correctly atributes

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/ProjectView.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/ProjectView.xaml
@@ -106,6 +106,7 @@
       StaysOpenOnEdit="{Binding IsProjectPackageReference, Converter={StaticResource InverseNullToVisibilityConverter}}"
       ItemsSource="{Binding Path=VersionsView}"
       Text="{Binding Path=UserInput, Mode=OneWay}"
+      SelectionChanged="Versions_SelectionChanged"
       SelectedItem="{Binding Path=SelectedVersion, Mode=TwoWay}">
       <ComboBox.ItemContainerStyle>
             <Style TargetType="{x:Type ComboBoxItem}" BasedOn="{StaticResource ComboBoxItemStyle}">

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/ProjectView.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/ProjectView.xaml.cs
@@ -116,7 +116,6 @@ namespace NuGet.PackageManagement.UI
                             {
                                 _versions.SelectedIndex++;
                             }
-                            PackageDetailControlModel.PreviousSelectedVersion = _versions.Text;
 
                             e.Handled = true;
                         }
@@ -133,7 +132,6 @@ namespace NuGet.PackageManagement.UI
                             {
                                 _versions.SelectedIndex--;
                             }
-                            PackageDetailControlModel.PreviousSelectedVersion = _versions.Text;
 
                             e.Handled = true;
                         }
@@ -274,6 +272,13 @@ namespace NuGet.PackageManagement.UI
             {
                 InstallButtonClicked(this, EventArgs.Empty);
             }
+        }
+
+        private void Versions_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            PackageDetailControlModel.PreviousSelectedVersion = e.AddedItems.Count > 0 ? e.AddedItems[0].ToString() : string.Empty;
+
+            return;
         }
     }
 }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11992

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
When the version changed by a click, the PreviousSelectedVersion wasn't updated so this caused a trigger of the filter when using a non-alphanumeric Key.

Example:
- Select a version using only the mouse
- Close the combobox
- Use a Key non-alphanumeric (this can be a alt+tab to change application, or there are times there is a Key.System randomly) and triggers the filter
- Open the combobox
- You only see the versions selected, but not all the versions

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
