### PR TITLE
Projects no longer rely on runtime assets from Microsoft.Build.* packages

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -126,7 +126,10 @@ If you want to test dotnet.exe explicitly, so you don't have to worry about whet
 ### Debugging NuGet Command Xplat Functionality (add-package/remove-package/list package)
 
 Functionality such as `dotnet.exe add package` or `dotnet list package`, is implemented in [NuGet.CommandLine.XPlat](../src/NuGet.Core/NuGet.CommandLine.XPlat/NuGet.CommandLine.XPlat.csproj).
-There are 2 ways to debug this:
+
+To debug with `MSBuildLocator`, you need to un-comment the `PackageReference` for `Microsoft.Build.Locator` in `NuGet.CommandLine.XPlat.csproj`. Additionally, un-comment the code utilizing `MSBuildLocator` in that project's `Program.cs`.
+
+There are 2 ways to debug this project:
 
 * Given that [NuGet.CommandLine.XPlat](../src/NuGet.Core/NuGet.CommandLine.XPlat/NuGet.CommandLine.XPlat.csproj) is an exe, you can set it as the startup project and run it as you would any other command line project in Visual Studio. Note that some commands list arguments in a different order to the dotnet cli.
 

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.csproj
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.csproj
@@ -39,9 +39,9 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(IsCore)' == 'true' ">
-    <PackageReference Include="Microsoft.Build.Framework" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" />
+    <PackageReference Include="Microsoft.Build.Framework" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core"  ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core"  ExcludeAssets="runtime" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.csproj
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.csproj
@@ -39,9 +39,9 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(IsCore)' == 'true' ">
-    <PackageReference Include="Microsoft.Build.Framework" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core"  ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core"  ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Build.Framework" ExcludeAssets="runtime" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" ExcludeAssets="runtime" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" ExcludeAssets="runtime" GeneratePathProperty="true" />
   </ItemGroup>
 
   <ItemGroup>
@@ -122,6 +122,12 @@
       <IlmergeCommand>$(IlmergeCommand) ^
         $(PathToBuiltNuGetPack) ^
         @(BuildArtifacts, ' ')</IlmergeCommand>
+      <IlmergeCommand Condition=" '$(IsCore)' == 'true' ">$(IlmergeCommand) ^
+        /lib:$(PkgMicrosoft_Build_Utilities_Core)\lib\netstandard2.0 ^
+        /lib:$(PkgMicrosoft_Build_Tasks_Core)\lib\netstandard2.0 ^
+        /lib:$(PkgMicrosoft_Build_Framework)\lib\netstandard2.0
+      </IlmergeCommand>
+
     </PropertyGroup>
     <Exec Command="$(IlmergeCommand)" ContinueOnError="false" />
   </Target>

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.Build.Tasks.csproj
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.Build.Tasks.csproj
@@ -48,7 +48,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(IsCore)' == 'true' ">
-    <PackageReference Include="Microsoft.Build.Framework" />
+    <PackageReference Include="Microsoft.Build.Framework" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" />
   </ItemGroup>

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.Build.Tasks.csproj
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.Build.Tasks.csproj
@@ -49,8 +49,8 @@
 
   <ItemGroup Condition=" '$(IsCore)' == 'true' ">
     <PackageReference Include="Microsoft.Build.Framework" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" ExcludeAssets="runtime" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/NuGet.CommandLine.XPlat.csproj
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/NuGet.CommandLine.XPlat.csproj
@@ -23,10 +23,11 @@
     <PackageReference Include="Microsoft.Build" ExcludeAssets="runtime" />
   </ItemGroup>
 
-<!-- Microsoft.Build.Locator is only used when debugging, and the compiler will skip copying this dependency from Release assemblies we insert because we only refer to it conditionally with the DEBUG configuration -->
-  <ItemGroup>
+<!-- Microsoft.Build.Locator is only used when debugging, and the compiler will skip copying this dependency from Release assemblies we insert because we only refer to it conditionally with the DEBUG configuration.
+  Uncomment the following when debugging. Also uncomment the MSBuildLocator code from Program.cs -->
+  <!-- <ItemGroup>
     <PackageReference Include="Microsoft.Build.Locator" PrivateAssets="All" />
-  </ItemGroup>
+  </ItemGroup> -->
 
   <ItemGroup>
     <Compile Remove="external\*" />

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/NuGet.CommandLine.XPlat.csproj
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/NuGet.CommandLine.XPlat.csproj
@@ -23,9 +23,8 @@
     <PackageReference Include="Microsoft.Build" ExcludeAssets="runtime" />
   </ItemGroup>
 
