### PR TITLE
Enables CA2101 rule and tries to fix some warnings

### DIFF
--- a/build/NuGet.ruleset
+++ b/build/NuGet.ruleset
@@ -82,7 +82,7 @@
     <Rule Id="CA2008" Action="None" />
     <Rule Id="CA2009" Action="None" />
     <Rule Id="CA2100" Action="None" />
-    <Rule Id="CA2101" Action="None" />
+    <Rule Id="CA2101" Action="Warning" />
     <Rule Id="CA2216" Action="None" />
     <Rule Id="CA2229" Action="None" />
     <Rule Id="CA2235" Action="None" />

--- a/src/NuGet.Core/NuGet.Common/PathUtil/DirectoryUtility.cs
+++ b/src/NuGet.Core/NuGet.Common/PathUtil/DirectoryUtility.cs
@@ -73,7 +73,7 @@ namespace NuGet.Common
 
         private const int UGO_RWX = 0x1ff; // 0777
 
-        [DllImport("libc", SetLastError = true)]
+        [DllImport("libc", SetLastError = true, CharSet = CharSet.Unicode)]
         private static extern int chmod(string pathname, int mode);
     }
 }

--- a/src/NuGet.Core/NuGet.Packaging/NuGetExtractionFileIO.cs
+++ b/src/NuGet.Core/NuGet.Packaging/NuGetExtractionFileIO.cs
@@ -158,13 +158,13 @@ namespace NuGet.Packaging
         }
 
 
-        [DllImport("libc", EntryPoint = "creat")]
-        private static extern int PosixCreate([MarshalAs(UnmanagedType.LPStr)] string pathname, int mode);
+        [DllImport("libc", EntryPoint = "creat", CharSet = CharSet.Unicode)]
+        private static extern int PosixCreate([MarshalAs(UnmanagedType.LPWStr)] string pathname, int mode);
 
-        [DllImport("libc", EntryPoint = "chmod")]
-        private static extern int PosixChmod([MarshalAs(UnmanagedType.LPStr)] string pathname, int mode);
+        [DllImport("libc", EntryPoint = "chmod", CharSet = CharSet.Unicode)]
+        private static extern int PosixChmod([MarshalAs(UnmanagedType.LPWStr)] string pathname, int mode);
 
-        [DllImport("libc", EntryPoint = "umask")]
+        [DllImport("libc", EntryPoint = "umask", CharSet = CharSet.Unicode)]
         private static extern int PosixUMask(int mask);
     }
 }

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Cms/NativeMethods.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Cms/NativeMethods.cs
@@ -15,7 +15,7 @@ namespace NuGet.Packaging.Signing
         internal const uint CERT_KEY_IDENTIFIER_PROP_ID = 20;
         internal const uint CERT_ID_KEY_IDENTIFIER = 2;
 
-        [DllImport("crypt32.dll", SetLastError = true)]
+        [DllImport("crypt32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
         public static extern SafeCryptMsgHandle CryptMsgOpenToEncode(
             CMSG_ENCODING dwMsgEncodingType,
             uint dwFlags,

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/Rfc3161TimestampWin32.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/Rfc3161TimestampWin32.cs
@@ -86,12 +86,12 @@ namespace NuGet.Packaging.Signing
         }
 
         [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-        [DllImport("crypt32.dll", CallingConvention = CallingConvention.Winapi, SetLastError = true)]
+        [DllImport("crypt32.dll", CallingConvention = CallingConvention.Winapi, SetLastError = true, CharSet = CharSet.Unicode)]
         internal static extern bool CryptRetrieveTimeStamp(
             [MarshalAs(UnmanagedType.LPWStr)] string wszUrl,
             CryptRetrieveTimeStampFlags dwRetrievalFlags,
             int dwTimeout,
-            [MarshalAs(UnmanagedType.LPStr)] string pszHashId,
+            [MarshalAs(UnmanagedType.LPWStr)] string pszHashId,
             ref CRYPT_TIMESTAMP_PARA pPara,
             [In] byte[] pbData,
             int cbData,

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/DirectoryUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/DirectoryUtilityTests.cs
@@ -10,6 +10,22 @@ namespace NuGet.Common.Test
 {
     public class DirectoryUtilityTests
     {
+        [PlatformTheory(Platform.Darwin, Platform.Linux)]
+        [InlineData("áéíóúäëïöü")]
+        [InlineData("ഔ")]
+        public void CreateSharedDirectory_WithUnicodeChars_CreatesDirectory(string dirPath)
+        {
+            // Arrange
+            using TestDirectory testDirectory = TestDirectory.Create();
+            string dirWithUnicode = Path.Combine(testDirectory, dirPath);
+
+            // Act
+            DirectoryUtility.CreateSharedDirectory(dirWithUnicode);
+
+            // Assert
+            Assert.Equal("777", StatPermissions(dirWithUnicode));
+        }
+
         [Fact]
         public void DirectoryUtility_CreateSharedDirectory_BasicSuccess()
         {


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1659

Regression? Last working version: N/A

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

- Sets CA2101 rule to Warning
- In all flagged DllImport's and Marshallings, set encoding to Unicode

## PR Checklist

- [ ] PR has a meaningful title
- [ ] PR has a linked issue.
- [ ] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception: tests in progress
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [ ] N/A
