### PR TITLE
Improve ci initialization script

### DIFF
--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -12,7 +12,7 @@ steps:
 - task: PowerShell@1
   inputs:
     scriptName: "$(Build.Repository.LocalPath)\\scripts\\cibuild\\ConfigureVstsBuild.ps1"
-    arguments: "-BuildRTM $(BuildRTM)"
+    arguments: "-BuildRTM $(BuildRTM) -RepositoryPath $(Build.Repository.LocalPath) -BranchName $(Build.SourceBranchName) -CommitHash $(Build.SourceVersion) -BuildNumber $(Build.BuildNumber)"
   displayName: "Configure VSTS CI Environment"
 
 - task: PublishBuildArtifacts@1

--- a/scripts/cibuild/ConfigureVstsBuild.ps1
+++ b/scripts/cibuild/ConfigureVstsBuild.ps1
@@ -1,36 +1,55 @@
 <#
 .SYNOPSIS
-Sets build variables during a VSTS build dynamically.
+Sets build variables during a CI build dynamically.
 
 .DESCRIPTION
-This script is used to dynamically set some build variables during VSTS build.
+This script is used to dynamically set some build variables during CI build.
 Specifically, this script determines the build number of the artifacts,
 also it sets the $(NupkgOutputDir) based on whether $(BuildRTM) is true or false.
 
 .PARAMETER BuildRTM
 True/false depending on whether nupkgs are being with or without the release labels.
 
