### PR TITLE
Revert "Signing:  enable signed package verification by default on Linux in .NET 7 SDK (#4727)"

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs
@@ -524,7 +524,7 @@ namespace NuGet.Packaging
                 // Please note: Linux/MAC case sensitive for env var name.
                 string signVerifyEnvVariable = _environmentVariableReader.GetEnvironmentVariable("DOTNET_NUGET_SIGNATURE_VERIFICATION");
 
-                bool canVerify = RuntimeEnvironmentHelper.IsLinux;
+                bool canVerify = false;
 
                 if (!string.IsNullOrEmpty(signVerifyEnvVariable))
                 {

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageArchiveReaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageArchiveReaderTests.cs
@@ -2102,7 +2102,7 @@ namespace NuGet.Packaging.Test
 
         private static bool CanVerifySignedPackages()
         {
-            return (RuntimeEnvironmentHelper.IsWindows || RuntimeEnvironmentHelper.IsLinux) &&
+            return RuntimeEnvironmentHelper.IsWindows &&
 #if IS_SIGNING_SUPPORTED
                 true;
 #else


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes:  https://github.com/NuGet/Home/issues/12043

Regression? Last working version:  .NET 7 Preview 7 SDK

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
This reverts commit febc77567fd4e9c51e4147df8c04bd4e26496b26.

.NET 7 RC1 SDK enabled NuGet signed package verification in restore operations by default on Linux.  We need to temporarily disable it until https://github.com/NuGet/Home/issues/12033 is resolved.

## PR Checklist

- [X] PR has a meaningful title
- [X] PR has a linked issue.
- [X] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [X] Test exception  (test coverage already exists)
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [X] N/A

CC @aortiz-msft, @richlander
