### PR TITLE
Catches failed NuGet.Commands resource events to localize NuGet.Commands with ILMerged nuget.exe resources 

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/NuGet.CommandLine.csproj
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGet.CommandLine.csproj
@@ -80,7 +80,9 @@
       <DependentUpon>NuGetResources.resx</DependentUpon>
     </Compile>
     <!-- nuget.exe localized assemblies -->
-    <EmbeddedResource Include="$(OutputPath)\**\$(AssemblyName).resources.dll" />
+    <EmbeddedResource Include="$(OutputPath)\**\$(AssemblyName).resources.dll" Exclude="@(MergeExclude)" />
+    <!-- NuGet.Commands localized assemblies -->
+    <LocResource Include="$(OutputPath)\**\NuGet.Commands.resources.dll" Exclude="@(MergeExclude)" />
   </ItemGroup>
 
   <ItemGroup>
@@ -115,6 +117,7 @@
       <IlmergeCommand>$(ILMergeExePath) /lib:$(OutputPath) /out:$(PathToMergedNuGetExe) @(MergeAllowDup -> '/allowdup:%(Identity)', ' ') /log:$(OutputPath)IlMergeLog.txt</IlmergeCommand>
       <IlmergeCommand Condition="Exists($(MS_PFX_PATH))">$(IlmergeCommand) /delaysign /keyfile:$(MS_PFX_PATH)</IlmergeCommand>
       <IlmergeCommand>$(IlmergeCommand) $(PathToBuiltNuGetExe) @(BuildArtifacts->'%(fullpath)', ' ')</IlmergeCommand>
+      <IlmergeCommand>$(IlmergeCommand) @(LocResource->'%(fullpath)', ' ')</IlmergeCommand>
     </PropertyGroup>
     <MakeDir Directories="$([System.IO.Path]::GetDirectoryName($(PathToMergedNuGetExe)))" />
     <Exec Command="$(IlmergeCommand)" ContinueOnError="false" />

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGet.CommandLine.csproj
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGet.CommandLine.csproj
@@ -80,9 +80,9 @@
       <DependentUpon>NuGetResources.resx</DependentUpon>
     </Compile>
     <!-- nuget.exe localized assemblies -->
-    <EmbeddedResource Include="$(OutputPath)\**\$(AssemblyName).resources.dll" Exclude="@(MergeExclude)" />
+    <EmbeddedResource Include="$(OutputPath)\**\$(AssemblyName).resources.dll" />
     <!-- NuGet.Commands localized assemblies -->
-    <LocResource Include="$(OutputPath)\**\NuGet.Commands.resources.dll" Exclude="@(MergeExclude)" />
+    <LocResource Include="$(OutputPath)\**\NuGet.Commands.resources.dll" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NuGet.Clients/NuGet.CommandLine/Program.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Program.cs
@@ -256,7 +256,6 @@ namespace NuGet.CommandLine
             AssemblyName name = new AssemblyName(args.Name);
             Assembly customLoadedAssembly = null;
 
-            Assembly customLoadedAssembly = null;
             if (string.Equals(name.Name, ThisExecutableName, StringComparison.OrdinalIgnoreCase))
             {
                 customLoadedAssembly = NuGetExeAssembly;

--- a/src/NuGet.Clients/NuGet.CommandLine/Program.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Program.cs
@@ -242,7 +242,7 @@ namespace NuGet.CommandLine
                 ManifestResourceInfo resource = NuGetExeAssembly.GetManifestResourceInfo(args.Name);
                 if (resource != null)
                 {
-                    // Return nuget.exe assembly, since it contains the requested resource by nuget.restources assembly
+                    // Return nuget.exe assembly, since it contains the requested resource by NuGet.Resources assembly
                     returnedResource = NuGetExeAssembly;
                 }
             }

