### PR TITLE
Fix CI failures in release-6.2.x branch

### DIFF
--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPushCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPushCommandTest.cs
@@ -2247,9 +2247,9 @@ namespace NuGet.CommandLine.Test
         }
 
         [Theory]
-        [InlineData("https://invalid-2a0358f1-88f2-48c0-b68a-bb150cac00bdnuget.org")]
-        [InlineData("https://invalid-2a0358f1-88f2-48c0-b68a-bb150cac00bdnuget.org/api/v2")]
-        [InlineData("https://invalid-2a0358f1-88f2-48c0-b68a-bb150cac00bdnuget.org/api/v2/Package")]
+        [InlineData("https://invalid.test")]
+        [InlineData("https://invalid.test/api/v2")]
+        [InlineData("https://invalid.test/api/v2/Package")]
         public void PushCommand_InvalidInput_V2HttpSource(string invalidInput)
         {
             var nugetexe = Util.GetNuGetExePath();
@@ -2291,9 +2291,9 @@ namespace NuGet.CommandLine.Test
                 else
                 {
                     Assert.True(
-                        result.Item3.Contains(
-                            "The remote name could not be resolved: 'invalid-2a0358f1-88f2-48c0-b68a-bb150cac00bdnuget.org'"),
-                        "Expected error message not found in " + result.Item3
+                        result.Errors.Contains(
+                            "The remote name could not be resolved: 'invalid.test'"),
+                        "Expected error message not found in " + result.Errors
                     );
                 }
 

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/NuGet.PackageManagement.UI.Test.csproj
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/NuGet.PackageManagement.UI.Test.csproj
@@ -76,11 +76,6 @@
     <ProjectReference Include="$(NuGetClientsSrcDirectory)NuGet.PackageManagement.VisualStudio\NuGet.PackageManagement.VisualStudio.csproj" />
     <ProjectReference Include="..\NuGet.PackageManagement.VisualStudio.Test\NuGet.PackageManagement.VisualStudio.Test.csproj" />
   </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Moq" />
-  </ItemGroup>
-
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetVerifyTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetVerifyTests.cs
@@ -51,7 +51,9 @@ namespace Dotnet.Integration.Test
             }
         }
 
-        [PlatformFact(Platform.Windows, Platform.Linux)] // https://github.com/NuGet/Home/issues/11178
+        // https://github.com/NuGet/Home/issues/11178
+        // https://github.com/NuGet/Home/issues/11892
+        [PlatformFact(Platform.Windows)]
         public void Verify_AuthorSignedAndTimestampedPackageWithOptionAll_Succeeds()
         {
             // Arrange
@@ -95,7 +97,9 @@ namespace Dotnet.Integration.Test
             }
         }
 
-        [PlatformFact(Platform.Windows, Platform.Linux)] // https://github.com/NuGet/Home/issues/11178
+        // https://github.com/NuGet/Home/issues/11892
+        // https://github.com/NuGet/Home/issues/11178
+        [PlatformFact(Platform.Windows)]
         public void Verify_SignedPackageWithAllowedCertificate_Succeeds()
         {
             // Arrange
@@ -116,7 +120,9 @@ namespace Dotnet.Integration.Test
             }
         }
 
-        [PlatformFact(Platform.Windows, Platform.Linux)] // https://github.com/NuGet/Home/issues/11178
+        // https://github.com/NuGet/Home/issues/11178
+        // https://github.com/NuGet/Home/issues/11892
+        [PlatformFact(Platform.Windows)]
         public void Verify_MultipleSignedPackagesWithWildCardAndDetailedVerbosity_MixedResults()
         {
             // Arrange


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1829

Regression? Last working version: No

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
3 tests are failing on CI for `release-6.2.x branch`.
![image](https://user-images.githubusercontent.com/52756182/187313058-3f2f82f9-7a50-41f2-a851-0b03a1a6336e.png)

These issues are fixed in dev in https://github.com/NuGet/NuGet.Client/commit/e9637ed865687c2153da78c6c6385f010277329c  commit. When I cherry-picked the commit, `CrossFramework_Tests_On_Windows` job failed on CI at `Restore` step with the below error message. 
`##[error]test\NuGet.Clients.Tests\NuGet.PackageManagement.UI.Test\NuGet.PackageManagement.UI.Test.csproj(0,0): Error NU1504: Duplicate 'PackageReference' items found. Remove the duplicate items or use the Update functionality to ensure a consistent restore behavior. The duplicate 'PackageReference' items are: Moq 4.16.1, Moq 4.16.1.`

NU1504 was added in 17.3. Given that CI is running on 17.3, it is causing CI failures because a test project has duplicated package reference to `Moq`in 6.2.x branch. This issue was fixed in `dev` branch in https://github.com/NuGet/NuGet.Client/pull/4559 PR.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [x] N/A
