### PR TITLE
while executing list package command, use SourceRepository from cache to avoid clearing valid sessions tokens from credential provider cache

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackage/ListPackageCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackage/ListPackageCommandRunner.cs
@@ -281,7 +281,6 @@ namespace NuGet.CommandLine.XPlat
             AddPackagesToDict(packages, packagesVersionsDict);
 
             //Prepare requests for each of the packages
-            var providers = Repository.Provider.GetCoreV3();
             var getLatestVersionsRequests = new List<Task>();
             foreach (var package in packagesVersionsDict)
             {
@@ -289,7 +288,6 @@ namespace NuGet.CommandLine.XPlat
                     PrepareLatestVersionsRequests(
                         package.Key,
                         listPackageArgs,
-                        providers,
                         packagesVersionsDict));
             }
 
@@ -569,21 +567,19 @@ namespace NuGet.CommandLine.XPlat
         /// </summary>
         /// <param name="package">The package to get the latest version for</param>
         /// <param name="listPackageArgs">List args for the token and source provider></param>
-        /// <param name="providers">The providers to use when looking at sources</param>
         /// <param name="packagesVersionsDict">A reference to the unique packages in the project
         /// to be able to handle different sources having different latest versions</param>
         /// <returns>A list of tasks for all latest versions for packages from all sources</returns>
         private IList<Task> PrepareLatestVersionsRequests(
             string package,
             ListPackageArgs listPackageArgs,
-            IEnumerable<Lazy<INuGetResourceProvider>> providers,
             Dictionary<string, IList<IPackageSearchMetadata>> packagesVersionsDict)
         {
             var latestVersionsRequests = new List<Task>();
             var sources = listPackageArgs.PackageSources;
             foreach (var packageSource in sources)
             {
-                latestVersionsRequests.Add(GetLatestVersionPerSourceAsync(packageSource, listPackageArgs, package, providers, packagesVersionsDict));
+                latestVersionsRequests.Add(GetLatestVersionPerSourceAsync(packageSource, listPackageArgs, package, packagesVersionsDict));
             }
             return latestVersionsRequests;
         }
@@ -627,7 +623,6 @@ namespace NuGet.CommandLine.XPlat
         /// <param name="packageSource">The source to look for packages at</param>
         /// <param name="listPackageArgs">The list args for the cancellation token</param>
         /// <param name="package">Package to look for updates for</param>
-        /// <param name="providers">The providers to use when looking at sources</param>
         /// <param name="packagesVersionsDict">A reference to the unique packages in the project
         /// to be able to handle different sources having different latest versions</param>
         /// <returns>An updated package with the highest version at a single source</returns>
@@ -635,10 +630,9 @@ namespace NuGet.CommandLine.XPlat
             PackageSource packageSource,
             ListPackageArgs listPackageArgs,
             string package,