--- a/src/NuGet.Clients/NuGet.CommandLine/Program.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Program.cs
@@ -206,6 +206,7 @@ namespace NuGet.CommandLine
         private void Initialize(CoreV2.NuGet.IFileSystem fileSystem, IConsole console)
         {
             AppDomain.CurrentDomain.AssemblyResolve += CurrentDomain_AssemblyResolve;
+            AppDomain.CurrentDomain.ResourceResolve += CurrentDomain_ResourceResolve;
 
             using (var catalog = new AggregateCatalog(new AssemblyCatalog(GetType().Assembly)))
             {
@@ -231,12 +232,31 @@ namespace NuGet.CommandLine
             }
         }
 
+        private Assembly CurrentDomain_ResourceResolve(object sender, ResolveEventArgs args)
+        {
+            Assembly returnedResource = null;
+
+            // We want to intercept NuGet.Resources resources and redirect it to nuget.exe assembly
+            if (!args.Name.StartsWith("NuGet.CommandLine", StringComparison.OrdinalIgnoreCase) && args.Name.StartsWith("NuGet", StringComparison.OrdinalIgnoreCase) && string.Equals("NuGet.Resources", args.RequestingAssembly.GetName().Name, StringComparison.OrdinalIgnoreCase))
+            {
+                ManifestResourceInfo resource = NuGetExeAssembly.GetManifestResourceInfo(args.Name);
+                if (resource != null)
+                {
+                    // Return nuget.exe assembly, since it contains the requested resource by nuget.restources assembly
+                    returnedResource = NuGetExeAssembly;
+                }
+            }
+
+            return returnedResource;
+        }
+
         // This method acts as a binding redirect
         private Assembly CurrentDomain_AssemblyResolve(object sender, ResolveEventArgs args)
         {
             AssemblyName name = new AssemblyName(args.Name);
             Assembly customLoadedAssembly = null;
 
+            Assembly customLoadedAssembly = null;
             if (string.Equals(name.Name, ThisExecutableName, StringComparison.OrdinalIgnoreCase))
             {
                 customLoadedAssembly = NuGetExeAssembly;

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetHelpCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetHelpCommandTest.cs
@@ -90,29 +90,5 @@ namespace NuGet.CommandLine.Test
             Assert.Equal(0, r.ExitCode);
             Assert.Contains("Show command help and usage information.", r.Output);
         }
-
-        [CIOnlyFact] // This test needs a fully localized build
-        public void HelpCommand_OverridesLanguageInSpanish_PrintsOutputInSpanish()
-        {
-            var clientCertsDescriptionSpanish = "Proporciona la capacidad de administrar la lista de certificados de cliente ubicados en archivos NuGet.config";
-
-            // Arrange
-            string nugetexe = Util.GetNuGetExePath();
-
-            // Act
-            CommandRunnerResult r = CommandRunner.Run(
-                nugetexe,
-                Directory.GetCurrentDirectory(),
-                "help help",
-                waitForExit: true,
-                environmentVariables: new Dictionary<string, string>()
-                {
-                    { "NUGET_CLI_LANGUAGE", "es-es" }
-                });
-
-            // Assert
-            Assert.Equal(0, r.ExitCode);
-            Assert.Contains(clientCertsDescriptionSpanish, r.Output);
-        }
     }
 }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetHelpCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetHelpCommandTest.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.IO;
 using NuGet.Test.Utility;
 using Xunit;

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetHelpCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetHelpCommandTest.cs
@@ -94,7 +94,7 @@ namespace NuGet.CommandLine.Test
         [CIOnlyFact] // This test needs a fully localized build
         public void HelpCommand_OverridesLanguageInSpanish_PrintsOutputInSpanish()
         {
-            string clientCertsDescriptionSpanish = "Proporciona la capacidad de administrar la lista de certificados de cliente ubicados en archivos NuGet.config";
+            var clientCertsDescriptionSpanish = "Proporciona la capacidad de administrar la lista de certificados de cliente ubicados en archivos NuGet.config";
 
             // Arrange
             string nugetexe = Util.GetNuGetExePath();

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetHelpCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetHelpCommandTest.cs
@@ -1,6 +1,3 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
-
 using System;
 using System.IO;
 using NuGet.Test.Utility;

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetHelpCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetHelpCommandTest.cs
@@ -1,4 +1,8 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
+using System.Collections.Generic;
 using System.IO;
 using NuGet.Test.Utility;
 using Xunit;
@@ -85,6 +89,30 @@ namespace NuGet.CommandLine.Test
             // Assert
             Assert.Equal(0, r.ExitCode);
             Assert.Contains("Show command help and usage information.", r.Output);
+        }
+
+        [CIOnlyFact] // This test needs a fully localized build
+        public void HelpCommand_OverridesLanguageInSpanish_PrintsOutputInSpanish()
+        {
+            string clientCertsDescriptionSpanish = "Proporciona la capacidad de administrar la lista de certificados de cliente ubicados en archivos NuGet.config";
+
+            // Arrange
+            string nugetexe = Util.GetNuGetExePath();
+
+            // Act
+            CommandRunnerResult r = CommandRunner.Run(
+                nugetexe,
+                Directory.GetCurrentDirectory(),
+                "help help",
+                waitForExit: true,
+                environmentVariables: new Dictionary<string, string>()
+                {
+                    { "NUGET_CLI_LANGUAGE", "es-es" }
+                });
+
+            // Assert
+            Assert.Equal(0, r.ExitCode);
+            Assert.Contains(clientCertsDescriptionSpanish, r.Output);
         }
     }
 }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12097

