### PR TITLE
Support for dotnet add package command for CPM projects

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommandRunner.cs
@@ -102,6 +102,16 @@ namespace NuGet.CommandLine.XPlat
 
             var originalPackageSpec = matchingPackageSpecs.FirstOrDefault();
 
+            // Check if the project files are correct for CPM
+            if (originalPackageSpec.RestoreMetadata.CentralPackageVersionsEnabled)
+            {
+                var isValid = msBuild.AreCentralVersionRequirementsSatisfied(packageReferenceArgs);
+                if (!isValid)
+                {
+                    return 1;
+                }
+            }
+
             // 2. Determine the version
 
             // Setup the Credential Service before making any potential http calls.

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommandRunner.cs
@@ -103,13 +103,9 @@ namespace NuGet.CommandLine.XPlat
             var originalPackageSpec = matchingPackageSpecs.FirstOrDefault();
 
             // Check if the project files are correct for CPM
-            if (originalPackageSpec.RestoreMetadata.CentralPackageVersionsEnabled)
+            if (originalPackageSpec.RestoreMetadata.CentralPackageVersionsEnabled && !msBuild.AreCentralVersionRequirementsSatisfied(packageReferenceArgs, originalPackageSpec))
             {
-                var isValid = msBuild.AreCentralVersionRequirementsSatisfied(packageReferenceArgs);
-                if (!isValid)
-                {
-                    return 1;
-                }
+                return 1;
             }
 
             // 2. Determine the version

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
@@ -358,6 +358,15 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Projects that use central package version management should not define the version on the PackageReference items but on the PackageVersion items: {0}.
+        /// </summary>
+        internal static string Error_CPM_AddPkg_VersionsNotAllowed {
+            get {
+                return ResourceManager.GetString("Error_CPM_AddPkg_VersionsNotAllowed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to MsBuild was unable to open Project &apos;{0}&apos;..
         /// </summary>
         internal static string Error_MsBuildUnableToOpenProject {

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
@@ -385,11 +385,38 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The packages {0} are implicitly referenced. You do not typically need to reference them from your project or in your central package versions management file. For more information, see https://aka.ms/sdkimplicitrefs.
+        /// </summary>
+        internal static string Error_CentralPackageVersions_AutoreferencedReferencesNotAllowed {
+            get {
+                return ResourceManager.GetString("Error_CentralPackageVersions_AutoreferencedReferencesNotAllowed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Centrally defined floating package versions are not allowed..
+        /// </summary>
+        internal static string Error_CentralPackageVersions_FloatingVersionsAreNotAllowed {
+            get {
+                return ResourceManager.GetString("Error_CentralPackageVersions_FloatingVersionsAreNotAllowed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The PackageReference items {0} do not have corresponding PackageVersion..
+        /// </summary>
+        internal static string Error_CentralPackageVersions_MissingPackageVersion {
+            get {
+                return ResourceManager.GetString("Error_CentralPackageVersions_MissingPackageVersion", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Projects that use central package version management should not define the version on the PackageReference items but on the PackageVersion items: {0}.
         /// </summary>
-        internal static string Error_CPM_AddPkg_VersionsNotAllowed {
+        internal static string Error_CentralPackageVersions_VersionsNotAllowed {
             get {
-                return ResourceManager.GetString("Error_CPM_AddPkg_VersionsNotAllowed", resourceCulture);
+                return ResourceManager.GetString("Error_CentralPackageVersions_VersionsNotAllowed", resourceCulture);
             }
         }
         

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
@@ -412,6 +412,15 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The package reference {0} specifies a VersionOverride but the ability to override a centrally defined version is currently disabled..
+        /// </summary>
+        internal static string Error_CentralPackageVersions_VersionOverrideDisabled {
+            get {
+                return ResourceManager.GetString("Error_CentralPackageVersions_VersionOverrideDisabled", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Projects that use central package version management should not define the version on the PackageReference items but on the PackageVersion items: {0}.
         /// </summary>
         internal static string Error_CentralPackageVersions_VersionsNotAllowed {

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
@@ -322,6 +322,33 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to VersionOverride for package &apos;{0}&apos; should not be empty..
+        /// </summary>
+        internal static string Error_AddPkg_CentralPackageVersions_EmptyVersionOverride {
+            get {
+                return ResourceManager.GetString("Error_AddPkg_CentralPackageVersions_EmptyVersionOverride", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Package reference for package &apos;{0}&apos; defined in incorrect location, PackageReference should be defined in project file..
+        /// </summary>
+        internal static string Error_AddPkg_CentralPackageVersions_PackageReference_WrongLocation {
+            get {
+                return ResourceManager.GetString("Error_AddPkg_CentralPackageVersions_PackageReference_WrongLocation", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to PackageVersion for package &apos;{0}&apos; defined in incorrect location, PackageVersion should be defined in Directory.Package.props..
+        /// </summary>
+        internal static string Error_AddPkg_CentralPackageVersions_PackageVersion_WrongLocation {
+            get {
+                return ResourceManager.GetString("Error_AddPkg_CentralPackageVersions_PackageVersion_WrongLocation", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Item &apos;{0}&apos; for &apos;{1}&apos; in Imported file &apos;{2}&apos;..
         /// </summary>
         internal static string Error_AddPkgErrorStringForImportedEdit {

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
@@ -761,4 +761,16 @@ Non-HTTPS access will be removed in a future version. Consider migrating to 'HTT
     <value>Projects that use central package version management should not define the version on the PackageReference items but on the PackageVersion items: {0}</value>
     <comment>0 - package id</comment>
   </data>
+  <data name="Error_AddPkg_CentralPackageVersions_EmptyVersionOverride" xml:space="preserve">
+    <value>VersionOverride for package '{0}' should not be empty.</value>
+    <comment>0 - package id</comment>
+  </data>
+  <data name="Error_AddPkg_CentralPackageVersions_PackageReference_WrongLocation" xml:space="preserve">
+    <value>Package reference for package '{0}' defined in incorrect location, PackageReference should be defined in project file.</value>
+    <comment>0 - package id</comment>
+  </data>
+  <data name="Error_AddPkg_CentralPackageVersions_PackageVersion_WrongLocation" xml:space="preserve">
+    <value>PackageVersion for package '{0}' defined in incorrect location, PackageVersion should be defined in Directory.Package.props.</value>
+    <comment>0 - package id</comment>
+  </data>
 </root>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
@@ -782,4 +782,8 @@ Non-HTTPS access will be removed in a future version. Consider migrating to 'HTT
   <data name="Error_CentralPackageVersions_MissingPackageVersion" xml:space="preserve">
     <value>The PackageReference items {0} do not have corresponding PackageVersion.</value>
   </data>
+  <data name="Error_CentralPackageVersions_VersionOverrideDisabled" xml:space="preserve">
+    <value>The package reference {0} specifies a VersionOverride but the ability to override a centrally defined version is currently disabled.</value>
+    <comment>0 - packagereference name</comment>
+  </data>
 </root>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
@@ -757,7 +757,7 @@ Non-HTTPS access will be removed in a future version. Consider migrating to 'HTT
     <value>PackageReference for package '{0}' added to '{1}' and PackageVersion added to central package management file '{2}'.</value>
     <comment>0 - The package ID. 1 - Directory.Packages.props file path. 2 - Project file path.</comment>
   </data>
-  <data name="Error_CPM_AddPkg_VersionsNotAllowed" xml:space="preserve">
+  <data name="Error_CentralPackageVersions_VersionsNotAllowed" xml:space="preserve">
     <value>Projects that use central package version management should not define the version on the PackageReference items but on the PackageVersion items: {0}</value>
     <comment>0 - package id</comment>
   </data>
@@ -772,5 +772,14 @@ Non-HTTPS access will be removed in a future version. Consider migrating to 'HTT
   <data name="Error_AddPkg_CentralPackageVersions_PackageVersion_WrongLocation" xml:space="preserve">
     <value>PackageVersion for package '{0}' defined in incorrect location, PackageVersion should be defined in Directory.Package.props.</value>
     <comment>0 - package id</comment>
+  </data>
+  <data name="Error_CentralPackageVersions_AutoreferencedReferencesNotAllowed" xml:space="preserve">
+    <value>The packages {0} are implicitly referenced. You do not typically need to reference them from your project or in your central package versions management file. For more information, see https://aka.ms/sdkimplicitrefs</value>
+  </data>
+  <data name="Error_CentralPackageVersions_FloatingVersionsAreNotAllowed" xml:space="preserve">
+    <value>Centrally defined floating package versions are not allowed.</value>
+  </data>
+  <data name="Error_CentralPackageVersions_MissingPackageVersion" xml:space="preserve">
+    <value>The PackageReference items {0} do not have corresponding PackageVersion.</value>
   </data>
 </root>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
@@ -757,4 +757,8 @@ Non-HTTPS access will be removed in a future version. Consider migrating to 'HTT
     <value>PackageReference for package '{0}' added to '{1}' and PackageVersion added to central package management file '{2}'.</value>
     <comment>0 - The package ID. 1 - Directory.Packages.props file path. 2 - Project file path.</comment>
   </data>
+  <data name="Error_CPM_AddPkg_VersionsNotAllowed" xml:space="preserve">
+    <value>Projects that use central package version management should not define the version on the PackageReference items but on the PackageVersion items: {0}</value>
+    <comment>0 - package id</comment>
+  </data>
 </root>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/MSBuildAPIUtility.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/MSBuildAPIUtility.cs
@@ -139,10 +139,9 @@ namespace NuGet.CommandLine.XPlat
                 // Emit a error if VersionOverride was specified for a package reference but that functionality is disabled
                 foreach (var item in dependenciesWithVersionOverride)
                 {
-                    //await _logger.LogAsync(RestoreLogMessage.CreateError(NuGetLogCode.NU1013, string.Format(CultureInfo.CurrentCulture, Strings.Error_CentralPackageVersions_VersionOverrideDisabled, item.Name)));
+                    packageReferenceArgs.Logger.LogError(string.Format(CultureInfo.CurrentCulture, Strings.Error_CentralPackageVersions_VersionOverrideDisabled, string.Join(";", dependenciesWithVersionOverride.Select(d => d.Name))));
+                    return false;
                 }
-
-                return false;
             }
 
             // The dependencies should not have versions explicitly defined if cpvm is enabled.

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/MSBuildAPIUtility.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/MSBuildAPIUtility.cs
@@ -132,10 +132,11 @@ namespace NuGet.CommandLine.XPlat
             string directoryPackagesPropsPath = project.GetPropertyValue(DirectoryPackagesPropsPathPropertyName);
 
             // Get VersionOverride if it exisits in the package reference.
-            IEnumerable<LibraryDependency> dependenciesWithVersionOverride = packageSpec.TargetFrameworks.SelectMany(tfm => tfm.Dependencies.Where(d => !d.AutoReferenced && d.VersionOverride != null));
+            IEnumerable<LibraryDependency> dependenciesWithVersionOverride = null;
 
             if (packageSpec.RestoreMetadata.CentralPackageVersionOverrideDisabled)
             {
+                dependenciesWithVersionOverride = packageSpec.TargetFrameworks.SelectMany(tfm => tfm.Dependencies.Where(d => !d.AutoReferenced && d.VersionOverride != null));
                 // Emit a error if VersionOverride was specified for a package reference but that functionality is disabled
                 foreach (var item in dependenciesWithVersionOverride)
                 {
@@ -188,7 +189,7 @@ namespace NuGet.CommandLine.XPlat
 
             ProjectItem packageReference = project.Items.Where(item => item.ItemType == PACKAGE_REFERENCE_TYPE_TAG && item.EvaluatedInclude.Equals(packageReferenceArgs.PackageId)).LastOrDefault();
             ProjectItem packageVersionInProps = packageVersions.LastOrDefault();
-            var versionOverride = dependenciesWithVersionOverride.FirstOrDefault(d => d.Name.Equals(packageReferenceArgs.PackageId));
+            var versionOverride = dependenciesWithVersionOverride?.FirstOrDefault(d => d.Name.Equals(packageReferenceArgs.PackageId));
 
             // If package reference exists and the user defined a VersionOverride or PackageVersions but didn't specified a version, no-op
             if (packageReference != null && (versionOverride != null || packageVersionInProps != null) && packageReferenceArgs.NoVersion)

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/MSBuildAPIUtility.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/MSBuildAPIUtility.cs
@@ -121,6 +121,39 @@ namespace NuGet.CommandLine.XPlat
         }
 
         /// <summary>
+        /// Check if the project files format are correct for CPM
+        /// </summary>
+        /// <param name="packageReferenceArgs">Arguments used in the command</param>
+        /// <returns></returns>
+        public bool AreCentralVersionRequirementsSatisfied(PackageReferenceArgs packageReferenceArgs)
+        {
+            var project = GetProject(packageReferenceArgs.ProjectPath);
+
+            // Get package version and VersionOverride if it already exists in the props file. Returns null if there is no matching package version.
+            ProjectItem packageReferenceInProps = project.Items.LastOrDefault(i => i.ItemType == PACKAGE_REFERENCE_TYPE_TAG && i.EvaluatedInclude.Equals(packageReferenceArgs.PackageId));
+            var versionOverrideExists = packageReferenceInProps?.Metadata?.FirstOrDefault(i => i.Name.Equals("VersionOverride"));
+
+            // Get package version if it already exists in the props file. Returns null if there is no matching package version.
+            ProjectItem packageVersionInProps = project.Items.LastOrDefault(i => i.ItemType == PACKAGE_VERSION_TYPE_TAG && i.EvaluatedInclude.Equals(packageReferenceArgs.PackageId));
+
+            // Version should not be defined in PackageReference item
+            if (packageReferenceInProps != null && versionOverrideExists == null && packageVersionInProps == null)
+            {
+                packageReferenceArgs.Logger.LogError(string.Format(CultureInfo.CurrentCulture, Strings.Error_CPM_AddPkg_VersionsNotAllowed, packageReferenceArgs.PackageId));
+                return false;
+            }
+
+            // If package reference exists and the user defined a VersionOverride or PackageVersions but didn't specified a version, no-op
+            if (packageReferenceInProps != null && (versionOverrideExists != null || packageVersionInProps != null) && packageReferenceArgs.NoVersion)
+            {
+                return false;
+            }
+
+            ProjectCollection.GlobalProjectCollection.UnloadProject(project);
+            return true;
+        }
+
+        /// <summary>
         /// Add an unconditional package reference to the project.
         /// </summary>
         /// <param name="projectPath">Path to the csproj file of the project.</param>
@@ -194,28 +227,42 @@ namespace NuGet.CommandLine.XPlat
             }
             else
             {
+                // Get package version and VersionOverride if it already exists in the props file. Returns null if there is no matching package version.
+                ProjectItem packageReferenceInProps = project.Items.LastOrDefault(i => i.ItemType == PACKAGE_REFERENCE_TYPE_TAG && i.EvaluatedInclude.Equals(libraryDependency.Name));
+                var versionOverrideExists = packageReferenceInProps?.Metadata.FirstOrDefault(i => i.Name.Equals("VersionOverride"));
+
                 if (!existingPackageReferences.Any())
                 {
                     //Add <PackageReference/> to the project file.
                     AddPackageReferenceIntoItemGroupCPM(project, itemGroup, libraryDependency);
                 }
 
-                // Get package version if it already exists in the props file. Returns null if there is no matching package version.
-                ProjectItem packageVersionInProps = project.Items.LastOrDefault(i => i.ItemType == PACKAGE_VERSION_TYPE_TAG && i.EvaluatedInclude.Equals(libraryDependency.Name));
-
-                // If no <PackageVersion /> exists in the Directory.Packages.props file.
-                if (packageVersionInProps == null)
+                if (versionOverrideExists != null)
                 {
-                    // Modifying the props file if project is onboarded to CPM.
-                    AddPackageVersionIntoItemGroupCPM(project, libraryDependency);
+                    // Update if VersionOverride instead of Directory.Packages.props file
+                    string packageVersion = libraryDependency.LibraryRange.VersionRange.OriginalString;
+                    UpdateVersionOverride(project, packageReferenceInProps, packageVersion);
                 }
                 else
                 {
-                    // Modify the Directory.Packages.props file with the version that is passed in.
-                    if (!noVersion)
+                    // Get package version if it already exists in the props file. Returns null if there is no matching package version.
+                    ProjectItem packageVersionInProps = project.Items.LastOrDefault(i => i.ItemType == PACKAGE_VERSION_TYPE_TAG && i.EvaluatedInclude.Equals(libraryDependency.Name));
+
+                    // If no <PackageVersion /> exists in the Directory.Packages.props file.
+                    if (packageVersionInProps == null)
                     {
-                        string packageVersion = libraryDependency.LibraryRange.VersionRange.OriginalString;
-                        UpdatePackageVersion(project, packageVersionInProps, packageVersion);
+                        // Modifying the props file if project is onboarded to CPM.
+                        AddPackageVersionIntoItemGroupCPM(project, libraryDependency);
+                    }
+                    else
+                    {
+                        // Modify the Directory.Packages.props file with the version that is passed in.
+                        if (!noVersion)
+                        {
+                            string packageVersion = libraryDependency.LibraryRange.VersionRange.OriginalString;
+                            UpdatePackageVersion(project, packageVersionInProps, packageVersion);
+                        }
+
                     }
                 }
             }
@@ -420,6 +467,25 @@ namespace NuGet.CommandLine.XPlat
                     packageVersion,
                     packageReferenceItem.Xml.ContainingProject.FullPath));
             }
+        }
+
+        /// <summary>
+        /// Updates VersionOverride from <PackageReference /> element if version is passed in as a CLI argument
+        /// </summary>
+        /// <param name="project"></param>
+        /// <param name="packageReference"></param>
+        /// <param name="versionCLIArgument"></param>
+        internal void UpdateVersionOverride(Project project, ProjectItem packageReference, string versionCLIArgument)
+        {
+            // Determine where the <PackageVersion /> item is decalred
+            ProjectItemElement packageReferenceItemElement = project.GetItemProvenance(packageReference).LastOrDefault()?.ItemElement;
+
+            // Get the Version attribute on the packageVersionItemElement.
+            ProjectMetadataElement versionOverrideAttribute = packageReferenceItemElement.Metadata.FirstOrDefault(i => i.Name.Equals("VersionOverride"));
+
+            // Update the version
+            versionOverrideAttribute.Value = versionCLIArgument;
+            packageReferenceItemElement.ContainingProject.Save();
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.LibraryModel/LibraryDependency.cs
+++ b/src/NuGet.Core/NuGet.LibraryModel/LibraryDependency.cs
@@ -124,7 +124,7 @@ namespace NuGet.LibraryModel
                    GeneratePathProperty == other.GeneratePathProperty &&
                    VersionCentrallyManaged == other.VersionCentrallyManaged &&
                    Aliases == other.Aliases &&
-                   VersionOverride == other.VersionOverride &&
+                   EqualityUtility.EqualsWithNullCheck(VersionOverride, other.VersionOverride) &&
                    ReferenceType == other.ReferenceType;
         }
 

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetAddPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetAddPackageTests.cs
@@ -684,6 +684,8 @@ namespace Dotnet.Integration.Test
                 stream.CopyToFile(destinationFilePath);
             }
         }
+
+        [Fact]
         public async Task AddPkg_WithCPM_WhenPackageVersionDoesNotExistAndVersionCLIArgNotPassed_Success()
         {
             using var pathContext = new SimpleTestPathContext();

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/MSBuildAPIUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/MSBuildAPIUtilityTests.cs
@@ -384,5 +384,74 @@ namespace NuGet.CommandLine.Xplat.Tests
             Assert.Contains(@$"<PackageVersion Include=""X"" Version=""2.0.0"" />", updatedPropsFile);
             Assert.DoesNotContain(@$"<PackageVersion Include=""X"" Version=""1.0.0"" />", updatedPropsFile);
         }
+
+        [PlatformFact(Platform.Windows)]
+        public void UpdateVersionOverrideInPropsFileWhenItExists_Success()
+        {
+            // Arrange
+            var testDirectory = TestDirectory.Create();
+            var projectCollection = new ProjectCollection(
+                            globalProperties: null,
+                            remoteLoggers: null,
+                            loggers: null,
+                            toolsetDefinitionLocations: ToolsetDefinitionLocations.Default,
+                            // Having more than 1 node spins up multiple msbuild.exe instances to run builds in parallel
+                            // However, these targets complete so quickly that the added overhead makes it take longer
+                            maxNodeCount: 1,
+                            onlyLogCriticalEvents: false,
+                            loadProjectsReadOnly: false);
+
+            var projectOptions = new ProjectOptions
+            {
+                LoadSettings = ProjectLoadSettings.DoNotEvaluateElementsWithFalseCondition,
+                ProjectCollection = projectCollection
+            };
+
+            // Arrange Directory.Packages.props file
+            var propsFile =
+@$"<Project>
+    <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    </PropertyGroup>
+    <ItemGroup>
+    <PackageVersion Include=""X"" Version=""1.0.0"" />
+    </ItemGroup>
+</Project>";
+            File.WriteAllText(Path.Combine(testDirectory, "Directory.Packages.props"), propsFile);
+
+            // Arrange project file
+            string projectContent =
+@$"<Project Sdk=""Microsoft.NET.Sdk"">    
+	<PropertyGroup>                   
+	<TargetFramework>net6.0</TargetFramework>
+	</PropertyGroup>
+    <ItemGroup>
+    <PackageReference Include=""X"" VersionOverride=""2.0.0""/>
+    </ItemGroup>
+</Project>";
+            File.WriteAllText(Path.Combine(testDirectory, "projectA.csproj"), projectContent);
+            var project = Project.FromFile(Path.Combine(testDirectory, "projectA.csproj"), projectOptions);
+
+            var msObject = new MSBuildAPIUtility(logger: new TestLogger());
+            // Get package version if it already exists in the props file. Returns null if there is no matching package version.
+            ProjectItem packageVersionInProps = project.Items.LastOrDefault(i => i.ItemType == "PackageVersion" && i.EvaluatedInclude.Equals("X"));
+
+            var libraryDependency = new LibraryDependency
+            {
+                LibraryRange = new LibraryRange(
+                        name: "X",
+                        versionRange: VersionRange.Parse("3.0.0"),
+                        typeConstraint: LibraryDependencyTarget.Package)
+            };
+
+            // Act
+            msObject.UpdateVersionOverride(project, packageVersionInProps, "3.0.0");
+
+            // Assert
+            Assert.Equal(projectContent, File.ReadAllText(Path.Combine(testDirectory, "projectA.csproj")));
+            string updatedPropsFile = File.ReadAllText(Path.Combine(testDirectory, "Directory.Packages.props"));
+            Assert.Contains(@$"<PackageVersion Include=""X"" Version=""1.0.0"" />", updatedPropsFile);
+            Assert.DoesNotContain(@$"<PackageVersion Include=""X"" VersionOverride=""3.0.0"" />", updatedPropsFile);
+        }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/MSBuildAPIUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/MSBuildAPIUtilityTests.cs
@@ -421,20 +421,20 @@ namespace NuGet.CommandLine.Xplat.Tests
 
             // Arrange project file
             string projectContent =
-@$"<Project Sdk=""Microsoft.NET.Sdk"">    
-	<PropertyGroup>                   
-	<TargetFramework>net6.0</TargetFramework>
-	</PropertyGroup>
-    <ItemGroup>
-    <PackageReference Include=""X"" VersionOverride=""2.0.0""/>
-    </ItemGroup>
+@$"<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include=""X"" VersionOverride=""3.0.0"" />
+  </ItemGroup>
 </Project>";
             File.WriteAllText(Path.Combine(testDirectory, "projectA.csproj"), projectContent);
             var project = Project.FromFile(Path.Combine(testDirectory, "projectA.csproj"), projectOptions);
 
             var msObject = new MSBuildAPIUtility(logger: new TestLogger());
             // Get package version if it already exists in the props file. Returns null if there is no matching package version.
-            ProjectItem packageVersionInProps = project.Items.LastOrDefault(i => i.ItemType == "PackageVersion" && i.EvaluatedInclude.Equals("X"));
+            ProjectItem packageVersionInProps = project.Items.LastOrDefault(i => i.ItemType == "PackageReference" && i.EvaluatedInclude.Equals("X"));
 
             var libraryDependency = new LibraryDependency
             {

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/NuGet.CommandLine.Xplat.Tests.csproj
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/NuGet.CommandLine.Xplat.Tests.csproj
@@ -21,7 +21,7 @@
       <PackageReference Include="Microsoft.Build" ExcludeAssets="runtime" />
       <PackageReference Include="Microsoft.Build.Framework" ExcludeAssets="runtime" />
       <PackageReference Include="Microsoft.Build.Locator" />
-      <PackageReference Include="System.Memory" Version="4.5.5" />
+      <PackageReference Include="System.Memory" />
   </ItemGroup>
   
   <Import Project="$(BuildCommonDirectory)common.targets" />

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/NuGet.CommandLine.Xplat.Tests.csproj
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/NuGet.CommandLine.Xplat.Tests.csproj
@@ -21,6 +21,7 @@
       <PackageReference Include="Microsoft.Build" ExcludeAssets="runtime" />
       <PackageReference Include="Microsoft.Build.Framework" ExcludeAssets="runtime" />
       <PackageReference Include="Microsoft.Build.Locator" />
+      <PackageReference Include="System.Memory" Version="4.5.5" />
   </ItemGroup>
   
   <Import Project="$(BuildCommonDirectory)common.targets" />


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/9022

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
This PR continues work from https://github.com/NuGet/Home/issues/11890 and finishes the rest of scenarios for the command `dotnet add package` in a CPM project.

Scenarios 1-4 were added by Pragnya in https://github.com/NuGet/NuGet.Client/pull/4700 and merged into the feature branch. This PR adds support for scenarios 9-16 (5-8 are not possible).
Design spec: https://github.com/NuGet/Home/blob/dev/proposed/2022/cpm-dotnet-cli-add-package-support.md

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [x] Documentation PR or issue filled
  - **OR**
  - [ ] N/A
