### PR TITLE
GetInstalledAndTransitivePackagesAsync transitive origins computation can be optional

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Common/IProjectContextInfoExtensions.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Common/IProjectContextInfoExtensions.cs
@@ -58,15 +58,27 @@ namespace NuGet.PackageManagement.VisualStudio
             IServiceBroker serviceBroker,
             CancellationToken cancellationToken)
         {
+            return await GetInstalledAndTransitivePackagesAsync(projectContextInfo, serviceBroker, useTransitiveOrigins: false, cancellationToken);
+        }
+
+        public static async ValueTask<IInstalledAndTransitivePackages> GetInstalledAndTransitivePackagesAsync(
+            this IProjectContextInfo projectContextInfo,
+            IServiceBroker serviceBroker,
+            bool useTransitiveOrigins,
+            CancellationToken cancellationToken)
+        {
             Assumes.NotNull(projectContextInfo);
             Assumes.NotNull(serviceBroker);
 
             cancellationToken.ThrowIfCancellationRequested();
 
+            IInstalledAndTransitivePackages projectPackages;
             using (INuGetProjectManagerService projectManager = await GetProjectManagerAsync(serviceBroker, cancellationToken))
             {
-                return await projectManager.GetInstalledAndTransitivePackagesAsync(new string[] { projectContextInfo.ProjectId }, cancellationToken);
+                projectPackages = await projectManager.GetInstalledAndTransitivePackagesAsync(new string[] { projectContextInfo.ProjectId }, useTransitiveOrigins, cancellationToken);
             }
+
+            return projectPackages;
         }
 
         /// <summary>