-            IEnumerable<Lazy<INuGetResourceProvider>> providers,
             Dictionary<string, IList<IPackageSearchMetadata>> packagesVersionsDict)
         {
-            var sourceRepository = Repository.CreateSource(providers, packageSource, FeedType.Undefined);
+            SourceRepository sourceRepository = _sourceRepositoryCache[packageSource];
             var packageMetadataResource = await sourceRepository.GetResourceAsync<PackageMetadataResource>(listPackageArgs.CancellationToken);
 
             using var sourceCacheContext = new SourceCacheContext();


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12090

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
While executing the list package command, `SourceRepository` object is created every time we need to interact with package sources. @zivkan explained why we should not be creating multiple instances of `SourceRepository` in https://github.com/NuGet/NuGet.Client/pull/4636#issuecomment-1132165355. We should use singleton instance of `SourceRepository` because NuGet caches the credential (for all resources) within that instance, but by creating a different instance whenever needed, it causes the credential to be re-obtained each time (although in that scenario, isRetry should be false on the first message to the credential provider).

> (although in that scenario, isRetry should be false on the first message to the credential provider).
This is because of a static variable https://github.com/NuGet/NuGet.Client/blob/d22c6743bf6237c39b98d5d680e06e6c33e97f1c/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpHandlerResourceV3.cs#L40
I will create another issue to discuss if this is correct approach or we need to tweak it.

We created source repository cache in https://github.com/NuGet/NuGet.Client/pull/4240 to fix https://github.com/NuGet/Home/issues/11169 but we didn't use the instance from cache in all the places.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception - No functional changes. Relying on existing test coverage https://github.com/NuGet/NuGet.Client/blob/dev/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs. I verified the behavior manually.
  
<details>
 <summary>Before fix: 2 requests for auth one with IsRetry: False and second one with IsRetry: True</summary>

 ``` log
dotnet list "C:\repos\artifacts-credprovider-329\Sample\Sample.csproj" package -v d --outdated

The following sources were used:
   https://api.nuget.org/v3/index.json
   https://devdiv.pkgs.visualstudio.com/DevDiv/_packaging/[Removed]/nuget/v3/index.json

  CACHE https://api.nuget.org/v3/registration5-gz-semver2/awssdk.core/index.json
[Removed]
  GET https://devdiv.pkgs.visualstudio.com/[Removed]/[Removed]/nuget/v3/registrations2-semver2/awssdk.core/index.json
debug: Using C:\Users\[Removed]\.nuget\plugins\netcore\CredentialProvider.Microsoft\CredentialProvider.Microsoft.dll as a credential provider plugin.
trace:     [CredentialProvider.185328]Running in plug-in mode
trace:     [CredentialProvider.185328]Command-line v0.1.25+cb125622a8f121aadf3e82f315b06fdb42198585: C:\Users\[Removed]\.nuget\plugins\netcore\CredentialProvider.Microsoft\CredentialProvider.Microsoft.dll -Plugin
trace:     [CredentialProvider.185328]Handling 'Request' 'Initialize'. Time elapsed in ms: 3 - Payload: {"ClientVersion":"6.2.0","Culture":"en-US","RequestTimeout":"00:00:05"}
trace:     [CredentialProvider.185328]Sending response: 'Request' 'Initialize'. Time elapsed in ms: 3
trace:     [CredentialProvider.185328]Time elapsed in milliseconds after sending response 'Request' 'Initialize': 4
trace:     [CredentialProvider.185328]Handling 'Request' 'GetOperationClaims'. Time elapsed in ms: 0 - Payload: {}
trace:     [CredentialProvider.185328]Sending response: 'Request' 'GetOperationClaims'. Time elapsed in ms: 4
trace:     [CredentialProvider.185328]Time elapsed in milliseconds after sending response 'Request' 'GetOperationClaims': 11
trace:     [CredentialProvider.185328]Handling 'Request' 'SetLogLevel'. Time elapsed in ms: 0 - Payload: {"LogLevel":"Debug"}
trace:     [CredentialProvider]Sending response: 'Request' 'SetLogLevel'. Time elapsed in ms: 1
trace:     [CredentialProvider]Time elapsed in milliseconds after sending response 'Request' 'SetLogLevel': 3
trace:     [CredentialProvider]Handling 'Request' 'GetAuthenticationCredentials'. Time elapsed in ms: 2 - Payload: {"Uri":"https://devdiv.pkgs.visualstudio.com/DevDiv/_packaging/[Removed]/nuget/v3/index.json","IsRetry":false,"IsNonInteractive":true,"CanShowDialog":false}
trace:     [CredentialProvider]Creating a progress reporter with interval: 00:00:02
trace:     [CredentialProvider]Handling auth request, Uri: https://devdiv.pkgs.visualstudio.com/DevDiv/_packaging/[Removed]/nuget/v3/index.json, IsRetry: False, IsNonInteractive: True, CanShowDialog: False
trace:     [CredentialProvider]URI: https://devdiv.pkgs.visualstudio.com/DevDiv/_packaging/[Removed]/nuget/v3/index.json
trace:     [CredentialProvider]VstsBuildTaskServiceEndpointCredentialProvider - This credential provider must be run under the Team Build tasks for NuGet with external endpoint credentials. Appropriate environment variable needs to be set.
trace:     [CredentialProvider]Skipping NuGetCredentialProvider.CredentialProviders.VstsBuildTaskServiceEndpoint.VstsBuildTaskServiceEndpointCredentialProvider, cannot provide credentials for https://devdiv.pkgs.visualstudio.com/DevDiv/_packaging/[Removed]/nuget/v3/index.json
trace:     [CredentialProvider]VstsBuildTaskCredentialProvider - This credential provider must be run under the Team Build tasks for NuGet. Appropriate environment variables must be set.
trace:     [CredentialProvider]Skipping NuGetCredentialProvider.CredentialProviders.VstsBuildTask.VstsBuildTaskCredentialProvider, cannot provide credentials for https://devdiv.pkgs.visualstudio.com/DevDiv/_packaging/[Removed]/nuget/v3/index.json
trace:     [CredentialProvider]VstsCredentialProvider - Matched well-known Azure DevOps Service hostname: devdiv.pkgs.visualstudio.com
trace:     [CredentialProvider]Using NuGetCredentialProvider.CredentialProviders.Vsts.VstsCredentialProvider to try to get credentials for https://devdiv.pkgs.visualstudio.com/DevDiv/_packaging/[Removed]/nuget/v3/index.json.
trace:     [CredentialProvider]IsRetry: False
trace:     [CredentialProvider]Found cached SessionToken for https://devdiv.pkgs.visualstudio.com/DevDiv/_packaging/[Removed]/nuget/v3/index.json
trace:     [CredentialProvider]Sending response: 'Request' 'GetAuthenticationCredentials'. Time elapsed in ms: 24
trace:     [CredentialProvider]Time elapsed in milliseconds after sending response 'Request' 'GetAuthenticationCredentials': 26
  NotFound https://devdiv.pkgs.visualstudio.com/[Removed]/[Removed]/nuget/v3/registrations2-semver2/awssdk.core/index.json 432ms
  CACHE https://api.nuget.org/v3/registration5-gz-semver2/awssdk.core/index.json
  CACHE https://api.nuget.org/v3/registration5-gz-semver2/awssdk.core/page/3.0.0-preview/3.3.5.json
[Removed]
  GET https://devdiv.pkgs.visualstudio.com/[Removed]/[Removed]/nuget/v3/registrations2-semver2/awssdk.core/index.json
trace:     [CredentialProvider]Handling 'Request' 'GetAuthenticationCredentials'. Time elapsed in ms: 0 - Payload: {"Uri":"https://devdiv.pkgs.visualstudio.com/DevDiv/_packaging/[Removed]/nuget/v3/index.json","IsRetry":true,"IsNonInteractive":true,"CanShowDialog":false}
trace:     [CredentialProvider]Creating a progress reporter with interval: 00:00:02
trace:     [CredentialProvider]Handling auth request, Uri: https://devdiv.pkgs.visualstudio.com/DevDiv/_packaging/[Removed]/nuget/v3/index.json, IsRetry: True, IsNonInteractive: True, CanShowDialog: False
trace:     [CredentialProvider]URI: https://devdiv.pkgs.visualstudio.com/DevDiv/_packaging/[Removed]/nuget/v3/index.json
trace:     [CredentialProvider]VstsBuildTaskServiceEndpointCredentialProvider - This credential provider must be run under the Team Build tasks for NuGet with external endpoint credentials. Appropriate environment variable needs to be set.
trace:     [CredentialProvider]Skipping NuGetCredentialProvider.CredentialProviders.VstsBuildTaskServiceEndpoint.VstsBuildTaskServiceEndpointCredentialProvider, cannot provide credentials for https://devdiv.pkgs.visualstudio.com/DevDiv/_packaging/[Removed]/nuget/v3/index.json
trace:     [CredentialProvider]VstsBuildTaskCredentialProvider - This credential provider must be run under the Team Build tasks for NuGet. Appropriate environment variables must be set.
trace:     [CredentialProvider]Skipping NuGetCredentialProvider.CredentialProviders.VstsBuildTask.VstsBuildTaskCredentialProvider, cannot provide credentials for https://devdiv.pkgs.visualstudio.com/DevDiv/_packaging/[Removed]/nuget/v3/index.json
trace:     [CredentialProvider]VstsCredentialProvider - Matched well-known Azure DevOps Service hostname: devdiv.pkgs.visualstudio.com
trace:     [CredentialProvider]Using NuGetCredentialProvider.CredentialProviders.Vsts.VstsCredentialProvider to try to get credentials for https://devdiv.pkgs.visualstudio.com/DevDiv/_packaging/[Removed]/nuget/v3/index.json.
trace:     [CredentialProvider]IsRetry: True
trace:     [CredentialProvider]Invalidating SessionToken cache for https://devdiv.pkgs.visualstudio.com/DevDiv/_packaging/[Removed]/nuget/v3/index.json
trace:     [CredentialProvider]GET https://devdiv.pkgs.visualstudio.com/DevDiv/_packaging/[Removed]/nuget/v3/index.json
trace:     [CredentialProvider]Found AAD Authority from 401 headers: https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47
trace:     [CredentialProvider]VstsCredentialProvider - Using AAD authority: https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47
trace:     [CredentialProvider]VstsCredentialProvider - Not running bearer token provider 'ADAL Cache'
trace:     [CredentialProvider]VstsCredentialProvider - Attempting to acquire bearer token using provider 'ADAL Windows Integrated Authentication'
    [CredentialProvider]VstsCredentialProvider - Acquired bearer token using 'ADAL Windows Integrated Authentication'
    [CredentialProvider]VstsCredentialProvider - Attempting to exchange the bearer token for an Azure DevOps session token.
trace:     [CredentialProvider]Requesting a SelfDescribing token valid for duration 04:00:00, valid until 9/14/2022 5:53:30 AM UTC. Note that the generated token may have different validity than requested.
trace:     [CredentialProvider]GET https://devdiv.pkgs.visualstudio.com/DevDiv/_packaging/[Removed]/nuget/v3/index.json
trace:     [CredentialProvider]VstsCredentialProvider - Found SessionToken for https://devdiv.pkgs.visualstudio.com/DevDiv/_packaging/[Removed]/nuget/v3/index.json
trace:     [CredentialProvider]Caching SessionToken for https://devdiv.pkgs.visualstudio.com/DevDiv/_packaging/[Removed]/nuget/v3/index.json
trace:     [CredentialProvider]Sending response: 'Request' 'GetAuthenticationCredentials'. Time elapsed in ms: 1798
trace:     [CredentialProvider]Time elapsed in milliseconds after sending response 'Request' 'GetAuthenticationCredentials': 1798
  NotFound https://devdiv.pkgs.visualstudio.com/[Removed]/[Removed]/nuget/v3/registrations2-semver2/awssdk.core/index.json 167ms
Project `Sample` has the following updates to its packages
   [net6.0]:
   Top-level Package      Requested   Resolved   Latest
   > AWSSDK.Core          3.7.13.1    3.7.13.1   3.7.13.2
```

</details>

<details>
<summary>After fix: only one auth prompt with IsRetry: False</summary>

```log
dotnet list "C:\repos\artifacts-credprovider-329\Sample\Sample.csproj" package -v d --outdated

The following sources were used:
   https://api.nuget.org/v3/index.json
   https://devdiv.pkgs.visualstudio.com/DevDiv/_packaging/[Removed]/nuget/v3/index.json

  CACHE https://api.nuget.org/v3/registration5-gz-semver2/awssdk.core/index.json
[Removed]
  GET https://devdiv.pkgs.visualstudio.com/[Removed]/[Removed]/nuget/v3/registrations2-semver2/awssdk.core/index.json
debug: Using C:\Users\[Removed]\.nuget\plugins\netcore\CredentialProvider.Microsoft\CredentialProvider.Microsoft.dll as a credential provider plugin.
trace:     [CredentialProvider.185328]Running in plug-in mode
trace:     [CredentialProvider.185328]Command-line v0.1.25+cb125622a8f121aadf3e82f315b06fdb42198585: C:\Users\[Removed]\.nuget\plugins\netcore\CredentialProvider.Microsoft\CredentialProvider.Microsoft.dll -Plugin
trace:     [CredentialProvider.185328]Handling 'Request' 'Initialize'. Time elapsed in ms: 3 - Payload: {"ClientVersion":"6.2.0","Culture":"en-US","RequestTimeout":"00:00:05"}
trace:     [CredentialProvider.185328]Sending response: 'Request' 'Initialize'. Time elapsed in ms: 3
trace:     [CredentialProvider.185328]Time elapsed in milliseconds after sending response 'Request' 'Initialize': 4
trace:     [CredentialProvider.185328]Handling 'Request' 'GetOperationClaims'. Time elapsed in ms: 0 - Payload: {}
trace:     [CredentialProvider.185328]Sending response: 'Request' 'GetOperationClaims'. Time elapsed in ms: 4
trace:     [CredentialProvider.185328]Time elapsed in milliseconds after sending response 'Request' 'GetOperationClaims': 11
trace:     [CredentialProvider.185328]Handling 'Request' 'SetLogLevel'. Time elapsed in ms: 0 - Payload: {"LogLevel":"Debug"}
trace:     [CredentialProvider]Sending response: 'Request' 'SetLogLevel'. Time elapsed in ms: 1
trace:     [CredentialProvider]Time elapsed in milliseconds after sending response 'Request' 'SetLogLevel': 3
trace:     [CredentialProvider]Handling 'Request' 'GetAuthenticationCredentials'. Time elapsed in ms: 2 - Payload: {"Uri":"https://devdiv.pkgs.visualstudio.com/DevDiv/_packaging/[Removed]/nuget/v3/index.json","IsRetry":false,"IsNonInteractive":true,"CanShowDialog":false}
trace:     [CredentialProvider]Creating a progress reporter with interval: 00:00:02
trace:     [CredentialProvider]Handling auth request, Uri: https://devdiv.pkgs.visualstudio.com/DevDiv/_packaging/[Removed]/nuget/v3/index.json, IsRetry: False, IsNonInteractive: True, CanShowDialog: False
trace:     [CredentialProvider]URI: https://devdiv.pkgs.visualstudio.com/DevDiv/_packaging/[Removed]/nuget/v3/index.json
trace:     [CredentialProvider]VstsBuildTaskServiceEndpointCredentialProvider - This credential provider must be run under the Team Build tasks for NuGet with external endpoint credentials. Appropriate environment variable needs to be set.
trace:     [CredentialProvider]Skipping NuGetCredentialProvider.CredentialProviders.VstsBuildTaskServiceEndpoint.VstsBuildTaskServiceEndpointCredentialProvider, cannot provide credentials for https://devdiv.pkgs.visualstudio.com/DevDiv/_packaging/[Removed]/nuget/v3/index.json
trace:     [CredentialProvider]VstsBuildTaskCredentialProvider - This credential provider must be run under the Team Build tasks for NuGet. Appropriate environment variables must be set.
trace:     [CredentialProvider]Skipping NuGetCredentialProvider.CredentialProviders.VstsBuildTask.VstsBuildTaskCredentialProvider, cannot provide credentials for https://devdiv.pkgs.visualstudio.com/DevDiv/_packaging/[Removed]/nuget/v3/index.json
trace:     [CredentialProvider]VstsCredentialProvider - Matched well-known Azure DevOps Service hostname: devdiv.pkgs.visualstudio.com
trace:     [CredentialProvider]Using NuGetCredentialProvider.CredentialProviders.Vsts.VstsCredentialProvider to try to get credentials for https://devdiv.pkgs.visualstudio.com/DevDiv/_packaging/[Removed]/nuget/v3/index.json.
trace:     [CredentialProvider]IsRetry: False
trace:     [CredentialProvider]Found cached SessionToken for https://devdiv.pkgs.visualstudio.com/DevDiv/_packaging/[Removed]/nuget/v3/index.json
trace:     [CredentialProvider]Sending response: 'Request' 'GetAuthenticationCredentials'. Time elapsed in ms: 24
trace:     [CredentialProvider]Time elapsed in milliseconds after sending response 'Request' 'GetAuthenticationCredentials': 26
  NotFound https://devdiv.pkgs.visualstudio.com/[Removed]/[Removed]/nuget/v3/registrations2-semver2/awssdk.core/index.json 432ms
Project `Sample` has the following updates to its packages
   [net6.0]:
   Top-level Package      Requested   Resolved   Latest
   > AWSSDK.Core          3.7.13.1    3.7.13.1   3.7.13.2
```

</details>

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [x] N/A