-  <!-- Microsoft.Build.Locator is needed when debugging, but should not be used in the assemblies we insert.
-       It also generates a build error if the output directory contains MSBuild dlls, so exclude msbuild assets when using the locator. -->
-  <ItemGroup Condition=" '$(Configuration)' == 'Debug' ">
+  <!-- Microsoft.Build.Locator is only used when debugging, and the compiler will trim this dependency from Release assemblies we insert. -->
+  <ItemGroup>
     <PackageReference Include="Microsoft.Build.Locator"  />
   </ItemGroup>
 

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/NuGet.CommandLine.XPlat.csproj
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/NuGet.CommandLine.XPlat.csproj
@@ -25,7 +25,7 @@
 
   <!-- Microsoft.Build.Locator is only used when debugging, and the compiler will trim this dependency from Release assemblies we insert. -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build.Locator"  />
+    <PackageReference Include="Microsoft.Build.Locator" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/NuGet.CommandLine.XPlat.csproj
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/NuGet.CommandLine.XPlat.csproj
@@ -20,23 +20,14 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.CommandLineUtils.Sources" PrivateAssets="All" />
     <PackageReference Include="System.Diagnostics.Debug" />
+    <PackageReference Include="Microsoft.Build" ExcludeAssets="runtime" />
   </ItemGroup>
 
   <!-- Microsoft.Build.Locator is needed when debugging, but should not be used in the assemblies we insert.
        It also generates a build error if the output directory contains MSBuild dlls, so exclude msbuild assets when using the locator. -->
-  <Choose>
-    <When Condition=" '$(Configuration)' == 'Debug' ">
-      <ItemGroup>
-        <PackageReference Include="Microsoft.Build" ExcludeAssets="runtime" />
-        <PackageReference Include="Microsoft.Build.Locator" />
-      </ItemGroup>
-    </When>
-    <Otherwise>
-      <ItemGroup>
-        <PackageReference Include="Microsoft.Build" />
-      </ItemGroup>
-    </Otherwise>
-  </Choose>
+  <ItemGroup Condition=" '$(Configuration)' == 'Debug' ">
+    <PackageReference Include="Microsoft.Build.Locator"  />
+  </ItemGroup>
 
   <ItemGroup>
     <Compile Remove="external\*" />

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/NuGet.CommandLine.XPlat.csproj
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/NuGet.CommandLine.XPlat.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="Microsoft.Build" ExcludeAssets="runtime" />
   </ItemGroup>
 
-  <!-- Microsoft.Build.Locator is only used when debugging, and the compiler will trim this dependency from Release assemblies we insert. -->
+<!-- Microsoft.Build.Locator is only used when debugging, and the compiler will skip copying this dependency from Release assemblies we insert because we only refer to it conditionally with the DEBUG configuration -->
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Locator" PrivateAssets="All" />
   </ItemGroup>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Program.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Program.cs
@@ -37,7 +37,8 @@ namespace NuGet.CommandLine.XPlat
         public static int MainInternal(string[] args, CommandOutputLogger log)
         {
 #if DEBUG
-            try
+            // Uncomment the following when debugging. Also uncomment the PackageReference for Microsoft.Build.Locator.
+            /*try
             {
                 // .NET JIT compiles one method at a time. If this method calls `MSBuildLocator` directly, the
                 // try block is never entered if Microsoft.Build.Locator.dll can't be found. So, run it in a
@@ -48,7 +49,7 @@ namespace NuGet.CommandLine.XPlat
             {
                 // MSBuildLocator is used only to enable Visual Studio debugging.
                 // It's not needed when using a patched dotnet sdk, so it doesn't matter if it fails.
-            }
+            }*/
 
             var debugNuGetXPlat = Environment.GetEnvironmentVariable("DEBUG_NUGET_XPLAT");
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1816

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
Similar to https://github.com/NuGet/NuGet.Client/pull/4751, MSBuild does not support runtime scenarios where the `Microsoft.Build` DLL is placed in an output directory.
See https://docs.microsoft.com/en-us/visualstudio/msbuild/updating-an-existing-application?view=vs-2022#use-nuget-packages-preferred

- Since `PackageReference` cannot have use the Condition on Configuration property, I removed it, knowing that the compiler will trim unused references.
- `IlmergeCommand` had to be pointed to the NET Framework path when running from .NET Core, because its behavior is to look for assemblies in the specified paths. Now that I've removed MSBuild's runtime assembly, it needs to know where to look.
  - `GeneratePathProperty` is a pretty cool feature, which enables me to do this :) Thanks @jeffkl !

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
