### PR TITLE
Remove obsolete `#if !NET45...#endif` conditions

### DIFF
--- a/build/Shared/HashCodeCombiner.cs
+++ b/build/Shared/HashCodeCombiner.cs
@@ -127,7 +127,6 @@ namespace NuGet.Shared
             }
         }
 
-#if !NET40
         internal void AddSequence<T>(IReadOnlyList<T> list)
         {
             if (list != null)
@@ -140,7 +139,7 @@ namespace NuGet.Shared
                 }
             }
         }
-#endif
+
         internal void AddDictionary<TKey, TValue>(IEnumerable<KeyValuePair<TKey, TValue>> dictionary)
         {
             if (dictionary != null)

--- a/src/NuGet.Core/NuGet.Common/CryptoHashUtility.cs
+++ b/src/NuGet.Core/NuGet.Common/CryptoHashUtility.cs
@@ -232,7 +232,6 @@ namespace NuGet.Common
         }
 #endif
 
-#if !NET45
         /// <summary>
         /// Extension method to convert NuGet.Common.HashAlgorithmName to System.Security.Cryptography.HashAlgorithmName
         /// </summary>
@@ -253,7 +252,6 @@ namespace NuGet.Common
                         nameof(hashAlgorithmName));
             }
         }
-#endif
 
         /// <summary>
         /// Extension method to convert NuGet.Common.HashAlgorithmName to an Oid string

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Utility/X509CertificateChain.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Utility/X509CertificateChain.cs
@@ -15,13 +15,10 @@ namespace NuGet.Packaging.Signing
         {
             if (!_isDisposed)
             {
-#if !NET45
-                //.NET 4.6 added Dispose method to X509Certificate
                 foreach (var item in this)
                 {
                     item.Dispose();
                 }
-#endif
 
                 Clear();
 

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Utility/X509ChainHolder.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Utility/X509ChainHolder.cs
@@ -31,15 +31,13 @@ namespace NuGet.Packaging.Signing
         {
             if (!_isDisposed)
             {
-#if !NET45
-                //.NET 4.6 added Dispose method to X509Certificate and X509Chain
                 foreach (var chainElement in Chain.ChainElements)
                 {
                     chainElement.Certificate.Dispose();
                 }
 
                 Chain.Dispose();
-#endif
+
                 GC.SuppressFinalize(this);
 
                 _isDisposed = true;


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes:  https://github.com/NuGet/Home/issues/12091

Regression? Last working version:  No

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
`#if !NET45...#endif` conditions are obsolete since we don't target NET45 anymore.  See https://github.com/NuGet/NuGet.Client/pull/4653.

## PR Checklist

- [X] PR has a meaningful title
- [X] PR has a linked issue.
- [X] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [X] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [X] N/A
