### PR TITLE
remove check for nugetrecommendpkgs 17.0

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -795,11 +795,6 @@ namespace NuGet.PackageManagement.UI
                 searchTask: null);
         }
 
-        public static bool IsRecommenderFlightEnabled(INuGetExperimentationService nuGetExperimentationService)
-        {
-            return nuGetExperimentationService.IsExperimentEnabled(ExperimentationConstants.PackageRecommender);
-        }
-
         /// <summary>
         /// This method is called from several event handlers. So, consolidating the use of JTF.Run in this method
         /// </summary>
@@ -822,7 +817,7 @@ namespace NuGet.PackageManagement.UI
 
             try
             {
-                bool useRecommender = await GetUseRecommendedPackagesAsync(loadContext, searchText);
+                bool useRecommender = GetUseRecommendedPackages(loadContext, searchText);
                 var loader = await PackageItemLoader.CreateAsync(
                     Model.Context.ServiceBroker,
                     Model.Context.ReconnectingSearchService,
@@ -865,32 +860,17 @@ namespace NuGet.PackageManagement.UI
             }
         }
 
-        private async Task<bool> GetUseRecommendedPackagesAsync(PackageLoadContext loadContext, string searchText)
+        private bool GetUseRecommendedPackages(PackageLoadContext loadContext, string searchText)
         {
             // only make recommendations when
-            //   the single source repository is nuget.org,
+            //   one of the source repositories is nuget.org,
             //   the package manager was opened for a project, not a solution,
             //   this is the Browse tab,
             //   and the search text is an empty string
-            _recommendPackages = false;
-            if (loadContext.IsSolution == false
-                && _topPanel.Filter == ItemFilter.All
-                && searchText == string.Empty
-                && SelectedSource.PackageSources.Any(item => TelemetryUtility.IsNuGetOrg(item.Source)))
-            {
-                _recommendPackages = true;
-            }
-
-            NuGetExperimentationService = await ServiceLocator.GetComponentModelServiceAsync<INuGetExperimentationService>();
-            // Check for A/B experiment here. For control group, return false instead of _recommendPackages
-            if (IsRecommenderFlightEnabled(NuGetExperimentationService))
-            {
-                return _recommendPackages;
-            }
-            else
-            {
-                return false;
-            }
+            return (loadContext.IsSolution == false
+                    && _topPanel.Filter == ItemFilter.All
+                    && searchText == string.Empty
+                    && SelectedSource.PackageSources.Any(item => TelemetryUtility.IsNuGetOrg(item.Source)));
         }
 
         private async ValueTask RefreshInstalledAndUpdatesTabsAsync()

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Experimentation/ExperimentationConstants.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Experimentation/ExperimentationConstants.cs
@@ -25,7 +25,6 @@ namespace NuGet.VisualStudio
         internal string FlightEnvironmentVariable { get; }
 
         public static readonly ExperimentationConstants PackageManagerBackgroundColor = new("nuGetPackageManagerBackgroundColor", "NUGET_PACKAGE_MANAGER_BACKGROUND_COLOR");
-        public static readonly ExperimentationConstants PackageRecommender = new("nugetrecommendpkgs", "NUGET_RECOMMEND_PACKAGES");
         public static readonly ExperimentationConstants BulkRestoreCoordination = new("nugetBulkRestoreCoordination", "NUGET_BULK_RESTORE_COORDINATION");
     }
 }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug
https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1591510
https://github.com/NuGet/Home/issues/12025

Fixes:
We will end the nugetrecommendpkgs flight after 17.4 GA, so we need to remove the code that checks for this flight.

Regression? Last working version:
Currently working as expected, but will stop working without this fix after we end the nugetrecommendpkgs flight.

## Description
Remove code that checks for nugetrecommendpkgs flight

## PR Checklist

- [ ] PR has a meaningful title
- [ ] PR has a linked issue.
- [ ] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [ ] N/A