+.PARAMETER RepositoryPath
+The path to the root of the NuGet.Client repo
+
+.PARAMETER BranchName
+The name of the branch being built
+
+.PARAMETER CommitHash
+The commit hash being built
+
+.PARAMETER BuildNumber
+The build number of the current build
 #>
 
 param
 (
     [Parameter(Mandatory=$True)]
-    [string]$BuildRTM
+    [string]$BuildRTM,
+    [Parameter(Mandatory=$true)]
+    [string]$RepositoryPath,
+    [Parameter(Mandatory=$true)]
+    [string]$BranchName,
+    [Parameter(Mandatory=$true)]
+    [string]$CommitHash,
+    [Parameter(Mandatory=$true)]
+    [string]$BuildNumber
 )
 
 Function Get-Version {
     param(
-        [string]$ProductVersion,
-        [string]$build
+        [string]$buildNumber
     )
-        Write-Host "Evaluating the new VSIX Version : ProductVersion $ProductVersion, build $build"
+        Write-Host "Evaluating the new VSIX Version : $buildNumber"
         # The major version is NuGetMajorVersion + 11, to match VS's number.
         # The new minor version is: 4.0.0 => 40000, 4.11.5 => 41105.
         # This assumes we only get to NuGet major/minor/patch 99 at worst, otherwise the logic breaks.
         # The final version for NuGet 4.0.0, build number 3128 would be 15.0.40000.3128
-        $versionParts = $ProductVersion -split '\.'
-        $major = $($versionParts[0] / 1) + 11
-        $finalVersion = "$major.0.$((-join ($versionParts | %{ '{0:D2}' -f ($_ -as [int]) } )).TrimStart("0")).$build"
+        $parsedVersion = [System.Version]::Parse($buildNumber)
+        $major = $parsedVersion.Major + 11
+        $patchVersion = $parsedVersion.Major * 10000 + $parsedVersion.Minor * 100 + $parsedVersion.Build
+        $finalVersion = "$major.0.$patchVersion.$($parsedVersion.Revision)"
 
         Write-Host "The new VSIX Version is: $finalVersion"
         return $finalVersion
@@ -38,11 +57,11 @@ Function Get-Version {
 
 Function Update-VsixVersion {
     param(
-        [string]$ReleaseProductVersion,
+        [string]$buildNumber,
         [string]$manifestName,
-        [int]$buildNumber
+        [string]$repositoryPath
     )
-    $vsixManifest = Join-Path $env:BUILD_REPOSITORY_LOCALPATH\src\NuGet.Clients\NuGet.VisualStudio.Client $manifestName
+    $vsixManifest = Join-Path "$repositoryPath\src\NuGet.Clients\NuGet.VisualStudio.Client" $manifestName
 
     Write-Host "Updating the VSIX version in manifest $vsixManifest"
 
@@ -52,7 +71,7 @@ Function Update-VsixVersion {
     # Reading the current version from the manifest
     $oldVersion = $root.Metadata.Identity.Version
     # Evaluate the new version
-    $newVersion = Get-Version $ReleaseProductVersion $buildNumber
+    $newVersion = Get-Version $buildNumber
     Write-Host "Updating the VSIX version [$oldVersion] => [$newVersion]"
     Write-Host "##vso[task.setvariable variable=VsixBuildNumber;]$newVersion"
     # setting the revision to the new version
@@ -86,9 +105,9 @@ Function Get-LocBranchExists {
     )
 
     Write-Host "Looking for branch '$branchName' in NuGet.Build.Localization"
-    $lsRemoteOpts = 'ls-remote', 'origin', $branchName
+    $lsRemoteOpts = 'ls-remote', '--exit-code', 'origin', "refs/heads/$branchName"
     $branchExists = & git -C $NuGetLocalization $lsRemoteOpts
-    return $branchExists
+    return $LASTEXITCODE -eq 0
 }
 
 $isRTMBuild = [boolean]::Parse($BuildRTM)
@@ -102,22 +121,20 @@ Set-RtmLabel -isRTMBuild $isRTMBuild
 $regKeyFileSystem = "HKLM:SYSTEM\CurrentControlSet\Control\FileSystem"
 $enableLongPathSupport = "LongPathsEnabled"
 
-$NuGetClientRoot = $env:BUILD_REPOSITORY_LOCALPATH
-$Submodules = Join-Path $NuGetClientRoot submodules -Resolve
+$Submodules = Join-Path $RepositoryPath submodules -Resolve
 
 # NuGet.Build.Localization repository set-up
 $NuGetLocalization = Join-Path $Submodules NuGet.Build.Localization -Resolve
 
 # Check if there is a localization branch associated with this branch repo
-$currentNuGetBranch = $env:BUILD_SOURCEBRANCHNAME
-if (Get-LocBranchExists $currentNuGetBranch)
+if (Get-LocBranchExists $BranchName)
 {
-    $NuGetLocalizationRepoBranch = $currentNuGetBranch
+    $NuGetLocalizationRepoBranch = $BranchName
 }
 else
 {
-    if ($currentNuGetBranch -like "*-MSRC") {
-        $currentNuGetBranch = $currentNuGetBranch -replace "-MSRC$", ""
+    if ($BranchName -like "*-MSRC") {
+        $currentNuGetBranch = $BranchName -replace "-MSRC$", ""
         if (Get-LocBranchExists $currentNuGetBranch) {
             $NuGetLocalizationRepoBranch = $currentNuGetBranch
         }
@@ -133,7 +150,7 @@ else
 Write-Host "NuGet.Build.Localization Branch: $NuGetLocalizationRepoBranch"
 
 # update submodule NuGet.Build.Localization
-$updateOpts = 'pull', 'origin', $NuGetLocalizationRepoBranch
+$updateOpts = 'switch', '-d', "origin/$NuGetLocalizationRepoBranch", "-q"
 Write-Host "git update NuGet.Build.Localization at $NuGetLocalization"
 & git -C $NuGetLocalization $updateOpts 2>&1 | Write-Host
 # Get the commit of the localization repository that will be used for this build.
@@ -153,14 +170,14 @@ if ($BuildRTM -eq $true)
 else
 {
     Write-Host "##vso[task.setvariable variable=VsixPublishDir;]VS15"
-    $newBuildCounter = $env:BUILD_BUILDNUMBER
-    $VsTargetBranch = & dotnet msbuild $env:BUILD_REPOSITORY_LOCALPATH\build\config.props /v:m /nologo /t:GetVsTargetBranch
-    $NuGetSdkVsVersion = & dotnet msbuild $env:BUILD_REPOSITORY_LOCALPATH\build\config.props /v:m /nologo /t:GetNuGetSdkVsSemanticVersion
-    Write-Host $VsTargetBranch
+    $newBuildCounter = $BuildNumber
+    $VsTargetBranch = & dotnet msbuild $RepositoryPath\build\config.props /v:m /nologo /t:GetVsTargetBranch
+    $NuGetSdkVsVersion = & dotnet msbuild $RepositoryPath\build\config.props /v:m /nologo /t:GetNuGetSdkVsSemanticVersion
+    Write-Host "VS target branch: $VsTargetBranch"
     $jsonRepresentation = @{
         BuildNumber = $newBuildCounter
-        CommitHash = $env:BUILD_SOURCEVERSION
-        BuildBranch = $env:BUILD_SOURCEBRANCHNAME
+        CommitHash = $CommitHash
+        BuildBranch = $BranchName
         LocalizationRepositoryBranch = $NuGetLocalizationRepoBranch
         LocalizationRepositoryCommitHash = $LocalizationRepoCommitHash
         VsTargetBranch = $VsTargetBranch.Trim()
@@ -168,16 +185,10 @@ else
     }
 
     # First create the file locally so that we can laster publish it as a build artifact from a local source file instead of a remote source file.
-    $localBuildInfoJsonFilePath = [System.IO.Path]::Combine("$Env:BUILD_REPOSITORY_LOCALPATH\artifacts", 'buildinfo.json')
+    $localBuildInfoJsonFilePath = [System.IO.Path]::Combine("$RepositoryPath\artifacts", 'buildinfo.json')
 
-    New-Item $localBuildInfoJsonFilePath -Force
+    New-Item $localBuildInfoJsonFilePath -Force | Out-Null
     $jsonRepresentation | ConvertTo-Json | Set-Content $localBuildInfoJsonFilePath
 
-    $productVersion = & dotnet msbuild $env:BUILD_REPOSITORY_LOCALPATH\build\config.props /v:m /nologo /t:GetSemanticVersion
-    if (-not $?)
-    {
-        Write-Error "Failed to get product version."
-        exit 1
-    }
-    Update-VsixVersion -manifestName source.extension.vsixmanifest -ReleaseProductVersion $productVersion -buildNumber $env:BUILDNUMBER
+    Update-VsixVersion -manifestName source.extension.vsixmanifest -buildNumber $BuildNumber -RepositoryPath $RepositoryPath
 }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1863

Regression? Last working version:

## Description
Cherry-pick https://github.com/NuGet/NuGet.Client/commit/9c349a023da147ba81a865f94ca1e52eb5ac028c commit into release-6.2.x branch. This is to fix a bug when build is triggered by "Approved for CI" label.

If the build is triggered by "Approved for CI" label, the "Configure VSTS CI Environment" step will fail to find the localization branch: [build](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=6695587&view=logs&j=d80b2849-30d4-52dd-74cd-d6536ba98fe0&t=64c204f9-1df6-57fc-6b34-ec5bd3372627&l=15)
```
Looking for branch 'head' in NuGet.Build.Localization
NuGet.Build.Localization Branch: head
git update NuGet.Build.Localization at D:\a\_work\1\s\submodules\NuGet.Build.Localization
fatal: couldn't find remote ref head
```

After cherry-pick this commit, the "Configure VSTS CI Environment" step will be like: [build](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=6699945&view=logs&j=d80b2849-30d4-52dd-74cd-d6536ba98fe0&t=64c204f9-1df6-57fc-6b34-ec5bd3372627&l=14)
```
Looking for branch 'head' in NuGet.Build.Localization
NuGet.Build.Localization Branch: dev
git update NuGet.Build.Localization at D:\a\_work\1\s\submodules\NuGet.Build.Localization
```

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
