### PR TITLE
Fixes CA2213 issues on NuGet client repo

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/NuGet.CommandLine.csproj
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGet.CommandLine.csproj
@@ -53,7 +53,7 @@
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="NuGet.Core">
-      <HintPath>$(NuGetPackageRoot)nuget.core\$(NuGetCoreV2Version)\lib\net40-Client\NuGet.Core.dll</HintPath>
+      <HintPath>$(NuGetPackageRoot)\nuget.core\$(NuGetCoreV2Version)\lib\net40-Client\NuGet.Core.dll</HintPath>
       <Aliases>CoreV2</Aliases>
     </Reference>
   </ItemGroup>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/NuGet.PackageManagement.UI.csproj
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/NuGet.PackageManagement.UI.csproj
@@ -568,4 +568,11 @@
   <ItemGroup>
     <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="Resources\PackageIconMonikers.imagemanifest">
+      <AutoGen>True</AutoGen>
+      <DesignTime>True</DesignTime>
+      <DependentUpon>PackageIconMonikers.tt</DependentUpon>
+    </None>
+  </ItemGroup>
 </Project>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/NuGet.PackageManagement.UI.csproj
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/NuGet.PackageManagement.UI.csproj
@@ -568,11 +568,4 @@
   <ItemGroup>
     <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />
   </ItemGroup>
-  <ItemGroup>
-    <None Include="Resources\PackageIconMonikers.imagemanifest">
-      <AutoGen>True</AutoGen>
-      <DesignTime>True</DesignTime>
-      <DependentUpon>PackageIconMonikers.tt</DependentUpon>
-    </None>
-  </ItemGroup>
 </Project>

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/NuGet.VisualStudio.Implementation.csproj
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/NuGet.VisualStudio.Implementation.csproj
@@ -38,13 +38,13 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.ProjectSystem.VS">
-      <HintPath>$(NuGetPackageRoot)microsoft.visualstudio.projectsystem\16.7.156-pre\lib\net472\Microsoft.VisualStudio.ProjectSystem.VS.dll</HintPath>
+      <HintPath>$(NuGetPackageRoot)\microsoft.visualstudio.projectsystem\16.7.156-pre\lib\net472\Microsoft.VisualStudio.ProjectSystem.VS.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.ProjectSystem.Managed">
-      <HintPath>$(NuGetPackageRoot)microsoft.visualstudio.projectsystem.managed\$(ProjectSystemManagedVersion)\lib\net472\Microsoft.VisualStudio.ProjectSystem.Managed.dll</HintPath>
+      <HintPath>$(NuGetPackageRoot)\microsoft.visualstudio.projectsystem.managed\$(ProjectSystemManagedVersion)\lib\net472\Microsoft.VisualStudio.ProjectSystem.Managed.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.ProjectSystem.Managed.VS">
-      <HintPath>$(NuGetPackageRoot)microsoft.visualstudio.projectsystem.managed.vs\$(ProjectSystemManagedVersion)\lib\net472\Microsoft.VisualStudio.ProjectSystem.Managed.VS.dll</HintPath>
+      <HintPath>$(NuGetPackageRoot)\microsoft.visualstudio.projectsystem.managed.vs\$(ProjectSystemManagedVersion)\lib\net472\Microsoft.VisualStudio.ProjectSystem.Managed.VS.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.ExtensionEngine">
       <HintPath>$(PkgMicrosoft_VSSDK_BuildTools)\tools\vssdk\Microsoft.VisualStudio.ExtensionEngine.dll</HintPath>

--- a/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpSourceAuthenticationHandler.cs
+++ b/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpSourceAuthenticationHandler.cs
@@ -20,7 +20,7 @@ namespace NuGet.Protocol
 
         // Only one source may prompt at a time
         private readonly static SemaphoreSlim _credentialPromptLock = new SemaphoreSlim(1, 1);
-        internal bool _isDisposed = false; // internal for testing purposes
+        private bool _isDisposed = false;
 
         private readonly PackageSource _packageSource;
         private readonly HttpClientHandler _clientHandler;
@@ -306,6 +306,8 @@ namespace NuGet.Protocol
             {
                 // free managed resources
                 _httpClientLock.Dispose();
+                _credentials = null;
+                _authStates = null;
             }
 
             _isDisposed = true;

--- a/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpSourceAuthenticationHandler.cs
+++ b/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpSourceAuthenticationHandler.cs
@@ -20,7 +20,7 @@ namespace NuGet.Protocol
 
         // Only one source may prompt at a time
         private readonly static SemaphoreSlim _credentialPromptLock = new SemaphoreSlim(1, 1);
