### PR TITLE
Add better handling of AggregateExceptions in static graph-based restore

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs
@@ -1044,7 +1044,7 @@ namespace NuGet.Build.Tasks.Console
             switch (exception)
             {
                 case AggregateException aggregateException:
-                    foreach (Exception innerException in aggregateException.InnerExceptions)
+                    foreach (Exception innerException in aggregateException.Flatten().InnerExceptions)
                     {
                         LogErrorFromException(innerException);
                     }

--- a/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildRestoreTaskTests.cs
+++ b/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildRestoreTaskTests.cs
@@ -766,7 +766,7 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
         }
 
         [PlatformFact(Platform.Windows)]
-        public void MsbuildRestore_StaticGraphEvaluation_HandlesInvalidProjectFileExceptionn()
+        public void MsbuildRestore_StaticGraphEvaluation_HandlesInvalidProjectFileException()
         {
             // Arrange
             using (var pathContext = new SimpleTestPathContext())
@@ -779,12 +779,10 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
                 var projectA = new SimpleTestProjectContext("a", ProjectStyle.PackageReference, pathContext.SolutionRoot);
 
                 var projectB = new SimpleTestProjectContext("b", ProjectStyle.PackageReference, pathContext.SolutionRoot);
-                var projectC = new SimpleTestProjectContext("c", ProjectStyle.PackageReference, pathContext.SolutionRoot);
 
                 var projectAFrameworkContext = new SimpleTestProjectFrameworkContext(net461);
 
                 projectAFrameworkContext.ProjectReferences.Add(projectB);
-                projectAFrameworkContext.ProjectReferences.Add(projectC);
 
                 var packageX = new SimpleTestPackageContext()
                 {
@@ -799,16 +797,13 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
                 solution.Create(pathContext.SolutionRoot);
 
                 File.Delete(projectB.ProjectPath);
-                File.Delete(projectC.ProjectPath);
 
-                // Restore the project with a PackageReference which generates assets
                 var result = _msbuildFixture.RunMsBuild(pathContext.WorkingDirectory, $"/t:restore /p:RestoreUseStaticGraphEvaluation=true {projectA.ProjectPath}", ignoreExitCode: true);
 
                 // Assert
                 Assert.True(result.ExitCode == 1, result.AllOutput);
 
                 result.AllOutput.Should().Contain($"error MSB4025: The project file could not be loaded. Could not find file '{projectB.ProjectPath}'");
-                result.AllOutput.Should().Contain($"error MSB4025: The project file could not be loaded. Could not find file '{projectC.ProjectPath}'");
             }
         }
 

--- a/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildRestoreTaskTests.cs
+++ b/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildRestoreTaskTests.cs
@@ -766,7 +766,7 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
         }
 
         [PlatformFact(Platform.Windows)]
-        public async Task MsbuildRestore_StaticGraphEvaluation_HandlesInvalidProjectFileExceptionn()
+        public void MsbuildRestore_StaticGraphEvaluation_HandlesInvalidProjectFileExceptionn()
         {
             // Arrange
             using (var pathContext = new SimpleTestPathContext())
@@ -793,29 +793,10 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
                 };
                 projectA.Frameworks.Add(projectAFrameworkContext);
 
-                packageX.Files.Clear();
                 projectA.AddPackageToAllFrameworks(packageX);
-                packageX.AddFile("lib/net461/a.dll");
 
                 solution.Projects.Add(projectA);
                 solution.Create(pathContext.SolutionRoot);
-
-                var configAPath = Path.Combine(Path.GetDirectoryName(projectA.ProjectPath), "NuGet.Config");
-                var configText =
-$@"<?xml version=""1.0"" encoding=""utf-8""?>
-<configuration>
-    <packageSources>
-        <add key=""LocalSource"" value=""{pathContext.PackageSource}"" />
-    </packageSources>
-</configuration>";
-                using (var writer = new StreamWriter(configAPath))
-                {
-                    writer.Write(configText);
-                }
-
-                await SimpleTestPackageUtility.CreateFolderFeedV3Async(
-                    pathContext.PackageSource,
-                    packageX);
 
                 File.Delete(projectB.ProjectPath);
                 File.Delete(projectC.ProjectPath);


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12100

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
A behavior change in MSBuild's static graph API means that an `AggregateException` is now thrown instead of an `InvalidProjectFileException`.  This change updates the exception handling in static graph-based restore to use a single method for handling logging of exceptions. 

1. If the exception is an `AggregateException`, call the `LogErrorFromException()` method on each inner exception
2. If the exception is an `InvalidProjectFileException`, call the MSBuild logging API that surfaces the extra information contained in the exception
3. All other exceptions are logged with the full stack trace so that user reports contain as much information as possible

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception 
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
