### PR TITLE
Ignore centrally pinned transitive dependencies when versions match

### DIFF
--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/Remote/RemoteDependencyWalker.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/Remote/RemoteDependencyWalker.cs
@@ -321,6 +321,12 @@ namespace NuGet.DependencyResolver
                         return (DependencyResult.PotentiallyDowngraded, d);
                     }
 
+                    // Only consider the dependency to be eclipsed if the versions are not identical for central transitive dependencies
+                    if (d.ReferenceType == LibraryDependencyReferenceType.None && VersionRangeComparer.Default.Equals(d.LibraryRange.VersionRange, childDependencyLibrary.VersionRange))
+                    {
+                        continue;
+                    }
+
                     return (DependencyResult.Eclipsed, d);
                 }
             }

--- a/test/TestUtilities/Test.Utility/CentralPackageVersionsManagementFile.cs
+++ b/test/TestUtilities/Test.Utility/CentralPackageVersionsManagementFile.cs
@@ -18,6 +18,7 @@ namespace NuGet.Test.Utility
         private const string DirectoryPackagesProps = "Directory.Packages.props";
 
         private readonly bool _managePackageVersionsCentrally;
+        private readonly bool _centralPackageTransitivePinningEnabled;
 
         private readonly Dictionary<string, string> _packageVersions = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
@@ -25,10 +26,11 @@ namespace NuGet.Test.Utility
 
         private readonly FileInfo _path;
 
-        private CentralPackageVersionsManagementFile(string directoryPath, bool managePackageVersionsCentrally)
+        private CentralPackageVersionsManagementFile(string directoryPath, bool managePackageVersionsCentrally, bool centralPackageTransitivePinningEnabled)
         {
             _path = new FileInfo(Path.Combine(directoryPath, DirectoryPackagesProps));
             _managePackageVersionsCentrally = managePackageVersionsCentrally;
+            _centralPackageTransitivePinningEnabled = centralPackageTransitivePinningEnabled;
         }
 
         /// <summary>
@@ -46,10 +48,11 @@ namespace NuGet.Test.Utility
         /// </summary>
         /// <param name="directoryPath">The path to a directory to create the central package management in.</param>
         /// <param name="managePackageVersionsCentrally"><c>true</c> to enable central package management (default), or <c>false</c> to disable it.</param>
+        /// <param name="centralPackageTransitivePinningEnabled"><c>true</c> to enable transitive pinning or <c>false</c> to disable it (default).</param>
         /// <returns></returns>
-        public static CentralPackageVersionsManagementFile Create(string directoryPath, bool managePackageVersionsCentrally = true)
+        public static CentralPackageVersionsManagementFile Create(string directoryPath, bool managePackageVersionsCentrally = true, bool centralPackageTransitivePinningEnabled = false)
         {
-            return new CentralPackageVersionsManagementFile(directoryPath, managePackageVersionsCentrally);
+            return new CentralPackageVersionsManagementFile(directoryPath, managePackageVersionsCentrally, centralPackageTransitivePinningEnabled);
         }
 
         /// <summary>
@@ -74,7 +77,8 @@ namespace NuGet.Test.Utility
             XDocument directoryPackagesPropsXml = new XDocument(
                 new XElement("Project",
                     new XElement("PropertyGroup",
-                        new XElement(ProjectBuildProperties.ManagePackageVersionsCentrally, new XText(_managePackageVersionsCentrally.ToString()))),
+                        new XElement(ProjectBuildProperties.ManagePackageVersionsCentrally, new XText(_managePackageVersionsCentrally.ToString())),
+                        new XElement(ProjectBuildProperties.CentralPackageTransitivePinningEnabled, new XText(_centralPackageTransitivePinningEnabled.ToString()))),
                     new XElement("ItemGroup", _packageVersions.Select(i => new XElement("PackageVersion", new XAttribute("Include", i.Key), new XAttribute("Version", i.Value)))),
                     new XElement("ItemGroup", _globalPackageReferences.Select(i => new XElement("GlobalPackageReference", new XAttribute("Include", i.Key), new XAttribute("Version", i.Value))))));
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11818

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
For central transitive pinned dependencies, don't eclipse them from the graph walk if the version is the same.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
