### PR TITLE
Increase HttpClientHandler.MaxConnectionsPerServer to 64 to improve PM UI performance in Visual Studio

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpHandlerResourceV3Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpHandlerResourceV3Provider.cs
@@ -8,7 +8,6 @@ using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
-using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Protocol.Core.Types;
 
@@ -50,7 +49,7 @@ namespace NuGet.Protocol
             };
 
 #if IS_DESKTOP
-            if (RuntimeEnvironmentHelper.IsWindows && packageSource.MaxHttpRequestsPerSource > 0)
+            if (packageSource.MaxHttpRequestsPerSource > 0)
             {
                 clientHandler.MaxConnectionsPerServer = packageSource.MaxHttpRequestsPerSource;
             }

--- a/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpHandlerResourceV3Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpHandlerResourceV3Provider.cs
@@ -6,8 +6,11 @@ using System.Diagnostics;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Runtime.Serialization;
+using System.Runtime.Serialization.Formatters;
 using System.Threading;
 using System.Threading.Tasks;
+using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Protocol.Core.Types;
 
@@ -47,6 +50,13 @@ namespace NuGet.Protocol
                 Proxy = proxy,
                 AutomaticDecompression = (DecompressionMethods.GZip | DecompressionMethods.Deflate)
             };
+
+#if IS_DESKTOP
+            if (RuntimeEnvironmentHelper.IsWindows)
+            {
+                clientHandler.MaxConnectionsPerServer = packageSource.MaxHttpRequestsPerSource;
+            }
+#endif
 
             // Setup http client handler client certificates
             if (packageSource.ClientCertificates != null)

--- a/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpHandlerResourceV3Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpHandlerResourceV3Provider.cs
@@ -6,8 +6,6 @@ using System.Diagnostics;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
-using System.Runtime.Serialization;
-using System.Runtime.Serialization.Formatters;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Common;

--- a/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpHandlerResourceV3Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpHandlerResourceV3Provider.cs
@@ -50,7 +50,7 @@ namespace NuGet.Protocol
             };
 
 #if IS_DESKTOP
-            if (RuntimeEnvironmentHelper.IsWindows)
+            if (RuntimeEnvironmentHelper.IsWindows && packageSource.MaxHttpRequestsPerSource > 0)
             {
                 clientHandler.MaxConnectionsPerServer = packageSource.MaxHttpRequestsPerSource;
             }