Regression? Last working version: N/A

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

This PR embeds nuget.resources assembly into nuget.exe and ILMerge nuget.commands resources, following the idea outline in the comment in nuget.exe project file:

https://github.com/NuGet/NuGet.Client/blob/be87c9ee11149780ce7de5fe35fe2653d565ccfd/src/NuGet.Clients/NuGet.CommandLine/NuGet.CommandLine.csproj#L105-L107

Also, this PR adds code to intercept CurrentDomain.ResourceResolve events in nuget.exe when looking for NuGet resources to indicate that NuGet assembly contains the required resource

Over time, nuget.exe file size has increase. This PR represents a 265KB increase in file size, compared to the last nuget.exe version with localization on NuGet.CommandLine and NuGet.Commands assemblies

nuget.exe version | File size in KB | Notes
---|---|---
nuget.3.5.0.exe | 4167 |  
nuget.4.9.6.exe | 5555 |  
nuget.5.11.3.exe | 6633 |  
nuget.6.0.3.exe | 6874 |  
nuget.6.1.0.exe | 6878 |  
nuget.6.2.0.exe | 6926 |  
nuget.6.3.1.exe | 6878 | NuGet.CommandLine + NuGet.Commands localization
nuget.6.4.0.exe | 6299 | Introduced nuget.exe localization only for NuGet.CommandLine
This pull request | 7143 | Adds localization of NuGet.Commands



## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception: Removed unit tests since functional test cannot run on localized nuget.exe; Tested manually, see section below
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [x] Documentation PR or issue filled: https://github.com/NuGet/docs.microsoft.com-nuget/issues/2949
  - **OR**
  - [ ] N/A


### Validation

Side to side comparison

#### `nuget.exe` Install

Before: All messages are in English
After: Some messages are translated, some others not because those are strings from nuget.packagemanagement, which are not ILMerged.

| Before | After |
|--------|-------|
| ![install-before](https://user-images.githubusercontent.com/1192347/193190962-5b587fb1-4c49-42a0-90db-a0074e9c341f.png) | ![install-after](https://user-images.githubusercontent.com/1192347/193191619-93bbd6e8-5f9d-4cf9-b2c6-6da3a3852369.png) ![install-after-2](https://user-images.githubusercontent.com/1192347/204763723-3f215c9b-4992-4c0e-b598-aed17ccd8fee.png) |


#### `nuget.exe` Restore

Before: some messages are localized
After: all restore messages are localized

| Before | After |
|--------|-------|
| ![restore-before](https://user-images.githubusercontent.com/1192347/193190628-85e1fc82-1756-4c4f-b2e9-355a26e8bba2.png) | ![restore-after](https://user-images.githubusercontent.com/1192347/193190578-8e441ed1-9fd9-47b4-acc4-93400904af04.png) ![restor-after-2](https://user-images.githubusercontent.com/1192347/204764231-b7cc0246-3a29-47bb-9960-53f40e7b7d8c.png) |
