### PR TITLE
fix build failures in dev branch due to renaming of parameter from cpvmEnabled to centralPackageTransitivePinningEnabled

### DIFF
--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
@@ -2943,9 +2943,9 @@ namespace NuGet.Commands.Test
                     new List<CentralPackageVersion>() {centralVersion2},
                     framework);
 
-                PackageSpec packageSpecA = CreatePackageSpec(new List<TargetFrameworkInformation>() { tfiA }, framework, projectNameA, projectPathA, cpvmEnabled: true);
-                PackageSpec packageSpecB = CreatePackageSpec(new List<TargetFrameworkInformation>() { tfiB }, framework, projectNameB, projectPathB, cpvmEnabled: true);
-                PackageSpec packageSpecC = CreatePackageSpec(new List<TargetFrameworkInformation>() { tfiC }, framework, projectNameC, projectPathC, cpvmEnabled: true);
+                PackageSpec packageSpecA = CreatePackageSpec(new List<TargetFrameworkInformation>() { tfiA }, framework, projectNameA, projectPathA, centralPackageManagementEnabled: true);
+                PackageSpec packageSpecB = CreatePackageSpec(new List<TargetFrameworkInformation>() { tfiB }, framework, projectNameB, projectPathB, centralPackageManagementEnabled: true);
+                PackageSpec packageSpecC = CreatePackageSpec(new List<TargetFrameworkInformation>() { tfiC }, framework, projectNameC, projectPathC, centralPackageManagementEnabled: true);
                 packageSpecA = packageSpecA.WithTestProjectReference(packageSpecB);
                 packageSpecB = packageSpecB.WithTestProjectReference(packageSpecC);
                 packageSpecA.RestoreMetadata.CentralPackageTransitivePinningEnabled = true;


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12020

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
In https://github.com/NuGet/NuGet.Client/commit/5957409d5b0316962864951c0295cae05ef24f46#diff-8de78cd9e645067e064929ca49f121aa8a1994934726e4bfdf1f4fd2a84522b7R2916 commit, parameter name was changed from `cpvmEnabled` to `centralPackageTransitivePinningEnabled` which is causing dev build failures.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue. -  I don't think we need an issue for this one. Happy to create one if team feels strongly about it.
- [x] Described changes

- **Tests**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  - [x] N/A
