### PR TITLE
Fix all build warnings and treat all future warnings as an error

### DIFF
--- a/build/common.project.props
+++ b/build/common.project.props
@@ -58,13 +58,14 @@
   <!-- Defaults -->
   <PropertyGroup>
     <TreatWarningsAsErrors Condition=" '$(TreatWarningsAsErrors)' == '' ">true</TreatWarningsAsErrors>
+    <MSBuildTreatWarningsAsErrors Condition=" '$(MSBuildTreatWarningsAsErrors)' == '' ">true</MSBuildTreatWarningsAsErrors>
   </PropertyGroup>
 
   <!-- Default project configuration -->
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">16.0</VisualStudioVersion>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">17.0</VisualStudioVersion>
     <NuGetTargets>$(MSBuildExtensionsPath)\Microsoft\NuGet\$(VisualStudioVersion)\Microsoft.NuGet.targets</NuGetTargets>
     <ComVisible>false</ComVisible>
   </PropertyGroup>

--- a/build/common.project.props
+++ b/build/common.project.props
@@ -58,7 +58,8 @@
   <!-- Defaults -->
   <PropertyGroup>
     <TreatWarningsAsErrors Condition=" '$(TreatWarningsAsErrors)' == '' ">true</TreatWarningsAsErrors>
-    <MSBuildTreatWarningsAsErrors Condition=" '$(MSBuildTreatWarningsAsErrors)' == '' ">true</MSBuildTreatWarningsAsErrors>
+    <!-- Treat all warnings as errors, except on official builds since we don't want new warnings to break servicing branches -->
+    <MSBuildTreatWarningsAsErrors Condition=" '$(MSBuildTreatWarningsAsErrors)' == '' And '$(IsOfficialBuild)' != 'true' ">true</MSBuildTreatWarningsAsErrors>
   </PropertyGroup>
 
   <!-- Default project configuration -->

--- a/build/loc.proj
+++ b/build/loc.proj
@@ -1,6 +1,5 @@
 <Project DefaultTargets="AfterBuild">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common.props" />
-  <Import Project="$(MicroBuildDirectory)Microsoft.VisualStudioEng.MicroBuild.Core.props"/>
 
   <!-- Configuration/global properties -->
   <PropertyGroup>

--- a/build/packages.targets
+++ b/build/packages.targets
@@ -91,16 +91,16 @@
     <ItemGroup>
         <PackageReference Update="FluentAssertions" Version="6.6.0" />
         <PackageReference Update="Microsoft.Build.Runtime" Version="$(MicrosoftBuildPackageVersion)" />
-        <PackageReference Update="Microsoft.CSharp" Version="$(SystemPackagesVersion)" />
         <PackageReference Update="Microsoft.CodeAnalysis" Version="3.0.0" />
         <PackageReference Update="Microsoft.CodeAnalysis.Build.Tasks" Version="3.0.0-dev-61717-03" />
         <PackageReference Update="Microsoft.CodeAnalysis.CSharp" Version="3.0.0-dev-61717-03" />
         <PackageReference Update="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.0.0" />
+        <PackageReference Update="Microsoft.CSharp" Version="$(SystemPackagesVersion)" />
         <PackageReference Update="Microsoft.Net.Compilers.netcore" Version="3.0.0-dev-61717-03" />
         <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-        <PackageReference Update="Microsoft.TestPlatform.Portable" Version="17.1.0" />
         <PackageReference Update="Microsoft.PowerShell.3.ReferenceAssemblies" Version="1.0.0" />
         <PackageReference Update="Microsoft.Test.Apex.VisualStudio" Version="17.3.32913.221" />
+        <PackageReference Update="Microsoft.TestPlatform.Portable" Version="17.1.0" />
         <PackageReference Update="Microsoft.VisualStudio.Sdk.TestFramework.Xunit" Version="17.2.7" />
         <PackageReference Update="Moq" Version="4.18.1" />
         <PackageReference Update="MSTest.TestAdapter" Version="2.2.10" />
@@ -108,6 +108,7 @@
         <PackageReference Update="NuGet.Core" Version="$(NuGetCoreV2Version)" />
         <PackageReference Update="Portable.BouncyCastle" Version="1.8.10" />
         <PackageReference Update="System.Collections" Version="$(SystemPackagesVersion)" />
+        <PackageReference Update="System.Configuration.ConfigurationManager" Version="4.4.0" />
         <PackageReference Update="System.IO.FileSystem.Primitives" Version="$(SystemPackagesVersion)" />
         <PackageReference Update="System.Memory" Version="4.5.5" />
         <PackageReference Update="System.Resources.ResourceManager" Version="$(SystemPackagesVersion)" />
