### PR TITLE
Remove strings resources in PM UI

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
@@ -466,15 +466,6 @@ namespace NuGet.PackageManagement.UI {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Upgrade.
-        /// </summary>
-        public static string Button_Upgrade {
-            get {
-                return ResourceManager.GetString("Button_Upgrade", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to _Yes.
         /// </summary>
         public static string Button_Yes {

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
@@ -1015,15 +1015,6 @@ namespace NuGet.PackageManagement.UI {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Filter:.
-        /// </summary>
-        public static string Label_Filter {
-            get {
-                return ResourceManager.GetString("Label_Filter", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Installed.
         /// </summary>
         public static string Label_Installed {
@@ -1200,15 +1191,6 @@ namespace NuGet.PackageManagement.UI {
         public static string Label_Repository {
             get {
                 return ResourceManager.GetString("Label_Repository", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Solution &apos;{0}&apos;.
-        /// </summary>
-        public static string Label_Solution {
-            get {
-                return ResourceManager.GetString("Label_Solution", resourceCulture);
             }
         }
         

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
@@ -168,9 +168,6 @@
   <data name="Label_FileConflictAction" xml:space="preserve">
     <value>File conflict action:</value>
   </data>
-  <data name="Label_Filter" xml:space="preserve">
-    <value>Filter:</value>
-  </data>
   <data name="Label_Options" xml:space="preserve">
     <value>Options</value>
   </data>
@@ -233,9 +230,6 @@
   </data>
   <data name="Text_ErrorOccurred" xml:space="preserve">
     <value>Error occurred</value>
-  </data>
-  <data name="Label_Solution" xml:space="preserve">
-    <value>Solution '{0}'</value>
   </data>
   <data name="WindowTitle_PreviewChanges" xml:space="preserve">
     <value>Preview Changes</value>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
@@ -649,9 +649,6 @@ Please see https://aka.ms/troubleshoot_nuget_cache for more help.</value>
   <data name="Error_ProjectNotInCache" xml:space="preserve">
     <value>Project {0} does not exist in the project system cache.</value>
   </data>
-  <data name="Button_Upgrade" xml:space="preserve">
-    <value>Upgrade</value>
-  </data>
   <data name="Text_UpgradeNuGetProjectDescription" xml:space="preserve">
     <value>Migrate this project from packages.config to PackageReference format.</value>
   </data>


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1858

Regression? Last working version: N/A

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Removes unused string resources from .resx file found in PM UI. Those unused strings dates back from the first versions of PM UI.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception. No new tests, a good PM UI run should work.
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A: No product changes
