### PR TITLE
Rename "cache" to "storage" in VS options clear button

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/NuGet.PackageManagement.UI.csproj
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/NuGet.PackageManagement.UI.csproj
@@ -440,6 +440,7 @@
   <ItemGroup>
     <EmbeddedResource Include="Options\GeneralOptionControl.resx">
       <DependentUpon>GeneralOptionControl.cs</DependentUpon>
+      <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Include="Options\PackageSourcesOptionsControl.resx">
       <DependentUpon>PackageSourcesOptionsControl.cs</DependentUpon>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/GeneralOptionControl.resx
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/GeneralOptionControl.resx
@@ -292,7 +292,7 @@
     <value>7</value>
   </data>
   <data name="localsCommandButton.Text" xml:space="preserve">
-    <value>&amp;Clear All NuGet Cache(s)</value>
+    <value>&amp;Clear All NuGet Storage</value>
   </data>
   <data name="&gt;&gt;localsCommandButton.Name" xml:space="preserve">
     <value>localsCommandButton</value>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
@@ -1636,7 +1636,7 @@ namespace NuGet.PackageManagement.UI {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to NuGet cache(s) clear failed at {0}. 
+        ///   Looks up a localized string similar to NuGet storage clear failed at {0}. 
         ///Error: {1}
         ///Please see https://aka.ms/troubleshoot_nuget_cache for more help..
         /// </summary>
@@ -1647,7 +1647,7 @@ namespace NuGet.PackageManagement.UI {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to NuGet cache(s) cleared at {0}.
+        ///   Looks up a localized string similar to NuGet storage cleared at {0}.
         /// </summary>
         public static string ShowMessage_LocalsCommandSuccess {
             get {
@@ -1656,7 +1656,7 @@ namespace NuGet.PackageManagement.UI {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Clearing all NuGet cache(s). .
+        ///   Looks up a localized string similar to Clearing all NuGet storage. .
         /// </summary>
         public static string ShowMessage_LocalsCommandWorking {
             get {

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
@@ -562,7 +562,7 @@
     <value>Can not access NuGet.Config, Please check NuGet.Config</value>
   </data>
   <data name="ShowMessage_LocalsCommandFailure" xml:space="preserve">
-    <value>NuGet cache(s) clear failed at {0}. 
+    <value>NuGet storage clear failed at {0}. 
 Error: {1}
 Please see https://aka.ms/troubleshoot_nuget_cache for more help.</value>
     <comment>{0} :error message;
@@ -570,11 +570,11 @@ Please see https://aka.ms/troubleshoot_nuget_cache for more help.</value>
 </comment>
   </data>
   <data name="ShowMessage_LocalsCommandSuccess" xml:space="preserve">
-    <value>NuGet cache(s) cleared at {0}</value>
+    <value>NuGet storage cleared at {0}</value>
     <comment>{0} for date and time string</comment>
   </data>
   <data name="ShowMessage_LocalsCommandWorking" xml:space="preserve">
-    <value>Clearing all NuGet cache(s). </value>
+    <value>Clearing all NuGet storage. </value>
   </data>
   <data name="ShowWarning_InvalidSource" xml:space="preserve">
     <value>The source specified is invalid. Please provide a valid source.</value>


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12076

Regression? No

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Change "Clear NuGet Cache(s)" to "Clear NuGet Storage", and related strings.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