@@ -119,9 +120,6 @@
         <PackageReference Update="xunit" Version="$(XunitVersion)" />
         <PackageReference Update="xunit.runner.visualstudio" Version="$(XunitVersion)" />
         <PackageReference Update="Xunit.StaFact" Version="1.0.37" />
-
-        <PackageReference Update="System.Configuration.ConfigurationManager" Version="4.4.0" Condition="'$(TargetFramework)' == '$(NETCoreTargetFramework)'" />
-        <PackageReference Update="System.Security.Cryptography.ProtectedData" Version="4.4.0" Condition="'$(TargetFramework)' == '$(NETCoreTargetFramework)'" />
     </ItemGroup>
 
   </Project>

--- a/build/packages.targets
+++ b/build/packages.targets
@@ -100,9 +100,11 @@
         <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.1.0" />
         <PackageReference Update="Microsoft.TestPlatform.Portable" Version="17.1.0" />
         <PackageReference Update="Microsoft.PowerShell.3.ReferenceAssemblies" Version="1.0.0" />
-        <PackageReference Update="Microsoft.Test.Apex.VisualStudio" Version="17.1.0-preview-2-31918-026" />
+        <PackageReference Update="Microsoft.Test.Apex.VisualStudio" Version="17.3.32913.221" />
         <PackageReference Update="Microsoft.VisualStudio.Sdk.TestFramework.Xunit" Version="17.2.7" />
         <PackageReference Update="Moq" Version="4.18.1" />
+        <PackageReference Update="MSTest.TestAdapter" Version="2.2.10" />
+        <PackageReference Update="MSTest.TestFramework" Version="2.2.10" />
         <PackageReference Update="NuGet.Core" Version="$(NuGetCoreV2Version)" />
         <PackageReference Update="Portable.BouncyCastle" Version="1.8.10" />
         <PackageReference Update="System.Collections" Version="$(SystemPackagesVersion)" />
@@ -117,6 +119,9 @@
         <PackageReference Update="xunit" Version="$(XunitVersion)" />
         <PackageReference Update="xunit.runner.visualstudio" Version="$(XunitVersion)" />
         <PackageReference Update="Xunit.StaFact" Version="1.0.37" />
+
+        <PackageReference Update="System.Configuration.ConfigurationManager" Version="4.4.0" Condition="'$(TargetFramework)' == '$(NETCoreTargetFramework)'" />
+        <PackageReference Update="System.Security.Cryptography.ProtectedData" Version="4.4.0" Condition="'$(TargetFramework)' == '$(NETCoreTargetFramework)'" />
     </ItemGroup>
 
   </Project>

--- a/build/sign.proj
+++ b/build/sign.proj
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="AfterBuild" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common.props" />
-  <Import Project="$(MicroBuildDirectory)Microsoft.VisualStudioEng.MicroBuild.Core.props"/>
 
   <!-- Configuration/global properties -->
   <PropertyGroup>

--- a/scripts/funcTests/runFuncTests.sh
+++ b/scripts/funcTests/runFuncTests.sh
@@ -148,8 +148,8 @@ then
 fi
 
 # restore packages
-echo "dotnet msbuild build/build.proj /t:Restore /p:VisualStudioVersion=16.0 /p:Configuration=Release /p:ReleaseLabel=beta /bl:$BUILD_STAGINGDIRECTORY/binlog/02.Restore.binlog"
-dotnet msbuild build/build.proj /t:Restore /p:VisualStudioVersion=16.0 /p:Configuration=Release /p:ReleaseLabel=beta /bl:$BUILD_STAGINGDIRECTORY/binlog/02.Restore.binlog
+echo "dotnet msbuild build/build.proj /t:Restore /p:Configuration=Release /p:ReleaseLabel=beta /bl:$BUILD_STAGINGDIRECTORY/binlog/02.Restore.binlog"
+dotnet msbuild build/build.proj /t:Restore /p:Configuration=Release /p:ReleaseLabel=beta /bl:$BUILD_STAGINGDIRECTORY/binlog/02.Restore.binlog
 
 if [ $? -ne 0 ]; then
 	echo "Restore failed!!"
@@ -159,8 +159,8 @@ fi
 echo "Restore finished at `date -u +"%Y-%m-%dT%H:%M:%S"`"
 
 # Unit tests
