### PR TITLE
Remove the using for Microsoft.Build.Locator in NuGet.CommandLine.XPlat

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Program.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Program.cs
@@ -11,10 +11,6 @@ using Microsoft.Extensions.CommandLineUtils;
 using NuGet.Common;
 using NuGet.Commands;
 
-#if DEBUG
-using Microsoft.Build.Locator;
-#endif
-
 namespace NuGet.CommandLine.XPlat
 {
     internal class Program
@@ -43,7 +39,7 @@ namespace NuGet.CommandLine.XPlat
                 // .NET JIT compiles one method at a time. If this method calls `MSBuildLocator` directly, the
                 // try block is never entered if Microsoft.Build.Locator.dll can't be found. So, run it in a
                 // lambda function to ensure we're in the try block. C# IIFE!
-                ((Action)(() => MSBuildLocator.RegisterDefaults()))();
+                ((Action)(() => Microsoft.Build.Locator.MSBuildLocator.RegisterDefaults()))();
             }
             catch
             {


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1833

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
Missed this in previous PR, https://github.com/NuGet/NuGet.Client/pull/4761
Only Debug builds would break, so CI is fine. Local `build.ps1` runs will fail temporarily until this is merged.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
