### PR TITLE
Remove preview message related to using central package management

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -138,11 +138,6 @@ namespace NuGet.Commands
 
                 if (isCpvmEnabled)
                 {
-                    _logger.LogMinimal(string.Format(
-                          CultureInfo.CurrentCulture,
-                          Strings.CentralPackageVersionManagementInPreview,
-                          _request.Project.FilePath));
-
                     var isCentralPackageTransitivePinningEnabled = _request.Project.RestoreMetadata?.CentralPackageTransitivePinningEnabled ?? false;
                     telemetry.TelemetryEvent[IsCentralPackageTransitivePinningEnabled] = isCentralPackageTransitivePinningEnabled;
                 }

--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -79,15 +79,6 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The project {0} is using CentralPackageVersionManagement, a NuGet preview feature..
-        /// </summary>
-        internal static string CentralPackageVersionManagementInPreview {
-            get {
-                return ResourceManager.GetString("CentralPackageVersionManagementInPreview", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to {0}File path: {1}.
         /// </summary>
         internal static string ClientCertificatesFileCertFilePath {

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -985,10 +985,6 @@ For more information, visit https://docs.nuget.org/docs/reference/command-line-r
     <value>Detected package downgrade: {0} from {1} to centrally defined {2}. Update the centrally managed package version to a higher version.</value>
     <comment>{0} is package id, {1} is the package version, {2} is the downgraded package version.</comment>
   </data>
-  <data name="CentralPackageVersionManagementInPreview" xml:space="preserve">
-    <value>The project {0} is using CentralPackageVersionManagement, a NuGet preview feature.</value>
-    <comment>{0} the project path.</comment>
-  </data>
   <data name="Error_CentralPackageVersions_MissingPackageVersion" xml:space="preserve">
     <value>The PackageReference items {0} do not have corresponding PackageVersion.</value>
   </data>

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
@@ -1188,47 +1188,6 @@ EndGlobal";
         }
 
         [PlatformFact(Platform.Windows)]
-        public void RestoreCommand_ProjectUsingCPVM_DisplaysCPVMInPreviewMessage()
-        {
-            using (var testDirectory = _msbuildFixture.CreateTestDirectory())
-            {
-                // Arrange
-                var projectName = "ClassLibrary1";
-                var workingDirectory = Path.Combine(testDirectory, projectName);
-                var projectFile = Path.Combine(workingDirectory, $"{projectName}.csproj");
-
-                _msbuildFixture.CreateDotnetNewProject(testDirectory.Path, projectName, " classlib", 60000);
-
-                using (var stream = new FileStream(projectFile, FileMode.Open, FileAccess.ReadWrite))
-                {
-                    var xml = XDocument.Load(stream);
-                    ProjectFileUtils.AddProperty(
-                        xml,
-                        "ManagePackageVersionsCentrally",
-                        "true");
-
-                    ProjectFileUtils.WriteXmlToFile(xml, stream);
-                }
-
-                // The test depends on the presence of these packages and their versions.
-                // Change to Directory.Packages.props when new cli that supports NuGet.props will be downloaded
-                var directoryPackagesPropsName = Path.Combine(workingDirectory, $"Directory.Build.props");
-                var directoryPackagesPropsContent = @"<Project>
-                        <PropertyGroup>
-                            <CentralPackageVersionsFileImported>true</CentralPackageVersionsFileImported>
-                        </PropertyGroup>
-                    </Project>";
-                File.WriteAllText(directoryPackagesPropsName, directoryPackagesPropsContent);
-
-                // Act
-                var result = _msbuildFixture.RunDotnet(workingDirectory, "restore");
-
-                // Assert
-                Assert.True(result.Output.Contains($"The project {projectFile} is using CentralPackageVersionManagement, a NuGet preview feature."));
-            }
-        }
-
-        [PlatformFact(Platform.Windows)]
         public async Task DotnetRestore_MultiTargettingWithAliases_Succeeds()
         {
             using (var pathContext = _msbuildFixture.CreateSimpleTestPathContext())


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11950

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
Remove the message about central package management being a preview feature.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