-        private bool _isDisposed = false;
+        internal bool _isDisposed = false; // internal for testing purposes
 
         private readonly PackageSource _packageSource;
         private readonly HttpClientHandler _clientHandler;
@@ -293,7 +293,7 @@ namespace NuGet.Protocol
             HttpHandlerResourceV3.CredentialsSuccessfullyUsed?.Invoke(uri, credentials);
         }
 
-        protected new void Dispose(bool disposing)
+        protected override void Dispose(bool disposing)
         {
             base.Dispose(disposing);
 

--- a/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpSourceAuthenticationHandler.cs
+++ b/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpSourceAuthenticationHandler.cs
@@ -20,6 +20,7 @@ namespace NuGet.Protocol
 
         // Only one source may prompt at a time
         private readonly static SemaphoreSlim _credentialPromptLock = new SemaphoreSlim(1, 1);
+        private bool _isDisposed = false;
 
         private readonly PackageSource _packageSource;
         private readonly HttpClientHandler _clientHandler;
@@ -290,6 +291,24 @@ namespace NuGet.Protocol
         private void CredentialsSuccessfullyUsed(Uri uri, ICredentials credentials)
         {
             HttpHandlerResourceV3.CredentialsSuccessfullyUsed?.Invoke(uri, credentials);
+        }
+
+        protected new void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+
+            if (_isDisposed)
+            {
+                return;
+            }
+
+            if (disposing)
+            {
+                // free managed resources
+                _httpClientLock.Dispose();
+            }
+
+            _isDisposed = true;
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpSourceAuthenticationHandler.cs
+++ b/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpSourceAuthenticationHandler.cs
@@ -26,10 +26,7 @@ namespace NuGet.Protocol
         private readonly HttpClientHandler _clientHandler;
         private readonly ICredentialService _credentialService;
 
-#pragma warning disable CA2213
-        // TODO: https://github.com/NuGet/Home/issues/12116
         private readonly SemaphoreSlim _httpClientLock = new SemaphoreSlim(1, 1);
-#pragma warning restore CA2213
         private Dictionary<string, AmbientAuthenticationState> _authStates = new Dictionary<string, AmbientAuthenticationState>();
         private HttpSourceCredentials _credentials;
 

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+NuGet.Protocol.HttpSourceAuthenticationHandler.Dispose(bool disposing) -> void

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -1,1 +1,1 @@
-NuGet.Protocol.HttpSourceAuthenticationHandler.Dispose(bool disposing) -> void
+override NuGet.Protocol.HttpSourceAuthenticationHandler.Dispose(bool disposing) -> void

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/netcoreapp5.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/netcoreapp5.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+NuGet.Protocol.HttpSourceAuthenticationHandler.Dispose(bool disposing) -> void

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/netcoreapp5.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/netcoreapp5.0/PublicAPI.Unshipped.txt
@@ -1,1 +1,1 @@
-NuGet.Protocol.HttpSourceAuthenticationHandler.Dispose(bool disposing) -> void
+override NuGet.Protocol.HttpSourceAuthenticationHandler.Dispose(bool disposing) -> void

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+NuGet.Protocol.HttpSourceAuthenticationHandler.Dispose(bool disposing) -> void

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,1 +1,1 @@
-NuGet.Protocol.HttpSourceAuthenticationHandler.Dispose(bool disposing) -> void
+override NuGet.Protocol.HttpSourceAuthenticationHandler.Dispose(bool disposing) -> void

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/HttpSource/HttpSourceAuthenticationHandlerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/HttpSource/HttpSourceAuthenticationHandlerTests.cs
@@ -534,22 +534,6 @@ namespace NuGet.Protocol.Tests
             Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
         }
 
