### PR TITLE
Ignore local sources when enforcing package source mapping with central package management

### DIFF
--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
@@ -1682,8 +1682,8 @@ namespace NuGet.Commands.Test
                     // NU1507: There are 3 package sources defined in your configuration. When using central package management, please map your package sources with package source mapping (https://aka.ms/nuget-package-source-mapping) or specify a single package source. The following sources are defined: D:\NuGet\.test\work\298ed94f\653dd6db\source, https://feed1, https://feed2
                     logger.WarningMessages.Should()
                         .Contain(i => i.Contains(NuGetLogCode.NU1507.ToString()))
-                        .Which.Should().Contain("There are 3 package sources defined in your configuration")
-                        .And.Contain($"The following sources are defined: {pathContext.PackageSource}, https://feed1, https://feed2");
+                        .Which.Should().Contain("There are 2 package sources defined in your configuration")
+                        .And.Contain($"The following sources are defined: https://feed1, https://feed2");
                 }
             }
         }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11951

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
Trim down configured sources to ones that are not local.  Moved the logic inside of the check for package source mapping to avoid the overhead in case the user is already opt-ed in.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
