### PR TITLE
VsPackageInstallerServices should not post ProjectNotNominatedException faults

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPackageInstallerServices.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPackageInstallerServices.cs
@@ -16,6 +16,7 @@ using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.PackageManagement;
 using NuGet.PackageManagement.VisualStudio;
+using NuGet.PackageManagement.VisualStudio.Exceptions;
 using NuGet.Packaging;
 using NuGet.Packaging.PackageExtraction;
 using NuGet.Packaging.Signing;
@@ -125,6 +126,10 @@ namespace NuGet.VisualStudio.Implementation.Extensibility
 
                         return packages;
                     });
+            }
+            catch (ProjectNotNominatedException)
+            {
+                throw;
             }
             catch (Exception exception)
             {
@@ -266,6 +271,10 @@ namespace NuGet.VisualStudio.Implementation.Extensibility
                         return packages;
                     });
             }
+            catch (ProjectNotNominatedException)
+            {
+                throw;
+            }
             catch (Exception exception)
             {
                 _telemetryProvider.PostFault(exception, typeof(VsPackageInstallerServices).FullName);
@@ -350,6 +359,10 @@ namespace NuGet.VisualStudio.Implementation.Extensibility
                     IEnumerable<PackageReference> installedPackageReferences = await GetInstalledPackageReferencesAsync(project);
 
                     return PackageServiceUtilities.IsPackageInList(installedPackageReferences, packageId, nugetVersion);
+                }
+                catch (ProjectNotNominatedException)
+                {
+                    throw;
                 }
                 catch (Exception exception)
                 {

--- a/src/NuGet.Clients/NuGet.VisualStudio/Extensibility/IVsPackageInstallerServices.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio/Extensibility/IVsPackageInstallerServices.cs
@@ -31,7 +31,7 @@ namespace NuGet.VisualStudio
         /// <param name="project">The project to check for NuGet package.</param>
         /// <param name="id">The id of the package to check.</param>
         /// <returns><c>true</c> if the package is install. <c>false</c> otherwise.</returns>
-        /// <exception cref="InvalidOperationException">A "project not nominated" exception will be thrown if the project is asynchronous and the project system has not yet told NuGet about the project.
+        /// <exception cref="InvalidOperationException">A "project not nominated" exception will be thrown if the project system has not yet told NuGet about the project.
         /// You can use <see cref="IVsNuGetProjectUpdateEvents"/> or Microsoft.VisualStudio.OperationProgress to be notified when the project is ready.</exception>
         [Obsolete("This method can cause UI delays if called on the UI thread. Use INuGetProjectService.GetInstalledPackagesAsync in the NuGet.VisualStudio.Contracts package instead, and check the specific package you're interested in")]
         bool IsPackageInstalled(Project project, string id);
@@ -43,7 +43,7 @@ namespace NuGet.VisualStudio
         /// <param name="id">The id of the package to check.</param>
         /// <param name="version">The version of the package to check.</param>
         /// <returns><c>true</c> if the package is install. <c>false</c> otherwise.</returns>
-        /// <exception cref="InvalidOperationException">A "project not nominated" exception will be thrown if the project is asynchronous and the project system has not yet told NuGet about the project.
+        /// <exception cref="InvalidOperationException">A "project not nominated" exception will be thrown if the project system has not yet told NuGet about the project.
         /// You can use <see cref="IVsNuGetProjectUpdateEvents"/> or Microsoft.VisualStudio.OperationProgress to be notified when the project is ready.</exception>
         [Obsolete("This method can cause UI delays if called on the UI thread. Use INuGetProjectService.GetInstalledPackagesAsync in the NuGet.VisualStudio.Contracts package instead, and check the specific package you're interested in")]
         bool IsPackageInstalled(Project project, string id, SemanticVersion version);
@@ -60,7 +60,7 @@ namespace NuGet.VisualStudio
         /// when client project compiles against this assembly, the compiler would attempt to bind against
         /// the other overload which accepts SemanticVersion and would require client project to reference NuGet.Core.
         /// </remarks>
-        /// <exception cref="InvalidOperationException">A "project not nominated" exception will be thrown if the project is asynchronous and the project system has not yet told NuGet about the project.
+        /// <exception cref="InvalidOperationException">A "project not nominated" exception will be thrown if the project system has not yet told NuGet about the project.
         /// You can use <see cref="IVsNuGetProjectUpdateEvents"/> or Microsoft.VisualStudio.OperationProgress to be notified when the project is ready.</exception>
         [Obsolete("This method can cause UI delays if called on the UI thread. Use INuGetProjectService.GetInstalledPackagesAsync in the NuGet.VisualStudio.Contracts package instead, and check the specific package you're interested in")]
         bool IsPackageInstalledEx(Project project, string id, string versionString);
@@ -69,7 +69,7 @@ namespace NuGet.VisualStudio
         /// Get the list of NuGet packages installed in the specified project.
         /// </summary>
         /// <param name="project">The project to get NuGet packages from.</param>
-        /// <exception cref="InvalidOperationException">A "project not nominated" exception will be thrown if the project is asynchronous and the project system has not yet told NuGet about the project.
+        /// <exception cref="InvalidOperationException">A "project not nominated" exception will be thrown if the project system has not yet told NuGet about the project.
         /// You can use <see cref="IVsNuGetProjectUpdateEvents"/> or Microsoft.VisualStudio.OperationProgress to be notified when the project is ready.</exception>
         [Obsolete("This method can cause UI delays if called on the UI thread. Use INuGetProjectService.GetInstalledPackagesAsync in the NuGet.VisualStudio.Contracts package instead")]
         IEnumerable<IVsPackageMetadata> GetInstalledPackages(Project project);

--- a/src/NuGet.Clients/NuGet.VisualStudio/Extensibility/IVsPackageInstallerServices.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio/Extensibility/IVsPackageInstallerServices.cs
@@ -31,6 +31,8 @@ namespace NuGet.VisualStudio
         /// <param name="project">The project to check for NuGet package.</param>
         /// <param name="id">The id of the package to check.</param>
         /// <returns><c>true</c> if the package is install. <c>false</c> otherwise.</returns>
+        /// <exception cref="InvalidOperationException">A "project not nominated" exception will be thrown if the project is asynchronous and the project system has not yet told NuGet about the project.
+        /// You can use <see cref="IVsNuGetProjectUpdateEvents"/> or Microsoft.VisualStudio.OperationProgress to be notified when the project is ready.</exception>
         [Obsolete("This method can cause UI delays if called on the UI thread. Use INuGetProjectService.GetInstalledPackagesAsync in the NuGet.VisualStudio.Contracts package instead, and check the specific package you're interested in")]
         bool IsPackageInstalled(Project project, string id);
 
@@ -41,6 +43,8 @@ namespace NuGet.VisualStudio
         /// <param name="id">The id of the package to check.</param>
         /// <param name="version">The version of the package to check.</param>
         /// <returns><c>true</c> if the package is install. <c>false</c> otherwise.</returns>
+        /// <exception cref="InvalidOperationException">A "project not nominated" exception will be thrown if the project is asynchronous and the project system has not yet told NuGet about the project.
+        /// You can use <see cref="IVsNuGetProjectUpdateEvents"/> or Microsoft.VisualStudio.OperationProgress to be notified when the project is ready.</exception>
         [Obsolete("This method can cause UI delays if called on the UI thread. Use INuGetProjectService.GetInstalledPackagesAsync in the NuGet.VisualStudio.Contracts package instead, and check the specific package you're interested in")]
         bool IsPackageInstalled(Project project, string id, SemanticVersion version);
 
@@ -56,6 +60,8 @@ namespace NuGet.VisualStudio
         /// when client project compiles against this assembly, the compiler would attempt to bind against
         /// the other overload which accepts SemanticVersion and would require client project to reference NuGet.Core.
         /// </remarks>
+        /// <exception cref="InvalidOperationException">A "project not nominated" exception will be thrown if the project is asynchronous and the project system has not yet told NuGet about the project.
+        /// You can use <see cref="IVsNuGetProjectUpdateEvents"/> or Microsoft.VisualStudio.OperationProgress to be notified when the project is ready.</exception>
         [Obsolete("This method can cause UI delays if called on the UI thread. Use INuGetProjectService.GetInstalledPackagesAsync in the NuGet.VisualStudio.Contracts package instead, and check the specific package you're interested in")]
         bool IsPackageInstalledEx(Project project, string id, string versionString);
 
@@ -63,6 +69,8 @@ namespace NuGet.VisualStudio
         /// Get the list of NuGet packages installed in the specified project.
         /// </summary>
         /// <param name="project">The project to get NuGet packages from.</param>
+        /// <exception cref="InvalidOperationException">A "project not nominated" exception will be thrown if the project is asynchronous and the project system has not yet told NuGet about the project.
+        /// You can use <see cref="IVsNuGetProjectUpdateEvents"/> or Microsoft.VisualStudio.OperationProgress to be notified when the project is ready.</exception>
         [Obsolete("This method can cause UI delays if called on the UI thread. Use INuGetProjectService.GetInstalledPackagesAsync in the NuGet.VisualStudio.Contracts package instead")]
         IEnumerable<IVsPackageMetadata> GetInstalledPackages(Project project);
     }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12103

Regression? No

## Description

Catch `ProjectNotNominatedException` in `VsProjectInstallerServices`, and rethrow without posting fault telemetry. These APIs are already marked obsolete, encouraging developers to use the async `INuGetProjectService.GetInstalledPackagesAsync` instead, where project status was already designed into the API.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception: DTE makes it impossible to unit test. Scenario is timing based, making it very difficult to reliably reproduce in an integration (E2E or Apex) test, and the impact is not high enough to warrant the effort.
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [x] Documentation PR or issue filled: https://github.com/NuGet/docs.microsoft.com-nuget/issues/2895
  - **OR**
  - [ ] N/A
