### PR TITLE
Removes hardcoded strings in nuget.exe help command

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/Command.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/Command.cs
@@ -44,7 +44,7 @@ namespace NuGet.CommandLine
         [Import]
         public Configuration.IMachineWideSettings MachineWideSettings { get; set; }
 
-        [Option("help", AltName = "?")]
+        [Option(typeof(NuGetCommand), "Option_Help", AltName = "?")]
         public bool Help { get; set; }
 
         [Option(typeof(NuGetCommand), "Option_Verbosity")]

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/HelpCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/HelpCommand.cs
@@ -1,10 +1,11 @@
-using System;
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
 using System.ComponentModel.Composition;
-using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
-using NuGet.Common;
 
 namespace NuGet.CommandLine
 {
@@ -44,7 +45,7 @@ namespace NuGet.CommandLine
 
         public override void ExecuteCommand()
         {
-            if (!String.IsNullOrEmpty(CommandName))
+            if (!string.IsNullOrEmpty(CommandName))
             {
                 ViewHelpForCommand(CommandName);
             }
@@ -64,10 +65,10 @@ namespace NuGet.CommandLine
 
         public void ViewHelp()
         {
-            Console.WriteLine("usage: {0} <command> [args] [options] ", _commandExe);
-            Console.WriteLine("Type '{0} help <command>' for help on a specific command.", _commandExe);
+            Console.WriteLine(string.Format(CultureInfo.CurrentCulture, NuGetCommand.HelpCommand_Usage, _commandExe));
+            Console.WriteLine(string.Format(CultureInfo.CurrentCulture, NuGetCommand.HelpCommand_Suggestion, _commandExe));
             Console.WriteLine();
-            Console.WriteLine("Available commands:");
+            Console.WriteLine(NuGetCommand.HelpCommand_AvailableCommands);
             Console.WriteLine();
 
             var commands = from c in _commandManager.GetCommands()
@@ -110,12 +111,12 @@ namespace NuGet.CommandLine
             ICommand command = _commandManager.GetCommand(commandName);
             CommandAttribute attribute = command.CommandAttribute;
 
-            Console.WriteLine("usage: {0} {1} {2}", _commandExe, attribute.CommandName, attribute.UsageSummary);
+            Console.WriteLine(string.Format(CultureInfo.CurrentCulture, NuGetCommand.HelpCommand_UsageDetail, _commandExe, attribute.CommandName, attribute.UsageSummary));
             Console.WriteLine();
 
-            if (!String.IsNullOrEmpty(attribute.AltName))
+            if (!string.IsNullOrEmpty(attribute.AltName))
             {
-                Console.WriteLine("alias: {0}", attribute.AltName);
+                Console.WriteLine(string.Format(CultureInfo.CurrentCulture, NuGetCommand.HelpCommand_Alias, attribute.AltName));
                 Console.WriteLine();
             }
 
@@ -133,20 +134,25 @@ namespace NuGet.CommandLine
 
             if (options.Count > 0)
             {
-                Console.WriteLine("options:");
+                Console.WriteLine(NuGetCommand.HelpCommand_Options);
                 Console.WriteLine();
 
                 // Get the max option width. +2 for showing + against multivalued properties
                 int maxOptionWidth = options.Max(o => o.Value.Name.Length) + 2;
                 // Get the max altname option width
-                int maxAltOptionWidth = options.Max(o => (o.Key.AltName ?? String.Empty).Length);
+                int maxAltOptionWidth = options.Max(o => (o.Key.AltName ?? string.Empty).Length);
 
-                foreach (var o in options)
+                foreach (KeyValuePair<OptionAttribute, PropertyInfo> o in options)
                 {
-                    Console.Write(" -{0, -" + (maxOptionWidth + 2) + "}", o.Value.Name +
-                        (TypeHelper.IsMultiValuedProperty(o.Value) ? " +" : String.Empty));
-                    Console.Write(" {0, -" + (maxAltOptionWidth + 4) + "}", GetAltText(o.Key.AltName));
-
+                    if (TypeHelper.IsMultiValuedProperty(o.Value))
+                    {
+                        Console.Write(string.Format(CultureInfo.CurrentCulture, $"-{{0, -{maxOptionWidth + 2}}} +", o.Value.Name));
+                    }
+                    else
+                    {
+                        Console.Write(string.Format(CultureInfo.CurrentCulture, $"-{{0, -{maxOptionWidth + 2}}}", o.Value.Name));
+                    }
+                    Console.Write(string.Format(CultureInfo.CurrentCulture, $" {{0, -{maxAltOptionWidth + 4}}}", GetAltText(o.Key.AltName)));
                     Console.PrintJustified((10 + maxAltOptionWidth + maxOptionWidth), o.Key.Description);
                 }
 
@@ -155,7 +161,7 @@ namespace NuGet.CommandLine
 
             if (!string.IsNullOrEmpty(attribute.UsageExample))
             {
-                Console.WriteLine("examples:");
+                Console.WriteLine(NuGetCommand.HelpCommand_Examples);
                 Console.WriteLine();
                 Console.WriteLine(attribute.UsageExample);
                 Console.WriteLine();
@@ -177,7 +183,7 @@ namespace NuGet.CommandLine
 
             foreach (var command in commands)
             {
-                Console.WriteLine(info.ToTitleCase(command.CommandName) + " Command");
+                Console.WriteLine(string.Format(CultureInfo.CurrentCulture, NuGetCommand.HelpCommand_Title, info.ToTitleCase(command.CommandName)));
                 ViewHelpForCommand(command.CommandName);
             }
         }
@@ -204,11 +210,11 @@ namespace NuGet.CommandLine
 
         private static string GetAltText(string altNameText)
         {
-            if (String.IsNullOrEmpty(altNameText))
+            if (string.IsNullOrEmpty(altNameText))
             {
-                return String.Empty;
+                return string.Empty;
             }
-            return String.Format(CultureInfo.CurrentCulture, " ({0})", altNameText);
+            return string.Format(CultureInfo.CurrentCulture, NuGetCommand.HelpCommand_AltText, altNameText);
         }
 
     }

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.Designer.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.Designer.cs
@@ -6355,6 +6355,15 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Show command help and usage information..
+        /// </summary>
+        internal static string Option_Help {
+            get {
+                return ResourceManager.GetString("Option_Help", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Do not prompt for user input or confirmations..
         /// </summary>
         internal static string Option_NonInteractive {

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.Designer.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.Designer.cs
@@ -19,7 +19,7 @@ namespace NuGet.CommandLine {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class NuGetCommand {
@@ -108,7 +108,7 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Path to certificate file added to a file client certificate source..
+        ///   Looks up a localized string similar to Path to certificate file..
         /// </summary>
         internal static string ClientCertificatesCommandFilePathDescription {
             get {
@@ -117,7 +117,7 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to FindBy added to a store client certificate source..
+        ///   Looks up a localized string similar to Search method to find certificate in certificate store (see docs)..
         /// </summary>
         internal static string ClientCertificatesCommandFindByDescription {
             get {
@@ -126,7 +126,7 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to FindValue added to a storage client certificate source..
+        ///   Looks up a localized string similar to Search the certificate store for the supplied value. Used with FindValue (see docs)..
         /// </summary>
         internal static string ClientCertificatesCommandFindValueDescription {
             get {
@@ -135,7 +135,7 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Bypass certificate validation..
+        ///   Looks up a localized string similar to Skip certificate validation..
         /// </summary>
         internal static string ClientCertificatesCommandForceDescription {
             get {
@@ -144,7 +144,7 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Determines to which package source client certificate will be applied to..
+        ///   Looks up a localized string similar to Package source name..
         /// </summary>
         internal static string ClientCertificatesCommandPackageSourceDescription {
             get {
@@ -153,7 +153,7 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Password for the certificate, if needed. This option can be used to specify the password for the certificate..
+        ///   Looks up a localized string similar to Password for the certificate, if needed..
         /// </summary>
         internal static string ClientCertificatesCommandPasswordDescription {
             get {
@@ -162,7 +162,7 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to StoreLocation added to a storage client certificate source..
+        ///   Looks up a localized string similar to Certificate store location (see docs)..
         /// </summary>
         internal static string ClientCertificatesCommandStoreLocationDescription {
             get {
@@ -171,7 +171,7 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to StoreName added to a storage client certificate source..
+        ///   Looks up a localized string similar to Certificate store name (see docs)..
         /// </summary>
         internal static string ClientCertificatesCommandStoreNameDescription {
             get {
@@ -180,7 +180,7 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Enables storing password for the certificate by disabling password encryption..
+        ///   Looks up a localized string similar to Enables storing portable certificate password by disabling password encryption..
         /// </summary>
         internal static string ClientCertificatesCommandStorePasswordInClearTextDescription {
             get {
@@ -206,7 +206,7 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &lt;List|Add|Update|Remove|&gt; [options].
+        ///   Looks up a localized string similar to &lt;List|Add|Update|Remove&gt; [options].
         /// </summary>
         internal static string ClientCertificatesCommandUsageSummary {
             get {
@@ -215,7 +215,7 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Provides the ability to manage list of client certificates located in %AppData%\NuGet\NuGet.config.
+        ///   Looks up a localized string similar to Provides the ability to manage list of client certificates located in NuGet.config files.
         /// </summary>
         internal static string ClientCertificatesDescription {
             get {
@@ -2476,6 +2476,87 @@ namespace NuGet.CommandLine {
         internal static string ForceRestoreCommand {
             get {
                 return ResourceManager.GetString("ForceRestoreCommand", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to alias: {0}.
+        /// </summary>
+        internal static string HelpCommand_Alias {
+            get {
+                return ResourceManager.GetString("HelpCommand_Alias", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to  ({0}).
+        /// </summary>
+        internal static string HelpCommand_AltText {
+            get {
+                return ResourceManager.GetString("HelpCommand_AltText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Available commands:.
+        /// </summary>
+        internal static string HelpCommand_AvailableCommands {
+            get {
+                return ResourceManager.GetString("HelpCommand_AvailableCommands", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to examples:.
+        /// </summary>
+        internal static string HelpCommand_Examples {
+            get {
+                return ResourceManager.GetString("HelpCommand_Examples", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to options:.
+        /// </summary>
+        internal static string HelpCommand_Options {
+            get {
+                return ResourceManager.GetString("HelpCommand_Options", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Type &apos;{0} help &lt;command&gt;&apos; for help on a specific command..
+        /// </summary>
+        internal static string HelpCommand_Suggestion {
+            get {
+                return ResourceManager.GetString("HelpCommand_Suggestion", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0} Command.
+        /// </summary>
+        internal static string HelpCommand_Title {
+            get {
+                return ResourceManager.GetString("HelpCommand_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to usage: {0} &lt;command&gt; [args] [options].
+        /// </summary>
+        internal static string HelpCommand_Usage {
+            get {
+                return ResourceManager.GetString("HelpCommand_Usage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to usage: {0} {1} {2}.
+        /// </summary>
+        internal static string HelpCommand_UsageDetail {
+            get {
+                return ResourceManager.GetString("HelpCommand_UsageDetail", resourceCulture);
             }
         }
         
@@ -11052,6 +11133,73 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Searches a given source using the query string provided. If no sources are specified, all sources defined in %AppData%\NuGet\NuGet.config are used..
+        /// </summary>
+        internal static string SearchCommandDescription {
+            get {
+                return ResourceManager.GetString("SearchCommandDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Include prerelease packages..
+        /// </summary>
+        internal static string SearchCommandPreRelease {
+            get {
+                return ResourceManager.GetString("SearchCommandPreRelease", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The package source to search. You can pass multiple -Source options to search multiple package sources..
+        /// </summary>
+        internal static string SearchCommandSourceDescription {
+            get {
+                return ResourceManager.GetString("SearchCommandSourceDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The number of results to return. The default value is 20..
+        /// </summary>
+        internal static string SearchCommandTake {
+            get {
+                return ResourceManager.GetString("SearchCommandTake", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Specify search terms..
+        /// </summary>
+        internal static string SearchCommandUsageDescription {
+            get {
+                return ResourceManager.GetString("SearchCommandUsageDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to nuget search foo
+        ///
+        ///nuget search foo -Verbosity detailed
+        ///
+        ///nuget search foo -PreRelease -Take 5.
+        /// </summary>
+        internal static string SearchCommandUsageExamples {
+            get {
+                return ResourceManager.GetString("SearchCommandUsageExamples", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to [search terms] [options].
+        /// </summary>
+        internal static string SearchCommandUsageSummary {
+            get {
+                return ResourceManager.GetString("SearchCommandUsageSummary", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Saves an API key for a given server URL. When no URL is provided API key is saved for the NuGet gallery..
         /// </summary>
         internal static string SetApiKeyCommandDescription {
@@ -12819,7 +12967,7 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to UserName to be used when connecting to an authenticated source..
+        ///   Looks up a localized string similar to Username to be used when connecting to an authenticated source..
         /// </summary>
         internal static string SourcesCommandUserNameDescription {
             get {
@@ -13756,6 +13904,7 @@ namespace NuGet.CommandLine {
                 return ResourceManager.GetString("TrustedSignersCommandUsageSummary", resourceCulture);
             }
         }
+        
         /// <summary>
         ///   Looks up a localized string similar to Overrides the default dependency resolution behavior..
         /// </summary>
@@ -13764,6 +13913,7 @@ namespace NuGet.CommandLine {
                 return ResourceManager.GetString("UpdateCommandDependencyVersion", resourceCulture);
             }
         }
+        
         /// <summary>
         ///   Looks up a localized string similar to Update packages to latest available versions. This command also updates NuGet.exe itself..
         /// </summary>

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.resx
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.resx
@@ -5663,4 +5663,7 @@ nuget client-certs List</value>
     <value>usage: {0} {1} {2}</value>
     <comment>{0} - executable name: nuget.exe; {1} - command name (not localizable); {2} - command summary description</comment>
   </data>
+  <data name="Option_Help" xml:space="preserve">
+    <value>Show command help and usage information.</value>
+  </data>
 </root>

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.resx
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.resx
@@ -5611,8 +5611,8 @@ nuget trusted-signers Remove -Name TrustedRepo</value>
     <value>Provides the ability to manage list of client certificates located in NuGet.config files</value>
   </data>
   <data name="ClientCertificatesCommandUsageSummary" xml:space="preserve">
-<value>&lt;List|Add|Update|Remove&gt; [options]</value>
-</data>
+    <value>&lt;List|Add|Update|Remove&gt; [options]</value>
+  </data>
   <data name="ClientCertificatesCommandUsageExamples" xml:space="preserve">
     <value>nuget client-certs Add -PackageSource Foo -Path .\MyCertificate.pfx
 
@@ -5629,5 +5629,38 @@ nuget client-certs Remove -PackageSource certificateName
 nuget client-certs
 
 nuget client-certs List</value>
+  </data>
+  <data name="HelpCommand_Alias" xml:space="preserve">
+    <value>alias: {0}</value>
+    <comment>{0} - short command name (not localizable)</comment>
+  </data>
+  <data name="HelpCommand_AltText" xml:space="preserve">
+    <value> ({0})</value>
+    <comment>{0} - command alternative name (not localizable); do not localize this string</comment>
+  </data>
+  <data name="HelpCommand_AvailableCommands" xml:space="preserve">
+    <value>Available commands:</value>
+  </data>
+  <data name="HelpCommand_Examples" xml:space="preserve">
+    <value>examples:</value>
+  </data>
+  <data name="HelpCommand_Options" xml:space="preserve">
+    <value>options:</value>
+  </data>
+  <data name="HelpCommand_Suggestion" xml:space="preserve">
+    <value>Type '{0} help &lt;command&gt;' for help on a specific command.</value>
+    <comment>{0} - executable name: nuget.exe; Don't localize text enclosed in single quotes: '{0} help command'</comment>
+  </data>
+  <data name="HelpCommand_Title" xml:space="preserve">
+    <value>{0} Command</value>
+    <comment>{0} - command name (not localizable)</comment>
+  </data>
+  <data name="HelpCommand_Usage" xml:space="preserve">
+    <value>usage: {0} &lt;command&gt; [args] [options]</value>
+    <comment>{0} - executable name: nuget.exe; Don't localize '&lt;command&gt; [args] [options]'</comment>
+  </data>
+  <data name="HelpCommand_UsageDetail" xml:space="preserve">
+    <value>usage: {0} {1} {2}</value>
+    <comment>{0} - executable name: nuget.exe; {1} - command name (not localizable); {2} - command summary description</comment>
   </data>
 </root>

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetHelpCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetHelpCommandTest.cs
@@ -8,19 +8,26 @@ namespace NuGet.CommandLine.Test
     public class NuGetHelpCommandTest
     {
         [Theory]
+        [InlineData("add")]
+        [InlineData("client-certs")]
         [InlineData("config")]
         [InlineData("delete")]
+        [InlineData("help")]
+        [InlineData("init")]
         [InlineData("install")]
         [InlineData("list")]
+        [InlineData("locals")]
         [InlineData("pack")]
         [InlineData("push")]
         [InlineData("restore")]
+        [InlineData("search")]
         [InlineData("setApiKey")]
+        [InlineData("sign")]
         [InlineData("sources")]
         [InlineData("spec")]
+        [InlineData("trusted-signers")]
         [InlineData("update")]
-        [InlineData("init")]
-        [InlineData("add")]
+        [InlineData("verify")]
         public void HelpCommand_HelpMessage(string command)
         {
             // Arrange
@@ -59,7 +66,25 @@ namespace NuGet.CommandLine.Test
         [Fact]
         public void HelpCommand_Failure_InvalidArguments()
         {
-            Util.TestCommandInvalidArguments("help aCommand otherCommand");
+            Util.TestCommandInvalidArguments("help aCommand otherCommand -ForceEnglishOutput");
+        }
+
+        [Fact]
+        public void HelpCommand_Help_ContainsLocalizedOption()
+        {
+            // Arrange
+            var nugetexe = Util.GetNuGetExePath();
+
+            // Act
+            var r = CommandRunner.Run(
+                nugetexe,
+                Directory.GetCurrentDirectory(),
+                "help help -ForceEnglishOutput",
+                waitForExit: true);
+
+            // Assert
+            Assert.Equal(0, r.ExitCode);
+            Assert.Contains("Show command help and usage information.", r.Output);
         }
     }
 }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetHelpCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetHelpCommandTest.cs
@@ -31,10 +31,10 @@ namespace NuGet.CommandLine.Test
         public void HelpCommand_HelpMessage(string command)
         {
             // Arrange
-            var nugetexe = Util.GetNuGetExePath();
+            string nugetexe = Util.GetNuGetExePath();
 
             // Act
-            var r = CommandRunner.Run(
+            CommandRunnerResult r = CommandRunner.Run(
                 nugetexe,
                 Directory.GetCurrentDirectory(),
                 "help " + command,
@@ -49,10 +49,10 @@ namespace NuGet.CommandLine.Test
         public void HelpCommand_SpecCommand()
         {
             // Arrange
-            var nugetexe = Util.GetNuGetExePath();
+            string nugetexe = Util.GetNuGetExePath();
 
             // Act
-            var r = CommandRunner.Run(
+            CommandRunnerResult r = CommandRunner.Run(
                 nugetexe,
                 Directory.GetCurrentDirectory(),
                 "help spec",
@@ -73,10 +73,10 @@ namespace NuGet.CommandLine.Test
         public void HelpCommand_Help_ContainsLocalizedOption()
         {
             // Arrange
-            var nugetexe = Util.GetNuGetExePath();
+            string nugetexe = Util.GetNuGetExePath();
 
             // Act
-            var r = CommandRunner.Run(
+            CommandRunnerResult r = CommandRunner.Run(
                 nugetexe,
                 Directory.GetCurrentDirectory(),
                 "help help -ForceEnglishOutput",


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12067

Regression? No Last working version: N/A

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Moves hardcoded strings from nuget.exe help command to a proper string resource.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added: Updated 1 test. Added 1 new test.
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [x] Documentation PR or issue filled: Since a new string is added for -help option, we may need to update -help option in all doc pages.
  - **OR**
  - [ ] N/A

## Validation

Image below shows nuget.exe help command wit a Before/After comparison

Left: Before
Right: After, help option has a different text.

![image](https://user-images.githubusercontent.com/1192347/187627582-3fcabb9d-49cb-403a-965b-35778fab4720.png)