-echo "dotnet msbuild build/build.proj /t:CoreUnitTests /p:VisualStudioVersion=16.0 /p:Configuration=Release /p:ReleaseLabel=beta /bl:$BUILD_STAGINGDIRECTORY/binlog/03.CoreUnitTests.binlog"
-dotnet msbuild build/build.proj /t:CoreUnitTests /p:VisualStudioVersion=16.0 /p:Configuration=Release /p:ReleaseLabel=beta /bl:$BUILD_STAGINGDIRECTORY/binlog/03.CoreUnitTests.binlog
+echo "dotnet msbuild build/build.proj /t:CoreUnitTests /p:Configuration=Release /p:ReleaseLabel=beta /bl:$BUILD_STAGINGDIRECTORY/binlog/03.CoreUnitTests.binlog"
+dotnet msbuild build/build.proj /t:CoreUnitTests /p:Configuration=Release /p:ReleaseLabel=beta /bl:$BUILD_STAGINGDIRECTORY/binlog/03.CoreUnitTests.binlog
 
 if [ $? -ne 0 ]; then
 	echo "CoreUnitTests failed!!"
@@ -170,8 +170,8 @@ fi
 echo "Core tests finished at `date -u +"%Y-%m-%dT%H:%M:%S"`"
 
 # Func tests
-echo "dotnet msbuild build/build.proj /t:CoreFuncTests /p:VisualStudioVersion=16.0 /p:Configuration=Release /p:ReleaseLabel=beta /bl:$BUILD_STAGINGDIRECTORY/binlog/04.CoreFuncTests.binlog"
-dotnet msbuild build/build.proj /t:CoreFuncTests /p:VisualStudioVersion=16.0 /p:Configuration=Release /p:ReleaseLabel=beta /bl:$BUILD_STAGINGDIRECTORY/binlog/04.CoreFuncTests.binlog
+echo "dotnet msbuild build/build.proj /t:CoreFuncTests /p:Configuration=Release /p:ReleaseLabel=beta /bl:$BUILD_STAGINGDIRECTORY/binlog/04.CoreFuncTests.binlog"
+dotnet msbuild build/build.proj /t:CoreFuncTests /p:Configuration=Release /p:ReleaseLabel=beta /bl:$BUILD_STAGINGDIRECTORY/binlog/04.CoreFuncTests.binlog
 
 if [ $? -ne 0 ]; then
 	RESULTCODE='1'

--- a/setup/Microsoft.VisualStudio.NuGet.BuildTools.swixproj
+++ b/setup/Microsoft.VisualStudio.NuGet.BuildTools.swixproj
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common.props" />
-  <Import Project="$(MicroBuildDirectory)Microsoft.VisualStudioEng.MicroBuild.Core.props" />
 
   <PropertyGroup>
     <OutputArchitecture>neutral</OutputArchitecture>

--- a/setup/Microsoft.VisualStudio.NuGet.BuildTools.vsmanproj
+++ b/setup/Microsoft.VisualStudio.NuGet.BuildTools.vsmanproj
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common.props" />
-  <Import Project="$(MicroBuildDirectory)Microsoft.VisualStudioEng.MicroBuild.Core.props" />
 
   <PropertyGroup>
     <!-- Define properties that drive the manifest creation here. -->

--- a/src/NuGet.Clients/NuGet.VisualStudio.Client/.vsixignore
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Client/.vsixignore
@@ -75,8 +75,6 @@ Microsoft.TeamFoundation.WorkItemTracking.Proxy.resources.dll
 Microsoft.TeamFoundation.WorkItemTracking.WebApi.dll
 Microsoft.VisualStudio.Debugger.Interop.16.0.dll
 Microsoft.VisualStudio.Interop.dll
-Microsoft.VisualStudio.LanguageServer.Protocol.dll
-Microsoft.VisualStudio.LanguageServer.Protocol.resources.dll
 Microsoft.VisualStudio.RpcContracts.dll
 Microsoft.VisualStudio.Services.Client.Interactive.dll
 Microsoft.VisualStudio.Services.Client.Interactive.resources.dll

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/NuGet.Packaging.Test.csproj
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/NuGet.Packaging.Test.csproj
@@ -19,6 +19,14 @@
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.Security" />
   </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == '$(NETCoreTargetFramework)' ">
+    <!--
+      For .netcoreapp3.0 a different version of System.Configuration.ConfigurationManager and System.Security.Cryptography.ProtectedData are used
+      which causes assembly resolution conflicts
+    -->
+    <PackageReference Include="System.Configuration.ConfigurationManager" ExcludeAssets="Compile" />
+    <PackageReference Include="System.Security.Cryptography.ProtectedData" ExcludeAssets="Compile" />
+  </ItemGroup>
 
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />

