### PR TITLE
Fix CI failures in release-6.3.x branch

### DIFF
--- a/build/packages.targets
+++ b/build/packages.targets
@@ -105,8 +105,9 @@
         <PackageReference Update="Moq" Version="4.16.1" />
         <PackageReference Update="NuGet.Core" Version="$(NuGetCoreV2Version)" />
         <PackageReference Update="Portable.BouncyCastle" Version="1.8.10" />
-        <PackageReference Update="System.Collections" Version="$(SystemPackagesVersion)" />
+        <PackageReference Update="System.Collections" Version="$(SystemPackagesVersion)" />      
         <PackageReference Update="System.IO.FileSystem.Primitives" Version="$(SystemPackagesVersion)" />
+        <PackageReference Update="System.Memory" Version="4.5.5" />
         <PackageReference Update="System.Resources.ResourceManager" Version="$(SystemPackagesVersion)" />
         <PackageReference Update="System.Runtime.Extensions" Version="$(SystemPackagesVersion)" />
         <PackageReference Update="System.Runtime.InteropServices" Version="$(SystemPackagesVersion)" />

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGet.CommandLine.Test.csproj
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGet.CommandLine.Test.csproj
@@ -38,6 +38,7 @@
     <PackageDownload Include="NuGet.Core" />
     <PackageReference Include="Microsoft.Build.Framework" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.TestPlatform.Portable" />
+    <PackageReference Include="System.Memory" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1838

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
Windows functional tests are failing on [release-6.3.x branch on CI](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=6640860&view=ms.vss-test-web.build-test-results-tab&runId=52845580&resultId=101698&paneView=debug). This issue was fixed recently in `dev` branch in https://github.com/NuGet/NuGet.Client/pull/4768 PR. In https://github.com/NuGet/NuGet.Client/pull/4768 we skipped few end-to-end tests also but for release-6.3.x branch only windows functional tests are failing. E2E tests are passing on the said release branch. Hence, I didn't cherry-pick the commit from `dev` to `release-6.3.x` branch instead I added a new commit just to fix the failing functional tests.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  - [x] N/A