-        [Fact]
-        public void Dispose_CallingDisposeWithoutArguments_DisposesInstance()
-        {
-            // Arrange
-            var packageSource = new PackageSource("http://package.source.test");
-            var clientHandler = new HttpClientHandler();
-            var credentialService = Mock.Of<ICredentialService>();
-            var handler = new HttpSourceAuthenticationHandler(packageSource, clientHandler, credentialService);
-
-            // Act
-            handler.Dispose();
-
-            // Assert
-            Assert.True(handler._isDisposed);
-        }
-
         private static LambdaMessageHandler GetLambdaMessageHandler(HttpStatusCode statusCode)
         {
             return new LambdaMessageHandler(

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/HttpSource/HttpSourceAuthenticationHandlerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/HttpSource/HttpSourceAuthenticationHandlerTests.cs
@@ -534,6 +534,22 @@ namespace NuGet.Protocol.Tests
             Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
         }
 
+        [Fact]
+        public void Dispose_CallingDisposeWithoutArguments_DisposesInstance()
+        {
+            // Arrange
+            var packageSource = new PackageSource("http://package.source.test");
+            var clientHandler = new HttpClientHandler();
+            var credentialService = Mock.Of<ICredentialService>();
+            var handler = new HttpSourceAuthenticationHandler(packageSource, clientHandler, credentialService);
+
+            // Act
+            handler.Dispose();
+
+            // Assert
+            Assert.True(handler._isDisposed);
+        }
+
         private static LambdaMessageHandler GetLambdaMessageHandler(HttpStatusCode statusCode)
         {
             return new LambdaMessageHandler(

--- a/test/TestUtilities/Test.Utility/Protocol/TestContent.cs
+++ b/test/TestUtilities/Test.Utility/Protocol/TestContent.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.IO;
 using System.Net;
 using System.Net.Http;
@@ -11,10 +12,9 @@ namespace Test.Utility
 {
     public class TestContent : HttpContent
     {
-#pragma warning disable CA2213
-        // TODO: https://github.com/NuGet/Home/issues/12116
-        private MemoryStream _stream;
-#pragma warning restore CA2213
+        private readonly MemoryStream _stream;
+        internal bool _isDisposed = false; // internal for testing purposes
+
         public TestContent(string s)
         {
             _stream = new MemoryStream(Encoding.UTF8.GetBytes(s));
@@ -30,6 +30,24 @@ namespace Test.Utility
         {
             length = _stream.Length;
             return true;
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+
+            if (_isDisposed)
+            {
+                return;
+            }
+
+            if (disposing)
+            {
+                // free managed resources
+                _stream.Dispose();
+            }
+
+            _isDisposed = true;
         }
     }
 }

--- a/test/TestUtilities/Test.Utility/Protocol/TestContent.cs
+++ b/test/TestUtilities/Test.Utility/Protocol/TestContent.cs
@@ -14,9 +14,10 @@ namespace Test.Utility
     public class TestContent : HttpContent
     {
 #pragma warning disable CA2213
-        // Need to disable this rule because the analyzer thinks We are not disposing _stream
+        // Need to disable this rule because the analyzer thinks we are not disposing _stream
         // when in reality, it is.
         // See https://github.com/dotnet/roslyn-analyzers/issues/6172
+        //     https://github.com/dotnet/roslyn-analyzers/issues/6202
         private readonly MemoryStream _stream;
 #pragma warning restore CA2213
         private bool _isDisposed = false;

--- a/test/TestUtilities/Test.Utility/Protocol/TestContent.cs
+++ b/test/TestUtilities/Test.Utility/Protocol/TestContent.cs
@@ -1,7 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
+#nullable enable
+
 using System.IO;
 using System.Net;
 using System.Net.Http;
@@ -13,7 +14,7 @@ namespace Test.Utility
     public class TestContent : HttpContent
     {
         private readonly MemoryStream _stream;
-        internal bool _isDisposed = false; // internal for testing purposes
+        private bool _isDisposed = false; // internal for testing purposes
 
         public TestContent(string s)
         {
@@ -21,7 +22,7 @@ namespace Test.Utility
             _stream.Seek(0, SeekOrigin.Begin);
         }
 
-        protected override Task SerializeToStreamAsync(Stream stream, TransportContext context)
+        protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context)
         {
             return _stream.CopyToAsync(stream);
         }

--- a/test/TestUtilities/Test.Utility/Protocol/TestContent.cs
+++ b/test/TestUtilities/Test.Utility/Protocol/TestContent.cs
@@ -19,7 +19,7 @@ namespace Test.Utility
         // See https://github.com/dotnet/roslyn-analyzers/issues/6172
         private readonly MemoryStream _stream;
 #pragma warning restore CA2213
-        private bool _isDisposed = false; // internal for testing purposes
+        private bool _isDisposed = false;
 
         public TestContent(string s)
         {

--- a/test/TestUtilities/Test.Utility/Protocol/TestContent.cs
+++ b/test/TestUtilities/Test.Utility/Protocol/TestContent.cs
@@ -13,7 +13,11 @@ namespace Test.Utility
 {
     public class TestContent : HttpContent
     {
+#pragma warning disable CA2213
+        // Need to disable this rule because the analyzer thinks We are not disposing _stream
+        // when in reality, it is
         private readonly MemoryStream _stream;
+#pragma warning restore CA2213
         private bool _isDisposed = false; // internal for testing purposes
 
         public TestContent(string s)

--- a/test/TestUtilities/Test.Utility/Protocol/TestContent.cs
+++ b/test/TestUtilities/Test.Utility/Protocol/TestContent.cs
@@ -15,7 +15,8 @@ namespace Test.Utility
     {
 #pragma warning disable CA2213
         // Need to disable this rule because the analyzer thinks We are not disposing _stream
-        // when in reality, it is
+        // when in reality, it is.
+        // See https://github.com/dotnet/roslyn-analyzers/issues/6172
         private readonly MemoryStream _stream;
 #pragma warning restore CA2213
         private bool _isDisposed = false; // internal for testing purposes

--- a/test/TestUtilities/Test.Utility/ReadTimeoutHonoringSlowStream.cs
+++ b/test/TestUtilities/Test.Utility/ReadTimeoutHonoringSlowStream.cs
@@ -15,6 +15,7 @@ namespace Test.Utility
         private readonly Stream _innerStream;
 #pragma warning restore CA2213
         private readonly CancellationToken _cancellationToken;
+        internal new bool _isDisposed = false; // internal for testing purposes
 
         public ReadTimeoutHonoringSlowStream(Stream innerStream)
             : this(innerStream, CancellationToken.None)
@@ -55,5 +56,23 @@ namespace Test.Utility
 
         public override int ReadTimeout { get; set; } = Timeout.Infinite;
         public override bool CanTimeout => true;
+
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+
+            if (_isDisposed)
+            {
+                return;
+            }
+
+            if (disposing)
+            {
+                // free managed resources
+                _innerStream.Dispose();
+            }
+
+            _isDisposed = true;
+        }
     }
 }

--- a/test/TestUtilities/Test.Utility/ReadTimeoutHonoringSlowStream.cs
+++ b/test/TestUtilities/Test.Utility/ReadTimeoutHonoringSlowStream.cs
@@ -10,10 +10,7 @@ namespace Test.Utility
 {
     public class ReadTimeoutHonoringSlowStream : SlowStream
     {
-#pragma warning disable CA2213
-        // TODO: https://github.com/NuGet/Home/issues/12116
         private readonly Stream _innerStream;
-#pragma warning restore CA2213
         private readonly CancellationToken _cancellationToken;
         internal new bool _isDisposed = false; // internal for testing purposes
 

--- a/test/TestUtilities/Test.Utility/SlowStream.cs
+++ b/test/TestUtilities/Test.Utility/SlowStream.cs
@@ -15,6 +15,7 @@ namespace Test.Utility
         private readonly Stream _innerStream;
 #pragma warning restore CA2213
         private readonly CancellationToken _cancellationToken;
+        internal bool _isDisposed = false; // internal for testing purposes
 
         public SlowStream(Stream innerStream)
             : this(innerStream, CancellationToken.None)
@@ -80,6 +81,24 @@ namespace Test.Utility
         {
             get { throw new NotSupportedException(); }
             set { throw new NotSupportedException(); }
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+
+            if (_isDisposed)
+            {
+                return;
+            }
+
+            if (disposing)
+            {
+                // free managed resources
+                _innerStream.Dispose();
+            }
+
+            _isDisposed = true;
         }
     }
 }

--- a/test/TestUtilities/Test.Utility/SlowStream.cs
+++ b/test/TestUtilities/Test.Utility/SlowStream.cs
@@ -10,10 +10,7 @@ namespace Test.Utility
 {
     public class SlowStream : Stream
     {
-#pragma warning disable CA2213
-        // TODO: https://github.com/NuGet/Home/issues/12116
         private readonly Stream _innerStream;
-#pragma warning restore CA2213
         private readonly CancellationToken _cancellationToken;
         internal bool _isDisposed = false; // internal for testing purposes
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12116

Regression? Last working version: N/A

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

- Fixes CA2213 rule by calling Dispose() on internal HTTP client on `HttpSourceAuthenticationHandler` class
- Fixes CA2213 rule in test code
- Added an inline suppression in test code, since Analyzer thinks the rule is not solved.
- Added unit tests for `HttpSourceAuthenticationHandler.Dispose()`
- Throw ObjectDisposedException when calling SendAsync() on HttpSourceAuthenticationHandler disposed object
- Added backslash dir separator in project files to fix issues in my devbox when using a NuGetPackageRoot without trailing backslash char.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added: Added 3 tests for product code
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A: No product change