--- a/test/NuGet.Tests.Apex/NuGet.OptProf/NuGet.OptProf.csproj
+++ b/test/NuGet.Tests.Apex/NuGet.OptProf/NuGet.OptProf.csproj
@@ -1,4 +1,4 @@
-<Project>
+﻿<Project>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'NuGet.sln'))\build\common.test.props" />
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
@@ -22,10 +22,21 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Test.Apex.VisualStudio" />
+    <PackageReference Include="Microsoft.Test.Apex.VisualStudio" ExcludeAssets="Compile" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.VisualStudio.Sdk" />
+    <PackageReference Include="MSTest.TestAdapter" />
+    <PackageReference Include="MSTest.TestFramework" />
     <PackageReference Include="Newtonsoft.Json" NoWarn="NU1605" />
     <PackageReference Include="Xunit.StaFact" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <!-- Manually consuming compile-time assets from Microsoft.Test.Apex.VisualStudio and excluding ones that cause compile warnings -->
+    <Reference Include="$(PkgMicrosoft_Test_Apex_VisualStudio)\lib\net46\*.dll"
+               Exclude="$(PkgMicrosoft_Test_Apex_VisualStudio)\lib\net46\Microsoft.Test.Apex.PrismIntegration.dll;
+                        $(PkgMicrosoft_Test_Apex_VisualStudio)\lib\net46\Microsoft.Test.Apex.RemoteCodeInjector.dll;
+                        $(PkgMicrosoft_Test_Apex_VisualStudio)\lib\net46\Microsoft.Test.Apex.RemoteCodeInjector.x64.dll"
+               Name="%(Filename)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGet.Tests.Apex.csproj
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGet.Tests.Apex.csproj
@@ -61,9 +61,17 @@
     <Compile Include="NuGetPackageSigningTests\RepositorySignedPackageTestCase.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Test.Apex.VisualStudio" />
+    <PackageReference Include="Microsoft.Test.Apex.VisualStudio" ExcludeAssets="Compile" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.VisualStudio.Sdk" />
     <PackageReference Include="Xunit.StaFact" />
+  </ItemGroup>
+  <ItemGroup>
+    <!-- Manually consuming compile-time assets from Microsoft.Test.Apex.VisualStudio and excluding ones that cause compile warnings -->
+    <Reference Include="$(PkgMicrosoft_Test_Apex_VisualStudio)\lib\net46\*.dll"
+               Exclude="$(PkgMicrosoft_Test_Apex_VisualStudio)\lib\net46\Microsoft.Test.Apex.PrismIntegration.dll;
+                        $(PkgMicrosoft_Test_Apex_VisualStudio)\lib\net46\Microsoft.Test.Apex.RemoteCodeInjector.dll;
+                        $(PkgMicrosoft_Test_Apex_VisualStudio)\lib\net46\Microsoft.Test.Apex.RemoteCodeInjector.x64.dll"
+               Name="%(Filename)" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1859

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
Fix all existing warnings in our build and enable `MSBuildTreatWarningsAsErrors` so that no new warnings are introduced.

* Set `VisualStudioVersion` to 17.0 otherwise we get a warning about using VS 2019 to build .NET 6 even though we are using a newer version of .NET SDK
* Remove `VisualStudioVersion` global property from non-Windows builds since its set by our own build logic
* Remove redundant imports to `$(MicroBuildDirectory)Microsoft.VisualStudioEng.MicroBuild.Core.props`
* Remove missing files in `src/NuGet.Clients/NuGet.VisualStudio.Client/.vsixignore`
* Use an older version of `System.Configuration.ConfigurationManager` in `test/NuGet.Core.Tests/NuGet.Packaging.Test/NuGet.Packaging.Test.csproj` when targeting .NET Core 3 since that version of the runtime uses an older version and we get resolve assembly reference warnings otherwise
* Manually consume the assets of `Microsoft.Test.Apex.VisualStudio` since it contains a bunch of DLLs in the `lib` folder that generate compilation warnings because they are not built against `AnyCPU`

There are still a bunch of warnings emitted by other parts of our build which I can not seem to fix:

![image](https://user-images.githubusercontent.com/17556515/190463440-a8a2a1be-6086-4a1b-8e51-ce1dddc0d022.png)

These are coming from DartLab execution and I've found at least one related issue:
-  https://github.com/microsoft/vstest/issues/3208

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
