### PR TITLE
Skip failing E2E tests & fix missing method exception blocking CI

### DIFF
--- a/build/packages.targets
+++ b/build/packages.targets
@@ -107,6 +107,7 @@
         <PackageReference Update="Portable.BouncyCastle" Version="1.8.10" />
         <PackageReference Update="System.Collections" Version="$(SystemPackagesVersion)" />
         <PackageReference Update="System.IO.FileSystem.Primitives" Version="$(SystemPackagesVersion)" />
+        <PackageReference Update="System.Memory" Version="4.5.5" />
         <PackageReference Update="System.Resources.ResourceManager" Version="$(SystemPackagesVersion)" />
         <PackageReference Update="System.Runtime.Extensions" Version="$(SystemPackagesVersion)" />
         <PackageReference Update="System.Runtime.InteropServices" Version="$(SystemPackagesVersion)" />

--- a/test/EndToEnd/tests/PackageNameSpaceTests.ps1
+++ b/test/EndToEnd/tests/PackageNameSpaceTests.ps1
@@ -1,5 +1,6 @@
 function Test-PackageSourceMappingRestore-WithSingleFeed
 {
+    [SkipTest('https://github.com/NuGet/Client.Engineering/issues/1826')]
     param($context)
 
     # Arrange
@@ -54,6 +55,7 @@ function Test-PackageSourceMappingRestore-WithSingleFeed
 
 function Test-PackageSourceMappingRestore-WithMultipleFeedsWithIdenticalPackages-RestoresCorrectPackage
 {
+    [SkipTest('https://github.com/NuGet/Client.Engineering/issues/1826')]
     param($context)
 
     # Arrange
@@ -116,6 +118,7 @@ function Test-PackageSourceMappingRestore-WithMultipleFeedsWithIdenticalPackages
 }
 
 function Test-VsPackageInstallerServices-PackageSourceMappingInstall-WithSingleFeed-Succeed {
+    [SkipTest('https://github.com/NuGet/Client.Engineering/issues/1826')]
     param(
         $context
     )
@@ -206,6 +209,7 @@ function Test-VsPackageInstallerServices-PackageSourceMappingInstall-WithSingleF
 
 function Test-VsPackageInstallerServices-PackageSourceMappingInstall-WithMultipleFeedsWithIdenticalPackages-RestoresCorrectPackageWithSpecifiedVersion
 {
+    [SkipTest('https://github.com/NuGet/Client.Engineering/issues/1826')]
     param($context)
 
     # Arrange
@@ -267,6 +271,7 @@ function Test-VsPackageInstallerServices-PackageSourceMappingInstall-WithMultipl
 
 function Test-VsPackageInstallerServices-PackageSourceMappingInstall-WithMultipleFeedsWithIdenticalPackages-RestoresCorrectPackageWithLatestVersion
 {
+    [SkipTest('https://github.com/NuGet/Client.Engineering/issues/1826')]
     param($context)
 
     # Arrange
@@ -328,6 +333,7 @@ function Test-VsPackageInstallerServices-PackageSourceMappingInstall-WithMultipl
 
 function Test-PC-PackageSourceMappingInstall-Succeed
 {
+    [SkipTest('https://github.com/NuGet/Client.Engineering/issues/1826')]
     param($context)
 
     # Arrange
@@ -410,6 +416,7 @@ function Test-PC-PackageSourceMappingInstall-Fails
 
 function Test-PC-PackageSourceMappingInstall-WithCorrectSourceOption-Succeed
 {
+    [SkipTest('https://github.com/NuGet/Client.Engineering/issues/1826')]
     param($context)
 
     # Arrange
@@ -518,6 +525,7 @@ function Test-PC-PackageSourceMappingInstall-WithWrongSourceOption-Fails
 
 function Test-PC-PackageSourceMappingUpdate-WithCorrectSourceOption-Succeed
 {
+    [SkipTest('https://github.com/NuGet/Client.Engineering/issues/1826')]
     param($context)
 
     # Arrange

--- a/test/EndToEnd/tests/UniversalWindowsProjectTest.ps1
+++ b/test/EndToEnd/tests/UniversalWindowsProjectTest.ps1
@@ -21,6 +21,7 @@ function Test-UwpNativeAppUninstallPackage {
 }
 
 function Test-UwpNativeProjectJsonBuild {
+    [SkipTest('https://github.com/NuGet/Client.Engineering/issues/1826')]
     param($context)
 
     $projectT = New-Project UwpNativeProjectJson

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGet.CommandLine.Test.csproj
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGet.CommandLine.Test.csproj
@@ -38,6 +38,7 @@
     <PackageDownload Include="NuGet.Core" />
     <PackageReference Include="Microsoft.Build.Framework" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.TestPlatform.Portable" />
+    <PackageReference Include="System.Memory" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12054
Fixes: https://github.com/NuGet/Home/issues/12059

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Two blocking CI issues are addressed by this PR.

1. Skip E2E tests which are failing and blocking CI. Follow-up issue to investigate root cause: https://github.com/NuGet/Client.Engineering/issues/1826

2. For https://github.com/NuGet/Home/issues/12059, I repro'd the issue locally, and debugging showed that the SxS MSBuild 17.04 assembly was being loaded (changed in https://www.nuget.org/packages/Microsoft.NET.StringTools/)
@nkolev92 found https://github.com/dotnet/msbuild/issues/7873 and that overriding this transitive for `System.Memory.dll` resolves the issue.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
