### PR TITLE
Properly handle duplicate central package version items in the restore graph when using custom build ordering in a solution file

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
@@ -1000,15 +1000,14 @@ namespace NuGet.Commands
         {
             foreach (var framework in frameworks)
             {
-                if (centralPackageVersions.ContainsKey(framework))
+                if (!centralPackageVersions.TryGetValue(framework, out Dictionary<string, CentralPackageVersion> versions))
                 {
-                    centralPackageVersions[framework].Add(centralPackageVersion.Name, centralPackageVersion);
+                    versions = new Dictionary<string, CentralPackageVersion>(StringComparer.OrdinalIgnoreCase);
+
+                    centralPackageVersions.Add(framework, versions);
                 }
-                else
-                {
-                    var deps = new Dictionary<string, CentralPackageVersion>() { [centralPackageVersion.Name] = centralPackageVersion };
-                    centralPackageVersions.Add(framework, deps);
-                }
+
+                versions[centralPackageVersion.Name] = centralPackageVersion;
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/MSBuildRestoreUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/MSBuildRestoreUtilityTests.cs
@@ -3485,6 +3485,14 @@ namespace NuGet.Commands.Test
                     { "VersionRange", "3.0.0" },
                     { "TargetFrameworks", "netcoreapp3.0" },
                 });
+                items.Add(new Dictionary<string, string>()
+                {
+                    { "Type", "CentralPackageVersion" },
+                    { "ProjectUniqueName", projectUniqueName },
+                    { "Id", "z" },
+                    { "VersionRange", "3.0.0" },
+                    { "TargetFrameworks", "netcoreapp3.0" },
+                });
 
                 var wrappedItems = items.Select(CreateItems).ToList();
 

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/MSBuildRestoreUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/MSBuildRestoreUtilityTests.cs
@@ -3485,14 +3485,6 @@ namespace NuGet.Commands.Test
                     { "VersionRange", "3.0.0" },
                     { "TargetFrameworks", "netcoreapp3.0" },
                 });
-                items.Add(new Dictionary<string, string>()
-                {
-                    { "Type", "CentralPackageVersion" },
-                    { "ProjectUniqueName", projectUniqueName },
-                    { "Id", "z" },
-                    { "VersionRange", "3.0.0" },
-                    { "TargetFrameworks", "netcoreapp3.0" },
-                });
 
                 var wrappedItems = items.Select(CreateItems).ToList();
 
@@ -3527,6 +3519,95 @@ namespace NuGet.Commands.Test
 
                 Assert.True(project1Spec.RestoreMetadata.CentralPackageVersionsEnabled);
             }
+        }
+
+        [Fact]
+        public void MSBuildRestoreUtility_GetDependencySpec_HandlesDuplicatesWhenCPVMEnabled()
+        {
+            // Arrange
+            using var workingDir = TestDirectory.Create();
+            const string projectName = "acpvm";
+            const string projectUniqueName = "21031AA5-93B3-4230-BA20-0EF4CFCEDAAB";
+            var project1Root = Path.Combine(workingDir, projectName);
+            var project1Path = Path.Combine(project1Root, $"{projectName}.csproj");
+
+            var items = new List<IDictionary<string, string>>
+                {
+                    new Dictionary<string, string>()
+                    {
+                        { "Type", "ProjectSpec" },
+                        { "ProjectName", projectName },
+                        { "ProjectStyle", "PackageReference" },
+                        { "ProjectUniqueName", projectUniqueName },
+                        { "ProjectPath", project1Path },
+                        { "CrossTargeting", "true" },
+                        { "_CentralPackageVersionsEnabled", "true"}
+                    },
+                    new Dictionary<string, string>()
+                    {
+                        { "Type", "TargetFrameworkInformation" },
+                        { "AssetTargetFallback", "" },
+                        { "PackageTargetFallback", "" },
+                        { "ProjectUniqueName", projectUniqueName },
+                        { "TargetFramework", "netcoreapp3.0" },
+                        { "TargetFrameworkIdentifier", ".NETCoreApp" },
+                        { "TargetFrameworkVersion", "v3.0" },
+                        { "TargetFrameworkMoniker", "NETCoreApp,Version=3.0" },
+                        { "TargetPlatformIdentifier", "" },
+                        { "TargetPlatformMoniker", "" },
+                        { "TargetPlatformVersion", "" },
+                    },
+                    // Package reference
+                    new Dictionary<string, string>()
+                    {
+                        { "Type", "Dependency" },
+                        { "ProjectUniqueName", projectUniqueName },
+                        { "Id", "x" },
+                        { "TargetFrameworks", "netcoreapp3.0" },
+                        { "IncludeAssets", "build;compile" },
+                        { "CrossTargeting", "true" },
+                    },
+                    // Duplicate central package versions
+                    new Dictionary<string, string>()
+                    {
+                        { "Type", "CentralPackageVersion" },
+                        { "ProjectUniqueName", projectUniqueName },
+                        { "Id", "x" },
+                        { "VersionRange", "1.0.0" },
+                        { "TargetFrameworks", "netcoreapp3.0" },
+                    },
+                    new Dictionary<string, string>()
+                    {
+                        { "Type", "CentralPackageVersion" },
+                        { "ProjectUniqueName", projectUniqueName },
+                        { "Id", "x" },
+                        { "VersionRange", "2.0.0" },
+                        { "TargetFrameworks", "netcoreapp3.0" },
+                    }
+                };
+
+            var wrappedItems = items.Select(CreateItems).ToList();
+
+            // Act
+            var dgSpec = MSBuildRestoreUtility.GetDependencySpec(wrappedItems);
+            var project1Spec = dgSpec.Projects.Single(e => e.Name == projectName);
+
+            // Assert
+            Assert.Equal(1, project1Spec.TargetFrameworks.Count());
+            Assert.Equal(1, project1Spec.TargetFrameworks.First().Dependencies.Count);
+            Assert.Equal(1, project1Spec.TargetFrameworks.First().CentralPackageVersions.Count);
+
+            var dependencyX = project1Spec.TargetFrameworks.First().Dependencies.Where(d => d.Name == "x").First();
+
+            Assert.Equal("[2.0.0, )", dependencyX.LibraryRange.VersionRange.ToNormalizedString());
+            Assert.Equal(LibraryIncludeFlags.Compile | LibraryIncludeFlags.Build, dependencyX.IncludeType);
+
+            var centralDependencyX = project1Spec.TargetFrameworks.First().CentralPackageVersions["x"];
+
+            Assert.Equal("x", centralDependencyX.Name);
+            Assert.Equal("[2.0.0, )", centralDependencyX.VersionRange.ToNormalizedString());
+
+            Assert.True(project1Spec.RestoreMetadata.CentralPackageVersionsEnabled);
         }
 
         [Fact]


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12021

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
When a user specified custom build ordering in a solution file, MSBuild generates a ProjectReference on the fly.  If a user still has an actual ProjectReference in a project, NuGet will get the PackageReference and PackageVersions items twice with duplicates in the restore graph.

This updates the logic to handle duplicates by implementing a last one wins strategy. 

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