--- a/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpSourceResourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpSourceResourceProvider.cs
@@ -14,6 +14,9 @@ namespace NuGet.Protocol
 {
     public class HttpSourceResourceProvider : ResourceProvider
     {
+#if IS_DESKTOP
+        private const int DefaultMaxHttpRequestsPerSource = 64;
+#endif
         // Only one HttpSource per source should exist. This is to reduce the number of TCP connections.
         private readonly ConcurrentDictionary<PackageSource, HttpSourceResource> _cache
             = new ConcurrentDictionary<PackageSource, HttpSourceResource>();
@@ -51,7 +54,7 @@ namespace NuGet.Protocol
 #if IS_DESKTOP
                 else if (ServicePointManager.DefaultConnectionLimit == ServicePointManager.DefaultPersistentConnectionLimit)
                 {
-                    source.PackageSource.MaxHttpRequestsPerSource = 64;
+                    source.PackageSource.MaxHttpRequestsPerSource = DefaultMaxHttpRequestsPerSource;
                 }
 #endif
 

--- a/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpSourceResourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpSourceResourceProvider.cs
@@ -6,6 +6,7 @@ using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
+using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Protocol.Core.Types;
 
@@ -47,6 +48,14 @@ namespace NuGet.Protocol
                 {
                     throttle = SemaphoreSlimThrottle.CreateSemaphoreThrottle(source.PackageSource.MaxHttpRequestsPerSource);
                 }
+
+#if IS_DESKTOP
+                if (RuntimeEnvironmentHelper.IsWindows
+                    && source.PackageSource.MaxHttpRequestsPerSource == 0)
+                {
+                    source.PackageSource.MaxHttpRequestsPerSource = 64;
+                }
+#endif
 
                 curResource = _cache.GetOrAdd(
                     source.PackageSource,

--- a/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpSourceResourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpSourceResourceProvider.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Diagnostics;
+using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Common;
@@ -49,7 +50,8 @@ namespace NuGet.Protocol
                     throttle = SemaphoreSlimThrottle.CreateSemaphoreThrottle(source.PackageSource.MaxHttpRequestsPerSource);
                 }
 #if IS_DESKTOP
-                else if (RuntimeEnvironmentHelper.IsWindows)
+                else if (RuntimeEnvironmentHelper.IsWindows
+                    && ServicePointManager.DefaultConnectionLimit == ServicePointManager.DefaultPersistentConnectionLimit)
                 {
                     source.PackageSource.MaxHttpRequestsPerSource = 64;
                 }

--- a/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpSourceResourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpSourceResourceProvider.cs
@@ -48,10 +48,8 @@ namespace NuGet.Protocol
                 {
                     throttle = SemaphoreSlimThrottle.CreateSemaphoreThrottle(source.PackageSource.MaxHttpRequestsPerSource);
                 }
-
 #if IS_DESKTOP
-                if (RuntimeEnvironmentHelper.IsWindows
-                    && source.PackageSource.MaxHttpRequestsPerSource == 0)
+                else if (RuntimeEnvironmentHelper.IsWindows)
                 {
                     source.PackageSource.MaxHttpRequestsPerSource = 64;
                 }

--- a/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpSourceResourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpSourceResourceProvider.cs
@@ -7,7 +7,6 @@ using System.Diagnostics;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
-using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Protocol.Core.Types;
 
@@ -50,8 +49,7 @@ namespace NuGet.Protocol
                     throttle = SemaphoreSlimThrottle.CreateSemaphoreThrottle(source.PackageSource.MaxHttpRequestsPerSource);
                 }
 #if IS_DESKTOP
-                else if (RuntimeEnvironmentHelper.IsWindows
-                    && ServicePointManager.DefaultConnectionLimit == ServicePointManager.DefaultPersistentConnectionLimit)
+                else if (ServicePointManager.DefaultConnectionLimit == ServicePointManager.DefaultPersistentConnectionLimit)
                 {
                     source.PackageSource.MaxHttpRequestsPerSource = 64;
                 }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/HttpHandlerResourceV3ProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/HttpHandlerResourceV3ProviderTests.cs
@@ -1,0 +1,74 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using NuGet.Configuration;
+using NuGet.Protocol.Core.Types;
+using NuGet.Test.Utility;
+using Xunit;
+
+namespace NuGet.Protocol.Tests
+{
+    public class HttpHandlerResourceV3ProviderTests
+    {
+#if IS_DESKTOP
+        [PlatformFact(Platform.Windows)]
+        public void MaxConnectionsPerServerIsSetToDefaultValue_Success()
+        {
+            // Arrange
+            var packageSource = new PackageSource("https://contoso.com/v3/index.json");
+
+            var sourceRepository = new SourceRepository(packageSource, new List<INuGetResourceProvider>() { new HttpSourceResourceProvider(), new HttpHandlerResourceV3Provider() });
+
+            // Act
+            _ = sourceRepository.GetResource<HttpSourceResource>();
+            HttpHandlerResource httpHandlerResource = sourceRepository.GetResource<HttpHandlerResource>();
+
+            // Assert
+            Assert.NotNull(httpHandlerResource);
+            Assert.Equal(64, httpHandlerResource.ClientHandler.MaxConnectionsPerServer);
+        }
+
+        [PlatformTheory(Platform.Windows)]
+        [InlineData(128)]
+        [InlineData(256)]
+        public void MaxConnectionsPerServerIsSetToMaxHttpRequestsPerSourceValue_Success(int maxHttpRequestsPerSource)
+        {
+            // Arrange
+            var packageSource = new PackageSource("https://contoso.com/v3/index.json") { MaxHttpRequestsPerSource = maxHttpRequestsPerSource };
+
+            var sourceRepository = new SourceRepository(packageSource, new List<INuGetResourceProvider>() { new HttpSourceResourceProvider(), new HttpHandlerResourceV3Provider() });
+
+            // Act
+            _ = sourceRepository.GetResource<HttpSourceResource>();
+            HttpHandlerResource httpHandlerResource = sourceRepository.GetResource<HttpHandlerResource>();
+
+            // Assert
+            Assert.NotNull(httpHandlerResource);
+            Assert.Equal(maxHttpRequestsPerSource, httpHandlerResource.ClientHandler.MaxConnectionsPerServer);
+        }
+#endif
+
+#if IS_CORECLR
+        [Theory]
+        [InlineData(64)]
+        [InlineData(0)]
+        [InlineData(2)]
+        public void MaxConnectionsPerServerIsNotEqualToMaxHttpRequestsPerSourceValue_Success(int maxHttpRequestsPerSource)
+        {
+            // Arrange
+            var packageSource = new PackageSource("https://contoso.com/v3/index.json") { MaxHttpRequestsPerSource = maxHttpRequestsPerSource };
+
+            var sourceRepository = new SourceRepository(packageSource, new[] { new HttpHandlerResourceV3Provider() });
+
+            // Act
+            _ = sourceRepository.GetResource<HttpSourceResource>();
+            HttpHandlerResource httpHandlerResource = sourceRepository.GetResource<HttpHandlerResource>();
+
+            // Assert
+            Assert.NotNull(httpHandlerResource);
+            Assert.NotEqual(maxHttpRequestsPerSource, httpHandlerResource.ClientHandler.MaxConnectionsPerServer);
+        }
+#endif
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/HttpHandlerResourceV3ProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/HttpHandlerResourceV3ProviderTests.cs
@@ -13,7 +13,7 @@ namespace NuGet.Protocol.Tests
     {
 #if IS_DESKTOP
         [PlatformFact(Platform.Windows)]
-        public void MaxConnectionsPerServerIsSetToDefaultValue_Success()
+        public void DefaultMaxHttpRequestsPerSourceForwardedToV3HttpClientHandler_Success()
         {
             // Arrange
             var packageSource = new PackageSource("https://contoso.com/v3/index.json");
@@ -32,7 +32,7 @@ namespace NuGet.Protocol.Tests
         [PlatformTheory(Platform.Windows)]
         [InlineData(128)]
         [InlineData(256)]
-        public void MaxConnectionsPerServerIsSetToMaxHttpRequestsPerSourceValue_Success(int maxHttpRequestsPerSource)
+        public void PackageSourceMaxHttpRequestsPerSourceForwardedToV3HttpClientHandler_Success(int maxHttpRequestsPerSource)
         {
             // Arrange
             var packageSource = new PackageSource("https://contoso.com/v3/index.json") { MaxHttpRequestsPerSource = maxHttpRequestsPerSource };
@@ -52,9 +52,9 @@ namespace NuGet.Protocol.Tests
 #if IS_CORECLR
         [Theory]
         [InlineData(64)]
-        [InlineData(0)]
+        [InlineData(128)]
         [InlineData(2)]
-        public void MaxConnectionsPerServerIsNotEqualToMaxHttpRequestsPerSourceValue_Success(int maxHttpRequestsPerSource)
+        public void PackageSourceMaxHttpRequestsPerSourceNotForwardedToV3HttpClientHandler_Success(int maxHttpRequestsPerSource)
         {
             // Arrange
             var packageSource = new PackageSource("https://contoso.com/v3/index.json") { MaxHttpRequestsPerSource = maxHttpRequestsPerSource };

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/HttpHandlerResourceV3ProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/HttpHandlerResourceV3ProviderTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using NuGet.Configuration;
 using NuGet.Protocol.Core.Types;
 using NuGet.Test.Utility;
@@ -13,15 +14,19 @@ namespace NuGet.Protocol.Tests
     {
 #if IS_DESKTOP
         [PlatformFact(Platform.Windows)]
-        public void DefaultMaxHttpRequestsPerSourceForwardedToV3HttpClientHandler_Success()
+        public async Task DefaultMaxHttpRequestsPerSourceIsForwardedToV3HttpClientHandler_SuccessAsync()
         {
             // Arrange
             var packageSource = new PackageSource("https://contoso.com/v3/index.json");
             var sourceRepository = new SourceRepository(packageSource, new List<INuGetResourceProvider>() { new HttpSourceResourceProvider(), new HttpHandlerResourceV3Provider() });
-            _ = sourceRepository.GetResource<HttpSourceResource>();
+
+            // HttpSourceResourceProvider updates PackageSource.MaxHttpRequestsPerSource value for .NET Framework code paths
+            // HttpSource constructor accepts a delegate that creates HttpHandlerResource and it stores the delegate in a private variable.
+            // Hence used discard to ignore the return value and fetched HttpHandlerResource from the source repository to verify behavior. 
+            _ = await sourceRepository.GetResourceAsync<HttpSourceResource>();
 
             // Act
-            HttpHandlerResource httpHandlerResource = sourceRepository.GetResource<HttpHandlerResource>();
+            HttpHandlerResource httpHandlerResource = await sourceRepository.GetResourceAsync<HttpHandlerResource>();
 
             // Assert
             Assert.NotNull(httpHandlerResource);
@@ -31,36 +36,43 @@ namespace NuGet.Protocol.Tests
         [PlatformTheory(Platform.Windows)]
         [InlineData(128)]
         [InlineData(256)]
-        public void PackageSourceMaxHttpRequestsPerSourceForwardedToV3HttpClientHandler_Success(int maxHttpRequestsPerSource)
+        public async Task PackageSourceMaxHttpRequestsPerSourceIsForwardedToV3HttpClientHandler_SuccessAsync(int maxHttpRequestsPerSource)
         {
             // Arrange
             var packageSource = new PackageSource("https://contoso.com/v3/index.json") { MaxHttpRequestsPerSource = maxHttpRequestsPerSource };
             var sourceRepository = new SourceRepository(packageSource, new List<INuGetResourceProvider>() { new HttpSourceResourceProvider(), new HttpHandlerResourceV3Provider() });
-            _ = sourceRepository.GetResource<HttpSourceResource>();
+
+            // HttpSourceResourceProvider updates PackageSource.MaxHttpRequestsPerSource value for .NET Framework code paths
+            // HttpSource constructor accepts a delegate that creates HttpHandlerResource and it stores the delegate in a private variable.
+            // Hence used discard to ignore the return value and fetched HttpHandlerResource from the source repository to verify behavior.
+            _ = await sourceRepository.GetResourceAsync<HttpSourceResource>();
 
             // Act            
-            HttpHandlerResource httpHandlerResource = sourceRepository.GetResource<HttpHandlerResource>();
+            HttpHandlerResource httpHandlerResource = await sourceRepository.GetResourceAsync<HttpHandlerResource>();
 
             // Assert
             Assert.NotNull(httpHandlerResource);
             Assert.Equal(maxHttpRequestsPerSource, httpHandlerResource.ClientHandler.MaxConnectionsPerServer);
         }
-#endif
+#elif IS_CORECLR
 
-#if IS_CORECLR
         [Theory]
         [InlineData(64)]
         [InlineData(128)]
         [InlineData(2)]
-        public void PackageSourceMaxHttpRequestsPerSourceNotForwardedToV3HttpClientHandler_Success(int maxHttpRequestsPerSource)
+        public async Task PackageSourceMaxHttpRequestsPerSourceIsNotForwardedToV3HttpClientHandler_SuccessAsync(int maxHttpRequestsPerSource)
         {
             // Arrange
             var packageSource = new PackageSource("https://contoso.com/v3/index.json") { MaxHttpRequestsPerSource = maxHttpRequestsPerSource };
             var sourceRepository = new SourceRepository(packageSource, new[] { new HttpHandlerResourceV3Provider() });
-            _ = sourceRepository.GetResource<HttpSourceResource>();
+
+            // HttpSourceResourceProvider updates PackageSource.MaxHttpRequestsPerSource value for .NET Framework code paths
+            // HttpSource constructor accepts a delegate that creates HttpHandlerResource and it stores the delegate in a private variable.
+            // Hence used discard to ignore the return value and fetched HttpHandlerResource from the source repository to verify behavior.
+            _ = await sourceRepository.GetResourceAsync<HttpSourceResource>();
 
             // Act            
-            HttpHandlerResource httpHandlerResource = sourceRepository.GetResource<HttpHandlerResource>();
+            HttpHandlerResource httpHandlerResource = await sourceRepository.GetResourceAsync<HttpHandlerResource>();
 
             // Assert
             Assert.NotNull(httpHandlerResource);

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/HttpHandlerResourceV3ProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/HttpHandlerResourceV3ProviderTests.cs
@@ -17,11 +17,10 @@ namespace NuGet.Protocol.Tests
         {
             // Arrange
             var packageSource = new PackageSource("https://contoso.com/v3/index.json");
-
             var sourceRepository = new SourceRepository(packageSource, new List<INuGetResourceProvider>() { new HttpSourceResourceProvider(), new HttpHandlerResourceV3Provider() });
+            _ = sourceRepository.GetResource<HttpSourceResource>();
 
             // Act
-            _ = sourceRepository.GetResource<HttpSourceResource>();
             HttpHandlerResource httpHandlerResource = sourceRepository.GetResource<HttpHandlerResource>();
 
             // Assert
@@ -36,11 +35,10 @@ namespace NuGet.Protocol.Tests
         {
             // Arrange
             var packageSource = new PackageSource("https://contoso.com/v3/index.json") { MaxHttpRequestsPerSource = maxHttpRequestsPerSource };
-
             var sourceRepository = new SourceRepository(packageSource, new List<INuGetResourceProvider>() { new HttpSourceResourceProvider(), new HttpHandlerResourceV3Provider() });
-
-            // Act
             _ = sourceRepository.GetResource<HttpSourceResource>();
+
+            // Act            
             HttpHandlerResource httpHandlerResource = sourceRepository.GetResource<HttpHandlerResource>();
 
             // Assert
@@ -58,11 +56,10 @@ namespace NuGet.Protocol.Tests
         {
             // Arrange
             var packageSource = new PackageSource("https://contoso.com/v3/index.json") { MaxHttpRequestsPerSource = maxHttpRequestsPerSource };
-
             var sourceRepository = new SourceRepository(packageSource, new[] { new HttpHandlerResourceV3Provider() });
-
-            // Act
             _ = sourceRepository.GetResource<HttpSourceResource>();
+
+            // Act            
             HttpHandlerResource httpHandlerResource = sourceRepository.GetResource<HttpHandlerResource>();
 
             // Assert

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/HttpHandlerResourceV3ProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/HttpHandlerResourceV3ProviderTests.cs
@@ -12,12 +12,14 @@ namespace NuGet.Protocol.Tests
 {
     public class HttpHandlerResourceV3ProviderTests
     {
+        private readonly string _testPackageSourceURL = "https://contoso.test/v3/index.json";
+
 #if IS_DESKTOP
         [PlatformFact(Platform.Windows)]
         public async Task DefaultMaxHttpRequestsPerSourceIsForwardedToV3HttpClientHandler_SuccessAsync()
         {
             // Arrange
-            var packageSource = new PackageSource("https://contoso.com/v3/index.json");
+            var packageSource = new PackageSource(_testPackageSourceURL);
             var sourceRepository = new SourceRepository(packageSource, new List<INuGetResourceProvider>() { new HttpSourceResourceProvider(), new HttpHandlerResourceV3Provider() });
 
             // HttpSourceResourceProvider updates PackageSource.MaxHttpRequestsPerSource value for .NET Framework code paths
@@ -39,7 +41,7 @@ namespace NuGet.Protocol.Tests
         public async Task PackageSourceMaxHttpRequestsPerSourceIsForwardedToV3HttpClientHandler_SuccessAsync(int maxHttpRequestsPerSource)
         {
             // Arrange
-            var packageSource = new PackageSource("https://contoso.com/v3/index.json") { MaxHttpRequestsPerSource = maxHttpRequestsPerSource };
+            var packageSource = new PackageSource(_testPackageSourceURL) { MaxHttpRequestsPerSource = maxHttpRequestsPerSource };
             var sourceRepository = new SourceRepository(packageSource, new List<INuGetResourceProvider>() { new HttpSourceResourceProvider(), new HttpHandlerResourceV3Provider() });
 
             // HttpSourceResourceProvider updates PackageSource.MaxHttpRequestsPerSource value for .NET Framework code paths
@@ -63,7 +65,7 @@ namespace NuGet.Protocol.Tests
         public async Task PackageSourceMaxHttpRequestsPerSourceIsNotForwardedToV3HttpClientHandler_SuccessAsync(int maxHttpRequestsPerSource)
         {
             // Arrange
-            var packageSource = new PackageSource("https://contoso.com/v3/index.json") { MaxHttpRequestsPerSource = maxHttpRequestsPerSource };
+            var packageSource = new PackageSource(_testPackageSourceURL) { MaxHttpRequestsPerSource = maxHttpRequestsPerSource };
             var sourceRepository = new SourceRepository(packageSource, new[] { new HttpHandlerResourceV3Provider() });
 
             // HttpSourceResourceProvider updates PackageSource.MaxHttpRequestsPerSource value for .NET Framework code paths

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/HttpSourceResourceProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/HttpSourceResourceProviderTests.cs
@@ -1,0 +1,48 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using NuGet.Configuration;
+using NuGet.Protocol.Core.Types;
+using NuGet.Test.Utility;
+using Xunit;
+
+namespace NuGet.Protocol.Tests
+{
+    public class HttpSourceResourceProviderTests
+    {
+
+#if IS_DESKTOP
+        [PlatformFact(Platform.Windows)]
+        public void EnsurePackageSourceClientCertificatesForwardedToV3HttpClientHandler()
+        {
+            // Arrange
+            var packageSource = new PackageSource("https://contoso.com/v3/index.json");
+            var sourceRepository = new SourceRepository(packageSource, new[] { new HttpSourceResourceProvider() });
+
+            // Act
+            HttpSourceResource httpSourceResource = sourceRepository.GetResource<HttpSourceResource>();
+
+            // Assert
+            Assert.NotNull(httpSourceResource);
+            Assert.Equal(64, sourceRepository.PackageSource.MaxHttpRequestsPerSource);
+        }
+#endif
+
+#if IS_CORECLR
+        [Fact]
+        public void EnsurePackageSourceClientCertificatesForwardedToV3HttpClientHandler()
+        {
+            // Arrange
+            var packageSource = new PackageSource("https://contoso.com/v3/index.json");
+            var sourceRepository = new SourceRepository(packageSource, new[] { new HttpSourceResourceProvider() });
+
+            // Act
+            HttpSourceResource httpSourceResource = sourceRepository.GetResource<HttpSourceResource>();
+
+            // Assert
+            Assert.NotNull(httpSourceResource);
+            Assert.Equal(0, sourceRepository.PackageSource.MaxHttpRequestsPerSource);
+        }
+#endif
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/HttpSourceResourceProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/HttpSourceResourceProviderTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Threading.Tasks;
 using NuGet.Configuration;
 using NuGet.Protocol.Core.Types;
 using NuGet.Test.Utility;
@@ -10,39 +11,53 @@ namespace NuGet.Protocol.Tests
 {
     public class HttpSourceResourceProviderTests
     {
-
 #if IS_DESKTOP
         [PlatformFact(Platform.Windows)]
-        public void MaxHttpRequestsPerSourceIsToDefaultValue_Success()
+        public async Task WhenMaxHttpRequestsPerSourceIsNotConfiguredThenItsValueIsSetToDefault_SuccessAsync()
         {
             // Arrange
             var packageSource = new PackageSource("https://contoso.com/v3/index.json");
             var sourceRepository = new SourceRepository(packageSource, new[] { new HttpSourceResourceProvider() });
 
             // Act
-            HttpSourceResource httpSourceResource = sourceRepository.GetResource<HttpSourceResource>();
+            HttpSourceResource httpSourceResource = await sourceRepository.GetResourceAsync<HttpSourceResource>();
 
             // Assert
             Assert.NotNull(httpSourceResource);
             Assert.Equal(64, sourceRepository.PackageSource.MaxHttpRequestsPerSource);
         }
-#endif
-
-#if IS_CORECLR
+#elif IS_CORECLR
         [Fact]
-        public void MaxHttpRequestsPerSourceIsSetToDefaultValue_Success()
+        public async Task WhenMaxHttpRequestsPerSourceIsNotConfiguredThenItsValueWillNotBeUpdated_SuccessAsync()
         {
             // Arrange
             var packageSource = new PackageSource("https://contoso.com/v3/index.json");
             var sourceRepository = new SourceRepository(packageSource, new[] { new HttpSourceResourceProvider() });
 
             // Act
-            HttpSourceResource httpSourceResource = sourceRepository.GetResource<HttpSourceResource>();
+            HttpSourceResource httpSourceResource = await sourceRepository.GetResourceAsync<HttpSourceResource>();
 
             // Assert
             Assert.NotNull(httpSourceResource);
             Assert.Equal(0, sourceRepository.PackageSource.MaxHttpRequestsPerSource);
         }
 #endif
+
+        [PlatformTheory]
+        [InlineData(128)]
+        [InlineData(256)]
+        public async Task WhenMaxHttpRequestsPerSourceIsConfiguredThenItsValueWillNotBeUpdated_SuccessAsync(int maxHttpRequestsPerSource)
+        {
+            // Arrange
+            var packageSource = new PackageSource("https://contoso.com/v3/index.json") { MaxHttpRequestsPerSource = maxHttpRequestsPerSource };
+            var sourceRepository = new SourceRepository(packageSource, new[] { new HttpSourceResourceProvider() });
+
+            // Act
+            HttpSourceResource httpSourceResource = await sourceRepository.GetResourceAsync<HttpSourceResource>();
+
+            // Assert
+            Assert.NotNull(httpSourceResource);
+            Assert.Equal(maxHttpRequestsPerSource, sourceRepository.PackageSource.MaxHttpRequestsPerSource);
+        }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/HttpSourceResourceProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/HttpSourceResourceProviderTests.cs
@@ -13,7 +13,7 @@ namespace NuGet.Protocol.Tests
 
 #if IS_DESKTOP
         [PlatformFact(Platform.Windows)]
-        public void EnsurePackageSourceClientCertificatesForwardedToV3HttpClientHandler()
+        public void MaxHttpRequestsPerSourceIsToDefaultValue_Success()
         {
             // Arrange
             var packageSource = new PackageSource("https://contoso.com/v3/index.json");
@@ -30,7 +30,7 @@ namespace NuGet.Protocol.Tests
 
 #if IS_CORECLR
         [Fact]
-        public void EnsurePackageSourceClientCertificatesForwardedToV3HttpClientHandler()
+        public void MaxHttpRequestsPerSourceIsSetToDefaultValue_Success()
         {
             // Arrange
             var packageSource = new PackageSource("https://contoso.com/v3/index.json");

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/HttpSourceResourceProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/HttpSourceResourceProviderTests.cs
@@ -11,12 +11,14 @@ namespace NuGet.Protocol.Tests
 {
     public class HttpSourceResourceProviderTests
     {
+        private readonly string _testPackageSourceURL = "https://contoso.test/v3/index.json";
+
 #if IS_DESKTOP
         [PlatformFact(Platform.Windows)]
         public async Task WhenMaxHttpRequestsPerSourceIsNotConfiguredThenItsValueIsSetToDefault_SuccessAsync()
         {
             // Arrange
-            var packageSource = new PackageSource("https://contoso.com/v3/index.json");
+            var packageSource = new PackageSource(_testPackageSourceURL);
             var sourceRepository = new SourceRepository(packageSource, new[] { new HttpSourceResourceProvider() });
 
             // Act
@@ -31,7 +33,7 @@ namespace NuGet.Protocol.Tests
         public async Task WhenMaxHttpRequestsPerSourceIsNotConfiguredThenItsValueWillNotBeUpdated_SuccessAsync()
         {
             // Arrange
-            var packageSource = new PackageSource("https://contoso.com/v3/index.json");
+            var packageSource = new PackageSource(_testPackageSourceURL);
             var sourceRepository = new SourceRepository(packageSource, new[] { new HttpSourceResourceProvider() });
 
             // Act
@@ -49,7 +51,7 @@ namespace NuGet.Protocol.Tests
         public async Task WhenMaxHttpRequestsPerSourceIsConfiguredThenItsValueWillNotBeUpdated_SuccessAsync(int maxHttpRequestsPerSource)
         {
             // Arrange
-            var packageSource = new PackageSource("https://contoso.com/v3/index.json") { MaxHttpRequestsPerSource = maxHttpRequestsPerSource };
+            var packageSource = new PackageSource(_testPackageSourceURL) { MaxHttpRequestsPerSource = maxHttpRequestsPerSource };
             var sourceRepository = new SourceRepository(packageSource, new[] { new HttpSourceResourceProvider() });
 
             // Act


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11923

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Thank you @mjolka for identifying this performance improvement and creating the linked issue. For context, [`HttpClientHandler.MaxConnectionsPerServer`](https://docs.microsoft.com/dotnet/api/system.net.http.httpclienthandler.maxconnectionsperserver?view=net-6.0) is by default `2` in .NET framework but the default value in .NET Core is `Int32.MaxValue`. Reference https://docs.microsoft.com/en-gb/archive/blogs/timomta/controlling-the-number-of-outgoing-connections-from-httpclient-net-core-or-full-framework. The performance improvements of Visual Studio PM UI mentioned in the linked issue description were great. Hence, in this PR I propose to increase `HttpClientHandler.MaxConnectionsPerServer` to `64` in `.NET Framework` code paths but don't change this property in `.NET` code paths because of the default value i.e., `Int32.MaxValue`. NuGet.exe on Windows [sets max connections limit per endpoint to 64](https://github.com/NuGet/NuGet.Client/blob/a56c42dbdd901c0c611eece400ce8565fffdfdf7/src/NuGet.Core/NuGet.Common/NetworkProtocolUtility.cs#L19). Hence, I used the same value `64` in this PR. The proposed changes also allow customers to tweak `HttpClientHandler.MaxConnectionsPerServer` by adding [`maxHttpRequestsPerSource`](https://github.com/NuGet/Home/issues/4538) in [NuGet.Config](https://docs.microsoft.com/en-us/nuget/reference/nuget-config-file) file.

I asked `.NET Networking team` if there would be any issues upgrading `MaxConnectionsPerServer` value in .NET Framework code paths. The response received so far from the team seems to be positive https://github.com/orgs/dotnet/teams/ncl/discussions/1. Hence, I went ahead with the changes. Thanks to @drewgillies for taking the time to test a private build with this fix. He mentioned that this fix made a lot of difference to the usability and performance of PM UI in Visual Studio.

Step | With preinstalled PMUI | With PMUI installed from a private build with this fix
-- | -- | --
Navigate to PMUI for solution, landing on Installed tab | 35s | 10s
Change to Browse tab | 36s | 13s
Change back to Installed tab | 15s | 3s
Change to Updates tab | 27s | 6s

~I don't have numbers handy right now, but I noticed great performance improvements in Visual Studio solution restore scenario. I will run a quick test and post the results here.~

EDIT: I captured few metrics. This PR reduced [OrchardCore](https://github.com/OrchardCMS/OrchardCore/commit/c4e37bdd6f63f3a5acdb018e101436cc5fd90a1f) VS Solution restore by **10 seconds**.

- VS Solution restore time without this fix.

MaxConnectionsPerSever | MaxHttpRequestsPerSource | Time for Solution restore
-- | -- | --
2 (Default) | Not set | **45 seconds**
2  (Default)| 64 | 42 seconds
2  (Default)| 128 | 39 seconds

- VS Solution restore time with this fix.

MaxConnectionsPerSever | MaxHttpRequestsPerSource | Time for Solution restore
-- | -- | --
64 | Default (64) | **35 seconds**
128 | 128 | 34 seconds

- `dotnet restore (7.0.100-preview.6)` for OrchardCore solution in my local machine took `32 seconds`. This number is close to VS solution restore scenario for default `MaxConnectionsPerSever` proposed in this PR which is `64`.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [x] N/A
