### PR TITLE
Correctly check for more than one HTTP source before warning about not using package source mapping with CPM

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -478,7 +478,7 @@ namespace NuGet.Commands
                 return false;
             }
 
-            if (!restoreRequest.PackageSourceMapping.IsEnabled && httpSourcesCount > 0)
+            if (!restoreRequest.PackageSourceMapping.IsEnabled && httpSourcesCount > 1)
             {
                 // Log a warning if there are more than one configured source and package source mapping is not enabled
                 await _logger.LogAsync(RestoreLogMessage.CreateWarning(NuGetLogCode.NU1507, string.Format(CultureInfo.CurrentCulture, Strings.Warning_CentralPackageVersions_MultipleSourcesWithoutPackageSourceMapping, httpSourcesCount, string.Join(", ", restoreRequest.DependencyProviders.RemoteProviders.Where(i => i.IsHttp).Select(i => i.Source.Name)))));

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
@@ -1588,10 +1588,89 @@ namespace NuGet.Commands.Test
             }
         }
 
+        [Fact]
+        public async Task RestoreCommand_CentralVersion_NoWarningWhenOnlyOneFeedAndPackageSourceMappingNotUsed()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                pathContext.PackageSource,
+                PackageSaveMode.Defaultv3,
+                    new SimpleTestPackageContext("foo", "1.0.0"));
+
+                using var context = new SourceCacheContext();
+
+                var packageSources = new List<PackageSource>
+                {
+                    new PackageSource(pathContext.PackageSource),
+                    new PackageSource("https://feed1"),
+                };
+
+                var projectName = "TestProject";
+                var projectPath = Path.Combine(pathContext.SolutionRoot, projectName);
+                var outputPath = Path.Combine(projectPath, "obj");
+                var dependencyBar = new LibraryDependency(
+                    new LibraryRange(
+                        "foo",
+                        null,
+                        LibraryDependencyTarget.All),
+                    LibraryIncludeFlags.All,
+                    LibraryIncludeFlags.All,
+                    new List<NuGetLogCode>(),
+                    autoReferenced: false,
+                    generatePathProperty: false,
+                    versionCentrallyManaged: false,
+                    LibraryDependencyReferenceType.Direct,
+                    aliases: null,
+                    versionOverride: null);
+
+                var centralVersionFoo = new CentralPackageVersion("foo", VersionRange.Parse("1.0.0"));
+
+                var tfi = CreateTargetFrameworkInformation(new List<LibraryDependency>() { dependencyBar }, new List<CentralPackageVersion>() { centralVersionFoo });
+                var packageSpec = new PackageSpec(new List<TargetFrameworkInformation>() { tfi })
+                {
+                    FilePath = projectPath,
+                    Name = projectName,
+                    RestoreMetadata = new ProjectRestoreMetadata()
+                    {
+                        ProjectName = projectName,
+                        ProjectUniqueName = projectName,
+                        CentralPackageVersionsEnabled = true,
+                        ProjectStyle = ProjectStyle.PackageReference,
+                        OutputPath = outputPath,
+                        Sources = packageSources
+                    }
+                };
+
+                var logger = new TestLogger();
+
+                PackageSourceMapping packageSourceMappingConfiguration = PackageSourceMapping.GetPackageSourceMapping(NullSettings.Instance);
+
+                var request = new TestRestoreRequest(packageSpec, packageSources, packagesDirectory: "", cacheContext: context, packageSourceMappingConfiguration: packageSourceMappingConfiguration, logger)
+                {
+                    LockFilePath = Path.Combine(projectPath, "project.assets.json"),
+                    ProjectStyle = ProjectStyle.PackageReference,
+
+                };
+
+                var restoreCommand = new RestoreCommand(request);
+
+                var result = await restoreCommand.ExecuteAsync();
+
+                // Assert
+                Assert.True(result.Success);
+
+                logger.Errors.Should().Be(0);
+
+                logger.WarningMessages.Should().NotContain(i => i.Contains(NuGetLogCode.NU1507.ToString()));
+            }
+        }
+
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        public async Task RestoreCommand_CentralVersion_WarningWhenPackageSourceMappingNotUsed(bool enablePackageSourceMapping)
+        public async Task RestoreCommand_CentralVersion_WarningWhenMoreThanOneFeedAndPackageSourceMappingNotUsed(bool enablePackageSourceMapping)
         {
             // Arrange
             using (var pathContext = new SimpleTestPathContext())


### PR DESCRIPTION

<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12095

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
Properly check for greater than 1 instead of 0.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