@@ -79,9 +91,9 @@ namespace NuGet.PackageManagement.VisualStudio
         /// <exception cref="ArgumentNullException">If any argument is null</exception>
         /// <remarks><see cref="NuGetProjectManagerService.GetPackageFoldersAsync(IReadOnlyCollection{string}, CancellationToken)"/></remarks>
         public static async ValueTask<IReadOnlyCollection<string>> GetPackageFoldersAsync(
-            this IProjectContextInfo projectContextInfo,
-            IServiceBroker serviceBroker,
-            CancellationToken cancellationToken)
+        this IProjectContextInfo projectContextInfo,
+        IServiceBroker serviceBroker,
+        CancellationToken cancellationToken)
         {
             if (projectContextInfo == null)
             {

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Common/IProjectContextInfoExtensions.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Common/IProjectContextInfoExtensions.cs
@@ -91,9 +91,9 @@ namespace NuGet.PackageManagement.VisualStudio
         /// <exception cref="ArgumentNullException">If any argument is null</exception>
         /// <remarks><see cref="NuGetProjectManagerService.GetPackageFoldersAsync(IReadOnlyCollection{string}, CancellationToken)"/></remarks>
         public static async ValueTask<IReadOnlyCollection<string>> GetPackageFoldersAsync(
-        this IProjectContextInfo projectContextInfo,
-        IServiceBroker serviceBroker,
-        CancellationToken cancellationToken)
+            this IProjectContextInfo projectContextInfo,
+            IServiceBroker serviceBroker,
+            CancellationToken cancellationToken)
         {
             if (projectContextInfo == null)
             {

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Common/IProjectContextInfoExtensions.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Common/IProjectContextInfoExtensions.cs
@@ -58,13 +58,13 @@ namespace NuGet.PackageManagement.VisualStudio
             IServiceBroker serviceBroker,
             CancellationToken cancellationToken)
         {
-            return await GetInstalledAndTransitivePackagesAsync(projectContextInfo, serviceBroker, useTransitiveOrigins: false, cancellationToken);
+            return await GetInstalledAndTransitivePackagesAsync(projectContextInfo, serviceBroker, includeTransitiveOrigins: false, cancellationToken);
         }
 
         public static async ValueTask<IInstalledAndTransitivePackages> GetInstalledAndTransitivePackagesAsync(
             this IProjectContextInfo projectContextInfo,
             IServiceBroker serviceBroker,
-            bool useTransitiveOrigins,
+            bool includeTransitiveOrigins,
             CancellationToken cancellationToken)
         {
             Assumes.NotNull(projectContextInfo);
@@ -75,7 +75,7 @@ namespace NuGet.PackageManagement.VisualStudio
             IInstalledAndTransitivePackages projectPackages;
             using (INuGetProjectManagerService projectManager = await GetProjectManagerAsync(serviceBroker, cancellationToken))
             {
-                projectPackages = await projectManager.GetInstalledAndTransitivePackagesAsync(new string[] { projectContextInfo.ProjectId }, useTransitiveOrigins, cancellationToken);
+                projectPackages = await projectManager.GetInstalledAndTransitivePackagesAsync(new string[] { projectContextInfo.ProjectId }, includeTransitiveOrigins, cancellationToken);
             }
 
             return projectPackages;

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Common/IProjectContextInfoExtensions.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Common/IProjectContextInfoExtensions.cs
@@ -56,10 +56,7 @@ namespace NuGet.PackageManagement.VisualStudio
         public static async ValueTask<IInstalledAndTransitivePackages> GetInstalledAndTransitivePackagesAsync(
             this IProjectContextInfo projectContextInfo,
             IServiceBroker serviceBroker,
-            CancellationToken cancellationToken)
-        {
-            return await GetInstalledAndTransitivePackagesAsync(projectContextInfo, serviceBroker, includeTransitiveOrigins: false, cancellationToken);
-        }
+            CancellationToken cancellationToken) => await GetInstalledAndTransitivePackagesAsync(projectContextInfo, serviceBroker, includeTransitiveOrigins: false, cancellationToken);
 
         public static async ValueTask<IInstalledAndTransitivePackages> GetInstalledAndTransitivePackagesAsync(
             this IProjectContextInfo projectContextInfo,

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/IPackageReferenceProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/IPackageReferenceProject.cs
@@ -10,6 +10,15 @@ namespace NuGet.PackageManagement.VisualStudio
     public interface IPackageReferenceProject
     {
         /// <summary>
+        /// Gets the both the installed (top level) and transitive package references for this project, including transitive origins, if needed.
+        /// Returns the package reference as two separate lists (installed and transitive).
+        /// </summary>
+        /// <param name="useTransitiveOrigins">Set it to <c>true</c> to get transitive origins in transitive packages list</param>
+        /// <param name="token">Cancellation token</param>
+        /// <returns>A <see cref="ProjectPackages"/> object with two lists: Installed and transitive packages</returns>
+        public Task<ProjectPackages> GetInstalledAndTransitivePackagesAsync(bool useTransitiveOrigins, CancellationToken token);
+
+        /// <summary>
         /// Gets the both the installed (top level) and transitive package references for this project.
         /// Returns the package reference as two separate lists (installed and transitive).
         /// </summary>

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/IPackageReferenceProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/IPackageReferenceProject.cs
@@ -13,10 +13,10 @@ namespace NuGet.PackageManagement.VisualStudio
         /// Gets both the installed (top level) and transitive package references for this project, optionally including transitive origins for transitive packages.
         /// Returns the package reference as two separate lists (installed and transitive).
         /// </summary>
-        /// <param name="useTransitiveOrigins">Set it to <c>true</c> to get transitive origins in transitive packages list</param>
+        /// <param name="includeTransitiveOrigins">Set it to <c>true</c> to get transitive origins in transitive packages list</param>
         /// <param name="token">Cancellation token</param>
         /// <returns>A <see cref="ProjectPackages"/>A struct with two lists: installed and transitive packages</returns>
-        public Task<ProjectPackages> GetInstalledAndTransitivePackagesAsync(bool useTransitiveOrigins, CancellationToken token);
+        public Task<ProjectPackages> GetInstalledAndTransitivePackagesAsync(bool includeTransitiveOrigins, CancellationToken token);
 
         /// <summary>
         /// Gets the both the installed (top level) and transitive package references for this project.

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/IPackageReferenceProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/IPackageReferenceProject.cs
@@ -10,12 +10,12 @@ namespace NuGet.PackageManagement.VisualStudio
     public interface IPackageReferenceProject
     {
         /// <summary>
-        /// Gets the both the installed (top level) and transitive package references for this project, including transitive origins, if needed.
+        /// Gets both the installed (top level) and transitive package references for this project, optionally including transitive origins for transitive packages.
         /// Returns the package reference as two separate lists (installed and transitive).
         /// </summary>
         /// <param name="useTransitiveOrigins">Set it to <c>true</c> to get transitive origins in transitive packages list</param>
         /// <param name="token">Cancellation token</param>
-        /// <returns>A <see cref="ProjectPackages"/> object with two lists: Installed and transitive packages</returns>
+        /// <returns>A <see cref="ProjectPackages"/>A struct with two lists: installed and transitive packages</returns>
         public Task<ProjectPackages> GetInstalledAndTransitivePackagesAsync(bool useTransitiveOrigins, CancellationToken token);
 
         /// <summary>

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/PackageReferenceProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/PackageReferenceProject.cs
@@ -217,10 +217,7 @@ namespace NuGet.PackageManagement.VisualStudio
         }
 
         /// <inheritdoc/>
-        public virtual async Task<ProjectPackages> GetInstalledAndTransitivePackagesAsync(CancellationToken token)
-        {
-            return await GetInstalledAndTransitivePackagesAsync(includeTransitiveOrigins: false, token);
-        }
+        public virtual async Task<ProjectPackages> GetInstalledAndTransitivePackagesAsync(CancellationToken token) => await GetInstalledAndTransitivePackagesAsync(includeTransitiveOrigins: false, token);
 
         protected abstract IEnumerable<PackageReference> ResolvedInstalledPackagesList(IEnumerable<LibraryDependency> libraries, NuGetFramework targetFramework, IReadOnlyList<LockFileTarget> targets, T installedPackages);
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/PackageReferenceProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/PackageReferenceProject.cs
@@ -164,6 +164,11 @@ namespace NuGet.PackageManagement.VisualStudio
                 Dictionary<string, TransitiveEntry> transitiveOrigins;
                 if (IsInstalledAndTransitiveComputationNeeded || TransitiveOriginsCache == null)
                 {
+                    if (targetsList == null) // special case
+                    {
+                        targetsList = (await GetTargetsListAsync(assetsPath, token))?.ToList();
+                    }
+
                     transitiveOrigins = calculatedTransitivePackages.Any() ? ComputeTransitivePackageOrigins(calculatedInstalledPackages, targetsList, token) : new Dictionary<string, TransitiveEntry>();
                 }
                 else

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetPackageSearchService.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetPackageSearchService.cs
@@ -502,7 +502,7 @@ namespace NuGet.PackageManagement.VisualStudio
                     CounterfactualLoggers.PMUITransitiveDependencies.EmitIfNeeded();
                     if (await ExperimentUtility.IsTransitiveOriginExpEnabled.GetValueAsync(cancellationToken))
                     {
-                        // We need installed and Transitive Packages
+                        // We need installed and transitive Packages
                         IInstalledAndTransitivePackages installedTabWithTransitiveDepsPackages = await GetInstalledAndTransitivePackagesAsync(projectContextInfos, useTransitiveOrigins: true, cancellationToken);
                         PackageCollection installedPackageCollection = PackageCollection.FromPackageReferences(installedTabWithTransitiveDepsPackages.InstalledPackages);
                         PackageCollection transitivePackageCollection = PackageCollection.FromPackageReferences(installedTabWithTransitiveDepsPackages.TransitivePackages);

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetPackageSearchService.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetPackageSearchService.cs
@@ -464,7 +464,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
             if (itemFilter == ItemFilter.All)
             {
-                // Browse Tab, Project or Solution View: No need of transitive origins data.
+                // Browse Tab, Project or Solution View: no need of transitive origins data.
                 IInstalledAndTransitivePackages browseTabPackages = await GetInstalledAndTransitivePackagesAsync(projectContextInfos, includeTransitiveOrigins: false, cancellationToken);
                 PackageCollection installedPackageCollection = PackageCollection.FromPackageReferences(browseTabPackages.InstalledPackages);
                 PackageCollection transitivePackageCollection = PackageCollection.FromPackageReferences(browseTabPackages.TransitivePackages);
@@ -473,7 +473,7 @@ namespace NuGet.PackageManagement.VisualStudio
                 packageFeeds.mainFeed = new MultiSourcePackageFeed(sourceRepositories, uiLogger, TelemetryActivity.NuGetTelemetryService);
                 try
                 {
-                    // Recommender needs Installed and transitive package lists, but it does not need transitive origins data.
+                    // Recommender needs installed and transitive package lists, but it does not need transitive origins data.
                     packageFeeds.recommenderFeed = new RecommenderPackageFeed(
                         sourceRepositories,
                         installedPackageCollection,
@@ -494,7 +494,7 @@ namespace NuGet.PackageManagement.VisualStudio
             {
                 if (isSolution)
                 {
-                    // Installed Tab, Solution View: only needs Installed packages.
+                    // Installed Tab, Solution View: only needs installed packages.
                     IReadOnlyCollection<IPackageReferenceContextInfo> installedSolutionTabPackages = await GetAllInstalledPackagesAsync(projectContextInfos, cancellationToken);
                     PackageCollection installedPackageCollection = PackageCollection.FromPackageReferences(installedSolutionTabPackages);
                     packageFeeds.mainFeed = new InstalledPackageFeed(installedPackageCollection, metadataProvider);
@@ -504,7 +504,7 @@ namespace NuGet.PackageManagement.VisualStudio
                     CounterfactualLoggers.PMUITransitiveDependencies.EmitIfNeeded();
                     if (await ExperimentUtility.IsTransitiveOriginExpEnabled.GetValueAsync(cancellationToken))
                     {
-                        // Installed Tab, Project View, Experiment On: needs Installed and Transitive packages AND transitive origins data
+                        // Installed Tab, Project View, Experiment On: needs installed, transitive packages and transitive origins data
                         IInstalledAndTransitivePackages installedTabWithTransitiveOrigins = await GetInstalledAndTransitivePackagesAsync(projectContextInfos, includeTransitiveOrigins: true, cancellationToken);
                         PackageCollection installedPackageCollection = PackageCollection.FromPackageReferences(installedTabWithTransitiveOrigins.InstalledPackages);
                         PackageCollection transitivePackageCollection = PackageCollection.FromPackageReferences(installedTabWithTransitiveOrigins.TransitivePackages);
@@ -513,7 +513,7 @@ namespace NuGet.PackageManagement.VisualStudio
                     }
                     else
                     {
-                        // Installed Tab, Project View, Experiment Off: only needs Installed packages
+                        // Installed Tab, Project View, Experiment Off: only needs installed packages
                         IReadOnlyCollection<IPackageReferenceContextInfo> installedTabPackages = await GetAllInstalledPackagesAsync(projectContextInfos, cancellationToken);
                         PackageCollection installedPackageCollection = PackageCollection.FromPackageReferences(installedTabPackages);
                         packageFeeds.mainFeed = new InstalledPackageFeed(installedPackageCollection, metadataProvider);
@@ -525,7 +525,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
             if (itemFilter == ItemFilter.Consolidate)
             {
-                // Consolidate tab, Solution View only: only needs Installed packages
+                // Consolidate tab, Solution View only: only needs installed packages
                 IReadOnlyCollection<IPackageReferenceContextInfo> installedTabPackages = await GetAllInstalledPackagesAsync(projectContextInfos, cancellationToken);
                 PackageCollection installedPackageCollection = PackageCollection.FromPackageReferences(installedTabPackages);
 
@@ -541,7 +541,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
             if (itemFilter == ItemFilter.UpdatesAvailable)
             {
-                // Updates tab, Project or Solution View: only needs Installed packages
+                // Updates tab, Project or Solution View: only needs installed packages
                 IReadOnlyCollection<IPackageReferenceContextInfo> updatedTabPackages = await GetAllInstalledPackagesAsync(projectContextInfos, cancellationToken);
                 PackageCollection installedPackageCollection = PackageCollection.FromPackageReferences(updatedTabPackages);
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetPackageSearchService.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetPackageSearchService.cs
@@ -503,7 +503,7 @@ namespace NuGet.PackageManagement.VisualStudio
                     if (await ExperimentUtility.IsTransitiveOriginExpEnabled.GetValueAsync(cancellationToken))
                     {
                         // We need installed and Transitive Packages
-                        IInstalledAndTransitivePackages installedTabWithTransitiveDepsPackages = await GetInstalledAndTransitivePackagesAsync(projectContextInfos, useTransitiveOrigins: false, cancellationToken);
+                        IInstalledAndTransitivePackages installedTabWithTransitiveDepsPackages = await GetInstalledAndTransitivePackagesAsync(projectContextInfos, useTransitiveOrigins: true, cancellationToken);
                         PackageCollection installedPackageCollection = PackageCollection.FromPackageReferences(installedTabWithTransitiveDepsPackages.InstalledPackages);
                         PackageCollection transitivePackageCollection = PackageCollection.FromPackageReferences(installedTabWithTransitiveDepsPackages.TransitivePackages);
 
@@ -539,7 +539,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
             if (itemFilter == ItemFilter.UpdatesAvailable)
             {
-                // Updatetabs tab: only needs Installed packages
+                // Updates tab: only needs Installed packages
                 IReadOnlyCollection<IPackageReferenceContextInfo> updatedTabPackages = await GetAllInstalledPackagesAsync(projectContextInfos, cancellationToken);
                 PackageCollection installedPackageCollection = PackageCollection.FromPackageReferences(updatedTabPackages);
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetPackageSearchService.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetPackageSearchService.cs
@@ -381,10 +381,10 @@ namespace NuGet.PackageManagement.VisualStudio
             return packageReferences.SelectMany(e => e).ToList();
         }
 
-        private async ValueTask<IInstalledAndTransitivePackages> GetInstalledAndTransitivePackagesAsync(IReadOnlyCollection<IProjectContextInfo> projectContextInfos, bool useTransitiveOrigins, CancellationToken cancellationToken)
+        private async ValueTask<IInstalledAndTransitivePackages> GetInstalledAndTransitivePackagesAsync(IReadOnlyCollection<IProjectContextInfo> projectContextInfos, bool includeTransitiveOrigins, CancellationToken cancellationToken)
         {
             IEnumerable<Task<IInstalledAndTransitivePackages>> tasks = projectContextInfos
-                .Select(project => project.GetInstalledAndTransitivePackagesAsync(_serviceBroker, useTransitiveOrigins, cancellationToken).AsTask());
+                .Select(project => project.GetInstalledAndTransitivePackagesAsync(_serviceBroker, includeTransitiveOrigins, cancellationToken).AsTask());
             IInstalledAndTransitivePackages[] installedAndTransitivePackagesArray = await Task.WhenAll(tasks);
             if (installedAndTransitivePackagesArray.Length == 1)
             {
@@ -465,7 +465,7 @@ namespace NuGet.PackageManagement.VisualStudio
             if (itemFilter == ItemFilter.All)
             {
                 // Browse Tab, Project or Solution View: No need of transitive origins data.
-                IInstalledAndTransitivePackages browseTabPackages = await GetInstalledAndTransitivePackagesAsync(projectContextInfos, useTransitiveOrigins: false, cancellationToken);
+                IInstalledAndTransitivePackages browseTabPackages = await GetInstalledAndTransitivePackagesAsync(projectContextInfos, includeTransitiveOrigins: false, cancellationToken);
                 PackageCollection installedPackageCollection = PackageCollection.FromPackageReferences(browseTabPackages.InstalledPackages);
                 PackageCollection transitivePackageCollection = PackageCollection.FromPackageReferences(browseTabPackages.TransitivePackages);
 
@@ -505,7 +505,7 @@ namespace NuGet.PackageManagement.VisualStudio
                     if (await ExperimentUtility.IsTransitiveOriginExpEnabled.GetValueAsync(cancellationToken))
                     {
                         // Installed Tab, Project View, Experiment On: needs Installed and Transitive packages AND transitive origins data
-                        IInstalledAndTransitivePackages installedTabWithTransitiveOrigins = await GetInstalledAndTransitivePackagesAsync(projectContextInfos, useTransitiveOrigins: true, cancellationToken);
+                        IInstalledAndTransitivePackages installedTabWithTransitiveOrigins = await GetInstalledAndTransitivePackagesAsync(projectContextInfos, includeTransitiveOrigins: true, cancellationToken);
                         PackageCollection installedPackageCollection = PackageCollection.FromPackageReferences(installedTabWithTransitiveOrigins.InstalledPackages);
                         PackageCollection transitivePackageCollection = PackageCollection.FromPackageReferences(installedTabWithTransitiveOrigins.TransitivePackages);
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetProjectManagerService.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetProjectManagerService.cs
@@ -200,13 +200,9 @@ namespace NuGet.PackageManagement.VisualStudio
             return new InstalledAndTransitivePackages(installedPackagesContextInfos, transitivePackageContextInfos);
         }
 
-
         public async ValueTask<IInstalledAndTransitivePackages> GetInstalledAndTransitivePackagesAsync(
             IReadOnlyCollection<string> projectIds,
-            CancellationToken cancellationToken)
-        {
-            return await GetInstalledAndTransitivePackagesAsync(projectIds, includeTransitiveOrigins: false, cancellationToken).ConfigureAwait(false);
-        }
+            CancellationToken cancellationToken) => await GetInstalledAndTransitivePackagesAsync(projectIds, includeTransitiveOrigins: false, cancellationToken);
 
         public async ValueTask<IReadOnlyCollection<PackageDependencyInfo>> GetInstalledPackagesDependencyInfoAsync(
             string projectId,

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetProjectManagerService.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetProjectManagerService.cs
@@ -164,7 +164,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
         public async ValueTask<IInstalledAndTransitivePackages> GetInstalledAndTransitivePackagesAsync(
             IReadOnlyCollection<string> projectIds,
-            bool useTransitiveOrigins,
+            bool includeTransitiveOrigins,
             CancellationToken cancellationToken)
         {
             Assumes.NotNullOrEmpty(projectIds);
@@ -180,7 +180,7 @@ namespace NuGet.PackageManagement.VisualStudio
             {
                 if (project is IPackageReferenceProject packageReferenceProject)
                 {
-                    prStyleTasks.Add(packageReferenceProject.GetInstalledAndTransitivePackagesAsync(useTransitiveOrigins, cancellationToken));
+                    prStyleTasks.Add(packageReferenceProject.GetInstalledAndTransitivePackagesAsync(includeTransitiveOrigins, cancellationToken));
                 }
                 else
                 {
@@ -205,7 +205,7 @@ namespace NuGet.PackageManagement.VisualStudio
             IReadOnlyCollection<string> projectIds,
             CancellationToken cancellationToken)
         {
-            return await GetInstalledAndTransitivePackagesAsync(projectIds, useTransitiveOrigins: false, cancellationToken).ConfigureAwait(false);
+            return await GetInstalledAndTransitivePackagesAsync(projectIds, includeTransitiveOrigins: false, cancellationToken).ConfigureAwait(false);
         }
 
         public async ValueTask<IReadOnlyCollection<PackageDependencyInfo>> GetInstalledPackagesDependencyInfoAsync(

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetProjectManagerService.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetProjectManagerService.cs
@@ -176,7 +176,7 @@ namespace NuGet.PackageManagement.VisualStudio
             // If this is a PR-style project, get installed and transitive package references. Otherwise, just get installed package references.
             var prStyleTasks = new List<Task<ProjectPackages>>();
             var nonPrStyleTasks = new List<Task<IEnumerable<PackageReference>>>();
-            foreach (NuGetProject? project in projects) // can this be parallel ?
+            foreach (NuGetProject? project in projects)
             {
                 if (project is IPackageReferenceProject packageReferenceProject)
                 {

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/INuGetProjectManagerService.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/INuGetProjectManagerService.cs
@@ -21,6 +21,13 @@ namespace NuGet.VisualStudio.Internal.Contracts
         ValueTask<IInstalledAndTransitivePackages> GetInstalledAndTransitivePackagesAsync(
             IReadOnlyCollection<string> projectIds,
             CancellationToken cancellationToken);
+        /// <summary>
+        /// Obtains the installed and transitive packages from all given projects, optionally including transitive origins for transitive packages.
+        /// </summary>
+        /// <param name="projectIds">Projects to retrieve installed and transitive packages</param>
+        /// <param name="includeTransitiveOrigins">Set it to <c>true</c> to get transitive origins of each transitive package</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>An object with two lists: installed and transitive packages from all projects</returns>
         ValueTask<IInstalledAndTransitivePackages> GetInstalledAndTransitivePackagesAsync(
             IReadOnlyCollection<string> projectIds,
             bool includeTransitiveOrigins,

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/INuGetProjectManagerService.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/INuGetProjectManagerService.cs
@@ -21,6 +21,10 @@ namespace NuGet.VisualStudio.Internal.Contracts
         ValueTask<IInstalledAndTransitivePackages> GetInstalledAndTransitivePackagesAsync(
             IReadOnlyCollection<string> projectIds,
             CancellationToken cancellationToken);
+        ValueTask<IInstalledAndTransitivePackages> GetInstalledAndTransitivePackagesAsync(
+            IReadOnlyCollection<string> projectIds,
+            bool useTransitiveOrigins,
+            CancellationToken cancellationToken);
         ValueTask<IReadOnlyCollection<NuGetFramework>> GetTargetFrameworksAsync(
             IReadOnlyCollection<string> projectIds,
             CancellationToken cancellationToken);

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/INuGetProjectManagerService.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/INuGetProjectManagerService.cs
@@ -23,7 +23,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
             CancellationToken cancellationToken);
         ValueTask<IInstalledAndTransitivePackages> GetInstalledAndTransitivePackagesAsync(
             IReadOnlyCollection<string> projectIds,
-            bool useTransitiveOrigins,
+            bool includeTransitiveOrigins,
             CancellationToken cancellationToken);
         ValueTask<IReadOnlyCollection<NuGetFramework>> GetTargetFrameworksAsync(
             IReadOnlyCollection<string> projectIds,

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+NuGet.VisualStudio.Internal.Contracts.INuGetProjectManagerService.GetInstalledAndTransitivePackagesAsync(System.Collections.Generic.IReadOnlyCollection<string!>! projectIds, bool useTransitiveOrigins, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<NuGet.VisualStudio.Internal.Contracts.IInstalledAndTransitivePackages!>

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/PublicAPI.Unshipped.txt
@@ -1,2 +1,2 @@
 #nullable enable
-NuGet.VisualStudio.Internal.Contracts.INuGetProjectManagerService.GetInstalledAndTransitivePackagesAsync(System.Collections.Generic.IReadOnlyCollection<string!>! projectIds, bool useTransitiveOrigins, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<NuGet.VisualStudio.Internal.Contracts.IInstalledAndTransitivePackages!>
+NuGet.VisualStudio.Internal.Contracts.INuGetProjectManagerService.GetInstalledAndTransitivePackagesAsync(System.Collections.Generic.IReadOnlyCollection<string!>! projectIds, bool includeTransitiveOrigins, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<NuGet.VisualStudio.Internal.Contracts.IInstalledAndTransitivePackages!>

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Actions/UIActionEngineTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Actions/UIActionEngineTests.cs
@@ -238,6 +238,9 @@ namespace NuGet.PackageManagement.UI.Test
             prjMgrSvc
                 .Setup(mgr => mgr.GetInstalledAndTransitivePackagesAsync(It.IsAny<IReadOnlyCollection<string>>(), It.IsAny<CancellationToken>()))
                 .Returns(new ValueTask<IInstalledAndTransitivePackages>(installedAndTransitive));
+            prjMgrSvc
+                .Setup(mgr => mgr.GetInstalledAndTransitivePackagesAsync(It.IsAny<IReadOnlyCollection<string>>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+                .Returns(new ValueTask<IInstalledAndTransitivePackages>(installedAndTransitive));
             var dictMetadata = new Dictionary<string, object>
             {
                 [NuGetProjectMetadataKeys.UniqueName] = "a",

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/CpsPackageReferenceProjectTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/CpsPackageReferenceProjectTests.cs
@@ -3918,35 +3918,35 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         [Fact]
         public async Task GetInstalledAndTransitivePackagesAsync_TransitiveOriginsParamSetToTrue_ReturnsTransitiveOriginsAsync()
         {
-            using (var rootDir = new SimpleTestPathContext())
-            {
-                IPackageReferenceProject project = await PrepareTestProjectAsync(rootDir);
+            using SimpleTestPathContext rootDir = new();
 
-                // Act
-                ProjectPackages packages = await project.GetInstalledAndTransitivePackagesAsync(true, CancellationToken.None);
+            // Arrange
+            IPackageReferenceProject project = await PrepareTestProjectAsync(rootDir);
 
-                // Assert
-                Assert.NotEmpty(packages.InstalledPackages);
-                Assert.NotEmpty(packages.TransitivePackages);
-                Assert.All(packages.TransitivePackages, pkg => Assert.NotEmpty(pkg.TransitiveOrigins));
-            }
+            // Act
+            ProjectPackages packages = await project.GetInstalledAndTransitivePackagesAsync(includeTransitiveOrigins: true, CancellationToken.None);
+
+            // Assert
+            Assert.NotEmpty(packages.InstalledPackages);
+            Assert.NotEmpty(packages.TransitivePackages);
+            Assert.All(packages.TransitivePackages, pkg => Assert.NotEmpty(pkg.TransitiveOrigins));
         }
 
         [Fact]
         public async Task GetInstalledAndTransitivePackagesAsync_TransitiveOriginsParamSetToFalse_ReturnsInstalledAndTransitivePackagesOnlyAsync()
         {
-            using (var rootDir = new SimpleTestPathContext())
-            {
-                IPackageReferenceProject project = await PrepareTestProjectAsync(rootDir);
+            using SimpleTestPathContext rootDir = new();
 
-                // Act
-                ProjectPackages packages = await project.GetInstalledAndTransitivePackagesAsync(true, CancellationToken.None);
+            // Arrange
+            IPackageReferenceProject project = await PrepareTestProjectAsync(rootDir);
 
-                // Assert
-                Assert.NotEmpty(packages.InstalledPackages);
-                Assert.NotEmpty(packages.TransitivePackages);
-                Assert.All(packages.TransitivePackages, pkg => Assert.Empty(pkg.TransitiveOrigins));
-            }
+            // Act
+            ProjectPackages packages = await project.GetInstalledAndTransitivePackagesAsync(includeTransitiveOrigins: false, CancellationToken.None);
+
+            // Assert
+            Assert.NotEmpty(packages.InstalledPackages);
+            Assert.NotEmpty(packages.TransitivePackages);
+            Assert.All(packages.TransitivePackages, pkg => Assert.Empty(pkg.TransitiveOrigins));
         }
 
         [Fact]

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/CpsPackageReferenceProjectTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/CpsPackageReferenceProjectTests.cs
@@ -3805,6 +3805,138 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         }
 
         [Fact]
+        public async Task GetInstalledAndTransitivePackagesAsync_SimpleCall_ReturnsNoTransitiveOriginDataAsync()
+        {
+            using (var rootDir = new SimpleTestPathContext())
+            {
+                // Setup
+                var projectName = "project1";
+                string projectFullPath = Path.Combine(rootDir.SolutionRoot, projectName + ".csproj");
+
+                // Project
+                var projectCache = new ProjectSystemCache();
+                IVsProjectAdapter projectAdapter = Mock.Of<IVsProjectAdapter>();
+                CpsPackageReferenceProject project = CreateCpsPackageReferenceProject(projectName, projectFullPath, projectCache);
+
+                ProjectNames projectNames = GetTestProjectNames(projectFullPath, projectName);
+                PackageSpec packageSpec = GetPackageSpec(projectName, projectFullPath, "[2.0.0, )");
+
+                // Restore info
+                DependencyGraphSpec projectRestoreInfo = ProjectTestHelpers.GetDGSpecFromPackageSpecs(packageSpec);
+                projectCache.AddProjectRestoreInfo(projectNames, projectRestoreInfo, new List<IAssetsLogMessage>());
+                projectCache.AddProject(projectNames, projectAdapter, project).Should().BeTrue();
+
+                // Package directories
+                var sources = new List<PackageSource>();
+                var packagesDir = new DirectoryInfo(Path.Combine(rootDir.SolutionRoot, "globalPackages"));
+                var packageSource = new DirectoryInfo(rootDir.PackageSource);
+                packagesDir.Create();
+                packageSource.Create();
+                sources.Add(new PackageSource(packageSource.FullName));
+
+                var logger = new TestLogger();
+                var request = new TestRestoreRequest(packageSpec, sources, packagesDir.FullName, logger)
+                {
+                    LockFilePath = Path.Combine(rootDir.SolutionRoot, "project.assets.json")
+                };
+
+                await SimpleTestPackageUtility.CreateFullPackageAsync(packageSource.FullName, "packageB", "1.0.0");
+                await SimpleTestPackageUtility.CreateFullPackageAsync(
+                    packageSource.FullName,
+                    "packageA",
+                    "2.15.3",
+                    new Packaging.Core.PackageDependency[]
+                    {
+                        new Packaging.Core.PackageDependency("packageB", VersionRange.Parse("1.0.0"))
+                    });
+
+                var command = new RestoreCommand(request);
+                RestoreResult result = await command.ExecuteAsync();
+                await result.CommitAsync(logger, CancellationToken.None);
+
+                // Act
+                ProjectPackages packages = await project.GetInstalledAndTransitivePackagesAsync(CancellationToken.None);
+
+                // Assert
+                Assert.True(result.Success);
+                Assert.NotEmpty(packages.InstalledPackages);
+                Assert.NotEmpty(packages.TransitivePackages);
+                Assert.All(packages.TransitivePackages, pkg => Assert.Empty(pkg.TransitiveOrigins));
+            }
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task GetInstalledAndTransitivePackagesAsync_UseTransitiveOriginsParam_CalculatesTransitiveOriginsWhenFlagIsTrueAsync(bool useTransitiveOrigins)
+        {
+            using (var rootDir = new SimpleTestPathContext())
+            {
+                // Setup
+                var projectName = "project1";
+                string projectFullPath = Path.Combine(rootDir.SolutionRoot, projectName + ".csproj");
+
+                // Project
+                var projectCache = new ProjectSystemCache();
+                IVsProjectAdapter projectAdapter = Mock.Of<IVsProjectAdapter>();
+                CpsPackageReferenceProject project = CreateCpsPackageReferenceProject(projectName, projectFullPath, projectCache);
+
+                ProjectNames projectNames = GetTestProjectNames(projectFullPath, projectName);
+                PackageSpec packageSpec = GetPackageSpec(projectName, projectFullPath, "[2.0.0, )");
+
+                // Restore info
+                DependencyGraphSpec projectRestoreInfo = ProjectTestHelpers.GetDGSpecFromPackageSpecs(packageSpec);
+                projectCache.AddProjectRestoreInfo(projectNames, projectRestoreInfo, new List<IAssetsLogMessage>());
+                projectCache.AddProject(projectNames, projectAdapter, project).Should().BeTrue();
+
+                // Package directories
+                var sources = new List<PackageSource>();
+                var packagesDir = new DirectoryInfo(Path.Combine(rootDir.SolutionRoot, "globalPackages"));
+                var packageSource = new DirectoryInfo(rootDir.PackageSource);
+                packagesDir.Create();
+                packageSource.Create();
+                sources.Add(new PackageSource(packageSource.FullName));
+
+                var logger = new TestLogger();
+                var request = new TestRestoreRequest(packageSpec, sources, packagesDir.FullName, logger)
+                {
+                    LockFilePath = Path.Combine(rootDir.SolutionRoot, "project.assets.json")
+                };
+
+                await SimpleTestPackageUtility.CreateFullPackageAsync(packageSource.FullName, "packageB", "1.0.0");
+                await SimpleTestPackageUtility.CreateFullPackageAsync(
+                    packageSource.FullName,
+                    "packageA",
+                    "2.15.3",
+                    new Packaging.Core.PackageDependency[]
+                    {
+                        new Packaging.Core.PackageDependency("packageB", VersionRange.Parse("1.0.0"))
+                    });
+
+                var command = new RestoreCommand(request);
+                RestoreResult result = await command.ExecuteAsync();
+                await result.CommitAsync(logger, CancellationToken.None);
+
+                // Act
+                ProjectPackages packages = await project.GetInstalledAndTransitivePackagesAsync(useTransitiveOrigins, CancellationToken.None);
+
+                // Assert
+                Assert.True(result.Success);
+                Assert.NotEmpty(packages.InstalledPackages);
+                Assert.NotEmpty(packages.TransitivePackages);
+
+                if (useTransitiveOrigins)
+                {
+                    Assert.All(packages.TransitivePackages, pkg => Assert.NotEmpty(pkg.TransitiveOrigins));
+                }
+                else
+                {
+                    Assert.All(packages.TransitivePackages, pkg => Assert.Empty(pkg.TransitiveOrigins));
+                }
+            }
+        }
+
+        [Fact]
         public async Task GetPackageSpecsAndAdditionalMessagesAsync_NoRestoreInfoInSolutionManager_ThrowsProjectNotNominatedException()
         {
             // Arrange

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/CpsPackageReferenceProjectTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/CpsPackageReferenceProjectTests.cs
@@ -3916,7 +3916,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         }
 
         [Fact]
-        public async Task GetInstalledAndTransitivePackagesAsync_TransitiveOriginsParamSetToTrue_Async()
+        public async Task GetInstalledAndTransitivePackagesAsync_TransitiveOriginsParamSetToTrue_ReturnsTransitiveOriginsAsync()
         {
             using (var rootDir = new SimpleTestPathContext())
             {
@@ -3933,7 +3933,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         }
 
         [Fact]
-        public async Task GetInstalledAndTransitivePackagesAsync_TransitiveOriginsParamSetToFalse_ReturnsTransitiveOriginsAsync()
+        public async Task GetInstalledAndTransitivePackagesAsync_TransitiveOriginsParamSetToFalse_ReturnsInstalledAndTransitivePackagesOnlyAsync()
         {
             using (var rootDir = new SimpleTestPathContext())
             {
@@ -3948,7 +3948,6 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 Assert.All(packages.TransitivePackages, pkg => Assert.Empty(pkg.TransitiveOrigins));
             }
         }
-
 
         [Fact]
         public async Task GetPackageSpecsAndAdditionalMessagesAsync_NoRestoreInfoInSolutionManager_ThrowsProjectNotNominatedException()

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/CpsPackageReferenceProjectTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/CpsPackageReferenceProjectTests.cs
@@ -3805,7 +3805,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         }
 
         [Fact]
-        public async Task GetInstalledAndTransitivePackagesAsync_SimpleCall_ReturnsNoTransitiveOriginDataAsync()
+        public async Task GetInstalledAndTransitivePackagesAsync_MethodWithNoParameters_ReturnsNoTransitiveOriginDataAsync()
         {
             using (var rootDir = new SimpleTestPathContext())
             {
@@ -3865,76 +3865,90 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             }
         }
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public async Task GetInstalledAndTransitivePackagesAsync_UseTransitiveOriginsParam_CalculatesTransitiveOriginsWhenFlagIsTrueAsync(bool useTransitiveOrigins)
+        private static async Task<IPackageReferenceProject> PrepareTestProjectAsync(SimpleTestPathContext rootDir)
+        {
+            // Setup
+            var projectName = "project1";
+            string projectFullPath = Path.Combine(rootDir.SolutionRoot, projectName + ".csproj");
+
+            // Project
+            var projectCache = new ProjectSystemCache();
+            IVsProjectAdapter projectAdapter = Mock.Of<IVsProjectAdapter>();
+            CpsPackageReferenceProject project = CreateCpsPackageReferenceProject(projectName, projectFullPath, projectCache);
+
+            ProjectNames projectNames = GetTestProjectNames(projectFullPath, projectName);
+            PackageSpec packageSpec = GetPackageSpec(projectName, projectFullPath, "[2.0.0, )");
+
+            // Restore info
+            DependencyGraphSpec projectRestoreInfo = ProjectTestHelpers.GetDGSpecFromPackageSpecs(packageSpec);
+            projectCache.AddProjectRestoreInfo(projectNames, projectRestoreInfo, new List<IAssetsLogMessage>());
+            projectCache.AddProject(projectNames, projectAdapter, project).Should().BeTrue();
+
+            // Package directories
+            var sources = new List<PackageSource>();
+            var packagesDir = new DirectoryInfo(Path.Combine(rootDir.SolutionRoot, "globalPackages"));
+            var packageSource = new DirectoryInfo(rootDir.PackageSource);
+            packagesDir.Create();
+            packageSource.Create();
+            sources.Add(new PackageSource(packageSource.FullName));
+
+            var logger = new TestLogger();
+            var request = new TestRestoreRequest(packageSpec, sources, packagesDir.FullName, logger)
+            {
+                LockFilePath = Path.Combine(rootDir.SolutionRoot, "project.assets.json")
+            };
+
+            await SimpleTestPackageUtility.CreateFullPackageAsync(packageSource.FullName, "packageB", "1.0.0");
+            await SimpleTestPackageUtility.CreateFullPackageAsync(
+                packageSource.FullName,
+                "packageA",
+                "2.15.3",
+                new Packaging.Core.PackageDependency[]
+                {
+                    new Packaging.Core.PackageDependency("packageB", VersionRange.Parse("1.0.0"))
+                });
+
+            var command = new RestoreCommand(request);
+            RestoreResult result = await command.ExecuteAsync();
+            await result.CommitAsync(logger, CancellationToken.None);
+
+            return project;
+        }
+
+        [Fact]
+        public async Task GetInstalledAndTransitivePackagesAsync_TransitiveOriginsParamSetToTrue_Async()
         {
             using (var rootDir = new SimpleTestPathContext())
             {
-                // Setup
-                var projectName = "project1";
-                string projectFullPath = Path.Combine(rootDir.SolutionRoot, projectName + ".csproj");
-
-                // Project
-                var projectCache = new ProjectSystemCache();
-                IVsProjectAdapter projectAdapter = Mock.Of<IVsProjectAdapter>();
-                CpsPackageReferenceProject project = CreateCpsPackageReferenceProject(projectName, projectFullPath, projectCache);
-
-                ProjectNames projectNames = GetTestProjectNames(projectFullPath, projectName);
-                PackageSpec packageSpec = GetPackageSpec(projectName, projectFullPath, "[2.0.0, )");
-
-                // Restore info
-                DependencyGraphSpec projectRestoreInfo = ProjectTestHelpers.GetDGSpecFromPackageSpecs(packageSpec);
-                projectCache.AddProjectRestoreInfo(projectNames, projectRestoreInfo, new List<IAssetsLogMessage>());
-                projectCache.AddProject(projectNames, projectAdapter, project).Should().BeTrue();
-
-                // Package directories
-                var sources = new List<PackageSource>();
-                var packagesDir = new DirectoryInfo(Path.Combine(rootDir.SolutionRoot, "globalPackages"));
-                var packageSource = new DirectoryInfo(rootDir.PackageSource);
-                packagesDir.Create();
-                packageSource.Create();
-                sources.Add(new PackageSource(packageSource.FullName));
-
-                var logger = new TestLogger();
-                var request = new TestRestoreRequest(packageSpec, sources, packagesDir.FullName, logger)
-                {
-                    LockFilePath = Path.Combine(rootDir.SolutionRoot, "project.assets.json")
-                };
-
-                await SimpleTestPackageUtility.CreateFullPackageAsync(packageSource.FullName, "packageB", "1.0.0");
-                await SimpleTestPackageUtility.CreateFullPackageAsync(
-                    packageSource.FullName,
-                    "packageA",
-                    "2.15.3",
-                    new Packaging.Core.PackageDependency[]
-                    {
-                        new Packaging.Core.PackageDependency("packageB", VersionRange.Parse("1.0.0"))
-                    });
-
-                var command = new RestoreCommand(request);
-                RestoreResult result = await command.ExecuteAsync();
-                await result.CommitAsync(logger, CancellationToken.None);
+                IPackageReferenceProject project = await PrepareTestProjectAsync(rootDir);
 
                 // Act
-                ProjectPackages packages = await project.GetInstalledAndTransitivePackagesAsync(useTransitiveOrigins, CancellationToken.None);
+                ProjectPackages packages = await project.GetInstalledAndTransitivePackagesAsync(true, CancellationToken.None);
 
                 // Assert
-                Assert.True(result.Success);
                 Assert.NotEmpty(packages.InstalledPackages);
                 Assert.NotEmpty(packages.TransitivePackages);
-
-                if (useTransitiveOrigins)
-                {
-                    Assert.All(packages.TransitivePackages, pkg => Assert.NotEmpty(pkg.TransitiveOrigins));
-                }
-                else
-                {
-                    Assert.All(packages.TransitivePackages, pkg => Assert.Empty(pkg.TransitiveOrigins));
-                }
+                Assert.All(packages.TransitivePackages, pkg => Assert.NotEmpty(pkg.TransitiveOrigins));
             }
         }
+
+        [Fact]
+        public async Task GetInstalledAndTransitivePackagesAsync_TransitiveOriginsParamSetToFalse_ReturnsTransitiveOriginsAsync()
+        {
+            using (var rootDir = new SimpleTestPathContext())
+            {
+                IPackageReferenceProject project = await PrepareTestProjectAsync(rootDir);
+
+                // Act
+                ProjectPackages packages = await project.GetInstalledAndTransitivePackagesAsync(true, CancellationToken.None);
+
+                // Assert
+                Assert.NotEmpty(packages.InstalledPackages);
+                Assert.NotEmpty(packages.TransitivePackages);
+                Assert.All(packages.TransitivePackages, pkg => Assert.Empty(pkg.TransitiveOrigins));
+            }
+        }
+
 
         [Fact]
         public async Task GetPackageSpecsAndAdditionalMessagesAsync_NoRestoreInfoInSolutionManager_ThrowsProjectNotNominatedException()

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectFactories.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectFactories.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.IO;
-using System.Linq;
 using System.Threading.Tasks;
 using Moq;
 using NuGet.Commands.Test;
@@ -11,7 +10,6 @@ using NuGet.Frameworks;
 using NuGet.LibraryModel;
 using NuGet.ProjectManagement;
 using NuGet.ProjectModel;
-using NuGet.RuntimeModel;
 using NuGet.Test.Utility;
 using NuGet.Versioning;
 using NuGet.VisualStudio;

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/NuGetPackageSearchServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/NuGetPackageSearchServiceTests.cs
@@ -530,8 +530,17 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
             var projectManagerService = new Mock<INuGetProjectManagerService>();
 
+            projectManagerService.Setup(x => x.GetInstalledPackagesAsync(
+                    It.IsAny<IReadOnlyCollection<string>>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns(new ValueTask<IReadOnlyCollection<IPackageReferenceContextInfo>>(_installedPackages.ToList()));
             projectManagerService.Setup(x => x.GetInstalledAndTransitivePackagesAsync(
                     It.IsAny<IReadOnlyCollection<string>>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns(new ValueTask<IInstalledAndTransitivePackages>(new InstalledAndTransitivePackages(_installedPackages.ToList(), _transitivePackages.ToList())));
+            projectManagerService.Setup(x => x.GetInstalledAndTransitivePackagesAsync(
+                    It.IsAny<IReadOnlyCollection<string>>(),
+                    It.IsAny<bool>(),
                     It.IsAny<CancellationToken>()))
                 .Returns(new ValueTask<IInstalledAndTransitivePackages>(new InstalledAndTransitivePackages(_installedPackages.ToList(), _transitivePackages.ToList())));
             projectManagerService.Setup(x => x.GetPackageFoldersAsync(

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/NuGetProjectManagerServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/NuGetProjectManagerServiceTests.cs
@@ -614,7 +614,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             Assert.True(result.Success);
 
             // Act
-            var installedAndTransitive = await _projectManager.GetInstalledAndTransitivePackagesAsync(new[] { projectId }, useTransitiveOrigins: true, CancellationToken.None);
+            var installedAndTransitive = await _projectManager.GetInstalledAndTransitivePackagesAsync(new[] { projectId }, includeTransitiveOrigins: true, CancellationToken.None);
 
             // Assert
             installedAndTransitive.InstalledPackages.Should().HaveCount(1);
@@ -765,7 +765,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             RestoreResult result = await command.ExecuteAsync();
             await result.CommitAsync(logger, CancellationToken.None);
             Assert.True(result.Success);
-            var installedAndTransitive = await _projectManager.GetInstalledAndTransitivePackagesAsync(new[] { projectId }, useTransitiveOrigins: true, CancellationToken.None);
+            var installedAndTransitive = await _projectManager.GetInstalledAndTransitivePackagesAsync(new[] { projectId }, includeTransitiveOrigins: true, CancellationToken.None);
 
             // Verify transitive package B
             var transitivePackageB = installedAndTransitive.TransitivePackages.Where(pkg => pkg.Identity.Id == "packageB").First();
@@ -869,7 +869,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             CounterfactualLoggers.TransitiveDependencies.Reset();
 
             // Act
-            var installedAndTransitive = await _projectManager.GetInstalledAndTransitivePackagesAsync(new[] { projectId }, useTransitiveOrigins: true, CancellationToken.None);
+            var installedAndTransitive = await _projectManager.GetInstalledAndTransitivePackagesAsync(new[] { projectId }, includeTransitiveOrigins: true, CancellationToken.None);
 
             var packagesB = installedAndTransitive
                 .TransitivePackages
@@ -975,7 +975,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             // Act
             var installedAndTransitive = await _projectManager.GetInstalledAndTransitivePackagesAsync(
                 new[] { projectId },
-                useTransitiveOrigins: true,
+                includeTransitiveOrigins: true,
                 CancellationToken.None);
 
             Assert.Equal(2, installedAndTransitive.InstalledPackages.Count);
@@ -1128,7 +1128,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             Assert.True(result.Success);
             Assert.True(File.Exists(pajFilepath));
 
-            var installedAndTransitive = await _projectManager.GetInstalledAndTransitivePackagesAsync(new[] { projectId }, useTransitiveOrigins: true, CancellationToken.None);
+            var installedAndTransitive = await _projectManager.GetInstalledAndTransitivePackagesAsync(new[] { projectId }, includeTransitiveOrigins: true, CancellationToken.None);
 
             // Act I
             var topPackagesB = installedAndTransitive
@@ -1314,7 +1314,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             Assert.True(File.Exists(pajFilepath));
 
             // Act
-            var installedAndTransitive = await _projectManager.GetInstalledAndTransitivePackagesAsync(new[] { projectId }, useTransitiveOrigins: true, CancellationToken.None);
+            var installedAndTransitive = await _projectManager.GetInstalledAndTransitivePackagesAsync(new[] { projectId }, includeTransitiveOrigins: true, CancellationToken.None);
 
             // Act I
             var topPackagesB = installedAndTransitive

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/NuGetProjectManagerServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/NuGetProjectManagerServiceTests.cs
@@ -975,6 +975,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             // Act
             var installedAndTransitive = await _projectManager.GetInstalledAndTransitivePackagesAsync(
                 new[] { projectId },
+                useTransitiveOrigins: true,
                 CancellationToken.None);
 
             Assert.Equal(2, installedAndTransitive.InstalledPackages.Count);

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/NuGetProjectManagerServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/NuGetProjectManagerServiceTests.cs
@@ -614,7 +614,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             Assert.True(result.Success);
 
             // Act
-            var installedAndTransitive = await _projectManager.GetInstalledAndTransitivePackagesAsync(new[] { projectId }, CancellationToken.None);
+            var installedAndTransitive = await _projectManager.GetInstalledAndTransitivePackagesAsync(new[] { projectId }, useTransitiveOrigins: true, CancellationToken.None);
 
             // Assert
             installedAndTransitive.InstalledPackages.Should().HaveCount(1);
@@ -765,7 +765,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             RestoreResult result = await command.ExecuteAsync();
             await result.CommitAsync(logger, CancellationToken.None);
             Assert.True(result.Success);
-            var installedAndTransitive = await _projectManager.GetInstalledAndTransitivePackagesAsync(new[] { projectId }, CancellationToken.None);
+            var installedAndTransitive = await _projectManager.GetInstalledAndTransitivePackagesAsync(new[] { projectId }, useTransitiveOrigins: true, CancellationToken.None);
 
             // Verify transitive package B
             var transitivePackageB = installedAndTransitive.TransitivePackages.Where(pkg => pkg.Identity.Id == "packageB").First();
@@ -869,7 +869,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             CounterfactualLoggers.TransitiveDependencies.Reset();
 
             // Act
-            var installedAndTransitive = await _projectManager.GetInstalledAndTransitivePackagesAsync(new[] { projectId }, CancellationToken.None);
+            var installedAndTransitive = await _projectManager.GetInstalledAndTransitivePackagesAsync(new[] { projectId }, useTransitiveOrigins: true, CancellationToken.None);
 
             var packagesB = installedAndTransitive
                 .TransitivePackages
@@ -1128,7 +1128,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             Assert.True(result.Success);
             Assert.True(File.Exists(pajFilepath));
 
-            var installedAndTransitive = await _projectManager.GetInstalledAndTransitivePackagesAsync(new[] { projectId }, CancellationToken.None);
+            var installedAndTransitive = await _projectManager.GetInstalledAndTransitivePackagesAsync(new[] { projectId }, useTransitiveOrigins: true, CancellationToken.None);
 
             // Act I
             var topPackagesB = installedAndTransitive
@@ -1314,7 +1314,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             Assert.True(File.Exists(pajFilepath));
 
             // Act
-            var installedAndTransitive = await _projectManager.GetInstalledAndTransitivePackagesAsync(new[] { projectId }, CancellationToken.None);
+            var installedAndTransitive = await _projectManager.GetInstalledAndTransitivePackagesAsync(new[] { projectId }, useTransitiveOrigins: true, CancellationToken.None);
 
             // Act I
             var topPackagesB = installedAndTransitive


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: 
https://github.com/NuGet/Client.Engineering/issues/1808
https://github.com/NuGet/Client.Engineering/issues/1780

Regression? Yes.
Last working version: VS 17.2

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

- Adds a new parameter to GetInstalledAndTransitivePackagesAsync (gitpa) to decide whether or not calculate transitive origins
- Use new gitpa API only on installed tab in project PM UI with experiment enabled
- Removes transitive origins computation in GetInstalledPackagesAsync API
- Special casing of each PM UI scenario to only get installed packages when required
- Added a special case to get targets list (assets file, expensive operation) when this is null when computing transitive origins.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception: Fixed current tests. Need more tests
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A: No product changes.


## Validation

Profiled PM UI first load with a project with 10 installed packages and a thousand (1118) transitive packages. I used PerfView and captured CPU samples. 

Perfview Histograms below shows a smaller CPU time usage. The Makespan metric is the duration of first and last sample captured in PerfView. A smaller Makespan indicates it took less time to run gitpa API. However, some cases, we had a larger Makespan, but histograms indicate a lower CPU usage. Measurements are in miliseconds

### Browse tab

Case | First | Last | Makespan | Improvement | PercImprovement | PerfView Histogram
-- | -- | -- | -- | -- | -- | --
Baseline | 3,147.42 | 7,448.17 | 4,300.75 |   |   | `____________00____0_____0_____0_`
Fix 1 | 3,081.87 | 6,079.17 | 2,997.30 | -0.303075764 | 0.696924236 | `___________ooo___oo____o________`


### Consolidade tab in Solution PM UI

First | Last | Description | Makespan | PerfView Histogram
-- | -- | -- | -- | --
4,379.66 | 8,469.06 | Baseline | 4,089.41 | `____________00___0___o_oo_______`
3,784.31 | 8,950.83 | Fix 1 | 5,166.52 | `________0o______o_oo____________`


### Installed tab

First | Last | Description | Makespan | Improvement | PercImprovement
-- | -- | -- | -- | -- | --
3,918.87 | 8,042.28 | Baseline  | 4123.41 |   |  
4849.036 | 7238.275 | Fix1,attempt1 | 2389.239 | -0.4205672 | 0.4205672
3184.073 | 7192.473 | Fix1,attempt2 | 4008.4 | -0.027891963 | 0.027891963
4,196.14 | 10,075.73 | Fix1,attempt3 | 5879.588 | 0.425904288 | -0.425904288


