### PR TITLE
Extend default plugin timeouts per #11793

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/Plugins/ProtocolConstants.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/ProtocolConstants.cs
@@ -24,7 +24,7 @@ namespace NuGet.Protocol.Plugins
         /// <summary>
         /// The default handshake timeout.
         /// </summary>
-        public static readonly TimeSpan HandshakeTimeout = TimeSpan.FromSeconds(5);
+        public static readonly TimeSpan HandshakeTimeout = TimeSpan.FromSeconds(30);
 
         /// <summary>
         /// The maximum timeout value.
@@ -40,6 +40,6 @@ namespace NuGet.Protocol.Plugins
         /// <summary>
         /// The default request timeout.
         /// </summary>
-        public static readonly TimeSpan RequestTimeout = TimeSpan.FromSeconds(5);
+        public static readonly TimeSpan RequestTimeout = TimeSpan.FromSeconds(30);
     }
 }

--- a/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/PluginTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/PluginTests.cs
@@ -108,7 +108,7 @@ namespace NuGet.Protocol.FuncTest
                 Assert.True(
                     Regex.IsMatch(
                         exception.Message,
-                        "^Plugin 'Plugin.Testable' failed within \\d.\\d{3} seconds with exit code -1.$"),
+                        "^Plugin 'Plugin.Testable' failed within \\d{2}.\\d{3} seconds with exit code -1.$"),
                     exception.Message);
             }
         }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11793

Regression? No

## Description
Plugin timeout defaults are increased from 5 seconds to 30 seconds based on discussion in issue https://github.com/NuGet/Home/issues/11793 and https://github.com/NuGet/Home/issues/8528#issuecomment-532885684

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
